### PR TITLE
feat: emit documented Spec 009 trace ops (rf2-hyxg)

### DIFF
--- a/implementation/src/re_frame/frame.cljc
+++ b/implementation/src/re_frame/frame.cljc
@@ -206,6 +206,13 @@
         (trace/emit! :machine :rf.machine/destroyed-on-frame-exit
                      {:frame      id
                       :machine-id machine-id
+                      :last-state (:state snapshot)})
+        ;; Per Spec 009 §:op-type vocabulary: :rf.machine.lifecycle/destroyed
+        ;; is the documented machine-instance-teardown signal. Pair with
+        ;; :rf.machine.lifecycle/created emitted at reg-machine.
+        (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
+                     {:frame      id
+                      :machine-id machine-id
                       :last-state (:state snapshot)})))
     (swap! frames update id assoc-in [:lifecycle :destroyed?] true)
     ;; (3) sub-cache disposal: walk every entry and dispose.
@@ -218,6 +225,10 @@
     (trace/emit! :frame :frame/destroyed
                  {:frame id})
     (swap! frames dissoc id)
+    ;; Per Spec 001 §Hot-reload semantics — destroying a frame removes it
+    ;; from the registrar, surfacing :rf.registry/handler-cleared so tools
+    ;; tracking the live registry observe the slot freed.
+    (registrar/unregister! :frame id)
     nil))
 
 (defn reset-frame!

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -639,6 +639,13 @@
     (let [;; Per Spec 005 §Registration: id comes from event[0] (the
           ;; surrounding reg-event-fx id), NOT from the spec map.
           machine-id (first event)
+          ;; Per Spec 009 §:op-type vocabulary: :rf.machine/event-received
+          ;; fires at the top of the handler so consumers see the inbound
+          ;; event before any state derivation.
+          _ (trace/emit! :rf.machine/event-received :rf.machine/event-received
+                         {:machine-id machine-id
+                          :event      event
+                          :frame      (or frame :rf/default)})
           ;; Stamp the live frame onto the machine def so spawn-id
           ;; allocation (frame-scoped per Spec 002) gets the right key.
           machine    (assoc machine :rf/frame (or frame :rf/default))
@@ -680,6 +687,17 @@
                     :event       inner-event
                     :before      snapshot
                     :after       next-snapshot})
+      ;; Per Spec 009 §:op-type vocabulary: :rf.machine/snapshot-updated
+      ;; fires whenever the handler writes the new snapshot to
+      ;; [:rf/machines machine-id]. Distinct from :rf.machine/transition
+      ;; in that it documents the app-db slot mutation specifically.
+      (when (not= snapshot next-snapshot)
+        (trace/emit! :rf.machine/snapshot-updated :rf.machine/snapshot-updated
+                     {:machine-id machine-id
+                      :path       path
+                      :before     snapshot
+                      :after      next-snapshot
+                      :frame      (or frame :rf/default)}))
       {:db new-db
        :fx fx})))
 
@@ -692,6 +710,12 @@
   [machine-id machine]
   (let [handler-fn (create-machine-handler machine)]
     (events/reg-event-fx machine-id handler-fn)
+    ;; Per Spec 009 §:op-type vocabulary: :rf.machine.lifecycle/created
+    ;; fires when a machine instance is registered. Tools observe this
+    ;; to track the machine population over hot reloads / boot.
+    (trace/emit! :rf.machine.lifecycle/created :rf.machine.lifecycle/created
+                 {:machine-id machine-id
+                  :initial    (:initial machine)})
     machine-id))
 
 ;; ---- framework-shipped sub -----------------------------------------------

--- a/implementation/src/re_frame/registrar.cljc
+++ b/implementation/src/re_frame/registrar.cljc
@@ -60,7 +60,10 @@
                     {:kind kind :id id})))
   (let [previous (get-in @kind->id->metadata [kind id])]
     (swap! kind->id->metadata assoc-in [kind id] metadata)
-    (when previous
+    (cond
+      ;; Re-registration path — fire hooks and emit handler-replaced when
+      ;; the handler-fn actually changed.
+      previous
       (let [different? (not= (:handler-fn previous) (:handler-fn metadata))]
         ;; Hot-reload notifications. Hooks run isolated — listener failures
         ;; don't propagate. Hooks fire on EVERY re-registration so dependent
@@ -76,20 +79,43 @@
         (when different?
           (when-let [emit! (late-bind/get-fn :trace/emit!)]
             (emit! :registry :rf.registry/handler-replaced
-                   {:kind kind :id id :different-fn? true})))))
+                   {:kind kind :id id :different-fn? true}))))
+      ;; First-time registration — emit handler-registered per Spec 009
+      ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
+      ;; this to track when fresh ids appear in the registry.
+      :else
+      (when-let [emit! (late-bind/get-fn :trace/emit!)]
+        (emit! :registry :rf.registry/handler-registered
+               {:kind kind :id id})))
     {:was previous :now metadata}))
 
 (defn unregister!
   "Remove a single id under kind. Hot-reload code paths use this; user code
   rarely does."
   [kind id]
-  (swap! kind->id->metadata update kind dissoc id)
+  (let [previous (get-in @kind->id->metadata [kind id])]
+    (swap! kind->id->metadata update kind dissoc id)
+    ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
+    ;; fires on explicit removal so hot-reload tools can update their
+    ;; views. Only emit when something was actually present.
+    (when previous
+      (when-let [emit! (late-bind/get-fn :trace/emit!)]
+        (emit! :registry :rf.registry/handler-cleared
+               {:kind kind :id id}))))
   nil)
 
 (defn clear-kind!
   "Remove every id under kind. Test fixtures use this to reset state."
   [kind]
-  (swap! kind->id->metadata dissoc kind)
+  (let [previous-ids (keys (get @kind->id->metadata kind))]
+    (swap! kind->id->metadata dissoc kind)
+    ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
+    ;; fires for each id so consumers see consistent registry transitions.
+    (when (seq previous-ids)
+      (when-let [emit! (late-bind/get-fn :trace/emit!)]
+        (doseq [id previous-ids]
+          (emit! :registry :rf.registry/handler-cleared
+                 {:kind kind :id id})))))
   nil)
 
 (defn clear-all!

--- a/implementation/src/re_frame/routing.cljc
+++ b/implementation/src/re_frame/routing.cljc
@@ -795,6 +795,14 @@
                          {:route-id      (:id prev)
                           :prev-fragment (:fragment prev)
                           :next-fragment fragment})
+            ;; Per Spec 009 §:op-type vocabulary: :route.url/fragment-changed
+            ;; is the canonical op-type for fragment-only navigation. Spec 012
+            ;; §Fragments references this name directly. Emitted alongside the
+            ;; legacy :rf.route/url-changed pending its eventual removal.
+            (trace/emit! :event :route.url/fragment-changed
+                         {:route-id      (:id prev)
+                          :prev-fragment (:fragment prev)
+                          :next-fragment fragment})
             {:db (assoc-in db [:route :fragment] fragment)})
 
         (some? m)

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -70,6 +70,12 @@
       (assoc meta
              :handler-fn    handler-fn
              :input-signals input-signals))
+    ;; Per Spec 009 §:op-type vocabulary: :sub/create marks subscription
+    ;; materialisation — emitted at registration time so tools see when
+    ;; the sub becomes available in the registry.
+    (trace/emit! :sub/create :sub/create
+                 {:sub-id        id
+                  :input-signals input-signals})
     id))
 
 (defn clear-sub
@@ -145,7 +151,17 @@
                      (when body-fn
                        (if (= @last-in-vals in-vals)
                          @last-result
-                         (let [v (try
+                         (let [;; Per Spec 009 §:op-type vocabulary: :sub/run
+                               ;; marks subscription recompute — emitted each
+                               ;; time the body actually runs against fresh
+                               ;; inputs. The memo path above does NOT count
+                               ;; as a re-run per Spec 006 §No-op via value
+                               ;; equality.
+                               _ (trace/emit! :sub/run :sub/run
+                                              {:sub-id  query-id
+                                               :query-v query-v
+                                               :frame   frame-id})
+                               v (try
                                    (let [v (if (empty? input-signals)
                                              (body-fn (first in-vals) query-v)
                                              ;; Layer-2+: deliver inputs as a coll if many,
@@ -251,6 +267,12 @@
   (let [query-id (first query-v)
         meta     (registrar/lookup :sub query-id)]
     (when meta
+      ;; Per Spec 009 §:op-type vocabulary: :sub/run marks a sub recompute.
+      ;; The pure compute-sub form fires the same op-type as the reactive
+      ;; recompute path so tools can observe both call sites uniformly.
+      (trace/emit! :sub/run :sub/run
+                   {:sub-id  query-id
+                    :query-v query-v})
       (let [body-fn (:handler-fn meta)
             inputs  (:input-signals meta)]
         (try

--- a/implementation/test/re_frame/trace_test.clj
+++ b/implementation/test/re_frame/trace_test.clj
@@ -457,7 +457,7 @@
         ;; Each is wrapped with `is-strict?` set to false so this test
         ;; documents the gap without blocking other assertions; flip
         ;; `is-strict?` to true once rf2-hyxg lands to enforce.
-        (let [is-strict? false
+        (let [is-strict? true
               gap-check  (fn [op-type operation]
                            (if is-strict?
                              (is (has-op? events op-type operation)


### PR DESCRIPTION
## Summary

Closes rf2-hyxg. Spec 009 §:op-type vocabulary documented several trace ops the implementation never emitted; the rf2-91tl trace-stream-completeness suite flagged the gap with a non-strict `gap-check`. Add the documented emissions at the natural call sites and flip the gap-check to strict.

- `:sub/run` — body-run site in `compute-and-cache!` and top of the pure `compute-sub` form (memo short-circuit per rf2-719e is NOT a re-run).
- `:sub/create` — at `reg-sub` registration.
- `:rf.registry/handler-registered` — first-time `register!` path.
- `:rf.registry/handler-cleared` — `unregister!` and `clear-kind!` paths. `destroy-frame!` now also calls `(registrar/unregister! :frame id)` so the frame slot is freed on teardown (previously left stale metadata in the registrar).
- `:rf.machine/event-received` — top of `create-machine-handler`'s body fn.
- `:rf.machine/snapshot-updated` — when the handler writes the new snapshot to `[:rf/machines machine-id]`; gated on snapshot inequality.
- `:rf.machine.lifecycle/created` — at `reg-machine`.
- `:rf.machine.lifecycle/destroyed` — at `destroy-frame!` for each active machine snapshot.
- `:route.url/fragment-changed` — fragment-only nav path in `routing.cljc` alongside the legacy `:rf.route/url-changed`.

## Test plan

- [x] `cd implementation && clojure -M:test` — 123 tests / 656 assertions / 0 failures, 0 errors (was 122/636 / 0 / 0).
- [x] rf2-91tl `gap-check` flipped to `is-strict? true` and the 9 strict assertions all pass.