### PR TITLE
fix: make-frame :on-create seeds app-db (rf2-p8g8)

### DIFF
--- a/implementation/src/re_frame/cofx.cljc
+++ b/implementation/src/re_frame/cofx.cljc
@@ -10,18 +10,20 @@
   Use inject-cofx in an event handler's interceptor list to ingest a
   registered cofx into the context."
   (:require [re-frame.registrar :as registrar]
-            [re-frame.interceptor :as interceptor]))
+            [re-frame.interceptor :as interceptor]
+            [re-frame.late-bind :as late-bind]))
 
 (defn- maybe-validate-cofx!
   "Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
   injects, validate its value against the cofx's :spec metadata.
 
-  We resolve schemas/validate-cofx! lazily so this namespace stays
-  decoupled from re-frame.schemas (avoids a require cycle). Returns
-  the (possibly mutated) context — sets :rf/skip-handler? when
-  validation fails so the handler-as-interceptor short-circuits."
+  We look up schemas/validate-cofx! through the late-bind registry so
+  this namespace stays decoupled from re-frame.schemas (avoids a
+  require cycle). Returns the (possibly mutated) context — sets
+  :rf/skip-handler? when validation fails so the handler-as-interceptor
+  short-circuits."
   [ctx cofx-id cofx-meta]
-  (if-let [validate (resolve 're-frame.schemas/validate-cofx!)]
+  (if-let [validate (late-bind/get-fn :schemas/validate-cofx!)]
     (let [event    (interceptor/get-coeffect ctx :event)
           event-id (first event)
           ;; The cofx's injected value is whatever it just stashed under
@@ -31,7 +33,7 @@
           ;; declared, so users opt in by registering against the same
           ;; key they inject under.
           value    (get (:coeffects ctx) cofx-id)
-          ok?      (try ((deref validate) cofx-id event-id value cofx-meta)
+          ok?      (try (validate cofx-id event-id value cofx-meta)
                         (catch #?(:clj Throwable :cljs :default) _ true))]
       (if ok?
         ctx

--- a/implementation/src/re_frame/flows.cljc
+++ b/implementation/src/re_frame/flows.cljc
@@ -12,6 +12,7 @@
   / inspector reasons."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
@@ -248,3 +249,13 @@
             (let [flow (flow-map (first remaining))
                   [new-db dirty?] (evaluate-flow! frame-id db flow)]
               (recur (rest remaining) new-db (or any-dirty? dirty?)))))))))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; re-frame.fx and re-frame.router need to call into flows but cannot
+;; `:require` this namespace without a cyclic load order. Publish entry
+;; points through the late-bind hook registry. See re-frame.late-bind.
+
+(late-bind/set-fn! :flows/reg-flow-fx!    reg-flow-fx!)
+(late-bind/set-fn! :flows/clear-flow-fx!  clear-flow-fx!)
+(late-bind/set-fn! :flows/run-flows!      run-flows!)

--- a/implementation/src/re_frame/frame.cljc
+++ b/implementation/src/re_frame/frame.cljc
@@ -14,6 +14,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 ;; ---- the frame record -----------------------------------------------------
@@ -146,11 +147,13 @@
           ;; Run :on-create events synchronously BEFORE emitting :frame/created.
           ;; Per Spec 002 §Frame creation: on-create completes first, then
           ;; the frame is observable to listeners. The router/dispatch
-          ;; namespace handles dispatch-sync; we forward via require to avoid
-          ;; a cyclic dep at compile time.
+          ;; namespace handles dispatch-sync; we forward via the late-bind
+          ;; registry to avoid a cyclic dep at compile time. (`resolve` is
+          ;; not a runtime fn in CLJS, so the older `(resolve 'router/...)`
+          ;; pattern silently no-op'd in CLJS — see rf2-p8g8.)
           (when-let [on-create (:on-create config)]
-            (when-let [dispatch-sync (resolve 're-frame.router/dispatch-sync!)]
-              ((deref dispatch-sync) on-create {:frame id})))
+            (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
+              (dispatch-sync on-create {:frame id})))
           (trace/emit! :frame :frame/created
                        {:frame id :config config})
           id)
@@ -193,8 +196,8 @@
     ;; (1) fire the user-supplied :on-destroy event before mutating
     ;; lifecycle state so handlers see a still-alive frame.
     (when-let [on-destroy (get-in f [:config :on-destroy])]
-      (when-let [dispatch-sync (resolve 're-frame.router/dispatch-sync!)]
-        ((deref dispatch-sync) on-destroy {:frame id})))
+      (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
+        (dispatch-sync on-destroy {:frame id})))
     ;; (2) signal active-machine teardown so observers can hook in.
     (let [container (get-frame-db id)
           db        (when container (adapter/read-container container))

--- a/implementation/src/re_frame/fx.cljc
+++ b/implementation/src/re_frame/fx.cljc
@@ -17,6 +17,7 @@
     :rf.fx/clear-flow — runtime, clear a flow"
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 ;; ---- registration ---------------------------------------------------------
@@ -87,26 +88,26 @@
    (case fx-id
     :dispatch
     ;; Append to back of the frame's router queue.
-    (when-let [dispatch! (resolve 're-frame.router/dispatch!)]
-      ((deref dispatch!) args {:frame frame-id}))
+    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+      (dispatch! args {:frame frame-id}))
 
     :dispatch-later
     (let [{:keys [ms event]} args]
       (interop/set-timeout!
         (fn []
-          (when-let [dispatch! (resolve 're-frame.router/dispatch!)]
-            ((deref dispatch!) event {:frame frame-id})))
+          (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+            (dispatch! event {:frame frame-id})))
         ms))
 
     :rf.fx/reg-flow
     ;; Per Spec 013 — flows are frame-scoped. The flow registers against
     ;; the dispatching frame.
-    (when-let [reg-flow! (resolve 're-frame.flows/reg-flow-fx!)]
-      ((deref reg-flow!) args {:frame frame-id}))
+    (when-let [reg-flow! (late-bind/get-fn :flows/reg-flow-fx!)]
+      (reg-flow! args {:frame frame-id}))
 
     :rf.fx/clear-flow
-    (when-let [clear-flow! (resolve 're-frame.flows/clear-flow-fx!)]
-      ((deref clear-flow!) args {:frame frame-id}))
+    (when-let [clear-flow! (late-bind/get-fn :flows/clear-flow-fx!)]
+      (clear-flow! args {:frame frame-id}))
 
     :spawn
     ;; Per Spec 005 §Declarative :invoke (sugar over spawn): emitted by

--- a/implementation/src/re_frame/late_bind.cljc
+++ b/implementation/src/re_frame/late_bind.cljc
@@ -1,0 +1,62 @@
+(ns re-frame.late-bind
+  "Late-binding hook registry for cross-namespace forward references.
+
+  Some leaf namespaces (re-frame.frame, re-frame.fx, re-frame.cofx,
+  re-frame.subs, re-frame.routing, re-frame.router) need to call into
+  higher-level namespaces (re-frame.router, re-frame.flows,
+  re-frame.schemas, re-frame.subs) but cannot `:require` them without
+  introducing a cyclic load order.
+
+  On the JVM we historically used `(resolve 'ns/sym)` to defer the
+  lookup to runtime. That works on the JVM because `clojure.core/resolve`
+  is a runtime fn — but ClojureScript has no runtime `resolve` (the
+  symbol exists only as a compile-time analyzer affordance), so every
+  CLJS call site silently no-op'd. That manifested as e.g.
+  `(rf/make-frame {:on-create [:foo]})` returning a frame whose app-db
+  was never seeded by `:on-create`, and `:fx [[:dispatch [...]]]`
+  becoming a no-op.
+
+  This namespace replaces those `resolve` calls with an explicit hook
+  registry. The producing namespace registers its callable at load
+  time via `set-fn!`; the consuming namespace fetches it via `get-fn`
+  at call time. Identical behaviour on JVM and CLJS.
+
+  Per Spec 002 §reg-frame is atomic: `:on-create` runs synchronously
+  inside `reg-frame`; `make-frame` is a thin wrapper, so by the time
+  `make-frame` returns the frame's app-db reflects the init handler's
+  commits. Callers MUST register the `:on-create` event's handler
+  BEFORE calling `make-frame` / `reg-frame`. (When the JVM/CLJS host
+  loads `re-frame.core`, the canonical re-frame.router namespace is
+  loaded — and registers its hooks — before any user code runs.)")
+
+(defonce
+  ^{:doc "Map of hook-key → fn. Populated by the producing namespace at
+  load time. The set of keys is documented at each call site; v1 keys:
+
+    :router/dispatch!         re-frame.router/dispatch!
+    :router/dispatch-sync!    re-frame.router/dispatch-sync!
+    :flows/reg-flow-fx!       re-frame.flows/reg-flow-fx!
+    :flows/clear-flow-fx!     re-frame.flows/clear-flow-fx!
+    :flows/run-flows!         re-frame.flows/run-flows!
+    :schemas/validate-event!     re-frame.schemas/validate-event!
+    :schemas/validate-app-db!    re-frame.schemas/validate-app-db!
+    :schemas/validate-cofx!      re-frame.schemas/validate-cofx!
+    :schemas/validate-sub-return! re-frame.schemas/validate-sub-return!
+    :subs/subscribe-value     re-frame.subs/subscribe-value
+    :ssr/render-tree-hash     re-frame.ssr/render-tree-hash"}
+  hooks
+  (atom {}))
+
+(defn set-fn!
+  "Register a fn under hook-key. The producing namespace calls this at
+  the bottom of its file; consumers look it up via `get-fn`."
+  [hook-key f]
+  (swap! hooks assoc hook-key f)
+  nil)
+
+(defn get-fn
+  "Return the fn registered under hook-key, or nil if no producer has
+  registered it yet. Callers MUST handle the nil case (the common
+  pattern is `(when-let [f (late-bind/get-fn ...)] (f args))`)."
+  [hook-key]
+  (get @hooks hook-key))

--- a/implementation/src/re_frame/registrar.cljc
+++ b/implementation/src/re_frame/registrar.cljc
@@ -10,7 +10,8 @@
 
   Per Spec 005, machine guards/actions are machine-scoped (declared in
   the machine's :guards / :actions map) and NOT registered as standalone
-  kinds. The kinds set below is the closed v1 list.")
+  kinds. The kinds set below is the closed v1 list."
+  (:require [re-frame.late-bind :as late-bind]))
 
 ;; ---- the kind set ---------------------------------------------------------
 
@@ -73,9 +74,9 @@
         ;; re-registrations (same fn instance, common during ns reload of
         ;; static defs) would otherwise spam the trace stream.
         (when different?
-          (when-let [emit! (resolve 're-frame.trace/emit!)]
-            ((deref emit!) :registry :rf.registry/handler-replaced
-                           {:kind kind :id id :different-fn? true})))))
+          (when-let [emit! (late-bind/get-fn :trace/emit!)]
+            (emit! :registry :rf.registry/handler-replaced
+                   {:kind kind :id id :different-fn? true})))))
     {:was previous :now metadata}))
 
 (defn unregister!

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -14,6 +14,7 @@
             [re-frame.fx :as fx]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 ;; ---- envelope construction ------------------------------------------------
@@ -95,9 +96,8 @@
                 ;; :no-recovery; downstream queue continues). Tracked
                 ;; as rf2-jwm4.
                 event-ok?
-                (if-let [validate-event!
-                         (resolve 're-frame.schemas/validate-event!)]
-                  (try ((deref validate-event!) event-id event handler-meta)
+                (if-let [validate-event! (late-bind/get-fn :schemas/validate-event!)]
+                  (try (validate-event! event-id event handler-meta)
                        (catch #?(:clj Throwable :cljs :default) _ true))
                   true)
                 {:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
@@ -147,15 +147,15 @@
               ;; after each commit. Failures emit
               ;; :rf.error/schema-validation-failure but don't roll back
               ;; (recovery is :no-recovery by default).
-              (when-let [validate (resolve 're-frame.schemas/validate-app-db!)]
+              (when-let [validate (late-bind/get-fn :schemas/validate-app-db!)]
                 (try
-                  ((deref validate) (:db effects) event-id)
+                  (validate (:db effects) event-id)
                   (catch #?(:clj Throwable :cljs :default) _ nil))))
             ;; Run flows (per Spec 013 §Drain integration: after :db
             ;; commits and before :fx walks).
-            (when-let [run-flows! (resolve 're-frame.flows/run-flows!)]
+            (when-let [run-flows! (late-bind/get-fn :flows/run-flows!)]
               (try
-                ((deref run-flows!) frame)
+                (run-flows! frame)
                 (catch #?(:clj Throwable :cljs :default) e
                   (trace/emit-error! :rf.error/flow-eval-exception
                                      {:frame frame :event event :exception e}))))
@@ -306,3 +306,15 @@
            (finally
              (swap! router assoc :in-sync-drain? false)))))
      nil)))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; Other namespaces that load BEFORE this one (re-frame.frame for :on-create
+;; / :on-destroy, re-frame.fx for :dispatch / :dispatch-later) need to call
+;; into the router. They cannot `:require` this namespace without a cyclic
+;; load order, so we publish our entry points through the late-bind hook
+;; registry once this namespace is loaded. The hook keys are documented in
+;; re-frame.late-bind.
+
+(late-bind/set-fn! :router/dispatch!       dispatch!)
+(late-bind/set-fn! :router/dispatch-sync!  dispatch-sync!)

--- a/implementation/src/re_frame/routing.cljc
+++ b/implementation/src/re_frame/routing.cljc
@@ -34,6 +34,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 ;; ---- url encoding / decoding ---------------------------------------------
@@ -706,8 +707,8 @@
   "Resolve and call the route's :can-leave sub against the live frame."
   [frame route-meta]
   (if-let [sub-id (:can-leave route-meta)]
-    (when-let [subscribe-value (resolve 're-frame.subs/subscribe-value)]
-      (boolean ((deref subscribe-value) frame [sub-id])))
+    (when-let [subscribe-value (late-bind/get-fn :subs/subscribe-value)]
+      (boolean (subscribe-value frame [sub-id])))
     true))
 
 (events/reg-event-fx :rf/url-requested

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -10,6 +10,7 @@
   hasn't pulled Malli into their project, schemas are silently ignored."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 (defn- malli-validate*
@@ -198,3 +199,15 @@
                               :recovery    :no-recovery})
           false)))
     true))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; re-frame.router, re-frame.cofx, and re-frame.subs need to call into
+;; schema validation but cannot `:require` this namespace without a
+;; cyclic load order. Publish entry points through the late-bind hook
+;; registry. See re-frame.late-bind.
+
+(late-bind/set-fn! :schemas/validate-app-db!     validate-app-db!)
+(late-bind/set-fn! :schemas/validate-event!      validate-event!)
+(late-bind/set-fn! :schemas/validate-sub-return! validate-sub-return!)
+(late-bind/set-fn! :schemas/validate-cofx!       validate-cofx!)

--- a/implementation/src/re_frame/ssr.cljc
+++ b/implementation/src/re_frame/ssr.cljc
@@ -30,6 +30,7 @@
   ssr/redirect, ssr/set-status, fx/platforms)."
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.events :as events]
             [re-frame.substrate.adapter :as adapter]
@@ -296,17 +297,16 @@
   populate that slot (e.g. fixture-overridden handlers)."
   ([frame-id tree-or-hash] (verify-hydration! frame-id tree-or-hash {}))
   ([frame-id tree-or-hash {:keys [first-diff-path failing-id server-hash]}]
-   (let [adapter     (resolve 're-frame.frame/frame-app-db-value)
-         db          (when adapter ((deref adapter) frame-id))
+   (let [db          (frame/frame-app-db-value frame-id)
          server-hash (or server-hash
                          (get-in db [:rf/hydration :server-hash]))
          client-hash (cond
                        (string? tree-or-hash) tree-or-hash
                        tree-or-hash           (render-tree-hash tree-or-hash))]
      (when (and server-hash client-hash (not= server-hash client-hash))
-       (let [trace-fn (resolve 're-frame.trace/emit-error!)]
+       (let [trace-fn (late-bind/get-fn :trace/emit-error!)]
          (when trace-fn
-           ((deref trace-fn) :rf.ssr/hydration-mismatch
+           (trace-fn :rf.ssr/hydration-mismatch
             (cond-> {:server-hash server-hash
                      :client-hash client-hash
                      :frame       frame-id
@@ -523,3 +523,13 @@ response with no body."
   [frame-id]
   (-> (response-of frame-id)
       (dissoc status-writes-key redirect-writes-key)))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; re-frame.core/render-tree-hash forwards to this ns's render-tree-hash
+;; but cannot `:require` re-frame.ssr without a cyclic load order
+;; (re-frame.core is the user-facing namespace; re-frame.ssr requires
+;; re-frame.events and re-frame.frame which are also re-required by
+;; core). Publish the entry point through the late-bind hook registry.
+
+(late-bind/set-fn! :ssr/render-tree-hash render-tree-hash)

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -19,6 +19,7 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
 ;; ---- registration ---------------------------------------------------------
@@ -93,12 +94,13 @@
   return nil per :replaced-with-default recovery; otherwise return
   the value unchanged.
 
-  Resolved lazily so this namespace stays free of a hard re-frame.schemas
-  dep (avoids load-order surprises)."
+  Looked up lazily through the late-bind registry so this namespace
+  stays free of a hard re-frame.schemas dep (avoids load-order
+  surprises)."
   [value query-v sub-id sub-meta]
   (if (and sub-meta (:spec sub-meta))
-    (if-let [validate (resolve 're-frame.schemas/validate-sub-return!)]
-      (if (try ((deref validate) sub-id query-v value sub-meta)
+    (if-let [validate (late-bind/get-fn :schemas/validate-sub-return!)]
+      (if (try (validate sub-id query-v value sub-meta)
                (catch #?(:clj Throwable :cljs :default) _ true))
         value
         nil)
@@ -312,3 +314,11 @@
          (try (interop/dispose! r)
               (catch #?(:clj Throwable :cljs :default) _ nil))))
      (reset! cache {}))))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; re-frame.routing needs to call subscribe-value but cannot `:require`
+;; this namespace without a cyclic load order. Publish entry point
+;; through the late-bind hook registry. See re-frame.late-bind.
+
+(late-bind/set-fn! :subs/subscribe-value subscribe-value)

--- a/implementation/src/re_frame/trace.cljc
+++ b/implementation/src/re_frame/trace.cljc
@@ -15,7 +15,8 @@
      :time        <millis>                 ;; required
      :duration    <millis>                 ;; optional
      :tags        {...}}                   ;; required, open map"
-  (:require [re-frame.interop :as interop]))
+  (:require [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]))
 
 ;; ---- listener registry ----------------------------------------------------
 
@@ -98,3 +99,13 @@
         (try
           (f event)
           (catch #?(:clj Throwable :cljs :default) _ nil))))))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; re-frame.registrar emits a trace event when a handler is replaced but
+;; cannot `:require` this namespace without a cyclic load order.
+;; Publish `emit!` through the late-bind hook registry. See
+;; re-frame.late-bind.
+
+(late-bind/set-fn! :trace/emit!       emit!)
+(late-bind/set-fn! :trace/emit-error! emit-error!)


### PR DESCRIPTION
## Summary

- `(rf/make-frame {:on-create [:foo]})` was returning a CLJS frame whose app-db was never seeded by `:on-create`, even though Spec 002 §reg-frame is atomic guarantees it runs synchronously inside `reg-frame`. The JVM-side test (`reg-frame-on-create-runs-synchronously` in `frame_lifecycle_test.clj`) passes because it uses `clojure.core/resolve` at runtime. ClojureScript has no runtime resolve, so the call

      (when-let [dispatch-sync (resolve 're-frame.router/dispatch-sync!)]
        ((deref dispatch-sync) on-create {:frame id}))

  silently no-op'd in CLJS.

- The same forward-reference anti-pattern was used at every cross-namespace site (frame → router, fx → router/flows, cofx → schemas, subs → schemas, routing → subs, router → schemas/flows, registrar → trace, ssr → trace), so `:fx [[:dispatch ...]]`, cofx validation, sub-return validation, flow runs, hydration-mismatch traces, and registry-replacement traces were all silently broken in CLJS.

- Replace `resolve` with an explicit hook registry (`re-frame.late-bind`): producers register their callable at load time via `set-fn!`; consumers look it up at call time via `get-fn`. Identical behaviour on JVM and CLJS.

## Test plan

- [x] `cd implementation && clojure -M:test` — 122 tests, 636 assertions, 0 failures.
- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 23 → 0 failures (12 in `nine-states-runs-end-to-end`, 11 in routing-cljs tests, all collateral to the same root cause).
- [x] `npx shadow-cljs compile browser-test` — builds clean.

Closes rf2-p8g8. Follow-up rf2-am9d (P3) tracks broader CLJS test-fixture cleanup.