### PR TITLE
fix: routing emits :rf.nav/scroll fx per Spec 012 (rf2-h5el)

### DIFF
--- a/docs/specification/conformance/fixtures/routing-scroll-restoration.edn
+++ b/docs/specification/conformance/fixtures/routing-scroll-restoration.edn
@@ -1,0 +1,76 @@
+;; Conformance fixture: routing/scroll-restoration
+;;
+;; Per Spec 012 §Scroll restoration: every successful navigation emits a
+;; :rf.nav/scroll fx whose args carry {:strategy :from :to :saved-pos
+;; :fragment}. The strategy resolves in this order:
+;;   1. :scroll key in :rf.route/navigate's opts (per-call override)
+;;   2. :scroll key on the route's metadata
+;;   3. implicit default — :top for forward navigation, :restore for
+;;      popstate / initial / SSR navigation
+;; A :scroll value of `false` (in opts or meta) suppresses the fx.
+;;
+;; Per [012 §Scroll restoration](../../012-Routing.md#scroll-restoration).
+
+{:fixture/id           :routing/scroll-restoration
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx}
+ :fixture/doc          "Navigation emits :rf.nav/scroll with the resolved strategy. Forward navigation defaults to :top; route metadata's :scroll wins; opts :scroll trumps both. :scroll false suppresses the fx."
+
+ :fixture/registry
+ {:route
+  {:route/home     {:path "/"}
+   :route/articles {:path "/articles"}
+   :route/article  {:path   "/articles/:id"
+                    :params [:map [:id :string]]
+                    :scroll :restore}
+   :route/profile  {:path   "/profile"
+                    :scroll false}}
+
+  :event
+  {:rf/init           {:doc "Seed."}
+   :rf.route/navigate {:doc "Programmatic navigation."}}
+
+  :fx
+  {:rf.nav/push-url    {:platforms #{:client}}
+   :rf.nav/replace-url {:platforms #{:client}}
+   :rf.nav/scroll      {:platforms #{:client}}}}
+
+ :fixture/handlers
+ {:fx {:rf.nav/push-url    [[:noop]]
+       :rf.nav/replace-url [[:noop]]
+       :rf.nav/scroll      [[:noop]]}}
+
+ :fixture/dispatches
+ [;; 1. Forward navigation to a route with no :scroll meta — default :top.
+  [:rf.route/navigate :route/articles]
+
+  ;; 2. Forward navigation to a route declaring :scroll :restore — meta wins.
+  [:rf.route/navigate :route/article {:id "intro"}]
+
+  ;; 3. :scroll false on the route suppresses the :rf.nav/scroll fx.
+  [:rf.route/navigate :route/profile]]
+
+ :fixture/expect
+ {:final-app-db
+  {:route {:id :route/profile :params {} :error nil}}
+
+  :effects-routed
+  ;; The push-url and scroll fxs interleave; what we assert is the
+  ;; presence and shape of each scroll-fx in source order, plus the
+  ;; absence of a third for the :scroll-false route.
+  [{:fx-id :rf.nav/push-url :args "/articles"}
+   {:fx-id :rf.nav/scroll
+    :args  {:strategy :top
+            :to       {:id :route/articles}}}
+   {:fx-id :rf.nav/push-url :args "/articles/intro"}
+   {:fx-id :rf.nav/scroll
+    :args  {:strategy :restore
+            :from     {:id :route/articles}
+            :to       {:id :route/article :params {:id "intro"}}}}
+   ;; :route/profile has :scroll false → no :rf.nav/scroll entry here.
+   {:fx-id :rf.nav/push-url :args "/profile"}]
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :rf.route/navigate}}
+   {:operation :event :tags {:event-id :rf.route/navigate}}
+   {:operation :event :tags {:event-id :rf.route/navigate}}]}}

--- a/implementation/src/re_frame/routing.cljc
+++ b/implementation/src/re_frame/routing.cljc
@@ -545,6 +545,78 @@
 
 ;; ---- standard handlers ----------------------------------------------------
 
+;; ---- scroll-restoration helpers -------------------------------------------
+;;
+;; Per Spec 012 §Scroll restoration: the runtime captures scroll positions
+;; per URL on every navigation so a later :restore strategy can re-apply
+;; them. The capture itself only makes sense on the client (DOM); on the
+;; JVM the map stays empty. We expose a small helper API so the CLJS fx
+;; implementation can populate it on every navigation, and so tests can
+;; seed values without poking the atom directly.
+
+(defonce ^:private saved-scroll-positions
+  ;; URL (string) → [x y]
+  (atom {}))
+
+(defn save-scroll-position!
+  "Record the current scroll position for a URL. Called by the CLJS host
+  on outgoing navigations so a future :restore can recover [x y]."
+  [url xy]
+  (swap! saved-scroll-positions assoc url xy))
+
+(defn lookup-scroll-position
+  "Return the saved [x y] for url, or nil if none."
+  [url]
+  (get @saved-scroll-positions url))
+
+(defn clear-scroll-positions!
+  "Test-time helper: reset the saved-position map."
+  []
+  (reset! saved-scroll-positions {}))
+
+(defn- route-descriptor
+  "Build the {:id :params :query} descriptor used by :rf.nav/scroll's
+  :from / :to args from a :route slice (or nil if no slice yet)."
+  [route-slice]
+  (when (and route-slice (:id route-slice))
+    (cond-> {:id (:id route-slice)}
+      (seq (:params route-slice)) (assoc :params (:params route-slice))
+      (seq (:query route-slice))  (assoc :query  (:query route-slice)))))
+
+(defn- resolve-scroll-strategy
+  "Per Spec 012 §Scroll restoration, resolution order:
+    1. opts' :scroll (per-call override)
+    2. route metadata's :scroll
+    3. implicit default (caller-supplied — :top for forward, :restore
+       for popstate / initial)
+  Returns the resolved strategy, or ::suppress when the resolved value
+  is `false` (which means: do not emit the fx)."
+  [route-meta opts default]
+  (let [from-opts (when (and (map? opts) (contains? opts :scroll))
+                    (:scroll opts))
+        from-meta (:scroll route-meta)]
+    (cond
+      ;; per-call override wins; explicit `false` suppresses
+      (some? from-opts) (if (false? from-opts) ::suppress from-opts)
+      (false? from-meta) ::suppress
+      (some? from-meta) from-meta
+      :else             default)))
+
+(defn- scroll-fx-entry
+  "Build the [:rf.nav/scroll args] fx entry for a navigation, or nil
+  when the resolved strategy is ::suppress (no fx emission).
+
+  Per Spec 012 §Scroll restoration §`:rf.nav/scroll` integration the args
+  shape is {:strategy :from :to :saved-pos :fragment}."
+  [{:keys [strategy from to saved-pos fragment]}]
+  (when (not= ::suppress strategy)
+    [:rf.nav/scroll
+     (cond-> {:strategy strategy}
+       from      (assoc :from      from)
+       to        (assoc :to        to)
+       saved-pos (assoc :saved-pos saved-pos)
+       fragment  (assoc :fragment  fragment))]))
+
 (events/reg-event-fx :rf.route/navigate
   (fn [{:keys [db]} [_ target params opts]]
     (let [{:keys [route-id path-params query-params]}
@@ -565,7 +637,21 @@
           push-fx (if (:replace? opts)
                     [:rf.nav/replace-url url]
                     [:rf.nav/push-url    url])
-          on-match-vec (vec (or (:on-match route-meta) []))]
+          on-match-vec (vec (or (:on-match route-meta) []))
+          ;; Per Spec 012 §Scroll restoration: forward navigation defaults
+          ;; to :top. Resolve the strategy from opts → route-meta → default.
+          fragment    (:fragment opts)
+          to-route    (cond-> {:id route-id}
+                        (seq path-params)  (assoc :params path-params)
+                        (seq query-params) (assoc :query  query-params))
+          strategy    (resolve-scroll-strategy route-meta opts :top)
+          scroll-fx   (scroll-fx-entry
+                        {:strategy  strategy
+                         :from      (route-descriptor (:route db))
+                         :to        to-route
+                         :saved-pos (when (= :restore strategy)
+                                      (lookup-scroll-position url))
+                         :fragment  fragment})]
       {:db (assoc db :route
                   {:id         route-id
                    :params     path-params
@@ -573,7 +659,8 @@
                    :transition (if (seq on-match-vec) :loading :idle)
                    :error      nil})
        :fx (vec (concat [push-fx]
-                        (mapv (fn [ev] [:dispatch ev]) on-match-vec)))})))
+                        (mapv (fn [ev] [:dispatch ev]) on-match-vec)
+                        (when scroll-fx [scroll-fx])))})))
 
 (defn- split-fragment
   "Split a URL into [url-without-fragment fragment]. Returns
@@ -597,11 +684,13 @@
 (defn reset-counters!
   "Reset the nav-token / pending-nav / route-registration counters to
   zero. Test-time helper so allocated ids are stable across fixture
-  runs."
+  runs. Also clears the saved-scroll-positions map per Spec 012
+  §Scroll restoration."
   []
   (reset! nav-token-counter 0)
   (reset! pending-nav-counter 0)
-  (reset! reg-counter 0))
+  (reset! reg-counter 0)
+  (reset! saved-scroll-positions {}))
 
 ;; ---- :rf/url-requested + can-leave gating + pending-nav protocol ----------
 ;;
@@ -710,7 +799,22 @@
         (some? m)
         (let [route-meta   (registrar/lookup :route (:route-id m))
               on-match-vec (vec (or (:on-match route-meta) []))
-              token        (alloc-nav-token)]
+              token        (alloc-nav-token)
+              ;; Per Spec 012 §Scroll restoration: a URL-driven navigation
+              ;; emits :rf.nav/scroll. URL changes from clicked links /
+              ;; programmatic pushes are forward-style (default :top); the
+              ;; route metadata's :scroll wins when declared.
+              to-route     (cond-> {:id (:route-id m)}
+                             (seq (:params m)) (assoc :params (:params m))
+                             (seq (:query m))  (assoc :query  (:query m)))
+              strategy     (resolve-scroll-strategy route-meta nil :top)
+              scroll-fx    (scroll-fx-entry
+                             {:strategy  strategy
+                              :from      (route-descriptor prev)
+                              :to        to-route
+                              :saved-pos (when (= :restore strategy)
+                                           (lookup-scroll-position url))
+                              :fragment  fragment})]
           (trace/emit! :event :route.nav-token/allocated
                        {:route-id  (:route-id m)
                         :nav-token token})
@@ -722,7 +826,8 @@
                        :transition :idle
                        :error      nil
                        :nav-token  token})
-           :fx (vec (mapv (fn [ev] [:dispatch ev]) on-match-vec))})
+           :fx (vec (concat (mapv (fn [ev] [:dispatch ev]) on-match-vec)
+                            (when scroll-fx [scroll-fx])))})
 
         :else
         (do (trace/emit-error! :rf.error/no-such-handler
@@ -731,7 +836,8 @@
 
 (events/reg-event-fx :rf.route/handle-url-change
   (fn [{:keys [db]} [_ url]]
-    (let [m (match-url url)]
+    (let [[path-q fragment] (split-fragment url)
+          m                 (match-url path-q)]
       (when (nil? m)
         ;; Unmatched URL — fixture corpus calls this :rf.error/no-such-handler
         ;; in the routing context. The default error projector maps it to a
@@ -739,18 +845,32 @@
         (trace/emit-error! :rf.error/no-such-handler
                            {:url url
                             :recovery :replaced-with-default}))
-      (let [route-id   (or (:route-id m) :rf.route/not-found)
-            params     (or (:params m) {:url url})
-            query      (or (:query m) {})
-            route-meta (registrar/lookup :route route-id)
-            on-match-vec (vec (or (:on-match route-meta) []))]
+      (let [route-id     (or (:route-id m) :rf.route/not-found)
+            params       (or (:params m) {:url url})
+            query        (or (:query m) {})
+            route-meta   (registrar/lookup :route route-id)
+            on-match-vec (vec (or (:on-match route-meta) []))
+            ;; Per Spec 012 §Scroll restoration: popstate / initial / SSR
+            ;; navigations default to :restore — the saved position trumps.
+            to-route     (cond-> {:id route-id}
+                           (seq params) (assoc :params params)
+                           (seq query)  (assoc :query  query))
+            strategy     (resolve-scroll-strategy route-meta nil :restore)
+            scroll-fx    (scroll-fx-entry
+                           {:strategy  strategy
+                            :from      (route-descriptor (:route db))
+                            :to        to-route
+                            :saved-pos (when (= :restore strategy)
+                                         (lookup-scroll-position url))
+                            :fragment  fragment})]
         {:db (assoc db :route
                     {:id         route-id
                      :params     params
                      :query      query
                      :transition (if (seq on-match-vec) :loading :idle)
                      :error      nil})
-         :fx (vec (mapv (fn [ev] [:dispatch ev]) on-match-vec))}))))
+         :fx (vec (concat (mapv (fn [ev] [:dispatch ev]) on-match-vec)
+                          (when scroll-fx [scroll-fx])))}))))
 
 ;; ---- standard navigation fx ----------------------------------------------
 
@@ -769,6 +889,31 @@
     #?(:cljs (.replaceState js/window.history nil "" url)
        :clj  (trace/emit! :fx :rf.fx/skipped-on-platform
                           {:fx-id :rf.nav/replace-url :url url}))))
+
+(fx/reg-fx :rf.nav/scroll
+  {:platforms #{:client}
+   :doc       "Per Spec 012 §Scroll restoration. Args: {:strategy :from
+:to :saved-pos :fragment}. Standard strategies are :top, :restore,
+:preserve. Map-form strategies are host-extensible; the runtime treats
+unknown strategies as :preserve (no-op)."}
+  (fn [_ {:keys [strategy saved-pos fragment]}]
+    #?(:cljs
+       (case strategy
+         :top      (if-let [el (and fragment
+                                    (.getElementById js/document fragment))]
+                     (.scrollIntoView el)
+                     (.scrollTo js/window 0 0))
+         :restore  (when (and saved-pos (sequential? saved-pos))
+                     (.scrollTo js/window
+                                (first saved-pos)
+                                (second saved-pos)))
+         :preserve nil
+         ;; map-form / unknown → host-extensible; default no-op so the
+         ;; runtime doesn't blow up on a strategy it doesn't recognise.
+         nil)
+       :clj
+       (trace/emit! :fx :rf.fx/skipped-on-platform
+                    {:fx-id :rf.nav/scroll :strategy strategy}))))
 
 ;; ---- subs over the slice --------------------------------------------------
 ;; Will be picked up by re-frame.subs/reg-sub when this ns loads.

--- a/implementation/test/re_frame/routing_test.clj
+++ b/implementation/test/re_frame/routing_test.clj
@@ -14,11 +14,12 @@
   - routing-nav-token-staleness  — two in-flight navigations; only the
                                    most recent token's result commits
   - routing-scroll-metadata-preserved — :scroll metadata on a route is
-                                   queryable via handler-meta. The
-                                   :rf.nav/scroll fx is not yet emitted
-                                   by routing.cljc (tracked as rf2-h5el);
-                                   this test pins what IS implemented:
-                                   metadata round-trips through registration.
+                                   queryable via handler-meta. Pins the
+                                   registration round-trip contract.
+  - routing-scroll-fx-emitted-on-navigate — every successful navigation
+                                   emits :rf.nav/scroll with the resolved
+                                   strategy / from / to / saved-pos /
+                                   fragment args; :scroll false suppresses.
   - routing-nested-layout-parent-link — :parent metadata is preserved by
                                    reg-route so views / handler-meta-driven
                                    tools can render the layout chain. The
@@ -199,12 +200,8 @@
 (deftest routing-scroll-metadata-preserved
   (testing "the :scroll metadata key is enumerable via handler-meta"
     ;; Per Spec 012 §Scroll restoration: a route may declare a :scroll
-    ;; strategy (:top / :restore / :preserve / map). The runtime is meant
-    ;; to emit a :rf.nav/scroll fx on navigation per the resolved strategy
-    ;; (filed as rf2-h5el). Until that lands, this test pins the
-    ;; baseline contract that conforming reads MUST satisfy: the :scroll
-    ;; key on registration round-trips through reg-route's metadata so
-    ;; tooling and future fx-emitting code can read it.
+    ;; strategy (:top / :restore / :preserve / map / false). Metadata is
+    ;; round-tripped through registration so tooling can enumerate it.
     (rf/reg-route :route/home
                   {:path   "/"
                    :scroll :top})
@@ -218,6 +215,89 @@
           ":scroll metadata is preserved as-declared")
       (is (= :restore (:scroll article-meta))
           ":scroll metadata is preserved per-route"))))
+
+(deftest routing-scroll-fx-emitted-on-navigate
+  (testing ":rf.route/navigate emits :rf.nav/scroll with the resolved strategy"
+    ;; Per Spec 012 §Scroll restoration: the runtime emits :rf.nav/scroll
+    ;; on every successful navigation, with args
+    ;; {:strategy :from :to :saved-pos :fragment}. Resolution order:
+    ;;   1. :scroll in :rf.route/navigate's opts (per-call override)
+    ;;   2. route metadata's :scroll
+    ;;   3. implicit default (:top for forward navigation)
+    ;; A :scroll value of `false` (opts or meta) suppresses the fx.
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-route :route/articles {:path "/articles"})
+    (rf/reg-route :route/article  {:path   "/articles/:id"
+                                   :params [:map [:id :string]]
+                                   :scroll :restore})
+    (rf/reg-route :route/profile  {:path   "/profile"
+                                   :scroll false})
+
+    (let [calls (atom [])]
+      ;; Override the spec's :platforms #{:client} default for the JVM
+      ;; test — re-register :rf.nav/scroll on both server+client so the
+      ;; do-fx interpreter actually invokes our capture.
+      (rf/reg-fx :rf.nav/scroll
+                 {:platforms #{:server :client}}
+                 (fn [_ args] (swap! calls conj args)))
+      ;; :rf.nav/push-url is :platforms #{:client} by default; suppress on
+      ;; the JVM the same way the other routing tests do.
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ _] nil))
+
+      ;; 1. Forward navigation to a route with no :scroll metadata —
+      ;;    default :top.
+      (rf/dispatch-sync [:rf.route/navigate :route/articles])
+      (is (= 1 (count @calls)) "navigate emits exactly one :rf.nav/scroll fx")
+      (let [a (first @calls)]
+        (is (= :top (:strategy a))
+            "default forward strategy is :top")
+        (is (= {:id :route/articles} (:to a))
+            ":to descriptor identifies the destination"))
+
+      ;; 2. Navigate to a route with :scroll :restore — strategy carries.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "intro"}])
+      (let [a (first @calls)]
+        (is (= :restore (:strategy a))
+            "route's :scroll :restore wins over the implicit :top default")
+        (is (= {:id :route/article :params {:id "intro"}} (:to a))
+            ":to carries id + params")
+        (is (= {:id :route/articles} (:from a))
+            ":from is the previous route slice"))
+
+      ;; 3. Per-call :scroll override in opts trumps route metadata.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:id "two"}
+                         {:scroll :preserve}])
+      (is (= :preserve (-> @calls first :strategy))
+          "opts :scroll wins over route metadata")
+
+      ;; 4. :scroll false on the route suppresses the fx entirely.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf.route/navigate :route/profile])
+      (is (empty? @calls)
+          ":scroll false on the route suppresses the :rf.nav/scroll fx")
+
+      ;; 5. :rf/url-changed (URL-driven) also emits the fx — default :top.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf/url-changed "/articles"])
+      (is (= :top (-> @calls first :strategy))
+          ":rf/url-changed emits :rf.nav/scroll with default :top")
+
+      ;; 6. :rf.route/handle-url-change (popstate / initial) defaults to
+      ;;    :restore — the saved position trumps a forward-style :top.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf.route/handle-url-change "/articles"])
+      (is (= :restore (-> @calls first :strategy))
+          ":rf.route/handle-url-change emits :rf.nav/scroll with default :restore")
+
+      ;; 7. Fragment in URL is forwarded in the fx args.
+      (reset! calls [])
+      (rf/dispatch-sync [:rf/url-changed "/articles/intro#section-2"])
+      (is (= "section-2" (-> @calls first :fragment))
+          "fragment from URL flows into :rf.nav/scroll args"))))
 
 ;; ---- Spec 012 §Nested layouts ---------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the missing `:rf.nav/scroll` effect emission in `routing.cljc` per Spec 012 §Scroll restoration. The runtime now resolves the scroll strategy from the per-call `:scroll` opt, the route's `:scroll` metadata, or an implicit default (`:top` for forward, `:restore` for popstate / initial / SSR), and emits `[:rf.nav/scroll {:strategy :from :to :saved-pos :fragment}]` on every successful navigation. `:scroll false` suppresses the fx entirely.

The fx is registered with `:platforms #{:client}` and a CLJS-side default that implements `:top` / `:restore` / `:preserve` against `window` / `document`; on the JVM the call records `:rf.fx/skipped-on-platform` per the spec.

## Changes

- `implementation/src/re_frame/routing.cljc`
  - Adds `saved-scroll-positions` atom + `save-scroll-position!` / `lookup-scroll-position` / `clear-scroll-positions!` helpers so a host can capture and restore per-URL `[x y]` tuples.
  - Adds `:rf.nav/scroll` fx registration with the standard strategy table.
  - Wires scroll-fx emission into `:rf.route/navigate`, `:rf/url-changed`, and `:rf.route/handle-url-change`.
  - `:rf.route/handle-url-change` now also splits the URL's `#fragment` so popstate / SSR paths can forward it through the fx args.
  - `reset-counters!` clears `saved-scroll-positions` for test isolation.
- `implementation/test/re_frame/routing_test.clj`
  - Adds `routing-scroll-fx-emitted-on-navigate` covering the strategy resolution order, `:scroll false` suppression, and fragment forwarding.
- `docs/specification/conformance/fixtures/routing-scroll-restoration.edn`
  - New fixture asserting `:rf.nav/scroll` entries in `:effects-routed` for the canonical resolution cases.

The existing `handler-meta` contract is unchanged.

Closes rf2-h5el.

## Test plan

- [x] `cd implementation && clojure -M:test -n re-frame.routing-test` — 6 tests / 33 assertions / 0 failures
- [x] `cd implementation && clojure -M:test` — 108 tests / 561 assertions / 0 failures
- [x] `cd implementation && clojure -M:test -n re-frame.conformance-test` — fixture loads
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — only pre-existing `routing-handle-url-change-cljs` / `routing-frame-provider-routing-cljs` / `nine-states-runs-end-to-end` failures (independent of these changes; they reproduce on `origin/main`)