### PR TITLE
fix: Spec 014 status-check before decode (rf2-lokk)

### DIFF
--- a/docs/specification/014-HTTPRequests.md
+++ b/docs/specification/014-HTTPRequests.md
@@ -123,6 +123,8 @@ Multipart upload: pass `(js/FormData.)` directly as `:body` (or as the return va
 
 The `:decode` key controls how the response body is parsed.
 
+**Decode runs only on success-eligible (2xx) responses.** Status classification happens *before* decode — see [§Classification order](#classification-order). On a 4xx or 5xx the body is surfaced raw (as the response text) under the `:body` tag of `:rf.http/http-4xx` / `:rf.http/http-5xx`; the `:decode` pipeline is skipped entirely. This means a JSON endpoint that returns an HTML 404 from the load balancer surfaces as `:rf.http/http-4xx` with the HTML at `:body`, NOT as `:rf.http/decode-failure`.
+
 ### Schema-driven (the canonical form)
 
 Pass a Malli schema as `:decode`:
@@ -137,7 +139,7 @@ The fx:
 3. Validates / coerces with Malli's `decode` against the schema.
 4. Hands the decoded value to `:accept`.
 
-If the body fails to decode (transport-OK but malformed payload), the fx classifies it as `:problem :decode` and routes through the failure path.
+If a 2xx response's body fails to decode (transport-OK, status-OK, but malformed payload), the fx classifies it as `:rf.http/decode-failure` and routes through the failure path. Decode never runs on a 4xx/5xx — see [§Classification order](#classification-order).
 
 ### Explicit content type
 
@@ -157,7 +159,7 @@ No Malli step. The user gets the raw decoded value in `:accept`.
 :decode (fn [response-text headers] decoded)
 ```
 
-Full control. Throwing inside this fn classifies as `:problem :decode`.
+Full control. Throwing inside this fn (on a 2xx response — it doesn't run on non-2xx) classifies as `:rf.http/decode-failure`.
 
 ### `:auto` (default)
 
@@ -260,6 +262,23 @@ For debugging visibility, **each intermediate attempt emits a `:rf.http/retry-at
 
 Pair tools and 10x panels surface the per-attempt trace; user code only sees the final outcome through `:on-failure` (or the default reply-to-origin path).
 
+## Classification order
+
+When a response arrives, the runtime classifies the outcome in this fixed order:
+
+1. **Transport / timeout / abort.** A network error, per-attempt timeout, or abort short-circuits the rest. Classified as `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, or `:rf.http/aborted`. The body never enters the picture.
+2. **HTTP status.** Once a response lands, status is checked **before** the body is touched.
+   - `2xx` → success-eligible; proceed to decode.
+   - `4xx` → `:rf.http/http-4xx`; the raw response text is surfaced at `:body`. Decode is skipped.
+   - `5xx` → `:rf.http/http-5xx`; same shape as `:http-4xx`. Decode is skipped.
+   - Anything else (a 1xx/3xx the runtime didn't follow) → `:rf.http/http-4xx`-shaped.
+3. **Decode** (only on 2xx). The configured `:decode` runs against the body. A throw / Malli rejection / parser error here classifies as `:rf.http/decode-failure`.
+4. **Accept** (only on a successful decode). The configured `:accept` (or the default) projects the decoded value to `{:ok v}` or `{:failure m}`. A `{:failure m}` here classifies as `:rf.http/accept-failure`.
+
+The order is **status-before-decode by design**: a JSON-API endpoint that returns an HTML 404 from a load balancer (or a CORS pre-flight 4xx with a generic HTML body, or a 503 with a Cloudfront error page) classifies as `:rf.http/http-4xx` / `:rf.http/http-5xx` with the raw body at `:body`, not as `:rf.http/decode-failure`. The HTTP failure category is the load-bearing piece of information for the caller; surfacing decode-failure on a 4xx would hide the real error.
+
+If a caller wants to see the structured error body that an API returns alongside a non-2xx (e.g., `{"error": "..."}` JSON on a 4xx), the caller decodes the raw `:body` themselves in the failure-handling branch — the framework hands you the bytes and the status, and you decide what to do with them.
+
 ## Failure categories (closed set)
 
 Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/*` namespace) plus category-specific tags. `:kind` is **framework-owned**; user payloads (from `:accept`) sit at `:detail`, never at `:kind`.
@@ -269,9 +288,9 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 | `:rf.http/transport` | Network / DNS / connection-refused / connection-reset error before the HTTP transaction completed | `:message`, `:cause` |
 | `:rf.http/cors` | CORS preflight rejected or response blocked by browser CORS policy. Distinct from `:transport` because CORS is a configuration error, not a network error. CLJS-only; JVM never emits this. | `:message`, `:url` |
 | `:rf.http/timeout` | Per-attempt timeout fired | `:elapsed-ms`, `:limit-ms` |
-| `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (raw or decoded), `:headers` |
+| `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (the raw response text — decode is skipped on non-2xx; see [§Classification order](#classification-order)), `:headers` |
 | `:rf.http/http-5xx` | Non-2xx 5xx response | same as `:http-4xx` |
-| `:rf.http/decode-failure` | Body couldn't be parsed (Malli error, JSON syntax error, custom decoder threw) | `:body-text`, `:cause`, `:malli-error?` |
+| `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (Malli error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:malli-error?` |
 | `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. The user's failure map sits at `:detail`; `:decoded` carries the pre-`:accept` decoded value for context. | `:detail` (user's verbatim failure map), `:decoded` |
 | `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal` | `:request-id` (if any), `:reason` (`:user` / `:request-id-superseded`) |
 

--- a/docs/specification/conformance/fixtures/http-managed-http-4xx-precedes-decode.edn
+++ b/docs/specification/conformance/fixtures/http-managed-http-4xx-precedes-decode.edn
@@ -1,0 +1,84 @@
+;; Conformance fixture: rf.http.managed/http-4xx-precedes-decode
+;;
+;; Per Spec 014 §Classification order — status classification fires BEFORE
+;; decode. A 4xx response whose body would FAIL the configured `:decode`
+;; (the canonical case: a JSON endpoint that 404s with an HTML load-balancer
+;; error page) classifies as `:rf.http/http-4xx`, NOT `:rf.http/decode-failure`.
+;; The raw response body lands at `:body` (not a decoded value), and `:decode`
+;; never runs on the response.
+;;
+;; This is the regression guard for rf2-lokk: the Phase 1 implementation
+;; previously decoded first and classified second, which meant a JSON-API
+;; endpoint hitting an HTML 404 surfaced as `:rf.http/decode-failure` and
+;; hid the real HTTP failure category from the caller. The order is now
+;; locked: status first, decode only on success-eligible (2xx).
+;;
+;; The fixture exercises the contract via :rf.http/managed-canned-failure
+;; configured with `:kind :rf.http/http-4xx` and the raw HTML body at
+;; `:body` — the same envelope the live fx synthesises after running the
+;; status check.
+
+{:fixture/id           :rf.http.managed/http-4xx-precedes-decode
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx
+                         :rf.http/managed}
+ :fixture/doc          "Status classification fires before decode. A 4xx response with an HTML body — issued from a handler that asked for `:decode :json` — classifies as :rf.http/http-4xx with the raw HTML at :body, NOT as :rf.http/decode-failure. Regression guard for rf2-lokk."
+
+ :fixture/registry
+ {:event {:page/load        {:doc "Issue the GET that 404s with HTML."}
+          :page/load-error  {:doc "Receive the failure payload."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-failure {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:page/load
+   [[:fx [[:rf.http/managed
+           {:request    {:method :get :url "/articles/missing"}
+            ;; The handler asks for :json — but the endpoint 404s with
+            ;; HTML. Per Spec 014 §Classification order, the status check
+            ;; runs first; :decode is never invoked on the 4xx body.
+            :decode     :json
+            :on-failure [:page/load-error]}]]]]
+
+   :page/load-error
+   [[:set [:page :error] [:event-arg 1]]]}
+
+  :fx
+  {:rf.http/managed                [[:noop]]
+   :rf.http/managed-canned-failure
+   [[:dispatch [:page/load-error
+                {:kind    :failure
+                 :failure {:kind        :rf.http/http-4xx
+                           :status      404
+                           :status-text "Not Found"
+                           :body        "<!doctype html><html><body><h1>Not Found</h1></body></html>"
+                           :headers     {"content-type" "text/html"}}}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}}
+
+ :fixture/dispatches
+ [[:page/load]]
+
+ :fixture/expect
+ {:final-app-db
+  {:page {:error {:kind    :failure
+                  :failure {:kind        :rf.http/http-4xx
+                            :status      404
+                            :status-text "Not Found"
+                            :body        "<!doctype html><html><body><h1>Not Found</h1></body></html>"
+                            :headers     {"content-type" "text/html"}}}}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :page/load}}
+   {:operation :rf.fx/override-applied :tags {:from :rf.http/managed
+                                              :to   :rf.http/managed-canned-failure}}
+   {:operation :event :tags {:event-id :page/load-error}}]
+
+  :effects-routed
+  [{:fx-id :rf.http/managed-canned-failure
+    :args  {:request    {:method :get :url "/articles/missing"}
+            :decode     :json
+            :on-failure [:page/load-error]}}]}}

--- a/examples/managed_http_counter/core.cljs
+++ b/examples/managed_http_counter/core.cljs
@@ -12,10 +12,10 @@
     Cancel            — :rf.http/managed-abort by :request-id
 
   The +1 and Fail buttons exercise a REAL round-trip: Fetch hits the
-  static file (or 404s), the response body is decoded, and the reply
-  lands back in app-db. The Retry-recover and Cancel buttons exercise
-  the canned-stub seam, which lets the app demonstrate the contract
-  without needing a stub HTTP server.
+  static file (or 404s), the response body is decoded (only on 2xx), and
+  the reply lands back in app-db. The Retry-recover and Cancel buttons
+  exercise the canned-stub seam, which lets the app demonstrate the
+  contract without needing a stub HTTP server.
 
   This example is intentionally minimal — the heavy contract testing
   lives in the JVM smoke (re-frame.http-managed-test) and the
@@ -84,15 +84,14 @@
       :else
       {:db (assoc db :status :loading :error nil)
        :fx [[:rf.http/managed
-             {:request {:method :get :url "api/does-not-exist"}
-              ;; :decode :text — http-server returns plain text for a 404
-              ;; ("Not found"). We decode-as-text so the 4xx classification
-              ;; reaches the failure branch with :rf.http/http-4xx; if we
-              ;; asked for :json the decode would fail FIRST and the
-              ;; failure would classify as :rf.http/decode-failure (a
-              ;; classification-ordering quirk in the Phase 1 impl that
-              ;; this app doesn't try to exercise).
-              :decode  :text}]]})))
+             ;; Per Spec 014 §Classification order, status-check fires
+             ;; before decode — so even with `:decode :json`, a 404 with
+             ;; an HTML or plain-text body classifies as :rf.http/http-4xx
+             ;; (the raw body lands at :body), not :rf.http/decode-failure.
+             ;; Leaving :decode at the default `:auto` here exercises the
+             ;; common case: a JSON endpoint that 404s with a load-balancer
+             ;; HTML page.
+             {:request {:method :get :url "api/does-not-exist"}}]]})))
 
 ;; -- Retry-recover (canned-stub at app level) --------------------------------
 ;;

--- a/implementation/src/re_frame/http_managed.cljc
+++ b/implementation/src/re_frame/http_managed.cljc
@@ -752,61 +752,71 @@
                         :internal-controller internal-controller})
            (.then (fn [{:keys [ok? status status-text headers body-text]}]
                     (let [ctx' (assoc ctx :url url)]
-                      (try
-                        (let [decoded (decode-response-body
-                                        {:body-text body-text
-                                         :headers   headers
-                                         :decode    decode
-                                         :decode-supplied? decode-supplied?
-                                         :request-id request-id
-                                         :url        url})]
-                          (cond
-                            (and (>= status 400) (< status 500))
-                            (maybe-retry! ctx'
-                                          (failure-map :rf.http/http-4xx
-                                                       {:status status
-                                                        :status-text status-text
-                                                        :body decoded
-                                                        :headers headers}))
+                      ;; Per Spec 014 §Failure categories: status classification
+                      ;; runs BEFORE decode. 4xx/5xx route to :rf.http/http-4xx /
+                      ;; :rf.http/http-5xx with the raw body-text — decode never
+                      ;; fires on a non-success response, so an HTML 404 from a
+                      ;; JSON endpoint classifies as :rf.http/http-4xx (not
+                      ;; :rf.http/decode-failure). Decode runs only on 2xx; if
+                      ;; that fails the failure category is :rf.http/decode-failure.
+                      (cond
+                        (and (>= status 400) (< status 500))
+                        (maybe-retry! ctx'
+                                      (failure-map :rf.http/http-4xx
+                                                   {:status status
+                                                    :status-text status-text
+                                                    :body body-text
+                                                    :headers headers}))
 
-                            (>= status 500)
-                            (maybe-retry! ctx'
-                                          (failure-map :rf.http/http-5xx
-                                                       {:status status
-                                                        :status-text status-text
-                                                        :body decoded
-                                                        :headers headers}))
+                        (>= status 500)
+                        (maybe-retry! ctx'
+                                      (failure-map :rf.http/http-5xx
+                                                   {:status status
+                                                    :status-text status-text
+                                                    :body body-text
+                                                    :headers headers}))
 
-                            ok?
-                            (let [accepted (run-accept accept decoded {:status status})]
-                              (cond
-                                (contains? accepted :ok)
-                                (finalise-success! ctx' accepted)
+                        ok?
+                        (try
+                          (let [decoded (decode-response-body
+                                          {:body-text body-text
+                                           :headers   headers
+                                           :decode    decode
+                                           :decode-supplied? decode-supplied?
+                                           :request-id request-id
+                                           :url        url})
+                                accepted (run-accept accept decoded {:status status})]
+                            (cond
+                              (contains? accepted :ok)
+                              (finalise-success! ctx' accepted)
 
-                                (contains? accepted :failure)
-                                (finalise-failure!
-                                  ctx'
-                                  (failure-map :rf.http/accept-failure
-                                               {:detail  (:failure accepted)
-                                                :decoded decoded
-                                                :request-id request-id}))))
+                              (contains? accepted :failure)
+                              (finalise-failure!
+                                ctx'
+                                (failure-map :rf.http/accept-failure
+                                             {:detail  (:failure accepted)
+                                              :decoded decoded
+                                              :request-id request-id}))))
+                          (catch :default e
+                            (let [d (ex-data e)]
+                              (maybe-retry!
+                                ctx'
+                                (failure-map :rf.http/decode-failure
+                                             {:body-text body-text
+                                              :cause     (.-message e)
+                                              :malli-error? (boolean (:malli-error? d))})))))
 
-                            :else
-                            (finalise-failure!
-                              ctx'
-                              (failure-map :rf.http/http-4xx
-                                           {:status status
-                                            :status-text status-text
-                                            :body decoded
-                                            :headers headers}))))
-                        (catch :default e
-                          (let [d (ex-data e)]
-                            (maybe-retry!
-                              ctx'
-                              (failure-map :rf.http/decode-failure
-                                           {:body-text body-text
-                                            :cause     (.-message e)
-                                            :malli-error? (boolean (:malli-error? d))})))))) ))
+                        :else
+                        ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx
+                        ;; that the runtime didn't follow) — surface as 4xx-shaped
+                        ;; failure with the raw body-text.
+                        (finalise-failure!
+                          ctx'
+                          (failure-map :rf.http/http-4xx
+                                       {:status status
+                                        :status-text status-text
+                                        :body body-text
+                                        :headers headers}))))))
            (.catch (fn [err]
                      (let [failure (classify-cljs-error err)]
                        (maybe-retry! (assoc ctx :url url) failure))))))))
@@ -959,54 +969,67 @@
 
                                 :else
                                 (let [{:keys [ok? status status-text headers body-text]} result]
-                                  (try
-                                    (let [decoded (decode-response-body
-                                                    {:body-text body-text
-                                                     :headers   headers
-                                                     :decode    decode
-                                                     :decode-supplied? decode-supplied?
-                                                     :request-id request-id
-                                                     :url        url})]
-                                      (cond
-                                        (and (>= status 400) (< status 500))
-                                        (maybe-retry-jvm!
-                                          ctx'
-                                          (failure-map :rf.http/http-4xx
-                                                       {:status status
-                                                        :status-text status-text
-                                                        :body decoded
-                                                        :headers headers}))
+                                  ;; Per Spec 014 §Failure categories: status
+                                  ;; classification runs BEFORE decode. 4xx/5xx
+                                  ;; route to :rf.http/http-4xx / :rf.http/http-5xx
+                                  ;; with the raw body-text — decode never fires
+                                  ;; on a non-success response, so an HTML 404 from
+                                  ;; a JSON endpoint classifies as :rf.http/http-4xx
+                                  ;; (not :rf.http/decode-failure). Decode runs
+                                  ;; only on 2xx; if that fails the failure category
+                                  ;; is :rf.http/decode-failure.
+                                  (cond
+                                    (and (>= status 400) (< status 500))
+                                    (maybe-retry-jvm!
+                                      ctx'
+                                      (failure-map :rf.http/http-4xx
+                                                   {:status status
+                                                    :status-text status-text
+                                                    :body body-text
+                                                    :headers headers}))
 
-                                        (>= status 500)
-                                        (maybe-retry-jvm!
-                                          ctx'
-                                          (failure-map :rf.http/http-5xx
-                                                       {:status status
-                                                        :status-text status-text
-                                                        :body decoded
-                                                        :headers headers}))
+                                    (>= status 500)
+                                    (maybe-retry-jvm!
+                                      ctx'
+                                      (failure-map :rf.http/http-5xx
+                                                   {:status status
+                                                    :status-text status-text
+                                                    :body body-text
+                                                    :headers headers}))
 
-                                        ok?
-                                        (let [accepted (run-accept accept decoded {:status status})]
-                                          (finalise-success-jvm!
-                                            (assoc ctx' :decoded decoded) accepted))
+                                    ok?
+                                    (try
+                                      (let [decoded (decode-response-body
+                                                      {:body-text body-text
+                                                       :headers   headers
+                                                       :decode    decode
+                                                       :decode-supplied? decode-supplied?
+                                                       :request-id request-id
+                                                       :url        url})
+                                            accepted (run-accept accept decoded {:status status})]
+                                        (finalise-success-jvm!
+                                          (assoc ctx' :decoded decoded) accepted))
+                                      (catch Throwable e
+                                        (let [d (ex-data e)]
+                                          (maybe-retry-jvm!
+                                            ctx'
+                                            (failure-map :rf.http/decode-failure
+                                                         {:body-text body-text
+                                                          :cause (.getMessage e)
+                                                          :malli-error? (boolean (:malli-error? d))})))))
 
-                                        :else
-                                        (finalise-failure-jvm!
-                                          ctx'
-                                          (failure-map :rf.http/http-4xx
-                                                       {:status status
-                                                        :status-text status-text
-                                                        :body decoded
-                                                        :headers headers}))))
-                                    (catch Throwable e
-                                      (let [d (ex-data e)]
-                                        (maybe-retry-jvm!
-                                          ctx'
-                                          (failure-map :rf.http/decode-failure
-                                                       {:body-text body-text
-                                                        :cause (.getMessage e)
-                                                        :malli-error? (boolean (:malli-error? d))})))))))))) )
+                                    :else
+                                    ;; Non-2xx that didn't fall in 4xx/5xx (e.g.
+                                    ;; 1xx/3xx that the runtime didn't follow) —
+                                    ;; surface as 4xx-shaped failure with the raw
+                                    ;; body-text.
+                                    (finalise-failure-jvm!
+                                      ctx'
+                                      (failure-map :rf.http/http-4xx
+                                                   {:status status
+                                                    :status-text status-text
+                                                    :body body-text
+                                                    :headers headers})))))))))
          (catch Throwable t
            (maybe-retry-jvm! ctx' (classify-jvm-error t)))))))
 

--- a/implementation/test/re_frame/http_managed_test.clj
+++ b/implementation/test/re_frame/http_managed_test.clj
@@ -183,6 +183,73 @@
           (is (= 404 (get-in db [:reply :failure :status]))))
         (finally (stop-server! srv))))))
 
+;; ---- 5b. HTML 404 with :decode :json — status check precedes decode ------
+;;
+;; Regression guard for rf2-lokk: a 4xx response whose body is HTML (or any
+;; shape that would FAIL :json decode) MUST classify as :rf.http/http-4xx,
+;; NOT :rf.http/decode-failure. Per Spec 014 §Failure categories, status
+;; classification runs BEFORE decode — decode never fires on a non-2xx
+;; response. The :body tag carries the raw response body-text.
+
+(deftest jvm-html-404-with-json-decode-routes-to-http-4xx
+  (testing "HTML 4xx response with :decode :json classifies as :rf.http/http-4xx (not :rf.http/decode-failure)"
+    (let [{:keys [server port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 404 "text/html"
+                               "<!doctype html><html><body><h1>Not Found</h1></body></html>")))]
+      (try
+        (rf/reg-event-fx :page/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/missing")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:page/load {}])
+        (let [db (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/http-4xx (:kind failure))
+              "status classification precedes decode: HTML body must NOT trigger :rf.http/decode-failure")
+          (is (= 404 (:status failure)))
+          ;; The :body is the RAW response body, not a decoded value.
+          (is (string? (:body failure))
+              ":body carries the raw response text on 4xx (decode skipped)")
+          (is (clojure.string/includes? (:body failure) "Not Found")))
+        (finally (stop-server! srv))))))
+
+;; ---- 5c. throwing decoder on 200 still routes to :rf.http/decode-failure -
+;;
+;; The complement of 5b: a 2xx response whose decode pipeline throws DOES land
+;; as :rf.http/decode-failure, since decode runs on success-eligible responses.
+;; We use a custom decoder fn that throws — the JVM's :json fallback parser is
+;; lenient (returns the raw string when malformed) so a thrown decoder is the
+;; portable way to exercise the decode-failure path.
+
+(deftest jvm-throwing-decoder-on-200-routes-to-decode-failure
+  (testing "200 response whose decode pipeline throws classifies as :rf.http/decode-failure"
+    (let [{:keys [server port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :page/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/ok")}
+                      :decode  (fn [_text _headers]
+                                 (throw (ex-info "boom" {})))}]]})))
+        (rf/dispatch-sync [:page/load {}])
+        (let [db (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/decode-failure (:kind failure))
+              "decode runs on 2xx; a thrown decoder surfaces as :rf.http/decode-failure"))
+        (finally (stop-server! srv))))))
+
 ;; ---- 6. retry exhaustion --------------------------------------------------
 
 (deftest jvm-retry-exhaustion


### PR DESCRIPTION
## Summary

- Re-order the `:rf.http/managed` per-attempt pipeline so HTTP **status classification fires before decode**. 4xx/5xx responses route to `:rf.http/http-4xx` / `:rf.http/http-5xx` with the raw response text at `:body`; decode runs only on 2xx. An HTML 404 from a JSON-API handler now classifies as `:rf.http/http-4xx` (not `:rf.http/decode-failure`).
- Spec 014 grows a §Classification order subsection that locks the order, and the §Failure categories table clarifies that the 4xx/5xx `:body` is raw text (decode is skipped) and that `:rf.http/decode-failure` only fires on a 2xx whose body the decode pipeline rejected.
- JVM smoke adds the explicit regression guard (HTML 404 with `:decode :json` → `:rf.http/http-4xx`) plus the complement (2xx + throwing decoder → `:rf.http/decode-failure`). A new conformance fixture (`http-managed-http-4xx-precedes-decode.edn`) carries the contract for non-CLJS ports.
- `examples/managed_http_counter` drops the `:decode :text` workaround on the Fail button and relies on the default `:auto`. The Playwright assertion (`:rf.http/http-4xx`) is unchanged and still passes.

## Pipeline change

Both CLJS (Fetch) and JVM (`java.net.http.HttpClient`) branches use the same shape:

```
status-check
  4xx -> :rf.http/http-4xx (raw body-text at :body, decode skipped)
  5xx -> :rf.http/http-5xx (raw body-text at :body, decode skipped)
  2xx -> decode -> accept -> success / decode-failure / accept-failure
  other (1xx/3xx not followed) -> :rf.http/http-4xx-shaped
```

## Test plan

- [x] `clojure -M:test` (197 tests / 958 assertions, all green)
- [x] `npm run test:cljs` (71 tests, all green)
- [x] `npm run test:browser` (56 tests, all green)
- [x] `npm run test:elision` (PASS)
- [x] `npm run test:examples` (incl. `managed-http-counter` Playwright smoke after the `:decode :text` cleanup, all green)