### PR TITLE
feat: remove get-view; view is canonical (rf2-sx7t / rf2-heo2)

### DIFF
--- a/docs/guide/02-your-first-app.md
+++ b/docs/guide/02-your-first-app.md
@@ -50,7 +50,7 @@ Here's the file, in full, with the surrounding ceremony removed:
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [(rf/get-view :counter)]))
+  (rdc/render root [(rf/view :counter)]))
 ```
 
 That's everything. Forty lines. Let's take it apart.
@@ -177,10 +177,10 @@ There's a tradeoff: plain Reagent functions also work, but they don't get frame-
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [(rf/get-view :counter)]))
+  (rdc/render root [(rf/view :counter)]))
 ```
 
-This is the part that's not really re-frame2 — it's the React/Reagent runtime asking "where in the page do I render?" `defonce` makes sure the root is created once even if the file is hot-reloaded. `(rf/get-view :counter)` looks up the registered render function and hands it back; `rdc/render` mounts it.
+This is the part that's not really re-frame2 — it's the React/Reagent runtime asking "where in the page do I render?" `defonce` makes sure the root is created once even if the file is hot-reloaded. `(rf/view :counter)` looks up the registered render function and hands it back; `rdc/render` mounts it.
 
 ## What just happened
 

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -71,7 +71,7 @@ The canonical way to use a registered view in hiccup is to `def` a var from the 
 
 This reads exactly like Reagent. There's nothing to learn. It just happens to work for the multi-frame case because of the registration that's also happening.
 
-An alternative form exists — `(rf/get-view :greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `get-view` is the escape hatch for those specific cases.
+An alternative form exists — `(rf/view :greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `view` is the escape hatch for those specific cases.
 
 ## Frames
 

--- a/docs/guide/06-server-side.md
+++ b/docs/guide/06-server-side.md
@@ -47,7 +47,7 @@ The re-frame2 approach: the server **serialises the final state** and ships it d
 ```clojure
 ;; Server side
 (let [final-db @(rf/get-frame-db request-frame)
-      hiccup   ((rf/get-view :app/root))
+      hiccup   ((rf/view :app/root))
       html     (rf/render-to-string hiccup {:frame request-frame})
       payload  {:rf/version    "1.0"
                 :rf/frame-id   :app/main
@@ -61,7 +61,7 @@ The re-frame2 approach: the server **serialises the final state** and ships it d
   (let [payload (read-server-payload)]
     (when payload
       (rf/dispatch-sync [:rf/hydrate payload] {:frame :app/main}))
-    (rdc/render root [(rf/get-view :app/root)])))
+    (rdc/render root [(rf/view :app/root)])))
 ```
 
 The framework's default `:rf/hydrate` handler is **`:replace-app-db`**: the server's serialised slice replaces whatever the client bootstrap had pre-seeded. This is locked. The reasoning: the server is authoritative for the initial app-db, and a defaulting merge policy would leave subtle ordering bugs (which slice wins?) under the rug.
@@ -195,7 +195,7 @@ A server handling concurrent requests can't have one global frame — each reque
                                       :on-create [:rf/server-init request]})]
       ;; with-frame creates the frame, runs the body, destroys the frame at end
       (let [final-db @(rf/get-frame-db f)
-            hiccup   ((rf/get-view :app/root))
+            hiccup   ((rf/view :app/root))
             html     (rf/render-to-string hiccup {:frame f})]
         {:status  200
          :headers {"Content-Type" "text/html"}

--- a/docs/specification/004-Views.md
+++ b/docs/specification/004-Views.md
@@ -119,7 +119,7 @@ Pattern-RemoteData's `:status` field is the canonical home for loading state. Pa
 ```
 
 - **Auto-id derivation.** The registered id is `(keyword (str *ns*) (str sym))` — the same shape Clojure uses for `defn` Vars. Override by attaching `^{:rf/id :explicit/id}` metadata to the symbol.
-- **Auto-defs the symbol.** `reg-view` defs `sym` to the wrapped render fn. There is no separate `(def sym (reg-view …))` step. Hiccup heads can be Var references (`[sym args]`) or `(rf/get-view :id)` results — both resolve to the same wrapped fn.
+- **Auto-defs the symbol.** `reg-view` defs `sym` to the wrapped render fn. There is no separate `(def sym (reg-view …))` step. Hiccup heads can be Var references (`[sym args]`) or `(rf/view :id)` results — both resolve to the same wrapped fn.
 - **Auto-injects `dispatch` and `subscribe`.** Inside the body, `dispatch` and `subscribe` are lexical bindings, bound at render-time to `(rf/dispatcher)` / `(rf/subscriber)` of the surrounding frame. They pick up the active frame on every render — there is no render-time-binding-vs-callback-time problem; the `:on-click` lambda below closes over the local `dispatch` and carries the frame into the callback automatically.
 
 ```clojure
@@ -206,16 +206,16 @@ v1 ships three forms for invoking a registered view. To honour the principle of 
 
 `reg-view` *defs* the symbol you supply. There is no separate `(def counter (reg-view …))` step — the macro is the one form that registers + binds. The id is auto-derived from `*ns*` + symbol; override via `^{:rf/id :explicit/id}` metadata on the symbol.
 
-### `get-view` — the canonical post-registration lookup
+### `view` — the canonical post-registration lookup
 
-Whatever the call-site shape, `(rf/get-view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the wrapped (frame-aware) Var-equivalent, re-resolved on every call so hot-reload re-registration is picked up immediately. The other call-site forms are sugar over `get-view`.
+Whatever the call-site shape, `(rf/view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the wrapped (frame-aware) Var-equivalent, re-resolved on every call so hot-reload re-registration is picked up immediately. The other call-site forms are sugar over `view`.
 
 ```clojure
-(rf/get-view :counter)               ;; → wrapped fn
-((rf/get-view :counter) "label")     ;; identical observably to: [counter "label"]
+(rf/view :counter)               ;; → wrapped fn
+((rf/view :counter) "label")     ;; identical observably to: [counter "label"]
 ```
 
-`get-view` returning `nil` for an unregistered keyword is a normal lookup miss (no error trace).
+`view` returning `nil` for an unregistered keyword is a normal lookup miss (no error trace).
 
 ### Alternative form (use only when the canonical form is awkward)
 
@@ -224,9 +224,9 @@ Whatever the call-site shape, `(rf/get-view :counter)` is the **canonical lookup
 ;;        - the view id is computed at runtime (dynamic dispatch);
 ;;        - the calling code doesn't have access to the Var (e.g., across module boundaries
 ;;          where the Var isn't exported but the registration is);
-;;        - hot-reload semantics matter — `get-view` re-resolves on every call, so
+;;        - hot-reload semantics matter — `view` re-resolves on every call, so
 ;;          re-registration is picked up without re-evaluating the call site.
-[(rf/get-view :counter) "Hello"]
+[(rf/view :counter) "Hello"]
 ```
 
 **Bare `[:counter "Hello"]` in raw hiccup** (where Reagent itself would have to interpret the keyword as a registered view) is **not supported in v1**. It requires modifying or extending Reagent's keyword-tag interpretation, which is deferred to the substrate-decoupling work in Spec 006 / [011](011-SSR.md). It can ship later as a non-breaking addition once the substrate decision is settled.
@@ -362,7 +362,7 @@ Registered views referenced from hiccup inherit the surrounding frame from React
 ```clojure
 (rf/reg-view outer []
   [:div
-   [counter "Inner"]                  ;; or [(rf/get-view :counter) "Inner"] for late-binding by id
+   [counter "Inner"]                  ;; or [(rf/view :counter) "Inner"] for late-binding by id
    [rf/frame-provider {:frame :other}
     [counter "Other-frame inner"]]])  ;; nested provider re-points
 ```
@@ -411,7 +411,7 @@ For the rare case where the user wants no Var binding (e.g. views generated prog
 
 ### `h` macro dropped (rf2-n4um)
 
-An earlier draft of this spec included an `h` macro that walked hiccup at compile time and rewrote namespaced-keyword heads (`[:my-app/widget args]`) into runtime `(rf/get-view :my-app/widget)` lookups. It has been removed from the v1 surface. The Var idiom — `(reg-view counter [...] ...)` defs `counter`; users write `[counter "Hello"]` — is the canonical call-site form. For late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites) the canonical handle is the explicit function-position form `[(rf/get-view :counter) "Hello"]`. Two surfaces, both data-friendly, no compile-time hiccup walker to learn or reason about.
+An earlier draft of this spec included an `h` macro that walked hiccup at compile time and rewrote namespaced-keyword heads (`[:my-app/widget args]`) into runtime `(rf/view :my-app/widget)` lookups. It has been removed from the v1 surface. The Var idiom — `(reg-view counter [...] ...)` defs `counter`; users write `[counter "Hello"]` — is the canonical call-site form. For late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites) the canonical handle is the explicit function-position form `[(rf/view :counter) "Hello"]`. Two surfaces, both data-friendly, no compile-time hiccup walker to learn or reason about.
 
 ### Form-3 (`reagent.core/create-class`) — out of scope for the macro
 
@@ -429,6 +429,6 @@ Inside a Form-3 body, the user captures frame-bound dispatch/subscribe explicitl
 
 ### Hot-reload behaviour for re-registered views
 
-Re-registering a view replaces the registry entry; `(get-view :id)` re-resolves on every render, so mounted components pick up the new render fn on next render with no further action. Reagent's component cache keys on the wrapper fn the macro emits; because that wrapper delegates to `(get-view view-id)` on each call, the cache hit returns the *new* render fn body once the registry is updated. No explicit invalidation needed.
+Re-registering a view replaces the registry entry; `(view :id)` re-resolves on every render, so mounted components pick up the new render fn on next render with no further action. Reagent's component cache keys on the wrapper fn the macro emits; because that wrapper delegates to `(view view-id)` on each call, the cache hit returns the *new* render fn body once the registry is updated. No explicit invalidation needed.
 
 The runtime emits `:rf.registry/handler-replaced` (per [009](009-Instrumentation.md)) when re-registration overwrites an existing view; tools branch on the trace event to refresh their UI.

--- a/docs/specification/AI-Audit.md
+++ b/docs/specification/AI-Audit.md
@@ -71,7 +71,7 @@ References to `G-A`/`G-B`/`G-C`/`G-D`/`G-E`/`G-F` in the tables below resolve to
 
 | Property | Score | Notes |
 |---|---|---|
-| P1 Regularity | ✓ | Two registration shapes (`reg-frame` / `make-frame`) is right. View invocation has two forms (`get-view` / Var) — the `h` macro was dropped (rf2-n4um). |
+| P1 Regularity | ✓ | Two registration shapes (`reg-frame` / `make-frame`) is right. View invocation has two forms (`view` / Var) — the `h` macro was dropped (rf2-n4um). |
 | P2 Named things | ✓ | Frames, handlers, views, fx all stably-id'd. Anonymous lambdas survive only inside view bodies (`:on-click #(dispatch ...)`) which is borderline acceptable. |
 | P3 Data before magic | ◐ | Dispatch envelope, effect map, frame metadata all data. `:fx-overrides` and `:interceptor-overrides` accept function values at the CLJS reference level. Pattern-level contract is id-based; CLJS reference also accepts fn values. |
 | P4 Public query surfaces | ✓ | `handlers`, `frame-meta`, `frame-ids`, `get-frame-db`, `snapshot-of`, `sub-topology` all in. |
@@ -269,9 +269,9 @@ Pattern contract is id-based (per recent edits), but the CLJS reference accepts 
 
 Plain Reagent fns rendered inside a non-default frame silently route to `:rf/default`. This violates P8 (hidden context). Either remove the footgun (mandate `reg-view`) or make it loud (runtime warning).
 
-### G-E. View invocation has two forms — Var canonical, `(get-view :id)` for late-binding
+### G-E. View invocation has two forms — Var canonical, `(view :id)` for late-binding
 
-The Var reference (`[counter "Hello"]`) is the canonical call-site form: `reg-view` defs the symbol, hiccup picks it up directly. `(get-view :id)` is the documented escape hatch for late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites). The earlier `h` macro draft has been dropped (rf2-n4um); two forms is the v1 surface.
+The Var reference (`[counter "Hello"]`) is the canonical call-site form: `reg-view` defs the symbol, hiccup picks it up directly. `(view :id)` is the documented escape hatch for late-binding by id (cross-module reference, runtime-computed ids, hot-reload-sensitive call sites). The earlier `h` macro draft has been dropped (rf2-n4um); two forms is the v1 surface.
 
 ### G-F. Form-1 / Form-2 / Form-3 component shapes
 

--- a/docs/specification/API.md
+++ b/docs/specification/API.md
@@ -77,8 +77,7 @@
 | `bound-dispatcher` | Fn | `(bound-dispatcher m)` → `(fn [event] ...)` | v1 | 002 |
 | `dispatcher` | Fn | `(dispatcher)` (called during render) → frame-bound dispatch fn | v1 | 004 |
 | `subscriber` | Fn | `(subscriber)` (called during render) → frame-bound subscribe fn | v1 | 004 |
-| `get-view` | Fn | `(get-view view-id)` → render-fn | v1 | 004 |
-| `view` | Fn | `(view view-id)` → render-fn (runtime-lookup handle; alias of `get-view`) | v1 | 001, 004 |
+| `view` | Fn | `(view view-id)` → render-fn (runtime-lookup handle) | v1 | 001, 004 |
 
 `with-frame`'s two shapes (bare keyword vs let-binding) are documented in [002 §with-frame](002-Frames.md#with-frame).
 
@@ -531,8 +530,8 @@ See [007-Stories.md](007-Stories.md).
 | `frame-dispatcher` (proposed earlier) | Renamed to `bound-dispatcher` | 002 |
 | `enable-performance-api-tracing!` (proposed earlier) | Bridge always active when tracing is on; production elides everything | 009 |
 | `add-trace-listener` / `remove-trace-listener` (proposed earlier) | Use `register-trace-cb` / `remove-trace-cb` | 009 |
-| Bare `[:my-view "args"]` keyword-tagged hiccup | Use the Var form `[my-view "args"]` (canonical) or `[(rf/get-view :my-view) "args"]` for late-binding by id | 004 |
-| `h` macro (proposed earlier) | Removed (rf2-n4um). Use the Var form `[my-view "args"]` or `[(rf/get-view :my-view) "args"]` | 004 |
+| Bare `[:my-view "args"]` keyword-tagged hiccup | Use the Var form `[my-view "args"]` (canonical) or `[(rf/view :my-view) "args"]` for late-binding by id | 004 |
+| `h` macro (proposed earlier) | Removed (rf2-n4um). Use the Var form `[my-view "args"]` or `[(rf/view :my-view) "args"]` | 004 |
 | `reg-global-interceptor` | Use `reg-frame :interceptors` (frame-level is the canonical "global within this frame"). For cross-frame observation use `register-trace-cb`. | MIGRATION M-17 |
 | `clear-global-interceptor` | No replacement needed — re-register `reg-frame` with an updated `:interceptors` vector (absent-key semantics clear it). | MIGRATION M-17 |
 | `reg-sub-raw` | Use `reg-sub` (app-db reads), Pattern-AsyncEffect (non-app-db sources), state machines (lifecycle), or the [006](006-ReactiveSubstrate.md) adapter contract (bridging external reactivity). | MIGRATION M-18 |

--- a/docs/specification/Construction-Prompts.md
+++ b/docs/specification/Construction-Prompts.md
@@ -318,7 +318,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 ```clojure
 (deftest feature-component-name-renders
   (rf/with-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
-    (let [hiccup ((rf/get-view :feature/component-name) "test-label" 42)
+    (let [hiccup ((rf/view :feature/component-name) "test-label" 42)
           html   (rf/render-to-string hiccup {:frame f})]
       (is (str/includes? html "test-label"))
       (is (str/includes? html "Count: 42")))))
@@ -956,7 +956,7 @@ The handler reads `(:route db)` for any path/query params it needs — the `:rou
                         :on-create    [:rf/server-init request]})]
       ;; rebound to f
       (let [final-db @(rf/get-frame-db f)
-            hiccup   ((rf/get-view :app/root))                ;; the registered root view
+            hiccup   ((rf/view :app/root))                ;; the registered root view
             html     (rf/render-to-string hiccup {:frame f})
             payload  {:rf/version "1.0"
                       :rf/frame-id frame-id
@@ -1009,7 +1009,7 @@ The drain settles before `with-frame` returns; the final state is captured.
     (when payload
       (rf/dispatch-sync [:rf/hydrate payload] {:frame :app/main}))
     (rdc/render (.getElementById js/document "app")
-                [(rf/get-view :app/root)])))
+                [(rf/view :app/root)])))
 
 (boot!)
 ```

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -876,11 +876,11 @@ The per-kind registration macros, `reg-flow`, `reg-route`, and the vector-form `
 
 ---
 
-### M-24. `h` macro removed — rewrite call sites to Var or `(get-view :id)`
+### M-24. `h` macro removed — rewrite call sites to Var or `(view :id)`
 
 **Type A** (mechanical).
 
-Per rf2-n4um / rf2-u33b: the `h` compile-time hiccup walker has been dropped from the v1 surface. The Var idiom (`reg-view counter [...] ...` defs `counter`; users write `[counter "Hello"]`) is the canonical call-site form; `(rf/get-view :id)` is the documented escape hatch for late-binding by id. Two call-site forms, no compile-time hiccup walker.
+Per rf2-n4um / rf2-u33b: the `h` compile-time hiccup walker has been dropped from the v1 surface. The Var idiom (`reg-view counter [...] ...` defs `counter`; users write `[counter "Hello"]`) is the canonical call-site form; `(rf/view :id)` is the documented escape hatch for late-binding by id. Two call-site forms, no compile-time hiccup walker.
 
 **What to look for** in the codebase:
 
@@ -901,8 +901,8 @@ Per rf2-n4um / rf2-u33b: the `h` compile-time hiccup walker has been dropped fro
 ;; before — call site genuinely needs late-binding by id (cross-module reference,
 ;; runtime-computed id, or hot-reload-sensitive call site)
 (rf/h [:my-app/widget arg])
-;; after — explicit get-view in function position
-[(rf/get-view :my-app/widget) arg]
+;; after — explicit view lookup in function position
+[(rf/view :my-app/widget) arg]
 
 ;; before — h wrapper around HTML-only hiccup
 (rf/h [:div [:p "hello"]])
@@ -910,9 +910,9 @@ Per rf2-n4um / rf2-u33b: the `h` compile-time hiccup walker has been dropped fro
 [:div [:p "hello"]]
 ```
 
-The agent rewrites mechanically. For the Var-ref form (the common case), the namespaced keyword's local-name becomes a symbol reference to the Var defed by `reg-view`. If the call-site context indicates late-binding intent (a comment to that effect, or the symbol isn't in scope at the call site), the agent emits the `[(rf/view :id) args]` form instead. Ambiguous sites default to Var-ref — the reverse migration to `get-view` is a one-line edit if the user later decides hot-reload semantics matter.
+The agent rewrites mechanically. For the Var-ref form (the common case), the namespaced keyword's local-name becomes a symbol reference to the Var defed by `reg-view`. If the call-site context indicates late-binding intent (a comment to that effect, or the symbol isn't in scope at the call site), the agent emits the `[(rf/view :id) args]` form instead. Ambiguous sites default to Var-ref — the reverse migration to `view` is a one-line edit if the user later decides hot-reload semantics matter.
 
-**Why?** Two view call-site forms is enough; three was drifty (P1 violation flagged in [AI-Audit §G-E](AI-Audit.md#g-e-view-invocation-has-two-forms--var-canonical-get-view-id-for-late-binding)). Same surface-shrinking principle as rf2-7cb2 (drop alpha) and rf2-iyzm (Var-ref canonical for views): when two surfaces cover every case the third was solving, the third is excess.
+**Why?** Two view call-site forms is enough; three was drifty (P1 violation flagged in [AI-Audit §G-E](AI-Audit.md#g-e-view-invocation-has-two-forms--var-canonical-view-id-for-late-binding)). Same surface-shrinking principle as rf2-7cb2 (drop alpha) and rf2-iyzm (Var-ref canonical for views): when two surfaces cover every case the third was solving, the third is excess.
 
 ---
 

--- a/examples/ssr/core.cljc
+++ b/examples/ssr/core.cljc
@@ -108,7 +108,7 @@
 ;; reg-view (defn-shape per Spec 004 §reg-view) auto-defs the symbol and
 ;; registers under (keyword *ns* sym) — overridden here via
 ;; ^{:rf/id ...} so the legacy :pages/articles / :app/root ids stay
-;; intact for the get-view callers below.
+;; intact for the view callers below.
 (rf/reg-view ^{:rf/id :pages/articles} articles-page []
   (let [arts (rf/subscribe-value [:articles])]
     [:div.page
@@ -121,7 +121,7 @@
        [:p "No articles."])]))
 
 (rf/reg-view ^{:rf/id :app/root} root-view []
-  [(rf/get-view :pages/articles)])
+  [(rf/view :pages/articles)])
 
 ;; ============================================================================
 ;; SERVER ENTRY POINT
@@ -140,7 +140,7 @@
        (rf/with-frame f
          (fn []
            (let [final-db (rf/get-frame-db f)
-                 hiccup   ((rf/get-view :app/root))
+                 hiccup   ((rf/view :app/root))
                  ;; render-to-string with :emit-hash? embeds
                  ;; data-rf-render-hash="<hex>" on the root element. The
                  ;; client recomputes the hash after its first render and
@@ -205,7 +205,7 @@
    (defn ^:export run []
      (when-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload] {:frame :app/main}))
-     (rdc/render root [(rf/get-view :app/root)])))
+     (rdc/render root [(rf/view :app/root)])))
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (JVM-runnable; exercises the server flow)
@@ -238,7 +238,7 @@
            ;; INSIDE render-to-string's tree walk; with-frame binds
            ;; *current-frame* across that walk so the sub reads from f
            ;; and not from :rf/default.
-           hiccup      ((rf/get-view :app/root))
+           hiccup      ((rf/view :app/root))
            html        (rf/with-frame f
                          (fn [] (rf/render-to-string hiccup {:emit-hash? true})))
            render-hash (rf/render-tree-hash hiccup)]

--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -283,22 +283,18 @@
      ((requiring-resolve 're-frame.views-macros/expand-reg-view)
       (meta &form) (symbol (str (ns-name *ns*))) *file* sym more)))
 
-(defn get-view
-  "Return the render fn for a registered view by id, or nil if not
-  registered. The wrapped fn called with the view's invocation args
-  yields the hiccup tree."
-  [id]
-  (when-let [meta (registrar/lookup :view id)]
-    (:handler-fn meta)))
-
 (defn view
   "Runtime-lookup handle for a registered view. Returns the registered
   render fn (whatever shape — Form-1, Form-2 — produced by `reg-view`
-  or `reg-view*`) or nil if not registered. Per Spec 001 §`(re-frame.core/view id)`
-  and Spec 004 §Calling a registered view: render trees use Vars;
-  runtime lookups use ids; this is the id-keyed lookup."
+  or `reg-view*`) or nil if not registered. The wrapped fn called with
+  the view's invocation args yields the hiccup tree.
+
+  Per Spec 001 §`(re-frame.core/view id)` and Spec 004 §Calling a
+  registered view: render trees use Vars; runtime lookups use ids; this
+  is the id-keyed lookup."
   [id]
-  (get-view id))
+  (when-let [meta (registrar/lookup :view id)]
+    (:handler-fn meta)))
 
 (defn render-to-string
   "Render a hiccup tree to an HTML string. Per Spec 011 §The render-tree

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -11,8 +11,8 @@
   reg-view auto-defs the local Var (per Spec 004 §reg-view defs the Var
   by default); the Var is the canonical call-site reference. For
   late-binding by id (e.g. across module boundaries, runtime-computed
-  ids, or hot-reload semantics), call `(re-frame.core/get-view :id)`
-  to obtain the wrapped fn and use `[(rf/get-view :id) args]` as the
+  ids, or hot-reload semantics), call `(re-frame.core/view :id)`
+  to obtain the wrapped fn and use `[(rf/view :id) args]` as the
   hiccup head."
   (:require ["react"        :as React]
             [reagent.core   :as r]
@@ -106,9 +106,3 @@
                   {:context-type frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
-
-(defn get-view
-  "Return the wrapped render fn for a registered view, or nil."
-  [view-id]
-  (when-let [meta (registrar/lookup :view view-id)]
-    (:handler-fn meta)))

--- a/implementation/src/re_frame/views_macros.clj
+++ b/implementation/src/re_frame/views_macros.clj
@@ -126,8 +126,8 @@
           line (:line form-meta)
           col  (:column form-meta)
           def-form (if docstring
-                     `(def ~sym ~docstring (re-frame.core/get-view ~id))
-                     `(def ~sym (re-frame.core/get-view ~id)))
+                     `(def ~sym ~docstring (re-frame.core/view ~id))
+                     `(def ~sym (re-frame.core/view ~id)))
           full-slot-meta (cond-> slot-meta
                            docstring (assoc :doc docstring))]
       `(do

--- a/implementation/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/test/re_frame/hot_reload_cljs_test.cljs
@@ -8,7 +8,7 @@
   The node-test runner has no DOM, so we don't mount through React.
   Instead we exercise the contract at the layer the substrate cares
   about: registry lookup of the wrapped render fn. After re-register,
-  re-frame.core/get-view (the lookup the substrate's render-cycle uses
+  re-frame.core/view (the lookup the substrate's render-cycle uses
   to resolve a view by id) returns the new render fn — the next render
   cycle invokes that, which is exactly what Reagent does on a mounted
   view when the captured render fn changes via hot-reload.
@@ -57,7 +57,7 @@
       ;; mechanics what matters is that the registrar's :view slot gets
       ;; replaced — exactly what reg-view* does.
       (rf/reg-view* :rf.hot-reload-test/widget v1-fn)
-      (let [render-v1 (rf/get-view :rf.hot-reload-test/widget)]
+      (let [render-v1 (rf/view :rf.hot-reload-test/widget)]
         ;; First render uses v1.
         (is (= [:span.v1 "v1-" 7] (render-v1 7))
             "v1 render fn produces v1 hiccup")
@@ -67,9 +67,9 @@
         (rf/reg-view* :rf.hot-reload-test/widget v2-fn)
         ;; The registry's :view slot now resolves to v2's wrapped fn.
         ;; Reagent's render cycle re-resolves the head on each render
-        ;; (the captured Var or the get-view return), so the next render
+        ;; (the captured Var or the view return), so the next render
         ;; uses v2.
-        (let [render-v2 (rf/get-view :rf.hot-reload-test/widget)]
+        (let [render-v2 (rf/view :rf.hot-reload-test/widget)]
           (is (= [:strong.v2 "v2-" 7] (render-v2 7))
               "post-rereg lookup returns v2's render fn")
           (is (= 1 @v1-renders)
@@ -88,10 +88,10 @@
         (fn []
           (reset! observed :body-v1)
           [:p "v1"]))
-      ;; Simulate the substrate's render cycle: resolve via get-view
-      ;; (this is what re-frame.views/get-view does and what the h macro
-      ;; rewrites to) and invoke. After the call, observed reflects v1.
-      ((rf/get-view :rf.hot-reload-test/probe))
+      ;; Simulate the substrate's render cycle: resolve via view
+      ;; (this is the canonical id-keyed lookup) and invoke.
+      ;; After the call, observed reflects v1.
+      ((rf/view :rf.hot-reload-test/probe))
       (is (= :body-v1 @observed))
       ;; Re-register with a DIFFERENT body.
       (rf/reg-view* :rf.hot-reload-test/probe
@@ -99,7 +99,7 @@
           (reset! observed :body-v2)
           [:p "v2"]))
       ;; Next "render" — fresh registry resolution — runs v2.
-      ((rf/get-view :rf.hot-reload-test/probe))
+      ((rf/view :rf.hot-reload-test/probe))
       (is (= :body-v2 @observed)
           "after re-registration, the next render mutates observed to v2"))))
 
@@ -121,11 +121,11 @@
       (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
         (reset! observed [:m1 t])
         [:h1.m1 t])
-      ((rf/get-view :rf.hot-reload-test/banner) "hello")
+      ((rf/view :rf.hot-reload-test/banner) "hello")
       (is (= [:m1 "hello"] @observed))
       (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
         (reset! observed [:m2 t])
         [:h2.m2 t])
-      ((rf/get-view :rf.hot-reload-test/banner) "world")
+      ((rf/view :rf.hot-reload-test/banner) "world")
       (is (= [:m2 "world"] @observed)
           "post-rereg lookup invokes the new macro-installed body"))))

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -77,7 +77,7 @@
     ;; auto-derives the id from (keyword *ns* sym); the ^{:rf/id ...}
     ;; metadata override pins an explicit keyword for assertion.
     (reg-view ^{:rf/id :greet} greet [n] [:p "hi " n])
-    (is (some? (rf/get-view :greet))
+    (is (some? (rf/view :greet))
         "the view is registered under the :view kind")
     (is (fn? greet)
         "the macro defs the supplied symbol to a callable render fn")))
@@ -92,7 +92,7 @@
   (testing "the macro defs the symbol to a callable render fn"
     (reg-view ^{:rf/id :ns/widget} my-widget [n] [:span "w-" n])
     ;; The registered view is in the registry.
-    (is (some? (rf/get-view :ns/widget))
+    (is (some? (rf/view :ns/widget))
         ":ns/widget is in the :view registry")
     ;; The defn-shape sym is bound to a fn — usable as a hiccup head.
     (is (fn? my-widget)

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -512,7 +512,7 @@
           "with-frame expansion references *current-frame*"))
     ;; reg-view (defn-shape per Spec 004 §reg-view) defs the symbol and
     ;; registers under (keyword (str *ns*) (str sym)). The expansion is
-    ;; (do (binding [...] (reg-view* ...)) (def sym (get-view ...))).
+    ;; (do (binding [...] (reg-view* ...)) (def sym (view ...))).
     (let [exp (macroexpand `(re-frame.views-macros/reg-view
                               ~'my-widget [] :body))]
       (is (= 'do (first exp))
@@ -898,9 +898,9 @@
     (is (= "<p>hello <strong>world</strong></p>"
            (rf/render-to-string [:greet "world"]))
         "render-to-string resolves [:greet args] via the :view registry")
-    (is (fn? (rf/get-view :greet))
-        "get-view returns the registered render fn")
-    (is (nil? (rf/get-view :no-such-view)))))
+    (is (fn? (rf/view :greet))
+        "view returns the registered render fn")
+    (is (nil? (rf/view :no-such-view)))))
 
 (deftest ssr-render-to-string-basics
   (testing "basic hiccup → HTML"

--- a/implementation/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/test/re_frame/ssr_end_to_end_test.clj
@@ -74,7 +74,7 @@
   (rf/with-frame frame-id
     (fn []
       (let [head (first render-tree)]
-        (if-let [view-fn (rf/get-view head)]
+        (if-let [view-fn (rf/view head)]
           (apply view-fn (rest render-tree))
           render-tree)))))
 

--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -45,7 +45,7 @@
     ;; which for this test file is `re-frame.views-macros-test` —
     ;; matched literally here rather than via runtime *ns* (the test
     ;; runner's *ns* is the test-runner ns, not the test file's ns).
-    (is (some? (rf/get-view :re-frame.views-macros-test/widget-a))
+    (is (some? (rf/view :re-frame.views-macros-test/widget-a))
         "the view is registered under (keyword 'this-ns' 'sym)")))
 
 ;; ---- auto-id derivation --------------------------------------------------
@@ -54,7 +54,7 @@
   (testing "the registered id is (keyword (str *ns*) (str sym)) when no
             metadata override is present"
     (rf/reg-view widget-b [_n] [:p "b"])
-    (is (some? (rf/get-view :re-frame.views-macros-test/widget-b))
+    (is (some? (rf/view :re-frame.views-macros-test/widget-b))
         "the registered id matches (keyword *ns* sym)")))
 
 ;; ---- ^{:rf/id ...} metadata override -------------------------------------
@@ -62,9 +62,9 @@
 (deftest reg-view-metadata-override-takes-precedence
   (testing "^{:rf/id :explicit/id} on the symbol wins over the auto-derived id"
     (rf/reg-view ^{:rf/id :explicit/widget} widget-c [_n] [:p "c"])
-    (is (some? (rf/get-view :explicit/widget))
+    (is (some? (rf/view :explicit/widget))
         "the registered id is the metadata override")
-    (is (nil? (rf/get-view :re-frame.views-macros-test/widget-c))
+    (is (nil? (rf/view :re-frame.views-macros-test/widget-c))
         "the auto-derived id is NOT registered when the override is present")))
 
 ;; ---- compile-error contract ----------------------------------------------


### PR DESCRIPTION
## Summary

Per rf2-sx7t Option 3: remove `get-view` entirely; `view` is the only runtime-lookup handle for a registered view. Pre-1.0; no deprecation period.

- `core.cljc`: remove `get-view`; promote `view` to the canonical fn (former `get-view` body inlined).
- `views.cljs`: remove the unused standalone `get-view`; lookups go through `re-frame.core/view`.
- `views-macros.clj`: macro emits `(re-frame.core/view ~id)` in the def-form.
- Sweep across docs, examples, and tests: every `get-view` call site rewritten to `view`. `API.md` drops the `get-view` row and the "alias of get-view" parenthetical on `view`. The `view`-named subsection in `004-Views.md` and the AI-Audit §G-E heading are updated; cross-references re-anchored.

Resolves rf2-sx7t. Same surface-shrinking principle as rf2-7cb2, rf2-n4um, rf2-iyzm, rf2-d0pi.

## Test plan

- [x] `clojure -M:test` (219 tests, 1032 assertions, 0/0)
- [x] `npm run test:cljs` (76 tests, 256 assertions, 0/0)
- [x] `npm run test:browser` (76 tests, 256 assertions, 0/0)
- [x] `npm run test:elision` (production + control sentinels: PASS)
- [x] `npm run test:examples` (8/8 PASS)
- [x] `grep -rn 'get-view' implementation/ docs/ examples/` returns zero non-historical matches