### PR TITLE
feat: on-spawn :set paths data-relative (rf2-smba / rf2-een2)

### DIFF
--- a/docs/specification/005-StateMachines.md
+++ b/docs/specification/005-StateMachines.md
@@ -385,6 +385,31 @@ This forces every cross-encapsulation write to be a *named, traced, reusable eve
 
 **State-keyword is not in the action's return shape either** — only the transition's `:target` decides the next state. Actions cannot bypass the FSM.
 
+## Path conventions in machine bodies
+
+Every callback the user supplies inside a machine body — guards, actions, `:on-spawn` — operates on the snapshot's **`:data`** map directly, not on the wrapping snapshot:
+
+| Slot | Signature | What it sees | What it returns |
+|---|---|---|---|
+| `:guard` | `(fn [data event] boolean)` | the `:data` map | a boolean |
+| `:action` | `(fn [data event] effects)` | the `:data` map | `{:data ... :fx ...}` (or `nil`) |
+| `:on-spawn` | `(fn [data spawned-id] new-data)` | the `:data` map | the new `:data` map |
+
+The runtime is responsible for unwrapping the snapshot before calling these fns and for patching the result back into the snapshot. **User code never names `[:data ...]` paths inside the body**; if a callback needs to read or write a field, it does so on `data` directly (e.g. `(:pending data)`, `(assoc data :pending id)`).
+
+The same principle holds for any data DSL the conformance corpus or a tooling layer interprets on top of the surface: a `:set` step inside a body operates on `:data`, so its path is data-relative. `[:set [:pending] x]` writes `data.:pending = x`. `[:set [:data :pending] x]` would write `data.:data.:pending = x`, which is virtually never what's wanted.
+
+### 3-arity escape hatch — snapshot introspection
+
+When a callback truly needs the discrete `:state` or any user `:meta` (rare), declare the third parameter:
+
+- `:guard (fn [data event {:keys [state meta]}] ...)`
+- `:action (fn [data event {:keys [state meta]}] ...)`
+
+`:on-spawn` doesn't currently take an introspection slot — the snapshot's `:state` at spawn time is the entry-bearing leaf state by definition, so the slot would carry no information beyond the lexical position of the `:invoke`. If a future use case needs it, the same 3-arity opt-in pattern applies.
+
+The 3-arity overload is **structurally detected** — implementations distinguish a fn that declares three fixed parameters from variadics like `(constantly true)`. No metadata is required on the fn.
+
 ## Registration — the machine IS the event handler
 
 A machine is registered as **one event handler** via `reg-event-fx` whose body comes from `create-machine-handler`.
@@ -1169,6 +1194,8 @@ The keys mirror [§Spawn-spec keys](#spawn-spec-keys), with two additions:
 
 - `:data` admits a function form `(fn [snap ev] data)` so the initial data can depend on the snapshot at the moment of entry — the snapshot is the *post-action* value (the transition's `:action` has already run, so any `:data` writes the action made are visible).
 - `:invoke-id` is an explicit alternative to `:id-prefix` + gensym — useful when a state should host exactly one actor with a known id (no need to record the id in the parent's `:data` because it's already a known constant).
+
+**Path convention.** The `:on-spawn` callback receives the snapshot's `:data` directly and returns a new `:data` map. The runtime patches the result back into the snapshot. Per [§Path conventions in machine bodies](#path-conventions-in-machine-bodies), this is uniform with `:guard` and `:action`: the body operates on `:data`, never on the wrapping snapshot. A typical body is `(assoc data :pending id)` or `(update data :workers (fnil conj []) id)` — *not* `(assoc-in snap [:data :pending] id)`.
 
 ### Desugaring rules
 

--- a/docs/specification/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
+++ b/docs/specification/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
@@ -109,4 +109,8 @@
   ;; id under :pending. Signature: (fn [data spawned-id] new-data). The
   ;; handler-body DSL form: read the spawned-id from the action's invocation
   ;; envelope and assoc it into :data under :pending.
-  {:auth/record-actor [[:set [:data :pending] [:event-arg 1]]]}}}
+  ;;
+  ;; Per [005 §Path conventions in machine bodies] (rf2-een2 / rf2-smba): the
+  ;; body's :set paths are data-relative — uniform with regular machine
+  ;; actions. The path is [:pending], not [:data :pending].
+  {:auth/record-actor [[:set [:pending] [:event-arg 1]]]}}}

--- a/docs/specification/conformance/fixtures/spawn-on-spawn-callback.edn
+++ b/docs/specification/conformance/fixtures/spawn-on-spawn-callback.edn
@@ -5,9 +5,10 @@
 ;; (../../005-StateMachines.md#declarative-invoke-sugar-over-spawn): when the
 ;; runtime processes a :spawn fx (whether from declarative :invoke desugar
 ;; or an action's hand-emitted :spawn), it allocates a deterministic actor
-;; id and threads (snapshot, spawned-id) through the user-supplied :on-spawn
-;; callback. The callback returns an updated snapshot — typically recording
-;; the actor-id in :data so later transitions can reference it.
+;; id and threads (data, spawned-id) through the user-supplied :on-spawn
+;; callback. The callback returns an updated :data map — typically recording
+;; the actor-id so later transitions can reference it. The runtime patches
+;; the returned :data back into the parent's snapshot.
 ;;
 ;; This fixture isolates the callback-fires-with-actor-id contract: the
 ;; on-spawn body writes the spawned-id under a distinct key (:born-with-id)
@@ -22,7 +23,7 @@
 {:fixture/id           :machine/spawn-on-spawn-callback
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke}
- :fixture/doc          "The :on-spawn callback receives (snapshot, spawned-id) and updates the snapshot. Verifies the callback fires with the just-allocated actor-id by recording the id in :data under a distinct key."
+ :fixture/doc          "The :on-spawn callback receives (data, spawned-id) and returns new data. Verifies the callback fires with the just-allocated actor-id by recording the id in :data under a distinct key."
 
  :fixture/registry
  {:machine
@@ -35,9 +36,12 @@
  {:machine-action
   ;; The on-spawn handler-body realises [:event-arg 1] as the spawned-id
   ;; (the synthetic event the harness threads through is
-  ;; [::on-spawn spawned-id]). Body :set paths are snapshot-relative; here
-  ;; we record the id under :data.:born-with-id.
-  {:supervisor/record-actor-id [[:set [:data :born-with-id] [:event-arg 1]]]}}
+  ;; [::on-spawn spawned-id]). Per [005 §Path conventions in machine bodies]
+  ;; (rf2-een2 / rf2-smba): body :set paths are data-relative — uniform
+  ;; with regular machine actions. Here the path is [:born-with-id], which
+  ;; lands at data.:born-with-id once the runtime patches the result back
+  ;; into the parent's snapshot.
+  {:supervisor/record-actor-id [[:set [:born-with-id] [:event-arg 1]]]}}
 
  :fixture/calls
  [{:call         :machine-transition

--- a/implementation/src/re_frame/conformance.cljc
+++ b/implementation/src/re_frame/conformance.cljc
@@ -339,26 +339,31 @@
       (when tree (walk-hiccup tree ctx)))))
 
 (defn realise-on-spawn-handler
-  "DSL → an on-spawn callback fn. Signature: (snap, spawned-id) → new-snap.
+  "DSL → an on-spawn callback fn. Signature: (data, spawned-id) → new-data.
 
   Per Spec 005 §Declarative :invoke (sugar over spawn): the on-spawn
-  callback receives the snapshot and the just-allocated actor id; it
-  returns an updated snapshot. The body's :set path is treated as
-  SNAPSHOT-relative (not data-relative), so [:set [:data :pending] x]
-  sets snap.:data.:pending = x — matching the conformance corpus's
-  convention for recording the actor id under a user-chosen slot."
+  callback receives the parent machine's :data and the just-allocated
+  actor id; it returns an updated :data map. The runtime patches the
+  result back into the snapshot at :data.
+
+  Per rf2-een2 / rf2-smba: the body's :set paths are DATA-relative —
+  uniform with regular machine actions, whose canonical contract is
+  (fn [data event] effects) and whose :set paths assoc-in into :data.
+  So [:set [:pending] x] writes data.:pending = x. (Pre-rf2-een2
+  semantics treated paths as snapshot-relative; that asymmetry is gone.)"
   [steps]
-  (fn [snap spawned-id]
+  (fn [data spawned-id]
     (let [synthetic-event [::on-spawn spawned-id]]
       (reduce
-        (fn [s step]
+        (fn [d step]
           (case (first step)
             :set (let [[_ path v] step
                        resolved (resolve-value v {:event synthetic-event
-                                                  :db (:data s)})]
-                   (if (empty? path) resolved (assoc-in s path resolved)))
-            s))
-        snap
+                                                  :data d
+                                                  :db   d})]
+                   (if (empty? path) resolved (assoc-in d path resolved)))
+            d))
+        data
         steps))))
 
 (defn realise-fx-handler

--- a/implementation/src/re_frame/machines.cljc
+++ b/implementation/src/re_frame/machines.cljc
@@ -491,8 +491,18 @@
                                       (when aref
                                         (or (chase-ref (:on-spawn-actions machine) aref)
                                             (chase-ref (:actions machine) aref))))
+                        ;; Per Spec 005 §Declarative :invoke (sugar over spawn):
+                        ;; the :on-spawn callback signature is (fn [data id] new-data).
+                        ;; Per rf2-een2 / rf2-smba: the callback operates on :data
+                        ;; (not the snapshot wrapper), uniform with regular actions
+                        ;; whose canonical contract is (fn [data event] effects).
+                        ;; The runtime patches the returned data back into the snapshot.
                         s'          (if on-spawn-fn
-                                      (or (on-spawn-fn s spawned-id) s)
+                                      (let [data     (:data s)
+                                            new-data (on-spawn-fn data spawned-id)]
+                                        (if new-data
+                                          (assoc s :data new-data)
+                                          s))
                                       s)]
                     [s' (conj acc-fx [:spawn spawn-args])])
                   [s acc-fx]))

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -441,8 +441,10 @@
                         (when (and (vector? step) (= :fn (first step)))
                           (boolean
                             (eval-value step {:data data :event event})))))]))
-        ;; Same machine-action steps, but realised as on-spawn callbacks
-        ;; (snapshot-relative :set paths) for use in :invoke desugaring.
+        ;; Same machine-action steps, but realised as on-spawn callbacks.
+        ;; Per rf2-een2 / rf2-smba: :set paths are data-relative — uniform
+        ;; with regular machine actions; the callback signature is
+        ;; (fn [data spawned-id] new-data).
         on-spawn-by-id
         (into {}
               (for [[id steps] (:machine-action handlers-map)]

--- a/implementation/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/test/re_frame/machines_cljs_test.cljs
@@ -360,8 +360,11 @@
           {:initial :idle
            :data    {:credentials {:user "alice" :pass "secret"}}
            :on-spawn-actions
-           {:auth/record-actor (fn [snap actor-id]
-                                 (assoc-in snap [:data :pending] actor-id))}
+           ;; Per Spec 005 §Declarative :invoke (rf2-een2 / rf2-smba):
+           ;; on-spawn callback signature is (fn [data spawned-id] new-data).
+           ;; The runtime patches the returned data back into the snapshot.
+           {:auth/record-actor (fn [data actor-id]
+                                 (assoc data :pending actor-id))}
            :states
            {:idle
             {:on {:submit :authenticating}}

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -605,7 +605,9 @@
                                         :start      [:begin]
                                         :on-spawn   :record}
                                :on    {:done :idle}}}
-           :actions {:record (fn [snap _] snap)}}
+           ;; Per Spec 005 §Declarative :invoke (rf2-een2 / rf2-smba):
+           ;; on-spawn callback signature is (fn [data spawned-id] new-data).
+           :on-spawn-actions {:record (fn [data _id] data)}}
           handler (rf/create-machine-handler machine)
           collect-ids (fn [frame-id]
                         (let [acc (atom [])]


### PR DESCRIPTION
## Summary

Per [rf2-smba] Option A: make `:on-spawn` callback paths data-relative, uniform with regular machine actions.

- **Implementation contract** — `:on-spawn` callbacks now receive `:data` (not the snapshot wrapper) and return new `:data`. Signature: `(fn [data spawned-id] new-data)`. The runtime patches the result back into the snapshot. Matches the canonical 2-arity contract for `:guard` / `:action`.
- **DSL** — conformance handler-body `:set` paths inside `:on-spawn` bodies are now data-relative. `[:set [:data :pending] x]` → `[:set [:pending] x]`. Lands at `data.:pending`, same place it landed before, but reachable via the same path shape that regular machine actions use.
- **Spec** — Spec 005 gains a `§Path conventions in machine bodies` section that codifies the uniform rule (callbacks see `:data`; DSL `:set` paths are data-relative); `§Declarative :invoke` gets an explicit Path convention paragraph cross-linking to it.

## Sweep counts

| Surface | Sites changed |
|---|---|
| Impl (machines.cljc, conformance.cljc) | 2 |
| Conformance fixtures | 2 (`invoke-spawn-on-entry-destroy-on-exit.edn`, `spawn-on-spawn-callback.edn`) |
| Tests (JVM + CLJS) | 3 (`conformance_test.clj`, `machines_cljs_test.cljs`, `smoke_test.clj`) |
| Spec | 1 (`005-StateMachines.md`: new `§Path conventions` + `§:on-spawn` Path convention paragraph) |
| Examples | 0 (no example currently uses `:on-spawn`) |

No escape-hatch op was added — the existing 3-arity opt-in pattern (`(fn [data event {:state :meta}] ...)`) is documented as the future shape if `:on-spawn` ever needs snapshot introspection. Today, `:state` at spawn time is the entry-bearing leaf state by definition, carrying no information beyond the lexical position of the `:invoke`.

## Test plan

- [x] `clojure -M:test` (JVM) — 219 tests / 1032 assertions / 0 failures
- [x] `npm run test:cljs` (Node CLJS) — 76 tests / 256 assertions / 0 failures
- [x] `npm run test:browser` (browser CLJS) — 76 tests / 256 assertions / 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:examples` — all 8 examples PASS