### PR TITLE
fix: flow conformance fixtures pass (rf2-wdhi)

### DIFF
--- a/implementation/src/re_frame/conformance.cljc
+++ b/implementation/src/re_frame/conformance.cljc
@@ -162,6 +162,57 @@
 
     :else (resolve-value form ctx)))
 
+;; ---- flow-body realisation -----------------------------------------------
+;;
+;; Per Spec 013, a flow's :output is a positional fn — `(fn [in1 in2 ...] ...)`.
+;; The conformance corpus describes flow bodies as DSL (e.g. `[[:fn :* [:event-arg 0] [:event-arg 1]]]`)
+;; so the same fixture is portable across implementations. The harness
+;; realises the body into a real fn whose positional args bind to
+;; `[:event-arg n]` references inside the DSL.
+;;
+;; This is the same evaluation shape as `eval-value*` (eager :fn application)
+;; lifted over a vector of body steps; the LAST step's resolved value is the
+;; output. Every step is evaluated for its side-effect-free value; non-final
+;; steps' values are discarded (matches the fixture corpus, where bodies are
+;; one-step expressions).
+
+(defn realise-flow-output-fn
+  "DSL body steps → flow :output fn taking positional inputs.
+
+  Each `[:event-arg n]` in the body resolves to the n-th positional input.
+  Returns a fn `(fn [& inputs] ...)` ready for `reg-flow`'s :output slot."
+  [steps]
+  (fn [& inputs]
+    (let [ctx       {:event (vec inputs) :db nil}
+          last-step (last steps)]
+      (cond
+        ;; Terminal :fn step — eager apply (mirrors eval-value*).
+        (and (vector? last-step) (= :fn (first last-step)))
+        (let [[_ k & extra-args] last-step
+              f         (builtin k)
+              resolved  (mapv #(resolve-value % ctx) extra-args)]
+          (apply f resolved))
+
+        :else
+        (resolve-value last-step ctx)))))
+
+(defn- resolve-fx-args
+  "Resolve fx args, leaving DSL fields that the conformance harness owns
+  alone. `:rf.fx/reg-flow`'s `:body` is itself a DSL body — it must NOT
+  be walked through resolve-value (which would treat `[:fn :k ...]` as
+  a value form and partially-apply it). Pull `:body` aside, resolve the
+  rest of the map normally, then realise `:body` into `:output`."
+  [fx-id args ctx]
+  (case fx-id
+    :rf.fx/reg-flow
+    (if (and (map? args) (contains? args :body))
+      (let [body          (:body args)
+            other-resolved (resolve-value (dissoc args :body) ctx)]
+        (assoc other-resolved :output (realise-flow-output-fn body)))
+      (resolve-value args ctx))
+
+    (resolve-value args ctx)))
+
 ;; ---- event-db / event-fx interpreter -------------------------------------
 
 (defn- apply-step
@@ -193,11 +244,16 @@
                  (cond
                    ;; Multi-form: [:fx [[fx-id args] ...]]
                    (and (vector? a) (every? vector? a))
-                   (assoc ctx :fx (into (or fx []) a))
+                   (assoc ctx :fx (into (or fx [])
+                                        (mapv (fn [[fx-id fx-args]]
+                                                [fx-id (resolve-fx-args fx-id fx-args ctx)])
+                                              a)))
 
                    ;; Single form: [:fx fx-id args]
                    :else
-                   (assoc ctx :fx (conj (or fx []) [a (resolve-value b ctx)]))))
+                   (assoc ctx :fx
+                          (conj (or fx [])
+                                [a (resolve-fx-args a b ctx)]))))
 
     :dispatch  (let [ev (resolve-value (second step) ctx)]
                  (assoc ctx :fx (conj (or fx []) [:dispatch ev])))

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -242,6 +242,23 @@
               meta  (get fx-registry id {})
               handler (conformance/realise-fx-handler id body adapter-helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
+    ;; flow registrations — per Spec 013, flows are registered on the
+    ;; current frame with positional :output fns. The fixture corpus
+    ;; declares flow shape under :fixture/registry :flow (with :inputs /
+    ;; :path / :doc) and the body DSL under :fixture/flow-bodies
+    ;; (a parallel {flow-id [steps]} map). The harness realises each
+    ;; body into a positional output fn and calls reg-flow.
+    ;;
+    ;; Dynamic flow registration via :rf.fx/reg-flow is handled in the
+    ;; conformance DSL interpreter (see resolve-fx-args in conformance.cljc).
+    (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
+          flow-bodies   (or (:fixture/flow-bodies fixture) {})]
+      (doseq [[flow-id flow-meta] flow-registry]
+        (when-let [body (get flow-bodies flow-id)]
+          (let [output-fn (conformance/realise-flow-output-fn body)]
+            (rf/reg-flow (-> flow-meta
+                             (assoc :id flow-id)
+                             (assoc :output output-fn)))))))
     ;; route registrations
     (doseq [[id meta] (get handlers-map :route)]
       (rf/reg-route id meta))


### PR DESCRIPTION
## Summary

The 5 flow-*.edn conformance fixtures fail because the conformance harness does not realise flow bodies. The runtime in `flows.cljc` is correct — the JVM smoke `flows_test.clj` exercises the same paths and passes.

Two gaps in the harness:

1. **Static flows**: fixtures declare flow shape under `:fixture/registry :flow` plus the body DSL under `:fixture/flow-bodies`. The harness ignored both, so `reg-flow` was never called and the flow's output was never materialised in app-db.

2. **Dynamic registration via `:rf.fx/reg-flow`**: fixtures pass the body in `:body` (a DSL form). The runtime fx handler validates `:output` must be a fn, so without translation `reg-flow` throws `:rf.error/flow-bad-output`.

## Fix

- Add `conformance/realise-flow-output-fn` — DSL body steps to positional output fn (mirrors `eval-value*`'s eager `:fn` application; the last step's resolved value is the output).
- `conformance/resolve-fx-args` specially handles `:rf.fx/reg-flow`: pulls `:body` aside (so `resolve-value` doesn't eagerly partial-apply its `:fn` forms), resolves the rest of the args map, then attaches `:output` realised from `:body`.
- `conformance_test/realise-handlers` walks `:fixture/registry :flow` and registers each flow with the realised `:output` fn.

No changes to `flows.cljc`. The fix is entirely in the conformance DSL interpreter and the test harness.

## Test plan

- [x] `cd implementation && clojure -M:test` — conformance corpus 66/66 passing (was 61/66)
- [x] All 5 flow fixtures pass: `:flow/recompute-on-input-change`, `:flow/multi-input-topo`, `:flow/noop-on-value-equal-input`, `:flow/toggle-via-fx`, `:flow/hot-reload-preserves-output`
- [x] No regression in other tests: 119 tests, 626 assertions, 0 failures, 0 errors
- [x] `flows_test.clj` (JVM smoke for the same code paths) continues to pass

Closes rf2-wdhi.