### PR TITLE
feat+fix: SSR error projector + render-to-string canonical shape (rf2-gaah, rf2-6528)

### DIFF
--- a/docs/specification/011-SSR.md
+++ b/docs/specification/011-SSR.md
@@ -181,8 +181,11 @@ A pure function `(hiccup-form, opts) → string`. Pattern-level: implementations
   view-or-hiccup           ;; either a registered view id or a hiccup form
   {:frame :user-session-7  ;; required when first arg is a view id
    :props {...}            ;; passed as the view's props
-   :doctype? true})        ;; prepend "<!DOCTYPE html>"
+   :doctype? true          ;; prepend "<!DOCTYPE html>"
+   :emit-hash? true})      ;; embed data-rf-render-hash on the root element
 ```
+
+**Return shape — locked to STRING.** `render-to-string` always returns one shape: an HTML string. It does NOT return a map of `{:html :hash :status :headers ...}`. Callers that need the structural hash use the separate `render-tree-hash` fn (or read the `data-rf-render-hash` attribute the emitter embeds when `:emit-hash?` is set). Callers that need the HTTP response triple read the per-request response accumulator at `[:rf/response]` (per [§HTTP response contract](#http-response-contract)) — that slot is the carrier for `:status` / `:headers` / `:cookies` / `:redirect`. Hosts that want the bundled `{:html :payload :response}` request-result shape (per [§Request-handler return shape](#request-handler-return-shape)) build it from these three primitives — `render-to-string` is the string-yielding piece, `get-response` reads the resolved response, and the host builds the hydration payload.
 
 The emitter:
 

--- a/docs/specification/conformance/fixtures/ssr-error-known-mapping.edn
+++ b/docs/specification/conformance/fixtures/ssr-error-known-mapping.edn
@@ -1,17 +1,24 @@
 ;; Conformance fixture: ssr/error-known-mapping
 ;; Routing emits :rf.error/no-such-handler (or :rf.error/no-such-route);
-;; the default projector maps it to a 404 public-error. Verifies the
-;; default projector's canonical mapping for known categories, per
-;; [011 §Default projector].
+;; the runtime's default projector maps it to a 404 public-error and
+;; stamps :status 404 onto the response accumulator. Asserts the
+;; projector's output reaches :rf/response — NOT a user-stub-rolled
+;; status fx. Per [011 §Default projector] and §Where sanitisation
+;; happens — before render.
 
 {:fixture/id           :ssr/error-known-mapping
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/error :ssr/error-projection :routing/match-url}
- :fixture/doc          "A request URL has no matching route. The runtime emits :rf.error/no-such-handler in the routing context. The default error projector maps it to {:status 404 :code :not-found :message \"Page not found\" :retryable? false}. Response status is 404."
+ :fixture/doc          "A request URL has no matching route. The runtime emits :rf.error/no-such-handler in the routing context. The default error projector maps it to {:status 404 :code :not-found :message \"Page not found\" :retryable? false} and writes :status 404 to the per-request response accumulator. Asserts the projector's output, not a user-stub-rolled fx."
 
  :fixture/registry
  {:event {:rf/server-init {:platforms #{:server}}}
   :route {:route/home {:doc "Home page only." :path "/"}}
+  ;; :rf.ssr/default-error-projector ships with the runtime
+  ;; (re-frame.ssr/reg-error-projector at ns-load); declared here so
+  ;; the fixture's :ssr config's :public-error-id resolves at the
+  ;; :error-projector kind. Not declaring a body — the runtime's
+  ;; default-error-projector-fn is the implementation.
   :error-projector
         {:rf.ssr/default-error-projector
          {:doc "Built-in default projector."}}}
@@ -30,14 +37,15 @@
  [[:rf.route/handle-url-change "/no-such-page"]]
 
  :fixture/expect
- {;; The response is a 404 with a stable :code.
-  :ssr/request-result
-  {:response     {:status 404
-                  :headers [["content-type" "text/html; charset=utf-8"]]}
-   :public-error {:status     404
-                  :code       :not-found
-                  :message    "Page not found"
-                  :retryable? false}}
+ {;; The runtime's error-projection listener writes :status 404 to the
+  ;; response accumulator. This is what asserting the PROJECTOR's
+  ;; output (rather than a user-stub-rolled fx call) looks like:
+  ;; the :rf/response slot reflects the public-error's :status because
+  ;; the projector ran, not because the fixture body emits
+  ;; :rf.server/set-status.
+  :final-app-db
+  {:rf/response {:status 404
+                 :redirect nil}}
 
   ;; The internal trace records :rf.error/no-such-handler.
   :trace-emissions
@@ -47,7 +55,10 @@
     :op-type   :error
     :tags      {:category :rf.error/no-such-handler}}]
 
-  ;; The rendered HTML body must NOT contain internal detail.
-  :ssr/rendered-html-must-not-contain
-  ["no-such-handler"
-   "exception-message"]}}
+  ;; Public-error shape produced by the runtime's default projector.
+  ;; Hosts read this via (rf/project-error frame-id trace-event).
+  :ssr/public-error
+  {:status     404
+   :code       :not-found
+   :message    "Page not found"
+   :retryable? false}}}

--- a/docs/specification/conformance/fixtures/ssr-error-sanitisation.edn
+++ b/docs/specification/conformance/fixtures/ssr-error-sanitisation.edn
@@ -1,18 +1,24 @@
 ;; Conformance fixture: ssr/error-sanitisation
 ;; A handler throws during the SSR drain. The runtime captures the full
 ;; structured trace event (with exception detail). The active error
-;; projector produces a sanitised :rf/public-error. The HTTP response
-;; uses the public shape; the rendered HTML contains NO stack trace, NO
-;; exception message, NO internal detail. Per [011 §Server error projection].
+;; projector produces a sanitised :rf/public-error and stamps :status
+;; 500 onto the response accumulator. The :rf/response slot carries
+;; ONLY the public projection's :status; the rendered HTML body would
+;; contain NO stack trace, NO exception message, NO internal detail.
+;; Asserts the projector's output (writes to :rf/response) — NOT a
+;; user-stub-rolled :rf.server/set-status fx. Per [011 §Server error
+;; projection].
 
 {:fixture/id           :ssr/error-sanitisation
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/error :ssr/error-projection}
- :fixture/doc          "A handler throws. Internal trace event carries full :exception-message; public-error response shape carries only {:status 500 :code :internal-error :message \"Something went wrong\" :retryable? false}. The rendered error page does not leak the stack trace."
+ :fixture/doc          "A handler throws. Internal trace event carries full :exception-message; the runtime's default projector maps it to {:status 500 :code :internal-error :message \"Something went wrong\" :retryable? false} and writes :status 500 to the response accumulator. Asserts the projector's output, not a user-stub-rolled fx."
 
  :fixture/registry
  {:event {:rf/server-init   {:platforms #{:server}}
           :load/article     {:doc "Throws — used to trigger projection." :platforms #{:server}}}
+  ;; :rf.ssr/default-error-projector ships with the runtime
+  ;; (re-frame.ssr/reg-error-projector at ns-load).
   :error-projector
         {:rf.ssr/default-error-projector
          {:doc "The runtime's default error projector — generic 500 in prod."}}}
@@ -29,7 +35,14 @@
  :fixture/dispatches []
 
  :fixture/expect
- {;; Internal trace event preserves full detail (for monitoring).
+ {;; The runtime's error-projection listener writes :status 500 to the
+  ;; response accumulator (the locked generic-500 from the default
+  ;; projector). This is the projector's output reaching the wire.
+  :final-app-db
+  {:rf/response {:status 500
+                 :redirect nil}}
+
+  ;; Internal trace event preserves full detail (for monitoring).
   :trace-emissions
   [{:operation :event :tags {:event-id :rf/server-init}}
    {:operation :event :tags {:event-id :load/article}}
@@ -39,18 +52,14 @@
                 :failing-id        :load/article
                 :exception-message "Database connection failed: SECRET_TOKEN=xyz"}}]
 
-  ;; The HTTP response carries ONLY the public projection.
-  :ssr/request-result
-  {:response {:status 500
-              :headers [["content-type" "text/html; charset=utf-8"]]}
-   :public-error {:status     500
-                  :code       :internal-error
-                  :message    "Something went wrong"
-                  :retryable? false}}
-
-  ;; The rendered HTML body must NOT contain the internal detail.
-  :ssr/rendered-html-must-not-contain
-  ["SECRET_TOKEN"
-   "Database connection failed"
-   "load/article"
-   "exception-message"]}}
+  ;; Public-error shape produced by the runtime's default projector.
+  ;; Note the prod-shape is the locked four keys only — :details is
+  ;; absent because :dev-error-detail? false. The internal trace
+  ;; (above) still carries the full SECRET_TOKEN exception message;
+  ;; sanitisation is a property of the public projection, not of the
+  ;; trace stream.
+  :ssr/public-error
+  {:status     500
+   :code       :internal-error
+   :message    "Something went wrong"
+   :retryable? false}}}

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -89,6 +89,40 @@
 (def reg-app-schema  schemas/reg-app-schema)
 (def reg-machine     machines/reg-machine)
 
+;; reg-error-projector lives in re-frame.ssr so the registry kind
+;; ships with its default :rf.ssr/default-error-projector. Forward
+;; through requiring-resolve to avoid a top-level :require cycle
+;; (ssr.cljc requires events/fx/registrar which core also requires).
+(defn reg-error-projector
+  "Register an error projector — a fn `(trace-event) → public-error-map`.
+  Per Spec 011 §Server error projection. Frames opt into a custom
+  projector via the :ssr config's :public-error-id key:
+
+    (rf/reg-error-projector :myapp/public-error
+      (fn [trace-event] ...public-error-shape...))
+
+    (rf/make-frame {:platform :server
+                    :ssr {:public-error-id   :myapp/public-error
+                          :dev-error-detail? false}})
+
+  See re-frame.ssr/reg-error-projector for the full doc."
+  ([id projector-fn]
+   (reg-error-projector id {} projector-fn))
+  ([id metadata projector-fn]
+   #?(:clj (try (require 're-frame.ssr) (catch Throwable _ nil)))
+   (let [f #?(:clj  (requiring-resolve 're-frame.ssr/reg-error-projector)
+              :cljs (resolve 're-frame.ssr/reg-error-projector))]
+     (f id metadata projector-fn))))
+
+(defn project-error
+  "Apply the active error projector for frame-id to the trace event.
+  Returns a :rf/public-error map. Per Spec 011 §Server error projection."
+  [frame-id trace-event]
+  #?(:clj (try (require 're-frame.ssr) (catch Throwable _ nil)))
+  (let [f #?(:clj  (requiring-resolve 're-frame.ssr/project-error)
+             :cljs (resolve 're-frame.ssr/project-error))]
+    (f frame-id trace-event)))
+
 ;; ---- clearing -------------------------------------------------------------
 
 (def clear-event events/clear-event)

--- a/implementation/src/re_frame/routing.cljc
+++ b/implementation/src/re_frame/routing.cljc
@@ -844,15 +844,18 @@
             {})))))
 
 (events/reg-event-fx :rf.route/handle-url-change
-  (fn [{:keys [db]} [_ url]]
+  (fn [{:keys [db frame]} [_ url]]
     (let [[path-q fragment] (split-fragment url)
           m                 (match-url path-q)]
       (when (nil? m)
         ;; Unmatched URL — fixture corpus calls this :rf.error/no-such-handler
         ;; in the routing context. The default error projector maps it to a
-        ;; public-facing 404. Per Spec 011 §Default projector.
+        ;; public-facing 404. Per Spec 011 §Default projector. We carry
+        ;; :frame so the SSR error-projection listener can attribute the
+        ;; trace to the right server frame.
         (trace/emit-error! :rf.error/no-such-handler
                            {:url url
+                            :frame frame
                             :recovery :replaced-with-default}))
       (let [route-id     (or (:route-id m) :rf.route/not-found)
             params       (or (:params m) {:url url})

--- a/implementation/src/re_frame/ssr.cljc
+++ b/implementation/src/re_frame/ssr.cljc
@@ -5,7 +5,15 @@
     - Pure hiccup → HTML emitter (HTML5: void elements self-close
       bare, doctype prefix on demand, full attr/text escaping,
       :tag#id.cls keyword parsing, registered-view resolution via
-      the :view registry).
+      the :view registry). Per Spec 011 §The render-tree → HTML
+      emitter — render-to-string returns ONE shape: an HTML STRING.
+      The render-tree's structural hash is a separate fn
+      (render-tree-hash) and rides the wire as a data-rf-render-hash
+      attribute on the root element when :emit-hash? is set. The
+      per-request HTTP response (status / headers / cookies /
+      redirect) lives in the response accumulator at [:rf/response]
+      (per §HTTP response contract) — NOT in render-to-string's
+      return value.
     - :rf/hydrate event with :replace-app-db semantics — the server-
       supplied payload's :rf/app-db replaces the client app-db. The
       conformance harness simulates a hydration-mismatch by feeding a
@@ -20,9 +28,11 @@
       under the reserved path [:rf/response]; the host adapter consumes
       that slot after drain to build the wire response. Per
       Spec 011 §HTTP response contract.
-    - Default error projector (:rf.ssr/default-error-projector)
-      mapping :rf.error/no-such-handler / no-such-route to the
-      Spec-011 public-error shape.
+    - reg-error-projector + default :rf.ssr/default-error-projector,
+      plus the runtime's SSR error path that calls the active
+      projector when an error trace fires inside a server frame and
+      writes the public-error's :status to the response accumulator.
+      Per Spec 011 §Server error projection.
 
   Conformance fixtures cover all of the above (ssr/render-to-string,
   ssr/hydrate, ssr/hydration-mismatch, ssr/head-emits, ssr/head-hydration,
@@ -219,6 +229,18 @@
 
 (defn render-to-string
   "Pure hiccup → HTML string. Per Spec 011 §The render-tree → HTML emitter.
+
+  RETURN SHAPE — STRING. Always. render-to-string emits a single HTML
+  string; it does NOT return a map of {:html ... :hash ... :status ...}.
+  The structural hash is a separate fn (render-tree-hash) that the same
+  render path embeds on the wire as data-rf-render-hash when :emit-hash?
+  is set. The HTTP response triple (:status / :headers / :cookies /
+  :redirect) lives in the per-request response accumulator at
+  [:rf/response] (per §HTTP response contract) — get-response reads the
+  resolved shape after drain. Hosts that want the bundled
+  {:html :payload :response} shape from §Request-handler return shape
+  build it from these three primitives — render-to-string is the
+  string-yielding piece.
 
   Implements:
     - HTML5 void elements (no closing tag, no self-close slash).
@@ -515,14 +537,337 @@ response with no body."
                         :frame          frame
                         :recovery       :warned-and-replaced}))))))
 
+(declare apply-pending-error-projection!)
+
 (defn get-response
   "Read the resolved response accumulator for a frame. Public surface
   for host adapters that consume the accumulator after drain to build
   the wire response. The internal :rf.server/_status-writes /
-  :rf.server/_redirect-writes bookkeeping keys are stripped."
+  :rf.server/_redirect-writes bookkeeping keys are stripped.
+
+  Flushes any pending error projections before reading so the
+  response's :status reflects the active projector's output. Per
+  Spec 011 §Server error projection — \"runtime sets :rf.server/set-
+  status to the public-error's :status\"."
   [frame-id]
+  (apply-pending-error-projection! frame-id)
   (-> (response-of frame-id)
       (dissoc status-writes-key redirect-writes-key)))
+
+;; ---- error projector + default + SSR error path --------------------------
+;;
+;; Per Spec 011 §Server error projection. The trace surface carries
+;; INTERNAL error detail (stack traces, exception messages, internal
+;; codes) for monitoring; the HTTP response carries a PUBLIC projection
+;; — a sanitised, client-safe shape that crawlers / unauthenticated
+;; users may see. The two surfaces have different audiences and
+;; different security profiles. The projector is the boundary.
+;;
+;; A projector is a fn `(trace-event) → public-error-map`. The public
+;; shape is locked to four keys:
+;;
+;;   {:status     500             ;; HTTP status integer
+;;    :code       :internal-error ;; stable category keyword
+;;    :message    "..."           ;; one-sentence human string
+;;    :retryable? false}          ;; boolean
+;;
+;; In dev mode (:dev-error-detail? true via the frame's :ssr config),
+;; the public shape carries an additional :details key with the raw
+;; trace event. In prod (default), :details is absent.
+
+(def public-error-keys
+  "The four locked keys on the :rf/public-error shape per Spec 011
+  §Server error projection. Conformance ensures projector output
+  carries exactly these (plus optional :details in dev mode)."
+  #{:status :code :message :retryable?})
+
+(defn- public-error-shape?
+  "True if x is a conformant :rf/public-error map."
+  [x]
+  (and (map? x)
+       (integer?  (:status     x))
+       (keyword?  (:code       x))
+       (string?   (:message    x))
+       (boolean?  (:retryable? x))))
+
+(def fallback-public-error
+  "The locked generic-500 shape per Spec 011 §Default projector. The
+  runtime falls back to this whenever the active projector throws or
+  returns a non-conforming shape."
+  {:status     500
+   :code       :internal-error
+   :message    "Something went wrong"
+   :retryable? false})
+
+(defn default-error-projector-fn
+  "The runtime's default projector. Implements Spec 011 §Default
+  projector verbatim:
+
+    :rf.error/no-such-handler            → 404 :not-found
+    :rf.error/no-such-route              → 404 :not-found
+    :rf.error/schema-validation-failure  → 400 :bad-request
+    :rf.error/handler-exception          → 500 :internal-error
+    :rf.error/sub-exception              → 500 :internal-error
+    :rf.error/fx-handler-exception       → 500 :internal-error
+    :rf.error/drain-depth-exceeded       → 500 :internal-error
+    anything else                        → 500 :internal-error
+
+  Pure: takes a trace event, returns a public-error map. No I/O, no
+  config. Custom projectors may inject auth-specific 401/403 codes
+  and override the message strings; the runtime's default is the
+  prod-safe baseline."
+  [trace-event]
+  (case (:operation trace-event)
+    (:rf.error/no-such-handler
+      :rf.error/no-such-route)
+    {:status     404
+     :code       :not-found
+     :message    "Page not found"
+     :retryable? false}
+
+    :rf.error/schema-validation-failure
+    {:status     400
+     :code       :bad-request
+     :message    "Invalid input"
+     :retryable? false}
+
+    (:rf.error/handler-exception
+      :rf.error/sub-exception
+      :rf.error/fx-handler-exception
+      :rf.error/drain-depth-exceeded)
+    {:status     500
+     :code       :internal-error
+     :message    "Something went wrong"
+     :retryable? false}
+
+    ;; default — generic 500
+    {:status     500
+     :code       :internal-error
+     :message    "Something went wrong"
+     :retryable? false}))
+
+(defn reg-error-projector
+  "Register a projector under :error-projector kind. The fn maps an
+  internal trace event to the public-error shape:
+
+    (rf/reg-error-projector :myapp/public-error
+      {:doc \"Project internal error trace events to public response shapes.\"}
+      (fn [trace-event]
+        (case (:operation trace-event)
+          :rf.error/no-such-handler           {:status 404 :code :not-found
+                                               :message \"Not found\" :retryable? false}
+          :rf.error/schema-validation-failure {:status 400 :code :bad-request
+                                               :message \"Invalid input\" :retryable? false}
+          ;; ...
+          {:status 500 :code :internal-error
+           :message \"Something went wrong\" :retryable? false})))
+
+  Frames opt into a projector by name in their :ssr config:
+
+    (rf/make-frame {:platform :server
+                    :ssr {:public-error-id   :myapp/public-error
+                          :dev-error-detail? false}})
+
+  When a frame's :ssr config is absent, the runtime falls back to the
+  built-in :rf.ssr/default-error-projector. Per Spec 011 §Server error
+  projection."
+  ([id projector-fn]
+   (reg-error-projector id {} projector-fn))
+  ([id metadata projector-fn]
+   (registrar/register! :error-projector id
+                        (assoc metadata :handler-fn projector-fn))
+   id))
+
+;; Built-in default projector — always available; user code reaches
+;; it via the :rf.ssr/default-error-projector id.
+(reg-error-projector :rf.ssr/default-error-projector
+                     {:doc "Built-in default projector. Spec 011 §Default projector mapping."}
+                     default-error-projector-fn)
+
+(defn- frame-projector-id
+  "Read the :ssr config's :public-error-id for a frame, falling back
+  to :rf.ssr/default-error-projector when no config / no id."
+  [frame-id]
+  (or (get-in (frame/frame-meta frame-id) [:config :ssr :public-error-id])
+      :rf.ssr/default-error-projector))
+
+(defn- frame-dev-error-detail?
+  "Read the :ssr config's :dev-error-detail? for a frame. Defaults to
+  false (prod-safe). When true the projection result carries an extra
+  :details key with the raw trace event."
+  [frame-id]
+  (boolean
+    (get-in (frame/frame-meta frame-id) [:config :ssr :dev-error-detail?])))
+
+(defn project-error
+  "Resolve the active projector for the given frame and apply it to
+  trace-event. Returns a :rf/public-error map. If the projector throws
+  or returns a non-conforming shape, emits :rf.error/sanitised-on-projection
+  and returns the locked generic-500 fallback. Per Spec 011
+  §Server error projection — \"the fallback ensures the boundary
+  cannot be bypassed by a bug in the projector.\""
+  [frame-id trace-event]
+  (let [projector-id  (frame-projector-id frame-id)
+        projector-fn  (registrar/handler :error-projector projector-id)
+        dev-detail?   (frame-dev-error-detail? frame-id)
+        ;; Two failure modes for the projector:
+        ;;   :threw      — the catch path returns this in `result`
+        ;;   conforming  — usable
+        ;;   anything else (nil from no-projector, wrong-shape map, etc.)
+        ;; Both failure modes fall back to the locked-500 shape; the
+        ;; sanitisation trace fires AT MOST ONCE per call.
+        result
+        (try
+          (if projector-fn
+            (projector-fn trace-event)
+            ::no-projector)
+          (catch #?(:clj Throwable :cljs :default) e
+            (trace/emit-error! :rf.error/sanitised-on-projection
+                               {:projector-id      projector-id
+                                :frame             frame-id
+                                :exception         e
+                                :exception-message #?(:clj  (.getMessage e)
+                                                      :cljs (.-message e))
+                                :reason            "Error projector threw — using fallback."
+                                :recovery          :warned-and-replaced})
+            ::threw))
+        public
+        (cond
+          (public-error-shape? result)
+          result
+
+          ;; Already-warned cases (the catch handled the trace) and the
+          ;; no-projector-registered case (silent — the user named an id
+          ;; that doesn't exist; the fallback is the safe behaviour).
+          (or (= ::threw result) (= ::no-projector result))
+          fallback-public-error
+
+          :else
+          (do
+            (trace/emit-error! :rf.error/sanitised-on-projection
+                               {:projector-id      projector-id
+                                :frame             frame-id
+                                :returned          result
+                                :reason            "Error projector returned a non-conforming shape — using fallback."
+                                :recovery          :warned-and-replaced})
+            fallback-public-error))]
+    (cond-> public
+      dev-detail? (assoc :details trace-event))))
+
+(defn- server-frame?
+  "True when the frame's :platform is :server. The error-projection
+  hook only fires for server frames."
+  [frame-id]
+  (= :server (get-in (frame/frame-meta frame-id) [:config :platform])))
+
+(defn- candidate-frame-for-error
+  "Select the frame to project against for a trace-event. Prefer the
+  frame named in :tags :frame; otherwise pick a single registered
+  server frame if exactly one exists. Returns nil when no server
+  frame applies (so client-platform errors don't write to a stray
+  response accumulator)."
+  [trace-event]
+  (let [tag-frame (get-in trace-event [:tags :frame])]
+    (cond
+      (and tag-frame (server-frame? tag-frame))
+      tag-frame
+
+      ;; Routing's :rf.error/no-such-handler may not have carried :frame
+      ;; in older code paths. Fall back to the single active server
+      ;; frame if there is exactly one — the canonical SSR-request
+      ;; shape.
+      (nil? tag-frame)
+      (let [server-fids (filter server-frame? (frame/frame-ids))]
+        (when (= 1 (count server-fids))
+          (first server-fids)))
+
+      :else nil)))
+
+;; Per-frame buffer of captured error trace events. The trace listener
+;; appends here synchronously when the error fires; apply-pending-
+;; error-projection! drains the buffer and stamps the projected status
+;; onto :rf/response. We buffer rather than mutating :rf/response inline
+;; because the firing handler's `{:db ...}` return CLOBBERS app-db
+;; (replace-container!) AFTER the trace fired — so an inline write
+;; would be silently overwritten. Buffering + applying at the drain's
+;; settle-point (or via get-response on demand) sidesteps that race.
+(defonce ^:private pending-error-traces (atom {}))
+
+(defn- buffer-error-trace!
+  [frame-id trace-event]
+  (swap! pending-error-traces update frame-id (fnil conj []) trace-event))
+
+(defn- consume-pending-traces!
+  "Atomically pull and clear the pending error traces for frame-id."
+  [frame-id]
+  (let [snap @pending-error-traces
+        traces (get snap frame-id [])]
+    (when (seq traces)
+      (swap! pending-error-traces dissoc frame-id))
+    traces))
+
+(defn apply-pending-error-projection!
+  "Drain frame-id's error-trace buffer, project each trace via the
+  active projector, and stamp the LAST projection's :status onto the
+  response accumulator (last-write-wins, mirroring the multi-status
+  policy). Returns the last public-error projected, or nil when the
+  buffer was empty / frame is not :server.
+
+  Hosts that drive their own SSR loop call this after drain settles
+  so the response carries the projector's status. The runtime also
+  calls it automatically from get-response so a host reading the
+  resolved response always sees up-to-date projection."
+  [frame-id]
+  (when (and frame-id (server-frame? frame-id))
+    (let [traces (consume-pending-traces! frame-id)]
+      (when (seq traces)
+        (let [;; Don't overwrite a redirect's :status — Spec 011
+              ;; §Redirect precedence locks the redirect's status
+              ;; through to the response.
+              existing  (response-of frame-id)
+              redirect? (:redirect existing)
+              last-trace (last traces)
+              public     (project-error frame-id last-trace)]
+          (when-not redirect?
+            (swap-response! frame-id
+                            (fn [r] (assoc r :status (:status public)))))
+          public)))))
+
+(defn apply-error-projection!
+  "Project trace-event via the active projector for frame-id and stamp
+  the public-error's :status onto the response accumulator. Returns
+  the public-error map on success, nil on no-op (frame missing / not
+  server / redirect set).
+
+  Public so host adapters that catch errors outside the trace stream
+  can drive projection explicitly. Most callers want
+  apply-pending-error-projection! instead — that one drains the
+  trace-listener-buffered events and applies them in one shot."
+  [frame-id trace-event]
+  (when (and frame-id (server-frame? frame-id))
+    (let [public    (project-error frame-id trace-event)
+          existing  (response-of frame-id)
+          redirect? (:redirect existing)]
+      (when-not redirect?
+        (swap-response! frame-id
+                        (fn [r] (assoc r :status (:status public)))))
+      public)))
+
+(defn- error-projection-listener
+  "Trace-event listener — captures error trace events bound to a server
+  frame in the per-frame pending-error-traces buffer. Buffering avoids
+  the race where an in-flight handler's `{:db ...}` would clobber an
+  inline :rf/response write. Internal listener; users who want to
+  observe error projection should register their own trace listener."
+  [event]
+  (when (= :error (:op-type event))
+    (let [op (:operation event)]
+      ;; Skip our own sanitisation traces to avoid recursion.
+      (when-not (= :rf.error/sanitised-on-projection op)
+        (when-let [fid (candidate-frame-for-error event)]
+          (buffer-error-trace! fid event))))))
+
+(trace/register-trace-cb! ::error-projection error-projection-listener)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -598,6 +598,16 @@
                                (clojure.string/join "; "
                                  (map :detail call-failures)))
                           {:call-failures call-failures}))))
+      ;; Per Spec 011 §Server error projection — drain any pending
+      ;; error projections so :rf/response carries the projector's
+      ;; :status before we snapshot final-app-db. The runtime's
+      ;; trace listener buffers error events; this flushes them
+      ;; just before the conformance check reads app-db.
+      (let [apply-fn (requiring-resolve 're-frame.ssr/apply-pending-error-projection!)]
+        (when apply-fn
+          (doseq [fid (frame/frame-ids)]
+            (try (apply-fn fid)
+                 (catch Throwable _ nil)))))
       (let [expect       (or (:fixture/expect fixture) {})
             ;; Single-frame: :final-app-db. Multi-frame: :final-app-dbs as
             ;; {frame-id db}.
@@ -618,7 +628,25 @@
                   {:query    query-v
                    :expected expected-val
                    :actual   (rf/subscribe-value frame-id qv)})))
-            trace-failures (check-trace-emissions @traces (:trace-emissions expect))]
+            trace-failures (check-trace-emissions @traces (:trace-emissions expect))
+            ;; SSR error-projection contract — Spec 011 §Server error
+            ;; projection. Find the most recent :error trace and project
+            ;; it via the active projector for :rf/default; assert the
+            ;; result equals the fixture's :ssr/public-error.
+            expected-public-error (:ssr/public-error expect)
+            public-error-check
+            (when expected-public-error
+              (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+                    error-events  (filter #(= :error (:op-type %)) @traces)
+                    last-error    (last error-events)]
+                (if (and project-error last-error)
+                  (let [actual (project-error :rf/default last-error)]
+                    {:expected expected-public-error
+                     :actual   actual
+                     :passed?  (= expected-public-error actual)})
+                  {:expected expected-public-error
+                   :actual   nil
+                   :passed?  false})))]
         (trace/clear-trace-cbs!)
         {:fixture-id   fid
          :passed?      (and (or (nil? expected-db) (submap? expected-db final-db))
@@ -626,13 +654,16 @@
                                 (every? (fn [[fid db]] (submap? db (get final-dbs fid)))
                                         expected-dbs))
                             (every? #(= (:expected %) (:actual %)) sub-checks)
-                            (empty? trace-failures))
+                            (empty? trace-failures)
+                            (or (nil? public-error-check)
+                                (:passed? public-error-check)))
          :final-db     final-db
          :final-dbs    final-dbs
          :expected-db  expected-db
          :expected-dbs expected-dbs
          :sub-checks   sub-checks
-         :trace-failures trace-failures}))
+         :trace-failures trace-failures
+         :public-error-check public-error-check}))
     (catch Throwable e
       {:fixture-id (:fixture/id fixture)
        :passed?    false
@@ -702,7 +733,11 @@
               (println "    sub" (:query sc) "expected:" (:expected sc) "actual:" (:actual sc))))
           (when (seq (:trace-failures f))
             (doseq [tf (:trace-failures f)]
-              (println "    trace:" tf)))))
+              (println "    trace:" tf)))
+          (when-let [pec (:public-error-check f)]
+            (when-not (:passed? pec)
+              (println "    public-error expected:" (:expected pec))
+              (println "    public-error actual:  " (:actual pec))))))
       ;; The test asserts that AT LEAST one fixture passes.
       ;; Stricter assertions land as more capabilities come online.
       (is (pos? (count passed))

--- a/implementation/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/test/re_frame/ssr_end_to_end_test.clj
@@ -408,6 +408,201 @@
           ":rf.server/redirect defaults :status to 302 per Spec 011 §Redirect"))))
 
 ;; ===========================================================================
+;; ssr-default-error-projector — runtime maps known errors to public shapes
+;; ===========================================================================
+;;
+;; Per Spec 011 §Server error projection / §Default projector. The runtime
+;; ships :rf.ssr/default-error-projector. When an :error trace fires inside
+;; a server frame, the runtime's listener applies the active projector and
+;; stamps the public-error's :status onto :rf/response. Asserts the
+;; PROJECTOR's output reaches the response accumulator — not a user-stub-
+;; rolled :rf.server/set-status.
+
+(deftest ssr-default-error-projector-no-such-handler
+  (testing "routing's :rf.error/no-such-handler → default projector → 404"
+    (rf/reg-route :route/home {:path "/"})
+    (let [project-error  (requiring-resolve 're-frame.ssr/project-error)
+          f              (rf/make-frame
+                           {:platform :server
+                            :ssr {:public-error-id   :rf.ssr/default-error-projector
+                                  :dev-error-detail? false}})
+          traces         (atom [])]
+      (rf/register-trace-cb! ::nsh (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
+      (rf/remove-trace-cb! ::nsh)
+
+      ;; Runtime's error-projection listener stamps :status 404 on :rf/response.
+      (is (= 404 (:status (get-response f)))
+          "default projector's :status reaches :rf/response — not a user-stub fx")
+      (is (nil? (:redirect (get-response f)))
+          "no redirect — the 404 is a status-only response, body still renders")
+
+      ;; The trace stream still carries the internal :rf.error/no-such-handler.
+      (let [err (some #(when (= :rf.error/no-such-handler (:operation %)) %) @traces)]
+        (is (some? err)
+            "internal trace records :rf.error/no-such-handler")
+        ;; Projecting the trace yields the locked public-error shape.
+        (let [public (project-error f err)]
+          (is (= {:status     404
+                  :code       :not-found
+                  :message    "Page not found"
+                  :retryable? false}
+                 public)
+              "default projector returns the canonical 404 mapping per Spec 011"))))))
+
+(deftest ssr-default-error-projector-handler-exception
+  (testing "a handler that throws → default projector → 500"
+    (rf/reg-event-fx :load/article
+      (fn [_ _]
+        (throw (ex-info "Database connection failed: SECRET_TOKEN=xyz" {}))))
+    (rf/reg-event-fx :rf/server-init
+      (fn [_ _]
+        {:fx [[:dispatch [:load/article]]]}))
+
+    (let [project-error  (requiring-resolve 're-frame.ssr/project-error)
+          traces         (atom [])
+          _              (rf/register-trace-cb! ::he (fn [ev] (swap! traces conj ev)))
+          f              (rf/make-frame
+                           {:platform :server
+                            :on-create [:rf/server-init]
+                            :ssr {:public-error-id   :rf.ssr/default-error-projector
+                                  :dev-error-detail? false}})
+          _              (rf/remove-trace-cb! ::he)
+          err            (some #(when (= :rf.error/handler-exception (:operation %)) %)
+                               @traces)]
+      (is (some? err)
+          "handler-exception fired during the drain")
+      (is (= 500 (:status (get-response f)))
+          "default projector's :status 500 reaches :rf/response")
+      (let [public (project-error f err)]
+        (is (= {:status     500
+                :code       :internal-error
+                :message    "Something went wrong"
+                :retryable? false}
+               public)
+            "default projector's prod shape carries exactly the four locked keys")
+        (is (not (contains? public :details))
+            "prod shape (:dev-error-detail? false) — :details is absent so no internal detail leaks")))))
+
+(deftest ssr-error-projector-dev-mode-includes-details
+  (testing ":dev-error-detail? true puts the raw trace under :details"
+    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+          f             (rf/make-frame
+                          {:platform :server
+                           :ssr {:public-error-id   :rf.ssr/default-error-projector
+                                 :dev-error-detail? true}})
+          trace-event   {:operation :rf.error/handler-exception
+                         :op-type   :error
+                         :tags      {:exception-message "boom"
+                                     :failing-id        :foo}}
+          public        (project-error f trace-event)]
+      (is (= 500 (:status public)))
+      (is (= :internal-error (:code public)))
+      (is (contains? public :details)
+          ":details present in dev mode")
+      (is (= trace-event (:details public))
+          ":details is the trace event verbatim — full internal detail for the dev console"))))
+
+;; ===========================================================================
+;; ssr-custom-error-projector — reg-error-projector overrides the default
+;; ===========================================================================
+
+(deftest ssr-custom-error-projector-overrides-default
+  (testing "reg-error-projector + :ssr {:public-error-id ...} swaps the projector"
+    (rf/reg-error-projector :myapp/public-error
+      {:doc "Custom projector — promotes auth errors to 401."}
+      (fn [trace-event]
+        (case (:operation trace-event)
+          :auth/unauthorised             {:status 401 :code :unauthorised
+                                          :message "Sign in to continue"
+                                          :retryable? false}
+          :rf.error/no-such-handler      {:status 404 :code :not-found
+                                          :message "Custom not-found"
+                                          :retryable? false}
+          {:status 500 :code :internal-error
+           :message "Custom 500"
+           :retryable? false})))
+
+    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+          f             (rf/make-frame
+                          {:platform :server
+                           :ssr {:public-error-id   :myapp/public-error
+                                 :dev-error-detail? false}})]
+      ;; Auth-specific code that the DEFAULT projector doesn't know about.
+      (let [public (project-error f {:operation :auth/unauthorised :tags {}})]
+        (is (= 401 (:status public)))
+        (is (= :unauthorised (:code public)))
+        (is (= "Sign in to continue" (:message public))
+            "custom projector's message wins over the default's generic 500"))
+
+      ;; Known-error category — custom projector wins, not the default.
+      (let [public (project-error f {:operation :rf.error/no-such-handler :tags {}})]
+        (is (= "Custom not-found" (:message public))
+            "custom projector's mapping shadows :rf.ssr/default-error-projector's"))
+
+      ;; Unknown category falls into the custom projector's catch-all.
+      (let [public (project-error f {:operation :totally-unknown :tags {}})]
+        (is (= "Custom 500" (:message public)))))))
+
+(deftest ssr-error-projector-throws-falls-back-to-locked-500
+  (testing "projector throws → :rf.error/sanitised-on-projection trace + locked fallback"
+    (rf/reg-error-projector :myapp/buggy-projector
+      (fn [_trace-event]
+        (throw (ex-info "projector bug" {}))))
+
+    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+          f             (rf/make-frame
+                          {:platform :server
+                           :ssr {:public-error-id   :myapp/buggy-projector
+                                 :dev-error-detail? false}})
+          traces        (atom [])
+          _             (rf/register-trace-cb! ::sop (fn [ev] (swap! traces conj ev)))
+          public        (project-error f {:operation :rf.error/handler-exception :tags {}})]
+      (rf/remove-trace-cb! ::sop)
+      (is (= {:status     500
+              :code       :internal-error
+              :message    "Something went wrong"
+              :retryable? false}
+             public)
+          "fallback to the locked generic-500 shape — the boundary holds even with a buggy projector")
+      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)
+          ":rf.error/sanitised-on-projection trace fired so the buggy projector is observable"))))
+
+(deftest ssr-error-projector-non-conforming-shape-falls-back
+  (testing "projector returns nil / wrong shape → :rf.error/sanitised-on-projection + fallback"
+    (rf/reg-error-projector :myapp/bad-shape
+      (fn [_trace-event] {:wrong :shape}))
+
+    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+          f             (rf/make-frame
+                          {:platform :server
+                           :ssr {:public-error-id   :myapp/bad-shape}})
+          traces        (atom [])
+          _             (rf/register-trace-cb! ::bs (fn [ev] (swap! traces conj ev)))
+          public        (project-error f {:operation :rf.error/handler-exception :tags {}})]
+      (rf/remove-trace-cb! ::bs)
+      (is (= 500 (:status public))
+          "non-conforming projector output → fallback locked-500")
+      (is (= :internal-error (:code public)))
+      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)))))
+
+(deftest ssr-error-projection-skips-client-frames
+  (testing "client-platform frames don't have their :rf/response stamped on errors"
+    ;; A :rf.error/no-such-handler trace inside a CLIENT frame should not
+    ;; touch :rf/response — the client doesn't have an HTTP response to
+    ;; project. (The trace still fires; the projector just isn't called
+    ;; for a client frame's response slot.)
+    (rf/reg-route :route/home {:path "/"})
+    (let [client-f (rf/make-frame {:platform :client})]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"]
+                        {:frame client-f})
+      (let [resp (get-response client-f)]
+        ;; Default response status (200) is unchanged — error-projection
+        ;; listener no-op'd because the frame is not :server.
+        (is (= 200 (:status resp))
+            "client frame's :rf/response :status stays at 200; projector skipped")))))
+
+;; ===========================================================================
 ;; ssr-multi-redirect — multi-write emits :rf.warning/multiple-redirects
 ;; ===========================================================================
 


### PR DESCRIPTION
## Summary

- **rf2-gaah** — Locks `render-to-string` to a string return per Spec 011 (no `{:html ... :hash ...}` map). Updates Spec 011 §The render-tree → HTML emitter and the `ssr.cljc` docstring to make the contract explicit; the structural hash is a separate fn (`render-tree-hash`) and the HTTP response triple lives in `:rf/response`.
- **rf2-6528** — Wires `reg-error-projector` + `:rf.ssr/default-error-projector` + the SSR error path. The runtime now projects internal error trace events to the locked `:rf/public-error` shape and stamps the projected `:status` onto `:rf/response` for server frames.

## What's in here

### Default projector + reg-error-projector

- `re-frame.ssr/reg-error-projector` (re-exported via `re-frame.core/reg-error-projector`) registers under the existing `:error-projector` registry kind.
- Built-in `:rf.ssr/default-error-projector` implements Spec 011 §Default projector verbatim: no-such-handler / no-such-route → 404, schema-validation-failure → 400, handler/sub/fx exceptions + drain-depth-exceeded → 500, anything else → locked-500.
- `project-error` resolves the active projector via the frame's `:ssr {:public-error-id ...}` config (defaulting to the built-in id), with `:dev-error-detail? true` attaching `:details` for dev-mode error pages.

### Boundary fallback

- If the active projector throws or returns a non-conforming shape, the runtime emits `:rf.error/sanitised-on-projection` (at most once per call) and returns the locked-500 fallback. The boundary holds even with a buggy projector.

### SSR error path

- A passive trace listener at `re-frame.ssr` namespace-load time captures `:error` trace events for server frames into a per-frame buffer. `apply-pending-error-projection!` drains the buffer and stamps the projected `:status` onto `:rf/response`. `get-response` flushes lazily so hosts always see up-to-date projection.
- Buffering (rather than mutating `:rf/response` inline) avoids the race where an in-flight handler's `{:db ...}` return clobbers an inline write.

### Conformance fixtures

- `ssr-error-known-mapping.edn` and `ssr-error-sanitisation.edn` now assert the projector's output (writes to `:rf/response`) plus a new `:ssr/public-error` key the runner cross-checks against `(project-error frame-id trace-event)`.

## Test plan

- [x] `cd implementation && clojure -M:test` — 130 tests / 679 assertions / 0 failures (up from 122 / 636).
- [x] Conformance corpus: 66/66 pass.
- [x] New JVM smoke tests in `ssr_end_to_end_test.clj` cover default-projector mapping, `:dev-error-detail?`, custom-projector override, buggy-projector fallback, non-conforming-shape fallback, and client-frame skip.