### PR TITLE
test infra: claim :flow/* capabilities + reset last-inputs (rf2-y3bo, rf2-xsfj)

### DIFF
--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -47,7 +47,15 @@
     :routing/blocking
     :routing/nav-token
     :actor/spawn
-    :actor/invoke})
+    :actor/invoke
+    ;; Flow capabilities — per Spec 013. The flow-*.edn fixtures
+    ;; (recompute-on-input-change, multi-input-topo, noop-on-value-equal-
+    ;; input, toggle-via-fx, hot-reload-preserves-output) declare these.
+    :flow/basic
+    :flow/topo
+    :flow/dirty-check
+    :flow/toggle
+    :flow/hot-reload})
 
 ;; ---- fixture loader -------------------------------------------------------
 

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -15,6 +15,14 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  ;; flows.cljc keeps a private last-inputs atom for dirty-checking
+  ;; (per Spec 013 §Dirty-check semantics). Without resetting it, an
+  ;; entry from a prior deftest can leak into a subsequent same-keyed
+  ;; flow registration and cause its first evaluation to no-op (the
+  ;; new-inputs would =-equal the stale last-inputs). Clear it here so
+  ;; cross-test order can't introduce hidden flakiness. See rf2-xsfj.
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
   (rf/init!)
   ;; Framework events / fx / subs are registered at namespace-load time
   ;; in routing.cljc, ssr.cljc, and machines.cljc; clear-all! wiped them.


### PR DESCRIPTION
## Summary

Two test-infrastructure fixes that surface and stabilise existing flow coverage:

- **rf2-y3bo** - Conformance runner's `claimed-capabilities` set didn't include `:flow/*`, so the 5 flow-*.edn fixtures from PR #10 were loaded but reported as not-exercised. Add `:flow/basic`, `:flow/topo`, `:flow/dirty-check`, `:flow/toggle`, `:flow/hot-reload` (the names the fixtures actually declare in their `:fixture/capabilities` sets) so the runner exercises them.
- **rf2-xsfj** - smoke_test.clj's `reset-runtime` fixture cleared the flows registry but left `re-frame.flows/last-inputs` (private dirty-check atom) untouched, so a stale entry from one deftest could cause a same-keyed flow's first evaluation to no-op in the next deftest. Mirror the reset already present in flows_test.clj.

## Behaviour change

Conformance summary:

|                              | before | after |
| ---------------------------- | ------ | ----- |
| total fixtures               | 65     | 65    |
| runnable                     | 57     | 62    |
| passed                       | 57     | 57    |
| failed                       | 0      | 5     |
| skipped                      | 8      | 3     |

The 5 newly-runnable flow fixtures all fail - the conformance harness's flow-realisation path appears not to wire flows from `:fixture/registry` / `:fixture/handlers` into the runtime. Tracked under follow-up **rf2-wdhi**. This PR is test-infrastructure only and does NOT change `flows.cljc`; the impl bug surfaced is for a separate PR.

`clojure -M:test` overall: 79 tests / 396 assertions / 0 failures (the conformance test asserts only `(pos? (count passed))`).

## Test plan

- [x] `cd implementation && clojure -M:test` - green
- [x] Confirmed 5 flow fixtures move from `Skipped (out-of-claim)` to `Failures` block
- [x] Smoke tests (`re-frame.smoke-test`) pass with the new last-inputs reset in place
- [x] Filed rf2-wdhi for the impl bugs the now-runnable flow fixtures expose