### PR TITLE
test: extend elision probe to :rf.epoch sentinels (rf2-gox8)

### DIFF
--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -84,7 +84,44 @@ const DEV_ONLY_SENTINELS = [
   // 014 §:auto). Emitted only when the user did NOT supply :decode AND
   // interop/debug-enabled?. The string fragment must elide in production.
   { source: 're-frame.http-managed/maybe-emit-decode-defaulted! (rf.warning/decode-defaulted)',
-    sentinel: 'rf.warning/decode-defaulted' }
+    sentinel: 'rf.warning/decode-defaulted' },
+  // re-frame.epoch — :rf.epoch/snapshotted trace op (Tool-Pair §Time-
+  // travel, Spec 009 §register-epoch-cb). Emitted by settle! after a
+  // drain-settle commits a record. The whole settle! body sits inside
+  // `(when interop/debug-enabled? ...)`; the string fragment must elide.
+  { source: 're-frame.epoch/settle! (rf.epoch/snapshotted)',
+    sentinel: 'rf.epoch/snapshotted' },
+  // re-frame.epoch — :rf.epoch/restored trace op. Emitted on the happy
+  // path of restore-epoch. The entire restore-epoch body is guarded by
+  // an `(if-not interop/debug-enabled? false ...)` early-return so the
+  // success arm and its string sentinel must elide in production.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restored)',
+    sentinel: 'rf.epoch/restored' },
+  // re-frame.epoch — :rf.epoch/restore-during-drain failure mode.
+  // Emitted via emit-restore-failure! when restore-epoch is called
+  // while a drain is in flight. Same elision gate as :rf.epoch/restored.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restore-during-drain)',
+    sentinel: 'rf.epoch/restore-during-drain' },
+  // re-frame.epoch — :rf.epoch/restore-unknown-epoch failure mode.
+  // Emitted when the requested epoch-id is no longer in the frame's
+  // ring buffer. Must elide.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restore-unknown-epoch)',
+    sentinel: 'rf.epoch/restore-unknown-epoch' },
+  // re-frame.epoch — :rf.epoch/restore-schema-mismatch failure mode.
+  // Emitted when the recorded :db-after no longer validates against
+  // every currently-registered app-schema. Must elide.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restore-schema-mismatch)',
+    sentinel: 'rf.epoch/restore-schema-mismatch' },
+  // re-frame.epoch — :rf.epoch/restore-missing-handler failure mode.
+  // Emitted when the recorded db references a registration (machine,
+  // route) that is no longer present in the registrar. Must elide.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restore-missing-handler)',
+    sentinel: 'rf.epoch/restore-missing-handler' },
+  // re-frame.epoch — :rf.epoch/restore-version-mismatch failure mode.
+  // Emitted when a machine snapshot's :rf/snapshot-version differs
+  // from the currently-registered machine's :version. Must elide.
+  { source: 're-frame.epoch/restore-epoch (rf.epoch/restore-version-mismatch)',
+    sentinel: 'rf.epoch/restore-version-mismatch' }
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/implementation/test/re_frame/elision_probe.cljs
+++ b/implementation/test/re_frame/elision_probe.cljs
@@ -24,6 +24,10 @@
   - `:rf.http/managed` Spec 014 trace ops (`:rf.http/retry-attempt`,
     `:rf.warning/decode-defaulted`) — emitted only inside
     `(when interop/debug-enabled? ...)` branches.
+  - `re-frame.epoch` public surface — `epoch-history`, `restore-epoch`,
+    `register-epoch-cb`, `remove-epoch-cb`, `configure :epoch-history`,
+    plus the `:rf.epoch/*` trace ops emitted by `settle!` and
+    `restore-epoch` (rf2-gox8 follow-up to rf2-shjf).
 
   Note the probe does NOT need to assert anything at runtime; it exists
   to root the dead-code-elimination graph at every surface. The grep
@@ -32,6 +36,7 @@
             [re-frame.registrar    :as registrar]
             [re-frame.schemas      :as schemas]
             [re-frame.trace        :as trace]
+            [re-frame.epoch        :as epoch]
             [re-frame.http-managed :as http-managed]))
 
 ;; ---- trace listener API ---------------------------------------------------
@@ -110,6 +115,55 @@
   ;; reachable; the probe doesn't actually issue a real request.
   (http-managed/clear-all-in-flight!))
 
+;; ---- Tool-Pair §Time-travel epoch surface (rf2-gox8) ----------------------
+
+(defn ^:export touch-epoch! []
+  ;; Per Tool-Pair §Time-travel and Spec 009 §`register-epoch-cb`, the
+  ;; epoch ns ships gated trace ops:
+  ;;
+  ;;   :rf.epoch/snapshotted              (settle! after drain-empty)
+  ;;   :rf.epoch/restored                 (restore-epoch happy path)
+  ;;   :rf.epoch/restore-during-drain     (failure mode 2)
+  ;;   :rf.epoch/restore-unknown-epoch    (failure mode 3)
+  ;;   :rf.epoch/restore-schema-mismatch  (failure mode 4)
+  ;;   :rf.epoch/restore-missing-handler  (failure mode 5)
+  ;;   :rf.epoch/restore-version-mismatch (failure mode 6)
+  ;;
+  ;; Every emit site sits inside `(when interop/debug-enabled? ...)`
+  ;; (or guarded by an `if-not interop/debug-enabled?` early-return in
+  ;; restore-epoch) so under :advanced + goog.DEBUG=false the bodies
+  ;; DCE and the `:rf.epoch/*` string fragments must NOT appear in the
+  ;; production bundle.
+  ;;
+  ;; The probe roots the dependency graph for the epoch surface by:
+  ;;   1. requiring re-frame.epoch directly (forces the ns body — and
+  ;;      therefore every gated branch — into the bundle, where DCE can
+  ;;      then prove the bodies dead under goog.DEBUG=false);
+  ;;   2. referencing every public symbol surfaced via re-frame.core so
+  ;;      the listener / history / restore / configure entry points
+  ;;      stay live;
+  ;;   3. exercising the drain-settle path via the dispatch-sync calls
+  ;;      in touch-registrar! — the eventual queue-empty fires
+  ;;      `:rf.epoch/snapshotted` through trace/emit!, sourcing the
+  ;;      snapshotted sentinel.
+  (rf/configure :epoch-history {:depth 10})
+  (rf/register-epoch-cb ::probe-epoch (fn [_record] nil))
+  (let [_history (rf/epoch-history :rf/default)]
+    nil)
+  (rf/remove-epoch-cb ::probe-epoch)
+  ;; Drive a restore failure-mode emit site so the unknown-epoch
+  ;; sentinel has a path through a documented entry point. The
+  ;; remaining failure ops survive via their literal occurrence in
+  ;; the gated emit-restore-failure! call sites in re-frame.epoch.
+  (rf/restore-epoch :rf/default 999999)
+  ;; Reference epoch's lower-level entry points directly so the ns is
+  ;; not pruned even before DCE looks at the gated bodies.
+  (epoch/clear-history!)
+  (epoch/clear-frame-history! :rf/default)
+  (epoch/clear-epoch-cbs!)
+  (let [_cfg (epoch/current-config)]
+    nil))
+
 ;; ---- entry point ----------------------------------------------------------
 
 (defn ^:export run []
@@ -117,6 +171,7 @@
   (touch-schemas!)
   (touch-registrar!)
   (touch-http-managed!)
+  (touch-epoch!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.
   (trace/emit! :event :rf.probe/direct-touch {:source :probe}))


### PR DESCRIPTION
## Summary

Small follow-up to rf2-shjf. The elision probe (rf2-11hn) already covered trace / schema / registrar / `:rf.http` surfaces but did not exercise the `re-frame.epoch` surface. This PR extends the probe and the bundle-grep test so we confirm the epoch surface also elides in production.

## New sentinels

Every emit site sits inside `(when interop/debug-enabled? ...)` (or under `restore-epoch`'s `(if-not interop/debug-enabled? false ...)` early-return), so under `:advanced` + `goog.DEBUG=false` the bodies must DCE and these string fragments must NOT appear in the production bundle:

- `rf.epoch/snapshotted` — `settle!` after drain-empty
- `rf.epoch/restored` — `restore-epoch` happy path
- `rf.epoch/restore-during-drain` — failure mode 2
- `rf.epoch/restore-unknown-epoch` — failure mode 3
- `rf.epoch/restore-schema-mismatch` — failure mode 4
- `rf.epoch/restore-missing-handler` — failure mode 5
- `rf.epoch/restore-version-mismatch` — failure mode 6

## New probe touches (`touch-epoch!`)

Roots the dependency graph for the epoch surface so DCE has something to prove dead:

- requires `re-frame.epoch` directly (forces the ns body — every gated branch — into the bundle);
- calls every public symbol re-exported via `re-frame.core`: `configure :epoch-history`, `register-epoch-cb`, `epoch-history`, `remove-epoch-cb`, `restore-epoch`;
- references the lower-level helpers `clear-history!`, `clear-frame-history!`, `clear-epoch-cbs!`, `current-config`;
- relies on `touch-registrar!`'s existing `dispatch-sync` calls to drive a drain-settle that fires `:rf.epoch/snapshotted`.

## Test plan

- [x] `cd implementation && npm install && npm run test:elision`
- [x] Production bundle: every new `:rf.epoch/*` sentinel reports `expected ABSENT, was ABSENT`.
- [x] Control bundle (`goog.DEBUG=true`): every new sentinel reports `expected PRESENT, was PRESENT`.