### PR TITLE
examples/todomvc: review-driven cleanup (rf2-94s1, rf2-pu9q, rf2-24or)

### DIFF
--- a/examples/todomvc/core.cljs
+++ b/examples/todomvc/core.cljs
@@ -1,5 +1,6 @@
 (ns todomvc.core
-  (:require [reagent.dom.client :as rdc]
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             [re-frame.substrate.reagent :as reagent-adapter]
@@ -11,21 +12,31 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defonce router-installed? (atom false))
+;; ---- hash → Spec 012 path adapter -----------------------------------------
+;;
+;; TodoMVC uses hash-based URLs (#/, #/active, #/completed); the Spec 012
+;; runtime routes path-strings. This tiny host-adapter strips the '#' (and an
+;; optional '!' for the legacy hashbang form) and dispatches
+;; :rf.route/handle-url-change so the registered routes in events.cljs match
+;; cleanly. Per Spec 012 §URL changes are events, the runtime updates
+;; app-db's :route slice from there.
 
-(defn current-hash []
-  (let [hash (.. js/window -location -hash)]
-    (if (seq hash) hash "#/")))
+(defn- hash->path
+  "Convert window.location.hash (e.g. \"#/active\", \"#!/completed\") to a
+  Spec 012 path. An empty hash maps to \"/\"."
+  [hash]
+  (let [stripped (-> hash
+                     (str/replace #"^#!?" "")
+                     (str/replace #"^/+" "/"))]
+    (if (str/blank? stripped) "/" stripped)))
 
-(defn install-router! []
-  (when-not @router-installed?
-    (.addEventListener js/window "hashchange"
-      (fn [_]
-        (rf/dispatch [:todo/url-changed (current-hash)])))
-    (reset! router-installed? true)))
+(defn- current-path []
+  (hash->path (.. js/window -location -hash)))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:todo/initialise (current-hash)])
-  (install-router!)
+  (rf/dispatch-sync [:todo/initialise])
+  (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
+  (.addEventListener js/window "hashchange"
+    (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-path)])))
   (rdc/render react-root [views/root-view]))

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -8,18 +8,19 @@
 (def ls-key "todos-reframe2")
 
 (defn- normalise-todo [{:keys [id title completed]}]
-  {:id        (int id)
-   :title     (str title)
-   :completed (boolean completed)})
+  (when-let [id' (try (int id) (catch :default _ nil))]
+    {:id        id'
+     :title     (str title)
+     :completed (boolean completed)}))
 
 (defn- storage->todos [raw]
   (if-not (seq raw)
     (sorted-map)
     (try
       (into (sorted-map)
-            (map (fn [todo]
-                   (let [todo' (normalise-todo todo)]
-                     [(:id todo') todo'])))
+            (comp (map normalise-todo)
+                  (remove nil?)
+                  (map (fn [todo] [(:id todo) todo])))
             (js->clj (js/JSON.parse raw) :keywordize-keys true))
       (catch :default _
         (sorted-map)))))

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -1,9 +1,11 @@
 (ns todomvc.db
   (:require [re-frame.core :as rf]))
 
+;; The :showing slot is no longer in the default db — Spec 012's :route slice
+;; owns it now. The :showing sub (in subs.cljs) derives :all/:active/:completed
+;; from :rf.route/id.
 (def default-db
-  {:todos   (sorted-map)
-   :showing :all})
+  {:todos (sorted-map)})
 
 (def ls-key "todos-reframe2")
 

--- a/examples/todomvc/events.cljs
+++ b/examples/todomvc/events.cljs
@@ -3,13 +3,20 @@
             [re-frame.core :as rf]
             [todomvc.db :as db]))
 
-(defn- filter-from-hash [hash]
-  (case hash
-    "#/active"    :active
-    "#!/active"   :active
-    "#/completed" :completed
-    "#!/completed" :completed
-    :all))
+;; ---- routes (Spec 012) ----------------------------------------------------
+;; TodoMVC's canonical URLs are hash-based (#/, #/active, #/completed). Spec
+;; 012 routes match path-strings, so the host-adapter (core.cljs) strips the
+;; leading '#' (and optional '!') from the URL hash before dispatching
+;; :rf.route/handle-url-change. The result is a Spec 012 path the registered
+;; routes match exactly.
+
+(rf/reg-route :todo/all       {:doc "Show all todos."       :path "/"})
+(rf/reg-route :todo/active    {:doc "Show active todos."    :path "/active"})
+(rf/reg-route :todo/completed {:doc "Show completed todos." :path "/completed"})
+
+;; Required by Spec 012 §Route-not-found. Unmatched URLs land here; we treat
+;; them as "show all" so a stray hash never breaks the app.
+(rf/reg-route :rf.route/not-found {:doc "Fallback." :path "/_404"})
 
 (defn- allocate-next-id [todos]
   ((fnil inc 0) (last (keys todos))))
@@ -32,14 +39,8 @@
 
 (rf/reg-event-fx :todo/initialise
   [(rf/inject-cofx :todo.storage/todos)]
-  (fn [{:todo.storage/keys [todos]} [_ current-hash]]
-    {:db (assoc db/default-db
-                :todos todos
-                :showing (filter-from-hash current-hash))}))
-
-(rf/reg-event-db :todo/url-changed
-  (fn [db [_ current-hash]]
-    (assoc db :showing (filter-from-hash current-hash))))
+  (fn [{:todo.storage/keys [todos]} _]
+    {:db (assoc db/default-db :todos todos)}))
 
 (rf/reg-event-fx :todo/add
   (fn [{:keys [db]} [_ title]]

--- a/examples/todomvc/subs.cljs
+++ b/examples/todomvc/subs.cljs
@@ -1,9 +1,15 @@
 (ns todomvc.subs
   (:require [re-frame.core :as rf]))
 
+;; :showing derives from the active Spec 012 route id. :rf.route/not-found and
+;; an unset route both fall through to :all so the UI defaults sensibly.
 (rf/reg-sub :showing
-  (fn [db _]
-    (:showing db)))
+  :<- [:rf.route/id]
+  (fn [route-id _]
+    (case route-id
+      :todo/active    :active
+      :todo/completed :completed
+      :all)))
 
 (rf/reg-sub :sorted-todos
   (fn [db _]

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -44,10 +44,10 @@
               (reset! suppress-blur false)
               (save)))})])))
 
-(defn todo-item []
+(defn todo-item [dispatch]
   ;; editing? is local component state by design — matches v1 TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
   (let [editing? (reagent/atom false)]
-    (fn [{:keys [id title completed]}]
+    (fn [_dispatch {:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  @editing? (conj "editing")))}
@@ -57,50 +57,48 @@
          {:type "checkbox"
           :checked completed
           :readOnly true
-          :on-click #(rf/dispatch [:todo/toggle-completed id])}]
+          :on-click #(dispatch [:todo/toggle-completed id])}]
         [:label {:on-double-click #(reset! editing? true)}
          title]
         [:button.destroy
-         {:on-click #(rf/dispatch [:todo/delete id])}]]
+         {:on-click #(dispatch [:todo/delete id])}]]
        (when @editing?
          [todo-input
           {:class "edit"
            :title title
-           :on-save #(rf/dispatch [:todo/save id %])
+           :on-save #(dispatch [:todo/save id %])
            :on-stop #(reset! editing? false)}])])))
 
-(defn task-entry []
+(defn task-entry [dispatch]
   [:header.header
    [:h1 "todos"]
    [todo-input
     {:id "new-todo"
      :class "new-todo"
      :placeholder "What needs to be done?"
-     :on-save #(rf/dispatch [:todo/add %])}]])
+     :on-save #(dispatch [:todo/add %])}]])
 
-(defn task-list []
-  (let [s (rf/subscriber)]
-    [:section.main {:id "main"}
-     [:input#toggle-all.toggle-all
-      {:type "checkbox"
-       :checked @(s [:all-complete?])
-       :readOnly true
-       :on-click #(rf/dispatch [:todo/toggle-all])}]
-     [:label {:for "toggle-all"} "Mark all as complete"]
-     [:ul.todo-list {:id "todo-list"}
-      (for [{:keys [id] :as todo} @(s [:visible-todos])]
-        ^{:key id}
-        [todo-item todo])]]))
+(defn task-list [dispatch subscribe]
+  [:section.main {:id "main"}
+   [:input#toggle-all.toggle-all
+    {:type "checkbox"
+     :checked @(subscribe [:all-complete?])
+     :readOnly true
+     :on-click #(dispatch [:todo/toggle-all])}]
+   [:label {:for "toggle-all"} "Mark all as complete"]
+   [:ul.todo-list {:id "todo-list"}
+    (for [{:keys [id] :as todo} @(subscribe [:visible-todos])]
+      ^{:key id}
+      [todo-item dispatch todo])]])
 
 (defn- filter-link [showing filter-kw label]
   [:a {:href (hash-for-filter filter-kw)
        :class (when (= showing filter-kw) "selected")}
    label])
 
-(defn footer-controls []
-  (let [s (rf/subscriber)
-        [active completed] @(s [:footer-counts])
-        showing @(s [:showing])]
+(defn footer-controls [dispatch subscribe]
+  (let [[active completed] @(subscribe [:footer-counts])
+        showing @(subscribe [:showing])]
     [:footer.footer {:id "footer"}
      [:span.todo-count {:id "todo-count"}
       [:strong active]
@@ -114,21 +112,22 @@
      (when (pos? completed)
        [:button.clear-completed
         {:id "clear-completed"
-         :on-click #(rf/dispatch [:todo/clear-completed])}
+         :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
 (def root-view
   (reg-view :todo.app/root-view
     (fn render-root-view []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos])]
+      (let [dispatch  (rf/dispatcher)
+            subscribe (rf/subscriber)
+            todos     @(subscribe [:todos])]
         [:<>
          [:section.todoapp
-          [task-entry]
+          [task-entry dispatch]
           (when (seq todos)
-            [task-list])
+            [task-list dispatch subscribe])
           (when (seq todos)
-            [footer-controls])]
+            [footer-controls dispatch subscribe])]
          [:footer.info
           [:p "Double-click to edit a todo"]
           [:p

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -1,13 +1,9 @@
 (ns todomvc.views
   (:require [clojure.string :as str]
-            [goog.object :as gobj]
             [reagent.core :as reagent]
             [re-frame.core :as rf]
             [re-frame.views])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
-
-(def enter-key "Enter")
-(def escape-key "Escape")
 
 (defn- hash-for-filter [filter-kw]
   (case filter-kw
@@ -27,27 +23,12 @@
                          (stop))
         handle-keydown
         (fn [event]
-          (let [key (.-key event)]
-            (cond
-              (= key enter-key)
-              (do (.preventDefault event)
-                  (save))
-
-              (= key escape-key)
-              (do (.preventDefault event)
-                  (reset! suppress-blur true)
-                  (stop))
-
-              :else nil)))
-        bind-node
-        (fn [node]
-          (when-let [prev @input-node]
-            (when-let [handler (gobj/get prev "__todomvcKeyHandler")]
-              (.removeEventListener prev "keydown" handler)))
-          (reset! input-node node)
-          (when node
-            (.addEventListener node "keydown" handle-keydown)
-            (gobj/set node "__todomvcKeyHandler" handle-keydown)))]
+          (case (.-key event)
+            "Enter"  (do (.preventDefault event) (save))
+            "Escape" (do (.preventDefault event)
+                         (reset! suppress-blur true)
+                         (stop))
+            nil))]
     (fn [props]
       [:input
        (merge
@@ -55,7 +36,8 @@
          {:type "text"
           :default-value (or title "")
           :autoFocus true
-          :ref bind-node
+          :ref #(reset! input-node %)
+          :on-key-down handle-keydown
           :on-blur
           (fn [_]
             (if @suppress-blur
@@ -63,12 +45,14 @@
               (save)))})])))
 
 (defn todo-item []
+  ;; editing? is local component state by design — matches v1 TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
   (let [editing? (reagent/atom false)]
     (fn [{:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  @editing? (conj "editing")))}
        [:div.view
+        ;; React's controlled-checkbox pattern: :on-click mutates app-db, :readOnly silences React's onChange warning, :checked reads from app-db.
         [:input.toggle
          {:type "checkbox"
           :checked completed


### PR DESCRIPTION
## Summary

Three review-driven cleanups to the TodoMVC example, on a single branch as three sequential commits.

**rf2-94s1 — polish (P3).** `todo-input`'s keydown handler was using a manual `addEventListener` + `__todomvcKeyHandler` ref-tagging dance to swap handlers across ref changes. React's synthetic `:on-key-down` does this for free; the handler became a flat `case` on `(.-key event)`, the `gobj` require dropped out, and the `bind-node` machinery collapsed to a one-line `:ref #(reset! input-node %)`. `db/normalise-todo` now wraps `(int id)` in a `try`/`catch` and the storage parser drops nil entries — per-item localStorage corruption is non-fatal where structural corruption already was. Two one-line explanatory comments added: one on the React controlled-checkbox idiom (`:on-click` + `:readOnly` + `:checked`), one on why `editing?` is a per-component Reagent atom rather than app-db state.

**rf2-pu9q — capture pattern (P2).** Sub-views (`task-entry`, `task-list`, `todo-item`, `footer-controls`) used to call `rf/dispatch` and `rf/subscribe` directly. They now take `dispatch` and `subscribe` as arguments; `root-view` captures `(rf/dispatcher)` and `(rf/subscriber)` once and threads them through. After the change, `grep -nE 'rf/(dispatch|subscribe)\b' examples/todomvc/views.cljs` returns no matches — only `(rf/dispatcher)` / `(rf/subscriber)` at the root. Stays decoupled from the open rf2-3442 (whether `reg-view` should auto-inject these).

**rf2-24or — Spec 012 routing (P2).** Replaced the hand-rolled `install-router!` / `current-hash` / `:todo/url-changed` plumbing with three Spec 012 route registrations (`:todo/all` `/`, `:todo/active` `/active`, `:todo/completed` `/completed`) plus a `:rf.route/not-found` fallback. The `:showing` slot is gone from `app-db`; the `:showing` sub now derives `:all`/`:active`/`:completed` from `:rf.route/id` (via Spec 012's `:route` slice). Because TodoMVC's URLs are hash-based (per the canonical Playwright contract: `href=\"#/active\"`, etc.) and Spec 012's match engine is path-based, `core.cljs` keeps a tiny host-adapter that strips the leading `#` (and optional `!` for the legacy hashbang form) from `window.location.hash` and dispatches `:rf.route/handle-url-change` with the resulting Spec 012 path. This is the same shape `examples/routing/` uses for `popstate`.

## Canonical TodoMVC compliance

All seven Playwright example specs pass, including `examples/playwright/todomvc.spec.cjs`. Specifically verified:

- New todo on Enter; whitespace-only input rejected; trim applied
- Toggle individual; toggle-all; clear-completed; counter pluralisation (1 item / 2 items)
- Edit on double-click; save on Enter; Escape cancels without save
- Filter routes `#/`, `#/active`, `#/completed` work; selected state on links; reload at `#/active` boots filtered
- Persistence across reload via `localStorage` key `todos-reframe2`

## Beads closed by this PR

- rf2-94s1 (commit cba8b0b)
- rf2-pu9q (commit f28f3a3)
- rf2-24or (commit 19a0d38)