### PR TITLE
feat: rf/machines + rf/machine-meta query API (rf2-cll7)

### DIFF
--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -206,6 +206,8 @@
 
 (def create-machine-handler machines/create-machine-handler)
 (def machine-transition     machines/machine-transition)
+(def machines               machines/machines)
+(def machine-meta           machines/machine-meta)
 
 (defn sub-machine
   "Subscribe to a machine's snapshot. Sugar over (subscribe [:rf/machine

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -706,10 +706,18 @@
 (defn reg-machine
   "Convenience: register a machine as an event handler under
   machine-id. Equivalent to
-  (reg-event-fx machine-id (create-machine-handler machine))."
+  (reg-event-fx machine-id (create-machine-handler machine)).
+
+  Per Spec 005 §Querying machines, the registration metadata is stamped
+  with :rf/machine? true and :rf/machine (the spec map). (rf/machines)
+  filters the :event registry by :rf/machine?; (rf/machine-meta id)
+  reads the spec back out via the standard registrar query API."
   [machine-id machine]
   (let [handler-fn (create-machine-handler machine)]
-    (events/reg-event-fx machine-id handler-fn)
+    (events/reg-event-fx machine-id
+                         {:rf/machine? true
+                          :rf/machine  machine}
+                         handler-fn)
     ;; Per Spec 009 §:op-type vocabulary: :rf.machine.lifecycle/created
     ;; fires when a machine instance is registered. Tools observe this
     ;; to track the machine population over hot reloads / boot.
@@ -717,6 +725,35 @@
                  {:machine-id machine-id
                   :initial    (:initial machine)})
     machine-id))
+
+;; ---- query API (Spec 005 §Querying machines) -----------------------------
+;;
+;; Two thin lookup fns over the existing event registry — derived views,
+;; not a new registry kind. (rf/machines) filters event handlers whose
+;; registration metadata carries :rf/machine? true; (rf/machine-meta id)
+;; returns the registered machine's spec map (the same map passed to
+;; reg-machine). Both are pure reads against the global registrar, so
+;; they're queryable across all frames (machine snapshots are per-frame;
+;; the registration is global).
+
+(defn machines
+  "Return a sequence of machine-ids — every event handler whose
+  registration metadata carries :rf/machine? true. Per Spec 005
+  §Querying machines."
+  []
+  (->> (registrar/handlers :event)
+       (keep (fn [[id m]] (when (:rf/machine? m) id)))
+       (vec)))
+
+(defn machine-meta
+  "Return the registered machine's spec map (:initial, :data, :guards,
+  :actions, :states, :doc, source coords) for machine-id, or nil if
+  no machine is registered under that id. Per Spec 005 §Querying
+  machines."
+  [machine-id]
+  (let [m (registrar/lookup :event machine-id)]
+    (when (:rf/machine? m)
+      (:rf/machine m))))
 
 ;; ---- framework-shipped sub -----------------------------------------------
 ;;

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -709,6 +709,45 @@
                (rf/compute-sub [:rf/machine :test/tiny] db))
             ":rf/machine sub returns the same snapshot")))))
 
+(deftest machines-introspection
+  (testing "(rf/machines) returns only ids whose registration was via reg-machine"
+    (let [tiny-spec   {:initial :idle
+                       :data    {:n 0}
+                       :doc     "A tiny test machine."
+                       :actions {:bump (fn [{:keys [data]} _]
+                                         {:data (update data :n inc)})}
+                       :states  {:idle {:on {:tick {:target :idle
+                                                    :action :bump}}}}}
+          other-spec  {:initial :off
+                       :states  {:off {:on {:flip :on}}
+                                 :on  {:on {:flip :off}}}}]
+      (rf/reg-machine :test/tiny  tiny-spec)
+      (rf/reg-machine :test/other other-spec)
+      ;; A regular event-handler must NOT show up in (rf/machines).
+      (rf/reg-event-db :test/regular (fn [db _] db))
+
+      (let [ids (set (rf/machines))]
+        (is (contains? ids :test/tiny)
+            "(rf/machines) lists machines registered via reg-machine")
+        (is (contains? ids :test/other)
+            "(rf/machines) lists every reg-machine id")
+        (is (not (contains? ids :test/regular))
+            "(rf/machines) excludes plain event handlers"))
+
+      (testing "(rf/machine-meta id) returns the spec map for registered machines"
+        (is (= tiny-spec (rf/machine-meta :test/tiny))
+            "machine-meta returns the spec map passed to reg-machine")
+        (is (= other-spec (rf/machine-meta :test/other)))
+        (is (= "A tiny test machine."
+               (:doc (rf/machine-meta :test/tiny)))
+            "the spec's :doc round-trips through machine-meta"))
+
+      (testing "(rf/machine-meta id) returns nil for unregistered or non-machine ids"
+        (is (nil? (rf/machine-meta :test/regular))
+            "non-machine event handlers return nil")
+        (is (nil? (rf/machine-meta :test/never-registered))
+            "unregistered ids return nil")))))
+
 (deftest ssr-with-fx-override
   (testing "SSR flow with :fx-overrides redirecting :http/get to a stub"
     (let [stub-fired? (atom false)]


### PR DESCRIPTION
## Summary

Implements bead **rf2-cll7** — Tool-Pair §How AI tools attach lists `(rf/machines)` and `(rf/machine-meta id)` as required surfaces. Currently neither is exported in `re-frame.core`; pair tools shouldn't have to know that machines are reachable via `[:rf/machines]` in app-db or via `(handler-meta :event id)` with a flag.

Per Spec 005 §Querying machines, two thin lookup fns over the existing event registry — derived views, not a new registry kind:

- `(rf/machines)` returns a vector of registered machine-ids — every event handler whose registration metadata carries `:rf/machine? true`.
- `(rf/machine-meta machine-id)` returns the registered machine's spec map (`:initial`, `:data`, `:guards`, `:actions`, `:states`, `:doc`), or `nil` for unregistered or non-machine ids.

## How

`reg-machine` now stamps `{:rf/machine? true :rf/machine <spec>}` onto the `:event` registration metadata via `reg-event-fx`'s middle-slot meta map. Its public signature is unchanged. Machine registration remains within the existing `:event` registry — no new kind.

Both queries are pure reads against the global registrar, so they're queryable across all frames (machine snapshots are per-frame; the registration is global). They are query APIs (no emission) — the metadata they read is data, not infrastructure, so no elision is needed (they cost nothing in production unless called).

## Test plan

- [x] JVM smoke test added in `smoke_test.clj`: registers two machines plus a regular event handler, asserts `(rf/machines)` lists only the machine ids, and that `(rf/machine-meta id)` round-trips the spec map and returns nil for unregistered/non-machine ids.
- [x] `cd implementation && clojure -M:test` — 131/687 passing (was 130/679).