### PR TITLE
fix: routing-cljs-test cross-test pollution (rf2-coks)

### DIFF
--- a/implementation/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/test/re_frame/cross_spec_cljs_test.cljs
@@ -11,13 +11,27 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
             [re-frame.views]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
+(defn- reset-runtime
+  "Per-test runtime reset for CLJS cross-spec tests.
+
+  We deliberately do NOT call (registrar/clear-all!) here. CLJS has no
+  runtime (require :reload), so a clear-all! would wipe routing's
+  framework events (:rf/url-changed, :rf.route/navigate, :rf.nav/scroll
+  fx, …) and machines.cljc's :rf/machine sub, which were registered at
+  ns-load time and CANNOT be re-registered without reloading the
+  defining ns. Subsequent CLJS test files (nine-states-cljs-test,
+  routing-cljs-test) depend on those registrations being intact —
+  rf2-coks tracked the cross-test pollution.
+
+  Tests that re-register the same id (e.g. :test/m, :seed) rely on
+  registrar/register!'s replacement semantics — that's a supported
+  hot-reload path, not a leak. Resetting frames, flows and the adapter
+  is enough to isolate per-test state."
+  [test-fn]
   (reset! frame/frames {})
   (reset! flows/flows {})
   (adapter/dispose-adapter!)

--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -11,15 +11,28 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
             [re-frame.trace :as trace]))
 
-(defn reset-runtime [test-fn]
-  (registrar/clear-all!)
+(defn reset-runtime
+  "Per-test runtime reset for CLJS machines tests.
+
+  We deliberately do NOT call (registrar/clear-all!) here. CLJS has no
+  runtime (require :reload), so a clear-all! would wipe routing's
+  framework events (:rf/url-changed, :rf.route/navigate, :rf.nav/scroll
+  fx, …) and machines.cljc's :rf/machine sub, which were registered at
+  ns-load time and CANNOT be re-registered without reloading the
+  defining ns. Subsequent CLJS test files (nine-states-cljs-test,
+  routing-cljs-test) depend on those registrations being intact —
+  rf2-coks tracked the cross-test pollution.
+
+  Each test in this file uses unique machine / event ids, so a registry
+  wipe is unnecessary for in-file isolation. Resetting frames, flows,
+  the adapter, the machine counters and trace cbs is enough."
+  [test-fn]
   (reset! frame/frames {})
   (reset! flows/flows {})
   (adapter/dispose-adapter!)


### PR DESCRIPTION
## Summary

Fixes 11 routing-cljs-test failures (and 12 pre-existing nine-states failures) on the `cljs (node-test)` and `cljs-browser` CI jobs. Both were caused by the same cross-test global-state pollution.

## Root cause

`cross_spec_cljs_test` and `machines_cljs_test` both used a per-test `reset-runtime` fixture that called `registrar/clear-all!`. That wipes everything in the registrar — including `routing.cljc`'s framework events (`:rf/url-changed`, `:rf.route/navigate`, `:rf.nav/*` fx, …) and `machines.cljc`'s `:rf/machine` sub, which are registered at ns-load time. CLJS has no runtime `(require :reload)` so those registrations can't be restored. Test files that ran alphabetically AFTER the polluters (`nine_states_cljs_test`, `routing_cljs_test`) saw a half-empty registry and failed.

## Fix

Drop `clear-all!` from both fixtures. Both fixtures use unique ids per test, so the wipe was never necessary for in-file isolation. The few tests that re-use ids (`:test/m`, `:seed`, …) rely on `register!`'s replacement semantics intentionally — that's a supported hot-reload path, not a leak.

The remaining `clear-all!` callers (`runtime_cljs_test`, `schemas_cljs_test`) are alphabetically after the routing-dependent tests, so their wipe doesn't pollute anything in scope. Left untouched per "minimal fix" guidance.

Both modified fixtures now carry an explanatory docstring so the next person doesn't reinstate `clear-all!`.

## Test plan

- [x] CLJS node-test: `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 23 failures → 0 failures
- [x] JVM tests: `cd implementation && clojure -M:test` — 0 failures, 0 errors (unchanged; only CLJS test files modified)
- [x] routing-cljs-test in isolation still passes
- [ ] CI green on `cljs (node-test)` and `cljs-browser`