### PR TITLE
ci: shadow-cljs :browser-test + Playwright runner (rf2-zoem)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,50 @@ jobs:
         run: |
           npx shadow-cljs compile node-test
           node out/node-test.js
+
+  cljs-browser:
+    name: CLJS (shadow-cljs :browser-test, headless Chromium)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-browser-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-browser-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      - name: Compile :browser-test, serve, and run Playwright runner
+        run: npm run test:browser

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -107,11 +107,26 @@ npx shadow-cljs compile node-test && node out/node-test.js
 The shadow-cljs config builds an `:node-test` target that runs
 `cljs.test` under Node, exercising the Reagent adapter end-to-end.
 
+**CLJS in a real browser** (headless Chromium via Playwright):
+
+```sh
+cd implementation
+npm install
+npx playwright install chromium    # one-time, ~120 MB download
+npm run test:browser
+```
+
+This builds the `:browser-test` target into `out/browser-test/`,
+serves it on `http://localhost:8021` via `http-server`, then drives
+headless Chromium to the runner page and parses the `cljs.test`
+summary (`Ran N tests containing M assertions.`). Exits 0 on green,
+1 on red. The same test namespaces (`*_cljs_test.cljs`) are picked
+up under both `:node-test` and `:browser-test`, so the assertion
+counts should match. Use this build when verifying anything that
+depends on a real DOM, real browser timing, or React's
+DOM-rendering pipeline.
+
 ## What's not in scope
 
 - The migration agent (re-frame v1 → v2). That's a separate
   AI-driven task per `../docs/specification/MIGRATION.md`.
-- Browser-mounted CLJS tests (e.g. for `frame-provider` /
-  React-context resolution). The `:node-test` build covers all
-  non-DOM behaviour; verifying the React context bridge needs a
-  browser harness.

--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -8,9 +8,27 @@
       "name": "re-frame-2-tests",
       "version": "0.0.0-SNAPSHOT",
       "devDependencies": {
+        "http-server": "14.1.1",
+        "playwright": "1.59.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "shadow-cljs": "2.28.20"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/asn1.js": {
@@ -60,6 +78,13 @@
         "inherits": "2.0.3"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -95,6 +120,26 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bn.js": {
@@ -273,6 +318,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
@@ -287,6 +349,26 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -307,6 +389,16 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -380,6 +472,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/define-data-property": {
@@ -530,6 +640,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -551,6 +668,27 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -565,6 +703,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -627,6 +780,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -709,6 +872,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -721,12 +894,81 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -862,6 +1104,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -873,6 +1128,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -952,6 +1224,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -1006,6 +1288,52 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -1180,6 +1508,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ripemd160": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
@@ -1231,6 +1566,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1240,6 +1582,13 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -1446,6 +1795,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -1510,6 +1872,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/url": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
@@ -1523,6 +1897,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -1554,6 +1935,20 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "1.3.1",

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -6,9 +6,12 @@
   "devDependencies": {
     "shadow-cljs": "2.28.20",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "playwright": "1.59.1",
+    "http-server": "14.1.1"
   },
   "scripts": {
-    "test:cljs": "shadow-cljs compile node-test && node out/node-test.js"
+    "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
+    "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs"
   }
 }

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/*
+ * Playwright runner for the shadow-cljs :browser-test build.
+ *
+ * Launches headless Chromium, navigates to the static-server URL serving
+ * out/browser-test/index.html (the page that shadow-cljs's :browser-test
+ * target generates with shadow.test.browser as the runner-ns), waits for
+ * cljs.test to finish, parses the summary, and exits 0 on green / 1 on red.
+ *
+ * Done-signal strategy: shadow.test.browser's default reporter writes the
+ * cljs.test :summary report via `console.log` (default cljs.test prints
+ * to *out*, which under the browser is the console). It does NOT render
+ * results to the DOM body and does NOT set a window flag. We therefore
+ * tap `page.on('console', ...)` and watch the captured stream for the
+ * summary line. The DOM is also scraped as a belt-and-braces fallback
+ * in case a custom reporter is wired up later, and `window.shadow$cljs_test_done`
+ * is checked first in case a runner-ns sets it.
+ *
+ * Summary line format (cljs.test default reporter):
+ *   "Ran N tests containing M assertions."
+ *   "P failures, Q errors."
+ */
+
+const { chromium } = require('playwright');
+
+const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
+const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || '120000', 10);
+const POLL_MS = 200;
+
+const RAN_RE = /Ran\s+(\d+)\s+tests?\s+containing\s+(\d+)\s+assertions?\./;
+const FAIL_RE = /(\d+)\s+failures?,\s*(\d+)\s+errors?\.?/;
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Capture every console line so we can scan for the cljs.test summary.
+  const consoleLines = [];
+  page.on('console', (msg) => {
+    const text = msg.text();
+    consoleLines.push(text);
+    console.log(`[browser:${msg.type()}] ${text}`);
+  });
+  page.on('pageerror', (err) => {
+    console.error(`[browser:pageerror] ${err.message}`);
+  });
+
+  console.log(`Navigating to ${URL} ...`);
+  await page.goto(URL, { waitUntil: 'load' });
+
+  // Look for the cljs.test summary in one of three places, in order of preference:
+  //   1. window.shadow$cljs_test_done   (custom hook a future runner may set)
+  //   2. console output                 (the default place shadow.test.browser logs)
+  //   3. document.body.innerText        (custom DOM reporter, if any)
+  const start = Date.now();
+  let ran = null;
+  let failErr = null;
+  let source = null;
+
+  const findInText = (text) => {
+    const r = text && text.match(RAN_RE);
+    const f = text && text.match(FAIL_RE);
+    return r && f ? { ran: r[0], failErr: f[0] } : null;
+  };
+
+  while (Date.now() - start < TIMEOUT_MS) {
+    // 1. window flag
+    const winPayload = await page.evaluate(() => {
+      return (typeof window !== 'undefined' && window.shadow$cljs_test_done) || null;
+    });
+    if (winPayload) {
+      const hit = findInText(typeof winPayload === 'string' ? winPayload : JSON.stringify(winPayload));
+      if (hit) { ran = hit.ran; failErr = hit.failErr; source = 'window.shadow$cljs_test_done'; break; }
+    }
+
+    // 2. console buffer
+    const consoleBlob = consoleLines.join('\n');
+    const hit = findInText(consoleBlob);
+    if (hit) { ran = hit.ran; failErr = hit.failErr; source = 'browser console'; break; }
+
+    // 3. DOM body
+    const bodyText = await page.evaluate(() => (document.body ? document.body.innerText : ''));
+    const hit3 = findInText(bodyText);
+    if (hit3) { ran = hit3.ran; failErr = hit3.failErr; source = 'document.body'; break; }
+
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+
+  if (!ran || !failErr) {
+    console.error(`Timed out after ${TIMEOUT_MS}ms waiting for cljs.test summary.`);
+    await browser.close();
+    process.exit(1);
+  }
+
+  console.log('--- cljs.test summary ---');
+  console.log(`(source: ${source})`);
+  console.log(ran);
+  console.log(failErr);
+  console.log('-------------------------');
+
+  const fm = failErr.match(FAIL_RE);
+  let exitCode = 0;
+  if (fm) {
+    const failures = parseInt(fm[1], 10);
+    const errors = parseInt(fm[2], 10);
+    if (failures > 0 || errors > 0) exitCode = 1;
+  } else {
+    console.error('Could not parse failures/errors counts; failing the run.');
+    exitCode = 1;
+  }
+
+  await browser.close();
+  process.exit(exitCode);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -11,14 +11,36 @@
  */
 
 const { spawn } = require('child_process');
+const fs = require('fs');
 const http = require('http');
 const path = require('path');
 
 const PORT = 8021;
 const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test');
+const INDEX = path.join(ROOT, 'index.html');
 const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
 const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
+
+// shadow-cljs's :browser-test target generates an index.html with an empty
+// <body>. Some example namespaces (e.g. examples/nine_states/core.cljs) do
+// `(rdc/create-root (js/document.getElementById "app"))` at namespace-load
+// time. Without an `#app` element, React 18 throws and aborts the test
+// runner before the cljs.test summary is printed. Patch the generated
+// index.html to include a hidden mount point. Idempotent.
+function ensureMountPoint() {
+  if (!fs.existsSync(INDEX)) return;
+  const html = fs.readFileSync(INDEX, 'utf8');
+  if (html.includes('id="app"')) return;
+  const patched = html.replace(
+    '<body>',
+    '<body><div id="app" style="display:none"></div>'
+  );
+  if (patched !== html) {
+    fs.writeFileSync(INDEX, patched, 'utf8');
+    console.log(`Patched ${INDEX} with <div id="app"> mount point.`);
+  }
+}
 
 function probe(port) {
   return new Promise((resolve) => {
@@ -43,6 +65,7 @@ async function waitForReady(port, deadline) {
 }
 
 (async () => {
+  ensureMountPoint();
   const isWin = process.platform === 'win32';
   // On Windows, npx is a .cmd shim — must go through the shell.
   const httpServerCmd = isWin ? 'npx.cmd' : 'npx';

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/*
+ * Orchestrator: spawn http-server over out/browser-test on port 8021,
+ * wait for it to be reachable, then run the Playwright runner.
+ * Always tear the server down (success or failure).
+ *
+ * Why this wrapper exists: the bead suggested a shell one-liner of
+ * `http-server ... & sleep 2 && node ...`. That works on POSIX but not
+ * on Windows, and `sleep 2` is a brittle race. This script is the same
+ * idea but cross-platform and with a real readiness probe.
+ */
+
+const { spawn } = require('child_process');
+const http = require('http');
+const path = require('path');
+
+const PORT = 8021;
+const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test');
+const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
+const READY_TIMEOUT_MS = 30000;
+const POLL_MS = 200;
+
+function probe(port) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: '127.0.0.1', port, path: '/', timeout: 1000 }, (res) => {
+      res.resume();
+      resolve(res.statusCode != null);
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForReady(port, deadline) {
+  while (Date.now() < deadline) {
+    if (await probe(port)) return true;
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  return false;
+}
+
+(async () => {
+  const isWin = process.platform === 'win32';
+  // On Windows, npx is a .cmd shim — must go through the shell.
+  const httpServerCmd = isWin ? 'npx.cmd' : 'npx';
+  const args = ['http-server', ROOT, '-p', String(PORT), '-s', '-c-1'];
+  const server = spawn(httpServerCmd, args, {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: isWin,
+  });
+
+  let serverDown = false;
+  server.on('exit', (code, signal) => {
+    serverDown = true;
+    if (code !== 0 && code !== null) {
+      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  if (!ready || serverDown) {
+    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+    if (!serverDown) server.kill();
+    process.exit(1);
+  }
+
+  const runner = spawn(process.execPath, [RUNNER], {
+    stdio: 'inherit',
+    env: { ...process.env, BROWSER_TEST_URL: `http://127.0.0.1:${PORT}` },
+  });
+
+  const code = await new Promise((resolve) => runner.on('exit', resolve));
+
+  if (!serverDown) {
+    server.kill();
+  }
+  process.exit(code == null ? 1 : code);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -7,4 +7,12 @@
   {:target    :node-test
    :output-to "out/node-test.js"
    :ns-regexp "cljs-test$"
-   :compiler-options {:warnings {:redef false}}}}}
+   :compiler-options {:warnings {:redef false}}}
+
+  :browser-test
+  {:target    :browser-test
+   :ns-regexp "-cljs-test$"
+   :test-dir  "out/browser-test"
+   :runner-ns shadow.test.browser
+   :devtools  {:http-port 8021
+               :http-root "out/browser-test"}}}}


### PR DESCRIPTION
## Summary

- Adds a `:browser-test` shadow-cljs target and a Playwright runner so the existing CLJS test namespaces also run under real headless Chromium, alongside the current `:node-test` Node-based job.
- Adds a `cljs-browser` GitHub Actions job that mirrors the existing `cljs` (Node) job's setup (JDK 17 + Node 20 + Clojure CLI + cache), installs Chromium with `npx playwright install --with-deps chromium`, then runs `npm run test:browser`. Action SHAs reused from the existing workflow per the org's pinning policy.
- Adds a small Node orchestrator (`scripts/serve-and-run-browser-tests.cjs`) that spawns `http-server` over `out/browser-test`, probes for readiness, then runs the Playwright runner. Cross-platform replacement for the POSIX-only `http-server ... & sleep 2 && node ...` shell idiom suggested in the bead.
- The orchestrator also injects a hidden `<div id="app">` mount point into the auto-generated `index.html`, so example namespaces that call `(rdc/create-root (.getElementById js/document "app"))` at namespace-load time don't abort the test runner before `cljs.test` finishes.
- Closes rf2-zoem; this is the concrete implementation for rf2-443l (browser-test infrastructure). Karma is deprecated upstream (Angular team, 2023); Playwright is the actively-maintained, multi-browser alternative.

## Notes

- **Branch ruleset on `main` intentionally NOT updated.** The new `cljs-browser` check is in addition to `jvm` and `cljs`, not instead of either. Add `cljs-browser` to required checks once the new job is observed stable.
- **Done-signal strategy:** `shadow.test.browser`'s default reporter writes the cljs.test summary to `console.log` (cljs.test's default `*print-fn*`), not to the DOM and not to a `window` flag. The Playwright runner therefore taps `page.on('console', ...)` and scans the captured stream for `Ran N tests containing M assertions.` / `P failures, Q errors.`. As a belt-and-braces fallback it also checks `window.shadow$cljs_test_done` (in case a future runner-ns sets it) and `document.body.innerText` (in case a custom DOM reporter is added). The runner script documents this choice in its header.
- The same `*_cljs_test.cljs` namespaces are picked up under both `:node-test` (`ns-regexp "cljs-test$"`) and `:browser-test` (`ns-regexp "-cljs-test$"`).
- **Known follow-up filed as `rf2-9tx3`:** locally, the runner times out after `runtime_cljs_test/reg-view-macro-double-def-investigation`. The most likely culprit is `nine_states_cljs_test`'s use of bare `clojure.core/assert` from inside a `with-frame` body — under Reagent + real-browser scheduling the throw propagates through a microtask in a way that doesn't happen under Node. CI on Linux may behave differently; this PR adds the harness, the test fix is a separate bead.

## Test plan

- [ ] CI: the new `cljs-browser` job behaves consistently with the local `node-test` failure pattern (or surfaces the rf2-9tx3 hang, in which case fix that bead next).
- [ ] CI: existing `jvm` and `cljs` jobs still behave as before (`jvm` green, `cljs` red on pre-existing failures).
- [ ] Local: `cd implementation && npm install && npx playwright install chromium && npm run test:browser` produces an output stream that includes the cljs.test summary line (or, until rf2-9tx3 is fixed, surfaces the hang clearly with logs of the tests that did run).
- [ ] Once `cljs-browser` is observed stable in CI, add it to the `main` branch ruleset's required checks.