### PR TITLE
feat: conformance DSL split :event-arg / :get-event-arg (rf2-pz9f / rf2-xb5o)

### DIFF
--- a/docs/specification/conformance/README.md
+++ b/docs/specification/conformance/README.md
@@ -116,6 +116,9 @@ The complete DSL operator set. The schemas live in [Spec-Schemas §`:rf/fixture-
 | Form | Meaning |
 |---|---|
 | `[:event-arg n]` | The n-th element of the event vector (0-based). `[:event-arg 1]` is typical for the first user-supplied arg. |
+| `[:event-arg n default-val]` | The n-th element of the event vector; `default-val` if the n-th element is `nil`. The 3rd element is **always** a default-for-nil — it is never type-dispatched, even when it's a keyword and the resolved value happens to be a map. For key-access into a map argument, use `:get-event-arg`. |
+| `[:get-event-arg n :key]` | `:key`-access into the n-th element of the event vector — equivalent to `(get (nth event n) :key)`. The n-th element is expected to be a map. |
+| `[:get-event-arg n :key default-val]` | Same as above with a default if `:key` is missing or its value is `nil`. |
 | `[:fn :keyword]` | Reference a host-builtin function by keyword. |
 | `[:fn :keyword arg1 arg2 ...]` | Partial application: `[:fn :conj :should-not-fire]` is `(fn [x] (conj x :should-not-fire))`. |
 

--- a/docs/specification/conformance/fixtures/dsl-event-arg-vs-get-event-arg.edn
+++ b/docs/specification/conformance/fixtures/dsl-event-arg-vs-get-event-arg.edn
@@ -1,0 +1,63 @@
+;; Conformance fixture: dsl/event-arg-vs-get-event-arg
+;; Per rf2-xb5o (resolves rf2-pz9f): the conformance handler-body DSL
+;; distinguishes:
+;;
+;;   [:event-arg n]                  — n-th event arg (verbatim)
+;;   [:event-arg n default-val]      — n-th event arg, default-val if nil
+;;                                     (UNCONDITIONAL: default-val is NEVER
+;;                                     interpreted as a key into the value)
+;;   [:get-event-arg n :key]         — key-access into the n-th arg (a map)
+;;   [:get-event-arg n :key default] — key-access with default if missing/nil
+;;
+;; This fixture exercises both forms in event handlers and asserts the
+;; observable result in app-db. The interesting case is when the runtime
+;; arg IS a map AND the 3rd element of [:event-arg ...] is a keyword:
+;; pre-rf2-xb5o, that triggered key-access; post-rf2-xb5o, the keyword
+;; is a default-for-nil that is NOT used (because the arg is non-nil).
+
+{:fixture/id           :dsl/event-arg-vs-get-event-arg
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub}
+ :fixture/doc          "Splits :event-arg (default-for-nil only) from :get-event-arg (key-access). Pre-rf2-xb5o, [:event-arg 1 :foo] with a map arg meant 'extract :foo'; post-rf2-xb5o, the map is returned verbatim and the keyword is unused."
+
+ :fixture/registry
+ {:event {:dsl/init                {:doc "Seed."}
+          :dsl/store-event-arg     {:doc "Store [:event-arg 1 :foo] at [:via-event-arg]."}
+          :dsl/store-get-event-arg {:doc "Store [:get-event-arg 1 :foo] at [:via-get-event-arg]."}
+          :dsl/store-default-fires {:doc "[:event-arg 1 :default-fires] when arg is nil — default-val returned."}}
+  :sub   {:via-event-arg     {:doc "Reads [:via-event-arg]."}
+          :via-get-event-arg {:doc "Reads [:via-get-event-arg]."}
+          :default-fires     {:doc "Reads [:default-fires]."}}}
+
+ :fixture/handlers
+ {:event {:dsl/init                [[:set [] {}]]
+          ;; The arg is the map {:foo 42}. With key-access overload, this
+          ;; would write 42; without (post-rf2-xb5o), the whole map writes.
+          :dsl/store-event-arg     [[:set [:via-event-arg]     [:event-arg 1 :foo]]]
+          ;; Explicit key-access: writes 42.
+          :dsl/store-get-event-arg [[:set [:via-get-event-arg] [:get-event-arg 1 :foo]]]
+          ;; Dispatched with NO 1st arg, so [:event-arg 1] is nil → default
+          ;; (the keyword) is returned.
+          :dsl/store-default-fires [[:set [:default-fires]     [:event-arg 1 :default-fires]]]}
+  :sub   {:via-event-arg     [[:get [:via-event-arg]]]
+          :via-get-event-arg [[:get [:via-get-event-arg]]]
+          :default-fires     [[:get [:default-fires]]]}}
+
+ :fixture/frame-config
+ {:on-create [:dsl/init]}
+
+ :fixture/dispatches
+ [[:dsl/store-event-arg     {:foo 42}]
+  [:dsl/store-get-event-arg {:foo 42}]
+  [:dsl/store-default-fires]]
+
+ :fixture/expect
+ {:final-app-db
+  {:via-event-arg     {:foo 42}        ;; whole map — no key-access
+   :via-get-event-arg 42               ;; key-access via :get-event-arg
+   :default-fires     :default-fires}  ;; nil arg → keyword default returned
+
+  :sub-values
+  {[:via-event-arg]     {:foo 42}
+   [:via-get-event-arg] 42
+   [:default-fires]     :default-fires}}}

--- a/docs/specification/conformance/fixtures/ssr-head-hydration.edn
+++ b/docs/specification/conformance/fixtures/ssr-head-hydration.edn
@@ -14,7 +14,7 @@
   :head  {:head/article {:doc "Article-page head model."}}}
 
  :fixture/handlers
- {:event {:rf/hydrate [[:set [] [:event-arg 1 :rf/app-db]]]}
+ {:event {:rf/hydrate [[:set [] [:get-event-arg 1 :rf/app-db]]]}
   :head  {:head/article
           [[:return-head
             {:title "Article: re-frame2 SSR — Example"

--- a/docs/specification/conformance/fixtures/ssr-hydration-mismatch.edn
+++ b/docs/specification/conformance/fixtures/ssr-hydration-mismatch.edn
@@ -18,7 +18,7 @@
   :view  {:root {:doc "Root view; greeting + count."}}}
 
  :fixture/handlers
- {:event {:rf/hydrate   [[:set [] [:event-arg 1 :rf/app-db]]]      ;; replace app-db with payload's :rf/app-db
+ {:event {:rf/hydrate   [[:set [] [:get-event-arg 1 :rf/app-db]]]  ;; replace app-db with payload's :rf/app-db
           :counter/init [[:set [] {:count 0 :greeting "Hello, client!"}]]}
   :sub   {:count    [[:get [:count]]]
           :greeting [[:get [:greeting]]]}}

--- a/implementation/src/re_frame/conformance.cljc
+++ b/implementation/src/re_frame/conformance.cljc
@@ -23,6 +23,9 @@
 
   Reflection (used as args to data ops):
     [:event-arg n]                  the n-th element of event (0-based)
+    [:event-arg n default-val]      n-th element of event; default-val if nil
+    [:get-event-arg n :key]         (get (nth event n) :key)  -- key-access
+    [:get-event-arg n :key default] key-access with default if missing/nil
     [:db-get path]                  read db at path
     [:fn :keyword]                  reference a builtin
     [:fn :keyword arg1 ...]         partial application of a builtin
@@ -100,23 +103,23 @@
   (cond
     (vector? form)
     (case (first form)
-      :event-arg    (let [[_ idx maybe] form
+      :event-arg    (let [[_ idx default-val] form
                           v (get (:event ctx) idx)]
-                      ;; Two shapes overload the third element:
-                      ;;   [:event-arg n default-for-nil]
-                      ;;   [:event-arg n key-into-value]   (when value is a map
-                      ;;                                    and 3rd is keyword)
-                      ;; Disambiguate by the type of the third element.
-                      (cond
-                        (and (>= (count form) 3)
-                             (keyword? maybe)
-                             (map? v))             (get v maybe)
-                        (and (>= (count form) 3)
-                             (nil? v))             maybe
-                        :else                      v))
-      :get-event-arg (let [[_ idx k] form
-                           m (get (:event ctx) idx)]
-                       (get m k))
+                      ;; The 3rd element is unconditionally a default-for-nil.
+                      ;; Per rf2-xb5o (resolves rf2-pz9f): no type-dispatch on
+                      ;; the 3rd element. For map-value key-access, use the
+                      ;; explicit [:get-event-arg n :key] form below.
+                      (if (and (>= (count form) 3) (nil? v))
+                        default-val
+                        v))
+      :get-event-arg (let [[_ idx k default-val] form
+                           m (get (:event ctx) idx)
+                           v (get m k)]
+                       ;; [:get-event-arg n :key]            -- (get (nth event n) :key)
+                       ;; [:get-event-arg n :key default]    -- with default if missing/nil
+                       (if (and (>= (count form) 4) (nil? v))
+                         default-val
+                         v))
       :db-get       (let [[_ path default] form
                           v (get-in (:db ctx) path)]
                       (if (and (nil? v) (>= (count form) 3)) default v))

--- a/implementation/test/re_frame/conformance_dsl_cljs_test.cljs
+++ b/implementation/test/re_frame/conformance_dsl_cljs_test.cljs
@@ -1,0 +1,43 @@
+(ns re-frame.conformance-dsl-cljs-test
+  "CLJS-side coverage for the conformance handler-body DSL evaluator.
+  Mirrors the JVM conformance-dsl-test — the conformance ns is .cljc so
+  resolve-value* runs on both hosts; the regression-guard for the
+  rf2-xb5o :event-arg / :get-event-arg split must hold on both."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.conformance :as conformance]))
+
+(deftest event-arg-no-key-access-overload
+  (testing ":event-arg's 3rd element is unconditionally default-for-nil"
+    (let [ctx {:event [:some-id {:foo 99}]}]
+      (testing "with a non-nil map arg, returns the arg verbatim"
+        (is (= {:foo 99}
+               (conformance/resolve-value* [:event-arg 1 :foo] ctx))
+            "[:event-arg n :foo] with a map arg must NOT do key-access")))
+
+    (testing "with nil arg, default-val is returned (keyword default works)"
+      (let [ctx {:event [:some-id]}]
+        (is (= :foo
+               (conformance/resolve-value* [:event-arg 1 :foo] ctx)))))
+
+    (testing "with nil arg, non-keyword default-val is returned"
+      (let [ctx {:event [:some-id]}]
+        (is (= {} (conformance/resolve-value* [:event-arg 1 {}] ctx)))
+        (is (= 0  (conformance/resolve-value* [:event-arg 1 0] ctx)))))
+
+    (testing "two-element form [:event-arg n] returns the n-th arg unchanged"
+      (let [ctx {:event [:some-id {:foo 99}]}]
+        (is (= {:foo 99}
+               (conformance/resolve-value* [:event-arg 1] ctx)))))))
+
+(deftest get-event-arg-key-access
+  (testing ":get-event-arg extracts a key from a map arg"
+    (let [ctx {:event [:some-id {:foo 99 :bar "x"}]}]
+      (is (= 99  (conformance/resolve-value* [:get-event-arg 1 :foo] ctx)))
+      (is (= "x" (conformance/resolve-value* [:get-event-arg 1 :bar] ctx)))
+      (is (= nil (conformance/resolve-value* [:get-event-arg 1 :missing] ctx)))))
+
+  (testing "[:get-event-arg n :key default] uses default for missing/nil"
+    (let [ctx {:event [:some-id {:foo 99 :nilval nil}]}]
+      (is (= 99       (conformance/resolve-value* [:get-event-arg 1 :foo :fallback] ctx)))
+      (is (= :default (conformance/resolve-value* [:get-event-arg 1 :missing :default] ctx)))
+      (is (= :default (conformance/resolve-value* [:get-event-arg 1 :nilval :default] ctx))))))

--- a/implementation/test/re_frame/conformance_dsl_test.clj
+++ b/implementation/test/re_frame/conformance_dsl_test.clj
@@ -1,0 +1,79 @@
+(ns re-frame.conformance-dsl-test
+  "Focused unit tests for the conformance handler-body DSL evaluator.
+
+  The conformance corpus runner (conformance-test) covers the DSL
+  end-to-end via real fixtures. These tests target individual DSL
+  shapes — specifically the rf2-xb5o split between :event-arg
+  (default-for-nil only) and :get-event-arg (key-access)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.conformance :as conformance]))
+
+;; ---- :event-arg / :get-event-arg split (rf2-xb5o / rf2-pz9f) -------------
+;;
+;; Per Mike's resolution of rf2-pz9f:
+;;   [:event-arg n]                  — n-th event arg
+;;   [:event-arg n default-val]      — n-th event arg, default-val if nil
+;;                                     (UNCONDITIONAL: no type-dispatch even
+;;                                     when default-val is a keyword and the
+;;                                     n-th arg is a map.)
+;;   [:get-event-arg n :key]         — key-access into n-th event arg
+;;   [:get-event-arg n :key default] — key-access with default if missing/nil
+;;
+;; The regression-guard below ensures we never re-introduce the prior
+;; type-dispatch overload where a keyword 3rd arg + map value silently
+;; meant "(get value keyword)" instead of "default-for-nil".
+
+(deftest event-arg-no-key-access-overload
+  (testing ":event-arg's 3rd element is unconditionally default-for-nil"
+    ;; Event: [:some-id {:foo 99}]. The map is the 1st event arg
+    ;; (index 1; index 0 is the event-id).
+    (let [ctx {:event [:some-id {:foo 99}]}]
+      (testing "with a non-nil map arg, returns the arg verbatim"
+        ;; Pre-rf2-xb5o: this returned 99 (key-access overload).
+        ;; Post-rf2-xb5o: the keyword 3rd arg is a default-for-nil and
+        ;; never fires because the value is non-nil — so the map is
+        ;; returned as-is.
+        (is (= {:foo 99}
+               (conformance/resolve-value* [:event-arg 1 :foo] ctx))
+            "[:event-arg n :foo] with a map arg must NOT do key-access")))
+
+    (testing "with nil arg, default-val is returned (keyword default works)"
+      ;; The arg at index 1 doesn't exist (event has only :some-id).
+      ;; The keyword default-val IS returned because v is nil.
+      (let [ctx {:event [:some-id]}]
+        (is (= :foo
+               (conformance/resolve-value* [:event-arg 1 :foo] ctx))
+            "[:event-arg n :foo] with nil arg returns :foo as default-for-nil")))
+
+    (testing "with nil arg, non-keyword default-val is returned"
+      (let [ctx {:event [:some-id]}]
+        (is (= {} (conformance/resolve-value* [:event-arg 1 {}] ctx)))
+        (is (= 0  (conformance/resolve-value* [:event-arg 1 0] ctx)))
+        (is (= [] (conformance/resolve-value* [:event-arg 1 []] ctx)))))
+
+    (testing "two-element form [:event-arg n] returns the n-th arg unchanged"
+      (let [ctx {:event [:some-id {:foo 99}]}]
+        (is (= {:foo 99}
+               (conformance/resolve-value* [:event-arg 1] ctx))))
+      (let [ctx {:event [:some-id]}]
+        (is (= nil (conformance/resolve-value* [:event-arg 1] ctx)))))))
+
+(deftest get-event-arg-key-access
+  (testing ":get-event-arg extracts a key from a map arg"
+    (let [ctx {:event [:some-id {:foo 99 :bar "x"}]}]
+      (is (= 99  (conformance/resolve-value* [:get-event-arg 1 :foo] ctx)))
+      (is (= "x" (conformance/resolve-value* [:get-event-arg 1 :bar] ctx)))
+      (is (= nil (conformance/resolve-value* [:get-event-arg 1 :missing] ctx)))))
+
+  (testing "[:get-event-arg n :key default] uses default for missing/nil"
+    (let [ctx {:event [:some-id {:foo 99 :nilval nil}]}]
+      (is (= 99       (conformance/resolve-value* [:get-event-arg 1 :foo :fallback] ctx))
+          "present non-nil value is returned (default ignored)")
+      (is (= :default (conformance/resolve-value* [:get-event-arg 1 :missing :default] ctx))
+          "missing key falls back to default")
+      (is (= :default (conformance/resolve-value* [:get-event-arg 1 :nilval :default] ctx))
+          "explicit nil value also falls back to default")))
+
+  (testing "[:get-event-arg n :key] on a nil arg returns nil"
+    (let [ctx {:event [:some-id]}]
+      (is (= nil (conformance/resolve-value* [:get-event-arg 1 :foo] ctx))))))


### PR DESCRIPTION
## Summary

Per Mike's resolution of rf2-pz9f (Option a), the conformance handler-body DSL splits the prior overloaded `:event-arg` shape:

- `[:event-arg n]` — n-th event arg
- `[:event-arg n default-val]` — default-for-nil only; **never** key-access, even when `default-val` is a keyword and the runtime arg is a map
- `[:get-event-arg n :key]` — explicit key-access into a map arg
- `[:get-event-arg n :key default-val]` — key-access with default if missing or nil (newly added)

`resolve-value`'s `:event-arg` branch loses the type-dispatch case. `:get-event-arg` already existed; this PR adds its 4-element default-for-nil form. The `conformance/README.md` reflection-form table documents both shapes explicitly.

## Fixture migration

| Outcome | Count | Files |
|---|---|---|
| Migrated to `:get-event-arg` | 2 | `ssr-hydration-mismatch.edn`, `ssr-head-hydration.edn` (both `[:event-arg 1 :rf/app-db]` → `[:get-event-arg 1 :rf/app-db]`) |
| Stayed as `:event-arg` (non-keyword 3rd arg) | 1 site, 3 occurrences | `routing-navigate.edn` `[:event-arg 2 {}]` |
| Stayed with explanatory comment (keyword default with non-map runtime arg) | 0 | none surfaced |

No fixture had ambiguous intent — the only keyword 3rd-arg sites in the corpus were the two SSR hydration handlers, where the runtime payload IS a map and the intent IS key-access.

## New regression-guard test

- `implementation/test/re_frame/conformance_dsl_test.clj` (JVM)
- `implementation/test/re_frame/conformance_dsl_cljs_test.cljs` (CLJS)

Both assert `[:event-arg 0 :foo]` with a map arg returns the map verbatim (not the value at `:foo`) — guards against re-introducing the overload.

`docs/specification/conformance/fixtures/dsl-event-arg-vs-get-event-arg.edn` exercises both shapes through real handlers + sub reads, so any host implementation regressing the split fails the corpus.

## Spec follow-up

`Spec-Schemas.md` describes `:get-event-arg` with a path-vector signature, which doesn't match the impl or corpus (single-key form). Filed as **rf2-ortt** (P3) to align the schema/prose with the canonical shape.

## Test plan

- [x] `clojure -M:test` (full JVM suite — 209 tests, 1005 assertions, 0 failures, includes 78/78 conformance fixtures green)
- [x] `npm run test:cljs` (CLJS node — 73 tests, 247 assertions, 0 failures)
- [x] `npm run test:browser` (browser — 71 tests, 236 assertions, 0 failures)
- [x] `npm run test:elision` (production-elision probe — PASS)
- [x] `npm run test:examples` (counter, flight-booker, managed-http-counter, nine-states, routing, temperature, timer, todomvc — all PASS)

Closes rf2-pz9f. Resolves rf2-xb5o.