### PR TITLE
fix: replace bare assert with cljs.test/is in CLJS tests (rf2-9tx3)

### DIFF
--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -45,7 +45,8 @@
    and `examples/7guis/06_circle_drawer.cljs`. In a real codebase this
    would split per CP-6 conventions across schema / events / subs /
    views / machines / tests files."
-  (:require [reagent.dom.client :as rdc]
+  (:require [cljs.test :refer-macros [is]]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
@@ -596,9 +597,9 @@
 
 (defn test-state-1-nothing []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
-    (assert (in-state? f :ui.state/nothing?))
-    (assert (not (in-state? f :ui.state/loading?)))
-    (assert (not (in-state? f :ui.state/empty?)))))
+    (is (in-state? f :ui.state/nothing?))
+    (is (not (in-state? f :ui.state/loading?)))
+    (is (not (in-state? f :ui.state/empty?)))))
 
 (defn test-state-2-loading []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
@@ -611,52 +612,52 @@
     ;; the `loading?` predicate is false at the *end* of the drain — which is
     ;; the correct semantic. We instead assert that the lifecycle visited
     ;; :loading by checking :attempt was bumped.
-    (assert (pos? (:attempt (rf/compute-sub [:todos] (rf/get-frame-db f)))))))
+    (is (pos? (:attempt (rf/compute-sub [:todos] (rf/get-frame-db f)))))))
 
 (defn test-state-3-empty []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:todos/load {:n 0}] {:frame f})
-    (assert       (in-state? f :ui.state/empty?))
-    (assert (not (in-state? f :ui.state/one?)))
-    (assert (not (in-state? f :ui.state/some?)))
-    (assert (not (in-state? f :ui.state/too-many?)))))
+    (is       (in-state? f :ui.state/empty?))
+    (is (not (in-state? f :ui.state/one?)))
+    (is (not (in-state? f :ui.state/some?)))
+    (is (not (in-state? f :ui.state/too-many?)))))
 
 (defn test-state-4-one []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:todos/load {:n 1}] {:frame f})
-    (assert       (in-state? f :ui.state/one?))
-    (assert (not (in-state? f :ui.state/empty?)))
-    (assert (not (in-state? f :ui.state/some?)))))
+    (is       (in-state? f :ui.state/one?))
+    (is (not (in-state? f :ui.state/empty?)))
+    (is (not (in-state? f :ui.state/some?)))))
 
 (defn test-state-5-some []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
-    (assert       (in-state? f :ui.state/some?))
-    (assert (not (in-state? f :ui.state/one?)))
-    (assert (not (in-state? f :ui.state/too-many?)))))
+    (is       (in-state? f :ui.state/some?))
+    (is (not (in-state? f :ui.state/one?)))
+    (is (not (in-state? f :ui.state/too-many?)))))
 
 (defn test-state-6-too-many []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:todos/load {:n 25}] {:frame f})
-    (assert       (in-state? f :ui.state/too-many?))
-    (assert (not (in-state? f :ui.state/some?)))))
+    (is       (in-state? f :ui.state/too-many?))
+    (is (not (in-state? f :ui.state/some?)))))
 
 (defn test-state-7-incorrect []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     ;; Type a too-short title, then submit — should land in :error / :incorrect?
     (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit]                {:frame f})
-    (assert       (in-state? f :ui.state/incorrect?))
-    (assert (not (in-state? f :ui.state/correct?)))))
+    (is       (in-state? f :ui.state/incorrect?))
+    (is (not (in-state? f :ui.state/correct?)))))
 
 (defn test-state-8-correct []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
     (rf/dispatch-sync [:todos/load {:n 0}]                  {:frame f})
     (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit]                    {:frame f})
-    (assert       (in-state? f :ui.state/correct?))
-    (assert (not (in-state? f :ui.state/incorrect?)))
-    (assert       (in-state? f :ui.state/one?))))    ;; correctness side-effect
+    (is       (in-state? f :ui.state/correct?))
+    (is (not (in-state? f :ui.state/incorrect?)))
+    (is       (in-state? f :ui.state/one?))))    ;; correctness side-effect
 
 (defn test-state-9-done []
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
@@ -664,9 +665,9 @@
     (rf/dispatch-sync [:todos/editor [:todos.editor/archive {:now 1}]] {:frame f})
     ;; Snapshot lives at [:rf/machines :todos/editor].
     (let [snap (get-in (rf/get-frame-db f) [:rf/machines :todos/editor])]
-      (assert (= :archived (:state snap)))
-      (assert (= 1         (:archived-at (:data snap)))))
-    (assert (in-state? f :ui.state/done?))))
+      (is (= :archived (:state snap)))
+      (is (= 1         (:archived-at (:data snap)))))
+    (is (in-state? f :ui.state/done?))))
 
 (defn run-all-tests []
   (test-state-1-nothing)


### PR DESCRIPTION
## Summary

Fixes [rf2-9tx3](../../). The nine_states example's test-state-* fixtures used bare `(clojure.core/assert ...)` inside `(with-frame ...)` blocks. The thrown JS Error escapes `cljs.test.run_block`'s try/catch via Reagent's batched scheduler (microtask boundary) in a real browser, hanging the test runner. Under `:node-test`, where Reagent's `*animation-frame` is synchronous, the same code merely registers as one `:error` rather than hanging — but it still aborts the rest of `run-all-tests`.

This PR converts each bare `assert` inside the `(with-frame ...)` blocks in `examples/nine_states/core.cljs` to `cljs.test/is`. The fixtures are invoked from `(deftest nine-states-runs-end-to-end ...)`, so `is` records into the active test env via the standard `do-report` path — no behavioural change under Node, no exception escaping into the Reagent scheduler under a real browser.

## Audit of other CLJS files

Bare `(assert ...)` inside `(with-frame ...)` exists in other example files (`examples/routing`, `examples/realworld/*`, `examples/login`, `examples/7guis/*`), but **none of those examples are exercised by the current shadow-cljs `:node-test` or `:browser-test` test sources**, so they do not contribute to the runner hang and are out of scope for this targeted fix.

## Verification

**Node** (`cd implementation && npx shadow-cljs compile node-test && node out/node-test.js`):

```
Ran 53 tests containing 175 assertions.
23 failures, 0 errors.
```

The previous lone `:error` from the bare `Assert failed:` is gone. Exit code is 1 because of the 23 (genuine) failures, but the runner completes cleanly.

**Browser** (`cd implementation && npm run test:browser`): the `nine-states-runs-end-to-end` test no longer ERRORs out. However, the browser-test runner still hangs at a different spot — after `runtime_cljs_test/reg-view-macro-double-def-investigation`, before `runtime_cljs_test/h-rewrites-namespaced-view-keys`. This matches **hypothesis 2** in the original bead and is out of scope for this PR. Filed as **rf2-fdhs**.

## Pre-existing test failures revealed

Removing the bare-assert mask exposes 12 pre-existing `nine-states-runs-end-to-end` failures across all 9 `test-state-*` fixtures. They share a single root cause: `(rf/make-frame {:on-create [:app/initialise]})` is creating a frame but its `:on-create` event isn't actually seeding the new frame's db — every read returns `nil`/empty. Filed as **rf2-p8g8** (separate from this PR per task instructions).

## Test plan

- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — runs to completion, no hang, no error
- [x] `cd implementation && npm run test:browser` — `nine-states-runs-end-to-end` no longer errors; remaining hang is unrelated and tracked in rf2-fdhs
- [x] Audited other CLJS test/example files; no other in-scope occurrences
- [ ] CI passes