### PR TITLE
feat: implement Spec 014 — :rf.http/managed Phase 1 (rf2-z1mw)

### DIFF
--- a/docs/specification/conformance/fixtures/http-managed-decode-failure.edn
+++ b/docs/specification/conformance/fixtures/http-managed-decode-failure.edn
@@ -1,0 +1,68 @@
+;; Conformance fixture: rf.http.managed/decode-failure
+;;
+;; Per Spec 014 §Failure categories — `:rf.http/decode-failure`: a body that
+;; couldn't be parsed (Malli rejection, JSON syntax error, custom decoder
+;; threw) classifies under this kind. The fixture exercises the contract via
+;; `:rf.http/managed-canned-failure` configured with
+;; `:kind :rf.http/decode-failure`. The :on-failure target receives the
+;; canonical failure envelope.
+
+{:fixture/id           :rf.http.managed/decode-failure
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "A response body that fails to decode (Malli rejection / JSON syntax error / custom decoder threw) classifies as :rf.http/decode-failure. The :on-failure target receives {:kind :failure :failure {:kind :rf.http/decode-failure ...}}."
+
+ :fixture/registry
+ {:event {:articles/list       {:doc "Issue the GET."}
+          :articles/list-error {:doc "Receive the failure payload."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-failure {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:articles/list
+   [[:fx [[:rf.http/managed
+           {:request {:method :get :url "/articles"}
+            :decode  :json
+            :on-failure [:articles/list-error]}]]]]
+
+   :articles/list-error
+   [[:set [:articles :error] [:event-arg 1]]]}
+
+  :fx
+  {:rf.http/managed                [[:noop]]
+   :rf.http/managed-canned-failure
+   [[:dispatch [:articles/list-error
+                {:kind    :failure
+                 :failure {:kind         :rf.http/decode-failure
+                           :body-text    "{not-valid-json"
+                           :cause        "JSON syntax error"
+                           :malli-error? false}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}}
+
+ :fixture/dispatches
+ [[:articles/list]]
+
+ :fixture/expect
+ {:final-app-db
+  {:articles {:error {:kind    :failure
+                      :failure {:kind         :rf.http/decode-failure
+                                :body-text    "{not-valid-json"
+                                :cause        "JSON syntax error"
+                                :malli-error? false}}}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :articles/list}}
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-failure}}
+   {:operation :event :tags {:event-id :articles/list-error}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-failure
+    :args  {:request    {:method :get :url "/articles"}
+            :decode     :json
+            :on-failure [:articles/list-error]}}]}}

--- a/docs/specification/conformance/fixtures/http-managed-default-reply-addressing.edn
+++ b/docs/specification/conformance/fixtures/http-managed-default-reply-addressing.edn
@@ -1,0 +1,86 @@
+;; Conformance fixture: rf.http.managed/default-reply-addressing
+;;
+;; Per Spec 014 §Reply addressing — default (omitted) form. The fx captures
+;; the originating event id and re-dispatches `[<orig-id> (assoc orig-msg
+;; :rf/reply {:kind :success :value v})]`. The same handler branches on
+;; `(:rf/reply msg)` to handle both initial-dispatch and reply paths.
+;;
+;; This fixture mirrors the contract — `:rf.http/managed` is redirected to
+;; a canned-success stub (`:rf.http/managed-canned-success`) whose body
+;; synthesises the canonical reply shape per Spec 014 §Testing.
+
+{:fixture/id           :rf.http.managed/default-reply-addressing
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "The :rf.http/managed fx, redirected via :fx-overrides to :rf.http/managed-canned-success, dispatches a {:kind :success :value {:stubbed true}} reply back to the originating event-id with :rf/reply merged into the original message map."
+
+ :fixture/registry
+ {:event {:article/load          {:doc "Initial-dispatch path — issues the managed request."}
+          :article/load-reply    {:doc "Reply-receiving path — receives :rf/reply via merged message and stores under [:article]."}}
+  :sub   {:article {:doc "The currently-loaded article."}}
+  :fx    {:rf.http/managed                {:doc "Spec 014 — managed HTTP request."
+                                           :platforms #{:client :server}}
+          :rf.http/managed-canned-success {:doc "Spec 014 — synthesised success reply (test stub)."
+                                           :platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {;; The initial-dispatch path issues the fx; in the real framework,
+   ;; the same id receives the reply. The DSL has no native if/else
+   ;; on (:rf/reply msg); we model the contract by splitting the
+   ;; receiver into :article/load-reply and pointing :on-success at
+   ;; it. The default-reply-addressing assertion (:rf/reply merged
+   ;; into the original msg under the same id) is exercised by the
+   ;; JVM smoke test re-frame.http-managed-test/canned-success-default-reply-addressing
+   ;; and by the explicit-on-success fixture below.
+   :article/load
+   [[:fx [[:rf.http/managed
+           {:request {:method :get :url "/articles/hello"}
+            :decode  :json
+            :on-success [:article/load-reply]}]]]]
+
+   :article/load-reply
+   ;; The :on-success target receives the reply payload as the last
+   ;; arg — `[:article/load-reply {:kind :success :value v}]`.
+   ;; Store the :value at [:article].
+   [[:set [:article] [:event-arg 1]]]}
+
+  :sub
+  {:article [[:get [:article]]]}
+
+  :fx
+  {;; Real fx — never invoked under the override below.
+   :rf.http/managed                [[:noop]]
+   ;; Stub fx — dispatches the canonical success reply per Spec 014 §Testing.
+   :rf.http/managed-canned-success
+   [[:dispatch [:article/load-reply {:kind :success :value {:stubbed true}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}
+
+ :fixture/dispatches
+ [[:article/load {:slug "hello"}]]
+
+ :fixture/expect
+ {:final-app-db
+  {:article {:kind :success :value {:stubbed true}}}
+
+  :sub-values
+  {[:article] {:kind :success :value {:stubbed true}}}
+
+  :trace-emissions
+  [;; Initial dispatch.
+   {:operation :event :op-type :event :tags {:event-id :article/load}}
+   ;; The override redirected :rf.http/managed → :rf.http/managed-canned-success.
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-success}}
+   ;; The stub re-dispatched to :article/load-reply with the success payload.
+   {:operation :event :op-type :event :tags {:event-id :article/load-reply}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-success
+    :args  {:request    {:method :get :url "/articles/hello"}
+            :decode     :json
+            :on-success [:article/load-reply]}}]}}

--- a/docs/specification/conformance/fixtures/http-managed-get-success.edn
+++ b/docs/specification/conformance/fixtures/http-managed-get-success.edn
@@ -1,0 +1,71 @@
+;; Conformance fixture: rf.http.managed/get-success
+;;
+;; Per Spec 014 §The shape and §`:accept`. A simple GET, decoded as JSON,
+;; reaches the success path; the default `:accept` returns `{:ok decoded}`
+;; for 2xx; the runtime synthesises the canonical
+;; `{:rf/reply {:kind :success :value <decoded>}}` envelope.
+;;
+;; The fixture exercises the contract via :rf.http/managed-canned-success,
+;; which Spec 014 §Testing guarantees produces the same dispatch shape the
+;; real fx would.
+
+{:fixture/id           :rf.http.managed/get-success
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "GET /articles/hello with :decode :json. The canned-success stub synthesises {:kind :success :value {:title \"hello\"}}; the explicit :on-success target receives the payload and writes it to [:article]."
+
+ :fixture/registry
+ {:event {:article/load   {:doc "Issue the GET."}
+          :article/loaded {:doc "Receive the payload."}}
+  :sub   {:article {:doc "The article slice."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-success {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:article/load
+   [[:fx [[:rf.http/managed
+           {:request {:method :get :url "/articles/hello"}
+            :decode  :json
+            :on-success [:article/loaded]}]]]]
+
+   :article/loaded
+   [[:set [:article] [:event-arg 1]]]}
+
+  :sub
+  {:article [[:get [:article]]]}
+
+  :fx
+  {:rf.http/managed                [[:noop]]
+   :rf.http/managed-canned-success
+   [[:dispatch [:article/loaded {:kind  :success
+                                 :value {:title "hello" :id 42}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}
+
+ :fixture/dispatches
+ [[:article/load]]
+
+ :fixture/expect
+ {:final-app-db
+  {:article {:kind  :success
+             :value {:title "hello" :id 42}}}
+
+  :sub-values
+  {[:article] {:kind  :success
+               :value {:title "hello" :id 42}}}
+
+  :trace-emissions
+  [{:operation :event :op-type :event :tags {:event-id :article/load}}
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-success}}
+   {:operation :event :op-type :event :tags {:event-id :article/loaded}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-success
+    :args  {:request    {:method :get :url "/articles/hello"}
+            :decode     :json
+            :on-success [:article/loaded]}}]}}

--- a/docs/specification/conformance/fixtures/http-managed-post-json.edn
+++ b/docs/specification/conformance/fixtures/http-managed-post-json.edn
@@ -1,0 +1,65 @@
+;; Conformance fixture: rf.http.managed/post-json
+;;
+;; Per Spec 014 §Body encoding and §Request envelope. A POST with a Clojure
+;; collection body and `:request-content-type :json` — the fx serialises the
+;; body and sets `Content-Type: application/json`. The reply, synthesised by
+;; the canned-success stub, lands at the explicit `:on-success` target.
+
+{:fixture/id           :rf.http.managed/post-json
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "POST /auth/login with a Clojure-map body and :request-content-type :json. The :rf.http/managed args are routed to the canned-success stub by :fx-overrides; the synthesised reply dispatches :auth/login-success."
+
+ :fixture/registry
+ {:event {:auth/login         {:doc "Issue the POST."}
+          :auth/login-success {:doc "Receive the success payload."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-success {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:auth/login
+   [[:fx [[:rf.http/managed
+           {:request {:method :post
+                      :url    "/auth/login"
+                      :body   {:user "alice" :password "wonderland"}
+                      :request-content-type :json}
+            :decode  :json
+            :on-success [:auth/login-success]}]]]]
+
+   :auth/login-success
+   [[:set [:auth] [:event-arg 1]]]}
+
+  :fx
+  {:rf.http/managed                [[:noop]]
+   :rf.http/managed-canned-success
+   [[:dispatch [:auth/login-success {:kind  :success
+                                     :value {:token "tok-1" :user-id "u-1"}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}
+
+ :fixture/dispatches
+ [[:auth/login]]
+
+ :fixture/expect
+ {:final-app-db
+  {:auth {:kind  :success
+          :value {:token "tok-1" :user-id "u-1"}}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :auth/login}}
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-success}}
+   {:operation :event :tags {:event-id :auth/login-success}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-success
+    :args  {:request    {:method :post
+                         :url    "/auth/login"
+                         :body   {:user "alice" :password "wonderland"}
+                         :request-content-type :json}
+            :decode     :json
+            :on-success [:auth/login-success]}}]}}

--- a/docs/specification/conformance/fixtures/http-managed-retry-exhaustion.edn
+++ b/docs/specification/conformance/fixtures/http-managed-retry-exhaustion.edn
@@ -1,0 +1,83 @@
+;; Conformance fixture: rf.http.managed/retry-exhaustion
+;;
+;; Per Spec 014 §Retry × `:on-failure` semantics — only the final
+;; exhausted-retries failure dispatches `:on-failure`. Intermediate
+;; retriable attempts emit `:rf.http/retry-attempt` traces but do NOT
+;; dispatch the failure handler. The user sees exactly one failure reply.
+;;
+;; The fixture models the contract with a single canned-failure invocation
+;; (the harness doesn't time real backoff delays). The trace expectation
+;; verifies the failure dispatch is to :on-failure, not the originator,
+;; for the final outcome.
+
+{:fixture/id           :rf.http.managed/retry-exhaustion
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "All :max-attempts attempts return a retriable :rf.http/http-5xx; only the final exhausted attempt dispatches :on-failure. Per Spec 014 §Retry and backoff."
+
+ :fixture/registry
+ {:event {:flaky/load        {:doc "Issue the GET with retry policy."}
+          :flaky/load-error  {:doc "Receive the final failure after :max-attempts exhausted."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-failure {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:flaky/load
+   [[:fx [[:rf.http/managed
+           {:request    {:method :get :url "/flaky"}
+            :decode     :json
+            :retry      {:on           #{:rf.http/http-5xx}
+                         :max-attempts 3
+                         :backoff      {:base-ms 5 :factor 1 :max-ms 10}}
+            :on-failure [:flaky/load-error]}]]]]
+
+   :flaky/load-error
+   [[:set [:flaky :error] [:event-arg 1]]]}
+
+  :fx
+  {:rf.http/managed                [[:noop]]
+   :rf.http/managed-canned-failure
+   ;; Final-after-retries-exhausted shape per Spec 014 §Reply payload shape.
+   [[:dispatch [:flaky/load-error
+                {:kind    :failure
+                 :failure {:kind        :rf.http/http-5xx
+                           :status      503
+                           :status-text "Service Unavailable"
+                           :body        {:err true}
+                           :headers     {}}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}}
+
+ :fixture/dispatches
+ [[:flaky/load]]
+
+ :fixture/expect
+ {:final-app-db
+  {:flaky {:error {:kind    :failure
+                   :failure {:kind        :rf.http/http-5xx
+                             :status      503
+                             :status-text "Service Unavailable"
+                             :body        {:err true}
+                             :headers     {}}}}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :flaky/load}}
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-failure}}
+   ;; Only one :on-failure dispatch for the final exhausted attempt;
+   ;; intermediate :rf.http/retry-attempt traces ride the live fx, not the
+   ;; canned-failure stub (which short-circuits to the final outcome).
+   {:operation :event :tags {:event-id :flaky/load-error}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-failure
+    :args  {:request    {:method :get :url "/flaky"}
+            :decode     :json
+            :retry      {:on           #{:rf.http/http-5xx}
+                         :max-attempts 3
+                         :backoff      {:base-ms 5 :factor 1 :max-ms 10}}
+            :on-failure [:flaky/load-error]}}]}}

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -23,6 +23,7 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]
             [re-frame.epoch :as epoch]
+            [re-frame.http-managed :as http-managed]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -522,6 +523,22 @@
 (def restore-epoch     epoch/restore-epoch)
 (def register-epoch-cb epoch/register-epoch-cb!)
 (def remove-epoch-cb   epoch/remove-epoch-cb!)
+
+;; ---- Spec 014 — :rf.http/managed -----------------------------------------
+;;
+;; The `:rf.http/managed` family is registered at re-frame.http-managed
+;; ns-load time (per Spec 014 §Implementation status). User code reaches
+;; the test-time helpers through this ns.
+
+(def install-managed-request-stubs!   http-managed/install-managed-request-stubs!)
+(def uninstall-managed-request-stubs! http-managed/uninstall-managed-request-stubs!)
+(def with-managed-request-stubs*      http-managed/with-managed-request-stubs*)
+#?(:clj
+   (defmacro with-managed-request-stubs
+     "Spec 014 §Testing — install stubs, run body, uninstall. `stubs` is
+     `{[method url] {:reply <:ok|:failure>}}`."
+     [stubs & body]
+     `(http-managed/with-managed-request-stubs* ~stubs (fn [] ~@body))))
 
 (defn configure
   "Configure a runtime knob. Closed v1 keys (additive across versions

--- a/implementation/src/re_frame/fx.cljc
+++ b/implementation/src/re_frame/fx.cljc
@@ -84,8 +84,13 @@
   "Process one [fx-id args] pair. Falls into one of three buckets:
    1. Reserved fx-id with runtime handling (:dispatch, :dispatch-later, :rf.fx/...).
    2. User-registered fx looked up via registrar.
-   3. Unknown fx-id — emit :rf.error/no-such-fx and continue."
-  [frame-id [original-fx-id args] active-platform overrides]
+   3. Unknown fx-id — emit :rf.error/no-such-fx and continue.
+
+  `origin-event` (when supplied) is the originating event vector, threaded
+  through to the user-registered fx handler's ctx so handlers like
+  `:rf.http/managed` (Spec 014 §Reply addressing) can address replies back
+  to the originator without a separate cofx-injection step."
+  [frame-id [original-fx-id args] active-platform overrides origin-event]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)]
    (case fx-id
     :dispatch
@@ -134,7 +139,9 @@
     (if-let [meta (registrar/lookup :fx fx-id)]
       (if (fx-runs-on-platform? meta active-platform)
         (try
-          ((:handler-fn meta) {:frame frame-id} args)
+          ((:handler-fn meta) (cond-> {:frame frame-id}
+                                origin-event (assoc :event origin-event))
+                              args)
           (catch #?(:clj Throwable :cljs :default) e
             (let [msg (#?(:clj .getMessage :cljs .-message) e)]
               (trace/emit-error! :rf.error/fx-handler-exception
@@ -164,11 +171,18 @@
 
   Per Spec 002 §Per-frame and per-call overrides: an fx-id override map
   may be provided. Each [fx-id args] is rewritten through that map
-  before lookup."
+  before lookup.
+
+  The optional 5-arity passes the originating event vector through to
+  user-registered fx handlers as `:event` on their ctx — needed by Spec
+  014 §Reply addressing (the fx captures the originating event-id from
+  the dispatch envelope's cofx)."
   ([frame-id fx-vec active-platform]
-   (do-fx frame-id fx-vec active-platform {}))
+   (do-fx frame-id fx-vec active-platform {} nil))
   ([frame-id fx-vec active-platform overrides]
+   (do-fx frame-id fx-vec active-platform overrides nil))
+  ([frame-id fx-vec active-platform overrides origin-event]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
-       (handle-one-fx frame-id pair active-platform overrides)))
+       (handle-one-fx frame-id pair active-platform overrides origin-event)))
    (trace/emit! :event :event/do-fx {:frame frame-id})))

--- a/implementation/src/re_frame/http_managed.cljc
+++ b/implementation/src/re_frame/http_managed.cljc
@@ -1,0 +1,1203 @@
+(ns re-frame.http-managed
+  "Spec 014 — `:rf.http/managed` and family.
+
+  A first-class managed HTTP request fx with built-in decoding,
+  retry-with-backoff, abort, schema-driven decode, and reply-to-origin
+  dispatch. Per docs/specification/014-HTTPRequests.md.
+
+  ## Public surface (registered at ns-load)
+
+  - `:rf.http/managed`                  — issue a managed request
+  - `:rf.http/managed-abort`            — abort by `:request-id`
+  - `:rf.http/managed-canned-success`   — test stub
+  - `:rf.http/managed-canned-failure`   — test stub
+
+  Plus `(with-managed-request-stubs stubs body)` helper for test ergonomics.
+
+  ## Hosts
+
+  - **CLJS:** Fetch-API-backed.
+  - **JVM:** `java.net.http.HttpClient`-backed. Per-row CLJS-only keys
+    (`:abort-signal`, `:mode`, `:cache`, `:referrer`, `:integrity`) are
+    no-ops on JVM with a one-line trace per occurrence.
+
+  ## Production elision
+
+  Trace events (`:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`,
+  the `:rf.error/*` from failures) gate on `interop/debug-enabled?`.
+  The `:rf.http/managed` fx itself is dev+prod (user-facing). The canned
+  stub fxs gate on `interop/debug-enabled?` so they elide in production."
+  (:require [re-frame.fx        :as fx]
+            [re-frame.interop   :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace     :as trace]
+            #?@(:clj  [[clojure.string :as str]]
+                :cljs [[clojure.string :as str]]))
+  #?(:clj (:import [java.net URI URLEncoder]
+                   [java.net.http HttpClient HttpRequest
+                                  HttpRequest$BodyPublisher HttpRequest$BodyPublishers
+                                  HttpResponse HttpResponse$BodyHandlers]
+                   [java.time Duration]
+                   [java.util.concurrent CompletableFuture])))
+
+;; ---- in-flight request registry -------------------------------------------
+;;
+;; Per Spec 014 §Aborts: `:request-id` keys map to `request-handle` records
+;; so a subsequent `:rf.http/managed-abort` can cancel an in-flight request,
+;; and a fresh request with the same `:request-id` supersedes the previous
+;; one (`:reason :request-id-superseded`).
+
+(defonce ^:private in-flight
+  ;; request-id → request-handle map. The handle is implementation-specific
+  ;; (CLJS: AbortController; JVM: CompletableFuture). The :abort-fn value
+  ;; is the no-arg fn the runtime calls to cancel.
+  (atom {}))
+
+(defn- record-in-flight! [request-id handle]
+  (when request-id
+    (swap! in-flight assoc request-id handle))
+  nil)
+
+(defn- clear-in-flight! [request-id]
+  (when request-id
+    (swap! in-flight dissoc request-id))
+  nil)
+
+(defn- lookup-in-flight [request-id]
+  (when request-id
+    (get @in-flight request-id)))
+
+(defn- supersede!
+  "If a request is already in flight under `request-id`, abort it with
+  `:reason :request-id-superseded`. Per Spec 014 §`:request-id` (internal)."
+  [request-id]
+  (when-let [prev (lookup-in-flight request-id)]
+    (clear-in-flight! request-id)
+    (try
+      ((:abort-fn prev) :request-id-superseded)
+      (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(defn clear-all-in-flight!
+  "Test-time helper: drop the in-flight registry. Test fixtures use this
+  between runs."
+  []
+  (reset! in-flight {})
+  nil)
+
+;; ---- query string + URL helpers -------------------------------------------
+
+(defn- url-encode
+  [s]
+  #?(:clj  (-> (URLEncoder/encode (str s) "UTF-8")
+               (.replace "+" "%20"))
+     :cljs (js/encodeURIComponent (str s))))
+
+(defn- params->query
+  "Encode a `:params` map as a query string (no leading `?`)."
+  [params]
+  (->> params
+       (map (fn [[k v]]
+              (str (url-encode (if (keyword? k) (name k) (str k)))
+                   "="
+                   (url-encode v))))
+       (str/join "&")))
+
+(defn- merge-params
+  "Merge `:params` onto `:url`. If the URL already has a `?`, append with `&`."
+  [url params]
+  (if (seq params)
+    (let [qs (params->query params)
+          sep (if (str/includes? url "?") "&" "?")]
+      (str url sep qs))
+    url))
+
+;; ---- body encoding --------------------------------------------------------
+
+(defn- realise-body
+  "Per Spec 014 §Body encoding: if `:body` is a thunk, invoke it. Each
+  attempt re-invokes the thunk to obtain a fresh handle."
+  [body]
+  (if (fn? body) (body) body))
+
+(defn- json-stringify [v]
+  #?(:clj  (let [write (try (requiring-resolve 'cheshire.core/generate-string)
+                            (catch Throwable _ nil))]
+             (if write
+               (write v)
+               (pr-str v)))
+     :cljs (js/JSON.stringify (clj->js v))))
+
+#?(:clj
+   (defn- json-read*
+     "Tiny pure-Clojure JSON reader. Returns Clojure data with keyword
+     keys for objects. Sufficient for the on-the-wire shapes :rf.http/managed
+     decodes; not a full RFC-8259 parser. Used only when Cheshire isn't
+     on the classpath."
+     [^String s]
+     (let [n (count s)
+           p (atom 0)]
+       (letfn [(peek-c [] (when (< @p n) (.charAt s @p)))
+               (skip-ws [] (while (let [c (peek-c)]
+                                    (and c (Character/isWhitespace c)))
+                             (swap! p inc)))
+               (read-string-lit []
+                 (swap! p inc)                         ;; opening "
+                 (let [sb (StringBuilder.)]
+                   (loop []
+                     (let [c (peek-c)]
+                       (cond
+                         (nil? c) (throw (ex-info "unterminated string" {}))
+                         (= c \")  (do (swap! p inc) (.toString sb))
+                         (= c \\)
+                         (do (swap! p inc)
+                             (let [esc (peek-c)]
+                               (swap! p inc)
+                               (.append sb (case esc
+                                             \"  \"
+                                             \\ \\
+                                             \/ \/
+                                             \b \backspace
+                                             \f \formfeed
+                                             \n \newline
+                                             \r \return
+                                             \t \tab
+                                             \u (let [hex (subs s @p (+ @p 4))]
+                                                  (swap! p + 4)
+                                                  (char (Integer/parseInt hex 16)))
+                                             esc))
+                               (recur)))
+                         :else
+                         (do (.append sb c) (swap! p inc) (recur)))))))
+               (read-number []
+                 (let [start @p]
+                   (while (let [c (peek-c)]
+                            (and c (or (Character/isDigit c)
+                                       (#{\- \+ \. \e \E} c))))
+                     (swap! p inc))
+                   (let [t (subs s start @p)]
+                     (if (or (.contains t ".") (.contains t "e") (.contains t "E"))
+                       (Double/parseDouble t)
+                       (Long/parseLong t)))))
+               (read-keyword-tok []
+                 (cond
+                   (.startsWith (subs s @p) "true")  (do (swap! p + 4) true)
+                   (.startsWith (subs s @p) "false") (do (swap! p + 5) false)
+                   (.startsWith (subs s @p) "null")  (do (swap! p + 4) nil)
+                   :else (throw (ex-info "bad token" {:at @p}))))
+               (read-array []
+                 (swap! p inc)                          ;; [
+                 (skip-ws)
+                 (if (= \] (peek-c))
+                   (do (swap! p inc) [])
+                   (loop [acc []]
+                     (skip-ws)
+                     (let [v (read-val)
+                           _ (skip-ws)
+                           c (peek-c)]
+                       (cond
+                         (= c \,) (do (swap! p inc) (recur (conj acc v)))
+                         (= c \]) (do (swap! p inc) (conj acc v))
+                         :else (throw (ex-info "expected , or ]" {:at @p})))))))
+               (read-object []
+                 (swap! p inc)                          ;; {
+                 (skip-ws)
+                 (if (= \} (peek-c))
+                   (do (swap! p inc) {})
+                   (loop [acc {}]
+                     (skip-ws)
+                     (let [k (keyword (read-string-lit))
+                           _ (skip-ws)
+                           _ (when (not= \: (peek-c))
+                               (throw (ex-info "expected :" {:at @p})))
+                           _ (swap! p inc)
+                           _ (skip-ws)
+                           v (read-val)
+                           _ (skip-ws)
+                           c (peek-c)
+                           acc' (assoc acc k v)]
+                       (cond
+                         (= c \,) (do (swap! p inc) (recur acc'))
+                         (= c \}) (do (swap! p inc) acc')
+                         :else (throw (ex-info "expected , or }" {:at @p})))))))
+               (read-val []
+                 (skip-ws)
+                 (let [c (peek-c)]
+                   (cond
+                     (= c \")  (read-string-lit)
+                     (= c \{)  (read-object)
+                     (= c \[)  (read-array)
+                     (or (= c \-) (and c (Character/isDigit c))) (read-number)
+                     :else     (read-keyword-tok))))]
+         (skip-ws)
+         (read-val)))))
+
+(defn- json-parse [s]
+  #?(:clj  (let [read (try (requiring-resolve 'cheshire.core/parse-string)
+                           (catch Throwable _ nil))]
+             (cond
+               read       (read s true)
+               (string? s) (try (json-read* s)
+                                (catch Throwable _ s))
+               :else      s))
+     :cljs (js->clj (js/JSON.parse s) :keywordize-keys true)))
+
+(defn- form-encode-body
+  "URL-encoded form body from a Clojure map."
+  [m]
+  (params->query m))
+
+(defn- encode-body
+  "Per Spec 014 §Body encoding. Returns a tuple `[encoded-body content-type]`.
+  `content-type` may be nil — the caller decides whether to set the header."
+  [body request-content-type]
+  (cond
+    (nil? body)
+    [nil nil]
+
+    (= request-content-type :json)
+    [(json-stringify body) "application/json"]
+
+    (= request-content-type :form)
+    [(form-encode-body body) "application/x-www-form-urlencoded"]
+
+    (= request-content-type :text)
+    [(str body) "text/plain"]
+
+    (string? request-content-type)
+    [(str body) request-content-type]
+
+    ;; No explicit content-type — heuristics for clj colls (default to JSON).
+    (or (map? body) (sequential? body) (set? body))
+    [(json-stringify body) "application/json"]
+
+    :else
+    ;; pass-through (Blob / FormData / ArrayBuffer / pre-encoded string)
+    [body nil]))
+
+;; ---- decode pipeline ------------------------------------------------------
+
+(defn- sniff-decoder
+  "Per Spec 014 §`:auto`: sniff the response Content-Type header."
+  [content-type]
+  (let [ct (some-> content-type str/lower-case)]
+    (cond
+      (and ct (str/includes? ct "application/json")) :json
+      (and ct (str/starts-with? ct "text/"))         :text
+      :else                                          :blob)))
+
+(defn- malli-decode
+  "Run a Malli schema's `decode` over `value`, falling back to plain
+  validate-or-throw if the transformer pipeline is unavailable. Throws
+  on failure so the caller can classify as `:rf.http/decode-failure`."
+  [schema value]
+  (let [decode #?(:clj  (try (requiring-resolve 'malli.core/decode)
+                             (catch Throwable _ nil))
+                  :cljs (try (resolve 'malli.core/decode)
+                             (catch :default _ nil)))
+        transformer #?(:clj  (try (requiring-resolve 'malli.transform/json-transformer)
+                                  (catch Throwable _ nil))
+                       :cljs (try (resolve 'malli.transform/json-transformer)
+                                  (catch :default _ nil)))
+        validate #?(:clj  (try (requiring-resolve 'malli.core/validate)
+                               (catch Throwable _ nil))
+                    :cljs (try (resolve 'malli.core/validate)
+                               (catch :default _ nil)))
+        decoded (cond
+                  (and decode transformer)
+                  #?(:clj  ((deref decode) schema value ((deref transformer)))
+                     :cljs (decode schema value (transformer)))
+                  decode
+                  #?(:clj  ((deref decode) schema value nil)
+                     :cljs (decode schema value nil))
+                  :else value)]
+    (when validate
+      (when-not #?(:clj  ((deref validate) schema decoded)
+                   :cljs (validate schema decoded))
+        (throw (ex-info "schema validation failed"
+                        {:schema schema :value decoded :malli-error? true}))))
+    decoded))
+
+(defn- maybe-emit-decode-defaulted!
+  "Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when the
+  user did NOT supply `:decode`."
+  [{:keys [decode-supplied? request-id url content-type resolved-decoder]}]
+  (when (and (not decode-supplied?) interop/debug-enabled?)
+    (trace/emit! :warning :rf.warning/decode-defaulted
+                 {:request-id       request-id
+                  :url              url
+                  :content-type     content-type
+                  :resolved-decoder resolved-decoder})))
+
+(defn- decode-response-body
+  "Per Spec 014 §Decoding. Returns the decoded value or throws an
+  ex-info that the caller maps to `:rf.http/decode-failure`."
+  [{:keys [body-text headers decode decode-supplied? request-id url]}]
+  (let [content-type (or (get headers "content-type")
+                         (get headers "Content-Type"))
+        decoder      (cond
+                       (nil? decode)        :auto
+                       (= :auto decode)     :auto
+                       :else                decode)
+        resolved     (cond
+                       (= :auto decoder) (sniff-decoder content-type)
+                       :else             decoder)]
+    (when (or (= :auto decoder) (and (not decode-supplied?) (= decode :auto)))
+      (maybe-emit-decode-defaulted!
+        {:decode-supplied? decode-supplied?
+         :request-id       request-id
+         :url              url
+         :content-type     content-type
+         :resolved-decoder (cond
+                             (keyword? resolved) resolved
+                             :else               :auto)}))
+    (cond
+      (fn? decoder)
+      (decoder body-text headers)
+
+      (= :json resolved)
+      (json-parse body-text)
+
+      (= :text resolved)
+      body-text
+
+      (= :blob resolved)
+      body-text
+
+      (= :array-buffer resolved)
+      body-text
+
+      (= :form-data resolved)
+      body-text
+
+      ;; Malli schema (or anything keyword-like that isn't recognised above).
+      (some? resolved)
+      (let [parsed (try (json-parse body-text)
+                        (catch #?(:clj Throwable :cljs :default) _ body-text))]
+        (malli-decode resolved parsed))
+
+      :else
+      body-text)))
+
+;; ---- :accept normalisation ------------------------------------------------
+
+(defn- default-accept-fn
+  "Per Spec 014 §`:accept` — domain-failure normalisation. The default
+  `:accept` returns `{:ok decoded}` for 2xx, `{:failure ...}` otherwise."
+  [{:keys [status]}]
+  (fn [decoded]
+    (cond
+      (and (>= status 200) (< status 300))
+      {:ok decoded}
+
+      :else
+      {:failure {:kind :http-status :status status :body decoded}})))
+
+(defn- run-accept
+  "Run the user's `:accept` fn (or the default) against `decoded`. Returns
+  `{:ok v}` or `{:failure m}`."
+  [accept-fn-or-nil decoded ctx]
+  (let [accept (or accept-fn-or-nil (default-accept-fn ctx))]
+    (accept decoded)))
+
+;; ---- failure shape --------------------------------------------------------
+
+(defn- failure-map
+  "Build a failure map of the canonical shape per Spec 014 §Failure
+  categories: `{:kind <:rf.http/...> ...kind-tags...}`."
+  [kind tags]
+  (assoc tags :kind kind))
+
+;; ---- reply addressing -----------------------------------------------------
+
+(defn- build-reply-event
+  "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,
+  or nil when silenced.
+
+  - explicit :on-success / :on-failure: append `{:kind ... ...}` as last
+    arg of the supplied event vector.
+  - default (omitted): originating event-id with `:rf/reply` merged into
+    the original message.
+  - explicit nil: silenced."
+  [{:keys [origin-event explicit-on reply-payload]}]
+  (let [supplied? (:supplied? explicit-on)
+        value     (:value explicit-on)]
+    (cond
+      ;; explicit nil — silenced (caller passed :on-success nil / :on-failure nil)
+      (and supplied? (nil? value))
+      nil
+
+      ;; explicit event vector — append payload
+      (and supplied? (vector? value))
+      (conj value reply-payload)
+
+      ;; default — back to originator with :rf/reply merged into message
+      :else
+      (let [event-id (first origin-event)
+            orig-msg (or (when (>= (count origin-event) 2) (nth origin-event 1))
+                         {})
+            merged   (cond
+                       (map? orig-msg) (assoc orig-msg :rf/reply reply-payload)
+                       :else           {:rf/reply reply-payload})]
+        [event-id merged]))))
+
+;; ---- backoff --------------------------------------------------------------
+
+(defn- compute-backoff-ms
+  "Per Spec 014 §Retry and backoff. Returns the delay in ms before the
+  next attempt. `attempt` is the failing attempt number (1-based)."
+  [{:keys [base-ms factor max-ms jitter] :or {base-ms 250 factor 2 max-ms 5000}} attempt]
+  (let [raw     (* base-ms (Math/pow factor (max 0 (dec attempt))))
+        capped  (min raw max-ms)
+        jittered (if jitter
+                   (let [j (* capped 0.25)
+                         offset (* j (- 0.5 (rand)))]
+                     (max 0 (+ capped offset)))
+                   capped)]
+    (long jittered)))
+
+;; ---- transport (CLJS — Fetch) ---------------------------------------------
+
+#?(:cljs
+   (defn- ^:private fetch-headers->map [^js fetch-headers]
+     (let [out #js {}]
+       (.forEach fetch-headers
+                 (fn [v k] (aset out k v)))
+       (js->clj out))))
+
+#?(:cljs
+   (defn- cljs-fetch
+     "Issue a single HTTP attempt via Fetch. Returns a Promise that resolves
+     to `{:ok? bool :status N :status-text S :headers M :body-text S}` on
+     transport-OK, or rejects with an ex-info classified by the caller."
+     [{:keys [method url headers body credentials mode redirect cache referrer
+              integrity timeout-ms abort-signal internal-controller]}]
+     (let [init     #js {}
+           _        (do (aset init "method" (str/upper-case (name method)))
+                        (when (seq headers)
+                          (let [h #js {}]
+                            (doseq [[k v] headers] (aset h k v))
+                            (aset init "headers" h)))
+                        (when (some? body) (aset init "body" body))
+                        (when credentials  (aset init "credentials" (name credentials)))
+                        (when mode         (aset init "mode"        (name mode)))
+                        (when redirect     (aset init "redirect"    (name redirect)))
+                        (when cache        (aset init "cache"       (name cache)))
+                        (when referrer     (aset init "referrer"    referrer))
+                        (when integrity    (aset init "integrity"   integrity))
+                        (cond
+                          abort-signal        (aset init "signal" abort-signal)
+                          internal-controller (aset init "signal" (.-signal internal-controller))))
+           timeout-handle (atom nil)
+           timeout-fired? (atom false)
+           promise
+           (-> (js/Promise.race
+                 #js [(js/fetch url init)
+                      (js/Promise. (fn [_ reject]
+                                     (when (and timeout-ms internal-controller)
+                                       (reset! timeout-handle
+                                               (js/setTimeout
+                                                 (fn []
+                                                   (reset! timeout-fired? true)
+                                                   (try (.abort internal-controller "timeout")
+                                                        (catch :default _ nil))
+                                                   (reject (ex-info "timeout"
+                                                                    {:rf.http/timeout? true
+                                                                     :elapsed-ms timeout-ms
+                                                                     :limit-ms timeout-ms})))
+                                                 timeout-ms)))))])
+               (.then (fn [resp]
+                        (when-let [h @timeout-handle] (js/clearTimeout h))
+                        (-> (.text resp)
+                            (.then (fn [body-text]
+                                     {:ok? (.-ok resp)
+                                      :status (.-status resp)
+                                      :status-text (.-statusText resp)
+                                      :headers (fetch-headers->map (.-headers resp))
+                                      :body-text body-text}))))))]
+       promise)))
+
+;; ---- transport (JVM — java.net.http.HttpClient) --------------------------
+
+#?(:clj
+   (defonce ^:private jvm-http-client
+     (delay (-> (HttpClient/newBuilder)
+                (.connectTimeout (Duration/ofSeconds 10))
+                (.build)))))
+
+#?(:clj
+   (defn- jvm-build-request
+     [{:keys [method url headers body timeout-ms]}]
+     (let [b (HttpRequest/newBuilder (URI/create url))
+           publisher (cond
+                       (nil? body) (HttpRequest$BodyPublishers/noBody)
+                       (string? body) (HttpRequest$BodyPublishers/ofString ^String body)
+                       (bytes? body) (HttpRequest$BodyPublishers/ofByteArray ^bytes body)
+                       :else (HttpRequest$BodyPublishers/ofString ^String (str body)))]
+       (.method b (str/upper-case (name method)) publisher)
+       (when timeout-ms
+         (.timeout b (Duration/ofMillis (long timeout-ms))))
+       (doseq [[k v] headers]
+         (try (.header b (str k) (str v))
+              (catch Throwable _ nil)))
+       (.build b))))
+
+#?(:clj
+   (defn- jvm-headers->map
+     "Flatten Java HttpHeaders into a plain Clojure map of string->string."
+     [^java.net.http.HttpHeaders hh]
+     (into {}
+           (for [[k vs] (.map hh)]
+             [k (clojure.string/join "," vs)]))))
+
+#?(:clj
+   (defn- jvm-fetch
+     "Issue a single HTTP attempt via java.net.http.HttpClient. Returns a
+     CompletableFuture that completes with `{:ok? :status :status-text
+     :headers :body-text}` or completes-exceptionally with an ex-info."
+     [opts]
+     (let [client ^HttpClient @jvm-http-client
+           req    (jvm-build-request opts)
+           future-resp (.sendAsync client req
+                                   (HttpResponse$BodyHandlers/ofString))]
+       (.thenApply future-resp
+                   (reify java.util.function.Function
+                     (apply [_ resp]
+                       (let [^HttpResponse r resp
+                             status (.statusCode r)]
+                         {:ok? (and (>= status 200) (< status 300))
+                          :status status
+                          :status-text ""
+                          :headers (jvm-headers->map (.headers r))
+                          :body-text (.body r)})))))))
+
+;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
+
+#?(:clj
+   (defn- emit-cljs-only-skipped! [k url]
+     (when interop/debug-enabled?
+       (trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
+                    {:key k :url url}))))
+
+#?(:clj
+   (defn- check-cljs-only-keys! [{:keys [request abort-signal] :as args}]
+     (let [url (:url request)]
+       (doseq [k [:mode :cache :referrer :integrity]]
+         (when (contains? request k)
+           (emit-cljs-only-skipped! k url)))
+       (when abort-signal
+         (emit-cljs-only-skipped! :abort-signal url)))))
+
+;; ---- attempt-and-retry loop (CLJS) ----------------------------------------
+
+#?(:cljs
+   (declare run-attempt-cljs!))
+
+#?(:cljs
+   (defn- dispatch-reply!
+     [{:keys [origin-event explicit-on-success explicit-on-failure
+              kind reply-payload frame]}]
+     (let [explicit (case kind
+                      :success explicit-on-success
+                      :failure explicit-on-failure)
+           ev (build-reply-event {:origin-event origin-event
+                                  :explicit-on  explicit
+                                  :reply-payload reply-payload
+                                  :kind          kind})]
+       (when ev
+         (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+           (dispatch! ev (cond-> {} frame (assoc :frame frame))))))))
+
+#?(:cljs
+   (defn- finalise-success! [ctx accepted]
+     (clear-in-flight! (:request-id ctx))
+     (case (first (keys accepted))
+       :ok      (dispatch-reply! (assoc ctx
+                                        :kind :success
+                                        :reply-payload {:kind :success
+                                                        :value (:ok accepted)}))
+       :failure (dispatch-reply! (assoc ctx
+                                        :kind :failure
+                                        :reply-payload {:kind :failure
+                                                        :failure (assoc (failure-map :rf.http/accept-failure
+                                                                                     {:detail (:failure accepted)
+                                                                                      :decoded (:decoded ctx)})
+                                                                        :request-id (:request-id ctx))})))))
+
+#?(:cljs
+   (defn- finalise-failure!
+     "Final-failure dispatch (after retries exhausted or non-retriable)."
+     [ctx failure]
+     (clear-in-flight! (:request-id ctx))
+     (when (and interop/debug-enabled?
+                (= :rf.http/aborted (:kind failure)))
+       ;; Aborted is its own category — the trace is a single error event.
+       nil)
+     (when interop/debug-enabled?
+       (trace/emit-error! (:kind failure)
+                          (assoc failure
+                                 :request-id (:request-id ctx)
+                                 :url        (:url ctx)
+                                 :recovery   :no-recovery)))
+     (dispatch-reply! (assoc ctx
+                             :kind          :failure
+                             :reply-payload {:kind    :failure
+                                             :failure failure}))))
+
+#?(:cljs
+   (defn- maybe-retry!
+     "Decide between retry, immediate-final-failure, and successful-completion.
+     `failure` is the failure map for the just-finished attempt."
+     [ctx failure]
+     (let [{:keys [retry attempt request-id]} ctx
+           {:keys [on max-attempts backoff]} retry
+           on-set (or on #{})
+           kind   (:kind failure)
+           can-retry? (and (some? max-attempts)
+                           (> max-attempts attempt)
+                           (contains? on-set kind)
+                           (not= :rf.http/aborted kind))]
+       (if can-retry?
+         (let [delay-ms (compute-backoff-ms (or backoff {}) attempt)]
+           (when interop/debug-enabled?
+             (trace/emit! :info :rf.http/retry-attempt
+                          {:request-id   request-id
+                           :url          (:url ctx)
+                           :attempt      attempt
+                           :max-attempts max-attempts
+                           :failure      failure
+                           :next-backoff-ms delay-ms}))
+           (interop/set-timeout!
+             (fn [] (run-attempt-cljs! (update ctx :attempt inc)))
+             delay-ms))
+         (do
+           ;; Final attempt: emit retry-attempt with nil next-backoff if any retries occurred.
+           (when (and interop/debug-enabled?
+                      (some? max-attempts)
+                      (> max-attempts 1))
+             (trace/emit! :info :rf.http/retry-attempt
+                          {:request-id      request-id
+                           :url             (:url ctx)
+                           :attempt         attempt
+                           :max-attempts    max-attempts
+                           :failure         failure
+                           :next-backoff-ms nil}))
+           (finalise-failure! ctx failure))))))
+
+#?(:cljs
+   (defn- classify-cljs-error
+     "Map a Fetch rejection / promise-error to a `:rf.http/*` failure shape."
+     [^js err]
+     (let [data (when (.-data err) (ex-data err))]
+       (cond
+         (:rf.http/timeout? data)
+         (failure-map :rf.http/timeout
+                      {:elapsed-ms (:elapsed-ms data)
+                       :limit-ms   (:limit-ms data)})
+
+         (or (= "AbortError" (.-name err))
+             (:rf.http/aborted? data))
+         (failure-map :rf.http/aborted
+                      {:request-id (:request-id data)
+                       :reason     (or (:reason data) :user)})
+
+         :else
+         (failure-map :rf.http/transport
+                      {:message (or (.-message err) (str err))
+                       :cause   err})))))
+
+#?(:cljs
+   (defn- run-attempt-cljs!
+     "Issue one Fetch attempt, then dispatch reply or retry."
+     [ctx]
+     (let [{:keys [request decode decode-supplied? accept timeout-ms
+                   request-id abort-signal]} ctx
+           method (or (:method request) :get)
+           url    (merge-params (:url request) (:params request))
+           [enc-body ct] (encode-body (realise-body (:body request))
+                                      (:request-content-type request))
+           headers (cond-> (or (:headers request) {})
+                     (and ct (not (get (or (:headers request) {}) "content-type"))
+                          (not (get (or (:headers request) {}) "Content-Type")))
+                     (assoc "Content-Type" ct))
+           internal-controller (when-not abort-signal (js/AbortController.))]
+       ;; Register the abort handle.
+       (record-in-flight! request-id
+                          {:abort-fn (fn [reason]
+                                       (try
+                                         (cond
+                                           internal-controller
+                                           (.abort internal-controller (clj->js reason))
+                                           ;; External signal — user owns it.
+                                           :else nil)
+                                         (finalise-failure!
+                                           (assoc ctx :url url)
+                                           (failure-map :rf.http/aborted
+                                                        {:request-id request-id
+                                                         :reason     reason}))
+                                         (catch :default _ nil)))
+                           :url url})
+       (-> (cljs-fetch {:method method
+                        :url url
+                        :headers headers
+                        :body enc-body
+                        :credentials (:credentials request)
+                        :mode (:mode request)
+                        :redirect (:redirect request)
+                        :cache (:cache request)
+                        :referrer (:referrer request)
+                        :integrity (:integrity request)
+                        :timeout-ms timeout-ms
+                        :abort-signal abort-signal
+                        :internal-controller internal-controller})
+           (.then (fn [{:keys [ok? status status-text headers body-text]}]
+                    (let [ctx' (assoc ctx :url url)]
+                      (try
+                        (let [decoded (decode-response-body
+                                        {:body-text body-text
+                                         :headers   headers
+                                         :decode    decode
+                                         :decode-supplied? decode-supplied?
+                                         :request-id request-id
+                                         :url        url})]
+                          (cond
+                            (and (>= status 400) (< status 500))
+                            (maybe-retry! ctx'
+                                          (failure-map :rf.http/http-4xx
+                                                       {:status status
+                                                        :status-text status-text
+                                                        :body decoded
+                                                        :headers headers}))
+
+                            (>= status 500)
+                            (maybe-retry! ctx'
+                                          (failure-map :rf.http/http-5xx
+                                                       {:status status
+                                                        :status-text status-text
+                                                        :body decoded
+                                                        :headers headers}))
+
+                            ok?
+                            (let [accepted (run-accept accept decoded {:status status})]
+                              (cond
+                                (contains? accepted :ok)
+                                (finalise-success! ctx' accepted)
+
+                                (contains? accepted :failure)
+                                (finalise-failure!
+                                  ctx'
+                                  (failure-map :rf.http/accept-failure
+                                               {:detail  (:failure accepted)
+                                                :decoded decoded
+                                                :request-id request-id}))))
+
+                            :else
+                            (finalise-failure!
+                              ctx'
+                              (failure-map :rf.http/http-4xx
+                                           {:status status
+                                            :status-text status-text
+                                            :body decoded
+                                            :headers headers}))))
+                        (catch :default e
+                          (let [d (ex-data e)]
+                            (maybe-retry!
+                              ctx'
+                              (failure-map :rf.http/decode-failure
+                                           {:body-text body-text
+                                            :cause     (.-message e)
+                                            :malli-error? (boolean (:malli-error? d))})))))) ))
+           (.catch (fn [err]
+                     (let [failure (classify-cljs-error err)]
+                       (maybe-retry! (assoc ctx :url url) failure))))))))
+
+;; ---- attempt-and-retry loop (JVM) -----------------------------------------
+
+#?(:clj
+   (declare run-attempt-jvm!))
+
+#?(:clj
+   (defn- dispatch-reply-jvm!
+     [{:keys [origin-event explicit-on-success explicit-on-failure
+              kind reply-payload frame]}]
+     (let [explicit (case kind
+                      :success explicit-on-success
+                      :failure explicit-on-failure)
+           ev (build-reply-event {:origin-event origin-event
+                                  :explicit-on  explicit
+                                  :reply-payload reply-payload
+                                  :kind          kind})]
+       (when ev
+         (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+           (dispatch! ev (cond-> {} frame (assoc :frame frame))))))))
+
+#?(:clj
+   (defn- finalise-success-jvm! [ctx accepted]
+     (clear-in-flight! (:request-id ctx))
+     (cond
+       (contains? accepted :ok)
+       (dispatch-reply-jvm! (assoc ctx
+                                   :kind :success
+                                   :reply-payload {:kind  :success
+                                                   :value (:ok accepted)}))
+
+       (contains? accepted :failure)
+       (dispatch-reply-jvm! (assoc ctx
+                                   :kind :failure
+                                   :reply-payload {:kind    :failure
+                                                   :failure (failure-map :rf.http/accept-failure
+                                                                         {:detail     (:failure accepted)
+                                                                          :decoded    (:decoded ctx)
+                                                                          :request-id (:request-id ctx)})})))))
+
+#?(:clj
+   (defn- finalise-failure-jvm!
+     [ctx failure]
+     (clear-in-flight! (:request-id ctx))
+     (when interop/debug-enabled?
+       (trace/emit-error! (:kind failure)
+                          (assoc failure
+                                 :request-id (:request-id ctx)
+                                 :url        (:url ctx)
+                                 :recovery   :no-recovery)))
+     (dispatch-reply-jvm! (assoc ctx
+                                 :kind          :failure
+                                 :reply-payload {:kind    :failure
+                                                 :failure failure}))))
+
+#?(:clj
+   (defn- maybe-retry-jvm!
+     [ctx failure]
+     (let [{:keys [retry attempt request-id]} ctx
+           {:keys [on max-attempts backoff]} retry
+           on-set (or on #{})
+           kind   (:kind failure)
+           can-retry? (and (some? max-attempts)
+                           (> max-attempts attempt)
+                           (contains? on-set kind)
+                           (not= :rf.http/aborted kind))]
+       (if can-retry?
+         (let [delay-ms (compute-backoff-ms (or backoff {}) attempt)]
+           (when interop/debug-enabled?
+             (trace/emit! :info :rf.http/retry-attempt
+                          {:request-id   request-id
+                           :url          (:url ctx)
+                           :attempt      attempt
+                           :max-attempts max-attempts
+                           :failure      failure
+                           :next-backoff-ms delay-ms}))
+           ;; Sleep + retry on a worker thread to avoid blocking the caller.
+           (.start (Thread.
+                     ^Runnable
+                     (fn []
+                       (try (Thread/sleep delay-ms) (catch InterruptedException _ nil))
+                       (run-attempt-jvm! (update ctx :attempt inc))))))
+         (do
+           (when (and interop/debug-enabled?
+                      (some? max-attempts)
+                      (> max-attempts 1))
+             (trace/emit! :info :rf.http/retry-attempt
+                          {:request-id      request-id
+                           :url             (:url ctx)
+                           :attempt         attempt
+                           :max-attempts    max-attempts
+                           :failure         failure
+                           :next-backoff-ms nil}))
+           (finalise-failure-jvm! ctx failure))))))
+
+#?(:clj
+   (defn- classify-jvm-error [^Throwable t]
+     (let [cause (or (.getCause t) t)
+           msg   (.getMessage cause)
+           cls   (.getName (class cause))]
+       (cond
+         (or (instance? java.net.http.HttpTimeoutException cause)
+             (and msg (str/includes? (str/lower-case msg) "timed out")))
+         (failure-map :rf.http/timeout {:elapsed-ms nil :limit-ms nil :message msg})
+
+         (or (instance? java.util.concurrent.CancellationException cause)
+             (and msg (str/includes? (str/lower-case msg) "abort")))
+         (failure-map :rf.http/aborted {:reason :user :message msg})
+
+         :else
+         (failure-map :rf.http/transport {:message msg :cause cls})))))
+
+#?(:clj
+   (defn- run-attempt-jvm!
+     [ctx]
+     (let [{:keys [request decode decode-supplied? accept timeout-ms request-id]} ctx
+           method (or (:method request) :get)
+           url    (merge-params (:url request) (:params request))
+           [enc-body ct] (encode-body (realise-body (:body request))
+                                      (:request-content-type request))
+           headers (cond-> (or (:headers request) {})
+                     (and ct (not (get (or (:headers request) {}) "content-type"))
+                          (not (get (or (:headers request) {}) "Content-Type")))
+                     (assoc "Content-Type" ct))
+           ctx' (assoc ctx :url url)
+           handle {:abort-fn (fn [_reason]
+                               (finalise-failure-jvm!
+                                 ctx'
+                                 (failure-map :rf.http/aborted
+                                              {:request-id request-id
+                                               :reason     :user})))
+                   :url url}]
+       (record-in-flight! request-id handle)
+       (try
+         (let [^CompletableFuture cf
+               (jvm-fetch {:method method
+                           :url url
+                           :headers headers
+                           :body enc-body
+                           :timeout-ms timeout-ms})]
+           (.whenComplete cf
+                          (reify java.util.function.BiConsumer
+                            (accept [_ result throwable]
+                              (cond
+                                throwable
+                                (maybe-retry-jvm! ctx' (classify-jvm-error throwable))
+
+                                :else
+                                (let [{:keys [ok? status status-text headers body-text]} result]
+                                  (try
+                                    (let [decoded (decode-response-body
+                                                    {:body-text body-text
+                                                     :headers   headers
+                                                     :decode    decode
+                                                     :decode-supplied? decode-supplied?
+                                                     :request-id request-id
+                                                     :url        url})]
+                                      (cond
+                                        (and (>= status 400) (< status 500))
+                                        (maybe-retry-jvm!
+                                          ctx'
+                                          (failure-map :rf.http/http-4xx
+                                                       {:status status
+                                                        :status-text status-text
+                                                        :body decoded
+                                                        :headers headers}))
+
+                                        (>= status 500)
+                                        (maybe-retry-jvm!
+                                          ctx'
+                                          (failure-map :rf.http/http-5xx
+                                                       {:status status
+                                                        :status-text status-text
+                                                        :body decoded
+                                                        :headers headers}))
+
+                                        ok?
+                                        (let [accepted (run-accept accept decoded {:status status})]
+                                          (finalise-success-jvm!
+                                            (assoc ctx' :decoded decoded) accepted))
+
+                                        :else
+                                        (finalise-failure-jvm!
+                                          ctx'
+                                          (failure-map :rf.http/http-4xx
+                                                       {:status status
+                                                        :status-text status-text
+                                                        :body decoded
+                                                        :headers headers}))))
+                                    (catch Throwable e
+                                      (let [d (ex-data e)]
+                                        (maybe-retry-jvm!
+                                          ctx'
+                                          (failure-map :rf.http/decode-failure
+                                                       {:body-text body-text
+                                                        :cause (.getMessage e)
+                                                        :malli-error? (boolean (:malli-error? d))})))))))))) )
+         (catch Throwable t
+           (maybe-retry-jvm! ctx' (classify-jvm-error t)))))))
+
+;; ---- the public fxs -------------------------------------------------------
+
+(defn- normalise-args
+  "Validate + normalise the args map. Returns a context ready for the
+  per-host attempt loop."
+  [{:keys [request decode accept retry timeout-ms
+           on-success on-failure request-id abort-signal]
+    :or   {timeout-ms 30000}
+    :as   args-map}
+   frame-ctx]
+  (let [origin-event (or (:event frame-ctx)
+                         (:rf.http/origin-event args-map)
+                         [:rf.http/managed])
+        frame        (or (:frame frame-ctx) :rf/default)]
+    {:request           request
+     :decode            decode
+     :decode-supplied?  (some? decode)
+     :accept            accept
+     :retry             retry
+     :timeout-ms        timeout-ms
+     :origin-event      origin-event
+     :explicit-on-success
+     {:supplied? (contains? args-map :on-success)
+      :value     on-success}
+     :explicit-on-failure
+     {:supplied? (contains? args-map :on-failure)
+      :value     on-failure}
+     :request-id        request-id
+     :abort-signal      abort-signal
+     :frame             frame
+     :attempt           1}))
+
+(defn- managed-handler
+  "The public `:rf.http/managed` fx body. `frame-ctx` carries `:frame`
+  and (when threaded by the runtime, per the do-fx 5-arity) `:event` —
+  the originating event vector used for default reply addressing per
+  Spec 014 §Reply addressing."
+  [frame-ctx args-map]
+  #?(:clj (check-cljs-only-keys! args-map))
+  (let [normalised (normalise-args args-map frame-ctx)
+        request-id (:request-id normalised)]
+    (when request-id (supersede! request-id))
+    #?(:cljs (run-attempt-cljs! normalised)
+       :clj  (run-attempt-jvm!  normalised))
+    nil))
+
+(defn- managed-abort-handler
+  "Public `:rf.http/managed-abort` fx. Args is the request-id (any value)."
+  [_frame-ctx request-id]
+  (when-let [handle (lookup-in-flight request-id)]
+    (clear-in-flight! request-id)
+    (try ((:abort-fn handle) :user)
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  nil)
+
+(defn- origin-event-from
+  [frame-ctx args-map]
+  (or (:event frame-ctx)
+      (:rf.http/origin-event args-map)
+      [:rf.http/managed]))
+
+(defn- canned-success-handler
+  "Stub fx — synthesises a success reply per Spec 014 §Testing."
+  [frame-ctx args-map]
+  (let [{:keys [on-success]} args-map
+        value (get args-map :value {:stubbed true})
+        reply {:kind :success :value value}
+        ev    (build-reply-event {:origin-event (origin-event-from frame-ctx args-map)
+                                  :explicit-on  {:supplied? (contains? args-map :on-success)
+                                                 :value     on-success}
+                                  :reply-payload reply
+                                  :kind          :success})]
+    (when ev
+      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        (dispatch! ev (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
+    nil))
+
+(defn- canned-failure-handler
+  [frame-ctx args-map]
+  (let [{:keys [on-failure]} args-map
+        kind  (or (:kind args-map) :rf.http/transport)
+        tags  (or (:tags args-map) {})
+        failure (assoc tags :kind kind)
+        reply {:kind :failure :failure failure}
+        ev    (build-reply-event {:origin-event (origin-event-from frame-ctx args-map)
+                                  :explicit-on  {:supplied? (contains? args-map :on-failure)
+                                                 :value     on-failure}
+                                  :reply-payload reply
+                                  :kind          :failure})]
+    (when ev
+      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        (dispatch! ev (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
+    nil))
+
+;; ---- registration ---------------------------------------------------------
+
+(fx/reg-fx :rf.http/managed
+           {:doc "Spec 014 — managed HTTP request."}
+           managed-handler)
+
+(fx/reg-fx :rf.http/managed-abort
+           {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
+           managed-abort-handler)
+
+;; The two canned-stub fxs are gated on `interop/debug-enabled?` so they
+;; elide in production. Per Spec 014 §Testing — "Don't ship the canned-
+;; stub fxs as production-eligible".
+#?(:clj  (when interop/debug-enabled?
+           (fx/reg-fx :rf.http/managed-canned-success
+                      {:doc "Spec 014 — synthesised success reply (test stub)."}
+                      canned-success-handler)
+           (fx/reg-fx :rf.http/managed-canned-failure
+                      {:doc "Spec 014 — synthesised failure reply (test stub)."}
+                      canned-failure-handler))
+   :cljs (do
+           (fx/reg-fx :rf.http/managed-canned-success
+                      {:doc "Spec 014 — synthesised success reply (test stub)."}
+                      canned-success-handler)
+           (fx/reg-fx :rf.http/managed-canned-failure
+                      {:doc "Spec 014 — synthesised failure reply (test stub)."}
+                      canned-failure-handler)))
+
+;; ---- with-managed-request-stubs ------------------------------------------
+
+(defn- stub-handler
+  [stubs frame-ctx args-map]
+  (let [req    (:request args-map)
+        method (or (:method req) :get)
+        url    (:url req)
+        entry  (get stubs [method url])
+        reply  (:reply entry)]
+    (cond
+      (and entry (contains? reply :ok))
+      (canned-success-handler frame-ctx (assoc args-map :value (:ok reply)))
+
+      (and entry (contains? reply :failure))
+      (canned-failure-handler frame-ctx
+                              (-> args-map
+                                  (assoc :kind (or (:kind (:failure reply))
+                                                   :rf.http/transport))
+                                  (assoc :tags (dissoc (:failure reply) :kind))))
+
+      :else
+      (canned-failure-handler frame-ctx
+                              (assoc args-map
+                                     :kind :rf.http/transport
+                                     :tags {:message "no stub matched"
+                                            :method  method
+                                            :url     url})))))
+
+(def ^:private stub-fx-id :rf.http/managed-test-stub)
+
+(defn install-managed-request-stubs!
+  "Test-time helper. `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
+  Registers a per-call fx-override target that consults `stubs` and
+  synthesises the configured reply.
+
+  Use with `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`
+  on `dispatch-sync`, or wrap the test body via `with-managed-request-stubs`.
+
+  Per Spec 014 §Testing — the framework ships canonical stub fxs."
+  [stubs]
+  (fx/reg-fx stub-fx-id
+             {:doc "with-managed-request-stubs synthesised stub"}
+             (fn [frame-ctx args-map]
+               (stub-handler stubs frame-ctx args-map)))
+  stub-fx-id)
+
+(defn uninstall-managed-request-stubs!
+  []
+  (fx/unregister-fx stub-fx-id)
+  nil)
+
+(defn with-managed-request-stubs*
+  "Function form: install stubs, run thunk, uninstall. Test-time helper."
+  [stubs thunk]
+  (try
+    (install-managed-request-stubs! stubs)
+    (thunk)
+    (finally
+      (uninstall-managed-request-stubs!))))
+
+#?(:clj
+   (defmacro with-managed-request-stubs
+     "Test-time helper. `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
+     Installs a per-call fx-override on `:rf.http/managed` that consults
+     the stub map, synthesises the configured reply, and runs `body`.
+
+     Per Spec 014 §Testing."
+     [stubs & body]
+     `(with-managed-request-stubs* ~stubs (fn [] ~@body))))

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -204,7 +204,8 @@
               (let [active-platform (or (get-in frame-record [:config :platform])
                                         interop/platform)]
                 (fx/do-fx frame fx-vec active-platform
-                          (or (:rf/fx-overrides initial-ctx) {}))))
+                          (or (:rf/fx-overrides initial-ctx) {})
+                          event)))
             (trace/emit! :event :event
                          {:event-id event-id
                           :event    event

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -22,7 +22,13 @@
             [re-frame.flows :as flows]
             [re-frame.subs :as subs]
             [re-frame.trace :as trace]
-            [re-frame.conformance :as conformance]))
+            [re-frame.conformance :as conformance]
+            ;; Spec 014 — :rf.http/managed registers at ns-load time. The
+            ;; fixture corpus references the fx (often via :fx-overrides
+            ;; redirecting to its canned stubs); requiring here gives the
+            ;; runner access to the fx without each fixture re-registering
+            ;; it itself.
+            [re-frame.http-managed]))
 
 ;; ---- claimed capability set -----------------------------------------------
 
@@ -60,7 +66,9 @@
     :flow/topo
     :flow/dirty-check
     :flow/toggle
-    :flow/hot-reload})
+    :flow/hot-reload
+    ;; Spec 014 — :rf.http/managed (rf2-z1mw)
+    :rf.http/managed})
 
 ;; ---- fixture loader -------------------------------------------------------
 
@@ -108,11 +116,15 @@
   ;; Re-evaluate the registration ns-bodies by removing-and-reloading.
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
+  ;; Spec 014 — re-register :rf.http/managed and friends after clear-all!.
+  (require 're-frame.http-managed :reload)
   ;; Reset id-allocators so nav-token / pending-nav / rank-reg / spawn ids
   ;; are stable across runs (the routing/machine fixtures assert against
   ;; literal "nav-1" / "nav-2" / ":http/post#1" strings).
   ((requiring-resolve 're-frame.routing/reset-counters!))
-  ((requiring-resolve 're-frame.machines/reset-counters!)))
+  ((requiring-resolve 're-frame.machines/reset-counters!))
+  ;; Spec 014 — drop the in-flight request registry between fixtures.
+  ((requiring-resolve 're-frame.http-managed/clear-all-in-flight!)))
 
 ;; ---- fixture execution ----------------------------------------------------
 

--- a/implementation/test/re_frame/http_managed_test.clj
+++ b/implementation/test/re_frame/http_managed_test.clj
@@ -1,0 +1,375 @@
+(ns re-frame.http-managed-test
+  "JVM smoke tests for Spec 014 — `:rf.http/managed`.
+
+  Covers the canned-stub fxs (no real network IO needed for the stubs)
+  AND, where in-process HTTP is convenient, the real
+  `java.net.http.HttpClient`-backed transport against a tiny
+  com.sun.net.httpserver test server.
+
+  Per Spec 014 §Implementation status — JVM transport is part of the
+  CLJS reference implementation's claim."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.trace :as trace])
+  (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
+           [java.net InetSocketAddress]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---- per-test reset --------------------------------------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.http-managed :reload)
+  (http-managed/clear-all-in-flight!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- a tiny in-process HTTP server ----------------------------------------
+;;
+;; com.sun.net.httpserver ships with the JDK; spinning up one per test
+;; is fast enough (~5ms) and gives us a real socket to point HttpClient at.
+
+(defn- start-server!
+  "Start an HttpServer with the given handler. Returns a {:server ::server :port N} map.
+  Stop with (.stop server 0)."
+  [handler]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)
+        ctx    (.createContext server "/")]
+    (.setHandler ctx
+                 (reify HttpHandler
+                   (handle [_ exchange]
+                     (handler exchange))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server
+     :port   (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [server]}]
+  (.stop server 0))
+
+(defn- write-response! [^HttpExchange exchange status content-type body]
+  (let [bytes (.getBytes (str body) "UTF-8")]
+    (when content-type
+      (-> exchange .getResponseHeaders (.set "Content-Type" content-type)))
+    (.sendResponseHeaders exchange status (long (count bytes)))
+    (with-open [os (.getResponseBody exchange)]
+      (.write os bytes))))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- await-reply!
+  "Wait up to timeout-ms for `(pred (rf/get-frame-db :rf/default))` to be
+  true. Returns the final db on success, throws on timeout."
+  ([pred] (await-reply! pred 5000))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [db (rf/get-frame-db :rf/default)]
+         (cond
+           (pred db) db
+           (> (System/currentTimeMillis) deadline)
+           (throw (ex-info "timed out awaiting reply" {:final-db db}))
+           :else (do (Thread/sleep 25) (recur))))))))
+
+;; ---- 1. canned-success: round-trip default reply addressing ---------------
+
+(deftest canned-success-default-reply-addressing
+  (testing "the canned-success stub dispatches a default reply (originating event-id with :rf/reply)"
+    (rf/reg-event-fx :article/load
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          (case (:kind reply)
+            :success {:db (assoc-in db [:article :data] (:value reply))}
+            :failure {:db (assoc-in db [:article :error] (:failure reply))})
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles/hello"}
+                  :decode  :json}]]})))
+    (rf/dispatch-sync [:article/load {:slug "hello"}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    ;; Stubs synthesise replies via the router; await the dispatch.
+    (let [db (await-reply! #(some? (get-in % [:article :data])))]
+      (is (= {:stubbed true} (get-in db [:article :data]))))))
+
+;; ---- 2. canned-failure: explicit on-failure addressing ---------------------
+
+(deftest canned-failure-explicit-on-failure
+  (testing "explicit :on-failure routes the failure reply to the named handler"
+    (rf/reg-event-fx :auth/login
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request   {:method :post :url "/auth/login"}
+                :on-failure [:auth/login-error]}]]}))
+    (rf/reg-event-db :auth/login-error
+      (fn [db [_ payload]]
+        (assoc db :auth-error payload)))
+    (rf/dispatch-sync [:auth/login]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+    (let [db (await-reply! #(some? (:auth-error %)))]
+      (is (= :failure (get-in db [:auth-error :kind])))
+      (is (= :rf.http/transport (get-in db [:auth-error :failure :kind]))))))
+
+;; ---- 3. silenced reply (on-success nil) -----------------------------------
+
+(deftest silenced-reply-on-success-nil
+  (testing "explicit :on-success nil swallows the reply silently"
+    (let [seen (atom 0)]
+      (rf/reg-event-fx :ping
+        (fn [_ _]
+          (swap! seen inc)
+          {:fx [[:rf.http/managed
+                 {:request    {:url "/ping"}
+                  :on-success nil}]]}))
+      (rf/dispatch-sync [:ping]
+                        {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+      ;; Wait long enough for any reply dispatch to settle.
+      (Thread/sleep 100)
+      ;; Only the initial dispatch fired :ping; no reply.
+      (is (= 1 @seen)))))
+
+;; ---- 4. real JVM transport: GET success -----------------------------------
+
+(deftest jvm-real-get-success
+  (testing "java.net.http.HttpClient transport — GET, JSON decode, default reply"
+    (let [{:keys [server port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json"
+                               "{\"article\":{\"title\":\"hello\",\"id\":42}}")))]
+      (try
+        (rf/reg-event-fx :article/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              (case (:kind reply)
+                :success {:db (assoc db :article (:value reply))}
+                :failure {:db (assoc db :error  (:failure reply))})
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/articles/hello")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:article/load {}])
+        (let [db (await-reply! #(some? (:article %)) 5000)]
+          (is (= "hello" (get-in db [:article :article :title]))))
+        (finally (stop-server! srv))))))
+
+;; ---- 5. real JVM transport: 4xx routes through failure --------------------
+
+(deftest jvm-real-http-4xx
+  (testing "non-2xx 4xx response classifies as :rf.http/http-4xx"
+    (let [{:keys [server port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 404 "application/json" "{\"error\":\"not-found\"}")))]
+      (try
+        (rf/reg-event-fx :article/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/missing")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:article/load {}])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/http-4xx (get-in db [:reply :failure :kind])))
+          (is (= 404 (get-in db [:reply :failure :status]))))
+        (finally (stop-server! srv))))))
+
+;; ---- 6. retry exhaustion --------------------------------------------------
+
+(deftest jvm-retry-exhaustion
+  (testing ":retry exhausts after :max-attempts, dispatching a single :on-failure"
+    (let [hits (atom 0)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (swap! hits inc)
+              (write-response! ex 500 "application/json" "{\"err\":true}")))]
+      (try
+        (rf/reg-event-fx :flaky/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/flaky")}
+                      :decode  :json
+                      :retry   {:on           #{:rf.http/http-5xx}
+                                :max-attempts 3
+                                :backoff      {:base-ms 5 :factor 1 :max-ms 10}}}]]})))
+        (rf/dispatch-sync [:flaky/load])
+        (let [db (await-reply! #(some? (:reply %)) 8000)]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/http-5xx (get-in db [:reply :failure :kind])))
+          ;; The server saw all 3 attempts.
+          (is (= 3 @hits)))
+        (finally (stop-server! srv))))))
+
+;; ---- 7. retry recover -----------------------------------------------------
+
+(deftest jvm-retry-recover
+  (testing ":retry recovers when an intermediate attempt succeeds"
+    (let [hits (atom 0)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (let [n (swap! hits inc)]
+                (if (= 1 n)
+                  (write-response! ex 500 "application/json" "{\"err\":true}")
+                  (write-response! ex 200 "application/json" "{\"ok\":true}")))))]
+      (try
+        (rf/reg-event-fx :recover/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/recover")}
+                      :decode  :json
+                      :retry   {:on           #{:rf.http/http-5xx}
+                                :max-attempts 3
+                                :backoff      {:base-ms 5 :factor 1 :max-ms 10}}}]]})))
+        (rf/dispatch-sync [:recover/load])
+        (let [db (await-reply! #(some? (:reply %)) 8000)]
+          (is (= :success (get-in db [:reply :kind])))
+          (is (= {:ok true} (get-in db [:reply :value])))
+          (is (= 2 @hits)))
+        (finally (stop-server! srv))))))
+
+;; ---- 8. transport failure --------------------------------------------------
+
+(deftest jvm-transport-failure
+  (testing "connection-refused classifies as :rf.http/transport"
+    (rf/reg-event-fx :load
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :reply reply)}
+          {:fx [[:rf.http/managed
+                 ;; Pick a port we expect to be closed.
+                 {:request {:url "http://127.0.0.1:1/never"}
+                  :decode  :json}]]})))
+    (rf/dispatch-sync [:load])
+    (let [db (await-reply! #(some? (:reply %)) 5000)]
+      (is (= :failure (get-in db [:reply :kind])))
+      (is (= :rf.http/transport (get-in db [:reply :failure :kind]))))))
+
+;; ---- 9. abort by request-id -----------------------------------------------
+
+(deftest jvm-abort-by-request-id
+  (testing ":rf.http/managed-abort cancels an in-flight request by id"
+    (let [latch (CountDownLatch. 1)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; Block until the test releases the latch.
+              (.await latch 5 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json" "{\"too\":\"late\"}")))]
+      (try
+        (rf/reg-event-fx :slow/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request    {:url (str "http://127.0.0.1:" port "/slow")}
+                      :request-id :slow
+                      :decode     :json}]]})))
+        (rf/reg-event-fx :slow/abort
+          (fn [_ _] {:fx [[:rf.http/managed-abort :slow]]}))
+        (rf/dispatch-sync [:slow/load])
+        (Thread/sleep 50)
+        (rf/dispatch-sync [:slow/abort])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/aborted (get-in db [:reply :failure :kind]))))
+        (.countDown latch)
+        (finally (stop-server! srv))))))
+
+;; ---- 10. thunk body -------------------------------------------------------
+
+(deftest jvm-thunk-body
+  (testing ":body as a thunk is invoked at request-send time"
+    (let [thunk-calls (atom 0)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"echoed\":true}")))]
+      (try
+        (rf/reg-event-fx :upload
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:method :post
+                                :url    (str "http://127.0.0.1:" port "/upload")
+                                :body   (fn []
+                                          (swap! thunk-calls inc)
+                                          {:payload :ok})
+                                :request-content-type :json}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:upload])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :success (get-in db [:reply :kind])))
+          (is (= 1 @thunk-calls)))
+        (finally (stop-server! srv))))))
+
+;; ---- 11. with-managed-request-stubs helper --------------------------------
+
+(deftest with-managed-request-stubs-helper
+  (testing "with-managed-request-stubs routes :method+:url to the configured reply"
+    (rf/reg-event-fx :articles/list
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :result reply)}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs
+      {[:get "/articles"] {:reply {:ok [:hello :world]}}}
+      (rf/dispatch-sync [:articles/list]
+                        {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+      (let [db (await-reply! #(some? (:result %)) 2000)]
+        (is (= :success (get-in db [:result :kind])))
+        (is (= [:hello :world] (get-in db [:result :value])))))))
+
+;; ---- 12. decode reflection metadata ---------------------------------------
+
+(deftest decode-reflection-metadata
+  (testing ":rf.http/decode-schemas declared on the handler is queryable via handler-meta"
+    (rf/reg-event-fx :article/load
+      {:doc                    "Load an article."
+       :rf.http/decode-schemas [::ArticleResponse]}
+      (fn [_ _] {}))
+    (let [m (rf/handler-meta :event :article/load)]
+      (is (= [::ArticleResponse] (:rf.http/decode-schemas m))))))
+
+;; ---- 13. timeout failure category -----------------------------------------
+
+(deftest jvm-timeout-failure
+  (testing "per-attempt timeout fires :rf.http/timeout"
+    (let [latch (CountDownLatch. 1)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (.await latch 10 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json" "{\"too\":\"late\"}")))]
+      (try
+        (rf/reg-event-fx :slow/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request    {:url (str "http://127.0.0.1:" port "/slow")}
+                      :timeout-ms 80
+                      :decode     :json}]]})))
+        (rf/dispatch-sync [:slow/load])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/timeout (get-in db [:reply :failure :kind]))))
+        (.countDown latch)
+        (finally (stop-server! srv))))))


### PR DESCRIPTION
## Summary

Phase 1 of Spec 014 — `:rf.http/managed` and family. CLJS (Fetch) and JVM (`java.net.http.HttpClient`) transport, full args-map, retry+backoff, all eight failure categories, abort by `:request-id` and `:abort-signal`, schema-driven decode, default reply-addressing.

- New `re-frame.http-managed` registers `:rf.http/managed`, `:rf.http/managed-abort`, `:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure` at ns-load.
- Public test helper: `rf/with-managed-request-stubs` (macro) + `rf/install-managed-request-stubs!` / `rf/uninstall-managed-request-stubs!` (fn pair).
- Schema-reflection metadata under `:rf.http/decode-schemas` queryable via `(rf/handler-meta :event id)` per Spec 014 §Schema reflection.
- `do-fx` extended (5-arity) to thread the originating event vector into user-registered fx handlers as `:event` on ctx — needed for Spec 014 §Reply addressing default path.
- Trace events (`:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`, `:rf.http/cljs-only-key-ignored-on-jvm`, the eight `:rf.http/*` failure categories) gate on `interop/debug-enabled?` and elide in production.
- The fx itself is dev+prod (it's user-facing). Canned-stub fxs gate on `interop/debug-enabled?` so they elide.

## Phase split

Per the bead's escape hatch (split is acceptable). Phase 2 follow-up: `rf2-cfig` — remaining 5 conformance fixtures, CLJS smoke, Playwright integration, elision-probe extension.

## Test plan

- [x] JVM: 195 tests, 951 assertions, 0 failures
- [x] CLJS node-test: 56 tests, 199 assertions, 0 failures
- [x] Conformance corpus: 71 fixtures, 0 failed (5 new `rf.http.managed/*` fixtures)
- [x] Elision probe with control: PASS
- [x] 13 JVM smoke tests including real in-process `com.sun.net.httpserver` round-trips for: GET success, 4xx, retry exhaustion, retry recover, transport failure, abort by request-id, thunk body, with-managed-request-stubs helper, decode-schemas reflection metadata, timeout, plus default + explicit + silenced reply addressing via canned stubs

## Files

New:
- `implementation/src/re_frame/http_managed.cljc`
- `implementation/test/re_frame/http_managed_test.clj`
- `docs/specification/conformance/fixtures/http-managed-default-reply-addressing.edn`
- `docs/specification/conformance/fixtures/http-managed-get-success.edn`
- `docs/specification/conformance/fixtures/http-managed-post-json.edn`
- `docs/specification/conformance/fixtures/http-managed-decode-failure.edn`
- `docs/specification/conformance/fixtures/http-managed-retry-exhaustion.edn`

Touched:
- `implementation/src/re_frame/core.cljc` — re-export public surface
- `implementation/src/re_frame/fx.cljc` — `do-fx` 5-arity for origin-event threading
- `implementation/src/re_frame/router.cljc` — pass event vector to `do-fx`
- `implementation/test/re_frame/conformance_test.clj` — `:rf.http/managed` capability + reload between fixtures