### PR TITLE
test: flow coverage (rf2-1cli)

### DIFF
--- a/docs/specification/conformance/fixtures/flow-hot-reload-preserves-output.edn
+++ b/docs/specification/conformance/fixtures/flow-hot-reload-preserves-output.edn
@@ -1,0 +1,58 @@
+;; Conformance fixture: flow/hot-reload-preserves-output
+;; Per Spec 013 §Re-registration and Spec 001 §Hot-reload semantics —
+;; reg-flow against an already-registered :id performs a surgical
+;; update: the new flow's definition replaces the old; last-inputs
+;; clears so the new body re-evaluates on the next event regardless of
+;; whether inputs changed.
+;;
+;; This fixture verifies the user-visible value at the output path:
+;; if the new body would compute the same output, the prior output is
+;; preserved across re-registration.
+
+{:fixture/id           :flow/hot-reload-preserves-output
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :flow/basic :flow/hot-reload}
+ :fixture/doc          "Re-registering a flow with an equivalent body keeps the prior output value at the flow's :path. Per Spec 001 §Hot-reload, the new flow re-evaluates on the next drain — so the user observes a continuous output as long as the new body is value-equivalent on the same inputs. (If the new body would compute a different value, the next drain materialises the new value.)"
+
+ :fixture/registry
+ {:event {:doubled/init      {:doc "Seed :n to 7."}
+          :doubled/reg-v1    {:doc "Register :double v1 — output is (* 2 n)."}
+          :doubled/reg-v2    {:doc "Re-register :double v2 — same output value."}
+          :doubled/poke      {:doc "No-op event to drive a drain."}}
+  :fx    {:rf.fx/reg-flow {:doc "Reserved — register a flow."
+                           :platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event {:doubled/init   [[:set [:n] 7]]
+          :doubled/reg-v1 [[:fx :rf.fx/reg-flow
+                            {:id     :doubled/value
+                             :inputs [[:n]]
+                             :body   [[:fn :* [:event-arg 0] 2]]
+                             :path   [:doubled]}]]
+          :doubled/reg-v2 [[:fx :rf.fx/reg-flow
+                            {:id     :doubled/value
+                             :inputs [[:n]]
+                             :body   [[:fn :+ [:event-arg 0] [:event-arg 0]]]
+                             :path   [:doubled]}]]
+          :doubled/poke   [[:set [:tick] [:event-arg 1]]]}}
+
+ :fixture/frame-config
+ {:on-create [:doubled/init]}
+
+ ;; Sequence:
+ ;;   on-create [:doubled/init]   — :n 7
+ ;;   [:doubled/reg-v1]           — register v1; flow first-fires on next drain
+ ;;   [:doubled/poke 1]           — drives a drain; v1 fires → :doubled 14
+ ;;   [:doubled/reg-v2]           — re-register with (+ n n); last-inputs cleared
+ ;;   [:doubled/poke 2]           — v2 fires; same output value 14
+ :fixture/dispatches
+ [[:doubled/reg-v1]
+  [:doubled/poke 1]
+  [:doubled/reg-v2]
+  [:doubled/poke 2]]
+
+ :fixture/expect
+ {:final-app-db
+  {:n       7
+   :tick    2
+   :doubled 14}}}

--- a/docs/specification/conformance/fixtures/flow-multi-input-topo.edn
+++ b/docs/specification/conformance/fixtures/flow-multi-input-topo.edn
@@ -1,0 +1,59 @@
+;; Conformance fixture: flow/multi-input-topo
+;; Per Spec 013 §Topological sort and cycle detection — flow B depends
+;; on flow A iff A's :path and any of B's :inputs share a path prefix
+;; in either direction. Mutating A's input cascades through B in a
+;; single drain pass; the topological sort places A before B.
+;;
+;; Layout:
+;;   :rect/area           → depends on [:width] [:height]; writes [:area]
+;;   :rect/area-doubled   → depends on [:area];            writes [:area*2]
+;;
+;; A single :rect/init seeds inputs; one drain settles both flows.
+
+{:fixture/id           :flow/multi-input-topo
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :flow/basic :flow/topo}
+ :fixture/doc          "Two-layer flow graph: flow B reads what flow A wrote. The topological sort places A before B so a single drain pass settles both. Cycle detection rejects mutual deps at registration; this fixture is acyclic by construction."
+
+ :fixture/registry
+ {:event {:rect/init  {:doc "Seed width and height."}
+          :rect/set-w {:doc "Update :width."}
+          :rect/set-h {:doc "Update :height."}}
+  :flow  {:rect/area
+          {:doc    "Width × height."
+           :inputs [[:width] [:height]]
+           :path   [:area]}
+          :rect/area-doubled
+          {:doc    "Area × 2 — depends on :rect/area's output."
+           :inputs [[:area]]
+           :path   [:area*2]}}}
+
+ :fixture/handlers
+ {:event {:rect/init  [[:set [:width]  2]
+                       [:set [:height] 3]]
+          :rect/set-w [[:set [:width]  [:event-arg 1]]]
+          :rect/set-h [[:set [:height] [:event-arg 1]]]}}
+
+ :fixture/flow-bodies
+ {:rect/area         [[:fn :* [:event-arg 0] [:event-arg 1]]]
+  :rect/area-doubled [[:fn :* [:event-arg 0] 2]]}
+
+ :fixture/frame-config
+ {:on-create [:rect/init]}
+
+ :fixture/dispatches
+ [[:rect/set-w 5]
+  [:rect/set-h 4]]
+
+ :fixture/expect
+ {:final-app-db
+  {:width  5
+   :height 4
+   :area   20
+   :area*2 40}
+
+  ;; Per Spec 013 §Topological sort: B depends on A iff A's :path
+  ;; intersects B's :inputs. The harness asserts the static dependency
+  ;; graph topologies — A runs before B in a single drain pass.
+  :flow-graph-topology
+  {:rect/area-doubled #{:rect/area}}}}

--- a/docs/specification/conformance/fixtures/flow-noop-on-value-equal-input.edn
+++ b/docs/specification/conformance/fixtures/flow-noop-on-value-equal-input.edn
@@ -1,0 +1,56 @@
+;; Conformance fixture: flow/noop-on-value-equal-input
+;; Per Spec 013 §Dirty-check semantics — a flow recomputes only when
+;; its inputs change by =-equality since its last evaluation. A handler
+;; that writes the same value back to an input path does NOT re-fire
+;; flows that depend on that path.
+;;
+;; This fixture verifies the no-op path. The flow's :output is wired
+;; to :tick-counter — an external counter the test asserts hasn't
+;; advanced when the input was rewritten with an =-equal value.
+
+{:fixture/id           :flow/noop-on-value-equal-input
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :flow/basic :flow/dirty-check}
+ :fixture/doc          "A handler that writes the same value back to an input path does not cause the flow to re-fire. Implementations track per-flow last-inputs as a vector; =-equal new-inputs is a no-op. First evaluation always fires (initial output materialises on first drain)."
+
+ :fixture/registry
+ {:event {:doubled/init      {:doc "Seed :n to 5."}
+          :doubled/replace-n {:doc "Replace :n with the supplied value."}}
+  :flow  {:doubled/value
+          {:doc    "Doubles :n at [:doubled]."
+           :inputs [[:n]]
+           :path   [:doubled]}}}
+
+ :fixture/handlers
+ {:event {:doubled/init      [[:set [:n] 5]]
+          :doubled/replace-n [[:set [:n] [:event-arg 1]]]}}
+
+ :fixture/flow-bodies
+ {:doubled/value [[:fn :* [:event-arg 0] 2]]}
+
+ :fixture/frame-config
+ {:on-create [:doubled/init]}
+
+ ;; First :doubled/replace-n with 5 is =-equal to current :n (5) — flow
+ ;; should NOT recompute.
+ ;; Second with 7 changes the value; flow recomputes to 14.
+ :fixture/dispatches
+ [[:doubled/replace-n 5]
+  [:doubled/replace-n 7]]
+
+ :fixture/expect
+ {:final-app-db
+  {:n        7
+   :doubled  14}
+
+  ;; The dirty-check is per-flow: paths that did not change between
+  ;; drains do not trigger their flow's :output. The harness verifies
+  ;; the recompute count via instrumentation. v1 dispatch sequence:
+  ;;
+  ;;   on-create [:doubled/init]    — sets :n 5;   flow first-fires → :doubled 10
+  ;;   [:doubled/replace-n 5]       — :n stays 5;  flow no-op (=-equal inputs)
+  ;;   [:doubled/replace-n 7]       — :n now 7;    flow fires → :doubled 14
+  ;;
+  ;; Expected recompute count for :doubled/value is 2.
+  :flow-recompute-counts
+  {:doubled/value 2}}}

--- a/docs/specification/conformance/fixtures/flow-recompute-on-input-change.edn
+++ b/docs/specification/conformance/fixtures/flow-recompute-on-input-change.edn
@@ -1,0 +1,53 @@
+;; Conformance fixture: flow/recompute-on-input-change
+;; Per Spec 013 §Drain integration — a flow recomputes when its input
+;; paths change after an event drain. The output value is materialised
+;; into app-db at the flow's :path before :fx walks.
+;;
+;; This is the canonical "flow as on-changes successor" smoke: width and
+;; height live in app-db; the :rectangle/area flow keeps :area in sync
+;; as inputs mutate.
+
+{:fixture/id           :flow/recompute-on-input-change
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :flow/basic}
+ :fixture/doc          "A flow with two input paths and one output path. Mutating either input via an event handler causes the :output fn to fire and the result to be assoc-in'd at the flow's :path. Each event drain runs the flow at most once and only writes when inputs differ from the last run."
+
+ :fixture/registry
+ {:event {:rect/init    {:doc "Seed width and height to 0."}
+          :rect/set-w   {:doc "Set the rectangle's width."}
+          :rect/set-h   {:doc "Set the rectangle's height."}}
+  :flow  {:rectangle/area
+          {:doc    "Materialised rectangle area — width × height."
+           :inputs [[:width] [:height]]
+           :path   [:area]}}
+  :sub   {:area/value {:doc "Read the materialised :area path."}}}
+
+ :fixture/handlers
+ {:event {:rect/init  [[:set [:width]  0]
+                       [:set [:height] 0]]
+          :rect/set-w [[:set [:width]  [:event-arg 1]]]
+          :rect/set-h [[:set [:height] [:event-arg 1]]]}
+  :sub   {:area/value [[:get [:area]]]}}
+
+ ;; The :output fn is described declaratively here. The conformance
+ ;; harness realises it as `(fn [w h] (* w h))`. Implementations that
+ ;; have not wired flow-body realisation yet will skip the fixture
+ ;; (capability :flow/basic not claimed) and report not-exercised.
+ :fixture/flow-bodies
+ {:rectangle/area [[:fn :* [:event-arg 0] [:event-arg 1]]]}
+
+ :fixture/frame-config
+ {:on-create [:rect/init]}
+
+ :fixture/dispatches
+ [[:rect/set-w 3]
+  [:rect/set-h 4]]
+
+ :fixture/expect
+ {:final-app-db
+  {:width  3
+   :height 4
+   :area   12}
+
+  :sub-values
+  {[:area/value] 12}}}

--- a/docs/specification/conformance/fixtures/flow-toggle-via-fx.edn
+++ b/docs/specification/conformance/fixtures/flow-toggle-via-fx.edn
@@ -1,0 +1,70 @@
+;; Conformance fixture: flow/toggle-via-fx
+;; Per Spec 013 §Dynamic toggle via fx — two reserved fx-ids let event
+;; handlers register and clear flows during normal event processing:
+;;
+;;   :rf.fx/reg-flow   — args are a flow map; registers the flow
+;;   :rf.fx/clear-flow — args are a flow id;  clears the flow
+;;
+;; A flow registered mid-event first runs on the NEXT event drain
+;; (per Spec 013 §Sequencing). Clearing a flow dissoc's its :path.
+
+{:fixture/id           :flow/toggle-via-fx
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx :flow/basic :flow/toggle}
+ :fixture/doc          "Round-trip the dynamic toggle: an event handler emits :rf.fx/reg-flow which registers the flow; a later event emits :rf.fx/clear-flow which deregisters and dissoc-in's the output path. The flow's first run lands on the event AFTER registration; clearing immediately vacates the slot."
+
+ :fixture/registry
+ {:event {:wizard/init       {:doc "Seed :step-2 inputs."}
+          :wizard/enter      {:doc "Register the :step-2/computed flow via fx."}
+          :wizard/bump-foo   {:doc "Mutate :step-2 :foo to drive a recompute."}
+          :wizard/leave      {:doc "Clear the :step-2/computed flow via fx."}}
+  :fx    {:rf.fx/reg-flow   {:doc "Reserved — register a flow at runtime."
+                             :platforms #{:client :server}}
+          :rf.fx/clear-flow {:doc "Reserved — clear a flow at runtime."
+                             :platforms #{:client :server}}}}
+
+ ;; The flow body is described declaratively; the harness wires it to
+ ;; (fn [foo bar] (+ foo bar)) when materialising the :rf.fx/reg-flow
+ ;; effect's args.
+ :fixture/handlers
+ {:event {:wizard/init     [[:set [:step-2 :foo] 3]
+                            [:set [:step-2 :bar] 4]]
+          :wizard/enter    [[:fx :rf.fx/reg-flow
+                             {:id     :step-2/computed
+                              :inputs [[:step-2 :foo] [:step-2 :bar]]
+                              :body   [[:fn :+ [:event-arg 0] [:event-arg 1]]]
+                              :path   [:step-2 :result]}]]
+          :wizard/bump-foo [[:set [:step-2 :foo] [:event-arg 1]]]
+          :wizard/leave    [[:fx :rf.fx/clear-flow :step-2/computed]]}}
+
+ :fixture/frame-config
+ {:on-create [:wizard/init]}
+
+ ;; Sequence:
+ ;;   :wizard/enter    — registers the flow. First evaluation fires on
+ ;;                      the NEXT drain (per Spec 013 §Sequencing); inputs
+ ;;                      are 3 + 4 → flow has not yet written.
+ ;;   :wizard/bump-foo — mutates :step-2 :foo to 5; flow runs on this drain
+ ;;                      (registered before the drain) → 5 + 4 = 9 at
+ ;;                      [:step-2 :result].
+ ;;   :wizard/leave    — clears the flow. The output path is dissoc-in'd.
+ :fixture/dispatches
+ [[:wizard/enter]
+  [:wizard/bump-foo 5]
+  [:wizard/leave]]
+
+ :fixture/expect
+ ;; After :wizard/leave, :step-2 retains :foo / :bar; :result is gone
+ ;; (clear-flow dissoc-in's the leaf at the flow's :path).
+ ;;
+ ;; NOTE: rf2-aqt7 — clear-flow with a single-element :path (e.g. [:area])
+ ;; currently leaves the key in app-db (off-by-one in update-in
+ ;; (butlast path)). This fixture uses a two-element :path
+ ;; ([:step-2 :result]) which exercises the working code path.
+ {:final-app-db
+  {:step-2 {:foo 5 :bar 4}}
+
+  ;; The harness checks that the flow registry no longer contains
+  ;; :step-2/computed after :wizard/leave fires.
+  :flow-registry-after
+  #{}}}

--- a/implementation/test/re_frame/flows_test.clj
+++ b/implementation/test/re_frame/flows_test.clj
@@ -1,0 +1,338 @@
+(ns re-frame.flows-test
+  "JVM smoke coverage for Spec 013 — Flows.
+
+  This file backstops the conformance fixtures in
+  docs/specification/conformance/fixtures/flow-*.edn. Where the fixtures
+  describe canonical flow shapes as data (skipped by the reference
+  harness until the :flow/* capability set is wired into the conformance
+  runner), the tests here exercise the same paths against the JVM
+  reference implementation directly:
+
+    - reg-flow / clear-flow round-trip
+    - dirty-check (=-equal inputs do NOT recompute)
+    - topological sort (B reads what A wrote; one drain pass)
+    - cycle detection at registration time
+    - hot-reload preserves the output value when the new body is
+      value-equivalent on current inputs
+    - :rf.fx/reg-flow / :rf.fx/clear-flow toggle round-trip
+    - clear-all / lifecycle interaction with the per-frame registry"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]))
+
+;; ---- per-test reset -------------------------------------------------------
+;;
+;; Mirrors the smoke_test.clj fixture so each deftest starts from a clean
+;; registrar / frames / flows state. Re-loading routing / ssr restores the
+;; framework events that clear-all! wiped (some smoke tests rely on
+;; :rf.route/navigate etc. resolving — keep the reset shape consistent so
+;; running these tests in any order works).
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  ;; flows.cljc keeps a private last-inputs atom for dirty-checking
+  ;; (per Spec 013 §Dirty-check semantics). The smoke-test fixture
+  ;; doesn't reset it; left alone, an entry from this namespace's tests
+  ;; can leak into a sibling namespace's identically-keyed flow and
+  ;; cause its first-evaluation to no-op (new-inputs would =-equal the
+  ;; stale last-inputs). Clear it here so cross-namespace test order
+  ;; can't introduce hidden flakiness.
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; 1. reg-flow / clear-flow lifecycle (registry side)
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-populates-registry
+  (testing "reg-flow stores the flow under [frame-id flow-id] in the per-frame registry"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (is (contains? (get @flows/flows :rf/default) :area)
+        "the flow lives under :rf/default's slot of the per-frame registry")
+    (is (some? (registrar/lookup :flow :area))
+        "the flow is also discoverable via the :flow registrar kind")))
+
+(deftest clear-flow-removes-from-registry-and-vacates-output-slot
+  (testing "clear-flow removes the flow and dissoc-in's its output path"
+    ;; rf2-aqt7: clear-flow's update-in path math is off-by-one for
+    ;; single-element :path vectors. Use a two-element :path here so
+    ;; the working branch (>= 2 elements) is exercised.
+    (rf/reg-event-db :seed (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:rect :w] [:rect :h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:seed])
+    (is (= 12 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        "flow ran on the drain after :seed and materialised :rect/:area")
+    (rf/clear-flow :area)
+    (is (not (contains? (get @flows/flows :rf/default) :area))
+        "the per-frame registry no longer carries :area")
+    (is (not (contains? (get (rf/get-frame-db :rf/default) :rect) :area))
+        "clear-flow dissoc'd the leaf at the flow's :path"))
+  (testing "calling clear-flow on an unknown id is a no-op (does not throw)"
+    (rf/clear-flow :no-such-flow)))
+
+(deftest reg-flow-validates-required-keys
+  (testing "missing :id throws"
+    (is (thrown? Throwable
+                 (rf/reg-flow {:inputs [[:n]] :output identity :path [:x]}))))
+  (testing ":inputs must be a vector"
+    (is (thrown? Throwable
+                 (rf/reg-flow {:id :bad :inputs :not-a-vec
+                               :output identity :path [:x]}))))
+  (testing ":output must be a fn"
+    (is (thrown? Throwable
+                 (rf/reg-flow {:id :bad :inputs [[:n]]
+                               :output 42 :path [:x]}))))
+  (testing ":path must be a vector"
+    (is (thrown? Throwable
+                 (rf/reg-flow {:id :bad :inputs [[:n]]
+                               :output identity :path :not-a-vec})))))
+
+(deftest reg-flow-detects-cycles-at-registration
+  (testing ":a depends on :b, :b depends on :a — registering the second throws"
+    (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
+    (is (thrown? Throwable
+                 (rf/reg-flow {:id :b :inputs [[:a]]
+                               :output identity :path [:b]}))
+        "the cyclic registration unwinds and throws :rf.error/flow-cycle")
+    (is (not (contains? (get @flows/flows :rf/default) :b))
+        "cycle-detection rolls back the partial registration of :b")))
+
+;; ---------------------------------------------------------------------------
+;; 2. Dirty-check / re-evaluation
+;; ---------------------------------------------------------------------------
+
+(deftest flow-recomputes-on-input-change
+  (testing "mutating an input path causes the flow to fire and the output to update"
+    (rf/reg-event-db :init (fn [_ _] {:w 0 :h 0}))
+    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    (rf/reg-event-db :h!   (fn [db [_ h]] (assoc db :h h)))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:init])
+    (is (= 0 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        "first drain after :init fires the flow with 0 × 0 = 0")
+    (rf/dispatch-sync [:w! 5])
+    (is (= 0 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        ":h is still 0 → 5 × 0 = 0; flow ran")
+    (rf/dispatch-sync [:h! 6])
+    (is (= 30 (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        "5 × 6 = 30 after both inputs are populated")))
+
+(deftest flow-noop-on-equal-input-rewrite
+  (testing "rewriting an input path with an =-equal value does NOT re-fire the flow"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :init      (fn [_ _] {:n 5}))
+      (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n]
+                              (swap! calls inc)
+                              (* 2 n))
+                    :path   [:derived :doubled]})
+      (rf/dispatch-sync [:init])
+      (is (= 1 @calls) "first drain fires the flow once (initial evaluation)")
+      (is (= 10 (get-in (rf/get-frame-db :rf/default) [:derived :doubled])))
+      ;; Replace :n with the same value (5 → 5).
+      (rf/dispatch-sync [:replace-n 5])
+      (is (= 1 @calls)
+          ":n was replaced with =-equal value; flow did NOT recompute")
+      (is (= 10 (get-in (rf/get-frame-db :rf/default) [:derived :doubled]))
+          "output unchanged")
+      ;; Now flip :n to a different value.
+      (rf/dispatch-sync [:replace-n 7])
+      (is (= 2 @calls)
+          ":n changed to 7; flow recomputed")
+      (is (= 14 (get-in (rf/get-frame-db :rf/default) [:derived :doubled]))))))
+
+(deftest flow-no-recompute-when-unrelated-path-changes
+  (testing "writing an unrelated path does not re-fire a flow whose inputs are stable"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :init      (fn [_ _] {:user {:name "alice"} :other 0}))
+      (rf/reg-event-db :bump-other (fn [db _] (update db :other inc)))
+      (rf/reg-flow {:id     :user/uppercase-name
+                    :inputs [[:user :name]]
+                    :output (fn [n]
+                              (swap! calls inc)
+                              (when n (.toUpperCase ^String n)))
+                    :path   [:user :uppercase-name]})
+      (rf/dispatch-sync [:init])
+      (is (= 1 @calls) "first evaluation always fires")
+      (is (= "ALICE" (get-in (rf/get-frame-db :rf/default)
+                             [:user :uppercase-name])))
+      (dotimes [_ 5] (rf/dispatch-sync [:bump-other]))
+      (is (= 1 @calls)
+          ":other changed but [:user :name] did not; flow stayed quiet"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Topological sort — B depends on A; one drain settles both
+;; ---------------------------------------------------------------------------
+
+(deftest flow-topo-sort-cascades-in-one-drain
+  (testing "B reads what A wrote; topo sort places A first; one drain settles both"
+    (rf/reg-event-db :init (fn [_ _] {:w 2 :h 3}))
+    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    ;; A: :area depends on :w :h, writes :rect/:area.
+    (rf/reg-flow {:id     :rect/area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    ;; B: :area*2 depends on :rect/:area, writes :rect/:area*2.
+    (rf/reg-flow {:id     :rect/area-doubled
+                  :inputs [[:rect :area]]
+                  :output (fn [a] (* 2 a))
+                  :path   [:rect :area*2]})
+    (rf/dispatch-sync [:init])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 6  (get-in db [:rect :area]))   "A fired with 2 × 3 = 6")
+      (is (= 12 (get-in db [:rect :area*2])) "B fired in the same drain with 6 × 2 = 12"))
+    (rf/dispatch-sync [:w! 5])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 15 (get-in db [:rect :area]))   "A re-fired: 5 × 3 = 15")
+      (is (= 30 (get-in db [:rect :area*2])) "B saw A's new output and re-fired: 30"))))
+
+(deftest flow-topo-sort-handles-prefix-overlap
+  (testing "B's :inputs is a prefix of A's :path — A still runs before B (Spec 013 §Dependency rule)"
+    (rf/reg-event-db :init (fn [_ _] {:user {:name "alice"} :note ""}))
+    ;; A writes deep at [:user :uppercase] — its :path is rooted in
+    ;; the same prefix as B's input.
+    (rf/reg-flow {:id     :user/uppercase
+                  :inputs [[:user :name]]
+                  :output (fn [n] (when n (.toUpperCase ^String n)))
+                  :path   [:user :uppercase]})
+    ;; B's input is [:user] — a prefix of A's :path. Per Spec 013,
+    ;; the dependency rule fires in either prefix direction.
+    (rf/reg-flow {:id     :user/note
+                  :inputs [[:user]]
+                  :output (fn [u]
+                            (str "user-keys:"
+                                 (pr-str (vec (sort (keys u))))))
+                  :path   [:summary :note]})
+    (rf/dispatch-sync [:init])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= "ALICE" (get-in db [:user :uppercase]))
+          "A wrote :user :uppercase")
+      (is (= "user-keys:[:name :uppercase]"
+             (get-in db [:summary :note]))
+          "B saw both :name and the just-written :uppercase in one drain"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Hot-reload — re-registration preserves output when bodies agree
+;; ---------------------------------------------------------------------------
+
+(deftest flow-hot-reload-preserves-equivalent-output
+  (testing "re-registering a flow with a body that produces the same output keeps the output stable"
+    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+    (rf/reg-event-db :tick (fn [db _] (update db :tick (fnil inc 0))))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:init])
+    (is (= 10 (get-in (rf/get-frame-db :rf/default) [:derived :doubled])))
+    ;; Re-register with a body that produces the SAME output for the
+    ;; current input. Per Spec 013 §Re-registration the next drain
+    ;; re-evaluates; the user-visible output stays 10.
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (+ n n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:tick])
+    (is (= 10 (get-in (rf/get-frame-db :rf/default) [:derived :doubled]))
+        "value-equivalent re-registration leaves the output stable")))
+
+(deftest flow-hot-reload-new-body-recomputes-on-next-drain
+  (testing "if the new body would produce a different value, the next drain materialises it"
+    (rf/reg-event-db :init  (fn [_ _] {:n 5}))
+    (rf/reg-event-db :tick  (fn [db _] (update db :tick (fnil inc 0))))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:init])
+    (is (= 10 (get-in (rf/get-frame-db :rf/default) [:derived :doubled])))
+    ;; Re-register with a 100x body; same input still 5.
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 100 n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:tick])
+    (is (= 500 (get-in (rf/get-frame-db :rf/default) [:derived :doubled]))
+        "after re-registration the new body produces 5 × 100 = 500")))
+
+;; ---------------------------------------------------------------------------
+;; 5. Toggle via :rf.fx/reg-flow / :rf.fx/clear-flow
+;; ---------------------------------------------------------------------------
+
+(deftest fx-reg-flow-and-clear-flow-round-trip
+  (testing ":rf.fx/reg-flow registers; :rf.fx/clear-flow removes; the output path is dissoc'd"
+    (rf/reg-event-db :init  (fn [_ _] {:wizard {:foo 3 :bar 4}}))
+    (rf/reg-event-fx :enter (fn [_ _]
+                              {:fx [[:rf.fx/reg-flow
+                                     {:id     :step-2/computed
+                                      :inputs [[:wizard :foo] [:wizard :bar]]
+                                      :output (fn [foo bar] (+ foo bar))
+                                      :path   [:wizard :result]}]]}))
+    (rf/reg-event-db :foo!  (fn [db [_ v]] (assoc-in db [:wizard :foo] v)))
+    (rf/reg-event-fx :leave (fn [_ _]
+                              {:fx [[:rf.fx/clear-flow :step-2/computed]]}))
+    (rf/dispatch-sync [:init])
+    (is (nil? (get-in (rf/get-frame-db :rf/default) [:wizard :result]))
+        "no flow yet — :result is unset")
+    ;; Register the flow during :enter. Per Spec 013 §Sequencing the flow
+    ;; first runs on the NEXT event drain.
+    (rf/dispatch-sync [:enter])
+    (is (contains? (get @flows/flows :rf/default) :step-2/computed)
+        "registry now carries :step-2/computed")
+    ;; Drive a drain with a benign event; the flow first-fires here.
+    (rf/dispatch-sync [:foo! 5])
+    (is (= 9 (get-in (rf/get-frame-db :rf/default) [:wizard :result]))
+        "flow ran on this drain with 5 + 4 = 9")
+    ;; Now clear via fx.
+    (rf/dispatch-sync [:leave])
+    (is (not (contains? (get @flows/flows :rf/default) :step-2/computed))
+        "registry slot removed")
+    (is (not (contains? (get (rf/get-frame-db :rf/default) :wizard) :result))
+        ":rf.fx/clear-flow dissoc-in'd the output path")))
+
+;; ---------------------------------------------------------------------------
+;; 6. clear-all / clean-state interaction with :flow registrar slot
+;; ---------------------------------------------------------------------------
+
+(deftest clear-all-clears-flow-registrar-slot
+  (testing "registrar/clear-all! removes the :flow kind so subsequent reg-flow starts clean"
+    (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
+    (rf/reg-flow {:id :two :inputs [[:a]] :output identity :path [:slots :two]})
+    (is (some? (registrar/lookup :flow :one)))
+    (is (some? (registrar/lookup :flow :two)))
+    (registrar/clear-all!)
+    (is (nil? (registrar/lookup :flow :one)))
+    (is (nil? (registrar/lookup :flow :two)))))
+
+(deftest reset-flows-atom-clears-per-frame-state
+  (testing "resetting flows/flows clears the per-frame registry; reg-flow repopulates fresh"
+    (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
+    (is (contains? (get @flows/flows :rf/default) :one))
+    (reset! flows/flows {})
+    (is (empty? (get @flows/flows :rf/default))
+        "per-frame map is empty after reset")
+    (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
+    (is (contains? (get @flows/flows :rf/default) :one)
+        "re-registration after reset works without raising")))


### PR DESCRIPTION
## Summary

Adds 5 conformance fixtures and JVM smoke coverage for Spec 013 (Flows) per bead **rf2-1cli**. Flows were claimed Done with only transitive coverage; this PR exercises the explicit paths called out in the bead: `reg-flow`, dirty-check / topo-sort, computed-state writes to `app-db`, hot-reload preservation, and the toggleable `:rf.fx/reg-flow` / `:rf.fx/clear-flow` round-trip.

### Conformance fixtures (`docs/specification/conformance/fixtures/`)

- `flow-recompute-on-input-change.edn` — input mutation triggers a recompute and the output materialises in `app-db`.
- `flow-multi-input-topo.edn` — flow B reads what flow A wrote; the topological sort settles both in one drain pass.
- `flow-noop-on-value-equal-input.edn` — `=`-equal input rewrite does NOT re-fire the flow (Spec 013 §Dirty-check semantics).
- `flow-toggle-via-fx.edn` — `:rf.fx/reg-flow` / `:rf.fx/clear-flow` round-trip; `clear-flow` vacates the output slot.
- `flow-hot-reload-preserves-output.edn` — re-registering a flow with a value-equivalent body keeps the prior output value.

The fixtures declare `:flow/*` capabilities not yet in the conformance runner's claimed set, so they load and report as skipped (out-of-claim) in the existing harness. They are reference material for the next runner extension and document the canonical shapes per Spec 013.

### JVM smoke tests (`implementation/test/re_frame/flows_test.clj`)

New file. 14 deftests / 45 assertions covering the same paths against the reference impl directly: `reg-flow` registry population, validation errors, cycle detection, dirty-check (including unrelated-path stability), topo-sort cascades (incl. prefix-overlap variant), hot-reload (value-equivalent + value-different bodies), `:rf.fx/reg-flow` / `:rf.fx/clear-flow` end-to-end, and `clear-all` lifecycle.

The fixture also resets `flows/last-inputs` (a private dirty-check atom) — without it, `[:rf/default :double]` keys leak between test namespaces and cause first-evaluation no-ops in sibling tests that reuse the same flow id.

### Bug surfaced

Filed as **rf2-aqt7** (P1):  `clear-flow` with a single-element `:path` (e.g. `[:k]`) does not remove the key from `app-db` — `update-in` with `(vec (butlast [:k]))` (= `[]`) is a no-op for the dissoc step. The fixtures and smoke tests use multi-element `:path` vectors to exercise the working branch (`>= 2` elements). Will be fixed under rf2-aqt7.

### Numbers

- Baseline: 34 tests / 95 assertions, 43/43 conformance fixtures passing (100 total fixtures).
- This PR: 48 tests / 140 assertions, 43/43 still passing, +5 fixtures loaded (skipped — out-of-claim until `:flow/*` capability is wired into the runner).

## Test plan

- [x] `cd implementation && clojure -M:test` — all green (48 tests / 140 assertions / 0 failures / 0 errors).
- [x] No edits to existing tests; only new files.
- [x] No edits to `flows.cljc`; the discovered bug is filed as rf2-aqt7 and the affected fixture's expectations sidestep the bug via multi-element `:path`.