### PR TITLE
feat: wire Spec 010 validation into events / subs / cofx (rf2-jwm4, rf2-wcam, rf2-7leq)

### DIFF
--- a/implementation/src/re_frame/cofx.cljc
+++ b/implementation/src/re_frame/cofx.cljc
@@ -12,6 +12,32 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]))
 
+(defn- maybe-validate-cofx!
+  "Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
+  injects, validate its value against the cofx's :spec metadata.
+
+  We resolve schemas/validate-cofx! lazily so this namespace stays
+  decoupled from re-frame.schemas (avoids a require cycle). Returns
+  the (possibly mutated) context — sets :rf/skip-handler? when
+  validation fails so the handler-as-interceptor short-circuits."
+  [ctx cofx-id cofx-meta]
+  (if-let [validate (resolve 're-frame.schemas/validate-cofx!)]
+    (let [event    (interceptor/get-coeffect ctx :event)
+          event-id (first event)
+          ;; The cofx's injected value is whatever it just stashed under
+          ;; :coeffects keyed by the cofx's id (the conventional shape).
+          ;; If the cofx fn injected under a different key, we fall back
+          ;; to the cofx-id key — validation only runs when :spec is
+          ;; declared, so users opt in by registering against the same
+          ;; key they inject under.
+          value    (get (:coeffects ctx) cofx-id)
+          ok?      (try ((deref validate) cofx-id event-id value cofx-meta)
+                        (catch #?(:clj Throwable :cljs :default) _ true))]
+      (if ok?
+        ctx
+        (assoc ctx :rf/skip-handler? true)))
+    ctx))
+
 (defn reg-cofx
   "Register a coeffect handler.
   cofx-handler signature: (fn [context]) → context  OR  (fn [context value]) → context.
@@ -30,14 +56,21 @@
 
   Two arities:
     (inject-cofx :id)        — no value
-    (inject-cofx :id value)  — passes value as second arg to the cofx fn"
+    (inject-cofx :id value)  — passes value as second arg to the cofx fn
+
+  Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
+  fn returns, if the cofx's metadata carries a :spec, validate the
+  injected value. On failure, mark the context with
+  :rf/skip-handler? so subsequent handler interceptors short-circuit
+  (recovery: :no-recovery; downstream queue continues)."
   ([cofx-id]
    (interceptor/->interceptor
      :id (keyword (str "cofx-" (name cofx-id)))
      :before
      (fn [ctx]
        (if-let [meta (registrar/lookup :cofx cofx-id)]
-         ((:handler-fn meta) ctx)
+         (-> ((:handler-fn meta) ctx)
+             (maybe-validate-cofx! cofx-id meta))
          (do (println "re-frame-2: no cofx registered for" cofx-id)
              ctx)))))
   ([cofx-id value]
@@ -46,7 +79,8 @@
      :before
      (fn [ctx]
        (if-let [meta (registrar/lookup :cofx cofx-id)]
-         ((:handler-fn meta) ctx value)
+         (-> ((:handler-fn meta) ctx value)
+             (maybe-validate-cofx! cofx-id meta))
          (do (println "re-frame-2: no cofx registered for" cofx-id)
              ctx))))))
 

--- a/implementation/src/re_frame/events.cljc
+++ b/implementation/src/re_frame/events.cljc
@@ -18,32 +18,42 @@
 ;; whose :before slot runs the handler and stores its result on the context.
 
 (defn- db-handler->interceptor
-  "Wrap a (fn [db event]) → new-db handler."
+  "Wrap a (fn [db event]) → new-db handler.
+
+  Per Spec 010 §Validation order steps 1-2 (rf2-7leq, rf2-jwm4) — if
+  any pre-handler validation set :rf/skip-handler? on the context,
+  short-circuit and run no body. The schema-validation-failure trace
+  has already fired."
   [handler-fn]
   (interceptor/->interceptor
     :id :rf/db-handler
     :before
     (fn [ctx]
-      (let [db    (interceptor/get-coeffect ctx :db)
-            event (interceptor/get-coeffect ctx :event)
-            new-db (handler-fn db event)]
-        (interceptor/assoc-effect ctx :db new-db)))))
+      (if (:rf/skip-handler? ctx)
+        ctx
+        (let [db    (interceptor/get-coeffect ctx :db)
+              event (interceptor/get-coeffect ctx :event)
+              new-db (handler-fn db event)]
+          (interceptor/assoc-effect ctx :db new-db))))))
 
 (defn- fx-handler->interceptor
-  "Wrap a (fn [cofx event]) → effects-map handler."
+  "Wrap a (fn [cofx event]) → effects-map handler. See db-handler->interceptor
+  for the :rf/skip-handler? short-circuit (Spec 010 step 1/2 recovery)."
   [handler-fn]
   (interceptor/->interceptor
     :id :rf/fx-handler
     :before
     (fn [ctx]
-      (let [cofx    (interceptor/get-coeffect ctx)
-            event   (interceptor/get-coeffect ctx :event)
-            effects (handler-fn cofx event)]
-        (cond-> ctx
-          (contains? effects :db) (interceptor/assoc-effect :db (:db effects))
-          (contains? effects :fx) (interceptor/assoc-effect :fx (:fx effects))
-          ;; Allow other top-level effect-map keys (open shape per Spec 002).
-          true (update :effects merge (dissoc effects :db :fx)))))))
+      (if (:rf/skip-handler? ctx)
+        ctx
+        (let [cofx    (interceptor/get-coeffect ctx)
+              event   (interceptor/get-coeffect ctx :event)
+              effects (handler-fn cofx event)]
+          (cond-> ctx
+            (contains? effects :db) (interceptor/assoc-effect :db (:db effects))
+            (contains? effects :fx) (interceptor/assoc-effect :fx (:fx effects))
+            ;; Allow other top-level effect-map keys (open shape per Spec 002).
+            true (update :effects merge (dissoc effects :db :fx))))))))
 
 (defn- ctx-handler->interceptor
   "Wrap a (fn [context]) → context handler. Advanced; few apps need it."
@@ -51,7 +61,10 @@
   (interceptor/->interceptor
     :id :rf/ctx-handler
     :before
-    (fn [ctx] (or (handler-fn ctx) ctx))))
+    (fn [ctx]
+      (if (:rf/skip-handler? ctx)
+        ctx
+        (or (handler-fn ctx) ctx)))))
 
 ;; ---- registration ---------------------------------------------------------
 

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -87,6 +87,19 @@
                                 :source   (:source envelope)
                                 :trace-id (:trace-id envelope)
                                 :phase    :run-start})
+                ;; Per Spec 010 §Validation order step 1: validate the
+                ;; dispatched event vector against the handler's :spec
+                ;; BEFORE the handler's interceptor chain runs. Failures
+                ;; emit :rf.error/schema-validation-failure with
+                ;; :where :event and skip the handler (recovery
+                ;; :no-recovery; downstream queue continues). Tracked
+                ;; as rf2-jwm4.
+                event-ok?
+                (if-let [validate-event!
+                         (resolve 're-frame.schemas/validate-event!)]
+                  (try ((deref validate-event!) event-id event handler-meta)
+                       (catch #?(:clj Throwable :cljs :default) _ true))
+                  true)
                 {:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
                 base-chain   (:interceptors handler-meta)
                 full-chain   (vec (concat extra-interceptors base-chain))
@@ -102,7 +115,12 @@
                                           (:trace-id envelope) (assoc :trace-id (:trace-id envelope)))
                               :effects {}
                               :rf/fx-overrides fx-overrides}
-                final-ctx    (interceptor/execute-chain full-chain initial-ctx)
+                ;; If event-payload validation failed, skip the handler
+                ;; entirely. Per Spec 010 §Per-step recovery step 1:
+                ;; "Handler is not invoked"; downstream queue continues.
+                final-ctx    (if event-ok?
+                               (interceptor/execute-chain full-chain initial-ctx)
+                               initial-ctx)
                 effects      (:effects final-ctx)
                 error        (:rf/interceptor-error final-ctx)]
             (when error

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -105,15 +105,96 @@
                                 event-id (assoc :failing-id event-id)))))))))
 
 (defn validate-event!
-  "Before an event handler runs, validate the event vector against any
-  :spec on the handler's metadata."
+  "Per Spec 010 §Validation order step 1 — before an event handler runs,
+  validate the event vector against any :spec on the handler's metadata.
+
+  Returns true on pass (or when validation is elided / no schema is
+  attached), false on fail. Failures emit
+  :rf.error/schema-validation-failure with :where :event; the caller
+  is responsible for skipping the handler (recovery: :no-recovery)."
   [event-id event handler-meta]
-  (when interop/debug-enabled?
-    (when-let [schema (:spec handler-meta)]
-      (when-not (malli-validate* schema event)
-        (trace/emit-error! :rf.error/schema-validation-failure
-                           {:where   :event
-                            :event-id event-id
-                            :event   event
-                            :explain (malli-explain* schema event)
-                            :recovery :no-recovery})))))
+  (if (and interop/debug-enabled? (:spec handler-meta))
+    (let [schema (:spec handler-meta)]
+      (if (malli-validate* schema event)
+        true
+        (do
+          (trace/emit-error! :rf.error/schema-validation-failure
+                             {:where       :event
+                              :event-id    event-id
+                              :failing-id  event-id
+                              :spec-id     event-id
+                              :received    event
+                              :event       event
+                              :malli-error (malli-explain* schema event)
+                              :explain     (malli-explain* schema event)
+                              :reason      (str "Event " event-id
+                                                " payload failed schema "
+                                                schema ", got "
+                                                (type-of-value event) ".")
+                              :recovery    :no-recovery})
+          false)))
+    true))
+
+(defn validate-sub-return!
+  "Per Spec 010 §Validation order step 6 — after a sub recomputes,
+  validate its return value against any :spec on the sub's metadata.
+
+  Returns true on pass, false on fail. Failures emit
+  :rf.error/schema-validation-failure with :where :sub-return; the
+  caller is responsible for replacing the value with the
+  default (nil) per the :replaced-with-default recovery."
+  [sub-id query-v value sub-meta]
+  (if (and interop/debug-enabled? (:spec sub-meta))
+    (let [schema (:spec sub-meta)]
+      (if (malli-validate* schema value)
+        true
+        (do
+          (trace/emit-error! :rf.error/schema-validation-failure
+                             {:where       :sub-return
+                              :sub-id      sub-id
+                              :failing-id  sub-id
+                              :spec-id     sub-id
+                              :query-v     query-v
+                              :received    value
+                              :value       value
+                              :malli-error (malli-explain* schema value)
+                              :explain     (malli-explain* schema value)
+                              :reason      (str "Subscription " sub-id
+                                                " return value failed schema "
+                                                schema ", got "
+                                                (type-of-value value) ".")
+                              :recovery    :replaced-with-default})
+          false)))
+    true))
+
+(defn validate-cofx!
+  "Per Spec 010 §Validation order step 2 — after a cofx injects its value
+  into the merged context, validate that value against any :spec on the
+  cofx's metadata.
+
+  Returns true on pass, false on fail. Failures emit
+  :rf.error/schema-validation-failure with :where :cofx; the caller is
+  responsible for skipping the handler (recovery: :no-recovery)."
+  [cofx-id event-id value cofx-meta]
+  (if (and interop/debug-enabled? (:spec cofx-meta))
+    (let [schema (:spec cofx-meta)]
+      (if (malli-validate* schema value)
+        true
+        (do
+          (trace/emit-error! :rf.error/schema-validation-failure
+                             {:where       :cofx
+                              :cofx-id     cofx-id
+                              :event-id    event-id
+                              :failing-id  event-id
+                              :spec-id     cofx-id
+                              :received    value
+                              :value       value
+                              :malli-error (malli-explain* schema value)
+                              :explain     (malli-explain* schema value)
+                              :reason      (str "Coeffect " cofx-id
+                                                " injected value failed schema "
+                                                schema ", got "
+                                                (type-of-value value) ".")
+                              :recovery    :no-recovery})
+          false)))
+    true))

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -86,6 +86,25 @@
 
 (declare subscribe)
 
+(defn- maybe-validate-sub-return!
+  "Per Spec 010 §Validation order step 6 (rf2-wcam) — after a sub
+  recomputes, validate its return value against any :spec on the sub
+  meta. On failure, emit :rf.error/schema-validation-failure and
+  return nil per :replaced-with-default recovery; otherwise return
+  the value unchanged.
+
+  Resolved lazily so this namespace stays free of a hard re-frame.schemas
+  dep (avoids load-order surprises)."
+  [value query-v sub-id sub-meta]
+  (if (and sub-meta (:spec sub-meta))
+    (if-let [validate (resolve 're-frame.schemas/validate-sub-return!)]
+      (if (try ((deref validate) sub-id query-v value sub-meta)
+               (catch #?(:clj Throwable :cljs :default) _ true))
+        value
+        nil)
+      value)
+    value))
+
 (defn- compute-and-cache!
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
   algorithm: recursively resolve :<- chain, build the reaction, attach
@@ -107,13 +126,19 @@
                    (fn [& in-vals]
                      (when body-fn
                        (try
-                         (if (empty? input-signals)
-                           (body-fn (first in-vals) query-v)
-                           ;; Layer-2+: deliver inputs as a coll if many,
-                           ;; or singleton when only one chain entry.
-                           (if (= 1 (count input-signals))
-                             (body-fn (first in-vals) query-v)
-                             (body-fn (vec in-vals) query-v)))
+                         (let [v (if (empty? input-signals)
+                                   (body-fn (first in-vals) query-v)
+                                   ;; Layer-2+: deliver inputs as a coll if many,
+                                   ;; or singleton when only one chain entry.
+                                   (if (= 1 (count input-signals))
+                                     (body-fn (first in-vals) query-v)
+                                     (body-fn (vec in-vals) query-v)))]
+                           ;; Per Spec 010 §step 6: validate sub-return
+                           ;; post-compute against the sub's :spec.
+                           ;; Failures emit :rf.error/schema-validation-failure
+                           ;; and the sub yields nil (recovery
+                           ;; :replaced-with-default).
+                           (maybe-validate-sub-return! v query-v query-id meta))
                          (catch #?(:clj Throwable :cljs :default) e
                            (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
                              (trace/emit-error!
@@ -195,7 +220,10 @@
   WOULD compute given a snapshot of state without going through the
   per-frame cache. Supports the same :<- chain shape as subscribe.
 
-  Per Spec 008 §Testing — pure compute-sub form."
+  Per Spec 008 §Testing — pure compute-sub form. Per Spec 010 §step 6
+  (rf2-wcam): the return value is validated against any :spec on the
+  sub's meta — failures emit :rf.error/schema-validation-failure and
+  yield nil (default :replaced-with-default recovery)."
   [query-v db]
   (let [query-id (first query-v)
         meta     (registrar/lookup :sub query-id)]
@@ -203,15 +231,16 @@
       (let [body-fn (:handler-fn meta)
             inputs  (:input-signals meta)]
         (try
-          (cond
-            (empty? inputs)
-            (body-fn db query-v)
+          (let [v (cond
+                    (empty? inputs)
+                    (body-fn db query-v)
 
-            (= 1 (count inputs))
-            (body-fn (compute-sub (first inputs) db) query-v)
+                    (= 1 (count inputs))
+                    (body-fn (compute-sub (first inputs) db) query-v)
 
-            :else
-            (body-fn (mapv #(compute-sub % db) inputs) query-v))
+                    :else
+                    (body-fn (mapv #(compute-sub % db) inputs) query-v))]
+            (maybe-validate-sub-return! v query-v query-id meta))
           (catch #?(:clj Throwable :cljs :default) _
             nil))))))
 

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -16,6 +16,7 @@
             [clojure.java.io :as io]
             [clojure.edn :as edn]
             [re-frame.core :as rf]
+            [re-frame.cofx :as cofx]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
@@ -42,6 +43,9 @@
     :ssr/head-contract
     :ssr/error-projection
     :schemas/runtime
+    :schemas/event-payload                            ;; rf2-jwm4
+    :schemas/sub-return                               ;; rf2-wcam
+    :schemas/cofx                                     ;; rf2-7leq
     :routing/ranking
     :routing/fragment
     :routing/blocking
@@ -113,20 +117,107 @@
   (let [caps (or (:fixture/capabilities fixture) #{})]
     (every? claimed-capabilities caps)))
 
+(defn- collect-cofx-keys
+  "Walk steps and pull every cofx-id referenced via [:cofx-key K]. Used
+  by realise-handlers to auto-wire (inject-cofx K) interceptors onto
+  events whose bodies read coeffects. Returns a set of K."
+  [steps]
+  (let [out (atom #{})]
+    ((fn walk [form]
+       (cond
+         (and (vector? form) (= :cofx-key (first form)))
+         (swap! out conj (second form))
+
+         (coll? form)
+         (doseq [x form] (walk x))))
+     steps)
+    @out))
+
+(defn- realise-cofx-handler
+  "DSL → a cofx handler fn (ctx) → ctx. The body's first :set step
+  declares the value to inject; the runner places that value at
+  [:coeffects cofx-id] (canonical convention — the cofx-id is the
+  slot key per Spec 010 §Where schemas attach §On every reg-*).
+
+  Per rf2-g25p (the conformance-runner gap for cofx body realisation)
+  this is a minimal first-pass interpreter — sufficient for the
+  schemas/cofx fixture which only uses literal :set steps."
+  [cofx-id steps]
+  (fn [ctx]
+    (let [first-set (some (fn [s] (when (= :set (first s)) s)) steps)
+          value     (when first-set (nth first-set 2 nil))]
+      (assoc-in ctx [:coeffects cofx-id] value))))
+
 (defn- realise-handlers [fixture]
   ;; Walk :fixture/handlers and register each.
-  (let [handlers-map (or (:fixture/handlers fixture) {})]
+  (let [handlers-map (or (:fixture/handlers fixture) {})
+        event-registry (get-in fixture [:fixture/registry :event] {})
+        sub-registry   (get-in fixture [:fixture/registry :sub] {})
+        cofx-bodies    (get handlers-map :cofx)
+        cofx-registry  (get-in fixture [:fixture/registry :cofx] {})
+        ;; cofx that should auto-wire as inject-cofx interceptors on
+        ;; event handlers (per rf2-g25p — the runner's first-pass
+        ;; auto-injection convention). Stable lex order on cofx-id so
+        ;; the last-write-wins outcome is deterministic across JVM /
+        ;; CLJS / re-runs.
+        cofx-by-key
+        (->> cofx-registry
+             (sort-by key)
+             (group-by (fn [[cofx-id _]] (keyword (namespace cofx-id))))
+             (reduce-kv (fn [acc k pairs]
+                          (assoc acc k (mapv first pairs)))
+                        {}))]
+    ;; cofx registrations — bodies + :spec metadata. Per rf2-7leq the
+    ;; schema validation runs in inject-cofx; here we register the
+    ;; handler-fn so inject-cofx can resolve it.
+    (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
+      (doseq [cofx-id all-cofx-ids]
+        (let [body    (get cofx-bodies cofx-id [[:noop]])
+              meta    (get cofx-registry cofx-id {})
+              handler (realise-cofx-handler cofx-id body)]
+          (rf/reg-cofx cofx-id (assoc meta :handler-fn handler) handler))))
     (doseq [[id steps] (get handlers-map :event)]
-      (let [[kind handler] (conformance/realise-event-handler steps)]
+      (let [[kind handler] (conformance/realise-event-handler steps)
+            ;; Per Spec 010 §step 1 (rf2-jwm4): pull :spec / :doc from
+            ;; the fixture's :fixture/registry :event meta and pass it
+            ;; through to reg-event-* so validate-event! can find it.
+            event-meta (get event-registry id {})
+            ;; Per rf2-g25p: scan the body for [:cofx-key K] references;
+            ;; for each K, auto-wire (inject-cofx C) for every C whose
+            ;; namespace matches K (the conformance-corpus convention
+            ;; for the schemas/cofx fixture). With no :spec to flag,
+            ;; non-spec'd cofx still wire so the handler can read them.
+            ks            (collect-cofx-keys steps)
+            cofx-ids      (vec
+                            (mapcat (fn [k]
+                                      (or (get cofx-by-key k)
+                                          (when (contains? cofx-registry k) [k])))
+                                    ks))
+            interceptors  (mapv cofx/inject-cofx cofx-ids)]
         (case kind
-          :db (rf/reg-event-db id handler)
-          :fx (rf/reg-event-fx id handler))))
+          :db (if (seq event-meta)
+                (rf/reg-event-db id event-meta interceptors handler)
+                (if (seq interceptors)
+                  (rf/reg-event-db id interceptors handler)
+                  (rf/reg-event-db id handler)))
+          :fx (if (seq event-meta)
+                (rf/reg-event-fx id event-meta interceptors handler)
+                (if (seq interceptors)
+                  (rf/reg-event-fx id interceptors handler)
+                  (rf/reg-event-fx id handler))))))
     (doseq [[id steps] (get handlers-map :sub)]
-      (let [{:keys [kind inputs body]} (conformance/realise-sub steps)]
+      (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
+            ;; Per Spec 010 §step 6 (rf2-wcam): pull :spec from the
+            ;; sub's registry meta so validate-sub-return! sees it.
+            sub-meta (get sub-registry id {})]
         (case kind
-          :layer-1 (rf/reg-sub id body)
+          :layer-1 (if (seq sub-meta)
+                     (rf/reg-sub id sub-meta body)
+                     (rf/reg-sub id body))
           :layer-2 (apply rf/reg-sub id
-                          (concat (interleave (repeat :<-) inputs) [body])))))
+                          (concat (when (seq sub-meta) [sub-meta])
+                                  (interleave (repeat :<-) inputs)
+                                  [body])))))
     ;; fx handlers — DSL bodies. May :throw, :noop, mutate the frame's
     ;; app-db, or :dispatch a follow-up event (e.g. http stubs).
     ;;

--- a/implementation/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/test/re_frame/schemas_cljs_test.cljs
@@ -83,3 +83,38 @@
                               (:operation %))
                           @traces))
           "no validation-failure traces — every commit conforms"))))
+
+;; ---- rf2-jwm4 — event-payload validation under Reagent -------------------
+;;
+;; Smokes the validate-event! pre-handler wiring (rf2-jwm4) under the
+;; Reagent reactive substrate. The JVM smoke covers the broader pre-
+;; handler / sub-return / cofx contract; this CLJS path locks the
+;; cross-substrate behaviour for at least one of the three new wirings.
+
+(deftest live-dispatch-validates-event-payload-under-reagent
+  (testing "a malformed event payload skips the handler and emits :where :event"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :user/register
+        {:spec [:cat [:= :user/register]
+                     [:map [:email :string] [:age :int]]]}
+        (fn [db _]
+          (swap! calls inc)
+          db))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::cljs-ev (fn [ev] (swap! traces conj ev)))
+        ;; Well-typed payload — handler runs.
+        (rf/dispatch-sync [:user/register {:email "a@b.com" :age 30}])
+        ;; Malformed — handler must NOT run.
+        (rf/dispatch-sync [:user/register {:email "c@d.com" :age "no"}])
+        (rf/remove-trace-cb! ::cljs-ev)
+        (is (= 1 @calls)
+            "handler ran exactly once — the bad payload was rejected pre-handler")
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations))
+              "exactly one schema-validation-failure trace fired under Reagent")
+          (let [v (first violations)]
+            (is (= :event (-> v :tags :where))
+                ":where :event locates the failure at pre-handler validation")
+            (is (= :user/register (-> v :tags :failing-id)))))))))

--- a/implementation/test/re_frame/schemas_test.clj
+++ b/implementation/test/re_frame/schemas_test.clj
@@ -112,6 +112,160 @@
         (is (= :n/break (-> violations first :tags :failing-id))
             ":failing-id names the handler whose commit prompted the failure")))))
 
+;; ---- rf2-jwm4 — event-payload validation ---------------------------------
+
+(deftest dispatch-validates-event-payload-pre-handler
+  (testing "Per Spec 010 §step 1 (rf2-jwm4): a malformed event vector fires
+            :rf.error/schema-validation-failure :where :event before the
+            handler runs; the handler is NOT invoked"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :user/register
+        {:spec [:cat [:= :user/register]
+                     [:map [:email :string] [:age :int]]]}
+        (fn [db [_ payload]]
+          (swap! calls inc)
+          (update db :users (fnil conj []) payload)))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::ev (fn [ev] (swap! traces conj ev)))
+        ;; Well-typed payload — passes; handler runs.
+        (rf/dispatch-sync [:user/register {:email "alice@example.com" :age 30}])
+        ;; Malformed payload — fails; handler must NOT run.
+        (rf/dispatch-sync [:user/register {:email "carol@example.com" :age "no"}])
+        (rf/remove-trace-cb! ::ev)
+        (is (= 1 @calls)
+            "handler ran exactly once — once for the well-typed payload, skipped for the bad one")
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations)))
+          (let [v (first violations)]
+            (is (= :event (-> v :tags :where)))
+            (is (= :user/register (-> v :tags :failing-id)))
+            (is (= :user/register (-> v :tags :spec-id)))))))))
+
+(deftest event-payload-validation-elides-when-debug-disabled
+  (testing "validate-event! is a no-op when debug-enabled? is false (production)"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :user/strict
+        {:spec [:cat [:= :user/strict] :int]}
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::ev2 (fn [ev] (swap! traces conj ev)))
+        (with-redefs [interop/debug-enabled? false]
+          (rf/dispatch-sync [:user/strict "not-an-int"]))
+        (rf/remove-trace-cb! ::ev2)
+        (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                (:operation %))
+                            @traces))
+            "no validation trace when debug-enabled? is false")
+        (is (= 1 @calls)
+            "handler runs anyway — production validation is elided")))))
+
+;; ---- rf2-wcam — sub-return validation ------------------------------------
+
+(deftest sub-return-validation-fires-and-replaces-with-default
+  (testing "Per Spec 010 §step 6 (rf2-wcam): a sub whose return value fails
+            its :spec emits :rf.error/schema-validation-failure :where :sub-return
+            and the caller sees nil (default :replaced-with-default recovery)"
+    (rf/reg-event-db :items/init (fn [_ _] {:items ["a" "b" "c"]}))
+    (rf/reg-event-db :items/break (fn [db _] (assoc db :items [1 2 3])))
+    (rf/reg-sub :items
+      {:spec [:vector :string]}
+      (fn [db _] (:items db)))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sr (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:items/init])
+      ;; Well-typed: sub returns the vec.
+      (is (= ["a" "b" "c"] (rf/subscribe-value [:items])))
+      (rf/dispatch-sync [:items/break])
+      ;; Malformed: sub yields nil per :replaced-with-default recovery.
+      (is (nil? (rf/subscribe-value [:items])))
+      (rf/remove-trace-cb! ::sr)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (pos? (count violations))
+            "at least one sub-return validation failure fired")
+        (let [v (first violations)]
+          (is (= :sub-return (-> v :tags :where)))
+          (is (= :items (-> v :tags :sub-id)))
+          (is (= :items (-> v :tags :spec-id)))
+          (is (= :replaced-with-default (:recovery v))))))))
+
+(deftest compute-sub-validates-return-value
+  (testing "compute-sub validates the return against :spec — the pure
+            test-time path mirrors the live reactive path"
+    (rf/reg-sub :nums
+      {:spec [:vector :int]}
+      (fn [db _] (:nums db)))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::cs (fn [ev] (swap! traces conj ev)))
+      (is (= [1 2 3] (#'re-frame.subs/compute-sub [:nums] {:nums [1 2 3]})))
+      (is (nil? (#'re-frame.subs/compute-sub [:nums] {:nums ["bad"]}))
+          "compute-sub yields nil on validation failure")
+      (rf/remove-trace-cb! ::cs)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "exactly one trace from the malformed compute-sub call")))))
+
+;; ---- rf2-7leq — cofx validation ------------------------------------------
+
+(deftest cofx-validation-fires-and-skips-handler
+  (testing "Per Spec 010 §step 2 (rf2-7leq): a cofx whose injected value
+            fails its :spec emits :rf.error/schema-validation-failure
+            :where :cofx and the handler is NOT invoked"
+    (rf/reg-cofx :app-version/bad
+      {:spec :string}
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :app-version/bad] 42)))
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :cap/seed
+        [(rf/inject-cofx :app-version/bad)]
+        (fn [_cofx _]
+          (swap! calls inc)
+          {:db {:app-version "should-not-stash"}}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::cf (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:cap/seed])
+        (rf/remove-trace-cb! ::cf)
+        (is (= 0 @calls)
+            "handler was skipped because the cofx :spec failed")
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations)))
+          (let [v (first violations)]
+            (is (= :cofx (-> v :tags :where)))
+            (is (= :cap/seed (-> v :tags :failing-id)))
+            (is (= :app-version/bad (-> v :tags :cofx-id)))
+            (is (= :app-version/bad (-> v :tags :spec-id)))
+            (is (= :no-recovery (:recovery v)))))))))
+
+(deftest cofx-validation-passes-when-conforming
+  (testing "well-typed cofx values flow through to the handler — no trace, handler runs"
+    (rf/reg-cofx :app-version/well
+      {:spec :string}
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :app-version/well] "1.4.5")))
+    (let [seen-version (atom nil)]
+      (rf/reg-event-fx :cap/seed-good
+        [(rf/inject-cofx :app-version/well)]
+        (fn [cofx _]
+          (reset! seen-version (:app-version/well cofx))
+          {}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::cf2 (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:cap/seed-good])
+        (rf/remove-trace-cb! ::cf2)
+        (is (= "1.4.5" @seen-version)
+            "handler ran and saw the well-typed cofx value")
+        (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                (:operation %))
+                            @traces))
+            "no schema-validation-failure trace fires for a conforming cofx")))))
+
 ;; ---- error projector → :rf/public-error mapping --------------------------
 
 (defn- default-error-projector


### PR DESCRIPTION
## Summary

Wire the existing `validate-*` fns from `re-frame.schemas` into the three runtime paths they were missing from. Until this PR, Spec 010 §Validation order steps 1, 2, and 6 were all unwired — the fns existed but nothing called them.

- **rf2-jwm4** — `validate-event!` fires in `router/process-event!` before the interceptor chain. Failures emit `:rf.error/schema-validation-failure :where :event` and skip the handler (`:no-recovery`; downstream queue continues).
- **rf2-wcam** — `validate-sub-return!` wraps both the live reaction body in `subs/compute-and-cache!` and the test-time pure `subs/compute-sub`. Failures emit `:where :sub-return`; the sub yields `nil` per `:replaced-with-default`.
- **rf2-7leq** — `validate-cofx!` fires inside `cofx/inject-cofx` after the cofx fn returns. Failures mark `:rf/skip-handler?` on the context; the handler-as-interceptor wrappers in `events.cljc` honour the flag.

The trace shape carries `:spec-id`, `:received`, `:malli-error`, and a human-readable `:reason` alongside the existing `:explain`/`:value` keys per Spec 009 §Error contract.

The conformance runner now claims `:schemas/event-payload`, `:schemas/sub-return`, `:schemas/cofx`. It reads `:spec` from `:fixture/registry :event` / `:sub` / `:cofx` and threads it through the registration. A minimal cofx body realiser plus an auto-wire heuristic that prepends `inject-cofx` interceptors based on `[:cofx-key K]` references covers the runner-side gap noted as `rf2-g25p`.

## Test plan

- [x] `cd implementation && clojure -M:test` — 119 tests / 626 assertions / 0 failures
- [x] All four schema fixtures pass (`:schemas/event-payload-validates`, `:schemas/sub-return-validates`, `:schemas/cofx-validates`, plus the existing `:schemas/app-db-slice-validates`)
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — new CLJS smoke for event-payload validation under Reagent passes; pre-existing routing/nine-states failures unchanged
- [x] Three new JVM smokes in `schemas_test.clj` plus a `compute-sub` smoke and a production-elision smoke