### PR TITLE
test: regression guards for rf2-562e + rf2-atsv (substrate verified removed)

### DIFF
--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -173,6 +173,35 @@
       (is (= 'def (first (last exp))))
       (is (= 'my-widget (second (last exp))))))
 
+  ;; rf2-atsv regression guard. The bug shape was an outer
+  ;; (def x (reg-view :id ...)) wrapper that double-def'd against the
+  ;; macro's own internal def. rf2-d0pi removed the substrate by making
+  ;; reg-view defn-shape — the macro itself emits the (single) def, and
+  ;; the legacy outer-def wrapper no longer compiles. Pin: exactly ONE
+  ;; def in the full expansion, no matter the input shape.
+  (testing "rf2-atsv: expansion contains exactly one def form"
+    (letfn [(count-defs [form]
+              (cond
+                (and (seq? form) (= 'def (first form)))
+                (+ 1 (apply + (map count-defs (rest form))))
+                (coll? form)
+                (apply + (map count-defs form))
+                :else 0))]
+      (let [exp-plain   (vm/expand-reg-view {} 'my.ns "my_ns.cljc"
+                                            'plain-view '([] [:p]))
+            exp-doc     (vm/expand-reg-view {} 'my.ns "my_ns.cljc"
+                                            'docced-view '("a doc" [] [:p]))
+            exp-id-meta (vm/expand-reg-view {} 'my.ns "my_ns.cljc"
+                                            (with-meta 'meta-view
+                                              {:rf/id :explicit/id})
+                                            '([] [:p]))]
+        (is (= 1 (count-defs exp-plain))
+            "plain (reg-view sym [args] body) emits exactly one def")
+        (is (= 1 (count-defs exp-doc))
+            "(reg-view sym docstring [args] body) emits exactly one def")
+        (is (= 1 (count-defs exp-id-meta))
+            "(reg-view ^{:rf/id ...} sym [args] body) emits exactly one def"))))
+
   (testing "vm/parse-reg-view-args parses the three accepted shapes"
     (is (= {:docstring nil :args '[] :body nil}
            (vm/parse-reg-view-args '([]))))


### PR DESCRIPTION
## Summary

Verify both bugs are fixed by rf2-d0pi (PR #54) and pin a regression guard.

- **rf2-562e** — `(defonce root)` collision with `(reg-view :*/root ...)`. Verified: no example file in tree has both `(defonce root ...)` AND `(reg-view root ...)` colliding on the symbol `root`. The silent auto-def-from-keyword substrate is gone (defn-shape macro requires a user-explicit symbol). **Closed as fixed.**
- **rf2-atsv** — outer `(def x (reg-view ...))` wrapper double-defs against the macro's own internal def. Verified: zero `(def x (reg-view ...))` wrappers in `examples/` or `implementation/`. The legacy outer-def shape no longer compiles (rf2-d0pi compile-error contract). Doc drift is tracked separately by rf2-xv7e. **Closed as fixed.**

## Change

One small regression-guard test in `implementation/test/re_frame/views_macros_test.clj`: asserts `vm/expand-reg-view` emits exactly **one** `def` form across the three accepted input shapes (plain / docstring / `^{:rf/id ...}` metadata override). This pins the substrate-removal — a future change that re-introduces a second `def` (the rf2-atsv shape) will fail this test.

## Test plan

- [x] `clojure -M:test -n re-frame.views-macros-test` — all 10 tests / 35 assertions green, including the new guard.