### PR TITLE
chore: target Reagent v2 (rf2-25aq)

### DIFF
--- a/examples/counter/core.cljs
+++ b/examples/counter/core.cljs
@@ -7,14 +7,12 @@
    NOTE on frame-provider: an earlier shape of this example wrapped
    `:counter-buttons` in `[rf/frame-provider {:frame :counter} ...]`
    so the subtree resolved its current frame to `:counter` rather
-   than `:rf/default`. That depends on React-context resolution
-   working under Reagent 1.2 + React 18, which is currently broken
-   (rf2-kdwc: class-component-style :context-type metadata isn't
-   wired up; the resolution falls back to :rf/default and the
-   subscription misses the :counter app-db). The example below uses
-   the default frame so the smoke test passes today; revisit once
-   rf2-kdwc lands or once the Reagent v2 migration (rf2-25aq)
-   replaces contextType with useContext."
+   than `:rf/default`. The kebab-vs-camelCase bug behind rf2-kdwc
+   (Reagent recognises the class-static field as `:contextType`, not
+   `:context-type`) was fixed under rf2-25aq alongside the Reagent v2
+   bump. The example still uses the default frame to keep the smoke
+   test focused; the frame-provider variant is exercised by
+   examples/login and the cross-spec test suite."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
             [re-frame.views]

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
          org.clojure/clojurescript {:mvn/version "1.11.132"}
-         reagent/reagent           {:mvn/version "1.2.0"}
+         reagent/reagent           {:mvn/version "2.0.1"}
          metosin/malli             {:mvn/version "0.13.0"}}
 
  :aliases

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1,5 +1,5 @@
 {:source-paths ["src" "test" "../examples"]
- :dependencies [[reagent       "1.2.0"]
+ :dependencies [[reagent       "2.0.1"]
                 [metosin/malli "0.13.0"]]
 
  :builds

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -90,18 +90,25 @@
 
 (defn reg-view*
   "Reagent-aware view registration. Wraps `render-fn` with the React
-  `:context-type` hook used to resolve the surrounding frame at render
-  time, then registers it in the :view kind of the registrar.
+  `:contextType` static-field metadata used to resolve the surrounding
+  frame at render time, then registers it in the :view kind of the
+  registrar.
 
   Per Spec 004 §reg-view*: this is the plain-fn surface delegated to
   by `re-frame.core/reg-view*` on CLJS. `metadata` is merged into the
   registry slot's metadata as-is; source-coord capture is performed
-  by the caller (`re-frame.core/reg-view*`)."
+  by the caller (`re-frame.core/reg-view*`).
+
+  Note (rf2-kdwc): Reagent's create-class / fn-to-class machinery
+  recognises `:contextType` (camelCase, the React static-field name),
+  not `:context-type` (kebab). The earlier shape used the kebab key
+  and was silently ignored, which is why frame-provider context
+  resolution fell back to :rf/default."
   [id metadata render-fn]
   (let [wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (apply render-fn args))
-                  {:context-type frame-context})]
+                  {:contextType frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
 


### PR DESCRIPTION
## Summary

Migrates the CLJS reference adapter from Reagent 1.2.0 to 2.0.1 per the project directive (rf2-25aq). Stop investing in Reagent 1.2 back-compat.

**Reagent version**: 1.2.0 -> 2.0.1 (latest stable on the 2.x line)

**Substrate changes**: one bug fix surfaced during validation. `re-frame.views/reg-view*` attached `:context-type` (kebab) metadata to its wrapper fn, but Reagent's `built-in-static-method-names` recognises only `:contextType` (camelCase, the React static-field name). The kebab key was silently ignored under both 1.2 and 2.x — that's the root cause of rf2-kdwc (frame-provider context propagation falling back to `:rf/default`). Renamed kebab -> camelCase. **Verdict on rf2-kdwc: fixed by this PR**, independently of the version bump.

**Example/doc sweeps**: `examples/counter` ns docstring updated to reflect that the rf2-kdwc kebab-vs-camelCase fix has landed. The rest of the example sweep happened upstream on rf2-d0pi (now merged to main); no further example changes needed here.

## Test results

All suites green against React 18.3.1 + Reagent 2.0.1.

- `clojure -M:test` — 207 tests / 994 assertions / 0 failures / 0 errors
- `npm run test:cljs` (node) — 71 tests / 236 assertions / 0 / 0
- `npm run test:browser` — 71 tests / 236 assertions / 0 / 0
- `npm run test:elision` — PASS (advanced-compile elision intact)
- `npm run test:examples` (Playwright) — 6/7 stable PASS; the 7gui Timer Reset spec is intermittently flaky (~50%); filed as **rf2-u95c**. The flake only surfaces now that the example actually renders end-to-end; pre-rf2-25aq the page never reached interactive state because of the `(ns-name nil)` runtime bug fixed upstream on rf2-d0pi.

## Decisions surfaced as follow-up beads

- **rf2-u95c** — Timer Playwright Reset spec is flaky under Reagent 2 (~50%). Likely interaction between Reagent 2's `flushSync` synchronous render path and the `:dispatch-later` retick loop. Out of scope for this PR.

## Notes

- **No React 19 bump.** Reagent 2 supports both React 18 and 19. Keeping the React 18.3.1 pin in `package.json` for now means the `reagent.dom.client` API is exercised against the same React the rest of the project has been validated against. A separate React 19 bump can land later.
- **No `defc` / `:f>` adoption.** Spec 004 keeps Form-1 (plain fn -> class component) as the canonical view shape; `defc` and the `reagent.hooks` ns are available if a future bead opts in. The class-component path still works in Reagent 2 — `:contextType` static-field metadata still resolves React context for class components, which is exactly what `reg-view*` needs.