### PR TITLE
feat: epoch history + restore-epoch + register-epoch-cb (rf2-shjf, recovered from PR #43)

### DIFF
--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -261,7 +261,9 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
 | `epoch-history` | Fn | `(epoch-history frame-id)` → vector of epoch records | v1 (dev-only) | Tool-Pair |
-| `restore-epoch` | Fn | `(restore-epoch frame-id epoch-id)` → nil | v1 (dev-only) | Tool-Pair |
+| `restore-epoch` | Fn | `(restore-epoch frame-id epoch-id)` → boolean (true on success) | v1 (dev-only) | Tool-Pair |
+| `register-epoch-cb` | Fn | `(register-epoch-cb key callback-fn)` — assembled-epoch listener | v1 (dev-only) | Tool-Pair, 009 |
+| `remove-epoch-cb` | Fn | `(remove-epoch-cb key)` | v1 (dev-only) | Tool-Pair, 009 |
 | `(rf/configure :epoch-history {:depth N})` | — | See [§Configure keys](#configure-keys). | v1 (dev-only) | Tool-Pair |
 
 Trace events emitted by epoch-history machinery:
@@ -269,7 +271,12 @@ Trace events emitted by epoch-history machinery:
 | `:operation` | Tags |
 |---|---|
 | `:rf.epoch/snapshotted` | `:frame`, `:epoch-id`, `:event-id` |
-| `:rf.epoch/restored` | `:frame`, `:from-epoch-id`, `:to-epoch-id` |
+| `:rf.epoch/restored` | `:frame`, `:epoch-id` |
+| `:rf.epoch/restore-unknown-epoch` | `:frame`, `:epoch-id`, `:history-size` |
+| `:rf.epoch/restore-schema-mismatch` | `:frame`, `:epoch-id`, `:failing-paths` |
+| `:rf.epoch/restore-missing-handler` | `:frame`, `:epoch-id`, `:missing` |
+| `:rf.epoch/restore-version-mismatch` | `:frame`, `:epoch-id`, `:machine-id`, `:version-recorded`, `:version-current` |
+| `:rf.epoch/restore-during-drain` | `:frame`, `:epoch-id` |
 
 ### DOM source-coord annotations (CLJS reference, opt-in)
 

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -22,6 +22,7 @@
             [re-frame.routing :as routing]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]
+            [re-frame.epoch :as epoch]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -466,7 +467,37 @@
 (def emit-trace!         trace/emit!)
 (def trace-buffer        trace/trace-buffer)
 (def clear-trace-buffer! trace/clear-trace-buffer!)
-(def configure           trace/configure)
+
+;; ---- epoch history (Tool-Pair §Time-travel) ------------------------------
+;;
+;; Per Tool-Pair §Time-travel and Spec 009 §`register-epoch-cb`. Every
+;; drain-settle records an `:rf/epoch-record` per frame. The history is
+;; queryable; the listener API mirrors register-trace-cb!; restore-epoch
+;; rewinds the frame's app-db to a recorded epoch's `:db-after`.
+;;
+;; All elided in production via `interop/debug-enabled?`.
+
+(def epoch-history     epoch/epoch-history)
+(def restore-epoch     epoch/restore-epoch)
+(def register-epoch-cb epoch/register-epoch-cb!)
+(def remove-epoch-cb   epoch/remove-epoch-cb!)
+
+(defn configure
+  "Configure a runtime knob. Closed v1 keys (additive across versions
+  per Spec-ulation):
+
+    :epoch-history {:depth N}    — set the per-frame epoch ring depth
+                                    (default 50). 0 disables recording.
+    :trace-buffer  {:depth N}    — set the retain-N trace ring buffer
+                                    depth (default 200). 0 disables.
+
+  Per Tool-Pair §How AI tools attach. Future keys (e.g. :performance-api
+  per Spec 009) will land additively."
+  [knob opts]
+  (case knob
+    :epoch-history (epoch/configure! opts)
+    :trace-buffer  (trace/configure-trace-buffer! opts)
+    nil))
 
 ;; ---- substrate adapter ----------------------------------------------------
 

--- a/implementation/src/re_frame/epoch.cljc
+++ b/implementation/src/re_frame/epoch.cljc
@@ -1,0 +1,596 @@
+(ns re-frame.epoch
+  "Per-frame epoch history. Per Tool-Pair §Time-travel and Spec-Schemas
+  §`:rf/epoch-record`.
+
+  Every event-cascade settle (drain reaching empty queue) marks an epoch
+  boundary. The runtime records, per frame, an `:rf/epoch-record` with:
+
+    :epoch-id       opaque, unique within a frame's history
+    :frame          frame keyword
+    :committed-at   timestamp
+    :event-id       the event keyword that triggered the cascade
+    :trigger-event  the full event vector
+    :db-before      app-db snapshot before the cascade
+    :db-after       app-db snapshot after the drain settled
+    :trace-events   the raw trace stream that produced this epoch
+    :sub-runs       structured projection of subscription activity
+    :renders        structured projection of render activity
+    :effects        structured projection of fx-walk activity
+
+  Records are kept in a per-frame ring buffer (default depth 50,
+  configurable via `(rf/configure :epoch-history {:depth N})`). Older
+  records are evicted when the buffer is full.
+
+  The entire epoch-history machinery is gated on `interop/debug-enabled?`,
+  the same compile-time goog-define as the trace surface. Production
+  builds elide; no allocation, no storage, no overhead.
+
+  Listener API (`register-epoch-cb!` / `remove-epoch-cb!`) mirrors the
+  raw-trace listener API in `re-frame.trace`. Listeners receive the
+  fully-assembled record after it lands in the ring buffer.
+
+  Restore (`restore-epoch`) rewinds a frame's app-db to the named
+  epoch's `:db-after`. Six documented failure modes (Tool-Pair table)
+  each emit a structured trace under `:rf.epoch/*` and leave the
+  frame's app-db unchanged."
+  (:require [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.trace :as trace]))
+
+;; ---- configuration --------------------------------------------------------
+
+(def ^:private default-depth 50)
+
+(defonce ^:private config
+  ;; Currently a single key (:depth) but kept as a map so future
+  ;; (rf/configure :epoch-history {...}) extensions don't break the shape.
+  (atom {:depth default-depth}))
+
+(defn configure!
+  "Update the epoch-history configuration. Currently supports {:depth N}.
+  N must be a non-negative integer; 0 disables recording (assembled
+  records can still fire on listeners but nothing lands in the ring
+  buffer)."
+  [opts]
+  (when (map? opts)
+    (swap! config merge (select-keys opts [:depth])))
+  nil)
+
+(defn current-config
+  "Return the current epoch-history configuration map. Public for tests
+  and tools that want to display the current depth."
+  []
+  @config)
+
+(defn- depth []
+  (:depth @config default-depth))
+
+;; ---- the per-frame ring buffer --------------------------------------------
+;;
+;; Per Tool-Pair §Time-travel "Bounded history": last N epochs per frame.
+;; Stored as a map of frame-id → vector (oldest-first). New records append
+;; to the back; the front evicts when the buffer exceeds the configured
+;; depth.
+
+(defonce ^:private histories
+  (atom {}))
+
+(defn- append-record [history record d]
+  (let [history+ (conj (or history []) record)
+        n        (count history+)]
+    (if (and (pos? d) (> n d))
+      (subvec history+ (- n d))
+      history+)))
+
+(defn- record!
+  "Append a record into the frame's history. The depth cap is read from
+  the config atom on each append so runtime (rf/configure ...) takes
+  effect immediately."
+  [record]
+  (let [d (depth)]
+    (when (pos? d)
+      (let [frame-id (:frame record)]
+        (swap! histories update frame-id append-record record d)))))
+
+(defn epoch-history
+  "Return the vector of `:rf/epoch-record` values for the frame, oldest-
+  first. Empty vector when the frame has no recorded epochs (or when
+  depth is 0, which disables recording)."
+  [frame-id]
+  (or (get @histories frame-id) []))
+
+(defn clear-history!
+  "Drop every recorded epoch for every frame. Test fixtures use this."
+  []
+  (reset! histories {})
+  nil)
+
+(defn clear-frame-history!
+  "Drop every recorded epoch for the named frame."
+  [frame-id]
+  (swap! histories dissoc frame-id)
+  nil)
+
+;; ---- listener registry ----------------------------------------------------
+
+(defonce ^:private listeners (atom {}))
+
+(defn register-epoch-cb!
+  "Register a callback fired once per drain-settle with the assembled
+  `:rf/epoch-record`. The id can be any comparable value; passing the
+  same id twice replaces. Per Spec 009 §`register-epoch-cb` —
+  assembled-epoch listener.
+
+  The callback receives a fully-formed record with `:db-after`,
+  `:sub-runs`, `:renders`, `:effects`, and `:trace-events` populated.
+  The record has already been appended to the frame's `epoch-history`
+  ring buffer when the callback runs.
+
+  Listener exceptions are caught and isolated; one broken listener
+  cannot break the runtime or block other listeners.
+
+  Returns the id."
+  [id f]
+  (swap! listeners assoc id f)
+  id)
+
+(defn remove-epoch-cb!
+  "Remove the listener registered under id."
+  [id]
+  (swap! listeners dissoc id)
+  nil)
+
+(defn clear-epoch-cbs!
+  []
+  (reset! listeners {})
+  nil)
+
+(defn- notify-listeners! [record]
+  (doseq [[_ f] @listeners]
+    (try
+      (f record)
+      (catch #?(:clj Throwable :cljs :default) _
+        ;; Per Spec 009 §Listener invocation rules: listener failures
+        ;; are isolated. Continue notifying.
+        nil))))
+
+;; ---- per-cascade trace capture --------------------------------------------
+;;
+;; The drain runs traces through `re-frame.trace/emit!` which fans out to
+;; every registered listener. We register an internal listener that
+;; appends every event into a per-cascade buffer; when the cascade
+;; settles, the buffer is harvested and projected into the structured
+;; record slots.
+;;
+;; The buffer is keyed by frame-id so concurrent drains across frames
+;; don't co-mingle. Within a frame, drain-execution is single-threaded
+;; (per Spec 002 §Run-to-completion) so no further locking is needed.
+
+(defonce ^:private capture-buffers
+  ;; frame-id → vector of trace events (in arrival order)
+  (atom {}))
+
+(defn- buffer-event! [frame-id event]
+  (swap! capture-buffers update frame-id (fnil conj []) event))
+
+(defn- harvest-buffer! [frame-id]
+  (let [b (get @capture-buffers frame-id [])]
+    (swap! capture-buffers dissoc frame-id)
+    b))
+
+(defn- in-flight-buffer
+  "Return the in-flight capture buffer for frame-id, or empty vector."
+  [frame-id]
+  (get @capture-buffers frame-id []))
+
+(defn- capture-event!
+  "Internal trace-capture entry point published through `re-frame.late-bind`
+  under `:epoch/capture-event`. `re-frame.trace/emit!` and
+  `re-frame.trace/emit-error!` invoke this for every event so the
+  cascade buffer is populated regardless of which user listeners are
+  registered.
+
+  Going through late-bind (rather than registering as a listener via
+  `register-trace-cb!`) ensures the user-facing `clear-trace-cbs!`
+  call does NOT wipe the internal capture path — pair tools that reset
+  the trace stream between sessions can do so without losing epoch
+  recording.
+
+  Events whose tags don't carry `:frame` are skipped — they can't be
+  tied to a specific cascade. The `:rf.epoch/*` trace events emitted by
+  this namespace itself are also skipped, so a listener-driven cascade
+  never feeds back into a capture buffer."
+  [event]
+  (when interop/debug-enabled?
+    (let [op       (:operation event)
+          tags     (:tags event)
+          frame-id (or (:frame tags)
+                       (:frame event))]
+      (when (and frame-id
+                 (not (contains? #{:rf.epoch/snapshotted
+                                   :rf.epoch/restored
+                                   :rf.epoch/restore-unknown-epoch
+                                   :rf.epoch/restore-schema-mismatch
+                                   :rf.epoch/restore-missing-handler
+                                   :rf.epoch/restore-version-mismatch
+                                   :rf.epoch/restore-during-drain}
+                                 op)))
+        (buffer-event! frame-id event)))))
+
+;; ---- record projection ----------------------------------------------------
+
+(defn- project-sub-runs
+  "Walk the captured trace events and build the `:sub-runs` vector.
+  Each :sub/run trace event surfaces as one entry with `:recomputed?
+  true`. Per Spec-Schemas §`:rf/epoch-record`: a sub queried via the
+  rf2-719e cache hit path does NOT emit `:sub/run` (the body fn does
+  not re-run), so cache-hit subs are absent from this projection.
+  `:result-changed?` is currently true when the sub recomputed (the
+  raw trace doesn't yet carry the prior value); tools requiring
+  fine-grained change-tracking should consume the raw trace stream
+  until rf2 wires post-compute equality back through the trace."
+  [events]
+  (into []
+        (comp
+          (filter (fn [ev] (= :sub/run (:operation ev))))
+          (map (fn [ev]
+                 (let [t (:tags ev)]
+                   {:sub-id          (:sub-id t)
+                    :query-v         (:query-v t)
+                    :recomputed?     true
+                    :result-changed? true}))))
+        events))
+
+(defn- project-renders
+  "Walk the captured trace events and build the `:renders` vector.
+  Renders are emitted by the view layer as `:render/run` (or similar)
+  trace events with `:render-key`, `:triggered-by`, and `:elapsed-ms`
+  tags. Per Spec-Schemas §`:rf/epoch-record`: `:render-key` identity
+  is TBD pending rf2-t5tx — treated as opaque.
+
+  No render trace is emitted by the runtime today; this projection
+  remains an empty vector until the view layer is wired to emit
+  per-render traces. The shape is contracted now so consumers can
+  rely on the slot existing."
+  [events]
+  (into []
+        (comp
+          (filter (fn [ev]
+                    (or (= :render/run (:operation ev))
+                        (= :view/render (:operation ev)))))
+          (map (fn [ev]
+                 (let [t (:tags ev)]
+                   {:render-key   (:render-key t)
+                    :triggered-by (:triggered-by t)
+                    :elapsed-ms   (:elapsed-ms t)}))))
+        events))
+
+(defn- project-effects
+  "Walk the captured trace events and build the `:effects` vector.
+
+  The runtime emits a per-fx trace only on warning/error paths
+  (skipped-on-platform / fx-handler-exception / no-such-fx). Successful
+  fx execution is observable only as the wrapper :event/do-fx trace.
+  This projection therefore captures the *visible* outcomes:
+
+    :warning :rf.fx/skipped-on-platform   → :outcome :skipped-on-platform
+    :error :rf.error/fx-handler-exception → :outcome :error
+    :error :rf.error/no-such-fx           → :outcome :error
+
+  `:ok` outcomes are not emitted as separate per-fx traces by the
+  runtime today; tools needing successful-fx attribution should
+  consume the raw trace stream alongside this projection. Documented
+  asymmetry; closing this gap is a parallel bead."
+  [events]
+  (into []
+        (comp
+          (filter (fn [ev]
+                    (let [op (:operation ev)]
+                      (or (= :rf.fx/skipped-on-platform op)
+                          (= :rf.error/fx-handler-exception op)
+                          (= :rf.error/no-such-fx op)))))
+          (map (fn [ev]
+                 (let [op (:operation ev)
+                       t  (:tags ev)]
+                   (cond
+                     (= :rf.fx/skipped-on-platform op)
+                     {:fx-id   (:fx-id t)
+                      :args    (:fx-args t)
+                      :outcome :skipped-on-platform}
+
+                     (= :rf.error/fx-handler-exception op)
+                     {:fx-id       (:fx-id t)
+                      :args        (:fx-args t)
+                      :outcome     :error
+                      :error-trace (:id ev)}
+
+                     (= :rf.error/no-such-fx op)
+                     {:fx-id       (:fx-id t)
+                      :args        (:fx-args t)
+                      :outcome     :error
+                      :error-trace (:id ev)})))))
+        events))
+
+;; ---- record assembly ------------------------------------------------------
+
+(defonce ^:private epoch-counter (atom 0))
+
+(defn- next-epoch-id []
+  (swap! epoch-counter inc))
+
+(defn- find-trigger-event
+  "Walk the buffered events to find the first :event/run-start trace.
+  That carries the `:event` and `:event-id` for the cascade.
+
+  When the cascade had no successful event handler (e.g. an unknown
+  event id or a frame-destroyed dispatch), no :run-start fires; fall
+  back to the first event we can find with an `:event-id` tag."
+  [events]
+  (or
+    (some (fn [ev]
+            (when (and (= :event (:op-type ev))
+                       (= :event (:operation ev))
+                       (= :run-start (get-in ev [:tags :phase])))
+              {:event-id (get-in ev [:tags :event-id])
+               :event    (get-in ev [:tags :event])}))
+          events)
+    (some (fn [ev]
+            (when-let [eid (get-in ev [:tags :event-id])]
+              {:event-id eid
+               :event    (or (get-in ev [:tags :event])
+                             [eid])}))
+          events)))
+
+(defn- build-record
+  [frame-id db-before db-after events]
+  (let [{:keys [event-id event]} (find-trigger-event events)]
+    {:epoch-id      (next-epoch-id)
+     :frame         frame-id
+     :committed-at  (interop/now-ms)
+     :event-id      event-id
+     :trigger-event event
+     :db-before     db-before
+     :db-after      db-after
+     :trace-events  events
+     :sub-runs      (project-sub-runs events)
+     :renders       (project-renders events)
+     :effects       (project-effects events)}))
+
+;; ---- drain-settle hook ----------------------------------------------------
+
+(defn settle!
+  "Hook called by the router when a drain reaches an empty queue. Per
+  Tool-Pair §Time-travel: 'every drain-settle (queue empty) appends an
+  epoch-record. Atomic; partial drains don't record.'
+
+  `db-before` is the app-db value snapshotted before the cascade began;
+  `db-after` is the value after the drain settled. The captured trace
+  buffer is harvested here and projected into the record."
+  [frame-id db-before db-after]
+  (when interop/debug-enabled?
+    (let [events (harvest-buffer! frame-id)]
+      ;; A truly empty cascade (no events captured for this frame) is
+      ;; a degenerate case — likely a rejected dispatch. Skip recording
+      ;; rather than emit a misleading record.
+      (when (seq events)
+        (let [record (build-record frame-id db-before db-after events)]
+          (record! record)
+          (trace/emit! :rf.epoch :rf.epoch/snapshotted
+                       {:frame    frame-id
+                        :epoch-id (:epoch-id record)
+                        :event-id (:event-id record)})
+          (notify-listeners! record))))))
+
+(defn discard-buffer!
+  "Drop the in-flight capture buffer for frame-id. Used when a drain
+  is aborted (e.g. depth-exceeded, frame destroyed mid-drain) to
+  avoid leaking a partial buffer into the next cascade. No record
+  is committed."
+  [frame-id]
+  (when interop/debug-enabled?
+    (harvest-buffer! frame-id))
+  nil)
+
+;; ---- restore failure-mode predicates --------------------------------------
+
+(defn- malli-validate-fn
+  "Return the malli validate fn (resolved at call site) or nil."
+  []
+  #?(:clj  (try (requiring-resolve 'malli.core/validate)
+                (catch Throwable _ nil))
+     :cljs (try (resolve 'malli.core/validate)
+                (catch :default _ nil))))
+
+(defn- registered-app-schemas []
+  (registrar/handlers :app-schema))
+
+(defn- schema-validate-ok?
+  "True when the recorded db validates against every currently-registered
+  app-schema. Defensive: when no schemas are registered or Malli is
+  not on the path, we consider the db valid (we can't disprove it)."
+  [db]
+  (let [schemas  (registered-app-schemas)
+        validate (malli-validate-fn)]
+    (or (empty? schemas)
+        (nil? validate)
+        (every? (fn [[_path meta]]
+                  (let [schema (:schema meta)
+                        path   (:path meta)
+                        v      (get-in db path)]
+                    (try (validate schema v)
+                         (catch #?(:clj Throwable :cljs :default) _ true))))
+                schemas))))
+
+(defn- failing-paths-for [db]
+  (let [schemas  (registered-app-schemas)
+        validate (malli-validate-fn)]
+    (if (or (empty? schemas) (nil? validate))
+      []
+      (vec
+        (keep (fn [[_id meta]]
+                (let [schema (:schema meta)
+                      path   (:path meta)
+                      v      (get-in db path)]
+                  (when-not (try (validate schema v)
+                                 (catch #?(:clj Throwable :cljs :default) _ true))
+                    path)))
+              schemas)))))
+
+(defn- missing-references
+  "Walk the recorded db for ids that are no longer present in the
+  registrar. Closed v1 surface — `:rf/machines` (machine-id keys must
+  reference a registered :head/machine snapshot via the machine
+  registry) and `:route` (`:id` must reference a registered :route).
+
+  Returns a vector of {:kind <kind> :id <id>} entries. Empty when
+  every reference resolves."
+  [db]
+  (let [missing (atom [])]
+    ;; Machines under :rf/machines: re-frame.machines registers under :head.
+    (doseq [[machine-id _snapshot] (:rf/machines db)]
+      (when-not (registrar/lookup :head machine-id)
+        (swap! missing conj {:kind :head :id machine-id})))
+    ;; Active route
+    (when-let [route-id (get-in db [:route :id])]
+      (when-not (registrar/lookup :route route-id)
+        (swap! missing conj {:kind :route :id route-id})))
+    @missing))
+
+(defn- machine-version-mismatch
+  "Walk the recorded db's `:rf/machines` for snapshot version drift.
+  Each snapshot may carry `:rf/snapshot-version`; the currently-
+  registered machine carries `:version` in its meta. When they
+  differ, return the first mismatch as
+  `{:machine-id <id> :recorded <int> :current <int>}`. nil when no
+  mismatch is found."
+  [db]
+  (some (fn [[machine-id snapshot]]
+          (let [recorded (:rf/snapshot-version snapshot)]
+            (when (some? recorded)
+              (let [meta    (registrar/lookup :head machine-id)
+                    current (:version meta)]
+                (when (and (some? current) (not= recorded current))
+                  {:machine-id machine-id
+                   :recorded   recorded
+                   :current    current})))))
+        (:rf/machines db)))
+
+;; ---- restore --------------------------------------------------------------
+
+(defn- find-epoch
+  [frame-id epoch-id]
+  (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
+        (epoch-history frame-id)))
+
+(defn- emit-restore-failure!
+  [operation tags]
+  (trace/emit-error! operation
+                     (assoc tags :recovery :no-recovery)))
+
+(defn restore-epoch
+  "Rewind the frame's `app-db` to the named epoch's `:db-after`. Emits
+  `:rf.epoch/restored` on success.
+
+  Failure modes (each is a no-op on `app-db` and emits a structured
+  error trace):
+
+    :rf.error/no-such-handler          (kind :frame) — frame not registered
+    :rf.epoch/restore-during-drain     — called while drain is in flight
+    :rf.epoch/restore-unknown-epoch    — epoch-id not in current history
+    :rf.epoch/restore-schema-mismatch  — db-after no longer validates
+    :rf.epoch/restore-missing-handler  — referenced registration absent
+    :rf.epoch/restore-version-mismatch — machine snapshot version drift
+
+  Returns `true` on success, `false` on any failure."
+  [frame-id epoch-id]
+  (if-not interop/debug-enabled?
+    false
+    (let [frame-record (frame/frame frame-id)]
+      (cond
+        ;; (1) Frame registered?
+        (nil? frame-record)
+        (do
+          (emit-restore-failure! :rf.error/no-such-handler
+                                 {:kind     :frame
+                                  :frame-id frame-id})
+          false)
+
+        ;; (2) In-flight drain?
+        (let [router (:router frame-record)
+              r      (when router @router)]
+          (and r (or (:in-drain? r) (:in-sync-drain? r))))
+        (do
+          (emit-restore-failure! :rf.epoch/restore-during-drain
+                                 {:frame    frame-id
+                                  :epoch-id epoch-id})
+          false)
+
+        :else
+        (let [history (epoch-history frame-id)
+              epoch   (find-epoch frame-id epoch-id)]
+          (cond
+            ;; (3) Epoch present in current history?
+            (nil? epoch)
+            (do
+              (emit-restore-failure! :rf.epoch/restore-unknown-epoch
+                                     {:frame        frame-id
+                                      :epoch-id     epoch-id
+                                      :history-size (count history)})
+              false)
+
+            :else
+            (let [db-target (:db-after epoch)]
+              (cond
+                ;; (4) Schema mismatch?
+                (not (schema-validate-ok? db-target))
+                (do
+                  (emit-restore-failure! :rf.epoch/restore-schema-mismatch
+                                         {:frame                  frame-id
+                                          :epoch-id               epoch-id
+                                          :schema-digest-recorded nil
+                                          :schema-digest-current  nil
+                                          :failing-paths          (failing-paths-for db-target)})
+                  false)
+
+                ;; (5) Missing handler referenced from db?
+                (let [missing (missing-references db-target)]
+                  (seq missing))
+                (do
+                  (emit-restore-failure! :rf.epoch/restore-missing-handler
+                                         {:frame    frame-id
+                                          :epoch-id epoch-id
+                                          :missing  (missing-references db-target)})
+                  false)
+
+                ;; (6) Machine snapshot version drift?
+                (let [m (machine-version-mismatch db-target)]
+                  (some? m))
+                (let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
+                  (emit-restore-failure! :rf.epoch/restore-version-mismatch
+                                         {:frame            frame-id
+                                          :epoch-id         epoch-id
+                                          :machine-id       machine-id
+                                          :version-recorded recorded
+                                          :version-current  current})
+                  false)
+
+                :else
+                (let [container (frame/get-frame-db frame-id)]
+                  (adapter/replace-container! container db-target)
+                  (trace/emit! :rf.epoch :rf.epoch/restored
+                               {:frame    frame-id
+                                :epoch-id epoch-id})
+                  true)))))))))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; The router calls into settle! at drain-empty. Publishing through the
+;; late-bind registry keeps router.cljc free of a require on this ns.
+
+(late-bind/set-fn! :epoch/settle!          settle!)
+(late-bind/set-fn! :epoch/discard-buffer!  discard-buffer!)
+(late-bind/set-fn! :epoch/in-flight-buffer in-flight-buffer)
+(late-bind/set-fn! :epoch/capture-event    capture-event!)

--- a/implementation/src/re_frame/late_bind.cljc
+++ b/implementation/src/re_frame/late_bind.cljc
@@ -43,7 +43,11 @@
     :schemas/validate-cofx!      re-frame.schemas/validate-cofx!
     :schemas/validate-sub-return! re-frame.schemas/validate-sub-return!
     :subs/subscribe-value     re-frame.subs/subscribe-value
-    :ssr/render-tree-hash     re-frame.ssr/render-tree-hash"}
+    :ssr/render-tree-hash     re-frame.ssr/render-tree-hash
+    :epoch/settle!            re-frame.epoch/settle!
+    :epoch/discard-buffer!    re-frame.epoch/discard-buffer!
+    :epoch/in-flight-buffer   re-frame.epoch/in-flight-buffer
+    :epoch/capture-event      re-frame.epoch/capture-event!"}
   hooks
   (atom {}))
 

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -236,13 +236,25 @@
 
   When the depth limit is hit, emit :rf.error/drain-depth-exceeded with
   :depth, :queue-size, and :last-event tags, then halt (the remaining
-  queued events are discarded)."
+  queued events are discarded).
+
+  Per Tool-Pair §Time-travel: every drain-settle (queue empty) appends
+  an `:rf/epoch-record` to the frame's epoch history. Atomic — partial
+  drains (e.g. depth-exceeded) discard the in-flight capture buffer
+  rather than commit a misleading record. The settle! / discard-buffer!
+  hooks are looked up through late-bind so this namespace stays free of
+  a require on re-frame.epoch."
   [frame-id]
   (let [frame-record (frame/frame frame-id)]
     (when frame-record
       (let [router       (:router frame-record)
             drain-depth  (get-in frame-record [:config :drain-depth] drain-depth-default)
-            last-event-a (atom nil)]
+            last-event-a (atom nil)
+            ;; Per Tool-Pair §Time-travel: snapshot `:db-before` at the
+            ;; instant the drain begins so the eventual `:rf/epoch-record`
+            ;; can carry the pre-cascade state regardless of how many
+            ;; intermediate handlers commit `:db`.
+            db-before    (frame/frame-app-db-value frame-id)]
         (swap! router assoc :in-drain? true)
         (try
           (loop [depth 0]
@@ -255,12 +267,24 @@
                                     :queue-size (count queue)
                                     :last-event @last-event-a
                                     :recovery   :no-recovery})
-                (swap! router assoc :queue interop/empty-queue :scheduled? false))
+                (swap! router assoc :queue interop/empty-queue :scheduled? false)
+                ;; Per Tool-Pair §Time-travel: a depth-exceeded drain is
+                ;; a *partial* drain — discard the in-flight capture
+                ;; buffer rather than emit a misleading epoch record.
+                (when-let [discard! (late-bind/get-fn :epoch/discard-buffer!)]
+                  (discard! frame-id)))
 
               :else
               (let [{:keys [queue]} @router]
                 (if (empty? queue)
-                  (swap! router assoc :scheduled? false)
+                  (do
+                    (swap! router assoc :scheduled? false)
+                    ;; Drain settle: queue is empty after at least one
+                    ;; processed event. Commit the epoch record.
+                    (when (pos? depth)
+                      (when-let [settle! (late-bind/get-fn :epoch/settle!)]
+                        (let [db-after (frame/frame-app-db-value frame-id)]
+                          (settle! frame-id db-before db-after)))))
                   (let [envelope (peek queue)]
                     (reset! last-event-a (:event envelope))
                     (swap! router update :queue pop)

--- a/implementation/src/re_frame/trace.cljc
+++ b/implementation/src/re_frame/trace.cljc
@@ -147,6 +147,20 @@
 
 ;; ---- emission -------------------------------------------------------------
 
+(defn- deliver-to-epoch-capture!
+  "Forward the assembled trace event to the epoch-capture buffer if
+  re-frame.epoch has registered its capture hook. The capture hook
+  is published through `re-frame.late-bind` (key `:epoch/capture-event`);
+  routing through there keeps this namespace free of a require on
+  re-frame.epoch and ensures `clear-trace-cbs!` (a user-facing API) does
+  NOT wipe the internal capture path. Per Tool-Pair §Time-travel and
+  Spec 009 §`register-epoch-cb`."
+  [event]
+  (when-let [capture (late-bind/get-fn :epoch/capture-event)]
+    (try
+      (capture event)
+      (catch #?(:clj Throwable :cljs :default) _ nil))))
+
 (defn emit!
   "Emit a trace event. In production builds (when interop/debug-enabled?
   is false at compile time), Closure DCE removes the body and the call
@@ -174,6 +188,7 @@
                      source   (assoc :source source)
                      recovery (assoc :recovery recovery))]
       (push-to-buffer! event)
+      (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]
         (try
           (f event)
@@ -196,6 +211,7 @@
                  :tags      (merge {:category error-operation} tags)
                  :recovery  (:recovery tags :no-recovery)}]
       (push-to-buffer! event)
+      (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]
         (try
           (f event)

--- a/implementation/test/re_frame/epoch_test.clj
+++ b/implementation/test/re_frame/epoch_test.clj
@@ -1,0 +1,527 @@
+(ns re-frame.epoch-test
+  "Tool-Pair §Time-travel — epoch recording, query, listener, restore.
+
+  Bead rf2-shjf coverage:
+
+    1. Recording — drain-settle commits a record; multi-event cascades
+       commit one record (not one per event).
+    2. Per-frame isolation — two frames, each gets its own ring.
+    3. Ring depth cap — dispatch >depth events; oldest get evicted.
+    4. Configurable depth — `(rf/configure :epoch-history {:depth N})`.
+    5. Listener — `register-epoch-cb` fires per drain-settle with the
+       assembled record; same-key replaces; remove unhooks; exception
+       isolation.
+    6. Restore happy path — `restore-epoch` rewinds app-db.
+    7. The six documented failure modes — each fires the documented
+       trace under `:rf.epoch/*` and leaves app-db unchanged.
+    8. Sub-runs / renders / effects projection from the trace stream."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
+            [re-frame.epoch :as epoch]))
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (trace/clear-trace-cbs!)
+  (epoch/clear-history!)
+  (epoch/clear-epoch-cbs!)
+  (epoch/configure! {:depth 50})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- record-trace! []
+  (let [recorded (atom [])]
+    (rf/register-trace-cb! ::recorder (fn [ev] (swap! recorded conj ev)))
+    recorded))
+
+(defn- has-error-op? [events op]
+  (some (fn [ev] (and (= :error (:op-type ev))
+                      (= op     (:operation ev))))
+        events))
+
+;; ---- recording -------------------------------------------------------------
+
+(deftest record-on-drain-settle
+  (testing "every drain-settle commits exactly one :rf/epoch-record"
+    (rf/reg-frame :test/main {:doc "epoch test frame"})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
+      (is (= 3 (count history)) "one record per drain-settle")
+      (is (every? :epoch-id history))
+      (is (every? :committed-at history))
+      (is (= [[:seed] [:inc] [:inc]]
+             (mapv :trigger-event history))
+          "trigger-event preserved per record"))))
+
+(deftest record-shape-canonical
+  (testing "an :rf/epoch-record carries the canonical shape"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+    (let [r (last (rf/epoch-history :test/main))]
+      (is (= :test/main (:frame r)))
+      (is (= :inc       (:event-id r)))
+      (is (= [:inc]     (:trigger-event r)))
+      (is (= {:n 0}     (:db-before r))
+          "db-before is the pre-cascade snapshot")
+      (is (= {:n 1}     (:db-after r))
+          "db-after is the post-settle snapshot")
+      (is (vector? (:trace-events r)))
+      (is (vector? (:sub-runs r)))
+      (is (vector? (:renders r)))
+      (is (vector? (:effects r))))))
+
+(deftest record-multi-event-cascade
+  (testing "a multi-event cascade (run-to-completion) commits ONE record"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:order []}))
+    (rf/reg-event-fx :outer
+      (fn [{:keys [db]} _]
+        {:db (update db :order conj :outer)
+         :fx [[:dispatch [:inner-1]]
+              [:dispatch [:inner-2]]]}))
+    (rf/reg-event-db :inner-1 (fn [db _] (update db :order conj :inner-1)))
+    (rf/reg-event-db :inner-2 (fn [db _] (update db :order conj :inner-2)))
+
+    (rf/dispatch-sync [:seed]  {:frame :test/main})
+    (rf/dispatch-sync [:outer] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)
+          last-r  (last history)]
+      ;; Two cascades: :seed and :outer (which itself cascades inner-1 / inner-2).
+      (is (= 2 (count history))
+          "the entire :outer cascade is one epoch, not three")
+      (is (= :outer (:event-id last-r))
+          "the outer event is the trigger of the cascade")
+      (is (= {:order []}
+             (:db-before last-r)))
+      (is (= {:order [:outer :inner-1 :inner-2]}
+             (:db-after last-r))))))
+
+;; ---- per-frame isolation ---------------------------------------------------
+
+(deftest per-frame-isolation
+  (testing "each frame has its own epoch ring; cascades don't co-mingle"
+    (rf/reg-frame :frame/a {})
+    (rf/reg-frame :frame/b {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :frame/a})
+    (rf/dispatch-sync [:inc]  {:frame :frame/a})
+
+    (rf/dispatch-sync [:seed] {:frame :frame/b})
+    (rf/dispatch-sync [:inc]  {:frame :frame/b})
+    (rf/dispatch-sync [:inc]  {:frame :frame/b})
+
+    (is (= 2 (count (rf/epoch-history :frame/a))))
+    (is (= 3 (count (rf/epoch-history :frame/b))))
+
+    (is (every? #(= :frame/a (:frame %)) (rf/epoch-history :frame/a)))
+    (is (every? #(= :frame/b (:frame %)) (rf/epoch-history :frame/b)))))
+
+;; ---- ring depth ------------------------------------------------------------
+
+(deftest ring-depth-evicts-oldest
+  (testing "when the ring fills, oldest records are evicted FIFO"
+    (rf/configure :epoch-history {:depth 3})
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (dotimes [_ 5] (rf/dispatch-sync [:inc] {:frame :test/main}))
+
+    (let [history (rf/epoch-history :test/main)
+          dbs     (mapv :db-after history)]
+      (is (= 3 (count history)) "ring depth caps history at 3")
+      (is (= [{:n 3} {:n 4} {:n 5}] dbs)
+          "the three most-recent are kept; oldest evicted"))))
+
+(deftest depth-zero-disables-recording
+  (testing "depth 0 disables ring recording"
+    (rf/configure :epoch-history {:depth 0})
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    (is (= [] (rf/epoch-history :test/main)))))
+
+;; ---- listener --------------------------------------------------------------
+
+(deftest listener-fires-per-drain-settle
+  (testing "register-epoch-cb fires once per drain-settle with the assembled record"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-cb ::watcher (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+
+      (is (= 3 (count @seen)))
+      (is (= [:seed :inc :inc]
+             (mapv :event-id @seen)))
+      (is (every? #(contains? % :db-after) @seen))
+      (is (every? #(contains? % :sub-runs) @seen))
+      (is (every? #(contains? % :renders) @seen))
+      (is (every? #(contains? % :effects) @seen))
+
+      (rf/remove-epoch-cb ::watcher))))
+
+(deftest listener-same-key-replaces
+  (testing "register-epoch-cb under the same key replaces the prior listener"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+
+    (let [a (atom 0)
+          b (atom 0)]
+      (rf/register-epoch-cb ::w (fn [_] (swap! a inc)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (is (= 1 @a))
+
+      (rf/register-epoch-cb ::w (fn [_] (swap! b inc)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+
+      (is (= 1 @a) "the original listener no longer fires after re-register under the same key")
+      (is (= 1 @b) "the replacement listener fires"))))
+
+(deftest listener-remove
+  (testing "remove-epoch-cb stops the listener"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (let [count-a (atom 0)]
+      (rf/register-epoch-cb ::w (fn [_] (swap! count-a inc)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/remove-epoch-cb ::w)
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+
+      (is (= 1 @count-a) "after removal, the listener does not accumulate"))))
+
+(deftest listener-exception-isolation
+  (testing "a throwing epoch listener does not crash other listeners or the runtime"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+
+    (let [survivor (atom 0)
+          throws   (atom 0)]
+      (rf/register-epoch-cb ::throwing
+        (fn [_] (swap! throws inc) (throw (ex-info "tool blew" {}))))
+      (rf/register-epoch-cb ::survivor
+        (fn [_] (swap! survivor inc)))
+
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+
+      (is (= 2 @throws)   "throwing listener is invoked")
+      (is (= 2 @survivor) "survivor listener accumulates")
+      (is (= 2 (count (rf/epoch-history :test/main)))
+          "epoch history records both cascades despite the throwing listener"))))
+
+;; ---- restore happy path ----------------------------------------------------
+
+(deftest restore-rewinds-app-db
+  (testing "restore-epoch sets app-db to the named epoch's :db-after"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})       ;; n=1
+    (rf/dispatch-sync [:inc]  {:frame :test/main})       ;; n=2
+    (rf/dispatch-sync [:inc]  {:frame :test/main})       ;; n=3
+
+    (let [history     (rf/epoch-history :test/main)
+          target      (nth history 1)        ;; the :inc that landed n=1
+          target-eid  (:epoch-id target)
+          recorded    (record-trace!)
+          ok?         (rf/restore-epoch :test/main target-eid)]
+      (is (true? ok?) "restore returned true")
+      (is (= {:n 1} (rf/get-frame-db :test/main))
+          "app-db rewound to the named epoch's :db-after")
+
+      (let [events @recorded]
+        (is (some (fn [ev]
+                    (and (= :rf.epoch/restored (:operation ev))
+                         (= target-eid (:epoch-id (:tags ev)))))
+                  events)
+            ":rf.epoch/restored fired with the matching epoch-id")))))
+
+;; ---- restore failure modes -------------------------------------------------
+
+(deftest restore-failure-unknown-frame
+  (testing "restore-epoch on an unknown frame fires :rf.error/no-such-handler (kind :frame)"
+    (let [recorded (record-trace!)
+          ok?      (rf/restore-epoch :no/such/frame :ignored)]
+      (is (false? ok?))
+      (let [events @recorded]
+        (is (has-error-op? events :rf.error/no-such-handler))
+        (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %) events)]
+          (is (= :frame (:kind (:tags ev))))
+          (is (= :no/such/frame (:frame-id (:tags ev)))))))))
+
+(deftest restore-failure-unknown-epoch
+  (testing "restore-epoch with an epoch-id not in history fires :rf.epoch/restore-unknown-epoch"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    (let [pre        (rf/get-frame-db :test/main)
+          recorded   (record-trace!)
+          ok?        (rf/restore-epoch :test/main :no-such-epoch)]
+      (is (false? ok?))
+      (is (= pre (rf/get-frame-db :test/main)) "app-db unchanged")
+      (let [events @recorded
+            ev     (some #(when (= :rf.epoch/restore-unknown-epoch (:operation %)) %) events)]
+        (is (some? ev) ":rf.epoch/restore-unknown-epoch fired")
+        (is (= :no-such-epoch (:epoch-id (:tags ev))))
+        (is (number? (:history-size (:tags ev))))))))
+
+(deftest restore-failure-schema-mismatch
+  (testing "restore-epoch on a db that no longer validates fires :rf.epoch/restore-schema-mismatch"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :set-bad
+      ;; Commit a value that LATER fails a tightened schema. We dispatch
+      ;; this BEFORE the schema is registered so the pre-restore commit
+      ;; succeeds; tightening the schema happens between dispatch and
+      ;; restore.
+      (fn [db _] (assoc db :n "not-an-int")))
+
+    (rf/dispatch-sync [:seed]    {:frame :test/main})
+    (rf/dispatch-sync [:set-bad] {:frame :test/main})
+    ;; Reset the db to something valid so we can verify the restore
+    ;; doesn't run when schema mismatch is detected.
+    (rf/dispatch-sync [:seed]    {:frame :test/main})
+
+    ;; Now register a schema that the bad-record's :db-after fails.
+    (rf/reg-app-schema [:n] [:int])
+
+    (let [pre      (rf/get-frame-db :test/main)
+          history  (rf/epoch-history :test/main)
+          target   (some (fn [r]
+                           (when (= "not-an-int" (:n (:db-after r)))
+                             r))
+                         history)
+          recorded (record-trace!)
+          ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+      (is (some? target) "we recorded the bad-db cascade")
+      (is (false? ok?)   "restore rejected")
+      (is (= pre (rf/get-frame-db :test/main)) "app-db unchanged")
+      (let [ev (some (fn [ev]
+                       (when (= :rf.epoch/restore-schema-mismatch (:operation ev))
+                         ev))
+                     @recorded)]
+        (is (some? ev) ":rf.epoch/restore-schema-mismatch fired")
+        (is (vector? (:failing-paths (:tags ev))))))))
+
+(deftest restore-failure-missing-handler
+  (testing "restore-epoch on a db referencing a now-unregistered head/route fires :rf.epoch/restore-missing-handler"
+    (rf/reg-frame :test/main {})
+    ;; Register a route so the recorded :route reference resolves; we'll
+    ;; later unregister it to trigger the missing-handler failure.
+    (rf/reg-route :route/users {:path "/users"})
+    (rf/reg-event-db :route-to (fn [db _] (assoc db :route {:id :route/users})))
+    (rf/dispatch-sync [:route-to] {:frame :test/main})
+    ;; A subsequent dispatch so the history holds at least one record
+    ;; whose :db-after references :route/users.
+    (let [target (last (rf/epoch-history :test/main))]
+      ;; Now blow away the route registration.
+      (registrar/unregister! :route :route/users)
+
+      (let [recorded (record-trace!)
+            pre      (rf/get-frame-db :test/main)
+            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+        (is (false? ok?))
+        (is (= pre (rf/get-frame-db :test/main)) "app-db unchanged")
+        (let [ev (some (fn [ev]
+                         (when (= :rf.epoch/restore-missing-handler (:operation ev))
+                           ev))
+                       @recorded)]
+          (is (some? ev) ":rf.epoch/restore-missing-handler fired")
+          (let [missing (:missing (:tags ev))]
+            (is (vector? missing))
+            (is (some #(and (= :route (:kind %))
+                            (= :route/users (:id %)))
+                      missing))))))))
+
+(deftest restore-failure-version-mismatch
+  (testing "restore-epoch on a db whose machine snapshot version drifts fires :rf.epoch/restore-version-mismatch"
+    (rf/reg-frame :test/main {})
+    ;; Register a machine head with version 1, then commit a snapshot
+    ;; carrying :rf/snapshot-version 1.
+    (registrar/register! :head :machine/tl
+      {:version 1 :handler-fn (fn [_ _] nil)})
+    (rf/reg-event-db :put-snap
+      (fn [db _]
+        (assoc-in db [:rf/machines :machine/tl]
+                  {:state :red :data {} :rf/snapshot-version 1})))
+    (rf/dispatch-sync [:put-snap] {:frame :test/main})
+
+    (let [target (last (rf/epoch-history :test/main))]
+      ;; Hot-reload bumps the machine version.
+      (registrar/register! :head :machine/tl
+        {:version 2 :handler-fn (fn [_ _] nil)})
+
+      (let [recorded (record-trace!)
+            pre      (rf/get-frame-db :test/main)
+            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+        (is (false? ok?))
+        (is (= pre (rf/get-frame-db :test/main)))
+        (let [ev (some (fn [ev]
+                         (when (= :rf.epoch/restore-version-mismatch (:operation ev))
+                           ev))
+                       @recorded)]
+          (is (some? ev) ":rf.epoch/restore-version-mismatch fired")
+          (is (= :machine/tl (:machine-id (:tags ev))))
+          (is (= 1 (:version-recorded (:tags ev))))
+          (is (= 2 (:version-current  (:tags ev)))))))))
+
+(deftest restore-failure-during-drain
+  (testing "restore-epoch called from inside a drain fires :rf.epoch/restore-during-drain"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    (let [target   (last (rf/epoch-history :test/main))
+          recorded (record-trace!)
+          attempt  (atom nil)]
+      ;; A handler that calls restore-epoch synchronously during a drain.
+      (rf/reg-event-db :try-restore
+        (fn [db _]
+          (reset! attempt (rf/restore-epoch :test/main (:epoch-id target)))
+          (assoc db :n 99)))
+      (rf/dispatch-sync [:try-restore] {:frame :test/main})
+
+      (is (false? @attempt) "restore returned false from inside the drain")
+      (let [ev (some (fn [ev]
+                       (when (= :rf.epoch/restore-during-drain (:operation ev))
+                         ev))
+                     @recorded)]
+        (is (some? ev) ":rf.epoch/restore-during-drain fired")
+        (is (= :test/main (:frame (:tags ev))))))))
+
+;; ---- structured projections ------------------------------------------------
+
+(deftest sub-runs-projection
+  (testing ":sub-runs reflects each :sub/run trace under the cascade"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-sub :n     (fn [db _] (:n db)))
+    (rf/reg-sub :n*2   :<- [:n] (fn [n _] (* 2 (or n 0))))
+
+    ;; Force a sub-run inside a handler (subscribe-value emits :sub/run
+    ;; from compute-sub when no cache exists for the query, AND from the
+    ;; reactive path when a fresh subscription materialises). Either
+    ;; way, the cascade contains :sub/run traces.
+    (rf/reg-event-fx :read-sub
+      (fn [_ _]
+        ;; Read both subs to exercise layer-1 and layer-2.
+        (let [_v (rf/subscribe-value :test/main [:n*2])]
+          {})))
+
+    (rf/dispatch-sync [:seed]      {:frame :test/main})
+    (rf/dispatch-sync [:read-sub]  {:frame :test/main})
+
+    (let [r        (last (rf/epoch-history :test/main))
+          sub-runs (:sub-runs r)]
+      (is (vector? sub-runs))
+      (is (some #(= :n   (:sub-id %)) sub-runs))
+      (is (some #(= :n*2 (:sub-id %)) sub-runs))
+      (is (every? :recomputed?     sub-runs))
+      (is (every? :result-changed? sub-runs)))))
+
+(deftest effects-projection-skipped-on-platform
+  (testing ":effects captures :skipped-on-platform outcomes"
+    (rf/reg-frame :test/main {})
+    (rf/reg-fx :client-only-fx {:platforms #{:client}}
+               (fn [_ _] :nope))
+    (rf/reg-event-fx :run
+      (fn [_ _] {:fx [[:client-only-fx :payload]]}))
+
+    (rf/dispatch-sync [:run] {:frame :test/main})
+
+    (let [r       (last (rf/epoch-history :test/main))
+          effects (:effects r)
+          ent     (some #(when (= :client-only-fx (:fx-id %)) %) effects)]
+      (is (some? ent) ":client-only-fx surfaces in :effects")
+      (is (= :skipped-on-platform (:outcome ent))))))
+
+(deftest effects-projection-no-such-fx
+  (testing ":effects captures :error outcomes for unknown fx-ids"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-fx :run
+      (fn [_ _] {:fx [[:no/such-fx :payload]]}))
+    (rf/dispatch-sync [:run] {:frame :test/main})
+
+    (let [r       (last (rf/epoch-history :test/main))
+          effects (:effects r)
+          ent     (some #(when (= :no/such-fx (:fx-id %)) %) effects)]
+      (is (some? ent))
+      (is (= :error (:outcome ent)))
+      (is (some? (:error-trace ent))))))
+
+(deftest effects-projection-fx-handler-exception
+  (testing ":effects captures :error outcomes for fx that throw"
+    (rf/reg-frame :test/main {})
+    (rf/reg-fx :throwing-fx (fn [_ _] (throw (ex-info "boom" {}))))
+    (rf/reg-event-fx :run
+      (fn [_ _] {:fx [[:throwing-fx :payload]]}))
+
+    (rf/dispatch-sync [:run] {:frame :test/main})
+
+    (let [r       (last (rf/epoch-history :test/main))
+          effects (:effects r)
+          ent     (some #(when (= :throwing-fx (:fx-id %)) %) effects)]
+      (is (some? ent))
+      (is (= :error (:outcome ent)))
+      (is (some? (:error-trace ent))))))
+
+;; ---- partial-drain semantics -----------------------------------------------
+
+(deftest depth-exceeded-discards-buffer
+  (testing "a depth-exceeded drain does NOT commit a partial epoch record"
+    (rf/reg-frame :test/main {:drain-depth 5})
+    (rf/reg-event-fx :loop
+      (fn [_ _] {:fx [[:dispatch [:loop]]]}))
+
+    (rf/dispatch-sync [:loop] {:frame :test/main})
+
+    ;; The drain hit depth 5 and discarded; no epoch record was committed
+    ;; (the cascade never settled cleanly).
+    (is (= [] (rf/epoch-history :test/main))
+        "no record committed for partial drains")))
+
+;; ---- recording is gated on debug-enabled? ---------------------------------
+
+(deftest configure-roundtrip
+  (testing "(rf/configure :epoch-history {:depth N}) updates the depth"
+    (rf/configure :epoch-history {:depth 7})
+    (is (= 7 (:depth (epoch/current-config))))
+    (rf/configure :epoch-history {:depth 12})
+    (is (= 12 (:depth (epoch/current-config))))))

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -405,3 +405,26 @@
                        (= :error (:op-type ev))))
                 @traces)
           "expected :rf.error/dispatch-sync-in-handler trace"))))
+
+;; ---- epoch history (Tool-Pair §Time-travel, rf2-shjf) ---------------------
+;;
+;; CLJS smoke test — JVM-side epoch_test.clj covers the broad surface; this
+;; verifies the same machinery loads + records under the Reagent substrate.
+
+(deftest epoch-history-cljs
+  (testing "drain-settle commits a record; register-epoch-cb fires per-cascade"
+    (rf/reg-frame :epoch/cljs {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-cb ::w (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :epoch/cljs})
+      (rf/dispatch-sync [:inc]  {:frame :epoch/cljs})
+      (rf/remove-epoch-cb ::w)
+
+      (let [history (rf/epoch-history :epoch/cljs)]
+        (is (= 2 (count history)) "two cascades, two records")
+        (is (= [:seed :inc] (mapv :event-id history)))
+        (is (= {:n 1} (:db-after (last history))))
+        (is (= 2 (count @seen)) "register-epoch-cb fired per-cascade")))))


### PR DESCRIPTION
## Summary

Recovery of the epoch-history work from closed PR #43 (`rf2-shjf-epoch-history`). The original PR was closed without merging during a botched conflict-resolution against parallel PRs (#41 rf2-smee, #42 rf2-k84s, #44 rf2-11hn, #45 rf2-vvsh) that landed on `main`. The agent's commit (`987b89b`) survived in the local object database; this branch rebases that commit onto current `origin/main` and resolves the resulting conflicts.

References:
- Closed predecessor: #43 (same scope, same author, rebased)
- Bead: `rf2-shjf` — Tool-Pair §Time-travel

## What this PR delivers (unchanged from #43)

- New `re-frame.epoch` namespace (596 LOC).
- Per-frame ring buffer of `:rf/epoch-record` values, recorded at every drain-settle. Default depth 50; configurable via `(rf/configure :epoch-history {:depth N})`. Depth 0 disables.
- `(rf/epoch-history frame-id)` — oldest-first vector of records.
- `(rf/restore-epoch frame-id epoch-id)` — rewinds frame's `app-db`; six documented failure modes (`restore-unknown-epoch`, `restore-schema-mismatch`, `restore-missing-handler`, `restore-version-mismatch`, `restore-during-drain`, `no-such-handler-kind-frame`) emit structured `:rf.epoch/*` traces and leave `app-db` untouched.
- `(rf/register-epoch-cb key cb)` / `(rf/remove-epoch-cb key)` — assembled-epoch listener API mirroring `register-trace-cb!`.
- Trace events: `:rf.epoch/snapshotted`, `:rf.epoch/restored`, plus the six failure-mode ops.
- Production elision: every emission, recording, listener notification, and restore call gates on `interop/debug-enabled?`. Closure DCE drops the bodies in `:advanced` builds.
- Hookups via `re-frame.late-bind` (no cycles): `:epoch/settle!`, `:epoch/discard-buffer!`, `:epoch/in-flight-buffer`, `:epoch/capture-event` published from `epoch.cljc`; `router.cljc` and `trace.cljc` reach them through `late-bind/get-fn`.
- 23 new JVM tests (`epoch_test.clj`, 527 LOC). 1 new CLJS smoke test. Covers ring-depth eviction, restore happy path + all six failure modes, listener replace/remove/exception isolation, partial-drain (depth-exceeded) does NOT record, sub-runs / effects projections, configure roundtrip, depth-zero disabled.

## Conflict resolution notes

- `implementation/src/re_frame/trace.cljc` — both `push-to-buffer!` (from rf2-smee retain-N ring buffer) and `deliver-to-epoch-capture!` (from rf2-shjf) called inside `emit!` and `emit-error!`. They compose cleanly: the user-facing trace buffer and the internal epoch-capture buffer both receive every event.
- `implementation/src/re_frame/core.cljc` — both rf2-smee (`(rf/configure :trace-buffer ...)`) and rf2-shjf (`(rf/configure :epoch-history ...)`) introduced a `configure` knob. Merged into a single `configure` defn with a `case` over both keys. Removed the redundant `(def configure trace/configure)` re-export; the new defn dispatches to `trace/configure-trace-buffer!` for `:trace-buffer` and `epoch/configure!` for `:epoch-history`.
- `router.cljc`, `late_bind.cljc`, `API.md` — auto-merged cleanly (independent additions).
- `runtime_cljs_test.cljs`, `epoch.cljc`, `epoch_test.clj` — additive, no conflicts.

## Verification

- **JVM tests**: 180 tests / 909 assertions, 0 failures, 0 errors.
- **CLJS node tests**: 55 tests / 191 assertions, 0 failures, 0 errors.
- **CLJS browser tests**: 55 tests / 191 assertions, 0 failures, 0 errors.
- **Production elision probe** (`npm run test:elision`): PASS — all eight existing dev-only sentinels still elide under `:advanced` with `goog.DEBUG=false`, all eight present in the control bundle.

## Test plan

- [x] JVM tests pass (`clojure -M:test`)
- [x] CLJS node tests pass (`shadow-cljs compile node-test && node out/node-test.js`)
- [x] CLJS browser tests pass (`npm run test:browser`)
- [x] Production-elision probe still PASSes (`npm run test:elision`)
- [x] Both `:trace-buffer` (rf2-smee) and `:epoch-history` (rf2-shjf) `configure` knobs reachable through unified `rf/configure`

## Open questions (carried over from #43)

- `:render-key` identity is treated as opaque per Spec-Schemas (TBD pending rf2-t5tx); no render trace is emitted by the runtime today, so `:renders` is empty until the view layer is wired.