### PR TITLE
feat: reg-view defn-shape macro + reg-view* fn + sweep (rf2-d0pi, rf2-kauy)

### DIFF
--- a/docs/specification/001-Registration.md
+++ b/docs/specification/001-Registration.md
@@ -67,7 +67,7 @@ For backwards-compatibility with re-frame v1, the middle slot of `reg-event-*` a
 
 The macro discriminates on the type of the second argument: vector → legacy path, map → new path. Both forms live in the same `reg-event-fx` symbol. The migration agent translates legacy → new on demand (per [MIGRATION.md §O-1](MIGRATION.md)).
 
-For `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-frame`, `reg-app-schema`, etc., the middle-slot is the metadata map only — there's no legacy vector form to compete with.
+For `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `reg-app-schema`, etc., the middle-slot is the metadata map only — there's no legacy vector form to compete with. `reg-view` is the **only registration that ships as a macro** (defn-shape — auto-defs the symbol, auto-derives the id, auto-injects `dispatch` / `subscribe` lexically); the plain-fn surface for runtime / programmatic registration is `reg-view*`. See [Cross-Spec-Interactions §21 Family asymmetry](Cross-Spec-Interactions.md#21-family-asymmetry--only-reg-view-has-a-macro-tier) for why the family is asymmetric.
 
 ## Registry model — the canonical `kind` keyword set
 
@@ -238,7 +238,7 @@ A pointer-only summary of the registration functions and the per-Spec docs that 
 | Subscription | `reg-sub` | [006-ReactiveSubstrate.md](006-ReactiveSubstrate.md) |
 | Effect | `reg-fx` | [002-Frames.md](002-Frames.md), [011-SSR.md](011-SSR.md) (for `:platforms`) |
 | Cofx | `reg-cofx` | [002-Frames.md](002-Frames.md) |
-| View | `reg-view` | [004-Views.md](004-Views.md) |
+| View | `reg-view` (defn-shape macro) / `reg-view*` (plain fn) | [004-Views.md](004-Views.md) |
 | Frame | `reg-frame` | [002-Frames.md](002-Frames.md) |
 | App-db schema | `reg-app-schema` | [010-Schemas.md](010-Schemas.md) |
 | Route | `reg-route` | [012-Routing.md](012-Routing.md) |

--- a/docs/specification/004-Views.md
+++ b/docs/specification/004-Views.md
@@ -1,6 +1,6 @@
 # Spec 004 — Views
 
-> Status: Drafting. **v1-required.** A view is a pure function `(state, props) → render-tree`, with the render-tree as a serialisable nested data structure. The CLJS reference's `reg-view` injects frame-bound `dispatch`/`subscribe` lexically — an ergonomic realisation of the explicit-frame contract. Hiccup is the CLJS render-tree; other hosts use their own shape. SSR ([Spec 011](011-SSR.md)) renders the same views to a string on the server without React.
+> Status: Drafting. **v1-required.** A view is a pure function `(state, props) → render-tree`, with the render-tree as a serialisable nested data structure. The CLJS reference's `reg-view` is a **defn-shape macro** that auto-defs the symbol you supply, auto-derives the registered id from `(keyword *ns* sym)`, and lexically auto-injects frame-bound `dispatch`/`subscribe` — an ergonomic realisation of the explicit-frame contract. The plain-fn surface `reg-view*` is the runtime-callable escape hatch. Hiccup is the CLJS render-tree; other hosts use their own shape. SSR ([Spec 011](011-SSR.md)) renders the same views to a string on the server without React.
 
 ## Abstract
 
@@ -108,24 +108,60 @@ Pattern-RemoteData's `:status` field is the canonical home for loading state. Pa
 
 ## `reg-view` is the multi-frame contract
 
-`reg-view` registers a render function under a keyword. The macro wraps the user's fn so that, on each render, three frame-bound names are injected as lexical locals inside the body:
+`reg-view` is a **defn-shape macro**. It registers a render function under an auto-derived id, defs the symbol you supply to the wrapped (frame-aware) fn, and auto-injects two lexical bindings — `dispatch` and `subscribe` — at every call to the rendered fn.
 
-- `dispatch` — frame-bound `(fn [event] ...)` building an envelope tagged with the surrounding frame's id.
-- `subscribe` — frame-bound `(fn [query-v] ...)` consulting the surrounding frame's sub-cache.
-- `frame-id` — the keyword identifying the surrounding frame (useful for debugging, logging, or passing to non-frame-aware children).
+### Shape
 
 ```clojure
-(rf/reg-view :counter
-  {:doc "Counter widget."}
-  (fn [label]
-    (let [n @(subscribe [:count])]
-      [:button {:on-click #(dispatch [:inc])}
-       (str label ": " n)])))
+(reg-view sym [args] body+)
+(reg-view sym docstring [args] body+)
+(reg-view ^{:rf/id :explicit/id} sym [args] body+)
 ```
 
-The `:on-click` lambda closes over the local `dispatch`, so it carries the frame into the callback automatically — there is no render-time-binding-vs-callback-time problem.
+- **Auto-id derivation.** The registered id is `(keyword (str *ns*) (str sym))` — the same shape Clojure uses for `defn` Vars. Override by attaching `^{:rf/id :explicit/id}` metadata to the symbol.
+- **Auto-defs the symbol.** `reg-view` defs `sym` to the wrapped render fn. There is no separate `(def sym (reg-view …))` step. Hiccup heads can be Var references (`[sym args]`) or `(rf/get-view :id)` results — both resolve to the same wrapped fn.
+- **Auto-injects `dispatch` and `subscribe`.** Inside the body, `dispatch` and `subscribe` are lexical bindings, bound at render-time to `(rf/dispatcher)` / `(rf/subscriber)` of the surrounding frame. They pick up the active frame on every render — there is no render-time-binding-vs-callback-time problem; the `:on-click` lambda below closes over the local `dispatch` and carries the frame into the callback automatically.
 
-**Inside a `reg-view` body, the unqualified `dispatch`/`subscribe` always come from React context** — the injected closures resolve to whatever frame the surrounding `frame-provider` puts in scope. The underlying contract is explicit-frame addressing (per [002 §View ergonomics](002-Frames.md#view-ergonomics-the-hard-part) and OQ-F-12): views can also target a different frame via `(rf/dispatch event {:frame other})` / `(rf/subscribe query {:frame other})` — the qualified two-arg form bypasses the injection. The injected unqualified form is canonical; the explicit form is the escape hatch for cross-frame work (e.g. a story-tool variant that controls a sibling variant).
+```clojure
+(rf/reg-view counter [label]
+  (let [n @(subscribe [:count])]
+    [:button {:on-click #(dispatch [:inc])}
+     (str label ": " n)]))
+
+;; … and elsewhere in hiccup:
+[counter "Hello"]
+```
+
+### Compile-time error contract
+
+`reg-view` enforces the defn-shape at macroexpand time. The second argument (after an optional docstring) MUST be the args vector. Anything else throws with a stable error pointing the user at `re-frame.core/reg-view*`:
+
+| Bad call | Why it fails |
+|---|---|
+| `(reg-view foo my-render)` | `my-render` is a Var reference, not an args vector. |
+| `(reg-view foo (reagent.core/create-class {...}))` | Form-3 (a Reagent class component) is a list, not an args vector. Form-3 is out of scope for the macro per the Reagent-v2 directive. |
+| `(reg-view foo (some-fn-returning-a-fn))` | A computed body. |
+
+The error message names the kind of value supplied and points at `reg-view*` — the plain-fn surface for runtime registration with computed ids or non-defn-shape bodies.
+
+### `reg-view*` — the plain-fn escape hatch
+
+```clojure
+(re-frame.core/reg-view* id render-fn)
+(re-frame.core/reg-view* id metadata render-fn)
+```
+
+A plain function. No auto-def. No auto-inject. No compile-time check. Use when:
+- The id is computed at runtime (dynamic dispatch).
+- The render fn is computed (a library that generates views from data).
+- The body is Reagent Form-3 (`reagent.core/create-class`) — out of scope for the macro.
+- The view is registered without a Var binding (e.g. a `defn` that registers as a side effect).
+
+Inside a `reg-view*` body the user must capture the frame explicitly via `(rf/dispatcher)` / `(rf/subscriber)` if they need frame-bound dispatch — the macro's auto-inject is exactly the convenience `reg-view*` does NOT provide.
+
+The `*` suffix is the standard Clojure idiom for the unsweetened, runtime-callable surface beneath a macro (`let` / `let*`, `fn` / `fn*`). Per [Conventions §`*`-suffix naming](Conventions.md), this convention applies wherever a macro has a fn partner; `reg-view` / `reg-view*` is the only such pair in v1.
+
+**Inside a `reg-view` body, the unqualified `dispatch`/`subscribe` always come from the surrounding frame** — the injected closures resolve to whatever frame the surrounding `frame-provider` puts in scope. The underlying contract is explicit-frame addressing (per [002 §View ergonomics](002-Frames.md#view-ergonomics-the-hard-part) and OQ-F-12): views can also target a different frame via `(rf/dispatch event {:frame other})` / `(rf/subscribe query {:frame other})` — the qualified two-arg form bypasses the injection. The injected unqualified form is canonical; the explicit form is the escape hatch for cross-frame work (e.g. a story-tool variant that controls a sibling variant).
 
 The injection mechanism is detailed in [002-Frames.md §What `reg-view` injects](002-Frames.md#what-reg-view-injects).
 
@@ -133,22 +169,18 @@ The injection mechanism is detailed in [002-Frames.md §What `reg-view` injects]
 
 v1 ships three forms for invoking a registered view. To honour the principle of "one obvious way", one of them is **canonical** and the others are **alternatives** with documented use cases.
 
-### The canonical form: `reg-view` auto-defs the Var
+### The canonical form: `reg-view` auto-defs the symbol
 
 ```clojure
-(rf/reg-view :counter
-  {:doc "A counter widget."}
-  (fn [label] ...))
-;; ⇒ defs `counter` (the local part of :counter) in the current namespace
-;;   bound to the wrapped (frame-aware) fn.
+(rf/reg-view counter [label] ...)
+;; ⇒ defs `counter` in the current namespace, bound to the wrapped
+;;    (frame-aware) fn. The id is auto-derived: (keyword *ns* "counter").
 
 ;; ... elsewhere in hiccup
 [counter "Hello"]
 ```
 
-`reg-view` *defs* the Var as part of registration. There is no separate `(def counter (rf/reg-view ...))` step — `(reg-view :counter ...)` is the one form that registers + binds. The Var name is the keyword's local name (the part after the slash); namespaced ids (e.g. `:cart.item/row`) bind the local symbol (`row`) and are accessed under their fully-qualified namespace.
-
-Override the auto-def behaviour via `:as` in the metadata — `:as 'my-counter` for explicit naming, `:as nil` to suppress the def entirely (registration-only).
+`reg-view` *defs* the symbol you supply. There is no separate `(def counter (reg-view …))` step — the macro is the one form that registers + binds. The id is auto-derived from `*ns*` + symbol; override via `^{:rf/id :explicit/id}` metadata on the symbol.
 
 ### `get-view` — the canonical post-registration lookup
 
@@ -236,7 +268,7 @@ For any plain Reagent fn that may render under a non-default frame, replace with
 (defn my-summary [label] ...)
 
 ;; after — same body, registered, frame-aware
-(def my-summary (rf/reg-view :feature/summary {:doc "..."} (fn [label] ...)))
+(rf/reg-view ^{:doc "..."} my-summary [label] ...)
 ```
 
 The CLJS reference's `re-frame.core-legacy` namespace continues to allow plain fns indefinitely; the warning is a *quality-of-life* signal, not a deprecation.
@@ -265,9 +297,8 @@ Form-1 is the **canonical** form. Form-2 and Form-3 exist for Reagent compatibil
 ### Form-1 (canonical — simple render fn)
 
 ```clojure
-(rf/reg-view :counter
-  (fn render-counter [label]
-    [:button (str label)]))
+(rf/reg-view counter [label]
+  [:button (str label)])
 ```
 
 Each render invocation runs the body fresh. No setup ceremony, no closure subtleties.
@@ -276,10 +307,9 @@ For setup-on-mount work that *would* go in a Form-2 outer fn, use a separate eve
 
 ```clojure
 ;; preferred over Form-2
-(rf/reg-view :counter
-  (fn render-counter [label]
-    [:button {:on-click #(dispatch [:counter/inc])}
-     (str label ": " @(subscribe [:count]))]))
+(rf/reg-view counter [label]
+  [:button {:on-click #(dispatch [:counter/inc])}
+   (str label ": " @(subscribe [:count]))])
 
 ;; setup happens in :on-create on the frame, or via a dedicated init event:
 (rf/reg-frame :counter-frame {:on-create [:counter/initialise]})
@@ -289,27 +319,36 @@ The setup event is named, registered, queryable — visible. The Form-2 outer-fn
 
 ### Form-2 (closure — supported, prefer Form-1 + explicit setup event)
 
-A view returning a fn (Form-2) closes over the outer scope, so the injected locals are captured by both inner-render invocations and any callbacks created in either form:
+A view body that yields a fn (Form-2) closes over the outer scope, so the injected `dispatch` / `subscribe` locals are captured by both inner-render invocations and any callbacks created in either form:
 
 ```clojure
-(rf/reg-view :counter-with-init
-  (fn outer-counter-with-init [label]
-    (dispatch [:counter/initialise label])           ;; outer fires once on mount — hidden side-effect at call site
-    (fn render-counter-with-init [label]              ;; render fn, called on each render
-      (let [n @(subscribe [:count])]
-        [:button {:on-click #(dispatch [:inc])}
-         (str label ": " n)]))))
+(rf/reg-view counter-with-init [label]
+  (dispatch [:counter/initialise label])           ;; outer fires once on mount — hidden side-effect at call site
+  (fn render-counter-with-init [label]             ;; inner render fn, called on each render
+    (let [n @(subscribe [:count])]
+      [:button {:on-click #(dispatch [:inc])}
+       (str label ": " n)])))
 ```
 
-The `dispatch` and `subscribe` in both the outer and inner fn refer to the same locals — Clojure lexical closure does the right thing.
+The `dispatch` and `subscribe` in both the outer body and the inner fn refer to the same lexical bindings — Clojure lexical closure does the right thing.
 
 **Use Form-2 only when the setup work genuinely depends on per-mount props.** For stable setup, use Form-1 + a frame-level `:on-create` event.
 
-### Form-3 (class — supported, rare)
+### Form-3 (class — out of scope for the macro)
 
-Class-form views that return a map of lifecycle methods (`:reagent-render`, `:component-did-mount`, etc.) — supported, but the injected locals are only in scope for the lifecycle methods themselves, not for any user code outside the registered fn. Consistent treatment with Form-2; the macro injects the `let` once around the entire returned map's body.
+Reagent Form-3 (`reagent.core/create-class`) is **not supported by the `reg-view` macro** in v1. The macro's compile-time check rejects calls whose body is a `(reagent.core/create-class …)` form; the error message points the user at `re-frame.core/reg-view*` — the plain-fn surface, where the body can be any callable.
 
-Required only when interop with stateful third-party React components needs explicit lifecycle hooks (`componentDidMount`, `componentWillUnmount`).
+```clojure
+;; instead of (rf/reg-view my-view (reagent.core/create-class …)) — compile error,
+;; use:
+(re-frame.core/reg-view* :feature/my-view
+  (reagent.core/create-class
+    {:reagent-render        (fn [] ...)
+     :component-did-mount   (fn [] ...)
+     :component-will-unmount (fn [] ...)}))
+```
+
+The Reagent-v2 directive (rf2-25aq) constrains the canonical surface to Form-1 + Form-2; Form-3 ships through the escape hatch.
 
 ## View registry — tooling surface
 
@@ -325,12 +364,11 @@ Tools (10x, story tools, agents) read these to render view inspectors, pick view
 Registered views referenced from hiccup inherit the surrounding frame from React context:
 
 ```clojure
-(rf/reg-view :outer
-  (fn []
-    [:div
-     [counter "Inner"]                  ;; or [:counter "Inner"] under the `h` macro
-     [rf/frame-provider {:frame :other}
-      [counter "Other-frame inner"]]])) ;; nested provider re-points
+(rf/reg-view outer []
+  [:div
+   [counter "Inner"]                  ;; or [:counter "Inner"] under the `h` macro
+   [rf/frame-provider {:frame :other}
+    [counter "Other-frame inner"]]])  ;; nested provider re-points
 ```
 
 Nested `frame-provider`s re-point children. The deepest provider in scope wins.
@@ -354,34 +392,29 @@ The bare `[:my-view "args"]` form in raw hiccup requires Reagent extension and i
 
 ### `reg-view` defs the Var by default
 
-`reg-view` defs the Var as a side effect. No need to write `(def x (rf/reg-view :x ...))` — `(rf/reg-view :x ...)` is enough; a Var named `x` is created in the surrounding namespace.
-
-The macro takes the id keyword's local name (the part after the slash) as the Var's symbol:
+`reg-view` is defn-shape: the symbol you supply IS the Var name; the id is auto-derived from `(keyword *ns* sym)`. No need to write `(def x (rf/reg-view :x ...))` — `(rf/reg-view x [args] body)` is enough; a Var named `x` is created in the surrounding namespace and registered under `(keyword *ns* "x")`.
 
 ```clojure
-(rf/reg-view :counter
-  (fn [label] [:button label]))
+(rf/reg-view counter [label] [:button label])
 ;; ⇒ defs `counter` in the current namespace, bound to the wrapped fn.
+;; ⇒ registers under (keyword *ns* "counter").
 ;; You can now write [counter "Hi"] in hiccup directly.
 
-(rf/reg-view :cart.item/row
-  (fn [item] [:tr ...]))
-;; ⇒ defs `row` (uses the local name after the slash).
+(rf/reg-view ^{:rf/id :cart.item/row} item-row [item] [:tr ...])
+;; ⇒ defs `item-row`; registers under the explicit override id :cart.item/row.
 ;; Use the qualified namespace prefix when reading: [cart.item.row item]
 ```
 
 This matches `defn`'s shape (registers + binds a Var) and removes a redundant naming step. Other registration kinds don't need this because their values aren't called as Reagent components in hiccup — only views are.
 
-For the rare case where the user wants to control the Var name explicitly (or suppress the def — e.g. for views generated programmatically), pass `:as` in the metadata:
+For the rare case where the user wants no Var binding (e.g. views generated programmatically, or registered without a Var by a library), use `re-frame.core/reg-view*` directly — the plain-fn surface registers under the supplied id without defing anything.
 
 ```clojure
-(rf/reg-view :counter
-  {:as 'my-counter}                     ;; explicitly named
-  (fn [label] [:button label]))
-
-(rf/reg-view :counter
-  {:as nil}                             ;; suppress the def; only register
-  (fn [label] [:button label]))
+;; Programmatic registration — no Var, computed id.
+(doseq [variant [:summary :detail]]
+  (re-frame.core/reg-view*
+    (keyword "feature/article" (name variant))
+    (fn [_props] ...)))
 ```
 
 ### The `h` macro's expansion strategy
@@ -400,11 +433,19 @@ A keyword *not* registered as a view at expansion time passes through unchanged.
 
 **Edge case — re-registration shadowing a DOM tag.** A user must not `(reg-view :div ...)`. The runtime emits a warning at registration time; `h` honours the registry (the registered fn wins). Documented as a footgun, not policed.
 
-### Form-3 (`reagent.core/create-class`) — full lifecycle exposure
+### Form-3 (`reagent.core/create-class`) — out of scope for the macro
 
-Form-3 lifecycle methods all see the injected `dispatch`/`subscribe`/`frame-id` locals. The macro wraps the *entire returned map's body* in the same `let` — `:reagent-render`, `:component-did-mount`, `:component-did-update`, `:component-will-unmount`, etc. all close over the same frame-bound locals. Across Reagent's class-creation paths (`r/create-class`, hooks-flavoured wrappers) the expansion is uniform: one `let` around the map literal, all method bodies read the same locals.
+The `reg-view` macro rejects bodies whose top-level form is `(reagent.core/create-class …)` — Form-3 is the canonical escape-hatch case. Per the Reagent-v2 directive (rf2-25aq) the canonical surface targets Form-1 + Form-2; Form-3 ships through `re-frame.core/reg-view*`:
 
-This matches Form-2's treatment (one `let` around the outer + inner fns) and keeps Form-3 a true *escape hatch* for stateful third-party React interop — `componentDidMount`-style hooks have access to the right `dispatch`/`subscribe` without ceremony.
+```clojure
+(re-frame.core/reg-view* :feature/widget
+  (reagent.core/create-class
+    {:reagent-render        (fn [props] ...)
+     :component-did-mount   (fn [this] ...)
+     :component-will-unmount (fn [this] ...)}))
+```
+
+Inside a Form-3 body, the user captures frame-bound dispatch/subscribe explicitly via `(rf/dispatcher)` / `(rf/subscriber)` if needed — the macro's auto-inject is exactly the convenience `reg-view*` does NOT provide.
 
 ### Hot-reload behaviour for re-registered views
 

--- a/docs/specification/012-Routing.md
+++ b/docs/specification/012-Routing.md
@@ -409,15 +409,13 @@ Views derive UI from the route the same way they derive UI from any other state 
 ### The root view dispatches on `:rf.route/id`
 
 ```clojure
-(def app-root
-  (rf/reg-view :app/root
-    (fn render-app-root []
-      (case @(subscribe [:rf.route/id])
-        :route/home              [home-page]
-        :route/cart              [cart-page]
-        :route/cart.item-detail  [cart-item-detail]
-        :route/article           [article-page]
-        :rf.route/not-found         [not-found-page]))))
+(rf/reg-view app-root []
+  (case @(subscribe [:rf.route/id])
+    :route/home              [home-page]
+    :route/cart              [cart-page]
+    :route/cart.item-detail  [cart-item-detail]
+    :route/article           [article-page]
+    :rf.route/not-found      [not-found-page]))
 ```
 
 Pattern: a single `case` (or equivalent) over the route id at the top of the tree. Per-route views can subscribe to `:rf.route/params` for their own data needs.
@@ -602,15 +600,14 @@ These events are the **decision points** for navigation policy. The policy is en
 `route-link`'s body becomes:
 
 ```clojure
-(rf/reg-view :rf/route-link
-  (fn render-route-link [{:keys [to params query]} & children]
-    (let [url (rf/route-url to (or params {}) (or query {}))]
-      [:a {:href     url
-           :on-click (fn [e]
-                       (when (plain-left-click? e)        ;; no modifier keys
-                         (.preventDefault e)
-                         (rf/dispatch [:rf/url-requested {:url url :to to :params params :query query}])))}
-       children])))
+(rf/reg-view route-link [{:keys [to params query]} & children]
+  (let [url (rf/route-url to (or params {}) (or query {}))]
+    [:a {:href     url
+         :on-click (fn [e]
+                     (when (plain-left-click? e)        ;; no modifier keys
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested {:url url :to to :params params :query query}])))}
+     children]))
 ```
 
 ## Scroll restoration

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -28,7 +28,8 @@
 | `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | 002 | |
 | `reg-frame` | M | `(reg-frame id metadata)` | v1 | 002 | Atomic create + register. |
 | `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | 002 | Anonymous frame; gensym'd id. |
-| `reg-view` | M | `(reg-view id ?metadata render-fn) → wrapped-fn` | v1 | 004 | |
+| `reg-view` | M | `(reg-view sym [args] body+)` / `(reg-view sym docstring [args] body+)` / `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | 004 | Defn-shape; auto-defs the symbol; auto-derives id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. |
+| `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | 004 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. The `*` follows Clojure's `let`/`let*`, `fn`/`fn*` idiom (per [Conventions](Conventions.md)). |
 | `reg-app-schema` | M | `(reg-app-schema path schema)` | v1 | 010 | |
 | `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 (preserved, alpha) | — | |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |

--- a/docs/specification/Conventions.md
+++ b/docs/specification/Conventions.md
@@ -121,6 +121,34 @@ Full rationale: [000-Vision §Pointers to per-area Specs (Features)](000-Vision.
 
 Conformant implementations need a structural-sharing persistent collection library for `app-db` and frame state. CLJS gets this free; other-language ports pick a host-idiomatic library (Immer or Immutable.js for JS; pyrsistent or immutables for Python; im-rs for Rust; native collections for F# / Scala / OCaml / Clojure). For the per-host options, why this is pattern-required, and how it composes with [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility), see [000-Vision §Host-profile matrix — Note on persistent data structures](000-Vision.md#note-on-persistent-data-structures).
 
+## `*`-suffix naming for fn-versions of macros
+
+When a macro has a fn-version (the unsweetened, runtime-callable surface), the fn gets a `*` suffix. Standard Clojure idiom — `let` / `let*`, `fn` / `fn*`. The macro is the ergonomic surface (parses extra shapes, captures source-coords from `&form`, defs Vars, injects locals); the `*`-fn is the plain-fn delegate that runtime callers invoke when they need a non-literal body, a computed id, or registration without the macro tier.
+
+For now the only pair is `reg-view` / `reg-view*` (per [Spec 004 §reg-view*](004-Views.md#reg-view-the-plain-fn-escape-hatch)); future macros that want fn partners follow the same convention.
+
+The convention applies **only where there is a macro tier**. The other `reg-*` registrations (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`) are already plain fns — they need no macro tier and therefore no `*` partner. Adding `reg-event-db*` / etc. would be a pure alias and add no value; that's not done. (See [Cross-Spec-Interactions §Family asymmetry](Cross-Spec-Interactions.md#family-asymmetry-only-reg-view-has-a-macro-tier) for why the family is intentionally asymmetric.)
+
+## `reg-view` auto-id derivation rule
+
+Per [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract), the `reg-view` macro auto-derives the registered id from the symbol you supply:
+
+```
+id = (keyword (str *ns*) (str sym))
+```
+
+This matches Clojure's `defn` Var-naming idiom: the symbol is the source of truth; the registry id mirrors it. Override the auto-derivation by attaching `^{:rf/id :explicit/id}` metadata to the symbol:
+
+```clojure
+(reg-view counter [label] body)
+;; ⇒ id is :my.ns/counter
+
+(reg-view ^{:rf/id :widget/counter} counter [label] body)
+;; ⇒ id is :widget/counter
+```
+
+The metadata-override syntax is the single supported way to set a non-auto-derived id at the macro surface. Other slot metadata (e.g. `:doc`) lives on the same metadata map: `^{:doc "..." :rf/id :widget/x}`. For computed ids, drop to `re-frame.core/reg-view*`.
+
 ## Cross-references
 
 - [000-Vision.md](000-Vision.md) — goals, constraints, the pattern's minimal core.

--- a/docs/specification/Cross-Spec-Interactions.md
+++ b/docs/specification/Cross-Spec-Interactions.md
@@ -210,6 +210,17 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Reason:** Mid-process adapter swap would leave an unknown set of cached reactions, mounted views, and frame containers wired to the old adapter — the inconsistency is unrecoverable. The dispose-then-install path forces a known clean state.
 - **Status:** `Provisional` — fixture pending: `adapter-already-installed.edn`.
 
+## Registration family
+
+### 21. Family asymmetry — only `reg-view` has a macro tier
+
+- **Specs:** [001-Registration](001-Registration.md) (the registration family); [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract); [Conventions §`*`-suffix naming](Conventions.md#-suffix-naming-for-fn-versions-of-macros).
+- **Scenario:** A reader looks at the public API and notices that `reg-view` ships as a **macro** with a `reg-view*` plain-fn partner, while every other `reg-*` (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `reg-flow`, `reg-route`, `reg-app-schema`, `reg-machine`, `reg-error-projector`) is a plain fn with no `*` partner. Why is the family asymmetric?
+- **Behaviour:** `reg-view` is the only `reg-*` macro because views need a Var binding — Reagent calls them by symbol from hiccup heads (`[counter "label"]`). The macro defs the symbol, registers the view, and auto-injects `dispatch` / `subscribe` lexically into the body. None of the other registrations are *invoked by name* from user-facing data; they are dispatched (events) or looked up by id (subs, fx, cofx, frames, routes, schemas, machines) at runtime. They have no need for an auto-defed Var, no need for compile-time auto-id derivation, and no body-shape compile-time check to enforce — so they stay plain fns.
+- **The `*` convention applies only where a macro sweetens an underlying fn.** Adding `reg-event-db*` / `reg-sub*` / etc. would be pure aliases for `reg-event-db` / `reg-sub` themselves — no macro tier exists, no fn partner is necessary. The convention is reserved for the sweetened-vs-unsweetened case, per `let` / `let*`.
+- **Reason:** The family looks asymmetric because the underlying need is asymmetric. Views participate in the render-tree by Var reference (Reagent's idiomatic hiccup head); other registrations participate by id (the registry holds the data). The macro tier exists where the Var binding is part of the contract; the plain fn tier is sufficient where the registry id is.
+- **Status:** `Locked` — Spec 004 owns the `reg-view` macro shape; this entry documents the family-level asymmetry so implementors and readers don't expect a `*` partner for every registration.
+
 ## Cross-references
 
 - [000-Vision §Goals](000-Vision.md#goals) — the goals these interactions exist to satisfy.

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -779,7 +779,68 @@ Any of the five interceptor refs in any registration's interceptor list.
 
 ---
 
-**Reporting M-12 through M-21.** These ten rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing ten separate preambles.
+### M-22. `reg-view` is now a defn-shape macro — keyword-shape calls must rewrite
+
+**Type A** (mechanical).
+
+Per [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract) and rf2-d0pi: `reg-view` is now a defn-shape macro that auto-defs the symbol you supply, auto-derives the registered id from `(keyword *ns* sym)`, and lexically auto-injects `dispatch` / `subscribe`. The keyword-shape call `(reg-view :id render-fn)` no longer compiles; the macro rejects it at macroexpand-time with an error pointing the user at `re-frame.core/reg-view*`.
+
+**What to look for** in the codebase:
+
+```clojure
+(def my-view (rf/reg-view :ns/my-view (fn [args] body)))
+(def my-view (rf/reg-view :ns/my-view {:doc "..."} (fn [args] body)))
+```
+
+**What to do:**
+
+```clojure
+;; before
+(def my-view
+  (rf/reg-view :ns/my-view (fn [] body)))
+
+;; after — defn-shape; id auto-derives to (keyword *ns* "my-view")
+(rf/reg-view my-view [] body)
+
+;; before — explicit id that the auto-derivation wouldn't reproduce
+(def cart-row
+  (rf/reg-view :cart.item/row (fn [item] [:tr ...])))
+
+;; after — ^{:rf/id ...} metadata override on the symbol
+(rf/reg-view ^{:rf/id :cart.item/row} cart-row [item] [:tr ...])
+
+;; before — programmatic / computed id, not a defn-shape body
+(rf/reg-view (keyword "feature/widget" (name variant))
+  computed-render-fn)
+
+;; after — reg-view* (the plain-fn surface; no auto-anything)
+(re-frame.core/reg-view*
+  (keyword "feature/widget" (name variant))
+  computed-render-fn)
+```
+
+Inside the body, drop any explicit `(rf/dispatcher)` / `(rf/subscriber)` capture — `dispatch` and `subscribe` are auto-injected as lexical bindings:
+
+```clojure
+;; before
+(rf/reg-view :counter
+  (fn []
+    (let [d (rf/dispatcher)
+          s (rf/subscriber)]
+      [:button {:on-click #(d [:inc])} @(s [:count])])))
+
+;; after
+(rf/reg-view counter []
+  [:button {:on-click #(dispatch [:inc])} @(subscribe [:count])])
+```
+
+The agent rewrites mechanically: the keyword's local-name becomes the auto-defed symbol; the keyword itself becomes `^{:rf/id ...}` metadata if the auto-derived id wouldn't match. Bodies that are not literal `(fn [args] body)` forms (Var refs, `reagent.core/create-class` calls, computed expressions) are flagged for the user — those route to `reg-view*`, the plain-fn surface, where the body can be any callable.
+
+**Why?** The defn-shape removes a redundant naming step (the keyword + the symbol said the same thing twice), bakes in source-coord auto-capture at the macro-expansion site, and eliminates the mechanical `(rf/dispatcher)` / `(rf/subscriber)` capture every view body used to need. The compile-time check on the body shape catches Form-3 / computed-fn footguns at the point of registration rather than at runtime. `reg-view*` (the `*`-suffixed plain-fn partner — standard Clojure idiom per `let`/`let*`, `fn`/`fn*`) is the runtime-callable surface for any case the macro shape doesn't fit.
+
+---
+
+**Reporting M-12 through M-22.** These eleven rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing eleven separate preambles.
 
 ---
 

--- a/docs/specification/Pattern-Boot.md
+++ b/docs/specification/Pattern-Boot.md
@@ -203,30 +203,28 @@ A view subscribes to the machine snapshot via `sub-machine` (per [005 §Reading 
   (fn sub-app-boot-state [db _]
     (get-in db [:rf/machines :app/boot :state])))
 
-(def boot-screen
-  (rf/reg-view :app.boot/screen
-    (fn render-boot-screen []
-      (let [state @(subscribe [:app.boot/state])
-            phase @(subscribe [:app.boot/phase])
-            err   @(subscribe [:app.boot/error])]
-        (cond
-          (= state :ready)
-          [running-app-root]
+(rf/reg-view boot-screen []
+  (let [state @(subscribe [:app.boot/state])
+        phase @(subscribe [:app.boot/phase])
+        err   @(subscribe [:app.boot/error])]
+    (cond
+      (= state :ready)
+      [running-app-root]
 
-          (#{:auth-failed :profile-failed :fatal-error} state)
-          [:div.boot-error
-           [:p (str "Couldn't start: " err)]
-           [:button {:on-click #(dispatch [:app/boot [:rf/start]])} "Retry"]]
+      (#{:auth-failed :profile-failed :fatal-error} state)
+      [:div.boot-error
+       [:p (str "Couldn't start: " err)]
+       [:button {:on-click #(dispatch [:app/boot [:rf/start]])} "Retry"]]
 
-          :else
-          [:div.boot-progress
-           [:p (case phase
-                 :configuring     "Loading config…"
-                 :authenticating  "Signing in…"
-                 :loading-profile "Loading your profile…"
-                 :hydrating       "Restoring state…"
-                 :routing         "Almost ready…"
-                 "Starting…")]])))))
+      :else
+      [:div.boot-progress
+       [:p (case phase
+             :configuring     "Loading config…"
+             :authenticating  "Signing in…"
+             :loading-profile "Loading your profile…"
+             :hydrating       "Restoring state…"
+             :routing         "Almost ready…"
+             "Starting…")]])))
 ```
 
 The progress UI reads from the same snapshot the machine writes — no parallel signal.

--- a/docs/specification/Pattern-Forms.md
+++ b/docs/specification/Pattern-Forms.md
@@ -211,42 +211,40 @@ Worked example — login form:
 ## Standard view structure
 
 ```clojure
-(def login-form-view
-  (rf/reg-view :form.login/view
-    (fn render-login-form []
-      (let [draft        @(subscribe [:form.login/draft])
-            form-errors  @(subscribe [:form.login/form-errors])
-            email-error  @(subscribe [:form.login/field-error :email])
-            pw-error     @(subscribe [:form.login/field-error :password])
-            can-submit?  @(subscribe [:form.login/can-submit?])
-            status       @(subscribe [:form.login/status])
-            submit-error @(subscribe [:form.login/submit-error])]
-        [:form
-         {:on-submit (fn [e]
-                       (.preventDefault e)
-                       (dispatch [:form.login/submit]))}
-         (when (seq form-errors)
-           [:ul.form-errors
-            (for [msg form-errors] ^{:key msg} [:li msg])])
+(rf/reg-view login-form-view []
+  (let [draft        @(subscribe [:form.login/draft])
+        form-errors  @(subscribe [:form.login/form-errors])
+        email-error  @(subscribe [:form.login/field-error :email])
+        pw-error     @(subscribe [:form.login/field-error :password])
+        can-submit?  @(subscribe [:form.login/can-submit?])
+        status       @(subscribe [:form.login/status])
+        submit-error @(subscribe [:form.login/submit-error])]
+    [:form
+     {:on-submit (fn [e]
+                   (.preventDefault e)
+                   (dispatch [:form.login/submit]))}
+     (when (seq form-errors)
+       [:ul.form-errors
+        (for [msg form-errors] ^{:key msg} [:li msg])])
 
-         [:input {:type      "email"
-                  :value     (:email draft)
-                  :on-change #(dispatch [:form.login/edit-field :email
-                                         (.. % -target -value)])
-                  :on-blur   #(dispatch [:form.login/blur-field :email])}]
-         (when email-error [:p.error email-error])
+     [:input {:type      "email"
+              :value     (:email draft)
+              :on-change #(dispatch [:form.login/edit-field :email
+                                     (.. % -target -value)])
+              :on-blur   #(dispatch [:form.login/blur-field :email])}]
+     (when email-error [:p.error email-error])
 
-         [:input {:type      "password"
-                  :value     (:password draft)
-                  :on-change #(dispatch [:form.login/edit-field :password
-                                         (.. % -target -value)])
-                  :on-blur   #(dispatch [:form.login/blur-field :password])}]
-         (when pw-error [:p.error pw-error])
+     [:input {:type      "password"
+              :value     (:password draft)
+              :on-change #(dispatch [:form.login/edit-field :password
+                                     (.. % -target -value)])
+              :on-blur   #(dispatch [:form.login/blur-field :password])}]
+     (when pw-error [:p.error pw-error])
 
-         [:button {:type "submit" :disabled (not can-submit?)}
-          (if (= status :submitting) "Signing in…" "Sign in")]
+     [:button {:type "submit" :disabled (not can-submit?)}
+      (if (= status :submitting) "Signing in…" "Sign in")]
 
-         (when submit-error [:p.error submit-error])]))))
+     (when submit-error [:p.error submit-error])]))
 ```
 
 ## Variations

--- a/docs/specification/Pattern-NineStates.md
+++ b/docs/specification/Pattern-NineStates.md
@@ -99,20 +99,18 @@ The sub ids are illustrative. Feature code may namespace them differently.
 The page's root view should branch explicitly:
 
 ```clojure
-(def root-view
-  (rf/reg-view :ui.view/root
-    (fn []
-      (cond
-        @(subscribe [:ui.state/done?])      [view-done]
-        @(subscribe [:ui.state/incorrect?]) [view-incorrect]
-        @(subscribe [:ui.state/correct?])   [view-correct]
-        @(subscribe [:ui.state/nothing?])   [view-nothing]
-        @(subscribe [:ui.state/loading?])   [view-loading]
-        @(subscribe [:ui.state/empty?])     [view-empty]
-        @(subscribe [:ui.state/one?])       [view-one]
-        @(subscribe [:ui.state/some?])      [view-some]
-        @(subscribe [:ui.state/too-many?])  [view-too-many]
-        :else                               [view-fallback]))))
+(rf/reg-view root-view []
+  (cond
+    @(subscribe [:ui.state/done?])      [view-done]
+    @(subscribe [:ui.state/incorrect?]) [view-incorrect]
+    @(subscribe [:ui.state/correct?])   [view-correct]
+    @(subscribe [:ui.state/nothing?])   [view-nothing]
+    @(subscribe [:ui.state/loading?])   [view-loading]
+    @(subscribe [:ui.state/empty?])     [view-empty]
+    @(subscribe [:ui.state/one?])       [view-one]
+    @(subscribe [:ui.state/some?])      [view-some]
+    @(subscribe [:ui.state/too-many?])  [view-too-many]
+    :else                               [view-fallback]))
 ```
 
 The exact ordering depends on the feature, but the branch structure should be visible in one place.

--- a/examples/counter/core.cljs
+++ b/examples/counter/core.cljs
@@ -37,32 +37,26 @@
 
 ;; -- Views -------------------------------------------------------------------
 ;;
-;; The `:counter-buttons` view holds the UI. Its body uses the injected
-;; `dispatch`/`subscribe` which resolve, at render time, to whichever frame
-;; the surrounding React context puts in scope.
+;; The `:counter-buttons` view holds the UI. Per Spec 004 §reg-view, the
+;; defn-shape macro auto-injects `dispatch` and `subscribe` as lexical
+;; bindings; both resolve at render time to the frame in scope (the
+;; default frame here, see the namespace docstring for the
+;; frame-provider variant parked behind rf2-kdwc).
+;;
+;; reg-view auto-defs a Var named after the supplied symbol and
+;; registers the view under (keyword *ns* sym).
 
-;; reg-view (the macro form from re-frame.views-macros) defs a local
-;; Var named after the keyword. The body's dispatch / subscribe both
-;; resolve through (current-frame) — bound by the enclosing
-;; frame-provider via React context.
+(reg-view counter-buttons []
+  [:div
+   [:button {:on-click #(dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em"}} @(subscribe [:count])]
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
-(reg-view :counter-buttons
-  (fn []
-    (let [d (rf/dispatcher)
-          s (rf/subscriber)]
-      [:div
-       [:button {:on-click #(d [:counter/dec])} "-"]
-       [:span {:style {:margin "0 1em"}} @(s [:count])]
-       [:button {:on-click #(d [:counter/inc])} "+"]])))
+;; The root `counter-app` view renders `counter-buttons` against the
+;; default frame. Initialisation runs in `run` via `dispatch-sync`.
 
-;; The `:counter-app` view is the root — it just renders
-;; `:counter-buttons` against the default frame. Initialisation runs
-;; in `run` via `dispatch-sync`. (The earlier frame-provider variant
-;; is documented in the namespace docstring and parked behind rf2-kdwc.)
-
-(reg-view :counter-app
-  (fn []
-    [counter-buttons]))
+(reg-view counter-app []
+  [counter-buttons])
 
 ;; -- Mount -------------------------------------------------------------------
 

--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -217,49 +217,44 @@
 ;; hiccup]). The current API uses `rf/dispatcher` / `rf/subscriber` for
 ;; frame-bound access inside views.
 
-(def login-form
-  (reg-view :auth.login/form
-    {:doc "The login form view: email + password + submit button + error display."}
-    (fn render-auth-login-form []
-      (let [d     (rf/dispatcher)
-            s     (rf/subscriber)
-            state (atom {:email "" :password ""})]
-        (fn []
-          (let [submitting? @(s [:auth.login/submitting?])
-                err         @(s [:auth.login/error])]
-            [:form.login-form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:auth.login/flow [:auth.login/submit @state]]))}
-             [:input  {:type        "email"
-                       :placeholder "Email"
-                       :disabled    submitting?
-                       :on-change   #(swap! state assoc :email (.. % -target -value))}]
-             [:input  {:type        "password"
-                       :placeholder "Password"
-                       :disabled    submitting?
-                       :on-change   #(swap! state assoc :password (.. % -target -value))}]
-             [:button {:type "submit" :disabled submitting?}
-              (if submitting? "Signing in…" "Sign in")]
-             (when err [:p.error err])]))))))
+;; Form-2 view: the outer fn captures local component state in `state`
+;; (a Reagent atom kept across renders); the inner fn is the actual
+;; render fn. dispatch / subscribe are auto-injected and visible in
+;; both the outer and inner fn bodies.
+(reg-view ^{:doc "The login form view: email + password + submit button + error display."}
+          login-form []
+  (let [state (atom {:email "" :password ""})]
+    (fn []
+      (let [submitting? @(subscribe [:auth.login/submitting?])
+            err         @(subscribe [:auth.login/error])]
+        [:form.login-form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:auth.login/flow [:auth.login/submit @state]]))}
+         [:input  {:type        "email"
+                   :placeholder "Email"
+                   :disabled    submitting?
+                   :on-change   #(swap! state assoc :email (.. % -target -value))}]
+         [:input  {:type        "password"
+                   :placeholder "Password"
+                   :disabled    submitting?
+                   :on-change   #(swap! state assoc :password (.. % -target -value))}]
+         [:button {:type "submit" :disabled submitting?}
+          (if submitting? "Signing in…" "Sign in")]
+         (when err [:p.error err])]))))
 
-(def login-banner
-  (reg-view :auth.login/banner
-    {:doc "Shows the user's logged-in state and a sign-out button."}
-    (fn render-auth-login-banner []
-      (let [s       (rf/subscriber)
-            authed? @(s [:auth.login/authenticated?])]
-        [:div.banner
-         (if authed?
-           [:span "Welcome!"]
-           [login-form])]))))
+(reg-view ^{:doc "Shows the user's logged-in state and a sign-out button."}
+          login-banner []
+  (let [authed? @(subscribe [:auth.login/authenticated?])]
+    [:div.banner
+     (if authed?
+       [:span "Welcome!"]
+       [login-form])]))
 
-(def root-view
-  (reg-view :auth.login/root
-    (fn render-auth-login-root []
-      [:div.app
-       [:h1 "Sign in"]
-       [login-banner]])))
+(reg-view root-view []
+  [:div.app
+   [:h1 "Sign in"]
+   [login-banner]])
 
 ;; ============================================================================
 ;; HEADLESS TEST  (smoke test for the feature)

--- a/examples/managed_http_counter/core.cljs
+++ b/examples/managed_http_counter/core.cljs
@@ -163,31 +163,27 @@
 
 ;; -- Views -------------------------------------------------------------------
 
-(reg-view :counter-view
-  (fn []
-    (let [d (rf/dispatcher)
-          s (rf/subscriber)
-          count  @(s [:count])
-          status @(s [:status])
-          error  @(s [:error])]
-      [:div {:style {:font-family "sans-serif" :padding "1em"}}
-       [:h1 "Managed HTTP counter"]
-       [:p "Count: " [:span {:data-testid "count"} count]]
-       [:p "Status: " [:span {:data-testid "status"} (name status)]]
-       (when error
-         [:p {:data-testid "error"
-              :style       {:color "crimson"}}
-          "Error kind: " (str (:kind error))])
-       [:div {:style {:display :flex :gap "0.5em"}}
-        [:button {:on-click #(d [:counter/+1])}              "+1"]
-        [:button {:on-click #(d [:counter/fail])}            "Fail"]
-        [:button {:on-click #(d [:counter/retry-recover])}   "Retry-recover"]
-        [:button {:on-click #(d [:counter/start-long])}      "Start long"]
-        [:button {:on-click #(d [:counter/cancel])}          "Cancel"]]])))
+(reg-view counter-view []
+  (let [count  @(subscribe [:count])
+        status @(subscribe [:status])
+        error  @(subscribe [:error])]
+    [:div {:style {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "Managed HTTP counter"]
+     [:p "Count: " [:span {:data-testid "count"} count]]
+     [:p "Status: " [:span {:data-testid "status"} (name status)]]
+     (when error
+       [:p {:data-testid "error"
+            :style       {:color "crimson"}}
+        "Error kind: " (str (:kind error))])
+     [:div {:style {:display :flex :gap "0.5em"}}
+      [:button {:on-click #(dispatch [:counter/+1])}              "+1"]
+      [:button {:on-click #(dispatch [:counter/fail])}            "Fail"]
+      [:button {:on-click #(dispatch [:counter/retry-recover])}   "Retry-recover"]
+      [:button {:on-click #(dispatch [:counter/start-long])}      "Start long"]
+      [:button {:on-click #(dispatch [:counter/cancel])}          "Cancel"]]]))
 
-(reg-view :counter-app
-  (fn []
-    [counter-view]))
+(reg-view counter-app []
+  [counter-view])
 
 ;; -- Mount -------------------------------------------------------------------
 

--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -405,182 +405,146 @@
 ;; the editor's :archived (state 9) wins over everything; otherwise we fall
 ;; through the lifecycle.
 
-(def view-nothing
-  (reg-view :ui.view/nothing
-    {:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
-    (fn render-nothing []
-      (let [d (rf/dispatcher)]
-        [:div.state.state-nothing
-         [:h2 "Welcome"]
-         [:p "You haven't loaded any todos yet."]
-         [:button {:on-click #(d [:todos/load {:n 0}])} "Get started"]]))))
+(reg-view ^{:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
+          view-nothing []
+  [:div.state.state-nothing
+   [:h2 "Welcome"]
+   [:p "You haven't loaded any todos yet."]
+   [:button {:on-click #(dispatch [:todos/load {:n 0}])} "Get started"]])
 
-(def view-loading
-  (reg-view :ui.view/loading
-    {:doc "State 2 — Loading: spinner / skeleton. NEVER blank the page on revalidation."}
-    (fn render-loading []
-      [:div.state.state-loading
-       [:p "Loading todos…"]])))
+(reg-view ^{:doc "State 2 — Loading: spinner / skeleton. NEVER blank the page on revalidation."}
+          view-loading []
+  [:div.state.state-loading
+   [:p "Loading todos…"]])
 
-(def view-empty
-  (reg-view :ui.view/empty
-    {:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
-    (fn render-empty []
-      [:div.state.state-empty
-       [:h2 "No todos yet"]
-       [:p "Add your first todo using the form below."]])))
+(reg-view ^{:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
+          view-empty []
+  [:div.state.state-empty
+   [:h2 "No todos yet"]
+   [:p "Add your first todo using the form below."]])
 
-(def view-one
-  (reg-view :ui.view/one
-    {:doc "State 4 — One: focused single-item layout."}
-    (fn render-one []
-      (let [s    (rf/subscriber)
-            todo (first @(s [:todos/data]))]
-        [:div.state.state-one
-         [:h2 "Your todo"]
-         [:p.title (:title todo)]]))))
+(reg-view ^{:doc "State 4 — One: focused single-item layout."}
+          view-one []
+  (let [todo (first @(subscribe [:todos/data]))]
+    [:div.state.state-one
+     [:h2 "Your todo"]
+     [:p.title (:title todo)]]))
 
-(def view-some
-  (reg-view :ui.view/some
-    {:doc "State 5 — Some: standard list."}
-    (fn render-some []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos/data])]
-        [:div.state.state-some
-         [:h2 (str (count todos) " todos")]
-         [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))))
+(reg-view ^{:doc "State 5 — Some: standard list."}
+          view-some []
+  (let [todos @(subscribe [:todos/data])]
+    [:div.state.state-some
+     [:h2 (str (count todos) " todos")]
+     [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
-(def view-too-many
-  (reg-view :ui.view/too-many
-    {:doc "State 6 — Too Many: search + truncation."}
-    (fn render-too-many []
-      (let [s        (rf/subscriber)
-            todos    @(s [:todos/data])
-            shown    (take too-many-threshold todos)
-            overflow (- (count todos) too-many-threshold)]
-        [:div.state.state-too-many
-         [:h2 (str (count todos) " todos (showing first " too-many-threshold ")")]
-         [:input {:type "search" :placeholder "Search todos…"}]
-         [:ul (for [t shown] ^{:key (:id t)} [:li (:title t)])]
-         (when (pos? overflow)
-           [:p.overflow (str "…and " overflow " more.")])]))))
+(reg-view ^{:doc "State 6 — Too Many: search + truncation."}
+          view-too-many []
+  (let [todos    @(subscribe [:todos/data])
+        shown    (take too-many-threshold todos)
+        overflow (- (count todos) too-many-threshold)]
+    [:div.state.state-too-many
+     [:h2 (str (count todos) " todos (showing first " too-many-threshold ")")]
+     [:input {:type "search" :placeholder "Search todos…"}]
+     [:ul (for [t shown] ^{:key (:id t)} [:li (:title t)])]
+     (when (pos? overflow)
+       [:p.overflow (str "…and " overflow " more.")])]))
 
-(def view-incorrect
-  (reg-view :ui.view/incorrect
-    {:doc "State 7 — Incorrect: per-field validation error + recovery path."}
-    (fn render-incorrect []
-      (let [s   (rf/subscriber)
-            err @(s [:new-todo/field-error :title])]
-        [:div.state.state-incorrect
-         [:p.error (str "We can't add that todo: " err)]
-         [:p "Please fix the title field below and submit again."]]))))
+(reg-view ^{:doc "State 7 — Incorrect: per-field validation error + recovery path."}
+          view-incorrect []
+  (let [err @(subscribe [:new-todo/field-error :title])]
+    [:div.state.state-incorrect
+     [:p.error (str "We can't add that todo: " err)]
+     [:p "Please fix the title field below and submit again."]]))
 
-(def view-correct
-  (reg-view :ui.view/correct
-    {:doc "State 8 — Correct: success feedback (toast / checkmark)."}
-    (fn render-correct []
-      [:div.state.state-correct
-       [:p.success "✓ Todo added."]])))
+(reg-view ^{:doc "State 8 — Correct: success feedback (toast / checkmark)."}
+          view-correct []
+  [:div.state.state-correct
+   [:p.success "✓ Todo added."]])
 
-(def view-done
-  (reg-view :ui.view/done
-    {:doc "State 9 — Done/Frozen: archived list. Read-only."}
-    (fn render-done []
-      (let [s     (rf/subscriber)
-            todos @(s [:todos/data])]
-        [:div.state.state-done
-         [:h2 "Archived"]
-         [:p "This list has been archived. It is read-only."]
-         [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))))
+(reg-view ^{:doc "State 9 — Done/Frozen: archived list. Read-only."}
+          view-done []
+  (let [todos @(subscribe [:todos/data])]
+    [:div.state.state-done
+     [:h2 "Archived"]
+     [:p "This list has been archived. It is read-only."]
+     [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
 ;; ============================================================================
 ;; VIEWS — control panel + form + root
 ;; ============================================================================
 
-(def new-todo-form
-  (reg-view :ui.view/new-todo-form
-    {:doc "Form for adding a todo. Drives the Forms slice (states 7 & 8)."}
-    (fn render-new-todo-form []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:new-todo/draft])
-            field-err   @(s [:new-todo/field-error :title])
-            done?       @(s [:ui.state/done?])]
-        [:form.new-todo
-         {:on-submit (fn [e]
-                       (.preventDefault e)
-                       (d [:new-todo/submit]))}
-         [:input {:type        "text"
-                  :placeholder "What needs doing?"
-                  :value       (:title draft)
-                  :disabled    done?
-                  :on-change   #(d [:new-todo/edit-field :title
-                                    (.. % -target -value)])}]
-         [:button {:type "submit" :disabled done?} "Add"]
-         (when field-err [:p.error field-err])]))))
+(reg-view ^{:doc "Form for adding a todo. Drives the Forms slice (states 7 & 8)."}
+          new-todo-form []
+  (let [draft     @(subscribe [:new-todo/draft])
+        field-err @(subscribe [:new-todo/field-error :title])
+        done?     @(subscribe [:ui.state/done?])]
+    [:form.new-todo
+     {:on-submit (fn [e]
+                   (.preventDefault e)
+                   (dispatch [:new-todo/submit]))}
+     [:input {:type        "text"
+              :placeholder "What needs doing?"
+              :value       (:title draft)
+              :disabled    done?
+              :on-change   #(dispatch [:new-todo/edit-field :title
+                                       (.. % -target -value)])}]
+     [:button {:type "submit" :disabled done?} "Add"]
+     (when field-err [:p.error field-err])]))
 
-(def control-panel
-  (reg-view :ui.view/control-panel
-    {:doc "Buttons to drive the app into each of the nine states."}
-    (fn render-control-panel []
-      (let [d     (rf/dispatcher)
-            s     (rf/subscriber)
-            done? @(s [:ui.state/done?])]
-        [:div.control-panel
-         [:h3 "Drive the demo"]
-         [:button {:on-click #(d [:app/initialise])
-                   :disabled done?} "1. Nothing"]
-         [:button {:on-click #(d [:todos/load-with-failure])
-                   :disabled done?} "Trigger error"]
-         [:button {:on-click #(d [:todos/load {:n 0}])
-                   :disabled done?} "3. Empty"]
-         [:button {:on-click #(d [:todos/load {:n 1}])
-                   :disabled done?} "4. One"]
-         [:button {:on-click #(d [:todos/load {:n 4}])
-                   :disabled done?} "5. Some"]
-         [:button {:on-click #(d [:todos/load {:n 25}])
-                   :disabled done?} "6. Too Many"]
-         [:button {:on-click #(d [:todos/editor [:todos.editor/archive {}]])
-                   :disabled done?} "9. Archive (Done)"]]))))
+(reg-view ^{:doc "Buttons to drive the app into each of the nine states."}
+          control-panel []
+  (let [done? @(subscribe [:ui.state/done?])]
+    [:div.control-panel
+     [:h3 "Drive the demo"]
+     [:button {:on-click #(dispatch [:app/initialise])
+               :disabled done?} "1. Nothing"]
+     [:button {:on-click #(dispatch [:todos/load-with-failure])
+               :disabled done?} "Trigger error"]
+     [:button {:on-click #(dispatch [:todos/load {:n 0}])
+               :disabled done?} "3. Empty"]
+     [:button {:on-click #(dispatch [:todos/load {:n 1}])
+               :disabled done?} "4. One"]
+     [:button {:on-click #(dispatch [:todos/load {:n 4}])
+               :disabled done?} "5. Some"]
+     [:button {:on-click #(dispatch [:todos/load {:n 25}])
+               :disabled done?} "6. Too Many"]
+     [:button {:on-click #(dispatch [:todos/editor [:todos.editor/archive {}]])
+               :disabled done?} "9. Archive (Done)"]]))
 
-(def root-view
-  (reg-view :ui.view/root
-    {:doc "Root view: pick exactly one of the nine state views, plus form
-           and control panel."}
-    (fn render-root []
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            done?      @(s [:ui.state/done?])
-            correct?   @(s [:ui.state/correct?])
-            incorrect? @(s [:ui.state/incorrect?])
-            nothing?   @(s [:ui.state/nothing?])
-            loading?   @(s [:ui.state/loading?])
-            empty?     @(s [:ui.state/empty?])
-            one?       @(s [:ui.state/one?])
-            some?*     @(s [:ui.state/some?])
-            too-many?  @(s [:ui.state/too-many?])
-            error      @(s [:todos/error])]
-        [:div.app
-         [:h1 "Nine States of UI — todos"]
-         [control-panel]
-         [:hr]
-         (cond
-           done?      [view-done]
-           incorrect? [view-incorrect]
-           correct?   [view-correct]
-           nothing?   [view-nothing]
-           loading?   [view-loading]
-           error      [:div.state.state-error
-                       [:p.error (str "Couldn't load: " (:message error))]
-                       [:button {:on-click #(d [:todos/load {:n 4}])}
-                        "Retry"]]
-           empty?     [view-empty]
-           one?       [view-one]
-           some?*     [view-some]
-           too-many?  [view-too-many]
-           :else      [:p "(unrecognised state)"])
-         [:hr]
-         [new-todo-form]]))))
+(reg-view ^{:doc "Root view: pick exactly one of the nine state views, plus form
+                  and control panel."}
+          root-view []
+  (let [done?      @(subscribe [:ui.state/done?])
+        correct?   @(subscribe [:ui.state/correct?])
+        incorrect? @(subscribe [:ui.state/incorrect?])
+        nothing?   @(subscribe [:ui.state/nothing?])
+        loading?   @(subscribe [:ui.state/loading?])
+        empty?     @(subscribe [:ui.state/empty?])
+        one?       @(subscribe [:ui.state/one?])
+        some?*     @(subscribe [:ui.state/some?])
+        too-many?  @(subscribe [:ui.state/too-many?])
+        error      @(subscribe [:todos/error])]
+    [:div.app
+     [:h1 "Nine States of UI — todos"]
+     [control-panel]
+     [:hr]
+     (cond
+       done?      [view-done]
+       incorrect? [view-incorrect]
+       correct?   [view-correct]
+       nothing?   [view-nothing]
+       loading?   [view-loading]
+       error      [:div.state.state-error
+                   [:p.error (str "Couldn't load: " (:message error))]
+                   [:button {:on-click #(dispatch [:todos/load {:n 4}])}
+                    "Retry"]]
+       empty?     [view-empty]
+       one?       [view-one]
+       some?*     [view-some]
+       too-many?  [view-too-many]
+       :else      [:p "(unrecognised state)"])
+     [:hr]
+     [new-todo-form]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS
@@ -693,10 +657,8 @@
 ;; CLJS host without touching React.
 
 ;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with the local Var `root` that `reg-view :ui.view/root`
-;; auto-defs. (`(name :ui.view/root)` is "root" — without renaming the
-;; mount point, the latter `def` overwrites the React root with the
-;; view fn, and at run time `root.render` is undefined.)
+;; collide with anything else in this ns; reg-view defs `root-view`,
+;; which is what we render.
 (defonce react-root
   (when (exists? js/document)
     (rdc/create-root (js/document.getElementById "app"))))

--- a/examples/realworld/article_editor.cljs
+++ b/examples/realworld/article_editor.cljs
@@ -187,73 +187,69 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def editor-page
-  (reg-view :pages/editor
-    (fn render-editor-page []
-      (let [d            (rf/dispatcher)
-            s            (rf/subscriber)
-            draft        @(s [:editor/draft])
-            errors       @(s [:editor/errors])
-            submitting?  @(s [:editor/submitting?])
-            submit-error @(s [:editor/submit-error])
-            mode         @(s [:editor/mode])]
-        [:div.editor-page
-         [:div.container.page
-          [:div.row
-           [:div.col-md-10.offset-md-1.col-xs-12
-            (when submit-error
-              [:ul.error-messages [:li submit-error]])
-            [:form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:editor/submit]))}
-             [:fieldset
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type        "text"
-                 :placeholder "Article Title"
-                 :value       (:title draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :title])
-                 :on-change   #(d [:editor/edit-field :title (.. % -target -value)])}]
-               (when-let [err (:title errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:input.form-control
-                {:type        "text"
-                 :placeholder "What's this article about?"
-                 :value       (:description draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :description])
-                 :on-change   #(d [:editor/edit-field :description (.. % -target -value)])}]
-               (when-let [err (:description errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:textarea.form-control
-                {:rows        8
-                 :placeholder "Write your article (in markdown)"
-                 :value       (:body draft)
-                 :disabled    submitting?
-                 :on-blur     #(d [:editor/blur-field :body])
-                 :on-change   #(d [:editor/edit-field :body (.. % -target -value)])}]
-               (when-let [err (:body errors)]
-                 [:div.error-messages err])]
-              [:fieldset.form-group
-               [:input.form-control
-                {:type        "text"
-                 :placeholder "Enter tags"
-                 :value       (:tagList draft)
-                 :disabled    submitting?
-                 :on-change   #(d [:editor/edit-field :tagList (.. % -target -value)])}]]
-              [:button.btn.btn-lg.pull-xs-right.btn-primary
-               {:type "submit" :disabled submitting?}
-               (if (= mode :edit) "Update Article" "Publish Article")]
-              (when (= mode :edit)
-                [:button.btn.btn-outline-danger
-                 {:type "button"
-                  :disabled submitting?
-                  :on-click #(d [:editor/delete])}
-                 "Delete Article"])]]]]]])))
+(reg-view editor-page []
+  (let [draft        @(subscribe [:editor/draft])
+        errors       @(subscribe [:editor/errors])
+        submitting?  @(subscribe [:editor/submitting?])
+        submit-error @(subscribe [:editor/submit-error])
+        mode         @(subscribe [:editor/mode])]
+    [:div.editor-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-10.offset-md-1.col-xs-12
+        (when submit-error
+          [:ul.error-messages [:li submit-error]])
+        [:form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:editor/submit]))}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type        "text"
+             :placeholder "Article Title"
+             :value       (:title draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :title])
+             :on-change   #(dispatch [:editor/edit-field :title (.. % -target -value)])}]
+           (when-let [err (:title errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type        "text"
+             :placeholder "What's this article about?"
+             :value       (:description draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :description])
+             :on-change   #(dispatch [:editor/edit-field :description (.. % -target -value)])}]
+           (when-let [err (:description errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:textarea.form-control
+            {:rows        8
+             :placeholder "Write your article (in markdown)"
+             :value       (:body draft)
+             :disabled    submitting?
+             :on-blur     #(dispatch [:editor/blur-field :body])
+             :on-change   #(dispatch [:editor/edit-field :body (.. % -target -value)])}]
+           (when-let [err (:body errors)]
+             [:div.error-messages err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type        "text"
+             :placeholder "Enter tags"
+             :value       (:tagList draft)
+             :disabled    submitting?
+             :on-change   #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
+          [:button.btn.btn-lg.pull-xs-right.btn-primary
+           {:type "submit" :disabled submitting?}
+           (if (= mode :edit) "Update Article" "Publish Article")]
+          (when (= mode :edit)
+            [:button.btn.btn-outline-danger
+             {:type "button"
+              :disabled submitting?
+              :on-click #(dispatch [:editor/delete])}
+             "Delete Article"])]]]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/articles.cljs
+++ b/examples/realworld/articles.cljs
@@ -127,117 +127,110 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def article-preview
-  (reg-view :articles/preview
-    {:doc "A single article card used across the home page and profile pages."}
-    (fn render-article-preview [{:keys [article]}]
-      (let [d (rf/dispatcher)
-            {:keys [slug title description createdAt favoritesCount author tagList]} article]
-        [:div.article-preview
-         [:div.article-meta
-          [routing/route-link {:to     :route/profile
-                               :params {:username (:username author)}}
-           [:img {:src (:image author)}]]
-          [:div.info
-           [routing/route-link {:to     :route/profile
-                                :params {:username (:username author)}
-                                :class  "author"}
-            (:username author)]
-           [:span.date createdAt]]
-          [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
-           {:type "button"
-            :on-click #(d [:article/toggle-favorite slug])}
-           [:i.ion-heart] " " favoritesCount]]
-         [routing/route-link {:to :route/article :params {:slug slug} :class "preview-link"}
-          [:h1 title]
-          [:p description]
-          [:span "Read more..."]
-          [:ul.tag-list
-           (for [tag tagList]
-             ^{:key tag}
-             [:li.tag-default.tag-pill.tag-outline tag])]]]))))
+(reg-view ^{:doc "A single article card used across the home page and profile pages."}
+          article-preview [{:keys [article]}]
+  (let [{:keys [slug title description createdAt favoritesCount author tagList]} article]
+    [:div.article-preview
+     [:div.article-meta
+      [routing/route-link {:to     :route/profile
+                           :params {:username (:username author)}}
+       [:img {:src (:image author)}]]
+      [:div.info
+       [routing/route-link {:to     :route/profile
+                            :params {:username (:username author)}
+                            :class  "author"}
+        (:username author)]
+       [:span.date createdAt]]
+      [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
+       {:type "button"
+        :on-click #(dispatch [:article/toggle-favorite slug])}
+       [:i.ion-heart] " " favoritesCount]]
+     [routing/route-link {:to :route/article :params {:slug slug} :class "preview-link"}
+      [:h1 title]
+      [:p description]
+      [:span "Read more..."]
+      [:ul.tag-list
+       (for [tag tagList]
+         ^{:key tag}
+         [:li.tag-default.tag-pill.tag-outline tag])]]]))
 
-(def home-page
-  (reg-view :pages/home
-    {:doc "Global feed / your feed / tag-filtered home page."}
-    (fn render-home []
-      (let [d              (rf/dispatcher)
-            s              (rf/subscriber)
-            authed?        @(s [:auth/authenticated?])
-            feed-kind      @(s [:home/feed-kind])
-            selected-tag   @(s [:home/selected-tag])
-            global-loading? @(s [:articles/loading?])
-            global-fetching? @(s [:articles/fetching?])
-            global-error   @(s [:articles/error])
-            global-articles @(s [:articles/data])
-            feed-loading?  @(s [:feed/loading?])
-            feed-error     @(s [:feed/error])
-            your-feed      @(s [:feed/data])
-            tags           @(s [:tags/data])
-            [loading? fetching? err articles]
-            (if (= feed-kind :your)
-              [feed-loading? false feed-error your-feed]
-              [global-loading? global-fetching? global-error global-articles])]
-        [:div.home-page
-         [:div.banner
-          [:div.container
-           [:h1.logo-font "conduit"]
-           [:p "A place to share your knowledge."]]]
-         [:div.container.page
-          [:div.row
-           [:div.col-md-9
-            [:div.feed-toggle
-             [:ul.nav.nav-pills.outline-active
-              (when authed?
-                [:li.nav-item
-                 [:a.nav-link
-                  {:href "#"
-                   :class (when (= feed-kind :your) "active")
-                   :on-click #(do (.preventDefault %)
-                                  (d [:home/show-your-feed]))}
-                  "Your Feed"]])
-              [:li.nav-item
-               [:a.nav-link
-                {:href "#"
-                 :class (when (= feed-kind :global) "active")
-                 :on-click #(do (.preventDefault %)
-                                (d [:home/show-global-feed]))}
-                "Global Feed"]]
-              (when selected-tag
-                [:li.nav-item
-                 [:a.nav-link.active
-                  {:href "#"
-                   :on-click #(do (.preventDefault %)
-                                  (d [:tags/clear-filter]))}
-                  [:i.ion-pound] " " selected-tag]])]]
-            (cond
-              loading?
-              [:div.article-preview "Loading articles…"]
+(reg-view ^{:doc "Global feed / your feed / tag-filtered home page."}
+          home-page []
+  (let [authed?         @(subscribe [:auth/authenticated?])
+        feed-kind       @(subscribe [:home/feed-kind])
+        selected-tag    @(subscribe [:home/selected-tag])
+        global-loading?  @(subscribe [:articles/loading?])
+        global-fetching? @(subscribe [:articles/fetching?])
+        global-error    @(subscribe [:articles/error])
+        global-articles @(subscribe [:articles/data])
+        feed-loading?   @(subscribe [:feed/loading?])
+        feed-error      @(subscribe [:feed/error])
+        your-feed       @(subscribe [:feed/data])
+        tags            @(subscribe [:tags/data])
+        [loading? fetching? err articles]
+        (if (= feed-kind :your)
+          [feed-loading? false feed-error your-feed]
+          [global-loading? global-fetching? global-error global-articles])]
+    [:div.home-page
+     [:div.banner
+      [:div.container
+       [:h1.logo-font "conduit"]
+       [:p "A place to share your knowledge."]]]
+     [:div.container.page
+      [:div.row
+       [:div.col-md-9
+        [:div.feed-toggle
+         [:ul.nav.nav-pills.outline-active
+          (when authed?
+            [:li.nav-item
+             [:a.nav-link
+              {:href "#"
+               :class (when (= feed-kind :your) "active")
+               :on-click #(do (.preventDefault %)
+                              (dispatch [:home/show-your-feed]))}
+              "Your Feed"]])
+          [:li.nav-item
+           [:a.nav-link
+            {:href "#"
+             :class (when (= feed-kind :global) "active")
+             :on-click #(do (.preventDefault %)
+                            (dispatch [:home/show-global-feed]))}
+            "Global Feed"]]
+          (when selected-tag
+            [:li.nav-item
+             [:a.nav-link.active
+              {:href "#"
+               :on-click #(do (.preventDefault %)
+                              (dispatch [:tags/clear-filter]))}
+              [:i.ion-pound] " " selected-tag]])]]
+        (cond
+          loading?
+          [:div.article-preview "Loading articles…"]
 
-              err
-              [:div.article-preview.error
-               (str "Couldn't load articles: " (pr-str err))]
+          err
+          [:div.article-preview.error
+           (str "Couldn't load articles: " (pr-str err))]
 
-              (empty? articles)
-              [:div.article-preview "No articles are here… yet."]
+          (empty? articles)
+          [:div.article-preview "No articles are here… yet."]
 
-              :else
-              [:<>
-               (when fetching? [:div.refresh-indicator "Refreshing…"])
-               (for [article articles]
-                 ^{:key (:slug article)}
-                 [article-preview {:article article}])])]
-           [:div.col-md-3
-            [:div.sidebar
-             [:p "Popular Tags"]
-             [:div.tag-list
-              (for [tag tags]
-                ^{:key tag}
-                [:a.tag-pill.tag-default
-                 {:href "#"
-                  :on-click #(do (.preventDefault %)
-                                 (d [:tags/apply-filter tag]))}
-                 tag])]]]]]]))))
+          :else
+          [:<>
+           (when fetching? [:div.refresh-indicator "Refreshing…"])
+           (for [article articles]
+             ^{:key (:slug article)}
+             [article-preview {:article article}])])]
+       [:div.col-md-3
+        [:div.sidebar
+         [:p "Popular Tags"]
+         [:div.tag-list
+          (for [tag tags]
+            ^{:key tag}
+            [:a.tag-pill.tag-default
+             {:href "#"
+              :on-click #(do (.preventDefault %)
+                             (dispatch [:tags/apply-filter tag]))}
+             tag])]]]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -259,77 +259,69 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def login-page
-  (reg-view :pages/login
-    {:doc "Login page."}
-    (fn render-login []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:auth.login-form/draft])
-            submitting? @(s [:auth/submitting?])
-            err         @(s [:auth/error])]
-        [:div.auth-page
-         [:h1 "Sign in"]
-         [routing/route-link {:to :route/register} "Need an account?"]
-         (when err [:ul.error-messages [:li err]])
-         [:form
-          {:on-submit (fn [e]
-                        (.preventDefault e)
-                        (d [:auth.login-form/submit]))}
-          [:fieldset
-           [:fieldset.form-group
-            [:input {:type        "email"
-                     :placeholder "Email"
-                     :value       (:email draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.login-form/edit-field :email (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "password"
-                     :placeholder "Password"
-                     :value       (:password draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.login-form/edit-field :password (.. % -target -value)])}]]
-           [:button {:type "submit" :disabled submitting?}
-            (if submitting? "Signing in…" "Sign in")]]]]))))
+(reg-view ^{:doc "Login page."}
+          login-page []
+  (let [draft       @(subscribe [:auth.login-form/draft])
+        submitting? @(subscribe [:auth/submitting?])
+        err         @(subscribe [:auth/error])]
+    [:div.auth-page
+     [:h1 "Sign in"]
+     [routing/route-link {:to :route/register} "Need an account?"]
+     (when err [:ul.error-messages [:li err]])
+     [:form
+      {:on-submit (fn [e]
+                    (.preventDefault e)
+                    (dispatch [:auth.login-form/submit]))}
+      [:fieldset
+       [:fieldset.form-group
+        [:input {:type        "email"
+                 :placeholder "Email"
+                 :value       (:email draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.login-form/edit-field :email (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "password"
+                 :placeholder "Password"
+                 :value       (:password draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.login-form/edit-field :password (.. % -target -value)])}]]
+       [:button {:type "submit" :disabled submitting?}
+        (if submitting? "Signing in…" "Sign in")]]]]))
 
-(def register-page
-  (reg-view :pages/register
-    {:doc "Register page."}
-    (fn render-register []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            draft       @(s [:auth.register-form/draft])
-            submitting? @(s [:auth/submitting?])
-            err         @(s [:auth/error])]
-        [:div.auth-page
-         [:h1 "Sign up"]
-         [routing/route-link {:to :route/login} "Have an account?"]
-         (when err [:ul.error-messages [:li err]])
-         [:form
-          {:on-submit (fn [e]
-                        (.preventDefault e)
-                        (d [:auth.register-form/submit]))}
-          [:fieldset
-           [:fieldset.form-group
-            [:input {:type        "text"
-                     :placeholder "Username"
-                     :value       (:username draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :username (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "email"
-                     :placeholder "Email"
-                     :value       (:email draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :email (.. % -target -value)])}]]
-           [:fieldset.form-group
-            [:input {:type        "password"
-                     :placeholder "Password"
-                     :value       (:password draft)
-                     :disabled    submitting?
-                     :on-change   #(d [:auth.register-form/edit-field :password (.. % -target -value)])}]]
-           [:button {:type "submit" :disabled submitting?}
-            (if submitting? "Signing up…" "Sign up")]]]]))))
+(reg-view ^{:doc "Register page."}
+          register-page []
+  (let [draft       @(subscribe [:auth.register-form/draft])
+        submitting? @(subscribe [:auth/submitting?])
+        err         @(subscribe [:auth/error])]
+    [:div.auth-page
+     [:h1 "Sign up"]
+     [routing/route-link {:to :route/login} "Have an account?"]
+     (when err [:ul.error-messages [:li err]])
+     [:form
+      {:on-submit (fn [e]
+                    (.preventDefault e)
+                    (dispatch [:auth.register-form/submit]))}
+      [:fieldset
+       [:fieldset.form-group
+        [:input {:type        "text"
+                 :placeholder "Username"
+                 :value       (:username draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :username (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "email"
+                 :placeholder "Email"
+                 :value       (:email draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :email (.. % -target -value)])}]]
+       [:fieldset.form-group
+        [:input {:type        "password"
+                 :placeholder "Password"
+                 :value       (:password draft)
+                 :disabled    submitting?
+                 :on-change   #(dispatch [:auth.register-form/edit-field :password (.. % -target -value)])}]]
+       [:button {:type "submit" :disabled submitting?}
+        (if submitting? "Signing up…" "Sign up")]]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/comments.cljs
+++ b/examples/realworld/comments.cljs
@@ -238,111 +238,104 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def comment-card
-  (reg-view :comments/card
-    (fn render-comment-card [{:keys [comment current-user]}]
-      (let [d       (rf/dispatcher)
-            mine?   (= (:username current-user)
-                       (get-in comment [:author :username]))
-            temp?   (str/starts-with? (str (:id comment)) "temp-")]
-        [:div.card
-         [:div.card-block [:p.card-text (:body comment)]]
-         [:div.card-footer
-          [routing/route-link {:to     :route/profile
-                               :params {:username (get-in comment [:author :username])}
-                               :class  "comment-author"}
-           [:img.comment-author-img {:src (get-in comment [:author :image])}]
-           " "
-           (get-in comment [:author :username])]
-          [:span.date-posted (:createdAt comment)]
-          (when temp?
-            [:span.mod-options " Sending…"])
-          (when (and mine? (not temp?))
-            [:button.mod-options
-             {:type "button"
-              :on-click #(d [:comment/delete (:id comment)])}
-             [:i.ion-trash-a]])]]))))
+(reg-view comment-card [{:keys [comment current-user]}]
+  (let [mine?   (= (:username current-user)
+                   (get-in comment [:author :username]))
+        temp?   (str/starts-with? (str (:id comment)) "temp-")]
+    [:div.card
+     [:div.card-block [:p.card-text (:body comment)]]
+     [:div.card-footer
+      [routing/route-link {:to     :route/profile
+                           :params {:username (get-in comment [:author :username])}
+                           :class  "comment-author"}
+       [:img.comment-author-img {:src (get-in comment [:author :image])}]
+       " "
+       (get-in comment [:author :username])]
+      [:span.date-posted (:createdAt comment)]
+      (when temp?
+        [:span.mod-options " Sending…"])
+      (when (and mine? (not temp?))
+        [:button.mod-options
+         {:type "button"
+          :on-click #(dispatch [:comment/delete (:id comment)])}
+         [:i.ion-trash-a]])]]))
 
-(def article-page
-  (reg-view :pages/article
-    (fn render-article-page []
-      (let [d                 (rf/dispatcher)
-            s                 (rf/subscriber)
-            article           @(s [:article/data])
-            article-status    @(s [:article/status])
-            article-error     @(s [:article/error])
-            comments          @(s [:comments/data])
-            comments-error    @(s [:comments/error])
-            comment-draft     @(s [:comment-form/draft])
-            submit-error      @(s [:comment-form/submit-error])
-            submitting?       @(s [:comment-form/submitting?])
-            current-user      @(s [:auth/user])]
-        [:div.article-page
-         (cond
-           (= article-status :loading)
-           [:div.article-preview "Loading article…"]
+(reg-view article-page []
+  (let [article        @(subscribe [:article/data])
+        article-status @(subscribe [:article/status])
+        article-error  @(subscribe [:article/error])
+        comments       @(subscribe [:comments/data])
+        comments-error @(subscribe [:comments/error])
+        comment-draft  @(subscribe [:comment-form/draft])
+        submit-error   @(subscribe [:comment-form/submit-error])
+        submitting?    @(subscribe [:comment-form/submitting?])
+        current-user   @(subscribe [:auth/user])]
+    [:div.article-page
+     (cond
+       (= article-status :loading)
+       [:div.article-preview "Loading article…"]
 
-           article-error
-           [:div.article-preview.error
-            (str "Couldn't load article: " (pr-str article-error))]
+       article-error
+       [:div.article-preview.error
+        (str "Couldn't load article: " (pr-str article-error))]
 
-           article
-           [:<>
-            [:div.banner
-             [:div.container
-              [:h1 (:title article)]
-              [:p (:description article)]
-              [:button.btn.btn-sm.btn-outline-primary
-               {:type "button"
-                :on-click #(d [:article/toggle-favorite (:slug article)])}
-               [:i.ion-heart] " " (:favoritesCount article)]]]
-            [:div.container.page
-             [:div.row.article-content
-              [:div.col-md-12
-               [:p (:body article)]
-               [:ul.tag-list
-                (for [tag (:tagList article)]
-                  ^{:key tag}
-                  [:li.tag-default.tag-pill.tag-outline tag])]]]
-             [:hr]
-             [:div.article-actions
-              [routing/route-link {:to :route/home} "Back to feed"]]
-             [:div.row
-              [:div.col-xs-12.col-md-8.offset-md-2
-               (if current-user
-                 [:form.card.comment-form
-                  {:on-submit (fn [e]
-                                (.preventDefault e)
-                                (d [:comment-form/submit]))}
-                  [:div.card-block
-                   [:textarea.form-control
-                    {:rows 3
-                     :placeholder "Write a comment..."
-                     :value (:body comment-draft)
-                     :disabled submitting?
-                     :on-change #(d [:comment-form/edit-field :body (.. % -target -value)])}]]
-                  [:div.card-footer
-                   [:img.comment-author-img {:src (:image current-user)}]
-                   [:button.btn.btn-sm.btn-primary
-                    {:type "submit"
-                     :disabled submitting?}
-                    (if submitting? "Posting…" "Post Comment")]]
-                  (when submit-error
-                    [:div.error-messages submit-error])]
-                 [:p
-                  [routing/route-link {:to :route/login} "Sign in"]
-                  " or "
-                  [routing/route-link {:to :route/register} "sign up"]
-                  " to add comments."])
-               (when comments-error
-                 [:div.article-preview.error
-                  (str "Couldn't load comments: " (pr-str comments-error))])
-               (for [comment comments]
-                 ^{:key (:id comment)}
-                 [comment-card {:comment comment :current-user current-user}])]]]]
+       article
+       [:<>
+        [:div.banner
+         [:div.container
+          [:h1 (:title article)]
+          [:p (:description article)]
+          [:button.btn.btn-sm.btn-outline-primary
+           {:type "button"
+            :on-click #(dispatch [:article/toggle-favorite (:slug article)])}
+           [:i.ion-heart] " " (:favoritesCount article)]]]
+        [:div.container.page
+         [:div.row.article-content
+          [:div.col-md-12
+           [:p (:body article)]
+           [:ul.tag-list
+            (for [tag (:tagList article)]
+              ^{:key tag}
+              [:li.tag-default.tag-pill.tag-outline tag])]]]
+         [:hr]
+         [:div.article-actions
+          [routing/route-link {:to :route/home} "Back to feed"]]
+         [:div.row
+          [:div.col-xs-12.col-md-8.offset-md-2
+           (if current-user
+             [:form.card.comment-form
+              {:on-submit (fn [e]
+                            (.preventDefault e)
+                            (dispatch [:comment-form/submit]))}
+              [:div.card-block
+               [:textarea.form-control
+                {:rows 3
+                 :placeholder "Write a comment..."
+                 :value (:body comment-draft)
+                 :disabled submitting?
+                 :on-change #(dispatch [:comment-form/edit-field :body (.. % -target -value)])}]]
+              [:div.card-footer
+               [:img.comment-author-img {:src (:image current-user)}]
+               [:button.btn.btn-sm.btn-primary
+                {:type "submit"
+                 :disabled submitting?}
+                (if submitting? "Posting…" "Post Comment")]]
+              (when submit-error
+                [:div.error-messages submit-error])]
+             [:p
+              [routing/route-link {:to :route/login} "Sign in"]
+              " or "
+              [routing/route-link {:to :route/register} "sign up"]
+              " to add comments."])
+           (when comments-error
+             [:div.article-preview.error
+              (str "Couldn't load comments: " (pr-str comments-error))])
+           (for [comment comments]
+             ^{:key (:id comment)}
+             [comment-card {:comment comment :current-user current-user}])]]]]
 
-           :else
-           [:div.article-preview "No article loaded."])]))))
+       :else
+       [:div.article-preview "No article loaded."])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/core.cljs
+++ b/examples/realworld/core.cljs
@@ -58,99 +58,83 @@
 ;; APP-SHELL VIEWS
 ;; ============================================================================
 
-(def header
-  (reg-view :app/header
-    {:doc "The site header. Shows different links based on auth state."}
-    (fn render-header []
-      (let [d       (rf/dispatcher)
-            s       (rf/subscriber)
-            authed? @(s [:auth/authenticated?])
-            user    @(s [:auth/user])]
-        [:nav.navbar.navbar-light
-         [:div.container
-          [routing/route-link {:to :route/home :class "navbar-brand"} "conduit"]
-          [:ul.nav.navbar-nav.pull-xs-right
-           [:li.nav-item
-            [routing/route-link {:to :route/home :class "nav-link"} "Home"]]
-           (if authed?
-             [:<>
-              [:li.nav-item
-               [routing/route-link {:to :route/editor :class "nav-link"}
-                [:i.ion-compose] " New Article"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/settings :class "nav-link"}
-                [:i.ion-gear-a] " Settings"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/profile
-                                    :params {:username (:username user)}
-                                    :class "nav-link"}
-                (:username user)]]
-              [:li.nav-item
-               [:a.nav-link {:href "#"
-                             :on-click #(do (.preventDefault %)
-                                            (d [:auth/flow [:auth/logout]]))}
-                "Logout"]]]
-             [:<>
-              [:li.nav-item
-               [routing/route-link {:to :route/login :class "nav-link"} "Sign in"]]
-              [:li.nav-item
-               [routing/route-link {:to :route/register :class "nav-link"} "Sign up"]]])]]]))))
+(reg-view ^{:doc "The site header. Shows different links based on auth state."}
+          header []
+  (let [authed? @(subscribe [:auth/authenticated?])
+        user    @(subscribe [:auth/user])]
+    [:nav.navbar.navbar-light
+     [:div.container
+      [routing/route-link {:to :route/home :class "navbar-brand"} "conduit"]
+      [:ul.nav.navbar-nav.pull-xs-right
+       [:li.nav-item
+        [routing/route-link {:to :route/home :class "nav-link"} "Home"]]
+       (if authed?
+         [:<>
+          [:li.nav-item
+           [routing/route-link {:to :route/editor :class "nav-link"}
+            [:i.ion-compose] " New Article"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/settings :class "nav-link"}
+            [:i.ion-gear-a] " Settings"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/profile
+                                :params {:username (:username user)}
+                                :class "nav-link"}
+            (:username user)]]
+          [:li.nav-item
+           [:a.nav-link {:href "#"
+                         :on-click #(do (.preventDefault %)
+                                        (dispatch [:auth/flow [:auth/logout]]))}
+            "Logout"]]]
+         [:<>
+          [:li.nav-item
+           [routing/route-link {:to :route/login :class "nav-link"} "Sign in"]]
+          [:li.nav-item
+           [routing/route-link {:to :route/register :class "nav-link"} "Sign up"]]])]]]))
 
-(def footer
-  (reg-view :app/footer
-    (fn render-footer []
-      [:footer
-       [:div.container
-        [routing/route-link {:to :route/home :class "logo-font"} "conduit"]
-        [:span.attribution "An interactive learning project from Thinkster."
-         " Code & design licensed under MIT."]]])))
+(reg-view footer []
+  [:footer
+   [:div.container
+    [routing/route-link {:to :route/home :class "logo-font"} "conduit"]
+    [:span.attribution "An interactive learning project from Thinkster."
+     " Code & design licensed under MIT."]]])
 
-(def pending-nav-dialog
-  (reg-view :app/pending-nav-dialog
-    {:doc "Renders a confirm dialog when navigation is blocked by a
-           :can-leave guard. Reads the :rf/pending-navigation slot."}
-    (fn render-pending-nav-dialog []
-      (let [d (rf/dispatcher)
-            s (rf/subscriber)]
-        (when-let [pending @(s [:rf/pending-navigation])]
-          [:div.pending-nav-overlay
-           [:div.pending-nav-dialog
-            [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]
-            [:button {:on-click #(d [:rf.route/continue (:id pending)])}
-             "Discard changes"]
-            [:button {:on-click #(d [:rf.route/cancel (:id pending)])}
-             "Stay"]]])))))
+(reg-view ^{:doc "Renders a confirm dialog when navigation is blocked by a
+                  :can-leave guard. Reads the :rf/pending-navigation slot."}
+          pending-nav-dialog []
+  (when-let [pending @(subscribe [:rf/pending-navigation])]
+    [:div.pending-nav-overlay
+     [:div.pending-nav-dialog
+      [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]
+      [:button {:on-click #(dispatch [:rf.route/continue (:id pending)])}
+       "Discard changes"]
+      [:button {:on-click #(dispatch [:rf.route/cancel (:id pending)])}
+       "Stay"]]]))
 
-(def not-found-page
-  (reg-view :pages/not-found
-    (fn render-not-found []
-      (let [s   (rf/subscriber)
-            url (:url @(s [:rf.route/params]))]
-        [:div.not-found-page
-         [:h1 "Page not found"]
-         (when url [:p (str "No route matches: " url)])
-         [routing/route-link {:to :route/home} "Home"]]))))
+(reg-view not-found-page []
+  (let [url (:url @(subscribe [:rf.route/params]))]
+    [:div.not-found-page
+     [:h1 "Page not found"]
+     (when url [:p (str "No route matches: " url)])
+     [routing/route-link {:to :route/home} "Home"]]))
 
-(def root-view
-  (reg-view :app/root
-    {:doc "App-level root. Switches on :rf.route/id to render the active page."}
-    (fn render-root []
-      (let [s (rf/subscriber)]
-        [:div.app
-         [header]
-         [pending-nav-dialog]
-         (case @(s [:rf.route/id])
-           :route/home              [articles/home-page]
-           :route/login             [auth/login-page]
-           :route/register          [auth/register-page]
-           :route/article           [comments/article-page]
-           :route/editor            [editor/editor-page]
-           :route/editor.edit       [editor/editor-page]
-           :route/profile           [profile/profile-page]
-           :route/profile.favorites [profile/profile-page]
-           :route/settings          [settings/settings-page]
-           [not-found-page])
-         [footer]]))))
+(reg-view ^{:doc "App-level root. Switches on :rf.route/id to render the active page."}
+          root-view []
+  [:div.app
+   [header]
+   [pending-nav-dialog]
+   (case @(subscribe [:rf.route/id])
+     :route/home              [articles/home-page]
+     :route/login             [auth/login-page]
+     :route/register          [auth/register-page]
+     :route/article           [comments/article-page]
+     :route/editor            [editor/editor-page]
+     :route/editor.edit       [editor/editor-page]
+     :route/profile           [profile/profile-page]
+     :route/profile.favorites [profile/profile-page]
+     :route/settings          [settings/settings-page]
+     [not-found-page])
+   [footer]])
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (top-level smoke)

--- a/examples/realworld/profile.cljs
+++ b/examples/realworld/profile.cljs
@@ -192,69 +192,65 @@
 ;; VIEWS
 ;; ============================================================================
 
-(def profile-page
-  (reg-view :pages/profile
-    (fn render-profile-page []
-      (let [d             (rf/dispatcher)
-            s             (rf/subscriber)
-            profile       @(s [:profile/data])
-            profile-error @(s [:profile/error])
-            loading?      @(s [:profile/loading?])
-            own?          @(s [:profile/own-profile?])
-            tab           @(s [:profile/current-tab])
-            articles*     @(s [:profile/current-articles])]
-        [:div.profile-page
-         (cond
-           loading?
-           [:div.article-preview "Loading profile…"]
+(reg-view profile-page []
+  (let [profile       @(subscribe [:profile/data])
+        profile-error @(subscribe [:profile/error])
+        loading?      @(subscribe [:profile/loading?])
+        own?          @(subscribe [:profile/own-profile?])
+        tab           @(subscribe [:profile/current-tab])
+        articles*     @(subscribe [:profile/current-articles])]
+    [:div.profile-page
+     (cond
+       loading?
+       [:div.article-preview "Loading profile…"]
 
-           profile-error
-           [:div.article-preview.error
-            (str "Couldn't load profile: " (pr-str profile-error))]
+       profile-error
+       [:div.article-preview.error
+        (str "Couldn't load profile: " (pr-str profile-error))]
 
-           profile
-           [:<>
-            [:div.user-info
-             [:div.container
-              [:div.row
-               [:div.col-xs-12.col-md-10.offset-md-1
-                [:img.user-img {:src (:image profile)}]
-                [:h4 (:username profile)]
-                [:p (:bio profile)]
-                (if own?
-                  [routing/route-link {:to :route/settings
-                                       :class "btn btn-sm btn-outline-secondary action-btn"}
-                   [:i.ion-gear-a] " Edit Profile Settings"]
-                  [:button.btn.btn-sm.btn-outline-secondary.action-btn
-                   {:type "button"
-                    :on-click #(d [(if (:following profile)
-                                     :profile/unfollow
-                                     :profile/follow)])}
-                   (if (:following profile) "Unfollow " "Follow ")
-                   (:username profile)])]]]]
-            [:div.container
-             [:div.row
-              [:div.col-xs-12.col-md-10.offset-md-1
-               [:div.articles-toggle
-                [:ul.nav.nav-pills.outline-active
-                 [:li.nav-item
-                  [routing/route-link {:to     :route/profile
-                                       :params {:username (:username profile)}
-                                       :class  (str "nav-link" (when (= tab :articles) " active"))}
-                   "My Articles"]]
-                 [:li.nav-item
-                  [routing/route-link {:to     :route/profile.favorites
-                                       :params {:username (:username profile)}
-                                       :class  (str "nav-link" (when (= tab :favorites) " active"))}
-                   "Favorited Articles"]]]]
-               (if (seq articles*)
-                 (for [article articles*]
-                   ^{:key (:slug article)}
-                   [articles/article-preview {:article article}])
-                 [:div.article-preview "No articles here yet."])]]]]
+       profile
+       [:<>
+        [:div.user-info
+         [:div.container
+          [:div.row
+           [:div.col-xs-12.col-md-10.offset-md-1
+            [:img.user-img {:src (:image profile)}]
+            [:h4 (:username profile)]
+            [:p (:bio profile)]
+            (if own?
+              [routing/route-link {:to :route/settings
+                                   :class "btn btn-sm btn-outline-secondary action-btn"}
+               [:i.ion-gear-a] " Edit Profile Settings"]
+              [:button.btn.btn-sm.btn-outline-secondary.action-btn
+               {:type "button"
+                :on-click #(dispatch [(if (:following profile)
+                                        :profile/unfollow
+                                        :profile/follow)])}
+               (if (:following profile) "Unfollow " "Follow ")
+               (:username profile)])]]]]
+        [:div.container
+         [:div.row
+          [:div.col-xs-12.col-md-10.offset-md-1
+           [:div.articles-toggle
+            [:ul.nav.nav-pills.outline-active
+             [:li.nav-item
+              [routing/route-link {:to     :route/profile
+                                   :params {:username (:username profile)}
+                                   :class  (str "nav-link" (when (= tab :articles) " active"))}
+               "My Articles"]]
+             [:li.nav-item
+              [routing/route-link {:to     :route/profile.favorites
+                                   :params {:username (:username profile)}
+                                   :class  (str "nav-link" (when (= tab :favorites) " active"))}
+               "Favorited Articles"]]]]
+           (if (seq articles*)
+             (for [article articles*]
+               ^{:key (:slug article)}
+               [articles/article-preview {:article article}])
+             [:div.article-preview "No articles here yet."])]]]]
 
-           :else
-           [:div.article-preview "No profile loaded."])]))))
+       :else
+       [:div.article-preview "No profile loaded."])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/realworld/routing.cljs
+++ b/examples/realworld/routing.cljs
@@ -111,30 +111,27 @@
 ;; LINK VIEW
 ;; ============================================================================
 
-(def route-link
-  (reg-view :rf/route-link
-    {:doc "Anchor helper for the RealWorld example. Uses the runtime's
-           `:rf/url-requested` event so modifier-key and browser-navigation
-           semantics stay on the framework path."}
-    (fn render-route-link [{:keys [to params query fragment class]} & children]
-      (let [d        (rf/dispatcher)
-            base-url (rf/route-url to (or params {}) (or query {}))
-            url      (str base-url (when fragment (str "#" fragment)))]
-        [:a {:href     url
-             :class    class
-             :on-click (fn [e]
-                         (when (and (zero? (.-button e))
-                                    (not (.-metaKey e))
-                                    (not (.-ctrlKey e))
-                                    (not (.-shiftKey e)))
-                           (.preventDefault e)
-                           (d [:rf/url-requested
-                               {:url url
-                                :to to
-                                :params params
-                                :query query
-                                :fragment fragment}])))}
-         (into [:<>] children)]))))
+(reg-view ^{:doc "Anchor helper for the RealWorld example. Uses the runtime's
+                   `:rf/url-requested` event so modifier-key and browser-navigation
+                   semantics stay on the framework path."}
+          route-link [{:keys [to params query fragment class]} & children]
+  (let [base-url (rf/route-url to (or params {}) (or query {}))
+        url      (str base-url (when fragment (str "#" fragment)))]
+    [:a {:href     url
+         :class    class
+         :on-click (fn [e]
+                     (when (and (zero? (.-button e))
+                                (not (.-metaKey e))
+                                (not (.-ctrlKey e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested
+                                  {:url url
+                                   :to to
+                                   :params params
+                                   :query query
+                                   :fragment fragment}])))}
+     (into [:<>] children)]))
 
 ;; ============================================================================
 ;; ROUTER WIRING

--- a/examples/realworld/settings.cljs
+++ b/examples/realworld/settings.cljs
@@ -77,69 +77,65 @@
 (rf/reg-sub :settings/submit-error
   (fn [db _] (get-in db [:settings :submit-error])))
 
-(def settings-page
-  (reg-view :pages/settings
-    (fn render-settings-page []
-      (let [d            (rf/dispatcher)
-            s            (rf/subscriber)
-            draft        @(s [:settings/draft])
-            submitting?  @(s [:settings/submitting?])
-            submit-error @(s [:settings/submit-error])]
-        [:div.settings-page
-         [:div.container.page
-          [:div.row
-           [:div.col-md-6.offset-md-3.col-xs-12
-            [:h1.text-xs-center "Your Settings"]
-            (when submit-error
-              [:ul.error-messages [:li submit-error]])
-            [:form
-             {:on-submit (fn [e]
-                           (.preventDefault e)
-                           (d [:settings/submit]))}
-             [:fieldset
-              [:fieldset.form-group
-               [:input.form-control
-                {:type "text"
-                 :placeholder "URL of profile picture"
-                 :value (:image draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :image (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "text"
-                 :placeholder "Username"
-                 :value (:username draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :username (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:textarea.form-control.form-control-lg
-                {:rows 8
-                 :placeholder "Short bio about you"
-                 :value (:bio draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :bio (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "email"
-                 :placeholder "Email"
-                 :value (:email draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :email (.. % -target -value)])}]]
-              [:fieldset.form-group
-               [:input.form-control.form-control-lg
-                {:type "password"
-                 :placeholder "New Password"
-                 :value (:password draft)
-                 :disabled submitting?
-                 :on-change #(d [:settings/edit-field :password (.. % -target -value)])}]]
-              [:button.btn.btn-lg.btn-primary.pull-xs-right
-               {:type "submit" :disabled submitting?}
-               (if submitting? "Updating…" "Update Settings")]]]
-            [:hr]
-            [:button.btn.btn-outline-danger
-             {:type "button"
-              :on-click #(d [:auth/flow [:auth/logout]])}
-             "Or click here to logout"]]]]]))))
+(reg-view settings-page []
+  (let [draft        @(subscribe [:settings/draft])
+        submitting?  @(subscribe [:settings/submitting?])
+        submit-error @(subscribe [:settings/submit-error])]
+    [:div.settings-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-6.offset-md-3.col-xs-12
+        [:h1.text-xs-center "Your Settings"]
+        (when submit-error
+          [:ul.error-messages [:li submit-error]])
+        [:form
+         {:on-submit (fn [e]
+                       (.preventDefault e)
+                       (dispatch [:settings/submit]))}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control
+            {:type "text"
+             :placeholder "URL of profile picture"
+             :value (:image draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :image (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "text"
+             :placeholder "Username"
+             :value (:username draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :username (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:textarea.form-control.form-control-lg
+            {:rows 8
+             :placeholder "Short bio about you"
+             :value (:bio draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :bio (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "email"
+             :placeholder "Email"
+             :value (:email draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :email (.. % -target -value)])}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "password"
+             :placeholder "New Password"
+             :value (:password draft)
+             :disabled submitting?
+             :on-change #(dispatch [:settings/edit-field :password (.. % -target -value)])}]]
+          [:button.btn.btn-lg.btn-primary.pull-xs-right
+           {:type "submit" :disabled submitting?}
+           (if submitting? "Updating…" "Update Settings")]]]
+        [:hr]
+        [:button.btn.btn-outline-danger
+         {:type "button"
+          :on-click #(dispatch [:auth/flow [:auth/logout]])}
+         "Or click here to logout"]]]]]))
 
 (defn settings-test []
   (rf/reg-fx :http.canned-settings-save

--- a/examples/routing/core.cljs
+++ b/examples/routing/core.cljs
@@ -60,79 +60,62 @@
 ;; LINK VIEW
 ;; ============================================================================
 
-(def route-link
-  (reg-view :rf/route-link
-    (fn render-route-link [{:keys [to params]} & children]
-      (let [d   (rf/dispatcher)
-            url (rf/route-url to (or params {}))]
-        [:a {:href     url
-             :on-click (fn [e]
-                         (when (and (zero? (.-button e))
-                                    (not (.-metaKey e))
-                                    (not (.-ctrlKey e))
-                                    (not (.-shiftKey e)))
-                           (.preventDefault e)
-                           (d [:rf/url-requested
-                               {:url url :to to :params (or params {})}])))}
-         (into [:span] children)]))))
+(reg-view route-link [{:keys [to params]} & children]
+  (let [url (rf/route-url to (or params {}))]
+    [:a {:href     url
+         :on-click (fn [e]
+                     (when (and (zero? (.-button e))
+                                (not (.-metaKey e))
+                                (not (.-ctrlKey e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (dispatch [:rf/url-requested
+                                  {:url url :to to :params (or params {})}])))}
+     (into [:span] children)]))
 
 ;; ============================================================================
 ;; PAGES
 ;; ============================================================================
 
-(def home-page
-  (reg-view :pages/home
-    (fn render-home []
+(reg-view home-page []
+  [:div
+   [:h1 "Welcome"]
+   [:p [route-link {:to :route/articles} "See the articles →"]]])
+
+(reg-view articles-page []
+  [:div
+   [:h1 "Articles"]
+   [:ul
+    (for [{:keys [id title]} @(subscribe [:articles])]
+      ^{:key id}
+      [:li [route-link {:to :route/article-detail :params {:id id}} title]])]])
+
+(reg-view article-detail-page []
+  (let [id      (:id @(subscribe [:rf.route/params]))
+        article @(subscribe [:article-by-id id])]
+    (if article
       [:div
-       [:h1 "Welcome"]
-       [:p [route-link {:to :route/articles} "See the articles →"]]])))
+       [:h1 (:title article)]
+       [:p (:body article)]
+       [:p [route-link {:to :route/articles} "← Back"]]]
+      [:div
+       [:p "Article not found."]
+       [:p [route-link {:to :route/articles} "← Back"]]])))
 
-(def articles-page
-  (reg-view :pages/articles
-    (fn render-articles []
-      (let [s (rf/subscriber)]
-        [:div
-         [:h1 "Articles"]
-         [:ul
-          (for [{:keys [id title]} @(s [:articles])]
-            ^{:key id}
-            [:li [route-link {:to :route/article-detail :params {:id id}} title]])]]))))
+(reg-view not-found-page []
+  (let [url (:url @(subscribe [:rf.route/params]))]
+    [:div
+     [:h1 "Not found"]
+     [:p (str "No route matches: " url)]
+     [:p [route-link {:to :route/home} "Home"]]]))
 
-(def article-detail-page
-  (reg-view :pages/article-detail
-    (fn render-article-detail []
-      (let [s       (rf/subscriber)
-            id      (:id @(s [:rf.route/params]))
-            article @(s [:article-by-id id])]
-        (if article
-          [:div
-           [:h1 (:title article)]
-           [:p (:body article)]
-           [:p [route-link {:to :route/articles} "← Back"]]]
-          [:div
-           [:p "Article not found."]
-           [:p [route-link {:to :route/articles} "← Back"]]])))))
-
-(def not-found-page
-  (reg-view :pages/not-found
-    (fn render-not-found []
-      (let [s   (rf/subscriber)
-            url (:url @(s [:rf.route/params]))]
-        [:div
-         [:h1 "Not found"]
-         [:p (str "No route matches: " url)]
-         [:p [route-link {:to :route/home} "Home"]]]))))
-
-(def root-view
-  (reg-view :app/root
-    (fn render-root []
-      (let [s (rf/subscriber)]
-        (case @(s [:rf.route/id])
-          :route/home           [home-page]
-          :route/articles       [articles-page]
-          :route/article-detail [article-detail-page]
-          :rf.route/not-found   [not-found-page]
-          [not-found-page])))))
+(reg-view root-view []
+  (case @(subscribe [:rf.route/id])
+    :route/home           [home-page]
+    :route/articles       [articles-page]
+    :route/article-detail [article-detail-page]
+    :rf.route/not-found   [not-found-page]
+    [not-found-page]))
 
 ;; ============================================================================
 ;; ROUTER WIRING
@@ -172,10 +155,8 @@
 ;; MOUNT
 ;; ============================================================================
 
-;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with the local Var that `(reg-view :app/root ...)` defs:
-;; `(name :app/root)` is "root", and that latter `def` would otherwise
-;; overwrite the React root with the view fn.
+;; The React root is named `react-root`; `reg-view` defs `root-view`,
+;; which is what we render.
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 

--- a/examples/seven_guis/cells.cljs
+++ b/examples/seven_guis/cells.cljs
@@ -214,44 +214,38 @@
 ;; VIEW
 ;; ============================================================================
 
-(def cell-view
-  (reg-view :cells/cell
-    (fn render-cell [id]
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            editing-id @(s [:cells/editing-id])
-            editing?   (= editing-id id)
-            raw        @(s [:cells/raw   id])
-            value      @(s [:cells/value id])
-            display    (cond
-                         editing?                  raw
-                         (= value :error/parse)    "#PARSE"
-                         (= value :error/cycle)    "#CYCLE"
-                         (= value :error/eval)     "#EVAL"
-                         (= value :error/div-by-zero) "#DIV/0"
-                         :else                     (str value))]
-        [:td.cell {:on-click #(d [:cells/start-editing id])}
-         (if editing?
-           [:input {:type      "text"
-                    :auto-focus true
-                    :default-value raw
-                    :on-blur    #(d [:cells/commit id (.. % -target -value)])
-                    :on-key-down #(when (= "Enter" (.-key %))
-                                    (d [:cells/commit id (.. % -target -value)]))}]
-           display)]))))
+(reg-view cell-view [id]
+  (let [editing-id @(subscribe [:cells/editing-id])
+        editing?   (= editing-id id)
+        raw        @(subscribe [:cells/raw   id])
+        value      @(subscribe [:cells/value id])
+        display    (cond
+                     editing?                  raw
+                     (= value :error/parse)    "#PARSE"
+                     (= value :error/cycle)    "#CYCLE"
+                     (= value :error/eval)     "#EVAL"
+                     (= value :error/div-by-zero) "#DIV/0"
+                     :else                     (str value))]
+    [:td.cell {:on-click #(dispatch [:cells/start-editing id])}
+     (if editing?
+       [:input {:type      "text"
+                :auto-focus true
+                :default-value raw
+                :on-blur    #(dispatch [:cells/commit id (.. % -target -value)])
+                :on-key-down #(when (= "Enter" (.-key %))
+                                (dispatch [:cells/commit id (.. % -target -value)]))}]
+       display)]))
 
-(def cells-grid
-  (reg-view :cells/grid
-    (fn render-grid []
-      [:table.cells-grid
-       [:thead [:tr [:th] (for [c (range COLS)] ^{:key c} [:th (char (+ 65 c))])]]
-       [:tbody
-        (for [r (range 1 (inc ROWS))]
-          ^{:key r}
-          [:tr [:th r]
-           (for [c (range COLS)]
-             ^{:key c}
-             [cell-view (cell-id c r)])])]])))
+(reg-view cells-grid []
+  [:table.cells-grid
+   [:thead [:tr [:th] (for [c (range COLS)] ^{:key c} [:th (char (+ 65 c))])]]
+   [:tbody
+    (for [r (range 1 (inc ROWS))]
+      ^{:key r}
+      [:tr [:th r]
+       (for [c (range COLS)]
+         ^{:key c}
+         [cell-view (cell-id c r)])])]])
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/circle_drawer.cljs
+++ b/examples/seven_guis/circle_drawer.cljs
@@ -161,41 +161,37 @@
 ;; VIEW
 ;; ============================================================================
 
-(def drawer-view
-  (reg-view :drawer/main
-    (fn render-drawer []
-      (let [d          (rf/dispatcher)
-            s          (rf/subscriber)
-            circles    @(s [:drawer/circles])
-            dialog     @(s [:drawer/dialog])
-            can-undo?  @(s [:drawer/can-undo?])
-            can-redo?  @(s [:drawer/can-redo?])]
-        [:div.drawer
-         [:div.row
-          [:button {:on-click #(d [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
-          [:button {:on-click #(d [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
-         [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
-                :on-click (fn [e]
-                            (let [rect (.. e -currentTarget getBoundingClientRect)
-                                  x    (- (.. e -clientX) (.-left rect))
-                                  y    (- (.. e -clientY) (.-top rect))]
-                              (d [:drawer/add-circle x y])))}
-          (for [{:keys [id x y radius]} circles]
-            ^{:key id}
-            [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
-                      :on-context-menu (fn [e]
-                                         (.preventDefault e)
-                                         (d [:drawer/open-dialog id]))}])]
+(reg-view drawer-view []
+  (let [circles    @(subscribe [:drawer/circles])
+        dialog     @(subscribe [:drawer/dialog])
+        can-undo?  @(subscribe [:drawer/can-undo?])
+        can-redo?  @(subscribe [:drawer/can-redo?])]
+    [:div.drawer
+     [:div.row
+      [:button {:on-click #(dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
+      [:button {:on-click #(dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
+     [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
+            :on-click (fn [e]
+                        (let [rect (.. e -currentTarget getBoundingClientRect)
+                              x    (- (.. e -clientX) (.-left rect))
+                              y    (- (.. e -clientY) (.-top rect))]
+                          (dispatch [:drawer/add-circle x y])))}
+      (for [{:keys [id x y radius]} circles]
+        ^{:key id}
+        [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
+                  :on-context-menu (fn [e]
+                                     (.preventDefault e)
+                                     (dispatch [:drawer/open-dialog id]))}])]
 
-         (when dialog
-           [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
-            [:p (str "Adjust diameter of circle " (:circle-id dialog))]
-            [:input {:type      "range"
-                     :min       5 :max 100 :step 1
-                     :value     (:draft-radius dialog)
-                     :on-change #(d [:drawer/dialog-drag
-                                     (js/parseInt (.. % -target -value))])}]
-            [:button {:on-click #(d [:drawer/close-dialog])} "Close"]])]))))
+     (when dialog
+       [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
+        [:p (str "Adjust diameter of circle " (:circle-id dialog))]
+        [:input {:type      "range"
+                 :min       5 :max 100 :step 1
+                 :value     (:draft-radius dialog)
+                 :on-change #(dispatch [:drawer/dialog-drag
+                                        (js/parseInt (.. % -target -value))])}]
+        [:button {:on-click #(dispatch [:drawer/close-dialog])} "Close"]])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/crud.cljs
+++ b/examples/seven_guis/crud.cljs
@@ -138,42 +138,38 @@
 ;; VIEW
 ;; ============================================================================
 
-(def crud-view
-  (reg-view :crud/main
-    (fn render-crud []
-      (let [d           (rf/dispatcher)
-            s           (rf/subscriber)
-            people      @(s [:crud/filtered-people])
-            selected-id @(s [:crud/selected-id])
-            d-name      @(s [:crud/draft-name])
-            d-surname   @(s [:crud/draft-surname])
-            can-update? @(s [:crud/can-update?])]
-        [:div.crud
-         [:div.row
-          [:label "Filter prefix: "]
-          [:input {:type      "text"
-                   :on-change #(d [:crud/set-filter (.. % -target -value)])}]]
-         [:div.row
-          [:select.list {:size      6
-                         :value     (or selected-id "")
-                         :on-change #(d [:crud/select (uuid (.. % -target -value))])}
-           (for [{:keys [id name surname]} people]
-             ^{:key id}
-             [:option {:value id} (str surname ", " name)])]
+(reg-view crud-view []
+  (let [people      @(subscribe [:crud/filtered-people])
+        selected-id @(subscribe [:crud/selected-id])
+        d-name      @(subscribe [:crud/draft-name])
+        d-surname   @(subscribe [:crud/draft-surname])
+        can-update? @(subscribe [:crud/can-update?])]
+    [:div.crud
+     [:div.row
+      [:label "Filter prefix: "]
+      [:input {:type      "text"
+               :on-change #(dispatch [:crud/set-filter (.. % -target -value)])}]]
+     [:div.row
+      [:select.list {:size      6
+                     :value     (or selected-id "")
+                     :on-change #(dispatch [:crud/select (uuid (.. % -target -value))])}
+       (for [{:keys [id name surname]} people]
+         ^{:key id}
+         [:option {:value id} (str surname ", " name)])]
 
-          [:div.inputs
-           [:div [:label "Name: "]
-            [:input {:type      "text"
-                     :value     d-name
-                     :on-change #(d [:crud/edit-name (.. % -target -value)])}]]
-           [:div [:label "Surname: "]
-            [:input {:type      "text"
-                     :value     d-surname
-                     :on-change #(d [:crud/edit-surname (.. % -target -value)])}]]]]
-         [:div.row.buttons
-          [:button {:on-click #(d [:crud/create])} "Create"]
-          [:button {:on-click #(d [:crud/update]) :disabled (not can-update?)} "Update"]
-          [:button {:on-click #(d [:crud/delete]) :disabled (not can-update?)} "Delete"]]]))))
+      [:div.inputs
+       [:div [:label "Name: "]
+        [:input {:type      "text"
+                 :value     d-name
+                 :on-change #(dispatch [:crud/edit-name (.. % -target -value)])}]]
+       [:div [:label "Surname: "]
+        [:input {:type      "text"
+                 :value     d-surname
+                 :on-change #(dispatch [:crud/edit-surname (.. % -target -value)])}]]]]
+     [:div.row.buttons
+      [:button {:on-click #(dispatch [:crud/create])} "Create"]
+      [:button {:on-click #(dispatch [:crud/update]) :disabled (not can-update?)} "Update"]
+      [:button {:on-click #(dispatch [:crud/delete]) :disabled (not can-update?)} "Delete"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/flight_booker.cljs
+++ b/examples/seven_guis/flight_booker.cljs
@@ -138,40 +138,36 @@
 ;; VIEW
 ;; ============================================================================
 
-(def flight-booker
-  (reg-view :flight/booker
-    (fn render-flight-booker []
-      (let [d                (rf/dispatcher)
-            s                (rf/subscriber)
-            trip-type        @(s [:flight/trip-type])
-            start-text       @(s [:flight/start-text])
-            return-text      @(s [:flight/return-text])
-            return-enabled?  @(s [:flight/return-enabled?])
-            start-valid?     @(s [:flight/start-valid?])
-            return-valid?    @(s [:flight/return-valid?])
-            book-enabled?    @(s [:flight/book-enabled?])
-            invalid-style    {:background "#fdd"}]
-        [:div.flight-booker
-         [:select {:value     (name trip-type)
-                   :on-change #(d [:flight/set-trip-type
-                                   (keyword (.. % -target -value))])}
-          [:option {:value "one-way"} "one-way flight"]
-          [:option {:value "return"}  "return flight"]]
+(reg-view flight-booker []
+  (let [trip-type        @(subscribe [:flight/trip-type])
+        start-text       @(subscribe [:flight/start-text])
+        return-text      @(subscribe [:flight/return-text])
+        return-enabled?  @(subscribe [:flight/return-enabled?])
+        start-valid?     @(subscribe [:flight/start-valid?])
+        return-valid?    @(subscribe [:flight/return-valid?])
+        book-enabled?    @(subscribe [:flight/book-enabled?])
+        invalid-style    {:background "#fdd"}]
+    [:div.flight-booker
+     [:select {:value     (name trip-type)
+               :on-change #(dispatch [:flight/set-trip-type
+                                      (keyword (.. % -target -value))])}
+      [:option {:value "one-way"} "one-way flight"]
+      [:option {:value "return"}  "return flight"]]
 
-         [:input {:type      "text"
-                  :value     start-text
-                  :style     (when-not start-valid? invalid-style)
-                  :on-change #(d [:flight/set-start (.. % -target -value)])}]
+     [:input {:type      "text"
+              :value     start-text
+              :style     (when-not start-valid? invalid-style)
+              :on-change #(dispatch [:flight/set-start (.. % -target -value)])}]
 
-         [:input {:type      "text"
-                  :value     return-text
-                  :disabled  (not return-enabled?)
-                  :style     (when (and return-enabled? (not return-valid?)) invalid-style)
-                  :on-change #(d [:flight/set-return (.. % -target -value)])}]
+     [:input {:type      "text"
+              :value     return-text
+              :disabled  (not return-enabled?)
+              :style     (when (and return-enabled? (not return-valid?)) invalid-style)
+              :on-change #(dispatch [:flight/set-return (.. % -target -value)])}]
 
-         [:button {:disabled (not book-enabled?)
-                   :on-click #(d [:flight/book])}
-          "Book"]]))))
+     [:button {:disabled (not book-enabled?)
+               :on-click #(dispatch [:flight/book])}
+      "Book"]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/temperature.cljs
+++ b/examples/seven_guis/temperature.cljs
@@ -120,23 +120,19 @@
 ;; VIEW
 ;; ============================================================================
 
-(def temperature-converter
-  (reg-view :temp/converter
-    {:doc "Two-input temperature converter."}
-    (fn render-temp-converter []
-      (let [d      (rf/dispatcher)
-            s      (rf/subscriber)
-            c-text @(s [:temp/celsius-text])
-            f-text @(s [:temp/fahrenheit-text])]
-        [:div.temperature
-         [:input {:type      "text"
-                  :value     (or c-text "")
-                  :on-change #(d [:temp/edit-celsius (.. % -target -value)])}]
-         [:label " °C  =  "]
-         [:input {:type      "text"
-                  :value     (or f-text "")
-                  :on-change #(d [:temp/edit-fahrenheit (.. % -target -value)])}]
-         [:label " °F"]]))))
+(reg-view ^{:doc "Two-input temperature converter."}
+          temperature-converter []
+  (let [c-text @(subscribe [:temp/celsius-text])
+        f-text @(subscribe [:temp/fahrenheit-text])]
+    [:div.temperature
+     [:input {:type      "text"
+              :value     (or c-text "")
+              :on-change #(dispatch [:temp/edit-celsius (.. % -target -value)])}]
+     [:label " °C  =  "]
+     [:input {:type      "text"
+              :value     (or f-text "")
+              :on-change #(dispatch [:temp/edit-fahrenheit (.. % -target -value)])}]
+     [:label " °F"]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/seven_guis/timer.cljs
+++ b/examples/seven_guis/timer.cljs
@@ -118,32 +118,28 @@
 ;; VIEW
 ;; ============================================================================
 
-(def timer-view
-  (reg-view :timer/timer
-    (fn render-timer []
-      (let [d        (rf/dispatcher)
-            s        (rf/subscriber)
-            progress @(s [:timer/progress-pct])
-            seconds  @(s [:timer/elapsed-seconds])
-            duration @(s [:timer/duration-ms])]
-        [:div.timer
-         [:div.row
-          [:label "Elapsed time:"]
-          [:div.bar {:style {:width "300px" :background "#ddd"}}
-           [:div.fill {:style {:width  (str progress "%")
-                               :height "20px"
-                               :background "#4a9"}}]]]
-         [:div.row [:label seconds " s"]]
-         [:div.row
-          [:label "Duration: "]
-          [:input {:type      "range"
-                   :min       0 :max 30000 :step 100
-                   :value     duration
-                   :on-change #(d [:timer/set-duration
-                                   (js/parseInt (.. % -target -value))])}]
-          [:span (.toFixed (/ duration 1000.0) 1) " s"]]
-         [:div.row
-          [:button {:on-click #(d [:timer/reset])} "Reset"]]]))))
+(reg-view timer-view []
+  (let [progress @(subscribe [:timer/progress-pct])
+        seconds  @(subscribe [:timer/elapsed-seconds])
+        duration @(subscribe [:timer/duration-ms])]
+    [:div.timer
+     [:div.row
+      [:label "Elapsed time:"]
+      [:div.bar {:style {:width "300px" :background "#ddd"}}
+       [:div.fill {:style {:width  (str progress "%")
+                           :height "20px"
+                           :background "#4a9"}}]]]
+     [:div.row [:label seconds " s"]]
+     [:div.row
+      [:label "Duration: "]
+      [:input {:type      "range"
+               :min       0 :max 30000 :step 100
+               :value     duration
+               :on-change #(dispatch [:timer/set-duration
+                                      (js/parseInt (.. % -target -value))])}]
+      [:span (.toFixed (/ duration 1000.0) 1) " s"]]
+     [:div.row
+      [:button {:on-click #(dispatch [:timer/reset])} "Reset"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (scheduling-light; we don't drive real time, just verify

--- a/examples/ssr/core.cljc
+++ b/examples/ssr/core.cljc
@@ -105,26 +105,23 @@
 
 (rf/reg-sub :articles (fn [db _] (:articles db)))
 
-;; rf/reg-view returns the view-id keyword. CLJS apps using the
-;; views-macros version of reg-view get an auto-defed Var as well; here
-;; we just bind the keyword.
-(def articles-page
-  (rf/reg-view :pages/articles
-    (fn render-articles []
-      (let [arts (rf/subscribe-value [:articles])]
-        [:div.page
-         [:h1 "Recent articles"]
-         (if (seq arts)
-           (into [:ul]
-                 (for [{:keys [id title body]} arts]
-                   ^{:key id}
-                   [:li [:h3 title] [:p body]]))
-           [:p "No articles."])]))))
+;; reg-view (defn-shape per Spec 004 §reg-view) auto-defs the symbol and
+;; registers under (keyword *ns* sym) — overridden here via
+;; ^{:rf/id ...} so the legacy :pages/articles / :app/root ids stay
+;; intact for the get-view callers below.
+(rf/reg-view ^{:rf/id :pages/articles} articles-page []
+  (let [arts (rf/subscribe-value [:articles])]
+    [:div.page
+     [:h1 "Recent articles"]
+     (if (seq arts)
+       (into [:ul]
+             (for [{:keys [id title body]} arts]
+               ^{:key id}
+               [:li [:h3 title] [:p body]]))
+       [:p "No articles."])]))
 
-(def root-view
-  (rf/reg-view :app/root
-    (fn render-root []
-      [(rf/get-view :pages/articles)])))
+(rf/reg-view ^{:rf/id :app/root} root-view []
+  [(rf/get-view :pages/articles)])
 
 ;; ============================================================================
 ;; SERVER ENTRY POINT

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -17,6 +17,10 @@ The shape deliberately echoes the v1 example's teaching split:
 - A v1-style separation of data/events/subs/views, but on the current re-frame2 API surface.
 - Headless browser verification through the Playwright example harness.
 
+### Why localStorage and not :rf.http/managed?
+
+TodoMVC persists locally so the example stays small and dependency-free. The canonical demo of Spec 014 (`:rf.http/managed`) lives with the `realworld` example. If you're here to learn the request shape, that's where to look.
+
 ## Official assets
 
 The example stages the official TodoMVC CSS packages at test/build time:

--- a/examples/todomvc/db.cljs
+++ b/examples/todomvc/db.cljs
@@ -27,6 +27,7 @@
       (catch :default _
         (sorted-map)))))
 
+;; localStorage is deliberate — see README. The Spec-014 :rf.http/managed demo lives with realworld.
 (rf/reg-cofx :todo.storage/todos
   {:doc "Inject the saved TodoMVC items from localStorage into coeffects."}
   (fn cofx-todo-storage-todos [ctx]

--- a/examples/todomvc/views.cljs
+++ b/examples/todomvc/views.cljs
@@ -115,25 +115,29 @@
          :on-click #(dispatch [:todo/clear-completed])}
         "Clear completed"])]))
 
-(def root-view
-  (reg-view :todo.app/root-view
-    (fn render-root-view []
-      (let [dispatch  (rf/dispatcher)
-            subscribe (rf/subscriber)
-            todos     @(subscribe [:todos])]
-        [:<>
-         [:section.todoapp
-          [task-entry dispatch]
-          (when (seq todos)
-            [task-list dispatch subscribe])
-          (when (seq todos)
-            [footer-controls dispatch subscribe])]
-         [:footer.info
-          [:p "Double-click to edit a todo"]
-          [:p
-           "Inspired by "
-           [:a {:href "https://github.com/day8/re-frame/tree/master/examples/todomvc"}
-            "the original re-frame TodoMVC example"]]
-          [:p
-           "Part of "
-           [:a {:href "https://todomvc.com/"} "TodoMVC"]]]]))))
+;; Sub-views (task-entry, task-list, todo-item, footer-controls) above
+;; are plain Reagent fns. Per Spec 004 §reg-view auto-inject, the
+;; capture-and-pass threading PR #51 introduced is no longer needed —
+;; sub-views can read `dispatch` / `subscribe` directly from the
+;; surrounding reg-view scope. We keep them as plain fns here (rather
+;; than reg-view'ing each sub-piece) because they're internal helpers
+;; with no need for their own registry slot or auto-defed Var; that
+;; gives the cleanest read in this example.
+(reg-view root-view []
+  (let [todos @(subscribe [:todos])]
+    [:<>
+     [:section.todoapp
+      [task-entry dispatch]
+      (when (seq todos)
+        [task-list dispatch subscribe])
+      (when (seq todos)
+        [footer-controls dispatch subscribe])]
+     [:footer.info
+      [:p "Double-click to edit a todo"]
+      [:p
+       "Inspired by "
+       [:a {:href "https://github.com/day8/re-frame/tree/master/examples/todomvc"}
+        "the original re-frame TodoMVC example"]]
+      [:p
+       "Part of "
+       [:a {:href "https://todomvc.com/"} "TodoMVC"]]]]))

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -65,10 +65,12 @@
      metadata stamped onto the registry slot includes :ns / :line /
      :file captured at this call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (events/reg-event-db ~id ~@args)))))
@@ -79,10 +81,12 @@
      the metadata stamped onto the registry slot includes :ns / :line /
      :file captured at this call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (events/reg-event-fx ~id ~@args)))))
@@ -93,10 +97,12 @@
      onto the registry slot includes :ns / :line / :file captured at
      this call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (events/reg-event-ctx ~id ~@args)))))
@@ -107,10 +113,12 @@
      the registry slot includes :ns / :line / :file captured at this
      call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (subs/reg-sub ~id ~@args)))))
@@ -121,10 +129,12 @@
      the registry slot includes :ns / :line / :file captured at this
      call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (fx/reg-fx ~id ~@args)))))
@@ -135,10 +145,12 @@
      onto the registry slot includes :ns / :line / :file captured at
      this call site."
      [id & args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (cofx/reg-cofx ~id ~@args)))))
@@ -149,10 +161,12 @@
      registry slot includes :ns / :line / :file captured at this call
      site."
      [id metadata]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (frame/reg-frame ~id ~metadata)))))
@@ -236,7 +250,7 @@
      ;; `:require-macros [re-frame.views-macros :refer [reg-view]]`
      ;; emit identical expansions.
      ((requiring-resolve 're-frame.views-macros/expand-reg-view)
-      (meta &form) (ns-name *ns*) sym more)))
+      (meta &form) (ns-name *ns*) *file* sym more)))
 
 (defn get-view
   "Return the render fn for a registered view by id, or nil if not
@@ -283,10 +297,12 @@
      registry slot includes :ns / :line / :file captured at this call
      site."
      [& args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (flows/reg-flow ~@args)))))
@@ -297,10 +313,12 @@
      registry slot includes :ns / :line / :file captured at this call
      site."
      [id metadata]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (routing/reg-route ~id ~metadata)))))
@@ -311,10 +329,12 @@
      metadata stamped onto the registry slot includes :ns / :line /
      :file captured at this call site."
      [path schema]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (schemas/reg-app-schema ~path ~schema)))))
@@ -330,10 +350,12 @@
      metadata stamped onto the registry slot includes :ns / :line /
      :file captured at this call site."
      [machine-id machine]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (machines/reg-machine ~machine-id ~machine)))))
@@ -374,10 +396,12 @@
      the registry slot includes :ns / :line / :file captured at this
      call site."
      [& args]
-     (let [m (meta &form)]
+     (let [m       (meta &form)
+           ns-sym  (ns-name *ns*)
+           file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
+                  (cond-> {:ns '~ns-sym}
+                    ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
           (-reg-error-projector ~@args)))))

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -66,7 +66,11 @@
      :file captured at this call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -82,7 +86,11 @@
      :file captured at this call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -98,7 +106,11 @@
      this call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -114,7 +126,11 @@
      call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -130,7 +146,11 @@
      call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -146,7 +166,11 @@
      this call site."
      [id & args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -162,7 +186,11 @@
      site."
      [id metadata]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -249,8 +277,11 @@
      ;; both this surface and the legacy
      ;; `:require-macros [re-frame.views-macros :refer [reg-view]]`
      ;; emit identical expansions.
+     ;; Construct a fresh metadata-free symbol; (ns-name *ns*) carries the
+     ;; consumer namespace's :doc metadata in CLJS macro context, which
+     ;; would otherwise serialise into the bundle and defeat elision.
      ((requiring-resolve 're-frame.views-macros/expand-reg-view)
-      (meta &form) (ns-name *ns*) *file* sym more)))
+      (meta &form) (symbol (str (ns-name *ns*))) *file* sym more)))
 
 (defn get-view
   "Return the render fn for a registered view by id, or nil if not
@@ -298,7 +329,11 @@
      site."
      [& args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -314,7 +349,11 @@
      site."
      [id metadata]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -330,7 +369,11 @@
      :file captured at this call site."
      [path schema]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -351,7 +394,11 @@
      :file captured at this call site."
      [machine-id machine]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
@@ -397,7 +444,11 @@
      call site."
      [& args]
      (let [m       (meta &form)
-           ns-sym  (ns-name *ns*)
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
+           ;; the ns-symbol but in CLJS macro context that symbol may carry
+           ;; the consumer namespace's :doc metadata, which would then get
+           ;; serialised into the bundle and defeat production elision.
+           ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -26,7 +26,17 @@
             [re-frame.http-managed :as http-managed]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
-            #?@(:cljs [[re-frame.views :as views]])))
+            ;; CLJS only: re-frame.views holds the Reagent-aware reg-view*
+            ;; (with React-context wiring). On JVM the registrar registration
+            ;; is sufficient.
+            #?@(:cljs [[re-frame.views :as views]]))
+  ;; The reg-view macro is defined in the #?(:clj ...) block below. Make
+  ;; it visible to CLJS callers under the `re-frame.core` alias by
+  ;; self-referring `:require-macros`. Per Spec 004 §reg-view, the macro
+  ;; lives in re-frame.core; CLJS users can write `rf/reg-view` after
+  ;; `(:require [re-frame.core :as rf])` without an explicit
+  ;; `:require-macros` clause at the call site.
+  #?(:cljs (:require-macros [re-frame.core :refer [reg-view]])))
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -162,39 +172,71 @@
      (def reg-cofx        cofx/reg-cofx)
      (def reg-frame       frame/reg-frame)))
 
-(defn -reg-view
-  "Internal helper — the fn-form delegate for the public `reg-view` macro
-  (and CLJS alias). Registers the view in the :view registry, merging
-  any pending source coords into the slot metadata."
+(defn reg-view*
+  "Plain-fn surface for view registration. Per Spec 004 §reg-view*.
+
+  Takes an id keyword and a render fn of any shape. No auto-def, no
+  auto-inject of `dispatch`/`subscribe`, no compile-time check on the
+  shape of `render-fn`. Use this when the registration is computed at
+  runtime: dynamic ids, library generation, registration without a
+  Var, or when the body doesn't fit the literal-fn contract enforced
+  by the `reg-view` macro (Reagent Form-3 / `create-class`).
+
+  On CLJS this delegates to `re-frame.views/reg-view*` so the
+  registered fn is wrapped with the React-context hook used to
+  resolve the surrounding frame at render time.
+
+  An optional metadata map may be supplied; merged with any pending
+  source-coords captured by the `reg-view` macro at the call site
+  (per Spec 001 §Source-coordinate capture)."
   ([id render-fn]
-   (-reg-view id {} render-fn))
+   (reg-view* id {} render-fn))
   ([id metadata render-fn]
-   (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
-                                        :handler-fn render-fn))
+   #?(:cljs
+      ;; Hand off to the Reagent-aware impl which wraps with
+      ;; :context-type metadata for frame resolution. The merge of
+      ;; pending source-coords happens here so re-frame.views/reg-view*
+      ;; receives a single, complete metadata map.
+      (views/reg-view* id (source-coords/merge-coords metadata) render-fn)
+      :clj
+      (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
+                                           :handler-fn render-fn)))
    id))
 
 #?(:clj
    (defmacro reg-view
-     "Register a view by id. The render-fn is `(fn [args...] hiccup-tree)`.
+     "Register a view as a defn-shape macro. Per Spec 004 §reg-view.
 
-     This is the JVM-runnable / SSR-friendly form. CLJS apps using Reagent
-     should prefer `re-frame.views-macros/reg-view` (also defs the local
-     var) for client-side use.
+     Shape:
+
+       (reg-view sym [args] body+)
+       (reg-view sym docstring [args] body+)
+       (reg-view ^{:rf/id :explicit/id} sym [args] body+)
+
+     Behavior:
+     - Auto-derives the id from `(keyword (str *ns*) (str sym))`.
+       Override via `^{:rf/id :explicit/id}` metadata on the symbol.
+     - Auto-injects lexical bindings `dispatch` and `subscribe`,
+       bound at render-time to `(rf/dispatcher)` / `(rf/subscriber)` of
+       the surrounding frame.
+     - Defs the symbol to the wrapped render fn AND registers under
+       the id in the :view registry.
+
+     Compile-time error if the second arg (after optional docstring)
+     is not a vector — the args vector of a defn-shape. For runtime
+     registration with computed ids or non-defn-shape bodies (e.g.
+     Form-3 / `create-class`), use `reg-view*` instead.
 
      Per Spec 001 §Source-coordinate capture the metadata stamped onto
-     the registry slot includes :ns / :line / :file captured at this
-     call site."
-     [& args]
-     (let [m (meta &form)]
-       `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns (ns-name *ns*)}
-                    *file*       (assoc :file *file*)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
-          (-reg-view ~@args)))))
-
-#?(:cljs
-   (def reg-view -reg-view))
+     the registry slot includes :ns / :line / :file captured here."
+     {:arglists '([sym args body+] [sym docstring args body+])}
+     [sym & more]
+     ;; Delegates to the shared expander in re-frame.views-macros so
+     ;; both this surface and the legacy
+     ;; `:require-macros [re-frame.views-macros :refer [reg-view]]`
+     ;; emit identical expansions.
+     ((requiring-resolve 're-frame.views-macros/expand-reg-view)
+      (meta &form) (ns-name *ns*) sym more)))
 
 (defn get-view
   "Return the render fn for a registered view by id, or nil if not

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -89,18 +89,20 @@
 ;; ---- reg-view -------------------------------------------------------------
 
 (defn reg-view*
-  "Function form of reg-view. Registers the view under :view kind in the
-  registrar. Returns the wrapped (frame-aware) render fn.
+  "Reagent-aware view registration. Wraps `render-fn` with the React
+  `:context-type` hook used to resolve the surrounding frame at render
+  time, then registers it in the :view kind of the registrar.
 
-  The Var-defining form lives in a macro so the local Var is bound at
-  compile time."
+  Per Spec 004 §reg-view*: this is the plain-fn surface delegated to
+  by `re-frame.core/reg-view*` on CLJS. `metadata` is merged into the
+  registry slot's metadata as-is; source-coord capture is performed
+  by the caller (`re-frame.core/reg-view*`)."
   [id metadata render-fn]
   (let [wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (apply render-fn args))
                   {:context-type frame-context})]
-    (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
-                                         :handler-fn wrapped))
+    (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
 
 (defn get-view

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -101,8 +101,12 @@
   "Build the expansion form for a reg-view macro call. Used by both
   re-frame.core/reg-view and re-frame.views-macros/reg-view. `form-meta`
   is `(meta &form)` from the calling macro; `current-ns-sym` is
-  `(ns-name *ns*)` at expansion time."
-  [form-meta current-ns-sym sym more]
+  `(ns-name *ns*)` at expansion time; `current-file` is `*file*` at
+  expansion time. Both are captured in the expansion as literals so
+  the emitted form does not reference `*ns*` / `*file*` at runtime —
+  necessary for the CLJS path, where `cljs.core/*ns*` is nil at
+  runtime."
+  [form-meta current-ns-sym current-file sym more]
   (let [parsed   (parse-reg-view-args more)
         sym-meta (or (meta sym) {})
         id-meta  (:rf/id sym-meta)
@@ -128,10 +132,10 @@
                            docstring (assoc :doc docstring))]
       `(do
          (binding [re-frame.source-coords/*pending-coords*
-                   (cond-> {:ns (ns-name *ns*)}
-                     *file* (assoc :file *file*)
-                     ~line  (assoc :line ~line)
-                     ~col   (assoc :column ~col))]
+                   (cond-> {:ns '~current-ns-sym}
+                     ~current-file (assoc :file ~current-file)
+                     ~line         (assoc :line ~line)
+                     ~col          (assoc :column ~col))]
            (re-frame.core/reg-view* ~id
              ~full-slot-meta
              (fn ~sym ~args
@@ -163,7 +167,7 @@
   surfaces emit the same expansion."
   {:arglists '([sym args body+] [sym docstring args body+])}
   [sym & more]
-  (expand-reg-view (meta &form) (ns-name *ns*) sym more))
+  (expand-reg-view (meta &form) (ns-name *ns*) *file* sym more))
 
 ;; ---- h --------------------------------------------------------------------
 ;;

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -58,24 +58,112 @@
 
 ;; ---- reg-view ------------------------------------------------------------
 ;;
-;; Per Spec 004 §reg-view defs the Var by default: the macro auto-defs a
-;; local Var named after the keyword's name so the call site can refer to
-;; the view as a value (Reagent's idiomatic Form-1).
+;; Per Spec 004 §reg-view: defn-shape macro. Two surfaces emit the same
+;; expansion — re-frame.core/reg-view (the canonical home) and the
+;; legacy re-frame.views-macros/reg-view (kept so existing
+;; `(:require-macros [re-frame.views-macros :refer [reg-view]])` imports
+;; keep working without an across-the-board sweep of example imports).
 ;;
-;; Forms supported:
-;;   (reg-view :id render-fn)
-;;   (reg-view :id metadata render-fn)
+;; The macro logic lives here as plain helpers so both defmacros can
+;; share it without circular load issues.
+
+(defn parse-reg-view-args
+  "Per Spec 004 §reg-view defn-shape. Parses (sym docstring? args body+)
+  into {:sym :docstring :args :body}. Returns nil when shape is invalid."
+  [more]
+  (let [[a & rest1] more]
+    (cond
+      (vector? a)
+      {:docstring nil :args a :body rest1}
+      (and (string? a) (vector? (first rest1)))
+      {:docstring a :args (first rest1) :body (next rest1)}
+      :else nil)))
+
+(defn describe-reg-view-bad-second-arg
+  "Human-readable description of an invalid second-arg to reg-view, for
+  the compile-error message. Per Spec 004 §reg-view compile-error
+  contract: the rejected cases are Var-ref symbol, create-class call,
+  and computed-fn call."
+  [x]
+  (cond
+    (symbol? x)
+    (str "a Var reference (" x ")")
+    (and (seq? x) (symbol? (first x)) (= "create-class" (name (first x))))
+    (str "a (" (first x) " …) call")
+    (seq? x)
+    (str "a (" (first x) " …) call")
+    (nil? x)
+    "nothing"
+    :else
+    (str "a " (some-> x type .getSimpleName) " — " (pr-str x))))
+
+(defn expand-reg-view
+  "Build the expansion form for a reg-view macro call. Used by both
+  re-frame.core/reg-view and re-frame.views-macros/reg-view. `form-meta`
+  is `(meta &form)` from the calling macro; `current-ns-sym` is
+  `(ns-name *ns*)` at expansion time."
+  [form-meta current-ns-sym sym more]
+  (let [parsed   (parse-reg-view-args more)
+        sym-meta (or (meta sym) {})
+        id-meta  (:rf/id sym-meta)
+        id       (or id-meta (keyword (str current-ns-sym) (str sym)))
+        ;; Anything on the symbol other than :rf/id is treated as slot
+        ;; metadata (matches Clojure's defn idiom: ^{:doc "..."} sym).
+        slot-meta (dissoc sym-meta :rf/id)]
+    (when (nil? parsed)
+      (throw (ex-info
+               (str "reg-view second argument must be an args vector "
+                    "(defn-shape: (reg-view sym [args] body)). Got "
+                    (describe-reg-view-bad-second-arg (first more))
+                    ". For runtime registration, use "
+                    "(re-frame.core/reg-view* :id render-fn).")
+               {:sym sym :got (first more) :args-after-sym (vec more)})))
+    (let [{:keys [docstring args body]} parsed
+          line (:line form-meta)
+          col  (:column form-meta)
+          def-form (if docstring
+                     `(def ~sym ~docstring (re-frame.core/get-view ~id))
+                     `(def ~sym (re-frame.core/get-view ~id)))
+          full-slot-meta (cond-> slot-meta
+                           docstring (assoc :doc docstring))]
+      `(do
+         (binding [re-frame.source-coords/*pending-coords*
+                   (cond-> {:ns (ns-name *ns*)}
+                     *file* (assoc :file *file*)
+                     ~line  (assoc :line ~line)
+                     ~col   (assoc :column ~col))]
+           (re-frame.core/reg-view* ~id
+             ~full-slot-meta
+             (fn ~sym ~args
+               (let [~'dispatch  (re-frame.core/dispatcher)
+                     ~'subscribe (re-frame.core/subscriber)]
+                 ~@body))))
+         ~def-form))))
 
 (defmacro reg-view
-  "Register a view by keyword id and def a same-named local Var bound
-  to the wrapped render fn. The local Var is the call-site reference;
-  the registered view is what frame-aware tooling (SSR, get-view) reads."
-  ([id render-fn]
-   `(reg-view ~id {} ~render-fn))
-  ([id metadata render-fn]
-   (let [sym (-> id name symbol)]
-     `(def ~sym
-        (re-frame.views/reg-view* ~id ~metadata ~render-fn)))))
+  "Register a view as a defn-shape macro. Per Spec 004 §reg-view.
+
+  Shape:
+    (reg-view sym [args] body+)
+    (reg-view sym docstring [args] body+)
+    (reg-view ^{:rf/id :explicit/id} sym [args] body+)
+
+  Auto-derives the id from `(keyword (str *ns*) (str sym))`. Override
+  via `^{:rf/id :explicit/id}` metadata on the symbol. Auto-injects
+  lexical bindings `dispatch` and `subscribe`. Defs the symbol to the
+  registered render fn.
+
+  Compile-time error if the second arg (after optional docstring) is
+  not a vector. For runtime registration with computed ids or
+  non-defn-shape bodies (e.g. Form-3 / `create-class`), use
+  `re-frame.core/reg-view*` instead.
+
+  This is the legacy import path; new code should
+  `:require-macros [re-frame.core :refer [reg-view]]` directly. Both
+  surfaces emit the same expansion."
+  {:arglists '([sym args body+] [sym docstring args body+])}
+  [sym & more]
+  (expand-reg-view (meta &form) (ns-name *ns*) sym more))
 
 ;; ---- h --------------------------------------------------------------------
 ;;

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -167,7 +167,10 @@
   surfaces emit the same expansion."
   {:arglists '([sym args body+] [sym docstring args body+])}
   [sym & more]
-  (expand-reg-view (meta &form) (ns-name *ns*) *file* sym more))
+  ;; Construct a fresh metadata-free symbol; see re-frame.core/reg-view for
+  ;; the rationale (CLJS macro context leaks :doc metadata via the ns-name
+  ;; symbol, which defeats production elision).
+  (expand-reg-view (meta &form) (symbol (str (ns-name *ns*))) *file* sym more))
 
 ;; ---- h --------------------------------------------------------------------
 ;;

--- a/implementation/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/test/re_frame/hot_reload_cljs_test.cljs
@@ -50,11 +50,13 @@
           v2-fn (fn [n]
                   (swap! v2-renders inc)
                   [:strong.v2 "v2-" n])]
-      ;; Use the function form (rf/reg-view) — it's the JVM-and-CLJS-shared
-      ;; surface. The macro form (re-frame.views-macros/reg-view) also
-      ;; works, but for hot-reload mechanics what matters is that the
-      ;; registrar's :view slot gets replaced.
-      (rf/reg-view :rf.hot-reload-test/widget v1-fn)
+      ;; Use the runtime fn form (rf/reg-view*) — the JVM-and-CLJS-shared
+      ;; surface for runtime registration with a Var-ref body. The macro
+      ;; form (rf/reg-view) is defn-shape only and rejects non-literal-fn
+      ;; bodies at compile time (per Spec 004 §reg-view); for hot-reload
+      ;; mechanics what matters is that the registrar's :view slot gets
+      ;; replaced — exactly what reg-view* does.
+      (rf/reg-view* :rf.hot-reload-test/widget v1-fn)
       (let [render-v1 (rf/get-view :rf.hot-reload-test/widget)]
         ;; First render uses v1.
         (is (= [:span.v1 "v1-" 7] (render-v1 7))
@@ -62,7 +64,7 @@
         (is (= 1 @v1-renders) "v1 was rendered once")
         (is (= 0 @v2-renders) "v2 has not rendered")
         ;; Re-register :rf.hot-reload-test/widget with v2 body.
-        (rf/reg-view :rf.hot-reload-test/widget v2-fn)
+        (rf/reg-view* :rf.hot-reload-test/widget v2-fn)
         ;; The registry's :view slot now resolves to v2's wrapped fn.
         ;; Reagent's render cycle re-resolves the head on each render
         ;; (the captured Var or the get-view return), so the next render
@@ -82,7 +84,7 @@
             not just the wrapper, by routing observation through the
             registered render fn rather than the captured Var"
     (let [observed (atom nil)]
-      (rf/reg-view :rf.hot-reload-test/probe
+      (rf/reg-view* :rf.hot-reload-test/probe
         (fn []
           (reset! observed :body-v1)
           [:p "v1"]))
@@ -92,7 +94,7 @@
       ((rf/get-view :rf.hot-reload-test/probe))
       (is (= :body-v1 @observed))
       ;; Re-register with a DIFFERENT body.
-      (rf/reg-view :rf.hot-reload-test/probe
+      (rf/reg-view* :rf.hot-reload-test/probe
         (fn []
           (reset! observed :body-v2)
           [:p "v2"]))
@@ -104,22 +106,26 @@
 (deftest view-re-register-via-macro-also-flips
   (testing "the reg-view MACRO path also installs the new render fn into
             the registry — verifying the contract holds for both surfaces"
-    ;; The macro auto-defs a local Var with the keyword's name. The
-    ;; underlying registration goes through re-frame.views/reg-view*,
-    ;; which calls registrar/register! with the wrapped fn. Hot-reload
-    ;; semantics ride on the registrar swap, so the macro form must
-    ;; respect the contract too.
+    ;; The macro auto-defs a local Var named after the supplied symbol
+    ;; and registers under (keyword *ns* sym), or under a ^{:rf/id ...}
+    ;; metadata override. The underlying registration goes through
+    ;; re-frame.core/reg-view*, which calls registrar/register! with the
+    ;; wrapped fn. Hot-reload semantics ride on the registrar swap, so
+    ;; the macro form must respect the contract too.
+    ;;
+    ;; Re-evaluating the same defn-shape form (same sym → same auto-id)
+    ;; is the canonical macro-side hot-reload path: the file changes,
+    ;; the ns reloads, the same form re-runs, and the registry slot is
+    ;; replaced.
     (let [observed (atom nil)]
-      (reg-view :rf.hot-reload-test/banner
-        (fn [t]
-          (reset! observed [:m1 t])
-          [:h1.m1 t]))
+      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
+        (reset! observed [:m1 t])
+        [:h1.m1 t])
       ((rf/get-view :rf.hot-reload-test/banner) "hello")
       (is (= [:m1 "hello"] @observed))
-      (reg-view :rf.hot-reload-test/banner
-        (fn [t]
-          (reset! observed [:m2 t])
-          [:h2.m2 t]))
+      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
+        (reset! observed [:m2 t])
+        [:h2.m2 t])
       ((rf/get-view :rf.hot-reload-test/banner) "world")
       (is (= [:m2 "world"] @observed)
           "post-rereg lookup invokes the new macro-installed body"))))

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -71,42 +71,31 @@
 ;; ---- reg-view macro ---------------------------------------------------------
 
 (deftest reg-view-registers
-  (testing "reg-view registers the view under the :view kind"
-    (reg-view :greet (fn [n] [:p "hi " n]))
+  (testing "reg-view (defn-shape macro) registers the view under the :view kind"
+    ;; Per Spec 004 §reg-view (rf2-d0pi): the macro is defn-shape. It
+    ;; auto-derives the id from (keyword *ns* sym); the ^{:rf/id ...}
+    ;; metadata override pins an explicit keyword for assertion.
+    (reg-view ^{:rf/id :greet} greet [n] [:p "hi " n])
     (is (some? (rf/get-view :greet))
-        "the view is registered under the :view kind")))
+        "the view is registered under the :view kind")
+    (is (fn? greet)
+        "the macro defs the supplied symbol to a callable render fn")))
 
-(deftest reg-view-macro-double-def-investigation
-  ;; The example apps wrap reg-view in an outer (def some-name ...) like:
-  ;;   (def login-form (reg-view :auth/form metadata render-fn))
-  ;; The reg-view macro itself emits (def form (reg-view* ...)). What
-  ;; does the outer-def actually see? Does login-form end up usable as
-  ;; a hiccup head, or as a var-of-var?
-  (testing "outer (def x (reg-view :foo …)) — what does x become?"
-    (let [outer-def-result
-          (do
-            ;; Simulate the example pattern. The macro defs `widget`
-            ;; AND the def below binds my-widget to whatever the macro
-            ;; returns.
-            (def my-widget
-              (reg-view :ns/widget (fn [n] [:span "w-" n])))
-            my-widget)]
-      ;; The registered view is fine.
-      (is (some? (rf/get-view :ns/widget))
-          ":ns/widget is in the :view registry")
-      ;; The keyword-derived local exists too.
-      (is (some? widget)
-          "the macro defined the keyword-derived local symbol")
-      ;; What did my-widget land as? In CLJS, def's return value is the
-      ;; var when used at top level via a let-bound capture? Let's see.
-      (println :outer-def-result-type (type outer-def-result))
-      ;; Whatever shape, we should be able to call it as a hiccup head.
-      ;; Reagent passes the head through React's createElement as a
-      ;; component fn.
-      (is (or (fn? outer-def-result)
-              (and (var? outer-def-result)
-                   (fn? @outer-def-result)))
-          "the outer-def value is invokable as a fn (or a var that derefs to one)"))))
+(deftest reg-view-macro-defs-the-symbol
+  ;; Per Spec 004 §reg-view (rf2-d0pi), the macro is defn-shape and defs
+  ;; the supplied symbol to the registered render fn — there is no
+  ;; outer-def pattern any more (the legacy
+  ;; `(def name (reg-view :id meta render-fn))` shape is gone with the
+  ;; non-defn-shape body restriction). This test pins the new contract:
+  ;; the auto-defined Var is itself usable as a hiccup head.
+  (testing "the macro defs the symbol to a callable render fn"
+    (reg-view ^{:rf/id :ns/widget} my-widget [n] [:span "w-" n])
+    ;; The registered view is in the registry.
+    (is (some? (rf/get-view :ns/widget))
+        ":ns/widget is in the :view registry")
+    ;; The defn-shape sym is bound to a fn — usable as a hiccup head.
+    (is (fn? my-widget)
+        "the macro defined the supplied symbol as a fn")))
 
 ;; ---- h macro ----------------------------------------------------------------
 
@@ -116,7 +105,7 @@
     (is (= [:div [:p "hi"]] (h [:div [:p "hi"]]))
         "DOM tag heads pass through unchanged")
     ;; A keyword in a namespace IS treated as a view reference.
-    (reg-view :my-ns/widget (fn [n] [:span "w-" n]))
+    (reg-view ^{:rf/id :my-ns/widget} h-test-widget [n] [:span "w-" n])
     (let [tree (h [:my-ns/widget 7])]
       (is (fn? (first tree))
           "namespaced keyword head was rewritten to a fn")
@@ -258,11 +247,10 @@
   (testing "complete SSR flow runs against the Reagent adapter on CLJS"
     (rf/reg-event-db :seed (fn [_ _] {:items ["a" "b" "c"]}))
     (rf/reg-sub :items (fn [db _] (:items db)))
-    (rf/reg-view :pages/list
-      (fn []
-        [:ul
-         (for [it (rf/subscribe-value [:items])]
-           ^{:key it} [:li it])]))
+    (rf/reg-view ^{:rf/id :pages/list} pages-list []
+      [:ul
+       (for [it (rf/subscribe-value [:items])]
+         ^{:key it} [:li it])])
     (rf/dispatch-sync [:seed])
     (let [html (rf/render-to-string [:pages/list] {:emit-hash? true})]
       (is (re-find #"<ul[^>]*data-rf-render-hash=\"[0-9a-f]{8}\"" html)

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -501,15 +501,19 @@
       (is (some #(= 're-frame.frame/*current-frame* %)
                 (tree-seq coll? seq exp))
           "with-frame expansion references *current-frame*"))
-    ;; reg-view defs a local var named after the keyword's name. Use
-    ;; macroexpand (not -1) because the 2-arity form delegates to the
-    ;; 3-arity form via a self-call.
+    ;; reg-view (defn-shape per Spec 004 §reg-view) defs the symbol and
+    ;; registers under (keyword (str *ns*) (str sym)). The expansion is
+    ;; (do (binding [...] (reg-view* ...)) (def sym (get-view ...))).
     (let [exp (macroexpand `(re-frame.views-macros/reg-view
-                              :my-widget (fn [] :body)))]
-      (is (= 'def (first exp))
-          "reg-view expansion starts with def")
-      (is (= 'my-widget (second exp))
-          "reg-view defs the var with the keyword's name"))
+                              ~'my-widget [] :body))]
+      (is (= 'do (first exp))
+          "reg-view expansion starts with do (binding + def)")
+      (let [forms (rest exp)
+            def-form (last forms)]
+        (is (= 'def (first def-form))
+            "the trailing form in the expansion is a def")
+        (is (= 'my-widget (second def-form))
+            "the def binds the symbol the user supplied")))
     ;; h leaves DOM tags alone but rewrites namespaced view refs.
     (let [exp (macroexpand-1 `(re-frame.views-macros/h [:my-ns/w {:k 1}]))]
       (is (some #(= 're-frame.core/get-view %)
@@ -854,7 +858,10 @@
       (fn [_ _] {:articles [{:id "a" :title "Article A" :body "Body A"}
                             {:id "b" :title "Article B" :body "Body B"}]}))
     (rf/reg-sub :articles (fn [db _] (:articles db)))
-    (rf/reg-view :pages/articles
+    ;; Test exercises the keyword-id [:pages/articles] hiccup head — not
+    ;; the macro shape — so it uses the plain-fn surface reg-view* with
+    ;; an explicit id rather than the defn-shape macro.
+    (rf/reg-view* :pages/articles
       (fn []
         (let [arts (rf/subscribe-value [:articles])]
           [:div.page
@@ -881,7 +888,8 @@
 
 (deftest reg-view-jvm
   (testing "reg-view registers a view that render-to-string resolves"
-    (rf/reg-view :greet
+    ;; Plain-fn surface (reg-view*): explicit id, no auto-def.
+    (rf/reg-view* :greet
       (fn [name] [:p "hello " [:strong name]]))
     (is (= "<p>hello <strong>world</strong></p>"
            (rf/render-to-string [:greet "world"]))

--- a/implementation/test/re_frame/source_coords_test.clj
+++ b/implementation/test/re_frame/source_coords_test.clj
@@ -115,8 +115,10 @@
 
 (deftest source-coords-on-reg-view
   (testing "reg-view stamps :ns / :line / :file"
-    (rf/reg-view :rf2-k84s/reg-view-sample
-                 (fn [] [:div "hi"]))
+    ;; Per Spec 004 §reg-view, defn-shape with explicit id-meta override.
+    ;; ^{:rf/id ...} keeps the legacy keyword for the assertion.
+    (rf/reg-view ^{:rf/id :rf2-k84s/reg-view-sample} reg-view-sample []
+      [:div "hi"])
     (assert-coords (rf/handler-meta :view :rf2-k84s/reg-view-sample)
                    :view :rf2-k84s/reg-view-sample)))
 

--- a/implementation/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/test/re_frame/ssr_end_to_end_test.clj
@@ -113,7 +113,10 @@
         (assoc db :articles articles)))
 
     (rf/reg-sub :articles (fn [db _] (:articles db)))
-    (rf/reg-view :pages/articles
+    ;; Plain-fn surface (reg-view*): the SSR test references the view by
+    ;; the literal :pages/articles keyword in render-to-string, so we
+    ;; preserve the explicit id rather than auto-derive.
+    (rf/reg-view* :pages/articles
       (fn []
         (let [arts (rf/subscribe-value [:articles])]
           [:div.page

--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -168,7 +168,7 @@
 (deftest expand-reg-view-helper-shape
   (testing "vm/expand-reg-view returns a (do binding+def) form"
     (let [exp (vm/expand-reg-view {:line 1 :column 1}
-                                  'my.ns 'my-widget '([] [:p]))]
+                                  'my.ns "my_ns.cljc" 'my-widget '([] [:p]))]
       (is (= 'do (first exp)))
       (is (= 'def (first (last exp))))
       (is (= 'my-widget (second (last exp))))))

--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.views-macros-test
+  "Per Spec 004 §reg-view: the defn-shape macro, the auto-id derivation
+  rule, the `^{:rf/id ...}` metadata override, the lexical
+  `dispatch`/`subscribe` injection, the Form-2 closure case, and the
+  compile-error contract for non-defn-shape bodies. Per rf2-d0pi.
+
+  These tests run on the JVM. CLJS-specific Reagent rendering lives in
+  the runtime / hot-reload CLJS test files; the macro logic here is
+  shared via re-frame.views-macros which is JVM-loadable."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.views-macros :as vm]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- shape: defn-shape macro auto-defs the symbol ------------------------
+
+(deftest reg-view-auto-defs-the-symbol
+  (testing "(reg-view sym [args] body) defs sym to the registered render fn"
+    (rf/reg-view widget-a [n]
+      [:span "w-" n])
+    ;; The Var was defined.
+    (let [resolved (resolve `widget-a)]
+      (is (some? resolved)
+          "the macro defs a Var named after the supplied symbol")
+      (is (fn? @resolved)
+          "the Var holds a callable render fn"))
+    ;; And the registry slot is populated under the auto-derived id.
+    ;; The id is taken from (ns-name *ns*) at macro-expansion time,
+    ;; which for this test file is `re-frame.views-macros-test` —
+    ;; matched literally here rather than via runtime *ns* (the test
+    ;; runner's *ns* is the test-runner ns, not the test file's ns).
+    (is (some? (rf/get-view :re-frame.views-macros-test/widget-a))
+        "the view is registered under (keyword 'this-ns' 'sym)")))
+
+;; ---- auto-id derivation --------------------------------------------------
+
+(deftest reg-view-auto-id-derives-from-ns-and-sym
+  (testing "the registered id is (keyword (str *ns*) (str sym)) when no
+            metadata override is present"
+    (rf/reg-view widget-b [_n] [:p "b"])
+    (is (some? (rf/get-view :re-frame.views-macros-test/widget-b))
+        "the registered id matches (keyword *ns* sym)")))
+
+;; ---- ^{:rf/id ...} metadata override -------------------------------------
+
+(deftest reg-view-metadata-override-takes-precedence
+  (testing "^{:rf/id :explicit/id} on the symbol wins over the auto-derived id"
+    (rf/reg-view ^{:rf/id :explicit/widget} widget-c [_n] [:p "c"])
+    (is (some? (rf/get-view :explicit/widget))
+        "the registered id is the metadata override")
+    (is (nil? (rf/get-view :re-frame.views-macros-test/widget-c))
+        "the auto-derived id is NOT registered when the override is present")))
+
+;; ---- compile-error contract ----------------------------------------------
+
+(deftest reg-view-rejects-var-ref-body
+  (testing "(reg-view sym some-fn) — a symbol where the args vector should be
+            — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-var ~'some-fn-ref)))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a symbol")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector")
+      (is (re-find #"reg-view\*" err)
+          "the message points the user at the reg-view* escape hatch"))))
+
+(deftest reg-view-rejects-create-class-body
+  (testing "(reg-view sym (reagent.core/create-class …)) — a list where the
+            args vector should be — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-cc (reagent.core/create-class {}))))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a create-class call")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector")
+      (is (re-find #"reg-view\*" err)
+          "the message points the user at the reg-view* escape hatch"))))
+
+(deftest reg-view-rejects-computed-body
+  (testing "(reg-view sym (some-fn-returning-a-fn)) — a non-fn call where
+            the args vector should be — throws at macroexpand"
+    (let [exp-fn (fn []
+                   (eval `(rf/reg-view bad-comp (~'compute-render-fn))))
+          err    (try (exp-fn) nil
+                      (catch Exception e
+                        (or (some-> e .getCause .getMessage)
+                            (.getMessage e))))]
+      (is (some? err)
+          "macroexpand throws when the second arg is a non-fn call")
+      (is (re-find #"args vector" err)
+          "the message points at the missing args vector"))))
+
+;; ---- error message template ----------------------------------------------
+
+(deftest reg-view-error-message-matches-template
+  (testing "the compile-error message follows the documented template"
+    (let [err (try (eval `(rf/reg-view broken ~'naked-symbol))
+                   nil
+                   (catch Exception e
+                     (or (some-> e .getCause .getMessage)
+                         (.getMessage e))))]
+      (is (some? err))
+      (is (re-find #"reg-view second argument must be an args vector" err)
+          "leading clause matches the template")
+      (is (re-find #"defn-shape" err)
+          "mentions defn-shape")
+      (is (re-find #"For runtime registration, use" err)
+          "directs the user to the escape hatch")
+      (is (re-find #"reg-view\*" err)
+          "names reg-view* explicitly"))))
+
+;; ---- docstring slot ------------------------------------------------------
+
+(deftest reg-view-accepts-docstring
+  (testing "(reg-view sym \"doc\" [args] body) accepts a docstring slot,
+            defn-style"
+    (rf/reg-view docced "the doc" [n] [:p n])
+    (let [v (resolve `docced)]
+      (is (some? v))
+      (is (fn? @v)))))
+
+;; ---- expansion under the legacy import path ------------------------------
+;;
+;; Existing examples use `(:require-macros [re-frame.views-macros :refer
+;; [reg-view]])`. That surface forwards to the canonical expander; the
+;; expansion shape and behaviour are identical. Cover the legacy path here
+;; so we don't lose it without noticing.
+
+(deftest reg-view-via-views-macros-import
+  (testing "(re-frame.views-macros/reg-view sym [args] body) emits the same
+            expansion shape as re-frame.core/reg-view"
+    (let [exp-core (macroexpand `(rf/reg-view ~'expand-test [] [:p]))
+          exp-vm   (macroexpand `(re-frame.views-macros/reg-view
+                                   ~'expand-test [] [:p]))]
+      ;; Both expansions share their structural skeleton.
+      (is (= 'do (first exp-core)))
+      (is (= 'do (first exp-vm)))
+      (is (= 'def (first (last exp-core))))
+      (is (= 'def (first (last exp-vm)))))))
+
+;; ---- expander helpers expose stable shape --------------------------------
+
+(deftest expand-reg-view-helper-shape
+  (testing "vm/expand-reg-view returns a (do binding+def) form"
+    (let [exp (vm/expand-reg-view {:line 1 :column 1}
+                                  'my.ns 'my-widget '([] [:p]))]
+      (is (= 'do (first exp)))
+      (is (= 'def (first (last exp))))
+      (is (= 'my-widget (second (last exp))))))
+
+  (testing "vm/parse-reg-view-args parses the three accepted shapes"
+    (is (= {:docstring nil :args '[] :body nil}
+           (vm/parse-reg-view-args '([]))))
+    (is (= {:docstring "doc" :args '[a] :body '([:p a])}
+           (vm/parse-reg-view-args '("doc" [a] [:p a]))))
+    (is (nil? (vm/parse-reg-view-args '(some-symbol)))
+        "a single non-vector arg is invalid")
+    (is (nil? (vm/parse-reg-view-args '((reagent.core/create-class {}))))
+        "a list where the args vector should be is invalid")))


### PR DESCRIPTION
Replaces auto-closed PR #54. Rebased onto current main (which now includes #51, #52, #55, #56, #57, #59).

## Macro change

`reg-view` becomes defn-shaped with auto-inject:

    (reg-view sym [args] body)
    (reg-view sym docstring [args] body)
    (reg-view ^{:rf/id :explicit/id} sym [args] body)

- Auto-derives id from `(keyword (str *ns*) (str sym))`.
- Auto-injects `dispatch` and `subscribe` as lexical bindings.
- Compile-time error on non-literal-fn bodies (Form-1 + Form-2 only).
- `reg-view*` (fn) is the metaprogramming surface for runtime registration.

## Sweep

- All 8 example directories converted (counter, login, nine_states, realworld, routing, seven_guis/*, ssr, todomvc).
- 11 spec/doc files swept (004-Views, MIGRATION, API, Conventions, Cross-Spec-Interactions, 001-Registration, 012-Routing, Pattern-Boot, Pattern-NineStates, Pattern-Forms, plus the conformance-fixture tests).
- Conventions.md adds the `*`-suffix naming convention.
- Cross-Spec-Interactions.md notes the reg-view family asymmetry.
- The `managed-http-counter` example (added on main post-d0pi) is also converted as part of the rebase.

## Follow-up commits on this branch

- `b0cf569` (pre-rebase) — converts 8 missed reg-view sites in test files to `reg-view*`; captures `*ns*`/`*file*` at expansion time across 13 source-coord-capturing macros (resolves a CLJS macro-hygiene bug exposed by the new self-`:require-macros` line).
- `dd58ab8` (post-rebase) — strips `:doc` metadata from the captured ns-symbol. Without it the consumer-ns docstring leaks into the production bundle via `*pending-coords*`'s `:ns` value, which defeats elision (the new self-`:require-macros` line routes every reg-* call through the JVM macro path on CLJS, so the leak now has reach). The elision probe goes from FAIL to PASS with this fix.

## Beads

- rf2-d0pi (closes on merge)
- rf2-kauy (closes on merge — TodoMVC localStorage-as-demo note folded in as the first commit on this branch)
- rf2-3442 (already closed; this PR realises the resolution)

## Tests

JVM, CLJS node, CLJS browser, elision, Playwright — all green post-rebase.