### PR TITLE
fix: browser-test runner hang at reg-view double-def + h-macro (rf2-fdhs)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -14,5 +14,16 @@
    :ns-regexp "-cljs-test$"
    :test-dir  "out/browser-test"
    :runner-ns shadow.test.browser
+   :compiler-options
+   ;; cljs-test-display.core/printing defaults to false. Without printing
+   ;; enabled, shadow.test.browser's reporter writes results only to the
+   ;; DOM and never produces the "Ran N tests containing M assertions"
+   ;; summary line our Playwright runner watches for in the console
+   ;; stream — which means the runner times out with a green test suite,
+   ;; presenting as a hang. Per cljs-test-display's design, set
+   ;; :closure-defines so cljs-test-display.core/printing = true at
+   ;; compile time so the summary lands on the console where the runner
+   ;; can see it.
+   {:closure-defines {cljs-test-display.core/printing true}}
    :devtools  {:http-port 8021
                :http-root "out/browser-test"}}}}


### PR DESCRIPTION
## Summary

The shadow-cljs `:browser-test` runner appeared to hang after `runtime_cljs_test/reg-view-macro-double-def-investigation` and `h-rewrites-namespaced-view-keys`, exiting only on the 120s timeout. Diagnostic instrumentation showed all 54 tests / 179 assertions actually complete cleanly under Reagent in headless Chromium — the apparent hang was the Playwright runner waiting for a `Ran N tests containing M assertions.` summary line on the console that `cljs-test-display` (shadow.test.browser's reporter) never wrote because `cljs-test-display.core/printing` defaults to `false`.

## Fix

Set `:compiler-options {:closure-defines {cljs-test-display.core/printing true}}` on the `:browser-test` build in `implementation/shadow-cljs.edn`. With printing on, cljs-test-display's `:summary` report method println's the summary on the console where `scripts/run-browser-tests.cjs` already polls for it.

The hang was misattributed to the most recently printed test (the `reg-view` / `h` macro pair), but the same misdiagnosis would surface on any change to the test output order — there was no real Reagent-scheduler interaction; the runner's summary-detection contract was simply one-sided.

## Test plan

- [x] `cd implementation && npx shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs` → `Ran 54 tests containing 179 assertions. 0 failures, 0 errors.` (was: `Timed out after 120000ms waiting for cljs.test summary.`)
- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` → `Ran 54 tests containing 179 assertions. 0 failures, 0 errors.` (parity confirmed)
- [ ] CI `cljs-browser` job completes (was: timing out)

Closes rf2-fdhs.