### PR TITLE
fix: suppress sub body recompute on value-equal input (rf2-719e)

### DIFF
--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -110,7 +110,18 @@
 (defn- compute-and-cache!
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
   algorithm: recursively resolve :<- chain, build the reaction, attach
-  on-dispose to evict the cache slot."
+  on-dispose to evict the cache slot.
+
+  Per Spec 006 §No-op via value equality (rf2-719e): the user's body fn
+  is wrapped in a value-equality memoization layer. Reagent's auto-run
+  reaction unconditionally invokes the compute fn on any source-watch
+  fire, then dedups *downstream notification* by `=`. That's one level
+  too late for the spec — the body fn itself must NOT re-run when the
+  resolved input value is `=` to the last-seen. The wrapper compares
+  `in-vals` against the previous invocation and short-circuits to the
+  cached return value when equal. Reagent's dependency tracking still
+  observes every `deref` because the wrapper *is* the compute fn — only
+  the user's body is suppressed."
   [frame-id query-v]
   (let [query-id     (first query-v)
         meta         (registrar/lookup :sub query-id)
@@ -123,40 +134,50 @@
         inputs (if (empty? input-signals)
                  [(frame/get-frame-db frame-id)]
                  (mapv (fn [input-q] (subscribe frame-id input-q)) input-signals))
+        ;; Per Spec 006 §No-op via value equality (rf2-719e): memoize the
+        ;; body call against the last-seen in-vals. The sentinel ensures
+        ;; the first invocation always runs.
+        last-in-vals (volatile! ::unset)
+        last-result  (volatile! nil)
         reaction (adapter/make-derived-value
                    inputs
                    (fn [& in-vals]
                      (when body-fn
-                       (try
-                         (let [v (if (empty? input-signals)
-                                   (body-fn (first in-vals) query-v)
-                                   ;; Layer-2+: deliver inputs as a coll if many,
-                                   ;; or singleton when only one chain entry.
-                                   (if (= 1 (count input-signals))
-                                     (body-fn (first in-vals) query-v)
-                                     (body-fn (vec in-vals) query-v)))]
-                           ;; Per Spec 010 §step 6: validate sub-return
-                           ;; post-compute against the sub's :spec.
-                           ;; Failures emit :rf.error/schema-validation-failure
-                           ;; and the sub yields nil (recovery
-                           ;; :replaced-with-default).
-                           (maybe-validate-sub-return! v query-v query-id meta))
-                         (catch #?(:clj Throwable :cljs :default) e
-                           (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
-                             (trace/emit-error!
-                               :rf.error/sub-exception
-                               {:failing-id        query-id
-                                :sub-id            query-id
-                                :sub-query         query-v
-                                :exception         e
-                                :exception-message msg
-                                :reason            (str "Subscription `" query-id
-                                                        "` threw while computing: "
-                                                        msg ". Returning nil.")
-                                :recovery          :replaced-with-default}))
-                           ;; Per Spec 009 §Error contract: replaced-with-default
-                           ;; means return nil.
-                           nil)))))
+                       (if (= @last-in-vals in-vals)
+                         @last-result
+                         (let [v (try
+                                   (let [v (if (empty? input-signals)
+                                             (body-fn (first in-vals) query-v)
+                                             ;; Layer-2+: deliver inputs as a coll if many,
+                                             ;; or singleton when only one chain entry.
+                                             (if (= 1 (count input-signals))
+                                               (body-fn (first in-vals) query-v)
+                                               (body-fn (vec in-vals) query-v)))]
+                                     ;; Per Spec 010 §step 6: validate sub-return
+                                     ;; post-compute against the sub's :spec.
+                                     ;; Failures emit :rf.error/schema-validation-failure
+                                     ;; and the sub yields nil (recovery
+                                     ;; :replaced-with-default).
+                                     (maybe-validate-sub-return! v query-v query-id meta))
+                                   (catch #?(:clj Throwable :cljs :default) e
+                                     (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
+                                       (trace/emit-error!
+                                         :rf.error/sub-exception
+                                         {:failing-id        query-id
+                                          :sub-id            query-id
+                                          :sub-query         query-v
+                                          :exception         e
+                                          :exception-message msg
+                                          :reason            (str "Subscription `" query-id
+                                                                  "` threw while computing: "
+                                                                  msg ". Returning nil.")
+                                          :recovery          :replaced-with-default}))
+                                     ;; Per Spec 009 §Error contract: replaced-with-default
+                                     ;; means return nil.
+                                     nil))]
+                           (vreset! last-in-vals in-vals)
+                           (vreset! last-result v)
+                           v)))))
         cache (:sub-cache (frame/frame frame-id))
         k     (cache-key query-v)]
     (when cache

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -344,21 +344,53 @@
                  (pr-str (remove #{21 201} seen))))))))
 
 (deftest sub-correctness-on-value-equal-input
-  (testing "[Spec 006 §No-op via value equality, partial] value-equal app-db replacement keeps the downstream value correct, even if Reagent's auto-run reaction recomputes (suboptimal but not a glitch — see open bead for the recompute-suppression follow-up)"
-    (rf/reg-event-db :stable/init (fn [_ _] {:n 5 :unrelated "z"}))
-    (rf/reg-event-db :stable/touch-unrelated
-                     (fn [db _] (assoc db :unrelated "z")))   ;; same value
-    (rf/reg-sub :stable/a (fn [db _] (:n db)))
-    (rf/reg-sub :stable/squared :<- [:stable/a] (fn [a _] (* a a)))
-    (rf/dispatch-sync [:stable/init])
-    (let [r (rf/subscribe [:stable/squared])]
-      (add-watch r ::touch (fn [_ _ _ _] nil))
-      (is (= 25 @r) "initial value correct")
-      (rf/dispatch-sync [:stable/touch-unrelated])
-      (r/flush)
-      (is (= 25 @r) "value still correct after a value-equal app-db replacement")
-      (remove-watch r ::touch)
-      (rf/unsubscribe [:stable/squared]))))
+  (testing "[Spec 006 §No-op via value equality, rf2-719e] a value-equal app-db replacement does NOT re-run the body fn of a layer-2 sub whose resolved input is value-equal — the wrapper short-circuits to the cached return value"
+    (let [a-runs       (atom 0)
+          squared-runs (atom 0)]
+      (rf/reg-event-db :stable/init (fn [_ _] {:n 5 :unrelated "z"}))
+      (rf/reg-event-db :stable/touch-unrelated
+                       (fn [db _] (assoc db :unrelated "z")))   ;; same value
+      (rf/reg-event-db :stable/bump-n
+                       (fn [db _] (update db :n inc)))          ;; real change
+      (rf/reg-sub :stable/a
+                  (fn [db _] (swap! a-runs inc) (:n db)))
+      (rf/reg-sub :stable/squared
+                  :<- [:stable/a]
+                  (fn [a _] (swap! squared-runs inc) (* a a)))
+      (rf/dispatch-sync [:stable/init])
+      (let [r (rf/subscribe [:stable/squared])]
+        (add-watch r ::touch (fn [_ _ _ _] nil))
+        (is (= 25 @r) "initial value correct")
+        (let [a-baseline       @a-runs
+              squared-baseline @squared-runs]
+          ;; Value-equal app-db replacement: neither body should re-run.
+          (rf/dispatch-sync [:stable/touch-unrelated])
+          (r/flush)
+          @r
+          (is (= 25 @r) "value still correct after a value-equal app-db replacement")
+          (is (= a-baseline @a-runs)
+              "layer-1 body should NOT re-run when its input is =-equal")
+          (is (= squared-baseline @squared-runs)
+              "layer-2 body should NOT re-run when its input is =-equal")
+          ;; Real change: each body should run exactly once more.
+          (rf/dispatch-sync [:stable/bump-n])
+          (r/flush)
+          (is (= 36 @r) "value updated after a real change")
+          (is (= (inc a-baseline) @a-runs)
+              "layer-1 body runs exactly once on a real input change")
+          (is (= (inc squared-baseline) @squared-runs)
+              "layer-2 body runs exactly once on a real input change")
+          ;; A second value-equal touch must again be a no-op.
+          (rf/dispatch-sync [:stable/touch-unrelated])
+          (r/flush)
+          @r
+          (is (= 36 @r) "value still correct after a second value-equal replacement")
+          (is (= (inc a-baseline) @a-runs)
+              "layer-1 body still suppressed on the second value-equal replacement")
+          (is (= (inc squared-baseline) @squared-runs)
+              "layer-2 body still suppressed on the second value-equal replacement"))
+        (remove-watch r ::touch)
+        (rf/unsubscribe [:stable/squared])))))
 
 (deftest dispatch-sync-in-handler-errors-cljs
   (testing "calling dispatch-sync from inside a handler raises a structured error"


### PR DESCRIPTION
## Summary

- Per Spec 006 §No-op via value equality, a value-equal `app-db` replacement must NOT propagate downstream — layer-2+ subs should not recompute when their resolved input is `=`-equal. Empirically the body fn was re-running because Reagent's auto-run reaction invokes its compute fn unconditionally on any source-watch fire and only dedups *downstream notification* by `=`, one level too late for the spec.
- `compute-and-cache!` in `subs.cljc` now wraps the user's body call with a value-equality memoization layer. Two volatile slots track the last-seen `in-vals` and the last result; when the new `in-vals` are `=`-equal to the previous, the wrapper returns the cached result without invoking the user's body. Reagent's dependency tracking still observes every `deref` because the wrapper *is* the compute fn — only the body is suppressed.
- `sub-correctness-on-value-equal-input` is tightened to assert body-fn invocation counts: zero re-runs on a value-equal touch, exactly one re-run on a real change, and a second value-equal touch is again a no-op. Previously it asserted only post-touch value correctness.

Closes rf2-719e.

## Test plan

- [x] `cd implementation && clojure -M:test` (122 tests, 636 assertions, 0 failures)
- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` (54 tests, 187 assertions, 0 failures)
- [x] Existing diamond / chain glitch-freedom tests unchanged and green
- [x] Tightened `sub-correctness-on-value-equal-input` passes: body fn does not re-run on a value-equal touch and runs exactly once on a real change