### PR TITLE
fix: timer Reset dispatch-sync under Reagent 2 (rf2-u95c)

### DIFF
--- a/examples/seven_guis/timer.cljs
+++ b/examples/seven_guis/timer.cljs
@@ -52,6 +52,13 @@
 ;; scheduled with. Reset bumps :tick-gen, so any in-flight tick from the
 ;; previous generation no-ops when it eventually fires. Reset also schedules
 ;; a fresh tick under the new generation, so the chain continues.
+;;
+;; The Reset *click handler* (see view) calls `dispatch-sync`, not
+;; `dispatch`. Under Reagent 2 (flushSync render), this guarantees the
+;; app-db update and DOM commit complete before the next scheduled tick
+;; (or before a polling test observer reads the DOM), so the brief 0.0
+;; reading is observable. The :tick-gen guard above and the synchronous
+;; commit here address two distinct races and are both required.
 
 (rf/reg-event-fx :timer/initialise
   {:doc "Seed the timer slice and start the periodic tick."}
@@ -139,7 +146,13 @@
                                       (js/parseInt (.. % -target -value))])}]
       [:span (.toFixed (/ duration 1000.0) 1) " s"]]
      [:div.row
-      [:button {:on-click #(dispatch [:timer/reset])} "Reset"]]]))
+      ;; dispatch-sync (not dispatch): under Reagent 2's flushSync render
+      ;; model, this guarantees app-db is updated and the DOM commits the
+      ;; 0.0 reading before control returns to the browser — and crucially
+      ;; before the next scheduled :timer/tick can fire. With async dispatch
+      ;; the post-Reset DOM commit could lag the next tick (and the test's
+      ;; 50ms poll), causing the brief 0.0 window to be missed.
+      [:button {:on-click #(rf/dispatch-sync [:timer/reset])} "Reset"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (scheduling-light; we don't drive real time, just verify


### PR DESCRIPTION
## Summary

After rf2-25aq bumped Reagent to 2.0.1, the seven-guis Timer Playwright spec began failing ~50% of runs. Reagent 2 renders ratom changes synchronously via `react-dom/flushSync`, which interleaves more tightly with the test's 50ms poll. Combined with the `:dispatch-later` retick loop, the post-Reset DOM commit could lag the next scheduled tick (and the test observer), causing the brief `0.0` reading to be missed.

## Change

One-liner in `examples/seven_guis/timer.cljs`: switch the Reset button's click handler from `rf/dispatch` to `rf/dispatch-sync`. Under Reagent 2's flushSync model this guarantees the `app-db` update and DOM commit complete before control returns to the browser — and crucially before the next `:timer/tick` fires.

```clojure
;; before
:on-click #(dispatch [:timer/reset])
;; after
:on-click #(rf/dispatch-sync [:timer/reset])
```

Also extended the existing comment block at the top of the EVENTS section to document the `dispatch-sync` rationale alongside the `:tick-gen` guard.

## Verification

- `npm run test:examples` x10: 10/10 pass (previously ~50%)
- `clojure -M:test`: 209 tests / 1008 assertions, 0 failures
- `npm run test:cljs`: 73 tests / 247 assertions, 0 failures
- `npm run test:browser`: 71 tests / 236 assertions, 0 failures
- `npm run test:elision`: PASS

## Cross-references

- rf2-25aq (Reagent 2 migration) — exposed this race by making the example actually render end-to-end
- rf2-eknx / PR #59 (tick generation token) — stays in place. That fix solves a different race (in-flight tick fires *after* Reset's app-db update). This PR addresses the test observability race (DOM commit must happen before the next tick / next poll). The two fixes are complementary.

## Test plan

- [x] Playwright examples suite passes 10 consecutive runs
- [x] JVM clj test suite green
- [x] CLJS node tests green
- [x] Browser cljs tests green
- [x] Elision probe green