### PR TITLE
feat: realworld uses :rf.http/managed (rf2-kauy / rf2-o8t6)

### DIFF
--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -1,16 +1,31 @@
 # RealWorld (Conduit) in re-frame2
 
-A worked example based on the [RealWorld spec](https://github.com/gothinkster/realworld) — the de-facto cross-framework benchmark for SPA frameworks. The goal here is breadth: show how the current re-frame2 surface composes across auth, routing, remote data, forms, machines, optimistic updates, and SSR-related payload concerns.
+The canonical re-frame2 demo for **Spec 014 — `:rf.http/managed`** (per [rf2-kauy](../../docs/EPs/re-frame2/) and rf2-o8t6). Built on the [RealWorld spec](https://github.com/gothinkster/realworld), the de-facto cross-framework benchmark for SPA frameworks.
+
+The goal here is breadth: show how the current re-frame2 surface composes across auth, routing, remote data, forms, machines, optimistic updates, and SSR-related payload concerns — all on top of `:rf.http/managed` for HTTP.
 
 **Status: worked sketch.** This is not presented as a polished production clone. It is a broad, current-API example set: every major RealWorld page now has a concrete namespace, and each namespace demonstrates the intended re-frame2 shape even where the implementation remains sketch-level.
 
-## What this example exercises
+## What this example demonstrates from Spec 014
 
-- **Auth state machine** — login, register, session-restore, logout as one machine.
-- **Pattern-RemoteData** — global feed, your feed, article detail, comments, profile banner, authored articles, favorited articles, and tags all use the same lifecycle slice.
+The normative contract lives in [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md). The realworld example specifically exercises:
+
+- **Default reply addressing** — `realworld.comments/:article/load` issues `:rf.http/managed` with no explicit `:on-success` / `:on-failure` and branches its handler on `(:rf/reply msg)` for both the initial dispatch and the reply paths. One handler, two roles.
+- **Explicit `:on-success` / `:on-failure`** — every other endpoint (auth, articles list, profile, comments, favourites, follow, settings, editor) uses the separate-handler shape: a small DB-only handler per success / failure that destructures `{:keys [value]}` / `{:keys [failure]}` from the appended reply payload.
+- **Schema-driven decode** — every request passes a Malli schema (`schema/UserResponse`, `ArticlesResponse`, `ArticleResponse`, `CommentsResponse`, `CommentResponse`, `ProfileResponse`, `TagsResponse`) as `:decode`. Decode runs only on 2xx (Spec 014 §Classification order); a 4xx HTML page never produces a `:rf.http/decode-failure`.
+- **Schema reflection** — every event handler that issues a managed request declares `:rf.http/decode-schemas` in its registration metadata. Tooling can introspect via `(rf/handler-meta :event :articles/load)` without invoking the handler (Spec 014 §Schema reflection).
+- **Retry + backoff** — read-only data fetches (articles list, profile, article detail, comments, feed) carry the shared `data-fetch-retry` policy: 3 attempts on `#{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}` with exponential backoff + jitter. Login / register / settings / submit / delete deliberately do NOT retry — single user-initiated action per click.
+- **Abort by `:request-id`** — `:articles/load` and `:feed/load` are tagged with stable `:request-id` keywords (and the per-slug requests with vector ids like `[:article/load slug]`); `(:articles/cancel)` and `(:feed/cancel)` issue `:rf.http/managed-abort` to cancel an in-flight load when the user navigates away or re-issues mid-fetch.
+- **Frame awareness** — replies route back to the originating frame automatically (Spec 014 §Frame awareness); the test fixtures spin per-test frames via `make-frame` and assert against `(get-frame-db f)`.
+- **Failure projection** — `realworld.http/failure->message` projects the closed-set `:rf.http/*` failure categories (`:rf.http/transport`, `:rf.http/timeout`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/accept-failure`, `:rf.http/aborted`) to human-readable messages, surfacing the Conduit `{:errors {:body [...]}}` shape when present.
+
+## Other patterns this example exercises
+
+- **Auth state machine** — login, register, session-restore, logout as one machine (Spec 005); each transition issues a managed-HTTP request and routes the reply through machine actions.
+- **Pattern-RemoteData** — global feed, your feed, article detail, comments, profile banner, authored articles, favorited articles, and tags all use the same lifecycle slice (Pattern-RemoteData).
 - **Pattern-Forms** — login, register, comment post, article editor, and settings reuse the same draft/submission shape.
 - **Routing** — route table, path params, query params, auth gating, route-driven loads, and navigation blocking for the editor.
-- **Optimistic updates** — favorite toggle, comment delete, and follow/unfollow all show rollback-friendly event shapes.
+- **Optimistic updates** — favorite toggle, comment delete, and follow/unfollow all show rollback-friendly event shapes against the managed-HTTP failure path.
 - **Schemas** — wire payloads and app-db slices are attached with `reg-app-schema`.
 - **SSR boundary** — the app-specific hydration payload helper lives alongside the generic SSR worked example in `examples/ssr/`.
 
@@ -18,14 +33,14 @@ A worked example based on the [RealWorld spec](https://github.com/gothinkster/re
 
 | File | Status | Notes |
 |---|---|---|
-| `core.cljs` | implemented | Entry point, app shell, route switch, mount. |
-| `schema.cljs` | implemented | Wire shapes plus app-db slice schemas used by the sketch. |
-| `http.cljs` | implemented | `:http` fx with auth token injection. |
+| `core.cljs` | implemented | Entry point, app shell, route switch, mount; installs the demo `:rf.http/managed` stub. |
+| `schema.cljs` | implemented | Wire shapes (User/Profile/Article/...) and their per-endpoint response wrappers used as `:decode` schemas. |
+| `http.cljs` | implemented | `request` builder + `data-fetch-retry` policy + `failure->message` projector for `:rf.http/managed`. |
 | `routing.cljs` | implemented | Route table, auth guard, route-link helper, browser wiring. |
-| `auth.cljs` | implemented | Auth machine plus login/register forms. |
-| `articles.cljs` | implemented | Home page, global feed, popular tags, tag filter UI. |
-| `favorites.cljs` | implemented | Favorite toggle and followed-authors feed. |
-| `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete. |
+| `auth.cljs` | implemented | Auth machine plus login/register forms (managed-HTTP). |
+| `articles.cljs` | implemented | Home page, global feed, popular tags, tag filter UI; managed-HTTP with retry + abort. |
+| `favorites.cljs` | implemented | Favorite toggle and followed-authors feed; optimistic updates with managed-HTTP rollback. |
+| `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete. **`:article/load` uses default reply addressing.** |
 | `article_editor.cljs` | implemented | New/edit/delete article plus unsaved-change guard. |
 | `profile.cljs` | implemented | Profile banner, authored/favorited tabs, follow/unfollow. |
 | `settings.cljs` | implemented | User settings form and logout affordance. |
@@ -34,6 +49,7 @@ A worked example based on the [RealWorld spec](https://github.com/gothinkster/re
 
 ## Architecture references
 
+- [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md) — **`:rf.http/managed`** (this is the canonical demo).
 - [`spec/Pattern-RemoteData.md`](../../spec/Pattern-RemoteData.md)
 - [`spec/Pattern-Forms.md`](../../spec/Pattern-Forms.md)
 - [`spec/012-Routing.md`](../../spec/012-Routing.md)
@@ -42,13 +58,13 @@ A worked example based on the [RealWorld spec](https://github.com/gothinkster/re
 
 ## How to run
 
-The example assumes a shadow-cljs build aliased `realworld` (typical
+The example assumes a shadow-cljs build aliased `examples/realworld` (typical
 `:modules {:realworld {:entries [realworld.core] :init-fn realworld.core/run}}`).
 
-In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`.
+In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`. The demo entry installs an in-process `:rf.http/managed` override (`:rf.http/managed.realworld-demo`) that synthesises canned responses for the common reads (global feed, tags, profile) — Spec 014 §Testing — so the headless smoke and Playwright run without a network.
 
 ```bash
-shadow-cljs watch realworld
+shadow-cljs watch examples/realworld
 # then open the served HTML and click around
 ```
 
@@ -56,7 +72,10 @@ shadow-cljs watch realworld
 
 The headless tests are browserless sketches. They live alongside the
 sources at `test/realworld/<feature>_test.cljs`, mirroring the source
-namespaces:
+namespaces. Each test stubs `:rf.http/managed` via `:fx-overrides`,
+delegating to the framework-shipped canned-stub fxs
+(`:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`)
+through small wrappers in `test/realworld/test_helpers.cljs`.
 
 | Source ns | Test ns |
 |---|---|
@@ -75,26 +94,15 @@ namespaces:
 Each test fn is a plain zero-arg `defn`; failures throw via `assert`. The
 shadow-cljs `node-test` build picks them up via the integration wrapper
 at `implementation/test/re_frame/realworld_cljs_test.cljs` (run with
-`npm run test:cljs` from the `implementation/` directory). Because most
-files are `.cljs`, you can also call them directly from a REPL in a CLJS
-host (Node or a browser build without the DOM-facing entrypoint):
+`npm run test:cljs` from the `implementation/` directory).
 
-```clojure
-(realworld.auth-test/login-happy-path-test)
-(realworld.articles-test/articles-load-test)
-(realworld.comments-test/comments-load-test)
-(realworld.article-editor-test/editor-create-test)
-(realworld.profile-test/profile-load-test)
-(realworld.favorites-test/favorite-toggle-test)
-(realworld.tags-test/tag-query-test)
-(realworld.settings-test/settings-test)
-(realworld.routing-test/routing-tests)
-(realworld.core-test/app-smoke-test)
-```
+The Playwright spec at `realworld.spec.cjs` exercises the user-visible
+flow against the `:rf.http/managed.realworld-demo` override and runs as
+part of `npm run test:examples`.
 
 ## Why RealWorld
 
 - **Cross-framework comparability.** The same app exists in React, Vue, Svelte, Solid, Elm, and many more.
 - **Larger than 7GUIs.** 7GUIs nails the primitives; RealWorld shows how they combine into a recognisable product shape.
-- **Pattern coverage.** This is where the routing, machine, forms, remote-data, and optimistic-update stories meet each other.
+- **Pattern coverage.** This is where the routing, machine, forms, remote-data, optimistic-update, and managed-HTTP stories meet each other.
 - **AI-friendly breadth.** The code is intentionally direct, repetitive where useful, and split by feature so individual flows stay easy to follow.

--- a/examples/realworld/article_editor.cljs
+++ b/examples/realworld/article_editor.cljs
@@ -8,8 +8,8 @@
    - ordinary HTTP effects for create / update / delete"
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -62,30 +62,35 @@
     (assoc db :editor (editor-slice))))
 
 (rf/reg-event-fx :editor/load-article
+  {:doc "Load an existing article into the editor in :edit mode.
+         data-fetch retry policy applies (Spec 014)."
+   :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:route :params :slug])]
       {:db (-> db
                (assoc :editor (assoc (editor-slice :edit slug blank-draft)
                                      :status :loading)))
-       :fx [[:http {:method     :get
-                    :url        (str "/articles/" slug)
-                    :on-success [:editor/loaded]
-                    :on-error   [:editor/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       (str "/articles/" slug)
+                          :decode     schema/ArticleResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id [:editor/load-article slug]
+                          :on-success [:editor/loaded]
+                          :on-failure [:editor/load-failed]})]]})))
 
 (rf/reg-event-db :editor/loaded
-  (fn [db [_ resp]]
-    (let [article  (:article resp)
-          draft    (draft-from-article article)]
+  (fn [db [_ {:keys [value]}]]
+    (let [article (:article value)
+          draft   (draft-from-article article)]
       (assoc db :editor (editor-slice :edit (:slug article) draft)))))
 
 (rf/reg-event-db :editor/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:editor :status] :error)
         (assoc-in [:editor :submit-error]
-                  (or (some-> err :errors :body first)
-                      (:message err)
-                      "Couldn't load article.")))))
+                  (rh/failure->message failure)))))
 
 (rf/reg-event-db :editor/edit-field
   (fn [db [_ field value]]
@@ -98,6 +103,10 @@
     (update-in db [:editor :touched] (fnil conj #{}) field)))
 
 (rf/reg-event-fx :editor/submit
+  {:doc "Save the article (POST for create, PUT for edit). NO retry — the
+         user's intent is one submission per click; surface errors so the
+         user can decide whether to retry (Spec 014)."
+   :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} _]
     (let [{:keys [mode slug draft]} (:editor db)
           errors (validate-draft draft)]
@@ -110,39 +119,44 @@
                  (assoc-in [:editor :submitted] draft)
                  (assoc-in [:editor :errors] {})
                  (assoc-in [:editor :submit-error] nil))
-         :fx [[:http {:method     (if (= mode :edit) :put :post)
-                      :url        (if (= mode :edit)
-                                    (str "/articles/" slug)
-                                    "/articles")
-                      :body       (article-body draft)
-                      :on-success [:editor/submit-success]
-                      :on-error   [:editor/submit-error]}]]}))))
+         :fx [[:rf.http/managed
+               (rh/request {:method     (if (= mode :edit) :put :post)
+                            :path       (if (= mode :edit)
+                                          (str "/articles/" slug)
+                                          "/articles")
+                            :body       (article-body draft)
+                            :decode     schema/ArticleResponse
+                            :on-success [:editor/submit-success]
+                            :on-failure [:editor/submit-error]})]]}))))
 
 (rf/reg-event-fx :editor/submit-success
-  (fn [{:keys [db]} [_ resp]]
-    (let [article (:article resp)
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    (let [article (:article value)
           draft   (draft-from-article article)]
       {:db (assoc db :editor (assoc (editor-slice :edit (:slug article) draft)
                                     :status :saved))
        :fx [[:dispatch [:rf.route/navigate :route/article {:slug (:slug article)}]]]})))
 
 (rf/reg-event-db :editor/submit-error
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:editor :status] :idle)
         (assoc-in [:editor :submit-error]
-                  (or (some-> err :errors :body first)
-                      (:message err)
-                      "Couldn't save article.")))))
+                  (rh/failure->message failure)))))
 
 (rf/reg-event-fx :editor/delete
+  {:doc "Delete the article. No retry — destructive action, one click."}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:editor :slug])]
       {:db (assoc-in db [:editor :status] :submitting)
-       :fx [[:http {:method     :delete
-                    :url        (str "/articles/" slug)
-                    :on-success [:editor/delete-success]
-                    :on-error   [:editor/delete-error]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :delete
+                          :path       (str "/articles/" slug)
+                          ;; The delete endpoint returns no body; :auto
+                          ;; handles 204/empty gracefully.
+                          :decode     :auto
+                          :on-success [:editor/delete-success]
+                          :on-failure [:editor/delete-error]})]]})))
 
 (rf/reg-event-fx :editor/delete-success
   (fn [{:keys [db]} _]
@@ -150,13 +164,11 @@
      :fx [[:dispatch [:rf.route/navigate :route/home]]]}))
 
 (rf/reg-event-db :editor/delete-error
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:editor :status] :idle)
         (assoc-in [:editor :submit-error]
-                  (or (some-> err :errors :body first)
-                      (:message err)
-                      "Couldn't delete article.")))))
+                  (rh/failure->message failure)))))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/realworld/articles.cljs
+++ b/examples/realworld/articles.cljs
@@ -7,8 +7,8 @@
    - home-page tabs expressed as ordinary navigation events
    - view reuse across the home page and profile pages"
   (:require [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -36,38 +36,57 @@
 
 (rf/reg-event-fx :articles/load
   {:doc "Fetch the global articles list, optionally filtered by the route's
-         `?tag=` query parameter."}
+         `?tag=` query parameter. Uses :rf.http/managed (Spec 014) with
+         a Malli-decoded response and the standard data-fetch retry policy.
+         The request is tagged with `:request-id :articles/load` so a
+         re-issue (e.g., user changes tag mid-load) supersedes the prior
+         in-flight request and an `:articles/cancel` fx aborts cleanly."
+   :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
-    (let [tag      (get-in db [:route :query :tag])
-          url      (if tag
-                     (str "/articles?tag=" tag)
-                     "/articles")
+    (let [tag       (get-in db [:route :query :tag])
+          path      (if tag
+                      (str "/articles?tag=" tag)
+                      "/articles")
           has-data? (seq (get-in db [:articles :data]))]
       {:db (-> db
                (assoc-in [:articles :status] (if has-data? :fetching :loading))
                (assoc-in [:articles :error] nil)
                (update-in [:articles :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        url
-                    :auth?      false
-                    :on-success [:articles/loaded]
-                    :on-error   [:articles/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       path
+                          :auth?      false
+                          :decode     schema/ArticlesResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id :articles/load
+                          :on-success [:articles/loaded]
+                          :on-failure [:articles/load-failed]})]]})))
 
 (rf/reg-event-db :articles/loaded
-  {:doc "Successful fetch. Replace the list and clear any prior error."}
-  (fn [db [_ resp]]
+  {:doc "Successful fetch. Replace the list and clear any prior error.
+         Receives `{:kind :success :value <ArticlesResponse>}` from
+         Spec 014's reply-addressing."}
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:articles :status] :loaded)
-        (assoc-in [:articles :data] (vec (:articles resp)))
+        (assoc-in [:articles :data] (vec (:articles value)))
         (assoc-in [:articles :error] nil)
         (assoc-in [:articles :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :articles/load-failed
-  {:doc "Failed fetch. Keep prior data when present and surface the error."}
-  (fn [db [_ err]]
+  {:doc "Failed fetch. Keep prior data when present and surface a
+         human-readable error message (projected from the Spec 014
+         failure map)."}
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:articles :status] :error)
-        (assoc-in [:articles :error] err))))
+        (assoc-in [:articles :error] (rh/failure->message failure)))))
+
+(rf/reg-event-fx :articles/cancel
+  {:doc "Abort an in-flight :articles/load. Useful when the user navigates
+         away from the home page mid-fetch (Spec 014 §Aborts)."}
+  (fn [_ _]
+    {:fx [[:rf.http/managed-abort :articles/load]]}))
 
 (rf/reg-event-db :articles/reset
   (fn [db _]
@@ -78,31 +97,37 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :tags/load
+  {:doc "Fetch the popular-tags list. Public endpoint; data-fetch retry."
+   :rf.http/decode-schemas [schema/TagsResponse]}
   (fn [{:keys [db]} _]
     {:db (-> db
              (assoc-in [:tags :status]
                        (if (seq (get-in db [:tags :data])) :fetching :loading))
              (assoc-in [:tags :error] nil)
              (update-in [:tags :attempt] (fnil inc 0)))
-     :fx [[:http {:method     :get
-                  :url        "/tags"
-                  :auth?      false
-                  :on-success [:tags/loaded]
-                  :on-error   [:tags/load-failed]}]]}))
+     :fx [[:rf.http/managed
+           (rh/request {:method     :get
+                        :path       "/tags"
+                        :auth?      false
+                        :decode     schema/TagsResponse
+                        :retry      rh/data-fetch-retry
+                        :request-id :tags/load
+                        :on-success [:tags/loaded]
+                        :on-failure [:tags/load-failed]})]]}))
 
 (rf/reg-event-db :tags/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:tags :status] :loaded)
-        (assoc-in [:tags :data] (vec (:tags resp)))
+        (assoc-in [:tags :data] (vec (:tags value)))
         (assoc-in [:tags :error] nil)
         (assoc-in [:tags :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :tags/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:tags :status] :error)
-        (assoc-in [:tags :error] err))))
+        (assoc-in [:tags :error] (rh/failure->message failure)))))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -11,8 +11,8 @@
    the machine snapshot itself lives at [:rf/machines :auth/flow]."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -62,7 +62,12 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :auth/flow
-  {:doc "The auth flow: idle → submitting/restoring → authed | error."}
+  {:doc "The auth flow: idle → submitting/restoring → authed | error.
+         HTTP requests go via :rf.http/managed (Spec 014). Login /
+         register / restore deliberately do NOT retry — the user's
+         intent is one submission per click; a transient error surfaces
+         in `:error` and the user retries themselves."
+   :rf.http/decode-schemas [schema/UserResponse]}
   (rf/create-machine-handler
     ;; Per Spec 005 §Where snapshots live: spec map does NOT carry :id;
     ;; the id is the surrounding reg-event-fx id.
@@ -80,46 +85,50 @@
       :begin-login
       (fn [_ [_ {:keys [email password]}]]
         {:data {:error nil}
-         :fx [[:http {:method     :post
-                      :url        "/users/login"
-                      :auth?      false
-                      :body       {:user {:email email :password password}}
-                      :on-success [:auth/flow [:auth/success]]
-                      :on-error   [:auth/flow [:auth/failure]]}]]})
+         :fx [[:rf.http/managed
+               (rh/request {:method     :post
+                            :path       "/users/login"
+                            :auth?      false
+                            :body       {:user {:email email :password password}}
+                            :decode     schema/UserResponse
+                            :on-success [:auth/flow [:auth/success]]
+                            :on-failure [:auth/flow [:auth/failure]]})]]})
 
       :begin-register
       (fn [_ [_ {:keys [username email password]}]]
         {:data {:error nil}
-         :fx [[:http {:method     :post
-                      :url        "/users"
-                      :auth?      false
-                      :body       {:user {:username username
-                                          :email email
-                                          :password password}}
-                      :on-success [:auth/flow [:auth/success]]
-                      :on-error   [:auth/flow [:auth/failure]]}]]})
+         :fx [[:rf.http/managed
+               (rh/request {:method     :post
+                            :path       "/users"
+                            :auth?      false
+                            :body       {:user {:username username
+                                                :email email
+                                                :password password}}
+                            :decode     schema/UserResponse
+                            :on-success [:auth/flow [:auth/success]]
+                            :on-failure [:auth/flow [:auth/failure]]})]]})
 
       :begin-restore
       (fn [_ _]
         {:data {:error nil}
-         :fx [[:http {:method     :get
-                      :url        "/user"
-                      :on-success [:auth/flow [:auth/success]]
-                      :on-error   [:auth/flow [:auth/restore-failed]]}]]})
+         :fx [[:rf.http/managed
+               (rh/request {:method     :get
+                            :path       "/user"
+                            :decode     schema/UserResponse
+                            :on-success [:auth/flow [:auth/success]]
+                            :on-failure [:auth/flow [:auth/restore-failed]]})]]})
 
       :store-session
-      (fn [_ [_ resp]]
-        (let [user (:user resp)]
+      (fn [_ [_ {:keys [value]}]]
+        (let [user (:user value)]
           {:data {:error nil}
            :fx [[:dispatch [:auth/store-session user]]
                 [:auth.session/store {:token (:token user)}]
                 [:dispatch [:rf.route/navigate :route/home]]]}))
 
       :record-error
-      (fn [_ [_ err]]
-        {:data {:error (or (some-> err :errors first)
-                           (:message err)
-                           "Authentication failed.")}})
+      (fn [_ [_ {:keys [failure]}]]
+        {:data {:error (rh/failure->message failure)}})
 
       :clear-session
       (fn [_ _]

--- a/examples/realworld/comments.cljs
+++ b/examples/realworld/comments.cljs
@@ -8,8 +8,8 @@
    - Post/delete flows are optimistic and roll back via ordinary events."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -55,38 +55,56 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :article/load
-  (fn [{:keys [db]} _]
-    (let [slug (get-in db [:route :params :slug])]
-      {:db (-> db
-               (assoc-in [:article :status]
-                         (if (get-in db [:article :data]) :fetching :loading))
-               (assoc-in [:article :error] nil)
-               (update-in [:article :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        (article-path slug)
-                    :auth?      false
-                    :on-success [:article/loaded]
-                    :on-error   [:article/load-failed]}]]})))
+  {:doc "Load the article matching `[:route :params :slug]`.
 
-(rf/reg-event-db :article/loaded
-  (fn [db [_ resp]]
-    (-> db
-        (assoc-in [:article :status] :loaded)
-        (assoc-in [:article :data] (:article resp))
-        (assoc-in [:article :error] nil)
-        (assoc-in [:article :loaded-at] (current-time-ms)))))
+         This handler demonstrates Spec 014's *default reply addressing*:
+         no `:on-success` / `:on-failure` is supplied, so the framework
+         re-dispatches the reply back to this same event id with
+         `:rf/reply` merged into the original message map. The handler
+         body branches on `(:rf/reply msg)` — one event id, two roles."
+   :rf.http/decode-schemas [schema/ArticleResponse]}
+  (fn [{:keys [db]} [_ msg]]
+    (if-let [reply (:rf/reply msg)]
+      ;; Reply branch — handle success or failure.
+      (case (:kind reply)
+        :success
+        {:db (-> db
+                 (assoc-in [:article :status] :loaded)
+                 (assoc-in [:article :data] (:article (:value reply)))
+                 (assoc-in [:article :error] nil)
+                 (assoc-in [:article :loaded-at] (current-time-ms)))}
 
-(rf/reg-event-db :article/load-failed
-  (fn [db [_ err]]
-    (-> db
-        (assoc-in [:article :status] :error)
-        (assoc-in [:article :error] err))))
+        :failure
+        {:db (-> db
+                 (assoc-in [:article :status] :error)
+                 (assoc-in [:article :error] (rh/failure->message (:failure reply))))})
+
+      ;; Initial dispatch — issue the managed request. Default reply
+      ;; addressing routes the reply back here.
+      (let [slug (get-in db [:route :params :slug])]
+        {:db (-> db
+                 (assoc-in [:article :status]
+                           (if (get-in db [:article :data]) :fetching :loading))
+                 (assoc-in [:article :error] nil)
+                 (update-in [:article :attempt] (fnil inc 0)))
+         :fx [[:rf.http/managed
+               (rh/request {:method     :get
+                            :path       (article-path slug)
+                            :auth?      false
+                            :decode     schema/ArticleResponse
+                            :retry      rh/data-fetch-retry
+                            :request-id [:article/load slug]})]]}))))
 
 ;; ============================================================================
 ;; COMMENTS
 ;; ============================================================================
 
 (rf/reg-event-fx :comments/load
+  {:doc "Load comments for the current article. Uses explicit success /
+         failure handlers (cf. :article/load above which uses default
+         reply addressing) — both shapes are valid Spec 014; pick whichever
+         reads best for the handler."
+   :rf.http/decode-schemas [schema/CommentsResponse]}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:route :params :slug])]
       {:db (-> db
@@ -94,25 +112,29 @@
                          (if (seq (get-in db [:comments :data])) :fetching :loading))
                (assoc-in [:comments :error] nil)
                (update-in [:comments :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        (comment-path slug)
-                    :auth?      false
-                    :on-success [:comments/loaded]
-                    :on-error   [:comments/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       (comment-path slug)
+                          :auth?      false
+                          :decode     schema/CommentsResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id [:comments/load slug]
+                          :on-success [:comments/loaded]
+                          :on-failure [:comments/load-failed]})]]})))
 
 (rf/reg-event-db :comments/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:comments :status] :loaded)
-        (assoc-in [:comments :data] (vec (:comments resp)))
+        (assoc-in [:comments :data] (vec (:comments value)))
         (assoc-in [:comments :error] nil)
         (assoc-in [:comments :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :comments/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:comments :status] :error)
-        (assoc-in [:comments :error] err))))
+        (assoc-in [:comments :error] (rh/failure->message failure)))))
 
 ;; ============================================================================
 ;; COMMENT FORM
@@ -125,6 +147,11 @@
         (update-in [:comment-form :touched] (fnil conj #{}) field))))
 
 (rf/reg-event-fx :comment-form/submit
+  {:doc "Optimistically post a new comment. NO retry — the user clicked
+         once. The temp-id correlates the optimistic UI card with the
+         eventual save / rollback (Spec 014 - explicit on-success/on-failure
+         where the partial event vector pre-populates correlation args)."
+   :rf.http/decode-schemas [schema/CommentResponse]}
   (fn [{:keys [db]} _]
     (let [slug      (get-in db [:route :params :slug])
           draft     (get-in db [:comment-form :draft])
@@ -149,15 +176,17 @@
                  (assoc-in [:comment-form :errors] {})
                  (assoc-in [:comment-form :submit-error] nil)
                  (update-in [:comments :data] (fnil conj []) temp-card))
-         :fx [[:http {:method     :post
-                      :url        (comment-path slug)
-                      :body       {:comment {:body body}}
-                      :on-success [:comment-form/submit-success temp-id]
-                      :on-error   [:comment-form/submit-error temp-id]}]]}))))
+         :fx [[:rf.http/managed
+               (rh/request {:method     :post
+                            :path       (comment-path slug)
+                            :body       {:comment {:body body}}
+                            :decode     schema/CommentResponse
+                            :on-success [:comment-form/submit-success temp-id]
+                            :on-failure [:comment-form/submit-error temp-id]})]]}))))
 
 (rf/reg-event-db :comment-form/submit-success
-  (fn [db [_ temp-id resp]]
-    (let [saved (:comment resp)]
+  (fn [db [_ temp-id {:keys [value]}]]
+    (let [saved (:comment value)]
       (-> db
           (assoc-in [:comment-form] (comment-form-defaults))
           (update-in [:comments :data]
@@ -168,18 +197,18 @@
                             vec)))))))
 
 (rf/reg-event-db :comment-form/submit-error
-  (fn [db [_ temp-id err]]
+  (fn [db [_ temp-id {:keys [failure]}]]
     (-> db
         (update-in [:comments :data]
                    (fn [comments]
                      (vec (remove #(= temp-id (:id %)) comments))))
         (assoc-in [:comment-form :status] :idle)
         (assoc-in [:comment-form :submit-error]
-                  (or (some-> err :errors :body first)
-                      (:message err)
-                      "Couldn't post comment.")))))
+                  (rh/failure->message failure)))))
 
 (rf/reg-event-fx :comment/delete
+  {:doc "Optimistically remove a comment, then DELETE. On failure, the
+         rollback handler re-inserts the comment at its original index."}
   (fn [{:keys [db]} [_ id]]
     (let [slug     (get-in db [:route :params :slug])
           comments (vec (get-in db [:comments :data]))
@@ -189,16 +218,18 @@
           prior    (when (some? index) {:index index :comment (nth comments index)})]
       {:db (update-in db [:comments :data]
                       (fn [xs] (vec (remove #(= id (:id %)) xs))))
-       :fx [[:http {:method     :delete
-                    :url        (str (comment-path slug) "/" id)
-                    :on-success [:comment/delete-success id]
-                    :on-error   [:comment/delete-rollback prior]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :delete
+                          :path       (str (comment-path slug) "/" id)
+                          :decode     :auto
+                          :on-success [:comment/delete-success id]
+                          :on-failure [:comment/delete-rollback prior]})]]})))
 
 (rf/reg-event-db :comment/delete-success
   (fn [db _] db))
 
 (rf/reg-event-db :comment/delete-rollback
-  (fn [db [_ {:keys [index comment]}]]
+  (fn [db [_ {:keys [index comment]} _failure-payload]]
     (if (and (some? index) comment)
       (update-in db [:comments :data]
                  (fn [xs]

--- a/examples/realworld/core.cljs
+++ b/examples/realworld/core.cljs
@@ -18,10 +18,18 @@
      settings.cljs         — user settings page
      routing.cljs          — route registrations + router wiring
      schema.cljs           — Malli schemas for the example slices
-     http.cljs             — :http registered fx
-     ssr.cljc              — hydration payload helper for the RealWorld app"
-  (:require [reagent.dom.client :as rdc]
+     http.cljs             — request-builder + retry policy for :rf.http/managed
+     ssr.cljc              — hydration payload helper for the RealWorld app
+
+   This is the canonical Spec 014 (`:rf.http/managed`) demo per
+   rf2-kauy / rf2-o8t6. Every Conduit endpoint goes via the
+   framework-shipped managed-HTTP fx; the demo entry below installs a
+   canned-stub override so the headless smoke and Playwright run without
+   a network."
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.reagent :as reagent-adapter]
             [realworld.schema]
             [realworld.http]
@@ -144,19 +152,25 @@
 ;; ----------------------------------------------------------------------------
 ;; DEMO STUBS
 ;;
-;; The realworld example would normally call out to https://api.realworld.io/api,
-;; which is unreliable for the headless smoke and slow for a demo. Override the
-;; :http effect with a small in-process stub that returns canned data for the
-;; routes the demo actually exercises (global feed, tags, profile). Anything
-;; not covered resolves to an empty-shape :on-success — enough for the app
-;; shell + main feed to render.
+;; The realworld example would normally hit https://api.realworld.io/api,
+;; which is unreliable for headless smoke and slow for a demo. Override
+;; :rf.http/managed with a small in-process stub that synthesises the
+;; canonical Spec 014 reply shape for the routes the demo actually
+;; exercises (global feed, tags, profile). Anything not covered resolves
+;; to an empty-payload success — enough for the app shell + main feed
+;; to render.
+;;
+;; The override uses :rf.http/managed-canned-success directly with a
+;; per-URL :value payload. This is the same shape Spec 014 §Testing
+;; documents — just routed by URL inspection in a wrapper fx so the
+;; demo doesn't have to know one URL ahead of time.
 ;; ----------------------------------------------------------------------------
 
 (def ^:private demo-articles
   [{:slug "hello-conduit"
     :title "Hello, Conduit"
     :description "A short greeting from the realworld stub."
-    :body "This article is served by the demo :http override."
+    :body "This article is served by the demo :rf.http/managed override."
     :tagList ["intro" "demo"]
     :createdAt "2026-01-01T00:00:00Z"
     :updatedAt "2026-01-01T00:00:00Z"
@@ -183,30 +197,46 @@
 (def ^:private demo-tags
   ["intro" "demo" "clojure" "re-frame"])
 
-(rf/reg-fx :http.demo-stub
-  {:doc       "Demo stub for realworld :http: routes URLs to canned responses
-               so the example runs standalone without a backend."
+(defn- demo-payload-for-url [url]
+  (let [u (str url)]
+    (cond
+      (str/includes? u "/articles/feed")
+      {:articles [] :articlesCount 0}
+
+      (re-find #"/articles/[^/]+/comments" u)
+      {:comments []}
+
+      (re-find #"/articles/[^/?]+$" u)
+      {:article (first demo-articles)}
+
+      (or (str/ends-with? u "/articles") (str/includes? u "/articles?"))
+      {:articles demo-articles :articlesCount (count demo-articles)}
+
+      (str/includes? u "/tags")
+      {:tags demo-tags}
+
+      (str/includes? u "/profiles/")
+      {:profile {:username "stub-bot" :bio "" :image "" :following false}}
+
+      :else {})))
+
+(rf/reg-fx :rf.http/managed.realworld-demo
+  {:doc       "Demo override for :rf.http/managed: routes by URL to canned
+               Conduit-shaped responses so the example runs standalone
+               without a backend. Delegates to :rf.http/managed-canned-success
+               with a synthesised :value per Spec 014 §Testing."
    :platforms #{:server :client}}
-  (fn fx-http-demo-stub [{:keys [frame]} {:keys [url on-success on-error]}]
-    (let [resp (cond
-                 (re-find #"/articles$|/articles\?" (str url))
-                 {:articles demo-articles :articlesCount (count demo-articles)}
-
-                 (re-find #"/articles/feed" (str url))
-                 {:articles [] :articlesCount 0}
-
-                 (re-find #"/tags" (str url))
-                 {:tags demo-tags}
-
-                 (re-find #"/profiles/" (str url))
-                 {:profile {:username "stub-bot" :bio "" :image "" :following false}}
-
-                 :else {})]
-      (js/setTimeout
-        (fn []
-          (when on-success
-            (rf/dispatch (conj on-success resp) {:frame frame})))
-        20))))
+  (fn fx-managed-demo-stub [frame-ctx args-map]
+    (let [url     (-> args-map :request :url)
+          payload (demo-payload-for-url url)
+          stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
+      ;; Drive the framework-shipped canned-success stub to get the
+      ;; correct reply shape (default reply addressing or explicit
+      ;; :on-success — Spec 014 §Reply addressing).
+      (when stub-fn
+        (js/setTimeout
+          (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
+          20)))))
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
 ;; the `root-view` reg-view above (rf2-562e). Gated on (exists? js/document)
@@ -217,10 +247,10 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  ;; Override :http on the default frame so all the realworld feature
-  ;; HTTP calls land on the demo stub (no real backend required).
+  ;; Override :rf.http/managed on the default frame so all the realworld
+  ;; feature HTTP calls land on the demo stub (no real backend required).
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
-                             :fx-overrides {:http :http.demo-stub}})
+                             :fx-overrides {:rf.http/managed :rf.http/managed.realworld-demo}})
   ;; The orchestrator serves this example at /realworld/; strip that
   ;; prefix before the route matcher sees the URL so :route/home (path "/")
   ;; matches.

--- a/examples/realworld/favorites.cljs
+++ b/examples/realworld/favorites.cljs
@@ -6,8 +6,8 @@
    Pattern-RemoteData slice so the home page can switch between feeds
    without throwing away already-loaded global articles."
   (:require [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]))
+            [realworld.schema :as schema]
+            [realworld.http :as rh]))
 
 (defn current-time-ms [] (.getTime (js/Date.)))
 
@@ -55,35 +55,53 @@
     (assoc db :feed (request-slice))))
 
 (rf/reg-event-fx :feed/load
+  {:doc "Fetch the authenticated user's feed. Tagged with
+         `:request-id :feed/load` so :feed/cancel can abort an in-flight
+         load when the user navigates away (Spec 014 §Aborts)."
+   :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     {:db (-> db
              (assoc-in [:feed :status]
                        (if (seq (get-in db [:feed :data])) :fetching :loading))
              (assoc-in [:feed :error] nil)
              (update-in [:feed :attempt] (fnil inc 0)))
-     :fx [[:http {:method     :get
-                  :url        "/articles/feed"
-                  :on-success [:feed/loaded]
-                  :on-error   [:feed/load-failed]}]]}))
+     :fx [[:rf.http/managed
+           (rh/request {:method     :get
+                        :path       "/articles/feed"
+                        :decode     schema/ArticlesResponse
+                        :retry      rh/data-fetch-retry
+                        :request-id :feed/load
+                        :on-success [:feed/loaded]
+                        :on-failure [:feed/load-failed]})]]}))
+
+(rf/reg-event-fx :feed/cancel
+  {:doc "Abort an in-flight :feed/load. Useful when the user navigates
+         away mid-load (Spec 014 §Aborts)."}
+  (fn [_ _]
+    {:fx [[:rf.http/managed-abort :feed/load]]}))
 
 (rf/reg-event-db :feed/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:feed :status] :loaded)
-        (assoc-in [:feed :data] (vec (:articles resp)))
+        (assoc-in [:feed :data] (vec (:articles value)))
         (assoc-in [:feed :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :feed/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:feed :status] :error)
-        (assoc-in [:feed :error] err))))
+        (assoc-in [:feed :error] (rh/failure->message failure)))))
 
 ;; ============================================================================
 ;; FAVORITES
 ;; ============================================================================
 
 (rf/reg-event-fx :article/toggle-favorite
+  {:doc "Optimistically flip the favorited flag and bump the count, then
+         POST or DELETE the favorite. On failure the prior state is
+         restored (rollback)."
+   :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} [_ slug]]
     (if-let [article (find-article db slug)]
       (let [prior {:favorited      (:favorited article)
@@ -95,15 +113,17 @@
         {:db (patch-article-everywhere db slug
                                        #(assoc % :favorited (not favorited?)
                                                  :favoritesCount next-count))
-         :fx [[:http {:method     (if favorited? :delete :post)
-                      :url        (str "/articles/" slug "/favorite")
-                      :on-success [:article/favorite-synced slug]
-                      :on-error   [:article/favorite-rollback slug prior]}]]})
+         :fx [[:rf.http/managed
+               (rh/request {:method     (if favorited? :delete :post)
+                            :path       (str "/articles/" slug "/favorite")
+                            :decode     schema/ArticleResponse
+                            :on-success [:article/favorite-synced slug]
+                            :on-failure [:article/favorite-rollback slug prior]})]]})
       {})))
 
 (rf/reg-event-db :article/favorite-synced
-  (fn [db [_ slug resp]]
-    (if-let [article (:article resp)]
+  (fn [db [_ slug {:keys [value]}]]
+    (if-let [article (:article value)]
       (patch-article-everywhere db slug
                                 (fn [_]
                                   (select-keys article
@@ -113,7 +133,7 @@
       db)))
 
 (rf/reg-event-db :article/favorite-rollback
-  (fn [db [_ slug {:keys [favorited favoritesCount]}]]
+  (fn [db [_ slug {:keys [favorited favoritesCount]} _failure-payload]]
     (patch-article-everywhere db slug
                               #(assoc % :favorited favorited
                                         :favoritesCount favoritesCount))))

--- a/examples/realworld/http.cljs
+++ b/examples/realworld/http.cljs
@@ -1,22 +1,28 @@
 (ns realworld.http
-  "The :http registered fx for the RealWorld example.
+  "HTTP helpers for the RealWorld (Conduit) example.
 
-   The RealWorld spec lives at:
-     https://github.com/gothinkster/realworld/tree/main/api
+   This is the canonical Spec 014 demo (rf2-kauy / rf2-o8t6). Every Conduit
+   endpoint goes out via `:rf.http/managed` — the framework-shipped managed
+   HTTP fx. The framework owns transport, decoding, status classification,
+   retry-with-backoff, abort, and reply addressing; the example just
+   composes request maps.
 
-   Production deployments point at https://api.realworld.io/api; for
-   local development the spec ships a Node + Postgres reference backend
-   that listens on http://localhost:3000/api.
+   This namespace ships TWO small helpers on top of `:rf.http/managed`:
 
-   Architecture:
-   - The :http fx accepts the Pattern-AsyncEffect shape: :method, :url,
-     :body, :on-success, :on-error.
-   - It auto-injects the Bearer token from the auth slice when present;
-     `:auth?` defaults to true for routes that need it.
-   - It serialises the :body to JSON; deserialises responses to keywordized
-     CLJ data; surfaces non-2xx as :on-error with the parsed error body.
-   - It is :platforms #{:server :client} so SSR and the client share the
-     same effect surface (per Spec 011)."
+   - `request` — build a request map (`{:request {...} :decode ... :retry ...}`)
+     that bakes in the API base URL, JSON content-type, and a Bearer token
+     pulled from the auth slice. Auth-on-by-default; pass `:auth? false` to
+     omit the header (login / register / public reads).
+   - `data-fetch-retry` — the standard retry policy used for read-only
+     fetches (transport, 5xx, timeout — not 4xx; the user's request was
+     valid even when the server is sad).
+
+   The RealWorld spec lives at https://github.com/gothinkster/realworld/tree/main/api.
+   Production points at https://api.realworld.io/api; locally the spec
+   ships a Node + Postgres reference backend on http://localhost:3000/api.
+   This file does not register any fx — the demo entry (`core.cljs`) wires
+   `:rf.http/managed` to a canned-stub override so the headless smoke and
+   Playwright run without a network."
   (:require [re-frame.core :as rf]))
 
 ;; ============================================================================
@@ -32,40 +38,112 @@
   (str api-base path))
 
 ;; ============================================================================
-;; FX  (CP-3)
+;; RETRY POLICIES (Spec 014 §Retry and backoff)
 ;; ============================================================================
 
-(rf/reg-fx :http
-  {:doc       "Issue an HTTP request to the RealWorld API. The :body is
-               JSON-encoded; responses are JSON-decoded with keywordized
-               keys. The current auth token is injected as a Bearer header
-               when present (override with :auth? false). On 2xx, dispatches
-               :on-success with the parsed body; on non-2xx or transport
-               error, dispatches :on-error with the parsed error body."
-   :platforms #{:server :client}}
-  (fn fx-http [{:keys [frame] :as _m}
-               {:keys [method url body on-success on-error auth?]
-                :or   {auth? true}}]
-    (let [token   (when auth?
-                    (some-> (rf/get-frame-db (or frame :rf/default))
-                            :auth :token))
-          headers (cond-> {"Content-Type" "application/json"
-                           "Accept"       "application/json"}
-                    token (assoc "Authorization" (str "Token " token)))
-          init    #js {:method  (-> method name clojure.string/upper-case)
-                       :headers (clj->js headers)
-                       :body    (when body (js/JSON.stringify (clj->js body)))}]
-      (-> (js/fetch (full-url url) init)
-          (.then (fn [resp]
-                   (-> (.json resp)
-                       (.then (fn [json]
-                                (let [data (js->clj json :keywordize-keys true)]
-                                  (if (.-ok resp)
-                                    (when on-success
-                                      (rf/dispatch (conj on-success data) {:frame frame}))
-                                    (when on-error
-                                      (rf/dispatch (conj on-error data) {:frame frame})))))))))
-          (.catch (fn [err]
-                    (when on-error
-                      (rf/dispatch (conj on-error {:errors {:body [(str err)]}}) {:frame frame}))))))))
+(def data-fetch-retry
+  "Standard retry policy for read-only data fetches (lists, profiles,
+   article detail, comments). Retries transport blips, 5xx, and timeouts
+   — not 4xx (the request shape was valid; retrying won't help). Three
+   attempts total with exponential backoff + jitter."
+  {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
+   :max-attempts 3
+   :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
 
+;; Login / register / settings deliberately do NOT retry — the user's
+;; intent is to submit one form once. A 5xx surfaces as an error so the
+;; user can retry by clicking again.
+
+;; ============================================================================
+;; REQUEST BUILDER
+;; ============================================================================
+
+(defn- token-from-frame
+  "Read the current JWT (or nil) from the auth slice on the given frame."
+  [frame]
+  (some-> (rf/get-frame-db (or frame :rf/default))
+          :auth :token))
+
+(defn request
+  "Build a Spec 014 `:rf.http/managed` args map for a Conduit endpoint.
+
+   Required keys: `:method`, `:path`. Other keys are optional and
+   correspond to the Spec 014 args map (see spec/014-HTTPRequests.md).
+
+   Auth header is injected by default when a token is present in the
+   frame's auth slice. Pass `:auth? false` to omit (login / register
+   / public reads).
+
+   Body, if a clj coll, is JSON-encoded (`:request-content-type :json`).
+   Decode defaults to `:json` (RealWorld returns JSON everywhere).
+
+   Use:
+     (rf/get-frame-db ...) reads `:frame` from the cofx; pass through
+     here as `:frame` if you need a non-default frame.
+
+   Example:
+     {:fx [[:rf.http/managed
+            (rh/request {:method :get
+                         :path   \"/articles\"
+                         :on-success [:articles/loaded]
+                         :on-failure [:articles/load-failed]
+                         :retry  rh/data-fetch-retry})]]}"
+  [{:keys [method path body decode accept retry timeout-ms
+           on-success on-failure request-id abort-signal
+           frame auth? extra-headers]
+    :or   {auth? true
+           method :get
+           decode :json}
+    :as   args}]
+  (let [token   (when auth? (token-from-frame frame))
+        headers (cond-> (or extra-headers {})
+                  token (assoc "Authorization" (str "Token " token))
+                  true  (assoc "Accept" "application/json"))
+        req     (cond-> {:method method
+                         :url    (full-url path)
+                         :headers headers}
+                  body (assoc :body body
+                              :request-content-type :json))
+        out     (cond-> {:request req
+                         :decode  decode}
+                  retry        (assoc :retry retry)
+                  timeout-ms   (assoc :timeout-ms timeout-ms)
+                  accept       (assoc :accept accept)
+                  request-id   (assoc :request-id request-id)
+                  abort-signal (assoc :abort-signal abort-signal)
+                  (contains? args :on-success) (assoc :on-success on-success)
+                  (contains? args :on-failure) (assoc :on-failure on-failure))]
+    out))
+
+;; ============================================================================
+;; FAILURE PROJECTION
+;; ============================================================================
+
+(defn failure->message
+  "Project a Spec 014 failure map (the inner `:failure` map of an
+   `{:kind :failure :failure {...}}` reply) to a human-readable string.
+   The Conduit API returns `{:errors {:body [\"...\"]}}` shapes for 4xx
+   validation failures; surface those when present, otherwise fall back
+   to a category-driven message."
+  [failure]
+  (let [body (:body failure)
+        ;; The :body for 4xx/5xx is the raw response text; some Conduit
+        ;; errors come through as plain JSON-shaped failure maps from
+        ;; `:rf.http/accept-failure` paths. Try to surface either.
+        body-msg (cond
+                   (and (map? body) (-> body :errors :body first)) (-> body :errors :body first)
+                   (and (map? body) (-> body :errors first)) (let [[k v] (first (:errors body))]
+                                                              (str (name k) ": " (first v)))
+                   (string? body) body
+                   :else nil)]
+    (or body-msg
+        (case (:kind failure)
+          :rf.http/transport      "Network error — please try again."
+          :rf.http/timeout        "Request timed out."
+          :rf.http/http-4xx       (str "Request rejected (status " (:status failure) ").")
+          :rf.http/http-5xx       (str "Server error (status " (:status failure) ").")
+          :rf.http/decode-failure "Couldn't parse server response."
+          :rf.http/accept-failure (or (-> failure :detail :message) "Unexpected response shape.")
+          :rf.http/aborted        "Request cancelled."
+          (:message failure))
+        "Request failed.")))

--- a/examples/realworld/profile.cljs
+++ b/examples/realworld/profile.cljs
@@ -9,8 +9,8 @@
    Follow/unfollow is optimistic and shared across the banner plus any
    article cards rendered from the profile routes."
   (:require [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing]
             [realworld.articles :as articles])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
@@ -39,6 +39,9 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :profile/load
+  {:doc "Load the public profile (username, bio, image, following).
+         Public endpoint; data-fetch retry."
+   :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
       {:db (-> db
@@ -46,110 +49,134 @@
                          (if (get-in db [:profile :data]) :fetching :loading))
                (assoc-in [:profile :error] nil)
                (update-in [:profile :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        (str "/profiles/" username)
-                    :auth?      false
-                    :on-success [:profile/loaded]
-                    :on-error   [:profile/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       (str "/profiles/" username)
+                          :auth?      false
+                          :decode     schema/ProfileResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id [:profile/load username]
+                          :on-success [:profile/loaded]
+                          :on-failure [:profile/load-failed]})]]})))
 
 (rf/reg-event-db :profile/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:profile :status] :loaded)
-        (assoc-in [:profile :data] (:profile resp))
+        (assoc-in [:profile :data] (:profile value))
         (assoc-in [:profile :error] nil)
         (assoc-in [:profile :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :profile/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:profile :status] :error)
-        (assoc-in [:profile :error] err))))
+        (assoc-in [:profile :error] (rh/failure->message failure)))))
 
 (rf/reg-event-fx :profile.articles/load
+  {:doc "Load the profile's authored articles. Public; data-fetch retry."
+   :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
       {:db (-> db
                (assoc-in [:profile.articles :status] :loading)
                (assoc-in [:profile.articles :error] nil)
                (update-in [:profile.articles :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        (str "/articles?author=" username)
-                    :auth?      false
-                    :on-success [:profile.articles/loaded]
-                    :on-error   [:profile.articles/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       (str "/articles?author=" username)
+                          :auth?      false
+                          :decode     schema/ArticlesResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id [:profile.articles/load username]
+                          :on-success [:profile.articles/loaded]
+                          :on-failure [:profile.articles/load-failed]})]]})))
 
 (rf/reg-event-db :profile.articles/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:profile.articles :status] :loaded)
-        (assoc-in [:profile.articles :data] (vec (:articles resp)))
+        (assoc-in [:profile.articles :data] (vec (:articles value)))
         (assoc-in [:profile.articles :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :profile.articles/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:profile.articles :status] :error)
-        (assoc-in [:profile.articles :error] err))))
+        (assoc-in [:profile.articles :error] (rh/failure->message failure)))))
 
 (rf/reg-event-fx :profile.favorites/load
+  {:doc "Load the profile's favorited articles. Public; data-fetch retry."
+   :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
       {:db (-> db
                (assoc-in [:profile.favorites :status] :loading)
                (assoc-in [:profile.favorites :error] nil)
                (update-in [:profile.favorites :attempt] (fnil inc 0)))
-       :fx [[:http {:method     :get
-                    :url        (str "/articles?favorited=" username)
-                    :auth?      false
-                    :on-success [:profile.favorites/loaded]
-                    :on-error   [:profile.favorites/load-failed]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :get
+                          :path       (str "/articles?favorited=" username)
+                          :auth?      false
+                          :decode     schema/ArticlesResponse
+                          :retry      rh/data-fetch-retry
+                          :request-id [:profile.favorites/load username]
+                          :on-success [:profile.favorites/loaded]
+                          :on-failure [:profile.favorites/load-failed]})]]})))
 
 (rf/reg-event-db :profile.favorites/loaded
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:profile.favorites :status] :loaded)
-        (assoc-in [:profile.favorites :data] (vec (:articles resp)))
+        (assoc-in [:profile.favorites :data] (vec (:articles value)))
         (assoc-in [:profile.favorites :loaded-at] (current-time-ms)))))
 
 (rf/reg-event-db :profile.favorites/load-failed
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:profile.favorites :status] :error)
-        (assoc-in [:profile.favorites :error] err))))
+        (assoc-in [:profile.favorites :error] (rh/failure->message failure)))))
 
 ;; ============================================================================
 ;; FOLLOW / UNFOLLOW
 ;; ============================================================================
 
 (rf/reg-event-fx :profile/follow
+  {:doc "Optimistically mark the profile as followed; reconcile on reply."
+   :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
       {:db (assoc-in db [:profile :data :following] true)
-       :fx [[:http {:method     :post
-                    :url        (str "/profiles/" username "/follow")
-                    :on-success [:profile/followed]
-                    :on-error   [:profile/follow-rollback false]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :post
+                          :path       (str "/profiles/" username "/follow")
+                          :decode     schema/ProfileResponse
+                          :on-success [:profile/followed]
+                          :on-failure [:profile/follow-rollback false]})]]})))
 
 (rf/reg-event-db :profile/followed
-  (fn [db [_ resp]]
-    (assoc-in db [:profile :data] (:profile resp))))
+  (fn [db [_ {:keys [value]}]]
+    (assoc-in db [:profile :data] (:profile value))))
 
 (rf/reg-event-fx :profile/unfollow
+  {:doc "Optimistically clear the followed flag; reconcile on reply."
+   :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
       {:db (assoc-in db [:profile :data :following] false)
-       :fx [[:http {:method     :delete
-                    :url        (str "/profiles/" username "/follow")
-                    :on-success [:profile/unfollowed]
-                    :on-error   [:profile/follow-rollback true]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :delete
+                          :path       (str "/profiles/" username "/follow")
+                          :decode     schema/ProfileResponse
+                          :on-success [:profile/unfollowed]
+                          :on-failure [:profile/follow-rollback true]})]]})))
 
 (rf/reg-event-db :profile/unfollowed
-  (fn [db [_ resp]]
-    (assoc-in db [:profile :data] (:profile resp))))
+  (fn [db [_ {:keys [value]}]]
+    (assoc-in db [:profile :data] (:profile value))))
 
 (rf/reg-event-db :profile/follow-rollback
-  (fn [db [_ previous-value]]
+  (fn [db [_ previous-value _failure-payload]]
     (assoc-in db [:profile :data :following] previous-value)))
 
 ;; ============================================================================

--- a/examples/realworld/realworld.spec.cjs
+++ b/examples/realworld/realworld.spec.cjs
@@ -1,21 +1,23 @@
 /*
- * RealWorld (Conduit) — smoke test (rf2-w3vn).
+ * RealWorld (Conduit) — Spec 014 (`:rf.http/managed`) demo (rf2-o8t6).
  *
- * The realworld example is large: ~13 namespaces, multiple feature
- * slices, full routing. Per the rf2-w3vn bead this spec is scoped to:
+ * The realworld example is the canonical Spec 014 demo per
+ * rf2-kauy / rf2-o8t6: every Conduit endpoint goes via `:rf.http/managed`,
+ * with a canned-stub override (Spec 014 §Testing) routing requests to
+ * synthesised replies — no network required.
  *
+ * Coverage:
  *   - Loads cleanly (no pageerror, no uncaught exceptions).
  *   - Main shell renders (navbar with "conduit" brand link).
- *   - Home page renders the global feed populated by the demo :http stub.
- *
- * The stub returns 2 articles for the global feed, so we expect to see
- * 2 .article-preview cards on the home page.
+ *   - Home page renders the global feed populated by the demo stub.
+ *   - Tag list renders in the sidebar.
+ *   - Clicking an article preview navigates to the article detail page.
  */
 
 const { expectVisible } = require('../../implementation/scripts/spec-helpers.cjs');
 
 module.exports = {
-  name: 'realworld (Conduit)',
+  name: 'realworld (Conduit) — Spec 014 demo',
   url: '/realworld/',
   run: async (page) => {
     // App shell mounts.
@@ -30,6 +32,13 @@ module.exports = {
     // Main feed populates from the demo stub: 2 article previews.
     await page.waitForFunction(
       () => document.querySelectorAll('.article-preview').length >= 2,
+      null,
+      { timeout: 10000 },
+    );
+
+    // Sidebar tag list renders (4 demo tags).
+    await page.waitForFunction(
+      () => document.querySelectorAll('.tag-list a.tag-pill').length >= 4,
       null,
       { timeout: 10000 },
     );

--- a/examples/realworld/schema.cljs
+++ b/examples/realworld/schema.cljs
@@ -67,6 +67,45 @@
 (def Tag :string)
 
 ;; ============================================================================
+;; WIRE-RESPONSE WRAPPERS
+;; ============================================================================
+;;
+;; The Conduit API wraps every payload in a singular/plural top-level key.
+;; These schemas describe the wire-shape envelope; they are passed as the
+;; `:decode` key to `:rf.http/managed` per Spec 014 §Schema-driven decode.
+
+(def UserResponse
+  "POST /users/login, POST /users (register), GET /user."
+  [:map [:user User]])
+
+(def ProfileResponse
+  "GET /profiles/:username, POST/DELETE /profiles/:username/follow."
+  [:map [:profile Profile]])
+
+(def ArticleResponse
+  "GET /articles/:slug, POST /articles, PUT /articles/:slug,
+   POST/DELETE /articles/:slug/favorite."
+  [:map [:article Article]])
+
+(def ArticlesResponse
+  "GET /articles, GET /articles/feed."
+  [:map
+   [:articles      [:vector Article]]
+   [:articlesCount {:optional true} :int]])
+
+(def CommentResponse
+  "POST /articles/:slug/comments."
+  [:map [:comment Comment]])
+
+(def CommentsResponse
+  "GET /articles/:slug/comments."
+  [:map [:comments [:vector Comment]]])
+
+(def TagsResponse
+  "GET /tags."
+  [:map [:tags [:vector :string]]])
+
+;; ============================================================================
 ;; APP-DB SLICES — Pattern-RemoteData shape per resource
 ;; ============================================================================
 ;;

--- a/examples/realworld/settings.cljs
+++ b/examples/realworld/settings.cljs
@@ -7,8 +7,8 @@
    - write the returned user back through `:auth/store-session`
    - keep logout on the existing auth machine path"
   (:require [re-frame.core :as rf]
-            [realworld.schema]
-            [realworld.http]
+            [realworld.schema :as schema]
+            [realworld.http :as rh]
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -38,35 +38,38 @@
         (update-in [:settings :touched] (fnil conj #{}) field))))
 
 (rf/reg-event-fx :settings/submit
+  {:doc "Save the user-settings draft. NO retry — single user-initiated
+         submission per click (Spec 014)."
+   :rf.http/decode-schemas [schema/UserResponse]}
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:settings :draft])]
       {:db (-> db
                (assoc-in [:settings :status] :submitting)
                (assoc-in [:settings :submitted] draft)
                (assoc-in [:settings :submit-error] nil))
-       :fx [[:http {:method     :put
-                    :url        "/user"
-                    :body       {:user (cond-> (select-keys draft [:image :username :bio :email])
-                                         (seq (:password draft))
-                                         (assoc :password (:password draft)))}
-                    :on-success [:settings/submit-success]
-                    :on-error   [:settings/submit-error]}]]})))
+       :fx [[:rf.http/managed
+             (rh/request {:method     :put
+                          :path       "/user"
+                          :body       {:user (cond-> (select-keys draft [:image :username :bio :email])
+                                               (seq (:password draft))
+                                               (assoc :password (:password draft)))}
+                          :decode     schema/UserResponse
+                          :on-success [:settings/submit-success]
+                          :on-failure [:settings/submit-error]})]]})))
 
 (rf/reg-event-fx :settings/submit-success
-  (fn [{:keys [db]} [_ resp]]
-    (let [user (:user resp)]
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    (let [user (:user value)]
       {:db (assoc db :settings (settings-slice user))
        :fx [[:dispatch [:auth/store-session user]]
             [:dispatch [:rf.route/navigate :route/profile {:username (:username user)}]]]})))
 
 (rf/reg-event-db :settings/submit-error
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:settings :status] :idle)
         (assoc-in [:settings :submit-error]
-                  (or (some-> err :errors :body first)
-                      (:message err)
-                      "Couldn't save settings.")))))
+                  (rh/failure->message failure)))))
 
 (rf/reg-sub :settings/draft
   (fn [db _] (get-in db [:settings :draft])))

--- a/examples/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/realworld/test/realworld/article_editor_test.cljs
@@ -1,32 +1,27 @@
 (ns realworld.article-editor-test
   "Headless tests for realworld.article-editor — create flow and
-   navigation guard. Extracted from realworld/article_editor.cljs under
-   rf2-4v73."
+   navigation guard. Retrofitted under rf2-o8t6 to use Spec 014's
+   `:rf.http/managed` substrate via the framework-shipped canned-stub fxs."
   (:require [re-frame.core :as rf]
-            [realworld.article-editor])
+            [realworld.article-editor]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn editor-create-test []
-  (rf/reg-fx :http.canned-editor-save
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:article {:slug "hello-world"
-                           :title "Hello"
-                           :description "Short"
-                           :body "Body"
-                           :tagList ["demo"]
-                           :createdAt "2026-05-01"
-                           :updatedAt "2026-05-01"
-                           :favorited false
-                           :favoritesCount 0
-                           :author {:username "alice" :bio nil :image nil :following false}}})
-          {:frame frame}))))
+  (th/reg-canned-success! :rf.http/managed.canned-editor-save
+                          {:article {:slug "hello-world"
+                                     :title "Hello"
+                                     :description "Short"
+                                     :body "Body"
+                                     :tagList ["demo"]
+                                     :createdAt "2026-05-01"
+                                     :updatedAt "2026-05-01"
+                                     :favorited false
+                                     :favoritesCount 0
+                                     :author {:username "alice" :bio nil :image nil :following false}}})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-editor-save}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})

--- a/examples/realworld/test/realworld/articles_test.cljs
+++ b/examples/realworld/test/realworld/articles_test.cljs
@@ -1,33 +1,29 @@
 (ns realworld.articles-test
   "Headless tests for realworld.articles — global feed loading + failure
-   paths. Extracted from realworld/articles.cljs under rf2-4v73."
+   paths. Retrofitted under rf2-o8t6 to use Spec 014's `:rf.http/managed`
+   substrate via the framework-shipped canned-stub fxs."
   (:require [re-frame.core :as rf]
-            [realworld.articles])
+            [realworld.articles]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn articles-load-test []
-  (rf/reg-fx :http.canned-articles
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:articles [{:slug "hello-world"
-                             :title "Hello, world"
-                             :description "An intro"
-                             :body "..."
-                             :tagList ["intro"]
-                             :createdAt "2026-05-01T00:00:00Z"
-                             :updatedAt "2026-05-01T00:00:00Z"
-                             :favorited false
-                             :favoritesCount 0
-                             :author {:username "alice" :bio nil :image nil
-                                      :following false}}]
-                 :articlesCount 1})
-          {:frame frame}))))
+  (th/reg-canned-success! :rf.http/managed.canned-articles
+                          {:articles [{:slug "hello-world"
+                                       :title "Hello, world"
+                                       :description "An intro"
+                                       :body "..."
+                                       :tagList ["intro"]
+                                       :createdAt "2026-05-01T00:00:00Z"
+                                       :updatedAt "2026-05-01T00:00:00Z"
+                                       :favorited false
+                                       :favoritesCount 0
+                                       :author {:username "alice" :bio nil :image nil
+                                                :following false}}]
+                           :articlesCount 1})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-articles}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-articles}})]
     (assert (= :idle (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
     (rf/dispatch-sync [:articles/load] {:frame f})
     (let [slice (rf/compute-sub [:articles] (rf/get-frame-db f))]
@@ -40,15 +36,13 @@
       (assert (= 2 (:attempt slice))))))
 
 (defn articles-load-failure-test []
-  (rf/reg-fx :http.canned-failure
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors {:body ["server error"]}})
-                     {:frame frame}))))
+  (th/reg-canned-failure! :rf.http/managed.canned-articles-failure
+                          :rf.http/http-5xx
+                          {:status 500
+                           :body   "server error"})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-failure}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-articles-failure}})]
     (rf/dispatch-sync [:articles/load] {:frame f})
     (assert (= :error (:status (rf/compute-sub [:articles] (rf/get-frame-db f)))))
     (assert (some? (rf/compute-sub [:articles/error] (rf/get-frame-db f))))))

--- a/examples/realworld/test/realworld/auth_test.cljs
+++ b/examples/realworld/test/realworld/auth_test.cljs
@@ -2,32 +2,31 @@
   "Headless tests for realworld.auth — the auth state machine.
 
    These were previously inline in realworld/auth.cljs; extracted under
-   rf2-4v73 so production code stays test-free.
+   rf2-4v73 so production code stays test-free. Retrofitted under rf2-o8t6
+   to use Spec 014's `:rf.http/managed` substrate — each test stubs
+   `:rf.http/managed` via `:fx-overrides` and synthesises the canonical
+   reply shape (`{:kind :success :value v}` / `{:kind :failure :failure m}`)
+   through the framework-shipped canned-stub fxs.
 
    Each test fn keeps its original signature (a plain zero-arg fn) so the
-   integration runner can call them as before. The realworld.feature-test
-   integration wrapper at implementation/test/re_frame/realworld_cljs_test.cljs
-   exposes them to the shadow-cljs node-test runner."
+   integration runner can call them as before."
   (:require [re-frame.core :as rf]
-            [realworld.auth])
+            [realworld.auth]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn login-happy-path-test []
-  (rf/reg-fx :http.canned-login-success
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch (conj on-success {:user {:email    "alice@example.com"
-                                              :username "alice"
-                                              :token    "jwt-abc"
-                                              :bio      nil
-                                              :image    nil}})
-                     {:frame frame}))))
+  (th/reg-canned-success! :rf.http/managed.login-success
+                          {:user {:email    "alice@example.com"
+                                  :username "alice"
+                                  :token    "jwt-abc"
+                                  :bio      nil
+                                  :image    nil}})
 
   (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:http :http.canned-login-success
-                                                :auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
+                                 :fx-overrides {:rf.http/managed     :rf.http/managed.login-success
+                                                :auth.session/store  :rf/no-op
+                                                :auth.session/clear  :rf/no-op}})]
     (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
 
     (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com"
@@ -41,15 +40,13 @@
     (assert (nil? (rf/compute-sub [:auth/user] (rf/get-frame-db f))))))
 
 (defn login-failure-test []
-  (rf/reg-fx :http.canned-failure
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors ["email or password is invalid"]})
-                     {:frame frame}))))
+  (th/reg-canned-failure! :rf.http/managed.login-failure
+                          :rf.http/http-4xx
+                          {:status 422
+                           :body   {:errors {:body ["email or password is invalid"]}}})
 
   (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:http :http.canned-failure}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.login-failure}})]
     (rf/dispatch-sync [:auth/flow [:auth/login {:email "x@y.z" :password "wrong"}]]
                       {:frame f})
     (assert (= :error (rf/compute-sub [:auth/state] (rf/get-frame-db f))))

--- a/examples/realworld/test/realworld/comments_test.cljs
+++ b/examples/realworld/test/realworld/comments_test.cljs
@@ -1,42 +1,47 @@
 (ns realworld.comments-test
   "Headless tests for realworld.comments — article-detail load and
-   comment-post happy path. Extracted from realworld/comments.cljs under
-   rf2-4v73."
+   comment-post happy path. Retrofitted under rf2-o8t6 to use Spec 014's
+   `:rf.http/managed` substrate via the framework-shipped canned-stub fxs.
+
+   The `:article/load` event uses default reply addressing (Spec 014
+   §Reply addressing — default form): no explicit `:on-success` /
+   `:on-failure`, so the framework re-dispatches `:article/load` with
+   `:rf/reply` merged into the original message. This test exercises
+   that path end-to-end via the canned-success stub."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [realworld.comments])
+            [realworld.comments]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn comments-load-test []
-  (rf/reg-fx :http.canned-article-and-comments
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                (cond
-                  (str/ends-with? url "/comments")
-                  {:comments [{:id 1
-                               :createdAt "2026-05-01"
-                               :updatedAt "2026-05-01"
-                               :body "First!"
-                               :author {:username "eve" :bio nil :image nil :following false}}]}
+  ;; URL-routed stub: the article-detail page issues two requests
+  ;; (`/articles/:slug` and `/articles/:slug/comments`); pick the canned
+  ;; payload from the URL.
+  (th/reg-canned-success-by-url! :rf.http/managed.canned-article-and-comments
+                                 (fn [url]
+                                   (cond
+                                     (str/ends-with? url "/comments")
+                                     {:comments [{:id 1
+                                                  :createdAt "2026-05-01"
+                                                  :updatedAt "2026-05-01"
+                                                  :body "First!"
+                                                  :author {:username "eve" :bio nil :image nil :following false}}]}
 
-                  :else
-                  {:article {:slug "hello"
-                             :title "Hello"
-                             :description "Short"
-                             :body "Body"
-                             :tagList ["demo"]
-                             :createdAt "2026-05-01"
-                             :updatedAt "2026-05-01"
-                             :favorited false
-                             :favoritesCount 0
-                             :author {:username "alice" :bio nil :image nil :following false}}}))
-          {:frame frame}))))
+                                     :else
+                                     {:article {:slug "hello"
+                                                :title "Hello"
+                                                :description "Short"
+                                                :body "Body"
+                                                :tagList ["demo"]
+                                                :createdAt "2026-05-01"
+                                                :updatedAt "2026-05-01"
+                                                :favorited false
+                                                :favoritesCount 0
+                                                :author {:username "alice" :bio nil :image nil :following false}}})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-article-and-comments}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-article-and-comments}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     (rf/dispatch-sync [:comment-form/initialise] {:frame f})
@@ -45,21 +50,37 @@
     (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))
 
 (defn comment-submit-test []
-  (rf/reg-fx :http.canned-comment-post
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                {:comment {:id 2
-                           :createdAt "2026-05-02"
-                           :updatedAt "2026-05-02"
-                           :body "Nice article."
-                           :author {:username "alice" :bio nil :image nil :following false}}})
-          {:frame frame}))))
+  (th/reg-canned-success-by-url! :rf.http/managed.canned-comment-post
+                                 (fn [method url]
+                                   (cond
+                                     ;; POST /articles/:slug/comments → returns the saved comment.
+                                     (and (= :post method) (str/ends-with? url "/comments"))
+                                     {:comment {:id 2
+                                                :createdAt "2026-05-02"
+                                                :updatedAt "2026-05-02"
+                                                :body "Nice article."
+                                                :author {:username "alice" :bio nil :image nil :following false}}}
+
+                                     ;; GET /articles/:slug/comments → empty initial list.
+                                     (and (= :get method) (str/ends-with? url "/comments"))
+                                     {:comments []}
+
+                                     :else
+                                     ;; The route-driven :article/load also fires; return
+                                     ;; an article so the page renders.
+                                     {:article {:slug "hello"
+                                                :title "Hello"
+                                                :description "Short"
+                                                :body "Body"
+                                                :tagList []
+                                                :createdAt "2026-05-01"
+                                                :updatedAt "2026-05-01"
+                                                :favorited false
+                                                :favoritesCount 0
+                                                :author {:username "alice" :bio nil :image nil :following false}}})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-comment-post}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-comment-post}})]
     (rf/dispatch-sync [:article/initialise] {:frame f})
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     (rf/dispatch-sync [:comment-form/initialise] {:frame f})
@@ -68,4 +89,6 @@
     (rf/dispatch-sync [:comment-form/edit-field :body "Nice article."] {:frame f})
     (rf/dispatch-sync [:comment-form/submit] {:frame f})
     (assert (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/get-frame-db f)))))
+    ;; Initial GET returned [] (no existing comments); POST returned 1
+    ;; saved comment → exactly 1 comment in the slice after submit.
     (assert (= 1 (count (rf/compute-sub [:comments/data] (rf/get-frame-db f)))))))

--- a/examples/realworld/test/realworld/core_test.cljs
+++ b/examples/realworld/test/realworld/core_test.cljs
@@ -1,38 +1,28 @@
 (ns realworld.core-test
   "Top-level smoke for realworld.core — boots the app and checks that
-   the per-feature initialisers populate the expected slices. Extracted
-   from realworld/core.cljs under rf2-4v73.
+   the per-feature initialisers populate the expected slices.
 
-   The test relies on a generic `:http.canned-success` stub (every :http
-   call resolves :on-success with an empty map). It used to live next to
-   the production :http fx in realworld/http.cljs; per the rf2-4v73
-   cleanup it now lives with the test that uses it."
+   Retrofitted under rf2-o8t6: the legacy `:http.canned-success` fixture
+   has been replaced with a `:rf.http/managed` override that delegates
+   to the framework-shipped `:rf.http/managed-canned-success` stub
+   (Spec 014 §Testing). Every managed-HTTP call resolves with an empty
+   map success — enough to exercise the on-create initialise fanout
+   without any per-feature-shape assumptions."
   (:require [re-frame.core :as rf]
-            [realworld.core])
+            [realworld.core]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
-;; ----------------------------------------------------------------------------
-;; Test stub  (id-valued override per Spec 002 §override seam).
-;;
-;; Tests bind :http -> :http.canned-success in :fx-overrides on make-frame so
-;; no real network calls happen. Per-test stubs (:http.canned-failure, etc.)
-;; live alongside the test that needs them.
-;; ----------------------------------------------------------------------------
-
-(rf/reg-fx :http.canned-success
-  {:doc       "Test stub: every :http call resolves :on-success with an
-               empty map. Tests register a richer canned response when they
-               need specific payloads."
-   :platforms #{:client :server}}
-  (fn fx-http-canned-success [{:keys [frame]} {:keys [on-success]}]
-    (when on-success
-      (rf/dispatch (conj on-success {}) {:frame frame}))))
+;; A generic success stub: every :rf.http/managed call resolves :success
+;; with an empty map. Tests register a richer canned response when they
+;; need specific payloads.
+(th/reg-canned-success! :rf.http/managed.canned-success-empty {})
 
 (defn app-smoke-test []
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:http :http.canned-success
-                                                :auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
+                                 :fx-overrides {:rf.http/managed     :rf.http/managed.canned-success-empty
+                                                :auth.session/store  :rf/no-op
+                                                :auth.session/clear  :rf/no-op}})]
     ;; After init: auth, articles, and tags slices are present.
     (let [db (rf/get-frame-db f)]
       (assert (contains? db :auth))

--- a/examples/realworld/test/realworld/favorites_test.cljs
+++ b/examples/realworld/test/realworld/favorites_test.cljs
@@ -1,33 +1,36 @@
 (ns realworld.favorites-test
   "Headless test for realworld.favorites — optimistic-update rollback.
-   Extracted from realworld/favorites.cljs under rf2-4v73."
+   Retrofitted under rf2-o8t6 to use Spec 014's `:rf.http/managed`
+   substrate via the framework-shipped canned-stub fxs."
   (:require [re-frame.core :as rf]
-            [realworld.favorites])
+            [realworld.favorites]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn favorite-toggle-test []
-  (rf/reg-fx :http.canned-favorite-rollback
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (when on-error
-        (rf/dispatch (conj on-error {:errors {:body ["rollback"]}}) {:frame frame}))))
+  (th/reg-canned-failure! :rf.http/managed.favorite-rollback
+                          :rf.http/http-4xx
+                          {:status 400
+                           :body   {:errors {:body ["rollback"]}}})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-favorite-rollback}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.favorite-rollback}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     (rf/dispatch-sync [:articles/loaded
-                       {:articles [{:slug "hello"
-                                    :title "Hello"
-                                    :description "Short"
-                                    :body "Body"
-                                    :tagList []
-                                    :createdAt "2026-05-01"
-                                    :updatedAt "2026-05-01"
-                                    :favorited false
-                                    :favoritesCount 0
-                                    :author {:username "alice" :bio nil :image nil :following false}}]}]
+                       {:kind :success
+                        :value {:articles [{:slug "hello"
+                                            :title "Hello"
+                                            :description "Short"
+                                            :body "Body"
+                                            :tagList []
+                                            :createdAt "2026-05-01"
+                                            :updatedAt "2026-05-01"
+                                            :favorited false
+                                            :favoritesCount 0
+                                            :author {:username "alice" :bio nil :image nil :following false}}]}}]
                       {:frame f})
     (rf/dispatch-sync [:article/toggle-favorite "hello"] {:frame f})
+    ;; Optimistic flip + canned 4xx → rollback to original state.
     (assert (false? (-> (rf/compute-sub [:articles/data] (rf/get-frame-db f))
                         first
                         :favorited)))

--- a/examples/realworld/test/realworld/profile_test.cljs
+++ b/examples/realworld/test/realworld/profile_test.cljs
@@ -1,34 +1,31 @@
 (ns realworld.profile-test
   "Headless test for realworld.profile — profile + authored-articles
-   load. Extracted from realworld/profile.cljs under rf2-4v73."
+   load. Retrofitted under rf2-o8t6 to use Spec 014's `:rf.http/managed`
+   substrate via the framework-shipped canned-stub fxs."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [realworld.profile])
+            [realworld.profile]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn profile-load-test []
-  (rf/reg-fx :http.canned-profile
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [url on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success
-                (if (str/includes? url "/profiles/")
-                  {:profile {:username "eve" :bio "Writes things" :image nil :following false}}
-                  {:articles [{:slug "one"
-                               :title "One"
-                               :description "Short"
-                               :body "Body"
-                               :tagList []
-                               :createdAt "2026-05-01"
-                               :updatedAt "2026-05-01"
-                               :favorited false
-                               :favoritesCount 0
-                               :author {:username "eve" :bio nil :image nil :following false}}]}))
-          {:frame frame}))))
+  (th/reg-canned-success-by-url! :rf.http/managed.canned-profile
+                                 (fn [url]
+                                   (if (str/includes? url "/profiles/")
+                                     {:profile {:username "eve" :bio "Writes things" :image nil :following false}}
+                                     {:articles [{:slug "one"
+                                                  :title "One"
+                                                  :description "Short"
+                                                  :body "Body"
+                                                  :tagList []
+                                                  :createdAt "2026-05-01"
+                                                  :updatedAt "2026-05-01"
+                                                  :favorited false
+                                                  :favoritesCount 0
+                                                  :author {:username "eve" :bio nil :image nil :following false}}]})))
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-profile}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-profile}})]
     (rf/dispatch-sync [:profile/initialise] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
     (assert (= "eve" (:username (rf/compute-sub [:profile/data] (rf/get-frame-db f)))))

--- a/examples/realworld/test/realworld/settings_test.cljs
+++ b/examples/realworld/test/realworld/settings_test.cljs
@@ -1,26 +1,23 @@
 (ns realworld.settings-test
   "Headless test for realworld.settings — settings save propagates new
-   user data into the auth slice. Extracted from realworld/settings.cljs
-   under rf2-4v73."
+   user data into the auth slice. Retrofitted under rf2-o8t6 to use
+   Spec 014's `:rf.http/managed` substrate via the framework-shipped
+   canned-stub fxs."
   (:require [re-frame.core :as rf]
-            [realworld.settings])
+            [realworld.settings]
+            [realworld.test-helpers :as th])
   (:require-macros [re-frame.views-macros :refer [with-frame]]))
 
 (defn settings-test []
-  (rf/reg-fx :http.canned-settings-save
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-success]}]
-      (when on-success
-        (rf/dispatch
-          (conj on-success {:user {:email "alice@example.com"
-                                   :token "jwt-2"
-                                   :username "alice"
-                                   :bio "New bio"
-                                   :image nil}})
-          {:frame frame}))))
+  (th/reg-canned-success! :rf.http/managed.canned-settings-save
+                          {:user {:email "alice@example.com"
+                                  :token "jwt-2"
+                                  :username "alice"
+                                  :bio "New bio"
+                                  :image nil}})
 
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:http :http.canned-settings-save}})]
+                                 :fx-overrides {:rf.http/managed :rf.http/managed.canned-settings-save}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"
                                             :username "alice"

--- a/examples/realworld/test/realworld/test_helpers.cljs
+++ b/examples/realworld/test/realworld/test_helpers.cljs
@@ -1,0 +1,51 @@
+(ns realworld.test-helpers
+  "Shared test helpers for the realworld example fixtures.
+
+   Per Spec 014 §Testing, the framework ships canned-stub fxs
+   (`:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`)
+   that synthesise the canonical reply shape. The realworld fixtures use
+   per-test wrappers that delegate to these stubs while supplying the
+   test-specific `:value` (success) or `:kind` + `:tags` (failure)."
+  (:require [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]))
+
+(defn reg-canned-success!
+  "Register an fx-id that delegates to :rf.http/managed-canned-success
+   with a fixed `:value`. Use as a per-test stub via :fx-overrides."
+  [fx-id value]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (stub frame-ctx (assoc args :value value))))))
+
+(defn reg-canned-success-by-url!
+  "Register an fx-id that delegates to :rf.http/managed-canned-success,
+   choosing `:value` per the request URL (and optionally method). `f`
+   receives the URL string (1-arity) or [method url] (2-arity from a
+   3-arity f); always returns the synthesised `:value` payload."
+  [fx-id f]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub   (registrar/handler :fx :rf.http/managed-canned-success)
+            req    (:request args)
+            method (or (:method req) :get)
+            url    (:url req)
+            arity  (try
+                     (.-length f)
+                     (catch :default _ 1))
+            value  (if (>= arity 2)
+                     (f method url)
+                     (f url))]
+        (stub frame-ctx (assoc args :value value))))))
+
+(defn reg-canned-failure!
+  "Register an fx-id that delegates to :rf.http/managed-canned-failure
+   with a fixed `:kind` and `:tags` failure category per Spec 014."
+  [fx-id kind tags]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (stub frame-ctx (assoc args :kind kind :tags tags))))))


### PR DESCRIPTION
## Summary

Retrofit every Conduit endpoint in `examples/realworld/` to Spec 014's `:rf.http/managed`, making realworld the **canonical Spec 014 demo** (per [rf2-kauy](.beads/issues.jsonl)'s decision: TodoMVC stays on localStorage; realworld becomes the Spec-014 reference).

- 19 endpoints converted across auth, articles, comments, article-editor, favorites, follow/unfollow, profile, tags, feed, and settings.
- New helpers in `realworld/http.cljs`: `request` builder + `data-fetch-retry` policy + `failure->message` projector. Schemas in `realworld/schema.cljs` extended with per-endpoint response wrappers (`UserResponse`, `ArticleResponse`, `ArticlesResponse`, `CommentResponse`, `CommentsResponse`, `ProfileResponse`, `TagsResponse`).
- Demo entry rewires `:fx-overrides {:rf.http/managed :rf.http/managed.realworld-demo}` against an override that delegates to `:rf.http/managed-canned-success` per Spec 014 §Testing.
- Test fixtures (8 files) retrofitted via a new `realworld.test-helpers` ns that wraps the framework-shipped canned-stub fxs.

## Spec 014 surfaces demonstrated

- **Default reply addressing** — `:article/load` issues `:rf.http/managed` with no explicit `:on-success` / `:on-failure`; the handler branches on `(:rf/reply msg)` for both initial dispatch and reply paths.
- **Explicit on-success / on-failure** — every other endpoint uses the separate-handler shape; success / failure handlers destructure `{:keys [value]}` / `{:keys [failure]}` from the appended payload.
- **Schema-driven decode** — every request passes a Malli schema as `:decode`.
- **Schema reflection** — every HTTP-issuing event registers `:rf.http/decode-schemas` for tooling introspection.
- **Retry + backoff** — read-only data fetches use `data-fetch-retry` (3 attempts on `#{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}` with exponential+jitter); submit / delete deliberately do NOT retry.
- **Abort by `:request-id`** — `:articles/load` and `:feed/load` are tagged with stable ids; `:articles/cancel` and `:feed/cancel` issue `:rf.http/managed-abort`.
- **Failure projection** — `failure->message` projects the closed-set `:rf.http/*` failure categories to human-readable strings, surfacing the Conduit `{:errors {:body [...]}}` shape when present.

## Test plan

- [x] `clojure -M:test`: 223 tests / 1047 assertions / 0 failures
- [x] `npm run test:cljs`: 94 tests / 295 assertions / 1 pre-existing failure (rf2-6r59 nine-states, in flight)
- [x] `npm run test:browser`: same baseline result
- [x] `npm run test:elision`: PASS
- [x] `npm run test:examples`: PASS (13 examples including the realworld Playwright spec, which now also asserts tag-list rendering)

## Cross-references

- [`spec/014-HTTPRequests.md`](spec/014-HTTPRequests.md) — the normative contract this demo exercises.
- [`examples/realworld/README.md`](examples/realworld/README.md) — rewritten to call out the Spec 014 surfaces this example demonstrates.