### PR TITLE
test: hot-reload semantics coverage (rf2-fzzg)

### DIFF
--- a/implementation/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/test/re_frame/hot_reload_cljs_test.cljs
@@ -1,0 +1,129 @@
+(ns re-frame.hot-reload-cljs-test
+  "CLJS-side hot-reload coverage for Spec 001 §Hot-reload semantics.
+
+  Three of the five contract guarantees are pinned on the JVM in
+  hot_reload_test.clj. Rule 4 — view re-registration causes mounted
+  views to re-render — is Reagent-side and lives here.
+
+  The node-test runner has no DOM, so we don't mount through React.
+  Instead we exercise the contract at the layer the substrate cares
+  about: registry lookup of the wrapped render fn. After re-register,
+  re-frame.core/get-view (the lookup the substrate's render-cycle uses
+  to resolve a view by id) returns the new render fn — the next render
+  cycle invokes that, which is exactly what Reagent does on a mounted
+  view when the captured render fn changes via hot-reload.
+
+  A render-counter atom (mutated inside each render-fn body) makes the
+  observation crisp: pre-rereg renders bump the v1 counter; post-rereg
+  renders bump the v2 counter.
+
+  Fixture note: runtime_cljs_test installs a `reset-runtime` fixture
+  that calls `registrar/clear-all!`. We deliberately do NOT do that
+  here — clearing the registrar in this file's fixture would wipe
+  example apps (notably nine-states.core) whose registrations land at
+  namespace-load time and CANNOT be re-loaded under CLJS. Each test
+  uses unique keywords so cross-test interference inside this file is
+  impossible without a global wipe."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.views])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(defn ensure-adapter [test-fn]
+  ;; Don't wipe the registrar — see fixture note above. Just make sure
+  ;; the Reagent adapter is installed so reg-view's wrapping fns work.
+  (when-not (adapter/current-adapter)
+    (rf/init! reagent-adapter/adapter))
+  (test-fn))
+
+(use-fixtures :each ensure-adapter)
+
+;; ---- (4) :view re-register flips the next render to the new body --------
+
+(deftest view-re-register-causes-rerender
+  (testing "after re-registering a view, the next render uses the new body"
+    (let [v1-renders (atom 0)
+          v2-renders (atom 0)
+          ;; v1 of :rf.hot-reload-test/widget — a render fn that bumps the v1 counter and
+          ;; returns a hiccup tree tagged :v1.
+          v1-fn (fn [n]
+                  (swap! v1-renders inc)
+                  [:span.v1 "v1-" n])
+          v2-fn (fn [n]
+                  (swap! v2-renders inc)
+                  [:strong.v2 "v2-" n])]
+      ;; Use the function form (rf/reg-view) — it's the JVM-and-CLJS-shared
+      ;; surface. The macro form (re-frame.views-macros/reg-view) also
+      ;; works, but for hot-reload mechanics what matters is that the
+      ;; registrar's :view slot gets replaced.
+      (rf/reg-view :rf.hot-reload-test/widget v1-fn)
+      (let [render-v1 (rf/get-view :rf.hot-reload-test/widget)]
+        ;; First render uses v1.
+        (is (= [:span.v1 "v1-" 7] (render-v1 7))
+            "v1 render fn produces v1 hiccup")
+        (is (= 1 @v1-renders) "v1 was rendered once")
+        (is (= 0 @v2-renders) "v2 has not rendered")
+        ;; Re-register :rf.hot-reload-test/widget with v2 body.
+        (rf/reg-view :rf.hot-reload-test/widget v2-fn)
+        ;; The registry's :view slot now resolves to v2's wrapped fn.
+        ;; Reagent's render cycle re-resolves the head on each render
+        ;; (the captured Var or the get-view return), so the next render
+        ;; uses v2.
+        (let [render-v2 (rf/get-view :rf.hot-reload-test/widget)]
+          (is (= [:strong.v2 "v2-" 7] (render-v2 7))
+              "post-rereg lookup returns v2's render fn")
+          (is (= 1 @v1-renders)
+              "v1 was NOT re-invoked by the post-rereg render")
+          (is (= 1 @v2-renders)
+              "v2 was rendered once")
+          ;; Render again to confirm the new body sticks.
+          (render-v2 9)
+          (is (= 2 @v2-renders) "v2 keeps being the active render fn")))))
+
+  (testing "subscribed observer atom — proves the render BODY changed,
+            not just the wrapper, by routing observation through the
+            registered render fn rather than the captured Var"
+    (let [observed (atom nil)]
+      (rf/reg-view :rf.hot-reload-test/probe
+        (fn []
+          (reset! observed :body-v1)
+          [:p "v1"]))
+      ;; Simulate the substrate's render cycle: resolve via get-view
+      ;; (this is what re-frame.views/get-view does and what the h macro
+      ;; rewrites to) and invoke. After the call, observed reflects v1.
+      ((rf/get-view :rf.hot-reload-test/probe))
+      (is (= :body-v1 @observed))
+      ;; Re-register with a DIFFERENT body.
+      (rf/reg-view :rf.hot-reload-test/probe
+        (fn []
+          (reset! observed :body-v2)
+          [:p "v2"]))
+      ;; Next "render" — fresh registry resolution — runs v2.
+      ((rf/get-view :rf.hot-reload-test/probe))
+      (is (= :body-v2 @observed)
+          "after re-registration, the next render mutates observed to v2"))))
+
+(deftest view-re-register-via-macro-also-flips
+  (testing "the reg-view MACRO path also installs the new render fn into
+            the registry — verifying the contract holds for both surfaces"
+    ;; The macro auto-defs a local Var with the keyword's name. The
+    ;; underlying registration goes through re-frame.views/reg-view*,
+    ;; which calls registrar/register! with the wrapped fn. Hot-reload
+    ;; semantics ride on the registrar swap, so the macro form must
+    ;; respect the contract too.
+    (let [observed (atom nil)]
+      (reg-view :rf.hot-reload-test/banner
+        (fn [t]
+          (reset! observed [:m1 t])
+          [:h1.m1 t]))
+      ((rf/get-view :rf.hot-reload-test/banner) "hello")
+      (is (= [:m1 "hello"] @observed))
+      (reg-view :rf.hot-reload-test/banner
+        (fn [t]
+          (reset! observed [:m2 t])
+          [:h2.m2 t]))
+      ((rf/get-view :rf.hot-reload-test/banner) "world")
+      (is (= [:m2 "world"] @observed)
+          "post-rereg lookup invokes the new macro-installed body"))))

--- a/implementation/test/re_frame/hot_reload_test.clj
+++ b/implementation/test/re_frame/hot_reload_test.clj
@@ -1,0 +1,223 @@
+(ns re-frame.hot-reload-test
+  "Targeted JVM coverage for Spec 001 §Hot-reload semantics.
+
+  Spec 001 guarantees five properties; this namespace pins three:
+    1. Re-registering an :event handler is non-destructive to in-flight
+       work — the handler currently in process-event! finishes against
+       its captured fn.
+    2. Re-registering a :sub disposes cached reactions across every
+       frame — no stale value can be served from any frame's sub-cache.
+    3. Re-registering a :frame is a surgical metadata update — live
+       app-db (including the :rf/machines snapshot for active machine
+       instances) is preserved.
+
+  CLJS-only Reagent rendering coverage (rule 4 — view re-registration)
+  lives in hot_reload_cljs_test.cljs.
+
+  The fixture in this namespace deliberately does NOT reset the
+  registrar between the pre- and post-re-registration assertions:
+  re-registration IS the unit of behaviour under test. Each deftest
+  performs both registrations within one test body."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  ;; Framework events / fx are registered at namespace-load time in
+  ;; routing.cljc and ssr.cljc; clear-all! wiped them. Re-eval those
+  ;; registrations so :rf/hydrate, :rf.nav/push-url etc. resurrect.
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr    :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- (1) :event re-register is non-destructive to in-flight work ---------
+
+(deftest event-handler-re-register-non-destructive
+  (testing "the handler currently in process-event! finishes with its captured fn,
+            even when an external thread re-registers the same id mid-flight"
+    (let [observations (atom [])
+          ;; CountDownLatches give us deterministic synchronisation: no
+          ;; Thread/sleep, no race. The handler signals it's mid-flight,
+          ;; the test thread re-registers, and signals the handler to
+          ;; continue. The handler then finishes against its captured fn.
+          enter-latch   (CountDownLatch. 1)
+          proceed-latch (CountDownLatch. 1)
+          v1-fn (fn [db [_ tag]]
+                  (swap! observations conj [:v1-start tag])
+                  (.countDown enter-latch)
+                  ;; Wait for the test thread to perform the re-registration.
+                  (.await proceed-latch 5 TimeUnit/SECONDS)
+                  ;; This line runs AFTER re-registration has landed in the
+                  ;; registry. The interceptor closure has v1-fn captured —
+                  ;; the body keeps running v1, proving non-destructive.
+                  (swap! observations conj [:v1-end tag])
+                  (assoc db :ran-version :v1))
+          v2-fn (fn [db [_ tag]]
+                  (swap! observations conj [:v2 tag])
+                  (assoc db :ran-version :v2))]
+      (rf/reg-event-db :step v1-fn)
+      ;; Run the dispatch on a worker thread so the test thread can
+      ;; re-register while the handler is parked at proceed-latch.
+      (let [drain-thread
+            (Thread.
+              ^Runnable (fn []
+                          (rf/dispatch-sync [:step :a])))]
+        (.start drain-thread)
+        ;; Wait for the v1 body to be in-flight.
+        (.await enter-latch 5 TimeUnit/SECONDS)
+        ;; Mid-flight re-registration. After this swap, the registry's
+        ;; :step entry is v2; but the running handler's interceptor
+        ;; closure still points at v1.
+        (rf/reg-event-db :step v2-fn)
+        ;; Release the handler so it can finish its captured body.
+        (.countDown proceed-latch)
+        (.join drain-thread 5000))
+      ;; The in-flight handler ran v1-start AND v1-end (its captured body
+      ;; completed, undisturbed by the registry swap). v2 was NOT invoked
+      ;; for the in-flight event.
+      (is (= [[:v1-start :a] [:v1-end :a]] @observations)
+          "in-flight handler ran v1 body to completion")
+      (is (= :v1 (:ran-version (rf/get-frame-db :rf/default)))
+          ":db effect from the v1 closure committed")
+      ;; The next dispatch picks up the new body via fresh registry lookup.
+      (rf/dispatch-sync [:step :b])
+      (is (= [[:v1-start :a] [:v1-end :a] [:v2 :b]] @observations)
+          "post-drain dispatches resolve to v2")
+      (is (= :v2 (:ran-version (rf/get-frame-db :rf/default)))
+          ":db effect from v2 committed for the post-drain event")))
+
+  (testing "in a multi-event chain, the handler currently executing keeps its
+            captured body even when it re-registers itself mid-handler"
+    ;; A second deterministic flavour of (1) that does NOT span threads:
+    ;; the handler mutates its own registry slot during its run and the
+    ;; rest of the same handler invocation must continue with the old fn.
+    (let [observations (atom [])
+          v1-fn (fn v1 [db [_ n]]
+                  (swap! observations conj [:v1-pre n])
+                  ;; Mid-handler self re-registration.
+                  (rf/reg-event-db :tick
+                    (fn v2 [db [_ n]]
+                      (swap! observations conj [:v2 n])
+                      (assoc db :seen-version :v2)))
+                  ;; The remainder of THIS invocation runs in the v1 closure.
+                  (swap! observations conj [:v1-post n])
+                  (assoc db :seen-version :v1))]
+      (rf/reg-event-db :tick v1-fn)
+      (rf/dispatch-sync [:tick 1])
+      (is (= [[:v1-pre 1] [:v1-post 1]] @observations)
+          "handler's body completes against its captured v1 fn")
+      (is (= :v1 (:seen-version (rf/get-frame-db :rf/default))))
+      ;; A subsequent dispatch sees the new body.
+      (rf/dispatch-sync [:tick 2])
+      (is (= [[:v1-pre 1] [:v1-post 1] [:v2 2]] @observations)
+          "the next dispatch resolves the new v2 body")
+      (is (= :v2 (:seen-version (rf/get-frame-db :rf/default)))))))
+
+;; ---- (2) :sub re-register evicts cache across all frames -----------------
+
+(deftest sub-re-register-evicts-cache-cross-frame
+  (testing "re-registering a :sub disposes its cached reaction in every frame"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    ;; Two frames each carrying their own :n.
+    (rf/dispatch-sync [:seed 3] {:frame :left})
+    (rf/dispatch-sync [:seed 5] {:frame :right})
+    ;; v1 of :answer is the identity over :n.
+    (rf/reg-sub :answer (fn [db _] (:n db)))
+    ;; Pin the cache slot in each frame by holding a reaction reference;
+    ;; subscribe-value would auto-unsubscribe and the slot would be evicted
+    ;; by ref-counting, masking the cache-cross-frame contract.
+    (let [pin-left  (rf/subscribe :left  [:answer])
+          pin-right (rf/subscribe :right [:answer])
+          left-cache  (:sub-cache (frame/frame :left))
+          right-cache (:sub-cache (frame/frame :right))]
+      (is (= 3 @pin-left)  "left frame's :answer reads :n=3 under v1")
+      (is (= 5 @pin-right) "right frame's :answer reads :n=5 under v1")
+      (is (contains? @left-cache  [:answer])
+          "left frame has a cache slot for [:answer]")
+      (is (contains? @right-cache [:answer])
+          "right frame has a cache slot for [:answer]")
+      ;; v2 of :answer multiplies by 100.
+      (rf/reg-sub :answer (fn [db _] (* 100 (:n db))))
+      ;; Both frames' cache slots must be GONE — the registrar's
+      ;; replacement-hook walked frame-ids and dissoced from each.
+      (is (not (contains? @left-cache  [:answer]))
+          "left frame's [:answer] cache slot was evicted")
+      (is (not (contains? @right-cache [:answer]))
+          "right frame's [:answer] cache slot was evicted")
+      ;; Next subscribe in each frame builds a fresh reaction with the v2 body.
+      (is (= 300 (rf/subscribe-value :left  [:answer]))
+          "left frame's next subscribe uses v2 (3 * 100)")
+      (is (= 500 (rf/subscribe-value :right [:answer]))
+          "right frame's next subscribe uses v2 (5 * 100)"))))
+
+;; ---- (3) :frame re-register preserves snapshot ---------------------------
+
+(deftest frame-re-register-preserves-snapshot
+  (testing "reg-frame on an already-registered id is a SURGICAL metadata
+            update — live app-db (including :rf/machines snapshot for
+            active machine instances) is preserved"
+    ;; Register a frame with an arbitrary doc.
+    (rf/reg-frame :tenant {:doc       "v1 metadata"
+                           :tenant-id :acme})
+    ;; Build a tiny machine and dispatch into it so :rf/machines is
+    ;; populated. We use a machine handler so the snapshot lands at
+    ;; [:rf/machines :traffic-light] per Spec 005.
+    (rf/reg-event-fx :traffic-light
+      (rf/create-machine-handler
+        {:initial :red
+         :data    {:ticks 0}
+         :actions {:tick-action
+                   (fn [{:keys [data]} _]
+                     {:data (update data :ticks inc)})}
+         :states
+         {:red    {:on {:tick {:target :green :action :tick-action}}}
+          :green  {:on {:tick {:target :yellow :action :tick-action}}}
+          :yellow {:on {:tick {:target :red    :action :tick-action}}}}}))
+    ;; Drive the machine forward twice in :tenant.
+    (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})
+    (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})
+    ;; Capture pre-reregistration state.
+    (let [pre-db          (rf/get-frame-db :tenant)
+          pre-snapshot    (get-in pre-db [:rf/machines :traffic-light])
+          pre-app-db-cont (frame/get-frame-db :tenant)]
+      (is (= :yellow (:state pre-snapshot))
+          "machine snapshot landed in :rf/machines under :traffic-light")
+      (is (= 2 (get-in pre-snapshot [:data :ticks]))
+          "machine data accumulated across two transitions")
+      ;; SURGICAL metadata update: re-register with new metadata.
+      (rf/reg-frame :tenant {:doc       "v2 metadata"
+                             :tenant-id :acme
+                             :version   2})
+      ;; The :app-db CONTAINER is the same identity (no replace happened).
+      (is (identical? pre-app-db-cont (frame/get-frame-db :tenant))
+          "frame's app-db container is preserved (same identity)")
+      ;; The :rf/machines snapshot is preserved verbatim.
+      (let [post-db (rf/get-frame-db :tenant)]
+        (is (= pre-snapshot
+               (get-in post-db [:rf/machines :traffic-light]))
+            "machine snapshot is preserved across frame re-registration"))
+      ;; Metadata was updated.
+      (is (= "v2 metadata"
+             (get-in (rf/frame-meta :tenant) [:config :doc]))
+          ":doc reflects the v2 metadata")
+      (is (= 2 (get-in (rf/frame-meta :tenant) [:config :version]))
+          "new :version key is present in the merged config")
+      ;; The machine still progresses against its preserved snapshot.
+      (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})
+      (let [final-snapshot (get-in (rf/get-frame-db :tenant)
+                                   [:rf/machines :traffic-light])]
+        (is (= :red (:state final-snapshot))
+            "post-rereg :tick advances :yellow → :red — snapshot was live")
+        (is (= 3 (get-in final-snapshot [:data :ticks]))
+            "machine data continues to accumulate from the preserved snapshot")))))


### PR DESCRIPTION
## Summary

Targeted tests for three Spec 001 §Hot-reload contract guarantees that previously had only partial coverage:

1. **`:event` re-registration is non-destructive to in-flight work** — the handler currently in `process-event!` finishes against its captured fn, even when a parallel thread re-registers the same id mid-flight.
2. **`:sub` re-registration evicts cached reactions across all frames** — both a left and right frame's cache slots for the re-registered query are disposed; the next subscribe builds against the new body.
3. **`:frame` re-registration is a surgical metadata update** — `app-db` container identity, the `:rf/machines` snapshot for active machine instances, and forward progress are all preserved (Spec 002).

CLJS coverage adds the fourth contract — `:view` re-registration causes the next render to use the new body, observed via render-counter atoms in the render-fn bodies.

## Files added

- `implementation/test/re_frame/hot_reload_test.clj` — three JVM deftests, 24 assertions.
- `implementation/test/re_frame/hot_reload_cljs_test.cljs` — two CLJS deftests, 11 assertions.

## Implementation notes

- The JVM `event-handler-re-register-non-destructive` test uses `CountDownLatch` for deterministic synchronisation rather than `Thread/sleep` — the handler signals it's mid-flight, the test thread re-registers, then signals the handler to continue. No race, no flake.
- The CLJS fixture deliberately does NOT call `registrar/clear-all!`. Doing so would wipe `nine-states.core`'s namespace-load registrations under `node-test` (which has no CLJS reload primitive). Each test uses uniquely-namespaced keywords (`:rf.hot-reload-test/...`) for isolation instead.
- No production code was modified.

## Test plan

- [x] JVM: `cd implementation && clojure -M:test` — 37 tests / 119 assertions, 0 failures.
- [x] CLJS: `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 21 tests / 52 assertions, 0 failures.