### PR TITLE
docs: conformance README documents render-time observables gap (rf2-j9yf)

### DIFF
--- a/docs/specification/conformance/README.md
+++ b/docs/specification/conformance/README.md
@@ -231,6 +231,12 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 
 Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration.
 
+## Render-time observables (out of scope)
+
+The corpus is host-agnostic pure-data event/sub/fx semantics. Render-time observables — React-context propagation through `frame-provider`, Reagent reactivity, component lifecycle, and the like — are not currently expressible as fixtures because the corpus has no render capability and no harness side that mounts a component tree to capture what happens during render. These behaviours are verified by host-side unit tests instead (e.g. `runtime_cljs_test.cljs` covers `frame-provider`'s establish-context and nested-override behaviour for the CLJS reference).
+
+If a port (CLJS, JVM SSR, future hosts) needs to claim conformance for render-time behaviour, this README will grow a `:reagent/render` (or equivalent) capability tag and a host-side fixture runner that mounts the fixture's tree and captures the observable. Tracked as future work — see bead `rf2-j9yf` for context.
+
 ## Cross-references
 
 - [Implementor-Checklist.md](../Implementor-Checklist.md) — decision-ordered companion to [000 §Host-profile matrix](../000-Vision.md#host-profile-matrix); Part 1 capability declarations and Part 3 (Conformance) tell the implementor which fixtures will run.


### PR DESCRIPTION
## Summary

Adds a "Render-time observables (out of scope)" subsection to `docs/specification/conformance/README.md` clarifying that the conformance corpus is host-agnostic pure-data event/sub/fx semantics and does not currently express render-time behaviours.

- Calls out frame-provider's React-context propagation, Reagent reactivity, and component lifecycle as render-time observables that fixtures cannot express today.
- Notes that these behaviours are covered by host-side unit tests (e.g. `runtime_cljs_test.cljs` for `frame-provider`).
- Records the forward path: a `:reagent/render` (or equivalent) capability tag plus a host-side fixture runner that mounts a tree and captures the observable. Tracked as future work under bead `rf2-j9yf`.

No code or fixture changes; documentation only.