### PR TITLE
test: drain semantics coverage (rf2-yqpg)

### DIFF
--- a/implementation/test/re_frame/drain_test.clj
+++ b/implementation/test/re_frame/drain_test.clj
@@ -1,0 +1,301 @@
+(ns re-frame.drain-test
+  "Targeted coverage for Spec 002 §Run-to-completion dispatch (drain
+  semantics). The login-machine-flow and dispatch-sync-in-handler-errors
+  smoke tests exercise these paths transitively; this namespace pins the
+  load-bearing properties directly so a future regression in router.cljc
+  surfaces here, not from a far-away cascade test.
+
+  Each deftest's docstring cites the specific Spec 002 anchor."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- 1. run-to-completion -------------------------------------------------
+
+(deftest run-to-completion-handler-finishes-before-next-event
+  ;; Spec 002 §Run-to-completion dispatch (drain semantics) §Rules rule 2:
+  ;; \"Every actor message sent during a domain-event's processing drains
+  ;; before the next domain event for that frame.\" Once drain is engaged,
+  ;; no further external events are processed for that frame until the
+  ;; cascade settles. The :fx [[:dispatch ...]] form is the in-handler
+  ;; primitive (Spec 002 §Run-to-completion: \"the in-handler shape is
+  ;; [[:dispatch event]] under :fx\")."
+  (testing "events queued during a handler run only AFTER that handler returns"
+    (let [order (atom [])]
+      ;; :outer pushes :outer-pre into the trace, dispatches :inner via :fx,
+      ;; then pushes :outer-post BEFORE the inner handler can run. Run-to-
+      ;; completion guarantees the outer handler completes (both pre and
+      ;; post entries land) before :inner is dequeued.
+      (rf/reg-event-fx :outer
+        (fn [_ _]
+          (swap! order conj :outer-pre)
+          ;; Returning :fx with a :dispatch — the inner event is appended
+          ;; to the back of the queue. It must NOT execute before this
+          ;; handler returns.
+          (let [fx-result {:fx [[:dispatch [:inner]]]}]
+            (swap! order conj :outer-post)
+            fx-result)))
+      (rf/reg-event-fx :inner
+        (fn [_ _]
+          (swap! order conj :inner)
+          {}))
+      (rf/dispatch-sync [:outer])
+      (is (= [:outer-pre :outer-post :inner] @order)
+          "the outer handler ran to completion before :inner was processed")))
+
+  (testing "deeper chain — every outer's :fx :dispatch waits for the outer to return"
+    (let [order (atom [])]
+      (rf/reg-event-fx :a
+        (fn [_ _]
+          (swap! order conj :a-start)
+          (let [r {:fx [[:dispatch [:b]]]}]
+            (swap! order conj :a-end)
+            r)))
+      (rf/reg-event-fx :b
+        (fn [_ _]
+          (swap! order conj :b-start)
+          (let [r {:fx [[:dispatch [:c]]]}]
+            (swap! order conj :b-end)
+            r)))
+      (rf/reg-event-fx :c
+        (fn [_ _]
+          (swap! order conj :c)
+          {}))
+      (rf/dispatch-sync [:a])
+      (is (= [:a-start :a-end :b-start :b-end :c] @order)
+          "no handler interleaves; each runs end-to-end before the next starts"))))
+
+;; ---- 2. drain depth limit -------------------------------------------------
+
+(deftest drain-depth-limit-aborts-with-structured-error
+  ;; Spec 002 §Run-to-completion dispatch §Rules rule 3:
+  ;; \"Depth-limited (dynamic). The drain enforces a configurable depth
+  ;; limit (:drain-depth). When exceeded, drain aborts with a machine-
+  ;; readable error: {:reason :drain-depth-exceeded :frame :auth :event
+  ;; [...] :depth N}. The limit is per-frame and runtime-overridable.\"
+  ;; The router halts the loop and clears the queue when the bound is hit;
+  ;; see implementation/src/re_frame/router.cljc."
+  (testing "a self-redispatching handler trips :rf.error/drain-depth-exceeded"
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::depth (fn [ev] (swap! traces conj ev)))
+      ;; Reg a frame with a small drain-depth so the test runs quickly.
+      (rf/reg-frame :drain.test/loop {:drain-depth 8})
+      (rf/reg-event-fx :loop-forever
+        (fn [_ _]
+          {:fx [[:dispatch [:loop-forever]]]}))
+      (rf/dispatch-sync [:loop-forever] {:frame :drain.test/loop})
+      (rf/remove-trace-cb! ::depth)
+      (let [hit (some (fn [ev]
+                        (when (= :rf.error/drain-depth-exceeded
+                                 (:operation ev))
+                          ev))
+                      @traces)]
+        (is (some? hit)
+            "expected :rf.error/drain-depth-exceeded trace event")
+        (when hit
+          (let [tags (:tags hit)]
+            (is (number? (:depth tags))
+                ":depth tag is a number")
+            (is (= :drain.test/loop (:frame tags))
+                ":frame tag identifies the offending frame")
+            (is (vector? (:last-event tags))
+                ":last-event tag carries the most-recently-dequeued event")
+            (is (= [:loop-forever] (:last-event tags))
+                ":last-event is the recursive event that drove the cascade"))))))
+
+  (testing "after the abort the queue is cleared (no stuck pending work)"
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::depth-2 (fn [ev] (swap! traces conj ev)))
+      (rf/reg-frame :drain.test/loop2 {:drain-depth 4})
+      (rf/reg-event-fx :loop2
+        (fn [_ _]
+          {:fx [[:dispatch [:loop2]]]}))
+      (rf/dispatch-sync [:loop2] {:frame :drain.test/loop2})
+      (rf/remove-trace-cb! ::depth-2)
+      (let [router (:router (frame/frame :drain.test/loop2))]
+        (is (zero? (count (:queue @router)))
+            "the router queue is drained empty after the depth-exceeded abort")
+        (is (false? (:scheduled? @router))
+            ":scheduled? is reset so future dispatches re-engage drain")))))
+
+;; ---- 3. dispatch-sync-in-handler ------------------------------------------
+
+(deftest dispatch-sync-in-handler-jvm
+  ;; Spec 002 §Run-to-completion §Render boundaries:
+  ;; \":dispatch-sync means 'skip the router queue when called from outside
+  ;;   any handler.' Calling it from inside a handler raises
+  ;;   :rf.error/dispatch-sync-in-handler ... the in-handler shape is
+  ;;   [[:dispatch event]] under :fx.\"
+  ;; The CLJS partner test (runtime_cljs_test.cljs §dispatch-sync-in-
+  ;; handler-errors-cljs) covers the browser path; this is the JVM
+  ;; equivalent plus the transitive-via-fx case the bead calls out."
+  (testing "directly calling rf/dispatch-sync from a handler raises the structured error"
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::dsih-direct (fn [ev] (swap! traces conj ev)))
+      (rf/reg-event-db :leaf (fn [db _] (assoc db :leaf? true)))
+      (rf/reg-event-fx :nested-direct
+        (fn [_ _]
+          (rf/dispatch-sync [:leaf])
+          {}))
+      (rf/dispatch-sync [:nested-direct])
+      (rf/remove-trace-cb! ::dsih-direct)
+      (is (some (fn [ev]
+                  (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
+                       (= :error (:op-type ev))
+                       (= :no-recovery (:recovery ev))))
+                @traces)
+          "expected :rf.error/dispatch-sync-in-handler with :no-recovery")))
+
+  (testing "calling dispatch-sync TRANSITIVELY through a user fx is also caught"
+    ;; Some fx handlers naively call dispatch-sync to chain another event.
+    ;; The drain still flags the call site even though it's one frame
+    ;; below the original handler — :in-drain? on the router is the
+    ;; primary guard, not the call-stack depth.
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::dsih-fx (fn [ev] (swap! traces conj ev)))
+      (rf/reg-event-db :leaf2 (fn [db _] (assoc db :leaf2? true)))
+      (rf/reg-fx :user.fx/sync-dispatch
+        {:platforms #{:server :client}}
+        (fn [_ ev]
+          ;; This is the wrong way to chain — should be :dispatch in the
+          ;; effects map. The router must still emit the structured
+          ;; error so the bug is observable.
+          (rf/dispatch-sync ev)))
+      (rf/reg-event-fx :nested-via-fx
+        (fn [_ _]
+          {:fx [[:user.fx/sync-dispatch [:leaf2]]]}))
+      (rf/dispatch-sync [:nested-via-fx])
+      (rf/remove-trace-cb! ::dsih-fx)
+      (is (some (fn [ev]
+                  (= :rf.error/dispatch-sync-in-handler (:operation ev)))
+                @traces)
+          "the transitive (via-fx) dispatch-sync still trips the in-handler guard"))))
+
+;; ---- 4. async vs sync interleaving ----------------------------------------
+
+(deftest async-dispatch-resolves-after-current-drain
+  ;; Spec 002 §Run-to-completion dispatch (drain semantics):
+  ;; \"events queued via dispatch resolve after the current drain; sync-
+  ;;   side events triggered via :fx [[:dispatch ...]] resolve in the same
+  ;;   drain.\" See also Spec 002 §Drain-loop pseudocode :dispatch fx
+  ;; comment: \"append to back of router queue; the outer drain picks it
+  ;;   up in this same drain cycle (run-to-completion).\""
+  (testing ":fx [[:dispatch ...]] events drain in-cycle; the cascade is observed atomically"
+    (let [order (atom [])]
+      (rf/reg-event-fx :seed
+        (fn [_ _]
+          (swap! order conj :seed)
+          ;; Two fx-side dispatches plus a :db update. All must drain
+          ;; before dispatch-sync returns.
+          {:db {:n 0}
+           :fx [[:dispatch [:bump]]
+                [:dispatch [:bump]]]}))
+      (rf/reg-event-db :bump
+        (fn [db _]
+          (swap! order conj :bump)
+          (update db :n inc)))
+      (rf/dispatch-sync [:seed])
+      (is (= [:seed :bump :bump] @order)
+          "both :fx-side :dispatch events ran inside the same dispatch-sync cycle")
+      (is (= 2 (:n (rf/get-frame-db :rf/default)))
+          "their effects are visible the moment dispatch-sync returns")))
+
+  (testing "rf/dispatch (the async API) defers to AFTER the current dispatch-sync drain"
+    ;; Calling rf/dispatch from outside any drain doesn't run the event
+    ;; synchronously — it goes through interop/next-tick (the JVM
+    ;; executor). The dispatch-sync below only sees its own work; the
+    ;; async-queued event arrives on a later drain.
+    (let [order (atom [])
+          done  (promise)]
+      (rf/reg-event-db :outside-async
+        (fn [db _]
+          (swap! order conj :outside-async)
+          (deliver done :ok)
+          (assoc db :outside? true)))
+      (rf/reg-event-db :sync-only
+        (fn [db _]
+          (swap! order conj :sync-only)
+          db))
+      ;; Queue an async dispatch first.
+      (rf/dispatch [:outside-async])
+      ;; Then run a sync drain. The async event MAY or may not have
+      ;; landed yet — but if it landed before the dispatch-sync, it
+      ;; would prepend before :sync-only in @order. The contract is:
+      ;; both events run, in dispatch order, but the sync drain does
+      ;; not block on the async one.
+      (rf/dispatch-sync [:sync-only])
+      ;; Now wait for the async one to settle.
+      (is (= :ok (deref done 2000 :timeout))
+          ":outside-async eventually drained on the executor")
+      (is (true? (:outside? (rf/get-frame-db :rf/default)))
+          ":outside-async's effect lands on app-db after its drain")
+      (is (some #{:sync-only} @order) ":sync-only ran")
+      (is (some #{:outside-async} @order) ":outside-async ran"))))
+
+;; ---- 5. per-frame drain isolation ----------------------------------------
+
+(deftest per-frame-drain-isolation
+  ;; Spec 002 §Run-to-completion dispatch §Rules rule 1:
+  ;; \"No cross-frame drain. Drain runs against the frame's own router
+  ;;   queue. A dispatch tagged with a *different* frame goes through the
+  ;;   ordinary async path — drain does not span frames. Cross-frame
+  ;;   coordination uses regular async (dispatch ev {:frame other}).\""
+  (testing "dispatching to frame B from inside frame A's handler does NOT interleave with A's drain"
+    (rf/reg-frame :drain.test/A {:doc "frame A"})
+    (rf/reg-frame :drain.test/B {:doc "frame B"})
+    (let [order (atom [])
+          b-done (promise)]
+      (rf/reg-event-db :A/work
+        (fn [db _]
+          (swap! order conj :A-start)
+          ;; Dispatch a cross-frame event — this hits frame B's queue
+          ;; via the async path. It must not run as part of A's drain.
+          (rf/dispatch [:B/work] {:frame :drain.test/B})
+          (swap! order conj :A-end)
+          (assoc db :a-ran? true)))
+      (rf/reg-event-db :B/work
+        (fn [db _]
+          (swap! order conj :B)
+          (deliver b-done :ok)
+          (assoc db :b-ran? true)))
+      (rf/dispatch-sync [:A/work] {:frame :drain.test/A})
+      ;; The moment dispatch-sync returns, A's cascade has settled. B's
+      ;; cascade may still be in flight on the executor.
+      (is (= [:A-start :A-end] (vec (filter #{:A-start :A-end} @order)))
+          "A's handler ran end-to-end without B interleaving inside it")
+      (is (= :ok (deref b-done 2000 :timeout))
+          "B's drain eventually fires on the executor")
+      (is (true? (:a-ran? (rf/get-frame-db :drain.test/A)))
+          "A's :db commit landed in A's app-db only")
+      (is (nil? (:b-ran? (rf/get-frame-db :drain.test/A)))
+          "B's :db commit did NOT spill into A's app-db")
+      (is (true? (:b-ran? (rf/get-frame-db :drain.test/B)))
+          "B's :db commit landed in B's app-db")
+      (is (nil? (:a-ran? (rf/get-frame-db :drain.test/B)))
+          "A's :db commit did NOT spill into B's app-db")))
+
+  (testing "two interleaved dispatch-sync calls keep their queues separate"
+    ;; This pins the per-frame router contract: each frame has its own
+    ;; queue and :scheduled?/:in-drain? flags.
+    (rf/reg-frame :drain.test/X {:doc "X"})
+    (rf/reg-frame :drain.test/Y {:doc "Y"})
+    (rf/reg-event-db :tick (fn [db _] (update db :n (fnil inc 0))))
+    (rf/dispatch-sync [:tick] {:frame :drain.test/X})
+    (rf/dispatch-sync [:tick] {:frame :drain.test/Y})
+    (rf/dispatch-sync [:tick] {:frame :drain.test/X})
+    (is (= 2 (:n (rf/get-frame-db :drain.test/X))))
+    (is (= 1 (:n (rf/get-frame-db :drain.test/Y))))))


### PR DESCRIPTION
## Summary

Adds `implementation/test/re_frame/drain_test.clj` with five targeted deftests pinning the load-bearing properties of Spec 002 §Run-to-completion dispatch (drain semantics). Today these are exercised only transitively via `login-machine-flow` and `dispatch-sync-in-handler-errors`; this namespace pins them directly so a regression in `router.cljc` surfaces here.

- `run-to-completion-handler-finishes-before-next-event` — §Rules rule 2: handler completes before queued events drain; includes a deeper `a -> b -> c` chain.
- `drain-depth-limit-aborts-with-structured-error` — §Rules rule 3: `:rf.error/drain-depth-exceeded` raises with `:depth` / `:frame` / `:last-event` tags; queue is cleared and `:scheduled?` is reset afterwards.
- `dispatch-sync-in-handler-jvm` — §Render boundaries: `:rf.error/dispatch-sync-in-handler` raises both directly and transitively (via a user fx that calls `dispatch-sync`). JVM partner to the existing CLJS `dispatch-sync-in-handler-errors-cljs`.
- `async-dispatch-resolves-after-current-drain` — `:fx [[:dispatch ...]]` events drain in-cycle; `rf/dispatch` defers to the executor and lands on a later drain.
- `per-frame-drain-isolation` — §Rules rule 1: cross-frame dispatch from inside frame A's handler doesn't interleave with A's drain; per-frame router queues stay separate.

Each docstring cites the relevant Spec 002 anchor. `router.cljc` is untouched. The "atomic rollback of failing handler's `:db`" phrasing in the bead brief is not what the implementation does today — filed as `rf2-8hi7` for a spec/impl gap decision; the test asserts actual `drain!` behavior.

## Test plan

- [x] `cd implementation && clojure -M:test` — 101 tests / 523 assertions / 0 failures (baseline before rebase: 79 / 397; this PR adds +5 deftests / +24 assertions on top of work that landed concurrently).
- [x] Drain test ns runs in isolation: `clojure -M:test -n re-frame.drain-test` — 5 tests / 25 assertions / 0 failures.
- [x] No edits to existing tests; no edits to `src/`.

Closes rf2-yqpg.