### PR TITLE
refactor: build-frame-provider drops vestigial build-time arg (rf2-4y60)

### DIFF
--- a/docs/specification/006-ReactiveSubstrate.md
+++ b/docs/specification/006-ReactiveSubstrate.md
@@ -631,13 +631,16 @@ What this gives:
 (defonce ^:private frame-context
   (.createContext js/React :rf/default))
 
-(defn provider [frame-keyword]
+(defn provider []
   ;; Returns a Reagent component the user includes in their tree:
   ;;   [provider :auth
   ;;     [some-view ...]]
   ;; The Provider's value is the keyword, never the frame record;
   ;; consumers resolve the keyword against the global frame registry on
   ;; every read, so re-registering frames is picked up automatically.
+  ;; 0-arity (rf2-4y60): a single built component services every frame —
+  ;; the frame keyword lives in the Provider's :value at render time, not
+  ;; in a build-time closure.
   (fn [frame-kw & children]
     (into [:> (.-Provider frame-context) {:value frame-kw}] children)))
 ```

--- a/implementation/src/re_frame/substrate/reagent.cljs
+++ b/implementation/src/re_frame/substrate/reagent.cljs
@@ -57,12 +57,15 @@
 
 ;; ---- context provider -----------------------------------------------------
 
-(defn- register-context-provider [frame-keyword]
+(defn- register-context-provider [_frame-keyword]
   ;; Implementation lives in re-frame.views (CLJS-only); this slot is
-  ;; populated dynamically by views/ns load.
-  (if-let [provider-builder (resolve 're-frame.views/build-frame-provider)]
-    ((deref provider-builder) frame-keyword)
-    nil))
+  ;; populated dynamically by views/ns load. The frame-keyword arg is
+  ;; ignored — `build-frame-provider` is 0-arity (rf2-4y60); the returned
+  ;; component takes the frame keyword at render time. The arg stays in
+  ;; the substrate signature per Spec 006 §Frame-provider via React
+  ;; context.
+  (when-let [provider-builder (resolve 're-frame.views/build-frame-provider)]
+    ((deref provider-builder))))
 
 ;; ---- disposal -------------------------------------------------------------
 

--- a/implementation/src/re_frame/views.cljs
+++ b/implementation/src/re_frame/views.cljs
@@ -24,20 +24,27 @@
 (defonce ^:private frame-context
   (.createContext React :rf/default))
 
+(defn- frame-provider-component
+  "The single Reagent component that backs every frame-provider. It takes
+  the frame keyword as its first render-time arg and scopes that keyword
+  to its subtree via React context. One built component services every
+  frame — the keyword lives in the Provider's `:value`, not in a
+  closure."
+  [frame-kw & children]
+  (into [:> (.-Provider frame-context) {:value frame-kw}] children))
+
 (defn build-frame-provider
   "Used by re-frame.substrate.reagent/register-context-provider. Returns
   a Reagent component that scopes a frame keyword to its subtree.
 
-  The build-time `_frame-keyword` arg is currently unused — the returned
-  Reagent component takes the frame keyword at render time so a single
-  built component services every frame. The substrate-side
-  `register-context-provider` slot still receives a frame-keyword on
-  call (per Spec 006 §Frame-provider via React context). Kept for
-  forward-compatibility with substrates that want per-frame
-  specialisation; flattening tracked separately."
-  [_frame-keyword]
-  (fn [frame-kw & children]
-    (into [:> (.-Provider frame-context) {:value frame-kw}] children)))
+  Zero-arity (rf2-4y60): the returned component takes the frame keyword
+  at render time, and a single built component services every frame, so
+  there is nothing to specialise at build time. Substrates whose
+  `register-context-provider` slot receives a frame-keyword on call (per
+  Spec 006 §Frame-provider via React context) discard it and call this
+  with no args."
+  []
+  frame-provider-component)
 
 (defn frame-provider
   "User-facing Reagent component that scopes a frame keyword to its
@@ -63,7 +70,7 @@
   surface."
   [props & children]
   (let [frame-kw (or (:frame props) :rf/default)]
-    (into [(build-frame-provider frame-kw) frame-kw] children)))
+    (into [(build-frame-provider) frame-kw] children)))
 
 ;; ---- frame resolution at render time -------------------------------------
 

--- a/implementation/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/test/re_frame/runtime_cljs_test.cljs
@@ -578,11 +578,13 @@
     ;; hook into re-frame.substrate.reagent/register-context-provider is
     ;; build-frame-provider. Both are callable; both produce the same
     ;; final hiccup shape when invoked with a frame keyword.
-    (let [provider     (re-frame.views/build-frame-provider :ignored)
+    ;; rf2-4y60: build-frame-provider is 0-arity — the returned component
+    ;; takes the frame keyword at render time.
+    (let [provider     (re-frame.views/build-frame-provider)
           substrate-tree (provider :hello [:span "x"])
           wrapper-tree   (rf/frame-provider {:frame :hello} [:span "x"])
-          ;; The wrapper invokes (build-frame-provider frame-kw) per call;
-          ;; the substrate-side returns a fresh component instance. Compare
+          ;; The wrapper invokes (build-frame-provider) per call;
+          ;; the substrate-side returns the same generic component. Compare
           ;; the inner Provider hiccup produced by each.
           unwrap         (fn [tree] (apply (first tree) (rest tree)))
           a              (unwrap wrapper-tree)


### PR DESCRIPTION
## Summary

`re-frame.views/build-frame-provider` took a `_frame-keyword` build-time arg and ignored it — the returned Reagent component takes the frame keyword at render time via the React Context Provider's `:value`, and a single built component services every frame. Flatten to 0-arity.

- `re-frame.views/build-frame-provider` is now 0-arity; returns the same generic component (factored out as `frame-provider-component`).
- `re-frame.views/frame-provider` updates its single callsite: `[(build-frame-provider) frame-kw children...]`.
- `re-frame.substrate.reagent/register-context-provider` keeps its substrate-level signature `[frame-keyword]` (per Spec 006 §Frame-provider via React context — the wider adapter contract) but ignores the arg and calls `(build-frame-provider)`.
- Spec 006 pseudocode for the Reagent provider updated to the 0-arity shape with an rf2-4y60 note.
- One test (`frame-provider-build-frame-provider-substrate`) updated; assertion intent unchanged.

## Test plan

- [x] `clojure -M:test` (JVM)  219 tests / 1032 assertions, 0 failures
- [x] `npm run test:cljs`      76 tests / 256 assertions, 0 failures
- [x] `npm run test:browser`   76 tests / 256 assertions, 0 failures
- [x] `npm run test:elision`   PASS
- [x] `npm run test:examples`  all 8 examples PASS