### PR TITLE
audit+test: production elision of trace/schema/epoch infrastructure (rf2-11hn)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,3 +127,54 @@ jobs:
 
       - name: Compile :browser-test, serve, and run Playwright runner
         run: npm run test:browser
+
+  cljs-elision:
+    name: CLJS production elision (Spec 009, bead rf2-11hn)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-elision-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-elision-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      # Build the elision probe (goog.DEBUG=false) and the control build
+      # (goog.DEBUG=true), then grep both for sentinel strings that only
+      # appear in dev-gated branches.  The contract:
+      #   - production bundle:  sentinels MUST be ABSENT
+      #   - control    bundle:  sentinels MUST be PRESENT
+      # If either fails, the elision contract (Spec 009 §Production
+      # builds) is broken or the test methodology has lost its signal.
+      - name: Verify production elision (advanced compile + grep)
+        run: npm run test:elision

--- a/docs/specification/009-Instrumentation.md
+++ b/docs/specification/009-Instrumentation.md
@@ -164,7 +164,7 @@ Alongside the raw trace stream, the framework exposes a parallel **assembled-epo
 - **After commit.** The callback receives a fully-formed record with `:db-after`, `:sub-runs`, `:renders`, `:effects`, and any optional `:trace-events` populated. The record has already been appended to the frame's `epoch-history` ring buffer when the callback runs.
 - **Exception isolation.** An exception thrown by an epoch callback is caught, logged via `re-frame.loggers`, and does not propagate. One broken epoch listener cannot break the app or block other listeners (raw-trace or epoch).
 - **Listener ordering** is not contract.
-- **Production elision.** The epoch listener machinery is gated on the same `goog-define trace-enabled?` as the raw-trace surface. Production builds elide registration, dispatch, and the epoch ring-buffer all together.
+- **Production elision.** The epoch listener machinery is gated on the same `re-frame.interop/debug-enabled?` flag (alias of `goog.DEBUG`) as the raw-trace surface — see [§Production builds](#production-builds-zero-overhead-zero-code). Production builds elide registration, dispatch, and the epoch ring-buffer all together.
 
 **When to use which.** `register-trace-cb` is the right shape for tools that need raw fine-grained spans (the Chrome Performance bridge, custom timing displays). `register-epoch-cb` is the right shape for tools that route diagnostics off "what just happened in this cascade" — pair-shaped tools, post-mortem dashboards, anything that wants the structured `:sub-runs` / `:renders` / `:effects` projection without re-folding the raw trace stream.
 
@@ -241,7 +241,7 @@ Closes the open trace, computes its duration, pushes it onto the trace buffer, a
 
 ### Compile-time elision
 
-All three macros expand to `(when (is-trace-enabled?) ...emit...)` gates. `is-trace-enabled?` reads the `re-frame.trace/trace-enabled?` closure-define (default `false`); when the constant is `false` in a production build, the closure compiler eliminates the gated branch and the macros become no-ops. See "Production builds" below for the full mechanism.
+All three macros expand to `(when re-frame.interop/debug-enabled? ...emit...)` gates. `debug-enabled?` is an alias of `goog.DEBUG` on CLJS (default `true` in dev, `false` in `:advanced` production builds); when the constant is `false` the closure compiler eliminates the gated branch and the macros become no-ops. See "Production builds" below for the full mechanism.
 
 ### Where trace emission lives
 
@@ -265,57 +265,95 @@ User code can also emit traces — `with-trace` and `merge-trace!` are public.
 
 ## Production builds: zero overhead, zero code
 
-**Trace emission is a development-only concern.** In production builds, all tracing code — every emit call site, the listener registry, the trace buffer, the Performance API bridge — is compile-time eliminated. The closure compiler's dead-code elimination removes everything; production binaries contain no trace machinery at all.
+**All dev-side instrumentation is a development-only concern.** In production builds, the trace surface, the schema validation surface (Spec 010), and the registrar's hot-reload trace emit (`:rf.registry/handler-{registered,replaced,cleared}`) are *all* compile-time eliminated through a single shared gate. The closure compiler's dead-code elimination removes the gated branches; production binaries contain no instrumentation machinery at all.
 
-### The mechanism: `goog-define trace-enabled?` + `is-trace-enabled?`
+### The mechanism: `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`)
 
-The convention in `re-frame.trace`:
+The CLJS implementation uses one shared flag — an alias of the standard `goog.DEBUG` closure-define — for every dev-only branch:
 
 ```clojure
-(ns re-frame.trace)
-#?(:cljs (goog-define trace-enabled? false)
-   :clj  (def ^boolean trace-enabled? false))
-
-(defn ^boolean is-trace-enabled? [] trace-enabled?)
+;; src/re_frame/interop.cljs
+(def ^boolean debug-enabled? "@define {boolean}" ^boolean goog/DEBUG)
 ```
 
-Every framework-internal trace emit is wrapped in `(when (is-trace-enabled?) ...)`. The macros (`with-trace`, `merge-trace!`, `finish-trace`) all expand to this gate.
+Every framework-internal dev branch — `trace/emit!`, `trace/emit-error!`, `schemas/validate-app-db!`, `schemas/validate-event!`, `schemas/validate-cofx!`, `schemas/validate-sub-return!`, and the `registrar/{register!,unregister!,clear-kind!}` trace emits — wraps its body in `(when interop/debug-enabled? ...)`. With `:advanced` compilation and `:closure-defines {goog.DEBUG false}`, Closure constant-folds the gate and DCEs every dependent allocation: trace maps, listener iteration, malli calls, error reason strings, the Performance API bridge.
 
-When `trace-enabled?` is `false` (the default), the closure compiler's advanced-compilation pass treats the constant as dead and elides the gated branch from the output bundle. Production builds:
+```edn
+;; user's shadow-cljs.edn — production build
+{:builds {:app {:target           :browser
+                :output-dir       "..."
+                :compiler-options {:closure-defines {goog.DEBUG false}}}}}
+```
 
-- Allocate no trace event maps.
-- Hold no listener registry.
-- Never invoke listener predicates.
-- Don't include the trace buffer in the bundle.
-- Don't include the Performance API bridge.
+(Most production CLJS builds already set `goog.DEBUG=false`; re-frame2 piggybacks on the canonical CLJS production flag rather than introducing its own.)
+
+The gate must be the **outermost** form of the body. `(when interop/debug-enabled? ...)` and `(if interop/debug-enabled? <body> <else>)` constant-fold reliably; `(when (and X interop/debug-enabled?) ...)` does NOT — Closure can't statically rule out `X`, and the dead branch survives into the bundle. The verifier (see [§Production-elision verification](#production-elision-verification)) catches that mistake.
+
+A reachable but dead branch in a production bundle:
+
+- Allocates no trace event maps.
+- Holds no listener registry beyond the (small) `defonce` cells (which carry `{}` and `0`).
+- Never invokes listener predicates.
+- Excludes the trace buffer payload.
+- Excludes the Performance API bridge.
+- Excludes the schema validation entry points and their malli/explanation calls.
 
 ### How users opt in (dev builds)
 
-Tools that consume traces (10x, re-frame-pair) instruct users to set the `trace-enabled?` closure-define to `true` in their dev build:
+CLJS dev builds default to `goog.DEBUG=true` — every gate stays live with no extra configuration. A user who wants trace machinery in a `:advanced` artefact (rare) can flip the flag explicitly:
 
 ```edn
-;; shadow-cljs.edn (dev build)
-{:closure-defines {re-frame.trace/trace-enabled? true}}
+;; shadow-cljs.edn — :advanced build with trace kept in
+{:closure-defines {goog.DEBUG true}}
 ```
-
-Closure compiler with the constant set to `true` keeps the gated branches; trace emission runs and listeners receive batches.
 
 ### User-side listener registration
 
-User-side `(rf/register-trace-cb ...)` calls should also be elided in production. Wrap them with the same predicate:
+User-side `(rf/register-trace-cb! ...)` calls should also elide in production. Wrap them with the same predicate the framework uses:
 
 ```clojure
-(when (rf/is-trace-enabled?)
-  (rf/register-trace-cb :my/listener callback-fn))
+(when ^boolean re-frame.interop/debug-enabled?
+  (rf/register-trace-cb! :my/listener callback-fn))
 ```
 
-In production (closure-define `false`), `is-trace-enabled?` is a constant `false`, the `when` is dead, and the entire registration is elided.
+In production (`goog.DEBUG=false`), `re-frame.interop/debug-enabled?` is the constant `false`, the `when` is dead, and the entire registration is elided.
 
 ### JVM builds
 
-JVM builds resolve `trace-enabled?` via a build-time `System/getProperty` (or equivalent build-time flag) read at namespace load — `(def ^boolean trace-enabled? (= "true" (System/getProperty "re-frame.trace.enabled" "false")))`. Default is `false` (trace disabled in production-built JVM artefacts). Setting `-Dre-frame.trace.enabled=true` at build/run time turns it on for that artefact.
+JVM has no `:advanced` and no compile-time DCE. The JVM half of the interop layer:
 
-JVM doesn't have the closure compiler's dead-code elimination — the gated code paths remain in the bytecode regardless of the flag's value — but the runtime cost is one boolean check on each emit, near-zero overhead. The compile-time-elision guarantee is **CLJS-only**; the JVM contract is "runtime-cheap when off, runs when on." Reader conditionals are not used for trace gating — the same `^boolean` value lives on both platforms; only its origin differs (closure-define on CLJS, system property on JVM).
+```clojure
+;; src/re_frame/interop.clj
+(def debug-enabled? true)
+```
+
+…hardcodes `debug-enabled?` to `true`. JVM artefacts always run the dev-side branches. Two reasons:
+
+1. The JVM is used in re-frame2 only for headless tests, SSR, and tooling-attached REPLs (per Spec 011 §JVM-runnable view rendering and Spec 008 §JVM-runnable test suites). None of those is a production-latency hot path.
+2. Trace events are how SSR errors, schema-validation failures, and hot-reload notifications surface — turning them off on the JVM would silently drop the only data channel those flows carry.
+
+Apps that ship a production JVM artefact (a Pedestal/ring service that uses re-frame2's runtime for state) and want to disable instrumentation should rebuild the framework with `interop.clj`'s `debug-enabled?` switched to `false` (or an `alter-var-root!` at boot) — but the canonical re-frame2 dev surface is CLJS. The compile-time-elision guarantee is **CLJS-only**; on JVM the contract is "code is present, runs cheaply when its inner predicate is also off."
+
+### Production-elision verification
+
+The contract above is enforced by an automated test in CI:
+
+1. `implementation/test/re_frame/elision_probe.cljs` is a probe namespace that exercises every gated surface — `register-trace-cb!`, `emit-trace!`, `validate-{app-db,event,sub-return,cofx}!`, `register!` / `unregister!` / `clear-kind!`, plus a representative `dispatch-sync` flow. The probe roots the dead-code-elimination graph at every surface so a leak surfaces in the bundle.
+2. `implementation/shadow-cljs.edn` declares two `:advanced` builds with `re-frame.elision-probe/run` as the entry point:
+   - `:elision-probe` — `:closure-defines {goog.DEBUG false}` (production)
+   - `:elision-probe-control` — `:closure-defines {goog.DEBUG true}` (control)
+3. `implementation/scripts/check-elision.cjs` greps both bundles for sentinel strings drawn from the gated branches (schema reason fragments and `:rf.registry/*` trace operation keywords). The contract:
+   - Production bundle: every sentinel MUST be ABSENT.
+   - Control bundle: every sentinel MUST be PRESENT.
+4. The CI workflow runs `npm run test:elision` (`shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs`) on every push/PR.
+
+The control build is what gives the test teeth: without it, a refactor that *moved* a sentinel string out of a gated branch would silently turn the negative assertion into a vacuous pass. With both bundles checked, any change that either breaks elision *or* loses methodology signal fails CI loudly.
+
+When a future surface is added (e.g. epoch history per [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach)), it follows the same pattern:
+
+- Wrap its dev-only body in `(when interop/debug-enabled? ...)`, outermost.
+- Touch the surface from `re-frame.elision-probe` so the DCE graph reaches it.
+- Add a sentinel to `DEV_ONLY_SENTINELS` in `check-elision.cjs` (a string literal or keyword name that only the gated branch contains).
 
 ## Hot path in dev builds
 
@@ -342,7 +380,7 @@ The Chrome Performance API ([User Timing](https://developer.mozilla.org/en-US/do
 (rf/configure :performance-api {:enabled? false})   ;; force-off
 ```
 
-Default: enabled when `(is-trace-enabled?)` returns true; disabled otherwise. So in a dev build with tracing on, the bridge is on out of the box; turning it off with `:enabled? false` keeps trace events flowing to listeners (10x, re-frame-pair, custom recorders) but stops the `performance.mark` / `performance.measure` calls. Useful when:
+Default: enabled when `re-frame.interop/debug-enabled?` is true; disabled otherwise. So in a dev build with tracing on, the bridge is on out of the box; turning it off with `:enabled? false` keeps trace events flowing to listeners (10x, re-frame-pair, custom recorders) but stops the `performance.mark` / `performance.measure` calls. Useful when:
 
 - The Performance panel marks are noisy and the user wants the trace stream without the timeline annotations.
 - A custom profiling integration owns the Performance API and re-frame2's marks would conflict.
@@ -352,7 +390,7 @@ Production builds elide the bridge code along with the rest of tracing (per "Pro
 
 ### Implementation: hardcoded into emit, gated separately
 
-The bridge sits inside the trace-emit path itself, **inside the `(when (is-trace-enabled?) ...)` compile-time gate**, with an additional `(when (performance-api-enabled?) ...)` runtime gate that reads the `:performance-api` config. So in production builds, the outer compile-time gate is dead, the entire emit path is elided, and the bridge calls disappear with everything else. In dev builds, the outer gate is live; the inner config gate decides whether the bridge fires.
+The bridge sits inside the trace-emit path itself, **inside the `(when interop/debug-enabled? ...)` compile-time gate**, with an additional `(when (performance-api-enabled?) ...)` runtime gate that reads the `:performance-api` config. So in production builds, the outer compile-time gate is dead, the entire emit path is elided, and the bridge calls disappear with everything else. In dev builds, the outer gate is live; the inner config gate decides whether the bridge fires.
 
 Two reasons for hardcoding the bridge into emit rather than registering it as a `register-trace-cb` listener:
 
@@ -401,8 +439,8 @@ External tools consume re-frame2 through stable surfaces. Production builds elid
 | Trace event shape (`:id`, `:operation`, `:op-type`, `:start`, `:end`, `:duration`, `:child-of`, `:tags`) | Preserved exactly |
 | `:op-type` discriminator vocabulary (`:event`, `:sub/run`, `:sub/create`, `:render`, `:raf`, `:event/do-fx`, ...) | Preserved; new values additive |
 | `:tags` for op-type-specific data (`:app-db-before`, `:app-db-after`, `:input-signals`, `:cached?`, `:value`, `:error`) | Preserved |
-| `is-trace-enabled?` | Preserved |
-| Compile-time elision via `goog-define trace-enabled?` | Preserved |
+| `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`) | Preserved |
+| Compile-time elision via `goog.DEBUG=false` + `:advanced` | Preserved |
 | `(trace-api-version)` integer (bumps on contract revisions) | Provided |
 | Public registrar query API (`handlers`/`handler-meta`/`frame-ids`/`frame-meta`/`get-frame-db`/`snapshot-of`/`sub-topology`/`sub-cache`) | See [002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api) |
 | Hot-reload notifications (`:rf.registry/handler-registered`, `:rf.registry/handler-cleared`, `:rf.registry/handler-replaced`, `:frame/created`, `:frame/destroyed`) | Trace events |
@@ -690,7 +728,7 @@ Tracing is the connective tissue between the runtime and every tool that observe
 
 ### Trace allocation cost in dev when no listeners
 
-When a listener is *never* registered, the macros' compile-time gate doesn't help — `is-trace-enabled?` is true (dev), so the body runs. The body should fast-fail when `(empty? @trace-cbs)`. The emit macros perform this check before allocating the trace map.
+When a listener is *never* registered, the macros' compile-time gate doesn't help — `interop/debug-enabled?` is true (dev), so the body runs. The body should fast-fail when `(empty? @trace-cbs)`. The emit macros perform this check before allocating the trace map.
 
 ### Privacy / sensitive data in traces
 

--- a/docs/specification/010-Schemas.md
+++ b/docs/specification/010-Schemas.md
@@ -129,7 +129,7 @@ All registered schemas are checked at every validation point. The intent is to c
 
 ### Production builds
 
-Validation is **elided** by default — schemas remain registered (so tooling can introspect them) but the validation calls are compile-time-eliminated, similar to trace emission. The mechanism: a closure-define `re-frame.spec/validation-enabled?` (default `false` in production) gates each validation site.
+Validation is **elided** by default — schemas remain registered (so tooling can introspect them) but the validation calls are compile-time-eliminated, alongside trace emission. The mechanism: every `validate-*!` body is wrapped in `(when re-frame.interop/debug-enabled? ...)`. `debug-enabled?` is an alias of `goog.DEBUG` (default `true` in dev, `false` in `:advanced` production), so under `:closure-defines {goog.DEBUG false}` the closure compiler constant-folds and DCEs every validation site — the malli call, the trace-error envelope, the human-readable reason string, and every keyword the failure tags carry. See [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) for the full elision contract and the CI verifier that enforces it.
 
 For users who want production validation at *system boundaries* — typically incoming events from untrusted sources (HTTP responses, websocket messages, postMessage) — re-frame2 ships a `:spec/validate-at-boundary` interceptor that the user adds to specific event handlers. Boundary validation runs even when global validation is elided.
 
@@ -143,7 +143,7 @@ For users who want production validation at *system boundaries* — typically in
 **Relationship to the handler's `:spec`.** `:spec/validate-at-boundary` re-uses the handler's existing `:spec` — it does **not** introduce a parallel schema. The interceptor's only job is to **force** validation against `:spec` regardless of the global elision flag. Concretely:
 
 - In **dev builds**, every event handler's `:spec` is checked anyway (per [§Validation order](#validation-order-on-event-processing) step 1). The boundary interceptor is a no-op in this mode — it doesn't run validation a second time.
-- In **production builds**, the global `re-frame.spec/validation-enabled?` is `false` and step-1 validation is elided. The boundary interceptor runs the same `:spec` check inline, so handlers carrying it still validate at the boundary.
+- In **production builds**, `re-frame.interop/debug-enabled?` is `false` and step-1 validation is elided. The boundary interceptor runs the same `:spec` check inline, so handlers carrying it still validate at the boundary.
 - In **production builds with no `:spec`** on the handler, the boundary interceptor is a no-op (nothing to validate against) and emits `:rf.warning/boundary-without-spec` once per `(handler-id)` to flag the misconfiguration.
 
 Failures from the boundary interceptor flow through the same `:rf.error/schema-validation-failure :where :event` path as dev-mode step-1 failures — the recovery (skip handler; downstream queue continues) is identical. The only difference is *whether the check ran*, not *what happens when it fails*.
@@ -274,7 +274,7 @@ Locked rules:
 
 - **One validator fn per frame** is in effect at any time. Last-write-wins on re-registration; tools warn if the source coords differ between registrations (same form re-register is benign hot-reload).
 - **The validator fn is pure** — same `(schema, value)` returns the same result. Implementations may memoise but tests must not depend on memoisation.
-- **The validator fn must be production-elidable** alongside `re-frame.spec/validation-enabled?` — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
+- **The validator fn must be production-elidable** alongside `re-frame.interop/debug-enabled?` — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
 - **Schema digests** ([§Schema digest](#schema-digest)) are computed from the schema **values** as serialised by the registered validator's `serialise` companion fn (see [§Schema digest](#schema-digest)) — not from the validator. Two ports using different validators against the same Malli-EDN schemas produce the same digest; two ports using *different* schema languages produce different digests by construction.
 
 What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (Malli for app schemas, JSON-Schema for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -245,7 +245,7 @@ All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Inst
 |---|---|---|---|---|
 | `register-trace-cb` | Fn | `(register-trace-cb key callback)` / `(register-trace-cb key callback opts)` | v1 (preserved) | 009 |
 | `remove-trace-cb` | Fn | `(remove-trace-cb key)` | v1 (preserved) | 009 |
-| `is-trace-enabled?` | Fn | `(is-trace-enabled?)` | v1 (preserved) | 009 |
+| `re-frame.interop/debug-enabled?` | Var | `^boolean` (alias of `goog.DEBUG` on CLJS; `true` on JVM) | v1 | 009 |
 | `trace-api-version` | Fn | `(trace-api-version)` → integer | v1 | 009 |
 | `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | 009 |
 | `clear-trace-buffer!` | Fn | `(clear-trace-buffer!)` → nil | v1 (dev-only) | 009 |

--- a/docs/specification/Implementor-Checklist.md
+++ b/docs/specification/Implementor-Checklist.md
@@ -276,7 +276,7 @@ For each capability included in Part 1, the implementor makes the per-capability
 
 - **Why it matters.** All tracing is dev-only. Production builds must elide every emit call site, the listener registry, the trace buffer, the Performance bridge (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
 - **Options by host.**
-  - **CLJS** — `goog-define trace-enabled?` + Closure compiler dead-code elimination.
+  - **CLJS** — `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`) + Closure compiler dead-code elimination, with a CI verifier (`scripts/check-elision.cjs`) that asserts dev-only sentinel strings are absent from `:advanced` `goog.DEBUG=false` bundles. See [009 §Production-elision verification](009-Instrumentation.md#production-elision-verification).
   - **JS / TS** — Build-time constant + tree-shake (Vite/Rollup with `define`); or `process.env.NODE_ENV` checks elided by the bundler.
   - **Python** — Module-level constant + `if __debug__:` (Python's `-O` flag elides assert and `__debug__` blocks).
   - **Rust** — Cargo features (`#[cfg(feature = "trace")]`); release builds omit the trace feature.

--- a/docs/specification/Tool-Pair.md
+++ b/docs/specification/Tool-Pair.md
@@ -88,7 +88,7 @@ All six failures have `:op-type :error` and `:recovery :no-recovery`. Pair tools
 
 **Restore caveat.** Even a *successful* restore rewinds `app-db` only; effects already fired (HTTP requests sent, navigation pushed, localStorage written) are not reversed. Pair-shaped tools surface this caveat in their UI before applying a restore.
 
-**Production elision.** Per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) the trace surface and epoch-history machinery is compile-time gated; production builds elide entirely.
+**Production elision.** Per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) the trace surface, schema validation, registrar trace emit, and epoch-history machinery share a single compile-time gate (`re-frame.interop/debug-enabled?`, alias of `goog.DEBUG`); production builds (`:advanced` + `goog.DEBUG=false`) elide all of it. CI's `npm run test:elision` job (Spec 009 §Production-elision verification) asserts the contract holds for every gated surface, including the epoch-history primitives once they land.
 
 ## REPL-eval
 

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
-    "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs"
+    "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
+    "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs"
   }
 }

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/*
+ * Production-elision verifier (Spec 009 §Production builds, bead rf2-11hn).
+ *
+ * Runs after `shadow-cljs release elision-probe` (and optionally
+ * `release elision-probe-control`) and asserts:
+ *
+ *   1. The :elision-probe bundle (goog.DEBUG=false) does NOT contain any
+ *      of the DEV_ONLY_SENTINELS — strings from re-frame.schemas /
+ *      re-frame.trace / re-frame.registrar that only appear inside
+ *      branches gated on `re-frame.interop/debug-enabled?`. If any
+ *      sentinel survives, dead-code elimination has failed somewhere
+ *      and the elision contract is broken.
+ *
+ *   2. The :elision-probe-control bundle (goog.DEBUG=true), if present,
+ *      DOES contain those sentinels. This confirms the grep
+ *      methodology has signal — without the control, a refactor that
+ *      moved the strings somewhere else would silently turn the
+ *      negative assertion into a vacuous pass.
+ *
+ * Strategy: grep, not parse. The closure compiler may rename symbols
+ * but does not rewrite string literals.  String literals from a
+ * gated branch are eliminated when the branch's `(when ...)` is dead.
+ *
+ * Sentinels are chosen because they:
+ *   - appear ONLY inside an interop/debug-enabled?-gated branch
+ *   - are textual fragments not synthesised from keywords
+ *   - are unique enough that a global grep is unambiguous
+ *
+ * Exit 0 on PASS, 1 on FAIL.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// ----- the elision contract --------------------------------------------------
+
+// Each sentinel is a string that appears ONLY inside a
+// (when interop/debug-enabled? ...) branch in the framework source.  If
+// any of these appears in the production bundle, that branch survived
+// dead-code elimination — i.e. the elision contract is broken.
+//
+// Sentinels are grouped by source so failures point at the leak.
+const DEV_ONLY_SENTINELS = [
+  // re-frame.schemas — validate-app-db! reason string.
+  { source: 're-frame.schemas/validate-app-db!',
+    sentinel: 'App-db at path ' },
+  // re-frame.schemas — validate-event! reason string.
+  { source: 're-frame.schemas/validate-event!',
+    sentinel: ' payload failed schema ' },
+  // re-frame.schemas — validate-sub-return! reason string.
+  { source: 're-frame.schemas/validate-sub-return!',
+    sentinel: ' return value failed schema ' },
+  // re-frame.schemas — validate-cofx! reason string.
+  { source: 're-frame.schemas/validate-cofx!',
+    sentinel: ' injected value failed schema ' },
+  // re-frame.registrar — handler-replaced trace op (only emitted from a
+  // gated branch in registrar/register!).  Keywords survive :advanced
+  // as string literals; this is a structural sentinel.
+  { source: 're-frame.registrar/register! (handler-replaced)',
+    sentinel: 'rf.registry/handler-replaced' },
+  // re-frame.registrar — handler-registered trace op.
+  { source: 're-frame.registrar/register! (handler-registered)',
+    sentinel: 'rf.registry/handler-registered' },
+  // re-frame.registrar — handler-cleared trace op.
+  { source: 're-frame.registrar/unregister! / clear-kind! (handler-cleared)',
+    sentinel: 'rf.registry/handler-cleared' },
+  // re-frame.router — :event/dispatched trace op (rf2-smee dispatch-id
+  // correlation).  Emitted via trace/emit! whose body is gated; the
+  // operation keyword should not survive.
+  { source: 're-frame.router/emit-dispatched-trace! (event/dispatched)',
+    sentinel: 'event/dispatched' }
+];
+
+// ----- helpers ---------------------------------------------------------------
+
+function readAllJs(dir) {
+  // Collect every *.js file under dir into a single concatenated blob.
+  // shadow-cljs :browser :advanced may split the runtime across files
+  // (cljs_base, the module's own file); a global grep is the right
+  // shape for the elision contract.
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+  const out = [];
+  const walk = (d) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        out.push(fs.readFileSync(full, 'utf8'));
+      }
+    }
+  };
+  walk(dir);
+  return out.join('\n');
+}
+
+function checkBundle(label, bundlePath, mustContain) {
+  const blob = readAllJs(bundlePath);
+  if (blob == null) {
+    console.error(`[elision] ${label}: bundle path missing — ${bundlePath}`);
+    console.error('         Did you run "shadow-cljs release elision-probe"?');
+    return false;
+  }
+  console.log(`[elision] ${label}: ${bundlePath}`);
+  console.log(`          bundle size: ${blob.length} chars`);
+
+  let ok = true;
+  for (const { source, sentinel } of DEV_ONLY_SENTINELS) {
+    const present = blob.includes(sentinel);
+    const expected = mustContain ? 'PRESENT' : 'ABSENT';
+    const actual   = present     ? 'PRESENT' : 'ABSENT';
+    const passed   = present === mustContain;
+    const tag      = passed ? 'OK' : 'FAIL';
+    console.log(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (!passed) ok = false;
+  }
+  return ok;
+}
+
+// ----- main ------------------------------------------------------------------
+
+function main() {
+  console.log('=== Production elision probe (Spec 009 §Production builds) ===');
+
+  const probeDir   = path.join(ROOT, 'out', 'elision-probe');
+  const controlDir = path.join(ROOT, 'out', 'elision-probe-control');
+
+  // Production bundle: sentinels MUST be absent.
+  const prodOk = checkBundle('production (goog.DEBUG=false)', probeDir, false);
+
+  // Control bundle: sentinels MUST be present (if compiled).
+  let controlOk = true;
+  if (fs.existsSync(controlDir)) {
+    controlOk = checkBundle('control    (goog.DEBUG=true) ', controlDir, true);
+  } else {
+    console.log('[elision] control bundle not built — skipping methodology check.');
+    console.log('          Run "npx shadow-cljs release elision-probe-control"');
+    console.log('          to enable the methodology assertion.');
+  }
+
+  if (prodOk && controlOk) {
+    console.log('=== PASS ===');
+    process.exit(0);
+  } else {
+    console.error('=== FAIL ===');
+    if (!prodOk) {
+      console.error('Production elision broke: at least one dev-only sentinel');
+      console.error('survived advanced compilation with goog.DEBUG=false.');
+      console.error('Per Spec 009 §Production builds, every emit / schema / ');
+      console.error('registrar dev-only branch must be gated on');
+      console.error('re-frame.interop/debug-enabled? so DCE removes it.');
+    }
+    if (!controlOk) {
+      console.error('Control bundle missing dev-only sentinels — the grep test');
+      console.error('would be vacuous.  A sentinel string was likely renamed,');
+      console.error('moved out of a gated branch, or removed.  Update');
+      console.error('DEV_ONLY_SENTINELS in this script to track the change.');
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -26,4 +26,33 @@
    ;; can see it.
    {:closure-defines {cljs-test-display.core/printing true}}
    :devtools  {:http-port 8021
-               :http-root "out/browser-test"}}}}
+               :http-root "out/browser-test"}}
+
+  ;; Production-elision probe (Spec 009 §Production builds, bead rf2-11hn).
+  ;;
+  ;; Compiles re-frame.elision-probe under :advanced with goog.DEBUG=false.
+  ;; The grep test (scripts/check-elision.cjs) asserts that string
+  ;; sentinels from the dev-gated branches do NOT appear in the bundle.
+  ;;
+  ;; The probe namespace exercises every gated surface (trace emit,
+  ;; schema validation, registrar trace emit). With goog.DEBUG=false the
+  ;; closure compiler constant-propagates re-frame.interop/debug-enabled?
+  ;; to false and DCEs the (when interop/debug-enabled? ...) bodies.
+  :elision-probe
+  {:target           :browser
+   :output-dir       "out/elision-probe"
+   :asset-path       "/elision-probe"
+   :compiler-options {:closure-defines {goog.DEBUG false}}
+   :modules          {:probe {:init-fn re-frame.elision-probe/run}}}
+
+  ;; Control build for the elision probe — same probe namespace, same
+  ;; :advanced compilation, but with goog.DEBUG=true. Used to confirm
+  ;; the grep methodology has signal: in this build, the dev-only
+  ;; sentinels MUST be present (otherwise the test's negative assertion
+  ;; would be vacuous).
+  :elision-probe-control
+  {:target           :browser
+   :output-dir       "out/elision-probe-control"
+   :asset-path       "/elision-probe-control"
+   :compiler-options {:closure-defines {goog.DEBUG true}}
+   :modules          {:probe {:init-fn re-frame.elision-probe/run}}}}}

--- a/implementation/src/re_frame/registrar.cljc
+++ b/implementation/src/re_frame/registrar.cljc
@@ -10,8 +10,17 @@
 
   Per Spec 005, machine guards/actions are machine-scoped (declared in
   the machine's :guards / :actions map) and NOT registered as standalone
-  kinds. The kinds set below is the closed v1 list."
-  (:require [re-frame.late-bind :as late-bind]))
+  kinds. The kinds set below is the closed v1 list.
+
+  ## Production elision
+
+  The :rf.registry/* trace emit sites in this namespace are gated on
+  `re-frame.interop/debug-enabled?` (per Spec 009 §Production builds) so
+  that the late-bind lookup, the call into trace/emit!, and the small
+  metadata map allocation all disappear from `:advanced` production
+  bundles where `goog.DEBUG` is `false`."
+  (:require [re-frame.interop   :as interop]
+            [re-frame.late-bind :as late-bind]))
 
 ;; ---- the kind set ---------------------------------------------------------
 
@@ -76,17 +85,25 @@
         ;; Only trace when the handler-fn actually changed — idempotent
         ;; re-registrations (same fn instance, common during ns reload of
         ;; static defs) would otherwise spam the trace stream.
-        (when different?
-          (when-let [emit! (late-bind/get-fn :trace/emit!)]
-            (emit! :registry :rf.registry/handler-replaced
-                   {:kind kind :id id :different-fn? true}))))
+        ;; The interop/debug-enabled? gate is OUTERMOST so :advanced +
+        ;; goog.DEBUG=false can constant-fold the entire branch (per
+        ;; Spec 009 §Production builds).  Inverting this — for example,
+        ;; `(when (and different? interop/debug-enabled?) ...)` —
+        ;; defeats the constant-fold because Closure can't statically
+        ;; rule out `different?`.
+        (when interop/debug-enabled?
+          (when different?
+            (when-let [emit! (late-bind/get-fn :trace/emit!)]
+              (emit! :registry :rf.registry/handler-replaced
+                     {:kind kind :id id :different-fn? true})))))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
       ;; this to track when fresh ids appear in the registry.
       :else
-      (when-let [emit! (late-bind/get-fn :trace/emit!)]
-        (emit! :registry :rf.registry/handler-registered
-               {:kind kind :id id})))
+      (when interop/debug-enabled?
+        (when-let [emit! (late-bind/get-fn :trace/emit!)]
+          (emit! :registry :rf.registry/handler-registered
+                 {:kind kind :id id}))))
     {:was previous :now metadata}))
 
 (defn unregister!
@@ -98,10 +115,11 @@
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires on explicit removal so hot-reload tools can update their
     ;; views. Only emit when something was actually present.
-    (when previous
-      (when-let [emit! (late-bind/get-fn :trace/emit!)]
-        (emit! :registry :rf.registry/handler-cleared
-               {:kind kind :id id}))))
+    (when interop/debug-enabled?
+      (when previous
+        (when-let [emit! (late-bind/get-fn :trace/emit!)]
+          (emit! :registry :rf.registry/handler-cleared
+                 {:kind kind :id id})))))
   nil)
 
 (defn clear-kind!
@@ -111,11 +129,12 @@
     (swap! kind->id->metadata dissoc kind)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires for each id so consumers see consistent registry transitions.
-    (when (seq previous-ids)
-      (when-let [emit! (late-bind/get-fn :trace/emit!)]
-        (doseq [id previous-ids]
-          (emit! :registry :rf.registry/handler-cleared
-                 {:kind kind :id id})))))
+    (when interop/debug-enabled?
+      (when (seq previous-ids)
+        (when-let [emit! (late-bind/get-fn :trace/emit!)]
+          (doseq [id previous-ids]
+            (emit! :registry :rf.registry/handler-cleared
+                   {:kind kind :id id}))))))
   nil)
 
 (defn clear-all!

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -115,10 +115,14 @@
   Returns true on pass (or when validation is elided / no schema is
   attached), false on fail. Failures emit
   :rf.error/schema-validation-failure with :where :event; the caller
-  is responsible for skipping the handler (recovery: :no-recovery)."
+  is responsible for skipping the handler (recovery: :no-recovery).
+
+  Per Spec 009 §Production builds the entire body lives inside a
+  `(when interop/debug-enabled? ...)` gate so :advanced+goog.DEBUG=false
+  DCE-elides every reason string, every keyword, and every malli call."
   [event-id event handler-meta]
-  (if (and interop/debug-enabled? (:spec handler-meta))
-    (let [schema (:spec handler-meta)]
+  (if interop/debug-enabled?
+    (if-let [schema (:spec handler-meta)]
       (if (malli-validate* schema event)
         true
         (do
@@ -136,7 +140,8 @@
                                                 schema ", got "
                                                 (type-of-value event) ".")
                               :recovery    :no-recovery})
-          false)))
+          false))
+      true)
     true))
 
 (defn validate-sub-return!
@@ -146,10 +151,13 @@
   Returns true on pass, false on fail. Failures emit
   :rf.error/schema-validation-failure with :where :sub-return; the
   caller is responsible for replacing the value with the
-  default (nil) per the :replaced-with-default recovery."
+  default (nil) per the :replaced-with-default recovery.
+
+  Per Spec 009 §Production builds the entire body lives inside a
+  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly."
   [sub-id query-v value sub-meta]
-  (if (and interop/debug-enabled? (:spec sub-meta))
-    (let [schema (:spec sub-meta)]
+  (if interop/debug-enabled?
+    (if-let [schema (:spec sub-meta)]
       (if (malli-validate* schema value)
         true
         (do
@@ -168,7 +176,8 @@
                                                 schema ", got "
                                                 (type-of-value value) ".")
                               :recovery    :replaced-with-default})
-          false)))
+          false))
+      true)
     true))
 
 (defn validate-cofx!
@@ -178,10 +187,13 @@
 
   Returns true on pass, false on fail. Failures emit
   :rf.error/schema-validation-failure with :where :cofx; the caller is
-  responsible for skipping the handler (recovery: :no-recovery)."
+  responsible for skipping the handler (recovery: :no-recovery).
+
+  Per Spec 009 §Production builds the entire body lives inside a
+  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly."
   [cofx-id event-id value cofx-meta]
-  (if (and interop/debug-enabled? (:spec cofx-meta))
-    (let [schema (:spec cofx-meta)]
+  (if interop/debug-enabled?
+    (if-let [schema (:spec cofx-meta)]
       (if (malli-validate* schema value)
         true
         (do
@@ -200,7 +212,8 @@
                                                 schema ", got "
                                                 (type-of-value value) ".")
                               :recovery    :no-recovery})
-          false)))
+          false))
+      true)
     true))
 
 ;; ---- late-bind hook registration ------------------------------------------

--- a/implementation/test/re_frame/elision_probe.cljs
+++ b/implementation/test/re_frame/elision_probe.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.elision-probe
+  "Production-elision probe (Spec 009 §Production builds).
+
+  This namespace is compiled under `:advanced` with
+  `:closure-defines {goog.DEBUG false}` by the `:elision-probe` shadow-cljs
+  build. The resulting JS bundle is then grep'd by
+  `scripts/check-elision.cjs` for dev-only string sentinels — they MUST
+  NOT appear, because their containing branches are gated on
+  `re-frame.interop/debug-enabled?` (an alias of `goog.DEBUG`).
+
+  The probe touches every gated surface so that, in a non-elided control
+  build (`goog.DEBUG=true`), the sentinels reliably *do* appear — that
+  control is what gives the elision assertion teeth.
+
+  Surfaces exercised:
+
+  - `register-trace-cb!` / `remove-trace-cb!` / `emit-trace!`
+    (Spec 009 §Emitting trace events)
+  - `reg-app-schema` + `validate-*!` (Spec 010 §Production builds)
+  - `register!` / `unregister!` / `clear-kind!` registrar trace emit
+    (Spec 009 §:op-type vocabulary — :rf.registry/*)
+  - dispatch through `dispatch-sync` to walk the router → events → fx
+    pipeline (Spec 009 §Where trace emission lives)
+
+  Note the probe does NOT need to assert anything at runtime; it exists
+  to root the dead-code-elimination graph at every surface. The grep
+  test is the assertion."
+  (:require [re-frame.core      :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas   :as schemas]
+            [re-frame.trace     :as trace]))
+
+;; ---- trace listener API ---------------------------------------------------
+
+(defn ^:export touch-trace! []
+  ;; Reach into every documented trace API so :advanced keeps the surface
+  ;; alive and we're testing the *body* gates, not surface-pruning.
+  (rf/register-trace-cb! ::probe (fn [_ev] nil))
+  (rf/emit-trace! :event :rf.probe/touched {:source :probe})
+  (rf/remove-trace-cb! ::probe)
+  ;; rf2-smee — trace ring buffer (Spec 009 §Retain-N).  These public
+  ;; entry points must elide their bodies in production.
+  (trace/configure-trace-buffer! {:depth 50})
+  (let [_buf (trace/trace-buffer {:op-type :event})]
+    nil)
+  (trace/clear-trace-buffer!))
+
+;; ---- schemas surface ------------------------------------------------------
+
+(defn ^:export touch-schemas! []
+  (rf/reg-app-schema [:user :name] :string)
+  (schemas/validate-app-db! {:user {:name "ok"}})
+  (schemas/validate-app-db! {:user {:name 42}}    :probe/event)
+  (schemas/validate-event!  :probe/event [:probe/event 1] {:spec :int})
+  (schemas/validate-cofx!   :probe/cofx :probe/event {} {:spec :map})
+  (schemas/validate-sub-return! :probe/sub [:probe/sub] :foo {:spec :keyword}))
+
+;; ---- registrar trace emit -------------------------------------------------
+
+(defn ^:export touch-registrar! []
+  ;; reg-event-db / dispatch-sync exercise registrar/register! and the
+  ;; router/events/fx trace emit sites in one shot.
+  (rf/reg-event-db :probe/init  (fn [_db _ev] {:counter 0}))
+  (rf/reg-event-db :probe/inc   (fn [db _ev] (update db :counter inc)))
+  (rf/reg-sub      :probe/count (fn [db _q] (:counter db)))
+  (rf/dispatch-sync [:probe/init])
+  (rf/dispatch-sync [:probe/inc])
+  ;; Re-register to fire :rf.registry/handler-replaced.
+  (rf/reg-event-db :probe/inc   (fn [db _ev] (update db :counter (fnil inc 0))))
+  ;; Exercise the registrar's unregister!/clear-kind! emit sites so that
+  ;; the :rf.registry/handler-cleared keyword has a path into the
+  ;; reachability graph too.
+  (registrar/unregister!  :event :probe/inc)
+  (registrar/clear-kind!  :sub))
+
+;; ---- entry point ----------------------------------------------------------
+
+(defn ^:export run []
+  (touch-trace!)
+  (touch-schemas!)
+  (touch-registrar!)
+  ;; Reference trace/emit! directly through the trace ns alias so its
+  ;; body, not just the public re-frame.core re-export, is reachable.
+  (trace/emit! :event :rf.probe/direct-touch {:source :probe}))


### PR DESCRIPTION
## Summary

- **Locks the production-elision contract** (Spec 009 §Production builds) behind a CI-grep verifier so future regressions fail loudly.
- **Closes two leaks** the audit found: `re-frame.schemas/{validate-event!,validate-sub-return!,validate-cofx!}` were not constant-folding (gate ordering), and `re-frame.registrar` trace emits were missing the outer `interop/debug-enabled?` gate. Bundle shrank ~10KB.
- **Documents the unified gate**: spec 009/010/Tool-Pair/API/Implementor-Checklist now name `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`) instead of the speculative `trace-enabled?` / `validation-enabled?` flags.

## What's in it

- `test/re_frame/elision_probe.cljs` — one-export probe namespace touching every gated surface (trace listener API, schema validators, registrar emit, trace-buffer, dispatch-id correlation).
- Two `:advanced` builds in `shadow-cljs.edn`:
  - `:elision-probe` (`goog.DEBUG=false`)
  - `:elision-probe-control` (`goog.DEBUG=true`)
- `scripts/check-elision.cjs` greps both bundles for 8 sentinel strings:
  - 4 schema reason fragments (`"App-db at path "`, `" payload failed schema "`, etc.)
  - 3 registrar trace ops (`rf.registry/handler-{registered,replaced,cleared}`)
  - 1 router trace op (`event/dispatched`)
- Contract: production must have ABSENT; control must have PRESENT.
- New CI job `cljs-elision` runs `npm run test:elision`.

## Why a control bundle

Without it, a refactor that moved a sentinel string out of a gated branch would silently turn the negative assertion vacuous. The control assertion fails when the methodology loses signal — both halves protect the test.

## Inline fixes

- `schemas.cljc` — restructured `(if (and interop/debug-enabled? (:spec ...)) ... true)` to `(if interop/debug-enabled? (if-let [schema ...] ...) true)`. The original form prevented Closure from constant-folding because it can't statically rule out the `:spec` lookup. Outermost-gate placement is now explicitly documented in 009 §Production builds as a contract.
- `registrar.cljc` — wrapped each `(when-let [emit! (late-bind/get-fn :trace/emit!)] ...)` in `(when interop/debug-enabled? ...)` so the late-bind lookup, the registry metadata map allocation, and the trace-op keyword all DCE.

## Pattern for future surfaces

Spelled out in 009 §Production-elision verification — when adding a new dev-only surface (e.g. rf2-shjf epoch-history):
1. Wrap the body in `(when interop/debug-enabled? ...)` *outermost*.
2. Touch the surface from `re-frame.elision-probe` so DCE reaches it.
3. Add a sentinel to `DEV_ONLY_SENTINELS` in `check-elision.cjs`.

## Test plan

- [x] `clojure -M:test` — 157/825 (matches main; this PR adds no JVM tests)
- [x] `npm run test:cljs` — 54/187 green
- [x] `npm run test:elision` — production bundle 8/8 sentinels ABSENT, control 8/8 PRESENT
- [ ] CI `cljs-elision` job green on PR
- [x] Spec docs (009/010/Tool-Pair/API/Implementor-Checklist) updated to name the actual flag