### PR TITLE
spec: Tool-Pair gaps from re-frame-pair audit

### DIFF
--- a/docs/specification/002-Frames.md
+++ b/docs/specification/002-Frames.md
@@ -327,7 +327,8 @@ The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe t
  :frame        :todo                   ;; resolved frame keyword
  :fx-overrides {:http stub-fn}         ;; per-dispatch fx replacements (master's dispatch-with)
  :trace-id     "..."                   ;; tooling/agent fields
- :source       :ui                     ;; e.g. :ui, :timer, :http, :repl, :machine
+ :source       :ui                     ;; e.g. :ui, :timer, :http, :repl, :machine — trigger kind
+ :origin       :pair                   ;; e.g. :app (default), :pair, :story, :test — actor identity
  :dispatched-at <ts>}
 ```
 
@@ -349,6 +350,20 @@ In priority order, where the frame keyword comes from:
 2. **Lexical `dispatch` injected by `reg-view`.** The closure carries the frame keyword resolved from React context at render. (See View Ergonomics, below.) Internally, the injected `dispatch` is `(fn [event] (dispatch event {:frame <captured>}))`.
 3. **Dynamic binding.** Inside `(with-frame :todo ...)` (test/REPL helper), a Clojure dynamic var carries the frame; the bare `(rf/dispatch [:foo])` in the body picks it up. This makes `(with-frame :todo (rf/dispatch [:foo]))` Just Work without an opts map.
 4. **Default.** `:rf/default`.
+
+### Dispatch origin tagging
+
+The dispatch opts map accepts an optional `:origin` key — a tag identifying the *actor* that issued the dispatch:
+
+```clojure
+(rf/dispatch [:user/login {:email e}] {:origin :pair})
+```
+
+`:origin` is unconstrained at the framework level — tools and applications agree on values (`:pair`, `:claude`, `:story`, `:test`, etc.). The value flows into the dispatch envelope and is lifted by the trace surface onto every `:event/dispatched` trace event under `:tags :origin` (per [009 §Origin tagging](009-Instrumentation.md#origin-tagging-origin)). The default when the opt is omitted is `:app`.
+
+Pair-shaped tools and other tooling surfaces set `:origin` to filter their own activity in post-mortem trace views — "show me only the dispatches the pair tool issued during this session" becomes a one-key filter on the trace stream. User application code typically omits the opt; framework code (the SSR boot path, the router, the machine timer) sets it to a runtime-reserved value (`:rf/router`, `:rf/ssr`, etc.) where the distinction is useful.
+
+`:origin` is **distinct from `:source`** (the existing envelope key). `:source` describes the trigger kind (`:ui` / `:timer` / `:http` / `:machine` / `:repl` / `:ssr-hydration`) — what *woke* the runtime. `:origin` describes the actor identity — *who* issued the dispatch. Both can be set independently; tools commonly set `:origin :pair` and let `:source` default to `:repl`.
 
 ## View ergonomics (the hard part)
 

--- a/docs/specification/009-Instrumentation.md
+++ b/docs/specification/009-Instrumentation.md
@@ -41,6 +41,41 @@ The shape is documented below.
 
 These are top-level fields on every event for re-frame2-aware traces; tools written against pre-v2 traces ignore them.
 
+### Dispatch correlation: `:dispatch-id` / `:parent-dispatch-id`
+
+Pair-shaped tools and per-event diagnostics need to correlate the *cascade* a dispatch belongs to — "this `:event/dispatched` was emitted by an effect that ran inside the cascade started by *that* dispatch." The runtime stamps two fields onto every `:event/dispatched` trace event under the top-level `:tags`:
+
+```clojure
+{:tags {:dispatch-id        <uuid-or-counter>   ;; this dispatch's identity
+        :parent-dispatch-id <uuid-or-counter>}  ;; the dispatch that caused this one (if any)
+ ...}
+```
+
+Semantics:
+
+- **`:dispatch-id`** is allocated by the runtime when a dispatch is enqueued, before routing. Implementations may use a process-monotonic counter, a UUID, or any opaque value with the same uniqueness contract: distinct within a single process for the lifetime of the trace surface. Tools treat it as opaque.
+- **`:parent-dispatch-id`** is set when the dispatch was emitted as a side-effect of another event's processing — typically inside an `fx` handler. Concretely: when an `fx` handler running inside the do-fx phase of dispatch *D₁* invokes `(rf/dispatch ...)`, the runtime records the new dispatch's `:parent-dispatch-id` as *D₁*'s `:dispatch-id`. If the dispatch was initiated outside any in-flight event (a timer, a UI handler, the REPL, the SSR boot path), `:parent-dispatch-id` is absent.
+- **Top-level dispatch.** A dispatch with no `:parent-dispatch-id` is a *root* of a cascade. Pair-shaped tools draw cascade trees by following `:parent-dispatch-id` upward.
+- **Distinct from `:child-of`.** The existing `:child-of` field on every trace event correlates *spans* (an `:event` span's children include its `:event/do-fx` span, which in turn parents each fx call). `:dispatch-id` / `:parent-dispatch-id` correlate *dispatches* — events queued through the router. The two are orthogonal: `:child-of` chains span the lifecycle of one event's processing; `:parent-dispatch-id` chains cascading dispatches across events.
+- **Production elision.** Both fields ride the trace stream and are elided in production with the rest of the trace surface.
+
+Tools consume these two fields to build dispatch-cascade views: "show me all dispatches descended from `[:user/login ...]`" is a transitive walk over `:parent-dispatch-id`.
+
+### Origin tagging: `:origin`
+
+When a tool (the pair tool, a story runner, the REPL, the SSR boot path) needs its own dispatches distinguishable from application dispatches, it can tag them with an `:origin` opt at dispatch time (per [002 §Dispatch origin tagging](002-Frames.md#dispatch-origin-tagging)). The runtime lifts the value onto every `:event/dispatched` trace event under `:tags :origin`:
+
+```clojure
+{:tags {:origin :pair        ;; tag set by the dispatching tool; default :app
+        :dispatch-id ...
+        ...}
+ ...}
+```
+
+`:origin` is unconstrained at the framework level — tools and applications agree on values (`:pair`, `:claude`, `:story`, `:test`, etc.). The default is `:app`. User application code typically omits the opt; tool surfaces set it so post-mortem filters like "show me only the dispatches I (the pair tool) issued during this session" become a one-key filter on the trace stream.
+
+`:origin` is **distinct from `:source`**: `:source` describes the *trigger kind* (`:ui` / `:timer` / `:http` / `:machine` / `:repl` / `:ssr-hydration`) and is essentially a "what woke the runtime?" axis; `:origin` describes the *actor identity* (which tool or app subsystem emitted the dispatch) and is used for filtering. Tools may set both.
+
 ### `:op-type` vocabulary
 
 Core values: `:event`, `:sub/run`, `:sub/create`, `:render`, `:raf`, `:event/do-fx`, `:reagent/quiescent`, `:sync`, `::fsm-trigger`.
@@ -100,6 +135,40 @@ The canonical listener API has one shape:
 ```
 
 Conventional keys: `:my-app/recorder`, `:my-app/timing-monitor`, etc. The two-arity form is the typical case; the three-arity form opts out of batching (per [§Per-event delivery](#per-event-delivery--opt-out-of-batching) below).
+
+#### `register-epoch-cb` — assembled-epoch listener
+
+Alongside the raw trace stream, the framework exposes a parallel **assembled-epoch listener** API. Where `register-trace-cb` delivers a debounced batch of raw spans, `register-epoch-cb` delivers one fully-assembled `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) per drain-settle:
+
+```clojure
+(rf/register-epoch-cb key callback-fn)
+;; Subscribes callback-fn to receive assembled epoch records.
+;;
+;; Arguments:
+;;   key         — keyword identifying the listener (replaces same-key registration)
+;;   callback-fn — invoked with one :rf/epoch-record per drain-settle.
+;;                 Signature: (fn [epoch-record] ...)
+;;
+;; The record is the same shape the runtime appends to (rf/epoch-history frame-id):
+;; assembled :event-id / :trigger-event / :db-before / :db-after, plus the structured
+;; :sub-runs / :renders / :effects projections derived from the cascade's traces.
+
+(rf/remove-epoch-cb key)
+;; Unsubscribes the listener registered under key.
+```
+
+**Invocation rules** (mirrors `register-trace-cb`):
+
+- **Per drain-settle, not per event.** The callback fires once when the run-to-completion drain reaches an empty queue and the epoch record is committed; multi-event cascades produce one record (and one callback invocation), not one per event.
+- **Not batched.** Unlike `register-trace-cb`'s default debounce window, epoch records are delivered as they commit — a drain settling produces an immediate callback. The drain itself coalesces; no further batching is added on top.
+- **After commit.** The callback receives a fully-formed record with `:db-after`, `:sub-runs`, `:renders`, `:effects`, and any optional `:trace-events` populated. The record has already been appended to the frame's `epoch-history` ring buffer when the callback runs.
+- **Exception isolation.** An exception thrown by an epoch callback is caught, logged via `re-frame.loggers`, and does not propagate. One broken epoch listener cannot break the app or block other listeners (raw-trace or epoch).
+- **Listener ordering** is not contract.
+- **Production elision.** The epoch listener machinery is gated on the same `goog-define trace-enabled?` as the raw-trace surface. Production builds elide registration, dispatch, and the epoch ring-buffer all together.
+
+**When to use which.** `register-trace-cb` is the right shape for tools that need raw fine-grained spans (the Chrome Performance bridge, custom timing displays). `register-epoch-cb` is the right shape for tools that route diagnostics off "what just happened in this cascade" — pair-shaped tools, post-mortem dashboards, anything that wants the structured `:sub-runs` / `:renders` / `:effects` projection without re-folding the raw trace stream.
+
+The two listener APIs are independent: tools may register either, both, or neither. They share the production-elision gate but have separate listener registries; no listener of one kind can interfere with the other.
 
 ### Listener invocation rules
 

--- a/docs/specification/010-Schemas.md
+++ b/docs/specification/010-Schemas.md
@@ -163,7 +163,12 @@ Schemas registered against handlers and `app-db` paths are queryable via the pub
 
 (rf/app-schemas)
 ;; → {[:user] UserSchema, [:todos] TodosSchema, [:auth] AuthSchema, [] WholeAppDbSchema}
+
+(rf/app-schemas frame-id)
+;; → same {path schema} map for the named frame; sugar for (rf/app-schemas {:frame frame-id})
 ```
+
+`(rf/app-schemas frame-id)` is the surface pair-shaped tools (per [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach)) call to reflect on the schemas registered against a given frame — the result is a `{path schema}` map of the `app-schema-at` declarations active for that frame, in the same shape `app-schemas-digest` hashes. The form is sugar for the `{:frame frame-id}`-opt arity: passing a bare keyword is the common pair-tool case; the opts-map arity is the configurable case (and the place future opts will land).
 
 Tools and agents read these to:
 

--- a/docs/specification/Spec-Schemas.md
+++ b/docs/specification/Spec-Schemas.md
@@ -91,7 +91,8 @@ Carried internally by every dispatch. User-facing event vector remains a vector;
    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
    [:interceptors          {:optional true} [:vector :any]]
    [:trace-id              {:optional true} :any]
-   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]]
+   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]] ;; trigger kind
+   [:origin                {:optional true} :keyword]                      ;; actor identity (default :app) — per [002 §Dispatch origin tagging]
    [:dispatched-at         {:optional true} :any]])                        ;; CLJS reference may add an impl-specific timestamp; tools tolerate
 ```
 
@@ -109,7 +110,8 @@ The opts map a user passes to `(dispatch event opts)` / `(dispatch-sync event op
    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
    [:interceptors          {:optional true} [:vector :any]]
    [:trace-id              {:optional true} :any]
-   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]]])
+   [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]]
+   [:origin                {:optional true} :keyword]])                     ;; actor identity tag — defaults to :app when omitted
 ```
 
 The promotion is structural: `(dispatch event opts)` → envelope is `(merge {:event event :frame :rf/default :dispatched-at (now)} opts)`. The runtime asserts `:event` and `:frame` are present after the merge.
@@ -962,11 +964,36 @@ Per-frame epoch snapshot, recorded on each drain-completion in dev builds. Used 
    [:trigger-event [:vector :any]]                                          ;; the full event vector
    [:db-before     :any]                                                    ;; app-db before the cascade
    [:db-after      :any]                                                    ;; app-db after drain settled
-   [:trace-events  {:optional true} [:vector :any]]                         ;; the cascade's trace events
+   [:trace-events  {:optional true} [:vector :any]]                         ;; the cascade's trace events (raw)
+   [:sub-runs      {:optional true} [:vector
+                                     [:map
+                                      [:sub-id           :any]
+                                      [:query-v          [:vector :any]]
+                                      [:result-changed?  :boolean]
+                                      [:recomputed?      :boolean]]]]      ;; per-sub activity in this cascade
+   [:renders       {:optional true} [:vector
+                                     [:map
+                                      [:render-key   :any]
+                                      [:triggered-by [:maybe :any]]        ;; sub-id or nil
+                                      [:elapsed-ms   :any]]]]              ;; per-render activity in this cascade
+   [:effects       {:optional true} [:vector
+                                     [:map
+                                      [:fx-id        :keyword]
+                                      [:args         :any]
+                                      [:outcome      [:enum :ok :error :skipped-on-platform]]
+                                      [:error-trace  {:optional true} :any]]]] ;; per-effect activity in this cascade
    ])
 ```
 
-The `:db-before` / `:db-after` pair lets pair tools display diffs cheaply. `:trace-events` is optional because for long histories the per-epoch trace can be large — implementations may choose to drop traces from older epochs.
+The `:db-before` / `:db-after` pair lets pair tools display diffs cheaply.
+
+**Structured slots are derived from `:trace-events`.** The `:sub-runs`, `:renders`, and `:effects` slots are pre-computed projections of the underlying `:trace-events` stream, surfacing the per-sub / per-render / per-effect activity of the cascade in a shape pair-shaped tools can route off without re-folding the raw trace each time. The legacy `:trace-events` slot remains the raw underpinning; the structured slots derive from it.
+
+- `:sub-runs` — every sub the cascade touched. `:recomputed?` is `false` on a cache hit (the sub was queried but its memoised value reused) and `true` when the sub re-ran. `:result-changed?` reports whether the post-run value differs from the prior cached value. The two together let a tool answer "which subs actually moved this cascade?" without re-deriving from the trace.
+- `:renders` — every render that fired during the cascade. `:triggered-by` names the sub-id whose value-change triggered the render, or is `nil` for the initial mount / a render driven by something other than a sub change. `:elapsed-ms` is the render's wall-clock duration. `:render-key` identifies the rendered unit; **TBD pending rf2-t5tx** — the choice between "the `reg-view` registration id" (coarse) and "a per-component-instance token" (fine) has not been pinned. Tools should treat it as opaque.
+- `:effects` — every effect dispatched in the cascade's `:event/do-fx` step. `:outcome` is `:ok` on success, `:error` if the effect threw or returned a structured error, `:skipped-on-platform` when the effect is registered with `:platforms` that exclude the current host (per [011](011-SSR.md)). `:error-trace` (when present) references the corresponding error trace event by `:id`.
+
+`:trace-events` is optional because for long histories the per-epoch trace can be large — implementations may choose to drop traces from older epochs. The structured slots have the same per-epoch-storage tradeoff and may likewise be elided for older epochs in the ring buffer.
 
 ### `:rf/fixture-file`
 

--- a/docs/specification/Tool-Pair.md
+++ b/docs/specification/Tool-Pair.md
@@ -7,6 +7,8 @@
 
 **This Spec is** the *runtime contract* — the set of public capabilities re-frame2 exposes that pair-shaped tools rely on. It tells an implementer "ship these capabilities and a pair tool can be built against you."
 
+> **Audit lineage.** Several surfaces below (`register-epoch-cb`, the structured `:sub-runs` / `:renders` / `:effects` slots on `:rf/epoch-record`, `:dispatch-id` / `:parent-dispatch-id` correlation, the `:origin` dispatch opt, `app-schemas` introspection, and the §Source-mapping helper enumeration) were added to this Spec following a cross-reference audit against [day8/re-frame-pair](https://github.com/day8/re-frame-pair)'s actual source — the upstream tool consumed surfaces this contract had not yet committed to. The audit is single-sourced here; downstream Specs (009 / 010 / 002 / Spec-Schemas) carry the additive normative text without re-citing the audit.
+
 > **Source-of-truth note:** Tool-Pair.md is the **canonical surface contract** for the time-travel / epoch-history capabilities and the trace-stream consumption shape. [API.md](API.md) reproduces these signatures (under §Epoch history) for fast lookup, but the *normative* descriptions live here; if the two drift, this Spec wins. The `epoch-history`, `restore-epoch`, and `(rf/configure :epoch-history {:depth N})` surface, plus the `:rf.epoch/snapshotted` / `:rf.epoch/restored` / `:rf.registry/handler-replaced` trace events, are pinned here and referenced from API.md.
 
 **This Spec is not** the pair tool itself. The actual pair tool — the Claude integration, the prompt design, the nREPL middleware — lives outside the spec, in a separate repository (the upstream is [day8/re-frame-pair](https://github.com/day8/re-frame-pair)). re-frame2 ships *its half* of the contract; the tool ships its half.
@@ -50,6 +52,7 @@ The two parts together form the **consolidated contract** — the complete set o
 | **Hot-swap handlers** | Re-registration replaces; emits `:rf.registry/handler-replaced` trace | [001 §Hot-reload semantics](001-Registration.md#hot-reload-semantics) |
 | **Stub fx** | `:fx-overrides` map (id-valued at the pattern level) on `dispatch` opts or `reg-frame` metadata | [002 §Per-frame and per-call overrides](002-Frames.md#per-frame-and-per-call-overrides) |
 | **Source coordinates** | `:ns`/`:line`/`:file` on every registration's metadata | [001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference) |
+| **Inspect registered schemas** | `(rf/app-schemas frame-id)`, `(rf/app-schema-at path opts)`, `(rf/app-schemas-digest opts)` | [010 §Schemas as a tooling and agent surface](010-Schemas.md#schemas-as-a-tooling-and-agent-surface) |
 | **Errors** | Structured `:rf.error/*` trace events with category + tags | [009 §Error contract](009-Instrumentation.md#error-contract) |
 
 This much is **already specified**. A pair tool built against re-frame2 (and conforming with [day8/re-frame-pair](https://github.com/day8/re-frame-pair)) needs nothing more than these surfaces to do everything in the capability list above except time-travel.
@@ -60,7 +63,7 @@ The capability that requires *new* commitments is **time-travel**, addressed bel
 
 The runtime contract for time-travel:
 
-**Recording.** Every event-cascade settle (drain reaching empty queue) marks an epoch boundary. The runtime records, per frame, an `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) consisting of `:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, and (optionally) `:trace-events`.
+**Recording.** Every event-cascade settle (drain reaching empty queue) marks an epoch boundary. The runtime records, per frame, an `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) consisting of `:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, and (optionally) `:trace-events`, plus the structured per-epoch projections `:sub-runs`, `:renders`, and `:effects` (each pre-derived from `:trace-events`; see [Spec-Schemas §`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record) for shapes). Pair tools route diagnostics off the structured slots — cache-hit-vs-rerun analysis (`:sub-runs[*].:recomputed?`), render-tag attribution (`:renders[*].:triggered-by`), and fx cascade outcome (`:effects[*].:outcome`) — without re-folding the raw trace stream each epoch.
 
 **Ordering.** Epochs within a frame are totally ordered by drain-completion time. Across frames, ordering is per-frame only — there is no global epoch sequence.
 
@@ -104,6 +107,19 @@ The "which button is at `src/app/profile/view.cljs:84`?" capability requires eve
 
 The annotation is opt-in (configured at re-frame2 startup) because it has a small DOM-bytes cost. With it on, a pair tool can take a click position, read the nearest annotation, and resolve back to a source coordinate.
 
+### Where the DOM-to-source helpers live (re-frame2 vs tool)
+
+The audit found the upstream pair tool ships `dom/source-at`, `dom/find-by-src`, and `dom/fire-click-at-src` helpers (it currently parses re-com's `data-rc-src` attribute, but the shape is general). Pair-shaped tools need *some* DOM-to-source bridge; the question is whether the helpers themselves are part of re-frame2's contract or live in the consuming tool.
+
+**re-frame2's commitment is the attribute, not the helpers.** Specifically:
+
+- The runtime emits the `data-rf2-source-coord` attribute on rendered DOM nodes when source-annotation is enabled. The attribute's *value format* is the contract (an opaque string the tool parses to recover `:ns` / `:line` / `:file` — schema in [Spec-Schemas](Spec-Schemas.md)).
+- The framework does **not** ship `dom-source-at` / `find-by-src` / `fire-click-at-src` style helpers. These are tool-side: the pair tool reads the attribute via its own host's DOM access (`document.querySelector` in CLJS, `page.locator` in Playwright-driven flows, etc.) and resolves the source coordinate locally.
+
+**Why tool-side, not framework-side:** the helpers depend on host-specific DOM access that re-frame2 the framework does not assume — a pair tool driving a browser via CDP, a server-rendered diagnostic dump, or a static analyzer all want different "lookup the attribute" implementations. Pinning a single helper signature here would either over-constrain consumers or under-serve them. The framework commits to the attribute (stable, cross-host, parseable); the consuming tool ships the host-appropriate query primitives on top.
+
+A future re-frame2 minor version may introduce framework-side helpers if the ecosystem converges on a single shape; the attribute contract is forward-compatible with that addition.
+
 ## How AI tools attach
 
 The runtime contract above is **complete and self-contained.** A pair-shaped tool — re-frame-pair, a Claude integration, a custom debug panel, a story tool, a future pair-improver — attaches to a running re-frame2 application using only the framework primitives listed below. **No re-frame-10x dependency is required**, and none should be assumed.
@@ -113,10 +129,14 @@ The full attachment surface, from the tool's point of view:
 | Need | Surface | Spec |
 |---|---|---|
 | Receive live trace events | `(rf/register-trace-cb :my-tool callback)` | [009 §The listener API](009-Instrumentation.md#the-listener-api) |
+| Receive per-drain assembled epoch records | `(rf/register-epoch-cb :my-tool callback)` | [009 §The listener API](009-Instrumentation.md#the-listener-api) |
 | Read recent trace history (events that already fired) | `(rf/trace-buffer)` (with optional filter map) | [009 §Retain-N trace ring buffer](009-Instrumentation.md#retain-n-trace-ring-buffer-dev-only) |
 | Read epoch history per frame | `(rf/epoch-history frame-id)` | [§Time-travel](#time-travel-epoch-snapshots-and-undo) |
 | Restore an epoch | `(rf/restore-epoch frame-id epoch-id)` | [§Time-travel](#time-travel-epoch-snapshots-and-undo) |
 | Configure history depth | `(rf/configure :epoch-history {:depth N})` and `(rf/configure :trace-buffer {:depth N})` | [API.md](API.md) |
+| Inspect registered app-db schemas | `(rf/app-schemas frame-id)` | [010 §Schemas as a tooling and agent surface](010-Schemas.md#schemas-as-a-tooling-and-agent-surface) |
+| Tag dispatches by actor (e.g. tool vs app) | `:origin` opt on `(rf/dispatch event opts)` | [002 §Dispatch origin tagging](002-Frames.md#dispatch-origin-tagging) |
+| Correlate a dispatch cascade | `:dispatch-id` + `:parent-dispatch-id` on `:event/dispatched` traces | [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id) |
 | Enumerate frames | `(rf/frame-ids)`, `(rf/frame-meta id)` | [002 §Public registrar query API](002-Frames.md#the-public-registrar-query-api) |
 | Read a frame's app-db | `(rf/get-frame-db frame-id)` / `(rf/snapshot-of path opts)` | [002 §Public registrar query API](002-Frames.md#the-public-registrar-query-api) |
 | Inspect the registry | `(rf/handlers kind)`, `(rf/handler-meta kind id)` | [001](001-Registration.md), [002](002-Frames.md) |
@@ -130,7 +150,9 @@ The full attachment surface, from the tool's point of view:
 
 The consumption pattern is therefore:
 
-> **A pair-shaped tool registers as a trace listener, reads recent history from the trace buffer, queries the registrar for shape, walks the epoch history for time-travel, and dispatches into frames to drive experiments. That's the entire surface.**
+> **A pair-shaped tool registers as a trace listener (and/or as an epoch listener for assembled per-cascade records), reads recent history from the trace buffer, queries the registrar for shape, walks the epoch history for time-travel, and dispatches into frames to drive experiments. That's the entire surface.**
+
+Two listener shapes coexist by design: `register-trace-cb` is the **raw** stream — every span the runtime emits, fine-grained — used by tools that need per-emit detail (live timing displays, Performance API consumers, custom recorders that must see in-flight events). `register-epoch-cb` is the **assembled** stream — one fully-shaped `:rf/epoch-record` per drain-settle, with the structured `:sub-runs` / `:renders` / `:effects` projections already computed — used by tools that route diagnostics off "what just happened in this cascade" rather than reconstructing it from the raw trace each time. Pair-shaped tools typically prefer the assembled stream for routing and reach for the raw stream only when they need detail the projection drops.
 
 This is **dev-only** end-to-end — every primitive listed above elides in production builds (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)). Pair-shaped tools do not ship in production binaries.
 


### PR DESCRIPTION
## Summary

Cross-reference audit against [day8/re-frame-pair](https://github.com/day8/re-frame-pair) identified six surfaces the upstream tool consumes that re-frame2's spec had not yet committed to. This PR is **spec-only** — additive normative text; no impl. The six pinned implementation beads (rf2-k84s, rf2-smee, rf2-cll7, rf2-shjf, rf2-vvsh, rf2-11hn) will be dispatched against the updated spec.

### Six gaps closed

1. **`register-epoch-cb`** — assembled-epoch listener mirroring `register-trace-cb!`, fires once per drain-settle with the assembled `:rf/epoch-record`. Documented in Tool-Pair §How AI tools attach + Spec 009 §The listener API.
2. **Per-epoch substructure** on `:rf/epoch-record` — `:sub-runs`, `:renders`, `:effects` derived from `:trace-events`. Lets pair tools route diagnostics off cache-hit / render-attribution / fx-cascade-outcome without re-folding the raw trace stream.
3. **`:dispatch-id` / `:parent-dispatch-id`** correlation tags on every `:event/dispatched` trace. Distinct from `:child-of` (which correlates spans, not dispatches). Documented in Spec 009 §The trace event envelope.
4. **`:origin` opt** on `(rf/dispatch event opts)` for actor-identity tagging. Distinct from `:source` (trigger kind). Defaults to `:app`; tool surfaces use `:pair`. Documented in Spec 002 + reflected in Spec-Schemas (`:rf/dispatch-opts` + `:rf/dispatch-envelope`).
5. **`(rf/app-schemas frame-id)`** — explicit frame-id arity for pair-tool consumption (sugar for the existing `{:frame frame-id}`-opt arity). Documented in Spec 010 + Tool-Pair surface table.
6. **DOM-to-source bridge surface** — explicit §Source-mapping subsection in Tool-Pair pinning the framework's commitment at the `data-rf2-source-coord` attribute. Helpers (`dom-source-at` / `find-by-src` / `fire-click-at-src`) stay tool-side; rationale documented.

### Files changed

- `docs/specification/Tool-Pair.md` — surface table updates, §Time-travel epoch-record fields, audit lineage note, §Source-mapping enumeration.
- `docs/specification/009-Instrumentation.md` — `register-epoch-cb`/`remove-epoch-cb`, dispatch correlation tags, origin tagging.
- `docs/specification/Spec-Schemas.md` — `:rf/epoch-record` extended fields, `:origin` on dispatch opts/envelope.
- `docs/specification/010-Schemas.md` — `(rf/app-schemas frame-id)` arity.
- `docs/specification/002-Frames.md` — `:origin` opt subsection, envelope shape.

### Open question filed

The `:render-key` identity question (Reagent component instance vs `reg-view` id) is flagged with a `TBD pending rf2-t5tx` pointer in Tool-Pair.md and Spec-Schemas.md, with the follow-up bead filed.

## Test plan

- [ ] Spec-only PR — no code paths exercised.
- [ ] Cross-references between Tool-Pair / 009 / 010 / 002 / Spec-Schemas resolve.
- [ ] Six implementation beads (rf2-k84s, rf2-smee, rf2-cll7, rf2-shjf, rf2-vvsh, rf2-11hn) can each cite the relevant spec section as their normative source.