### PR TITLE
feat: state-machine API rewrite + tightened contract (rf2-hbt1, rf2-qppo)

### DIFF
--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -67,23 +67,52 @@ The fix isn't to write better `cond` clauses. The fix is to step back and notice
 
 ```clojure
 (def login-flow
-  {:id      :auth.login/flow
-   :initial :idle
-   :context {:attempts 0 :error nil}
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:under-retry-limit
+    (fn [data _event] (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error
+    (fn [_ _] {:data {:error nil}})
+
+    :issue-request
+    (fn [_data [_ creds]]
+      {:fx [[:http {:method     :post
+                    :url        "/api/login"
+                    :body       creds
+                    :on-success [:auth.login/flow [:auth.login/success]]
+                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+
+    :record-error
+    (fn [data [_ err]]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc :error (or (:message err) "Login failed.")))})
+
+    :lock-account
+    (fn [_ _] {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+
+    :store-session
+    (fn [_data [_ {:keys [token]}]]
+      {:fx [[:auth.session/store {:token token}]]})}
+
    :states
    {:idle
-    {:on {:auth.login/submit {:target  :submitting
-                              :actions [:auth.login/clear-error]}}}
+    {:on {:auth.login/submit {:target :submitting
+                              :action :clear-error}}}
 
     :submitting
-    {:entry [:auth.login/issue-request]
-     :on    {:auth.login/success {:target  :authed
-                                  :actions [:auth.login/store-session]}
-             :auth.login/failure [{:target  :error-shown
-                                   :cond    :auth.login/under-retry-limit
-                                   :actions [:auth.login/record-error]}
-                                  {:target  :locked-out
-                                   :actions [:auth.login/lock-account]}]}}
+    {:entry :issue-request
+     :on    {:auth.login/success {:target :authed
+                                  :action :store-session}
+             :auth.login/failure [{:target :error-shown
+                                   :guard  :under-retry-limit
+                                   :action :record-error}
+                                  {:target :locked-out
+                                   :action :lock-account}]}}
 
     :error-shown
     {:on {:auth.login/dismiss {:target :idle}
@@ -99,26 +128,27 @@ This is a **transition table**. It's pure data. You can read it top to bottom an
 - The starting state is `:idle`.
 - From `:idle`, the event `:auth.login/submit` takes us to `:submitting`.
 - From `:submitting`, the event `:auth.login/success` takes us to `:authed`.
-- From `:submitting`, the event `:auth.login/failure` takes us to `:error-shown` if the guard `:auth.login/under-retry-limit` is true, otherwise to `:locked-out`.
-- The actions on each transition (`:auth.login/clear-error`, `:auth.login/issue-request`, `:auth.login/record-error`, `:auth.login/lock-account`, `:auth.login/store-session`) are referenced by id. They're registered separately.
+- From `:submitting`, the event `:auth.login/failure` takes us to `:error-shown` if the guard `:under-retry-limit` passes, otherwise to `:locked-out`.
+- Each transition's `:action` and each state's `:entry` are referenced by id; the named guard / action lives in the spec's `:guards` / `:actions` map and runs when the runtime applies the transition.
 
 The whole flow is in one piece of data. You can pretty-print it. You can render it to a graph. You can check it against a schema. You can hand it to an AI and say "here's the auth flow, add a two-factor state between submitting and authed" — the AI has the whole context in front of it.
 
-The runtime takes this data, plus the registered guards/actions, plus the snapshot of the machine's current state, and applies the transition rules. The runtime — not the developer — is responsible for "if we're in :submitting and a :failure arrives, check the guard, fire the action, transition to the right next state." The developer is responsible only for *describing the transitions as data*.
+The runtime takes this data, plus the snapshot of the machine's current state, and applies the transition rules. The runtime — not the developer — is responsible for "if we're in `:submitting` and a `:failure` arrives, check the guard, fire the action, transition to the right next state." The developer is responsible only for *describing the transitions as data*.
 
 ## What's in a transition
 
 The grammar is borrowed (with adaptation) from [xstate](https://xstate.js.org/), which is the canonical state-machine library in the JavaScript world. Specifically:
 
 - **`:initial`** — the starting state.
-- **`:context`** — extended state that lives alongside the discrete state. Counters, error messages, transient data.
+- **`:data`** — extended state that lives alongside the discrete state. Counters, error messages, transient data. (xstate calls this slot "context"; we use `:data` to avoid the existing "context" overloading in re-frame's interceptor pipeline and React-context idioms.)
 - **`:states`** — the state nodes, keyed by name.
 - **`:on`** — for a state, the events it responds to and where they go.
 - **`:target`** — the next state name.
-- **`:cond`** — a guard: a predicate that must return true for the transition to fire.
-- **`:actions`** — registered actions that fire on this transition.
-- **`:entry`/`:exit`** — actions that fire when entering or leaving a state, regardless of which event triggered the transition.
+- **`:guard`** — a predicate that must return true for the transition to fire. A keyword references the spec's `:guards` map; an inline `(fn [data event] ...)` is fine for a one-liner.
+- **`:action`** — fires on this transition. Same shape as `:guard`: keyword reference into `:actions`, or inline fn.
+- **`:entry` / `:exit`** — actions that fire when entering or leaving a state, regardless of which event triggered the transition. Same shape — keyword or inline fn.
 - **`:meta`** — arbitrary user-defined annotations (e.g. `:terminal?`).
+- **`:guards` / `:actions`** (top-level on the spec) — the machine's own named guard / action implementations. Resolution is machine-local; there's no global registry.
 
 xstate users will recognise all of this. We deliberately stay close to xstate's vocabulary because (a) it's well-thought-out and (b) AIs already know it. When you ask an AI "give me the state machine for a login flow," it produces something that's already nearly correct in re-frame2's grammar.
 
@@ -126,32 +156,146 @@ What we adapt:
 
 - **Machines are event handlers, not actor objects.** xstate has explicit `ActorRef` runtime objects with their own mailboxes. re-frame2 doesn't. A machine is "an event handler whose body interprets a transition table." All events to that machine flow through `dispatch` like any other event; there's no separate sending mechanism.
 - **Effects are returned as data.** xstate's actions can directly call out to the world. re-frame2's actions return effect maps which the runtime interprets — same shape as event handlers.
-- **The actor-system boundary is the frame.** Multiple machines composed within a frame share that frame's drain, ensuring run-to-completion behaviour. Cross-frame communication is async dispatch, not in-process message passing.
+- **The snapshot lives in `app-db`.** Every machine's runtime state — its `:state` and `:data` — sits at `[:rf/machines <id>]` in the frame's `app-db`. Not in a parallel registry, not in a per-machine atom. Undo, time-travel, persistence, SSR hydration all extend to machines for free, because their state is in the db.
+- **Guards and actions live with the machine.** Each `create-machine-handler` spec carries its own `:guards` and `:actions` maps. Cross-machine reuse is via Clojure vars, not a global registry. A machine is a self-contained piece of data; reading its spec tells you everything its guards and actions do.
 
-These adaptations keep the pattern consistent with the rest of re-frame2. A state machine, in this codebase, is *the same kind of thing as an event handler*, just with more structure.
+These adaptations keep the pattern consistent with the rest of re-frame2.
 
-## What the substrate covers
+## Wiring a machine into the rest of re-frame
 
-The shape above — flat states, plain `:on` transitions, `:entry`/`:exit` actions — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model. A flavour:
+Once the transition table is defined, registering it as an event handler is one line:
 
-- **Hierarchical states.** A compound state contains sub-states; entering the parent cascades to its declared `:initial` child; transitions from a deep state can target a sibling or an ancestor and the runtime computes the LCA. Useful when the auth flow has an `:authenticated` super-state with `:cart` / `:browsing` sub-states under it.
-- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or "advance through derived states." Bounded depth, microstep-loop semantics, defined trace events.
-- **Delayed `:after` transitions.** A state can declare "if no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
-- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data rather than as `:entry [:spawn ...]` / `:exit [:destroy-machine ...]`. The child's lifecycle is bound to the parent state.
-- **Machine-scoped `:guards` and `:actions` maps.** Guards and actions referenced by keyword resolve into a machine-local map — `(get-in spec [:guards :under-retry-limit?])`. Named compound logic is more inspectable than inline lambdas, and it lives where the machine lives, not in the global registry.
+```clojure
+(rf/reg-event-fx :auth.login/flow
+  {:doc "Login flow: idle → submitting → authed / error-shown / locked-out."}
+  (rf/create-machine-handler login-flow))
+```
 
-Each of these is opt-in — implementations declare which capabilities they support, and the conformance corpus grades against the claimed set. The full grammar is in [Spec 005](../specification/005-StateMachines.md). The point of mentioning them here is that the model scales: when your machine grows, the substrate has well-named answers ready, and you don't end up smuggling state-machine logic into ordinary event handlers.
+The machine's id is the surrounding `reg-event-fx` id (`:auth.login/flow`). The snapshot lives at `[:rf/machines :auth.login/flow]` in `app-db`; the runtime reads / writes it there. **You don't pick a path — there is one canonical path.**
+
+`(rf/create-machine-handler spec)` returns a regular `reg-event-fx`-shaped handler. It does the work of "look up the snapshot, call `machine-transition`, write the new snapshot, return the action effects." `machine-transition` is pure, so all the testing and tooling guarantees of regular events apply to machines.
+
+If you don't need any other registration metadata (no `:doc`, no `:interceptors`), there's a one-step convenience:
+
+```clojure
+(rf/reg-machine :auth.login/flow login-flow)
+```
+
+This is exactly `(reg-event-fx machine-id (create-machine-handler machine))` — same effect, less ceremony.
+
+## Dispatching to a machine
+
+Sub-events route via the machine's id and an inner event vector:
+
+```clojure
+(rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
+(rf/dispatch [:auth.login/flow [:auth.login/dismiss]])
+```
+
+The outer keyword is the machine; the inner vector is the event the machine sees. The runtime resolves the inner event against the current state's `:on` map, runs the guard, fires the action, and writes the new snapshot back to `[:rf/machines :auth.login/flow]`.
+
+For HTTP / async callbacks, the convention "build a 2-element template, conj the result on resolve" works as in any other re-frame fx:
+
+```clojure
+;; The :issue-request action returns this fx vector:
+[:http {:url        "/api/login"
+        :on-success [:auth.login/flow [:auth.login/success]]   ;; 2-element template
+        :on-error   [:auth.login/flow [:auth.login/failure]]}]
+
+;; The :http fx implementation does (rf/dispatch (conj on-success response)),
+;; producing [:auth.login/flow [:auth.login/success] response].
+;; The runtime folds the trailing response onto the inner event so the action
+;; sees [:auth.login/success response].
+```
+
+This "extras-fold" makes the standard fx-callback convention work without ceremony — every async callback ships a value into the machine the same way.
+
+## Guards and actions
+
+Guards are predicates. They live in the spec's `:guards` map and are referenced from transitions by keyword:
+
+```clojure
+:guards
+{:under-retry-limit
+ (fn [data _event] (< (:attempts data) 3))}
+```
+
+A guard sees `(fn [data event] boolean)` — `data` is the snapshot's `:data` slot directly. Returning truthy lets the transition fire; returning falsy makes the runtime walk to the next candidate (or fall through to the parent state, if any).
+
+Actions are functions that produce data updates and / or effects. They live in `:actions`:
+
+```clojure
+:actions
+{:record-error
+ (fn [data [_ err]]
+   {:data (-> data
+              (update :attempts inc)
+              (assoc :error (or (:message err) "Login failed.")))})
+
+ :issue-request
+ (fn [_data [_ creds]]
+   {:fx [[:http {:method     :post
+                 :url        "/api/login"
+                 :body       creds
+                 :on-success [:auth.login/flow [:auth.login/success]]
+                 :on-error   [:auth.login/flow [:auth.login/failure]]}]]})}
+```
+
+An action sees `(fn [data event] effects)` and returns either:
+
+- `:data` — a map merged into the existing data slot (last write wins on key collision; explicit `nil` clears a key).
+- `:fx` — effects to fire (HTTP, navigation, follow-up dispatches).
+- both, or `nil` for no effects.
+
+Just like ordinary `reg-event-fx` returns. The contract is consistent.
+
+> **Why `:data` is the parameter, not a destructure key.** Most guards and actions only care about the machine's own data — not about its discrete state, not about its meta. Passing `:data` directly keeps the 99% case monomorphic and stops `(fn [{:keys [data]} _] ...)` boilerplate from spreading through your codebase. The body reads `(:attempts data)`, not `(get-in snapshot [:data :attempts])`.
+
+### When a guard or action needs the discrete state
+
+The 3-arity escape hatch — `(fn [data event {:keys [state meta]}] ...)` — is opt-in. Declaring a third parameter signals to the runtime that this fn wants the introspection slot. `state` is the snapshot's discrete state; `meta` is any user `:meta`.
+
+```clojure
+(fn capture-browsing-position [_data _event {:keys [state]}]
+  {:data {:last-browsing-state state}})        ;; the FSM keyword
+```
+
+Unless your guard or action needs to branch on the current state name (genuinely rare), stay with 2-arity. The 3-arity is the explicit signal "I'm doing introspection." The runtime arity-detects on the fn itself — no metadata, no flag.
 
 ## Reading a machine: `sub-machine`
 
 Views that need to read a machine's current state read it through a sub:
 
 ```clojure
-@(rf/sub-machine :auth.login/event-handler)
+@(rf/sub-machine :auth.login/flow)
 ;; → {:state :submitting :data {:attempts 1 :error nil}}
 ```
 
 `sub-machine` is sugar over the framework-shipped `:rf/machine` sub. It returns the snapshot — `{:state :data}` — or `nil` if the machine hasn't been created yet. Views typically destructure the `:state` and switch on it; complex UIs read the `:data` slot too. This is the single supported read path; there's no separate "actor reference" object to thread around.
+
+For convenience, you can build named reg-subs over `[:rf/machine machine-id]` to project the bits you care about:
+
+```clojure
+(rf/reg-sub :auth.login/state
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
+
+(rf/reg-sub :auth.login/submitting?
+  :<- [:auth.login/state]
+  (fn [state _] (= :submitting state)))
+```
+
+These read the machine's snapshot through normal sub plumbing — Reagent reactions fire on the slice you actually subscribed to.
+
+## What the substrate covers
+
+The shape above — flat states, plain `:on` transitions, `:entry` / `:exit` actions, machine-local `:guards` / `:actions` — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model. A flavour:
+
+- **Hierarchical states.** A compound state contains sub-states; entering the parent cascades to its declared `:initial` child; transitions from a deep state can target a sibling or an ancestor and the runtime computes the LCA. Useful when the auth flow has an `:authenticated` super-state with `:cart` / `:browsing` sub-states under it.
+- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or "advance through derived states." Bounded depth, microstep-loop semantics, defined trace events.
+- **Delayed `:after` transitions.** A state can declare "if no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
+- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data rather than as `:entry [:spawn ...]` / `:exit [:destroy-machine ...]`. The child's lifecycle is bound to the parent state.
+
+Each of these is opt-in — implementations declare which capabilities they support, and the conformance corpus grades against the claimed set. The full grammar is in [Spec 005](../specification/005-StateMachines.md). The point of mentioning them here is that the model scales: when your machine grows, the substrate has well-named answers ready, and you don't end up smuggling state-machine logic into ordinary event handlers.
 
 ## Patterns that bottom out in machines
 
@@ -161,56 +305,6 @@ Two of the recurring shapes from [chapter 03](03-events-state-cycle.md) end up b
 - [Pattern-Boot](../specification/Pattern-Boot.md) — multi-step initialisation with sequential dependencies, visible progress, fail-fatal points, and recoverable retry. For trivial boots a chained event sequence works; for non-trivial boots the canonical answer is a boot machine.
 
 Both are pattern docs (convention), not Specs (contract). When the shape of a feature you're building is one of these, read the pattern doc and copy the shape.
-
-## Wiring a machine into the rest of re-frame
-
-Once the transition table is defined, registering it as an event handler is one line:
-
-```clojure
-(rf/reg-event-fx :auth.login/event-handler
-  {:doc          "All :auth.login/* events route through here, interpreted as a machine."
-   :machine-path [:auth :login]}
-  (rf/machine-handler [:auth :login] login-flow))
-```
-
-The `:machine-path` is where in `app-db` the machine's snapshot lives. The snapshot is a small map: `{:state :submitting :context {:attempts 1 :error nil}}`. The runtime reads/writes this snapshot at that path; the machine doesn't manage its own state separately.
-
-`(rf/machine-handler path definition)` is a helper that returns a regular `reg-event-fx`-shaped handler. It does the work of "look up the snapshot, call `machine-transition`, write the new snapshot, return the action effects." The handler is pure (`machine-transition` is pure), so all the testing and tooling guarantees of regular events apply to machines.
-
-## Guards and actions
-
-Guards are predicates. Registered separately, by id:
-
-```clojure
-(rf/reg-machine-guard :auth.login/under-retry-limit
-  {:doc "True if fewer than 3 prior attempts."}
-  (fn [{:keys [context]} _event]
-    (< (:attempts context) 3)))
-```
-
-Actions are functions that produce context updates and/or effects. Also registered:
-
-```clojure
-(rf/reg-machine-action :auth.login/issue-request
-  {:doc "Fire the login HTTP request."}
-  (fn [_snapshot [_ creds]]
-    {:fx [[:http {:method :post :url "/api/login" :body creds
-                  :on-success [:auth.login/success]
-                  :on-error   [:auth.login/failure]}]]}))
-
-(rf/reg-machine-action :auth.login/record-error
-  (fn [{:keys [context]} [_ err]]
-    {:context (-> context
-                  (update :attempts inc)
-                  (assoc :error (:message err)))}))
-```
-
-Actions can return:
-
-- `:context` — updates to the extended state.
-- `:fx` — effects to fire (HTTP, navigation, follow-up dispatches).
-
-Just like ordinary `reg-event-fx` returns. The contract is consistent.
 
 ## When to reach for a machine, and when not to
 
@@ -230,27 +324,28 @@ Don't reach for a machine when:
 
 ## Headless testing
 
-Because `machine-transition` is pure — and because actions/guards are registered functions — you can test a machine without dispatching anything:
+Because `machine-transition` is pure — and because guards and actions are inline-or-named-in-the-spec functions — you can test a machine without dispatching anything:
 
 ```clojure
 (deftest login-flow-happy-path
-  (let [snapshot {:state :idle :context {:attempts 0 :error nil}}]
-    (let [[s1 _fx] (rf/machine-transition login-flow snapshot
-                                          [:auth.login/submit {:email "a@b.com"
-                                                               :password "..."}])]
-      (is (= :submitting (:state s1))))
+  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
+        [s1 _fx] (rf/machine-transition login-flow s0
+                                        [:auth.login/submit {:email "a@b.com"
+                                                             :password "..."}])]
+    (is (= :submitting (:state s1)))
 
     (let [[s2 _fx] (rf/machine-transition login-flow
-                                          {:state :submitting :context {:attempts 0}}
+                                          {:state :submitting :data {:attempts 0}}
                                           [:auth.login/success {:user {:id 1}}])]
       (is (= :authed (:state s2))))))
 
 (deftest login-flow-lockout
-  (let [snapshot {:state :submitting :context {:attempts 2}}]
-    (let [[s _fx] (rf/machine-transition login-flow snapshot
-                                         [:auth.login/failure {:message "wrong creds"}])]
-      ;; 2 prior + 1 current = 3, hits the guard, transitions to :locked-out
-      (is (= :locked-out (:state s))))))
+  (let [snapshot {:state :submitting :data {:attempts 3}}
+        [s _fx] (rf/machine-transition login-flow snapshot
+                                       [:auth.login/failure {:message "wrong creds"}])]
+    ;; attempts has already hit the retry limit; the :under-retry-limit guard
+    ;; rejects the first clause, the second clause's :locked-out wins.
+    (is (= :locked-out (:state s)))))
 ```
 
 These tests run on the JVM. No browser. No network. No mocks. Each one runs in microseconds. You can have hundreds.
@@ -259,11 +354,15 @@ This is the testing experience for *flows that are non-trivial* — exactly the 
 
 ## Composing machines
 
-Real apps have more than one machine: an auth machine, a checkout-wizard machine, a websocket-connection machine. They coexist within a frame, each at its own `:machine-path`.
+Real apps have more than one machine: an auth machine, a checkout-wizard machine, a websocket-connection machine. They coexist within a frame, each at its own `[:rf/machines <id>]`.
 
 When machines need to talk to each other, they do so through dispatch — the auth machine's `:auth.login/success` action might dispatch `[:user/load-profile]`, which is handled by a regular `reg-event-fx` handler that updates the user-profile slice. There's no special inter-machine messaging. It's all events, all going through the same queue, all running to completion.
 
 The drain semantics matter here. If an action dispatches a child event, that child event runs *before* subscriptions update. So if a state machine moves through `:idle → :submitting → :authed → :loading-profile → :ready` in a single user click, the view sees only `:idle` (before) and `:ready` (after) — never any in-between flicker. The pattern's commitment to atomic state changes pays off most strongly in flows like this.
+
+## A runnable example
+
+The complete login flow from this chapter — including the runnable smoke tests — lives at [`examples/state_machine_walkthrough/`](https://github.com/day8/re-frame2/tree/main/examples/state_machine_walkthrough) and is exercised on every JVM test run via `re-frame.examples-test/state-machine-walkthrough-runs-headless`. Drop it in front of you while reading; tweak the transition table and watch the smoke tests adapt.
 
 ## The deeper claim
 
@@ -271,7 +370,7 @@ State machines are a small example of the broader thesis [chapter 08](08-the-dyn
 
 A finite state machine has, by construction, a small set of reachable states. You can enumerate them. You can prove things about transitions. You can render the whole flow as a diagram. You can ask "from this state, what can happen?" and the answer is bounded.
 
-A pile of `if`/`cond` clauses spread across event handlers has none of these properties. The reachable states are implicit. The transitions are scattered. There's no diagram. The answer to "from this state, what can happen?" requires reading every handler that touches the state field.
+A pile of `if` / `cond` clauses spread across event handlers has none of these properties. The reachable states are implicit. The transitions are scattered. There's no diagram. The answer to "from this state, what can happen?" requires reading every handler that touches the state field.
 
 The choice between them isn't a matter of style. It's a matter of which dynamic model you can hold in your head. Machines are smaller models. Smaller models are easier to debug, refactor, extend, and reason about.
 

--- a/docs/specification/001-Registration.md
+++ b/docs/specification/001-Registration.md
@@ -67,7 +67,7 @@ For backwards-compatibility with re-frame v1, the middle slot of `reg-event-*` a
 
 The macro discriminates on the type of the second argument: vector → legacy path, map → new path. Both forms live in the same `reg-event-fx` symbol. The migration agent translates legacy → new on demand (per [MIGRATION.md §O-1](MIGRATION.md)).
 
-For `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-frame`, `reg-app-schema`, etc., the middle-slot is the metadata map only — there's no legacy vector form to compete with.
+For `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `reg-app-schema`, etc., the middle-slot is the metadata map only — there's no legacy vector form to compete with. `reg-view` is the **only registration that ships as a macro** (defn-shape — auto-defs the symbol, auto-derives the id, auto-injects `dispatch` / `subscribe` lexically); the plain-fn surface for runtime / programmatic registration is `reg-view*`. See [Cross-Spec-Interactions §21 Family asymmetry](Cross-Spec-Interactions.md#21-family-asymmetry--only-reg-view-has-a-macro-tier) for why the family is asymmetric.
 
 ## Registry model — the canonical `kind` keyword set
 
@@ -238,7 +238,7 @@ A pointer-only summary of the registration functions and the per-Spec docs that 
 | Subscription | `reg-sub` | [006-ReactiveSubstrate.md](006-ReactiveSubstrate.md) |
 | Effect | `reg-fx` | [002-Frames.md](002-Frames.md), [011-SSR.md](011-SSR.md) (for `:platforms`) |
 | Cofx | `reg-cofx` | [002-Frames.md](002-Frames.md) |
-| View | `reg-view` | [004-Views.md](004-Views.md) |
+| View | `reg-view` (defn-shape macro) / `reg-view*` (plain fn) | [004-Views.md](004-Views.md) |
 | Frame | `reg-frame` | [002-Frames.md](002-Frames.md) |
 | App-db schema | `reg-app-schema` | [010-Schemas.md](010-Schemas.md) |
 | Route | `reg-route` | [012-Routing.md](012-Routing.md) |

--- a/docs/specification/004-Views.md
+++ b/docs/specification/004-Views.md
@@ -1,6 +1,6 @@
 # Spec 004 — Views
 
-> Status: Drafting. **v1-required.** A view is a pure function `(state, props) → render-tree`, with the render-tree as a serialisable nested data structure. The CLJS reference's `reg-view` injects frame-bound `dispatch`/`subscribe` lexically — an ergonomic realisation of the explicit-frame contract. Hiccup is the CLJS render-tree; other hosts use their own shape. SSR ([Spec 011](011-SSR.md)) renders the same views to a string on the server without React.
+> Status: Drafting. **v1-required.** A view is a pure function `(state, props) → render-tree`, with the render-tree as a serialisable nested data structure. The CLJS reference's `reg-view` is a **defn-shape macro** that auto-defs the symbol you supply, auto-derives the registered id from `(keyword *ns* sym)`, and lexically auto-injects frame-bound `dispatch`/`subscribe` — an ergonomic realisation of the explicit-frame contract. The plain-fn surface `reg-view*` is the runtime-callable escape hatch. Hiccup is the CLJS render-tree; other hosts use their own shape. SSR ([Spec 011](011-SSR.md)) renders the same views to a string on the server without React.
 
 ## Abstract
 
@@ -108,24 +108,60 @@ Pattern-RemoteData's `:status` field is the canonical home for loading state. Pa
 
 ## `reg-view` is the multi-frame contract
 
-`reg-view` registers a render function under a keyword. The macro wraps the user's fn so that, on each render, three frame-bound names are injected as lexical locals inside the body:
+`reg-view` is a **defn-shape macro**. It registers a render function under an auto-derived id, defs the symbol you supply to the wrapped (frame-aware) fn, and auto-injects two lexical bindings — `dispatch` and `subscribe` — at every call to the rendered fn.
 
-- `dispatch` — frame-bound `(fn [event] ...)` building an envelope tagged with the surrounding frame's id.
-- `subscribe` — frame-bound `(fn [query-v] ...)` consulting the surrounding frame's sub-cache.
-- `frame-id` — the keyword identifying the surrounding frame (useful for debugging, logging, or passing to non-frame-aware children).
+### Shape
 
 ```clojure
-(rf/reg-view :counter
-  {:doc "Counter widget."}
-  (fn [label]
-    (let [n @(subscribe [:count])]
-      [:button {:on-click #(dispatch [:inc])}
-       (str label ": " n)])))
+(reg-view sym [args] body+)
+(reg-view sym docstring [args] body+)
+(reg-view ^{:rf/id :explicit/id} sym [args] body+)
 ```
 
-The `:on-click` lambda closes over the local `dispatch`, so it carries the frame into the callback automatically — there is no render-time-binding-vs-callback-time problem.
+- **Auto-id derivation.** The registered id is `(keyword (str *ns*) (str sym))` — the same shape Clojure uses for `defn` Vars. Override by attaching `^{:rf/id :explicit/id}` metadata to the symbol.
+- **Auto-defs the symbol.** `reg-view` defs `sym` to the wrapped render fn. There is no separate `(def sym (reg-view …))` step. Hiccup heads can be Var references (`[sym args]`) or `(rf/get-view :id)` results — both resolve to the same wrapped fn.
+- **Auto-injects `dispatch` and `subscribe`.** Inside the body, `dispatch` and `subscribe` are lexical bindings, bound at render-time to `(rf/dispatcher)` / `(rf/subscriber)` of the surrounding frame. They pick up the active frame on every render — there is no render-time-binding-vs-callback-time problem; the `:on-click` lambda below closes over the local `dispatch` and carries the frame into the callback automatically.
 
-**Inside a `reg-view` body, the unqualified `dispatch`/`subscribe` always come from React context** — the injected closures resolve to whatever frame the surrounding `frame-provider` puts in scope. The underlying contract is explicit-frame addressing (per [002 §View ergonomics](002-Frames.md#view-ergonomics-the-hard-part) and OQ-F-12): views can also target a different frame via `(rf/dispatch event {:frame other})` / `(rf/subscribe query {:frame other})` — the qualified two-arg form bypasses the injection. The injected unqualified form is canonical; the explicit form is the escape hatch for cross-frame work (e.g. a story-tool variant that controls a sibling variant).
+```clojure
+(rf/reg-view counter [label]
+  (let [n @(subscribe [:count])]
+    [:button {:on-click #(dispatch [:inc])}
+     (str label ": " n)]))
+
+;; … and elsewhere in hiccup:
+[counter "Hello"]
+```
+
+### Compile-time error contract
+
+`reg-view` enforces the defn-shape at macroexpand time. The second argument (after an optional docstring) MUST be the args vector. Anything else throws with a stable error pointing the user at `re-frame.core/reg-view*`:
+
+| Bad call | Why it fails |
+|---|---|
+| `(reg-view foo my-render)` | `my-render` is a Var reference, not an args vector. |
+| `(reg-view foo (reagent.core/create-class {...}))` | Form-3 (a Reagent class component) is a list, not an args vector. Form-3 is out of scope for the macro per the Reagent-v2 directive. |
+| `(reg-view foo (some-fn-returning-a-fn))` | A computed body. |
+
+The error message names the kind of value supplied and points at `reg-view*` — the plain-fn surface for runtime registration with computed ids or non-defn-shape bodies.
+
+### `reg-view*` — the plain-fn escape hatch
+
+```clojure
+(re-frame.core/reg-view* id render-fn)
+(re-frame.core/reg-view* id metadata render-fn)
+```
+
+A plain function. No auto-def. No auto-inject. No compile-time check. Use when:
+- The id is computed at runtime (dynamic dispatch).
+- The render fn is computed (a library that generates views from data).
+- The body is Reagent Form-3 (`reagent.core/create-class`) — out of scope for the macro.
+- The view is registered without a Var binding (e.g. a `defn` that registers as a side effect).
+
+Inside a `reg-view*` body the user must capture the frame explicitly via `(rf/dispatcher)` / `(rf/subscriber)` if they need frame-bound dispatch — the macro's auto-inject is exactly the convenience `reg-view*` does NOT provide.
+
+The `*` suffix is the standard Clojure idiom for the unsweetened, runtime-callable surface beneath a macro (`let` / `let*`, `fn` / `fn*`). Per [Conventions §`*`-suffix naming](Conventions.md), this convention applies wherever a macro has a fn partner; `reg-view` / `reg-view*` is the only such pair in v1.
+
+**Inside a `reg-view` body, the unqualified `dispatch`/`subscribe` always come from the surrounding frame** — the injected closures resolve to whatever frame the surrounding `frame-provider` puts in scope. The underlying contract is explicit-frame addressing (per [002 §View ergonomics](002-Frames.md#view-ergonomics-the-hard-part) and OQ-F-12): views can also target a different frame via `(rf/dispatch event {:frame other})` / `(rf/subscribe query {:frame other})` — the qualified two-arg form bypasses the injection. The injected unqualified form is canonical; the explicit form is the escape hatch for cross-frame work (e.g. a story-tool variant that controls a sibling variant).
 
 The injection mechanism is detailed in [002-Frames.md §What `reg-view` injects](002-Frames.md#what-reg-view-injects).
 
@@ -133,22 +169,18 @@ The injection mechanism is detailed in [002-Frames.md §What `reg-view` injects]
 
 v1 ships three forms for invoking a registered view. To honour the principle of "one obvious way", one of them is **canonical** and the others are **alternatives** with documented use cases.
 
-### The canonical form: `reg-view` auto-defs the Var
+### The canonical form: `reg-view` auto-defs the symbol
 
 ```clojure
-(rf/reg-view :counter
-  {:doc "A counter widget."}
-  (fn [label] ...))
-;; ⇒ defs `counter` (the local part of :counter) in the current namespace
-;;   bound to the wrapped (frame-aware) fn.
+(rf/reg-view counter [label] ...)
+;; ⇒ defs `counter` in the current namespace, bound to the wrapped
+;;    (frame-aware) fn. The id is auto-derived: (keyword *ns* "counter").
 
 ;; ... elsewhere in hiccup
 [counter "Hello"]
 ```
 
-`reg-view` *defs* the Var as part of registration. There is no separate `(def counter (rf/reg-view ...))` step — `(reg-view :counter ...)` is the one form that registers + binds. The Var name is the keyword's local name (the part after the slash); namespaced ids (e.g. `:cart.item/row`) bind the local symbol (`row`) and are accessed under their fully-qualified namespace.
-
-Override the auto-def behaviour via `:as` in the metadata — `:as 'my-counter` for explicit naming, `:as nil` to suppress the def entirely (registration-only).
+`reg-view` *defs* the symbol you supply. There is no separate `(def counter (reg-view …))` step — the macro is the one form that registers + binds. The id is auto-derived from `*ns*` + symbol; override via `^{:rf/id :explicit/id}` metadata on the symbol.
 
 ### `get-view` — the canonical post-registration lookup
 
@@ -236,7 +268,7 @@ For any plain Reagent fn that may render under a non-default frame, replace with
 (defn my-summary [label] ...)
 
 ;; after — same body, registered, frame-aware
-(def my-summary (rf/reg-view :feature/summary {:doc "..."} (fn [label] ...)))
+(rf/reg-view ^{:doc "..."} my-summary [label] ...)
 ```
 
 The CLJS reference's `re-frame.core-legacy` namespace continues to allow plain fns indefinitely; the warning is a *quality-of-life* signal, not a deprecation.
@@ -265,9 +297,8 @@ Form-1 is the **canonical** form. Form-2 and Form-3 exist for Reagent compatibil
 ### Form-1 (canonical — simple render fn)
 
 ```clojure
-(rf/reg-view :counter
-  (fn render-counter [label]
-    [:button (str label)]))
+(rf/reg-view counter [label]
+  [:button (str label)])
 ```
 
 Each render invocation runs the body fresh. No setup ceremony, no closure subtleties.
@@ -276,10 +307,9 @@ For setup-on-mount work that *would* go in a Form-2 outer fn, use a separate eve
 
 ```clojure
 ;; preferred over Form-2
-(rf/reg-view :counter
-  (fn render-counter [label]
-    [:button {:on-click #(dispatch [:counter/inc])}
-     (str label ": " @(subscribe [:count]))]))
+(rf/reg-view counter [label]
+  [:button {:on-click #(dispatch [:counter/inc])}
+   (str label ": " @(subscribe [:count]))])
 
 ;; setup happens in :on-create on the frame, or via a dedicated init event:
 (rf/reg-frame :counter-frame {:on-create [:counter/initialise]})
@@ -289,27 +319,36 @@ The setup event is named, registered, queryable — visible. The Form-2 outer-fn
 
 ### Form-2 (closure — supported, prefer Form-1 + explicit setup event)
 
-A view returning a fn (Form-2) closes over the outer scope, so the injected locals are captured by both inner-render invocations and any callbacks created in either form:
+A view body that yields a fn (Form-2) closes over the outer scope, so the injected `dispatch` / `subscribe` locals are captured by both inner-render invocations and any callbacks created in either form:
 
 ```clojure
-(rf/reg-view :counter-with-init
-  (fn outer-counter-with-init [label]
-    (dispatch [:counter/initialise label])           ;; outer fires once on mount — hidden side-effect at call site
-    (fn render-counter-with-init [label]              ;; render fn, called on each render
-      (let [n @(subscribe [:count])]
-        [:button {:on-click #(dispatch [:inc])}
-         (str label ": " n)]))))
+(rf/reg-view counter-with-init [label]
+  (dispatch [:counter/initialise label])           ;; outer fires once on mount — hidden side-effect at call site
+  (fn render-counter-with-init [label]             ;; inner render fn, called on each render
+    (let [n @(subscribe [:count])]
+      [:button {:on-click #(dispatch [:inc])}
+       (str label ": " n)])))
 ```
 
-The `dispatch` and `subscribe` in both the outer and inner fn refer to the same locals — Clojure lexical closure does the right thing.
+The `dispatch` and `subscribe` in both the outer body and the inner fn refer to the same lexical bindings — Clojure lexical closure does the right thing.
 
 **Use Form-2 only when the setup work genuinely depends on per-mount props.** For stable setup, use Form-1 + a frame-level `:on-create` event.
 
-### Form-3 (class — supported, rare)
+### Form-3 (class — out of scope for the macro)
 
-Class-form views that return a map of lifecycle methods (`:reagent-render`, `:component-did-mount`, etc.) — supported, but the injected locals are only in scope for the lifecycle methods themselves, not for any user code outside the registered fn. Consistent treatment with Form-2; the macro injects the `let` once around the entire returned map's body.
+Reagent Form-3 (`reagent.core/create-class`) is **not supported by the `reg-view` macro** in v1. The macro's compile-time check rejects calls whose body is a `(reagent.core/create-class …)` form; the error message points the user at `re-frame.core/reg-view*` — the plain-fn surface, where the body can be any callable.
 
-Required only when interop with stateful third-party React components needs explicit lifecycle hooks (`componentDidMount`, `componentWillUnmount`).
+```clojure
+;; instead of (rf/reg-view my-view (reagent.core/create-class …)) — compile error,
+;; use:
+(re-frame.core/reg-view* :feature/my-view
+  (reagent.core/create-class
+    {:reagent-render        (fn [] ...)
+     :component-did-mount   (fn [] ...)
+     :component-will-unmount (fn [] ...)}))
+```
+
+The Reagent-v2 directive (rf2-25aq) constrains the canonical surface to Form-1 + Form-2; Form-3 ships through the escape hatch.
 
 ## View registry — tooling surface
 
@@ -325,12 +364,11 @@ Tools (10x, story tools, agents) read these to render view inspectors, pick view
 Registered views referenced from hiccup inherit the surrounding frame from React context:
 
 ```clojure
-(rf/reg-view :outer
-  (fn []
-    [:div
-     [counter "Inner"]                  ;; or [:counter "Inner"] under the `h` macro
-     [rf/frame-provider {:frame :other}
-      [counter "Other-frame inner"]]])) ;; nested provider re-points
+(rf/reg-view outer []
+  [:div
+   [counter "Inner"]                  ;; or [:counter "Inner"] under the `h` macro
+   [rf/frame-provider {:frame :other}
+    [counter "Other-frame inner"]]])  ;; nested provider re-points
 ```
 
 Nested `frame-provider`s re-point children. The deepest provider in scope wins.
@@ -354,34 +392,29 @@ The bare `[:my-view "args"]` form in raw hiccup requires Reagent extension and i
 
 ### `reg-view` defs the Var by default
 
-`reg-view` defs the Var as a side effect. No need to write `(def x (rf/reg-view :x ...))` — `(rf/reg-view :x ...)` is enough; a Var named `x` is created in the surrounding namespace.
-
-The macro takes the id keyword's local name (the part after the slash) as the Var's symbol:
+`reg-view` is defn-shape: the symbol you supply IS the Var name; the id is auto-derived from `(keyword *ns* sym)`. No need to write `(def x (rf/reg-view :x ...))` — `(rf/reg-view x [args] body)` is enough; a Var named `x` is created in the surrounding namespace and registered under `(keyword *ns* "x")`.
 
 ```clojure
-(rf/reg-view :counter
-  (fn [label] [:button label]))
+(rf/reg-view counter [label] [:button label])
 ;; ⇒ defs `counter` in the current namespace, bound to the wrapped fn.
+;; ⇒ registers under (keyword *ns* "counter").
 ;; You can now write [counter "Hi"] in hiccup directly.
 
-(rf/reg-view :cart.item/row
-  (fn [item] [:tr ...]))
-;; ⇒ defs `row` (uses the local name after the slash).
+(rf/reg-view ^{:rf/id :cart.item/row} item-row [item] [:tr ...])
+;; ⇒ defs `item-row`; registers under the explicit override id :cart.item/row.
 ;; Use the qualified namespace prefix when reading: [cart.item.row item]
 ```
 
 This matches `defn`'s shape (registers + binds a Var) and removes a redundant naming step. Other registration kinds don't need this because their values aren't called as Reagent components in hiccup — only views are.
 
-For the rare case where the user wants to control the Var name explicitly (or suppress the def — e.g. for views generated programmatically), pass `:as` in the metadata:
+For the rare case where the user wants no Var binding (e.g. views generated programmatically, or registered without a Var by a library), use `re-frame.core/reg-view*` directly — the plain-fn surface registers under the supplied id without defing anything.
 
 ```clojure
-(rf/reg-view :counter
-  {:as 'my-counter}                     ;; explicitly named
-  (fn [label] [:button label]))
-
-(rf/reg-view :counter
-  {:as nil}                             ;; suppress the def; only register
-  (fn [label] [:button label]))
+;; Programmatic registration — no Var, computed id.
+(doseq [variant [:summary :detail]]
+  (re-frame.core/reg-view*
+    (keyword "feature/article" (name variant))
+    (fn [_props] ...)))
 ```
 
 ### The `h` macro's expansion strategy
@@ -400,11 +433,19 @@ A keyword *not* registered as a view at expansion time passes through unchanged.
 
 **Edge case — re-registration shadowing a DOM tag.** A user must not `(reg-view :div ...)`. The runtime emits a warning at registration time; `h` honours the registry (the registered fn wins). Documented as a footgun, not policed.
 
-### Form-3 (`reagent.core/create-class`) — full lifecycle exposure
+### Form-3 (`reagent.core/create-class`) — out of scope for the macro
 
-Form-3 lifecycle methods all see the injected `dispatch`/`subscribe`/`frame-id` locals. The macro wraps the *entire returned map's body* in the same `let` — `:reagent-render`, `:component-did-mount`, `:component-did-update`, `:component-will-unmount`, etc. all close over the same frame-bound locals. Across Reagent's class-creation paths (`r/create-class`, hooks-flavoured wrappers) the expansion is uniform: one `let` around the map literal, all method bodies read the same locals.
+The `reg-view` macro rejects bodies whose top-level form is `(reagent.core/create-class …)` — Form-3 is the canonical escape-hatch case. Per the Reagent-v2 directive (rf2-25aq) the canonical surface targets Form-1 + Form-2; Form-3 ships through `re-frame.core/reg-view*`:
 
-This matches Form-2's treatment (one `let` around the outer + inner fns) and keeps Form-3 a true *escape hatch* for stateful third-party React interop — `componentDidMount`-style hooks have access to the right `dispatch`/`subscribe` without ceremony.
+```clojure
+(re-frame.core/reg-view* :feature/widget
+  (reagent.core/create-class
+    {:reagent-render        (fn [props] ...)
+     :component-did-mount   (fn [this] ...)
+     :component-will-unmount (fn [this] ...)}))
+```
+
+Inside a Form-3 body, the user captures frame-bound dispatch/subscribe explicitly via `(rf/dispatcher)` / `(rf/subscriber)` if needed — the macro's auto-inject is exactly the convenience `reg-view*` does NOT provide.
 
 ### Hot-reload behaviour for re-registered views
 

--- a/docs/specification/005-StateMachines.md
+++ b/docs/specification/005-StateMachines.md
@@ -30,6 +30,8 @@ The snapshot is `{:state :data}`:
 
 The pair `{:state :data}` reads as the natural English idiom and matches a vocabulary that's well-represented in AI training corpora. We use `:data` to avoid the existing "context" overloading in re-frame's interceptor pipeline and React-context affordances.
 
+> **`:data` is the parameter name passed to guards and actions, not a destructure key.** Per [§Guards](#guards) / [§Actions](#actions), guards and actions receive `(fn [data event] ...)` — `data` is the snapshot's `:data` slot directly, a plain map. Bodies that read individual fields write `(:circle-id data)`, not `(get-in snapshot [:data :circle-id])`. The 3-arity opt-in `(fn [data event {:state :meta}] ...)` adds the introspection slot when needed; users that don't declare it never see the snapshot wrapper.
+
 ## Snapshot shape
 
 ```clojure
@@ -224,35 +226,50 @@ Internal transitions are how to update `:data` without re-running entry/exit mac
 
 ### Guards
 
-A guard is `(fn [snapshot event] boolean)`. **One inline fn or one keyword reference into the machine's `:guards` map** — never a compound data form.
+A guard is **`(fn [data event] boolean)`** — 2-arity is canonical. **One inline fn or one keyword reference into the machine's `:guards` map** — never a compound data form.
+
+`data` is the snapshot's `:data` slot directly (a map). The fn never sees the snapshot wrapper; pulling `:data` from a snapshot is the runtime's job, not the user's. This keeps the 99% case monomorphic and stops `:keys [data]` boilerplate from spreading through the corpus.
 
 ```clojure
-;; inline fn
-:guard (fn [{:keys [data]} [_ id]]
+;; inline fn — data is the snapshot's :data slot, passed directly
+:guard (fn [data [_ id]]
          (some? (:circle-id data)))
 
 ;; keyword reference — resolves to (get-in spec [:guards :circle-exists?])
 :guard :circle-exists?
 
 ;; compound logic — write the fn
-:guard (fn [snap ev] (and (active? snap ev) (under-quota? snap ev)))
+:guard (fn [data ev] (and (active? data ev) (under-quota? data ev)))
 
 ;; even better — declare a named compound in the machine's :guards map
 (rf/create-machine-handler
   {:guards {:active-and-under-quota?
-            (fn [snap ev] (and (active? snap ev) (under-quota? snap ev)))}
+            (fn [data ev] (and (active? data ev) (under-quota? data ev)))}
    :states {... :on {... {:guard :active-and-under-quota?}}}})
 ;; the name carries semantic meaning that visualisers / AIs read.
 ```
+
+#### 3-arity escape hatch — `:state` / `:meta` introspection
+
+The 3-arity overload is **opt-in** by declaring a third parameter:
+
+```clojure
+:guard (fn [data event {:keys [state meta]}]
+         ...)
+```
+
+`{:state :meta}` is the snapshot's introspection slot — the discrete state and any user `:meta`. Use it for the rare guard or action that needs to branch on the current state name (e.g. dispatch on `:state` itself rather than `:data`). The vast majority of guards and actions are state-blind and don't need the third arg; declaring it is the explicit signal to the runtime that introspection is wanted.
+
+Implementations arity-detect the fn at call time: a fn that declares a fixed 3-arg invocation is called with `[data event {:state :meta}]`; everything else (the canonical 2-arity, plus variadic helpers like `(constantly true)`) is called with `[data event]`. The detection is structural — no metadata needed on the fn — so inline `(fn [data ev ctx] ...)` vs `(fn [data ev] ...)` is the only declaration the user makes.
 
 Compound logic is expressed via function composition or as a named entry in the machine's `:guards` map — the name carries semantic content visualisers and AIs read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-guard`.
 
 ### Actions
 
-An action is `(fn [snapshot event] effects)` returning the `{:data :fx}` shape (or `nil`). **One inline fn or one keyword reference into the machine's `:actions` map** — never a vector.
+An action is **`(fn [data event] effects)`** returning the `{:data :fx}` shape (or `nil`). 2-arity is canonical; 3-arity opt-in is the same `[data event {:state :meta}]` escape hatch as for guards. **One inline fn or one keyword reference into the machine's `:actions` map** — never a vector.
 
 ```clojure
-;; inline
+;; inline — data is the snapshot's :data slot, passed directly
 :action (fn [_ [_ id radius]]
           {:data {:circle-id id :initial-radius radius :preview-radius radius}})
 
@@ -270,9 +287,9 @@ An action is `(fn [snapshot event] effects)` returning the `{:data :fx}` shape (
 Multiple steps in one action are **fn composition**, not a vector:
 
 ```clojure
-:action (fn [snap ev]
-          (let [a (action-clear snap ev)
-                b (action-record-attempt snap ev)]
+:action (fn [data ev]
+          (let [a (action-clear data ev)
+                b (action-record-attempt data ev)]
             {:data (merge (:data a) (:data b))
              :fx   (into (:fx a []) (:fx b []))}))
 ```
@@ -281,7 +298,7 @@ If the composition is reused, name it in the machine's `:actions` map:
 
 ```clojure
 (rf/create-machine-handler
-  {:actions {:clear-and-record (fn [snap ev] ...)}
+  {:actions {:clear-and-record (fn [data ev] ...)}
    :states {... :on {... {:action :clear-and-record}}}})
 ```
 
@@ -336,9 +353,9 @@ A machine *almost never* needs to write `app-db` directly; it acts on its own st
 
 > **Why this is locked.** Strict encapsulation is one of the named consequences of [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility). If actions could read or write `app-db` outside `[:rf/machines <id>]`, machine logic would create state changes that don't show up in any machine snapshot and don't roll back when the surrounding machine snapshot does. The whole machine's state has to live inside the frame's persistent value to revert with it; encapsulation is what stops machines from leaking state into parts of the value that aren't theirs.
 
-- **Action signature:** `(fn [snapshot event] effects)`.
-- **Guard signature:** `(fn [snapshot event] boolean)`.
-- **Snapshot:** `{:state :data}` only — no `:db`, no cofx.
+- **Action signature:** `(fn [data event] effects)` — 2-arity canonical; 3-arity opt-in is `(fn [data event {:state :meta}] effects)`.
+- **Guard signature:** `(fn [data event] boolean)` — 2-arity canonical; 3-arity opt-in is `(fn [data event {:state :meta}] boolean)`.
+- **What the fn sees:** the snapshot's `:data` slot directly (a map). The full `{:state :data :meta}` snapshot is reachable only via the 3-arity opt-in. Never `app-db`; never cofx.
 
 The impure plumbing (reading the snapshot from `app-db` at `[:rf/machines <id>]`, writing `:data` back as a `:db` write, lowering `:fx` / `:raise` / `:spawn` into standard re-frame effects) lives in the *handler boundary* — the fn returned by `create-machine-handler`. **Inside the boundary: pure. Outside: standard re-frame.**
 
@@ -355,7 +372,7 @@ Whoever fires the event has the data; they pass it. The machine never reaches ou
 ```clojure
 :close-dialog
 {:target :idle
- :action (fn [{:keys [data]} _]
+ :action (fn [data _]
            {:fx   [[:dispatch [:drawer/apply-radius
                                (:circle-id data)
                                (:preview-radius data)]]]
@@ -378,7 +395,7 @@ A machine is registered as **one event handler** via `reg-event-fx` whose body c
   (rf/create-machine-handler
     {:initial :idle                                       ;; initial FSM-keyword
      :data    {:circle-id nil :initial-radius nil :preview-radius nil}
-     :guards  {:circle-exists? (fn [{:keys [data]} _] (some? (:circle-id data)))}
+     :guards  {:circle-exists? (fn [data _] (some? (:circle-id data)))}
      :actions {:clear-error    (fn [_ _] {:data {:error nil}})}
      :states  { ... }}))
 ```
@@ -397,7 +414,7 @@ Reference resolution:
 **Cross-machine reuse via Clojure vars.** When a guard or action is shared across machines, define it as a Clojure var and reference the var from each machine's `:guards` / `:actions` map:
 
 ```clojure
-(defn user-authenticated? [{:keys [data]} _]
+(defn user-authenticated? [data _]
   (some? (:user-id data)))
 
 (rf/reg-event-fx :auth/login {}
@@ -475,7 +492,7 @@ Applied to machines: the transition table is a data DSL because it describes nam
 
 ## Inspectability bias
 
-> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [snap ev] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
+> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [data ev] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
 
 The id is the meaning at the call site; the inline fn is opaque to readers. The machine-scoped resolution mechanics — how keyword references in transition slots resolve against the machine's `:guards` / `:actions` maps, and how cross-machine reuse via Clojure vars works — are specified once in [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler).
 
@@ -485,11 +502,11 @@ Why the bias:
 
 - **Visualisers read ids, not fn bodies.** A diagram exporter that renders the transition table can label an arrow with `:under-quota?` and have it mean something. An inline fn becomes "[fn]" — a hole in the rendered diagram.
 - **AIs read ids, not fn bodies.** When an AI reasons about a machine — generating tests, proposing changes, explaining behaviour — a keyword reference is a stable name it can resolve against the machine's `:guards` / `:actions` map (visible via `(machine-meta <id>)`). An inline fn is a closure with no public name.
-- **Humans read ids, not fn bodies.** A reviewer scanning a transition table sees `:guard :under-quota?` and knows what gates the transition; with `:guard (fn [snap ev] ...)` they have to read the body to find out.
+- **Humans read ids, not fn bodies.** A reviewer scanning a transition table sees `:guard :under-quota?` and knows what gates the transition; with `:guard (fn [data ev] ...)` they have to read the body to find out.
 - **Tests read ids.** Level-1 (`machine-transition`) and Level-2 tests can stub or assert against named guards/actions by id — re-define the spec's `:guards` / `:actions` entry with a deterministic stand-in. Inline fns can only be replaced by re-writing the entire transition table.
 - **Conformance fixtures read ids.** A fixture's expected `:fx` vector can name `[:dispatch [:audit/login-ok]]` against the action `:record-success` declared in the machine's `:actions` map; inline-fn equivalents are not addressable.
 
-Inline fns remain acceptable for **trivial bodies that don't add meaning by being named** — e.g. `:guard (fn [{:keys [data]} _] (some? (:circle-id data)))` is fine; naming it as `:has-circle?` may add no information beyond what the body already shows. The test is whether the fn body is a single non-branching expression: yes → inline is OK; no → name it in `:guards` / `:actions`.
+Inline fns remain acceptable for **trivial bodies that don't add meaning by being named** — e.g. `:guard (fn [data _] (some? (:circle-id data)))` is fine; naming it as `:has-circle?` may add no information beyond what the body already shows. The test is whether the fn body is a single non-branching expression: yes → inline is OK; no → name it in `:guards` / `:actions`.
 
 Cross-references: [Construction-Prompts.md](Construction-Prompts.md) covers scaffolding guidance.
 
@@ -858,7 +875,7 @@ Guards in `:always` resolve against the **machine's `:guards` map** (per [§Regi
 
 ```clojure
 {:initial :asking
- :guards  {:enough-correct? (fn [{:keys [data]} _] (>= (:correct-count data) 10))}
+ :guards  {:enough-correct? (fn [data _] (>= (:correct-count data) 10))}
  :actions {:count-correct   (fn [_ _] {:data {:correct-count inc}})
            :count-wrong     (fn [_ _] {:data {:wrong-count inc}})}
  :states
@@ -996,7 +1013,7 @@ Tools subscribe to whichever granularity they need: `:scheduled` for timeline vi
 
 ```clojure
 {:initial :idle
- :guards  {:still-loading? (fn [{:keys [data]} _] (:loading? data))}
+ :guards  {:still-loading? (fn [data _] (:loading? data))}
  :states
  {:idle    {:on {:fetch :loading}}
 
@@ -1175,13 +1192,13 @@ Before / after:
 
 ;; create-machine-handler rewrites to (runtime sees this):
 {:loading
- {:entry (fn [{:keys [data] :as snap} ev]
+ {:entry (fn [data _ev]
            {:fx [[:spawn {:machine-id :request/protocol
                           :id-prefix  :request/protocol
                           :data       {:url (:endpoint data)}
                           :on-spawn   (fn [d id] (assoc d :pending id))
                           :start      [:begin]}]]})
-  :exit  (fn [{:keys [data]} _]
+  :exit  (fn [data _]
            {:fx [[:destroy-machine (:pending data)]]})
   :on    {:succeeded :loaded
           :failed    :error}}}
@@ -1510,7 +1527,7 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
 
       :commit
       ;; Persist the previewed radius via :drawer/apply-radius and clear :data.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx   [[:dispatch [:drawer/apply-radius
                             (:circle-id data)
                             (:preview-radius data)]]]

--- a/docs/specification/012-Routing.md
+++ b/docs/specification/012-Routing.md
@@ -409,15 +409,13 @@ Views derive UI from the route the same way they derive UI from any other state 
 ### The root view dispatches on `:rf.route/id`
 
 ```clojure
-(def app-root
-  (rf/reg-view :app/root
-    (fn render-app-root []
-      (case @(subscribe [:rf.route/id])
-        :route/home              [home-page]
-        :route/cart              [cart-page]
-        :route/cart.item-detail  [cart-item-detail]
-        :route/article           [article-page]
-        :rf.route/not-found         [not-found-page]))))
+(rf/reg-view app-root []
+  (case @(subscribe [:rf.route/id])
+    :route/home              [home-page]
+    :route/cart              [cart-page]
+    :route/cart.item-detail  [cart-item-detail]
+    :route/article           [article-page]
+    :rf.route/not-found      [not-found-page]))
 ```
 
 Pattern: a single `case` (or equivalent) over the route id at the top of the tree. Per-route views can subscribe to `:rf.route/params` for their own data needs.
@@ -602,15 +600,14 @@ These events are the **decision points** for navigation policy. The policy is en
 `route-link`'s body becomes:
 
 ```clojure
-(rf/reg-view :rf/route-link
-  (fn render-route-link [{:keys [to params query]} & children]
-    (let [url (rf/route-url to (or params {}) (or query {}))]
-      [:a {:href     url
-           :on-click (fn [e]
-                       (when (plain-left-click? e)        ;; no modifier keys
-                         (.preventDefault e)
-                         (rf/dispatch [:rf/url-requested {:url url :to to :params params :query query}])))}
-       children])))
+(rf/reg-view route-link [{:keys [to params query]} & children]
+  (let [url (rf/route-url to (or params {}) (or query {}))]
+    [:a {:href     url
+         :on-click (fn [e]
+                     (when (plain-left-click? e)        ;; no modifier keys
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested {:url url :to to :params params :query query}])))}
+     children]))
 ```
 
 ## Scroll restoration

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -28,7 +28,8 @@
 | `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | 002 | |
 | `reg-frame` | M | `(reg-frame id metadata)` | v1 | 002 | Atomic create + register. |
 | `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | 002 | Anonymous frame; gensym'd id. |
-| `reg-view` | M | `(reg-view id ?metadata render-fn) → wrapped-fn` | v1 | 004 | |
+| `reg-view` | M | `(reg-view sym [args] body+)` / `(reg-view sym docstring [args] body+)` / `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | 004 | Defn-shape; auto-defs the symbol; auto-derives id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. |
+| `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | 004 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. The `*` follows Clojure's `let`/`let*`, `fn`/`fn*` idiom (per [Conventions](Conventions.md)). |
 | `reg-app-schema` | M | `(reg-app-schema path schema)` | v1 | 010 | |
 | `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 (preserved, alpha) | — | |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |

--- a/docs/specification/CP-5-MachineGuide.md
+++ b/docs/specification/CP-5-MachineGuide.md
@@ -13,13 +13,13 @@ Acceptable inline cases (single non-branching expression):
 
 ```clojure
 ;; Trivial guard — single non-branching expression.
-:guard (fn [{:keys [data]} _] (some? (:circle-id data)))
+:guard (fn [data _] (some? (:circle-id data)))
 
 ;; Trivial action — pure data update, single non-branching expression.
 :action (fn [_ [_ new-r]] {:data {:preview-radius new-r}})
 
 ;; Trivial action — single :fx entry, no branching.
-:action (fn [{:keys [data]} _]
+:action (fn [data _]
           {:fx [[:dispatch [:drawer/apply-radius
                             (:circle-id data)
                             (:preview-radius data)]]]})
@@ -29,22 +29,22 @@ Cases that should be named in `:guards` / `:actions` instead (branching, composi
 
 ```clojure
 ;; Branching → name it.
-:action (fn [{:keys [data]} ev]
+:action (fn [data ev]
           (if (over-quota? data)
             {:data {:error :quota}}
             {:data {:attempts (inc (:attempts data))}
              :fx   [[:dispatch [:audit/recorded ev]]]}))
 
 ;; Composed → name the composition.
-:action (fn [snap ev]
-          (let [a (record-attempt snap ev) b (clear-error snap ev)]
+:action (fn [data ev]
+          (let [a (record-attempt data ev) b (clear-error data ev)]
             {:data (merge (:data a) (:data b))
              :fx   (into (:fx a []) (:fx b []))}))
 
 ;; Multi-fx + branching → name it.
-:guard (fn [snap ev]
-         (and (under-quota? snap ev)
-              (not (locked-out? snap ev))
+:guard (fn [data ev]
+         (and (under-quota? data ev)
+              (not (locked-out? data ev))
               (some? (:credentials (second ev)))))
 ```
 
@@ -162,12 +162,14 @@ xstate needs history states because its runtime lacks first-class snapshot-as-va
   {:actions
    {:capture-browsing-position
     ;; Stash the current browsing-state into :data so we can restore it later.
-    (fn [{:keys [state data]} _]
+    ;; This is an opt-in 3-arity body — the third arg unlocks the :state slot;
+    ;; the canonical 2-arity form (fn [data event] ...) only sees :data.
+    (fn [_data _event {:keys [state]}]
       {:data {:last-browsing-state state}})                 ;; the FSM keyword
 
     :restore-browsing-position
     ;; Re-enter at the previously-captured state.
-    (fn [{:keys [data]} _]
+    (fn [data _]
       {:fx [[:raise [:flow/jump-to (:last-browsing-state data)]]]})}
    :states
    {:browsing

--- a/docs/specification/Construction-Prompts.md
+++ b/docs/specification/Construction-Prompts.md
@@ -386,13 +386,13 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
      :guards
      {:under-retry-limit
       ;; Has this login had fewer than 3 prior attempts?
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         (< (:attempts data) 3))}
 
      :actions
      {:begin-submit
       ;; Clear the prior error and emit the HTTP request for credential check.
-      (fn [_snap [_ creds]]
+      (fn [_data [_ creds]]
         {:data {:error nil}
          :fx   [[:http {:method     :post
                         :url        "/api/login"
@@ -402,7 +402,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
       :record-failure
       ;; Bump the attempts counter and surface a credentials error.
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         {:data {:attempts (inc (:attempts data))
                 :error    :credentials}})
 

--- a/docs/specification/Conventions.md
+++ b/docs/specification/Conventions.md
@@ -121,6 +121,34 @@ Full rationale: [000-Vision §Pointers to per-area Specs (Features)](000-Vision.
 
 Conformant implementations need a structural-sharing persistent collection library for `app-db` and frame state. CLJS gets this free; other-language ports pick a host-idiomatic library (Immer or Immutable.js for JS; pyrsistent or immutables for Python; im-rs for Rust; native collections for F# / Scala / OCaml / Clojure). For the per-host options, why this is pattern-required, and how it composes with [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility), see [000-Vision §Host-profile matrix — Note on persistent data structures](000-Vision.md#note-on-persistent-data-structures).
 
+## `*`-suffix naming for fn-versions of macros
+
+When a macro has a fn-version (the unsweetened, runtime-callable surface), the fn gets a `*` suffix. Standard Clojure idiom — `let` / `let*`, `fn` / `fn*`. The macro is the ergonomic surface (parses extra shapes, captures source-coords from `&form`, defs Vars, injects locals); the `*`-fn is the plain-fn delegate that runtime callers invoke when they need a non-literal body, a computed id, or registration without the macro tier.
+
+For now the only pair is `reg-view` / `reg-view*` (per [Spec 004 §reg-view*](004-Views.md#reg-view-the-plain-fn-escape-hatch)); future macros that want fn partners follow the same convention.
+
+The convention applies **only where there is a macro tier**. The other `reg-*` registrations (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`) are already plain fns — they need no macro tier and therefore no `*` partner. Adding `reg-event-db*` / etc. would be a pure alias and add no value; that's not done. (See [Cross-Spec-Interactions §Family asymmetry](Cross-Spec-Interactions.md#family-asymmetry-only-reg-view-has-a-macro-tier) for why the family is intentionally asymmetric.)
+
+## `reg-view` auto-id derivation rule
+
+Per [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract), the `reg-view` macro auto-derives the registered id from the symbol you supply:
+
+```
+id = (keyword (str *ns*) (str sym))
+```
+
+This matches Clojure's `defn` Var-naming idiom: the symbol is the source of truth; the registry id mirrors it. Override the auto-derivation by attaching `^{:rf/id :explicit/id}` metadata to the symbol:
+
+```clojure
+(reg-view counter [label] body)
+;; ⇒ id is :my.ns/counter
+
+(reg-view ^{:rf/id :widget/counter} counter [label] body)
+;; ⇒ id is :widget/counter
+```
+
+The metadata-override syntax is the single supported way to set a non-auto-derived id at the macro surface. Other slot metadata (e.g. `:doc`) lives on the same metadata map: `^{:doc "..." :rf/id :widget/x}`. For computed ids, drop to `re-frame.core/reg-view*`.
+
 ## Cross-references
 
 - [000-Vision.md](000-Vision.md) — goals, constraints, the pattern's minimal core.

--- a/docs/specification/Cross-Spec-Interactions.md
+++ b/docs/specification/Cross-Spec-Interactions.md
@@ -210,6 +210,17 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Reason:** Mid-process adapter swap would leave an unknown set of cached reactions, mounted views, and frame containers wired to the old adapter — the inconsistency is unrecoverable. The dispose-then-install path forces a known clean state.
 - **Status:** `Provisional` — fixture pending: `adapter-already-installed.edn`.
 
+## Registration family
+
+### 21. Family asymmetry — only `reg-view` has a macro tier
+
+- **Specs:** [001-Registration](001-Registration.md) (the registration family); [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract); [Conventions §`*`-suffix naming](Conventions.md#-suffix-naming-for-fn-versions-of-macros).
+- **Scenario:** A reader looks at the public API and notices that `reg-view` ships as a **macro** with a `reg-view*` plain-fn partner, while every other `reg-*` (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `reg-flow`, `reg-route`, `reg-app-schema`, `reg-machine`, `reg-error-projector`) is a plain fn with no `*` partner. Why is the family asymmetric?
+- **Behaviour:** `reg-view` is the only `reg-*` macro because views need a Var binding — Reagent calls them by symbol from hiccup heads (`[counter "label"]`). The macro defs the symbol, registers the view, and auto-injects `dispatch` / `subscribe` lexically into the body. None of the other registrations are *invoked by name* from user-facing data; they are dispatched (events) or looked up by id (subs, fx, cofx, frames, routes, schemas, machines) at runtime. They have no need for an auto-defed Var, no need for compile-time auto-id derivation, and no body-shape compile-time check to enforce — so they stay plain fns.
+- **The `*` convention applies only where a macro sweetens an underlying fn.** Adding `reg-event-db*` / `reg-sub*` / etc. would be pure aliases for `reg-event-db` / `reg-sub` themselves — no macro tier exists, no fn partner is necessary. The convention is reserved for the sweetened-vs-unsweetened case, per `let` / `let*`.
+- **Reason:** The family looks asymmetric because the underlying need is asymmetric. Views participate in the render-tree by Var reference (Reagent's idiomatic hiccup head); other registrations participate by id (the registry holds the data). The macro tier exists where the Var binding is part of the contract; the plain fn tier is sufficient where the registry id is.
+- **Status:** `Locked` — Spec 004 owns the `reg-view` macro shape; this entry documents the family-level asymmetry so implementors and readers don't expect a `*` partner for every registration.
+
 ## Cross-references
 
 - [000-Vision §Goals](000-Vision.md#goals) — the goals these interactions exist to satisfy.

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -779,7 +779,68 @@ Any of the five interceptor refs in any registration's interceptor list.
 
 ---
 
-**Reporting M-12 through M-21.** These ten rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing ten separate preambles.
+### M-22. `reg-view` is now a defn-shape macro — keyword-shape calls must rewrite
+
+**Type A** (mechanical).
+
+Per [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract) and rf2-d0pi: `reg-view` is now a defn-shape macro that auto-defs the symbol you supply, auto-derives the registered id from `(keyword *ns* sym)`, and lexically auto-injects `dispatch` / `subscribe`. The keyword-shape call `(reg-view :id render-fn)` no longer compiles; the macro rejects it at macroexpand-time with an error pointing the user at `re-frame.core/reg-view*`.
+
+**What to look for** in the codebase:
+
+```clojure
+(def my-view (rf/reg-view :ns/my-view (fn [args] body)))
+(def my-view (rf/reg-view :ns/my-view {:doc "..."} (fn [args] body)))
+```
+
+**What to do:**
+
+```clojure
+;; before
+(def my-view
+  (rf/reg-view :ns/my-view (fn [] body)))
+
+;; after — defn-shape; id auto-derives to (keyword *ns* "my-view")
+(rf/reg-view my-view [] body)
+
+;; before — explicit id that the auto-derivation wouldn't reproduce
+(def cart-row
+  (rf/reg-view :cart.item/row (fn [item] [:tr ...])))
+
+;; after — ^{:rf/id ...} metadata override on the symbol
+(rf/reg-view ^{:rf/id :cart.item/row} cart-row [item] [:tr ...])
+
+;; before — programmatic / computed id, not a defn-shape body
+(rf/reg-view (keyword "feature/widget" (name variant))
+  computed-render-fn)
+
+;; after — reg-view* (the plain-fn surface; no auto-anything)
+(re-frame.core/reg-view*
+  (keyword "feature/widget" (name variant))
+  computed-render-fn)
+```
+
+Inside the body, drop any explicit `(rf/dispatcher)` / `(rf/subscriber)` capture — `dispatch` and `subscribe` are auto-injected as lexical bindings:
+
+```clojure
+;; before
+(rf/reg-view :counter
+  (fn []
+    (let [d (rf/dispatcher)
+          s (rf/subscriber)]
+      [:button {:on-click #(d [:inc])} @(s [:count])])))
+
+;; after
+(rf/reg-view counter []
+  [:button {:on-click #(dispatch [:inc])} @(subscribe [:count])])
+```
+
+The agent rewrites mechanically: the keyword's local-name becomes the auto-defed symbol; the keyword itself becomes `^{:rf/id ...}` metadata if the auto-derived id wouldn't match. Bodies that are not literal `(fn [args] body)` forms (Var refs, `reagent.core/create-class` calls, computed expressions) are flagged for the user — those route to `reg-view*`, the plain-fn surface, where the body can be any callable.
+
+**Why?** The defn-shape removes a redundant naming step (the keyword + the symbol said the same thing twice), bakes in source-coord auto-capture at the macro-expansion site, and eliminates the mechanical `(rf/dispatcher)` / `(rf/subscriber)` capture every view body used to need. The compile-time check on the body shape catches Form-3 / computed-fn footguns at the point of registration rather than at runtime. `reg-view*` (the `*`-suffixed plain-fn partner — standard Clojure idiom per `let`/`let*`, `fn`/`fn*`) is the runtime-callable surface for any case the macro shape doesn't fit.
+
+---
+
+**Reporting M-12 through M-22.** These eleven rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing eleven separate preambles.
 
 ---
 

--- a/docs/specification/Pattern-AsyncEffect.md
+++ b/docs/specification/Pattern-AsyncEffect.md
@@ -134,7 +134,7 @@ For **boot-time-fixed values** that originate from the host environment — a bu
 :hydrate
 {:on {:succeeded
       {:target :ready
-       :action (fn [{:keys [data]} _]
+       :action (fn [data _]
                  {:fx [[:dispatch [:ws/socket
                                    [:connect {:url        (-> data :config :ws-url)
                                               :auth-token (-> data :session :token)}]]]]})}}}

--- a/docs/specification/Pattern-Boot.md
+++ b/docs/specification/Pattern-Boot.md
@@ -85,28 +85,28 @@ Each phase uses `:invoke` to spawn the async work; transitions on success or fai
       (fn [_ _] (some? (.getItem js/localStorage "auth/token")))
 
       :under-retry-limit?
-      (fn [{:keys [data]} _] (< (:phase-attempt data) 3))}
+      (fn [data _] (< (:phase-attempt data) 3))}
 
      :actions
      {:set-phase
       ;; Update visible-progress slice in :data so the boot UI can render.
-      (fn [{:keys [data]} [_ phase]]
+      (fn [data [_ phase]]
         {:data (assoc data :phase phase :phase-attempt 0)})
 
       :record-config
-      (fn [{:keys [data]} [_ config]]
+      (fn [data [_ config]]
         {:data (assoc data :config config)})
 
       :record-user
-      (fn [{:keys [data]} [_ user]]
+      (fn [data [_ user]]
         {:data (assoc data :user user)})
 
       :bump-attempt
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (update data :phase-attempt inc)})
 
       :record-error
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (assoc data :error err)})
 
       :resolve-initial-route

--- a/docs/specification/Pattern-Boot.md
+++ b/docs/specification/Pattern-Boot.md
@@ -203,30 +203,28 @@ A view subscribes to the machine snapshot via `sub-machine` (per [005 §Reading 
   (fn sub-app-boot-state [db _]
     (get-in db [:rf/machines :app/boot :state])))
 
-(def boot-screen
-  (rf/reg-view :app.boot/screen
-    (fn render-boot-screen []
-      (let [state @(subscribe [:app.boot/state])
-            phase @(subscribe [:app.boot/phase])
-            err   @(subscribe [:app.boot/error])]
-        (cond
-          (= state :ready)
-          [running-app-root]
+(rf/reg-view boot-screen []
+  (let [state @(subscribe [:app.boot/state])
+        phase @(subscribe [:app.boot/phase])
+        err   @(subscribe [:app.boot/error])]
+    (cond
+      (= state :ready)
+      [running-app-root]
 
-          (#{:auth-failed :profile-failed :fatal-error} state)
-          [:div.boot-error
-           [:p (str "Couldn't start: " err)]
-           [:button {:on-click #(dispatch [:app/boot [:rf/start]])} "Retry"]]
+      (#{:auth-failed :profile-failed :fatal-error} state)
+      [:div.boot-error
+       [:p (str "Couldn't start: " err)]
+       [:button {:on-click #(dispatch [:app/boot [:rf/start]])} "Retry"]]
 
-          :else
-          [:div.boot-progress
-           [:p (case phase
-                 :configuring     "Loading config…"
-                 :authenticating  "Signing in…"
-                 :loading-profile "Loading your profile…"
-                 :hydrating       "Restoring state…"
-                 :routing         "Almost ready…"
-                 "Starting…")]])))))
+      :else
+      [:div.boot-progress
+       [:p (case phase
+             :configuring     "Loading config…"
+             :authenticating  "Signing in…"
+             :loading-profile "Loading your profile…"
+             :hydrating       "Restoring state…"
+             :routing         "Almost ready…"
+             "Starting…")]])))
 ```
 
 The progress UI reads from the same snapshot the machine writes — no parallel signal.

--- a/docs/specification/Pattern-Forms.md
+++ b/docs/specification/Pattern-Forms.md
@@ -211,42 +211,40 @@ Worked example — login form:
 ## Standard view structure
 
 ```clojure
-(def login-form-view
-  (rf/reg-view :form.login/view
-    (fn render-login-form []
-      (let [draft        @(subscribe [:form.login/draft])
-            form-errors  @(subscribe [:form.login/form-errors])
-            email-error  @(subscribe [:form.login/field-error :email])
-            pw-error     @(subscribe [:form.login/field-error :password])
-            can-submit?  @(subscribe [:form.login/can-submit?])
-            status       @(subscribe [:form.login/status])
-            submit-error @(subscribe [:form.login/submit-error])]
-        [:form
-         {:on-submit (fn [e]
-                       (.preventDefault e)
-                       (dispatch [:form.login/submit]))}
-         (when (seq form-errors)
-           [:ul.form-errors
-            (for [msg form-errors] ^{:key msg} [:li msg])])
+(rf/reg-view login-form-view []
+  (let [draft        @(subscribe [:form.login/draft])
+        form-errors  @(subscribe [:form.login/form-errors])
+        email-error  @(subscribe [:form.login/field-error :email])
+        pw-error     @(subscribe [:form.login/field-error :password])
+        can-submit?  @(subscribe [:form.login/can-submit?])
+        status       @(subscribe [:form.login/status])
+        submit-error @(subscribe [:form.login/submit-error])]
+    [:form
+     {:on-submit (fn [e]
+                   (.preventDefault e)
+                   (dispatch [:form.login/submit]))}
+     (when (seq form-errors)
+       [:ul.form-errors
+        (for [msg form-errors] ^{:key msg} [:li msg])])
 
-         [:input {:type      "email"
-                  :value     (:email draft)
-                  :on-change #(dispatch [:form.login/edit-field :email
-                                         (.. % -target -value)])
-                  :on-blur   #(dispatch [:form.login/blur-field :email])}]
-         (when email-error [:p.error email-error])
+     [:input {:type      "email"
+              :value     (:email draft)
+              :on-change #(dispatch [:form.login/edit-field :email
+                                     (.. % -target -value)])
+              :on-blur   #(dispatch [:form.login/blur-field :email])}]
+     (when email-error [:p.error email-error])
 
-         [:input {:type      "password"
-                  :value     (:password draft)
-                  :on-change #(dispatch [:form.login/edit-field :password
-                                         (.. % -target -value)])
-                  :on-blur   #(dispatch [:form.login/blur-field :password])}]
-         (when pw-error [:p.error pw-error])
+     [:input {:type      "password"
+              :value     (:password draft)
+              :on-change #(dispatch [:form.login/edit-field :password
+                                     (.. % -target -value)])
+              :on-blur   #(dispatch [:form.login/blur-field :password])}]
+     (when pw-error [:p.error pw-error])
 
-         [:button {:type "submit" :disabled (not can-submit?)}
-          (if (= status :submitting) "Signing in…" "Sign in")]
+     [:button {:type "submit" :disabled (not can-submit?)}
+      (if (= status :submitting) "Signing in…" "Sign in")]
 
-         (when submit-error [:p.error submit-error])]))))
+     (when submit-error [:p.error submit-error])]))
 ```
 
 ## Variations

--- a/docs/specification/Pattern-LongRunningWork.md
+++ b/docs/specification/Pattern-LongRunningWork.md
@@ -50,8 +50,8 @@ A state machine that processes one batch per state transition, yields to the bro
                :input       nil
                :result      []}
      :guards
-     {:done?      (fn [{:keys [data]} _] (>= (:processed data) (:total data)))
-      :more-work? (fn [{:keys [data]} _] (<  (:processed data) (:total data)))}
+     {:done?      (fn [data _] (>= (:processed data) (:total data)))
+      :more-work? (fn [data _] (<  (:processed data) (:total data)))}
 
      :actions
      {:start-job
@@ -64,7 +64,7 @@ A state machine that processes one batch per state transition, yields to the bro
                 :result     []}})
 
       :process-chunk
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (let [{:keys [input chunk-size processed result]} data
               chunk    (subvec input processed (min (+ processed chunk-size) (count input)))
               outputs  (mapv expensive-fn chunk)]

--- a/docs/specification/Pattern-NineStates.md
+++ b/docs/specification/Pattern-NineStates.md
@@ -99,20 +99,18 @@ The sub ids are illustrative. Feature code may namespace them differently.
 The page's root view should branch explicitly:
 
 ```clojure
-(def root-view
-  (rf/reg-view :ui.view/root
-    (fn []
-      (cond
-        @(subscribe [:ui.state/done?])      [view-done]
-        @(subscribe [:ui.state/incorrect?]) [view-incorrect]
-        @(subscribe [:ui.state/correct?])   [view-correct]
-        @(subscribe [:ui.state/nothing?])   [view-nothing]
-        @(subscribe [:ui.state/loading?])   [view-loading]
-        @(subscribe [:ui.state/empty?])     [view-empty]
-        @(subscribe [:ui.state/one?])       [view-one]
-        @(subscribe [:ui.state/some?])      [view-some]
-        @(subscribe [:ui.state/too-many?])  [view-too-many]
-        :else                               [view-fallback]))))
+(rf/reg-view root-view []
+  (cond
+    @(subscribe [:ui.state/done?])      [view-done]
+    @(subscribe [:ui.state/incorrect?]) [view-incorrect]
+    @(subscribe [:ui.state/correct?])   [view-correct]
+    @(subscribe [:ui.state/nothing?])   [view-nothing]
+    @(subscribe [:ui.state/loading?])   [view-loading]
+    @(subscribe [:ui.state/empty?])     [view-empty]
+    @(subscribe [:ui.state/one?])       [view-one]
+    @(subscribe [:ui.state/some?])      [view-some]
+    @(subscribe [:ui.state/too-many?])  [view-too-many]
+    :else                               [view-fallback]))
 ```
 
 The exact ordering depends on the feature, but the branch structure should be visible in one place.

--- a/docs/specification/Pattern-WebSocket.md
+++ b/docs/specification/Pattern-WebSocket.md
@@ -83,11 +83,11 @@ The connection machine composes the locked substrate:
 
      :guards
      {:max-retries-exceeded?
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (>= (:retries data) (:max-retries data)))
 
       :has-queued-messages?
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (seq (:queue data)))}
 
      :actions
@@ -96,33 +96,33 @@ The connection machine composes the locked substrate:
       ;;   (rf/dispatch [:ws/connection [:ws/connect {:url        "wss://api.example.com/ws"
       ;;                                              :auth-token (some-token)}]])
       ;; The opts land in :data; subsequent reconnect attempts reuse them.
-      (fn [{:keys [data]} [_ {:keys [url auth-token]}]]
+      (fn [data [_ {:keys [url auth-token]}]]
         {:data (assoc data :url url :auth-token auth-token)})
 
       :bump-retry
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (-> data
                    (update :retries inc)
                    (update :backoff-ms #(min (* 2 %) (:max-backoff data))))})
 
       :reset-retry
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (assoc data :retries 0 :backoff-ms 1000)})
 
       :record-token
       ;; Used when the running app refreshes the auth token without a full reconnect.
-      (fn [{:keys [data]} [_ token]]
+      (fn [data [_ token]]
         {:data (assoc data :auth-token token)})
 
       :send-auth
       ;; The socket actor accepts a [:send msg] event; route into it.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx [[:dispatch [(:socket-id data) [:send {:type  :auth
                                                     :token (:auth-token data)}]]]]})
 
       :resubscribe
       ;; On (re)connect, re-issue subscriptions tracked in :data.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx (mapv (fn [topic]
                      [:dispatch [(:socket-id data)
                                  [:send {:type :subscribe :topic topic}]]])
@@ -130,18 +130,18 @@ The connection machine composes the locked substrate:
 
       :flush-queue
       ;; Send any messages buffered while disconnected; clear the queue.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (assoc data :queue [])
          :fx   (mapv (fn [msg] [:dispatch [(:socket-id data) [:send msg]]])
                      (:queue data))})
 
       :enqueue-message
       ;; Buffer a send while disconnected.
-      (fn [{:keys [data]} [_ msg]]
+      (fn [data [_ msg]]
         {:data (update data :queue conj msg)})
 
       :record-error
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (assoc data :error err)})}
 
      :states
@@ -184,7 +184,7 @@ The connection machine composes the locked substrate:
                                         ;; named dispatched event; the running-app
                                         ;; handlers commit it.
                                         {:fx [[:dispatch [:ws/handle-message msg]]]})}
-                :ws/send     {:action (fn [{:keys [data]} [_ msg]]
+                :ws/send     {:action (fn [data [_ msg]]
                                         {:fx [[:dispatch [(:socket-id data)
                                                           [:send msg]]]]})}}
        :initial :idle
@@ -228,7 +228,7 @@ To subscribe / unsubscribe at runtime, dispatch a sub/unsub event into the conne
 ```clojure
 ;; Subscribe to a topic — pure :data update + send.
 :ws/subscribe
-{:action (fn [{:keys [data]} [_ topic]]
+{:action (fn [data [_ topic]]
            {:data (update data :subscriptions conj topic)
             :fx   [[:dispatch [(:socket-id data) [:send {:type :subscribe :topic topic}]]]]})}
 ```
@@ -241,7 +241,7 @@ Some WebSocket protocols are request-reply with a correlation id. The pattern: t
 
 ```clojure
 :ws/request
-{:action (fn [{:keys [data]} [_ {:keys [reply] :as msg}]]
+{:action (fn [data [_ {:keys [reply] :as msg}]]
            (let [id (random-uuid)]
              {:data (assoc-in data [:in-flight id] reply)
               :fx   [[:dispatch [(:socket-id data) [:send (assoc msg :id id)]]]]}))}

--- a/examples/counter/core.cljs
+++ b/examples/counter/core.cljs
@@ -37,32 +37,26 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; The `:counter-buttons` view holds the UI. Its body uses the injected
-;; `dispatch`/`subscribe` which resolve, at render time, to whichever frame
-;; the surrounding React context puts in scope.
+;; The `:counter-buttons` view holds the UI. Per Spec 004 §reg-view, the
+;; defn-shape macro auto-injects `dispatch` and `subscribe` as lexical
+;; bindings; both resolve at render time to the frame in scope (the
+;; default frame here, see the namespace docstring for the
+;; frame-provider variant parked behind rf2-kdwc).
+;;
+;; reg-view auto-defs a Var named after the supplied symbol and
+;; registers the view under (keyword *ns* sym).
 
-;; reg-view (the macro form from re-frame.views-macros) defs a local
-;; Var named after the keyword. The body's dispatch / subscribe both
-;; resolve through (current-frame) — bound by the enclosing
-;; frame-provider via React context.
+(reg-view counter-buttons []
+  [:div
+   [:button {:on-click #(dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em"}} @(subscribe [:count])]
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-(reg-view :counter-buttons
-  (fn []
-    (let [d (rf/dispatcher)
-          s (rf/subscriber)]
-      [:div
-       [:button {:on-click #(d [:counter/dec])} "-"]
-       [:span {:style {:margin "0 1em"}} @(s [:count])]
-       [:button {:on-click #(d [:counter/inc])} "+"]])))
+;; The root `counter-app` view renders `counter-buttons` against the
+;; default frame. Initialisation runs in `run` via `dispatch-sync`.
 
-;; The `:counter-app` view is the root — it just renders
-;; `:counter-buttons` against the default frame. Initialisation runs
-;; in `run` via `dispatch-sync`. (The earlier frame-provider variant
-;; is documented in the namespace docstring and parked behind rf2-kdwc.)
-
-(reg-view :counter-app
-  (fn []
-    [counter-buttons]))
+(reg-view counter-app []
+  [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------
 

--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -108,18 +108,18 @@
      :guards
      {:under-retry-limit
       ;; True if the flow has had fewer than 3 prior failed attempts.
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         (< (:attempts data) 3))}
 
      :actions
      {:clear-error
       ;; Reset error and prepare to submit.
-      (fn [_ _event]
+      (fn [_data _event]
         {:data {:error nil}})
 
       :issue-request
       ;; Issue the login HTTP request. Returns effects, not side-effects.
-      (fn [_snapshot [_ creds]]
+      (fn [_data [_ creds]]
         {:fx [[:http {:method     :post
                       :url        "/api/login"
                       :body       creds
@@ -128,19 +128,19 @@
 
       :record-error
       ;; Record the failure into :data and bump the attempt counter.
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (-> data
                    (update :attempts inc)
                    (assoc :error (or (:message err) "Login failed.")))})
 
       :lock-account
       ;; Mark the account as locked after too many failed attempts.
-      (fn [_snapshot _event]
+      (fn [_data _event]
         {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
 
       :store-session
       ;; Persist the session token returned by a successful login.
-      (fn [_snapshot [_ {:keys [token]}]]
+      (fn [_data [_ {:keys [token]}]]
         {:fx [[:auth.session/store {:token token}]]})}
 
      :states

--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -217,49 +217,44 @@
 ;; hiccup]). The current API uses `rf/dispatcher` / `rf/subscriber` for
 ;; frame-bound access inside views.
 
-(def login-form
-  (reg-view :auth.login/form
-    {:doc "The login form view: email + password + submit button + error display."}
-    (fn render-auth-login-form []
-      (let [d     (rf/dispatcher)
-            s     (rf/subscriber)
-            state (atom {:email "" :password ""})]
-        (fn []
-          (let [submitting? @(s [:auth.login/submitting?])
-                err         @(s [:auth.login/error])]
-            [:form.login-form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:auth.login/flow [:auth.login/submit @state]]))}
-             [:input  {:type        "email"
-                       :placeholder "Email"
-                       :disabled    submitting?
-                       :on-change   #(swap! state assoc :email (.. % -target -value))}]
-             [:input  {:type        "password"
-                       :placeholder "Password"
-                       :disabled    submitting?
-                       :on-change   #(swap! state assoc :password (.. % -target -value))}]
-             [:button {:type "submit" :disabled submitting?}
-              (if submitting? "Signing in…" "Sign in")]
-             (when err [:p.error err])]))))))
+;; Form-2 view: the outer fn captures local component state in `state`
+;; (a Reagent atom kept across renders); the inner fn is the actual
+;; render fn. dispatch / subscribe are auto-injected and visible in
+;; both the outer and inner fn bodies.
+(reg-view ^{:doc "The login form view: email + password + submit button + error display."}
+          login-form []
+  (let [state (atom {:email "" :password ""})]
+    (fn []
+      (let [submitting? @(subscribe [:auth.login/submitting?])
+            err         @(subscribe [:auth.login/error])]
+        [:form.login-form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:auth.login/flow [:auth.login/submit @state]]))}
+         [:input  {:type        "email"
+                   :placeholder "Email"
+                   :disabled    submitting?
+                   :on-change   #(swap! state assoc :email (.. % -target -value))}]
+         [:input  {:type        "password"
+                   :placeholder "Password"
+                   :disabled    submitting?
+                   :on-change   #(swap! state assoc :password (.. % -target -value))}]
+         [:button {:type "submit" :disabled submitting?}
+          (if submitting? "Signing in…" "Sign in")]
+         (when err [:p.error err])]))))
 
-(def login-banner
-  (reg-view :auth.login/banner
-    {:doc "Shows the user's logged-in state and a sign-out button."}
-    (fn render-auth-login-banner []
-      (let [s       (rf/subscriber)
-            authed? @(s [:auth.login/authenticated?])]
-        [:div.banner
-         (if authed?
-           [:span "Welcome!"]
-           [login-form])]))))
+(reg-view ^{:doc "Shows the user's logged-in state and a sign-out button."}
+          login-banner []
+  (let [authed? @(subscribe [:auth.login/authenticated?])]
+    [:div.banner
+     (if authed?
+       [:span "Welcome!"]
+       [login-form])]))
 
-(def root-view
-  (reg-view :auth.login/root
-    (fn render-auth-login-root []
-      [:div.app
-       [:h1 "Sign in"]
-       [login-banner]])))
+(reg-view root-view []
+  [:div.app
+   [:h1 "Sign in"]
+   [login-banner]])
 
 ;; ============================================================================
 ;; HEADLESS TEST  (smoke test for the feature)

--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -405,182 +405,146 @@
 ;; the editor's :archived (state 9) wins over everything; otherwise we fall
 ;; through the lifecycle.
 
-(def view-nothing
-  (reg-view :ui.view/nothing
-    {:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
-    (fn render-nothing []
-      (let [d (rf/dispatcher)]
-        [:div.state.state-nothing
-         [:h2 "Welcome"]
-         [:p "You haven't loaded any todos yet."]
-         [:button {:on-click #(d [:todos/load {:n 0}])} "Get started"]]))))
+(reg-view ^{:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
+          view-nothing []
+  [:div.state.state-nothing
+   [:h2 "Welcome"]
+   [:p "You haven't loaded any todos yet."]
+   [:button {:on-click #(dispatch [:todos/load {:n 0}])} "Get started"]])
 
-(def view-loading
-  (reg-view :ui.view/loading
-    {:doc "State 2 — Loading: spinner / skeleton. NEVER blank the page on revalidation."}
-    (fn render-loading []
-      [:div.state.state-loading
-       [:p "Loading todos…"]])))
+(reg-view ^{:doc "State 2 — Loading: spinner / skeleton. NEVER blank the page on revalidation."}
+          view-loading []
+  [:div.state.state-loading
+   [:p "Loading todos…"]])
 
-(def view-empty
-  (reg-view :ui.view/empty
-    {:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
-    (fn render-empty []
-      [:div.state.state-empty
-       [:h2 "No todos yet"]
-       [:p "Add your first todo using the form below."]])))
+(reg-view ^{:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
+          view-empty []
+  [:div.state.state-empty
+   [:h2 "No todos yet"]
+   [:p "Add your first todo using the form below."]])
 
-(def view-one
-  (reg-view :ui.view/one
-    {:doc "State 4 — One: focused single-item layout."}
-    (fn render-one []
-      (let [s    (rf/subscriber)
-            todo (first @(s [:todos/data]))]
-        [:div.state.state-one
-         [:h2 "Your todo"]
-         [:p.title (:title todo)]]))))
+(reg-view ^{:doc "State 4 — One: focused single-item layout."}
+          view-one []
+  (let [todo (first @(subscribe [:todos/data]))]
+    [:div.state.state-one
+     [:h2 "Your todo"]
+     [:p.title (:title todo)]]))
 
-(def view-some
-  (reg-view :ui.view/some
-    {:doc "State 5 — Some: standard list."}
-    (fn render-some []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos/data])]
-        [:div.state.state-some
-         [:h2 (str (count todos) " todos")]
-         [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))))
+(reg-view ^{:doc "State 5 — Some: standard list."}
+          view-some []
+  (let [todos @(subscribe [:todos/data])]
+    [:div.state.state-some
+     [:h2 (str (count todos) " todos")]
+     [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
-(def view-too-many
-  (reg-view :ui.view/too-many
-    {:doc "State 6 — Too Many: search + truncation."}
-    (fn render-too-many []
-      (let [s        (rf/subscriber)
-            todos    @(s [:todos/data])
-            shown    (take too-many-threshold todos)
-            overflow (- (count todos) too-many-threshold)]
-        [:div.state.state-too-many
-         [:h2 (str (count todos) " todos (showing first " too-many-threshold ")")]
-         [:input {:type "search" :placeholder "Search todos…"}]
-         [:ul (for [t shown] ^{:key (:id t)} [:li (:title t)])]
-         (when (pos? overflow)
-           [:p.overflow (str "…and " overflow " more.")])]))))
+(reg-view ^{:doc "State 6 — Too Many: search + truncation."}
+          view-too-many []
+  (let [todos    @(subscribe [:todos/data])
+        shown    (take too-many-threshold todos)
+        overflow (- (count todos) too-many-threshold)]
+    [:div.state.state-too-many
+     [:h2 (str (count todos) " todos (showing first " too-many-threshold ")")]
+     [:input {:type "search" :placeholder "Search todos…"}]
+     [:ul (for [t shown] ^{:key (:id t)} [:li (:title t)])]
+     (when (pos? overflow)
+       [:p.overflow (str "…and " overflow " more.")])]))
 
-(def view-incorrect
-  (reg-view :ui.view/incorrect
-    {:doc "State 7 — Incorrect: per-field validation error + recovery path."}
-    (fn render-incorrect []
-      (let [s   (rf/subscriber)
-            err @(s [:new-todo/field-error :title])]
-        [:div.state.state-incorrect
-         [:p.error (str "We can't add that todo: " err)]
-         [:p "Please fix the title field below and submit again."]]))))
+(reg-view ^{:doc "State 7 — Incorrect: per-field validation error + recovery path."}
+          view-incorrect []
+  (let [err @(subscribe [:new-todo/field-error :title])]
+    [:div.state.state-incorrect
+     [:p.error (str "We can't add that todo: " err)]
+     [:p "Please fix the title field below and submit again."]]))
 
-(def view-correct
-  (reg-view :ui.view/correct
-    {:doc "State 8 — Correct: success feedback (toast / checkmark)."}
-    (fn render-correct []
-      [:div.state.state-correct
-       [:p.success "✓ Todo added."]])))
+(reg-view ^{:doc "State 8 — Correct: success feedback (toast / checkmark)."}
+          view-correct []
+  [:div.state.state-correct
+   [:p.success "✓ Todo added."]])
 
-(def view-done
-  (reg-view :ui.view/done
-    {:doc "State 9 — Done/Frozen: archived list. Read-only."}
-    (fn render-done []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos/data])]
-        [:div.state.state-done
-         [:h2 "Archived"]
-         [:p "This list has been archived. It is read-only."]
-         [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))))
+(reg-view ^{:doc "State 9 — Done/Frozen: archived list. Read-only."}
+          view-done []
+  (let [todos @(subscribe [:todos/data])]
+    [:div.state.state-done
+     [:h2 "Archived"]
+     [:p "This list has been archived. It is read-only."]
+     [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
 ;; ============================================================================
 ;; VIEWS — control panel + form + root
 ;; ============================================================================
 
-(def new-todo-form
-  (reg-view :ui.view/new-todo-form
-    {:doc "Form for adding a todo. Drives the Forms slice (states 7 & 8)."}
-    (fn render-new-todo-form []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:new-todo/draft])
-            field-err   @(s [:new-todo/field-error :title])
-            done?       @(s [:ui.state/done?])]
-        [:form.new-todo
-         {:on-submit (fn [e]
-                       (.preventDefault e)
-                       (d [:new-todo/submit]))}
-         [:input {:type        "text"
-                  :placeholder "What needs doing?"
-                  :value       (:title draft)
-                  :disabled    done?
-                  :on-change   #(d [:new-todo/edit-field :title
-                                    (.. % -target -value)])}]
-         [:button {:type "submit" :disabled done?} "Add"]
-         (when field-err [:p.error field-err])]))))
+(reg-view ^{:doc "Form for adding a todo. Drives the Forms slice (states 7 & 8)."}
+          new-todo-form []
+  (let [draft     @(subscribe [:new-todo/draft])
+        field-err @(subscribe [:new-todo/field-error :title])
+        done?     @(subscribe [:ui.state/done?])]
+    [:form.new-todo
+     {:on-submit (fn [e]
+                   (.preventDefault e)
+                   (dispatch [:new-todo/submit]))}
+     [:input {:type        "text"
+              :placeholder "What needs doing?"
+              :value       (:title draft)
+              :disabled    done?
+              :on-change   #(dispatch [:new-todo/edit-field :title
+                                       (.. % -target -value)])}]
+     [:button {:type "submit" :disabled done?} "Add"]
+     (when field-err [:p.error field-err])]))
 
-(def control-panel
-  (reg-view :ui.view/control-panel
-    {:doc "Buttons to drive the app into each of the nine states."}
-    (fn render-control-panel []
-      (let [d     (rf/dispatcher)
-            s     (rf/subscriber)
-            done? @(s [:ui.state/done?])]
-        [:div.control-panel
-         [:h3 "Drive the demo"]
-         [:button {:on-click #(d [:app/initialise])
-                   :disabled done?} "1. Nothing"]
-         [:button {:on-click #(d [:todos/load-with-failure])
-                   :disabled done?} "Trigger error"]
-         [:button {:on-click #(d [:todos/load {:n 0}])
-                   :disabled done?} "3. Empty"]
-         [:button {:on-click #(d [:todos/load {:n 1}])
-                   :disabled done?} "4. One"]
-         [:button {:on-click #(d [:todos/load {:n 4}])
-                   :disabled done?} "5. Some"]
-         [:button {:on-click #(d [:todos/load {:n 25}])
-                   :disabled done?} "6. Too Many"]
-         [:button {:on-click #(d [:todos/editor [:todos.editor/archive {}]])
-                   :disabled done?} "9. Archive (Done)"]]))))
+(reg-view ^{:doc "Buttons to drive the app into each of the nine states."}
+          control-panel []
+  (let [done? @(subscribe [:ui.state/done?])]
+    [:div.control-panel
+     [:h3 "Drive the demo"]
+     [:button {:on-click #(dispatch [:app/initialise])
+               :disabled done?} "1. Nothing"]
+     [:button {:on-click #(dispatch [:todos/load-with-failure])
+               :disabled done?} "Trigger error"]
+     [:button {:on-click #(dispatch [:todos/load {:n 0}])
+               :disabled done?} "3. Empty"]
+     [:button {:on-click #(dispatch [:todos/load {:n 1}])
+               :disabled done?} "4. One"]
+     [:button {:on-click #(dispatch [:todos/load {:n 4}])
+               :disabled done?} "5. Some"]
+     [:button {:on-click #(dispatch [:todos/load {:n 25}])
+               :disabled done?} "6. Too Many"]
+     [:button {:on-click #(dispatch [:todos/editor [:todos.editor/archive {}]])
+               :disabled done?} "9. Archive (Done)"]]))
 
-(def root-view
-  (reg-view :ui.view/root
-    {:doc "Root view: pick exactly one of the nine state views, plus form
-           and control panel."}
-    (fn render-root []
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            done?      @(s [:ui.state/done?])
-            correct?   @(s [:ui.state/correct?])
-            incorrect? @(s [:ui.state/incorrect?])
-            nothing?   @(s [:ui.state/nothing?])
-            loading?   @(s [:ui.state/loading?])
-            empty?     @(s [:ui.state/empty?])
-            one?       @(s [:ui.state/one?])
-            some?*     @(s [:ui.state/some?])
-            too-many?  @(s [:ui.state/too-many?])
-            error      @(s [:todos/error])]
-        [:div.app
-         [:h1 "Nine States of UI — todos"]
-         [control-panel]
-         [:hr]
-         (cond
-           done?      [view-done]
-           incorrect? [view-incorrect]
-           correct?   [view-correct]
-           nothing?   [view-nothing]
-           loading?   [view-loading]
-           error      [:div.state.state-error
-                       [:p.error (str "Couldn't load: " (:message error))]
-                       [:button {:on-click #(d [:todos/load {:n 4}])}
-                        "Retry"]]
-           empty?     [view-empty]
-           one?       [view-one]
-           some?*     [view-some]
-           too-many?  [view-too-many]
-           :else      [:p "(unrecognised state)"])
-         [:hr]
-         [new-todo-form]]))))
+(reg-view ^{:doc "Root view: pick exactly one of the nine state views, plus form
+                  and control panel."}
+          root-view []
+  (let [done?      @(subscribe [:ui.state/done?])
+        correct?   @(subscribe [:ui.state/correct?])
+        incorrect? @(subscribe [:ui.state/incorrect?])
+        nothing?   @(subscribe [:ui.state/nothing?])
+        loading?   @(subscribe [:ui.state/loading?])
+        empty?     @(subscribe [:ui.state/empty?])
+        one?       @(subscribe [:ui.state/one?])
+        some?*     @(subscribe [:ui.state/some?])
+        too-many?  @(subscribe [:ui.state/too-many?])
+        error      @(subscribe [:todos/error])]
+    [:div.app
+     [:h1 "Nine States of UI — todos"]
+     [control-panel]
+     [:hr]
+     (cond
+       done?      [view-done]
+       incorrect? [view-incorrect]
+       correct?   [view-correct]
+       nothing?   [view-nothing]
+       loading?   [view-loading]
+       error      [:div.state.state-error
+                   [:p.error (str "Couldn't load: " (:message error))]
+                   [:button {:on-click #(dispatch [:todos/load {:n 4}])}
+                    "Retry"]]
+       empty?     [view-empty]
+       one?       [view-one]
+       some?*     [view-some]
+       too-many?  [view-too-many]
+       :else      [:p "(unrecognised state)"])
+     [:hr]
+     [new-todo-form]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS
@@ -693,10 +657,8 @@
 ;; CLJS host without touching React.
 
 ;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with the local Var `root` that `reg-view :ui.view/root`
-;; auto-defs. (`(name :ui.view/root)` is "root" — without renaming the
-;; mount point, the latter `def` overwrites the React root with the
-;; view fn, and at run time `root.render` is undefined.)
+;; collide with anything else in this ns; reg-view defs `root-view`,
+;; which is what we render.
 (defonce react-root
   (when (exists? js/document)
     (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/realworld/article_editor.cljs
+++ b/examples/realworld/article_editor.cljs
@@ -187,73 +187,69 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def editor-page
-  (reg-view :pages/editor
-    (fn render-editor-page []
-      (let [d            (rf/dispatcher)
-            s            (rf/subscriber)
-            draft        @(s [:editor/draft])
-            errors       @(s [:editor/errors])
-            submitting?  @(s [:editor/submitting?])
-            submit-error @(s [:editor/submit-error])
-            mode         @(s [:editor/mode])]
-        [:div.editor-page
-         [:div.container.page
-          [:div.row
-           [:div.col-md-10.offset-md-1.col-xs-12
-            (when submit-error
-              [:ul.error-messages [:li submit-error]])
-            [:form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:editor/submit]))}
-             [:fieldset
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type        "text"
-                 :placeholder "Article Title"
-                 :value       (:title draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :title])
-                 :on-change   #(d [:editor/edit-field :title (.. % -target -value)])}]
-               (when-let [err (:title errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:input.form-control
-                {:type        "text"
-                 :placeholder "What's this article about?"
-                 :value       (:description draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :description])
-                 :on-change   #(d [:editor/edit-field :description (.. % -target -value)])}]
-               (when-let [err (:description errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:textarea.form-control
-                {:rows        8
-                 :placeholder "Write your article (in markdown)"
-                 :value       (:body draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :body])
-                 :on-change   #(d [:editor/edit-field :body (.. % -target -value)])}]
-               (when-let [err (:body errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:input.form-control
-                {:type        "text"
-                 :placeholder "Enter tags"
-                 :value       (:tagList draft)
-                 :disabled    submitting?
-                 :on-change   #(d [:editor/edit-field :tagList (.. % -target -value)])}]]
-              [:button.btn.btn-lg.pull-xs-right.btn-primary
-               {:type "submit" :disabled submitting?}
-               (if (= mode :edit) "Update Article" "Publish Article")]
-              (when (= mode :edit)
-                [:button.btn.btn-outline-danger
-                 {:type "button"
-                  :disabled submitting?
-                  :on-click #(d [:editor/delete])}
-                 "Delete Article"])]]]]]])))
+(reg-view editor-page []
+  (let [draft        @(subscribe [:editor/draft])
+        errors       @(subscribe [:editor/errors])
+        submitting?  @(subscribe [:editor/submitting?])
+        submit-error @(subscribe [:editor/submit-error])
+        mode         @(subscribe [:editor/mode])]
+    [:div.editor-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-10.offset-md-1.col-xs-12
+        (when submit-error
+          [:ul.error-messages [:li submit-error]])
+        [:form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:editor/submit]))}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type        "text"
+             :placeholder "Article Title"
+             :value       (:title draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :title])
+             :on-change   #(dispatch [:editor/edit-field :title (.. % -target -value)])}]
+           (when-let [err (:title errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type        "text"
+             :placeholder "What's this article about?"
+             :value       (:description draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :description])
+             :on-change   #(dispatch [:editor/edit-field :description (.. % -target -value)])}]
+           (when-let [err (:description errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:textarea.form-control
+            {:rows        8
+             :placeholder "Write your article (in markdown)"
+             :value       (:body draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :body])
+             :on-change   #(dispatch [:editor/edit-field :body (.. % -target -value)])}]
+           (when-let [err (:body errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type        "text"
+             :placeholder "Enter tags"
+             :value       (:tagList draft)
+             :disabled    submitting?
+             :on-change   #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
+          [:button.btn.btn-lg.pull-xs-right.btn-primary
+           {:type "submit" :disabled submitting?}
+           (if (= mode :edit) "Update Article" "Publish Article")]
+          (when (= mode :edit)
+            [:button.btn.btn-outline-danger
+             {:type "button"
+              :disabled submitting?
+              :on-click #(dispatch [:editor/delete])}
+             "Delete Article"])]]]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/articles.cljs
+++ b/examples/realworld/articles.cljs
@@ -127,117 +127,110 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def article-preview
-  (reg-view :articles/preview
-    {:doc "A single article card used across the home page and profile pages."}
-    (fn render-article-preview [{:keys [article]}]
-      (let [d (rf/dispatcher)
-            {:keys [slug title description createdAt favoritesCount author tagList]} article]
-        [:div.article-preview
-         [:div.article-meta
-          [routing/route-link {:to     :route/profile
-                               :params {:username (:username author)}}
-           [:img {:src (:image author)}]]
-          [:div.info
-           [routing/route-link {:to     :route/profile
-                                :params {:username (:username author)}
-                                :class  "author"}
-            (:username author)]
-           [:span.date createdAt]]
-          [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
-           {:type "button"
-            :on-click #(d [:article/toggle-favorite slug])}
-           [:i.ion-heart] " " favoritesCount]]
-         [routing/route-link {:to :route/article :params {:slug slug} :class "preview-link"}
-          [:h1 title]
-          [:p description]
-          [:span "Read more..."]
-          [:ul.tag-list
-           (for [tag tagList]
-             ^{:key tag}
-             [:li.tag-default.tag-pill.tag-outline tag])]]]))))
+(reg-view ^{:doc "A single article card used across the home page and profile pages."}
+          article-preview [{:keys [article]}]
+  (let [{:keys [slug title description createdAt favoritesCount author tagList]} article]
+    [:div.article-preview
+     [:div.article-meta
+      [routing/route-link {:to     :route/profile
+                           :params {:username (:username author)}}
+       [:img {:src (:image author)}]]
+      [:div.info
+       [routing/route-link {:to     :route/profile
+                            :params {:username (:username author)}
+                            :class  "author"}
+        (:username author)]
+       [:span.date createdAt]]
+      [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
+       {:type "button"
+        :on-click #(dispatch [:article/toggle-favorite slug])}
+       [:i.ion-heart] " " favoritesCount]]
+     [routing/route-link {:to :route/article :params {:slug slug} :class "preview-link"}
+      [:h1 title]
+      [:p description]
+      [:span "Read more..."]
+      [:ul.tag-list
+       (for [tag tagList]
+         ^{:key tag}
+         [:li.tag-default.tag-pill.tag-outline tag])]]]))
 
-(def home-page
-  (reg-view :pages/home
-    {:doc "Global feed / your feed / tag-filtered home page."}
-    (fn render-home []
-      (let [d              (rf/dispatcher)
-            s              (rf/subscriber)
-            authed?        @(s [:auth/authenticated?])
-            feed-kind      @(s [:home/feed-kind])
-            selected-tag   @(s [:home/selected-tag])
-            global-loading? @(s [:articles/loading?])
-            global-fetching? @(s [:articles/fetching?])
-            global-error   @(s [:articles/error])
-            global-articles @(s [:articles/data])
-            feed-loading?  @(s [:feed/loading?])
-            feed-error     @(s [:feed/error])
-            your-feed      @(s [:feed/data])
-            tags           @(s [:tags/data])
-            [loading? fetching? err articles]
-            (if (= feed-kind :your)
-              [feed-loading? false feed-error your-feed]
-              [global-loading? global-fetching? global-error global-articles])]
-        [:div.home-page
-         [:div.banner
-          [:div.container
-           [:h1.logo-font "conduit"]
-           [:p "A place to share your knowledge."]]]
-         [:div.container.page
-          [:div.row
-           [:div.col-md-9
-            [:div.feed-toggle
-             [:ul.nav.nav-pills.outline-active
-              (when authed?
-                [:li.nav-item
-                 [:a.nav-link
-                  {:href "#"
-                   :class (when (= feed-kind :your) "active")
-                   :on-click #(do (.preventDefault %)
-                                  (d [:home/show-your-feed]))}
-                  "Your Feed"]])
-              [:li.nav-item
-               [:a.nav-link
-                {:href "#"
-                 :class (when (= feed-kind :global) "active")
-                 :on-click #(do (.preventDefault %)
-                                (d [:home/show-global-feed]))}
-                "Global Feed"]]
-              (when selected-tag
-                [:li.nav-item
-                 [:a.nav-link.active
-                  {:href "#"
-                   :on-click #(do (.preventDefault %)
-                                  (d [:tags/clear-filter]))}
-                  [:i.ion-pound] " " selected-tag]])]]
-            (cond
-              loading?
-              [:div.article-preview "Loading articles…"]
+(reg-view ^{:doc "Global feed / your feed / tag-filtered home page."}
+          home-page []
+  (let [authed?         @(subscribe [:auth/authenticated?])
+        feed-kind       @(subscribe [:home/feed-kind])
+        selected-tag    @(subscribe [:home/selected-tag])
+        global-loading?  @(subscribe [:articles/loading?])
+        global-fetching? @(subscribe [:articles/fetching?])
+        global-error    @(subscribe [:articles/error])
+        global-articles @(subscribe [:articles/data])
+        feed-loading?   @(subscribe [:feed/loading?])
+        feed-error      @(subscribe [:feed/error])
+        your-feed       @(subscribe [:feed/data])
+        tags            @(subscribe [:tags/data])
+        [loading? fetching? err articles]
+        (if (= feed-kind :your)
+          [feed-loading? false feed-error your-feed]
+          [global-loading? global-fetching? global-error global-articles])]
+    [:div.home-page
+     [:div.banner
+      [:div.container
+       [:h1.logo-font "conduit"]
+       [:p "A place to share your knowledge."]]]
+     [:div.container.page
+      [:div.row
+       [:div.col-md-9
+        [:div.feed-toggle
+         [:ul.nav.nav-pills.outline-active
+          (when authed?
+            [:li.nav-item
+             [:a.nav-link
+              {:href "#"
+               :class (when (= feed-kind :your) "active")
+               :on-click #(do (.preventDefault %)
+                              (dispatch [:home/show-your-feed]))}
+              "Your Feed"]])
+          [:li.nav-item
+           [:a.nav-link
+            {:href "#"
+             :class (when (= feed-kind :global) "active")
+             :on-click #(do (.preventDefault %)
+                            (dispatch [:home/show-global-feed]))}
+            "Global Feed"]]
+          (when selected-tag
+            [:li.nav-item
+             [:a.nav-link.active
+              {:href "#"
+               :on-click #(do (.preventDefault %)
+                              (dispatch [:tags/clear-filter]))}
+              [:i.ion-pound] " " selected-tag]])]]
+        (cond
+          loading?
+          [:div.article-preview "Loading articles…"]
 
-              err
-              [:div.article-preview.error
-               (str "Couldn't load articles: " (pr-str err))]
+          err
+          [:div.article-preview.error
+           (str "Couldn't load articles: " (pr-str err))]
 
-              (empty? articles)
-              [:div.article-preview "No articles are here… yet."]
+          (empty? articles)
+          [:div.article-preview "No articles are here… yet."]
 
-              :else
-              [:<>
-               (when fetching? [:div.refresh-indicator "Refreshing…"])
-               (for [article articles]
-                 ^{:key (:slug article)}
-                 [article-preview {:article article}])])]
-           [:div.col-md-3
-            [:div.sidebar
-             [:p "Popular Tags"]
-             [:div.tag-list
-              (for [tag tags]
-                ^{:key tag}
-                [:a.tag-pill.tag-default
-                 {:href "#"
-                  :on-click #(do (.preventDefault %)
-                                 (d [:tags/apply-filter tag]))}
-                 tag])]]]]]]))))
+          :else
+          [:<>
+           (when fetching? [:div.refresh-indicator "Refreshing…"])
+           (for [article articles]
+             ^{:key (:slug article)}
+             [article-preview {:article article}])])]
+       [:div.col-md-3
+        [:div.sidebar
+         [:p "Popular Tags"]
+         [:div.tag-list
+          (for [tag tags]
+            ^{:key tag}
+            [:a.tag-pill.tag-default
+             {:href "#"
+              :on-click #(do (.preventDefault %)
+                             (dispatch [:tags/apply-filter tag]))}
+             tag])]]]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -259,77 +259,69 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def login-page
-  (reg-view :pages/login
-    {:doc "Login page."}
-    (fn render-login []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:auth.login-form/draft])
-            submitting? @(s [:auth/submitting?])
-            err         @(s [:auth/error])]
-        [:div.auth-page
-         [:h1 "Sign in"]
-         [routing/route-link {:to :route/register} "Need an account?"]
-         (when err [:ul.error-messages [:li err]])
-         [:form
-          {:on-submit (fn [e]
-                        (.preventDefault e)
-                        (d [:auth.login-form/submit]))}
-          [:fieldset
-           [:fieldset.form-group
-            [:input {:type        "email"
-                     :placeholder "Email"
-                     :value       (:email draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.login-form/edit-field :email (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "password"
-                     :placeholder "Password"
-                     :value       (:password draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.login-form/edit-field :password (.. % -target -value)])}]]
-           [:button {:type "submit" :disabled submitting?}
-            (if submitting? "Signing in…" "Sign in")]]]]))))
+(reg-view ^{:doc "Login page."}
+          login-page []
+  (let [draft       @(subscribe [:auth.login-form/draft])
+        submitting? @(subscribe [:auth/submitting?])
+        err         @(subscribe [:auth/error])]
+    [:div.auth-page
+     [:h1 "Sign in"]
+     [routing/route-link {:to :route/register} "Need an account?"]
+     (when err [:ul.error-messages [:li err]])
+     [:form
+      {:on-submit (fn [e]
+                    (.preventDefault e)
+                    (dispatch [:auth.login-form/submit]))}
+      [:fieldset
+       [:fieldset.form-group
+        [:input {:type        "email"
+                 :placeholder "Email"
+                 :value       (:email draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.login-form/edit-field :email (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "password"
+                 :placeholder "Password"
+                 :value       (:password draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.login-form/edit-field :password (.. % -target -value)])}]]
+       [:button {:type "submit" :disabled submitting?}
+        (if submitting? "Signing in…" "Sign in")]]]]))
 
-(def register-page
-  (reg-view :pages/register
-    {:doc "Register page."}
-    (fn render-register []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:auth.register-form/draft])
-            submitting? @(s [:auth/submitting?])
-            err         @(s [:auth/error])]
-        [:div.auth-page
-         [:h1 "Sign up"]
-         [routing/route-link {:to :route/login} "Have an account?"]
-         (when err [:ul.error-messages [:li err]])
-         [:form
-          {:on-submit (fn [e]
-                        (.preventDefault e)
-                        (d [:auth.register-form/submit]))}
-          [:fieldset
-           [:fieldset.form-group
-            [:input {:type        "text"
-                     :placeholder "Username"
-                     :value       (:username draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :username (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "email"
-                     :placeholder "Email"
-                     :value       (:email draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :email (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "password"
-                     :placeholder "Password"
-                     :value       (:password draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :password (.. % -target -value)])}]]
-           [:button {:type "submit" :disabled submitting?}
-            (if submitting? "Signing up…" "Sign up")]]]]))))
+(reg-view ^{:doc "Register page."}
+          register-page []
+  (let [draft       @(subscribe [:auth.register-form/draft])
+        submitting? @(subscribe [:auth/submitting?])
+        err         @(subscribe [:auth/error])]
+    [:div.auth-page
+     [:h1 "Sign up"]
+     [routing/route-link {:to :route/login} "Have an account?"]
+     (when err [:ul.error-messages [:li err]])
+     [:form
+      {:on-submit (fn [e]
+                    (.preventDefault e)
+                    (dispatch [:auth.register-form/submit]))}
+      [:fieldset
+       [:fieldset.form-group
+        [:input {:type        "text"
+                 :placeholder "Username"
+                 :value       (:username draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :username (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "email"
+                 :placeholder "Email"
+                 :value       (:email draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :email (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "password"
+                 :placeholder "Password"
+                 :value       (:password draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :password (.. % -target -value)])}]]
+       [:button {:type "submit" :disabled submitting?}
+        (if submitting? "Signing up…" "Sign up")]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/comments.cljs
+++ b/examples/realworld/comments.cljs
@@ -238,111 +238,104 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def comment-card
-  (reg-view :comments/card
-    (fn render-comment-card [{:keys [comment current-user]}]
-      (let [d       (rf/dispatcher)
-            mine?   (= (:username current-user)
-                       (get-in comment [:author :username]))
-            temp?   (str/starts-with? (str (:id comment)) "temp-")]
-        [:div.card
-         [:div.card-block [:p.card-text (:body comment)]]
-         [:div.card-footer
-          [routing/route-link {:to     :route/profile
-                               :params {:username (get-in comment [:author :username])}
-                               :class  "comment-author"}
-           [:img.comment-author-img {:src (get-in comment [:author :image])}]
-           " "
-           (get-in comment [:author :username])]
-          [:span.date-posted (:createdAt comment)]
-          (when temp?
-            [:span.mod-options " Sending…"])
-          (when (and mine? (not temp?))
-            [:button.mod-options
-             {:type "button"
-              :on-click #(d [:comment/delete (:id comment)])}
-             [:i.ion-trash-a]])]]))))
+(reg-view comment-card [{:keys [comment current-user]}]
+  (let [mine?   (= (:username current-user)
+                   (get-in comment [:author :username]))
+        temp?   (str/starts-with? (str (:id comment)) "temp-")]
+    [:div.card
+     [:div.card-block [:p.card-text (:body comment)]]
+     [:div.card-footer
+      [routing/route-link {:to     :route/profile
+                           :params {:username (get-in comment [:author :username])}
+                           :class  "comment-author"}
+       [:img.comment-author-img {:src (get-in comment [:author :image])}]
+       " "
+       (get-in comment [:author :username])]
+      [:span.date-posted (:createdAt comment)]
+      (when temp?
+        [:span.mod-options " Sending…"])
+      (when (and mine? (not temp?))
+        [:button.mod-options
+         {:type "button"
+          :on-click #(dispatch [:comment/delete (:id comment)])}
+         [:i.ion-trash-a]])]]))
 
-(def article-page
-  (reg-view :pages/article
-    (fn render-article-page []
-      (let [d                 (rf/dispatcher)
-            s                 (rf/subscriber)
-            article           @(s [:article/data])
-            article-status    @(s [:article/status])
-            article-error     @(s [:article/error])
-            comments          @(s [:comments/data])
-            comments-error    @(s [:comments/error])
-            comment-draft     @(s [:comment-form/draft])
-            submit-error      @(s [:comment-form/submit-error])
-            submitting?       @(s [:comment-form/submitting?])
-            current-user      @(s [:auth/user])]
-        [:div.article-page
-         (cond
-           (= article-status :loading)
-           [:div.article-preview "Loading article…"]
+(reg-view article-page []
+  (let [article        @(subscribe [:article/data])
+        article-status @(subscribe [:article/status])
+        article-error  @(subscribe [:article/error])
+        comments       @(subscribe [:comments/data])
+        comments-error @(subscribe [:comments/error])
+        comment-draft  @(subscribe [:comment-form/draft])
+        submit-error   @(subscribe [:comment-form/submit-error])
+        submitting?    @(subscribe [:comment-form/submitting?])
+        current-user   @(subscribe [:auth/user])]
+    [:div.article-page
+     (cond
+       (= article-status :loading)
+       [:div.article-preview "Loading article…"]
 
-           article-error
-           [:div.article-preview.error
-            (str "Couldn't load article: " (pr-str article-error))]
+       article-error
+       [:div.article-preview.error
+        (str "Couldn't load article: " (pr-str article-error))]
 
-           article
-           [:<>
-            [:div.banner
-             [:div.container
-              [:h1 (:title article)]
-              [:p (:description article)]
-              [:button.btn.btn-sm.btn-outline-primary
-               {:type "button"
-                :on-click #(d [:article/toggle-favorite (:slug article)])}
-               [:i.ion-heart] " " (:favoritesCount article)]]]
-            [:div.container.page
-             [:div.row.article-content
-              [:div.col-md-12
-               [:p (:body article)]
-               [:ul.tag-list
-                (for [tag (:tagList article)]
-                  ^{:key tag}
-                  [:li.tag-default.tag-pill.tag-outline tag])]]]
-             [:hr]
-             [:div.article-actions
-              [routing/route-link {:to :route/home} "Back to feed"]]
-             [:div.row
-              [:div.col-xs-12.col-md-8.offset-md-2
-               (if current-user
-                 [:form.card.comment-form
-                  {:on-submit (fn [e]
-                                (.preventDefault e)
-                                (d [:comment-form/submit]))}
-                  [:div.card-block
-                   [:textarea.form-control
-                    {:rows 3
-                     :placeholder "Write a comment..."
-                     :value (:body comment-draft)
-                     :disabled submitting?
-                     :on-change #(d [:comment-form/edit-field :body (.. % -target -value)])}]]
-                  [:div.card-footer
-                   [:img.comment-author-img {:src (:image current-user)}]
-                   [:button.btn.btn-sm.btn-primary
-                    {:type "submit"
-                     :disabled submitting?}
-                    (if submitting? "Posting…" "Post Comment")]]
-                  (when submit-error
-                    [:div.error-messages submit-error])]
-                 [:p
-                  [routing/route-link {:to :route/login} "Sign in"]
-                  " or "
-                  [routing/route-link {:to :route/register} "sign up"]
-                  " to add comments."])
-               (when comments-error
-                 [:div.article-preview.error
-                  (str "Couldn't load comments: " (pr-str comments-error))])
-               (for [comment comments]
-                 ^{:key (:id comment)}
-                 [comment-card {:comment comment :current-user current-user}])]]]]
+       article
+       [:<>
+        [:div.banner
+         [:div.container
+          [:h1 (:title article)]
+          [:p (:description article)]
+          [:button.btn.btn-sm.btn-outline-primary
+           {:type "button"
+            :on-click #(dispatch [:article/toggle-favorite (:slug article)])}
+           [:i.ion-heart] " " (:favoritesCount article)]]]
+        [:div.container.page
+         [:div.row.article-content
+          [:div.col-md-12
+           [:p (:body article)]
+           [:ul.tag-list
+            (for [tag (:tagList article)]
+              ^{:key tag}
+              [:li.tag-default.tag-pill.tag-outline tag])]]]
+         [:hr]
+         [:div.article-actions
+          [routing/route-link {:to :route/home} "Back to feed"]]
+         [:div.row
+          [:div.col-xs-12.col-md-8.offset-md-2
+           (if current-user
+             [:form.card.comment-form
+              {:on-submit (fn [e]
+                            (.preventDefault e)
+                            (dispatch [:comment-form/submit]))}
+              [:div.card-block
+               [:textarea.form-control
+                {:rows 3
+                 :placeholder "Write a comment..."
+                 :value (:body comment-draft)
+                 :disabled submitting?
+                 :on-change #(dispatch [:comment-form/edit-field :body (.. % -target -value)])}]]
+              [:div.card-footer
+               [:img.comment-author-img {:src (:image current-user)}]
+               [:button.btn.btn-sm.btn-primary
+                {:type "submit"
+                 :disabled submitting?}
+                (if submitting? "Posting…" "Post Comment")]]
+              (when submit-error
+                [:div.error-messages submit-error])]
+             [:p
+              [routing/route-link {:to :route/login} "Sign in"]
+              " or "
+              [routing/route-link {:to :route/register} "sign up"]
+              " to add comments."])
+           (when comments-error
+             [:div.article-preview.error
+              (str "Couldn't load comments: " (pr-str comments-error))])
+           (for [comment comments]
+             ^{:key (:id comment)}
+             [comment-card {:comment comment :current-user current-user}])]]]]
 
-           :else
-           [:div.article-preview "No article loaded."])]))))
+       :else
+       [:div.article-preview "No article loaded."])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/core.cljs
+++ b/examples/realworld/core.cljs
@@ -58,99 +58,83 @@
 ;; APP-SHELL VIEWS
 ;; ============================================================================
 
-(def header
-  (reg-view :app/header
-    {:doc "The site header. Shows different links based on auth state."}
-    (fn render-header []
-      (let [d       (rf/dispatcher)
-            s       (rf/subscriber)
-            authed? @(s [:auth/authenticated?])
-            user    @(s [:auth/user])]
-        [:nav.navbar.navbar-light
-         [:div.container
-          [routing/route-link {:to :route/home :class "navbar-brand"} "conduit"]
-          [:ul.nav.navbar-nav.pull-xs-right
-           [:li.nav-item
-            [routing/route-link {:to :route/home :class "nav-link"} "Home"]]
-           (if authed?
-             [:<>
-              [:li.nav-item
-               [routing/route-link {:to :route/editor :class "nav-link"}
-                [:i.ion-compose] " New Article"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/settings :class "nav-link"}
-                [:i.ion-gear-a] " Settings"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/profile
-                                    :params {:username (:username user)}
-                                    :class "nav-link"}
-                (:username user)]]
-              [:li.nav-item
-               [:a.nav-link {:href "#"
-                             :on-click #(do (.preventDefault %)
-                                            (d [:auth/flow [:auth/logout]]))}
-                "Logout"]]]
-             [:<>
-              [:li.nav-item
-               [routing/route-link {:to :route/login :class "nav-link"} "Sign in"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/register :class "nav-link"} "Sign up"]]])]]]))))
+(reg-view ^{:doc "The site header. Shows different links based on auth state."}
+          header []
+  (let [authed? @(subscribe [:auth/authenticated?])
+        user    @(subscribe [:auth/user])]
+    [:nav.navbar.navbar-light
+     [:div.container
+      [routing/route-link {:to :route/home :class "navbar-brand"} "conduit"]
+      [:ul.nav.navbar-nav.pull-xs-right
+       [:li.nav-item
+        [routing/route-link {:to :route/home :class "nav-link"} "Home"]]
+       (if authed?
+         [:<>
+          [:li.nav-item
+           [routing/route-link {:to :route/editor :class "nav-link"}
+            [:i.ion-compose] " New Article"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/settings :class "nav-link"}
+            [:i.ion-gear-a] " Settings"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/profile
+                                :params {:username (:username user)}
+                                :class "nav-link"}
+            (:username user)]]
+          [:li.nav-item
+           [:a.nav-link {:href "#"
+                         :on-click #(do (.preventDefault %)
+                                        (dispatch [:auth/flow [:auth/logout]]))}
+            "Logout"]]]
+         [:<>
+          [:li.nav-item
+           [routing/route-link {:to :route/login :class "nav-link"} "Sign in"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/register :class "nav-link"} "Sign up"]]])]]]))
 
-(def footer
-  (reg-view :app/footer
-    (fn render-footer []
-      [:footer
-       [:div.container
-        [routing/route-link {:to :route/home :class "logo-font"} "conduit"]
-        [:span.attribution "An interactive learning project from Thinkster."
-         " Code & design licensed under MIT."]]])))
+(reg-view footer []
+  [:footer
+   [:div.container
+    [routing/route-link {:to :route/home :class "logo-font"} "conduit"]
+    [:span.attribution "An interactive learning project from Thinkster."
+     " Code & design licensed under MIT."]]])
 
-(def pending-nav-dialog
-  (reg-view :app/pending-nav-dialog
-    {:doc "Renders a confirm dialog when navigation is blocked by a
-           :can-leave guard. Reads the :rf/pending-navigation slot."}
-    (fn render-pending-nav-dialog []
-      (let [d (rf/dispatcher)
-            s (rf/subscriber)]
-        (when-let [pending @(s [:rf/pending-navigation])]
-          [:div.pending-nav-overlay
-           [:div.pending-nav-dialog
-            [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]
-            [:button {:on-click #(d [:rf.route/continue (:id pending)])}
-             "Discard changes"]
-            [:button {:on-click #(d [:rf.route/cancel (:id pending)])}
-             "Stay"]]])))))
+(reg-view ^{:doc "Renders a confirm dialog when navigation is blocked by a
+                  :can-leave guard. Reads the :rf/pending-navigation slot."}
+          pending-nav-dialog []
+  (when-let [pending @(subscribe [:rf/pending-navigation])]
+    [:div.pending-nav-overlay
+     [:div.pending-nav-dialog
+      [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]
+      [:button {:on-click #(dispatch [:rf.route/continue (:id pending)])}
+       "Discard changes"]
+      [:button {:on-click #(dispatch [:rf.route/cancel (:id pending)])}
+       "Stay"]]]))
 
-(def not-found-page
-  (reg-view :pages/not-found
-    (fn render-not-found []
-      (let [s   (rf/subscriber)
-            url (:url @(s [:rf.route/params]))]
-        [:div.not-found-page
-         [:h1 "Page not found"]
-         (when url [:p (str "No route matches: " url)])
-         [routing/route-link {:to :route/home} "Home"]]))))
+(reg-view not-found-page []
+  (let [url (:url @(subscribe [:rf.route/params]))]
+    [:div.not-found-page
+     [:h1 "Page not found"]
+     (when url [:p (str "No route matches: " url)])
+     [routing/route-link {:to :route/home} "Home"]]))
 
-(def root-view
-  (reg-view :app/root
-    {:doc "App-level root. Switches on :rf.route/id to render the active page."}
-    (fn render-root []
-      (let [s (rf/subscriber)]
-        [:div.app
-         [header]
-         [pending-nav-dialog]
-         (case @(s [:rf.route/id])
-           :route/home              [articles/home-page]
-           :route/login             [auth/login-page]
-           :route/register          [auth/register-page]
-           :route/article           [comments/article-page]
-           :route/editor            [editor/editor-page]
-           :route/editor.edit       [editor/editor-page]
-           :route/profile           [profile/profile-page]
-           :route/profile.favorites [profile/profile-page]
-           :route/settings          [settings/settings-page]
-           [not-found-page])
-         [footer]]))))
+(reg-view ^{:doc "App-level root. Switches on :rf.route/id to render the active page."}
+          root-view []
+  [:div.app
+   [header]
+   [pending-nav-dialog]
+   (case @(subscribe [:rf.route/id])
+     :route/home              [articles/home-page]
+     :route/login             [auth/login-page]
+     :route/register          [auth/register-page]
+     :route/article           [comments/article-page]
+     :route/editor            [editor/editor-page]
+     :route/editor.edit       [editor/editor-page]
+     :route/profile           [profile/profile-page]
+     :route/profile.favorites [profile/profile-page]
+     :route/settings          [settings/settings-page]
+     [not-found-page])
+   [footer]])
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (top-level smoke)

--- a/examples/realworld/profile.cljs
+++ b/examples/realworld/profile.cljs
@@ -192,69 +192,65 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def profile-page
-  (reg-view :pages/profile
-    (fn render-profile-page []
-      (let [d             (rf/dispatcher)
-            s             (rf/subscriber)
-            profile       @(s [:profile/data])
-            profile-error @(s [:profile/error])
-            loading?      @(s [:profile/loading?])
-            own?          @(s [:profile/own-profile?])
-            tab           @(s [:profile/current-tab])
-            articles*     @(s [:profile/current-articles])]
-        [:div.profile-page
-         (cond
-           loading?
-           [:div.article-preview "Loading profile…"]
+(reg-view profile-page []
+  (let [profile       @(subscribe [:profile/data])
+        profile-error @(subscribe [:profile/error])
+        loading?      @(subscribe [:profile/loading?])
+        own?          @(subscribe [:profile/own-profile?])
+        tab           @(subscribe [:profile/current-tab])
+        articles*     @(subscribe [:profile/current-articles])]
+    [:div.profile-page
+     (cond
+       loading?
+       [:div.article-preview "Loading profile…"]
 
-           profile-error
-           [:div.article-preview.error
-            (str "Couldn't load profile: " (pr-str profile-error))]
+       profile-error
+       [:div.article-preview.error
+        (str "Couldn't load profile: " (pr-str profile-error))]
 
-           profile
-           [:<>
-            [:div.user-info
-             [:div.container
-              [:div.row
-               [:div.col-xs-12.col-md-10.offset-md-1
-                [:img.user-img {:src (:image profile)}]
-                [:h4 (:username profile)]
-                [:p (:bio profile)]
-                (if own?
-                  [routing/route-link {:to :route/settings
-                                       :class "btn btn-sm btn-outline-secondary action-btn"}
-                   [:i.ion-gear-a] " Edit Profile Settings"]
-                  [:button.btn.btn-sm.btn-outline-secondary.action-btn
-                   {:type "button"
-                    :on-click #(d [(if (:following profile)
-                                     :profile/unfollow
-                                     :profile/follow)])}
-                   (if (:following profile) "Unfollow " "Follow ")
-                   (:username profile)])]]]]
-            [:div.container
-             [:div.row
-              [:div.col-xs-12.col-md-10.offset-md-1
-               [:div.articles-toggle
-                [:ul.nav.nav-pills.outline-active
-                 [:li.nav-item
-                  [routing/route-link {:to     :route/profile
-                                       :params {:username (:username profile)}
-                                       :class  (str "nav-link" (when (= tab :articles) " active"))}
-                   "My Articles"]]
-                 [:li.nav-item
-                  [routing/route-link {:to     :route/profile.favorites
-                                       :params {:username (:username profile)}
-                                       :class  (str "nav-link" (when (= tab :favorites) " active"))}
-                   "Favorited Articles"]]]]
-               (if (seq articles*)
-                 (for [article articles*]
-                   ^{:key (:slug article)}
-                   [articles/article-preview {:article article}])
-                 [:div.article-preview "No articles here yet."])]]]]
+       profile
+       [:<>
+        [:div.user-info
+         [:div.container
+          [:div.row
+           [:div.col-xs-12.col-md-10.offset-md-1
+            [:img.user-img {:src (:image profile)}]
+            [:h4 (:username profile)]
+            [:p (:bio profile)]
+            (if own?
+              [routing/route-link {:to :route/settings
+                                   :class "btn btn-sm btn-outline-secondary action-btn"}
+               [:i.ion-gear-a] " Edit Profile Settings"]
+              [:button.btn.btn-sm.btn-outline-secondary.action-btn
+               {:type "button"
+                :on-click #(dispatch [(if (:following profile)
+                                        :profile/unfollow
+                                        :profile/follow)])}
+               (if (:following profile) "Unfollow " "Follow ")
+               (:username profile)])]]]]
+        [:div.container
+         [:div.row
+          [:div.col-xs-12.col-md-10.offset-md-1
+           [:div.articles-toggle
+            [:ul.nav.nav-pills.outline-active
+             [:li.nav-item
+              [routing/route-link {:to     :route/profile
+                                   :params {:username (:username profile)}
+                                   :class  (str "nav-link" (when (= tab :articles) " active"))}
+               "My Articles"]]
+             [:li.nav-item
+              [routing/route-link {:to     :route/profile.favorites
+                                   :params {:username (:username profile)}
+                                   :class  (str "nav-link" (when (= tab :favorites) " active"))}
+               "Favorited Articles"]]]]
+           (if (seq articles*)
+             (for [article articles*]
+               ^{:key (:slug article)}
+               [articles/article-preview {:article article}])
+             [:div.article-preview "No articles here yet."])]]]]
 
-           :else
-           [:div.article-preview "No profile loaded."])]))))
+       :else
+       [:div.article-preview "No profile loaded."])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/routing.cljs
+++ b/examples/realworld/routing.cljs
@@ -111,30 +111,27 @@
 ;; LINK VIEW
 ;; ============================================================================
 
-(def route-link
-  (reg-view :rf/route-link
-    {:doc "Anchor helper for the RealWorld example. Uses the runtime's
-           `:rf/url-requested` event so modifier-key and browser-navigation
-           semantics stay on the framework path."}
-    (fn render-route-link [{:keys [to params query fragment class]} & children]
-      (let [d        (rf/dispatcher)
-            base-url (rf/route-url to (or params {}) (or query {}))
-            url      (str base-url (when fragment (str "#" fragment)))]
-        [:a {:href     url
-             :class    class
-             :on-click (fn [e]
-                         (when (and (zero? (.-button e))
-                                    (not (.-metaKey e))
-                                    (not (.-ctrlKey e))
-                                    (not (.-shiftKey e)))
-                           (.preventDefault e)
-                           (d [:rf/url-requested
-                               {:url url
-                                :to to
-                                :params params
-                                :query query
-                                :fragment fragment}])))}
-         (into [:<>] children)]))))
+(reg-view ^{:doc "Anchor helper for the RealWorld example. Uses the runtime's
+                   `:rf/url-requested` event so modifier-key and browser-navigation
+                   semantics stay on the framework path."}
+          route-link [{:keys [to params query fragment class]} & children]
+  (let [base-url (rf/route-url to (or params {}) (or query {}))
+        url      (str base-url (when fragment (str "#" fragment)))]
+    [:a {:href     url
+         :class    class
+         :on-click (fn [e]
+                     (when (and (zero? (.-button e))
+                                (not (.-metaKey e))
+                                (not (.-ctrlKey e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested
+                                  {:url url
+                                   :to to
+                                   :params params
+                                   :query query
+                                   :fragment fragment}])))}
+     (into [:<>] children)]))
 
 ;; ============================================================================
 ;; ROUTER WIRING

--- a/examples/realworld/settings.cljs
+++ b/examples/realworld/settings.cljs
@@ -77,69 +77,65 @@
 (rf/reg-sub :settings/submit-error
   (fn [db _] (get-in db [:settings :submit-error])))
 
-(def settings-page
-  (reg-view :pages/settings
-    (fn render-settings-page []
-      (let [d            (rf/dispatcher)
-            s            (rf/subscriber)
-            draft        @(s [:settings/draft])
-            submitting?  @(s [:settings/submitting?])
-            submit-error @(s [:settings/submit-error])]
-        [:div.settings-page
-         [:div.container.page
-          [:div.row
-           [:div.col-md-6.offset-md-3.col-xs-12
-            [:h1.text-xs-center "Your Settings"]
-            (when submit-error
-              [:ul.error-messages [:li submit-error]])
-            [:form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:settings/submit]))}
-             [:fieldset
-              [:fieldset.form-group
-               [:input.form-control
-                {:type "text"
-                 :placeholder "URL of profile picture"
-                 :value (:image draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :image (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "text"
-                 :placeholder "Username"
-                 :value (:username draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :username (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:textarea.form-control.form-control-lg
-                {:rows 8
-                 :placeholder "Short bio about you"
-                 :value (:bio draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :bio (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "email"
-                 :placeholder "Email"
-                 :value (:email draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :email (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "password"
-                 :placeholder "New Password"
-                 :value (:password draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :password (.. % -target -value)])}]]
-              [:button.btn.btn-lg.btn-primary.pull-xs-right
-               {:type "submit" :disabled submitting?}
-               (if submitting? "Updating…" "Update Settings")]]]
-            [:hr]
-            [:button.btn.btn-outline-danger
-             {:type "button"
-              :on-click #(d [:auth/flow [:auth/logout]])}
-             "Or click here to logout"]]]]]))))
+(reg-view settings-page []
+  (let [draft        @(subscribe [:settings/draft])
+        submitting?  @(subscribe [:settings/submitting?])
+        submit-error @(subscribe [:settings/submit-error])]
+    [:div.settings-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-6.offset-md-3.col-xs-12
+        [:h1.text-xs-center "Your Settings"]
+        (when submit-error
+          [:ul.error-messages [:li submit-error]])
+        [:form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:settings/submit]))}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control
+            {:type "text"
+             :placeholder "URL of profile picture"
+             :value (:image draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :image (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "text"
+             :placeholder "Username"
+             :value (:username draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :username (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:textarea.form-control.form-control-lg
+            {:rows 8
+             :placeholder "Short bio about you"
+             :value (:bio draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :bio (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "email"
+             :placeholder "Email"
+             :value (:email draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :email (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "password"
+             :placeholder "New Password"
+             :value (:password draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :password (.. % -target -value)])}]]
+          [:button.btn.btn-lg.btn-primary.pull-xs-right
+           {:type "submit" :disabled submitting?}
+           (if submitting? "Updating…" "Update Settings")]]]
+        [:hr]
+        [:button.btn.btn-outline-danger
+         {:type "button"
+          :on-click #(dispatch [:auth/flow [:auth/logout]])}
+         "Or click here to logout"]]]]]))
 
 (defn settings-test []
   (rf/reg-fx :http.canned-settings-save

--- a/examples/routing/core.cljs
+++ b/examples/routing/core.cljs
@@ -60,79 +60,62 @@
 ;; LINK VIEW
 ;; ============================================================================
 
-(def route-link
-  (reg-view :rf/route-link
-    (fn render-route-link [{:keys [to params]} & children]
-      (let [d   (rf/dispatcher)
-            url (rf/route-url to (or params {}))]
-        [:a {:href     url
-             :on-click (fn [e]
-                         (when (and (zero? (.-button e))
-                                    (not (.-metaKey e))
-                                    (not (.-ctrlKey e))
-                                    (not (.-shiftKey e)))
-                           (.preventDefault e)
-                           (d [:rf/url-requested
-                               {:url url :to to :params (or params {})}])))}
-         (into [:span] children)]))))
+(reg-view route-link [{:keys [to params]} & children]
+  (let [url (rf/route-url to (or params {}))]
+    [:a {:href     url
+         :on-click (fn [e]
+                     (when (and (zero? (.-button e))
+                                (not (.-metaKey e))
+                                (not (.-ctrlKey e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested
+                                  {:url url :to to :params (or params {})}])))}
+     (into [:span] children)]))
 
 ;; ============================================================================
 ;; PAGES
 ;; ============================================================================
 
-(def home-page
-  (reg-view :pages/home
-    (fn render-home []
+(reg-view home-page []
+  [:div
+   [:h1 "Welcome"]
+   [:p [route-link {:to :route/articles} "See the articles →"]]])
+
+(reg-view articles-page []
+  [:div
+   [:h1 "Articles"]
+   [:ul
+    (for [{:keys [id title]} @(subscribe [:articles])]
+      ^{:key id}
+      [:li [route-link {:to :route/article-detail :params {:id id}} title]])]])
+
+(reg-view article-detail-page []
+  (let [id      (:id @(subscribe [:rf.route/params]))
+        article @(subscribe [:article-by-id id])]
+    (if article
       [:div
-       [:h1 "Welcome"]
-       [:p [route-link {:to :route/articles} "See the articles →"]]])))
+       [:h1 (:title article)]
+       [:p (:body article)]
+       [:p [route-link {:to :route/articles} "← Back"]]]
+      [:div
+       [:p "Article not found."]
+       [:p [route-link {:to :route/articles} "← Back"]]])))
 
-(def articles-page
-  (reg-view :pages/articles
-    (fn render-articles []
-      (let [s (rf/subscriber)]
-        [:div
-         [:h1 "Articles"]
-         [:ul
-          (for [{:keys [id title]} @(s [:articles])]
-            ^{:key id}
-            [:li [route-link {:to :route/article-detail :params {:id id}} title]])]]))))
+(reg-view not-found-page []
+  (let [url (:url @(subscribe [:rf.route/params]))]
+    [:div
+     [:h1 "Not found"]
+     [:p (str "No route matches: " url)]
+     [:p [route-link {:to :route/home} "Home"]]]))
 
-(def article-detail-page
-  (reg-view :pages/article-detail
-    (fn render-article-detail []
-      (let [s       (rf/subscriber)
-            id      (:id @(s [:rf.route/params]))
-            article @(s [:article-by-id id])]
-        (if article
-          [:div
-           [:h1 (:title article)]
-           [:p (:body article)]
-           [:p [route-link {:to :route/articles} "← Back"]]]
-          [:div
-           [:p "Article not found."]
-           [:p [route-link {:to :route/articles} "← Back"]]])))))
-
-(def not-found-page
-  (reg-view :pages/not-found
-    (fn render-not-found []
-      (let [s   (rf/subscriber)
-            url (:url @(s [:rf.route/params]))]
-        [:div
-         [:h1 "Not found"]
-         [:p (str "No route matches: " url)]
-         [:p [route-link {:to :route/home} "Home"]]]))))
-
-(def root-view
-  (reg-view :app/root
-    (fn render-root []
-      (let [s (rf/subscriber)]
-        (case @(s [:rf.route/id])
-          :route/home           [home-page]
-          :route/articles       [articles-page]
-          :route/article-detail [article-detail-page]
-          :rf.route/not-found   [not-found-page]
-          [not-found-page])))))
+(reg-view root-view []
+  (case @(subscribe [:rf.route/id])
+    :route/home           [home-page]
+    :route/articles       [articles-page]
+    :route/article-detail [article-detail-page]
+    :rf.route/not-found   [not-found-page]
+    [not-found-page]))
 
 ;; ============================================================================
 ;; ROUTER WIRING
@@ -172,10 +155,8 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with the local Var that `(reg-view :app/root ...)` defs:
-;; `(name :app/root)` is "root", and that latter `def` would otherwise
-;; overwrite the React root with the view fn.
+;; The React root is named `react-root`; `reg-view` defs `root-view`,
+;; which is what we render.
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 

--- a/examples/seven_guis/cells.cljs
+++ b/examples/seven_guis/cells.cljs
@@ -214,44 +214,38 @@
 ;; VIEW
 ;; ============================================================================
 
-(def cell-view
-  (reg-view :cells/cell
-    (fn render-cell [id]
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            editing-id @(s [:cells/editing-id])
-            editing?   (= editing-id id)
-            raw        @(s [:cells/raw   id])
-            value      @(s [:cells/value id])
-            display    (cond
-                         editing?                  raw
-                         (= value :error/parse)    "#PARSE"
-                         (= value :error/cycle)    "#CYCLE"
-                         (= value :error/eval)     "#EVAL"
-                         (= value :error/div-by-zero) "#DIV/0"
-                         :else                     (str value))]
-        [:td.cell {:on-click #(d [:cells/start-editing id])}
-         (if editing?
-           [:input {:type      "text"
-                    :auto-focus true
-                    :default-value raw
-                    :on-blur    #(d [:cells/commit id (.. % -target -value)])
-                    :on-key-down #(when (= "Enter" (.-key %))
-                                    (d [:cells/commit id (.. % -target -value)]))}]
-           display)]))))
+(reg-view cell-view [id]
+  (let [editing-id @(subscribe [:cells/editing-id])
+        editing?   (= editing-id id)
+        raw        @(subscribe [:cells/raw   id])
+        value      @(subscribe [:cells/value id])
+        display    (cond
+                     editing?                  raw
+                     (= value :error/parse)    "#PARSE"
+                     (= value :error/cycle)    "#CYCLE"
+                     (= value :error/eval)     "#EVAL"
+                     (= value :error/div-by-zero) "#DIV/0"
+                     :else                     (str value))]
+    [:td.cell {:on-click #(dispatch [:cells/start-editing id])}
+     (if editing?
+       [:input {:type      "text"
+                :auto-focus true
+                :default-value raw
+                :on-blur    #(dispatch [:cells/commit id (.. % -target -value)])
+                :on-key-down #(when (= "Enter" (.-key %))
+                                (dispatch [:cells/commit id (.. % -target -value)]))}]
+       display)]))
 
-(def cells-grid
-  (reg-view :cells/grid
-    (fn render-grid []
-      [:table.cells-grid
-       [:thead [:tr [:th] (for [c (range COLS)] ^{:key c} [:th (char (+ 65 c))])]]
-       [:tbody
-        (for [r (range 1 (inc ROWS))]
-          ^{:key r}
-          [:tr [:th r]
-           (for [c (range COLS)]
-             ^{:key c}
-             [cell-view (cell-id c r)])])]])))
+(reg-view cells-grid []
+  [:table.cells-grid
+   [:thead [:tr [:th] (for [c (range COLS)] ^{:key c} [:th (char (+ 65 c))])]]
+   [:tbody
+    (for [r (range 1 (inc ROWS))]
+      ^{:key r}
+      [:tr [:th r]
+       (for [c (range COLS)]
+         ^{:key c}
+         [cell-view (cell-id c r)])])]])
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/circle_drawer.cljs
+++ b/examples/seven_guis/circle_drawer.cljs
@@ -161,41 +161,37 @@
 ;; VIEW
 ;; ============================================================================
 
-(def drawer-view
-  (reg-view :drawer/main
-    (fn render-drawer []
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            circles    @(s [:drawer/circles])
-            dialog     @(s [:drawer/dialog])
-            can-undo?  @(s [:drawer/can-undo?])
-            can-redo?  @(s [:drawer/can-redo?])]
-        [:div.drawer
-         [:div.row
-          [:button {:on-click #(d [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
-          [:button {:on-click #(d [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
-         [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
-                :on-click (fn [e]
-                            (let [rect (.. e -currentTarget getBoundingClientRect)
-                                  x    (- (.. e -clientX) (.-left rect))
-                                  y    (- (.. e -clientY) (.-top rect))]
-                              (d [:drawer/add-circle x y])))}
-          (for [{:keys [id x y radius]} circles]
-            ^{:key id}
-            [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
-                      :on-context-menu (fn [e]
-                                         (.preventDefault e)
-                                         (d [:drawer/open-dialog id]))}])]
+(reg-view drawer-view []
+  (let [circles    @(subscribe [:drawer/circles])
+        dialog     @(subscribe [:drawer/dialog])
+        can-undo?  @(subscribe [:drawer/can-undo?])
+        can-redo?  @(subscribe [:drawer/can-redo?])]
+    [:div.drawer
+     [:div.row
+      [:button {:on-click #(dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
+      [:button {:on-click #(dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
+     [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
+            :on-click (fn [e]
+                        (let [rect (.. e -currentTarget getBoundingClientRect)
+                              x    (- (.. e -clientX) (.-left rect))
+                              y    (- (.. e -clientY) (.-top rect))]
+                          (dispatch [:drawer/add-circle x y])))}
+      (for [{:keys [id x y radius]} circles]
+        ^{:key id}
+        [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
+                  :on-context-menu (fn [e]
+                                     (.preventDefault e)
+                                     (dispatch [:drawer/open-dialog id]))}])]
 
-         (when dialog
-           [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
-            [:p (str "Adjust diameter of circle " (:circle-id dialog))]
-            [:input {:type      "range"
-                     :min       5 :max 100 :step 1
-                     :value     (:draft-radius dialog)
-                     :on-change #(d [:drawer/dialog-drag
-                                     (js/parseInt (.. % -target -value))])}]
-            [:button {:on-click #(d [:drawer/close-dialog])} "Close"]])]))))
+     (when dialog
+       [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
+        [:p (str "Adjust diameter of circle " (:circle-id dialog))]
+        [:input {:type      "range"
+                 :min       5 :max 100 :step 1
+                 :value     (:draft-radius dialog)
+                 :on-change #(dispatch [:drawer/dialog-drag
+                                        (js/parseInt (.. % -target -value))])}]
+        [:button {:on-click #(dispatch [:drawer/close-dialog])} "Close"]])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/crud.cljs
+++ b/examples/seven_guis/crud.cljs
@@ -138,42 +138,38 @@
 ;; VIEW
 ;; ============================================================================
 
-(def crud-view
-  (reg-view :crud/main
-    (fn render-crud []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            people      @(s [:crud/filtered-people])
-            selected-id @(s [:crud/selected-id])
-            d-name      @(s [:crud/draft-name])
-            d-surname   @(s [:crud/draft-surname])
-            can-update? @(s [:crud/can-update?])]
-        [:div.crud
-         [:div.row
-          [:label "Filter prefix: "]
-          [:input {:type      "text"
-                   :on-change #(d [:crud/set-filter (.. % -target -value)])}]]
-         [:div.row
-          [:select.list {:size      6
-                         :value     (or selected-id "")
-                         :on-change #(d [:crud/select (uuid (.. % -target -value))])}
-           (for [{:keys [id name surname]} people]
-             ^{:key id}
-             [:option {:value id} (str surname ", " name)])]
+(reg-view crud-view []
+  (let [people      @(subscribe [:crud/filtered-people])
+        selected-id @(subscribe [:crud/selected-id])
+        d-name      @(subscribe [:crud/draft-name])
+        d-surname   @(subscribe [:crud/draft-surname])
+        can-update? @(subscribe [:crud/can-update?])]
+    [:div.crud
+     [:div.row
+      [:label "Filter prefix: "]
+      [:input {:type      "text"
+               :on-change #(dispatch [:crud/set-filter (.. % -target -value)])}]]
+     [:div.row
+      [:select.list {:size      6
+                     :value     (or selected-id "")
+                     :on-change #(dispatch [:crud/select (uuid (.. % -target -value))])}
+       (for [{:keys [id name surname]} people]
+         ^{:key id}
+         [:option {:value id} (str surname ", " name)])]
 
-          [:div.inputs
-           [:div [:label "Name: "]
-            [:input {:type      "text"
-                     :value     d-name
-                     :on-change #(d [:crud/edit-name (.. % -target -value)])}]]
-           [:div [:label "Surname: "]
-            [:input {:type      "text"
-                     :value     d-surname
-                     :on-change #(d [:crud/edit-surname (.. % -target -value)])}]]]]
-         [:div.row.buttons
-          [:button {:on-click #(d [:crud/create])} "Create"]
-          [:button {:on-click #(d [:crud/update]) :disabled (not can-update?)} "Update"]
-          [:button {:on-click #(d [:crud/delete]) :disabled (not can-update?)} "Delete"]]]))))
+      [:div.inputs
+       [:div [:label "Name: "]
+        [:input {:type      "text"
+                 :value     d-name
+                 :on-change #(dispatch [:crud/edit-name (.. % -target -value)])}]]
+       [:div [:label "Surname: "]
+        [:input {:type      "text"
+                 :value     d-surname
+                 :on-change #(dispatch [:crud/edit-surname (.. % -target -value)])}]]]]
+     [:div.row.buttons
+      [:button {:on-click #(dispatch [:crud/create])} "Create"]
+      [:button {:on-click #(dispatch [:crud/update]) :disabled (not can-update?)} "Update"]
+      [:button {:on-click #(dispatch [:crud/delete]) :disabled (not can-update?)} "Delete"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/flight_booker.cljs
+++ b/examples/seven_guis/flight_booker.cljs
@@ -138,40 +138,36 @@
 ;; VIEW
 ;; ============================================================================
 
-(def flight-booker
-  (reg-view :flight/booker
-    (fn render-flight-booker []
-      (let [d                (rf/dispatcher)
-            s                (rf/subscriber)
-            trip-type        @(s [:flight/trip-type])
-            start-text       @(s [:flight/start-text])
-            return-text      @(s [:flight/return-text])
-            return-enabled?  @(s [:flight/return-enabled?])
-            start-valid?     @(s [:flight/start-valid?])
-            return-valid?    @(s [:flight/return-valid?])
-            book-enabled?    @(s [:flight/book-enabled?])
-            invalid-style    {:background "#fdd"}]
-        [:div.flight-booker
-         [:select {:value     (name trip-type)
-                   :on-change #(d [:flight/set-trip-type
-                                   (keyword (.. % -target -value))])}
-          [:option {:value "one-way"} "one-way flight"]
-          [:option {:value "return"}  "return flight"]]
+(reg-view flight-booker []
+  (let [trip-type        @(subscribe [:flight/trip-type])
+        start-text       @(subscribe [:flight/start-text])
+        return-text      @(subscribe [:flight/return-text])
+        return-enabled?  @(subscribe [:flight/return-enabled?])
+        start-valid?     @(subscribe [:flight/start-valid?])
+        return-valid?    @(subscribe [:flight/return-valid?])
+        book-enabled?    @(subscribe [:flight/book-enabled?])
+        invalid-style    {:background "#fdd"}]
+    [:div.flight-booker
+     [:select {:value     (name trip-type)
+               :on-change #(dispatch [:flight/set-trip-type
+                                      (keyword (.. % -target -value))])}
+      [:option {:value "one-way"} "one-way flight"]
+      [:option {:value "return"}  "return flight"]]
 
-         [:input {:type      "text"
-                  :value     start-text
-                  :style     (when-not start-valid? invalid-style)
-                  :on-change #(d [:flight/set-start (.. % -target -value)])}]
+     [:input {:type      "text"
+              :value     start-text
+              :style     (when-not start-valid? invalid-style)
+              :on-change #(dispatch [:flight/set-start (.. % -target -value)])}]
 
-         [:input {:type      "text"
-                  :value     return-text
-                  :disabled  (not return-enabled?)
-                  :style     (when (and return-enabled? (not return-valid?)) invalid-style)
-                  :on-change #(d [:flight/set-return (.. % -target -value)])}]
+     [:input {:type      "text"
+              :value     return-text
+              :disabled  (not return-enabled?)
+              :style     (when (and return-enabled? (not return-valid?)) invalid-style)
+              :on-change #(dispatch [:flight/set-return (.. % -target -value)])}]
 
-         [:button {:disabled (not book-enabled?)
-                   :on-click #(d [:flight/book])}
-          "Book"]]))))
+     [:button {:disabled (not book-enabled?)
+               :on-click #(dispatch [:flight/book])}
+      "Book"]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/temperature.cljs
+++ b/examples/seven_guis/temperature.cljs
@@ -120,23 +120,19 @@
 ;; VIEW
 ;; ============================================================================
 
-(def temperature-converter
-  (reg-view :temp/converter
-    {:doc "Two-input temperature converter."}
-    (fn render-temp-converter []
-      (let [d      (rf/dispatcher)
-            s      (rf/subscriber)
-            c-text @(s [:temp/celsius-text])
-            f-text @(s [:temp/fahrenheit-text])]
-        [:div.temperature
-         [:input {:type      "text"
-                  :value     (or c-text "")
-                  :on-change #(d [:temp/edit-celsius (.. % -target -value)])}]
-         [:label " °C  =  "]
-         [:input {:type      "text"
-                  :value     (or f-text "")
-                  :on-change #(d [:temp/edit-fahrenheit (.. % -target -value)])}]
-         [:label " °F"]]))))
+(reg-view ^{:doc "Two-input temperature converter."}
+          temperature-converter []
+  (let [c-text @(subscribe [:temp/celsius-text])
+        f-text @(subscribe [:temp/fahrenheit-text])]
+    [:div.temperature
+     [:input {:type      "text"
+              :value     (or c-text "")
+              :on-change #(dispatch [:temp/edit-celsius (.. % -target -value)])}]
+     [:label " °C  =  "]
+     [:input {:type      "text"
+              :value     (or f-text "")
+              :on-change #(dispatch [:temp/edit-fahrenheit (.. % -target -value)])}]
+     [:label " °F"]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/timer.cljs
+++ b/examples/seven_guis/timer.cljs
@@ -104,32 +104,28 @@
 ;; VIEW
 ;; ============================================================================
 
-(def timer-view
-  (reg-view :timer/timer
-    (fn render-timer []
-      (let [d        (rf/dispatcher)
-            s        (rf/subscriber)
-            progress @(s [:timer/progress-pct])
-            seconds  @(s [:timer/elapsed-seconds])
-            duration @(s [:timer/duration-ms])]
-        [:div.timer
-         [:div.row
-          [:label "Elapsed time:"]
-          [:div.bar {:style {:width "300px" :background "#ddd"}}
-           [:div.fill {:style {:width  (str progress "%")
-                               :height "20px"
-                               :background "#4a9"}}]]]
-         [:div.row [:label seconds " s"]]
-         [:div.row
-          [:label "Duration: "]
-          [:input {:type      "range"
-                   :min       0 :max 30000 :step 100
-                   :value     duration
-                   :on-change #(d [:timer/set-duration
-                                   (js/parseInt (.. % -target -value))])}]
-          [:span (.toFixed (/ duration 1000.0) 1) " s"]]
-         [:div.row
-          [:button {:on-click #(d [:timer/reset])} "Reset"]]]))))
+(reg-view timer-view []
+  (let [progress @(subscribe [:timer/progress-pct])
+        seconds  @(subscribe [:timer/elapsed-seconds])
+        duration @(subscribe [:timer/duration-ms])]
+    [:div.timer
+     [:div.row
+      [:label "Elapsed time:"]
+      [:div.bar {:style {:width "300px" :background "#ddd"}}
+       [:div.fill {:style {:width  (str progress "%")
+                           :height "20px"
+                           :background "#4a9"}}]]]
+     [:div.row [:label seconds " s"]]
+     [:div.row
+      [:label "Duration: "]
+      [:input {:type      "range"
+               :min       0 :max 30000 :step 100
+               :value     duration
+               :on-change #(dispatch [:timer/set-duration
+                                      (js/parseInt (.. % -target -value))])}]
+      [:span (.toFixed (/ duration 1000.0) 1) " s"]]
+     [:div.row
+      [:button {:on-click #(dispatch [:timer/reset])} "Reset"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (scheduling-light; we don't drive real time, just verify

--- a/examples/ssr/core.cljc
+++ b/examples/ssr/core.cljc
@@ -105,26 +105,23 @@
 
 (rf/reg-sub :articles (fn [db _] (:articles db)))
 
-;; rf/reg-view returns the view-id keyword. CLJS apps using the
-;; views-macros version of reg-view get an auto-defed Var as well; here
-;; we just bind the keyword.
-(def articles-page
-  (rf/reg-view :pages/articles
-    (fn render-articles []
-      (let [arts (rf/subscribe-value [:articles])]
-        [:div.page
-         [:h1 "Recent articles"]
-         (if (seq arts)
-           (into [:ul]
-                 (for [{:keys [id title body]} arts]
-                   ^{:key id}
-                   [:li [:h3 title] [:p body]]))
-           [:p "No articles."])]))))
+;; reg-view (defn-shape per Spec 004 §reg-view) auto-defs the symbol and
+;; registers under (keyword *ns* sym) — overridden here via
+;; ^{:rf/id ...} so the legacy :pages/articles / :app/root ids stay
+;; intact for the get-view callers below.
+(rf/reg-view ^{:rf/id :pages/articles} articles-page []
+  (let [arts (rf/subscribe-value [:articles])]
+    [:div.page
+     [:h1 "Recent articles"]
+     (if (seq arts)
+       (into [:ul]
+             (for [{:keys [id title body]} arts]
+               ^{:key id}
+               [:li [:h3 title] [:p body]]))
+       [:p "No articles."])]))
 
-(def root-view
-  (rf/reg-view :app/root
-    (fn render-root []
-      [(rf/get-view :pages/articles)])))
+(rf/reg-view ^{:rf/id :app/root} root-view []
+  [(rf/get-view :pages/articles)])
 
 ;; ============================================================================
 ;; SERVER ENTRY POINT

--- a/examples/state_machine_walkthrough/core.cljc
+++ b/examples/state_machine_walkthrough/core.cljc
@@ -1,0 +1,238 @@
+(ns state-machine-walkthrough.core
+  "Runnable companion to docs/guide/05-state-machines.md.
+
+  This is the login-flow chapter as code. Every prose snippet in ch.05
+  appears here in the order the chapter introduces it; each section
+  ends with a smoke-test fn that drives the machine through the
+  scenario the chapter describes.
+
+  Why .cljc: the chapter promises 'runs in microseconds on the JVM, no
+  browser, no network.' The same code runs under shadow-cljs node-test
+  for the CLJS surface. The HTTP side is exercised via the id-valued
+  override seam (`:fx-overrides`) so no real network traffic happens.
+
+  Read alongside docs/guide/05-state-machines.md."
+  (:require [re-frame.core :as rf]))
+
+;; ============================================================================
+;; THE TRANSITION TABLE — chapter §The same flow as a machine
+;; ============================================================================
+;;
+;; Pure data. `:guards` and `:actions` live with the spec — there is no
+;; global registry. References inside `:states` resolve against this
+;; map; cross-machine reuse is via Clojure vars (define a fn, name it
+;; locally in each machine's :guards / :actions).
+
+(def login-flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:under-retry-limit
+    ;; 2-arity is canonical: (fn [data event] ...). `data` is the
+    ;; snapshot's :data slot directly — pulling it from a snapshot
+    ;; wrapper is the runtime's job.
+    (fn [data _event]
+      (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error
+    (fn [_data _event] {:data {:error nil}})
+
+    :issue-request
+    ;; Returns effects, not side-effects. The :http fx implementation
+    ;; conj's the response onto the :on-success template; the runtime
+    ;; folds the trailing arg onto the inner event.
+    (fn [_data [_ creds]]
+      {:fx [[:http {:method     :post
+                    :url        "/api/login"
+                    :body       creds
+                    :on-success [:auth.login/flow [:auth.login/success]]
+                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+
+    :record-error
+    (fn [data [_ err]]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc :error (or (:message err) "Login failed.")))})
+
+    :lock-account
+    (fn [_data _event]
+      {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+
+    :store-session
+    (fn [_data [_ {:keys [token]}]]
+      {:fx [[:auth.session/store {:token token}]]})}
+
+   :states
+   {:idle
+    {:on {:auth.login/submit {:target :submitting
+                              :action :clear-error}}}
+
+    :submitting
+    {:entry :issue-request
+     :on    {:auth.login/success {:target :authed
+                                  :action :store-session}
+             :auth.login/failure [{:target :error-shown
+                                   :guard  :under-retry-limit
+                                   :action :record-error}
+                                  {:target :locked-out
+                                   :action :lock-account}]}}
+
+    :error-shown
+    {:on {:auth.login/dismiss {:target :idle}
+          :auth.login/submit  {:target :submitting}}}
+
+    :authed      {:meta {:terminal? true}}
+    :locked-out  {:meta {:terminal? true}}}})
+
+;; ============================================================================
+;; FX — chapter §Wiring a machine into the rest of re-frame
+;; ============================================================================
+;;
+;; The :http and :auth.session/store fx are stubs for the example: they
+;; show the shape, not real network/storage. The smoke test below uses
+;; the id-valued override seam (`:fx-overrides`) to swap :http for a
+;; canned-success or canned-failure stub at frame-creation time.
+
+(rf/reg-fx :http
+  {:doc "Stub: a real implementation would call (js/fetch ...)."}
+  (fn [_m _args] nil))
+
+(rf/reg-fx :auth.session/store
+  {:doc "Stub: a real implementation would write localStorage."}
+  (fn [_m _args] nil))
+
+(rf/reg-fx :http.canned-success
+  {:doc "Test stub: every :http call resolves to a canned success."}
+  (fn [{:keys [frame]} {:keys [on-success]}]
+    (when on-success
+      (rf/dispatch (conj on-success {:user  {:id "test-user"}
+                                     :token "test-token"})
+                   {:frame frame}))))
+
+(rf/reg-fx :http.canned-failure
+  {:doc "Test stub: every :http call resolves to a canned failure."}
+  (fn [{:keys [frame]} {:keys [on-error]}]
+    (when on-error
+      (rf/dispatch (conj on-error {:message "bad creds"})
+                   {:frame frame}))))
+
+;; ============================================================================
+;; REGISTRATION — chapter §Wiring a machine into the rest of re-frame
+;; ============================================================================
+;;
+;; Two equivalent forms; we use the convenience `reg-machine`. The
+;; longer form `(reg-event-fx machine-id (create-machine-handler m))`
+;; is what reg-machine wraps, and is the form to use when you need
+;; registration metadata (`:doc`, `:interceptors`, ...).
+
+(rf/reg-machine :auth.login/flow login-flow)
+
+;; ============================================================================
+;; SUBSCRIPTIONS — chapter §Reading a machine: sub-machine
+;; ============================================================================
+
+(rf/reg-sub :auth.login/state
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
+
+(rf/reg-sub :auth.login/error
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :data :error])))
+
+(rf/reg-sub :auth.login/submitting?
+  :<- [:auth.login/state]
+  (fn [state _] (= :submitting state)))
+
+(rf/reg-sub :auth.login/authenticated?
+  :<- [:auth.login/state]
+  (fn [state _] (= :authed state)))
+
+;; ============================================================================
+;; HEADLESS TESTS — chapter §Headless testing
+;; ============================================================================
+;;
+;; Two flavours of test:
+;;
+;; 1. Pure machine-transition: pass a snapshot + event, get back the
+;;    next snapshot. No frame, no app-db, no fx execution. JVM-runnable.
+;;
+;; 2. Drain-level: spin up a frame with a fx-override, dispatch into
+;;    the machine id, read the resulting app-db slice. Exercises the
+;;    full registration → drain → snapshot-write path including the
+;;    :on-success / :on-error callback fold.
+
+(defn pure-happy-path-test
+  "Drives the transition table directly via machine-transition. No
+  frame, no app-db. The chapter's first test."
+  []
+  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
+        [s1 fx1] (rf/machine-transition login-flow s0
+                                        [:auth.login/submit
+                                         {:email "a@b.com" :password "secret"}])]
+    (assert (= :submitting (:state s1))
+            (str "expected :submitting, got " (:state s1)))
+    ;; Entering :submitting fires the :issue-request action's :fx.
+    (assert (= 1 (count fx1)) (str "expected one :http fx, got " fx1))
+    (assert (= :http (ffirst fx1)) (str "expected :http fx-id, got " (ffirst fx1)))
+
+    (let [[s2 _] (rf/machine-transition login-flow s1
+                                        [:auth.login/success {:token "t"}])]
+      (assert (= :authed (:state s2))
+              (str "expected :authed, got " (:state s2))))
+    :ok))
+
+(defn pure-lockout-test
+  "Once :data :attempts reaches the retry limit, the :under-retry-limit
+  guard fails and the second :auth.login/failure clause's :locked-out
+  target wins. The guard checks the snapshot BEFORE the action runs;
+  :record-error then bumps the counter on hits, so attempts=3 is the
+  first counter value at which the guard rejects."
+  []
+  (let [snapshot {:state :submitting :data {:attempts 3 :error nil}}
+        [s _fx] (rf/machine-transition login-flow snapshot
+                                       [:auth.login/failure {:message "bad creds"}])]
+    (assert (= :locked-out (:state s))
+            (str "expected :locked-out at attempts=3, got " (:state s)))
+    :ok))
+
+(defn drain-happy-path-test
+  "Full drain: registers the machine, dispatches into it, asserts the
+  app-db landed at :authed. Uses the fx-overrides seam to swap :http
+  for a canned-success stub."
+  []
+  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-success}})]
+    (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                          {:email "a@b.com"
+                                           :password "secret"}]]
+                      {:frame f})
+    (let [state (rf/compute-sub [:auth.login/state] (rf/get-frame-db f))]
+      (assert (= :authed state)
+              (str "expected :authed after canned success, got " state)))
+    :ok))
+
+(defn drain-retry-then-lockout-test
+  "Three failures cycle :submitting → :error-shown → :idle ×3, then a
+  fourth :submit fails the guard and lands at :locked-out."
+  []
+  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-failure}})]
+    (dotimes [_ 3]
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                            {:email "x@y.z" :password "wrong"}]]
+                        {:frame f})
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/dismiss]] {:frame f}))
+    (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                          {:email "x@y.z" :password "wrong"}]]
+                      {:frame f})
+    (let [state (rf/compute-sub [:auth.login/state] (rf/get-frame-db f))]
+      (assert (= :locked-out state)
+              (str "expected :locked-out on 4th attempt, got " state)))
+    :ok))
+
+(defn smoke-tests
+  "Run all four headless tests. Returns :ok or throws."
+  []
+  (pure-happy-path-test)
+  (pure-lockout-test)
+  (drain-happy-path-test)
+  (drain-retry-then-lockout-test)
+  :ok)

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -17,6 +17,10 @@ The shape deliberately echoes the v1 example's teaching split:
 - A v1-style separation of data/events/subs/views, but on the current re-frame2 API surface.
 - Headless browser verification through the Playwright example harness.
 
+### Why localStorage and not :rf.http/managed?
+
+TodoMVC persists locally so the example stays small and dependency-free. The canonical demo of Spec 014 (`:rf.http/managed`) lives with the `realworld` example. If you're here to learn the request shape, that's where to look.
+
 ## Official assets
 
 The example stages the official TodoMVC CSS packages at test/build time:

--- a/examples/todomvc/core.cljs
+++ b/examples/todomvc/core.cljs
@@ -1,5 +1,6 @@
 (ns todomvc.core
-  (:require [reagent.dom.client :as rdc]
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             [re-frame.substrate.reagent :as reagent-adapter]
@@ -11,21 +12,31 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defonce router-installed? (atom false))
+;; ---- hash → Spec 012 path adapter -----------------------------------------
+;;
+;; TodoMVC uses hash-based URLs (#/, #/active, #/completed); the Spec 012
+;; runtime routes path-strings. This tiny host-adapter strips the '#' (and an
+;; optional '!' for the legacy hashbang form) and dispatches
+;; :rf.route/handle-url-change so the registered routes in events.cljs match
+;; cleanly. Per Spec 012 §URL changes are events, the runtime updates
+;; app-db's :route slice from there.
 
-(defn current-hash []
-  (let [hash (.. js/window -location -hash)]
-    (if (seq hash) hash "#/")))
+(defn- hash->path
+  "Convert window.location.hash (e.g. \"#/active\", \"#!/completed\") to a
+  Spec 012 path. An empty hash maps to \"/\"."
+  [hash]
+  (let [stripped (-> hash
+                     (str/replace #"^#!?" "")
+                     (str/replace #"^/+" "/"))]
+    (if (str/blank? stripped) "/" stripped)))
 
-(defn install-router! []
-  (when-not @router-installed?
-    (.addEventListener js/window "hashchange"
-      (fn [_]
-        (rf/dispatch [:todo/url-changed (current-hash)])))
-    (reset! router-installed? true)))
+(defn- current-path []
+  (hash->path (.. js/window -location -hash)))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:todo/initialise (current-hash)])
-  (install-router!)
+  (rf/dispatch-sync [:todo/initialise])
+  (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
+  (.addEventListener js/window "hashchange"
+    (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-path)])))
   (rdc/render react-root [views/root-view]))

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -8,18 +8,19 @@
 (def ls-key "todos-reframe2")
 
 (defn- normalise-todo [{:keys [id title completed]}]
-  {:id        (int id)
-   :title     (str title)
-   :completed (boolean completed)})
+  (when-let [id' (try (int id) (catch :default _ nil))]
+    {:id        id'
+     :title     (str title)
+     :completed (boolean completed)}))
 
 (defn- storage->todos [raw]
   (if-not (seq raw)
     (sorted-map)
     (try
       (into (sorted-map)
-            (map (fn [todo]
-                   (let [todo' (normalise-todo todo)]
-                     [(:id todo') todo'])))
+            (comp (map normalise-todo)
+                  (remove nil?)
+                  (map (fn [todo] [(:id todo) todo])))
             (js->clj (js/JSON.parse raw) :keywordize-keys true))
       (catch :default _
         (sorted-map)))))

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -1,9 +1,11 @@
 (ns todomvc.db
   (:require [re-frame.core :as rf]))
 
+;; The :showing slot is no longer in the default db — Spec 012's :route slice
+;; owns it now. The :showing sub (in subs.cljs) derives :all/:active/:completed
+;; from :rf.route/id.
 (def default-db
-  {:todos   (sorted-map)
-   :showing :all})
+  {:todos (sorted-map)})
 
 (def ls-key "todos-reframe2")
 

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -27,6 +27,7 @@
       (catch :default _
         (sorted-map)))))
 
+;; localStorage is deliberate — see README. The Spec-014 :rf.http/managed demo lives with realworld.
 (rf/reg-cofx :todo.storage/todos
   {:doc "Inject the saved TodoMVC items from localStorage into coeffects."}
   (fn cofx-todo-storage-todos [ctx]

--- a/examples/todomvc/events.cljs
+++ b/examples/todomvc/events.cljs
@@ -3,13 +3,20 @@
             [re-frame.core :as rf]
             [todomvc.db :as db]))
 
-(defn- filter-from-hash [hash]
-  (case hash
-    "#/active"    :active
-    "#!/active"   :active
-    "#/completed" :completed
-    "#!/completed" :completed
-    :all))
+;; ---- routes (Spec 012) ----------------------------------------------------
+;; TodoMVC's canonical URLs are hash-based (#/, #/active, #/completed). Spec
+;; 012 routes match path-strings, so the host-adapter (core.cljs) strips the
+;; leading '#' (and optional '!') from the URL hash before dispatching
+;; :rf.route/handle-url-change. The result is a Spec 012 path the registered
+;; routes match exactly.
+
+(rf/reg-route :todo/all       {:doc "Show all todos."       :path "/"})
+(rf/reg-route :todo/active    {:doc "Show active todos."    :path "/active"})
+(rf/reg-route :todo/completed {:doc "Show completed todos." :path "/completed"})
+
+;; Required by Spec 012 §Route-not-found. Unmatched URLs land here; we treat
+;; them as "show all" so a stray hash never breaks the app.
+(rf/reg-route :rf.route/not-found {:doc "Fallback." :path "/_404"})
 
 (defn- allocate-next-id [todos]
   ((fnil inc 0) (last (keys todos))))
@@ -32,14 +39,8 @@
 
 (rf/reg-event-fx :todo/initialise
   [(rf/inject-cofx :todo.storage/todos)]
-  (fn [{:todo.storage/keys [todos]} [_ current-hash]]
-    {:db (assoc db/default-db
-                :todos todos
-                :showing (filter-from-hash current-hash))}))
-
-(rf/reg-event-db :todo/url-changed
-  (fn [db [_ current-hash]]
-    (assoc db :showing (filter-from-hash current-hash))))
+  (fn [{:todo.storage/keys [todos]} _]
+    {:db (assoc db/default-db :todos todos)}))
 
 (rf/reg-event-fx :todo/add
   (fn [{:keys [db]} [_ title]]

--- a/examples/todomvc/subs.cljs
+++ b/examples/todomvc/subs.cljs
@@ -1,9 +1,15 @@
 (ns todomvc.subs
   (:require [re-frame.core :as rf]))
 
+;; :showing derives from the active Spec 012 route id. :rf.route/not-found and
+;; an unset route both fall through to :all so the UI defaults sensibly.
 (rf/reg-sub :showing
-  (fn [db _]
-    (:showing db)))
+  :<- [:rf.route/id]
+  (fn [route-id _]
+    (case route-id
+      :todo/active    :active
+      :todo/completed :completed
+      :all)))
 
 (rf/reg-sub :sorted-todos
   (fn [db _]

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -44,10 +44,10 @@
               (reset! suppress-blur false)
               (save)))})])))
 
-(defn todo-item []
+(defn todo-item [dispatch]
   ;; editing? is local component state by design — matches v1 TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
   (let [editing? (reagent/atom false)]
-    (fn [{:keys [id title completed]}]
+    (fn [_dispatch {:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  @editing? (conj "editing")))}
@@ -57,50 +57,48 @@
          {:type "checkbox"
           :checked completed
           :readOnly true
-          :on-click #(rf/dispatch [:todo/toggle-completed id])}]
+          :on-click #(dispatch [:todo/toggle-completed id])}]
         [:label {:on-double-click #(reset! editing? true)}
          title]
         [:button.destroy
-         {:on-click #(rf/dispatch [:todo/delete id])}]]
+         {:on-click #(dispatch [:todo/delete id])}]]
        (when @editing?
          [todo-input
           {:class "edit"
            :title title
-           :on-save #(rf/dispatch [:todo/save id %])
+           :on-save #(dispatch [:todo/save id %])
            :on-stop #(reset! editing? false)}])])))
 
-(defn task-entry []
+(defn task-entry [dispatch]
   [:header.header
    [:h1 "todos"]
    [todo-input
     {:id "new-todo"
      :class "new-todo"
      :placeholder "What needs to be done?"
-     :on-save #(rf/dispatch [:todo/add %])}]])
+     :on-save #(dispatch [:todo/add %])}]])
 
-(defn task-list []
-  (let [s (rf/subscriber)]
-    [:section.main {:id "main"}
-     [:input#toggle-all.toggle-all
-      {:type "checkbox"
-       :checked @(s [:all-complete?])
-       :readOnly true
-       :on-click #(rf/dispatch [:todo/toggle-all])}]
-     [:label {:for "toggle-all"} "Mark all as complete"]
-     [:ul.todo-list {:id "todo-list"}
-      (for [{:keys [id] :as todo} @(s [:visible-todos])]
-        ^{:key id}
-        [todo-item todo])]]))
+(defn task-list [dispatch subscribe]
+  [:section.main {:id "main"}
+   [:input#toggle-all.toggle-all
+    {:type "checkbox"
+     :checked @(subscribe [:all-complete?])
+     :readOnly true
+     :on-click #(dispatch [:todo/toggle-all])}]
+   [:label {:for "toggle-all"} "Mark all as complete"]
+   [:ul.todo-list {:id "todo-list"}
+    (for [{:keys [id] :as todo} @(subscribe [:visible-todos])]
+      ^{:key id}
+      [todo-item dispatch todo])]])
 
 (defn- filter-link [showing filter-kw label]
   [:a {:href (hash-for-filter filter-kw)
        :class (when (= showing filter-kw) "selected")}
    label])
 
-(defn footer-controls []
-  (let [s (rf/subscriber)
-        [active completed] @(s [:footer-counts])
-        showing @(s [:showing])]
+(defn footer-controls [dispatch subscribe]
+  (let [[active completed] @(subscribe [:footer-counts])
+        showing @(subscribe [:showing])]
     [:footer.footer {:id "footer"}
      [:span.todo-count {:id "todo-count"}
       [:strong active]
@@ -114,21 +112,22 @@
      (when (pos? completed)
        [:button.clear-completed
         {:id "clear-completed"
-         :on-click #(rf/dispatch [:todo/clear-completed])}
+         :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
 (def root-view
   (reg-view :todo.app/root-view
     (fn render-root-view []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos])]
+      (let [dispatch  (rf/dispatcher)
+            subscribe (rf/subscriber)
+            todos     @(subscribe [:todos])]
         [:<>
          [:section.todoapp
-          [task-entry]
+          [task-entry dispatch]
           (when (seq todos)
-            [task-list])
+            [task-list dispatch subscribe])
           (when (seq todos)
-            [footer-controls])]
+            [footer-controls dispatch subscribe])]
          [:footer.info
           [:p "Double-click to edit a todo"]
           [:p

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -1,13 +1,9 @@
 (ns todomvc.views
   (:require [clojure.string :as str]
-            [goog.object :as gobj]
             [reagent.core :as reagent]
             [re-frame.core :as rf]
             [re-frame.views])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
-
-(def enter-key "Enter")
-(def escape-key "Escape")
 
 (defn- hash-for-filter [filter-kw]
   (case filter-kw
@@ -27,27 +23,12 @@
                          (stop))
         handle-keydown
         (fn [event]
-          (let [key (.-key event)]
-            (cond
-              (= key enter-key)
-              (do (.preventDefault event)
-                  (save))
-
-              (= key escape-key)
-              (do (.preventDefault event)
-                  (reset! suppress-blur true)
-                  (stop))
-
-              :else nil)))
-        bind-node
-        (fn [node]
-          (when-let [prev @input-node]
-            (when-let [handler (gobj/get prev "__todomvcKeyHandler")]
-              (.removeEventListener prev "keydown" handler)))
-          (reset! input-node node)
-          (when node
-            (.addEventListener node "keydown" handle-keydown)
-            (gobj/set node "__todomvcKeyHandler" handle-keydown)))]
+          (case (.-key event)
+            "Enter"  (do (.preventDefault event) (save))
+            "Escape" (do (.preventDefault event)
+                         (reset! suppress-blur true)
+                         (stop))
+            nil))]
     (fn [props]
       [:input
        (merge
@@ -55,7 +36,8 @@
          {:type "text"
           :default-value (or title "")
           :autoFocus true
-          :ref bind-node
+          :ref #(reset! input-node %)
+          :on-key-down handle-keydown
           :on-blur
           (fn [_]
             (if @suppress-blur
@@ -63,12 +45,14 @@
               (save)))})])))
 
 (defn todo-item []
+  ;; editing? is local component state by design — matches v1 TodoMVC; not in app-db so it isn't persisted/inspected (TodoMVC tradeoff).
   (let [editing? (reagent/atom false)]
     (fn [{:keys [id title completed]}]
       [:li {:class (str/join " " (cond-> []
                                  completed (conj "completed")
                                  @editing? (conj "editing")))}
        [:div.view
+        ;; React's controlled-checkbox pattern: :on-click mutates app-db, :readOnly silences React's onChange warning, :checked reads from app-db.
         [:input.toggle
          {:type "checkbox"
           :checked completed

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -115,25 +115,29 @@
          :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
-(def root-view
-  (reg-view :todo.app/root-view
-    (fn render-root-view []
-      (let [dispatch  (rf/dispatcher)
-            subscribe (rf/subscriber)
-            todos     @(subscribe [:todos])]
-        [:<>
-         [:section.todoapp
-          [task-entry dispatch]
-          (when (seq todos)
-            [task-list dispatch subscribe])
-          (when (seq todos)
-            [footer-controls dispatch subscribe])]
-         [:footer.info
-          [:p "Double-click to edit a todo"]
-          [:p
-           "Inspired by "
-           [:a {:href "https://github.com/day8/re-frame/tree/master/examples/todomvc"}
-            "the original re-frame TodoMVC example"]]
-          [:p
-           "Part of "
-           [:a {:href "https://todomvc.com/"} "TodoMVC"]]]]))))
+;; Sub-views (task-entry, task-list, todo-item, footer-controls) above
+;; are plain Reagent fns. Per Spec 004 §reg-view auto-inject, the
+;; capture-and-pass threading PR #51 introduced is no longer needed —
+;; sub-views can read `dispatch` / `subscribe` directly from the
+;; surrounding reg-view scope. We keep them as plain fns here (rather
+;; than reg-view'ing each sub-piece) because they're internal helpers
+;; with no need for their own registry slot or auto-defed Var; that
+;; gives the cleanest read in this example.
+(reg-view root-view []
+  (let [todos @(subscribe [:todos])]
+    [:<>
+     [:section.todoapp
+      [task-entry dispatch]
+      (when (seq todos)
+        [task-list dispatch subscribe])
+      (when (seq todos)
+        [footer-controls dispatch subscribe])]
+     [:footer.info
+      [:p "Double-click to edit a todo"]
+      [:p
+       "Inspired by "
+       [:a {:href "https://github.com/day8/re-frame/tree/master/examples/todomvc"}
+        "the original re-frame TodoMVC example"]]
+      [:p
+       "Part of "
+       [:a {:href "https://todomvc.com/"} "TodoMVC"]]]]))

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -24,7 +24,18 @@
             [re-frame.trace :as trace]
             [re-frame.epoch :as epoch]
             [re-frame.substrate.adapter :as adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            ;; CLJS only: re-frame.views holds the Reagent-aware reg-view*
+            ;; (with React-context wiring). On JVM the registrar registration
+            ;; is sufficient.
+            #?(:cljs [re-frame.views :as views]))
+  ;; The reg-view macro is defined in the #?(:clj ...) block below. Make
+  ;; it visible to CLJS callers under the `re-frame.core` alias by
+  ;; self-referring `:require-macros`. Per Spec 004 §reg-view, the macro
+  ;; lives in re-frame.core; CLJS users can write `rf/reg-view` after
+  ;; `(:require [re-frame.core :as rf])` without an explicit
+  ;; `:require-macros` clause at the call site.
+  #?(:cljs (:require-macros [re-frame.core :refer [reg-view]])))
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -160,39 +171,71 @@
      (def reg-cofx        cofx/reg-cofx)
      (def reg-frame       frame/reg-frame)))
 
-(defn -reg-view
-  "Internal helper — the fn-form delegate for the public `reg-view` macro
-  (and CLJS alias). Registers the view in the :view registry, merging
-  any pending source coords into the slot metadata."
+(defn reg-view*
+  "Plain-fn surface for view registration. Per Spec 004 §reg-view*.
+
+  Takes an id keyword and a render fn of any shape. No auto-def, no
+  auto-inject of `dispatch`/`subscribe`, no compile-time check on the
+  shape of `render-fn`. Use this when the registration is computed at
+  runtime: dynamic ids, library generation, registration without a
+  Var, or when the body doesn't fit the literal-fn contract enforced
+  by the `reg-view` macro (Reagent Form-3 / `create-class`).
+
+  On CLJS this delegates to `re-frame.views/reg-view*` so the
+  registered fn is wrapped with the React-context hook used to
+  resolve the surrounding frame at render time.
+
+  An optional metadata map may be supplied; merged with any pending
+  source-coords captured by the `reg-view` macro at the call site
+  (per Spec 001 §Source-coordinate capture)."
   ([id render-fn]
-   (-reg-view id {} render-fn))
+   (reg-view* id {} render-fn))
   ([id metadata render-fn]
-   (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
-                                        :handler-fn render-fn))
+   #?(:cljs
+      ;; Hand off to the Reagent-aware impl which wraps with
+      ;; :context-type metadata for frame resolution. The merge of
+      ;; pending source-coords happens here so re-frame.views/reg-view*
+      ;; receives a single, complete metadata map.
+      (views/reg-view* id (source-coords/merge-coords metadata) render-fn)
+      :clj
+      (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
+                                           :handler-fn render-fn)))
    id))
 
 #?(:clj
    (defmacro reg-view
-     "Register a view by id. The render-fn is `(fn [args...] hiccup-tree)`.
+     "Register a view as a defn-shape macro. Per Spec 004 §reg-view.
 
-     This is the JVM-runnable / SSR-friendly form. CLJS apps using Reagent
-     should prefer `re-frame.views-macros/reg-view` (also defs the local
-     var) for client-side use.
+     Shape:
+
+       (reg-view sym [args] body+)
+       (reg-view sym docstring [args] body+)
+       (reg-view ^{:rf/id :explicit/id} sym [args] body+)
+
+     Behavior:
+     - Auto-derives the id from `(keyword (str *ns*) (str sym))`.
+       Override via `^{:rf/id :explicit/id}` metadata on the symbol.
+     - Auto-injects lexical bindings `dispatch` and `subscribe`,
+       bound at render-time to `(rf/dispatcher)` / `(rf/subscriber)` of
+       the surrounding frame.
+     - Defs the symbol to the wrapped render fn AND registers under
+       the id in the :view registry.
+
+     Compile-time error if the second arg (after optional docstring)
+     is not a vector — the args vector of a defn-shape. For runtime
+     registration with computed ids or non-defn-shape bodies (e.g.
+     Form-3 / `create-class`), use `reg-view*` instead.
 
      Per Spec 001 §Source-coordinate capture the metadata stamped onto
-     the registry slot includes :ns / :line / :file captured at this
-     call site."
-     [& args]
-     (let [m (meta &form)]
-       `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
-          (-reg-view ~@args)))))
-
-#?(:cljs
-   (def reg-view -reg-view))
+     the registry slot includes :ns / :line / :file captured here."
+     {:arglists '([sym args body+] [sym docstring args body+])}
+     [sym & more]
+     ;; Delegates to the shared expander in re-frame.views-macros so
+     ;; both this surface and the legacy
+     ;; `:require-macros [re-frame.views-macros :refer [reg-view]]`
+     ;; emit identical expansions.
+     ((requiring-resolve 're-frame.views-macros/expand-reg-view)
+      (meta &form) (ns-name *ns*) sym more)))
 
 (defn get-view
   "Return the render fn for a registered view by id, or nil if not

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -67,6 +67,55 @@
     :else             (throw (ex-info ":rf.error/machine-bad-action-form"
                                       {:action action}))))
 
+;; ---- guard/action contract --------------------------------------------------
+;;
+;; Per Spec 005 §Guards / §Actions, the canonical signature is:
+;;
+;;   (fn [data event] ...)              ; 2-arity — the 99% case
+;;   (fn [data event ctx] ...)          ; 3-arity — opt-in introspection
+;;
+;; `data` is the machine's :data slot directly (a map). `event` is the inbound
+;; event vector. `ctx` (3-arity escape hatch) is `{:state ... :meta ...}` —
+;; the snapshot's discrete-state and any user `:meta`. Returning to the 2-
+;; arity surface from the 3-arity body is a one-line `(let [data data] ...)`;
+;; no migration cost when introspection is no longer needed.
+
+(defn- declares-3-arity?
+  "True iff f explicitly declares a 3-fixed-arg invocation. Distinguishes
+  user opt-in 3-arity from variadic helpers like (constantly ...). On the
+  JVM, walks the fn class's declared invoke methods (variadics are
+  RestFns with no declared invoke(O,O,O) on the fn class itself); on
+  CLJS, looks for the multi-arity dispatch slot or matches .-length."
+  [f]
+  #?(:clj  (boolean
+             (some
+               (fn [^java.lang.reflect.Method m]
+                 (and (= "invoke" (.getName m))
+                      (= 3 (.getParameterCount m))))
+               (.getDeclaredMethods (class f))))
+     :cljs (or (= 3 (.-length f))
+               (some? (unchecked-get f "cljs$core$IFn$_invoke$arity$3")))))
+
+(defn- call-guard
+  "Invoke a resolved guard fn against a snapshot + event with the
+  canonical contract. 2-arity sees [data event]; 3-arity opt-in sees
+  [data event {:state :meta}]."
+  [g snapshot event]
+  (let [data (:data snapshot)]
+    (if (declares-3-arity? g)
+      (g data event {:state (:state snapshot) :meta (:meta snapshot)})
+      (g data event))))
+
+(defn- call-action
+  "Invoke a resolved action fn against a snapshot + event with the
+  canonical contract. 2-arity sees [data event]; 3-arity opt-in sees
+  [data event {:state :meta}]."
+  [f snapshot event]
+  (let [data (:data snapshot)]
+    (if (declares-3-arity? f)
+      (f data event {:state (:state snapshot) :meta (:meta snapshot)})
+      (f data event))))
+
 ;; ---- spawn counter --------------------------------------------------------
 ;;
 ;; Per Spec 005 §Declarative :invoke (sugar over spawn): on entry to an
@@ -256,7 +305,7 @@
                              (get-in n [:on :*])))
                 hit    (some (fn [t]
                                (let [g (resolve-guard machine (:guard t))]
-                                 (when (g snapshot event) t)))
+                                 (when (call-guard g snapshot event) t)))
                              cands)]
             (if hit
               {:transition hit :decl-path prefix}
@@ -295,7 +344,7 @@
 (defn- run-action [machine snap action-ref event]
   (if action-ref
     (let [f (resolve-action machine action-ref)
-          result (f snap event)]
+          result (call-action f snap event)]
       (or result {}))
     {}))
 
@@ -468,7 +517,7 @@
                      :else             [always])
             hit    (some (fn [t]
                            (let [g (resolve-guard machine (:guard t))]
-                             (when (g snapshot nil) t)))
+                             (when (call-guard g snapshot nil) t)))
                          always)]
         (if hit
           {:transition (assoc hit :decl-path prefix) :decl-path prefix}

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -55,18 +55,20 @@
 ;; ---- reg-view -------------------------------------------------------------
 
 (defn reg-view*
-  "Function form of reg-view. Registers the view under :view kind in the
-  registrar. Returns the wrapped (frame-aware) render fn.
+  "Reagent-aware view registration. Wraps `render-fn` with the React
+  `:context-type` hook used to resolve the surrounding frame at render
+  time, then registers it in the :view kind of the registrar.
 
-  The Var-defining form lives in a macro so the local Var is bound at
-  compile time."
+  Per Spec 004 §reg-view*: this is the plain-fn surface delegated to
+  by `re-frame.core/reg-view*` on CLJS. `metadata` is merged into the
+  registry slot's metadata as-is; source-coord capture is performed
+  by the caller (`re-frame.core/reg-view*`)."
   [id metadata render-fn]
   (let [wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (apply render-fn args))
                   {:context-type frame-context})]
-    (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
-                                         :handler-fn wrapped))
+    (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
 
 (defn get-view

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -58,24 +58,112 @@
 
 ;; ---- reg-view ------------------------------------------------------------
 ;;
-;; Per Spec 004 §reg-view defs the Var by default: the macro auto-defs a
-;; local Var named after the keyword's name so the call site can refer to
-;; the view as a value (Reagent's idiomatic Form-1).
+;; Per Spec 004 §reg-view: defn-shape macro. Two surfaces emit the same
+;; expansion — re-frame.core/reg-view (the canonical home) and the
+;; legacy re-frame.views-macros/reg-view (kept so existing
+;; `(:require-macros [re-frame.views-macros :refer [reg-view]])` imports
+;; keep working without an across-the-board sweep of example imports).
 ;;
-;; Forms supported:
-;;   (reg-view :id render-fn)
-;;   (reg-view :id metadata render-fn)
+;; The macro logic lives here as plain helpers so both defmacros can
+;; share it without circular load issues.
+
+(defn parse-reg-view-args
+  "Per Spec 004 §reg-view defn-shape. Parses (sym docstring? args body+)
+  into {:sym :docstring :args :body}. Returns nil when shape is invalid."
+  [more]
+  (let [[a & rest1] more]
+    (cond
+      (vector? a)
+      {:docstring nil :args a :body rest1}
+      (and (string? a) (vector? (first rest1)))
+      {:docstring a :args (first rest1) :body (next rest1)}
+      :else nil)))
+
+(defn describe-reg-view-bad-second-arg
+  "Human-readable description of an invalid second-arg to reg-view, for
+  the compile-error message. Per Spec 004 §reg-view compile-error
+  contract: the rejected cases are Var-ref symbol, create-class call,
+  and computed-fn call."
+  [x]
+  (cond
+    (symbol? x)
+    (str "a Var reference (" x ")")
+    (and (seq? x) (symbol? (first x)) (= "create-class" (name (first x))))
+    (str "a (" (first x) " …) call")
+    (seq? x)
+    (str "a (" (first x) " …) call")
+    (nil? x)
+    "nothing"
+    :else
+    (str "a " (some-> x type .getSimpleName) " — " (pr-str x))))
+
+(defn expand-reg-view
+  "Build the expansion form for a reg-view macro call. Used by both
+  re-frame.core/reg-view and re-frame.views-macros/reg-view. `form-meta`
+  is `(meta &form)` from the calling macro; `current-ns-sym` is
+  `(ns-name *ns*)` at expansion time."
+  [form-meta current-ns-sym sym more]
+  (let [parsed   (parse-reg-view-args more)
+        sym-meta (or (meta sym) {})
+        id-meta  (:rf/id sym-meta)
+        id       (or id-meta (keyword (str current-ns-sym) (str sym)))
+        ;; Anything on the symbol other than :rf/id is treated as slot
+        ;; metadata (matches Clojure's defn idiom: ^{:doc "..."} sym).
+        slot-meta (dissoc sym-meta :rf/id)]
+    (when (nil? parsed)
+      (throw (ex-info
+               (str "reg-view second argument must be an args vector "
+                    "(defn-shape: (reg-view sym [args] body)). Got "
+                    (describe-reg-view-bad-second-arg (first more))
+                    ". For runtime registration, use "
+                    "(re-frame.core/reg-view* :id render-fn).")
+               {:sym sym :got (first more) :args-after-sym (vec more)})))
+    (let [{:keys [docstring args body]} parsed
+          line (:line form-meta)
+          col  (:column form-meta)
+          def-form (if docstring
+                     `(def ~sym ~docstring (re-frame.core/get-view ~id))
+                     `(def ~sym (re-frame.core/get-view ~id)))
+          full-slot-meta (cond-> slot-meta
+                           docstring (assoc :doc docstring))]
+      `(do
+         (binding [re-frame.source-coords/*pending-coords*
+                   (cond-> {:ns (ns-name *ns*)}
+                     *file* (assoc :file *file*)
+                     ~line  (assoc :line ~line)
+                     ~col   (assoc :column ~col))]
+           (re-frame.core/reg-view* ~id
+             ~full-slot-meta
+             (fn ~sym ~args
+               (let [~'dispatch  (re-frame.core/dispatcher)
+                     ~'subscribe (re-frame.core/subscriber)]
+                 ~@body))))
+         ~def-form))))
 
 (defmacro reg-view
-  "Register a view by keyword id and def a same-named local Var bound
-  to the wrapped render fn. The local Var is the call-site reference;
-  the registered view is what frame-aware tooling (SSR, get-view) reads."
-  ([id render-fn]
-   `(reg-view ~id {} ~render-fn))
-  ([id metadata render-fn]
-   (let [sym (-> id name symbol)]
-     `(def ~sym
-        (re-frame.views/reg-view* ~id ~metadata ~render-fn)))))
+  "Register a view as a defn-shape macro. Per Spec 004 §reg-view.
+
+  Shape:
+    (reg-view sym [args] body+)
+    (reg-view sym docstring [args] body+)
+    (reg-view ^{:rf/id :explicit/id} sym [args] body+)
+
+  Auto-derives the id from `(keyword (str *ns*) (str sym))`. Override
+  via `^{:rf/id :explicit/id}` metadata on the symbol. Auto-injects
+  lexical bindings `dispatch` and `subscribe`. Defs the symbol to the
+  registered render fn.
+
+  Compile-time error if the second arg (after optional docstring) is
+  not a vector. For runtime registration with computed ids or
+  non-defn-shape bodies (e.g. Form-3 / `create-class`), use
+  `re-frame.core/reg-view*` instead.
+
+  This is the legacy import path; new code should
+  `:require-macros [re-frame.core :refer [reg-view]]` directly. Both
+  surfaces emit the same expansion."
+  {:arglists '([sym args body+] [sym docstring args body+])}
+  [sym & more]
+  (expand-reg-view (meta &form) (ns-name *ns*) sym more))
 
 ;; ---- h --------------------------------------------------------------------
 ;;

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -393,7 +393,11 @@
         actions-by-id
         (into {}
               (for [[id steps] (:machine-action handlers-map)]
-                [id (fn [snap event]
+                ;; Per Spec 005 §Guards / §Actions canonical 2-arity:
+                ;; the user-facing fn receives (data event), not the
+                ;; snapshot. The fixture-step interpreter still threads
+                ;; a local `ctx` map for its own reduction state.
+                [id (fn [data event]
                       (let [final (reduce
                                     (fn [{:keys [data] :as ctx} step]
                                       (case (first step)
@@ -411,19 +415,20 @@
                                                   (update ctx :fx (fnil conj [])
                                                           [a (eval-value b ctx)]))
                                         ctx))
-                                    {:data (:data snap) :event event :fx []}
+                                    {:data data :event event :fx []}
                                     steps)]
                         (cond-> {}
-                          (not= (:data snap) (:data final)) (assoc :data (:data final))
+                          (not= data (:data final)) (assoc :data (:data final))
                           (seq (:fx final)) (assoc :fx (:fx final)))))]))
         guards-by-id
         (into {}
               (for [[id steps] (:machine-guard handlers-map)]
-                [id (fn [snap event]
+                ;; Per Spec 005 §Guards canonical 2-arity: (fn [data event]).
+                [id (fn [data event]
                       (let [step (first steps)]
                         (when (and (vector? step) (= :fn (first step)))
                           (boolean
-                            (eval-value step {:data (:data snap) :event event})))))]))
+                            (eval-value step {:data data :event event})))))]))
         ;; Same machine-action steps, but realised as on-spawn callbacks
         ;; (snapshot-relative :set paths) for use in :invoke desugaring.
         on-spawn-by-id

--- a/implementation/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/test/re_frame/cross_spec_cljs_test.cljs
@@ -83,12 +83,12 @@
          :states  {:idle    {:on {:go {:target :acting :action :record-role}}}
                    :acting  {}}
          :actions {:record-role
-                   (fn [snapshot _event]
+                   (fn [_data _event]
                      ;; Read a sub from inside the action — the machine
                      ;; cascade has not committed yet but the sub sees
                      ;; the *current* committed app-db.
                      (reset! observed-by-action (rf/subscribe-value [:user-role]))
-                     snapshot)}}]
+                     nil)}}]
     (rf/reg-machine :auth/check machine)
     (rf/dispatch-sync [:auth/check [:go]])
     (is (= :admin @observed-by-action)
@@ -302,9 +302,9 @@
                    :states  {:idle {:on {:go {:target :done :action :emit-fx}}}
                              :done {}}
                    :actions {:emit-fx
-                             (fn [snap _]
-                               (assoc snap :fx [[:throwy :a]
-                                                [:record :b]]))}}]
+                             (fn [_data _event]
+                               {:fx [[:throwy :a]
+                                     [:record :b]]})}}]
       (rf/reg-machine :test/m machine)
       (let [traces (collect-traces ::xspec-12)]
         (rf/dispatch-sync [:test/m [:go]])
@@ -335,10 +335,10 @@
                                                   :action :tag}}}
                               :working {:on {:go {:target :idle
                                                   :action :tag}}}}
-                    :actions {:tag (fn [snap _]
-                                     (assoc-in snap [:data :who] :v1))}}
+                    :actions {:tag (fn [data _]
+                                     {:data (assoc data :who :v1)})}}
         machine-v2 (assoc-in machine-v1 [:actions :tag]
-                             (fn [snap _] (assoc-in snap [:data :who] :v2)))]
+                             (fn [data _] {:data (assoc data :who :v2)}))]
     (rf/reg-machine :test/m machine-v1)
     (rf/dispatch-sync [:test/m [:go]])
     (is (= :v1 (get-in (rf/get-frame-db :rf/default)

--- a/implementation/test/re_frame/examples_test.clj
+++ b/implementation/test/re_frame/examples_test.clj
@@ -13,9 +13,10 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (rf/init!)
-  ;; Drop any cached require of ssr.core so each test re-evaluates the
-  ;; example's namespace-level handlers against a fresh registrar.
+  ;; Drop any cached require of example namespaces so each test re-evaluates
+  ;; their namespace-level handlers against a fresh registrar.
   (remove-ns 'ssr.core)
+  (remove-ns 'state-machine-walkthrough.core)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -26,3 +27,13 @@
     (let [result (@(resolve 'ssr.core/ssr-tests))]
       (is (= :ok result)
           "ssr.core/ssr-tests returned :ok — the full server flow worked"))))
+
+(deftest state-machine-walkthrough-runs-headless
+  (testing "examples/state-machine-walkthrough/core.cljc — every code block in
+            ch.05 § Headless testing runs and matches the chapter's claims."
+    (require 'state-machine-walkthrough.core :reload)
+    (let [result (@(resolve 'state-machine-walkthrough.core/smoke-tests))]
+      (is (= :ok result)
+          "state-machine-walkthrough.core/smoke-tests returned :ok — the
+           login-machine drove through happy path, retry-then-lockout, and
+           pure machine-transition tests."))))

--- a/implementation/test/re_frame/hot_reload_test.clj
+++ b/implementation/test/re_frame/hot_reload_test.clj
@@ -178,7 +178,7 @@
         {:initial :red
          :data    {:ticks 0}
          :actions {:tick-action
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      {:data (update data :ticks inc)})}
          :states
          {:red    {:on {:tick {:target :green :action :tick-action}}}

--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -168,11 +168,11 @@
     (let [machine
           {:initial :asking
            :data    {:correct-count 9}
-           :guards  {:enough? (fn [snap _]
-                                (>= (get-in snap [:data :correct-count]) 10))}
-           :actions {:count   (fn [snap _]
+           :guards  {:enough? (fn [data _]
+                                (>= (:correct-count data) 10))}
+           :actions {:count   (fn [data _]
                                 {:data {:correct-count
-                                        (inc (get-in snap [:data :correct-count]))}})}
+                                        (inc (:correct-count data))}})}
            :states
            {:asking {:always [{:guard :enough? :target :winner}]
                      :on     {:answer-correct {:action :count}}}
@@ -194,11 +194,11 @@
     (let [machine
           {:initial :asking
            :data    {:correct-count 5}
-           :guards  {:enough? (fn [snap _]
-                                (>= (get-in snap [:data :correct-count]) 10))}
-           :actions {:count   (fn [snap _]
+           :guards  {:enough? (fn [data _]
+                                (>= (:correct-count data) 10))}
+           :actions {:count   (fn [data _]
                                 {:data {:correct-count
-                                        (inc (get-in snap [:data :correct-count]))}})}
+                                        (inc (:correct-count data))}})}
            :states
            {:asking {:always [{:guard :enough? :target :winner}]
                      :on     {:answer-correct {:action :count}}}

--- a/implementation/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/test/re_frame/pattern_smoke_test.clj
@@ -115,7 +115,7 @@
       (rf/create-machine-handler
         {:initial :configuring
          :data    {:config nil}
-         :actions {:record-config (fn [{:keys [data]} [_ c]]
+         :actions {:record-config (fn [data [_ c]]
                                     {:data (assoc data :config c)})}
          :states
          {:configuring {:on {:configured {:target :loading
@@ -210,11 +210,11 @@
         {:initial :disconnected
          :data    {:retries 0 :max-retries 2}
          :guards  {:max-retries-exceeded?
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      (>= (:retries data) (:max-retries data)))}
-         :actions {:bump-retry  (fn [{:keys [data]} _]
+         :actions {:bump-retry  (fn [data _]
                                   {:data (update data :retries inc)})
-                   :reset-retry (fn [{:keys [data]} _]
+                   :reset-retry (fn [data _]
                                   {:data (assoc data :retries 0)})}
          :states
          {:disconnected   {:on {:ws/connect {:target :connecting}}}
@@ -321,16 +321,16 @@
   (let [machine
         {:initial :idle
          :data    {:total 0 :processed 0 :chunk-size 2 :input nil :result []}
-         :guards  {:done?      (fn [{:keys [data]} _]
+         :guards  {:done?      (fn [data _]
                                  (>= (:processed data) (:total data)))
-                   :more-work? (fn [{:keys [data]} _]
+                   :more-work? (fn [data _]
                                  (< (:processed data) (:total data)))}
          :actions {:start-job
                    (fn [_ [_ input]]
                      {:data {:total (count input) :input input
                              :chunk-size 2 :processed 0 :result []}})
                    :process-chunk
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      (let [{:keys [input chunk-size processed result]} data
                            chunk (subvec input processed
                                          (min (+ processed chunk-size)

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -501,15 +501,19 @@
       (is (some #(= 're-frame.frame/*current-frame* %)
                 (tree-seq coll? seq exp))
           "with-frame expansion references *current-frame*"))
-    ;; reg-view defs a local var named after the keyword's name. Use
-    ;; macroexpand (not -1) because the 2-arity form delegates to the
-    ;; 3-arity form via a self-call.
+    ;; reg-view (defn-shape per Spec 004 §reg-view) defs the symbol and
+    ;; registers under (keyword (str *ns*) (str sym)). The expansion is
+    ;; (do (binding [...] (reg-view* ...)) (def sym (get-view ...))).
     (let [exp (macroexpand `(re-frame.views-macros/reg-view
-                              :my-widget (fn [] :body)))]
-      (is (= 'def (first exp))
-          "reg-view expansion starts with def")
-      (is (= 'my-widget (second exp))
-          "reg-view defs the var with the keyword's name"))
+                              ~'my-widget [] :body))]
+      (is (= 'do (first exp))
+          "reg-view expansion starts with do (binding + def)")
+      (let [forms (rest exp)
+            def-form (last forms)]
+        (is (= 'def (first def-form))
+            "the trailing form in the expansion is a def")
+        (is (= 'my-widget (second def-form))
+            "the def binds the symbol the user supplied")))
     ;; h leaves DOM tags alone but rewrites namespaced view refs.
     (let [exp (macroexpand-1 `(re-frame.views-macros/h [:my-ns/w {:k 1}]))]
       (is (some #(= 're-frame.core/get-view %)
@@ -854,7 +858,10 @@
       (fn [_ _] {:articles [{:id "a" :title "Article A" :body "Body A"}
                             {:id "b" :title "Article B" :body "Body B"}]}))
     (rf/reg-sub :articles (fn [db _] (:articles db)))
-    (rf/reg-view :pages/articles
+    ;; Test exercises the keyword-id [:pages/articles] hiccup head — not
+    ;; the macro shape — so it uses the plain-fn surface reg-view* with
+    ;; an explicit id rather than the defn-shape macro.
+    (rf/reg-view* :pages/articles
       (fn []
         (let [arts (rf/subscribe-value [:articles])]
           [:div.page
@@ -881,7 +888,8 @@
 
 (deftest reg-view-jvm
   (testing "reg-view registers a view that render-to-string resolves"
-    (rf/reg-view :greet
+    ;; Plain-fn surface (reg-view*): explicit id, no auto-def.
+    (rf/reg-view* :greet
       (fn [name] [:p "hello " [:strong name]]))
     (is (= "<p>hello <strong>world</strong></p>"
            (rf/render-to-string [:greet "world"]))

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -413,7 +413,7 @@
     (let [m {:id     :auth
              :initial :checking
              :data    {:authed? true}
-             :guards  {:authed? (fn [snap _] (:authed? (:data snap)))}
+             :guards  {:authed? (fn [data _] (:authed? data))}
              :states
              {:checking {:always [{:guard :authed? :target :authed}]}
               :authed   {}
@@ -431,8 +431,8 @@
              :data    {:n 0}
              :actions {:start (fn [_ _]
                                 {:fx [[:raise [:bump]] [:raise [:bump]]]})
-                       :bump  (fn [snap _]
-                                {:data {:n (inc (:n (:data snap)))}})}
+                       :bump  (fn [data _]
+                                {:data {:n (inc (:n data))}})}
              :states
              {:idle {:on {:start {:target :busy :action :start}
                           :bump  {:action :bump}}}
@@ -692,7 +692,7 @@
            :data    {:attempts 0 :error nil}
            :guards
            {:under-retry-limit
-            (fn [{:keys [data]} _] (< (:attempts data) 3))}
+            (fn [data _] (< (:attempts data) 3))}
            :actions
            {:clear-error    (fn [_ _] {:data {:error nil}})
             :issue-request  (fn [_ [_ creds]]
@@ -701,7 +701,7 @@
                                             :body       creds
                                             :on-success [:auth.login/flow [:auth.login/success]]
                                             :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
-            :record-error   (fn [{:keys [data]} [_ err]]
+            :record-error   (fn [data [_ err]]
                               {:data (-> data
                                          (update :attempts inc)
                                          (assoc :error (or (:message err) "Login failed.")))})
@@ -755,7 +755,7 @@
     (rf/reg-machine :test/tiny
       {:initial :idle
        :data    {:n 0}
-       :actions {:bump (fn [{:keys [data]} _] {:data (update data :n inc)})}
+       :actions {:bump (fn [data _] {:data (update data :n inc)})}
        :states  {:idle {:on {:tick {:target :idle :action :bump}}}}})
     (let [f (rf/make-frame {})]
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
@@ -773,7 +773,7 @@
     (let [tiny-spec   {:initial :idle
                        :data    {:n 0}
                        :doc     "A tiny test machine."
-                       :actions {:bump (fn [{:keys [data]} _]
+                       :actions {:bump (fn [data _]
                                          {:data (update data :n inc)})}
                        :states  {:idle {:on {:tick {:target :idle
                                                     :action :bump}}}}}

--- a/implementation/test/re_frame/source_coords_test.clj
+++ b/implementation/test/re_frame/source_coords_test.clj
@@ -115,8 +115,10 @@
 
 (deftest source-coords-on-reg-view
   (testing "reg-view stamps :ns / :line / :file"
-    (rf/reg-view :rf2-k84s/reg-view-sample
-                 (fn [] [:div "hi"]))
+    ;; Per Spec 004 §reg-view, defn-shape with explicit id-meta override.
+    ;; ^{:rf/id ...} keeps the legacy keyword for the assertion.
+    (rf/reg-view ^{:rf/id :rf2-k84s/reg-view-sample} reg-view-sample []
+      [:div "hi"])
     (assert-coords (rf/handler-meta :view :rf2-k84s/reg-view-sample)
                    :view :rf2-k84s/reg-view-sample)))
 

--- a/implementation/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/test/re_frame/ssr_end_to_end_test.clj
@@ -113,7 +113,10 @@
         (assoc db :articles articles)))
 
     (rf/reg-sub :articles (fn [db _] (:articles db)))
-    (rf/reg-view :pages/articles
+    ;; Plain-fn surface (reg-view*): the SSR test references the view by
+    ;; the literal :pages/articles keyword in render-to-string, so we
+    ;; preserve the explicit id rather than auto-derive.
+    (rf/reg-view* :pages/articles
       (fn []
         (let [arts (rf/subscribe-value [:articles])]
           [:div.page

--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.views-macros-test
+  "Per Spec 004 §reg-view: the defn-shape macro, the auto-id derivation
+  rule, the `^{:rf/id ...}` metadata override, the lexical
+  `dispatch`/`subscribe` injection, the Form-2 closure case, and the
+  compile-error contract for non-defn-shape bodies. Per rf2-d0pi.
+
+  These tests run on the JVM. CLJS-specific Reagent rendering lives in
+  the runtime / hot-reload CLJS test files; the macro logic here is
+  shared via re-frame.views-macros which is JVM-loadable."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.views-macros :as vm]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- shape: defn-shape macro auto-defs the symbol ------------------------
+
+(deftest reg-view-auto-defs-the-symbol
+  (testing "(reg-view sym [args] body) defs sym to the registered render fn"
+    (rf/reg-view widget-a [n]
+      [:span "w-" n])
+    ;; The Var was defined.
+    (let [resolved (resolve `widget-a)]
+      (is (some? resolved)
+          "the macro defs a Var named after the supplied symbol")
+      (is (fn? @resolved)
+          "the Var holds a callable render fn"))
+    ;; And the registry slot is populated under the auto-derived id.
+    ;; The id is taken from (ns-name *ns*) at macro-expansion time,
+    ;; which for this test file is `re-frame.views-macros-test` —
+    ;; matched literally here rather than via runtime *ns* (the test
+    ;; runner's *ns* is the test-runner ns, not the test file's ns).
+    (is (some? (rf/get-view :re-frame.views-macros-test/widget-a))
+        "the view is registered under (keyword 'this-ns' 'sym)")))
+
+;; ---- auto-id derivation --------------------------------------------------
+
+(deftest reg-view-auto-id-derives-from-ns-and-sym
+  (testing "the registered id is (keyword (str *ns*) (str sym)) when no
+            metadata override is present"
+    (rf/reg-view widget-b [_n] [:p "b"])
+    (is (some? (rf/get-view :re-frame.views-macros-test/widget-b))
+        "the registered id matches (keyword *ns* sym)")))
+
+;; ---- ^{:rf/id ...} metadata override -------------------------------------
+
+(deftest reg-view-metadata-override-takes-precedence
+  (testing "^{:rf/id :explicit/id} on the symbol wins over the auto-derived id"
+    (rf/reg-view ^{:rf/id :explicit/widget} widget-c [_n] [:p "c"])
+    (is (some? (rf/get-view :explicit/widget))
+        "the registered id is the metadata override")
+    (is (nil? (rf/get-view :re-frame.views-macros-test/widget-c))
+        "the auto-derived id is NOT registered when the override is present")))
+
+;; ---- compile-error contract ----------------------------------------------
+
+(deftest reg-view-rejects-var-ref-body
+  (testing "(reg-view sym some-fn) — a symbol where the args vector should be
+            — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-var ~'some-fn-ref)))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a symbol")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector")
+      (is (re-find #"reg-view\*" err)
+          "the message points the user at the reg-view* escape hatch"))))
+
+(deftest reg-view-rejects-create-class-body
+  (testing "(reg-view sym (reagent.core/create-class …)) — a list where the
+            args vector should be — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-cc (reagent.core/create-class {}))))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a create-class call")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector")
+      (is (re-find #"reg-view\*" err)
+          "the message points the user at the reg-view* escape hatch"))))
+
+(deftest reg-view-rejects-computed-body
+  (testing "(reg-view sym (some-fn-returning-a-fn)) — a non-fn call where
+            the args vector should be — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-comp (~'compute-render-fn))))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a non-fn call")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector"))))
+
+;; ---- error message template ----------------------------------------------
+
+(deftest reg-view-error-message-matches-template
+  (testing "the compile-error message follows the documented template"
+    (let [err (try (eval `(rf/reg-view broken ~'naked-symbol))
+                   nil
+                   (catch Exception e
+                     (or (some-> e .getCause .getMessage)
+                         (.getMessage e))))]
+      (is (some? err))
+      (is (re-find #"reg-view second argument must be an args vector" err)
+          "leading clause matches the template")
+      (is (re-find #"defn-shape" err)
+          "mentions defn-shape")
+      (is (re-find #"For runtime registration, use" err)
+          "directs the user to the escape hatch")
+      (is (re-find #"reg-view\*" err)
+          "names reg-view* explicitly"))))
+
+;; ---- docstring slot ------------------------------------------------------
+
+(deftest reg-view-accepts-docstring
+  (testing "(reg-view sym \"doc\" [args] body) accepts a docstring slot,
+            defn-style"
+    (rf/reg-view docced "the doc" [n] [:p n])
+    (let [v (resolve `docced)]
+      (is (some? v))
+      (is (fn? @v)))))
+
+;; ---- expansion under the legacy import path ------------------------------
+;;
+;; Existing examples use `(:require-macros [re-frame.views-macros :refer
+;; [reg-view]])`. That surface forwards to the canonical expander; the
+;; expansion shape and behaviour are identical. Cover the legacy path here
+;; so we don't lose it without noticing.
+
+(deftest reg-view-via-views-macros-import
+  (testing "(re-frame.views-macros/reg-view sym [args] body) emits the same
+            expansion shape as re-frame.core/reg-view"
+    (let [exp-core (macroexpand `(rf/reg-view ~'expand-test [] [:p]))
+          exp-vm   (macroexpand `(re-frame.views-macros/reg-view
+                                   ~'expand-test [] [:p]))]
+      ;; Both expansions share their structural skeleton.
+      (is (= 'do (first exp-core)))
+      (is (= 'do (first exp-vm)))
+      (is (= 'def (first (last exp-core))))
+      (is (= 'def (first (last exp-vm)))))))
+
+;; ---- expander helpers expose stable shape --------------------------------
+
+(deftest expand-reg-view-helper-shape
+  (testing "vm/expand-reg-view returns a (do binding+def) form"
+    (let [exp (vm/expand-reg-view {:line 1 :column 1}
+                                  'my.ns 'my-widget '([] [:p]))]
+      (is (= 'do (first exp)))
+      (is (= 'def (first (last exp))))
+      (is (= 'my-widget (second (last exp))))))
+
+  (testing "vm/parse-reg-view-args parses the three accepted shapes"
+    (is (= {:docstring nil :args '[] :body nil}
+           (vm/parse-reg-view-args '([]))))
+    (is (= {:docstring "doc" :args '[a] :body '([:p a])}
+           (vm/parse-reg-view-args '("doc" [a] [:p a]))))
+    (is (nil? (vm/parse-reg-view-args '(some-symbol)))
+        "a single non-vector arg is invalid")
+    (is (nil? (vm/parse-reg-view-args '((reagent.core/create-class {}))))
+        "a list where the args vector should be is invalid")))


### PR DESCRIPTION
## Summary

Folds the rf2-qppo decision (tighten guard/action contract) into the rf2-hbt1 ch.05 rewrite. Three logical commits, in order:

1. **Impl + test sweep** — `machines.cljc` arity-detects guard/action/sub-machine sub-fns and dispatches accordingly; the canonical signature is now `(fn [data event] ...)` 2-arity, with opt-in 3-arity `(fn [data event {:state :meta}] ...)` for the rare introspection case. Test corpus swept.
2. **Docs sweep** — Spec 005 §Guards / §Actions / §Naming / §Strict encapsulation rewritten around the new contract (and §Naming gains an explicit "`:data` is the parameter, not a destructure key" line). Pattern-LongRunningWork, Pattern-Boot, Pattern-WebSocket, Pattern-AsyncEffect, CP-5-MachineGuide, Construction-Prompts all swept. Spawn-spec `:data` fns (different signature; takes parent snapshot) keep their `:keys [data]` form deliberately.
3. **ch.05 rewrite + runnable example** — `docs/guide/05-state-machines.md` rewritten around the actual v1 surface (`create-machine-handler` / `reg-machine` / `sub-machine`; spec-local `:guards` / `:actions`; `[:rf/machines <id>]` storage scheme). Drops every aspirational symbol the old chapter referenced (`reg-machine-guard`, `reg-machine-action`, `machine-handler`, `:machine-path`, `:context`). Adds runnable companion at `examples/state_machine_walkthrough/core.cljc` wired into JVM examples_test so every test run verifies the chapter's claims.

### Contract change — before / after

```clojure
;; before — every fn destructured the snapshot wrapper:
(fn [{:keys [data]} [_ err]] (update data :attempts inc))

;; after — :data is passed directly; introspection is opt-in via 3-arity:
(fn [data [_ err]] (update data :attempts inc))
(fn [data event {:keys [state]}] ...)              ; opt-in
```

### Files swept (mechanical sweep of `(fn [{:keys [data]} ...] ...)` → `(fn [data ...] ...)`)

Implementation: `implementation/src/re_frame/machines.cljc` (impl change), `examples/login/core.cljs` (worked example), `implementation/test/re_frame/{conformance,hot_reload,smoke,pattern_smoke,cross_spec_cljs,machines_cljs}_test.{clj,cljs}` (test corpus).

Specification: `docs/specification/{005-StateMachines,Pattern-LongRunningWork,Pattern-Boot,Pattern-WebSocket,Pattern-AsyncEffect,CP-5-MachineGuide,Construction-Prompts}.md`.

Guide: `docs/guide/05-state-machines.md` (full rewrite).

### Runnable example

`examples/state_machine_walkthrough/core.cljc` — `.cljc` so the chapter's "runs in microseconds on the JVM, no browser" claim is literally true. Four headless tests: `pure-happy-path-test`, `pure-lockout-test`, `drain-happy-path-test`, `drain-retry-then-lockout-test`. Wired into `re-frame.examples-test/state-machine-walkthrough-runs-headless`.

## Test plan

- [x] `clojure -M:test` — all green (193 tests, 960 assertions, 0 failures)
- [x] Build smoke for shadow-cljs example targets — all 7 example builds compile (pre-existing reg-view warnings unrelated to this change)
- [ ] CLJS node-test suite — pre-existing breakage on the `rf2-d0pi-reg-view-defn-shape` base (test files reference the old `reg-view` runtime form); not introduced or worsened by this PR
- [x] No new beads filed — rich-grammar slot verification (`:guard` singular, `:entry`, multi-target arrays) confirmed against Spec 005 / `machine-transition` impl; no gaps surfaced