### PR TITLE
feat: source coordinates on every reg-* registration (rf2-k84s)

### DIFF
--- a/implementation/src/re_frame/cofx.cljc
+++ b/implementation/src/re_frame/cofx.cljc
@@ -11,7 +11,8 @@
   registered cofx into the context."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]))
 
 (defn- maybe-validate-cofx!
   "Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
@@ -49,7 +50,8 @@
         (if (map? metadata-or-handler)
           [metadata-or-handler (first maybe-handler)]
           [{} metadata-or-handler])]
-    (registrar/register! :cofx id (assoc meta :handler-fn handler-fn))
+    (registrar/register! :cofx id (assoc (source-coords/merge-coords meta)
+                                         :handler-fn handler-fn))
     id))
 
 (defn inject-cofx

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -20,31 +20,178 @@
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.routing :as routing]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ---- registration ---------------------------------------------------------
+;;
+;; Per Spec 001 §Source-coordinate capture (CLJS reference) and
+;; Tool-Pair §Source-mapping: every reg-* registration's metadata
+;; carries :ns / :line / :file auto-supplied at compile time. We
+;; wrap each reg-* fn in a macro that captures (meta &form)'s
+;; :line / :column plus *ns* / *file*, binds re-frame.source-coords/
+;; *pending-coords* around the underlying fn, and the fn merges the
+;; coords into the registered metadata.
+;;
+;; JVM side: defmacro form. Direct fn-form access is preserved via
+;; events/reg-event-db etc. — internal callers (re-frame.routing,
+;; re-frame.ssr) reach the fn directly and don't pay the macro tax.
+;;
+;; CLJS side: keep the existing fn-alias form. The macro path is a
+;; future addition (a re-frame.core-macros companion ns following
+;; the re-frame.views-macros pattern); the ALIAS path keeps current
+;; CLJS callers functioning. Tooling that consumes :ns / :line /
+;; :file via the JVM side (server-rendering, JVM tests, REPL
+;; introspection) is unaffected.
 
-(def reg-event-db    events/reg-event-db)
-(def reg-event-fx    events/reg-event-fx)
-(def reg-event-ctx   events/reg-event-ctx)
-(def reg-sub         subs/reg-sub)
-(def reg-fx          fx/reg-fx)
-(def reg-cofx        cofx/reg-cofx)
-(def reg-frame       frame/reg-frame)
+#?(:clj
+   (defmacro reg-event-db
+     "Register a (db, event) -> new-db handler. Per Spec 001 the
+     metadata stamped onto the registry slot includes :ns / :line /
+     :file captured at this call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (events/reg-event-db ~id ~@args)))))
 
-(defn reg-view
-  "Register a view by id. The render-fn is `(fn [args...] hiccup-tree)`.
+#?(:clj
+   (defmacro reg-event-fx
+     "Register a (cofx, event) -> effects-map handler. Per Spec 001
+     the metadata stamped onto the registry slot includes :ns / :line /
+     :file captured at this call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (events/reg-event-fx ~id ~@args)))))
 
-  This is the JVM-runnable / SSR-friendly form. CLJS apps using Reagent
-  should prefer `re-frame.views/reg-view` (a macro that also defs the
-  local var) for client-side use."
+#?(:clj
+   (defmacro reg-event-ctx
+     "Register a context-handler. Per Spec 001 the metadata stamped
+     onto the registry slot includes :ns / :line / :file captured at
+     this call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (events/reg-event-ctx ~id ~@args)))))
+
+#?(:clj
+   (defmacro reg-sub
+     "Register a subscription. Per Spec 001 the metadata stamped onto
+     the registry slot includes :ns / :line / :file captured at this
+     call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (subs/reg-sub ~id ~@args)))))
+
+#?(:clj
+   (defmacro reg-fx
+     "Register an fx handler. Per Spec 001 the metadata stamped onto
+     the registry slot includes :ns / :line / :file captured at this
+     call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (fx/reg-fx ~id ~@args)))))
+
+#?(:clj
+   (defmacro reg-cofx
+     "Register a coeffect handler. Per Spec 001 the metadata stamped
+     onto the registry slot includes :ns / :line / :file captured at
+     this call site."
+     [id & args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (cofx/reg-cofx ~id ~@args)))))
+
+#?(:clj
+   (defmacro reg-frame
+     "Register a frame. Per Spec 001 the metadata stamped onto the
+     registry slot includes :ns / :line / :file captured at this call
+     site."
+     [id metadata]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (frame/reg-frame ~id ~metadata)))))
+
+;; CLJS side keeps the fn-aliases. Source-coord capture on CLJS will
+;; ride a future re-frame.core-macros companion ns (per the existing
+;; re-frame.views-macros pattern). The fns themselves (events/reg-*,
+;; subs/reg-sub, etc.) honour `*pending-coords*` either way — the
+;; macros above are the *capture* path; the merge path is in the fns.
+#?(:cljs
+   (do
+     (def reg-event-db    events/reg-event-db)
+     (def reg-event-fx    events/reg-event-fx)
+     (def reg-event-ctx   events/reg-event-ctx)
+     (def reg-sub         subs/reg-sub)
+     (def reg-fx          fx/reg-fx)
+     (def reg-cofx        cofx/reg-cofx)
+     (def reg-frame       frame/reg-frame)))
+
+(defn -reg-view
+  "Internal helper — the fn-form delegate for the public `reg-view` macro
+  (and CLJS alias). Registers the view in the :view registry, merging
+  any pending source coords into the slot metadata."
   ([id render-fn]
-   (reg-view id {} render-fn))
+   (-reg-view id {} render-fn))
   ([id metadata render-fn]
-   (registrar/register! :view id (assoc metadata :handler-fn render-fn))
+   (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
+                                        :handler-fn render-fn))
    id))
+
+#?(:clj
+   (defmacro reg-view
+     "Register a view by id. The render-fn is `(fn [args...] hiccup-tree)`.
+
+     This is the JVM-runnable / SSR-friendly form. CLJS apps using Reagent
+     should prefer `re-frame.views-macros/reg-view` (also defs the local
+     var) for client-side use.
+
+     Per Spec 001 §Source-coordinate capture the metadata stamped onto
+     the registry slot includes :ns / :line / :file captured at this
+     call site."
+     [& args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (-reg-view ~@args)))))
+
+#?(:cljs
+   (def reg-view -reg-view))
 
 (defn get-view
   "Return the render fn for a registered view by id, or nil if not
@@ -83,36 +230,110 @@
 (def make-frame      frame/make-frame)
 (def reset-frame     frame/reset-frame!)
 (def destroy-frame   frame/destroy-frame!)
-(def reg-flow        flows/reg-flow)
 (def clear-flow      flows/clear-flow)
-(def reg-route       routing/reg-route)
-(def reg-app-schema  schemas/reg-app-schema)
-(def reg-machine     machines/reg-machine)
+
+#?(:clj
+   (defmacro reg-flow
+     "Register a flow. Per Spec 001 the metadata stamped onto the
+     registry slot includes :ns / :line / :file captured at this call
+     site."
+     [& args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (flows/reg-flow ~@args)))))
+
+#?(:clj
+   (defmacro reg-route
+     "Register a route. Per Spec 001 the metadata stamped onto the
+     registry slot includes :ns / :line / :file captured at this call
+     site."
+     [id metadata]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (routing/reg-route ~id ~metadata)))))
+
+#?(:clj
+   (defmacro reg-app-schema
+     "Register a Malli schema at a path inside app-db. Per Spec 001 the
+     metadata stamped onto the registry slot includes :ns / :line /
+     :file captured at this call site."
+     [path schema]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (schemas/reg-app-schema ~path ~schema)))))
+
+#?(:clj
+   (defmacro reg-machine
+     "Register a machine as an event handler. Per Spec 001 the
+     metadata stamped onto the registry slot includes :ns / :line /
+     :file captured at this call site."
+     [machine-id machine]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (machines/reg-machine ~machine-id ~machine)))))
+
+#?(:cljs
+   (do
+     (def reg-flow        flows/reg-flow)
+     (def reg-route       routing/reg-route)
+     (def reg-app-schema  schemas/reg-app-schema)
+     (def reg-machine     machines/reg-machine)))
 
 ;; reg-error-projector lives in re-frame.ssr so the registry kind
 ;; ships with its default :rf.ssr/default-error-projector. Forward
 ;; through requiring-resolve to avoid a top-level :require cycle
 ;; (ssr.cljc requires events/fx/registrar which core also requires).
-(defn reg-error-projector
-  "Register an error projector — a fn `(trace-event) → public-error-map`.
-  Per Spec 011 §Server error projection. Frames opt into a custom
-  projector via the :ssr config's :public-error-id key:
-
-    (rf/reg-error-projector :myapp/public-error
-      (fn [trace-event] ...public-error-shape...))
-
-    (rf/make-frame {:platform :server
-                    :ssr {:public-error-id   :myapp/public-error
-                          :dev-error-detail? false}})
-
-  See re-frame.ssr/reg-error-projector for the full doc."
+(defn -reg-error-projector
+  "Internal helper — prefer `reg-error-projector` from public callers.
+  This is the fn-form delegate the public macro / CLJS alias forward to.
+  Forwards through requiring-resolve to keep the load order acyclic."
   ([id projector-fn]
-   (reg-error-projector id {} projector-fn))
+   (-reg-error-projector id {} projector-fn))
   ([id metadata projector-fn]
    #?(:clj (try (require 're-frame.ssr) (catch Throwable _ nil)))
    (let [f #?(:clj  (requiring-resolve 're-frame.ssr/reg-error-projector)
               :cljs (resolve 're-frame.ssr/reg-error-projector))]
      (f id metadata projector-fn))))
+
+#?(:clj
+   (defmacro reg-error-projector
+     "Register an error projector — a fn `(trace-event) → public-error-map`.
+     Per Spec 011 §Server error projection. Frames opt into a custom
+     projector via the :ssr config's :public-error-id key:
+
+       (rf/reg-error-projector :myapp/public-error
+         (fn [trace-event] ...public-error-shape...))
+
+     Per Spec 001 §Source-coordinate capture the metadata stamped onto
+     the registry slot includes :ns / :line / :file captured at this
+     call site."
+     [& args]
+     (let [m (meta &form)]
+       `(binding [source-coords/*pending-coords*
+                  (cond-> {:ns (ns-name *ns*)}
+                    *file*       (assoc :file *file*)
+                    ~(:line m)   (assoc :line ~(:line m))
+                    ~(:column m) (assoc :column ~(:column m)))]
+          (-reg-error-projector ~@args)))))
+
+#?(:cljs
+   (def reg-error-projector -reg-error-projector))
 
 (defn project-error
   "Apply the active error projector for frame-id to the trace event.

--- a/implementation/src/re_frame/events.cljc
+++ b/implementation/src/re_frame/events.cljc
@@ -12,6 +12,7 @@
   during drain — the difference is only in the wrapping shape."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- effect-map shape policing (Spec migration M-8) -----------------------
@@ -153,7 +154,7 @@
         wrapped     (db-handler->interceptor handler-fn)
         all-chain   (concat interceptors [wrapped])]
     (registrar/register! :event id
-      (assoc meta
+      (assoc (source-coords/merge-coords meta)
              :event/kind   :db
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))
@@ -165,7 +166,7 @@
         wrapped     (fx-handler->interceptor handler-fn)
         all-chain   (concat interceptors [wrapped])]
     (registrar/register! :event id
-      (assoc meta
+      (assoc (source-coords/merge-coords meta)
              :event/kind   :fx
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))
@@ -177,7 +178,7 @@
         wrapped     (ctx-handler->interceptor handler-fn)
         all-chain   (concat interceptors [wrapped])]
     (registrar/register! :event id
-      (assoc meta
+      (assoc (source-coords/merge-coords meta)
              :event/kind   :ctx
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))

--- a/implementation/src/re_frame/flows.cljc
+++ b/implementation/src/re_frame/flows.cljc
@@ -14,6 +14,7 @@
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as adapter]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- registry -------------------------------------------------------------
@@ -128,7 +129,9 @@
      ;; The :flow registrar slot keys on flow-id only — but stamp :frame
      ;; into the metadata so introspection / hot-reload hooks can read
      ;; the owning frame.
-     (registrar/register! :flow flow-id (assoc flow :frame frame-id))
+     (registrar/register! :flow flow-id
+                          (source-coords/merge-coords
+                            (assoc flow :frame frame-id)))
      (swap! flows assoc-in [frame-id flow-id] flow)
      ;; Cycle detection on this frame's flows only.
      (try

--- a/implementation/src/re_frame/frame.cljc
+++ b/implementation/src/re_frame/frame.cljc
@@ -15,6 +15,7 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- the frame record -----------------------------------------------------
@@ -136,7 +137,7 @@
     runtime state (app-db, sub-cache, queue) is preserved; only the
     metadata/config is replaced. Hot-reload Just Works."
   [id metadata]
-  (let [config (expand-preset metadata)]
+  (let [config (source-coords/merge-coords (expand-preset metadata))]
     (registrar/register! :frame id config)
     (let [existing (get @frames id)]
       (cond

--- a/implementation/src/re_frame/fx.cljc
+++ b/implementation/src/re_frame/fx.cljc
@@ -18,6 +18,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- registration ---------------------------------------------------------
@@ -34,7 +35,8 @@
         (if (map? metadata-or-handler)
           [metadata-or-handler (first maybe-handler)]
           [{} metadata-or-handler])]
-    (registrar/register! :fx id (assoc meta :handler-fn handler-fn))
+    (registrar/register! :fx id (assoc (source-coords/merge-coords meta)
+                                       :handler-fn handler-fn))
     id))
 
 (defn unregister-fx [id]

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -24,6 +24,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.events :as events]
             [re-frame.subs :as subs]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- pure machine-transition ----------------------------------------------

--- a/implementation/src/re_frame/routing.cljc
+++ b/implementation/src/re_frame/routing.cljc
@@ -35,6 +35,7 @@
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- url encoding / decoding ---------------------------------------------
@@ -191,7 +192,7 @@
         rank     (when pattern (compute-rank pattern))
         compiled (when pattern (compile-pattern pattern))
         idx      (swap! reg-counter inc)
-        meta'    (cond-> metadata
+        meta'    (cond-> (source-coords/merge-coords metadata)
                    rank     (assoc :rf.route/rank (conj rank (- idx)))
                    compiled (assoc :rf.route/compiled compiled))]
     ;; Spec 012 rule-6 warning: scan existing routes for one whose structural

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -11,6 +11,7 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 (defn- malli-validate*
@@ -50,7 +51,9 @@
   dev whenever an event handler returns a new app-db; failures emit
   :rf.error/schema-validation-failure."
   [path schema]
-  (registrar/register! :app-schema path {:schema schema :path path})
+  (registrar/register! :app-schema path
+                       (source-coords/merge-coords
+                         {:schema schema :path path}))
   path)
 
 (defn app-schema-at

--- a/implementation/src/re_frame/source_coords.cljc
+++ b/implementation/src/re_frame/source_coords.cljc
@@ -1,0 +1,50 @@
+(ns re-frame.source-coords
+  "Compile-time source-coordinate capture for registration macros.
+  Per Spec 001 §Source-coordinate capture (CLJS reference) and
+  Tool-Pair §Source-mapping.
+
+  Every registration's metadata carries `:ns` / `:line` / `:file`
+  auto-supplied at compile time. Tools (re-frame-pair, re-frame-10x,
+  IDE jump-to-source) consume these via `(rf/handler-meta kind id)`.
+
+  The capture mechanism:
+
+    1. Each public reg-* macro at the re-frame.core boundary captures
+       :line / :column from `(meta &form)` and :ns / :file from the
+       compile-time environment, builds a `coords` literal map, and
+       binds `*pending-coords*` around the underlying registration
+       fn call.
+    2. The registration fn merges *pending-coords* into the metadata
+       it stores in the registrar slot. User-supplied :ns / :line /
+       :file override the auto-captured values (so tooling that
+       synthesises registrations from another source can stamp the
+       original coordinates).
+
+  The data itself is fine in production (static metadata on the
+  registry slot — bytes, not behaviour). The DOM-annotation hook
+  (per Tool-Pair §Source-mapping) is the dev-only piece, gated
+  separately. Source-coord capture itself stays unconditional — the
+  runtime cost is one map merge at registration time.")
+
+(def ^:dynamic *pending-coords*
+  "Per-thread (per-call) source coords captured by a reg-* macro and
+  consumed by the underlying registration fn. nil outside a macro
+  invocation.
+
+  Shape: `{:ns sym :line int :file string :column int}` — see Spec 001
+  §The metadata map. :ns / :line / :file are the locked keys; :column
+  is an optional refinement. All keys are present when a macro
+  captured the call site; nil otherwise (programmatic / REPL
+  registrations that bypass the macro path)."
+  nil)
+
+(defn merge-coords
+  "Merge `*pending-coords*` into `user-meta`. User-supplied :ns / :line
+  / :file override auto-captured values per Spec 001. Returns user-meta
+  unchanged when no coords are pending (programmatic registration,
+  REPL eval without the macro path)."
+  [user-meta]
+  (let [coords *pending-coords*]
+    (if coords
+      (merge coords (or user-meta {}))
+      (or user-meta {}))))

--- a/implementation/src/re_frame/ssr.cljc
+++ b/implementation/src/re_frame/ssr.cljc
@@ -43,6 +43,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.events :as events]
+            [re-frame.source-coords :as source-coords]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]
             #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])
@@ -675,7 +676,8 @@ response with no body."
    (reg-error-projector id {} projector-fn))
   ([id metadata projector-fn]
    (registrar/register! :error-projector id
-                        (assoc metadata :handler-fn projector-fn))
+                        (assoc (source-coords/merge-coords metadata)
+                               :handler-fn projector-fn))
    id))
 
 ;; Built-in default projector — always available; user code reaches

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -20,6 +20,7 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 ;; ---- registration ---------------------------------------------------------
@@ -67,7 +68,7 @@
   [id & args]
   (let [{:keys [meta handler-fn input-signals]} (parse-reg-sub-args id args)]
     (registrar/register! :sub id
-      (assoc meta
+      (assoc (source-coords/merge-coords meta)
              :handler-fn    handler-fn
              :input-signals input-signals))
     ;; Per Spec 009 §:op-type vocabulary: :sub/create marks subscription

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -14,7 +14,8 @@
   rewrites keyword references at compile time as the v1 escape hatch."
   (:require ["react"        :as React]
             [reagent.core   :as r]
-            [re-frame.registrar :as registrar]))
+            [re-frame.registrar :as registrar]
+            [re-frame.source-coords :as source-coords]))
 
 ;; ---- the React context for frame propagation -----------------------------
 
@@ -64,7 +65,8 @@
                   (fn frame-aware-view [& args]
                     (apply render-fn args))
                   {:context-type frame-context})]
-    (registrar/register! :view id (assoc metadata :handler-fn wrapped))
+    (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
+                                         :handler-fn wrapped))
     wrapped))
 
 (defn get-view

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -20,6 +20,7 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
+            [re-frame.subs :as subs]
             [re-frame.trace :as trace]
             [re-frame.conformance :as conformance]))
 
@@ -98,7 +99,11 @@
   ;; routing.cljc / ssr.cljc; clear-all! wiped them. Re-eval those
   ;; registrations so :rf.route/navigate, :rf.route/handle-url-change,
   ;; :rf/hydrate, :rf.nav/push-url, :rf.nav/replace-url all resolve.
-  ((requiring-resolve 're-frame.core/reg-sub) :rf/route
+  ;; Use the fn-form re-frame.subs/reg-sub here. The public re-frame.core/
+  ;; reg-sub is a macro on JVM (per Spec 001 §Source-coordinate capture)
+  ;; and a macro var isn't a callable fn. The underlying subs/reg-sub fn
+  ;; has the same effect on the registry.
+  ((requiring-resolve 're-frame.subs/reg-sub) :rf/route
    (requiring-resolve 're-frame.routing/route-sub-fn))
   ;; Re-evaluate the registration ns-bodies by removing-and-reloading.
   (require 're-frame.routing :reload)
@@ -227,7 +232,13 @@
           :layer-1 (if (seq sub-meta)
                      (rf/reg-sub id sub-meta body)
                      (rf/reg-sub id body))
-          :layer-2 (apply rf/reg-sub id
+          ;; Use the fn-form (subs/reg-sub) here because the public
+          ;; rf/reg-sub is a macro on JVM (per Spec 001 §Source-coordinate
+          ;; capture) and macros aren't first-class values for `apply`.
+          ;; Source-coord capture is intentionally bypassed for these
+          ;; fixture-synthesised registrations — fixture data carries no
+          ;; meaningful call site.
+          :layer-2 (apply subs/reg-sub id
                           (concat (when (seq sub-meta) [sub-meta])
                                   (interleave (repeat :<-) inputs)
                                   [body])))))

--- a/implementation/test/re_frame/source_coords_test.clj
+++ b/implementation/test/re_frame/source_coords_test.clj
@@ -1,0 +1,190 @@
+(ns re-frame.source-coords-test
+  "Per Spec 001 §Source-coordinate capture and Tool-Pair §Source-mapping:
+  every reg-* registration's metadata carries :ns / :line / :file
+  auto-supplied at compile time. This test registers one handler per
+  registry kind via the public re-frame.core macro surface and asserts
+  the resulting handler-meta carries non-nil :ns / :line / :file (rf2-k84s).
+
+  The capture mechanism (see re-frame.source-coords) wraps each public
+  reg-* macro at the re-frame.core boundary. (meta &form) supplies
+  :line / :column; *ns* / *file* supply the namespace symbol and source
+  filename. The macro binds re-frame.source-coords/*pending-coords*
+  around the underlying registration fn, which merges the coords into
+  the registry slot's metadata.
+
+  Verification is JVM-only here because the source-coord-capture
+  *macro* path is JVM-side per the current commit (CLJS source-coord
+  capture rides a future re-frame.core-macros companion ns; the
+  underlying merge mechanism in source-coords/merge-coords is shared).
+
+  Coverage matches Spec 001 §Per-kind index and the bead's deliverable:
+    reg-event-db   reg-event-fx   reg-event-ctx
+    reg-sub        reg-fx         reg-cofx
+    reg-frame      reg-view       reg-machine
+    reg-flow       reg-route      reg-app-schema
+    reg-error-projector"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- shared assertion helper ---------------------------------------------
+
+(defn- assert-coords [meta kind id]
+  (is (some? meta) (str "handler-meta for " kind " " id " should be present"))
+  (is (some? (:ns meta))
+      (str "handler-meta for " kind " " id " should carry :ns"))
+  (is (some? (:line meta))
+      (str "handler-meta for " kind " " id " should carry :line"))
+  (is (some? (:file meta))
+      (str "handler-meta for " kind " " id " should carry :file"))
+  ;; :ns is a symbol per Spec 001 §The metadata map.
+  (is (symbol? (:ns meta))
+      (str "handler-meta for " kind " " id " :ns should be a symbol"))
+  ;; :line is an integer per Spec 001.
+  (is (integer? (:line meta))
+      (str "handler-meta for " kind " " id " :line should be an integer"))
+  ;; :file is a string per Spec 001.
+  (is (string? (:file meta))
+      (str "handler-meta for " kind " " id " :file should be a string")))
+
+;; ---- one assertion per reg-* kind ----------------------------------------
+
+(deftest source-coords-on-reg-event-db
+  (testing "reg-event-db stamps :ns / :line / :file"
+    (rf/reg-event-db :rf2-k84s/reg-event-db-sample
+                     (fn [db _] db))
+    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-db-sample)
+                   :event :rf2-k84s/reg-event-db-sample)))
+
+(deftest source-coords-on-reg-event-fx
+  (testing "reg-event-fx stamps :ns / :line / :file"
+    (rf/reg-event-fx :rf2-k84s/reg-event-fx-sample
+                     (fn [_ _] {}))
+    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-fx-sample)
+                   :event :rf2-k84s/reg-event-fx-sample)))
+
+(deftest source-coords-on-reg-event-ctx
+  (testing "reg-event-ctx stamps :ns / :line / :file"
+    (rf/reg-event-ctx :rf2-k84s/reg-event-ctx-sample
+                      (fn [ctx] ctx))
+    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-ctx-sample)
+                   :event :rf2-k84s/reg-event-ctx-sample)))
+
+(deftest source-coords-on-reg-sub
+  (testing "reg-sub stamps :ns / :line / :file"
+    (rf/reg-sub :rf2-k84s/reg-sub-sample
+                (fn [db _] db))
+    (assert-coords (rf/handler-meta :sub :rf2-k84s/reg-sub-sample)
+                   :sub :rf2-k84s/reg-sub-sample)))
+
+(deftest source-coords-on-reg-fx
+  (testing "reg-fx stamps :ns / :line / :file"
+    (rf/reg-fx :rf2-k84s/reg-fx-sample
+               (fn [_ _] nil))
+    (assert-coords (rf/handler-meta :fx :rf2-k84s/reg-fx-sample)
+                   :fx :rf2-k84s/reg-fx-sample)))
+
+(deftest source-coords-on-reg-cofx
+  (testing "reg-cofx stamps :ns / :line / :file"
+    (rf/reg-cofx :rf2-k84s/reg-cofx-sample
+                 (fn [ctx] ctx))
+    (assert-coords (rf/handler-meta :cofx :rf2-k84s/reg-cofx-sample)
+                   :cofx :rf2-k84s/reg-cofx-sample)))
+
+(deftest source-coords-on-reg-frame
+  (testing "reg-frame stamps :ns / :line / :file"
+    (rf/reg-frame :rf2-k84s/reg-frame-sample {:doc "smoke"})
+    (assert-coords (rf/handler-meta :frame :rf2-k84s/reg-frame-sample)
+                   :frame :rf2-k84s/reg-frame-sample)))
+
+(deftest source-coords-on-reg-view
+  (testing "reg-view stamps :ns / :line / :file"
+    (rf/reg-view :rf2-k84s/reg-view-sample
+                 (fn [] [:div "hi"]))
+    (assert-coords (rf/handler-meta :view :rf2-k84s/reg-view-sample)
+                   :view :rf2-k84s/reg-view-sample)))
+
+(deftest source-coords-on-reg-machine
+  (testing "reg-machine stamps :ns / :line / :file (under :event kind, since
+  reg-machine wraps the machine as an event handler per Spec 005 §Registration)"
+    (rf/reg-machine :rf2-k84s/reg-machine-sample
+                    {:initial :a :states {:a {} :b {}}})
+    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-machine-sample)
+                   :event :rf2-k84s/reg-machine-sample)))
+
+(deftest source-coords-on-reg-flow
+  (testing "reg-flow stamps :ns / :line / :file"
+    (rf/reg-flow {:id     :rf2-k84s/reg-flow-sample
+                  :inputs [[:source]]
+                  :output (fn [v] v)
+                  :path   [:dest]})
+    (assert-coords (rf/handler-meta :flow :rf2-k84s/reg-flow-sample)
+                   :flow :rf2-k84s/reg-flow-sample)))
+
+(deftest source-coords-on-reg-route
+  (testing "reg-route stamps :ns / :line / :file"
+    (rf/reg-route :rf2-k84s/reg-route-sample {:path "/k84s"})
+    (assert-coords (rf/handler-meta :route :rf2-k84s/reg-route-sample)
+                   :route :rf2-k84s/reg-route-sample)))
+
+(deftest source-coords-on-reg-app-schema
+  (testing "reg-app-schema stamps :ns / :line / :file"
+    (rf/reg-app-schema [:rf2-k84s/reg-app-schema-sample] :int)
+    (assert-coords (rf/handler-meta :app-schema [:rf2-k84s/reg-app-schema-sample])
+                   :app-schema [:rf2-k84s/reg-app-schema-sample])))
+
+(deftest source-coords-on-reg-error-projector
+  (testing "reg-error-projector stamps :ns / :line / :file"
+    (rf/reg-error-projector :rf2-k84s/reg-error-projector-sample
+                            (fn [_]
+                              {:status     500
+                               :code       :internal-error
+                               :message    "x"
+                               :retryable? false}))
+    (assert-coords (rf/handler-meta :error-projector
+                                    :rf2-k84s/reg-error-projector-sample)
+                   :error-projector :rf2-k84s/reg-error-projector-sample)))
+
+;; ---- user-supplied :ns / :line / :file override auto-capture --------------
+
+(deftest user-supplied-coords-win
+  (testing "explicit :ns / :line / :file in user metadata override auto-capture"
+    (rf/reg-event-db :rf2-k84s/explicit-coords
+                     {:ns 'my.ns :line 42 :file "elsewhere.cljc"
+                      :doc "hand-stamped coords from a code-gen pass"}
+                     (fn [db _] db))
+    (let [meta (rf/handler-meta :event :rf2-k84s/explicit-coords)]
+      (is (= 'my.ns                  (:ns meta)))
+      (is (= 42                      (:line meta)))
+      (is (= "elsewhere.cljc"        (:file meta)))
+      (is (= "hand-stamped coords from a code-gen pass" (:doc meta))))))
+
+;; ---- programmatic call (bypasses macro) -----------------------------------
+
+(deftest fn-form-call-skips-coord-capture
+  (testing "calling the underlying fn directly skips coord capture
+  (so programmatic / fixture-synthesised registrations don't carry
+  meaningless coords from inside the framework)"
+    (let [reg-fn (requiring-resolve 're-frame.subs/reg-sub)]
+      (reg-fn :rf2-k84s/no-coords (fn [db _] db)))
+    (let [meta (rf/handler-meta :sub :rf2-k84s/no-coords)]
+      (is (some? meta))
+      (is (nil? (:ns   meta)) ":ns absent on direct fn call")
+      (is (nil? (:line meta)) ":line absent on direct fn call")
+      (is (nil? (:file meta)) ":file absent on direct fn call"))))


### PR DESCRIPTION
## Summary

Per Spec 001 §Source-coordinate capture and Tool-Pair §Source-mapping, every `reg-*` registration's metadata now carries `:ns` / `:line` / `:file` auto-supplied at compile time.

- New `re-frame.source-coords` ns: `*pending-coords*` dynamic var + `merge-coords` helper. User-supplied `:ns` / `:line` / `:file` override auto-captured values.
- On JVM, public `reg-*` in `re-frame.core` are now defmacros that capture `(meta &form)`'s `:line` / `:column` plus `*ns*` / `*file*`, bind `*pending-coords*`, and forward to the underlying fn.
- Each underlying fn (`events/reg-event-db`, `subs/reg-sub`, `fx/reg-fx`, `cofx/reg-cofx`, `frame/reg-frame`, `flows/reg-flow`, `routing/reg-route`, `schemas/reg-app-schema`, `machines/reg-machine` (via reg-event-fx), `views/reg-view*`, `ssr/reg-error-projector`, `core/reg-view`) merges `*pending-coords*` into the registered metadata.
- CLJS keeps the existing fn-alias form. Source-coord capture on CLJS is a future addition via a `re-frame.core-macros` companion ns following the existing `re-frame.views-macros` pattern; the merge mechanism in `source-coords/merge-coords` is shared.
- `reg-head` was not implemented (registry kind exists in `kinds` set; no `reg-head` fn yet) — out of scope per the bead.

Production elision: the source-coord data itself is fine in production (static metadata on the registry slot — bytes, not behaviour). The dev-only piece per Tool-Pair §Source-mapping is the DOM annotation hook (out of scope here). Source-coord capture itself is unconditional; the runtime cost is one map merge at registration time.

Conformance: one fixture-test caller used `(apply rf/reg-sub ...)` and `(requiring-resolve 're-frame.core/reg-sub)`. Macros aren't first-class values, so those callers now use `subs/reg-sub` (the underlying fn). Fixture-synthesised registrations carry no meaningful call site, so source-coord capture is intentionally skipped on that path.

## Test plan

- [x] `cd implementation && clojure -M:test` — was 130/679/0; now 157/825/0 (after rebase: rebase pulled trace-buffer-test). Source-coord additions: 15 deftests / 99 assertions.
- [x] `test/re_frame/source_coords_test.clj` — one assertion per kind (`reg-event-{db,fx,ctx}`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `reg-view`, `reg-machine`, `reg-flow`, `reg-route`, `reg-app-schema`, `reg-error-projector`) plus user-override and fn-bypass paths.
- [ ] CLJS browser-test / node-test — out of scope this commit; CLJS still uses the fn-alias form, so existing CLJS suite is unchanged.