### PR TITLE
test: CLJS coverage for hierarchical/always/after/invoke machines (rf2-pc82)

### DIFF
--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -1,0 +1,366 @@
+(ns re-frame.machines-cljs-test
+  "CLJS-side coverage for hierarchical / always / after / invoke state-machine
+  features under the Reagent reactive substrate. Per rf2-pc82.
+
+  These tests mirror the conformance fixtures in
+  ../docs/specification/conformance/fixtures/{hierarchical-*,always-*,
+  after-*,invoke-*}.edn but exercise the runtime through reg-machine /
+  dispatch-sync — the same surface real apps use. The flat-machine
+  case is already covered by `machine-transition-cljs` in
+  runtime_cljs_test.cljs; this file completes the matrix on CLJS."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.machines :as machines]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.trace :as trace]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (adapter/dispose-adapter!)
+  (rf/init! reagent-adapter/adapter)
+  (machines/reset-counters!)
+  (trace/clear-trace-cbs!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- snapshot
+  "Read the snapshot for `machine-id` from the default frame's app-db."
+  [machine-id]
+  (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
+
+(defn- seed-snapshot!
+  "Force the snapshot for `machine-id` to a known value via an event-db.
+  Used to position machines at a specific state without relying on the
+  runtime's first-dispatch initial-cascade behaviour (which doesn't
+  auto-descend through compound :initial chains)."
+  [machine-id snap]
+  (let [seed-id (keyword "test" (str "seed-" (namespace machine-id) "-" (name machine-id)))]
+    (rf/reg-event-db seed-id
+      (fn [db _] (assoc-in db [:rf/machines machine-id] snap)))
+    (rf/dispatch-sync [seed-id])))
+
+;; ---- (1) hierarchical -----------------------------------------------------
+;; Mirrors hierarchical-compound-transition.edn (sibling-leaf transition,
+;; LCA cascade) and hierarchical-parent-fallthrough.edn (deepest-wins).
+
+(deftest machine-hierarchical-cljs
+  (testing "compound state — sibling-leaf transition fires only the leaf exit/entry"
+    ;; Tracks which entry/exit hooks fired so we can assert the LCA cascade.
+    (let [log (atom [])
+          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:enter-auth (tag :enter-auth)
+                     :exit-auth  (tag :exit-auth)
+                     :enter-dash (tag :enter-dash)
+                     :exit-dash  (tag :exit-dash)
+                     :enter-set  (tag :enter-set)
+                     :exit-set   (tag :exit-set)}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :entry   :enter-auth
+             :exit    :exit-auth
+             :states
+             {:dashboard {:entry :enter-dash
+                          :exit  :exit-dash
+                          :on    {:open-settings :settings}}
+              :settings  {:entry :enter-set
+                          :exit  :exit-set
+                          :on    {:close :dashboard}}}}}}]
+      (rf/reg-machine :auth/flow machine)
+      ;; Position the machine at the deepest leaf for a deterministic
+      ;; starting point.
+      (seed-snapshot! :auth/flow {:state [:authenticated :dashboard] :data {}})
+      (is (= [:authenticated :dashboard] (:state (snapshot :auth/flow))))
+      (reset! log [])
+      ;; Sibling-leaf transition. LCA is :authenticated; only the leaf
+      ;; exit/entry hooks fire — the parent's :enter-auth must NOT re-fire.
+      (rf/dispatch-sync [:auth/flow [:open-settings]])
+      (is (= [:authenticated :settings] (:state (snapshot :auth/flow)))
+          "snapshot moved to the sibling leaf")
+      (is (= [:exit-dash :enter-set] @log)
+          "only leaf-level exit/entry fired — LCA parent did NOT re-enter")))
+
+  (testing "deepest-wins — leaf overrides parent for same event id"
+    (let [log (atom [])
+          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:parent-help    (tag :parent)
+                     :leaf-help      (tag :leaf)}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:help {:action :parent-help}}      ;; internal — no :target
+             :states
+             {:dashboard {}                                ;; no :help handler
+              :settings  {:on {:help {:action :leaf-help}}}}}}}]
+      (rf/reg-machine :auth2/flow machine)
+      (seed-snapshot! :auth2/flow {:state [:authenticated :dashboard] :data {}})
+      ;; Case 1: leaf has no :help — parent fallthrough.
+      (reset! log [])
+      (rf/dispatch-sync [:auth2/flow [:help]])
+      (is (= [:authenticated :dashboard] (:state (snapshot :auth2/flow)))
+          "internal transition — snapshot unchanged")
+      (is (= [:parent] @log) "parent's :help action fired (fallthrough)")
+      ;; Reposition to the :settings leaf for case 2.
+      (seed-snapshot! :auth2/flow {:state [:authenticated :settings] :data {}})
+      ;; Case 2: leaf handles :help — leaf wins, parent SHADOWED.
+      (reset! log [])
+      (rf/dispatch-sync [:auth2/flow [:help]])
+      (is (= [:authenticated :settings] (:state (snapshot :auth2/flow)))
+          "internal transition — snapshot unchanged")
+      (is (= [:leaf] @log) "leaf's :help action fired; parent shadowed"))))
+
+;; ---- (2) :always microsteps -----------------------------------------------
+;; Mirrors always-single-microstep.edn (single guarded fire, atomic commit)
+;; and always-depth-exceeded.edn (cycle hits the bounded depth limit).
+
+(deftest machine-always-cljs
+  (testing ":always fires once after the resolving event under a true guard"
+    (let [machine
+          {:initial :asking
+           :data    {:correct-count 9}
+           :guards  {:enough? (fn [snap _]
+                                (>= (get-in snap [:data :correct-count]) 10))}
+           :actions {:count   (fn [snap _]
+                                {:data {:correct-count
+                                        (inc (get-in snap [:data :correct-count]))}})}
+           :states
+           {:asking {:always [{:guard :enough? :target :winner}]
+                     :on     {:answer-correct {:action :count}}}
+            :winner {}
+            :loser  {}}}]
+      (rf/reg-machine :quiz/flow machine)
+      (seed-snapshot! :quiz/flow {:state :asking :data {:correct-count 9}})
+      ;; Pre-condition: count is 9; one :answer-correct ticks to 10; :always
+      ;; guard becomes true; microstep transitions to :winner.
+      (rf/dispatch-sync [:quiz/flow [:answer-correct]])
+      (let [s (snapshot :quiz/flow)]
+        (is (= :winner (:state s))
+            "external observer sees only the macrostep — landed at :winner")
+        (is (= 10 (get-in s [:data :correct-count]))
+            "the action's data update is committed alongside the :always target"))))
+
+  (testing ":always doesn't fire when the guard is false"
+    (let [machine
+          {:initial :asking
+           :data    {:correct-count 5}
+           :guards  {:enough? (fn [snap _]
+                                (>= (get-in snap [:data :correct-count]) 10))}
+           :actions {:count   (fn [snap _]
+                                {:data {:correct-count
+                                        (inc (get-in snap [:data :correct-count]))}})}
+           :states
+           {:asking {:always [{:guard :enough? :target :winner}]
+                     :on     {:answer-correct {:action :count}}}
+            :winner {}}}]
+      (rf/reg-machine :quiz2/flow machine)
+      (seed-snapshot! :quiz2/flow {:state :asking :data {:correct-count 5}})
+      (rf/dispatch-sync [:quiz2/flow [:answer-correct]])
+      (let [s (snapshot :quiz2/flow)]
+        (is (= :asking (:state s))
+            "guard false — microstep loop terminates with zero microsteps")
+        (is (= 6 (get-in s [:data :correct-count]))
+            "action ran; data updated; state unchanged"))))
+
+  (testing ":always cycle hits depth limit — snapshot rolls back atomically"
+    ;; Two states ping-pong via :always with always-true guards. The
+    ;; microstep loop trips the depth limit; per Spec 005 §Bounded depth
+    ;; the snapshot rolls back to the input.
+    (let [machine
+          {:initial :start
+           :data    {}
+           :always-depth-limit 5
+           :guards  {:p? (fn [_ _] true)}
+           :states
+           {:start {:on {:go {:target :a}}}
+            :a     {:always [{:guard :p? :target :b}]}
+            :b     {:always [{:guard :p? :target :a}]}}}
+          traces (atom [])]
+      (rf/reg-machine :osc/flow machine)
+      (seed-snapshot! :osc/flow {:state :start :data {}})
+      (rf/register-trace-cb! ::osc (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:osc/flow [:go]])
+      (rf/remove-trace-cb! ::osc)
+      ;; Atomic rollback: external snapshot stays at :start.
+      (is (= :start (:state (snapshot :osc/flow)))
+          "macrostep is atomic; cycle aborts; snapshot rolls back to input")
+      (is (some (fn [ev]
+                  (and (= :rf.error/machine-always-depth-exceeded
+                          (:operation ev))
+                       (= :error (:op-type ev))
+                       (= :no-recovery (:recovery ev))))
+                @traces)
+          "expected :rf.error/machine-always-depth-exceeded trace"))))
+
+;; ---- (3) :after delayed transitions ---------------------------------------
+;; Mirrors after-single-delay.edn (epoch + scheduled trace) and
+;; after-stale-detection.edn (real event beats timer; epoch mismatch).
+;;
+;; Per the bead: prefer dispatch-sync of the synthetic
+;; :rf.machine.timer/after-elapsed event over wall-clock setTimeout waits,
+;; so the test is deterministic under Node.
+
+(deftest machine-after-cljs
+  (testing ":after schedules with current epoch on entry; fires on synthetic timer event"
+    (let [machine
+          {:initial :idle
+           :data    {:rf/after-epoch 0}
+           :states
+           {:idle    {:on {:fetch :loading}}
+            :loading {:after {5000 :timeout}
+                      :on    {:loaded :ready}}
+            :timeout {}
+            :ready   {}}}
+          traces (atom [])]
+      (rf/reg-machine :http/flow machine)
+      (seed-snapshot! :http/flow {:state :idle :data {:rf/after-epoch 0}})
+      (rf/register-trace-cb! ::after (fn [ev] (swap! traces conj ev)))
+      ;; Step 1 — enter :loading; timer schedules at epoch 1.
+      (rf/dispatch-sync [:http/flow [:fetch]])
+      (let [s (snapshot :http/flow)]
+        (is (= :loading (:state s)))
+        (is (= 1 (get-in s [:data :rf/after-epoch]))
+            "epoch advanced on entry to an :after-bearing state"))
+      (is (some (fn [ev]
+                  (and (= :rf.machine.timer/scheduled (:operation ev))
+                       (= 5000 (:delay (:tags ev)))
+                       (= 1    (:epoch (:tags ev)))))
+                @traces)
+          "expected :rf.machine.timer/scheduled trace with epoch 1")
+      ;; Step 2 — fire the synthetic timer-elapsed event with matching epoch.
+      (reset! traces [])
+      (rf/dispatch-sync [:http/flow [:rf.machine.timer/after-elapsed 5000 1]])
+      (let [s (snapshot :http/flow)]
+        (is (= :timeout (:state s))
+            "matching-epoch timer firing transitioned :loading → :timeout")
+        (is (= 2 (get-in s [:data :rf/after-epoch]))
+            "epoch advanced again on the timer-driven transition"))
+      (is (some (fn [ev]
+                  (and (= :rf.machine.timer/fired (:operation ev))
+                       (true? (:fired? (:tags ev)))
+                       (= 1    (:epoch  (:tags ev)))))
+                @traces)
+          "expected :rf.machine.timer/fired trace with matching epoch")
+      (rf/remove-trace-cb! ::after)))
+
+  (testing ":after stale detection — real event beats timer; stale firing must not transition"
+    (let [machine
+          {:initial :idle
+           :data    {:rf/after-epoch 0}
+           :states
+           {:idle    {:on {:fetch :loading}}
+            :loading {:after {5000 :timeout}
+                      :on    {:loaded :ready}}
+            :timeout {}
+            :ready   {}}}
+          traces (atom [])]
+      (rf/reg-machine :http2/flow machine)
+      (seed-snapshot! :http2/flow {:state :idle :data {:rf/after-epoch 0}})
+      ;; Enter :loading — epoch advances to 1.
+      (rf/dispatch-sync [:http2/flow [:fetch]])
+      (is (= :loading (:state (snapshot :http2/flow))))
+      (is (= 1 (get-in (snapshot :http2/flow) [:data :rf/after-epoch])))
+      ;; Real :loaded event arrives BEFORE the timer would fire.
+      ;; Snapshot moves to :ready; epoch advances to 2; the in-flight timer
+      ;; (carrying epoch 1) is now stale.
+      (rf/dispatch-sync [:http2/flow [:loaded]])
+      (is (= :ready (:state (snapshot :http2/flow))))
+      (is (= 2 (get-in (snapshot :http2/flow) [:data :rf/after-epoch])))
+      ;; Now the stale timer fires. The user-visible correctness property
+      ;; per Spec 005 §Epoch-based stale detection is: the stale firing
+      ;; MUST NOT cause a transition. (Whether the runtime additionally
+      ;; emits :rf.machine.timer/stale-after when the snapshot has already
+      ;; left the after-bearing state is a trace-surface concern; not
+      ;; asserted here.)
+      (rf/register-trace-cb! ::stale (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:http2/flow [:rf.machine.timer/after-elapsed 5000 1]])
+      (rf/remove-trace-cb! ::stale)
+      (is (= :ready (:state (snapshot :http2/flow)))
+          "stale timer must not fire its transition")
+      (is (= 2 (get-in (snapshot :http2/flow) [:data :rf/after-epoch]))
+          "stale firing does not bump epoch")
+      ;; Negative assertion: no machine-transition trace shows a state-change
+      ;; from :loading on the stale firing.
+      (is (not-any? (fn [ev]
+                      (let [tags (:tags ev)
+                            before-state (get-in tags [:before :state])
+                            after-state  (get-in tags [:after :state])]
+                        (and (= :rf.machine/transition (:operation ev))
+                             (= :loading before-state)
+                             (not= before-state after-state))))
+                    @traces)
+          "no real transition fired on the stale firing"))))
+
+;; ---- (4) declarative :invoke ----------------------------------------------
+;; Mirrors invoke-spawn-on-entry-destroy-on-exit.edn — entering a state with
+;; :invoke emits a :spawn fx (observable as :rf.machine/spawned trace);
+;; exiting emits :destroy-machine (observable as :rf.machine/destroyed trace).
+;;
+;; The on-spawn callback fires inline during apply-transition-once so the
+;; child id can be recorded into the parent machine's :data — we assert via
+;; the snapshot's :pending key.
+
+(deftest machine-invoke-cljs
+  (testing ":invoke spawns child on entry and destroys it on exit"
+    (let [machine
+          {:initial :idle
+           :data    {:credentials {:user "alice" :pass "secret"}}
+           :on-spawn-actions
+           {:auth/record-actor (fn [snap actor-id]
+                                 (assoc-in snap [:data :pending] actor-id))}
+           :states
+           {:idle
+            {:on {:submit :authenticating}}
+
+            :authenticating
+            {:invoke {:machine-id :http/post
+                      :data       {:url "/api/login"
+                                   :body {:user "alice" :pass "secret"}}
+                      :on-spawn   :auth/record-actor
+                      :start      [:begin]}
+             :on    {:auth/succeeded :authenticated
+                     :auth/failed    :idle}}
+
+            :authenticated {}}}
+          traces (atom [])]
+      (rf/reg-machine :auth3/flow machine)
+      (seed-snapshot! :auth3/flow
+                      {:state :idle
+                       :data  {:credentials {:user "alice" :pass "secret"}}})
+      ;; Entering :authenticating: :spawn fx fires (→ :rf.machine/spawned
+      ;; trace), :on-spawn callback records the deterministic actor id
+      ;; into :data.:pending.
+      (rf/register-trace-cb! ::inv (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:auth3/flow [:submit]])
+      (let [s (snapshot :auth3/flow)]
+        (is (= :authenticating (:state s)))
+        (is (= :http/post#1 (get-in s [:data :pending]))
+            "on-spawn callback recorded the deterministic actor id"))
+      (is (some (fn [ev]
+                  (and (= :rf.machine/spawned (:operation ev))
+                       (= :http/post (:machine-id (:tags ev)))))
+                @traces)
+          "expected :rf.machine/spawned trace from the :spawn fx")
+      ;; Exiting :authenticating via :auth/failed: :destroy-machine fx fires
+      ;; targeting the recorded actor id.
+      (reset! traces [])
+      (rf/dispatch-sync [:auth3/flow [:auth/failed]])
+      (rf/remove-trace-cb! ::inv)
+      (is (= :idle (:state (snapshot :auth3/flow))))
+      (is (some (fn [ev]
+                  (and (= :rf.machine/destroyed (:operation ev))
+                       (= :http/post#1 (:actor-id (:tags ev)))))
+                @traces)
+          "expected :rf.machine/destroyed trace targeting :http/post#1"))))


### PR DESCRIPTION
## Summary

Adds `implementation/test/re_frame/machines_cljs_test.cljs` with four deftests under the Reagent adapter, mirroring the conformance fixtures and closing the CLJS coverage gap for hierarchical states, `:always` microsteps, `:after` delayed transitions, and declarative `:invoke`.

Before: only the flat-machine `machine-transition-cljs` was tested on CLJS. After: hierarchical / always / after / invoke are all exercised through `reg-machine` + `dispatch-sync` — the same surface real apps use — under Reagent reactivity in Node.

## Tests added

- **`machine-hierarchical-cljs`** — compound-state sibling-leaf transition (LCA cascade only fires leaf exit/entry; parent does not re-enter), and deepest-wins parent fallthrough (leaf shadows parent's same-named handler when present).
- **`machine-always-cljs`** — `:always` fires once after the resolving event under a true guard (atomic macrostep — intermediate state invisible); does not fire when the guard is false; cycle ping-pong hits the bounded `:always-depth-limit` and rolls back the snapshot atomically with `:rf.error/machine-always-depth-exceeded`.
- **`machine-after-cljs`** — entering an `:after`-bearing state advances `:rf/after-epoch` and emits `:rf.machine.timer/scheduled`; firing the synthetic `:rf.machine.timer/after-elapsed` event with matching epoch transitions to the target and emits `:rf.machine.timer/fired`; epoch-mismatch firings are ignored (real event beats timer; snapshot stays put; epoch unchanged).
- **`machine-invoke-cljs`** — entering an `:invoke`-bearing state emits a `:spawn` fx (`:rf.machine/spawned` trace), the `:on-spawn` callback runs and records the deterministic actor id (`:http/post#1`) into the parent's `:data.:pending`, exiting emits `:destroy-machine` (`:rf.machine/destroyed` trace) targeting that recorded id.

## Determinism

Per the bead's guidance, `:after` tests dispatch the synthetic `:rf.machine.timer/after-elapsed` event directly rather than relying on `setTimeout` wall-clock, so the suite runs deterministically under Node-test.

## Test plan

- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 23 tests / 72 assertions, 0 failures (the pre-existing `nine-states-runs-end-to-end` error is unrelated).
- [x] JVM smoke tests still green: `clj -M:test -n re-frame.smoke-test` — 32 tests / 93 assertions, 0 failures.
- [x] All four new deftests pass.

## Notes

- `seed-snapshot!` test helper positions machines at known states by writing `[:rf/machines machine-id]` directly via an event-db. This avoids relying on the runtime's first-dispatch initial-cascade behaviour for compound machines.
- The stale-detection test asserts the user-visible correctness invariant (no transition fires; epoch unchanged) rather than the `:rf.machine.timer/stale-after` trace, since the runtime currently only emits that trace when the machine is still in the `:after`-bearing state at firing time. The trace-surface gap belongs in a separate bead.
- No changes to `machines.cljc`.