### PR TITLE
test: comprehensive routing coverage (rf2-hh37)

### DIFF
--- a/docs/specification/conformance/fixtures/routing-can-leave-blocks.edn
+++ b/docs/specification/conformance/fixtures/routing-can-leave-blocks.edn
@@ -1,0 +1,66 @@
+;; Conformance fixture: routing/can-leave-blocks
+;;
+;; Complements route-navigation-blocked: this fixture drives the full
+;; pending-nav protocol — block, then *cancel*. After cancel, the slot
+;; clears and the original route remains active (no URL change). The
+;; canonical "continue" path is covered by the older fixture; this one
+;; locks down the cancel branch so both arms are conformance-checked.
+;;
+;; Per [012 §Navigation blocking — pending-nav protocol]
+;; (../../012-Routing.md#navigation-blocking--pending-nav-protocol).
+
+{:fixture/id           :routing/can-leave-blocks
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/blocking}
+ :fixture/doc          "A :can-leave guard rejects an outbound navigation; :rf/pending-navigation is set; :rf.route/navigation-blocked trace fires; the URL does not change. User dispatches :rf.route/cancel — the slot clears and the original route is still active."
+
+ :fixture/registry
+ {:route
+  {:editor/article {:path      "/editor/articles/:id"
+                    :params    [:map [:id :string]]
+                    :can-leave :editor/can-leave?}
+   :route/cart     {:path "/cart"}}
+
+  :event
+  {:editor/set-dirty {:doc "Mark the form dirty."}}
+
+  :sub
+  {:editor/dirty?     {:doc "Whether the editor form has unsaved changes."}
+   :editor/can-leave? {:doc "True when the form is clean."}}}
+
+ :fixture/handlers
+ {:event
+  {:editor/set-dirty [[:set [:editor :dirty?] true]]}
+
+  :sub
+  {:editor/dirty?     [[:get [:editor :dirty?]]]
+   :editor/can-leave? [[:get [:editor :dirty?]]
+                       [:fn :not]]}}
+
+ :fixture/dispatches
+ [;; Step 1: Land on :editor/article id=A.
+  [:rf/url-changed "/editor/articles/A"]
+
+  ;; Step 2: Dirty the form. :can-leave? now returns false.
+  [:editor/set-dirty]
+
+  ;; Step 3: Try to leave. Guard rejects; :rf/pending-navigation is set.
+  [:rf/url-requested {:url "/cart"}]
+
+  ;; Step 4: User chooses Stay — :rf.route/cancel clears the slot.
+  [:rf.route/cancel "pn-1"]]
+
+ :fixture/expect
+ {:final-app-db
+  ;; Original route is still active; no slice change. Pending-nav cleared.
+  {:route                 {:id :editor/article :params {:id "A"}
+                           :query {} :fragment nil
+                           :transition :idle :error nil}
+   :editor                {:dirty? true}
+   :rf/pending-navigation nil}
+
+  :trace-emissions
+  [;; Block fires when the guard rejects.
+   {:operation :rf.route/navigation-blocked
+    :tags      {:requested-url   "/cart"
+                :rejecting-route :editor/article}}]}}

--- a/docs/specification/conformance/fixtures/routing-fragment-as-slice.edn
+++ b/docs/specification/conformance/fixtures/routing-fragment-as-slice.edn
@@ -1,0 +1,39 @@
+;; Conformance fixture: routing/fragment-as-slice
+;;
+;; The URL #fragment is a first-class slot in the :route slice — populated
+;; on initial navigation, updatable on fragment-only changes, and cleared
+;; when the next URL has no fragment. This fixture isolates the slice
+;; lifecycle separately from `route-fragment-change`'s on-match-doesn't-
+;; re-fire behaviour.
+;;
+;; Per [012 §Fragments — Fragment in the slice]
+;; (../../012-Routing.md#fragment-in-the-slice).
+
+{:fixture/id           :routing/fragment-as-slice
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/fragment}
+ :fixture/doc          "The :route slice's :fragment field tracks the URL #fragment. Initial navigation seeds it; same-path/different-fragment updates it; navigation to a URL without a fragment clears it (nil). The slice-level shape is the only thing this fixture asserts — on-match firing is covered by route-fragment-change."
+
+ :fixture/registry
+ {:route
+  {:route/docs {:path   "/docs/:page"
+                :params [:map [:page :string]]}}}
+
+ :fixture/dispatches
+ [;; Step 1: Visit /docs/routing#scroll-restoration. :fragment seeded.
+  [:rf/url-changed "/docs/routing#scroll-restoration"]
+
+  ;; Step 2: Same path/params, different fragment. :fragment updates.
+  [:rf/url-changed "/docs/routing#caching"]
+
+  ;; Step 3: Same path/params, NO fragment. :fragment clears to nil.
+  ;; Note: :rf/url-changed treats this as a fragment-only update from
+  ;; "caching" → nil (slice-level).
+  [:rf/url-changed "/docs/routing"]]
+
+ :fixture/expect
+ {:final-app-db
+  {:route {:id       :route/docs
+           :params   {:page "routing"}
+           :query    {}
+           :fragment nil}}}}

--- a/docs/specification/conformance/fixtures/routing-multi-frame.edn
+++ b/docs/specification/conformance/fixtures/routing-multi-frame.edn
@@ -1,0 +1,44 @@
+;; Conformance fixture: routing/multi-frame
+;;
+;; Each frame has its own :route slice — the same registered routes can
+;; be navigated independently in two frames. The default frame is
+;; URL-bound; non-default frames update only their own slice.
+;;
+;; Per [012 §Multi-frame routing](../../012-Routing.md#multi-frame-routing).
+
+{:fixture/id           :routing/multi-frame
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler}
+ :fixture/doc          "Two frames navigate the same registered routes independently. Each frame's :route slice carries its own id/params; the registry is shared but the slice is per-frame."
+
+ :fixture/registry
+ {:route
+  {:route/home          {:path "/"}
+   :route/articles      {:path "/articles"}
+   :route/article       {:path   "/articles/:id"
+                         :params [:map [:id :string]]}}}
+
+ :fixture/frames
+ [{:id :tab.left  :doc "Left tab — independent route."}
+  {:id :tab.right :doc "Right tab — independent route."}]
+
+ :fixture/dispatches
+ [;; Left tab navigates to /articles.
+  {:event [:rf/url-changed "/articles"] :frame :tab.left}
+
+  ;; Right tab independently navigates to /articles/intro.
+  {:event [:rf/url-changed "/articles/intro"] :frame :tab.right}
+
+  ;; Left tab navigates again to a different route.
+  {:event [:rf/url-changed "/"] :frame :tab.left}]
+
+ :fixture/expect
+ ;; Slices are partial-matched per :final-app-dbs (submap semantics) so the
+ ;; runtime-allocated :nav-token (per-navigation epoch) is not asserted —
+ ;; the route ids and params are. This isolates the multi-frame property
+ ;; from per-fixture nav-token allocation order.
+ {:final-app-dbs
+  {:tab.left  {:route {:id :route/home :params {} :query {} :fragment nil
+                       :transition :idle :error nil}}
+   :tab.right {:route {:id :route/article :params {:id "intro"} :query {}
+                       :fragment nil :transition :idle :error nil}}}}}

--- a/docs/specification/conformance/fixtures/routing-not-found.edn
+++ b/docs/specification/conformance/fixtures/routing-not-found.edn
@@ -1,0 +1,55 @@
+;; Conformance fixture: routing/not-found
+;;
+;; An unmatched URL routes to :rf.route/not-found via :rf.route/handle-url-change.
+;; The runtime emits :rf.error/no-such-handler with :recovery
+;; :replaced-with-default per the routing context. The not-found route's
+;; :on-match events fire just like any other route.
+;;
+;; Per [012 §Route-not-found](../../012-Routing.md#route-not-found--routenot-found-canonical).
+
+{:fixture/id           :routing/not-found
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/error}
+ :fixture/doc          "An unmatched URL — no path-pattern matches — routes to :rf.route/not-found via :rf.route/handle-url-change. The runtime emits :rf.error/no-such-handler with the URL in :tags. :rf.route/not-found is an ordinary registered route; its :on-match events fire like any other route."
+
+ :fixture/registry
+ {:route
+  {:route/home         {:path "/"}
+   :rf.route/not-found {:path     "/404"
+                        :on-match [[:analytics/log-404]]}}
+
+  :event
+  {:analytics/log-404 {:doc "Logs the 404 hit."}}}
+
+ :fixture/handlers
+ {:event
+  ;; Capture the unmatched URL so we can verify the on-match path runs.
+  {:analytics/log-404 [[:set [:analytics :last-404] true]]}}
+
+ :fixture/dispatches
+ ;; :rf.route/handle-url-change is the runtime's URL-driven entry point —
+ ;; Spec 012 §URL changes are events specifies it routes to
+ ;; :rf.route/not-found on miss. The :rf/url-changed branch only emits the
+ ;; error trace and leaves the slice unchanged.
+ [[:rf.route/handle-url-change "/garbage/path"]]
+
+ :fixture/expect
+ {:final-app-db
+  ;; :transition is implementation-defined here (some runtimes leave
+  ;; :loading after on-match drain; others normalise to :idle). Partial-
+  ;; match — assert the locked fields only.
+  {:route     {:id     :rf.route/not-found
+               :params {:url "/garbage/path"}
+               :query  {}
+               :error  nil}
+   :analytics {:last-404 true}}
+
+  :trace-emissions
+  [;; The runtime emits :rf.error/no-such-handler when match-url returns nil.
+   {:operation :rf.error/no-such-handler
+    :op-type   :error
+    :recovery  :replaced-with-default
+    :tags      {:url "/garbage/path"}}
+
+   ;; The not-found route's :on-match events still fire.
+   {:operation :event :tags {:event-id :analytics/log-404}}]}}

--- a/docs/specification/conformance/fixtures/routing-on-match-fires.edn
+++ b/docs/specification/conformance/fixtures/routing-on-match-fires.edn
@@ -1,0 +1,55 @@
+;; Conformance fixture: routing/on-match-fires
+;;
+;; A route's :on-match events fire — in order — when the route becomes active
+;; via :rf/url-changed (URL-driven navigation) or :rf.route/navigate
+;; (programmatic). Each :on-match dispatches as an ordinary event, so the
+;; events' handlers populate app-db like any other handler would.
+;;
+;; Per [012 §Per-route data loading](../../012-Routing.md#per-route-data-loading).
+
+{:fixture/id           :routing/on-match-fires
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler}
+ :fixture/doc          "When a route declares :on-match [[:e1] [:e2]], navigating to that route dispatches :e1 then :e2 in order. URL-driven (via :rf/url-changed) and programmatic (via :rf.route/navigate) both fire the loaders."
+
+ :fixture/registry
+ {:route
+  {:route/cart {:path     "/cart"
+                :on-match [[:cart/load-items]
+                           [:user/load-prefs]]}}
+
+  :event
+  {:rf/init          {:doc "Seed."}
+   :cart/load-items  {:doc "Load cart items."}
+   :user/load-prefs  {:doc "Load user prefs."}}}
+
+ :fixture/handlers
+ {:event
+  ;; Each loader appends a marker to a vector so we can verify on-match
+  ;; dispatch order. The :rf/init handler seeds an empty vector — `conj`
+  ;; against the default nil produces a list (which prepends), defeating
+  ;; the order check.
+  {:rf/init        [[:set [:load-log] []]]
+   :cart/load-items [[:update [:load-log] [:fn :conj] :cart/load-items]]
+   :user/load-prefs [[:update [:load-log] [:fn :conj] :user/load-prefs]]}}
+
+ :fixture/frame-config {:on-create [:rf/init]}
+
+ :fixture/dispatches
+ ;; URL-driven navigation: :rf/url-changed dispatches the on-match events.
+ [[:rf/url-changed "/cart"]]
+
+ :fixture/expect
+ {:final-app-db
+  {:route    {:id :route/cart :params {} :query {} :fragment nil
+              :transition :idle :error nil}
+   :load-log [:cart/load-items :user/load-prefs]}
+
+  :trace-emissions
+  [;; Token allocated when the route becomes active.
+   {:operation :route.nav-token/allocated
+    :tags      {:route-id :route/cart}}
+
+   ;; The two on-match events fire in declaration order.
+   {:operation :event :tags {:event-id :cart/load-items}}
+   {:operation :event :tags {:event-id :user/load-prefs}}]}}

--- a/docs/specification/conformance/fixtures/routing-on-match-rerun-on-param-change.edn
+++ b/docs/specification/conformance/fixtures/routing-on-match-rerun-on-param-change.edn
@@ -1,0 +1,59 @@
+;; Conformance fixture: routing/on-match-rerun-on-param-change
+;;
+;; Per Spec 012 §Per-route data loading: same-route-id navigations with
+;; CHANGED :params (or :query) re-fire :on-match — the route is becoming
+;; active again under new inputs. Fragment-only changes do NOT re-fire
+;; (covered by `route-fragment-change`); this fixture covers the
+;; opposite case — params change → loaders re-run.
+;;
+;; Per [012 §Per-route data loading](../../012-Routing.md#per-route-data-loading).
+
+{:fixture/id           :routing/on-match-rerun-on-param-change
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler}
+ :fixture/doc          "Navigating to /articles/A then /articles/B (same :route-id, different :params) re-fires :on-match. The loader handler appends the params snapshot to a log so the fixture verifies both navigations dispatched their loaders."
+
+ :fixture/registry
+ {:route
+  {:route/article {:path     "/articles/:id"
+                   :params   [:map [:id :string]]
+                   :on-match [[:article/load]]}}
+
+  :event
+  {:rf/init       {:doc "Seed."}
+   :article/load  {:doc "Loader — re-fires when params change."}}}
+
+ :fixture/handlers
+ {:event
+  ;; Loader appends a marker each time it fires. The conformance runtime
+  ;; emits :event traces with :event-id; the load-count counter and the
+  ;; trace stream together verify the on-match fires twice — once for
+  ;; A, once for B.
+  {:rf/init       [[:set [:load-count] 0]]
+   :article/load  [[:update [:load-count] [:fn :inc]]]}}
+
+ :fixture/frame-config {:on-create [:rf/init]}
+
+ :fixture/dispatches
+ [;; Step 1: Navigate to /articles/A. :article/load fires.
+  [:rf/url-changed "/articles/A"]
+
+  ;; Step 2: Same route-id, different params. The slice changes; :on-match
+  ;; re-fires.
+  [:rf/url-changed "/articles/B"]]
+
+ :fixture/expect
+ {:final-app-db
+  {:route      {:id :route/article :params {:id "B"} :query {} :fragment nil}
+   :load-count 2}                                          ;; A + B
+
+  :trace-emissions
+  [;; First navigation: nav-token allocated, loader fires.
+   {:operation :route.nav-token/allocated
+    :tags      {:route-id :route/article}}
+   {:operation :event :tags {:event-id :article/load}}
+
+   ;; Second navigation: fresh nav-token, loader re-fires.
+   {:operation :route.nav-token/allocated
+    :tags      {:route-id :route/article}}
+   {:operation :event :tags {:event-id :article/load}}]}}

--- a/docs/specification/conformance/fixtures/routing-query-string-coercion.edn
+++ b/docs/specification/conformance/fixtures/routing-query-string-coercion.edn
@@ -1,0 +1,63 @@
+;; Conformance fixture: routing/query-string-coercion
+;;
+;; Spec 012 §Query strings and fragments locks the per-key coercion
+;; cascade: when a route declares a :query Malli :map schema, raw URL
+;; values are coerced into the declared types. The first-pass type set is
+;; :int, :keyword, :boolean. Strings and unknown types pass through.
+;;
+;; Per [012 §Query strings and fragments]
+;; (../../012-Routing.md#query-strings-and-fragments).
+
+{:fixture/id           :routing/query-string-coercion
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url}
+ :fixture/doc          "Per-key coercion of query-string values via the route's :query schema. :int parses to a number, :keyword turns into a keyword, :boolean true/false strings become booleans, :string passes through. :query-defaults populate keys absent from the URL. Optional schema keys without a value also pass through."
+
+ :fixture/registry
+ {:route
+  {:route/articles
+   {:path           "/articles"
+    :query          [:map
+                     [:q :string]
+                     [:page  {:optional true} :int]
+                     [:tag   {:optional true} :keyword]
+                     [:draft? {:optional true} :boolean]]
+    :query-defaults {:page 1}}}}
+
+ :fixture/calls
+ [;; All four coercion shapes at once.
+  {:call :match-url :url "/articles?q=clojure&page=3&tag=lang&draft?=true"
+   :expect {:route-id :route/articles
+            :params   {}
+            :query    {:q "clojure" :page 3 :tag :lang :draft? true}
+            :validation-failed? false}}
+
+  ;; :boolean false coerces from the literal "false".
+  {:call :match-url :url "/articles?q=x&draft?=false"
+   :expect {:route-id :route/articles
+            :params   {}
+            :query    {:q "x" :draft? false :page 1}
+            :validation-failed? false}}
+
+  ;; :query-defaults populate when the key is absent.
+  {:call :match-url :url "/articles?q=y"
+   :expect {:route-id :route/articles
+            :params   {}
+            :query    {:q "y" :page 1}
+            :validation-failed? false}}
+
+  ;; :int over a non-integer string falls back to the raw string (the
+  ;; permissive coerce-query-value behaviour). The fixture documents
+  ;; this rather than requiring a hard validation failure — Spec 010
+  ;; layered validation is an enhancement; the current contract is
+  ;; "pass-through on parse failure".
+  {:call :match-url :url "/articles?q=z&page=not-a-number"
+   :expect {:route-id :route/articles
+            :params   {}
+            :query    {:q "z" :page "not-a-number"}
+            :validation-failed? false}}
+
+  ;; route-url's 3-arity emits the query string in input order.
+  {:call :route-url :route-id :route/articles :params {}
+                    :query {:q "clojure" :page 2}
+   :expect "/articles?q=clojure&page=2"}]}

--- a/docs/specification/conformance/fixtures/routing-redirect-on-match.edn
+++ b/docs/specification/conformance/fixtures/routing-redirect-on-match.edn
@@ -1,0 +1,51 @@
+;; Conformance fixture: routing/redirect-on-match
+;;
+;; A route's :on-match event short-circuits to a different route by
+;; dispatching :rf.route/navigate. This is the pattern Spec 012 §Redirects
+;; and guards canonicalises: redirects are interceptors-or-events that
+;; replace the navigation target rather than a special :redirect-on-match
+;; route-metadata key.
+;;
+;; Per [012 §Redirects and guards](../../012-Routing.md#redirects-and-guards)
+;; and [012 §Per-route data loading](../../012-Routing.md#per-route-data-loading).
+
+{:fixture/id           :routing/redirect-on-match
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx}
+ :fixture/doc          "A legacy URL whose :on-match dispatches :rf.route/navigate to the canonical destination. The :route slice ends on the canonical route. The legacy nav-token is allocated first; the redirect dispatches :rf.route/navigate which replaces the slice."
+
+ :fixture/registry
+ {:route
+  {:route/legacy-cart {:path     "/old/cart"
+                       :on-match [[:rf.route/navigate :route/cart]]}
+   :route/cart        {:path "/cart"}}
+
+  :event
+  {:rf.route/navigate {:doc "Navigate to a registered route."}}
+
+  :fx
+  {:rf.nav/push-url    {:platforms #{:client}}
+   :rf.nav/replace-url {:platforms #{:client}}}}
+
+ :fixture/handlers
+ {:fx {:rf.nav/push-url    [[:noop]]
+       :rf.nav/replace-url [[:noop]]}}
+
+ :fixture/dispatches
+ ;; Visiting /old/cart triggers the legacy route's :on-match, which
+ ;; dispatches :rf.route/navigate to the canonical :route/cart.
+ [[:rf/url-changed "/old/cart"]]
+
+ :fixture/expect
+ ;; Slice ends up on :route/cart (the redirect target). :rf.route/navigate
+ ;; overwrites the slice with the destination's id and params.
+ {:final-app-db
+  {:route {:id :route/cart :params {} :query {} :error nil}}
+
+  :trace-emissions
+  [;; Token allocated for the legacy route (:rf/url-changed branch).
+   {:operation :route.nav-token/allocated
+    :tags      {:route-id :route/legacy-cart}}
+
+   ;; The redirect: :rf.route/navigate fires the canonical destination.
+   {:operation :event :tags {:event-id :rf.route/navigate}}]}}

--- a/implementation/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/test/re_frame/routing_cljs_test.cljs
@@ -1,0 +1,130 @@
+(ns re-frame.routing-cljs-test
+  "CLJS-side routing tests. Verifies the routing pipeline runs under the
+  Reagent reactive substrate and locks the multi-frame routing contract.
+
+  - routing-handle-url-change-cljs       — :rf/url-changed / handle-url-change
+                                           drive the slice under the Reagent
+                                           adapter; subscriptions resolve.
+  - routing-frame-provider-routing-cljs  — multi-frame routing: each frame's
+                                           :route slice is independent, the
+                                           registry is shared, subscriptions
+                                           resolve per-frame.
+
+  Note on test isolation: routing.cljc registers framework events
+  (:rf/url-changed, :rf.route/navigate, etc.) at namespace-load time.
+  CLJS has no runtime `(require :reload)`, so the JVM-side trick of
+  reloading the routing ns to resurrect cleared registrations does not
+  work here. These tests use frame creation (not registrar reset) for
+  isolation: each test creates fresh frames and the framework events
+  remain registered from the initial CLJS load.
+
+  Per Spec 012 §URL changes are events, §Reading the route is a sub,
+  §Multi-frame routing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.routing :as routing]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.reagent :as reagent-adapter]))
+
+(defn install-adapter [test-fn]
+  ;; Ensure the Reagent adapter is installed for derived sub computation.
+  ;; We do NOT call (registrar/clear-all!) here — it would wipe routing's
+  ;; framework events (:rf.route/navigate, :rf/url-changed, ...) which
+  ;; were registered at routing.cljc's ns-load and CLJS cannot re-load
+  ;; namespaces at runtime to restore them.
+  (when-not (adapter/current-adapter)
+    (rf/init! reagent-adapter/adapter))
+  (routing/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each install-adapter)
+
+;; ---- Spec 012 §URL changes are events / §Reading the route is a sub -----
+
+(deftest routing-handle-url-change-cljs
+  (testing ":rf/url-changed drives the slice on CLJS"
+    ;; Per Spec 012 §URL changes are events: the runtime's URL-driven
+    ;; entry point is :rf/url-changed (or :rf.route/handle-url-change for
+    ;; SSR-equivalent code paths). Both write the :route slice from the
+    ;; URL and dispatch :on-match events. Subscriptions over the slice
+    ;; resolve under the Reagent adapter.
+    ;;
+    ;; Test isolation: a fresh frame so prior tests' :route slices don't
+    ;; leak in.
+    (let [f (rf/make-frame {:doc "isolated frame for this test"})]
+      (rf/reg-route :route.cljs/home
+                    {:path "/cljs/home"})
+      (rf/reg-route :route.cljs/article
+                    {:path     "/cljs/articles/:id"
+                     :params   [:map [:id :string]]
+                     :on-match [[:cljs/article-load]]})
+      (rf/reg-event-db :cljs/article-load
+                       (fn [db _] (assoc db :article-loaded? true)))
+      (rf/reg-sub :rf.cljs.route/id
+                  (fn [db _] (get-in db [:route :id])))
+      (rf/reg-sub :rf.cljs.route/params
+                  (fn [db _] (get-in db [:route :params])))
+
+      ;; URL-driven nav. The slice is set; :on-match dispatches.
+      (rf/dispatch-sync [:rf/url-changed "/cljs/articles/intro"] {:frame f})
+      (is (= :route.cljs/article
+             (rf/subscribe-value f [:rf.cljs.route/id]))
+          ":rf.route/id sub resolves under the Reagent adapter")
+      (is (= {:id "intro"}
+             (rf/subscribe-value f [:rf.cljs.route/params]))
+          ":rf.route/params sub resolves under the Reagent adapter")
+      (is (true? (:article-loaded? (rf/get-frame-db f)))
+          ":on-match's [:cljs/article-load] dispatched and ran")
+
+      ;; A second navigation through the same path with new params re-fires.
+      (rf/dispatch-sync [:rf/url-changed "/cljs/articles/welcome"] {:frame f})
+      (is (= {:id "welcome"}
+             (rf/subscribe-value f [:rf.cljs.route/params]))
+          "new params land in the slice on subsequent navigation")
+      (is (some? (get-in (rf/get-frame-db f) [:route :nav-token]))
+          "fresh nav-token allocated on each full navigation"))))
+
+;; ---- Spec 012 §Multi-frame routing ---------------------------------------
+
+(deftest routing-frame-provider-routing-cljs
+  (testing "two frames carry independent :route slices over a shared registry"
+    ;; Per Spec 012 §Multi-frame routing: each frame's :route slice is
+    ;; independent — same registered routes, different active route per
+    ;; frame. Subscriptions resolve per-frame. This is the contract React
+    ;; context-aware routing components rely on (story-variant frames,
+    ;; devcards, per-test fixtures).
+    (rf/reg-route :route.cljs2/home          {:path "/cljs2/"})
+    (rf/reg-route :route.cljs2/articles      {:path "/cljs2/articles"})
+    (rf/reg-route :route.cljs2/article       {:path   "/cljs2/articles/:id"
+                                              :params [:map [:id :string]]})
+    (rf/reg-sub :rf.cljs2/route (fn [db _] (:route db)))
+
+    (let [left  (rf/make-frame {:doc "left tab frame"})
+          right (rf/make-frame {:doc "right tab frame"})]
+
+      ;; Each frame navigates independently.
+      (rf/dispatch-sync [:rf/url-changed "/cljs2/articles"]
+                        {:frame left})
+      (rf/dispatch-sync [:rf/url-changed "/cljs2/articles/intro"]
+                        {:frame right})
+
+      (let [left-route  (rf/subscribe-value left  [:rf.cljs2/route])
+            right-route (rf/subscribe-value right [:rf.cljs2/route])]
+        (is (= :route.cljs2/articles (:id left-route))
+            "left frame's :route is :route.cljs2/articles")
+        (is (= :route.cljs2/article  (:id right-route))
+            "right frame's :route is :route.cljs2/article")
+        (is (= {} (:params left-route))
+            "left frame has no :params (collection route)")
+        (is (= {:id "intro"} (:params right-route))
+            "right frame has the article id"))
+
+      ;; Re-navigate on the left only — right is unaffected.
+      (rf/dispatch-sync [:rf/url-changed "/cljs2/"] {:frame left})
+      (is (= :route.cljs2/home
+             (:id (rf/subscribe-value left [:rf.cljs2/route])))
+          "left re-navigated to :route.cljs2/home")
+      (is (= :route.cljs2/article
+             (:id (rf/subscribe-value right [:rf.cljs2/route])))
+          "right is unaffected by left's navigation"))))

--- a/implementation/test/re_frame/routing_test.clj
+++ b/implementation/test/re_frame/routing_test.clj
@@ -1,0 +1,245 @@
+(ns re-frame.routing-test
+  "JVM smoke tests for re-frame.routing. The conformance fixtures cover
+  the canonical surface (URL ↔ params, fragment, blocking, nav-token);
+  these tests exercise the JVM-pipeline composition end-to-end and
+  pin a few behaviours the conformance DSL doesn't express directly:
+
+  - routing-bootstrap            — reg-route + dispatch :rf.route/navigate
+                                   updates the :route slice end-to-end
+  - routing-pending-nav-protocol — full pause / continue / cancel
+                                   walk-through (the conformance fixtures
+                                   cover continue and cancel separately;
+                                   this one drives the slot's full
+                                   lifecycle from one test)
+  - routing-nav-token-staleness  — two in-flight navigations; only the
+                                   most recent token's result commits
+  - routing-scroll-metadata-preserved — :scroll metadata on a route is
+                                   queryable via handler-meta. The
+                                   :rf.nav/scroll fx is not yet emitted
+                                   by routing.cljc (tracked as rf2-h5el);
+                                   this test pins what IS implemented:
+                                   metadata round-trips through registration.
+  - routing-nested-layout-parent-link — :parent metadata is preserved by
+                                   reg-route so views / handler-meta-driven
+                                   tools can render the layout chain. The
+                                   :rf.route/chain sub is not yet built-in;
+                                   this test asserts the registry-level
+                                   contract.
+
+  Per Spec 012 §URL changes are events, §Navigation blocking — pending-nav
+  protocol, §Navigation tokens — stale-result suppression, §Scroll
+  restoration, §Nested layouts."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  ;; Framework events / fx (routing.cljc, ssr.cljc) are registered at
+  ;; ns-load; clear-all! wiped them. Reload to resurrect.
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  ((requiring-resolve 're-frame.routing/reset-counters!))
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- Spec 012 §Navigation is an event -------------------------------------
+
+(deftest routing-bootstrap
+  (testing "reg-route + dispatch :rf.route/navigate writes the :route slice"
+    ;; Per Spec 012 §Navigation is an event: dispatching :rf.route/navigate
+    ;; with a route-id + params updates :route.{id,params,query,...} and
+    ;; emits a :rf.nav/push-url effect.
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    ;; Capture the URL that lands at :rf.nav/push-url.
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ url] (swap! pushed conj url)))
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "intro"}])
+      (let [slice (:route (rf/get-frame-db :rf/default))]
+        (is (= :route/article (:id slice))
+            "the :route slice carries the navigation target")
+        (is (= {:id "intro"} (:params slice))
+            ":params from the navigate vector landed in the slice")
+        (is (= :idle (:transition slice))
+            "no :on-match → transition stays :idle"))
+      (is (= ["/articles/intro"] @pushed)
+          ":rf.nav/push-url received the unparsed URL"))))
+
+;; ---- Spec 012 §Navigation blocking — pending-nav protocol ----------------
+
+(deftest routing-pending-nav-protocol
+  (testing "block via :can-leave; continue and cancel both clear the slot"
+    ;; Per Spec 012 §Navigation blocking — pending-nav protocol: a route
+    ;; declares :can-leave (sub-id → boolean). When the sub returns false,
+    ;; :rf/url-requested writes :rf/pending-navigation and does not push.
+    ;; :rf.route/continue clears the slot AND completes the navigation.
+    ;; :rf.route/cancel clears the slot WITHOUT navigating.
+    (rf/reg-route :editor/article
+                  {:path      "/editor/articles/:id"
+                   :params    [:map [:id :string]]
+                   :can-leave :editor/can-leave?})
+    (rf/reg-route :route/cart {:path "/cart"})
+
+    (rf/reg-event-db :editor/dirty
+                     (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-sub :editor/can-leave?
+                (fn [db _]
+                  ;; "OK to leave" = NOT dirty.
+                  (not (get-in db [:editor :dirty?]))))
+
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+
+    ;; 1. Land on the editor route. nav-token allocates; slice is set.
+    (rf/dispatch-sync [:rf/url-changed "/editor/articles/A"])
+    (is (= :editor/article (get-in (rf/get-frame-db :rf/default)
+                                   [:route :id]))
+        "initial nav landed on :editor/article")
+
+    ;; 2. Dirty the form so :can-leave? returns false.
+    (rf/dispatch-sync [:editor/dirty true])
+
+    ;; 3. Try to leave. Guard rejects → pending slot is set; URL unchanged.
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart"}])
+    (let [pending (:rf/pending-navigation (rf/get-frame-db :rf/default))]
+      (is (some? pending)
+          ":rf/pending-navigation is populated on guard rejection")
+      (is (= "/cart" (get-in pending [:request :url]))
+          "the requested URL is captured for resume")
+      (is (= :editor/article
+             (get-in (rf/get-frame-db :rf/default) [:route :id]))
+          "the :route slice does NOT change when blocked"))
+
+    ;; 4. CANCEL — slot clears; original route stays active.
+    (rf/dispatch-sync [:rf.route/cancel "pn-1"])
+    (is (nil? (:rf/pending-navigation (rf/get-frame-db :rf/default)))
+        "cancel clears :rf/pending-navigation")
+    (is (= :editor/article
+           (get-in (rf/get-frame-db :rf/default) [:route :id]))
+        "cancel does NOT navigate")
+
+    ;; 5. Now block again — and CONTINUE this time.
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart"}])
+    (is (some? (:rf/pending-navigation (rf/get-frame-db :rf/default)))
+        "second blocked request reseats the slot")
+    (rf/dispatch-sync [:rf.route/continue "pn-2"])
+    (is (nil? (:rf/pending-navigation (rf/get-frame-db :rf/default)))
+        "continue clears :rf/pending-navigation")
+    (is (= :route/cart (get-in (rf/get-frame-db :rf/default) [:route :id]))
+        "continue completes the original navigation")))
+
+;; ---- Spec 012 §Navigation tokens — stale-result suppression --------------
+
+(deftest routing-nav-token-staleness
+  (testing "two in-flight navigations: the older nav-token's result is suppressed"
+    ;; Per Spec 012 §Navigation tokens — stale-result suppression: each
+    ;; navigation allocates a fresh nav-token; async results carry the
+    ;; token captured at request time; when a result arrives whose token
+    ;; mismatches the current slice's :nav-token, the runtime suppresses
+    ;; it and emits :route.nav-token/stale-suppressed.
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-event-db :article/loaded
+                     (fn [db [_ id payload]]
+                       (assoc db :article {:id id :payload payload})))
+
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::nav-token (fn [ev] (swap! traces conj ev)))
+
+      ;; 1. Navigate to /articles/A. nav-token allocates → "nav-1".
+      (rf/dispatch-sync [:rf/url-changed "/articles/A"])
+      (is (= "nav-1" (get-in (rf/get-frame-db :rf/default)
+                             [:route :nav-token]))
+          "first navigation got nav-1")
+
+      ;; 2. Before A's response lands, navigate to /articles/B → "nav-2".
+      (rf/dispatch-sync [:rf/url-changed "/articles/B"])
+      (is (= "nav-2" (get-in (rf/get-frame-db :rf/default)
+                             [:route :nav-token]))
+          "second navigation advanced the epoch to nav-2")
+
+      ;; 3. A's stale response carries "nav-1"; current is "nav-2";
+      ;; the runtime suppresses [:article/loaded "A" "A-payload"].
+      (rf/dispatch-sync [:rf.test/simulate-http-resolution
+                         {:on-success-event   [:article/loaded "A" "A-payload"]
+                          :carried-nav-token  "nav-1"}])
+
+      ;; 4. B's response carries "nav-2"; matches current; commits.
+      (rf/dispatch-sync [:rf.test/simulate-http-resolution
+                         {:on-success-event   [:article/loaded "B" "B-payload"]
+                          :carried-nav-token  "nav-2"}])
+
+      (rf/remove-trace-cb! ::nav-token)
+
+      (is (= {:id "B" :payload "B-payload"}
+             (:article (rf/get-frame-db :rf/default)))
+          "only B's payload committed; A's was suppressed")
+
+      (is (some (fn [ev]
+                  (and (= :route.nav-token/stale-suppressed (:operation ev))
+                       (= "nav-1" (-> ev :tags :carried-token))
+                       (= "nav-2" (-> ev :tags :current-token))
+                       (= :article/loaded (-> ev :tags :event-id))))
+                @traces)
+          "expected :route.nav-token/stale-suppressed trace for the A response"))))
+
+;; ---- Spec 012 §Scroll restoration -----------------------------------------
+
+(deftest routing-scroll-metadata-preserved
+  (testing "the :scroll metadata key is enumerable via handler-meta"
+    ;; Per Spec 012 §Scroll restoration: a route may declare a :scroll
+    ;; strategy (:top / :restore / :preserve / map). The runtime is meant
+    ;; to emit a :rf.nav/scroll fx on navigation per the resolved strategy
+    ;; (filed as rf2-h5el). Until that lands, this test pins the
+    ;; baseline contract that conforming reads MUST satisfy: the :scroll
+    ;; key on registration round-trips through reg-route's metadata so
+    ;; tooling and future fx-emitting code can read it.
+    (rf/reg-route :route/home
+                  {:path   "/"
+                   :scroll :top})
+    (rf/reg-route :route/article
+                  {:path   "/articles/:id"
+                   :params [:map [:id :string]]
+                   :scroll :restore})
+    (let [home-meta    (rf/handler-meta :route :route/home)
+          article-meta (rf/handler-meta :route :route/article)]
+      (is (= :top (:scroll home-meta))
+          ":scroll metadata is preserved as-declared")
+      (is (= :restore (:scroll article-meta))
+          ":scroll metadata is preserved per-route"))))
+
+;; ---- Spec 012 §Nested layouts ---------------------------------------------
+
+(deftest routing-nested-layout-parent-link
+  (testing ":parent metadata round-trips through reg-route"
+    ;; Per Spec 012 §Nested layouts: a child route declares :parent
+    ;; <route-id> so views can render the layout chain. The :rf.route/chain
+    ;; sub is the runtime's enumeration entry point but is not yet
+    ;; framework-registered; the registry-level contract — :parent is
+    ;; enumerable via handler-meta — IS implemented and is what tooling
+    ;; queries. This test pins that registry-level contract.
+    (rf/reg-route :route/account             {:path "/account"})
+    (rf/reg-route :route/account.settings    {:path   "/account/settings"
+                                              :parent :route/account})
+    (rf/reg-route :route/account.billing     {:path   "/account/billing"
+                                              :parent :route/account})
+    (let [settings-meta (rf/handler-meta :route :route/account.settings)
+          billing-meta  (rf/handler-meta :route :route/account.billing)
+          account-meta  (rf/handler-meta :route :route/account)]
+      (is (= :route/account (:parent settings-meta))
+          ":route/account.settings carries :parent :route/account")
+      (is (= :route/account (:parent billing-meta))
+          ":route/account.billing carries :parent :route/account")
+      (is (nil? (:parent account-meta))
+          "the parent route itself has no :parent (chain root)"))))


### PR DESCRIPTION
## Summary

Audits Spec 012's surface and gap-fills routing coverage at three levels.

### Conformance fixtures (8 new in `docs/specification/conformance/fixtures/`)

- `routing-on-match-fires.edn` — `:on-match` events fire in declaration order on URL-driven navigation.
- `routing-on-match-rerun-on-param-change.edn` — same route id with changed params re-fires `:on-match` (the inverse of `route-fragment-change`'s no-rerun rule).
- `routing-not-found.edn` — unmatched URL routes to `:rf.route/not-found` via `:rf.route/handle-url-change`; `:rf.error/no-such-handler` trace fires; the not-found route's `:on-match` runs.
- `routing-redirect-on-match.edn` — a route's `:on-match` short-circuits to a different route via `:rf.route/navigate` (the spec's interceptor/event redirect pattern).
- `routing-can-leave-blocks.edn` — `:can-leave` guard blocks navigation; the cancel branch (complementing the existing `route-navigation-blocked.edn` continue branch) clears `:rf/pending-navigation` without navigating.
- `routing-query-string-coercion.edn` — per-key coercion of query strings: `:int`, `:keyword`, `:boolean`, `:string`; `:query-defaults` populate absent keys; pass-through on parse failure.
- `routing-fragment-as-slice.edn` — `:fragment` slot lifecycle: seeded on initial nav, updated on fragment-only changes, cleared to nil when next URL has no fragment.
- `routing-multi-frame.edn` — two frames navigate the same registered routes independently with per-frame `:route` slices.

### JVM smoke tests (5 new in `implementation/test/re_frame/routing_test.clj`)

- `routing-bootstrap` — `reg-route` + `:rf.route/navigate` end-to-end; verifies `:rf.nav/push-url` fires with the unparsed URL.
- `routing-pending-nav-protocol` — full block / cancel / re-block / continue walk-through; pins both branches in one test.
- `routing-nav-token-staleness` — two in-flight navs; the older nav-token's response is suppressed, B's commits.
- `routing-scroll-metadata-preserved` — `:scroll` route metadata round-trips through `reg-route` (the registry contract; the `:rf.nav/scroll` fx emission is not yet implemented — filed as rf2-h5el).
- `routing-nested-layout-parent-link` — `:parent` metadata is preserved by `reg-route` so layout-chain tooling can enumerate it (the registry-level contract from Spec 012 §Nested layouts).

### CLJS tests (2 new in `implementation/test/re_frame/routing_cljs_test.cljs`)

- `routing-handle-url-change-cljs` — `:rf/url-changed` drives the slice under the Reagent adapter; subscriptions resolve; `:on-match` dispatches; same-route param change re-fires the loader and allocates a fresh nav-token.
- `routing-frame-provider-routing-cljs` — multi-frame routing under the Reagent adapter; per-frame `:route` slices; subscriptions resolve per-frame; per-frame navigations are independent.

### DSL / impl gaps surfaced

Two of the fixtures the bead listed moved into JVM smoke tests instead of conformance fixtures because the conformance DSL has no operator for asserting registry metadata directly:

- `routing-scroll-restoration` → `routing-scroll-metadata-preserved` JVM test. The runtime does not yet emit `:rf.nav/scroll` on navigation; tracked as **rf2-h5el** (filed during this work).
- `routing-nested-layout` → `routing-nested-layout-parent-link` JVM test. The `:rf.route/chain` sub is not yet framework-registered; the registry-level `:parent` contract is the implemented surface.

## Verification

- `cd implementation && clojure -M:test` — **39 tests / 117 assertions / 0 failures** (baseline 34 / 95). All 51 conformance fixtures pass, including the 8 new ones.
- `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — **21 tests / 52 assertions / 0 failures** (baseline 19 / 41).

## Test plan

- [x] `clojure -M:test` green
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` green
- [x] No modifications to `routing.cljc`, `smoke_test.clj`, or `runtime_cljs_test.cljs`
- [x] Each new fixture / test cites the relevant Spec 012 section
- [x] Impl gap (missing `:rf.nav/scroll` fx) filed as rf2-h5el rather than worked around in code