### PR TITLE
docs: sweep 7 missed files for old-shape reg-view (rf2-xv7e)

### DIFF
--- a/docs/guide/02-your-first-app.md
+++ b/docs/guide/02-your-first-app.md
@@ -38,19 +38,18 @@ Here's the file, in full, with the surrounding ceremony removed:
   (fn [db _query] (:count db)))
 
 ;; View
-(rf/reg-view :counter
-  (fn []
-    [:div
-     [:button {:on-click #(dispatch [:counter/dec])} "-"]
-     [:span @(subscribe [:count])]
-     [:button {:on-click #(dispatch [:counter/inc])} "+"]]))
+(rf/reg-view counter []
+  [:div
+   [:button {:on-click #(dispatch [:counter/dec])} "-"]
+   [:span @(subscribe [:count])]
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
 ;; Mount
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [(rf/view :counter)]))
+  (rdc/render root [counter]))
 ```
 
 That's everything. Forty lines. Let's take it apart.
@@ -139,17 +138,16 @@ The `:<-` is the input declaration. The framework builds a dependency graph from
 ## The view
 
 ```clojure
-(rf/reg-view :counter
-  (fn []
-    [:div
-     [:button {:on-click #(dispatch [:counter/dec])} "-"]
-     [:span @(subscribe [:count])]
-     [:button {:on-click #(dispatch [:counter/inc])} "+"]]))
+(rf/reg-view counter []
+  [:div
+   [:button {:on-click #(dispatch [:counter/dec])} "-"]
+   [:span @(subscribe [:count])]
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 ```
 
 This is the only piece with substantive shape. Let's look at it carefully.
 
-`reg-view` registers a render function under the keyword `:counter`. The render function returns **hiccup** — a Clojure data structure that describes a DOM tree. `[:div ...]` is a `<div>`. `[:button {:on-click ...} "-"]` is a `<button>` with a click handler and the text `"-"`.
+`reg-view` is a defn-shape macro. It registers a render function (under the auto-derived id `(keyword *ns* "counter")`) and defs the symbol `counter` in the current namespace, bound to the wrapped fn. Hiccup elsewhere can reference it as `[counter]`. The render function returns **hiccup** — a Clojure data structure that describes a DOM tree. `[:div ...]` is a `<div>`. `[:button {:on-click ...} "-"]` is a `<button>` with a click handler and the text `"-"`.
 
 Inside the body, two names are available that you didn't define:
 
@@ -177,10 +175,10 @@ There's a tradeoff: plain Reagent functions also work, but they don't get frame-
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [(rf/view :counter)]))
+  (rdc/render root [counter]))
 ```
 
-This is the part that's not really re-frame2 — it's the React/Reagent runtime asking "where in the page do I render?" `defonce` makes sure the root is created once even if the file is hot-reloaded. `(rf/view :counter)` looks up the registered render function and hands it back; `rdc/render` mounts it.
+This is the part that's not really re-frame2 — it's the React/Reagent runtime asking "where in the page do I render?" `defonce` makes sure the root is created once even if the file is hot-reloaded. `[counter]` is hiccup referencing the Var that `reg-view` defed; `rdc/render` mounts it.
 
 ## What just happened
 
@@ -188,7 +186,7 @@ When the page loads, here's what runs:
 
 1. `reg-frame :rf/default` registers (and creates) the default frame. The `:on-create` event `[:counter/initialise]` fires synchronously. The handler returns `{:count 5}`. The frame's `app-db` is now `{:count 5}`.
 
-2. `run` is called. It mounts the `:counter` view at the root.
+2. `run` is called. It mounts the `counter` view at the root.
 
 3. The view's body runs. `@(subscribe [:count])` returns `5`. The hiccup tree is `[:div [:button "-"] [:span 5] [:button "+"]]`. Reagent renders that as DOM.
 

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -39,17 +39,15 @@ For most apps, this works fine. There's no ceremony, no registration, nothing to
 But there's a sharper version: **registered views**.
 
 ```clojure
-(def greeting
-  (rf/reg-view :greeting
-    (fn [name]
-      [:div.greeting
-       [:h1 "Hello"]
-       [:p "Welcome back, " [:strong name] "."]])))
+(rf/reg-view greeting [name]
+  [:div.greeting
+   [:h1 "Hello"]
+   [:p "Welcome back, " [:strong name] "."]])
 ```
 
 Two things change:
 
-1. The view is registered under a keyword, `:greeting`. It's now in the registry alongside events, subs, fx. Tooling can list it. AIs can introspect it. You can query its `:doc`/`:spec` metadata.
+1. The view is registered under an auto-derived keyword, `(keyword *ns* "greeting")`. It's now in the registry alongside events, subs, fx. Tooling can list it. AIs can introspect it. You can query its `:doc`/`:spec` metadata.
 
 2. **Inside the view's body, `dispatch` and `subscribe` are bound to the surrounding frame.** This is the load-bearing reason to register views. Without it, plain Reagent functions read state from a hard-coded default frame; you can't put two instances of the same view next to each other showing different state.
 
@@ -57,11 +55,10 @@ For a single-frame app, plain views are fine. For anything else — and "anythin
 
 ### The Var-reference idiom
 
-The canonical way to use a registered view in hiccup is to `def` a var from the registration's return value, then reference the var like any other Reagent component:
+`reg-view` is defn-shape: it auto-defs the symbol you supply. Reference that var like any other Reagent component:
 
 ```clojure
-(def greeting
-  (rf/reg-view :greeting (fn [name] ...)))
+(rf/reg-view greeting [name] ...)
 
 ;; ... elsewhere
 [:div
@@ -71,7 +68,7 @@ The canonical way to use a registered view in hiccup is to `def` a var from the 
 
 This reads exactly like Reagent. There's nothing to learn. It just happens to work for the multi-frame case because of the registration that's also happening.
 
-An alternative form exists — `(rf/view :greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `view` is the escape hatch for those specific cases.
+An alternative form exists — `(rf/view :my-ns/greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `view` is the escape hatch for those specific cases.
 
 ## Frames
 
@@ -227,12 +224,10 @@ Two counters, side by side, isolated:
 (rf/reg-event-db :counter/inc        (fn [db _] (update db :count inc)))
 (rf/reg-sub      :count              (fn [db _] (:count db)))
 
-(def counter
-  (rf/reg-view :counter
-    (fn []
-      [:div
-       [:button {:on-click #(dispatch [:counter/inc])} "+"]
-       [:span @(subscribe [:count])]])))
+(rf/reg-view counter []
+  [:div
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]
+   [:span @(subscribe [:count])]])
 
 ;; Two frames, one for each side.
 (rf/reg-frame :left  {:on-create [:counter/initialise]})

--- a/docs/specification/002-Frames.md
+++ b/docs/specification/002-Frames.md
@@ -33,7 +33,7 @@ This Spec inherits the constraints and goals from 000 and adds two frame-specifi
 ;; View ergonomics
 [rf/frame-provider {:frame :todo}       ;; React context: keyword in, not value
  [todo-list]]
-(rf/reg-view :counter {,,,} (fn [label] ,,,))   ;; injects frame-bound `dispatch`/`subscribe`
+(rf/reg-view counter [label] ,,,)               ;; defn-shape; injects frame-bound `dispatch`/`subscribe`
 
 ;; Plain (non-view) APIs — frame-aware variants
 (rf/dispatch      [:foo])                          ;; defaults to :rf/default
@@ -397,12 +397,10 @@ So the CLJS reference has to **convert render-time frame knowledge into a closur
 `reg-view` is the registered, frame-aware view abstraction. Inside a registered view's body, `dispatch` and `subscribe` are **lexically bound locals** — closures pre-bound to the frame resolved from React context at render time. Callbacks that close over these locals automatically carry the frame.
 
 ```clojure
-(rf/reg-view :counter
-  {:doc "A counter widget with isolated state."}
-  (fn [label]
-    (let [n @(subscribe [:count])]                  ;; frame-bound subscribe
-      [:button {:on-click #(dispatch [:inc])}        ;; frame-bound dispatch closed over
-       (str label ": " n)])))
+(rf/reg-view ^{:doc "A counter widget with isolated state."} counter [label]
+  (let [n @(subscribe [:count])]                  ;; frame-bound subscribe
+    [:button {:on-click #(dispatch [:inc])}        ;; frame-bound dispatch closed over
+     (str label ": " n)]))
 ```
 
 Naming convention: **unqualified `dispatch`/`subscribe` inside `reg-view` are the frame-bound locals.** Qualified `re-frame.core/dispatch` continues to refer to the global function (defaults to `:rf/default`, also useful at the REPL).

--- a/docs/specification/005-StateMachines.md
+++ b/docs/specification/005-StateMachines.md
@@ -1654,41 +1654,40 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
 ;; VIEW
 ;; ----------------------------------------------------------------------------
 
-(rf/reg-view :drawer/main
-  (fn []
-    (let [circles                @(rf/subscribe [:drawer/circles-with-preview])
-          ;; sub-machine returns the whole snapshot; inline-destructure it.
-          {state :state ed :data} @(rf/sub-machine :drawer/editor)
-          editing?               (= state :editing)
-          can-undo?              @(rf/subscribe [:drawer/can-undo?])
-          can-redo?              @(rf/subscribe [:drawer/can-redo?])]
-      [:div.drawer
-       [:div.row
-        [:button {:on-click #(rf/dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
-        [:button {:on-click #(rf/dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
-       [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
-              :on-click (fn [e]
-                          (when-not editing?
-                            (let [r (.. e -currentTarget getBoundingClientRect)
-                                  x (- (.. e -clientX) (.-left r))
-                                  y (- (.. e -clientY) (.-top r))]
-                              (rf/dispatch [:drawer/add-circle x y]))))}
-        (for [{:keys [id x y radius]} circles]
-          ^{:key id}
-          [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
-                    :on-context-menu (fn [e] (.preventDefault e)
-                                       ;; pass radius in the event payload — machine cannot read :db
-                                       (rf/dispatch [:drawer/editor [:right-click-circle id radius]]))}])]
-       (when editing?
-         [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
-          [:p (str "Adjust diameter of circle " (:circle-id ed))]
-          [:input {:type "range" :min 5 :max 100 :step 1
-                   :value (:preview-radius ed)
-                   :on-change #(rf/dispatch [:drawer/editor [:drag-slider
-                                                             (js/parseInt (.. % -target -value))]])}]
-          [:div.row
-           [:button {:on-click #(rf/dispatch [:drawer/editor [:close-dialog]])}  "Commit"]
-           [:button {:on-click #(rf/dispatch [:drawer/editor [:cancel-dialog]])} "Cancel"]]])])))
+(rf/reg-view main []
+  (let [circles                @(rf/subscribe [:drawer/circles-with-preview])
+        ;; sub-machine returns the whole snapshot; inline-destructure it.
+        {state :state ed :data} @(rf/sub-machine :drawer/editor)
+        editing?               (= state :editing)
+        can-undo?              @(rf/subscribe [:drawer/can-undo?])
+        can-redo?              @(rf/subscribe [:drawer/can-redo?])]
+    [:div.drawer
+     [:div.row
+      [:button {:on-click #(rf/dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
+      [:button {:on-click #(rf/dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
+     [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
+            :on-click (fn [e]
+                        (when-not editing?
+                          (let [r (.. e -currentTarget getBoundingClientRect)
+                                x (- (.. e -clientX) (.-left r))
+                                y (- (.. e -clientY) (.-top r))]
+                            (rf/dispatch [:drawer/add-circle x y]))))}
+      (for [{:keys [id x y radius]} circles]
+        ^{:key id}
+        [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
+                  :on-context-menu (fn [e] (.preventDefault e)
+                                     ;; pass radius in the event payload — machine cannot read :db
+                                     (rf/dispatch [:drawer/editor [:right-click-circle id radius]]))}])]
+     (when editing?
+       [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
+        [:p (str "Adjust diameter of circle " (:circle-id ed))]
+        [:input {:type "range" :min 5 :max 100 :step 1
+                 :value (:preview-radius ed)
+                 :on-change #(rf/dispatch [:drawer/editor [:drag-slider
+                                                           (js/parseInt (.. % -target -value))]])}]
+        [:div.row
+         [:button {:on-click #(rf/dispatch [:drawer/editor [:close-dialog]])}  "Commit"]
+         [:button {:on-click #(rf/dispatch [:drawer/editor [:cancel-dialog]])} "Cancel"]]])]))
 ```
 
 **Modeling rule the example illustrates:** preview is *display* state, not domain state. The drag never persists into `:circles`; instead the `:drawer/circles-with-preview` sub merges `:preview-radius` from the editor's `:data` into the rendered circles at read time. Cancel is therefore a no-op on domain state — there is nothing to revert because nothing was persisted.

--- a/docs/specification/007-Stories.md
+++ b/docs/specification/007-Stories.md
@@ -226,11 +226,10 @@ Control types map to common widgets: `:text`, `:textarea`, `:number`, `:boolean`
 Args are passed to the view as data. By default the view renders with the current args:
 
 ```clojure
-(rf/reg-view :login-form
-  (fn [args]                                   ;; receives the current args
-    [:form
-     [:input {:placeholder (:placeholder args)}]
-     [:button (:submit-label args)]]))
+(rf/reg-view login-form [args]                ;; receives the current args
+  [:form
+   [:input {:placeholder (:placeholder args)}]
+   [:button (:submit-label args)]])
 ```
 
 When a control mutates an arg, the story tool dispatches `[:story/set-arg <story-id> <arg-key> <new-value>]` into the variant's frame; the view re-renders with the new args.

--- a/docs/specification/Construction-Prompts.md
+++ b/docs/specification/Construction-Prompts.md
@@ -276,34 +276,32 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 **Template — Form-1 (simple render fn):**
 
 ```clojure
-(rf/reg-view :feature/component-name
-  {:doc  "One-sentence what-and-why."
-   :spec [:cat :string :int]}                 ;; optional Malli schema for the props vector (after the view id)
-  (fn render-feature-component-name [label count-prop]
-    (let [items @(subscribe [:feature/items])]    ;; frame-bound; resolves on the surrounding frame
-      [:div.feature
-       [:h3 label]
-       [:p (str "Count: " count-prop)]
-       (for [item items]
-         ^{:key (:id item)}
-         [:div.item
-          [:span (:label item)]
-          [:button {:on-click #(dispatch [:feature/select (:id item)])} "Select"]])])))
+(rf/reg-view ^{:doc  "One-sentence what-and-why."
+               :spec [:cat :string :int]}    ;; optional Malli schema for the props vector
+             component-name [label count-prop]
+  (let [items @(subscribe [:feature/items])]   ;; frame-bound; resolves on the surrounding frame
+    [:div.feature
+     [:h3 label]
+     [:p (str "Count: " count-prop)]
+     (for [item items]
+       ^{:key (:id item)}
+       [:div.item
+        [:span (:label item)]
+        [:button {:on-click #(dispatch [:feature/select (:id item)])} "Select"]])]))
 ```
 
 **Template — Form-2 (closure for once-on-mount setup):**
 
 ```clojure
-(rf/reg-view :feature/component-name
-  (fn outer-feature-component-name [label]
-    ;; Outer fn: runs once on mount. Use for setup that should fire once per
-    ;; component lifecycle (e.g., dispatching an :on-create-style init event,
-    ;; registering a frame, opening a websocket).
-    (dispatch [:feature/component-mounted])
-    (fn render-feature-component-name [label]
-      ;; Render fn: runs every render.
-      (let [n @(subscribe [:feature/count])]
-        [:div label ": " n]))))
+(rf/reg-view component-name [label]
+  ;; Outer body: runs once on mount. Use for setup that should fire once per
+  ;; component lifecycle (e.g., dispatching an :on-create-style init event,
+  ;; registering a frame, opening a websocket).
+  (dispatch [:feature/component-mounted])
+  (fn render-feature-component-name [label]
+    ;; Inner render fn: runs every render.
+    (let [n @(subscribe [:feature/count])]
+      [:div label ": " n])))
 ```
 
 **Pattern-level discipline (per [004](004-Views.md) and [011](011-SSR.md)):**
@@ -318,7 +316,7 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 ```clojure
 (deftest feature-component-name-renders
   (rf/with-frame [f (rf/make-frame {:on-create [:feature/initialise]})]
-    (let [hiccup ((rf/view :feature/component-name) "test-label" 42)
+    (let [hiccup [component-name "test-label" 42]
           html   (rf/render-to-string hiccup {:frame f})]
       (is (str/includes? html "test-label"))
       (is (str/includes? html "Count: 42")))))
@@ -336,15 +334,13 @@ The override seam is **id-valued at the pattern level**. The CLJS reference also
 **Example — full worked artefact:**
 
 ```clojure
-(rf/reg-view :cart/summary
-  {:doc "Total cost and item count for the current cart."}
-  (fn render-cart-summary []
-    (let [items @(subscribe [:cart/items])
-          total @(subscribe [:cart/total])]
-      [:div.cart-summary
-       [:span (str (count items) " items")]
-       [:span (str "$" (format "%.2f" total))]
-       [:button {:on-click #(dispatch [:cart/checkout])} "Checkout"]])))
+(rf/reg-view ^{:doc "Total cost and item count for the current cart."} summary []
+  (let [items @(subscribe [:cart/items])
+        total @(subscribe [:cart/total])]
+    [:div.cart-summary
+     [:span (str (count items) " items")]
+     [:span (str "$" (format "%.2f" total))]
+     [:button {:on-click #(dispatch [:cart/checkout])} "Checkout"]]))
 ```
 
 ### CP-5. Scaffold a state machine
@@ -557,20 +553,19 @@ After this action, `(:pending-request data)` is the new actor's id; subsequent t
 The framework-registered `:rf/machine` sub returns the snapshot for any machine; the wrapper `sub-machine` is the canonical user-facing form:
 
 ```clojure
-(rf/reg-view :auth.login/form
-  (fn render-auth-login-form []
-    (let [{:keys [state data]} @(rf/sub-machine :auth.login/flow)]
-      [:form
-       (case state
-         :idle        [submit-button]
-         :submitting  [spinner]
-         :error-shown [:<>
-                       [:p (str "Error: " (:error data))]
-                       [:button {:on-click #(rf/dispatch [:auth.login/flow [:dismiss]])}
-                        "Try again"]]
-         :authed      [:p "Welcome!"]
-         :locked-out  [:p "Account locked."]
-         nil          [:p "Loading..."])])))           ;; nil before initialisation
+(rf/reg-view login-form []
+  (let [{:keys [state data]} @(rf/sub-machine :auth.login/flow)]
+    [:form
+     (case state
+       :idle        [submit-button]
+       :submitting  [spinner]
+       :error-shown [:<>
+                     [:p (str "Error: " (:error data))]
+                     [:button {:on-click #(rf/dispatch [:auth.login/flow [:dismiss]])}
+                      "Try again"]]
+       :authed      [:p "Welcome!"]
+       :locked-out  [:p "Account locked."]
+       nil          [:p "Loading..."])]))             ;; nil before initialisation
 ```
 
 For projections, compose against `:rf/machine` via `:<-`:
@@ -697,8 +692,8 @@ test/my_app/
     (reduce + (map #(* (:qty %) (:price %)) items))))
 
 ;; my-app/cart/views.cljs
-(rf/reg-view :cart/summary {…})              ;; via CP-4
-(rf/reg-view :cart/item-list {…})
+(rf/reg-view summary [] …)                   ;; via CP-4 (registers :my-app.cart.views/summary)
+(rf/reg-view item-list [] …)
 
 ;; on app boot
 (rf/reg-app-schema [:cart] cs/CartState)
@@ -803,20 +798,18 @@ The handler reads `(:route db)` for any path/query params it needs — the `:rou
 **Template — route-aware root view:**
 
 ```clojure
-(def root-view
-  (rf/reg-view :app/root
-    (fn render-app-root []
-      (let [route-id   @(subscribe [:rf.route/id])
-            transition @(subscribe [:rf.route/transition])]
-        [:div
-         (when (= transition :loading) [progress-bar])
-         (case route-id
-           :route/home              [home-page]
-           :route/cart              [cart-page]
-           :route/cart.item-detail  [cart-item-detail-page]
-           :route/search            [search-page]
-           :rf.route/not-found         [not-found-page]
-           [not-found-page])]))))
+(rf/reg-view root-view []
+  (let [route-id   @(subscribe [:rf.route/id])
+        transition @(subscribe [:rf.route/transition])]
+    [:div
+     (when (= transition :loading) [progress-bar])
+     (case route-id
+       :route/home              [home-page]
+       :route/cart              [cart-page]
+       :route/cart.item-detail  [cart-item-detail-page]
+       :route/search            [search-page]
+       :rf.route/not-found         [not-found-page]
+       [not-found-page])]))
 ```
 
 **Template — links (use the registered `route-link` view):**

--- a/docs/specification/MIGRATION.md
+++ b/docs/specification/MIGRATION.md
@@ -444,7 +444,7 @@ The agent doesn't need to render the tree — a static walk over the hiccup form
 
 Then offer the user three options per call site:
 
-- **Convert to `reg-view`** — wrap the body in `(rf/reg-view :feature/component-name {:doc "..."} (fn [args] ...))`. The component picks up the surrounding frame correctly. This is the recommended path.
+- **Convert to `reg-view`** — replace the `defn` with `(rf/reg-view ^{:doc "..."} component-name [args] ...)` (defn-shape; auto-defs the symbol and registers under `(keyword *ns* "component-name")`). The component picks up the surrounding frame correctly. This is the recommended path.
 - **Use `(rf/dispatcher)` / `(rf/subscriber)` render-time helpers** — for plain fns that the user wants to keep as plain fns, replace bare `dispatch` / `subscribe` with the helper-bound forms. See [004 §Affordance for plain fns](004-Views.md#affordance-for-plain-fns-rfdispatcher--rfsubscriber).
 - **Leave as-is** — the user accepts that the component routes to `:rf/default`. Acceptable if the component is genuinely meant to read/write the default frame regardless of where it renders.
 
@@ -1012,12 +1012,10 @@ Plain Reagent fns target only `:rf/default`. If the codebase plans to introduce 
      (str label ": " n)]))
 
 ;; after
-(rf/reg-view :counter
-  {:doc "Counter widget."}
-  (fn [label]
-    (let [n @(subscribe [:count])]                       ;; unqualified — frame-bound local
-      [:button {:on-click #(dispatch [:inc])}            ;; unqualified — frame-bound local
-       (str label ": " n)])))
+(rf/reg-view ^{:doc "Counter widget."} counter [label]
+  (let [n @(subscribe [:count])]                         ;; unqualified — frame-bound local
+    [:button {:on-click #(dispatch [:inc])}              ;; unqualified — frame-bound local
+     (str label ": " n)]))
 ```
 
 Note the `re-frame.core/` prefix is dropped inside `reg-view` bodies — `dispatch` and `subscribe` are lexical locals injected by the macro.

--- a/docs/specification/Pattern-RemoteData.md
+++ b/docs/specification/Pattern-RemoteData.md
@@ -185,18 +185,17 @@ Convenience subs per slice (the `:loading?` / `:fetching?` split is the load-bea
 Views read the convenience subs:
 
 ```clojure
-(rf/reg-view :pages/articles
-  (fn []
-    (cond
-      @(subscribe [:articles/loading?])
-      [:p "Loading…"]
+(rf/reg-view articles []
+  (cond
+    @(subscribe [:articles/loading?])
+    [:p "Loading…"]
 
-      @(subscribe [:articles/error])
-      [:p.error (str "Couldn't load: " @(subscribe [:articles/error]))]
+    @(subscribe [:articles/error])
+    [:p.error (str "Couldn't load: " @(subscribe [:articles/error]))]
 
-      :else
-      [:ul (for [a @(subscribe [:articles/data])]
-             ^{:key (:id a)} [:li (:title a)])])))
+    :else
+    [:ul (for [a @(subscribe [:articles/data])]
+           ^{:key (:id a)} [:li (:title a)])]))
 ```
 
 ## Variations


### PR DESCRIPTION
## Summary

Follow-up to rf2-d0pi (PR #54). The previous sweep covered 11 enumerated spec/doc files; subsequent grep surfaced 7 more containing old-shape `(reg-view :kw (fn [args] body))` calls. This bead converts those to defn-shape `(reg-view sym [args] body)` per [Spec 004 §`reg-view` defs the Var by default](../tree/master/docs/specification/004-Views.md#reg-view-defs-the-var-by-default).

Per-file conversion counts:
- `docs/guide/02-your-first-app.md` — 2 sites + mount narrative
- `docs/guide/04-views-and-frames.md` — 3 sites
- `docs/specification/002-Frames.md` — 2 sites
- `docs/specification/005-StateMachines.md` — 1 site (`:drawer/main`)
- `docs/specification/007-Stories.md` — 1 site (`:login-form`)
- `docs/specification/Pattern-RemoteData.md` — 1 site (`:pages/articles`)
- `docs/specification/Construction-Prompts.md` — 5 sites (CP-4 Form-1/Form-2 templates, cart/summary worked example, auth.login/form sub-machine view, feature-modules sketch, route-aware root view)

Also opportunistically updated two MIGRATION.md prose entries (M-21 "Convert to `reg-view`" recommended path; O-2 "after" example) where the old shape was being recommended as the target form. M-22 retains its old-shape examples — those document the migration itself per the bead's "leave historical contexts" rule.

After-sweep grep `grep -rn 'reg-view :' docs/` returns only historical/migration residue (Spec 004 narrative + M-22 entries) — zero non-historical residue.

## Test plan

- [x] `clojure -M:test` — 219 tests / 1032 assertions, 0 failures
- [x] `npm run test:cljs` — 76 tests / 256 assertions, 0 failures
- [x] `npm run test:browser` — 83 tests / 288 assertions, 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:examples` — all 8 examples PASS