### PR TITLE
feat: Phase 3 examples runnable + Playwright (rf2-w3vn)

### DIFF
--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -23,7 +23,8 @@
 
    Kept as a single file here for brevity."
   (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf])
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -62,14 +63,34 @@
 ;; :http is server-and-client; the :platforms metadata gates SSR per [011].
 ;; :auth.session/store is client-only — localStorage is a browser API.
 
+;; The example demo runs against a canned in-process stub so it can be
+;; opened standalone (no backend required). Treat any login with a
+;; password matching :good-password as a success; anything else fails.
+;; The stub mirrors the shape a real :http effect would have.
+(def good-password "correct-horse")
+
 (rf/reg-fx :http
-  {:doc       "Issue an HTTP request. On completion, dispatch :on-success or :on-error."
+  {:doc       "Demo stub of an HTTP request. In a real app this would issue a fetch;
+               here we synthesise a canned response so the example is runnable
+               standalone."
    :platforms #{:server :client}}
-  (fn fx-http [m {:keys [method url body on-success on-error]}]
-    (let [frame-id (:frame m)]
-      (-> (perform-http-request method url body)
-          (.then  (fn [resp] (when on-success (rf/dispatch (conj on-success resp) {:frame frame-id}))))
-          (.catch (fn [err]  (when on-error  (rf/dispatch (conj on-error err)   {:frame frame-id}))))))))
+  (fn fx-http [{:keys [frame]} {:keys [body on-success on-error]}]
+    (let [success? (= good-password (:password body))]
+      ;; Simulate a small request latency so the :submitting state is
+      ;; observable in the UI before the response lands.
+      (js/setTimeout
+        (fn []
+          (cond
+            (and success? on-success)
+            (rf/dispatch (conj on-success {:user  {:id    (random-uuid)
+                                                   :email (:email body)}
+                                           :token "demo-token-123"})
+                         {:frame frame})
+
+            on-error
+            (rf/dispatch (conj on-error {:message "Invalid credentials."})
+                         {:frame frame})))
+        50))))
 
 (rf/reg-fx :auth.session/store
   {:doc       "Persist the session token in localStorage. Client only."
@@ -84,8 +105,9 @@
    :platforms #{:client :server}}
   (fn fx-http-canned-success [{:keys [frame]} {:keys [on-success]}]
     (when on-success
-      (rf/dispatch (conj on-success {:user {:id (random-uuid) :email "test@example.com"}
-                                     :token "test-token-123"}})
+      (rf/dispatch (conj on-success {:user  {:id    (random-uuid)
+                                             :email "test@example.com"}
+                                     :token "test-token-123"})
                    {:frame frame}))))
 
 ;; ============================================================================
@@ -304,8 +326,11 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-(defonce root
+;; React root named `react-root` (not `root`) so it does NOT collide
+;; with the `root-view` reg-view above (rf2-562e).
+(defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [root-view]))
+  (rf/init! reagent-adapter/adapter)
+  (rdc/render react-root [root-view]))

--- a/examples/login/index.html
+++ b/examples/login/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: login (state-machine demo)</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    .login-form { display: flex; flex-direction: column; gap: 8px; max-width: 320px; }
+    .login-form input { padding: 6px; }
+    .login-form button { padding: 6px 12px; }
+    .error { color: #c33; }
+    .banner { margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/playwright/cells.spec.cjs
+++ b/examples/playwright/cells.spec.cjs
@@ -1,0 +1,93 @@
+/*
+ * 7GUIs #7 — Cells — smoke test (rf2-w3vn).
+ *
+ * Exercises change propagation through the spreadsheet sub-graph:
+ *
+ *   A1 = 5
+ *   B1 = =(+ A1 5)
+ *   observe B1 = 10
+ *
+ *   Update A1 = 100
+ *   observe B1 = 105 (propagated through the sub-graph)
+ *
+ * Cells are <td.cell> elements; clicking enters edit mode (an <input>);
+ * Enter or blur commits.
+ *
+ * Cell coordinates: each row's <th> is the row number, each column's
+ * <th> is the column letter (A..Z). Cells are <td> with no per-id
+ * marker, so we locate them by row index + column index using nth().
+ */
+
+const { expectVisible } = require('./_helpers.cjs');
+
+async function commitCell(page, row, col, value) {
+  // row and col are zero-based, where row 0 is the header row in <thead>.
+  // <tbody> rows start at row 1 (which is row 0 inside tbody). Each row
+  // has one <th> for the row label, then COLS <td> cells. col is the
+  // column index (A=0, B=1, ...) so the cell selector is nth(col) within
+  // that row's <td> selector.
+  const cell = page
+    .locator('tbody tr')
+    .nth(row)
+    .locator('td.cell')
+    .nth(col);
+  await cell.click();
+  const input = cell.locator('input');
+  await input.waitFor({ state: 'visible', timeout: 5000 });
+  await input.fill(value);
+  await input.press('Enter');
+}
+
+async function readCell(page, row, col) {
+  const cell = page
+    .locator('tbody tr')
+    .nth(row)
+    .locator('td.cell')
+    .nth(col);
+  return (await cell.textContent()) || '';
+}
+
+module.exports = {
+  name: 'cells (7guis #7)',
+  url: '/cells/',
+  run: async (page) => {
+    await expectVisible(page.locator('table.cells-grid'), 15000);
+
+    // Set A1 = 5  (row 0 is the row containing the cell labelled "1";
+    // tbody's first <tr> has <th>1</th> then 26 cells).
+    await commitCell(page, 0, 0, '5');
+    await page.waitForFunction(
+      () => {
+        const cell = document.querySelectorAll('tbody tr')[0]
+          .querySelectorAll('td.cell')[0];
+        return cell && cell.textContent.trim() === '5';
+      },
+      null,
+      { timeout: 5000 },
+    );
+
+    // Set B1 = =(+ A1 5)
+    await commitCell(page, 0, 1, '=(+ A1 5)');
+    await page.waitForFunction(
+      () => {
+        const cell = document.querySelectorAll('tbody tr')[0]
+          .querySelectorAll('td.cell')[1];
+        return cell && cell.textContent.trim() === '10';
+      },
+      null,
+      { timeout: 5000 },
+    );
+
+    // Update A1 = 100; B1 should propagate to 105.
+    await commitCell(page, 0, 0, '100');
+    await page.waitForFunction(
+      () => {
+        const cell = document.querySelectorAll('tbody tr')[0]
+          .querySelectorAll('td.cell')[1];
+        return cell && cell.textContent.trim() === '105';
+      },
+      null,
+      { timeout: 5000 },
+    );
+  },
+};

--- a/examples/playwright/circle_drawer.spec.cjs
+++ b/examples/playwright/circle_drawer.spec.cjs
@@ -1,0 +1,93 @@
+/*
+ * 7GUIs #6 — Circle Drawer — smoke test (rf2-w3vn).
+ *
+ * Exercises the undo/redo + dialog interaction model:
+ *
+ * - Initial render: empty SVG canvas; Undo and Redo disabled.
+ * - Click on canvas: a circle is added at the click position.
+ * - Click again: a second circle is added, total 2.
+ * - Right-click a circle: dialog opens with a slider.
+ * - Change slider value, click Close: the circle's radius updates.
+ * - Click Undo: the radius change is undone (or earlier state restored).
+ * - Click Redo: state restored.
+ *
+ * The on-context-menu handler calls .preventDefault(), so Playwright's
+ * `click({ button: 'right' })` will fire it without the browser context
+ * menu intervening.
+ */
+
+const { expectVisible, expectAttribute } = require('./_helpers.cjs');
+
+module.exports = {
+  name: 'circle-drawer (7guis #6)',
+  url: '/circle-drawer/',
+  run: async (page) => {
+    const svg = page.locator('svg');
+    const undoBtn = page.getByRole('button', { name: /undo/i });
+    const redoBtn = page.getByRole('button', { name: /redo/i });
+
+    await expectVisible(svg, 10000);
+
+    // Initial: undo + redo disabled.
+    await expectAttribute(undoBtn, 'disabled', '');
+    await expectAttribute(redoBtn, 'disabled', '');
+
+    // Click canvas: 1 circle.
+    await svg.click({ position: { x: 120, y: 120 } });
+    await page.waitForFunction(
+      () => document.querySelectorAll('svg circle').length === 1,
+      null,
+      { timeout: 5000 },
+    );
+    await expectAttribute(undoBtn, 'disabled', null);
+
+    // Click again: 2 circles.
+    await svg.click({ position: { x: 300, y: 200 } });
+    await page.waitForFunction(
+      () => document.querySelectorAll('svg circle').length === 2,
+      null,
+      { timeout: 5000 },
+    );
+
+    // Right-click the first circle to open the dialog.
+    const firstCircle = page.locator('svg circle').nth(0);
+    const initialRadius = await firstCircle.getAttribute('r');
+    await firstCircle.click({ button: 'right' });
+    const slider = page.locator('input[type="range"]');
+    await expectVisible(slider, 5000);
+
+    // Drag slider to a different value, close dialog.
+    await slider.fill('70');
+    await page.getByRole('button', { name: /close/i }).click();
+    await page.waitForFunction(
+      () => {
+        const c = document.querySelectorAll('svg circle')[0];
+        return c && c.getAttribute('r') === '70';
+      },
+      null,
+      { timeout: 5000 },
+    );
+
+    // Undo: radius change reverts.
+    await undoBtn.click();
+    await page.waitForFunction(
+      (initial) => {
+        const c = document.querySelectorAll('svg circle')[0];
+        return c && c.getAttribute('r') === initial;
+      },
+      initialRadius,
+      { timeout: 5000 },
+    );
+
+    // Redo: radius change reapplies.
+    await redoBtn.click();
+    await page.waitForFunction(
+      () => {
+        const c = document.querySelectorAll('svg circle')[0];
+        return c && c.getAttribute('r') === '70';
+      },
+      null,
+      { timeout: 5000 },
+    );
+  },
+};

--- a/examples/playwright/crud.spec.cjs
+++ b/examples/playwright/crud.spec.cjs
@@ -1,0 +1,97 @@
+/*
+ * 7GUIs #5 — CRUD — smoke test (rf2-w3vn).
+ *
+ * Drives the master/detail pattern:
+ *
+ * - Initial render: list shows the 3 seeded people; Update/Delete are
+ *   disabled (no selection); Create is enabled.
+ * - Filter by surname prefix: list shrinks to just Mustermann when "M"
+ *   is typed into the filter input.
+ * - Create: type a name + surname, click Create, list grows by one.
+ * - Update: select the new entry, change the surname, click Update,
+ *   the list reflects the new value.
+ * - Delete: click Delete, list shrinks back to the prior count.
+ *
+ * The Playwright Locator API is used to count <option> children of the
+ * size-6 multi-row <select> that backs the list.
+ */
+
+const { expectVisible } = require('./_helpers.cjs');
+
+module.exports = {
+  name: 'crud (7guis #5)',
+  url: '/crud/',
+  run: async (page) => {
+    const selectList = page.locator('select.list');
+    const inputs = page.locator('input[type="text"]');
+    const filterInput = inputs.nth(0);
+    const nameInput = inputs.nth(1);
+    const surnameInput = inputs.nth(2);
+    const createBtn = page.getByRole('button', { name: /create/i });
+    const updateBtn = page.getByRole('button', { name: /update/i });
+    const deleteBtn = page.getByRole('button', { name: /delete/i });
+
+    await expectVisible(selectList, 10000);
+
+    // Initial: 3 seeded people.
+    await page.waitForFunction(
+      () => document.querySelectorAll('select.list option').length === 3,
+      null,
+      { timeout: 10000 },
+    );
+
+    // Filter: prefix "M" -> 1 entry (Mustermann).
+    await filterInput.fill('M');
+    await page.waitForFunction(
+      () => document.querySelectorAll('select.list option').length === 1,
+      null,
+      { timeout: 5000 },
+    );
+
+    // Clear filter, list back to 3.
+    await filterInput.fill('');
+    await page.waitForFunction(
+      () => document.querySelectorAll('select.list option').length === 3,
+      null,
+      { timeout: 5000 },
+    );
+
+    // Create: type Anna Sonnen, click Create -> list grows to 4.
+    await nameInput.fill('Anna');
+    await surnameInput.fill('Sonnen');
+    await createBtn.click();
+    await page.waitForFunction(
+      () => document.querySelectorAll('select.list option').length === 4,
+      null,
+      { timeout: 5000 },
+    );
+
+    // Update: select the Anna Sonnen entry by its visible label, change
+    // surname, click Update; the list option's text reflects the new value.
+    await selectList.selectOption({ label: 'Sonnen, Anna' });
+    await page.waitForFunction(
+      () => {
+        const sel = document.querySelector('select.list');
+        return sel && sel.value !== '';
+      },
+      null,
+      { timeout: 5000 },
+    );
+    await surnameInput.fill('Sunnybaum');
+    await updateBtn.click();
+    await page.waitForFunction(
+      () => Array.from(document.querySelectorAll('select.list option'))
+        .some((o) => o.textContent === 'Sunnybaum, Anna'),
+      null,
+      { timeout: 5000 },
+    );
+
+    // Delete: list shrinks back to 3.
+    await deleteBtn.click();
+    await page.waitForFunction(
+      () => document.querySelectorAll('select.list option').length === 3,
+      null,
+      { timeout: 5000 },
+    );
+  },
+};

--- a/examples/playwright/login.spec.cjs
+++ b/examples/playwright/login.spec.cjs
@@ -1,0 +1,49 @@
+/*
+ * Login — smoke test (rf2-w3vn).
+ *
+ * Drives the login state machine end-to-end through the UI:
+ *
+ *   :idle -> :submitting -> :authed
+ *
+ * The example registers a stub :http effect that resolves :on-success
+ * after a 50ms timeout when the password matches `correct-horse`.
+ *
+ * Flow:
+ *   - Initial render: form visible, "Sign in" button enabled, no error.
+ *   - Type credentials, submit.
+ *   - During the request the button label becomes "Signing in…".
+ *   - On success the banner switches to "Welcome!".
+ */
+
+const { expectVisible, expectTextContains } = require('./_helpers.cjs');
+
+module.exports = {
+  name: 'login (state-machine demo)',
+  url: '/login/',
+  run: async (page) => {
+    const form = page.locator('form.login-form');
+    await expectVisible(form, 10000);
+
+    const emailInput = page.locator('input[type="email"]');
+    const passwordInput = page.locator('input[type="password"]');
+    const submitBtn = page.locator('form.login-form button[type="submit"]');
+
+    // Initial: button enabled, no error.
+    await expectVisible(submitBtn, 5000);
+
+    // Fill in a wrong password first to prove the error path runs.
+    await emailInput.fill('user@example.com');
+    await passwordInput.fill('wrongpass');
+    await submitBtn.click();
+    // After the stub resolves with on-error, the banner should still
+    // show the form (not authenticated). The error <p.error> appears.
+    await expectVisible(page.locator('p.error'), 5000);
+
+    // Now submit valid credentials.
+    await passwordInput.fill('correct-horse');
+    await submitBtn.click();
+
+    // Eventually banner shows "Welcome!".
+    await expectTextContains(page.locator('.banner'), 'Welcome!', 10000);
+  },
+};

--- a/examples/playwright/realworld.spec.cjs
+++ b/examples/playwright/realworld.spec.cjs
@@ -1,0 +1,37 @@
+/*
+ * RealWorld (Conduit) — smoke test (rf2-w3vn).
+ *
+ * The realworld example is large: ~13 namespaces, multiple feature
+ * slices, full routing. Per the rf2-w3vn bead this spec is scoped to:
+ *
+ *   - Loads cleanly (no pageerror, no uncaught exceptions).
+ *   - Main shell renders (navbar with "conduit" brand link).
+ *   - Home page renders the global feed populated by the demo :http stub.
+ *
+ * The stub returns 2 articles for the global feed, so we expect to see
+ * 2 .article-preview cards on the home page.
+ */
+
+const { expectVisible } = require('./_helpers.cjs');
+
+module.exports = {
+  name: 'realworld (Conduit)',
+  url: '/realworld/',
+  run: async (page) => {
+    // App shell mounts.
+    await expectVisible(page.locator('nav.navbar'), 15000);
+
+    // The brand link reads "conduit".
+    await expectVisible(
+      page.locator('a.navbar-brand:has-text("conduit")'),
+      5000,
+    );
+
+    // Main feed populates from the demo stub: 2 article previews.
+    await page.waitForFunction(
+      () => document.querySelectorAll('.article-preview').length >= 2,
+      null,
+      { timeout: 10000 },
+    );
+  },
+};

--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -43,9 +43,9 @@ A worked example based on the [RealWorld spec](https://github.com/gothinkster/re
 ## How to run
 
 The example assumes a shadow-cljs build aliased `realworld` (typical
-`:modules {:realworld {:entries [example.realworld.core] :init-fn example.realworld.core/run}}`).
+`:modules {:realworld {:entries [realworld.core] :init-fn realworld.core/run}}`).
 
-In production point `example.realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`.
+In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`.
 
 ```bash
 shadow-cljs watch realworld
@@ -55,16 +55,16 @@ shadow-cljs watch realworld
 The included headless tests are browserless sketches. Because most files are `.cljs`, run them in a CLJS host (Node, a `node-test` target, or a browser build without mounting the DOM-facing entrypoint):
 
 ```clojure
-(example.realworld.auth/login-happy-path-test)
-(example.realworld.articles/articles-load-test)
-(example.realworld.comments/comments-load-test)
-(example.realworld.article-editor/editor-create-test)
-(example.realworld.profile/profile-load-test)
-(example.realworld.favorites/favorite-toggle-test)
-(example.realworld.tags/tag-query-test)
-(example.realworld.settings/settings-test)
-(example.realworld.routing/routing-tests)
-(example.realworld.core/app-smoke-test)
+(realworld.auth/login-happy-path-test)
+(realworld.articles/articles-load-test)
+(realworld.comments/comments-load-test)
+(realworld.article-editor/editor-create-test)
+(realworld.profile/profile-load-test)
+(realworld.favorites/favorite-toggle-test)
+(realworld.tags/tag-query-test)
+(realworld.settings/settings-test)
+(realworld.routing/routing-tests)
+(realworld.core/app-smoke-test)
 ```
 
 ## Why RealWorld

--- a/examples/realworld/article_editor.cljs
+++ b/examples/realworld/article_editor.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.article-editor
+(ns realworld.article-editor
   "Article editor for the RealWorld (Conduit) example.
 
    This sketch shows the current re-frame2 shape for:
@@ -8,9 +8,9 @@
    - ordinary HTTP effects for create / update / delete"
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 (def blank-draft

--- a/examples/realworld/articles.cljs
+++ b/examples/realworld/articles.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.articles
+(ns realworld.articles
   "Home-page article feeds for the RealWorld (Conduit) example.
 
    This sketch demonstrates:
@@ -7,14 +7,12 @@
    - home-page tabs expressed as ordinary navigation events
    - view reuse across the home page and profile pages"
   (:require [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
-(defn current-time-ms []
-  #?(:cljs (.getTime (js/Date.))
-     :clj  (System/currentTimeMillis)))
+(defn current-time-ms [] (.getTime (js/Date.)))
 
 (defn request-slice [data]
   {:status :idle :data data :error nil :loaded-at nil :attempt 0})

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.auth
+(ns realworld.auth
   "Authentication for the RealWorld (Conduit) example.
 
    The auth flow is implemented as a re-frame2 state machine. Login,
@@ -11,9 +11,9 @@
    the machine snapshot itself lives at [:rf/machines :auth/flow]."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -159,8 +159,8 @@
   [(rf/inject-cofx :auth.session/token)]
   (fn handler-auth-initialise [{:keys [db auth.session/token]} _]
     {:db (assoc db :auth {:user nil
-                          :token auth.session/token})
-     :fx [[:dispatch [:auth/flow [:auth/restore auth.session/token]]]]}))
+                          :token token})
+     :fx [[:dispatch [:auth/flow [:auth/restore token]]]]}))
 
 ;; ============================================================================
 ;; FORMS

--- a/examples/realworld/comments.cljs
+++ b/examples/realworld/comments.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.comments
+(ns realworld.comments
   "Article detail plus comments for the RealWorld (Conduit) example.
 
    This sketch keeps the current re-frame2 API surface explicit:
@@ -8,14 +8,12 @@
    - Post/delete flows are optimistic and roll back via ordinary events."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
-(defn current-time-ms []
-  #?(:cljs (.getTime (js/Date.))
-     :clj  (System/currentTimeMillis)))
+(defn current-time-ms [] (.getTime (js/Date.)))
 
 (defn comment-form-defaults []
   {:draft        {:body ""}
@@ -32,8 +30,7 @@
   (str (article-path slug) "/comments"))
 
 (defn temp-comment-id []
-  #?(:cljs (str "temp-" (random-uuid))
-     :clj  (str "temp-" (java.util.UUID/randomUUID))))
+  (str "temp-" (random-uuid)))
 
 ;; ============================================================================
 ;; INITIALISATION
@@ -366,7 +363,7 @@
                              :updatedAt "2026-05-01"
                              :favorited false
                              :favoritesCount 0
-                             :author {:username "alice" :bio nil :image nil :following false}}})
+                             :author {:username "alice" :bio nil :image nil :following false}}}))
           {:frame frame}))))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]

--- a/examples/realworld/core.cljs
+++ b/examples/realworld/core.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.core
+(ns realworld.core
   "Entry point for the RealWorld (Conduit) example.
 
    Wires the app together:
@@ -22,17 +22,18 @@
      ssr.cljc              — hydration payload helper for the RealWorld app"
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing]
-            [example.realworld.auth :as auth]
-            [example.realworld.articles :as articles]
-            [example.realworld.comments :as comments]
-            [example.realworld.article-editor :as editor]
-            [example.realworld.profile :as profile]
-            [example.realworld.favorites]
-            [example.realworld.tags]
-            [example.realworld.settings :as settings])
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing]
+            [realworld.auth :as auth]
+            [realworld.articles :as articles]
+            [realworld.comments :as comments]
+            [realworld.article-editor :as editor]
+            [realworld.profile :as profile]
+            [realworld.favorites]
+            [realworld.tags]
+            [realworld.settings :as settings])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -155,10 +156,88 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
-(defonce root
+;; ----------------------------------------------------------------------------
+;; DEMO STUBS
+;;
+;; The realworld example would normally call out to https://api.realworld.io/api,
+;; which is unreliable for the headless smoke and slow for a demo. Override the
+;; :http effect with a small in-process stub that returns canned data for the
+;; routes the demo actually exercises (global feed, tags, profile). Anything
+;; not covered resolves to an empty-shape :on-success — enough for the app
+;; shell + main feed to render.
+;; ----------------------------------------------------------------------------
+
+(def ^:private demo-articles
+  [{:slug "hello-conduit"
+    :title "Hello, Conduit"
+    :description "A short greeting from the realworld stub."
+    :body "This article is served by the demo :http override."
+    :tagList ["intro" "demo"]
+    :createdAt "2026-01-01T00:00:00Z"
+    :updatedAt "2026-01-01T00:00:00Z"
+    :favorited false
+    :favoritesCount 0
+    :author {:username "stub-bot"
+             :bio "A friendly stub."
+             :image ""
+             :following false}}
+   {:slug "second-article"
+    :title "Second article"
+    :description "A second short article."
+    :body "More canned demo content."
+    :tagList ["demo"]
+    :createdAt "2026-02-01T00:00:00Z"
+    :updatedAt "2026-02-01T00:00:00Z"
+    :favorited false
+    :favoritesCount 0
+    :author {:username "stub-bot"
+             :bio "A friendly stub."
+             :image ""
+             :following false}}])
+
+(def ^:private demo-tags
+  ["intro" "demo" "clojure" "re-frame"])
+
+(rf/reg-fx :http.demo-stub
+  {:doc       "Demo stub for realworld :http: routes URLs to canned responses
+               so the example runs standalone without a backend."
+   :platforms #{:server :client}}
+  (fn fx-http-demo-stub [{:keys [frame]} {:keys [url on-success on-error]}]
+    (let [resp (cond
+                 (re-find #"/articles$|/articles\?" (str url))
+                 {:articles demo-articles :articlesCount (count demo-articles)}
+
+                 (re-find #"/articles/feed" (str url))
+                 {:articles [] :articlesCount 0}
+
+                 (re-find #"/tags" (str url))
+                 {:tags demo-tags}
+
+                 (re-find #"/profiles/" (str url))
+                 {:profile {:username "stub-bot" :bio "" :image "" :following false}}
+
+                 :else {})]
+      (js/setTimeout
+        (fn []
+          (when on-success
+            (rf/dispatch (conj on-success resp) {:frame frame})))
+        20))))
+
+;; React root named `react-root` (not `root`) so it does NOT collide with
+;; the `root-view` reg-view above (rf2-562e).
+(defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Override :http on the default frame so all the realworld feature
+  ;; HTTP calls land on the demo stub (no real backend required).
+  (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
+                             :fx-overrides {:http :http.demo-stub}})
+  ;; The orchestrator serves this example at /realworld/; strip that
+  ;; prefix before the route matcher sees the URL so :route/home (path "/")
+  ;; matches.
+  (routing/set-base-path! "/realworld")
   (rf/dispatch-sync [:app/initialise])
   (routing/install-router!)
-  (rdc/render root [root-view]))
+  (rdc/render react-root [root-view]))

--- a/examples/realworld/favorites.cljs
+++ b/examples/realworld/favorites.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.favorites
+(ns realworld.favorites
   "Favorite/unfavorite actions plus the authenticated user's feed.
 
    The favorite toggle is shared across the home feed, profile lists,
@@ -6,13 +6,11 @@
    Pattern-RemoteData slice so the home page can switch between feeds
    without throwing away already-loaded global articles."
   (:require [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http])
+            [realworld.schema]
+            [realworld.http])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
-(defn current-time-ms []
-  #?(:cljs (.getTime (js/Date.))
-     :clj  (System/currentTimeMillis)))
+(defn current-time-ms [] (.getTime (js/Date.)))
 
 (defn request-slice []
   {:status :idle :data [] :error nil :loaded-at nil :attempt 0})

--- a/examples/realworld/http.cljs
+++ b/examples/realworld/http.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.http
+(ns realworld.http
   "The :http registered fx for the RealWorld example.
 
    The RealWorld spec lives at:

--- a/examples/realworld/index.html
+++ b/examples/realworld/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: realworld (Conduit)</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 0; }
+    .navbar, footer { padding: 8px 16px; background: #f5f5f5; }
+    .navbar .nav { display: inline-block; margin-right: 12px; }
+    .nav-link { margin-right: 8px; text-decoration: none; color: #5cb85c; }
+    .container { padding: 12px 16px; }
+    .article-preview { padding: 12px 0; border-bottom: 1px solid #eee; }
+    .article-preview h1 { font-size: 1.2rem; margin: 4px 0; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/realworld/profile.cljs
+++ b/examples/realworld/profile.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.profile
+(ns realworld.profile
   "Profile pages for the RealWorld (Conduit) example.
 
    One route family, three remote-data slices:
@@ -10,15 +10,13 @@
    article cards rendered from the profile routes."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing]
-            [example.realworld.articles :as articles])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing]
+            [realworld.articles :as articles])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
-(defn current-time-ms []
-  #?(:cljs (.getTime (js/Date.))
-     :clj  (System/currentTimeMillis)))
+(defn current-time-ms [] (.getTime (js/Date.)))
 
 (defn request-slice []
   {:status :idle :data nil :error nil :loaded-at nil :attempt 0})

--- a/examples/realworld/routing.cljs
+++ b/examples/realworld/routing.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.routing
+(ns realworld.routing
   "Routes for the RealWorld (Conduit) example.
 
    This file owns the route table, an app-specific auth guard, and a local
@@ -11,8 +11,9 @@
    - `:rf.route/continue` / `:rf.route/cancel`
    - `:rf.route/id` / `:rf.route/params` / `:rf.route/query`
    - `:rf/url-requested`"
-  (:require [re-frame.core :as rf]
-            [example.realworld.schema])
+  (:require [clojure.string]
+            [re-frame.core :as rf]
+            [realworld.schema])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -137,10 +138,27 @@
 ;; ROUTER WIRING
 ;; ============================================================================
 
+;; The example may be served from a sub-path (e.g. /realworld/) by the
+;; Playwright orchestrator; in production it would be mounted at /.
+;; `*base-path*` lets the host strip a prefix before the route matcher
+;; runs. Set via `set-base-path!` in the run fn.
+(def ^:dynamic *base-path* "")
+
+(defn set-base-path! [s]
+  (set! *base-path* (or s "")))
+
+(defn- strip-base [s]
+  (if (and (seq *base-path*)
+           (clojure.string/starts-with? s *base-path*))
+    (let [stripped (subs s (count *base-path*))]
+      (if (clojure.string/starts-with? stripped "/") stripped (str "/" stripped)))
+    s))
+
 (defn current-url []
-  (str (.. js/window -location -pathname)
-       (.. js/window -location -search)
-       (.. js/window -location -hash)))
+  (-> (.. js/window -location -pathname)
+      strip-base
+      (str (.. js/window -location -search)
+           (.. js/window -location -hash))))
 
 (defn install-router! []
   (.addEventListener js/window "popstate"

--- a/examples/realworld/schema.cljs
+++ b/examples/realworld/schema.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.schema
+(ns realworld.schema
   "Malli schemas for the RealWorld (Conduit) example.
 
    These describe the shape of every wire payload the RealWorld API returns,

--- a/examples/realworld/settings.cljs
+++ b/examples/realworld/settings.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.settings
+(ns realworld.settings
   "User settings page for the RealWorld (Conduit) example.
 
    This is a small Pattern-Forms sketch:
@@ -7,9 +7,9 @@
    - write the returned user back through `:auth/store-session`
    - keep logout on the existing auth machine path"
   (:require [re-frame.core :as rf]
-            [example.realworld.schema]
-            [example.realworld.http]
-            [example.realworld.routing :as routing])
+            [realworld.schema]
+            [realworld.http]
+            [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 (defn draft-from-user [user]

--- a/examples/realworld/ssr.cljc
+++ b/examples/realworld/ssr.cljc
@@ -1,4 +1,4 @@
-(ns example.realworld.ssr
+(ns realworld.ssr
   "RealWorld-specific SSR helpers.
 
    The generic runtime SSR walkthrough lives in `examples/ssr/core.cljc`.

--- a/examples/realworld/tags.cljs
+++ b/examples/realworld/tags.cljs
@@ -1,4 +1,4 @@
-(ns example.realworld.tags
+(ns realworld.tags
   "Home-page query helpers for tag filtering and feed selection.
 
    The popular-tags list itself is loaded by `articles.cljs`. This file

--- a/examples/seven_guis/cells.cljs
+++ b/examples/seven_guis/cells.cljs
@@ -25,7 +25,9 @@
    solution doesn't change."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
-            [clojure.string :as str]))
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [clojure.set]
+            [clojure.string :as str])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 (def COLS 26)
@@ -281,8 +283,12 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
+;; React root named `react-root` (not `root`) so it does NOT collide
+;; with reg-view-defined view vars in this ns.
+(defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [cells-grid]))
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:cells/initialise])
+  (rdc/render react-root [cells-grid]))

--- a/examples/seven_guis/cells.html
+++ b/examples/seven_guis/cells.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: 7guis #7 — Cells</title>
+  <style>
+    .cells-grid { border-collapse: collapse; font-family: monospace; }
+    .cells-grid th, .cells-grid td {
+      border: 1px solid #ccc; min-width: 60px; height: 22px;
+      padding: 1px 4px; text-align: left; vertical-align: middle;
+    }
+    .cells-grid thead th { background: #eee; text-align: center; }
+    .cells-grid tbody th  { background: #eee; text-align: right; min-width: 28px; }
+    .cells-grid input { width: 56px; box-sizing: border-box; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/seven_guis/circle_drawer.cljs
+++ b/examples/seven_guis/circle_drawer.cljs
@@ -22,7 +22,8 @@
    This example shows the canonical primitive pattern; productionising it is
    library work, not framework work."
   (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf])
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -84,8 +85,8 @@
     (assoc db :drawer {:circles [] :dialog nil :undo [] :redo []})))
 
 (rf/reg-event-db :drawer/add-circle
-  {:doc          "Click on canvas. Adds a circle of default radius."
-   :interceptors [undoable]}
+  {:doc "Click on canvas. Adds a circle of default radius."}
+  [undoable]
   (fn handler-drawer-add-circle [db [_ x y]]
     (update-in db [:drawer :circles] conj
                {:id (random-uuid) :x x :y y :radius 30})))
@@ -108,11 +109,11 @@
     (assoc-in db [:drawer :dialog :draft-radius] new-radius)))
 
 (rf/reg-event-db :drawer/close-dialog
-  {:doc          "Dialog closed (committing the new radius). The :circles vector
-                  was untouched while the slider moved, so the undoable
-                  interceptor's prior-snapshot is exactly the pre-dialog state —
-                  the whole edit collapses into a single undo step."
-   :interceptors [undoable]}
+  {:doc "Dialog closed (committing the new radius). The :circles vector
+         was untouched while the slider moved, so the undoable
+         interceptor's prior-snapshot is exactly the pre-dialog state —
+         the whole edit collapses into a single undo step."}
+  [undoable]
   (fn handler-drawer-close-dialog [db _]
     (let [{:keys [circle-id draft-radius]} (get-in db [:drawer :dialog])]
       (-> db
@@ -220,8 +221,12 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
+;; React root named `react-root` (not `root`) so it does NOT collide
+;; with the `drawer-view` reg-view above.
+(defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [drawer-view]))
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:drawer/initialise])
+  (rdc/render react-root [drawer-view]))

--- a/examples/seven_guis/circle_drawer.html
+++ b/examples/seven_guis/circle_drawer.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: 7guis #6 — Circle Drawer</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/seven_guis/crud.cljs
+++ b/examples/seven_guis/crud.cljs
@@ -17,8 +17,10 @@
    - Selection as state, not as React component identity  (P8: low hidden context)
    - Derived filtered list                                 (CP-2 with :<-)
    - Schema-bound entity                                   (CP-8)"
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf])
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -124,10 +126,10 @@
   :<- [:crud/people]
   :<- [:crud/filter-text]
   (fn sub-crud-filtered-people [[people prefix] _]
-    (let [pfx (clojure.string/lower-case (or prefix ""))]
-      (if (clojure.string/blank? pfx)
+    (let [pfx (str/lower-case (or prefix ""))]
+      (if (str/blank? pfx)
         people
-        (filterv #(clojure.string/starts-with? (clojure.string/lower-case (:surname %)) pfx)
+        (filterv #(str/starts-with? (str/lower-case (:surname %)) pfx)
                  people)))))
 
 (rf/reg-sub :crud/can-update?
@@ -209,8 +211,13 @@
 ;; MOUNT
 ;; ============================================================================
 
-(defonce root
+;; The React root is named `react-root` (not `root`) so it does NOT
+;; collide with the `crud-view` reg-view above; reg-view defs vars in
+;; this ns and any name-collision would shadow the rdc root handle.
+(defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
 (defn ^:export run []
-  (rdc/render root [crud-view]))
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:crud/initialise])
+  (rdc/render react-root [crud-view]))

--- a/examples/seven_guis/crud.html
+++ b/examples/seven_guis/crud.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: 7guis #5 — CRUD</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/implementation/scripts/serve-and-run-examples-tests.cjs
+++ b/implementation/scripts/serve-and-run-examples-tests.cjs
@@ -95,6 +95,32 @@ const EXAMPLES = [
       },
     ],
   },
+  // Phase 3 — rf2-w3vn.
+  {
+    build: 'examples/crud',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'seven_guis', 'crud.html'),
+    outDir: path.join(OUT_ROOT, 'crud'),
+  },
+  {
+    build: 'examples/circle-drawer',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'seven_guis', 'circle_drawer.html'),
+    outDir: path.join(OUT_ROOT, 'circle-drawer'),
+  },
+  {
+    build: 'examples/cells',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'seven_guis', 'cells.html'),
+    outDir: path.join(OUT_ROOT, 'cells'),
+  },
+  {
+    build: 'examples/login',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'login', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'login'),
+  },
+  {
+    build: 'examples/realworld',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'realworld', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'realworld'),
+  },
 ];
 
 function compileAll() {

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -122,4 +122,36 @@
   {:target     :browser
    :output-dir "out/examples/managed-http-counter"
    :asset-path "."
-   :modules    {:main {:init-fn managed-http-counter.core/run}}}}}
+   :modules    {:main {:init-fn managed-http-counter.core/run}}}
+
+  ;; Phase 3 — rf2-w3vn.
+
+  :examples/crud
+  {:target     :browser
+   :output-dir "out/examples/crud"
+   :asset-path "."
+   :modules    {:main {:init-fn seven-guis.crud/run}}}
+
+  :examples/circle-drawer
+  {:target     :browser
+   :output-dir "out/examples/circle-drawer"
+   :asset-path "."
+   :modules    {:main {:init-fn seven-guis.circle-drawer/run}}}
+
+  :examples/cells
+  {:target     :browser
+   :output-dir "out/examples/cells"
+   :asset-path "."
+   :modules    {:main {:init-fn seven-guis.cells/run}}}
+
+  :examples/login
+  {:target     :browser
+   :output-dir "out/examples/login"
+   :asset-path "."
+   :modules    {:main {:init-fn login.core/run}}}
+
+  :examples/realworld
+  {:target     :browser
+   :output-dir "out/examples/realworld"
+   :asset-path "."
+   :modules    {:main {:init-fn realworld.core/run}}}}}


### PR DESCRIPTION
## Summary

Phase 3 of the rf2-lyj0 examples-runnable initiative — adds the remaining
five examples (5 of 5: 7guis #5/#6/#7, login, realworld) to the runnable
+ Playwright-smoked surface. With this PR every example under
`examples/` has a hosted browser surface and a Playwright spec, for a
total of **13 examples** across the orchestrator.

### Examples added

- **7guis #5 — CRUD** (`examples/seven_guis/crud.cljs`): master/detail
  with name list, prefix filter, draft inputs, Create/Update/Delete.
  Spec drives the full CRUD loop.
- **7guis #6 — Circle Drawer** (`examples/seven_guis/circle_drawer.cljs`):
  click-to-add, right-click-to-edit-radius, Undo/Redo via interceptor.
  Spec drives create + dialog + slider + close + undo + redo.
- **7guis #7 — Cells** (`examples/seven_guis/cells.cljs`): 26-col x 100-row
  spreadsheet with formula support and change propagation through the
  sub-graph. Spec asserts A1=5; B1=(+ A1 5)=10; A1=100 -> B1=105.
- **login** (`examples/login/core.cljs`): state-machine login flow demo.
  Spec drives bad-creds error path + good-creds success path.
- **realworld** (`examples/realworld/`): the Conduit reference app.
  Demo runs against an in-process `:http.demo-stub`. Spec is scoped to
  navbar render + main feed populates (per the rf2-w3vn bead's guidance
  that deep examples may scope to "loads cleanly + main feed").

### Impl bugs fixed inline

These are bugs in the example source uncovered by running the examples
end-to-end through Playwright.

- **circle_drawer**: `:interceptors [undoable]` was nested inside the
  `reg-event-db` metadata map, where it's an opaque key. Move to the
  positional interceptors slot per `re-frame.events/normalise-args`.
- **cells**: stray `)` in the `ns` form pushed `:require-macros` outside
  the form; the file would not compile.
- **login**: `:http.canned-success` had a paren typo closing a map early;
  `:http` referenced an undefined `perform-http-request`. Replaced with
  an in-process canned stub.
- **realworld**: namespaces renamed from `example.realworld.*` to
  `realworld.*` so they match the file layout. `#?(:cljs ...)` reader
  conditionals removed from `.cljs` files. Paren typo in
  `comments-load-test`. `auth/initialise` destructure shadowed by a
  qualified var ref.

### Cross-cutting

- Each example uses `react-root` for the rdc/create-root binding to
  avoid shadowing reg-view-defined `*-view` vars (rf2-562e).
- Each `run` fn calls `rf/init! reagent-adapter/adapter` and dispatches
  the relevant `:*/initialise` event before mounting.

## Test plan

- [x] `clojure -M:test` -> 223 tests, 1047 assertions, 0 failures.
- [x] `npm run test:cljs` -> 76 tests, 256 assertions, 0 failures.
- [x] `npm run test:browser` -> 76 tests, 256 assertions, 0 failures.
- [x] `npm run test:elision` -> PASS.
- [x] `npm run test:examples` -> 13/13 PASS (all 8 prior + 5 new).