### PR TITLE
fix: drop :result-changed? from :sub-runs entries (rf2-7e2y)

### DIFF
--- a/docs/specification/Spec-Schemas.md
+++ b/docs/specification/Spec-Schemas.md
@@ -968,10 +968,9 @@ Per-frame epoch snapshot, recorded on each drain-completion in dev builds. Used 
    [:trace-events  {:optional true} [:vector :any]]                         ;; the cascade's trace events (raw)
    [:sub-runs      {:optional true} [:vector
                                      [:map
-                                      [:sub-id           :any]
-                                      [:query-v          [:vector :any]]
-                                      [:result-changed?  :boolean]
-                                      [:recomputed?      :boolean]]]]      ;; per-sub activity in this cascade
+                                      [:sub-id      :any]
+                                      [:query-v     [:vector :any]]
+                                      [:recomputed? :boolean]]]]           ;; per-sub activity in this cascade
    [:renders       {:optional true} [:vector
                                      [:map
                                       [:render-key   :any]
@@ -990,7 +989,7 @@ The `:db-before` / `:db-after` pair lets pair tools display diffs cheaply.
 
 **Structured slots are derived from `:trace-events`.** The `:sub-runs`, `:renders`, and `:effects` slots are pre-computed projections of the underlying `:trace-events` stream, surfacing the per-sub / per-render / per-effect activity of the cascade in a shape pair-shaped tools can route off without re-folding the raw trace each time. The legacy `:trace-events` slot remains the raw underpinning; the structured slots derive from it.
 
-- `:sub-runs` — every sub the cascade touched. `:recomputed?` is `false` on a cache hit (the sub was queried but its memoised value reused) and `true` when the sub re-ran. `:result-changed?` reports whether the post-run value differs from the prior cached value. The two together let a tool answer "which subs actually moved this cascade?" without re-deriving from the trace.
+- `:sub-runs` — every sub the cascade re-ran. `:recomputed?` is `true` for every entry: under [Spec 006 §No-op via value equality (rf2-719e)](006-Subscriptions.md), a sub whose inputs are value-equal to the prior call does not re-run its body and therefore does not emit `:sub/run`, so cache-hit subs are absent from this projection. The slot answers "which subs moved this cascade?" without re-deriving from the trace. (rf2-7e2y dropped a `:result-changed?` slot that was structurally always true under the same semantics — consumers wanting the input-changed-but-value-equal distinction must consume the raw trace until that distinction is wired through as a separate signal.)
 - `:renders` — every render that fired during the cascade. `:triggered-by` names the sub-id whose value-change triggered the render, or is `nil` for the initial mount / a render driven by something other than a sub change. `:elapsed-ms` is the render's wall-clock duration. `:render-key` identifies the rendered unit; **TBD pending rf2-t5tx** — the choice between "the `reg-view` registration id" (coarse) and "a per-component-instance token" (fine) has not been pinned. Tools should treat it as opaque.
 - `:effects` — every effect dispatched in the cascade's `:event/do-fx` step. `:outcome` is `:ok` on success, `:error` if the effect threw or returned a structured error, `:skipped-on-platform` when the effect is registered with `:platforms` that exclude the current host (per [011](011-SSR.md)). `:error-trace` (when present) references the corresponding error trace event by `:id`.
 

--- a/implementation/src/re_frame/epoch.cljc
+++ b/implementation/src/re_frame/epoch.cljc
@@ -227,21 +227,16 @@
   Each :sub/run trace event surfaces as one entry with `:recomputed?
   true`. Per Spec-Schemas §`:rf/epoch-record`: a sub queried via the
   rf2-719e cache hit path does NOT emit `:sub/run` (the body fn does
-  not re-run), so cache-hit subs are absent from this projection.
-  `:result-changed?` is currently true when the sub recomputed (the
-  raw trace doesn't yet carry the prior value); tools requiring
-  fine-grained change-tracking should consume the raw trace stream
-  until rf2 wires post-compute equality back through the trace."
+  not re-run), so cache-hit subs are absent from this projection."
   [events]
   (into []
         (comp
           (filter (fn [ev] (= :sub/run (:operation ev))))
           (map (fn [ev]
                  (let [t (:tags ev)]
-                   {:sub-id          (:sub-id t)
-                    :query-v         (:query-v t)
-                    :recomputed?     true
-                    :result-changed? true}))))
+                   {:sub-id      (:sub-id t)
+                    :query-v     (:query-v t)
+                    :recomputed? true}))))
         events))
 
 (defn- project-renders

--- a/implementation/test/re_frame/epoch_test.clj
+++ b/implementation/test/re_frame/epoch_test.clj
@@ -453,8 +453,12 @@
       (is (vector? sub-runs))
       (is (some #(= :n   (:sub-id %)) sub-runs))
       (is (some #(= :n*2 (:sub-id %)) sub-runs))
-      (is (every? :recomputed?     sub-runs))
-      (is (every? :result-changed? sub-runs)))))
+      (is (every? :recomputed? sub-runs))
+      ;; rf2-7e2y: :result-changed? was structurally always true (only
+      ;; recomputed subs emit :sub/run under rf2-719e value-equality
+      ;; suppression) and has been dropped — every entry must NOT carry
+      ;; the slot.
+      (is (every? #(not (contains? % :result-changed?)) sub-runs)))))
 
 (deftest effects-projection-skipped-on-platform
   (testing ":effects captures :skipped-on-platform outcomes"


### PR DESCRIPTION
## Summary

The `:sub-runs` projection on `:rf/epoch-record` carried a `:result-changed?` boolean that was structurally always `true`. The rf2-719e value-equality short-circuit in `compute-and-cache!` gates `:sub/run` trace emission behind the `(not= last-in-vals in-vals)` branch — so any trace event reaching the projection IS a recompute with a novel result. The slot carried no information.

This PR takes option 1 from the bead's three options: drop the slot.

- `implementation/src/re_frame/epoch.cljc` — remove `:result-changed?` from the entry shape; tighten the projection's docstring (no more "currently true; tools wanting fine-grained tracking should consume the raw trace until rf2 wires post-compute equality" qualifier — that future work, if we want it, lives behind a different flag).
- `docs/specification/Spec-Schemas.md` — drop `:result-changed?` from the `EpochRecord` Malli shape; rewrite the `:sub-runs` prose to explain the absence (cache-hit subs aren't in the projection because `:sub/run` is gated, so every entry is a recompute) and note `rf2-7e2y` for traceability. Anyone wanting the input-changed-but-value-equal distinction must consume the raw trace and would need a separate flag wired through.
- `implementation/test/re_frame/epoch_test.clj` — replace the `every? :result-changed?` assertion with `every? #(not (contains? % :result-changed?))` to lock the slot's absence.

`:recomputed?` is retained. It IS structurally always `true` under the same gating, but it's the canonical structural witness for "this entry corresponds to a body re-run" and consumers prefer reading the slot to reasoning about the projection's filter contract.

## Evidence the slot was structurally always true

`implementation/src/re_frame/subs.cljc` line 200-244, inside `compute-and-cache!`'s `make-derived-value` body fn:

```clojure
(if (= @last-in-vals in-vals)
  @last-result
  (let [_ (trace/emit! :sub/run :sub/run {...})
        v (try ...)]
    (vreset! last-in-vals in-vals)
    (vreset! last-result v)
    v))
```

`:sub/run` only fires on the value-inequality branch. The projection then filters trace events by `(= :sub/run (:operation ev))` and the old code hard-coded `:result-changed? true` on every match. Always-true by construction.

## Consumer impact

I grepped re-frame-pair2 (`C:/Users/miket/code/re-frame-pair2/`) for `result-changed`. The only hit is `STATUS.md` — the discovery doc that filed this bead. **No active consumer reads the slot.** No follow-up PR needed in re-frame-pair2.

## Test plan

- [x] `clojure -M:test` (JVM) — 219 tests, 1032 assertions, 0 failures
- [x] `npm run test:cljs` — 76 tests, 256 assertions, 0 failures
- [x] `npm run test:browser` — 76 tests, 256 assertions, 0 failures
- [x] `npm run test:elision` — PASS (control + production sentinels match)
- [x] `npm run test:examples` — PASS (initial run flaked on flight-booker + managed-http-counter; rerun clean)