### PR TITLE
fix: conformance DSL :fx eval-value + cofx body realisation (rf2-8vo0, rf2-g25p)

### DIFF
--- a/docs/specification/conformance/fixtures/destroy-clears-snapshot.edn
+++ b/docs/specification/conformance/fixtures/destroy-clears-snapshot.edn
@@ -23,13 +23,13 @@
 
  :fixture/handlers
  {:machine-action
-  ;; The action emits a literal :destroy-machine fx targeting the
-  ;; previously-recorded actor id. The handler-body DSL passes the fx
-  ;; args verbatim, so the actor-id is bound at action-write time. (User
-  ;; code in a real machine would close over the id via :data — out of
-  ;; scope for the conformance corpus's small DSL.)
+  ;; The action emits a :destroy-machine fx targeting the recorded
+  ;; child id. Per rf2-8vo0, the runner now passes :fx args through
+  ;; `eval-value`, so the reflection form `[:get [:child-id]]` resolves
+  ;; against the snapshot's :data at action-eval time — letting the
+  ;; fixture express the natural data-flow rather than hardcoding the id.
   {:supervisor/destroy-worker
-   [[:fx :destroy-machine :worker#1]]}}
+   [[:fx :destroy-machine [:get [:child-id]]]]}}
 
  :fixture/calls
  [{:call         :machine-transition

--- a/docs/specification/conformance/fixtures/schema-cofx-validates.edn
+++ b/docs/specification/conformance/fixtures/schema-cofx-validates.edn
@@ -12,9 +12,7 @@
 ;; This capability — :schemas/cofx — is finer-grained than the baseline
 ;; :schemas/runtime. Ports that have wired cofx-injection validation
 ;; declare :schemas/cofx alongside :schemas/runtime; ports that haven't
-;; are skipped on this fixture. The runtime gap (validate-cofx! not yet
-;; wired) is tracked as rf2-7leq; the conformance-runner gap (cofx body
-;; realisation from fixture DSL) is tracked as rf2-g25p.
+;; are skipped on this fixture.
 ;;
 ;; Dynamic-host only.
 
@@ -38,10 +36,11 @@
           {:doc "Read :app-version from coeffects and stash it in app-db."}}}
 
  :fixture/handlers
- ;; The cofx body DSL is gated on the runner supporting cofx body
- ;; realisation (rf2-g25p). Until that lands, the cofx registrations are
- ;; metadata-only and this fixture is skipped via the :schemas/cofx
- ;; capability gate. The bodies below describe the intended behaviour.
+ ;; Per rf2-g25p the runner now realises cofx bodies via `eval-value`,
+ ;; so the `:set` step's value is the value injected at [:coeffects cofx-id].
+ ;; The path slot is symbolic — convention is `[k]` where `k` is the
+ ;; bare key shared by namespaced cofx-ids (matches `[:cofx-key k]`
+ ;; reads in event bodies via the runner's auto-injection heuristic).
  {:cofx  {:app-version/well [[:set [:app-version] "1.4.5"]]
           :app-version/bad  [[:set [:app-version] 42]]}
   :event {:cap/seed [[:set [:app-version] [:cofx-key :app-version]]]}}

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -134,19 +134,32 @@
     @out))
 
 (defn- realise-cofx-handler
-  "DSL → a cofx handler fn (ctx) → ctx. The body's first :set step
-  declares the value to inject; the runner places that value at
+  "DSL → a cofx handler fn (ctx) → ctx. The body's :set steps
+  declare the value to inject; the runner places that value at
   [:coeffects cofx-id] (canonical convention — the cofx-id is the
   slot key per Spec 010 §Where schemas attach §On every reg-*).
 
-  Per rf2-g25p (the conformance-runner gap for cofx body realisation)
-  this is a minimal first-pass interpreter — sufficient for the
-  schemas/cofx fixture which only uses literal :set steps."
+  Per rf2-g25p, the body is realised against the inject-cofx ctx —
+  values pass through `eval-value` so reflection forms (e.g.
+  [:cofx-key K], [:fn :k a b]) resolve against the inbound coeffects
+  /event the same way they do in event handler bodies. Multiple :set
+  steps run in order; the final `:set` step wins (last-write semantics
+  matching the canonical single-injection convention)."
   [cofx-id steps]
   (fn [ctx]
-    (let [first-set (some (fn [s] (when (= :set (first s)) s)) steps)
-          value     (when first-set (nth first-set 2 nil))]
-      (assoc-in ctx [:coeffects cofx-id] value))))
+    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
+          dsl-ctx    {:db    (get-in ctx [:coeffects :db])
+                      :event (get-in ctx [:coeffects :event])
+                      :cofx  (:coeffects ctx)}]
+      (reduce (fn [c step]
+                (case (first step)
+                  :set  (let [[_ _path value] step
+                              v (eval-value value dsl-ctx)]
+                          (assoc-in c [:coeffects cofx-id] v))
+                  :noop c
+                  c))
+              ctx
+              steps))))
 
 (defn- realise-handlers [fixture]
   ;; Walk :fixture/handlers and register each.
@@ -377,9 +390,15 @@
                                                   (assoc ctx :data
                                                          (assoc-in data path
                                                                    (eval-value v ctx))))
+                                        ;; Per rf2-8vo0: pass :fx args through
+                                        ;; eval-value so reflection forms (e.g.
+                                        ;; [:get [:child-id]]) resolve against
+                                        ;; the snapshot's :data, mirroring how
+                                        ;; :set / :dispatch already eval their
+                                        ;; values.
                                         :fx     (let [[_ a b] step]
                                                   (update ctx :fx (fnil conj [])
-                                                          [a b]))
+                                                          [a (eval-value b ctx)]))
                                         ctx))
                                     {:data (:data snap) :event event :fx []}
                                     steps)]


### PR DESCRIPTION
## Summary

Two gap-fills in the conformance fixture interpreter (`implementation/test/re_frame/conformance_test.clj`):

- **rf2-8vo0** — `realise-machine-handlers` `:fx` op now passes its args through `eval-value`, mirroring `:set` / `:dispatch`. Reflection forms in the second slot (e.g. `[:get [:child-id]]`) resolve against the snapshot's `:data` at action-eval time instead of arriving at the runtime literally. The `destroy-clears-snapshot.edn` fixture is updated to use the natural `[:get [:child-id]]` form, removing its hardcoded `:worker#1` workaround.
- **rf2-g25p** — `realise-cofx-handler` now runs the DSL body via `eval-value`, so `:set` values that reference `[:cofx-key K]`, `[:fn :k a b]`, `[:event-arg n]` etc. resolve like they do in event handler bodies. Replaces the previous first-pass implementation that only read the literal third element of the first `:set` step. Multiple `:set` steps now run in order with last-write semantics; the resolved value is injected at `[:coeffects cofx-id]` per the canonical convention. The `schema-cofx-validates.edn` fixture's gating comment is updated.

Both changes stay strictly within the existing DSL — no new ops introduced.

## Test plan

- [x] `cd implementation && clojure -M:test` — 122 tests, 636 assertions, 0 failures
- [x] Conformance corpus 66/66 (no regressions)
- [x] `:machine/destroy-clears-snapshot` still passes with the now-resolved `[:get [:child-id]]` reflection form (verifies rf2-8vo0)
- [x] `:schemas/cofx-validates` still passes with full DSL body realisation (verifies rf2-g25p)