### PR TITLE
feat: drop h macro (rf2-n4um / rf2-u33b)

### DIFF
--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -71,7 +71,7 @@ The canonical way to use a registered view in hiccup is to `def` a var from the 
 
 This reads exactly like Reagent. There's nothing to learn. It just happens to work for the multi-frame case because of the registration that's also happening.
 
-Two alternative forms exist — `(rf/get-view :greeting)` for runtime-id'd dispatch, and `(rf/h [:greeting "Mike"])` for compile-time keyword expansion — but the Var idiom is what you'll see most. The other two are escape hatches for specific cases.
+An alternative form exists — `(rf/get-view :greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `get-view` is the escape hatch for those specific cases.
 
 ## Frames
 

--- a/docs/specification/004-Views.md
+++ b/docs/specification/004-Views.md
@@ -208,7 +208,7 @@ v1 ships three forms for invoking a registered view. To honour the principle of 
 
 ### `get-view` — the canonical post-registration lookup
 
-Whatever the call-site shape, `(rf/get-view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the wrapped (frame-aware) Var-equivalent, re-resolved on every call so hot-reload re-registration is picked up immediately. `h` and the other call-site forms are sugar over `get-view`.
+Whatever the call-site shape, `(rf/get-view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the wrapped (frame-aware) Var-equivalent, re-resolved on every call so hot-reload re-registration is picked up immediately. The other call-site forms are sugar over `get-view`.
 
 ```clojure
 (rf/get-view :counter)               ;; → wrapped fn
@@ -217,47 +217,19 @@ Whatever the call-site shape, `(rf/get-view :counter)` is the **canonical lookup
 
 `get-view` returning `nil` for an unregistered keyword is a normal lookup miss (no error trace).
 
-### Alternative forms (use only when the canonical form is awkward)
+### Alternative form (use only when the canonical form is awkward)
 
 ```clojure
-;; Alt 1 — Explicit function-position lookup. Use when:
+;; Explicit function-position lookup. Use when:
 ;;        - the view id is computed at runtime (dynamic dispatch);
 ;;        - the calling code doesn't have access to the Var (e.g., across module boundaries
-;;          where the Var isn't exported but the registration is).
+;;          where the Var isn't exported but the registration is);
+;;        - hot-reload semantics matter — `get-view` re-resolves on every call, so
+;;          re-registration is picked up without re-evaluating the call site.
 [(rf/get-view :counter) "Hello"]
-
-;; Alt 2 — h macro. Walks hiccup at compile time, substitutes registered keywords.
-;;        Use when:
-;;        - you want hiccup to read as pure data (highest data-orientation, P3);
-;;        - the view set is known at compile time;
-;;        - you don't mind opting into the h wrapper at every call site.
-(rf/h [:counter "Hello"])
 ```
 
-**Bare `[:counter "Hello"]` in raw hiccup** (without an `h` wrapper, where Reagent itself would have to interpret the keyword as a registered view) is **not supported in v1**. It requires modifying or extending Reagent's keyword-tag interpretation, which is deferred to the substrate-decoupling work in Spec 006 / [011](011-SSR.md). It can ship later as a non-breaking addition once the substrate decision is settled.
-
-### The `h` macro
-
-`(rf/h hiccup-form)` walks the hiccup at compile time, substituting `[:registered-keyword args ...]` with `[(rf/get-view :registered-keyword) args ...]` for every keyword present in the view registry at expansion time. Unregistered keywords pass through unchanged (so DOM tags like `:div` are untouched).
-
-```clojure
-;; user writes
-(rf/h
-  [:div.page
-   [:counter "Left"]
-   [:counter "Right"]
-   [:label "Hello"]])              ;; :label is a DOM tag; passes through
-
-;; expands to
-[:div.page
- [(rf/get-view :counter) "Left"]
- [(rf/get-view :counter) "Right"]
- [:label "Hello"]]
-```
-
-Compile-time expansion means the registry must be populated when the macro fires — typically at REPL or build time, after `reg-view` calls have run. For dynamic dispatch (where the keyword isn't known at compile time), use form (1) directly.
-
-`h` is opt-in: hiccup outside `(rf/h ...)` retains today's Reagent semantics (DOM tags + Var references + anonymous fns).
+**Bare `[:counter "Hello"]` in raw hiccup** (where Reagent itself would have to interpret the keyword as a registered view) is **not supported in v1**. It requires modifying or extending Reagent's keyword-tag interpretation, which is deferred to the substrate-decoupling work in Spec 006 / [011](011-SSR.md). It can ship later as a non-breaking addition once the substrate decision is settled.
 
 ## Plain Reagent fns: staged adoption (with a loud footgun warning)
 
@@ -390,7 +362,7 @@ Registered views referenced from hiccup inherit the surrounding frame from React
 ```clojure
 (rf/reg-view outer []
   [:div
-   [counter "Inner"]                  ;; or [:counter "Inner"] under the `h` macro
+   [counter "Inner"]                  ;; or [(rf/get-view :counter) "Inner"] for late-binding by id
    [rf/frame-provider {:frame :other}
     [counter "Other-frame inner"]]])  ;; nested provider re-points
 ```
@@ -405,10 +377,6 @@ Reusable-component concerns are addressed by:
 2. **Reusable widgets need access to surrounding context** (theme, locale, router, frame) — [002's `frame-provider`](002-Frames.md#what-frame-provider-is-cljs-reference) plus user-defined React contexts for non-frame state.
 
 ## Open questions
-
-### `h` macro and dynamic keyword tags
-
-`(rf/h [first-tag-var label])` where `first-tag-var` is a runtime-resolved keyword — does the macro fall through gracefully (treating the keyword as a DOM tag) or error? Recommendation: fall through; runtime substitution is the user's responsibility.
 
 The bare `[:my-view "args"]` form in raw hiccup requires Reagent extension and is out of scope for v1; it is deferred to the substrate-decoupling work in [Spec 006](006-ReactiveSubstrate.md).
 
@@ -441,21 +409,9 @@ For the rare case where the user wants no Var binding (e.g. views generated prog
     (fn [_props] ...)))
 ```
 
-### The `h` macro's expansion strategy
+### `h` macro dropped (rf2-n4um)
 
-Recursive walk + runtime lookup, with the keyword set frozen at compile time.
-
-(a) **Recursive walk.** `h` walks the entire hiccup tree, not only the top level. Substitution happens wherever a vector starts with a keyword that was registered as a `:view` *at expansion time*. This matches author intent: AIs and humans write `(h [:layout [:counter] [:counter]])` and expect both `:counter` references to substitute.
-
-(b) **Runtime lookup with a compile-time keyword set.** At expansion, `h` consults the registrar to enumerate the set of keywords currently registered as `:view`. Each match in the hiccup expands to `[(rf/get-view :keyword) args ...]` — a *runtime* registry lookup. This gives:
-
-- **Determinism at expansion** — the keyword set is captured when the form is compiled. A view registered after expansion does not magically activate inside an already-compiled form. The user can re-evaluate the form to pick it up.
-- **Hot-reload friendliness** — `(get-view :counter)` re-resolves on every render, so re-registering `:counter` (developer saves a file) takes effect without re-expanding `h`.
-- **Aligns with `reg-view`'s auto-def form** — `(reg-view :counter ...)` produces a callable Var; `(h [:counter])` produces `[(get-view :counter)]`. The two are observably equivalent at the call-site.
-
-A keyword *not* registered as a view at expansion time passes through unchanged. DOM tags (`:div`, `:span`, …) and unregistered keywords are untouched. The dynamic-keyword-tag case (`[some-keyword-var ...]`) falls through to runtime — `h` does not attempt to rewrite it; the runtime treats it as a DOM tag.
-
-**Edge case — re-registration shadowing a DOM tag.** A user must not `(reg-view :div ...)`. The runtime emits a warning at registration time; `h` honours the registry (the registered fn wins). Documented as a footgun, not policed.
+An earlier draft of this spec included an `h` macro that walked hiccup at compile time and rewrote namespaced-keyword heads (`[:my-app/widget args]`) into runtime `(rf/get-view :my-app/widget)` lookups. It has been removed from the v1 surface. The Var idiom — `(reg-view counter [...] ...)` defs `counter`; users write `[counter "Hello"]` — is the canonical call-site form. For late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites) the canonical handle is the explicit function-position form `[(rf/get-view :counter) "Hello"]`. Two surfaces, both data-friendly, no compile-time hiccup walker to learn or reason about.
 
 ### Form-3 (`reagent.core/create-class`) — out of scope for the macro
 

--- a/docs/specification/AI-Audit.md
+++ b/docs/specification/AI-Audit.md
@@ -71,7 +71,7 @@ References to `G-A`/`G-B`/`G-C`/`G-D`/`G-E`/`G-F` in the tables below resolve to
 
 | Property | Score | Notes |
 |---|---|---|
-| P1 Regularity | ◐ | Two registration shapes (`reg-frame` / `make-frame`) is right. View invocation has *three* (`get-view` / Var / `h` macro) — that's drifty. CP-4 should specify when each is canonical. |
+| P1 Regularity | ✓ | Two registration shapes (`reg-frame` / `make-frame`) is right. View invocation has two forms (`get-view` / Var) — the `h` macro was dropped (rf2-n4um). |
 | P2 Named things | ✓ | Frames, handlers, views, fx all stably-id'd. Anonymous lambdas survive only inside view bodies (`:on-click #(dispatch ...)`) which is borderline acceptable. |
 | P3 Data before magic | ◐ | Dispatch envelope, effect map, frame metadata all data. `:fx-overrides` and `:interceptor-overrides` accept function values at the CLJS reference level. Pattern-level contract is id-based; CLJS reference also accepts fn values. |
 | P4 Public query surfaces | ✓ | `handlers`, `frame-meta`, `frame-ids`, `get-frame-db`, `snapshot-of`, `sub-topology` all in. |
@@ -269,9 +269,9 @@ Pattern contract is id-based (per recent edits), but the CLJS reference accepts 
 
 Plain Reagent fns rendered inside a non-default frame silently route to `:rf/default`. This violates P8 (hidden context). Either remove the footgun (mandate `reg-view`) or make it loud (runtime warning).
 
-### G-E. View invocation has three forms (P1 violation)
+### G-E. View invocation has two forms — Var canonical, `(get-view :id)` for late-binding
 
-`(get-view :id)`, Var reference, `h` macro. Pick a canonical for primary use; treat the others as alternatives with documented use cases.
+The Var reference (`[counter "Hello"]`) is the canonical call-site form: `reg-view` defs the symbol, hiccup picks it up directly. `(get-view :id)` is the documented escape hatch for late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites). The earlier `h` macro draft has been dropped (rf2-n4um); two forms is the v1 surface.
 
 ### G-F. Form-1 / Form-2 / Form-3 component shapes
 

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -79,7 +79,6 @@
 | `subscriber` | Fn | `(subscriber)` (called during render) → frame-bound subscribe fn | v1 | 004 |
 | `get-view` | Fn | `(get-view view-id)` → render-fn | v1 | 004 |
 | `view` | Fn | `(view view-id)` → render-fn (runtime-lookup handle; alias of `get-view`) | v1 | 001, 004 |
-| `h` | M | `(h hiccup-form)` | v1 | 004 |
 
 `with-frame`'s two shapes (bare keyword vs let-binding) are documented in [002 §with-frame](002-Frames.md#with-frame).
 
@@ -532,7 +531,8 @@ See [007-Stories.md](007-Stories.md).
 | `frame-dispatcher` (proposed earlier) | Renamed to `bound-dispatcher` | 002 |
 | `enable-performance-api-tracing!` (proposed earlier) | Bridge always active when tracing is on; production elides everything | 009 |
 | `add-trace-listener` / `remove-trace-listener` (proposed earlier) | Use `register-trace-cb` / `remove-trace-cb` | 009 |
-| Bare `[:my-view "args"]` keyword-tagged hiccup (without `h`) | Use `(rf/h [:my-view "args"])` or `[(rf/get-view :my-view) "args"]` | 004 |
+| Bare `[:my-view "args"]` keyword-tagged hiccup | Use the Var form `[my-view "args"]` (canonical) or `[(rf/get-view :my-view) "args"]` for late-binding by id | 004 |
+| `h` macro (proposed earlier) | Removed (rf2-n4um). Use the Var form `[my-view "args"]` or `[(rf/get-view :my-view) "args"]` | 004 |
 | `reg-global-interceptor` | Use `reg-frame :interceptors` (frame-level is the canonical "global within this frame"). For cross-frame observation use `register-trace-cb`. | MIGRATION M-17 |
 | `clear-global-interceptor` | No replacement needed — re-register `reg-frame` with an updated `:interceptors` vector (absent-key semantics clear it). | MIGRATION M-17 |
 | `reg-sub-raw` | Use `reg-sub` (app-db reads), Pattern-AsyncEffect (non-app-db sources), state machines (lifecycle), or the [006](006-ReactiveSubstrate.md) adapter contract (bridging external reactivity). | MIGRATION M-18 |

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -876,13 +876,53 @@ The per-kind registration macros, `reg-flow`, `reg-route`, and the vector-form `
 
 ---
 
-**Reporting M-12 through M-23.** These twelve rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing twelve separate preambles.
+### M-24. `h` macro removed — rewrite call sites to Var or `(get-view :id)`
+
+**Type A** (mechanical).
+
+Per rf2-n4um / rf2-u33b: the `h` compile-time hiccup walker has been dropped from the v1 surface. The Var idiom (`reg-view counter [...] ...` defs `counter`; users write `[counter "Hello"]`) is the canonical call-site form; `(rf/get-view :id)` is the documented escape hatch for late-binding by id. Two call-site forms, no compile-time hiccup walker.
+
+**What to look for** in the codebase:
+
+```clojure
+(rf/h [:div [:my-app/widget arg]])
+(rf/h [:my-app/widget arg])
+(rf/h [:div [:p "hello"]])
+```
+
+**What to do:**
+
+```clojure
+;; before — namespaced view keyword nested in hiccup (the most common case)
+(rf/h [:div [:my-app/widget arg]])
+;; after — Var-ref form. The reg-view macro defed the Var; reach for it directly.
+[:div [my-app/widget arg]]
+
+;; before — call site genuinely needs late-binding by id (cross-module reference,
+;; runtime-computed id, or hot-reload-sensitive call site)
+(rf/h [:my-app/widget arg])
+;; after — explicit get-view in function position
+[(rf/get-view :my-app/widget) arg]
+
+;; before — h wrapper around HTML-only hiccup
+(rf/h [:div [:p "hello"]])
+;; after — drop the wrapper entirely
+[:div [:p "hello"]]
+```
+
+The agent rewrites mechanically. For the Var-ref form (the common case), the namespaced keyword's local-name becomes a symbol reference to the Var defed by `reg-view`. If the call-site context indicates late-binding intent (a comment to that effect, or the symbol isn't in scope at the call site), the agent emits the `[(rf/view :id) args]` form instead. Ambiguous sites default to Var-ref — the reverse migration to `get-view` is a one-line edit if the user later decides hot-reload semantics matter.
+
+**Why?** Two view call-site forms is enough; three was drifty (P1 violation flagged in [AI-Audit §G-E](AI-Audit.md#g-e-view-invocation-has-two-forms--var-canonical-get-view-id-for-late-binding)). Same surface-shrinking principle as rf2-7cb2 (drop alpha) and rf2-iyzm (Var-ref canonical for views): when two surfaces cover every case the third was solving, the third is excess.
+
+---
+
+**Reporting M-12 through M-24.** These thirteen rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing thirteen separate preambles.
 
 ---
 
 ## Type-tag summary
 
-- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**, **M-22**, **M-23 (registration / subscribe shape rewrites only — lifecycle annotations are dropped with a flag, not silently rewritten)**.
+- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**, **M-22**, **M-23 (registration / subscribe shape rewrites only — lifecycle annotations are dropped with a flag, not silently rewritten)**, **M-24** (`h` macro removal).
 - **Type B — flag for human review.** Agent identifies hit sites, explains the change, but does NOT rewrite without explicit approval — the rewrite depends on intent that static analysis can't recover. Rules: **M-3** (run-to-completion drain semantics; timing-sensitive code may depend on the old async-dispatch behaviour and silent reordering would break it); **M-10** (reserved-namespace collisions; the rewrite depends on whether the user intended to override a framework event or accidentally collided); **M-11** (plain Reagent fns rendered under non-default frames; the rewrite depends on whether the component should follow its surrounding frame or pin to the default); **M-12** (render-count test re-baselining); **M-13** (error-handler ownership); **M-14** (`:rf.route/not-found` requirement when adopting Spec 012); **M-15** (app-db seeding move); **M-17 (multi-frame app variant)** (rewrite path depends on whether the global interceptor was meant to apply to every frame, was observer-shaped, or only belonged on the default frame); **M-18** (`reg-sub-raw` removal; rewrite path depends on what the raw body does — app-db read, non-app-db source, lifecycle management, or side-effects-from-subs anti-pattern); **M-19 (opt-in)** (multi-positional dispatch/subscribe → map-payload; the rewrite is mechanical given handler-side parameter names, but the trigger is the codebase owner's choice — multi-positional is tolerated indefinitely); **M-21 (`on-changes`, `enrich`, `after` portions)** (rewrite path depends on whether the interceptor's body is computing derived state, validating, side-effecting, or escape-hatching; agent suggests flow / schema / fx / custom `->interceptor` based on body shape).
 
 Per [000-Vision §C1](000-Vision.md#c1-mechanical-migration-via-ai-agent), Type B rules require human review precisely because side-effects can be silently reordered with observable consequences.

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -549,7 +549,7 @@
   (subscriber))
 
 ;; ---- view ergonomics (CLJS only) ------------------------------------------
-;; reg-view (the macro), h, with-frame live in re-frame.views-macros (CLJS-
+;; reg-view (the macro), with-frame live in re-frame.views-macros (CLJS-
 ;; only macros — users `(:require-macros [re-frame.views-macros :refer ...])`).
 ;; frame-provider is a Reagent component re-exported here so `rf/frame-provider`
 ;; is the canonical user-facing surface (per Spec 002 §What `frame-provider` is

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.views
-  "Views — reg-view, the h macro, frame-provider. Per Spec 004.
+  "Views — reg-view, frame-provider. Per Spec 004.
 
   CLJS-only (Reagent-side). The pure-data render-tree contract lives in
   Spec 011 (SSR); this namespace ties view registration into the Reagent
@@ -9,9 +9,11 @@
   supported via Reagent's native handling.
 
   reg-view auto-defs the local Var (per Spec 004 §reg-view defs the Var
-  by default); the Var is the canonical call-site reference. Bare
-  `[:keyword args]` in raw hiccup is post-v1; the (h [...]) macro
-  rewrites keyword references at compile time as the v1 escape hatch."
+  by default); the Var is the canonical call-site reference. For
+  late-binding by id (e.g. across module boundaries, runtime-computed
+  ids, or hot-reload semantics), call `(re-frame.core/get-view :id)`
+  to obtain the wrapped fn and use `[(rf/get-view :id) args]` as the
+  hiccup head."
   (:require ["react"        :as React]
             [reagent.core   :as r]
             [re-frame.registrar :as registrar]

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -1,10 +1,10 @@
 (ns re-frame.views-macros
   "Compile-time macros that go alongside re-frame.views (CLJS).
 
-  Per Spec 002 §View ergonomics and Spec 004 §The h macro / §reg-view
-  defs the Var by default. The macros expand into runtime calls against
-  re-frame.core (for the JVM-shared dispatcher / subscriber / dynamic
-  *current-frame*) and re-frame.views (for the React-context bridge).
+  Per Spec 002 §View ergonomics and Spec 004 §reg-view defs the Var by
+  default. The macros expand into runtime calls against re-frame.core
+  (for the JVM-shared dispatcher / subscriber / dynamic *current-frame*)
+  and re-frame.views (for the React-context bridge).
 
   These macros are JVM-loadable (this is a .clj file) and consumed by
   ClojureScript compilation via:
@@ -12,7 +12,7 @@
     (ns my-app.core
       (:require        [re-frame.views :as v])
       (:require-macros [re-frame.views-macros :refer [reg-view with-frame
-                                                         bound-fn h]]))"
+                                                         bound-fn]]))"
   ;; bound-fn shadows clojure.core/bound-fn — the v2 surface deliberately
   ;; reuses the name (per Spec 002 §bound-fn) for the frame-capturing form.
   (:refer-clojure :exclude [bound-fn]))
@@ -171,45 +171,3 @@
   ;; the rationale (CLJS macro context leaks :doc metadata via the ns-name
   ;; symbol, which defeats production elision).
   (expand-reg-view (meta &form) (symbol (str (ns-name *ns*))) *file* sym more))
-
-;; ---- h --------------------------------------------------------------------
-;;
-;; Per Spec 004 §The h macro: walk a hiccup tree at compile time and rewrite
-;; bare keyword head positions that name registered views into runtime
-;; (rf/get-view :keyword) calls. HTML tag-name keywords (`:div`, `:p`, …)
-;; are NOT rewritten — they remain DOM tags.
-;;
-;; Heuristic for "this keyword names a view":
-;;   - It's namespaced (`:my-app/widget`) — host DOM tags are never
-;;     namespaced.
-;;
-;; This is a coarse approximation; applications can override by passing
-;; an explicit symbol head.
-
-(defn- view-keyword? [x]
-  (and (keyword? x) (some? (namespace x))))
-
-(defn- rewrite-hiccup [form]
-  (cond
-    (and (vector? form)
-         (view-keyword? (first form)))
-    (let [k     (first form)
-          args  (rest form)]
-      `[(re-frame.core/get-view ~k) ~@(map rewrite-hiccup args)])
-
-    (vector? form)
-    (mapv rewrite-hiccup form)
-
-    (map? form)
-    (reduce-kv (fn [m kk vv] (assoc m kk (rewrite-hiccup vv))) {} form)
-
-    :else form))
-
-(defmacro h
-  "Compile-time hiccup walker that rewrites [:my-ns/widget args] into
-  [(rf/get-view :my-ns/widget) args]. Bare keyword heads (`:div`,
-  `:span`, …) are left alone — they're DOM tags. Per Spec 004 §The h
-  macro: an opt-in escape hatch; the canonical view-call form remains
-  the local Var defined by reg-view."
-  [hiccup]
-  (rewrite-hiccup hiccup))

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -11,7 +11,7 @@
             [re-frame.substrate.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views])
-  (:require-macros [re-frame.views-macros :refer [with-frame bound-fn h reg-view]]))
+  (:require-macros [re-frame.views-macros :refer [with-frame bound-fn reg-view]]))
 
 ;; Snapshot/restore the registrar around each test (rf2-am9d). Wiping the
 ;; registrar with clear-all! is hostile to CLJS test isolation: framework
@@ -151,20 +151,6 @@
       (is (= [:span "view-body-" 1] (intercept-me-view 1))
           "Var-reference resolves to the registered render fn"))))
 
-;; ---- h macro ----------------------------------------------------------------
-
-(deftest h-rewrites-namespaced-view-keys
-  (testing "h rewrites [:my-ns/widget args] but leaves DOM tags alone"
-    ;; Bare keyword heads (DOM tags) pass through unchanged.
-    (is (= [:div [:p "hi"]] (h [:div [:p "hi"]]))
-        "DOM tag heads pass through unchanged")
-    ;; A keyword in a namespace IS treated as a view reference.
-    (reg-view ^{:rf/id :my-ns/widget} h-test-widget [n] [:span "w-" n])
-    (let [tree (h [:my-ns/widget 7])]
-      (is (fn? (first tree))
-          "namespaced keyword head was rewritten to a fn")
-      (is (= [:span "w-" 7] ((first tree) 7))
-          "the rewritten fn produces the registered view's output"))))
 
 ;; ---- frame isolation ------------------------------------------------------
 

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -522,12 +522,7 @@
         (is (= 'def (first def-form))
             "the trailing form in the expansion is a def")
         (is (= 'my-widget (second def-form))
-            "the def binds the symbol the user supplied")))
-    ;; h leaves DOM tags alone but rewrites namespaced view refs.
-    (let [exp (macroexpand-1 `(re-frame.views-macros/h [:my-ns/w {:k 1}]))]
-      (is (some #(= 're-frame.core/get-view %)
-                (tree-seq coll? seq exp))
-          "h expansion references get-view for namespaced keywords"))))
+            "the def binds the symbol the user supplied")))))
 
 (deftest verify-hydration-emits-mismatch
   (testing "rf/hydrate stashes :rf/hydration metadata; verify-hydration! detects mismatch"


### PR DESCRIPTION
Replaces auto-closed PR #62. Rebased onto current main.

The h macro was a Spec-004 proposal; the implementation captured it in views_macros.clj but no production call sites adopted it. Clean removal.

## Beads

- rf2-u33b (closes on merge)
- rf2-n4um (already closed; this PR realises the resolution)

## Tests

JVM, CLJS node, CLJS browser, elision, Playwright — all green post-rebase.