### PR TITLE
examples/realworld: extract inline tests to a test harness (rf2-4v73)

### DIFF
--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -20,7 +20,7 @@ A worked example based on the [RealWorld spec](https://github.com/gothinkster/re
 |---|---|---|
 | `core.cljs` | implemented | Entry point, app shell, route switch, mount. |
 | `schema.cljs` | implemented | Wire shapes plus app-db slice schemas used by the sketch. |
-| `http.cljs` | implemented | `:http` fx with auth token injection and canned test override. |
+| `http.cljs` | implemented | `:http` fx with auth token injection. |
 | `routing.cljs` | implemented | Route table, auth guard, route-link helper, browser wiring. |
 | `auth.cljs` | implemented | Auth machine plus login/register forms. |
 | `articles.cljs` | implemented | Home page, global feed, popular tags, tag filter UI. |
@@ -52,19 +52,44 @@ shadow-cljs watch realworld
 # then open the served HTML and click around
 ```
 
-The included headless tests are browserless sketches. Because most files are `.cljs`, run them in a CLJS host (Node, a `node-test` target, or a browser build without mounting the DOM-facing entrypoint):
+## Headless tests
+
+The headless tests are browserless sketches. They live alongside the
+sources at `test/realworld/<feature>_test.cljs`, mirroring the source
+namespaces:
+
+| Source ns | Test ns |
+|---|---|
+| `realworld.auth` | `realworld.auth-test` |
+| `realworld.articles` | `realworld.articles-test` |
+| `realworld.article-editor` | `realworld.article-editor-test` |
+| `realworld.comments` | `realworld.comments-test` |
+| `realworld.favorites` | `realworld.favorites-test` |
+| `realworld.profile` | `realworld.profile-test` |
+| `realworld.settings` | `realworld.settings-test` |
+| `realworld.tags` | `realworld.tags-test` |
+| `realworld.routing` | `realworld.routing-test` |
+| `realworld.ssr` | `realworld.ssr-test` |
+| `realworld.core` | `realworld.core-test` |
+
+Each test fn is a plain zero-arg `defn`; failures throw via `assert`. The
+shadow-cljs `node-test` build picks them up via the integration wrapper
+at `implementation/test/re_frame/realworld_cljs_test.cljs` (run with
+`npm run test:cljs` from the `implementation/` directory). Because most
+files are `.cljs`, you can also call them directly from a REPL in a CLJS
+host (Node or a browser build without the DOM-facing entrypoint):
 
 ```clojure
-(realworld.auth/login-happy-path-test)
-(realworld.articles/articles-load-test)
-(realworld.comments/comments-load-test)
-(realworld.article-editor/editor-create-test)
-(realworld.profile/profile-load-test)
-(realworld.favorites/favorite-toggle-test)
-(realworld.tags/tag-query-test)
-(realworld.settings/settings-test)
-(realworld.routing/routing-tests)
-(realworld.core/app-smoke-test)
+(realworld.auth-test/login-happy-path-test)
+(realworld.articles-test/articles-load-test)
+(realworld.comments-test/comments-load-test)
+(realworld.article-editor-test/editor-create-test)
+(realworld.profile-test/profile-load-test)
+(realworld.favorites-test/favorite-toggle-test)
+(realworld.tags-test/tag-query-test)
+(realworld.settings-test/settings-test)
+(realworld.routing-test/routing-tests)
+(realworld.core-test/app-smoke-test)
 ```
 
 ## Why RealWorld

--- a/examples/realworld/article_editor.cljs
+++ b/examples/realworld/article_editor.cljs
@@ -11,7 +11,7 @@
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (def blank-draft
   {:title "" :description "" :body "" :tagList ""})
@@ -251,42 +251,4 @@
               :on-click #(dispatch [:editor/delete])}
              "Delete Article"])]]]]]]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn editor-create-test []
-  (rf/reg-fx :http.canned-editor-save
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:article {:slug "hello-world"
-                           :title "Hello"
-                           :description "Short"
-                           :body "Body"
-                           :tagList ["demo"]
-                           :createdAt "2026-05-01"
-                           :updatedAt "2026-05-01"
-                           :favorited false
-                           :favoritesCount 0
-                           :author {:username "alice" :bio nil :image nil :following false}}})
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-editor-save}})]
-    (rf/dispatch-sync [:editor/initialise] {:frame f})
-    (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
-    (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})
-    (rf/dispatch-sync [:editor/edit-field :body "Body"] {:frame f})
-    (rf/dispatch-sync [:editor/submit] {:frame f})
-    (assert (= :saved (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
-    (assert (false? (rf/compute-sub [:editor/dirty?] (rf/get-frame-db f))))))
-
-(defn editor-can-leave-test []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
-    (rf/dispatch-sync [:editor/initialise] {:frame f})
-    (assert (true? (rf/compute-sub [:editor/can-leave?] (rf/get-frame-db f))))
-    (rf/dispatch-sync [:editor/edit-field :title "Changed"] {:frame f})
-    (assert (false? (rf/compute-sub [:editor/can-leave?] (rf/get-frame-db f))))))    
+    

--- a/examples/realworld/articles.cljs
+++ b/examples/realworld/articles.cljs
@@ -10,7 +10,7 @@
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (defn current-time-ms [] (.getTime (js/Date.)))
 
@@ -230,54 +230,3 @@
                              (dispatch [:tags/apply-filter tag]))}
              tag])]]]]]]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn articles-load-test []
-  (rf/reg-fx :http.canned-articles
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:articles [{:slug "hello-world"
-                             :title "Hello, world"
-                             :description "An intro"
-                             :body "..."
-                             :tagList ["intro"]
-                             :createdAt "2026-05-01T00:00:00Z"
-                             :updatedAt "2026-05-01T00:00:00Z"
-                             :favorited false
-                             :favoritesCount 0
-                             :author {:username "alice" :bio nil :image nil
-                                      :following false}}]
-                 :articlesCount 1})
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-articles}})]
-    (assert (= :idle (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
-    (rf/dispatch-sync [:articles/load] {:frame f})
-    (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
-      (assert (= :loaded (:status slice)))
-      (assert (= 1 (count (:data slice))))
-      (assert (= "hello-world" (-> slice :data first :slug))))
-    (rf/dispatch-sync [:articles/load] {:frame f})
-    (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
-      (assert (= :loaded (:status slice)))
-      (assert (= 2 (:attempt slice))))))
-
-(defn articles-load-failure-test []
-  (rf/reg-fx :http.canned-failure
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors {:body ["server error"]}})
-                     {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-failure}})]
-    (rf/dispatch-sync [:articles/load] {:frame f})
-    (assert (= :error (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
-    (assert (some? (rf/compute-sub [:articles/error] (rf/get-frame-db f))))))

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -14,7 +14,7 @@
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================
 ;; FX / COFX
@@ -323,52 +323,3 @@
        [:button {:type "submit" :disabled submitting?}
         (if submitting? "Signing up…" "Sign up")]]]]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn login-happy-path-test []
-  (rf/reg-fx :http.canned-login-success
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch (conj on-success {:user {:email    "alice@example.com"
-                                              :username "alice"
-                                              :token    "jwt-abc"
-                                              :bio      nil
-                                              :image    nil}})
-                     {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:http :http.canned-login-success
-                                                :auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
-    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
-
-    (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com"
-                                                :password "correct-horse"}]]
-                      {:frame f})
-    (assert (= :authed (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
-    (assert (= "alice" (:username (rf/compute-sub [:auth/user] (rf/get-frame-db f)))))
-
-    (rf/dispatch-sync [:auth/flow [:auth/logout]] {:frame f})
-    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
-    (assert (nil? (rf/compute-sub [:auth/user] (rf/get-frame-db f))))))
-
-(defn login-failure-test []
-  (rf/reg-fx :http.canned-failure
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors ["email or password is invalid"]})
-                     {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:http :http.canned-failure}})]
-    (rf/dispatch-sync [:auth/flow [:auth/login {:email "x@y.z" :password "wrong"}]]
-                      {:frame f})
-    (assert (= :error (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
-    (assert (some? (rf/compute-sub [:auth/error] (rf/get-frame-db f))))
-
-    (rf/dispatch-sync [:auth/flow [:auth/dismiss]] {:frame f})
-    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))))

--- a/examples/realworld/comments.cljs
+++ b/examples/realworld/comments.cljs
@@ -11,7 +11,7 @@
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (defn current-time-ms [] (.getTime (js/Date.)))
 
@@ -334,69 +334,3 @@
        :else
        [:div.article-preview "No article loaded."])]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn comments-load-test []
-  (rf/reg-fx :http.canned-article-and-comments
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                (cond
-                  (str/ends-with? url "/comments")
-                  {:comments [{:id 1
-                               :createdAt "2026-05-01"
-                               :updatedAt "2026-05-01"
-                               :body "First!"
-                               :author {:username "eve" :bio nil :image nil :following false}}]}
-
-                  :else
-                  {:article {:slug "hello"
-                             :title "Hello"
-                             :description "Short"
-                             :body "Body"
-                             :tagList ["demo"]
-                             :createdAt "2026-05-01"
-                             :updatedAt "2026-05-01"
-                             :favorited false
-                             :favoritesCount 0
-                             :author {:username "alice" :bio nil :image nil :following false}}}))
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-article-and-comments}})]
-    (rf/dispatch-sync [:article/initialise] {:frame f})
-    (rf/dispatch-sync [:comments/initialise] {:frame f})
-    (rf/dispatch-sync [:comment-form/initialise] {:frame f})
-    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
-    (assert (= "hello" (:slug (rf/compute-sub [:article/data] (rf/get-frame-db f)))))
-    (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))
-
-(defn comment-submit-test []
-  (rf/reg-fx :http.canned-comment-post
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:comment {:id 2
-                           :createdAt "2026-05-02"
-                           :updatedAt "2026-05-02"
-                           :body "Nice article."
-                           :author {:username "alice" :bio nil :image nil :following false}}})
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-comment-post}})]
-    (rf/dispatch-sync [:article/initialise] {:frame f})
-    (rf/dispatch-sync [:comments/initialise] {:frame f})
-    (rf/dispatch-sync [:comment-form/initialise] {:frame f})
-    (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
-    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
-    (rf/dispatch-sync [:comment-form/edit-field :body "Nice article."] {:frame f})
-    (rf/dispatch-sync [:comment-form/submit] {:frame f})
-    (assert (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/get-frame-db f)))))
-    (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))

--- a/examples/realworld/core.cljs
+++ b/examples/realworld/core.cljs
@@ -34,7 +34,7 @@
             [realworld.favorites]
             [realworld.tags]
             [realworld.settings :as settings])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================
 ;; INITIALISATION
@@ -138,21 +138,6 @@
    [footer]])
 
 ;; ============================================================================
-;; HEADLESS TESTS  (top-level smoke)
-;; ============================================================================
-
-(defn app-smoke-test []
-  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                    :fx-overrides {:http :http.canned-success
-                                                   :auth.session/store :rf/no-op
-                                                   :auth.session/clear :rf/no-op}})]
-    ;; After init: auth, articles, and tags slices are present.
-    (let [db (rf/get-frame-db f)]
-      (assert (contains? db :auth))
-      (assert (contains? db :articles))
-      (assert (contains? db :tags)))))
-
-;; ============================================================================
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
@@ -224,9 +209,11 @@
         20))))
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
-;; the `root-view` reg-view above (rf2-562e).
+;; the `root-view` reg-view above (rf2-562e). Gated on (exists? js/document)
+;; so the ns is safe to require under :node-test (rf2-4v73).
 (defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+  (when (exists? js/document)
+    (rdc/create-root (js/document.getElementById "app"))))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)

--- a/examples/realworld/favorites.cljs
+++ b/examples/realworld/favorites.cljs
@@ -7,8 +7,7 @@
    without throwing away already-loaded global articles."
   (:require [re-frame.core :as rf]
             [realworld.schema]
-            [realworld.http])
-  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+            [realworld.http]))
 
 (defn current-time-ms [] (.getTime (js/Date.)))
 
@@ -129,36 +128,3 @@
 (rf/reg-sub :feed/loading? :<- [:feed]
   (fn [slice _] (#{:loading :fetching} (:status slice))))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn favorite-toggle-test []
-  (rf/reg-fx :http.canned-favorite-rollback
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors {:body ["rollback"]}}) {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-favorite-rollback}})]
-    (rf/dispatch-sync [:articles/initialise] {:frame f})
-    (rf/dispatch-sync [:articles/loaded
-                       {:articles [{:slug "hello"
-                                    :title "Hello"
-                                    :description "Short"
-                                    :body "Body"
-                                    :tagList []
-                                    :createdAt "2026-05-01"
-                                    :updatedAt "2026-05-01"
-                                    :favorited false
-                                    :favoritesCount 0
-                                    :author {:username "alice" :bio nil :image nil :following false}}]}]
-                      {:frame f})
-    (rf/dispatch-sync [:article/toggle-favorite "hello"] {:frame f})
-    (assert (false? (-> (rf/compute-sub [:articles/data] (rf/get-frame-db f))
-                        first
-                        :favorited)))
-    (assert (= 0 (-> (rf/compute-sub [:articles/data] (rf/get-frame-db f))
-                     first
-                     :favoritesCount)))))

--- a/examples/realworld/http.cljs
+++ b/examples/realworld/http.cljs
@@ -69,19 +69,3 @@
                     (when on-error
                       (rf/dispatch (conj on-error {:errors {:body [(str err)]}}) {:frame frame}))))))))
 
-;; ============================================================================
-;; TEST STUB — id-valued override per Spec 002 §override seam
-;; ============================================================================
-;;
-;; Tests bind :http -> :http.canned-success in :fx-overrides on make-frame so
-;; no real network calls happen. Per-test stubs (:http.canned-failure, etc.)
-;; are typically registered inside the test that needs them.
-
-(rf/reg-fx :http.canned-success
-  {:doc       "Test stub: every :http call resolves :on-success with an
-               empty map. Tests register a richer canned response when they
-               need specific payloads."
-   :platforms #{:client :server}}
-  (fn fx-http-canned-success [{:keys [frame]} {:keys [on-success]}]
-    (when on-success
-      (rf/dispatch (conj on-success {}) {:frame frame}))))

--- a/examples/realworld/profile.cljs
+++ b/examples/realworld/profile.cljs
@@ -8,13 +8,12 @@
 
    Follow/unfollow is optimistic and shared across the banner plus any
    article cards rendered from the profile routes."
-  (:require [clojure.string :as str]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing]
             [realworld.articles :as articles])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (defn current-time-ms [] (.getTime (js/Date.)))
 
@@ -250,34 +249,3 @@
        :else
        [:div.article-preview "No profile loaded."])]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn profile-load-test []
-  (rf/reg-fx :http.canned-profile
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                (if (str/includes? url "/profiles/")
-                  {:profile {:username "eve" :bio "Writes things" :image nil :following false}}
-                  {:articles [{:slug "one"
-                               :title "One"
-                               :description "Short"
-                               :body "Body"
-                               :tagList []
-                               :createdAt "2026-05-01"
-                               :updatedAt "2026-05-01"
-                               :favorited false
-                               :favoritesCount 0
-                               :author {:username "eve" :bio nil :image nil :following false}}]}))
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-profile}})]
-    (rf/dispatch-sync [:profile/initialise] {:frame f})
-    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
-    (assert (= "eve" (:username (rf/compute-sub [:profile/data] (rf/get-frame-db f)))))
-    (assert (= 1 (count (rf/compute-sub [:profile.articles/data] (rf/get-frame-db f)))))))

--- a/examples/realworld/routing.cljs
+++ b/examples/realworld/routing.cljs
@@ -14,7 +14,7 @@
   (:require [clojure.string]
             [re-frame.core :as rf]
             [realworld.schema])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -166,24 +166,3 @@
       (rf/dispatch [:rf.route/handle-url-change (current-url)])))
   (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
 
-;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-
-(defn routing-tests []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
-    (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "hello"}] {:frame f})
-    (assert (= :route/article (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
-    (assert (= "hello" (:slug (rf/compute-sub [:rf.route/params] (rf/get-frame-db f)))))
-
-    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
-    (assert (= :route/profile (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
-
-    (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
-    (assert (= :route/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
-
-    (rf/dispatch-sync [:rf.route/handle-url-change "/?tag=clojure"] {:frame f})
-    (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
-
-    (rf/dispatch-sync [:rf.route/handle-url-change "/garbage/path"] {:frame f})
-    (assert (= :rf.route/not-found (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))))

--- a/examples/realworld/settings.cljs
+++ b/examples/realworld/settings.cljs
@@ -10,7 +10,7 @@
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (defn draft-from-user [user]
   {:image    (or (:image user) "")
@@ -137,28 +137,3 @@
           :on-click #(dispatch [:auth/flow [:auth/logout]])}
          "Or click here to logout"]]]]]))
 
-(defn settings-test []
-  (rf/reg-fx :http.canned-settings-save
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success {:user {:email "alice@example.com"
-                                   :token "jwt-2"
-                                   :username "alice"
-                                   :bio "New bio"
-                                   :image nil}})
-          {:frame frame}))))
-
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-settings-save}})]
-    (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
-                                            :token "jwt-1"
-                                            :username "alice"
-                                            :bio nil
-                                            :image nil}]
-                      {:frame f})
-    (rf/dispatch-sync [:settings/load] {:frame f})
-    (rf/dispatch-sync [:settings/edit-field :bio "New bio"] {:frame f})
-    (rf/dispatch-sync [:settings/submit] {:frame f})
-    (assert (= "New bio" (get-in (rf/get-frame-db f) [:auth :user :bio])))))

--- a/examples/realworld/ssr.cljc
+++ b/examples/realworld/ssr.cljc
@@ -49,11 +49,3 @@
         (rf/dispatch-sync [:rf/hydrate payload] {:frame frame-id})
         payload))))
 
-(defn hydration-payload-test []
-  (let [db {:route {:id :route/home}
-            :auth {:user {:username "alice"} :token "jwt"}
-            :articles {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
-            :transient {:popup true}}
-        payload (hydration-payload db [:div "hello"])]
-    (assert (= #{:route :auth :articles}
-               (set (keys (:rf/app-db payload)))))))

--- a/examples/realworld/tags.cljs
+++ b/examples/realworld/tags.cljs
@@ -6,8 +6,7 @@
    - `?tag=<name>` filters the global articles list
    - `?feed=your` switches the home page to the authenticated feed
    - navigation is always expressed as `:rf.route/navigate` events"
-  (:require [re-frame.core :as rf])
-  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+  (:require [re-frame.core :as rf]))
 
 (defn home-query [db]
   (get-in db [:route :query] {}))
@@ -47,9 +46,3 @@
   :<- [:home/query]
   (fn [query _] (if (= "your" (:feed query)) :your :global)))
 
-(defn tag-query-test []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
-    (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
-    (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
-    (rf/dispatch-sync [:home/show-your-feed] {:frame f})
-    (assert (= "your" (:feed (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))))

--- a/examples/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/realworld/test/realworld/article_editor_test.cljs
@@ -1,0 +1,43 @@
+(ns realworld.article-editor-test
+  "Headless tests for realworld.article-editor — create flow and
+   navigation guard. Extracted from realworld/article_editor.cljs under
+   rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.article-editor])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn editor-create-test []
+  (rf/reg-fx :http.canned-editor-save
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success
+                {:article {:slug "hello-world"
+                           :title "Hello"
+                           :description "Short"
+                           :body "Body"
+                           :tagList ["demo"]
+                           :createdAt "2026-05-01"
+                           :updatedAt "2026-05-01"
+                           :favorited false
+                           :favoritesCount 0
+                           :author {:username "alice" :bio nil :image nil :following false}}})
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-editor-save}})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
+    (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})
+    (rf/dispatch-sync [:editor/edit-field :body "Body"] {:frame f})
+    (rf/dispatch-sync [:editor/submit] {:frame f})
+    (assert (= :saved (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
+    (assert (false? (rf/compute-sub [:editor/dirty?] (rf/get-frame-db f))))))
+
+(defn editor-can-leave-test []
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    (assert (true? (rf/compute-sub [:editor/can-leave?] (rf/get-frame-db f))))
+    (rf/dispatch-sync [:editor/edit-field :title "Changed"] {:frame f})
+    (assert (false? (rf/compute-sub [:editor/can-leave?] (rf/get-frame-db f))))))

--- a/examples/realworld/test/realworld/articles_test.cljs
+++ b/examples/realworld/test/realworld/articles_test.cljs
@@ -1,0 +1,54 @@
+(ns realworld.articles-test
+  "Headless tests for realworld.articles — global feed loading + failure
+   paths. Extracted from realworld/articles.cljs under rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.articles])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn articles-load-test []
+  (rf/reg-fx :http.canned-articles
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success
+                {:articles [{:slug "hello-world"
+                             :title "Hello, world"
+                             :description "An intro"
+                             :body "..."
+                             :tagList ["intro"]
+                             :createdAt "2026-05-01T00:00:00Z"
+                             :updatedAt "2026-05-01T00:00:00Z"
+                             :favorited false
+                             :favoritesCount 0
+                             :author {:username "alice" :bio nil :image nil
+                                      :following false}}]
+                 :articlesCount 1})
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-articles}})]
+    (assert (= :idle (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
+      (assert (= :loaded (:status slice)))
+      (assert (= 1 (count (:data slice))))
+      (assert (= "hello-world" (-> slice :data first :slug))))
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
+      (assert (= :loaded (:status slice)))
+      (assert (= 2 (:attempt slice))))))
+
+(defn articles-load-failure-test []
+  (rf/reg-fx :http.canned-failure
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-error]}]
+      (when on-error
+        (rf/dispatch (conj on-error {:errors {:body ["server error"]}})
+                     {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-failure}})]
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (assert (= :error (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
+    (assert (some? (rf/compute-sub [:articles/error] (rf/get-frame-db f))))))

--- a/examples/realworld/test/realworld/auth_test.cljs
+++ b/examples/realworld/test/realworld/auth_test.cljs
@@ -1,0 +1,59 @@
+(ns realworld.auth-test
+  "Headless tests for realworld.auth — the auth state machine.
+
+   These were previously inline in realworld/auth.cljs; extracted under
+   rf2-4v73 so production code stays test-free.
+
+   Each test fn keeps its original signature (a plain zero-arg fn) so the
+   integration runner can call them as before. The realworld.feature-test
+   integration wrapper at implementation/test/re_frame/realworld_cljs_test.cljs
+   exposes them to the shadow-cljs node-test runner."
+  (:require [re-frame.core :as rf]
+            [realworld.auth])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn login-happy-path-test []
+  (rf/reg-fx :http.canned-login-success
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-success]}]
+      (when on-success
+        (rf/dispatch (conj on-success {:user {:email    "alice@example.com"
+                                              :username "alice"
+                                              :token    "jwt-abc"
+                                              :bio      nil
+                                              :image    nil}})
+                     {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
+                                 :fx-overrides {:http :http.canned-login-success
+                                                :auth.session/store :rf/no-op
+                                                :auth.session/clear :rf/no-op}})]
+    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
+
+    (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com"
+                                                :password "correct-horse"}]]
+                      {:frame f})
+    (assert (= :authed (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
+    (assert (= "alice" (:username (rf/compute-sub [:auth/user] (rf/get-frame-db f)))))
+
+    (rf/dispatch-sync [:auth/flow [:auth/logout]] {:frame f})
+    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
+    (assert (nil? (rf/compute-sub [:auth/user] (rf/get-frame-db f))))))
+
+(defn login-failure-test []
+  (rf/reg-fx :http.canned-failure
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-error]}]
+      (when on-error
+        (rf/dispatch (conj on-error {:errors ["email or password is invalid"]})
+                     {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
+                                 :fx-overrides {:http :http.canned-failure}})]
+    (rf/dispatch-sync [:auth/flow [:auth/login {:email "x@y.z" :password "wrong"}]]
+                      {:frame f})
+    (assert (= :error (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
+    (assert (some? (rf/compute-sub [:auth/error] (rf/get-frame-db f))))
+
+    (rf/dispatch-sync [:auth/flow [:auth/dismiss]] {:frame f})
+    (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))))

--- a/examples/realworld/test/realworld/comments_test.cljs
+++ b/examples/realworld/test/realworld/comments_test.cljs
@@ -1,0 +1,71 @@
+(ns realworld.comments-test
+  "Headless tests for realworld.comments — article-detail load and
+   comment-post happy path. Extracted from realworld/comments.cljs under
+   rf2-4v73."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [realworld.comments])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn comments-load-test []
+  (rf/reg-fx :http.canned-article-and-comments
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [url on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success
+                (cond
+                  (str/ends-with? url "/comments")
+                  {:comments [{:id 1
+                               :createdAt "2026-05-01"
+                               :updatedAt "2026-05-01"
+                               :body "First!"
+                               :author {:username "eve" :bio nil :image nil :following false}}]}
+
+                  :else
+                  {:article {:slug "hello"
+                             :title "Hello"
+                             :description "Short"
+                             :body "Body"
+                             :tagList ["demo"]
+                             :createdAt "2026-05-01"
+                             :updatedAt "2026-05-01"
+                             :favorited false
+                             :favoritesCount 0
+                             :author {:username "alice" :bio nil :image nil :following false}}}))
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-article-and-comments}})]
+    (rf/dispatch-sync [:article/initialise] {:frame f})
+    (rf/dispatch-sync [:comments/initialise] {:frame f})
+    (rf/dispatch-sync [:comment-form/initialise] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
+    (assert (= "hello" (:slug (rf/compute-sub [:article/data] (rf/get-frame-db f)))))
+    (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))
+
+(defn comment-submit-test []
+  (rf/reg-fx :http.canned-comment-post
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [url on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success
+                {:comment {:id 2
+                           :createdAt "2026-05-02"
+                           :updatedAt "2026-05-02"
+                           :body "Nice article."
+                           :author {:username "alice" :bio nil :image nil :following false}}})
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-comment-post}})]
+    (rf/dispatch-sync [:article/initialise] {:frame f})
+    (rf/dispatch-sync [:comments/initialise] {:frame f})
+    (rf/dispatch-sync [:comment-form/initialise] {:frame f})
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
+    (rf/dispatch-sync [:comment-form/edit-field :body "Nice article."] {:frame f})
+    (rf/dispatch-sync [:comment-form/submit] {:frame f})
+    (assert (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/get-frame-db f)))))
+    (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))

--- a/examples/realworld/test/realworld/core_test.cljs
+++ b/examples/realworld/test/realworld/core_test.cljs
@@ -1,0 +1,40 @@
+(ns realworld.core-test
+  "Top-level smoke for realworld.core — boots the app and checks that
+   the per-feature initialisers populate the expected slices. Extracted
+   from realworld/core.cljs under rf2-4v73.
+
+   The test relies on a generic `:http.canned-success` stub (every :http
+   call resolves :on-success with an empty map). It used to live next to
+   the production :http fx in realworld/http.cljs; per the rf2-4v73
+   cleanup it now lives with the test that uses it."
+  (:require [re-frame.core :as rf]
+            [realworld.core])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+;; ----------------------------------------------------------------------------
+;; Test stub  (id-valued override per Spec 002 §override seam).
+;;
+;; Tests bind :http -> :http.canned-success in :fx-overrides on make-frame so
+;; no real network calls happen. Per-test stubs (:http.canned-failure, etc.)
+;; live alongside the test that needs them.
+;; ----------------------------------------------------------------------------
+
+(rf/reg-fx :http.canned-success
+  {:doc       "Test stub: every :http call resolves :on-success with an
+               empty map. Tests register a richer canned response when they
+               need specific payloads."
+   :platforms #{:client :server}}
+  (fn fx-http-canned-success [{:keys [frame]} {:keys [on-success]}]
+    (when on-success
+      (rf/dispatch (conj on-success {}) {:frame frame}))))
+
+(defn app-smoke-test []
+  (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :fx-overrides {:http :http.canned-success
+                                                :auth.session/store :rf/no-op
+                                                :auth.session/clear :rf/no-op}})]
+    ;; After init: auth, articles, and tags slices are present.
+    (let [db (rf/get-frame-db f)]
+      (assert (contains? db :auth))
+      (assert (contains? db :articles))
+      (assert (contains? db :tags)))))

--- a/examples/realworld/test/realworld/favorites_test.cljs
+++ b/examples/realworld/test/realworld/favorites_test.cljs
@@ -1,0 +1,36 @@
+(ns realworld.favorites-test
+  "Headless test for realworld.favorites — optimistic-update rollback.
+   Extracted from realworld/favorites.cljs under rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.favorites])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn favorite-toggle-test []
+  (rf/reg-fx :http.canned-favorite-rollback
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-error]}]
+      (when on-error
+        (rf/dispatch (conj on-error {:errors {:body ["rollback"]}}) {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-favorite-rollback}})]
+    (rf/dispatch-sync [:articles/initialise] {:frame f})
+    (rf/dispatch-sync [:articles/loaded
+                       {:articles [{:slug "hello"
+                                    :title "Hello"
+                                    :description "Short"
+                                    :body "Body"
+                                    :tagList []
+                                    :createdAt "2026-05-01"
+                                    :updatedAt "2026-05-01"
+                                    :favorited false
+                                    :favoritesCount 0
+                                    :author {:username "alice" :bio nil :image nil :following false}}]}]
+                      {:frame f})
+    (rf/dispatch-sync [:article/toggle-favorite "hello"] {:frame f})
+    (assert (false? (-> (rf/compute-sub [:articles/data] (rf/get-frame-db f))
+                        first
+                        :favorited)))
+    (assert (= 0 (-> (rf/compute-sub [:articles/data] (rf/get-frame-db f))
+                     first
+                     :favoritesCount)))))

--- a/examples/realworld/test/realworld/profile_test.cljs
+++ b/examples/realworld/test/realworld/profile_test.cljs
@@ -1,0 +1,35 @@
+(ns realworld.profile-test
+  "Headless test for realworld.profile — profile + authored-articles
+   load. Extracted from realworld/profile.cljs under rf2-4v73."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [realworld.profile])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn profile-load-test []
+  (rf/reg-fx :http.canned-profile
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [url on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success
+                (if (str/includes? url "/profiles/")
+                  {:profile {:username "eve" :bio "Writes things" :image nil :following false}}
+                  {:articles [{:slug "one"
+                               :title "One"
+                               :description "Short"
+                               :body "Body"
+                               :tagList []
+                               :createdAt "2026-05-01"
+                               :updatedAt "2026-05-01"
+                               :favorited false
+                               :favoritesCount 0
+                               :author {:username "eve" :bio nil :image nil :following false}}]}))
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-profile}})]
+    (rf/dispatch-sync [:profile/initialise] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+    (assert (= "eve" (:username (rf/compute-sub [:profile/data] (rf/get-frame-db f)))))
+    (assert (= 1 (count (rf/compute-sub [:profile.articles/data] (rf/get-frame-db f)))))))

--- a/examples/realworld/test/realworld/routing_test.cljs
+++ b/examples/realworld/test/realworld/routing_test.cljs
@@ -1,0 +1,25 @@
+(ns realworld.routing-test
+  "Headless tests for realworld.routing — route table coverage including
+   path params, query, and not-found fallback. Extracted from
+   realworld/routing.cljs under rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.routing])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn routing-tests []
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+    (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "hello"}] {:frame f})
+    (assert (= :route/article (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+    (assert (= "hello" (:slug (rf/compute-sub [:rf.route/params] (rf/get-frame-db f)))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+    (assert (= :route/profile (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
+    (assert (= :route/settings (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/?tag=clojure"] {:frame f})
+    (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/garbage/path"] {:frame f})
+    (assert (= :rf.route/not-found (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))))

--- a/examples/realworld/test/realworld/settings_test.cljs
+++ b/examples/realworld/test/realworld/settings_test.cljs
@@ -1,0 +1,33 @@
+(ns realworld.settings-test
+  "Headless test for realworld.settings — settings save propagates new
+   user data into the auth slice. Extracted from realworld/settings.cljs
+   under rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.settings])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn settings-test []
+  (rf/reg-fx :http.canned-settings-save
+    {:platforms #{:client :server}}
+    (fn [{:keys [frame]} {:keys [on-success]}]
+      (when on-success
+        (rf/dispatch
+          (conj on-success {:user {:email "alice@example.com"
+                                   :token "jwt-2"
+                                   :username "alice"
+                                   :bio "New bio"
+                                   :image nil}})
+          {:frame frame}))))
+
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:http :http.canned-settings-save}})]
+    (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
+                                            :token "jwt-1"
+                                            :username "alice"
+                                            :bio nil
+                                            :image nil}]
+                      {:frame f})
+    (rf/dispatch-sync [:settings/load] {:frame f})
+    (rf/dispatch-sync [:settings/edit-field :bio "New bio"] {:frame f})
+    (rf/dispatch-sync [:settings/submit] {:frame f})
+    (assert (= "New bio" (get-in (rf/get-frame-db f) [:auth :user :bio])))))

--- a/examples/realworld/test/realworld/ssr_test.cljc
+++ b/examples/realworld/test/realworld/ssr_test.cljc
@@ -1,0 +1,17 @@
+(ns realworld.ssr-test
+  "Headless test for realworld.ssr — `hydration-payload` selects the
+   correct SSR-safe slice keys. Extracted from realworld/ssr.cljc under
+   rf2-4v73.
+
+   `.cljc` mirrors the source: the helper is portable and the test only
+   touches portable data."
+  (:require [realworld.ssr :as ssr]))
+
+(defn hydration-payload-test []
+  (let [db {:route {:id :route/home}
+            :auth {:user {:username "alice"} :token "jwt"}
+            :articles {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
+            :transient {:popup true}}
+        payload (ssr/hydration-payload db [:div "hello"])]
+    (assert (= #{:route :auth :articles}
+               (set (keys (:rf/app-db payload)))))))

--- a/examples/realworld/test/realworld/tags_test.cljs
+++ b/examples/realworld/test/realworld/tags_test.cljs
@@ -1,0 +1,14 @@
+(ns realworld.tags-test
+  "Headless test for realworld.tags — tag filter and feed-kind query
+   round-trip via the route slice. Extracted from realworld/tags.cljs
+   under rf2-4v73."
+  (:require [re-frame.core :as rf]
+            [realworld.tags])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn tag-query-test []
+  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+    (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
+    (assert (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))
+    (rf/dispatch-sync [:home/show-your-feed] {:frame f})
+    (assert (= "your" (:feed (rf/compute-sub [:rf.route/query] (rf/get-frame-db f)))))))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:source-paths ["src" "test" "../examples"]
+{:source-paths ["src" "test" "../examples" "../examples/realworld/test"]
  :dependencies [[reagent       "2.0.1"]
                 [metosin/malli "0.13.0"]]
 

--- a/implementation/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/test/re_frame/realworld_cljs_test.cljs
@@ -1,0 +1,90 @@
+(ns re-frame.realworld-cljs-test
+  "Integration test: drives the realworld (Conduit) example's headless
+   test fixtures (rf2-4v73). Each fixture spins a fresh frame via
+   `make-frame`, drives a feature flow with a canned :http stub, and
+   asserts the resulting app-db / sub state.
+
+   The fixtures live under examples/realworld/test/realworld/ — extracted
+   from the production realworld source under rf2-4v73 so the example's
+   .cljs files are now test-free.
+
+   Per rf2-am9d this ns uses snapshot/restore via re-frame.test-support
+   so the contract is uniform across CLJS fixtures: the snapshot captures
+   the realworld example's ns-load registrations, and the restore on the
+   way out leaves them intact for any subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]
+            [realworld.core]
+            [realworld.auth-test :as auth-t]
+            [realworld.articles-test :as articles-t]
+            [realworld.article-editor-test :as editor-t]
+            [realworld.comments-test :as comments-t]
+            [realworld.favorites-test :as favorites-t]
+            [realworld.profile-test :as profile-t]
+            [realworld.settings-test :as settings-t]
+            [realworld.tags-test :as tags-t]
+            [realworld.routing-test :as routing-t]
+            [realworld.ssr-test :as ssr-t]
+            [realworld.core-test :as core-t]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; Each fixture is a plain `defn` (preserves original signature; the
+;; example used to call them directly from the REPL). Failures throw via
+;; `assert`, which surfaces as a test failure under cljs.test.
+
+(deftest realworld-auth-flow
+  (testing "login happy path drives the auth machine to :authed and back"
+    (auth-t/login-happy-path-test))
+  (testing "login failure surfaces error and dismiss returns to :idle"
+    (auth-t/login-failure-test)))
+
+(deftest realworld-articles-feed
+  (testing "global feed loads and re-loads bumping :attempt"
+    (articles-t/articles-load-test))
+  (testing "global feed surfaces :error on http failure"
+    (articles-t/articles-load-failure-test)))
+
+(deftest realworld-article-editor
+  (testing "editor create flow saves and clears :dirty?"
+    (editor-t/editor-create-test))
+  (testing "editor :can-leave? blocks once the draft diverges"
+    (editor-t/editor-can-leave-test)))
+
+(deftest realworld-comments
+  (testing "article + comments load on route change"
+    (comments-t/comments-load-test))
+  (testing "comment submit clears the form and appends to the list"
+    (comments-t/comment-submit-test)))
+
+(deftest realworld-favorites
+  (testing "favorite toggle rolls back on :http failure"
+    (favorites-t/favorite-toggle-test)))
+
+(deftest realworld-profile
+  (testing "profile + authored-articles populate from canned stub"
+    (profile-t/profile-load-test)))
+
+(deftest realworld-settings
+  (testing "settings save propagates the new bio into auth/user"
+    (settings-t/settings-test)))
+
+(deftest realworld-tags
+  (testing "tag filter and feed-kind round-trip via :rf.route/query"
+    (tags-t/tag-query-test)))
+
+(deftest realworld-routing
+  (testing "navigate, handle-url-change, query, and not-found all resolve"
+    (routing-t/routing-tests)))
+
+(deftest realworld-ssr
+  (testing "hydration-payload selects the SSR-safe slice keys"
+    (ssr-t/hydration-payload-test)))
+
+(deftest realworld-core-smoke
+  (testing "app boot populates :auth, :articles, and :tags slices"
+    (core-t/app-smoke-test)))


### PR DESCRIPTION
## Summary

- Moves the headless test fixtures previously inline in `examples/realworld/*.cljs` into a sibling test harness at `examples/realworld/test/realworld/<feature>_test.cljs`. Source files are now test-free.
- Adds an integration wrapper at `implementation/test/re_frame/realworld_cljs_test.cljs` that exposes each fixture to the shadow-cljs `node-test` / `browser-test` runners (mirrors the `nine_states_cljs_test` convention).
- Extends `implementation/shadow-cljs.edn` `:source-paths` to include the new test directory; updates the realworld `README.md` to point at the new namespaces.
- Fifteen fixtures moved across eleven test namespaces (auth, articles, article-editor, comments, favorites, profile, settings, tags, routing, ssr, core). Per-feature `:http.canned-*` stubs and the generic `:http.canned-success` stub move with the tests; production source no longer contains test infrastructure.
- Gates `realworld.core/react-root` on `(exists? js/document)` so `realworld.core` is safe to require from `:node-test` (same pattern as `nine_states.core`).

## Test plan

- [x] `clojure -M:test` (JVM) — 223 tests / 1047 assertions / 0 failures, 0 errors
- [x] `npm run test:cljs` — realworld tests pass; one pre-existing nine-states failure unrelated to this PR
- [x] `npm run test:browser` — same shape as `test:cljs`
- [x] `npm run test:elision` — passes
- [x] `npm run test:examples` (Playwright) — all 13 examples PASS, including realworld