### PR TITLE
feat: trace-buffer ring + :dispatch-id correlation + :origin opt (rf2-smee)

### DIFF
--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -240,9 +240,12 @@
 
 ;; ---- trace ----------------------------------------------------------------
 
-(def register-trace-cb! trace/register-trace-cb!)
-(def remove-trace-cb!   trace/remove-trace-cb!)
-(def emit-trace!        trace/emit!)
+(def register-trace-cb!  trace/register-trace-cb!)
+(def remove-trace-cb!    trace/remove-trace-cb!)
+(def emit-trace!         trace/emit!)
+(def trace-buffer        trace/trace-buffer)
+(def clear-trace-buffer! trace/clear-trace-buffer!)
+(def configure           trace/configure)
 
 ;; ---- substrate adapter ----------------------------------------------------
 

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -17,6 +17,28 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
+;; ---- dispatch-id allocation -----------------------------------------------
+;;
+;; Per Spec 009 §Dispatch correlation: every dispatch is stamped with a
+;; process-monotonic :dispatch-id at queue time. When the dispatch is
+;; emitted as a side-effect of another event's processing (typically inside
+;; an fx handler running in do-fx), the new dispatch's :parent-dispatch-id
+;; is the in-flight event's :dispatch-id. *current-dispatch-id* tracks the
+;; in-flight dispatch during process-event!; child dispatches read it to
+;; populate :parent-dispatch-id.
+;;
+;; All of this rides the dev-only trace surface; production builds (where
+;; interop/debug-enabled? is false at compile time) elide the allocation
+;; (the counter increments harmlessly but the values are never read by
+;; anyone except trace consumers, which are themselves dead).
+
+(defonce ^:private dispatch-counter (atom 0))
+
+(defn- next-dispatch-id []
+  (swap! dispatch-counter inc))
+
+(def ^:dynamic ^:private *current-dispatch-id* nil)
+
 ;; ---- envelope construction ------------------------------------------------
 
 (defn- build-envelope
@@ -28,15 +50,26 @@
     :fx-overrides       per-call fx-id-to-fx-id remapping
     :interceptor-overrides
     :trace-id           tooling
-    :source             :ui :timer :http :repl :machine ..."
+    :source             :ui :timer :http :repl :machine ...
+    :origin             actor identity tag (:app default; :pair, :story,
+                        :test, ... per Spec 002 §Dispatch origin tagging)
+    :dispatch-id        process-monotonic id allocated here per
+                        Spec 009 §Dispatch correlation
+    :parent-dispatch-id the in-flight dispatch's id when this dispatch is
+                        emitted from inside another event's processing"
   [event opts]
-  {:event                  event
-   :frame                  (or (:frame opts) (frame/current-frame))
-   :fx-overrides           (:fx-overrides opts {})
-   :interceptor-overrides  (:interceptor-overrides opts {})
-   :trace-id               (:trace-id opts)
-   :source                 (:source opts :ui)
-   :dispatched-at          (interop/now-ms)})
+  (let [dispatch-id        (when interop/debug-enabled? (next-dispatch-id))
+        parent-dispatch-id (when interop/debug-enabled? *current-dispatch-id*)]
+    (cond-> {:event                  event
+             :frame                  (or (:frame opts) (frame/current-frame))
+             :fx-overrides           (:fx-overrides opts {})
+             :interceptor-overrides  (:interceptor-overrides opts {})
+             :trace-id               (:trace-id opts)
+             :source                 (:source opts :ui)
+             :origin                 (:origin opts :app)
+             :dispatched-at          (interop/now-ms)}
+      dispatch-id        (assoc :dispatch-id        dispatch-id)
+      parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id))))
 
 ;; ---- per-event drain ------------------------------------------------------
 
@@ -57,9 +90,14 @@
      :interceptor-overrides  (merge per-frame-interceptors per-call-interceptors)
      :extra-interceptors     (vec (concat (:interceptors frame-cfg [])))}))
 
-(defn- process-event!
-  "Per-event drain. Resolve handler, run interceptor chain, apply :db,
-  walk :fx in source order. Per Spec 002 §Drain-loop pseudocode."
+(defn- process-event*
+  "Per-event drain body. Resolve handler, run interceptor chain, apply :db,
+  walk :fx in source order. Per Spec 002 §Drain-loop pseudocode.
+
+  This is the inner of `process-event!`; the outer wraps it in a binding of
+  *current-dispatch-id* so child dispatches issued from within fx handlers
+  inherit the in-flight dispatch's id as their :parent-dispatch-id (Spec
+  009 §Dispatch correlation)."
   [envelope]
   (let [{:keys [event frame]} envelope
         event-id              (first event)
@@ -173,6 +211,15 @@
                           :frame    frame
                           :phase    :run-end})))))))
 
+(defn- process-event!
+  "Wrap process-event* in a binding of *current-dispatch-id* so child
+  dispatches issued from within an fx handler inherit this event's
+  :dispatch-id as their :parent-dispatch-id. Per Spec 009 §Dispatch
+  correlation."
+  [envelope]
+  (binding [*current-dispatch-id* (:dispatch-id envelope)]
+    (process-event* envelope)))
+
 ;; ---- outer drain ----------------------------------------------------------
 
 (def ^:private drain-depth-default 100)
@@ -236,6 +283,24 @@
 
 ;; ---- public dispatch ------------------------------------------------------
 
+(defn- emit-dispatched-trace!
+  "Emit the :event :event/dispatched trace event for this envelope. Per
+  Spec 009 §Dispatch correlation, :dispatch-id and :parent-dispatch-id
+  ride on :tags. Per Spec 002 §Dispatch origin tagging, :origin rides
+  on :tags too. Spec elision is automatic — trace/emit! short-circuits
+  when interop/debug-enabled? is false at compile time."
+  [envelope sync?]
+  (trace/emit! :event :event/dispatched
+               (cond-> {:event    (:event envelope)
+                        :frame    (:frame envelope)
+                        :origin   (:origin envelope)
+                        :source   (:source envelope)
+                        :sync?    sync?}
+                 (:dispatch-id envelope)
+                 (assoc :dispatch-id (:dispatch-id envelope))
+                 (:parent-dispatch-id envelope)
+                 (assoc :parent-dispatch-id (:parent-dispatch-id envelope)))))
+
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:
   FIFO at the runtime layer; no reordering, no priority lanes. The drain
@@ -251,6 +316,7 @@
 
        :else
        (let [router (:router frame-record)]
+         (emit-dispatched-trace! envelope false)
          (swap! router update :queue conj envelope)
          (ensure-drain-scheduled! (:frame envelope) router)))
      nil)))
@@ -292,6 +358,7 @@
 
        :else
        (let [router (:router frame-record)]
+         (emit-dispatched-trace! envelope true)
          ;; Put the seed at the front and mark scheduled to suppress async.
          ;; :in-sync-drain? lets a nested dispatch-sync detect the unsafe
          ;; call and refuse rather than silently interleave.

--- a/implementation/src/re_frame/trace.cljc
+++ b/implementation/src/re_frame/trace.cljc
@@ -46,6 +46,105 @@
 (defn- next-event-id []
   (swap! event-counter inc))
 
+;; ---- retain-N trace ring buffer (dev-only) -------------------------------
+;;
+;; Per Spec 009 §Retain-N trace ring buffer. Holds the most recent N completed
+;; trace events; queryable via (trace-buffer). All ring-buffer machinery is
+;; gated on interop/debug-enabled? (the same compile-time flag the rest of the
+;; trace surface rides) so production builds drop the buffer entirely — no
+;; allocation, no append, no storage.
+
+(def ^:private default-buffer-depth
+  "Per Spec 009 §Retain-N trace ring buffer: default 200 events."
+  200)
+
+(defonce ^:private buffer-depth (atom default-buffer-depth))
+
+(defonce ^:private trace-buffer-state
+  ;; The buffer is a plain vector held under an atom. Append is conj+slice;
+  ;; the slot count caps memory. depth=0 disables the buffer entirely (the
+  ;; delivery path still works — see configure-trace-buffer!).
+  (atom []))
+
+(defn- push-to-buffer!
+  "Append ev to the ring buffer, evicting the oldest entry when the slot
+  count is exceeded. No-op when the configured depth is 0."
+  [ev]
+  (when interop/debug-enabled?
+    (let [depth @buffer-depth]
+      (when (pos? depth)
+        (swap! trace-buffer-state
+               (fn [v]
+                 (let [v' (conj v ev)
+                       n  (count v')]
+                   (if (> n depth)
+                     (subvec v' (- n depth))
+                     v'))))))))
+
+(defn trace-buffer
+  "Return the trace ring buffer's current contents, oldest first.
+
+  With opts, filters the result. Recognised keys:
+    :operation  — keep only events with this :operation value.
+    :op-type    — keep only events with this :op-type value.
+    :since      — keep only events whose :id is strictly greater than this.
+    :frame      — keep only events whose :tags :frame matches.
+
+  Filters compose: every supplied key must match. Returns an empty vector
+  in production (the buffer never receives events when interop/debug-enabled?
+  is false at compile time).
+
+  Per Spec 009 §Retain-N trace ring buffer."
+  ([] (trace-buffer {}))
+  ([opts]
+   (if-not interop/debug-enabled?
+     []
+     (let [{:keys [operation op-type since frame]} opts
+           pred (fn [ev]
+                  (and (or (nil? operation) (= operation (:operation ev)))
+                       (or (nil? op-type)   (= op-type   (:op-type ev)))
+                       (or (nil? since)     (and (number? (:id ev))
+                                                 (> (:id ev) since)))
+                       (or (nil? frame)
+                           (= frame (or (:frame ev)
+                                        (get-in ev [:tags :frame]))))))]
+       (filterv pred @trace-buffer-state)))))
+
+(defn clear-trace-buffer!
+  "Empty the ring buffer. Tooling uses this between sessions. No-op in
+  production. Per Spec 009 §Retain-N trace ring buffer."
+  []
+  (when interop/debug-enabled?
+    (reset! trace-buffer-state []))
+  nil)
+
+(defn configure-trace-buffer!
+  "Set the ring buffer's depth. depth=0 disables the buffer (the delivery
+  path still works). The new depth applies on the next append; existing
+  entries are trimmed to fit immediately. No-op in production.
+
+  Per Spec 009 §Retain-N trace ring buffer."
+  [{:keys [depth]}]
+  (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
+    (reset! buffer-depth depth)
+    (swap! trace-buffer-state
+           (fn [v]
+             (let [n (count v)]
+               (cond
+                 (zero? depth) []
+                 (> n depth)   (subvec v (- n depth))
+                 :else         v)))))
+  nil)
+
+(defn configure
+  "Generic config dispatch. Recognises :trace-buffer; future config knobs
+  add cases here. Per Spec 009 §Retain-N trace ring buffer
+  (`(rf/configure :trace-buffer {:depth N})`)."
+  [k opts]
+  (case k
+    :trace-buffer (configure-trace-buffer! opts)
+    nil))
+
 ;; ---- emission -------------------------------------------------------------
 
 (defn emit!
@@ -74,6 +173,7 @@
                             :tags      (dissoc tags :source :recovery)}
                      source   (assoc :source source)
                      recovery (assoc :recovery recovery))]
+      (push-to-buffer! event)
       (doseq [[_ f] @listeners]
         (try
           (f event)
@@ -95,6 +195,7 @@
                  :time      (interop/now-ms)
                  :tags      (merge {:category error-operation} tags)
                  :recovery  (:recovery tags :no-recovery)}]
+      (push-to-buffer! event)
       (doseq [[_ f] @listeners]
         (try
           (f event)

--- a/implementation/test/re_frame/trace_buffer_test.clj
+++ b/implementation/test/re_frame/trace_buffer_test.clj
@@ -1,0 +1,232 @@
+(ns re-frame.trace-buffer-test
+  "Spec 009 §Retain-N trace ring buffer + §Dispatch correlation, plus
+  Spec 002 §Dispatch origin tagging.
+
+  rf2-smee — three deliverables in one suite:
+    1. Trace ring buffer: append, filter, depth/eviction, clear, elision.
+    2. :dispatch-id allocation + :parent-dispatch-id linkage (top-level
+       dispatches have no parent; dispatches issued from within an fx
+       handler inherit the in-flight event's :dispatch-id).
+    3. :origin opt: defaults to :app, opt overrides to anything else,
+       lands on the :event/dispatched trace under :tags :origin.
+
+  JVM-only by intent — the trace + router machinery is platform-agnostic
+  and CLJS adds no signal."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (trace/clear-trace-cbs!)
+  (rf/clear-trace-buffer!)
+  ;; Restore default depth between tests so a depth-tweaking test does
+  ;; not bleed configuration into the next.
+  (rf/configure :trace-buffer {:depth 200})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- dispatched-events
+  "Return only the :event :event/dispatched events from a buffer/coll."
+  [evs]
+  (filterv #(and (= :event (:op-type %))
+                 (= :event/dispatched (:operation %)))
+           evs))
+
+;; ---- 1. Ring buffer --------------------------------------------------------
+
+(deftest trace-buffer-appends-events
+  (testing "every emit! lands in the ring buffer"
+    (rf/reg-event-db :ping (fn [db _] (assoc db :seen? true)))
+    (rf/dispatch-sync [:ping])
+    (let [buf (rf/trace-buffer)]
+      (is (vector? buf) "trace-buffer returns a vector")
+      (is (seq buf) "buffer has entries after a dispatch")
+      ;; The :event/dispatched envelope is the most reliable signal.
+      (is (some #(= :event/dispatched (:operation %)) buf)
+          "the :event/dispatched trace lands in the buffer"))))
+
+(deftest trace-buffer-filters
+  (testing "filter by :operation, :op-type, :since, :frame compose"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (rf/dispatch-sync [:ping])
+    (let [all       (rf/trace-buffer)
+          dispatched (rf/trace-buffer {:operation :event/dispatched})]
+      (is (seq dispatched))
+      (is (every? #(= :event/dispatched (:operation %)) dispatched)
+          ":operation filter narrows to one operation")
+      (is (<= (count dispatched) (count all)))
+      (let [event-only (rf/trace-buffer {:op-type :event})]
+        (is (every? #(= :event (:op-type %)) event-only)
+            ":op-type filter narrows to the discriminator")))
+    (testing ":since filters strictly greater than the given id"
+      (let [pre-id (-> (rf/trace-buffer) last :id)]
+        (rf/dispatch-sync [:ping])
+        (let [after (rf/trace-buffer {:since pre-id})]
+          (is (seq after))
+          (is (every? #(> (:id %) pre-id) after)))))
+    (testing ":frame filter matches via :tags :frame"
+      ;; Both default-frame and a named frame produce events; the named
+      ;; frame's events should be the only match.
+      (rf/reg-frame :tb/scope {:doc "scoped frame"})
+      (rf/clear-trace-buffer!)
+      (rf/reg-event-db :scoped (fn [db _] db))
+      (rf/dispatch-sync [:scoped] {:frame :tb/scope})
+      (rf/dispatch-sync [:ping])
+      (let [scoped (rf/trace-buffer {:frame :tb/scope})]
+        (is (seq scoped))
+        (is (every? #(= :tb/scope
+                        (or (:frame %) (get-in % [:tags :frame])))
+                    scoped))))
+    (testing "filters compose"
+      (let [combo (rf/trace-buffer {:operation :event/dispatched
+                                    :op-type   :event})]
+        (is (every? #(and (= :event/dispatched (:operation %))
+                          (= :event (:op-type %)))
+                    combo))))))
+
+(deftest trace-buffer-respects-depth
+  (testing "configure :trace-buffer {:depth N} caps the slot count"
+    (rf/configure :trace-buffer {:depth 5})
+    (rf/reg-event-db :spam (fn [db _] db))
+    (dotimes [_ 30] (rf/dispatch-sync [:spam]))
+    (let [buf (rf/trace-buffer)]
+      (is (<= (count buf) 5)
+          (str "buffer should not exceed configured depth; got " (count buf)))
+      (is (pos? (count buf))
+          "buffer should still have the most recent slots populated")))
+  (testing "depth=0 disables the buffer"
+    (rf/configure :trace-buffer {:depth 0})
+    (rf/clear-trace-buffer!)
+    (rf/reg-event-db :spam (fn [db _] db))
+    (dotimes [_ 5] (rf/dispatch-sync [:spam]))
+    (is (= [] (rf/trace-buffer))
+        "with depth 0, no events accumulate")))
+
+(deftest trace-buffer-clear
+  (testing "clear-trace-buffer! empties the buffer"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (is (seq (rf/trace-buffer)))
+    (rf/clear-trace-buffer!)
+    (is (= [] (rf/trace-buffer)))))
+
+(deftest trace-buffer-rides-debug-flag
+  (testing "the buffer machinery is wrapped in interop/debug-enabled?"
+    ;; This is a structural check rather than a runtime simulation: the
+    ;; production-elision contract is that no buffer state mutates when
+    ;; the flag is false at compile time. We assert the source contains
+    ;; the gate at the right call sites; combined with the existing
+    ;; trace-test envelope coverage, this protects the elision contract.
+    (let [src (slurp "src/re_frame/trace.cljc")]
+      (is (re-find #"\(defn-? push-to-buffer![\s\S]*?interop/debug-enabled\?" src)
+          "push-to-buffer! is gated on interop/debug-enabled?")
+      (is (re-find #"\(defn-? trace-buffer[\s\S]*?interop/debug-enabled\?" src)
+          "trace-buffer reader returns [] under the same gate")
+      (is (re-find #"\(defn-? clear-trace-buffer![\s\S]*?interop/debug-enabled\?" src)
+          "clear-trace-buffer! is gated")
+      (is (re-find #"\(defn-? configure-trace-buffer![\s\S]*?interop/debug-enabled\?" src)
+          "configure-trace-buffer! is gated"))))
+
+;; ---- 2. :dispatch-id correlation -------------------------------------------
+
+(deftest dispatch-id-allocated-on-every-dispatch
+  (testing "every :event/dispatched trace carries a numeric :dispatch-id under :tags"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (rf/dispatch-sync [:ping])
+    (let [evs (dispatched-events (rf/trace-buffer))
+          ids (map #(get-in % [:tags :dispatch-id]) evs)]
+      (is (seq evs))
+      (is (every? some? ids)
+          "every :event/dispatched has a :dispatch-id")
+      (is (every? number? ids)
+          ":dispatch-id values are numeric (counter-shaped)")
+      (is (= (count (distinct ids)) (count ids))
+          ":dispatch-id values are unique within a process"))))
+
+(deftest top-level-dispatch-has-no-parent
+  (testing "a dispatch issued from outside any in-flight event has no :parent-dispatch-id"
+    (rf/reg-event-db :standalone (fn [db _] db))
+    (rf/dispatch-sync [:standalone])
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:standalone] (get-in % [:tags :event])))
+                  first)]
+      (is ev "the :event/dispatched trace was emitted")
+      (is (nil? (get-in ev [:tags :parent-dispatch-id]))
+          "top-level dispatch has no :parent-dispatch-id"))))
+
+(deftest fx-dispatch-inherits-parent-dispatch-id
+  (testing "a dispatch issued from inside an event's fx walk inherits the parent's :dispatch-id"
+    (rf/reg-event-fx :outer (fn [_ _]
+                              {:fx [[:dispatch [:inner]]]}))
+    (rf/reg-event-db :inner (fn [db _] (assoc db :inner? true)))
+    (rf/dispatch-sync [:outer])
+    (let [evs   (dispatched-events (rf/trace-buffer))
+          outer (->> evs
+                     (filter #(= [:outer] (get-in % [:tags :event])))
+                     first)
+          inner (->> evs
+                     (filter #(= [:inner] (get-in % [:tags :event])))
+                     first)]
+      (is outer "outer :event/dispatched present")
+      (is inner "inner :event/dispatched present")
+      (is (number? (get-in outer [:tags :dispatch-id])))
+      (is (nil?    (get-in outer [:tags :parent-dispatch-id]))
+          "outer (top-level) has no parent")
+      (is (= (get-in outer [:tags :dispatch-id])
+             (get-in inner [:tags :parent-dispatch-id]))
+          "inner's :parent-dispatch-id == outer's :dispatch-id"))))
+
+;; ---- 3. :origin opt --------------------------------------------------------
+
+(deftest origin-defaults-to-app
+  (testing "no :origin opt → :tags :origin = :app"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :app (get-in ev [:tags :origin]))
+          "default :origin is :app per Spec 002 §Dispatch origin tagging"))))
+
+(deftest origin-opt-overrides-default
+  (testing ":origin :pair lands on the trace event"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:origin :pair})
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :pair (get-in ev [:tags :origin]))
+          ":origin :pair lifted onto :tags :origin"))))
+
+(deftest origin-distinct-from-source
+  (testing ":origin and :source ride independently"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:origin :pair :source :repl})
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :pair (get-in ev [:tags :origin]))   ":origin lands under :tags :origin")
+      ;; :source is hoisted to top-level by emit!, per the existing contract.
+      (is (= :repl (:source ev))                  ":source is hoisted to top-level"))))


### PR DESCRIPTION
## Summary

Three deliverables in one PR; all dev-only and gated on `interop/debug-enabled?` so production builds elide the surface entirely.

- **Trace ring buffer** (Spec 009 §Retain-N). Per-process atom-backed circular vector in `re-frame.trace`. `(rf/trace-buffer)` returns oldest-first; `(rf/trace-buffer opts)` filters by `:operation`, `:op-type`, `:since`, `:frame` (composing). `(rf/clear-trace-buffer!)` empties. `(rf/configure :trace-buffer {:depth N})` configures depth; default 200 per Spec 009; `:depth 0` disables. Append happens inside `trace/emit!` and `trace/emit-error!`.
- **`:dispatch-id` / `:parent-dispatch-id` correlation** (Spec 009 §Dispatch correlation). Process-monotonic counter in `re-frame.router`; every `build-envelope` allocates a `:dispatch-id`. `process-event!` binds a dynamic `*current-dispatch-id*` around the inner body so any dispatch issued from inside an fx handler inherits it as `:parent-dispatch-id`. The new `:event :event/dispatched` trace fires at queue time (both `dispatch!` and `dispatch-sync!`) carrying both ids on `:tags`.
- **`:origin` opt** (Spec 002 §Dispatch origin tagging). Optional `:origin` opt on `(rf/dispatch event opts)`; default `:app`; lands on `:event/dispatched` under `:tags :origin`. Distinct from `:source` (trigger kind vs. actor identity); both ride independently.

Closes rf2-smee.

## Test plan

- [x] JVM smoke covers ring-buffer append, filter (4 axes), depth eviction, depth=0 disable, clear.
- [x] JVM smoke covers `:dispatch-id` allocation, top-level dispatch has no `:parent-dispatch-id`, fx-emitted dispatch inherits parent's dispatch-id.
- [x] JVM smoke covers `:origin` defaulting to `:app`, `:pair` opt overriding, `:origin` distinct from `:source`.
- [x] Structural grep test locks the production-elision contract for the buffer machinery.
- [x] `clojure -M:test` green: 130/679 → 141/718 (+11 tests / +39 assertions).
- [x] CLJS Node tests green: 54/187, no regressions.
- [x] Existing `trace_test.clj` (the trace-stream completeness suite) still passes — no breakage to `register-trace-cb!` or the existing envelope contract.