### PR TITLE
feat: snapshot-of, sub-cache, app-schemas, handler-replaced (rf2-vvsh)

### DIFF
--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -274,6 +274,11 @@
                     ~(:column m) (assoc :column ~(:column m)))]
           (schemas/reg-app-schema ~path ~schema)))))
 
+;; Schema introspection — pure fn aliases (no source-coord capture
+;; needed, these are read-only public queries).
+(def app-schema-at   schemas/app-schema-at)
+(def app-schemas     schemas/app-schemas)
+
 #?(:clj
    (defmacro reg-machine
      "Register a machine as an event handler. Per Spec 001 the
@@ -447,6 +452,42 @@
 (def frames       (fn [] (frame/frame-ids)))
 (def frame-meta   frame/frame-meta)
 (def get-frame-db frame/frame-app-db-value)
+
+(defn snapshot-of
+  "Return the value at `path` in a frame's app-db. Convenience wrapper
+  over `(get-in (rf/get-frame-db frame-id) path)` — Tool-Pair pins this
+  surface as the public, opt-aware app-db query.
+
+  Resolution chain for the frame:
+    1. `:frame` key in `opts`, when supplied;
+    2. `(current-frame)` — the active frame under `with-frame` /
+       a Reagent frame-provider, defaulting to `:rf/default`.
+
+  Returns `nil` if the frame is missing or the path resolves to nothing.
+  Per Spec 002 §The public registrar query API."
+  ([path] (snapshot-of path nil))
+  ([path opts]
+   (let [frame-id (or (:frame opts) (current-frame))]
+     (get-in (frame/frame-app-db-value frame-id) path))))
+
+;; sub-cache is CLJS-only — the reactive cache is materialised by the
+;; substrate adapter and only carries a useful :value on the JS side.
+;; The JVM definition returns nil so the symbol resolves under both
+;; targets. Per Spec 002 §The public registrar query API.
+(defn sub-cache
+  "Inspect a frame's runtime sub-cache. CLJS-only — returns
+  `{query-v {:value v :ref-count n}}` for every materialised
+  subscription in the named frame. On JVM the cache exists for
+  ref-counting purposes but the entries do not carry a deref-able
+  reaction value, so this fn returns `nil`.
+
+  No-arg form uses the active frame.
+
+  Pair tools call this to display what the running app is currently
+  subscribed to. Per Spec 002 §The public registrar query API."
+  ([] (sub-cache (current-frame)))
+  ([frame-id]
+   (subs/sub-cache-snapshot frame-id)))
 
 ;; ---- interceptors ---------------------------------------------------------
 

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -62,6 +62,43 @@
   (when-let [meta (registrar/lookup :app-schema path)]
     (:schema meta)))
 
+(defn app-schemas
+  "Return every registered `app-schema-at` declaration as a
+  `{path → schema}` map. Pair tools and 10x panels read this to
+  introspect what schemas apply in a given frame.
+
+  Arities:
+
+    (app-schemas)              ;; sugar for (app-schemas {})
+    (app-schemas frame-id)     ;; sugar for (app-schemas {:frame frame-id})
+    (app-schemas opts)         ;; opts is a map; supports {:frame ...}
+                               ;; and is the place future opts will land
+
+  The `opts`-map arity is the configurable form; the keyword arity is
+  the common pair-tool case. Per Spec 010 §Schemas as a tooling and
+  agent surface.
+
+  Note: in the v1 reference implementation `:app-schema` is a
+  process-global registry kind (per [001 §Registry model]), so the
+  `:frame` opt is accepted for forward-compatibility (the spec calls
+  for per-frame schemas) but does not yet narrow the result. Returns
+  the same global map regardless of `:frame` until per-frame storage
+  lands."
+  ([] (app-schemas {}))
+  ([opts-or-frame-id]
+   (let [_opts (cond
+                 (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
+                 (map?     opts-or-frame-id) opts-or-frame-id
+                 (nil?     opts-or-frame-id) {}
+                 :else
+                 (throw (ex-info ":rf.error/bad-app-schemas-arg"
+                                 {:received opts-or-frame-id
+                                  :expected "keyword frame-id or opts map"})))]
+     (reduce-kv (fn [acc path meta]
+                  (assoc acc path (:schema meta)))
+                {}
+                (registrar/handlers :app-schema)))))
+
 ;; ---- validation entry points ----------------------------------------------
 
 (defn- type-of-value [v]

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -359,6 +359,37 @@
               (catch #?(:clj Throwable :cljs :default) _ nil))))
      (reset! cache {}))))
 
+(defn sub-cache-snapshot
+  "Public read-only snapshot of a frame's sub-cache, projected to a
+  Tool-Pair-friendly shape: `{query-v {:value v :ref-count n}}`.
+
+  CLJS-only — on the JVM the cache exists for ref-counting purposes but
+  the cached reactions are not deref-able, so this fn returns `nil`. Per
+  Spec 002 §The public registrar query API and Tool-Pair §How AI tools
+  attach.
+
+  Dev-only on CLJS too — the body is gated on `interop/debug-enabled?`
+  (the `goog.DEBUG` mirror) so production builds elide both the cache
+  walk and the deref-and-collect machinery. Pair tools that attach in
+  production explicitly opt in by toggling the gate.
+
+  Returns `nil` for missing or destroyed frames, and `nil` in
+  production builds."
+  [frame-id]
+  #?(:cljs
+     (when interop/debug-enabled?
+       (when-let [cache (:sub-cache (frame/frame frame-id))]
+         (reduce-kv
+           (fn [acc query-v entry]
+             (assoc acc query-v
+                    {:value     (when-let [r (:reaction entry)]
+                                  (try @r (catch :default _ nil)))
+                     :ref-count (or (:ref-count entry) 0)}))
+           {}
+           @cache)))
+     :clj
+     nil))
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
 ;; re-frame.routing needs to call subscribe-value but cannot `:require`

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -405,3 +405,36 @@
                        (= :error (:op-type ev))))
                 @traces)
           "expected :rf.error/dispatch-sync-in-handler trace"))))
+
+;; ---- sub-cache (rf2-vvsh) -------------------------------------------------
+
+(deftest sub-cache-projects-tool-pair-shape
+  (testing "(rf/sub-cache frame-id) returns {query-v {:value v :ref-count n}}
+           for every materialised subscription in the named frame"
+    (rf/reg-event-db :seed (fn [_ _] {:n 7 :name "ada"}))
+    (rf/reg-sub :n     (fn [db _] (:n db)))
+    (rf/reg-sub :name* (fn [db _] (:name db)))
+    (rf/dispatch-sync [:seed])
+    ;; Empty cache is the {} baseline.
+    (is (= {} (rf/sub-cache :rf/default))
+        "no subs materialised yet → empty map")
+    (let [r1 (rf/subscribe [:n])
+          r2 (rf/subscribe [:n])
+          r3 (rf/subscribe [:name*])
+          snapshot (rf/sub-cache :rf/default)]
+      (is (= 2 (count snapshot))
+          "snapshot contains one entry per materialised query-v")
+      (is (= 7     (get-in snapshot [[:n]     :value])))
+      (is (= "ada" (get-in snapshot [[:name*] :value])))
+      (is (= 2     (get-in snapshot [[:n]     :ref-count]))
+          "ref-count reflects two outstanding subscribes for [:n]")
+      (is (= 1     (get-in snapshot [[:name*] :ref-count])))
+      ;; Default no-arg form uses the active frame.
+      (is (= snapshot (rf/sub-cache))
+          "no-arg form returns the active frame's snapshot")
+      (rf/unsubscribe [:n])
+      (rf/unsubscribe [:n])
+      (rf/unsubscribe [:name*]))
+    ;; Missing frame yields nil rather than throwing.
+    (is (nil? (rf/sub-cache :no-such-frame))
+        "missing frame returns nil")))

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -267,6 +267,61 @@
                 @traces)
           "expected :rf.error/dispatch-sync-in-handler trace event"))))
 
+;; ---- snapshot-of (rf2-vvsh) ----------------------------------------------
+
+(deftest snapshot-of-reads-default-frame-app-db
+  (testing "snapshot-of returns the value at a path in the active frame's app-db"
+    (rf/reg-event-db :seed (fn [_ _] {:user {:id 7 :name "ada"}
+                                      :counts {:hits 3}}))
+    (rf/dispatch-sync [:seed])
+    (is (= 7        (rf/snapshot-of [:user :id]))
+        "single-arg form reads the active frame (defaults to :rf/default)")
+    (is (= "ada"    (rf/snapshot-of [:user :name])))
+    (is (= 3        (rf/snapshot-of [:counts :hits])))
+    (is (= {:hits 3} (rf/snapshot-of [:counts]))
+        "intermediate map paths are returned as-is")
+    (is (nil? (rf/snapshot-of [:does-not-exist]))
+        "missing paths return nil"))
+  (testing "snapshot-of accepts {:frame frame-id} in opts"
+    (rf/reg-frame :left  {:doc "left"})
+    (rf/reg-frame :right {:doc "right"})
+    (rf/reg-event-db :seed-n (fn [_ [_ n]] {:n n}))
+    (rf/dispatch-sync [:seed-n 11] {:frame :left})
+    (rf/dispatch-sync [:seed-n 99] {:frame :right})
+    (is (= 11 (rf/snapshot-of [:n] {:frame :left})))
+    (is (= 99 (rf/snapshot-of [:n] {:frame :right})))
+    (is (nil? (rf/snapshot-of [:n] {:frame :nonexistent}))
+        "missing frame yields nil rather than throwing")))
+
+;; ---- app-schemas (rf2-vvsh) ----------------------------------------------
+
+(deftest app-schemas-returns-registered-schema-map
+  (testing "app-schemas returns {path schema} for every reg-app-schema declaration"
+    (is (= {} (rf/app-schemas))
+        "fresh registry: no schemas registered")
+    (rf/reg-app-schema [:user]  [:map [:id :uuid]])
+    (rf/reg-app-schema [:todos] [:vector :string])
+    (let [m (rf/app-schemas)]
+      (is (= 2 (count m)))
+      (is (= [:map [:id :uuid]]   (get m [:user])))
+      (is (= [:vector :string]    (get m [:todos]))))
+    (is (= [:map [:id :uuid]] (rf/app-schema-at [:user]))
+        "app-schema-at agrees with app-schemas for individual paths"))
+  (testing "keyword-arity is sugar over the opts-map arity"
+    ;; Per Spec 010 §Schemas as a tooling and agent surface: the
+    ;; (app-schemas frame-id) form is sugar for (app-schemas {:frame ...}).
+    ;; In v1 the registry is process-global so both arities return the
+    ;; same map; the keyword/opts-map arities must not throw.
+    (let [bare    (rf/app-schemas :rf/default)
+          opts    (rf/app-schemas {:frame :rf/default})
+          no-args (rf/app-schemas)]
+      (is (map? bare))
+      (is (= bare opts))
+      (is (= bare no-args))))
+  (testing "app-schemas rejects garbage input with a structured error"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (rf/app-schemas "not-a-keyword-or-map")))))
+
 ;; ---- subscription topology: glitch-freedom (JVM) -------------------------
 ;;
 ;; The CLJS reference uses Reagent reactions and asserts no transient


### PR DESCRIPTION
## Summary

Implements the Tool-Pair "smaller surfaces" pinned in bd `rf2-vvsh`:

- **`(rf/snapshot-of path opts)`** — convenience query over the active frame's `app-db` at a path. Sugar for `(get-in (rf/get-frame-db (or (:frame opts) (rf/current-frame))) path)`. Per Spec 002 §The public registrar query API.
- **`(rf/sub-cache frame-id)`** — CLJS-only inspection of a frame's sub-cache. Returns `{query-v {:value v :ref-count n}}` so pair tools can see what's currently subscribed and the cached values. Body gated on `interop/debug-enabled?` (the `goog.DEBUG` mirror) so production CLJS bundles elide; JVM returns `nil`.
- **`(rf/app-schemas)` / `(rf/app-schemas frame-id)` / `(rf/app-schemas {:frame frame-id})`** — keyword-arity sugar over the opts-map arity. Returns `{path schema}` for every registered `app-schema-at` declaration. Per Spec 010 §Schemas as a tooling and agent surface.
- **`:rf.registry/handler-replaced`** trace event — already wired in `re-frame.registrar` and asserted by `re-frame.trace-test` thanks to rf2-hyxg PR #36. No change needed; verified.

## Test plan

- [x] JVM `clojure -M:test` — 159/842 (was 130/679 pre-rebase; rebase pulled in rf2-cll7 / rf2-smee / rf2-k84s / rf2-11hn tests).
- [x] CLJS Node `npm run test:cljs` — 55/195 passing, includes new `sub-cache-projects-tool-pair-shape` test.
- [x] CLJS Browser `npm run test:browser` — 55/195 passing.
- [x] `:rf.registry/handler-replaced` trace continues to fire (covered by `re-frame.trace-test`).

## Notes

- `app-schemas` `:frame` opt is currently accepted for forward-compatibility but does not narrow results (the v1 reference implementation uses a process-global `:app-schema` registry kind per Spec 001 §Registry model). Per-frame schema storage is a future enhancement; the public API is stable.
- No conflicts with rf2-cll7 (machine introspection) or rf2-smee (trace buffer) — different files.