### PR TITLE
spec: Spec-Schemas :get-event-arg signature matches impl (rf2-ortt)

### DIFF
--- a/docs/specification/Spec-Schemas.md
+++ b/docs/specification/Spec-Schemas.md
@@ -273,7 +273,8 @@ Conformance-corpus event/sub/view handler bodies are described as data so any ho
    [:tuple [:= :get]               [:vector :any]]                       ;; [:get path]               -- read; used in sub bodies / preds
    ;; --- event / cofx access ---
    [:tuple [:= :event-arg]         :int]                                 ;; [:event-arg N]            -- the Nth element of the event vector
-   [:tuple [:= :get-event-arg]     :int [:vector :any]]                  ;; [:get-event-arg N path]   -- (get-in (nth event N) path)
+   [:tuple [:= :get-event-arg]     :int :keyword]                        ;; [:get-event-arg N :key]            -- (get (nth event N) :key)
+   [:tuple [:= :get-event-arg]     :int :keyword :any]                   ;; [:get-event-arg N :key default]    -- key-access with default if missing/nil
    [:tuple [:= :cofx-without]      :keyword]                             ;; [:cofx-without :db]       -- assert :db absent (test fixture)
    ;; --- effects / dispatch ---
    [:tuple [:= :dispatch]          [:vector :any]]                       ;; [:dispatch [:event ...]]
@@ -299,7 +300,7 @@ The body of a fixture event handler / sub computation is a vector of these ops, 
 | `:merge-into-db` | event-db, event-fx | `(merge db m)` |
 | `:get` | sub, predicate | Read from current `db` — produces the sub's return value |
 | `:event-arg` | event, sub | Selects an event-vector argument by index |
-| `:get-event-arg` | event, sub | `(get-in (nth event N) path)` |
+| `:get-event-arg` | event, sub | `(get (nth event N) :key)` — single-key access into the Nth event arg; an optional 4th element is a default returned when the key is missing/nil |
 | `:cofx-without` | event-fx | Asserts a cofx key is absent — test fixture |
 | `:dispatch` | event-fx | Adds `[:dispatch event]` to the effect-map's `:fx` |
 | `:fx` | event-fx | Adds entries to the effect-map's `:fx` directly |


### PR DESCRIPTION
## Summary

`docs/specification/Spec-Schemas.md` (the `:rf/handler-body-dsl` entry) described `:get-event-arg` as

```clojure
[:tuple [:= :get-event-arg] :int [:vector :any]]   ;; (get-in (nth event N) path)
```

but the conformance impl (`re-frame.conformance/resolve-value`) and every fixture in `docs/specification/conformance/fixtures/` use the single-key form: `[:get-event-arg N :key]` / `[:get-event-arg N :key default-val]`. The spec drifted from reality — confirmed against `dsl-event-arg-vs-get-event-arg.edn` (PR #70) which is the canonical fixture for the `:event-arg` vs `:get-event-arg` split.

This PR updates the schema lines and prose row to match the impl + corpus:

```clojure
[:tuple [:= :get-event-arg] :int :keyword]        ;; [:get-event-arg N :key]
[:tuple [:= :get-event-arg] :int :keyword :any]   ;; [:get-event-arg N :key default]
```

No code changes, no fixture changes — purely a docs reconciliation.

A grep across the repo found zero existing path-vector usages (`[:get-event-arg N [...]]`), so no follow-up bead is warranted; the path-vector form has no real use case in the corpus today and was an artefact of the spec drifting ahead of (or behind) the impl.

Closes the docs side of rf2-ortt.

## Test plan

- [x] Re-read Spec-Schemas.md `:get-event-arg` rows; signature now matches `re-frame.conformance/resolve-value`.
- [x] `clojure -M:test` (JVM) — 219 tests / 1032 assertions, 0 failures, 0 errors. (Sanity only — no code touched.)
- [x] Verified no path-vector form `[:get-event-arg N [...]]` exists anywhere in the repo.