### PR TITLE
feat: state-machine API rewrite + tightened contract (rf2-hbt1, rf2-qppo)

### DIFF
--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -67,23 +67,52 @@ The fix isn't to write better `cond` clauses. The fix is to step back and notice
 
 ```clojure
 (def login-flow
-  {:id      :auth.login/flow
-   :initial :idle
-   :context {:attempts 0 :error nil}
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:under-retry-limit
+    (fn [data _event] (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error
+    (fn [_ _] {:data {:error nil}})
+
+    :issue-request
+    (fn [_data [_ creds]]
+      {:fx [[:http {:method     :post
+                    :url        "/api/login"
+                    :body       creds
+                    :on-success [:auth.login/flow [:auth.login/success]]
+                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+
+    :record-error
+    (fn [data [_ err]]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc :error (or (:message err) "Login failed.")))})
+
+    :lock-account
+    (fn [_ _] {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+
+    :store-session
+    (fn [_data [_ {:keys [token]}]]
+      {:fx [[:auth.session/store {:token token}]]})}
+
    :states
    {:idle
-    {:on {:auth.login/submit {:target  :submitting
-                              :actions [:auth.login/clear-error]}}}
+    {:on {:auth.login/submit {:target :submitting
+                              :action :clear-error}}}
 
     :submitting
-    {:entry [:auth.login/issue-request]
-     :on    {:auth.login/success {:target  :authed
-                                  :actions [:auth.login/store-session]}
-             :auth.login/failure [{:target  :error-shown
-                                   :cond    :auth.login/under-retry-limit
-                                   :actions [:auth.login/record-error]}
-                                  {:target  :locked-out
-                                   :actions [:auth.login/lock-account]}]}}
+    {:entry :issue-request
+     :on    {:auth.login/success {:target :authed
+                                  :action :store-session}
+             :auth.login/failure [{:target :error-shown
+                                   :guard  :under-retry-limit
+                                   :action :record-error}
+                                  {:target :locked-out
+                                   :action :lock-account}]}}
 
     :error-shown
     {:on {:auth.login/dismiss {:target :idle}
@@ -99,26 +128,27 @@ This is a **transition table**. It's pure data. You can read it top to bottom an
 - The starting state is `:idle`.
 - From `:idle`, the event `:auth.login/submit` takes us to `:submitting`.
 - From `:submitting`, the event `:auth.login/success` takes us to `:authed`.
-- From `:submitting`, the event `:auth.login/failure` takes us to `:error-shown` if the guard `:auth.login/under-retry-limit` is true, otherwise to `:locked-out`.
-- The actions on each transition (`:auth.login/clear-error`, `:auth.login/issue-request`, `:auth.login/record-error`, `:auth.login/lock-account`, `:auth.login/store-session`) are referenced by id. They're registered separately.
+- From `:submitting`, the event `:auth.login/failure` takes us to `:error-shown` if the guard `:under-retry-limit` passes, otherwise to `:locked-out`.
+- Each transition's `:action` and each state's `:entry` are referenced by id; the named guard / action lives in the spec's `:guards` / `:actions` map and runs when the runtime applies the transition.
 
 The whole flow is in one piece of data. You can pretty-print it. You can render it to a graph. You can check it against a schema. You can hand it to an AI and say "here's the auth flow, add a two-factor state between submitting and authed" — the AI has the whole context in front of it.
 
-The runtime takes this data, plus the registered guards/actions, plus the snapshot of the machine's current state, and applies the transition rules. The runtime — not the developer — is responsible for "if we're in :submitting and a :failure arrives, check the guard, fire the action, transition to the right next state." The developer is responsible only for *describing the transitions as data*.
+The runtime takes this data, plus the snapshot of the machine's current state, and applies the transition rules. The runtime — not the developer — is responsible for "if we're in `:submitting` and a `:failure` arrives, check the guard, fire the action, transition to the right next state." The developer is responsible only for *describing the transitions as data*.
 
 ## What's in a transition
 
 The grammar is borrowed (with adaptation) from [xstate](https://xstate.js.org/), which is the canonical state-machine library in the JavaScript world. Specifically:
 
 - **`:initial`** — the starting state.
-- **`:context`** — extended state that lives alongside the discrete state. Counters, error messages, transient data.
+- **`:data`** — extended state that lives alongside the discrete state. Counters, error messages, transient data. (xstate calls this slot "context"; we use `:data` to avoid the existing "context" overloading in re-frame's interceptor pipeline and React-context idioms.)
 - **`:states`** — the state nodes, keyed by name.
 - **`:on`** — for a state, the events it responds to and where they go.
 - **`:target`** — the next state name.
-- **`:cond`** — a guard: a predicate that must return true for the transition to fire.
-- **`:actions`** — registered actions that fire on this transition.
-- **`:entry`/`:exit`** — actions that fire when entering or leaving a state, regardless of which event triggered the transition.
+- **`:guard`** — a predicate that must return true for the transition to fire. A keyword references the spec's `:guards` map; an inline `(fn [data event] ...)` is fine for a one-liner.
+- **`:action`** — fires on this transition. Same shape as `:guard`: keyword reference into `:actions`, or inline fn.
+- **`:entry` / `:exit`** — actions that fire when entering or leaving a state, regardless of which event triggered the transition. Same shape — keyword or inline fn.
 - **`:meta`** — arbitrary user-defined annotations (e.g. `:terminal?`).
+- **`:guards` / `:actions`** (top-level on the spec) — the machine's own named guard / action implementations. Resolution is machine-local; there's no global registry.
 
 xstate users will recognise all of this. We deliberately stay close to xstate's vocabulary because (a) it's well-thought-out and (b) AIs already know it. When you ask an AI "give me the state machine for a login flow," it produces something that's already nearly correct in re-frame2's grammar.
 
@@ -126,32 +156,146 @@ What we adapt:
 
 - **Machines are event handlers, not actor objects.** xstate has explicit `ActorRef` runtime objects with their own mailboxes. re-frame2 doesn't. A machine is "an event handler whose body interprets a transition table." All events to that machine flow through `dispatch` like any other event; there's no separate sending mechanism.
 - **Effects are returned as data.** xstate's actions can directly call out to the world. re-frame2's actions return effect maps which the runtime interprets — same shape as event handlers.
-- **The actor-system boundary is the frame.** Multiple machines composed within a frame share that frame's drain, ensuring run-to-completion behaviour. Cross-frame communication is async dispatch, not in-process message passing.
+- **The snapshot lives in `app-db`.** Every machine's runtime state — its `:state` and `:data` — sits at `[:rf/machines <id>]` in the frame's `app-db`. Not in a parallel registry, not in a per-machine atom. Undo, time-travel, persistence, SSR hydration all extend to machines for free, because their state is in the db.
+- **Guards and actions live with the machine.** Each `create-machine-handler` spec carries its own `:guards` and `:actions` maps. Cross-machine reuse is via Clojure vars, not a global registry. A machine is a self-contained piece of data; reading its spec tells you everything its guards and actions do.
 
-These adaptations keep the pattern consistent with the rest of re-frame2. A state machine, in this codebase, is *the same kind of thing as an event handler*, just with more structure.
+These adaptations keep the pattern consistent with the rest of re-frame2.
 
-## What the substrate covers
+## Wiring a machine into the rest of re-frame
 
-The shape above — flat states, plain `:on` transitions, `:entry`/`:exit` actions — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model. A flavour:
+Once the transition table is defined, registering it as an event handler is one line:
 
-- **Hierarchical states.** A compound state contains sub-states; entering the parent cascades to its declared `:initial` child; transitions from a deep state can target a sibling or an ancestor and the runtime computes the LCA. Useful when the auth flow has an `:authenticated` super-state with `:cart` / `:browsing` sub-states under it.
-- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or "advance through derived states." Bounded depth, microstep-loop semantics, defined trace events.
-- **Delayed `:after` transitions.** A state can declare "if no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
-- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data rather than as `:entry [:spawn ...]` / `:exit [:destroy-machine ...]`. The child's lifecycle is bound to the parent state.
-- **Machine-scoped `:guards` and `:actions` maps.** Guards and actions referenced by keyword resolve into a machine-local map — `(get-in spec [:guards :under-retry-limit?])`. Named compound logic is more inspectable than inline lambdas, and it lives where the machine lives, not in the global registry.
+```clojure
+(rf/reg-event-fx :auth.login/flow
+  {:doc "Login flow: idle → submitting → authed / error-shown / locked-out."}
+  (rf/create-machine-handler login-flow))
+```
 
-Each of these is opt-in — implementations declare which capabilities they support, and the conformance corpus grades against the claimed set. The full grammar is in [Spec 005](../specification/005-StateMachines.md). The point of mentioning them here is that the model scales: when your machine grows, the substrate has well-named answers ready, and you don't end up smuggling state-machine logic into ordinary event handlers.
+The machine's id is the surrounding `reg-event-fx` id (`:auth.login/flow`). The snapshot lives at `[:rf/machines :auth.login/flow]` in `app-db`; the runtime reads / writes it there. **You don't pick a path — there is one canonical path.**
+
+`(rf/create-machine-handler spec)` returns a regular `reg-event-fx`-shaped handler. It does the work of "look up the snapshot, call `machine-transition`, write the new snapshot, return the action effects." `machine-transition` is pure, so all the testing and tooling guarantees of regular events apply to machines.
+
+If you don't need any other registration metadata (no `:doc`, no `:interceptors`), there's a one-step convenience:
+
+```clojure
+(rf/reg-machine :auth.login/flow login-flow)
+```
+
+This is exactly `(reg-event-fx machine-id (create-machine-handler machine))` — same effect, less ceremony.
+
+## Dispatching to a machine
+
+Sub-events route via the machine's id and an inner event vector:
+
+```clojure
+(rf/dispatch [:auth.login/flow [:auth.login/submit credentials]])
+(rf/dispatch [:auth.login/flow [:auth.login/dismiss]])
+```
+
+The outer keyword is the machine; the inner vector is the event the machine sees. The runtime resolves the inner event against the current state's `:on` map, runs the guard, fires the action, and writes the new snapshot back to `[:rf/machines :auth.login/flow]`.
+
+For HTTP / async callbacks, the convention "build a 2-element template, conj the result on resolve" works as in any other re-frame fx:
+
+```clojure
+;; The :issue-request action returns this fx vector:
+[:http {:url        "/api/login"
+        :on-success [:auth.login/flow [:auth.login/success]]   ;; 2-element template
+        :on-error   [:auth.login/flow [:auth.login/failure]]}]
+
+;; The :http fx implementation does (rf/dispatch (conj on-success response)),
+;; producing [:auth.login/flow [:auth.login/success] response].
+;; The runtime folds the trailing response onto the inner event so the action
+;; sees [:auth.login/success response].
+```
+
+This "extras-fold" makes the standard fx-callback convention work without ceremony — every async callback ships a value into the machine the same way.
+
+## Guards and actions
+
+Guards are predicates. They live in the spec's `:guards` map and are referenced from transitions by keyword:
+
+```clojure
+:guards
+{:under-retry-limit
+ (fn [data _event] (< (:attempts data) 3))}
+```
+
+A guard sees `(fn [data event] boolean)` — `data` is the snapshot's `:data` slot directly. Returning truthy lets the transition fire; returning falsy makes the runtime walk to the next candidate (or fall through to the parent state, if any).
+
+Actions are functions that produce data updates and / or effects. They live in `:actions`:
+
+```clojure
+:actions
+{:record-error
+ (fn [data [_ err]]
+   {:data (-> data
+              (update :attempts inc)
+              (assoc :error (or (:message err) "Login failed.")))})
+
+ :issue-request
+ (fn [_data [_ creds]]
+   {:fx [[:http {:method     :post
+                 :url        "/api/login"
+                 :body       creds
+                 :on-success [:auth.login/flow [:auth.login/success]]
+                 :on-error   [:auth.login/flow [:auth.login/failure]]}]]})}
+```
+
+An action sees `(fn [data event] effects)` and returns either:
+
+- `:data` — a map merged into the existing data slot (last write wins on key collision; explicit `nil` clears a key).
+- `:fx` — effects to fire (HTTP, navigation, follow-up dispatches).
+- both, or `nil` for no effects.
+
+Just like ordinary `reg-event-fx` returns. The contract is consistent.
+
+> **Why `:data` is the parameter, not a destructure key.** Most guards and actions only care about the machine's own data — not about its discrete state, not about its meta. Passing `:data` directly keeps the 99% case monomorphic and stops `(fn [{:keys [data]} _] ...)` boilerplate from spreading through your codebase. The body reads `(:attempts data)`, not `(get-in snapshot [:data :attempts])`.
+
+### When a guard or action needs the discrete state
+
+The 3-arity escape hatch — `(fn [data event {:keys [state meta]}] ...)` — is opt-in. Declaring a third parameter signals to the runtime that this fn wants the introspection slot. `state` is the snapshot's discrete state; `meta` is any user `:meta`.
+
+```clojure
+(fn capture-browsing-position [_data _event {:keys [state]}]
+  {:data {:last-browsing-state state}})        ;; the FSM keyword
+```
+
+Unless your guard or action needs to branch on the current state name (genuinely rare), stay with 2-arity. The 3-arity is the explicit signal "I'm doing introspection." The runtime arity-detects on the fn itself — no metadata, no flag.
 
 ## Reading a machine: `sub-machine`
 
 Views that need to read a machine's current state read it through a sub:
 
 ```clojure
-@(rf/sub-machine :auth.login/event-handler)
+@(rf/sub-machine :auth.login/flow)
 ;; → {:state :submitting :data {:attempts 1 :error nil}}
 ```
 
 `sub-machine` is sugar over the framework-shipped `:rf/machine` sub. It returns the snapshot — `{:state :data}` — or `nil` if the machine hasn't been created yet. Views typically destructure the `:state` and switch on it; complex UIs read the `:data` slot too. This is the single supported read path; there's no separate "actor reference" object to thread around.
+
+For convenience, you can build named reg-subs over `[:rf/machine machine-id]` to project the bits you care about:
+
+```clojure
+(rf/reg-sub :auth.login/state
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
+
+(rf/reg-sub :auth.login/submitting?
+  :<- [:auth.login/state]
+  (fn [state _] (= :submitting state)))
+```
+
+These read the machine's snapshot through normal sub plumbing — Reagent reactions fire on the slice you actually subscribed to.
+
+## What the substrate covers
+
+The shape above — flat states, plain `:on` transitions, `:entry` / `:exit` actions, machine-local `:guards` / `:actions` — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model. A flavour:
+
+- **Hierarchical states.** A compound state contains sub-states; entering the parent cascades to its declared `:initial` child; transitions from a deep state can target a sibling or an ancestor and the runtime computes the LCA. Useful when the auth flow has an `:authenticated` super-state with `:cart` / `:browsing` sub-states under it.
+- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or "advance through derived states." Bounded depth, microstep-loop semantics, defined trace events.
+- **Delayed `:after` transitions.** A state can declare "if no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
+- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data rather than as `:entry [:spawn ...]` / `:exit [:destroy-machine ...]`. The child's lifecycle is bound to the parent state.
+
+Each of these is opt-in — implementations declare which capabilities they support, and the conformance corpus grades against the claimed set. The full grammar is in [Spec 005](../specification/005-StateMachines.md). The point of mentioning them here is that the model scales: when your machine grows, the substrate has well-named answers ready, and you don't end up smuggling state-machine logic into ordinary event handlers.
 
 ## Patterns that bottom out in machines
 
@@ -161,56 +305,6 @@ Two of the recurring shapes from [chapter 03](03-events-state-cycle.md) end up b
 - [Pattern-Boot](../specification/Pattern-Boot.md) — multi-step initialisation with sequential dependencies, visible progress, fail-fatal points, and recoverable retry. For trivial boots a chained event sequence works; for non-trivial boots the canonical answer is a boot machine.
 
 Both are pattern docs (convention), not Specs (contract). When the shape of a feature you're building is one of these, read the pattern doc and copy the shape.
-
-## Wiring a machine into the rest of re-frame
-
-Once the transition table is defined, registering it as an event handler is one line:
-
-```clojure
-(rf/reg-event-fx :auth.login/event-handler
-  {:doc          "All :auth.login/* events route through here, interpreted as a machine."
-   :machine-path [:auth :login]}
-  (rf/machine-handler [:auth :login] login-flow))
-```
-
-The `:machine-path` is where in `app-db` the machine's snapshot lives. The snapshot is a small map: `{:state :submitting :context {:attempts 1 :error nil}}`. The runtime reads/writes this snapshot at that path; the machine doesn't manage its own state separately.
-
-`(rf/machine-handler path definition)` is a helper that returns a regular `reg-event-fx`-shaped handler. It does the work of "look up the snapshot, call `machine-transition`, write the new snapshot, return the action effects." The handler is pure (`machine-transition` is pure), so all the testing and tooling guarantees of regular events apply to machines.
-
-## Guards and actions
-
-Guards are predicates. Registered separately, by id:
-
-```clojure
-(rf/reg-machine-guard :auth.login/under-retry-limit
-  {:doc "True if fewer than 3 prior attempts."}
-  (fn [{:keys [context]} _event]
-    (< (:attempts context) 3)))
-```
-
-Actions are functions that produce context updates and/or effects. Also registered:
-
-```clojure
-(rf/reg-machine-action :auth.login/issue-request
-  {:doc "Fire the login HTTP request."}
-  (fn [_snapshot [_ creds]]
-    {:fx [[:http {:method :post :url "/api/login" :body creds
-                  :on-success [:auth.login/success]
-                  :on-error   [:auth.login/failure]}]]}))
-
-(rf/reg-machine-action :auth.login/record-error
-  (fn [{:keys [context]} [_ err]]
-    {:context (-> context
-                  (update :attempts inc)
-                  (assoc :error (:message err)))}))
-```
-
-Actions can return:
-
-- `:context` — updates to the extended state.
-- `:fx` — effects to fire (HTTP, navigation, follow-up dispatches).
-
-Just like ordinary `reg-event-fx` returns. The contract is consistent.
 
 ## When to reach for a machine, and when not to
 
@@ -230,27 +324,28 @@ Don't reach for a machine when:
 
 ## Headless testing
 
-Because `machine-transition` is pure — and because actions/guards are registered functions — you can test a machine without dispatching anything:
+Because `machine-transition` is pure — and because guards and actions are inline-or-named-in-the-spec functions — you can test a machine without dispatching anything:
 
 ```clojure
 (deftest login-flow-happy-path
-  (let [snapshot {:state :idle :context {:attempts 0 :error nil}}]
-    (let [[s1 _fx] (rf/machine-transition login-flow snapshot
-                                          [:auth.login/submit {:email "a@b.com"
-                                                               :password "..."}])]
-      (is (= :submitting (:state s1))))
+  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
+        [s1 _fx] (rf/machine-transition login-flow s0
+                                        [:auth.login/submit {:email "a@b.com"
+                                                             :password "..."}])]
+    (is (= :submitting (:state s1)))
 
     (let [[s2 _fx] (rf/machine-transition login-flow
-                                          {:state :submitting :context {:attempts 0}}
+                                          {:state :submitting :data {:attempts 0}}
                                           [:auth.login/success {:user {:id 1}}])]
       (is (= :authed (:state s2))))))
 
 (deftest login-flow-lockout
-  (let [snapshot {:state :submitting :context {:attempts 2}}]
-    (let [[s _fx] (rf/machine-transition login-flow snapshot
-                                         [:auth.login/failure {:message "wrong creds"}])]
-      ;; 2 prior + 1 current = 3, hits the guard, transitions to :locked-out
-      (is (= :locked-out (:state s))))))
+  (let [snapshot {:state :submitting :data {:attempts 3}}
+        [s _fx] (rf/machine-transition login-flow snapshot
+                                       [:auth.login/failure {:message "wrong creds"}])]
+    ;; attempts has already hit the retry limit; the :under-retry-limit guard
+    ;; rejects the first clause, the second clause's :locked-out wins.
+    (is (= :locked-out (:state s)))))
 ```
 
 These tests run on the JVM. No browser. No network. No mocks. Each one runs in microseconds. You can have hundreds.
@@ -259,11 +354,15 @@ This is the testing experience for *flows that are non-trivial* — exactly the 
 
 ## Composing machines
 
-Real apps have more than one machine: an auth machine, a checkout-wizard machine, a websocket-connection machine. They coexist within a frame, each at its own `:machine-path`.
+Real apps have more than one machine: an auth machine, a checkout-wizard machine, a websocket-connection machine. They coexist within a frame, each at its own `[:rf/machines <id>]`.
 
 When machines need to talk to each other, they do so through dispatch — the auth machine's `:auth.login/success` action might dispatch `[:user/load-profile]`, which is handled by a regular `reg-event-fx` handler that updates the user-profile slice. There's no special inter-machine messaging. It's all events, all going through the same queue, all running to completion.
 
 The drain semantics matter here. If an action dispatches a child event, that child event runs *before* subscriptions update. So if a state machine moves through `:idle → :submitting → :authed → :loading-profile → :ready` in a single user click, the view sees only `:idle` (before) and `:ready` (after) — never any in-between flicker. The pattern's commitment to atomic state changes pays off most strongly in flows like this.
+
+## A runnable example
+
+The complete login flow from this chapter — including the runnable smoke tests — lives at [`examples/state_machine_walkthrough/`](https://github.com/day8/re-frame2/tree/main/examples/state_machine_walkthrough) and is exercised on every JVM test run via `re-frame.examples-test/state-machine-walkthrough-runs-headless`. Drop it in front of you while reading; tweak the transition table and watch the smoke tests adapt.
 
 ## The deeper claim
 
@@ -271,7 +370,7 @@ State machines are a small example of the broader thesis [chapter 08](08-the-dyn
 
 A finite state machine has, by construction, a small set of reachable states. You can enumerate them. You can prove things about transitions. You can render the whole flow as a diagram. You can ask "from this state, what can happen?" and the answer is bounded.
 
-A pile of `if`/`cond` clauses spread across event handlers has none of these properties. The reachable states are implicit. The transitions are scattered. There's no diagram. The answer to "from this state, what can happen?" requires reading every handler that touches the state field.
+A pile of `if` / `cond` clauses spread across event handlers has none of these properties. The reachable states are implicit. The transitions are scattered. There's no diagram. The answer to "from this state, what can happen?" requires reading every handler that touches the state field.
 
 The choice between them isn't a matter of style. It's a matter of which dynamic model you can hold in your head. Machines are smaller models. Smaller models are easier to debug, refactor, extend, and reason about.
 

--- a/docs/specification/005-StateMachines.md
+++ b/docs/specification/005-StateMachines.md
@@ -30,6 +30,8 @@ The snapshot is `{:state :data}`:
 
 The pair `{:state :data}` reads as the natural English idiom and matches a vocabulary that's well-represented in AI training corpora. We use `:data` to avoid the existing "context" overloading in re-frame's interceptor pipeline and React-context affordances.
 
+> **`:data` is the parameter name passed to guards and actions, not a destructure key.** Per [§Guards](#guards) / [§Actions](#actions), guards and actions receive `(fn [data event] ...)` — `data` is the snapshot's `:data` slot directly, a plain map. Bodies that read individual fields write `(:circle-id data)`, not `(get-in snapshot [:data :circle-id])`. The 3-arity opt-in `(fn [data event {:state :meta}] ...)` adds the introspection slot when needed; users that don't declare it never see the snapshot wrapper.
+
 ## Snapshot shape
 
 ```clojure
@@ -224,35 +226,50 @@ Internal transitions are how to update `:data` without re-running entry/exit mac
 
 ### Guards
 
-A guard is `(fn [snapshot event] boolean)`. **One inline fn or one keyword reference into the machine's `:guards` map** — never a compound data form.
+A guard is **`(fn [data event] boolean)`** — 2-arity is canonical. **One inline fn or one keyword reference into the machine's `:guards` map** — never a compound data form.
+
+`data` is the snapshot's `:data` slot directly (a map). The fn never sees the snapshot wrapper; pulling `:data` from a snapshot is the runtime's job, not the user's. This keeps the 99% case monomorphic and stops `:keys [data]` boilerplate from spreading through the corpus.
 
 ```clojure
-;; inline fn
-:guard (fn [{:keys [data]} [_ id]]
+;; inline fn — data is the snapshot's :data slot, passed directly
+:guard (fn [data [_ id]]
          (some? (:circle-id data)))
 
 ;; keyword reference — resolves to (get-in spec [:guards :circle-exists?])
 :guard :circle-exists?
 
 ;; compound logic — write the fn
-:guard (fn [snap ev] (and (active? snap ev) (under-quota? snap ev)))
+:guard (fn [data ev] (and (active? data ev) (under-quota? data ev)))
 
 ;; even better — declare a named compound in the machine's :guards map
 (rf/create-machine-handler
   {:guards {:active-and-under-quota?
-            (fn [snap ev] (and (active? snap ev) (under-quota? snap ev)))}
+            (fn [data ev] (and (active? data ev) (under-quota? data ev)))}
    :states {... :on {... {:guard :active-and-under-quota?}}}})
 ;; the name carries semantic meaning that visualisers / AIs read.
 ```
+
+#### 3-arity escape hatch — `:state` / `:meta` introspection
+
+The 3-arity overload is **opt-in** by declaring a third parameter:
+
+```clojure
+:guard (fn [data event {:keys [state meta]}]
+         ...)
+```
+
+`{:state :meta}` is the snapshot's introspection slot — the discrete state and any user `:meta`. Use it for the rare guard or action that needs to branch on the current state name (e.g. dispatch on `:state` itself rather than `:data`). The vast majority of guards and actions are state-blind and don't need the third arg; declaring it is the explicit signal to the runtime that introspection is wanted.
+
+Implementations arity-detect the fn at call time: a fn that declares a fixed 3-arg invocation is called with `[data event {:state :meta}]`; everything else (the canonical 2-arity, plus variadic helpers like `(constantly true)`) is called with `[data event]`. The detection is structural — no metadata needed on the fn — so inline `(fn [data ev ctx] ...)` vs `(fn [data ev] ...)` is the only declaration the user makes.
 
 Compound logic is expressed via function composition or as a named entry in the machine's `:guards` map — the name carries semantic content visualisers and AIs read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-guard`.
 
 ### Actions
 
-An action is `(fn [snapshot event] effects)` returning the `{:data :fx}` shape (or `nil`). **One inline fn or one keyword reference into the machine's `:actions` map** — never a vector.
+An action is **`(fn [data event] effects)`** returning the `{:data :fx}` shape (or `nil`). 2-arity is canonical; 3-arity opt-in is the same `[data event {:state :meta}]` escape hatch as for guards. **One inline fn or one keyword reference into the machine's `:actions` map** — never a vector.
 
 ```clojure
-;; inline
+;; inline — data is the snapshot's :data slot, passed directly
 :action (fn [_ [_ id radius]]
           {:data {:circle-id id :initial-radius radius :preview-radius radius}})
 
@@ -270,9 +287,9 @@ An action is `(fn [snapshot event] effects)` returning the `{:data :fx}` shape (
 Multiple steps in one action are **fn composition**, not a vector:
 
 ```clojure
-:action (fn [snap ev]
-          (let [a (action-clear snap ev)
-                b (action-record-attempt snap ev)]
+:action (fn [data ev]
+          (let [a (action-clear data ev)
+                b (action-record-attempt data ev)]
             {:data (merge (:data a) (:data b))
              :fx   (into (:fx a []) (:fx b []))}))
 ```
@@ -281,7 +298,7 @@ If the composition is reused, name it in the machine's `:actions` map:
 
 ```clojure
 (rf/create-machine-handler
-  {:actions {:clear-and-record (fn [snap ev] ...)}
+  {:actions {:clear-and-record (fn [data ev] ...)}
    :states {... :on {... {:action :clear-and-record}}}})
 ```
 
@@ -336,9 +353,9 @@ A machine *almost never* needs to write `app-db` directly; it acts on its own st
 
 > **Why this is locked.** Strict encapsulation is one of the named consequences of [Goal 2 — Frame state revertibility](000-Vision.md#frame-state-revertibility). If actions could read or write `app-db` outside `[:rf/machines <id>]`, machine logic would create state changes that don't show up in any machine snapshot and don't roll back when the surrounding machine snapshot does. The whole machine's state has to live inside the frame's persistent value to revert with it; encapsulation is what stops machines from leaking state into parts of the value that aren't theirs.
 
-- **Action signature:** `(fn [snapshot event] effects)`.
-- **Guard signature:** `(fn [snapshot event] boolean)`.
-- **Snapshot:** `{:state :data}` only — no `:db`, no cofx.
+- **Action signature:** `(fn [data event] effects)` — 2-arity canonical; 3-arity opt-in is `(fn [data event {:state :meta}] effects)`.
+- **Guard signature:** `(fn [data event] boolean)` — 2-arity canonical; 3-arity opt-in is `(fn [data event {:state :meta}] boolean)`.
+- **What the fn sees:** the snapshot's `:data` slot directly (a map). The full `{:state :data :meta}` snapshot is reachable only via the 3-arity opt-in. Never `app-db`; never cofx.
 
 The impure plumbing (reading the snapshot from `app-db` at `[:rf/machines <id>]`, writing `:data` back as a `:db` write, lowering `:fx` / `:raise` / `:spawn` into standard re-frame effects) lives in the *handler boundary* — the fn returned by `create-machine-handler`. **Inside the boundary: pure. Outside: standard re-frame.**
 
@@ -355,7 +372,7 @@ Whoever fires the event has the data; they pass it. The machine never reaches ou
 ```clojure
 :close-dialog
 {:target :idle
- :action (fn [{:keys [data]} _]
+ :action (fn [data _]
            {:fx   [[:dispatch [:drawer/apply-radius
                                (:circle-id data)
                                (:preview-radius data)]]]
@@ -378,7 +395,7 @@ A machine is registered as **one event handler** via `reg-event-fx` whose body c
   (rf/create-machine-handler
     {:initial :idle                                       ;; initial FSM-keyword
      :data    {:circle-id nil :initial-radius nil :preview-radius nil}
-     :guards  {:circle-exists? (fn [{:keys [data]} _] (some? (:circle-id data)))}
+     :guards  {:circle-exists? (fn [data _] (some? (:circle-id data)))}
      :actions {:clear-error    (fn [_ _] {:data {:error nil}})}
      :states  { ... }}))
 ```
@@ -397,7 +414,7 @@ Reference resolution:
 **Cross-machine reuse via Clojure vars.** When a guard or action is shared across machines, define it as a Clojure var and reference the var from each machine's `:guards` / `:actions` map:
 
 ```clojure
-(defn user-authenticated? [{:keys [data]} _]
+(defn user-authenticated? [data _]
   (some? (:user-id data)))
 
 (rf/reg-event-fx :auth/login {}
@@ -475,7 +492,7 @@ Applied to machines: the transition table is a data DSL because it describes nam
 
 ## Inspectability bias
 
-> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [snap ev] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
+> **Inspectability bias.** Machine tables should prefer **named guards and actions declared in the machine's `:guards` / `:actions` maps** over inline fns. The id (`:under-quota?`) carries semantic meaning that visualisers, AIs, and humans all read; an inline `(fn [data ev] ...)` is opaque to inspection. Inline fns are escape hatches for trivial logic (one-liners with no branching), not the default form.
 
 The id is the meaning at the call site; the inline fn is opaque to readers. The machine-scoped resolution mechanics — how keyword references in transition slots resolve against the machine's `:guards` / `:actions` maps, and how cross-machine reuse via Clojure vars works — are specified once in [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler).
 
@@ -485,11 +502,11 @@ Why the bias:
 
 - **Visualisers read ids, not fn bodies.** A diagram exporter that renders the transition table can label an arrow with `:under-quota?` and have it mean something. An inline fn becomes "[fn]" — a hole in the rendered diagram.
 - **AIs read ids, not fn bodies.** When an AI reasons about a machine — generating tests, proposing changes, explaining behaviour — a keyword reference is a stable name it can resolve against the machine's `:guards` / `:actions` map (visible via `(machine-meta <id>)`). An inline fn is a closure with no public name.
-- **Humans read ids, not fn bodies.** A reviewer scanning a transition table sees `:guard :under-quota?` and knows what gates the transition; with `:guard (fn [snap ev] ...)` they have to read the body to find out.
+- **Humans read ids, not fn bodies.** A reviewer scanning a transition table sees `:guard :under-quota?` and knows what gates the transition; with `:guard (fn [data ev] ...)` they have to read the body to find out.
 - **Tests read ids.** Level-1 (`machine-transition`) and Level-2 tests can stub or assert against named guards/actions by id — re-define the spec's `:guards` / `:actions` entry with a deterministic stand-in. Inline fns can only be replaced by re-writing the entire transition table.
 - **Conformance fixtures read ids.** A fixture's expected `:fx` vector can name `[:dispatch [:audit/login-ok]]` against the action `:record-success` declared in the machine's `:actions` map; inline-fn equivalents are not addressable.
 
-Inline fns remain acceptable for **trivial bodies that don't add meaning by being named** — e.g. `:guard (fn [{:keys [data]} _] (some? (:circle-id data)))` is fine; naming it as `:has-circle?` may add no information beyond what the body already shows. The test is whether the fn body is a single non-branching expression: yes → inline is OK; no → name it in `:guards` / `:actions`.
+Inline fns remain acceptable for **trivial bodies that don't add meaning by being named** — e.g. `:guard (fn [data _] (some? (:circle-id data)))` is fine; naming it as `:has-circle?` may add no information beyond what the body already shows. The test is whether the fn body is a single non-branching expression: yes → inline is OK; no → name it in `:guards` / `:actions`.
 
 Cross-references: [Construction-Prompts.md](Construction-Prompts.md) covers scaffolding guidance.
 
@@ -858,7 +875,7 @@ Guards in `:always` resolve against the **machine's `:guards` map** (per [§Regi
 
 ```clojure
 {:initial :asking
- :guards  {:enough-correct? (fn [{:keys [data]} _] (>= (:correct-count data) 10))}
+ :guards  {:enough-correct? (fn [data _] (>= (:correct-count data) 10))}
  :actions {:count-correct   (fn [_ _] {:data {:correct-count inc}})
            :count-wrong     (fn [_ _] {:data {:wrong-count inc}})}
  :states
@@ -996,7 +1013,7 @@ Tools subscribe to whichever granularity they need: `:scheduled` for timeline vi
 
 ```clojure
 {:initial :idle
- :guards  {:still-loading? (fn [{:keys [data]} _] (:loading? data))}
+ :guards  {:still-loading? (fn [data _] (:loading? data))}
  :states
  {:idle    {:on {:fetch :loading}}
 
@@ -1175,13 +1192,13 @@ Before / after:
 
 ;; create-machine-handler rewrites to (runtime sees this):
 {:loading
- {:entry (fn [{:keys [data] :as snap} ev]
+ {:entry (fn [data _ev]
            {:fx [[:spawn {:machine-id :request/protocol
                           :id-prefix  :request/protocol
                           :data       {:url (:endpoint data)}
                           :on-spawn   (fn [d id] (assoc d :pending id))
                           :start      [:begin]}]]})
-  :exit  (fn [{:keys [data]} _]
+  :exit  (fn [data _]
            {:fx [[:destroy-machine (:pending data)]]})
   :on    {:succeeded :loaded
           :failed    :error}}}
@@ -1510,7 +1527,7 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
 
       :commit
       ;; Persist the previewed radius via :drawer/apply-radius and clear :data.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx   [[:dispatch [:drawer/apply-radius
                             (:circle-id data)
                             (:preview-radius data)]]]

--- a/docs/specification/CP-5-MachineGuide.md
+++ b/docs/specification/CP-5-MachineGuide.md
@@ -13,13 +13,13 @@ Acceptable inline cases (single non-branching expression):
 
 ```clojure
 ;; Trivial guard — single non-branching expression.
-:guard (fn [{:keys [data]} _] (some? (:circle-id data)))
+:guard (fn [data _] (some? (:circle-id data)))
 
 ;; Trivial action — pure data update, single non-branching expression.
 :action (fn [_ [_ new-r]] {:data {:preview-radius new-r}})
 
 ;; Trivial action — single :fx entry, no branching.
-:action (fn [{:keys [data]} _]
+:action (fn [data _]
           {:fx [[:dispatch [:drawer/apply-radius
                             (:circle-id data)
                             (:preview-radius data)]]]})
@@ -29,22 +29,22 @@ Cases that should be named in `:guards` / `:actions` instead (branching, composi
 
 ```clojure
 ;; Branching → name it.
-:action (fn [{:keys [data]} ev]
+:action (fn [data ev]
           (if (over-quota? data)
             {:data {:error :quota}}
             {:data {:attempts (inc (:attempts data))}
              :fx   [[:dispatch [:audit/recorded ev]]]}))
 
 ;; Composed → name the composition.
-:action (fn [snap ev]
-          (let [a (record-attempt snap ev) b (clear-error snap ev)]
+:action (fn [data ev]
+          (let [a (record-attempt data ev) b (clear-error data ev)]
             {:data (merge (:data a) (:data b))
              :fx   (into (:fx a []) (:fx b []))}))
 
 ;; Multi-fx + branching → name it.
-:guard (fn [snap ev]
-         (and (under-quota? snap ev)
-              (not (locked-out? snap ev))
+:guard (fn [data ev]
+         (and (under-quota? data ev)
+              (not (locked-out? data ev))
               (some? (:credentials (second ev)))))
 ```
 
@@ -162,12 +162,14 @@ xstate needs history states because its runtime lacks first-class snapshot-as-va
   {:actions
    {:capture-browsing-position
     ;; Stash the current browsing-state into :data so we can restore it later.
-    (fn [{:keys [state data]} _]
+    ;; This is an opt-in 3-arity body — the third arg unlocks the :state slot;
+    ;; the canonical 2-arity form (fn [data event] ...) only sees :data.
+    (fn [_data _event {:keys [state]}]
       {:data {:last-browsing-state state}})                 ;; the FSM keyword
 
     :restore-browsing-position
     ;; Re-enter at the previously-captured state.
-    (fn [{:keys [data]} _]
+    (fn [data _]
       {:fx [[:raise [:flow/jump-to (:last-browsing-state data)]]]})}
    :states
    {:browsing

--- a/docs/specification/Construction-Prompts.md
+++ b/docs/specification/Construction-Prompts.md
@@ -386,13 +386,13 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
      :guards
      {:under-retry-limit
       ;; Has this login had fewer than 3 prior attempts?
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         (< (:attempts data) 3))}
 
      :actions
      {:begin-submit
       ;; Clear the prior error and emit the HTTP request for credential check.
-      (fn [_snap [_ creds]]
+      (fn [_data [_ creds]]
         {:data {:error nil}
          :fx   [[:http {:method     :post
                         :url        "/api/login"
@@ -402,7 +402,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 
       :record-failure
       ;; Bump the attempts counter and surface a credentials error.
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         {:data {:attempts (inc (:attempts data))
                 :error    :credentials}})
 

--- a/docs/specification/Pattern-AsyncEffect.md
+++ b/docs/specification/Pattern-AsyncEffect.md
@@ -134,7 +134,7 @@ For **boot-time-fixed values** that originate from the host environment — a bu
 :hydrate
 {:on {:succeeded
       {:target :ready
-       :action (fn [{:keys [data]} _]
+       :action (fn [data _]
                  {:fx [[:dispatch [:ws/socket
                                    [:connect {:url        (-> data :config :ws-url)
                                               :auth-token (-> data :session :token)}]]]]})}}}

--- a/docs/specification/Pattern-Boot.md
+++ b/docs/specification/Pattern-Boot.md
@@ -85,28 +85,28 @@ Each phase uses `:invoke` to spawn the async work; transitions on success or fai
       (fn [_ _] (some? (.getItem js/localStorage "auth/token")))
 
       :under-retry-limit?
-      (fn [{:keys [data]} _] (< (:phase-attempt data) 3))}
+      (fn [data _] (< (:phase-attempt data) 3))}
 
      :actions
      {:set-phase
       ;; Update visible-progress slice in :data so the boot UI can render.
-      (fn [{:keys [data]} [_ phase]]
+      (fn [data [_ phase]]
         {:data (assoc data :phase phase :phase-attempt 0)})
 
       :record-config
-      (fn [{:keys [data]} [_ config]]
+      (fn [data [_ config]]
         {:data (assoc data :config config)})
 
       :record-user
-      (fn [{:keys [data]} [_ user]]
+      (fn [data [_ user]]
         {:data (assoc data :user user)})
 
       :bump-attempt
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (update data :phase-attempt inc)})
 
       :record-error
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (assoc data :error err)})
 
       :resolve-initial-route

--- a/docs/specification/Pattern-LongRunningWork.md
+++ b/docs/specification/Pattern-LongRunningWork.md
@@ -50,8 +50,8 @@ A state machine that processes one batch per state transition, yields to the bro
                :input       nil
                :result      []}
      :guards
-     {:done?      (fn [{:keys [data]} _] (>= (:processed data) (:total data)))
-      :more-work? (fn [{:keys [data]} _] (<  (:processed data) (:total data)))}
+     {:done?      (fn [data _] (>= (:processed data) (:total data)))
+      :more-work? (fn [data _] (<  (:processed data) (:total data)))}
 
      :actions
      {:start-job
@@ -64,7 +64,7 @@ A state machine that processes one batch per state transition, yields to the bro
                 :result     []}})
 
       :process-chunk
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (let [{:keys [input chunk-size processed result]} data
               chunk    (subvec input processed (min (+ processed chunk-size) (count input)))
               outputs  (mapv expensive-fn chunk)]

--- a/docs/specification/Pattern-WebSocket.md
+++ b/docs/specification/Pattern-WebSocket.md
@@ -83,11 +83,11 @@ The connection machine composes the locked substrate:
 
      :guards
      {:max-retries-exceeded?
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (>= (:retries data) (:max-retries data)))
 
       :has-queued-messages?
-      (fn [{:keys [data]} _]
+      (fn [data _]
         (seq (:queue data)))}
 
      :actions
@@ -96,33 +96,33 @@ The connection machine composes the locked substrate:
       ;;   (rf/dispatch [:ws/connection [:ws/connect {:url        "wss://api.example.com/ws"
       ;;                                              :auth-token (some-token)}]])
       ;; The opts land in :data; subsequent reconnect attempts reuse them.
-      (fn [{:keys [data]} [_ {:keys [url auth-token]}]]
+      (fn [data [_ {:keys [url auth-token]}]]
         {:data (assoc data :url url :auth-token auth-token)})
 
       :bump-retry
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (-> data
                    (update :retries inc)
                    (update :backoff-ms #(min (* 2 %) (:max-backoff data))))})
 
       :reset-retry
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (assoc data :retries 0 :backoff-ms 1000)})
 
       :record-token
       ;; Used when the running app refreshes the auth token without a full reconnect.
-      (fn [{:keys [data]} [_ token]]
+      (fn [data [_ token]]
         {:data (assoc data :auth-token token)})
 
       :send-auth
       ;; The socket actor accepts a [:send msg] event; route into it.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx [[:dispatch [(:socket-id data) [:send {:type  :auth
                                                     :token (:auth-token data)}]]]]})
 
       :resubscribe
       ;; On (re)connect, re-issue subscriptions tracked in :data.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:fx (mapv (fn [topic]
                      [:dispatch [(:socket-id data)
                                  [:send {:type :subscribe :topic topic}]]])
@@ -130,18 +130,18 @@ The connection machine composes the locked substrate:
 
       :flush-queue
       ;; Send any messages buffered while disconnected; clear the queue.
-      (fn [{:keys [data]} _]
+      (fn [data _]
         {:data (assoc data :queue [])
          :fx   (mapv (fn [msg] [:dispatch [(:socket-id data) [:send msg]]])
                      (:queue data))})
 
       :enqueue-message
       ;; Buffer a send while disconnected.
-      (fn [{:keys [data]} [_ msg]]
+      (fn [data [_ msg]]
         {:data (update data :queue conj msg)})
 
       :record-error
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (assoc data :error err)})}
 
      :states
@@ -184,7 +184,7 @@ The connection machine composes the locked substrate:
                                         ;; named dispatched event; the running-app
                                         ;; handlers commit it.
                                         {:fx [[:dispatch [:ws/handle-message msg]]]})}
-                :ws/send     {:action (fn [{:keys [data]} [_ msg]]
+                :ws/send     {:action (fn [data [_ msg]]
                                         {:fx [[:dispatch [(:socket-id data)
                                                           [:send msg]]]]})}}
        :initial :idle
@@ -228,7 +228,7 @@ To subscribe / unsubscribe at runtime, dispatch a sub/unsub event into the conne
 ```clojure
 ;; Subscribe to a topic — pure :data update + send.
 :ws/subscribe
-{:action (fn [{:keys [data]} [_ topic]]
+{:action (fn [data [_ topic]]
            {:data (update data :subscriptions conj topic)
             :fx   [[:dispatch [(:socket-id data) [:send {:type :subscribe :topic topic}]]]]})}
 ```
@@ -241,7 +241,7 @@ Some WebSocket protocols are request-reply with a correlation id. The pattern: t
 
 ```clojure
 :ws/request
-{:action (fn [{:keys [data]} [_ {:keys [reply] :as msg}]]
+{:action (fn [data [_ {:keys [reply] :as msg}]]
            (let [id (random-uuid)]
              {:data (assoc-in data [:in-flight id] reply)
               :fx   [[:dispatch [(:socket-id data) [:send (assoc msg :id id)]]]]}))}

--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -108,18 +108,18 @@
      :guards
      {:under-retry-limit
       ;; True if the flow has had fewer than 3 prior failed attempts.
-      (fn [{:keys [data]} _event]
+      (fn [data _event]
         (< (:attempts data) 3))}
 
      :actions
      {:clear-error
       ;; Reset error and prepare to submit.
-      (fn [_ _event]
+      (fn [_data _event]
         {:data {:error nil}})
 
       :issue-request
       ;; Issue the login HTTP request. Returns effects, not side-effects.
-      (fn [_snapshot [_ creds]]
+      (fn [_data [_ creds]]
         {:fx [[:http {:method     :post
                       :url        "/api/login"
                       :body       creds
@@ -128,19 +128,19 @@
 
       :record-error
       ;; Record the failure into :data and bump the attempt counter.
-      (fn [{:keys [data]} [_ err]]
+      (fn [data [_ err]]
         {:data (-> data
                    (update :attempts inc)
                    (assoc :error (or (:message err) "Login failed.")))})
 
       :lock-account
       ;; Mark the account as locked after too many failed attempts.
-      (fn [_snapshot _event]
+      (fn [_data _event]
         {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
 
       :store-session
       ;; Persist the session token returned by a successful login.
-      (fn [_snapshot [_ {:keys [token]}]]
+      (fn [_data [_ {:keys [token]}]]
         {:fx [[:auth.session/store {:token token}]]})}
 
      :states

--- a/examples/state_machine_walkthrough/core.cljc
+++ b/examples/state_machine_walkthrough/core.cljc
@@ -1,0 +1,238 @@
+(ns state-machine-walkthrough.core
+  "Runnable companion to docs/guide/05-state-machines.md.
+
+  This is the login-flow chapter as code. Every prose snippet in ch.05
+  appears here in the order the chapter introduces it; each section
+  ends with a smoke-test fn that drives the machine through the
+  scenario the chapter describes.
+
+  Why .cljc: the chapter promises 'runs in microseconds on the JVM, no
+  browser, no network.' The same code runs under shadow-cljs node-test
+  for the CLJS surface. The HTTP side is exercised via the id-valued
+  override seam (`:fx-overrides`) so no real network traffic happens.
+
+  Read alongside docs/guide/05-state-machines.md."
+  (:require [re-frame.core :as rf]))
+
+;; ============================================================================
+;; THE TRANSITION TABLE — chapter §The same flow as a machine
+;; ============================================================================
+;;
+;; Pure data. `:guards` and `:actions` live with the spec — there is no
+;; global registry. References inside `:states` resolve against this
+;; map; cross-machine reuse is via Clojure vars (define a fn, name it
+;; locally in each machine's :guards / :actions).
+
+(def login-flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+
+   :guards
+   {:under-retry-limit
+    ;; 2-arity is canonical: (fn [data event] ...). `data` is the
+    ;; snapshot's :data slot directly — pulling it from a snapshot
+    ;; wrapper is the runtime's job.
+    (fn [data _event]
+      (< (:attempts data) 3))}
+
+   :actions
+   {:clear-error
+    (fn [_data _event] {:data {:error nil}})
+
+    :issue-request
+    ;; Returns effects, not side-effects. The :http fx implementation
+    ;; conj's the response onto the :on-success template; the runtime
+    ;; folds the trailing arg onto the inner event.
+    (fn [_data [_ creds]]
+      {:fx [[:http {:method     :post
+                    :url        "/api/login"
+                    :body       creds
+                    :on-success [:auth.login/flow [:auth.login/success]]
+                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+
+    :record-error
+    (fn [data [_ err]]
+      {:data (-> data
+                 (update :attempts inc)
+                 (assoc :error (or (:message err) "Login failed.")))})
+
+    :lock-account
+    (fn [_data _event]
+      {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+
+    :store-session
+    (fn [_data [_ {:keys [token]}]]
+      {:fx [[:auth.session/store {:token token}]]})}
+
+   :states
+   {:idle
+    {:on {:auth.login/submit {:target :submitting
+                              :action :clear-error}}}
+
+    :submitting
+    {:entry :issue-request
+     :on    {:auth.login/success {:target :authed
+                                  :action :store-session}
+             :auth.login/failure [{:target :error-shown
+                                   :guard  :under-retry-limit
+                                   :action :record-error}
+                                  {:target :locked-out
+                                   :action :lock-account}]}}
+
+    :error-shown
+    {:on {:auth.login/dismiss {:target :idle}
+          :auth.login/submit  {:target :submitting}}}
+
+    :authed      {:meta {:terminal? true}}
+    :locked-out  {:meta {:terminal? true}}}})
+
+;; ============================================================================
+;; FX — chapter §Wiring a machine into the rest of re-frame
+;; ============================================================================
+;;
+;; The :http and :auth.session/store fx are stubs for the example: they
+;; show the shape, not real network/storage. The smoke test below uses
+;; the id-valued override seam (`:fx-overrides`) to swap :http for a
+;; canned-success or canned-failure stub at frame-creation time.
+
+(rf/reg-fx :http
+  {:doc "Stub: a real implementation would call (js/fetch ...)."}
+  (fn [_m _args] nil))
+
+(rf/reg-fx :auth.session/store
+  {:doc "Stub: a real implementation would write localStorage."}
+  (fn [_m _args] nil))
+
+(rf/reg-fx :http.canned-success
+  {:doc "Test stub: every :http call resolves to a canned success."}
+  (fn [{:keys [frame]} {:keys [on-success]}]
+    (when on-success
+      (rf/dispatch (conj on-success {:user  {:id "test-user"}
+                                     :token "test-token"})
+                   {:frame frame}))))
+
+(rf/reg-fx :http.canned-failure
+  {:doc "Test stub: every :http call resolves to a canned failure."}
+  (fn [{:keys [frame]} {:keys [on-error]}]
+    (when on-error
+      (rf/dispatch (conj on-error {:message "bad creds"})
+                   {:frame frame}))))
+
+;; ============================================================================
+;; REGISTRATION — chapter §Wiring a machine into the rest of re-frame
+;; ============================================================================
+;;
+;; Two equivalent forms; we use the convenience `reg-machine`. The
+;; longer form `(reg-event-fx machine-id (create-machine-handler m))`
+;; is what reg-machine wraps, and is the form to use when you need
+;; registration metadata (`:doc`, `:interceptors`, ...).
+
+(rf/reg-machine :auth.login/flow login-flow)
+
+;; ============================================================================
+;; SUBSCRIPTIONS — chapter §Reading a machine: sub-machine
+;; ============================================================================
+
+(rf/reg-sub :auth.login/state
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
+
+(rf/reg-sub :auth.login/error
+  (fn [db _] (get-in db [:rf/machines :auth.login/flow :data :error])))
+
+(rf/reg-sub :auth.login/submitting?
+  :<- [:auth.login/state]
+  (fn [state _] (= :submitting state)))
+
+(rf/reg-sub :auth.login/authenticated?
+  :<- [:auth.login/state]
+  (fn [state _] (= :authed state)))
+
+;; ============================================================================
+;; HEADLESS TESTS — chapter §Headless testing
+;; ============================================================================
+;;
+;; Two flavours of test:
+;;
+;; 1. Pure machine-transition: pass a snapshot + event, get back the
+;;    next snapshot. No frame, no app-db, no fx execution. JVM-runnable.
+;;
+;; 2. Drain-level: spin up a frame with a fx-override, dispatch into
+;;    the machine id, read the resulting app-db slice. Exercises the
+;;    full registration → drain → snapshot-write path including the
+;;    :on-success / :on-error callback fold.
+
+(defn pure-happy-path-test
+  "Drives the transition table directly via machine-transition. No
+  frame, no app-db. The chapter's first test."
+  []
+  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
+        [s1 fx1] (rf/machine-transition login-flow s0
+                                        [:auth.login/submit
+                                         {:email "a@b.com" :password "secret"}])]
+    (assert (= :submitting (:state s1))
+            (str "expected :submitting, got " (:state s1)))
+    ;; Entering :submitting fires the :issue-request action's :fx.
+    (assert (= 1 (count fx1)) (str "expected one :http fx, got " fx1))
+    (assert (= :http (ffirst fx1)) (str "expected :http fx-id, got " (ffirst fx1)))
+
+    (let [[s2 _] (rf/machine-transition login-flow s1
+                                        [:auth.login/success {:token "t"}])]
+      (assert (= :authed (:state s2))
+              (str "expected :authed, got " (:state s2))))
+    :ok))
+
+(defn pure-lockout-test
+  "Once :data :attempts reaches the retry limit, the :under-retry-limit
+  guard fails and the second :auth.login/failure clause's :locked-out
+  target wins. The guard checks the snapshot BEFORE the action runs;
+  :record-error then bumps the counter on hits, so attempts=3 is the
+  first counter value at which the guard rejects."
+  []
+  (let [snapshot {:state :submitting :data {:attempts 3 :error nil}}
+        [s _fx] (rf/machine-transition login-flow snapshot
+                                       [:auth.login/failure {:message "bad creds"}])]
+    (assert (= :locked-out (:state s))
+            (str "expected :locked-out at attempts=3, got " (:state s)))
+    :ok))
+
+(defn drain-happy-path-test
+  "Full drain: registers the machine, dispatches into it, asserts the
+  app-db landed at :authed. Uses the fx-overrides seam to swap :http
+  for a canned-success stub."
+  []
+  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-success}})]
+    (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                          {:email "a@b.com"
+                                           :password "secret"}]]
+                      {:frame f})
+    (let [state (rf/compute-sub [:auth.login/state] (rf/get-frame-db f))]
+      (assert (= :authed state)
+              (str "expected :authed after canned success, got " state)))
+    :ok))
+
+(defn drain-retry-then-lockout-test
+  "Three failures cycle :submitting → :error-shown → :idle ×3, then a
+  fourth :submit fails the guard and lands at :locked-out."
+  []
+  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-failure}})]
+    (dotimes [_ 3]
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                            {:email "x@y.z" :password "wrong"}]]
+                        {:frame f})
+      (rf/dispatch-sync [:auth.login/flow [:auth.login/dismiss]] {:frame f}))
+    (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                          {:email "x@y.z" :password "wrong"}]]
+                      {:frame f})
+    (let [state (rf/compute-sub [:auth.login/state] (rf/get-frame-db f))]
+      (assert (= :locked-out state)
+              (str "expected :locked-out on 4th attempt, got " state)))
+    :ok))
+
+(defn smoke-tests
+  "Run all four headless tests. Returns :ok or throws."
+  []
+  (pure-happy-path-test)
+  (pure-lockout-test)
+  (drain-happy-path-test)
+  (drain-retry-then-lockout-test)
+  :ok)

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -67,6 +67,55 @@
     :else             (throw (ex-info ":rf.error/machine-bad-action-form"
                                       {:action action}))))
 
+;; ---- guard/action contract --------------------------------------------------
+;;
+;; Per Spec 005 §Guards / §Actions, the canonical signature is:
+;;
+;;   (fn [data event] ...)              ; 2-arity — the 99% case
+;;   (fn [data event ctx] ...)          ; 3-arity — opt-in introspection
+;;
+;; `data` is the machine's :data slot directly (a map). `event` is the inbound
+;; event vector. `ctx` (3-arity escape hatch) is `{:state ... :meta ...}` —
+;; the snapshot's discrete-state and any user `:meta`. Returning to the 2-
+;; arity surface from the 3-arity body is a one-line `(let [data data] ...)`;
+;; no migration cost when introspection is no longer needed.
+
+(defn- declares-3-arity?
+  "True iff f explicitly declares a 3-fixed-arg invocation. Distinguishes
+  user opt-in 3-arity from variadic helpers like (constantly ...). On the
+  JVM, walks the fn class's declared invoke methods (variadics are
+  RestFns with no declared invoke(O,O,O) on the fn class itself); on
+  CLJS, looks for the multi-arity dispatch slot or matches .-length."
+  [f]
+  #?(:clj  (boolean
+             (some
+               (fn [^java.lang.reflect.Method m]
+                 (and (= "invoke" (.getName m))
+                      (= 3 (.getParameterCount m))))
+               (.getDeclaredMethods (class f))))
+     :cljs (or (= 3 (.-length f))
+               (some? (unchecked-get f "cljs$core$IFn$_invoke$arity$3")))))
+
+(defn- call-guard
+  "Invoke a resolved guard fn against a snapshot + event with the
+  canonical contract. 2-arity sees [data event]; 3-arity opt-in sees
+  [data event {:state :meta}]."
+  [g snapshot event]
+  (let [data (:data snapshot)]
+    (if (declares-3-arity? g)
+      (g data event {:state (:state snapshot) :meta (:meta snapshot)})
+      (g data event))))
+
+(defn- call-action
+  "Invoke a resolved action fn against a snapshot + event with the
+  canonical contract. 2-arity sees [data event]; 3-arity opt-in sees
+  [data event {:state :meta}]."
+  [f snapshot event]
+  (let [data (:data snapshot)]
+    (if (declares-3-arity? f)
+      (f data event {:state (:state snapshot) :meta (:meta snapshot)})
+      (f data event))))
+
 ;; ---- spawn counter --------------------------------------------------------
 ;;
 ;; Per Spec 005 §Declarative :invoke (sugar over spawn): on entry to an
@@ -256,7 +305,7 @@
                              (get-in n [:on :*])))
                 hit    (some (fn [t]
                                (let [g (resolve-guard machine (:guard t))]
-                                 (when (g snapshot event) t)))
+                                 (when (call-guard g snapshot event) t)))
                              cands)]
             (if hit
               {:transition hit :decl-path prefix}
@@ -295,7 +344,7 @@
 (defn- run-action [machine snap action-ref event]
   (if action-ref
     (let [f (resolve-action machine action-ref)
-          result (f snap event)]
+          result (call-action f snap event)]
       (or result {}))
     {}))
 
@@ -468,7 +517,7 @@
                      :else             [always])
             hit    (some (fn [t]
                            (let [g (resolve-guard machine (:guard t))]
-                             (when (g snapshot nil) t)))
+                             (when (call-guard g snapshot nil) t)))
                          always)]
         (if hit
           {:transition (assoc hit :decl-path prefix) :decl-path prefix}

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -405,7 +405,11 @@
         actions-by-id
         (into {}
               (for [[id steps] (:machine-action handlers-map)]
-                [id (fn [snap event]
+                ;; Per Spec 005 §Guards / §Actions canonical 2-arity:
+                ;; the user-facing fn receives (data event), not the
+                ;; snapshot. The fixture-step interpreter still threads
+                ;; a local `ctx` map for its own reduction state.
+                [id (fn [data event]
                       (let [final (reduce
                                     (fn [{:keys [data] :as ctx} step]
                                       (case (first step)
@@ -423,19 +427,20 @@
                                                   (update ctx :fx (fnil conj [])
                                                           [a (eval-value b ctx)]))
                                         ctx))
-                                    {:data (:data snap) :event event :fx []}
+                                    {:data data :event event :fx []}
                                     steps)]
                         (cond-> {}
-                          (not= (:data snap) (:data final)) (assoc :data (:data final))
+                          (not= data (:data final)) (assoc :data (:data final))
                           (seq (:fx final)) (assoc :fx (:fx final)))))]))
         guards-by-id
         (into {}
               (for [[id steps] (:machine-guard handlers-map)]
-                [id (fn [snap event]
+                ;; Per Spec 005 §Guards canonical 2-arity: (fn [data event]).
+                [id (fn [data event]
                       (let [step (first steps)]
                         (when (and (vector? step) (= :fn (first step)))
                           (boolean
-                            (eval-value step {:data (:data snap) :event event})))))]))
+                            (eval-value step {:data data :event event})))))]))
         ;; Same machine-action steps, but realised as on-spawn callbacks
         ;; (snapshot-relative :set paths) for use in :invoke desugaring.
         on-spawn-by-id

--- a/implementation/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/test/re_frame/cross_spec_cljs_test.cljs
@@ -83,12 +83,12 @@
          :states  {:idle    {:on {:go {:target :acting :action :record-role}}}
                    :acting  {}}
          :actions {:record-role
-                   (fn [snapshot _event]
+                   (fn [_data _event]
                      ;; Read a sub from inside the action — the machine
                      ;; cascade has not committed yet but the sub sees
                      ;; the *current* committed app-db.
                      (reset! observed-by-action (rf/subscribe-value [:user-role]))
-                     snapshot)}}]
+                     nil)}}]
     (rf/reg-machine :auth/check machine)
     (rf/dispatch-sync [:auth/check [:go]])
     (is (= :admin @observed-by-action)
@@ -302,9 +302,9 @@
                    :states  {:idle {:on {:go {:target :done :action :emit-fx}}}
                              :done {}}
                    :actions {:emit-fx
-                             (fn [snap _]
-                               (assoc snap :fx [[:throwy :a]
-                                                [:record :b]]))}}]
+                             (fn [_data _event]
+                               {:fx [[:throwy :a]
+                                     [:record :b]]})}}]
       (rf/reg-machine :test/m machine)
       (let [traces (collect-traces ::xspec-12)]
         (rf/dispatch-sync [:test/m [:go]])
@@ -335,10 +335,10 @@
                                                   :action :tag}}}
                               :working {:on {:go {:target :idle
                                                   :action :tag}}}}
-                    :actions {:tag (fn [snap _]
-                                     (assoc-in snap [:data :who] :v1))}}
+                    :actions {:tag (fn [data _]
+                                     {:data (assoc data :who :v1)})}}
         machine-v2 (assoc-in machine-v1 [:actions :tag]
-                             (fn [snap _] (assoc-in snap [:data :who] :v2)))]
+                             (fn [data _] {:data (assoc data :who :v2)}))]
     (rf/reg-machine :test/m machine-v1)
     (rf/dispatch-sync [:test/m [:go]])
     (is (= :v1 (get-in (rf/get-frame-db :rf/default)

--- a/implementation/test/re_frame/examples_test.clj
+++ b/implementation/test/re_frame/examples_test.clj
@@ -13,9 +13,10 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (rf/init!)
-  ;; Drop any cached require of ssr.core so each test re-evaluates the
-  ;; example's namespace-level handlers against a fresh registrar.
+  ;; Drop any cached require of example namespaces so each test re-evaluates
+  ;; their namespace-level handlers against a fresh registrar.
   (remove-ns 'ssr.core)
+  (remove-ns 'state-machine-walkthrough.core)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -26,3 +27,13 @@
     (let [result (@(resolve 'ssr.core/ssr-tests))]
       (is (= :ok result)
           "ssr.core/ssr-tests returned :ok — the full server flow worked"))))
+
+(deftest state-machine-walkthrough-runs-headless
+  (testing "examples/state-machine-walkthrough/core.cljc — every code block in
+            ch.05 § Headless testing runs and matches the chapter's claims."
+    (require 'state-machine-walkthrough.core :reload)
+    (let [result (@(resolve 'state-machine-walkthrough.core/smoke-tests))]
+      (is (= :ok result)
+          "state-machine-walkthrough.core/smoke-tests returned :ok — the
+           login-machine drove through happy path, retry-then-lockout, and
+           pure machine-transition tests."))))

--- a/implementation/test/re_frame/hot_reload_test.clj
+++ b/implementation/test/re_frame/hot_reload_test.clj
@@ -178,7 +178,7 @@
         {:initial :red
          :data    {:ticks 0}
          :actions {:tick-action
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      {:data (update data :ticks inc)})}
          :states
          {:red    {:on {:tick {:target :green :action :tick-action}}}

--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -168,11 +168,11 @@
     (let [machine
           {:initial :asking
            :data    {:correct-count 9}
-           :guards  {:enough? (fn [snap _]
-                                (>= (get-in snap [:data :correct-count]) 10))}
-           :actions {:count   (fn [snap _]
+           :guards  {:enough? (fn [data _]
+                                (>= (:correct-count data) 10))}
+           :actions {:count   (fn [data _]
                                 {:data {:correct-count
-                                        (inc (get-in snap [:data :correct-count]))}})}
+                                        (inc (:correct-count data))}})}
            :states
            {:asking {:always [{:guard :enough? :target :winner}]
                      :on     {:answer-correct {:action :count}}}
@@ -194,11 +194,11 @@
     (let [machine
           {:initial :asking
            :data    {:correct-count 5}
-           :guards  {:enough? (fn [snap _]
-                                (>= (get-in snap [:data :correct-count]) 10))}
-           :actions {:count   (fn [snap _]
+           :guards  {:enough? (fn [data _]
+                                (>= (:correct-count data) 10))}
+           :actions {:count   (fn [data _]
                                 {:data {:correct-count
-                                        (inc (get-in snap [:data :correct-count]))}})}
+                                        (inc (:correct-count data))}})}
            :states
            {:asking {:always [{:guard :enough? :target :winner}]
                      :on     {:answer-correct {:action :count}}}

--- a/implementation/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/test/re_frame/pattern_smoke_test.clj
@@ -115,7 +115,7 @@
       (rf/create-machine-handler
         {:initial :configuring
          :data    {:config nil}
-         :actions {:record-config (fn [{:keys [data]} [_ c]]
+         :actions {:record-config (fn [data [_ c]]
                                     {:data (assoc data :config c)})}
          :states
          {:configuring {:on {:configured {:target :loading
@@ -210,11 +210,11 @@
         {:initial :disconnected
          :data    {:retries 0 :max-retries 2}
          :guards  {:max-retries-exceeded?
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      (>= (:retries data) (:max-retries data)))}
-         :actions {:bump-retry  (fn [{:keys [data]} _]
+         :actions {:bump-retry  (fn [data _]
                                   {:data (update data :retries inc)})
-                   :reset-retry (fn [{:keys [data]} _]
+                   :reset-retry (fn [data _]
                                   {:data (assoc data :retries 0)})}
          :states
          {:disconnected   {:on {:ws/connect {:target :connecting}}}
@@ -321,16 +321,16 @@
   (let [machine
         {:initial :idle
          :data    {:total 0 :processed 0 :chunk-size 2 :input nil :result []}
-         :guards  {:done?      (fn [{:keys [data]} _]
+         :guards  {:done?      (fn [data _]
                                  (>= (:processed data) (:total data)))
-                   :more-work? (fn [{:keys [data]} _]
+                   :more-work? (fn [data _]
                                  (< (:processed data) (:total data)))}
          :actions {:start-job
                    (fn [_ [_ input]]
                      {:data {:total (count input) :input input
                              :chunk-size 2 :processed 0 :result []}})
                    :process-chunk
-                   (fn [{:keys [data]} _]
+                   (fn [data _]
                      (let [{:keys [input chunk-size processed result]} data
                            chunk (subvec input processed
                                          (min (+ processed chunk-size)

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -413,7 +413,7 @@
     (let [m {:id     :auth
              :initial :checking
              :data    {:authed? true}
-             :guards  {:authed? (fn [snap _] (:authed? (:data snap)))}
+             :guards  {:authed? (fn [data _] (:authed? data))}
              :states
              {:checking {:always [{:guard :authed? :target :authed}]}
               :authed   {}
@@ -431,8 +431,8 @@
              :data    {:n 0}
              :actions {:start (fn [_ _]
                                 {:fx [[:raise [:bump]] [:raise [:bump]]]})
-                       :bump  (fn [snap _]
-                                {:data {:n (inc (:n (:data snap)))}})}
+                       :bump  (fn [data _]
+                                {:data {:n (inc (:n data))}})}
              :states
              {:idle {:on {:start {:target :busy :action :start}
                           :bump  {:action :bump}}}
@@ -692,7 +692,7 @@
            :data    {:attempts 0 :error nil}
            :guards
            {:under-retry-limit
-            (fn [{:keys [data]} _] (< (:attempts data) 3))}
+            (fn [data _] (< (:attempts data) 3))}
            :actions
            {:clear-error    (fn [_ _] {:data {:error nil}})
             :issue-request  (fn [_ [_ creds]]
@@ -701,7 +701,7 @@
                                             :body       creds
                                             :on-success [:auth.login/flow [:auth.login/success]]
                                             :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
-            :record-error   (fn [{:keys [data]} [_ err]]
+            :record-error   (fn [data [_ err]]
                               {:data (-> data
                                          (update :attempts inc)
                                          (assoc :error (or (:message err) "Login failed.")))})
@@ -755,7 +755,7 @@
     (rf/reg-machine :test/tiny
       {:initial :idle
        :data    {:n 0}
-       :actions {:bump (fn [{:keys [data]} _] {:data (update data :n inc)})}
+       :actions {:bump (fn [data _] {:data (update data :n inc)})}
        :states  {:idle {:on {:tick {:target :idle :action :bump}}}}})
     (let [f (rf/make-frame {})]
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
@@ -773,7 +773,7 @@
     (let [tiny-spec   {:initial :idle
                        :data    {:n 0}
                        :doc     "A tiny test machine."
-                       :actions {:bump (fn [{:keys [data]} _]
+                       :actions {:bump (fn [data _]
                                          {:data (update data :n inc)})}
                        :states  {:idle {:on {:tick {:target :idle
                                                     :action :bump}}}}}


### PR DESCRIPTION
Replaces auto-closed PR #58. Rebased onto current main.

Three logical changes:

- **machines.cljc**: tighten the guard/action contract to `(fn [data event] ...)` with a 3-arity escape hatch for the rare cases that need the snapshot map (rf2-qppo).
- **Spec 005 + Pattern docs**: sweep guard/action signatures to the data-direct shape; §Naming locks the contract.
- **Guide ch.05**: rewrite around the v1 state-machine surface, with a runnable companion `examples/state_machine_walkthrough/core.cljc`.

## Beads

- rf2-hbt1 (closes on merge)
- rf2-qppo (closes on merge)

## Tests

JVM (208 tests / 992 assertions), CLJS node (71 tests / 236 assertions), CLJS browser, elision, Playwright — all green post-rebase.