### PR TITLE
test: schema integration coverage (rf2-dznb)

### DIFF
--- a/docs/specification/conformance/fixtures/schema-app-db-slice-validates.edn
+++ b/docs/specification/conformance/fixtures/schema-app-db-slice-validates.edn
@@ -1,0 +1,65 @@
+;; Conformance fixture: schemas/app-db-slice-validates
+;; Per Spec 010 §Validation order step 4 — :app-db path schemas validate
+;; the slice at the registered path AFTER the handler's :db effect commits.
+;; A handler that violates the slice's shape triggers
+;; :rf.error/schema-validation-failure with :where :app-db and the
+;; offending :path. Recovery defaults to :no-recovery in dev (the bad
+;; commit is observable) — production switches to :replaced-with-default.
+;;
+;; This fixture pairs with error-schema-failure.edn (same surface, different
+;; framing): error-schema-failure focuses on the error trace shape; this
+;; fixture focuses on the slice-validates contract — well-typed payloads
+;; pass, malformed payloads fail.
+;;
+;; Dynamic-host only — statically typed hosts catch shape violations at
+;; compile time and produce no runtime trace.
+
+{:fixture/id           :schemas/app-db-slice-validates
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/error :schemas/runtime}
+ :fixture/doc          "An :app-schema-at registered at [:user] validates the slice after every :db commit. A well-typed value passes silently; a malformed value emits :rf.error/schema-validation-failure with :where :app-db."
+ :fixture/dynamic-host-only? true
+
+ :fixture/registry
+ {:event {:user/init     {:doc "Seed a well-typed user."}
+          :user/set-good {:doc "Sets :user to a well-typed map (passes)."}
+          :user/set-bad  {:doc "Sets :user to a value violating the schema."}}
+  :sub   {:user {:doc "Current user slice."}}
+  :app-schema
+  {[:user] [:map [:id :int] [:email :string]]}}
+
+ :fixture/handlers
+ {:event {:user/init     [[:set [:user] {:id 1 :email "alice@example.com"}]]
+          :user/set-good [[:set [:user] {:id 2 :email "bob@example.com"}]]
+          :user/set-bad  [[:set [:user] {:id "not-an-int" :email "carol@example.com"}]]}
+  :sub   {:user [[:get [:user]]]}}
+
+ :fixture/frame-config {:on-create [:user/init]}
+
+ :fixture/dispatches
+ ;; First the well-typed payload (no error trace), then the malformed one
+ ;; (raises :rf.error/schema-validation-failure).
+ [[:user/set-good]
+  [:user/set-bad]]
+
+ :fixture/expect
+ ;; Final app-db reflects the bad commit — recovery is :no-recovery, so the
+ ;; offending :db effect IS still applied; the trace records the violation.
+ {:final-app-db {:user {:id "not-an-int" :email "carol@example.com"}}
+
+  :sub-values   {[:user] {:id "not-an-int" :email "carol@example.com"}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :user/init}}
+   {:operation :event :tags {:event-id :user/set-good}}
+   ;; No schema-validation-failure between :user/set-good (well-typed) and
+   ;; :user/set-bad — the runner asserts the order of NEW emissions; absent
+   ;; emissions in between are fine.
+   {:operation :event :tags {:event-id :user/set-bad}}
+   {:operation :rf.error/schema-validation-failure
+    :op-type   :error
+    :tags      {:category   :rf.error/schema-validation-failure
+                :failing-id :user/set-bad
+                :where      :app-db
+                :path       [:user]}
+    :recovery  :no-recovery}]}}

--- a/docs/specification/conformance/fixtures/schema-cofx-validates.edn
+++ b/docs/specification/conformance/fixtures/schema-cofx-validates.edn
@@ -1,0 +1,67 @@
+;; Conformance fixture: schemas/cofx-validates
+;; Per Spec 010 §Validation order step 2 — after a cofx injects its value
+;; into the merged context, the runtime validates that value against the
+;; cofx's :spec. Well-formed values flow through to the handler; malformed
+;; values emit :rf.error/schema-validation-failure with :where :cofx and
+;; the handler is NOT invoked (recovery: :no-recovery; downstream queue
+;; continues, mirroring the event-payload step).
+;;
+;; This fixture pairs with reg-cofx's :spec metadata (Spec 010 §Where
+;; schemas attach §On every reg-*).
+;;
+;; This capability — :schemas/cofx — is finer-grained than the baseline
+;; :schemas/runtime. Ports that have wired cofx-injection validation
+;; declare :schemas/cofx alongside :schemas/runtime; ports that haven't
+;; are skipped on this fixture. The runtime gap (validate-cofx! not yet
+;; wired) is tracked as rf2-7leq; the conformance-runner gap (cofx body
+;; realisation from fixture DSL) is tracked as rf2-g25p.
+;;
+;; Dynamic-host only.
+
+{:fixture/id           :schemas/cofx-validates
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error :schemas/runtime :schemas/cofx}
+ :fixture/doc          "A reg-cofx handler with a :spec validates the value the cofx injects, after injection and before the event-fx handler runs. A well-formed coeffect map flows through to the handler; a malformed value emits :rf.error/schema-validation-failure with :where :cofx, and the handler is NOT invoked."
+ :fixture/dynamic-host-only? true
+
+ :fixture/registry
+ ;; Two cofx, both injecting :app-version under :coeffects. The well cofx
+ ;; returns a string (passes the :string schema). The bad cofx returns a
+ ;; number (fails the :string schema).
+ {:cofx  {:app-version/well
+          {:doc  "Inject a well-typed app-version string."
+           :spec :string}
+          :app-version/bad
+          {:doc  "Inject a malformed app-version (number, schema rejects)."
+           :spec :string}}
+  :event {:cap/seed
+          {:doc "Read :app-version from coeffects and stash it in app-db."}}}
+
+ :fixture/handlers
+ ;; The cofx body DSL is gated on the runner supporting cofx body
+ ;; realisation (rf2-g25p). Until that lands, the cofx registrations are
+ ;; metadata-only and this fixture is skipped via the :schemas/cofx
+ ;; capability gate. The bodies below describe the intended behaviour.
+ {:cofx  {:app-version/well [[:set [:app-version] "1.4.5"]]
+          :app-version/bad  [[:set [:app-version] 42]]}
+  :event {:cap/seed [[:set [:app-version] [:cofx-key :app-version]]]}}
+
+ :fixture/frame-config {}
+
+ :fixture/dispatches
+ [[:cap/seed]]
+
+ :fixture/expect
+ ;; The malformed cofx triggered :where :cofx and the handler was skipped —
+ ;; :app-version stays unset.
+ {:final-app-db {}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :cap/seed}}
+   {:operation :rf.error/schema-validation-failure
+    :op-type   :error
+    :tags      {:category   :rf.error/schema-validation-failure
+                :failing-id :cap/seed
+                :where      :cofx
+                :cofx-id    :app-version/bad}
+    :recovery  :no-recovery}]}}

--- a/docs/specification/conformance/fixtures/schema-event-payload-validates.edn
+++ b/docs/specification/conformance/fixtures/schema-event-payload-validates.edn
@@ -1,0 +1,69 @@
+;; Conformance fixture: schemas/event-payload-validates
+;; Per Spec 010 §Validation order step 1 — every dispatched event vector
+;; is validated against the handler's :spec BEFORE the handler runs.
+;; Well-typed payloads dispatch normally; malformed payloads emit
+;; :rf.error/schema-validation-failure with :where :event and the handler
+;; is NOT invoked (recovery: :no-recovery; downstream queue continues).
+;;
+;; This capability — :schemas/event-payload — is finer-grained than the
+;; baseline :schemas/runtime (which today's reference implementation only
+;; covers app-db slice validation). Ports that have wired event-payload
+;; validation declare :schemas/event-payload alongside :schemas/runtime;
+;; ports that haven't are skipped on this fixture. The runtime gap is
+;; tracked as rf2-jwm4 (validate-event! exists in re-frame.schemas but is
+;; not yet called by the router).
+;;
+;; Dynamic-host only — statically typed hosts reject malformed payloads at
+;; the call site and produce no runtime trace.
+
+{:fixture/id           :schemas/event-payload-validates
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error :schemas/runtime :schemas/event-payload}
+ :fixture/doc          "A reg-event-* handler with a :spec validates the dispatched event vector before it runs. A well-typed event reaches the handler; a malformed event emits :rf.error/schema-validation-failure with :where :event and the handler is skipped."
+ :fixture/dynamic-host-only? true
+
+ :fixture/registry
+ ;; The :spec is a Malli sequence schema describing the event vector itself —
+ ;; first element must be the literal event-id, second must be a map with a
+ ;; :string :email and an :int :age.
+ {:event {:user/register
+          {:doc  "Register a new user with a typed payload."
+           :spec [:cat [:= :user/register]
+                       [:map [:email :string] [:age :int]]]}
+          :user/init
+          {:doc "Seed empty users vec."}}
+  :sub   {:users {:doc "All registered users."}}}
+
+ :fixture/handlers
+ {:event {:user/init      [[:set [:users] []]]
+          :user/register  [[:update [:users] [:fn :conj [:event-arg 1]]]]}
+  :sub   {:users [[:get [:users]]]}}
+
+ :fixture/frame-config {:on-create [:user/init]}
+
+ :fixture/dispatches
+ ;; First a well-typed payload (the handler runs and the user lands in :users),
+ ;; then a malformed payload (handler is NOT invoked; trace records :where :event).
+ [[:user/register {:email "alice@example.com" :age 30}]
+  [:user/register {:email "carol@example.com" :age "not-an-int"}]]
+
+ :fixture/expect
+ ;; The well-typed payload reached the handler; the malformed one was rejected
+ ;; before it ran — :users carries exactly one entry.
+ {:final-app-db {:users [{:email "alice@example.com" :age 30}]}
+
+  :sub-values   {[:users] [{:email "alice@example.com" :age 30}]}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :user/init}}
+   {:operation :event :tags {:event-id :user/register}}
+   ;; Second dispatch attempts :user/register with a bad payload —
+   ;; the runtime emits the schema-validation-failure trace and skips the
+   ;; handler. Note: the :event trace event still fires (the dispatch was
+   ;; attempted) — it's the handler INVOCATION that's skipped.
+   {:operation :rf.error/schema-validation-failure
+    :op-type   :error
+    :tags      {:category   :rf.error/schema-validation-failure
+                :failing-id :user/register
+                :where      :event}
+    :recovery  :no-recovery}]}}

--- a/docs/specification/conformance/fixtures/schema-sub-return-validates.edn
+++ b/docs/specification/conformance/fixtures/schema-sub-return-validates.edn
@@ -1,0 +1,58 @@
+;; Conformance fixture: schemas/sub-return-validates
+;; Per Spec 010 §Validation order step 6 — a sub's return value is
+;; validated against its :spec AFTER each materialisation/recompute.
+;; Well-formed returns flow through to consumers; malformed returns
+;; emit :rf.error/schema-validation-failure with :where :sub-return.
+;; Default recovery is :replaced-with-default — the sub yields nil to
+;; its consumer (mirrors the per-step recovery for sub-exception in
+;; Spec 010 §Per-step recovery).
+;;
+;; This capability — :schemas/sub-return — is finer-grained than the
+;; baseline :schemas/runtime. Ports that have wired sub-return validation
+;; declare :schemas/sub-return alongside :schemas/runtime; ports that
+;; haven't are skipped on this fixture. The runtime gap is tracked as
+;; rf2-wcam.
+;;
+;; Dynamic-host only.
+
+{:fixture/id           :schemas/sub-return-validates
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/sub :core/error :schemas/runtime :schemas/sub-return}
+ :fixture/doc          "A reg-sub registered with a :spec validates the sub's return value after it computes. Well-formed returns reach the caller; malformed returns emit :rf.error/schema-validation-failure with :where :sub-return and the caller sees nil (default :replaced-with-default recovery)."
+ :fixture/dynamic-host-only? true
+
+ :fixture/registry
+ {:event {:items/init  {:doc "Seed a well-typed items vec."}
+          :items/break {:doc "Set :items to a value the sub will malform."}}
+  :sub   {:items
+          {:doc  "Layer-1 sub returning :items as-is."
+           :spec [:vector :string]}}}
+
+ :fixture/handlers
+ {:event {:items/init  [[:set [:items] ["a" "b" "c"]]]
+          :items/break [[:set [:items] [1 2 3]]]}
+  :sub   {:items [[:get [:items]]]}}
+
+ :fixture/frame-config {:on-create [:items/init]}
+
+ :fixture/dispatches
+ [[:items/break]]
+
+ :fixture/expect
+ ;; The :items slot in app-db holds whatever the handler wrote — the schema
+ ;; is on the SUB's return shape, not the slot. The sub's return is what's
+ ;; replaced with nil after validation fails.
+ {:final-app-db {:items [1 2 3]}
+
+  :sub-values   {[:items] nil}                 ;; :replaced-with-default
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :items/init}}
+   {:operation :event :tags {:event-id :items/break}}
+   {:operation :rf.error/schema-validation-failure
+    :op-type   :error
+    :tags      {:category   :rf.error/schema-validation-failure
+                :failing-id :items
+                :where      :sub-return
+                :sub-id     :items}
+    :recovery  :replaced-with-default}]}}

--- a/implementation/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/test/re_frame/schemas_cljs_test.cljs
@@ -1,0 +1,85 @@
+(ns re-frame.schemas-cljs-test
+  "CLJS-side smoke for Spec 010 — schema validation runs at dispatch
+  time under the Reagent reactive substrate.
+
+  The JVM smoke (re-frame.schemas-test) covers the elision toggle and
+  the error-projector → :rf/public-error mapping shape; this file
+  confirms that under the Reagent adapter — the production substrate
+  for browser apps — a live dispatch with a malformed :db commit
+  surfaces a :rf.error/schema-validation-failure trace through the
+  same path it would on the JVM. The fact that the trace reaches the
+  registered callback under Reagent is what locks the cross-substrate
+  contract.
+
+  This is a smoke — one happy path, one violation path. The conformance
+  fixtures (schema-app-db-slice-validates.edn et al.) cover the broader
+  contract."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ;; Pull malli into the bundle. re-frame.schemas/malli-validate*
+            ;; uses (resolve 'malli.core/validate) — which on CLJS only
+            ;; finds vars already loaded into the runtime. Without this
+            ;; require, the resolve returns nil and validation silently
+            ;; passes (the JVM's requiring-resolve has no CLJS analogue).
+            ;; The conformance fixtures for app-db slice validation rely
+            ;; on user code requiring malli at app boot; this test does
+            ;; the same.
+            [malli.core]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.reagent :as reagent-adapter]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (adapter/dispose-adapter!)
+  (rf/init! reagent-adapter/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- live dispatch fires app-db schema validation -------------------------
+
+(deftest live-dispatch-validates-app-db-under-reagent
+  (testing "a malformed :db commit emits :rf.error/schema-validation-failure under the Reagent adapter"
+    (rf/reg-app-schema [:n] [:int])
+    (rf/reg-event-db :n/init  (fn [_ _] {:n 0}))
+    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::cljs-live (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:n/init])
+      (rf/dispatch-sync [:n/break])
+      (rf/remove-trace-cb! ::cljs-live)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "exactly one schema-validation-failure trace fired under Reagent")
+        (let [v (first violations)]
+          (is (= :app-db (-> v :tags :where))
+              ":where :app-db locates the failure in the post-handler validation step")
+          (is (= [:n] (-> v :tags :path))
+              ":path names the registered slot")
+          (is (= "boom" (-> v :tags :value))
+              ":value carries the offending value verbatim")
+          (is (= :n/break (-> v :tags :failing-id))
+              ":failing-id names the handler whose commit prompted the failure"))))))
+
+(deftest live-dispatch-well-typed-passes-silently
+  (testing "well-typed :db commits trigger no schema-validation-failure trace"
+    (rf/reg-app-schema [:n] [:int])
+    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::cljs-ok (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:n/init])
+      (rf/dispatch-sync [:n/inc])
+      (rf/dispatch-sync [:n/inc])
+      (rf/remove-trace-cb! ::cljs-ok)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure
+                              (:operation %))
+                          @traces))
+          "no validation-failure traces — every commit conforms"))))

--- a/implementation/test/re_frame/schemas_test.clj
+++ b/implementation/test/re_frame/schemas_test.clj
@@ -1,0 +1,222 @@
+(ns re-frame.schemas-test
+  "JVM smoke tests for Spec 010 — Schemas (Malli runtime validation).
+
+  Two surfaces here:
+
+    1. **Elision toggle**. In dev builds (per Spec 010 §Dev builds) all
+       registered schemas are checked at every validation point. In
+       production builds (per Spec 010 §Production builds) validation is
+       compile-time-elided via a host gate — `goog.DEBUG` on CLJS, the
+       JVM mirror `re-frame.interop/debug-enabled?` here. These tests
+       flip the gate via `with-redefs` and assert the dev-mode trace
+       fires while the prod-mode call is silent.
+
+    2. **Error projector → :rf/public-error mapping**. Per Spec 010 + 011
+       §Default projector, the runtime ships a default projector mapping
+       internal trace events to the locked four-key public-error shape
+       (`:status :code :message :retryable?`). The schema-validation
+       failure category maps to a 400 :bad-request. The default-projector
+       fn proper isn't yet wired into the registrar (tracked as rf2-6528);
+       we test the *mapping contract* here as a pure fn so the contract
+       is locked even before the registry-side wiring lands.
+
+  These tests exercise schemas on the JVM via the plain-atom adapter —
+  the conformance fixtures cover the dispatch-time integration; this
+  file covers the elision toggle (which fixtures cannot flip from EDN)
+  and the projector-mapping shape (which is a separate surface from the
+  trace emission)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.interop :as interop]
+            [re-frame.schemas :as schemas]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- elision toggle -------------------------------------------------------
+
+(deftest app-db-validation-fires-when-debug-enabled
+  (testing "validate-app-db! emits :rf.error/schema-validation-failure when debug-enabled? is true"
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::dev (fn [ev] (swap! traces conj ev)))
+      ;; Dev mode is the JVM default; validate-app-db! should walk the
+      ;; registered schemas and emit on a malformed value.
+      (with-redefs [interop/debug-enabled? true]
+        (schemas/validate-app-db! {:count "not-an-int"} :test/handler))
+      (rf/remove-trace-cb! ::dev)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "exactly one schema-validation-failure trace fired")
+        (let [v (first violations)]
+          (is (= :app-db (-> v :tags :where)))
+          (is (= [:count] (-> v :tags :path)))
+          (is (= "not-an-int" (-> v :tags :value)))
+          (is (= :test/handler (-> v :tags :failing-id))))))))
+
+(deftest app-db-validation-elides-when-debug-disabled
+  (testing "validate-app-db! is a no-op when debug-enabled? is false (production)"
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::prod (fn [ev] (swap! traces conj ev)))
+      ;; Production mode — the validation site elides; even with a
+      ;; malformed value, no trace fires.
+      (with-redefs [interop/debug-enabled? false]
+        (schemas/validate-app-db! {:count "not-an-int"} :test/handler))
+      (rf/remove-trace-cb! ::prod)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure
+                              (:operation %))
+                          @traces))
+          "no schema-validation-failure trace when validation is elided"))))
+
+(deftest well-typed-value-passes-silently
+  (testing "validate-app-db! with a conforming value emits no trace"
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::ok (fn [ev] (swap! traces conj ev)))
+      (with-redefs [interop/debug-enabled? true]
+        (schemas/validate-app-db! {:count 42} :test/handler))
+      (rf/remove-trace-cb! ::ok)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure
+                              (:operation %))
+                          @traces))
+          "well-typed value triggers no validation-failure trace"))))
+
+(deftest dispatch-fires-app-db-validation
+  (testing "live dispatch through the runtime triggers app-db validation post-:db commit"
+    (rf/reg-app-schema [:n] [:int])
+    (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::live (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:n/init])
+      (rf/dispatch-sync [:n/break])
+      (rf/remove-trace-cb! ::live)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "the malformed :n/break commit fires exactly one schema trace")
+        (is (= :n/break (-> violations first :tags :failing-id))
+            ":failing-id names the handler whose commit prompted the failure")))))
+
+;; ---- error projector → :rf/public-error mapping --------------------------
+
+(defn- default-error-projector
+  "The default projector contract per Spec 011 §Default projector. The
+  runtime-resident registry-backed projector isn't yet wired (rf2-6528),
+  but the mapping is locked. This fn implements the table verbatim so
+  these tests pin the mapping contract.
+
+  Returns the locked four-key public-error shape:
+    {:status :code :message :retryable?}
+
+  In dev mode (:dev-error-detail? true) the public shape carries an
+  additional :details key with the original trace event."
+  ([trace-event] (default-error-projector trace-event {}))
+  ([trace-event {:keys [dev-error-detail?]}]
+   (let [base (case (:operation trace-event)
+                :rf.error/no-such-handler
+                {:status 404 :code :not-found
+                 :message "Page not found" :retryable? false}
+
+                :rf.error/schema-validation-failure
+                {:status 400 :code :bad-request
+                 :message "Invalid input" :retryable? false}
+
+                :rf.error/handler-exception
+                {:status 500 :code :internal-error
+                 :message "Something went wrong" :retryable? false}
+
+                :rf.error/sub-exception
+                {:status 500 :code :internal-error
+                 :message "Something went wrong" :retryable? false}
+
+                :rf.error/fx-handler-exception
+                {:status 500 :code :internal-error
+                 :message "Something went wrong" :retryable? false}
+
+                :rf.error/drain-depth-exceeded
+                {:status 500 :code :internal-error
+                 :message "Something went wrong" :retryable? false}
+
+                ;; default — generic 500
+                {:status 500 :code :internal-error
+                 :message "Something went wrong" :retryable? false})]
+     (cond-> base
+       dev-error-detail? (assoc :details trace-event)))))
+
+(deftest projector-maps-schema-failure-to-bad-request
+  (testing "schema-validation-failure projects to a locked 400 :bad-request"
+    (let [trace-event {:operation :rf.error/schema-validation-failure
+                       :op-type   :error
+                       :tags      {:where :event :event-id :user/register
+                                   :event [:user/register {:age "no"}]}
+                       :recovery  :no-recovery}
+          public      (default-error-projector trace-event)]
+      (is (= 400 (:status public)))
+      (is (= :bad-request (:code public)))
+      (is (= "Invalid input" (:message public)))
+      (is (false? (:retryable? public))
+          "schema validation failure is NOT retryable — the input is the bug")
+      (is (= #{:status :code :message :retryable?} (set (keys public)))
+          "prod-mode public shape is the locked four keys only — no :details leak"))))
+
+(deftest projector-includes-details-in-dev
+  (testing "with :dev-error-detail? true the public shape carries the original trace under :details"
+    (let [trace-event {:operation :rf.error/schema-validation-failure
+                       :tags      {:where :app-db :path [:user] :value "bad"}}
+          public      (default-error-projector trace-event {:dev-error-detail? true})]
+      (is (= 400 (:status public)))
+      (is (= :bad-request (:code public)))
+      (is (contains? public :details)
+          ":details carries the original trace event in dev mode")
+      (is (= trace-event (:details public))
+          ":details is the trace event verbatim — full internal detail"))))
+
+(deftest projector-falls-back-to-generic-500
+  (testing "an unknown error category projects to the locked generic-500 shape"
+    (let [trace-event {:operation :rf.error/something-unmapped
+                       :tags      {}}
+          public      (default-error-projector trace-event)]
+      (is (= 500 (:status public)))
+      (is (= :internal-error (:code public)))
+      (is (= "Something went wrong" (:message public)))
+      (is (false? (:retryable? public))))))
+
+(deftest projector-maps-no-such-handler-to-404
+  (testing ":rf.error/no-such-handler in routing context projects to 404"
+    (let [trace-event {:operation :rf.error/no-such-handler
+                       :tags      {:url "/no-such-page"}}
+          public      (default-error-projector trace-event)]
+      (is (= 404 (:status public)))
+      (is (= :not-found (:code public))))))
+
+(deftest projector-output-shape-is-stable
+  (testing "every projection returns the locked four keys (no extras in prod)"
+    (doseq [op [:rf.error/no-such-handler
+                :rf.error/schema-validation-failure
+                :rf.error/handler-exception
+                :rf.error/sub-exception
+                :rf.error/fx-handler-exception
+                :rf.error/drain-depth-exceeded
+                :rf.error/some-future-category]]
+      (let [public (default-error-projector {:operation op :tags {}})]
+        (is (= #{:status :code :message :retryable?} (set (keys public)))
+            (str "projection for " op " must carry exactly the four locked keys"))
+        (is (integer? (:status public)))
+        (is (keyword? (:code public)))
+        (is (string? (:message public)))
+        (is (boolean? (:retryable? public)))))))


### PR DESCRIPTION
## Summary

Spec 010 (Schemas — Malli runtime validation) coverage. One conformance fixture per validation point, JVM smoke for the elision toggle and the error-projector mapping, and a CLJS smoke confirming schema validation runs at dispatch under the Reagent adapter.

### Fixtures

- `schema-app-db-slice-validates.edn` — app-db slice schema fires post-:db commit (well-typed payload passes silently, malformed raises with `:where :app-db`). Capability `:schemas/runtime` — runs and passes today.
- `schema-event-payload-validates.edn` — handler `:spec` validates the dispatched event vector pre-handler. Capability `:schemas/event-payload` — skipped until `validate-event!` is wired (rf2-jwm4).
- `schema-sub-return-validates.edn` — sub `:spec` validates the return value post-compute, default `:replaced-with-default`. Capability `:schemas/sub-return` — skipped until wired (rf2-wcam).
- `schema-cofx-validates.edn` — cofx `:spec` validates injected value pre-handler. Capability `:schemas/cofx` — skipped until wired (rf2-7leq) plus the runner gap (rf2-g25p).

Per the brief, the `schema-elision-prod-mode` fixture was deferred — the conformance DSL cannot toggle the goog-define / debug-enabled? flag from EDN. The elision contract is covered in the JVM smoke instead.

### JVM smoke (`implementation/test/re_frame/schemas_test.clj`)

- `validate-app-db!` fires under `debug-enabled?` true and elides under false (`with-redefs` flips the gate the way a prod build would).
- Live dispatch through the runtime triggers the post-:db validation.
- Default error projector maps `:rf.error/schema-validation-failure` to the locked 400 `:bad-request` public-error shape — output is exactly the four locked keys (`:status :code :message :retryable?`), `:details` is absent in prod and present in dev. The projector fn proper isn't yet wired into the registrar (rf2-6528); these tests pin the mapping contract as a pure fn so it's locked before the registry-side wiring lands.

### CLJS smoke (`implementation/test/re_frame/schemas_cljs_test.cljs`)

- Live dispatch under the Reagent adapter fires the same trace the JVM sees on a malformed `:db` commit; well-typed commits pass silently.
- Requires `malli.core` directly so it lands in the bundle — `re-frame.schemas/malli-validate*` uses `(resolve 'malli.core/validate)` which has no `requiring-resolve` analogue on CLJS, so user code must require malli at boot.

### Beads filed for runtime gaps

- rf2-jwm4 — Spec 010 wiring: `validate-event!` pre-handler
- rf2-wcam — Spec 010 wiring: sub-return `:spec` validation post-compute
- rf2-7leq — Spec 010 wiring: cofx `:spec` validation post-injection
- rf2-6528 — Spec 010/011 wiring: `reg-error-projector` + default-error-projector
- rf2-g25p — Conformance runner: realise cofx handler bodies from fixture DSL

## Test plan

- [x] `cd implementation && clojure -M:test` — 43 tests, 154 assertions, 0 failures (was 34 tests; +9 new in `re-frame.schemas-test`)
- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 21 tests, 47 assertions, 0 failures (+2 new in `re-frame.schemas-cljs-test`)
- [x] Conformance corpus: 47 fixtures, 44 runnable, 44 passed, 3 skipped (out-of-claim — the three fine-grained capabilities)