### PR TITLE
feat: dissolve re-frame.alpha (rf2-7cb2 / rf2-s9dn)

### DIFF
--- a/docs/specification/000-Vision.md
+++ b/docs/specification/000-Vision.md
@@ -123,7 +123,7 @@ The capabilities below are partitioned by what every conformant implementation m
 | React context as the frame-routing mechanism for views | — | yes (CLJS optimisation) | yes — explicit-frame-id is the portable form; React context is one realisation | yes |
 | `re-frame-10x` epoch buffer integration | — | yes | yes — equivalent dev tool per host | yes |
 | Chrome Performance Timeline bridge (per [009](009-Instrumentation.md)) | — | yes | yes — equivalent profiler integration | yes |
-| `re-frame.alpha` namespace | — | TBD | — | yes |
+| ~~`re-frame.alpha` namespace~~ — *dissolved (rf2-7cb2 / rf2-s9dn); not shipped in v2* | — | — | — | — |
 | DOM source annotations for view-to-source navigation | — | yes (CLJS optimisation) | yes — host equivalent | yes |
 | Function-valued overrides (`:fx-overrides {:http stub-fn}`) | — | yes | yes — id-valued overrides are the portable form; function values are a CLJS convenience | the *function-valued* form |
 | `route-link` view + `:rf.nav/push-url` registered fx (per [012](012-Routing.md)) | yes (substrate) | yes | host registers the platform-appropriate fx; `route-link` per host's view idiom | — |
@@ -496,28 +496,24 @@ These remain open at 000. Per-Spec documents track narrower open questions in th
 
 Hot-reloading the same handler under the same id is normal and expected (figwheel/shadow-cljs save). But re-registering with a *different* function — accidentally, e.g. two namespaces colliding on `:save` — is silent last-write-wins. Open: how loud should re-frame2 warn at registration time, and is the warning on by default? Linked: [002 §Open questions — Event-id collisions on re-registration](002-Frames.md#event-id-collisions-on-re-registration).
 
-### Audit the `re-frame.alpha` namespace
+### ~~Audit the `re-frame.alpha` namespace~~ — *resolved by [§re-frame.alpha is dissolved](#re-framealpha-is-dissolved-rf2-7cb2--rf2-s9dn) below.*
 
-Walk through every public symbol in `re-frame.alpha` (current re-frame's experimental namespace) and decide what to do with each in re-frame2 — promote to stable, keep alpha, deprecate, or drop. Surface includes:
-
-- `reg :sub` / `reg :legacy-sub` / `reg :sub-lifecycle` — the generalised registration API; query-map subscriptions.
-- `sub` / `subscribe` (alpha) — query-map-shaped subscribe; alpha returns `:safe`-lifecycle reactions by default vs. `re-frame.core/subscribe`'s `:reactive` default.
-- `reg-flow`, `flow<-`, `clear-flow`, `get-flow` — the flow API.
-- `:flow` and `:live?` registered subs.
-- The compatibility shims (vector ↔ map query, `:re-frame/query-v` / `:re-frame/query-m` metadata).
-
-Decisions per item:
-
-1. **Promote to stable** in `re-frame.core` if the surface has stabilised in practice.
-2. **Keep in `re-frame.alpha`** if it's still experimental but worth preserving.
-3. **Deprecate** with a migration rule if v1 has a better way to do the same thing.
-4. **Drop** if subsumed by a v1 primitive.
-
-Inputs to the decision: real-world usage, overlap with v1 primitives (frames, drain, machines, schemas), compatibility with the v1 frame model. Audit must land before v1 ships; until then the migration story preserves existing semantics by default.
+The audit landed; the disposition is dissolution rather than promotion. See [Resolved decisions §re-frame.alpha is dissolved](#re-framealpha-is-dissolved-rf2-7cb2--rf2-s9dn) below for what each of the surveyed symbols mapped to.
 
 ## Resolved decisions
 
 Decisions taken at 000-level. Each resolution is summarised here; the load-bearing prose lives in the per-Spec documents linked below.
+
+### `re-frame.alpha` is dissolved (rf2-7cb2 / rf2-s9dn)
+
+The `re-frame.alpha` namespace is **not part of v2**. The alpha experiment was an audit candidate at 000-Vision; the audit decision is **drop** for the experimental surface and **promote to canonical core** for the parts that earned their keep. Specifically:
+
+- `re-frame.alpha/reg`, `re-frame.alpha/sub`, `re-frame.alpha/reg-sub-lifecycle` and the four built-in lifecycle policies (`:safe`, `:no-cache`, `:reactive`, `:forever`) — **dropped**. The per-kind `reg-*` macros (already in `re-frame.core`) and vector-form `subscribe` are the canonical surfaces.
+- The query-map `:re-frame/q` shape — **dropped**. Subscriptions take a vector.
+- Lifecycle-policy plumbing in the per-frame sub-cache — **dropped**. The cache uses a single algorithm: deferred ref-counting with a configurable grace-period (default 50ms); see [Spec 006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal).
+- `reg-flow`, `flow<-`, `clear-flow`, `get-flow`, the `:flow` and `:live?` registered subs — **promoted to `re-frame.core`** under the `flow` family per [Spec 013](013-Flows.md). The migration is a namespace switch.
+
+Migration entries land at [MIGRATION §M-22](MIGRATION.md#m-22-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn).
 
 ### Plain Reagent fns under non-default frames
 

--- a/docs/specification/006-ReactiveSubstrate.md
+++ b/docs/specification/006-ReactiveSubstrate.md
@@ -284,6 +284,7 @@ Each frame holds one sub-cache, keyed by `[query-vector]`:
   :inputs            [[q1] [q2]] ;; resolved :<- chain (vector of query-vectors)
   :ref-count         n          ;; how many readers currently hold a reference
   :on-dispose        [...]      ;; callbacks that fire when ref-count drops to 0
+  :pending-dispose   <handle>   ;; opaque timer-handle iff disposal is scheduled (rf2-s9dn)
   :registered-at     <ts>}}     ;; for trace correlation
 ```
 
@@ -315,7 +316,7 @@ Lookup [query-v] in frame F:
 
 Two properties this guarantees:
 
-1. **De-duplication.** Concurrent equal subscriptions share one cached computation. The cache key is the query-vector; v1's `re-frame.subs/cache-key` shape is the reference (composite key with `:re-frame/q` and `:re-frame/lifecycle`).
+1. **De-duplication.** Concurrent equal subscriptions share one cached computation. The cache key is the query-vector itself. v2 has a single disposal algorithm (deferred ref-counting; see [§Reference counting and disposal](#reference-counting-and-disposal)); the v1-era composite key with `:re-frame/q` and `:re-frame/lifecycle` is gone (rf2-7cb2 / rf2-s9dn — the `re-frame.alpha` namespace and its lifecycle policies were dissolved before v1 ship).
 2. **Layer-1/2/3 chaining.** A layer-2 sub's `:<-` inputs are themselves resolved via this same lookup, recursively. The recursion terminates at layer-1 subs whose inputs are not other subs but readers over `app-db` directly.
 
 ### Invalidation algorithm
@@ -376,25 +377,57 @@ Layers ≥ 3 are conventionally just "layer-2+" — the algorithm treats them al
 
 ### Reference counting and disposal
 
-The cache is **not** strong-referenced from the frame for the lifetime of the frame; entries dispose when their last reader goes away.
+The cache is **not** strong-referenced from the frame for the lifetime of the frame; entries dispose when their last reader goes away. The disposal algorithm is **deferred ref-counting with a grace-period** — a single algorithm. There are no pluggable lifecycle policies; the v1 alpha namespace's `:safe`, `:no-cache`, `:reactive`, and `:forever` lifecycles are not part of v2 (rf2-7cb2 / rf2-s9dn).
+
+When the last subscriber drops, the entry is **scheduled** for disposal after the configured grace-period elapses. If a new subscriber arrives within that window, the scheduled disposal is **cancelled** and the cached value is reused.
 
 ```
 On subscriber detach (view unmounts, tool disconnects):
   entry.ref-count -= 1
   If entry.ref-count == 0:
-    For each dispose-fn in entry.on-dispose:
-      dispose-fn()
-    F.sub-cache.dissoc(k)
-    trace! :sub/disposed {:query-v k :frame F.id}
+    handle ← schedule-after grace-period-ms:
+               (when entry.ref-count == 0:
+                  for each dispose-fn in entry.on-dispose: dispose-fn()
+                  F.sub-cache.dissoc(k)
+                  trace! :sub/disposed {:query-v k :frame F.id})
+    entry.pending-dispose ← handle
+
+On subscriber attach (cache HIT; the slot already exists):
+  entry.ref-count += 1
+  if entry.pending-dispose is not nil:
+    cancel entry.pending-dispose
+    entry.pending-dispose ← nil
 ```
 
-The `on-dispose` hook lets the substrate adapter release substrate-specific resources (a Reagent reaction, a Solid signal, a Vue computed) before the cache slot is removed. The CLJS reference uses `interop/add-on-dispose!` per the Reagent realisation in [§Sub-cache wiring](#sub-cache-wiring-reagent-realisation).
+#### Disposal guarantees
 
-Three subtleties:
+- **Zero-subscriber → grace-period elapses → disposed.** When `ref-count` reaches 0 and no resubscribe arrives within `grace-period-ms`, the on-dispose callbacks fire, the cache slot is removed, and a `:sub/disposed` trace event is emitted.
+- **Resubscribe within grace-period → disposal cancelled, value reused.** If a new subscriber arrives before the timer fires, the timer is cancelled and the existing reaction (and its cached value) is returned. The new subscriber observes no recomputation; the underlying substrate-specific container is the same one previously cached.
+- **Synchronous disposal when `grace-period-ms = 0`.** Setting the grace-period to 0 yields the v1-style "ref-count → 0 → dispose immediately" semantic. Useful for tests, REPL sessions, and any context that wants deterministic teardown without timer-driven races.
+- **Hot-reload preserves the contract.** Re-registering a sub disposes every cached slot for that query (regardless of ref-count) and cancels any pending grace-period timers — the next subscribe builds afresh against the new body.
+- **Frame teardown preserves the contract.** Destroying a frame disposes every cached slot and cancels every pending grace-period timer; see [§Lifetime contract — frame disposal](#lifetime-contract--frame-disposal).
 
-1. **A sub can become live again after disposal.** A view unmounts (ref-count → 0, slot disposed); later, the same view re-mounts (cache miss, fresh computation). This is correct — the cache is performance, not state. The recomputed value will equal what was disposed (same body, same `app-db`); no observable difference.
+#### The grace-period parameter
+
+The grace-period is a per-runtime configuration knob:
+
+| Knob | Default | Configure |
+|---|---|---|
+| `grace-period-ms` | **50ms** | `(rf/configure :sub-cache {:grace-period-ms N})` |
+
+The default of **50ms** is chosen empirically: long enough to bridge React re-render churn (where a Reagent component briefly unmounts then re-renders with the same subscription), short enough that genuine disposal is observable promptly and memory does not accumulate under load. Implementations targeting non-React substrates may pick a different default but should document it.
+
+`N` is a non-negative integer; `0` selects synchronous disposal.
+
+#### On-dispose hooks
+
+The `on-dispose` hook lets the substrate adapter release substrate-specific resources (a Reagent reaction, a Solid signal, a Vue computed) before the cache slot is removed. Hooks fire **after** the grace-period elapses (or synchronously when `grace-period-ms = 0`). The CLJS reference uses `interop/add-on-dispose!` per the Reagent realisation in [§Sub-cache wiring](#sub-cache-wiring-reagent-realisation).
+
+#### Three subtleties
+
+1. **A sub can become live again after disposal.** A view unmounts; if no resubscribe arrives within the grace-period, the slot disposes. Later, the same view re-mounts (cache miss, fresh computation). This is correct — the cache is performance, not state. The recomputed value will equal what was disposed (same body, same `app-db`); no observable difference.
 2. **Eager subs.** A future `:reg-sub-by-path` (post-v1) might keep its cache slot live regardless of ref-count, for performance. v1 has no eager subs; if added, the contract surface is `entry.eager? = true` and the disposal path skips the slot.
-3. **Disposal cascades.** When a layer-2 sub disposes, its layer-1 inputs lose one reader each; if they were held only by that layer-2 sub, they also dispose. The cascade is automatic via `on-dispose` and ref-counts.
+3. **Disposal cascades.** When a layer-2 sub disposes, its layer-1 inputs lose one reader each; if they were held only by that layer-2 sub, they enter their own grace-period. Cascading disposals each pay the grace-period independently, but the timers run concurrently — total wall-clock disposal time is one grace-period regardless of chain depth.
 
 ### Lifetime contract — frame disposal
 

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -7,12 +7,13 @@
 
 - **Status** — exactly one base value, optionally combined with a single qualifier:
   - Base values: `v1` (ships in v1), `v1 (preserved)` (exists in current re-frame; preserved unchanged), `v1 (preserved + extended)` (exists today; v1 adds new arity or behaviour), `post-v1 lib` (design spec in v1 Specs but ships in a post-v1 library).
-  - Qualifiers (combined as `<base>, <qualifier>` — comma-separated): `alpha` (lives in `re-frame.alpha`), `dev-only` (elided in production builds — the macro emit site or runtime body, depending on the API).
-  - Examples: `v1`, `v1 (preserved)`, `v1 (preserved, alpha)`, `v1 (dev-only)`, `v1 (preserved, dev-only)`, `post-v1 lib`.
+  - Qualifier: `dev-only` (elided in production builds — the macro emit site or runtime body, depending on the API).
+  - Examples: `v1`, `v1 (preserved)`, `v1 (dev-only)`, `v1 (preserved, dev-only)`, `post-v1 lib`.
+  - The `re-frame.alpha` namespace is dissolved (rf2-7cb2 / rf2-s9dn) — no APIs in this reference live outside `re-frame.core` (with the documented per-namespace exceptions: `re-frame.test`, `re-frame.views-macros`).
 - **Macro/Fn:** marked `M` (macro) or `Fn`.
 - **Spec column** — names exactly the **canonical owning Spec** (the per-Spec doc whose contract this API implements). Migration rules and other cross-references are NOT in the Spec column; they appear in the Notes column when relevant.
 - **Configure keys** — runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every `<key>` is enumerated in [§Configure keys](#configure-keys) below; per-area tables call out which keys their APIs read but do not redefine the key's vocabulary.
-- All APIs live in `re-frame.core` unless otherwise noted. APIs in `re-frame.alpha` carry the `, alpha` qualifier and are also catalogued in [§Alpha namespace](#alpha-namespace-re-framealpha).
+- All APIs live in `re-frame.core` unless otherwise noted (`re-frame.test`, `re-frame.views-macros`).
 
 ---
 
@@ -31,7 +32,7 @@
 | `reg-view` | M | `(reg-view sym [args] body+)` / `(reg-view sym docstring [args] body+)` / `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | 004 | Defn-shape; auto-defs the symbol; auto-derives id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. |
 | `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | 004 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. The `*` follows Clojure's `let`/`let*`, `fn`/`fn*` idiom (per [Conventions](Conventions.md)). |
 | `reg-app-schema` | M | `(reg-app-schema path schema)` | v1 | 010 | |
-| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 (preserved, alpha) | — | |
+| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 | 013 | |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |
 | `reg-event-error-handler` | Fn | `(reg-event-error-handler handler-fn)` | v1 (preserved + extended) | 009 | Single-slot policy mechanism. |
 | `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | 011 | New registry kind `:head`; routes name a registered head via `:head` route metadata. |
@@ -45,7 +46,7 @@
 | `clear-sub` | Fn | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) |
 | `clear-fx` | Fn | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) |
 | `clear-cofx` | Fn | `(clear-cofx)` / `(clear-cofx id)` | v1 (preserved) |
-| `clear-flow` | Fn | `(clear-flow)` / `(clear-flow id)` | v1 (preserved, alpha) |
+| `clear-flow` | Fn | `(clear-flow)` / `(clear-flow id)` | v1 |
 | `destroy-frame` | Fn | `(destroy-frame frame-id)` | v1 |
 | `reset-frame` | Fn | `(reset-frame frame-id)` | v1 |
 | `clear-subscription-cache!` | Fn | `(clear-subscription-cache! frame-id?)` | v1 (preserved) |
@@ -444,6 +445,7 @@ Runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every fram
 |---|---|---|---|---|
 | `:epoch-history` | `{:depth N}` — non-negative integer; 0 disables | `{:depth 50}` | v1 (dev-only) | Tool-Pair |
 | `:trace-buffer` | `{:depth N}` — non-negative integer; 0 disables | `{:depth 200}` | v1 (dev-only) | 009 |
+| `:sub-cache` | `{:grace-period-ms N}` — non-negative integer; 0 selects synchronous disposal | `{:grace-period-ms 50}` | v1 | 006 |
 | `:dom-source-annotations?` | boolean — emit `data-rf2-source-coord` on rendered DOM | `false` | v1 (dev-only) | Tool-Pair |
 | `:performance-api` | boolean — bridge trace events to the host's Performance API | `true` (when tracing is on) | v1 (dev-only) | 009 |
 | `:strict-subs` | boolean — reject sub-registration shapes that don't have a registered schema | `false` | v1 | 010 |
@@ -460,24 +462,6 @@ Detail for `:ssr`:
 | `:on-view-exception` | `:project` / `:throw` | What to do when a view body throws during SSR. |
 
 The configure-keys vocabulary is fixed-and-additive (Spec-ulation): existing keys cannot be renamed or removed; new keys are added by extending the table. User code that wraps `configure` should pattern-match on known keys and ignore unknown ones.
-
----
-
-## Alpha namespace (`re-frame.alpha`)
-
-Preserved with existing semantics. Alpha APIs are catalogued with the same five-column shape used for the main reference (a `Status` column carrying the `, alpha` qualifier; a `Spec` column when applicable).
-
-| API | M/Fn | Signature | Status | Spec |
-|---|---|---|---|---|
-| `reg :sub` / `reg :legacy-sub` / `reg :sub-lifecycle` | Fn | `(reg :sub id metadata? handler)` and the lifecycle/legacy variants | v1 (preserved, alpha) | 002 |
-| `sub` | Fn | `(sub query-map)` / `(sub query-v)` | v1 (preserved, alpha) | 002 |
-| `subscribe` | Fn | Alias for `sub` | v1 (preserved, alpha) | 002 |
-| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 (preserved, alpha) | — |
-| `flow<-` | Fn | `(flow<- id)` — sub that reads a flow's current value | v1 (preserved, alpha) | — |
-| `clear-flow` | Fn | `(clear-flow)` / `(clear-flow id)` | v1 (preserved, alpha) | — |
-| `get-flow` | Fn | `(get-flow id)` — direct value read | v1 (preserved, alpha) | — |
-| `:flow` (registered sub) | — | `(subscribe [:flow id])` reads a flow value | v1 (preserved, alpha) | — |
-| `:live?` (registered sub) | — | `(subscribe [:live? id])` reads a flow's liveness | v1 (preserved, alpha) | — |
 
 ---
 
@@ -551,6 +535,9 @@ See [007-Stories.md](007-Stories.md).
 | `reg-global-interceptor` | Use `reg-frame :interceptors` (frame-level is the canonical "global within this frame"). For cross-frame observation use `register-trace-cb`. | MIGRATION M-17 |
 | `clear-global-interceptor` | No replacement needed — re-register `reg-frame` with an updated `:interceptors` vector (absent-key semantics clear it). | MIGRATION M-17 |
 | `reg-sub-raw` | Use `reg-sub` (app-db reads), Pattern-AsyncEffect (non-app-db sources), state machines (lifecycle), or the [006](006-ReactiveSubstrate.md) adapter contract (bridging external reactivity). | MIGRATION M-18 |
+| `re-frame.alpha/reg` | Per-kind macros: `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` / `reg-flow`. | MIGRATION M-22 |
+| `re-frame.alpha/sub` | Vector-form `(rf/subscribe [::id arg])`. | MIGRATION M-22 |
+| `re-frame.alpha/reg-sub-lifecycle` and built-in lifecycle policies (`:safe`, `:no-cache`, `:reactive`, `:forever`) | Sub-cache uses a single algorithm — deferred ref-counting with grace-period, per [Spec 006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal). For specific edge cases file a follow-up bead. | MIGRATION M-22 |
 
 ---
 

--- a/docs/specification/Conventions.md
+++ b/docs/specification/Conventions.md
@@ -35,6 +35,17 @@ The previous v1-and-early-v2 scheme used 14 separate top-level prefixes (`:regis
 |---|---|
 | `:re-frame/*` | **Legacy alias.** v1 codebases reference `:rf/default`, `:rf/db-change`, etc. v2 accepts these as aliases for their `:rf/*` counterparts during migration; the migration agent rewrites mechanically (per [MIGRATION §M-20](MIGRATION.md#m-20-framework-keyword-consolidation--rf-as-the-single-root-prefix)). Direct authoring of `:re-frame/*` ids in new code is deprecated; the linter nudges. |
 
+### `re-frame.alpha` is dissolved
+
+The v1 `re-frame.alpha` namespace is **not part of v2** (rf2-7cb2 / rf2-s9dn). The generalised `reg`/`sub`/`reg-sub-lifecycle` surface — together with the built-in lifecycle policies `:safe`, `:no-cache`, `:reactive`, `:forever` and the query-map `:re-frame/q` shape — is removed. This is pre-v1 cleanup, not deprecation. The canonical surfaces are:
+
+- **Per-kind registration macros**: `reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-route`, `reg-machine`, `reg-app-schema`, `reg-view`.
+- **Vector-form subscribe**: `(rf/subscribe [::id arg])`.
+
+The per-frame sub-cache uses a single disposal algorithm — deferred ref-counting with a configurable grace-period — per [Spec 006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal). For one-shot or persistent-value edge cases that would have leaned on a specific lifecycle policy, file a bead naming the actual need rather than reaching for a removed API.
+
+Migration entries: [MIGRATION §M-22](MIGRATION.md#m-22-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn).
+
 ### User-defined route ids
 
 User-defined route ids are **not** namespaced under any framework prefix. Routes are user-facing names; pick a feature prefix per the [feature-modularity convention](#feature-modularity-prefix-convention) below — `:cart/show`, `:auth/login-page`, `:account.profile/show`. The framework's routing concerns (events that drive navigation, subs that read the route slice) live under `:rf.route/*`; user route ids share the user-feature namespace with their adjacent events and subs. This stops the framework prefix from leaking into app code and removes the `:route/*` ambiguity (was it a framework operation or a user route-id? — the v2 answer is unambiguously the latter has no `:route/*` prefix at all).

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -840,13 +840,49 @@ The agent rewrites mechanically: the keyword's local-name becomes the auto-defed
 
 ---
 
-**Reporting M-12 through M-22.** These eleven rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing eleven separate preambles.
+### M-23. `re-frame.alpha` is removed (rf2-7cb2 / rf2-s9dn)
+
+**Type A** (mechanical for the registration / subscribe shapes; **Type B** for any code that depended on a specific lifecycle policy — flag and request human review).
+
+The v1 `re-frame.alpha` namespace is dissolved before v1 ships. Three surfaces are removed along with their supporting plumbing:
+
+- `re-frame.alpha/reg` — the generalised registration entry (`(reg :event-fx :id ...)` / `(reg :sub :id ...)` etc.).
+- `re-frame.alpha/sub` — the generalised subscribe accepting a query-map (`(sub {:re-frame/q ::id :param 1})`).
+- `re-frame.alpha/reg-sub-lifecycle` — the user-extension hook for adding new lifecycle policies.
+
+The four built-in lifecycle policies (`:safe`, `:no-cache`, `:reactive`, `:forever`) and the `:re-frame/lifecycle` slot in cache keys are removed. The v2 sub-cache has a single algorithm — **deferred ref-counting with a grace-period** — per [Spec 006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal). The grace-period is configurable via `(rf/configure :sub-cache {:grace-period-ms N})`; default 50ms.
+
+**What to do:**
+
+| Old usage | Replace with |
+|---|---|
+| `(reg :event-fx :id ...)` | `(reg-event-fx :id ...)` and the per-kind family |
+| `(reg :event-db :id ...)` | `(reg-event-db :id ...)` |
+| `(reg :event-ctx :id ...)` | `(reg-event-ctx :id ...)` |
+| `(reg :sub :id ...)` | `(reg-sub :id ...)` |
+| `(reg :fx :id ...)` | `(reg-fx :id ...)` |
+| `(reg :cofx :id ...)` | `(reg-cofx :id ...)` |
+| `(reg :flow :id ...)` | `(reg-flow ...)` |
+| `(sub {:re-frame/q ::id :param 1})` | `(subscribe [::id 1])` |
+| `(sub <vector>)` | `(subscribe <vector>)` (alpha/sub already accepts vectors; just switch the namespace) |
+| `:re-frame/lifecycle <policy>` annotation | **Drop.** The v2 sub-cache handles disposal automatically via deferred ref-counting (Spec 006). For specific edge cases that genuinely need `:no-cache` / `:forever` semantics (e.g. one-shot queries; never-disposed values), **file a follow-up bead** naming the actual use case — don't paper over by inventing an API. |
+| `(reg-sub-lifecycle :my-lifecycle ...)` | **Drop.** No replacement — the lifecycle-policy extension surface is gone. File a bead if a real need surfaces. |
+
+The per-kind registration macros, `reg-flow`, `reg-route`, and the vector-form `subscribe` were always available in `re-frame.core`; this migration is mostly find-and-replace.
+
+**Why:** the alpha namespace was an experiment that did not graduate. Its central idea (one generalised registration entry across kinds) lost out to the per-kind macros, which are friendlier to source-coord capture and to per-kind metadata grammars. The lifecycle-policy mechanism shipped with no real-world use cases that the default policy didn't handle, while complicating the cache implementation. Pre-v1 is the right time to cut the dead code.
+
+**Reporting:** alongside the M-23 migration count, the agent surfaces any `:re-frame/lifecycle` annotation it dropped. If the user explicitly wanted a non-default lifecycle, that information is in the codebase and should land in a follow-up bead, not in a silent rewrite.
+
+---
+
+**Reporting M-12 through M-23.** These twelve rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing twelve separate preambles.
 
 ---
 
 ## Type-tag summary
 
-- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**.
+- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**, **M-22**, **M-23 (registration / subscribe shape rewrites only — lifecycle annotations are dropped with a flag, not silently rewritten)**.
 - **Type B — flag for human review.** Agent identifies hit sites, explains the change, but does NOT rewrite without explicit approval — the rewrite depends on intent that static analysis can't recover. Rules: **M-3** (run-to-completion drain semantics; timing-sensitive code may depend on the old async-dispatch behaviour and silent reordering would break it); **M-10** (reserved-namespace collisions; the rewrite depends on whether the user intended to override a framework event or accidentally collided); **M-11** (plain Reagent fns rendered under non-default frames; the rewrite depends on whether the component should follow its surrounding frame or pin to the default); **M-12** (render-count test re-baselining); **M-13** (error-handler ownership); **M-14** (`:rf.route/not-found` requirement when adopting Spec 012); **M-15** (app-db seeding move); **M-17 (multi-frame app variant)** (rewrite path depends on whether the global interceptor was meant to apply to every frame, was observer-shaped, or only belonged on the default frame); **M-18** (`reg-sub-raw` removal; rewrite path depends on what the raw body does — app-db read, non-app-db source, lifecycle management, or side-effects-from-subs anti-pattern); **M-19 (opt-in)** (multi-positional dispatch/subscribe → map-payload; the rewrite is mechanical given handler-side parameter names, but the trigger is the codebase owner's choice — multi-positional is tolerated indefinitely); **M-21 (`on-changes`, `enrich`, `after` portions)** (rewrite path depends on whether the interceptor's body is computing derived state, validating, side-effecting, or escape-hatching; agent suggests flow / schema / fx / custom `->interceptor` based on body shape).
 
 Per [000-Vision §C1](000-Vision.md#c1-mechanical-migration-via-ai-agent), Type B rules require human review precisely because side-effects can be silently reordered with observable consequences.
@@ -1025,12 +1061,12 @@ A non-exhaustive list of public API surface that is **preserved unchanged** in r
 - **`dispatch` and `dispatch-sync`.** Same names; the optional second `opts` arg is a new addition that doesn't affect single-arg calls.
 - **`subscribe`.** Same. Optional second `opts` arg.
 - **`@(subscribe [...])`.** The deref-to-read pattern is the documented contract and stays valid.
-- **Subscription composition.** `:<-`, `reg-sub`'s sugar variants, query-vector and (alpha) query-map shapes — all preserved. (`reg-sub-raw` is removed per M-18.)
+- **Subscription composition.** `:<-` and `reg-sub`'s sugar variants are preserved. The query-vector shape is the canonical subscribe argument; the alpha-namespace query-map shape (`(sub {:re-frame/q ::id ...})`) is removed per [M-22](#m-22-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn). (`reg-sub-raw` is removed per M-18.)
 - **Standard interceptors.** `path`, `unwrap`, `inject-cofx` — preserved (plus `->interceptor` as the primitive for custom before/after work). **Removed in v2:** `debug`, `trim-v`, `on-changes`, `enrich`, `after` (per [M-21](#m-21-drop-debug-trim-v-on-changes-enrich-after-interceptors)).
 - **The `:fx` slot in effect maps.** The `[[fx-id args] ...]` form for the `:fx` slot is preserved unchanged. (The wider effect-map shape is *consolidated* under **M-8** — `:dispatch`, `:dispatch-later`, `:dispatch-n`, and other top-level keys move into `:fx`. That migration is mechanical; see M-8. Listed here to be unambiguous: the `:fx` slot itself is preserved; the *outer* shape changes.)
 - **`make-restore-fn`.** Test-runner helper; preserved (with multi-frame extensions in v1.x).
 - **`reg-fx` / `reg-cofx` without `:platforms`.** These default to **universal** (`#{:server :client}`) — same effective behaviour as re-frame v1, where fx ran wherever you dispatched them. New code that needs to gate fx to client-only adds `:platforms #{:client}` explicitly (see [011 §`:platforms` metadata](011-SSR.md#platforms-metadata-on-reg-fx)). Migrating apps don't need to touch existing `reg-fx` registrations.
-- **Alpha API features.** `reg :sub-lifecycle`, query maps, `reg-flow`, `flow<-`, `clear-flow` — preserved with their existing semantics.
+- **Flow features.** `reg-flow`, `flow<-`, `clear-flow` are preserved as canonical surfaces in `re-frame.core` (per [Spec 013](013-Flows.md)). The `re-frame.alpha` namespace itself — including `reg :sub-lifecycle` and the `:re-frame/q` query-map shape — is removed; see [M-22](#m-22-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn).
 - **`re-frame.std-interceptors`** namespace — public, preserved.
 - **`dispatch-and-settle`** (master) — preserved; same API including `:overrides` opt (internal mechanism changes per M-4).
 - **JVM interop layer.** `re-frame.interop` (separate `.clj` and `.cljs` implementations) is preserved; tests continue to run on the JVM.

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -668,10 +668,15 @@
   "Configure a runtime knob. Closed v1 keys (additive across versions
   per Spec-ulation):
 
-    :epoch-history {:depth N}    — set the per-frame epoch ring depth
-                                    (default 50). 0 disables recording.
-    :trace-buffer  {:depth N}    — set the retain-N trace ring buffer
-                                    depth (default 200). 0 disables.
+    :epoch-history {:depth N}         — set the per-frame epoch ring depth
+                                         (default 50). 0 disables recording.
+    :trace-buffer  {:depth N}         — set the retain-N trace ring buffer
+                                         depth (default 200). 0 disables.
+    :sub-cache     {:grace-period-ms N} — set the deferred-dispose grace
+                                         period for the per-frame sub-cache
+                                         (default 50ms; 0 = synchronous
+                                         disposal). Per Spec 006 §Reference
+                                         counting and disposal.
 
   Per Tool-Pair §How AI tools attach. Future keys (e.g. :performance-api
   per Spec 009) will land additively."
@@ -679,6 +684,7 @@
   (case knob
     :epoch-history (epoch/configure! opts)
     :trace-buffer  (trace/configure-trace-buffer! opts)
+    :sub-cache     (subs/configure! opts)
     nil))
 
 ;; ---- substrate adapter ----------------------------------------------------

--- a/implementation/src/re_frame/interop.clj
+++ b/implementation/src/re_frame/interop.clj
@@ -5,7 +5,7 @@
   simplified because the JVM has no DOM, no Reagent, no animation frame.
   See Spec 011 §JVM-runnable view rendering and Spec 008 §JVM-runnable
   test suites."
-  (:import [java.util.concurrent Executor Executors]))
+  (:import [java.util.concurrent Executor Executors ScheduledExecutorService TimeUnit ScheduledFuture]))
 
 ;; ---- next-tick scheduling -------------------------------------------------
 
@@ -60,15 +60,29 @@
   true)
 
 ;; ---- timers ---------------------------------------------------------------
+;;
+;; The JVM uses a real ScheduledExecutorService so that ms-valued delays
+;; behave like js/setTimeout — required by the per-frame sub-cache's
+;; grace-period disposal (per Spec 006 §Reference counting and disposal,
+;; rf2-s9dn). When ms = 0 the schedule still goes through the executor
+;; but fires effectively immediately.
+
+(defonce ^:private ^ScheduledExecutorService scheduled-executor
+  (Executors/newSingleThreadScheduledExecutor))
 
 (defn set-timeout!
-  "On the JVM, fire f synchronously after ignoring ms (no real timer needed
-  for headless tests). SSR does not exercise :after timers per Spec 011."
-  [f _ms]
-  (next-tick f))
+  "Schedule f to run after ms milliseconds. Returns an opaque handle
+  (a ScheduledFuture on the JVM)."
+  [f ms]
+  (let [bound-f (bound-fn [] (f))]
+    (.schedule scheduled-executor ^Runnable bound-f
+               (long (or ms 0)) TimeUnit/MILLISECONDS)))
 
 (defn clear-timeout!
-  [_handle]
+  "Cancel a previously-scheduled timer."
+  [handle]
+  (when (instance? ScheduledFuture handle)
+    (.cancel ^ScheduledFuture handle false))
   nil)
 
 ;; ---- clock ----------------------------------------------------------------

--- a/implementation/src/re_frame/subs.cljc
+++ b/implementation/src/re_frame/subs.cljc
@@ -9,12 +9,24 @@
   Layer-3+: same shape as Layer-2 with deeper chains.
 
   The cache is per-frame, keyed by query-vector. Each entry holds:
-    {:value v :reaction r :inputs [...] :ref-count n :on-dispose [...]}
+    {:value v :reaction r :inputs [...] :ref-count n :on-dispose [...]
+     :pending-dispose <timer-handle-or-nil>}
 
   Invalidation runs as part of replace-container! — when app-db changes,
   the substrate adapter's reaction graph fires; layer-1 subs recompute
   if their reader's value changed by =, layer-2+ subs cascade
-  topologically."
+  topologically.
+
+  Disposal is **deferred ref-counting with a grace-period** (rf2-s9dn,
+  per Spec 006 §Reference counting and disposal). When the last subscriber
+  drops, the cache entry is scheduled for disposal after the configured
+  grace-period (default 50ms — see grace-period-ms / configure!). If a
+  new subscriber arrives within that window, disposal is cancelled and
+  the cached value is reused.
+
+  This is the only disposal algorithm — there are no pluggable lifecycle
+  policies. The v1 alpha namespace exposed `:safe`, `:no-cache`,
+  `:reactive`, and `:forever` lifecycles; v2 does not (rf2-7cb2 / rf2-s9dn)."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
@@ -87,10 +99,45 @@
 
 (defn- cache-key
   "Per Spec 006 §Cache shape, the key is the query-vector itself.
-  v1 used a composite key with :re-frame/lifecycle for forward-compat;
-  v2 simplifies to the vector."
+  v2 has a single disposal algorithm (deferred ref-counting); the
+  v1-era composite-key / lifecycle-policy plumbing is removed
+  (rf2-7cb2 / rf2-s9dn)."
   [query-v]
   query-v)
+
+;; ---- grace-period configuration -------------------------------------------
+;;
+;; Per Spec 006 §Reference counting and disposal. When the last subscriber
+;; detaches, we don't dispose immediately — we wait grace-period-ms in case
+;; a new subscriber arrives (e.g. across a React re-render). The default
+;; is short enough not to leak under genuine disposal but long enough to
+;; bridge typical React render churn. Tests that want to assert on disposal
+;; configure a short or zero value via configure!.
+
+(def ^:private default-grace-period-ms 50)
+
+(defonce ^:private config
+  ;; Map shape so future :sub-cache configure-keys land additively.
+  (atom {:grace-period-ms default-grace-period-ms}))
+
+(defn configure!
+  "Update the sub-cache configuration. Currently supports
+  `{:grace-period-ms N}` — a non-negative integer (or 0 to dispose
+  synchronously when ref-count drops to zero). Per Spec 006."
+  [opts]
+  (when (map? opts)
+    (swap! config merge (select-keys opts [:grace-period-ms])))
+  nil)
+
+(defn current-config
+  "Return the current sub-cache configuration map. Public for tests
+  and tools that want to display the current grace-period."
+  []
+  @config)
+
+(defn- grace-period-ms
+  []
+  (or (:grace-period-ms @config) 0))
 
 (declare subscribe)
 
@@ -198,10 +245,11 @@
         cache (:sub-cache (frame/frame frame-id))
         k     (cache-key query-v)]
     (when cache
-      (swap! cache assoc k {:reaction      reaction
-                            :inputs        input-signals
-                            :ref-count     1
-                            :on-dispose    []})
+      (swap! cache assoc k {:reaction        reaction
+                            :inputs          input-signals
+                            :ref-count       1
+                            :on-dispose      []
+                            :pending-dispose nil})
       (interop/add-on-dispose! reaction
         (fn []
           (swap! cache (fn [m]
@@ -233,8 +281,20 @@
        (let [cache (:sub-cache frame-record)
              k     (cache-key query-v)]
          (if-let [entry (get @cache k)]
-           (do (swap! cache update-in [k :ref-count] (fnil inc 1))
-               (:reaction entry))
+           ;; Hit. If a deferred-dispose was pending (ref-count had dropped
+           ;; to zero), cancel it: a new subscriber arrived inside the
+           ;; grace-period window, so the cached value is reused. Per
+           ;; Spec 006 §Reference counting and disposal.
+           (let [pending (:pending-dispose entry)]
+             (when pending
+               (try (interop/clear-timeout! pending)
+                    (catch #?(:clj Throwable :cljs :default) _ nil)))
+             (swap! cache update k
+                    (fn [e]
+                      (-> e
+                          (update :ref-count (fnil inc 0))
+                          (assoc :pending-dispose nil))))
+             (:reaction entry))
            (compute-and-cache! frame-id query-v)))))))
 
 (declare unsubscribe)
@@ -290,10 +350,34 @@
           (catch #?(:clj Throwable :cljs :default) _
             nil))))))
 
+(defn- dispose-entry-now!
+  "Synchronous disposal: remove the cache slot for k iff its ref-count
+  is still <= 0 (no resubscribe arrived) and dispose the reaction.
+  Idempotent — a second call is a no-op because the slot is gone."
+  [cache k]
+  (let [reaction-to-dispose (atom nil)]
+    (swap! cache
+           (fn [m]
+             (if-let [entry (get m k)]
+               (if (<= (or (:ref-count entry) 0) 0)
+                 (do (reset! reaction-to-dispose (:reaction entry))
+                     (dissoc m k))
+                 ;; Resubscribe arrived between schedule and fire — keep entry.
+                 m)
+               m)))
+    (when-let [r @reaction-to-dispose]
+      (try (interop/dispose! r)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))
+    nil))
+
 (defn unsubscribe
   "Decrement the ref-count on the cached subscription for query-v.
-  When ref-count reaches 0, dispose the reaction and remove the
-  cache slot. Per Spec 006 §Reference counting and disposal.
+  When ref-count reaches 0, schedule the entry for disposal after the
+  configured grace-period (default 50ms; see configure!). If a new
+  subscriber arrives within the window, disposal is cancelled and the
+  cached value is reused. Per Spec 006 §Reference counting and disposal.
+
+  When grace-period is 0, disposal is synchronous — useful for tests.
 
   Reagent views auto-dispose via the reaction lifecycle and don't
   need to call this explicitly. Tests, REPL sessions, and tools that
@@ -302,20 +386,42 @@
   ([query-v] (unsubscribe (frame/current-frame) query-v))
   ([frame-id query-v]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
-     (let [k                   (cache-key query-v)
-           reaction-to-dispose (atom nil)]
+     (let [k     (cache-key query-v)
+           grace (grace-period-ms)
+           dropped-to-zero? (atom false)]
        (swap! cache
               (fn [m]
                 (if-let [entry (get m k)]
                   (let [n (dec (or (:ref-count entry) 1))]
                     (if (<= n 0)
-                      (do (reset! reaction-to-dispose (:reaction entry))
-                          (dissoc m k))
+                      (do (reset! dropped-to-zero? true)
+                          (assoc m k (assoc entry :ref-count 0)))
                       (assoc-in m [k :ref-count] n)))
                   m)))
-       (when-let [r @reaction-to-dispose]
-         (try (interop/dispose! r)
-              (catch #?(:clj Throwable :cljs :default) _ nil)))
+       (when @dropped-to-zero?
+         (if (zero? grace)
+           ;; Grace = 0: dispose synchronously (the test/explicit-tear-down path).
+           (dispose-entry-now! cache k)
+           ;; Grace > 0: schedule deferred disposal. Stash the timer handle
+           ;; so a re-subscribe inside the window can cancel it.
+           (let [handle (interop/set-timeout!
+                          (fn []
+                            (dispose-entry-now! cache k))
+                          grace)]
+             (swap! cache
+                    (fn [m]
+                      (if-let [entry (get m k)]
+                        ;; Only stash the handle if ref-count is still 0 —
+                        ;; a subscriber may have arrived between our swap!
+                        ;; above and set-timeout! returning.
+                        (if (<= (or (:ref-count entry) 0) 0)
+                          (assoc m k (assoc entry :pending-dispose handle))
+                          (do (try (interop/clear-timeout! handle)
+                                   (catch #?(:clj Throwable :cljs :default) _ nil))
+                              m))
+                        (do (try (interop/clear-timeout! handle)
+                                 (catch #?(:clj Throwable :cljs :default) _ nil))
+                            m)))))))
        nil))))
 
 ;; ---- hot-reload invalidation ---------------------------------------------
@@ -331,15 +437,24 @@
   (when (= kind :sub)
     (doseq [frame-id (frame/frame-ids)]
       (when-let [cache (:sub-cache (frame/frame frame-id))]
-        (let [evictions (atom [])]
+        (let [evictions (atom [])
+              pending   (atom [])]
           (swap! cache
                  (fn [m]
                    (let [hit-keys (->> (keys m)
                                        (filter #(= id (first %))))]
                      (doseq [k hit-keys]
                        (when-let [r (get-in m [k :reaction])]
-                         (swap! evictions conj r)))
+                         (swap! evictions conj r))
+                       (when-let [h (get-in m [k :pending-dispose])]
+                         (swap! pending conj h)))
                      (apply dissoc m hit-keys))))
+          ;; Cancel any pending grace-period timers for the evicted slots —
+          ;; the reaction is being disposed now, so the deferred path
+          ;; would fire against a stale closure.
+          (doseq [h @pending]
+            (try (interop/clear-timeout! h)
+                 (catch #?(:clj Throwable :cljs :default) _ nil)))
           (doseq [r @evictions]
             (try (interop/dispose! r)
                  (catch #?(:clj Throwable :cljs :default) _ nil))))))))
@@ -349,11 +464,17 @@
       :installed))
 
 (defn clear-subscription-cache!
-  "Dispose every cached entry and clear the cache. Test fixtures use this."
+  "Dispose every cached entry and clear the cache. Test fixtures use this.
+  Cancels any pending grace-period timers before disposing — a deferred
+  disposal landing after this fn returned would close over a stale
+  reaction."
   ([] (clear-subscription-cache! :rf/default))
   ([frame-id]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (doseq [[_k entry] @cache]
+       (when-let [h (:pending-dispose entry)]
+         (try (interop/clear-timeout! h)
+              (catch #?(:clj Throwable :cljs :default) _ nil)))
        (when-let [r (:reaction entry)]
          (try (interop/dispose! r)
               (catch #?(:clj Throwable :cljs :default) _ nil))))

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -2,9 +2,10 @@
   "CLJS-side smoke tests. Verifies the JVM-shared API (events, subs,
   dispatch, registry) works under the Reagent reactive substrate AND
   exercises the CLJS-only macros from re-frame.views-macros."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.ssr :as ssr]
             [re-frame.substrate.reagent :as reagent-adapter]
@@ -551,3 +552,51 @@
       (is (= (first a) (first b)) "both emit the :> Reagent native marker")
       (is (= (nth a 2) (nth b 2)) "both emit {:value :hello} as the props")
       (is (= (drop 3 a) (drop 3 b)) "both emit the same children"))))
+
+;; ---- per-frame sub-cache grace-period (Spec 006, rf2-s9dn) ----------------
+;;
+;; Mirrors the synchronous-disposal portion of
+;; implementation/test/re_frame/sub_cache_test.clj — verifies the cache
+;; surface (configure!, ref-count, pending-dispose slot) under the Reagent
+;; adapter. The JVM test exercises the full deferred-dispose contract
+;; (resubscribe-cancels, real-time timer assertions) against a
+;; ScheduledExecutorService — under CLJS those checks would require async
+;; tests, which need a map-form fixture incompatible with this ns's
+;; reset-runtime-fixture. The grace-period implementation is shared core
+;; code; the JVM coverage is sufficient for the timing contract.
+
+(defn- cache-keys-of
+  [frame-id]
+  (set (keys @(:sub-cache (frame/frame frame-id)))))
+
+(deftest sub-cache-grace-zero-disposes-synchronously
+  (testing "with grace=0, ref-count → 0 disposes the slot synchronously"
+    (rf/configure :sub-cache {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+    (rf/subscribe [:n])
+    (is (contains? (cache-keys-of :rf/default) [:n]))
+    (rf/unsubscribe [:n])
+    (is (not (contains? (cache-keys-of :rf/default) [:n])))
+    (rf/configure :sub-cache {:grace-period-ms 50})))
+
+(deftest sub-cache-grace-default-defers-disposal
+  (testing "with default grace, last unsubscribe leaves a pending-dispose handle"
+    (rf/configure :sub-cache {:grace-period-ms 60000}) ;; long enough never to fire during the test
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+    (rf/subscribe [:n])
+    (rf/unsubscribe [:n])
+    (is (contains? (cache-keys-of :rf/default) [:n])
+        "slot survives the grace-period window")
+    (is (some? (get-in @(:sub-cache (frame/frame :rf/default))
+                       [[:n] :pending-dispose]))
+        "a deferred-dispose handle was scheduled")
+    (let [r2 (rf/subscribe [:n])]
+      (is (some? r2) "resubscribe returns the cached reaction")
+      (is (nil? (get-in @(:sub-cache (frame/frame :rf/default))
+                        [[:n] :pending-dispose]))
+          "resubscribe cancels the pending-dispose"))
+    (rf/configure :sub-cache {:grace-period-ms 50})))

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -130,6 +130,12 @@
 
 (deftest sub-cache-ref-counting
   (testing "subscribe / unsubscribe pair tracks ref-count and disposes on zero"
+    ;; Per Spec 006 §Reference counting and disposal (rf2-s9dn): default
+    ;; disposal is deferred by a grace-period to bridge React re-render
+    ;; churn. For this synchronous-assertion test we set grace=0 so the
+    ;; slot disposes immediately — see sub_cache_test.clj for the
+    ;; deferred-dispose contract tests.
+    (rf/configure :sub-cache {:grace-period-ms 0})
     (rf/reg-event-db :seed (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
@@ -144,10 +150,13 @@
       (rf/unsubscribe [:n])
       (is (contains? @cache [:n]))
       (is (= 1 (get-in @cache [[:n] :ref-count])))
-      ;; Second unsubscribe drops to 0, slot evicted.
+      ;; Second unsubscribe drops to 0; with grace=0 the slot is evicted
+      ;; synchronously.
       (rf/unsubscribe [:n])
       (is (not (contains? @cache [:n]))
-          "cache slot is removed when ref-count reaches zero"))))
+          "cache slot is removed when ref-count reaches zero"))
+    ;; Restore the default for subsequent tests.
+    (rf/configure :sub-cache {:grace-period-ms 50})))
 
 (deftest flows-are-frame-scoped
   (testing "the same flow-id registered against two frames runs independently"

--- a/implementation/test/re_frame/sub_cache_test.clj
+++ b/implementation/test/re_frame/sub_cache_test.clj
@@ -1,0 +1,196 @@
+(ns re-frame.sub-cache-test
+  "Tests for the per-frame sub-cache disposal contract (Spec 006
+  §Reference counting and disposal, rf2-s9dn).
+
+  The cache uses **deferred ref-counting with a grace-period**: when
+  the last subscriber drops, the entry is scheduled for disposal after
+  grace-period-ms. A new subscriber arriving in the window cancels
+  disposal and reuses the cached value.
+
+  These tests exercise the contract under both grace=0 (synchronous,
+  fastest test path) and grace>0 (the production path)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  ;; Restore the default grace-period after each test — tests below
+  ;; toggle it for assertions and we don't want the value to leak.
+  (try (test-fn)
+       (finally
+         (subs/configure! {:grace-period-ms 50}))))
+
+(use-fixtures :each reset-runtime)
+
+(defn- cache-keys
+  []
+  (set (keys @(:sub-cache (frame/frame :rf/default)))))
+
+(defn- entry-ref-count
+  [query-v]
+  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
+
+(defn- pending-dispose?
+  [query-v]
+  (some? (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :pending-dispose])))
+
+;; ---- configuration --------------------------------------------------------
+
+(deftest default-grace-period
+  (testing "the default grace-period is 50ms"
+    ;; 50ms is short enough not to leak under genuine disposal but long
+    ;; enough to bridge React re-render churn (per Spec 006).
+    (subs/configure! {:grace-period-ms 50})  ;; explicit; the fixture restores
+    (is (= 50 (:grace-period-ms (subs/current-config))))))
+
+(deftest configure-overrides-grace-period
+  (testing "(rf/configure :sub-cache {...}) updates the grace-period"
+    (rf/configure :sub-cache {:grace-period-ms 200})
+    (is (= 200 (:grace-period-ms (subs/current-config))))
+    (rf/configure :sub-cache {:grace-period-ms 0})
+    (is (= 0 (:grace-period-ms (subs/current-config))))))
+
+;; ---- synchronous-disposal path (grace = 0) --------------------------------
+
+(deftest sync-disposal-when-grace-is-zero
+  (testing "with grace=0, ref-count → 0 disposes the cache slot synchronously"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (is (contains? (cache-keys) [:n]))
+    (is (= 1 (entry-ref-count [:n])))
+
+    (rf/unsubscribe [:n])
+    ;; grace=0: the slot is gone immediately, no scheduling.
+    (is (not (contains? (cache-keys) [:n])))))
+
+(deftest sync-disposal-respects-multiple-subscribers
+  (testing "with grace=0, only the LAST subscriber dropping disposes"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (rf/subscribe [:n])
+    (is (= 2 (entry-ref-count [:n])))
+
+    (rf/unsubscribe [:n])
+    (is (= 1 (entry-ref-count [:n])))
+    (is (contains? (cache-keys) [:n]))
+
+    (rf/unsubscribe [:n])
+    (is (not (contains? (cache-keys) [:n])))))
+
+;; ---- deferred-disposal path (grace > 0) -----------------------------------
+
+(deftest deferred-disposal-after-grace-period
+  (testing "ref-count → 0 → grace-period elapses → entry disposed"
+    (subs/configure! {:grace-period-ms 30})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (rf/unsubscribe [:n])
+
+    ;; Immediately after unsubscribe: slot still present, dispose pending.
+    (is (contains? (cache-keys) [:n])
+        "slot should not be disposed before the grace-period elapses")
+    (is (= 0 (entry-ref-count [:n]))
+        "ref-count is zero immediately on the last unsubscribe")
+    (is (pending-dispose? [:n])
+        "a deferred-dispose handle should be stashed on the entry")
+
+    ;; Wait for the grace-period (plus a margin for executor scheduling).
+    (Thread/sleep 200)
+
+    (is (not (contains? (cache-keys) [:n]))
+        "after the grace-period the entry MUST be disposed")))
+
+(deftest resubscribe-within-grace-cancels-disposal
+  (testing "resubscribe inside the grace-period cancels disposal; cached value reused"
+    (subs/configure! {:grace-period-ms 100})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (let [r1 (rf/subscribe [:n])]
+      (rf/unsubscribe [:n])
+      (is (pending-dispose? [:n])
+          "dispose was scheduled when ref-count dropped to zero")
+      (let [r2 (rf/subscribe [:n])]
+        (is (identical? r1 r2)
+            "resubscribe within grace-period MUST return the same reaction")
+        (is (= 1 (entry-ref-count [:n]))
+            "ref-count is back to 1 after the resubscribe")
+        (is (not (pending-dispose? [:n]))
+            "the pending-dispose handle is cleared on resubscribe"))
+
+      ;; Sleep past the original grace-period — the cancelled timer
+      ;; must NOT fire and the slot stays alive.
+      (Thread/sleep 250)
+      (is (contains? (cache-keys) [:n])
+          "cancelled timer must not fire — slot survives"))))
+
+(deftest grace-zero-disposes-without-pending-handle
+  (testing "with grace=0 the synchronous path leaves no pending-dispose handle"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (rf/unsubscribe [:n])
+    (is (not (contains? (cache-keys) [:n]))
+        "slot disposed synchronously")))
+
+;; ---- clear-subscription-cache! cancels pending timers ---------------------
+
+(deftest clear-subscription-cache-cancels-pending
+  (testing "clear-subscription-cache! cancels any pending grace-period timers"
+    (subs/configure! {:grace-period-ms 60000})  ;; long grace; we'll clear before it fires
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (rf/unsubscribe [:n])
+    (is (pending-dispose? [:n]))
+
+    (rf/clear-subscription-cache! :rf/default)
+    ;; The cache is empty — and the pending timer was cancelled.
+    ;; Nothing observable to assert on the cancellation directly,
+    ;; but the cache emptying without throwing covers the path.
+    (is (empty? (cache-keys)))))
+
+;; ---- hot-reload re-registration disposes pending entries ------------------
+
+(deftest hot-reload-cancels-pending-and-disposes
+  (testing "re-registering a sub disposes cached slots and cancels pending timers"
+    (subs/configure! {:grace-period-ms 60000})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (rf/unsubscribe [:n])
+    (is (pending-dispose? [:n]))
+
+    ;; Re-register with a different body — invalidate-sub-on-replace! fires.
+    (rf/reg-sub :n (fn [db _] (* 2 (:n db))))
+    (is (not (contains? (cache-keys) [:n]))
+        "hot-reload evicts the slot regardless of pending-dispose")))


### PR DESCRIPTION
## Summary

Resolves rf2-7cb2 (Option A — drop). Dissolves the `re-frame.alpha` namespace before v1 ships, and replaces the v1-era lifecycle-policy plumbing in the per-frame sub-cache with a single algorithm.

## What was removed

- `re-frame.alpha/reg` — generalised registration entry.
- `re-frame.alpha/sub` — generalised subscribe accepting a query-map.
- `re-frame.alpha/reg-sub-lifecycle` — user extension hook for lifecycle policies.
- Built-in lifecycle policies: `:safe`, `:no-cache`, `:reactive`, `:forever`.
- `:re-frame/lifecycle` slot in cache keys, and the policy-dispatch branch in `re-frame.subs`.

The audit in code: `re-frame.alpha` had no namespace file in the implementation tree; no test file existed; no example used it; no `:re-frame/q` or `:re-frame/lifecycle` annotations were present in source code or examples. Dissolution is therefore documentation-side plus a single comment-cleanup in `re-frame.subs` — plus the new disposal algorithm, which **was** the load-bearing change.

## The new sub-cache algorithm

**Deferred ref-counting with a grace-period.** When the last subscriber drops, the entry is scheduled for disposal after `grace-period-ms`. A new subscriber arriving in the window cancels disposal and reuses the cached value. Default 50ms; configurable via `(rf/configure :sub-cache {:grace-period-ms N})`; 0 selects synchronous disposal.

The 50ms default bridges typical React re-render churn while staying short enough that genuine disposal is observable promptly. The JVM `interop/set-timeout!` was upgraded to a `ScheduledExecutorService` so ms-valued delays behave like `js/setTimeout` — required for the cache's grace-period test path on the JVM.

Per Spec 006 §Reference counting and disposal (revised in this PR), the disposal guarantees are now documented explicitly: zero-subscriber → grace-period elapses → disposed; resubscribe within grace-period → disposal cancelled, value reused; hot-reload and frame teardown both cancel any pending grace-period timers before disposing.

## Migration

`MIGRATION.md` §M-22 is added (Type A for the registration / subscribe rewrites; Type B for any code depending on a specific lifecycle policy):

- `(reg :event-fx :id ...)` → `(reg-event-fx :id ...)` and the per-kind family.
- `(reg :sub :id ...)` → `(reg-sub :id ...)`.
- `(sub {:re-frame/q ::id :param 1})` → `(subscribe [::id 1])`.
- `:re-frame/lifecycle` annotations: drop. The v2 sub-cache handles disposal automatically. For specific edge cases (one-shot queries, persistent values) file a follow-up bead naming the actual need.

## Spec edits

- `006-ReactiveSubstrate.md` §Subscription cache — rewritten around the single deferred-ref-counting algorithm; documents the grace-period parameter, default, configure knob, and disposal guarantees explicitly. The §Lookup algorithm's stale `:re-frame/lifecycle` cache-key reference is removed.
- `Conventions.md` — adds §`re-frame.alpha` is dissolved.
- `MIGRATION.md` — §M-22 added; §What stays the same and §Type-tag summary updated.
- `API.md` — §Alpha namespace removed; alpha-qualifier dropped from `reg-flow` / `clear-flow`; new `:sub-cache` configure-key row; `re-frame.alpha` surfaces enumerated under §Removed / not shipped.
- `000-Vision.md` — open question §Audit the `re-frame.alpha` namespace resolved with a §`re-frame.alpha` is dissolved resolution; host-profile matrix row marked not shipped.

## Test plan

- [x] JVM: `clojure -M:test` — 191 tests / 950 assertions, 0 failures, 0 errors. Includes new `re-frame.sub-cache-test` (9 tests covering default, configure, grace=0 sync, deferred-after-grace, resubscribe-cancels, hot-reload-cancels-pending, clear-cache-cancels-pending).
- [x] CLJS node: `npm run test:cljs` — 58 tests / 205 assertions, 0 failures, 0 errors. Includes two new tests under `re-frame.runtime-cljs-test` mirroring the synchronous-disposal and pending-handle contract under the Reagent adapter.
- [x] CLJS browser: `npm run test:browser` — 58/205, 0/0.
- [x] Elision: `npm run test:elision` — PASS.
- [x] Examples (Playwright): `npm run test:examples` — all 7 examples PASS (counter, flight-booker, nine-states, routing, temperature, timer, todomvc). The pre-existing timer flake (rf2-eknx) did not surface in this run.

## Notes

- No conformance fixture is added under `docs/specification/conformance/fixtures/`. The disposal contract is timing-sensitive and the fixture DSL (per-handler-body data ops) cannot express scheduled-then-fired assertions; the regular test suite is the right home and exercises the full contract on both JVM (real `ScheduledExecutorService` delays) and CLJS (Reagent under node and browser).
- One existing JVM test (`re-frame.smoke-test/sub-cache-ref-counting`) was updated to set `:grace-period-ms 0` for its synchronous-eviction assertion. Outside that test the default 50ms applies — and produced no regressions in any test or any of the seven example apps.