### PR TITLE
fix: clear-flow handles single-element :path (rf2-aqt7)

### DIFF
--- a/implementation/src/re_frame/flows.cljc
+++ b/implementation/src/re_frame/flows.cljc
@@ -149,9 +149,20 @@
        (let [path (:path flow)]
          (when-let [container (frame/get-frame-db frame-id)]
            (let [cur    (adapter/read-container container)
-                 new-db (if (and (vector? path) (seq path))
-                          (update-in cur (vec (butlast path)) dissoc (last path))
-                          (dissoc cur path))]
+                 ;; rf2-aqt7: when :path is a single-element vector [:k],
+                 ;; (butlast [:k]) is () and (update-in cur [] dissoc :k)
+                 ;; does NOT dissoc — Clojure's update-in on the empty
+                 ;; path falls into (assoc {} nil (apply f val args)),
+                 ;; producing {... nil nil}. Special-case length 1 so
+                 ;; the leaf is dissoc'd directly.
+                 new-db (cond
+                          (not (vector? path))         (dissoc cur path)
+                          (empty? path)                cur
+                          (= 1 (count path))           (dissoc cur (first path))
+                          :else                        (update-in cur
+                                                                  (vec (butlast path))
+                                                                  dissoc
+                                                                  (last path)))]
              (adapter/replace-container! container new-db)))
          (swap! flows update frame-id dissoc id)
          (swap! last-inputs dissoc [frame-id id])

--- a/implementation/test/re_frame/flows_test.clj
+++ b/implementation/test/re_frame/flows_test.clj
@@ -86,6 +86,28 @@
   (testing "calling clear-flow on an unknown id is a no-op (does not throw)"
     (rf/clear-flow :no-such-flow)))
 
+(deftest clear-flow-handles-single-element-path
+  (testing "rf2-aqt7: clear-flow with a single-element :path dissocs the top-level key"
+    ;; The repro from rf2-aqt7: a flow whose :path is a one-element vector
+    ;; [:area]. Before the fix, clear-flow's (update-in cur [] dissoc :area)
+    ;; left :area in app-db (and silently introduced an {nil nil} entry).
+    (rf/reg-event-db :seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:area]})
+    (rf/dispatch-sync [:seed])
+    (is (= 12 (get (rf/get-frame-db :rf/default) :area))
+        "flow ran on the drain after :seed and materialised :area")
+    (rf/clear-flow :area)
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (not (contains? db :area))
+          "single-element :path is dissoc'd cleanly")
+      (is (not (contains? db nil))
+          "no spurious {nil nil} entry from update-in on empty path")
+      (is (= {:w 3 :h 4} db)
+          "siblings of the cleared key are untouched"))))
+
 (deftest reg-flow-validates-required-keys
   (testing "missing :id throws"
     (is (thrown? Throwable


### PR DESCRIPTION
## Summary

- Fixes **rf2-aqt7** (P1): `clear-flow` left a flow's output key in app-db when the flow's `:path` was a single-element vector like `[:k]`.
- Root cause: `(update-in cur [] dissoc :k)` does not dissoc — Clojure's `update-in` with an empty path falls into `(assoc {} nil (apply f val args))`, producing `{:k 12, ... nil nil}` instead of removing `:k`.
- Special-cases `(count path) == 1` to `(dissoc cur (first path))`. Deeper paths still go through `update-in` with `butlast`, so the public contract is unchanged.

## Test plan

- [x] Added `clear-flow-handles-single-element-path` smoke test in `implementation/test/re_frame/flows_test.clj` reproducing the rf2-aqt7 scenario (`:path [:area]`, dispatch a seed event, `clear-flow`, assert `:area` removed and no spurious `nil` entry).
- [x] `cd implementation && clojure -M:test` — 79 tests, 396 assertions, 0 failures, 0 errors.
- [x] Existing `clear-flow-removes-from-registry-and-vacates-output-slot` (which exercises a two-element `:path`) still passes — confirms the deeper-path branch was not regressed.