### PR TITLE
test: snapshot/restore registrar pattern across CLJS fixtures (rf2-am9d)

### DIFF
--- a/implementation/src/re_frame/test_support.cljc
+++ b/implementation/src/re_frame/test_support.cljc
@@ -1,0 +1,186 @@
+(ns re-frame.test-support
+  "Test fixture helpers shared between JVM and CLJS test suites.
+
+  ## Why this namespace exists (rf2-am9d, follow-up to rf2-coks / rf2-p8g8)
+
+  Tests need per-test isolation of *user-test-registered* handlers, subs,
+  views, machines, fx, etc. — without wiping *framework-shipped*
+  registrations that landed at namespace-load time and (under CLJS)
+  cannot be re-loaded at runtime.
+
+  Earlier fixtures in the CLJS test suite reached for `registrar/clear-all!`,
+  which is fundamentally hostile to CLJS isolation:
+
+    - `re-frame.routing` registers `:rf/url-changed`, `:rf.route/navigate`,
+      `:rf.nav/scroll` (and friends) at ns-load.
+    - `re-frame.machines` registers the `:rf/machine` sub at ns-load.
+    - Example apps (e.g. `nine-states.core`) register their handlers /
+      subs / views / machines at ns-load.
+
+  CLJS has no `(require ... :reload)` analogue, so once those slots are
+  wiped they cannot be reinstated for downstream tests in the same run.
+  rf2-coks documented the resulting cross-test pollution.
+
+  The right pattern is **snapshot/restore**: capture
+  `@registrar/kind->id->metadata` before the test, allow the test to
+  register additional ids, then reset the registrar to the captured map
+  on the way out. Framework-shipped registrations survive (they're in
+  the snapshot); user-test registrations are rolled back; the next test
+  starts from the same baseline as this one.
+
+  The same shape works on the JVM. JVM tests can additionally rely on
+  `:reload` to resurrect registrations after `clear-all!`, but that's
+  the expensive route; snapshot/restore is faster and substrate-agnostic.
+
+  ## Public API
+
+  - [[snapshot-registrar]] — capture the current registrar state.
+  - [[restore-registrar!]] — restore the registrar to a captured snapshot.
+  - [[with-fresh-registrar]] — bracket a thunk with snapshot + restore.
+  - [[reset-runtime-fixture]] — `clojure.test`/`cljs.test` `:each`
+    fixture that snapshot/restores the registrar AND resets the
+    per-process state held by frames / flows / adapter / machine
+    counters / trace listeners."
+  (:require [re-frame.registrar :as registrar]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.machines :as machines]
+            [re-frame.trace :as trace]
+            [re-frame.substrate.adapter :as adapter]))
+
+;; ---- registrar snapshot/restore -------------------------------------------
+
+(defn snapshot-registrar
+  "Capture the current registrar contents.
+
+  Returns the value of `@registrar/kind->id->metadata` — a plain map of
+  `kind → id → metadata` — at the moment of the call. Pair with
+  [[restore-registrar!]] to roll the registrar back to this point.
+
+  The returned value is the persistent map the registrar atom holds; it
+  is safe to keep across mutations (subsequent `register!` calls produce
+  new persistent maps and don't alter the captured one)."
+  []
+  @registrar/kind->id->metadata)
+
+(defn restore-registrar!
+  "Reset the registrar to a previously captured snapshot.
+
+  Any registrations made since the snapshot are dropped; any registrations
+  removed since the snapshot are restored. Use this in test fixtures to
+  undo per-test pollution while preserving framework / example
+  registrations that landed at ns-load time."
+  [snapshot]
+  (reset! registrar/kind->id->metadata snapshot)
+  nil)
+
+(defn with-fresh-registrar
+  "Run `body-fn` with a snapshot/restore bracket around the registrar.
+
+  Captures the registrar before `body-fn`, runs `body-fn`, then restores
+  the registrar to the captured state — even if `body-fn` throws.
+  Returns whatever `body-fn` returned.
+
+  Intended for use in `clojure.test` / `cljs.test` `:each` fixtures:
+
+      (defn fixture [test-fn]
+        (with-fresh-registrar test-fn))
+
+      (use-fixtures :each fixture)
+
+  Tests can `reg-event-db` / `reg-sub` / `reg-view` / etc. freely; the
+  registrar is rolled back on the way out so those user registrations
+  don't leak into the next test, while ns-load-time framework
+  registrations (which are part of the captured snapshot) survive."
+  [body-fn]
+  (let [snap (snapshot-registrar)]
+    (try
+      (body-fn)
+      (finally
+        (restore-registrar! snap)))))
+
+;; ---- full per-test runtime reset ------------------------------------------
+
+(defn reset-runtime-fixture
+  "Build a `clojure.test` / `cljs.test` `:each` fixture that resets the
+  per-process re-frame runtime around each test.
+
+  Per call (i.e. per test), the fixture:
+
+    1. Captures the current registrar (so user-test registrations can be
+       rolled back without losing ns-load-time framework / example
+       registrations).
+    2. Resets `frame/frames` and `flows/flows` to `{}`.
+    3. Disposes the currently-installed substrate adapter.
+    4. Resets the machines spawn-counter.
+    5. Clears trace listeners.
+    6. If an `:adapter` was supplied, installs it and ensures the
+       `:rf/default` frame. Otherwise leaves adapter installation to
+       the test (or to a separate fixture).
+    7. If an `:init-fn` was supplied, invokes it (zero-arg). Use this
+       hook for per-suite setup that needs the registrar / adapter live
+       — e.g. resetting routing counters via
+       `(routing/reset-counters!)`.
+    8. Runs the test.
+    9. Restores the registrar to the captured snapshot.
+   10. Resets `frame/frames` and `flows/flows` back to `{}` for symmetry.
+
+  Steps 9–10 run in a `finally` block so they fire even on test
+  exceptions.
+
+  Options (all optional):
+    :adapter      — substrate adapter to install. If omitted, no adapter
+                    is installed by the fixture.
+    :init-fn      — zero-arg fn run after adapter install, before the test.
+    :clear-kinds  — collection of registry kinds (e.g. `[:app-schema]`) to
+                    `clear-kind!` AFTER the snapshot capture and BEFORE
+                    the test body runs. Use this when example apps
+                    loaded by ns-load time register entries under a
+                    kind your test wants a clean slate for. The
+                    snapshot still includes those entries, so they're
+                    restored on the way out — they only disappear for
+                    the duration of the test.
+
+  Returns a fixture fn suitable for `(use-fixtures :each ...)`.
+
+  Example (CLJS):
+
+      (use-fixtures :each
+        (test-support/reset-runtime-fixture
+          {:adapter reagent-adapter/adapter}))
+
+  Example with example-app collision avoidance — schemas tests want a
+  clean :app-schema slate without losing nine-states.core's other
+  registrations:
+
+      (use-fixtures :each
+        (test-support/reset-runtime-fixture
+          {:adapter     reagent-adapter/adapter
+           :clear-kinds [:app-schema]}))
+
+  Example (JVM, default plain-atom adapter):
+
+      (use-fixtures :each
+        (test-support/reset-runtime-fixture
+          {:adapter plain-atom/adapter}))"
+  ([] (reset-runtime-fixture {}))
+  ([{:keys [adapter init-fn clear-kinds]}]
+   (fn [test-fn]
+     (let [snap (snapshot-registrar)]
+       (try
+         (reset! frame/frames {})
+         (reset! flows/flows {})
+         (adapter/dispose-adapter!)
+         (machines/reset-counters!)
+         (trace/clear-trace-cbs!)
+         (when adapter
+           (adapter/install-adapter! adapter)
+           (frame/ensure-default-frame!))
+         (doseq [k clear-kinds]
+           (registrar/clear-kind! k))
+         (when init-fn (init-fn))
+         (test-fn)
+         (finally
+           (restore-registrar! snap)
+           (reset! frame/frames {})
+           (reset! flows/flows {})))))))

--- a/implementation/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/test/re_frame/cross_spec_cljs_test.cljs
@@ -10,35 +10,21 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
             [re-frame.views]))
 
-(defn- reset-runtime
-  "Per-test runtime reset for CLJS cross-spec tests.
-
-  We deliberately do NOT call (registrar/clear-all!) here. CLJS has no
-  runtime (require :reload), so a clear-all! would wipe routing's
-  framework events (:rf/url-changed, :rf.route/navigate, :rf.nav/scroll
-  fx, …) and machines.cljc's :rf/machine sub, which were registered at
-  ns-load time and CANNOT be re-registered without reloading the
-  defining ns. Subsequent CLJS test files (nine-states-cljs-test,
-  routing-cljs-test) depend on those registrations being intact —
-  rf2-coks tracked the cross-test pollution.
-
-  Tests that re-register the same id (e.g. :test/m, :seed) rely on
-  registrar/register!'s replacement semantics — that's a supported
-  hot-reload path, not a leak. Resetting frames, flows and the adapter
-  is enough to isolate per-test state."
-  [test-fn]
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (adapter/dispose-adapter!)
-  (rf/init! reagent-adapter/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; Snapshot/restore the registrar around each test (rf2-am9d). We do NOT
+;; call (registrar/clear-all!): CLJS has no runtime (require :reload), so
+;; wiping the registrar would permanently lose routing's framework events
+;; (:rf/url-changed, :rf.route/navigate, :rf.nav/scroll fx, …) and
+;; machines.cljc's :rf/machine sub, which were registered at ns-load time.
+;; Snapshot/restore preserves those while rolling back the test's own
+;; registrations on the way out.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
 
 (defn- collect-traces [k]
   (let [traces (atom [])]

--- a/implementation/test/re_frame/hash_check_cljs_test.cljs
+++ b/implementation/test/re_frame/hash_check_cljs_test.cljs
@@ -1,6 +1,14 @@
 (ns re-frame.hash-check-cljs-test
-  (:require [cljs.test :refer-macros [deftest is]]
-            [re-frame.ssr :as ssr]))
+  "JVM ↔ CLJS canonical-edn / render-tree-hash parity smoke. The fixture
+  uses re-frame.test-support/reset-runtime-fixture for symmetry with
+  the rest of the CLJS suite (rf2-am9d) — even though this test only
+  reads pure ssr fns, fixture uniformity makes it harder to accidentally
+  re-introduce registrar pollution if the test grows."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.ssr :as ssr]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/reset-runtime-fixture))
 
 (deftest jvm-cljs-hash-parity
   (let [tree      [:div {:class "x"} [:p "hi"]]

--- a/implementation/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/test/re_frame/hot_reload_cljs_test.cljs
@@ -17,28 +17,24 @@
   observation crisp: pre-rereg renders bump the v1 counter; post-rereg
   renders bump the v2 counter.
 
-  Fixture note: runtime_cljs_test installs a `reset-runtime` fixture
-  that calls `registrar/clear-all!`. We deliberately do NOT do that
-  here — clearing the registrar in this file's fixture would wipe
-  example apps (notably nine-states.core) whose registrations land at
-  namespace-load time and CANNOT be re-loaded under CLJS. Each test
-  uses unique keywords so cross-test interference inside this file is
-  impossible without a global wipe."
+  Fixture: per rf2-am9d this file uses the shared
+  `re-frame.test-support/reset-runtime-fixture`, which snapshots the
+  registrar before each test and restores it after. Snapshot/restore
+  preserves ns-load-time framework / example registrations (notably
+  routing's framework events and nine-states.core's view set) — those
+  cannot be re-loaded under CLJS — while still rolling back this
+  file's per-test `reg-view` calls so the :rf.hot-reload-test/* slots
+  don't leak into other test ns runs."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
             [re-frame.views])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
-(defn ensure-adapter [test-fn]
-  ;; Don't wipe the registrar — see fixture note above. Just make sure
-  ;; the Reagent adapter is installed so reg-view's wrapping fns work.
-  (when-not (adapter/current-adapter)
-    (rf/init! reagent-adapter/adapter))
-  (test-fn))
-
-(use-fixtures :each ensure-adapter)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
 
 ;; ---- (4) :view re-register flips the next render to the new body --------
 

--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -10,38 +10,18 @@
   runtime_cljs_test.cljs; this file completes the matrix on CLJS."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
-            [re-frame.machines :as machines]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
-(defn reset-runtime
-  "Per-test runtime reset for CLJS machines tests.
-
-  We deliberately do NOT call (registrar/clear-all!) here. CLJS has no
-  runtime (require :reload), so a clear-all! would wipe routing's
-  framework events (:rf/url-changed, :rf.route/navigate, :rf.nav/scroll
-  fx, …) and machines.cljc's :rf/machine sub, which were registered at
-  ns-load time and CANNOT be re-registered without reloading the
-  defining ns. Subsequent CLJS test files (nine-states-cljs-test,
-  routing-cljs-test) depend on those registrations being intact —
-  rf2-coks tracked the cross-test pollution.
-
-  Each test in this file uses unique machine / event ids, so a registry
-  wipe is unnecessary for in-file isolation. Resetting frames, flows,
-  the adapter, the machine counters and trace cbs is enough."
-  [test-fn]
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (adapter/dispose-adapter!)
-  (rf/init! reagent-adapter/adapter)
-  (machines/reset-counters!)
-  (trace/clear-trace-cbs!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; Snapshot/restore the registrar around each test (rf2-am9d). We do NOT
+;; call (registrar/clear-all!): CLJS has no runtime (require :reload), so
+;; wiping the registrar would permanently lose routing's framework events
+;; and machines.cljc's :rf/machine sub, which were registered at ns-load
+;; time. The reset-runtime-fixture also resets the machines spawn-counter
+;; and clears trace listeners, both of which these tests need.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
 
 (defn- snapshot
   "Read the snapshot for `machine-id` from the default frame's app-db."

--- a/implementation/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/test/re_frame/nine_states_cljs_test.cljs
@@ -5,22 +5,26 @@
 
   The example registers its handlers / subs / views / machines at
   namespace-load time. CLJS has no runtime (require :reload), so this
-  test runs WITHOUT resetting the registrar — the registrations land
-  once when the example's ns is loaded by shadow-cljs and stay live
-  for the test run. Each test-state-N fixture inside the example uses
-  make-frame to spin up a fresh frame, so per-test isolation comes
-  from frame creation, not registry resets."
-  (:require [cljs.test :refer-macros [deftest is]]
-            [re-frame.core :as rf]
-            [re-frame.substrate.adapter :as adapter]
+  test relies on those registrations staying live for the test run.
+  Each test-state-N fixture inside the example uses make-frame to spin
+  up a fresh frame, so per-test isolation comes from frame creation,
+  not registry resets.
+
+  Per rf2-am9d the fixture uses snapshot/restore via
+  re-frame.test-support so the contract is uniform across CLJS
+  fixtures — the snapshot captures the example's ns-load
+  registrations, and the restore on the way out leaves them intact for
+  any subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
             [re-frame.views]
             [nine-states.core :as ns-core]))
 
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
 (deftest nine-states-runs-end-to-end
-  ;; Ensure the Reagent adapter is installed (the example's tests use
-  ;; subscribe-value, which needs an adapter for derived values).
-  (when-not (adapter/current-adapter)
-    (rf/init! reagent-adapter/adapter))
   (is (= :ok (ns-core/run-all-tests))
       "nine-states.core/run-all-tests should walk all 9 UI states and return :ok"))

--- a/implementation/test/re_frame/routing_cljs_test.cljs
+++ b/implementation/test/re_frame/routing_cljs_test.cljs
@@ -22,23 +22,20 @@
   §Multi-frame routing."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.routing :as routing]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.reagent :as reagent-adapter]))
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
 
-(defn install-adapter [test-fn]
-  ;; Ensure the Reagent adapter is installed for derived sub computation.
-  ;; We do NOT call (registrar/clear-all!) here — it would wipe routing's
-  ;; framework events (:rf.route/navigate, :rf/url-changed, ...) which
-  ;; were registered at routing.cljc's ns-load and CLJS cannot re-load
-  ;; namespaces at runtime to restore them.
-  (when-not (adapter/current-adapter)
-    (rf/init! reagent-adapter/adapter))
-  (routing/reset-counters!)
-  (test-fn))
-
-(use-fixtures :each install-adapter)
+;; Snapshot/restore the registrar around each test (rf2-am9d). We do NOT
+;; call (registrar/clear-all!): it would wipe routing's framework events
+;; (:rf.route/navigate, :rf/url-changed, …) registered at routing.cljc's
+;; ns-load, and CLJS cannot re-load namespaces at runtime to restore
+;; them. routing/reset-counters! runs in :init-fn so per-test counter
+;; sequences (nav-token, pending-nav, …) start from zero.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn routing/reset-counters!}))
 
 ;; ---- Spec 012 §URL changes are events / §Reading the route is a sub -----
 

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -5,25 +5,22 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [reagent.core :as r]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.ssr :as ssr]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
             [re-frame.views])
   (:require-macros [re-frame.views-macros :refer [with-frame bound-fn h reg-view]]))
 
-(defn reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (adapter/dispose-adapter!)
-  (rf/init! reagent-adapter/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; Snapshot/restore the registrar around each test (rf2-am9d). Wiping the
+;; registrar with clear-all! is hostile to CLJS test isolation: framework
+;; events / subs registered at ns-load (re-frame.routing, re-frame.machines)
+;; and example apps (nine-states.core) cannot be re-loaded under CLJS, so
+;; once cleared they're gone for the rest of the test run. Snapshot/restore
+;; preserves them while still rolling back per-test registrations.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
 
 ;; ---- shared dispatch + sub --------------------------------------------------
 

--- a/implementation/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/test/re_frame/schemas_cljs_test.cljs
@@ -25,21 +25,27 @@
             ;; the same.
             [malli.core]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.reagent :as reagent-adapter]))
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (adapter/dispose-adapter!)
-  (rf/init! reagent-adapter/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; Snapshot/restore the registrar around each test (rf2-am9d). The earlier
+;; (registrar/clear-all!) wiped framework registrations (routing,
+;; machines) — fine while these tests ran in isolation, but hostile to
+;; cross-ns CLJS test runs because CLJS cannot reload them. Snapshot/
+;; restore preserves them and still rolls back per-test :app-schema /
+;; reg-event-db / reg-sub on the way out.
+;;
+;; :clear-kinds [:app-schema] gives the test a clean :app-schema slate
+;; per-test. Without this, nine-states.core's ns-load app-schemas
+;; (registered for :todos and :new-todo) survive in the snapshot and
+;; produce extra schema-validation-failure traces that this smoke
+;; doesn't expect. The snapshot still holds those entries, so the
+;; restore on the way out leaves nine-states.core's schemas intact for
+;; downstream tests.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter     reagent-adapter/adapter
+     :clear-kinds [:app-schema]}))
 
 ;; ---- live dispatch fires app-db schema validation -------------------------
 


### PR DESCRIPTION
## Summary

- Adds `re-frame.test-support` (shared `.cljc`) with a positive API for the snapshot/restore pattern: `snapshot-registrar`, `restore-registrar!`, `with-fresh-registrar`, and a `reset-runtime-fixture` builder for `clojure.test` / `cljs.test`.
- Migrates every CLJS test fixture (8 files) to the shared helper. The previous mix — some fixtures wiped the registrar with `clear-all!` (hostile to CLJS, which can't re-load the routing / machines / example-app ns-load registrations), others didn't reset it at all — is replaced with a uniform snapshot/restore bracket.
- Closes the rf2-coks follow-up that rf2-p8g8 spawned.

## Why

CLJS has no runtime `(require ... :reload)`, so once the registrar is `clear-all!`-ed, framework-shipped registrations (`re-frame.routing`'s URL-changed event, `re-frame.machines`'s `:rf/machine` sub) and example-app registrations (`nine-states.core`) are gone for the rest of the test run. Snapshot/restore preserves them while still rolling back per-test pollution.

## Helper API

```clojure
;; Captures @registrar/kind->id->metadata. Pair with restore-registrar!.
(test-support/snapshot-registrar)

;; Reset to a captured snapshot.
(test-support/restore-registrar! snap)

;; Bracket a thunk.
(test-support/with-fresh-registrar #(do-stuff))

;; Build a :each fixture. Options:
;;   :adapter      — substrate adapter to install
;;   :init-fn      — zero-arg fn run after adapter install
;;   :clear-kinds  — kinds to clear at fixture start (snapshot still
;;                   restores them on the way out)
(use-fixtures :each
  (test-support/reset-runtime-fixture
    {:adapter reagent-adapter/adapter}))
```

## Migrated fixtures

| File                       | Before                          | After                                   |
|----------------------------|---------------------------------|-----------------------------------------|
| runtime_cljs_test          | `clear-all!` + ad-hoc           | shared helper                           |
| cross_spec_cljs_test       | snapshot-shaped (rf2-coks)      | shared helper                           |
| machines_cljs_test         | snapshot-shaped + counter reset | shared helper (counter reset built-in)  |
| schemas_cljs_test          | `clear-all!` + ad-hoc           | shared helper, `:clear-kinds [:app-schema]` to avoid nine-states.core's ns-load app-schemas |
| routing_cljs_test          | install-adapter + counter reset | shared helper, `:init-fn routing/reset-counters!` |
| nine_states_cljs_test      | no fixture                      | shared helper (symmetry)                |
| hot_reload_cljs_test       | install-adapter only            | shared helper (per-test view re-reg now restored) |
| hash_check_cljs_test       | no fixture                      | shared helper (symmetry)                |

JVM smoke fixtures still rely on `clear-all!` + `(require ... :reload)`. They could move to the helper too, but that's a separate cleanup.

## Test plan

- [x] `cd implementation && npx shadow-cljs compile node-test && node out/node-test.js` — 54 tests, 187 assertions, 0 failures, 0 errors.
- [x] `cd implementation && npm run test:browser` — 54 tests, 187 assertions, 0 failures, 0 errors.
- [x] `cd implementation && clojure -M:test` — 130 tests, 679 assertions, 0 failures, 0 errors.