### PR TITLE
docs: guide audit + managed-HTTP chapter (rf2-x13a)

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -123,6 +123,6 @@ Almost everything. The same six dominoes. The same opinionated stance on a singl
 
 If the argument lands, the next chapter ([02 — Your first app](02-your-first-app.md)) walks through a counter end-to-end. It's the smallest possible re-frame2 program, in narrative form, with the shape of every primitive made visible.
 
-If the argument is unconvincing, the deeper essay on *why* less-powerful-is-more lives at [08 — The dynamic-model story](08-the-dynamic-model.md). It's the long-form version of this chapter, with citations and a Dijkstra quote.
+If the argument is unconvincing, the deeper essay on *why* less-powerful-is-more lives at [09 — The dynamic-model story](09-the-dynamic-model.md). It's the long-form version of this chapter, with citations and a Dijkstra quote.
 
 If you want the precise contracts before the prose, the [specification](../../spec/) is one click away.

--- a/docs/guide/02-your-first-app.md
+++ b/docs/guide/02-your-first-app.md
@@ -201,15 +201,15 @@ That's the entire dynamic story. Five steps, all named, no surprises.
 ```clojure
 (deftest counter-flow
   (rf/with-frame [f (rf/make-frame {:on-create [:counter/initialise]})]
-    (is (= 5 (rf/compute-sub [:count] @(rf/get-frame-db f))))
+    (is (= 5 (rf/compute-sub [:count] (rf/get-frame-db f))))
     (rf/dispatch-sync [:counter/inc] {:frame f})
-    (is (= 6 (rf/compute-sub [:count] @(rf/get-frame-db f))))
+    (is (= 6 (rf/compute-sub [:count] (rf/get-frame-db f))))
     (rf/dispatch-sync [:counter/dec] {:frame f})
     (rf/dispatch-sync [:counter/dec] {:frame f})
-    (is (= 4 (rf/compute-sub [:count] @(rf/get-frame-db f))))))
+    (is (= 4 (rf/compute-sub [:count] (rf/get-frame-db f))))))
 ```
 
-That test runs on the JVM. There's no browser. There's no React. The `with-frame` block creates a fresh frame, binds it as the current frame for the body, and the test asserts against its `app-db`. Tests like this run in milliseconds and you can have thousands of them. (Per-test cleanup is handled by your test fixture — typically a `use-fixtures` that calls `destroy-frame!` between tests; the framework's testing helpers in [Spec 008](../../spec/008-Testing.md) wire that up for you.)
+That test runs on the JVM. There's no browser. There's no React. The `with-frame` block binds `f` to the freshly-made frame's id and pins `*current-frame*` to it for the body; `make-frame` returns the gensym'd id keyword and the runtime fires `:on-create` synchronously. `get-frame-db` returns the current `app-db` *value* (not a deref-able container) — `compute-sub` runs the registered `:count` sub against that value. Tests like this run in milliseconds and you can have thousands of them. (Per-test cleanup is handled by your test fixture — typically a `use-fixtures` that calls `destroy-frame!` between tests; the framework's testing helpers in [Spec 008](../../spec/008-Testing.md) wire that up for you.)
 
 ## What the example covered
 
@@ -226,6 +226,7 @@ What we didn't cover yet:
 - **Effects** that aren't state changes — HTTP, navigation, localStorage. Coming in [03 — Events, state, and the cycle](03-events-state-cycle.md).
 - **Multiple frames** — you only need them when you need them. Coming in [04 — Views and frames](04-views-and-frames.md).
 - **State machines** — for flows where "what's the next state?" is the load-bearing question. Coming in [05 — State machines](05-state-machines.md).
+- **HTTP requests, the canonical way** — the `:rf.http/managed` fx with retry, abort, decode, and reply addressing. Coming in [06 — Doing HTTP requests](06-doing-http-requests.md).
 
 ## A small extension
 

--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -43,87 +43,89 @@ Here's the same login event in re-frame2 idiom:
 (rf/reg-event-fx :user/login
   (fn [{:keys [db]} [_ creds]]
     {:db (assoc db :auth/loading? true)
-     :fx [[:http {:method     :post
-                  :url        "/api/login"
-                  :body       creds
-                  :on-success [:user/login-success]
-                  :on-error   [:user/login-error]}]]}))
+     :fx [[:rf.http/managed
+           {:request    {:method :post
+                         :url    "/api/login"
+                         :body   creds
+                         :request-content-type :json}
+            :on-success [:user/login-success]
+            :on-failure [:user/login-error]}]]}))
 ```
 
 Three things changed:
 
 1. The registration is `reg-event-fx`, not `reg-event-db`. The "fx" stands for "effects" — this handler returns a map of effects, not a new db.
 2. The handler is **still pure**. It returns a Clojure map. Every value in that map is just data — strings, keywords, vectors. No `js/fetch`, no callbacks, no promises.
-3. The map describes everything: "set the db to this; *also*, fire an HTTP effect with these args, and on success dispatch this event, on error dispatch this one."
+3. The map describes everything: "set the db to this; *also*, fire a managed HTTP request with these args, and on success dispatch this event, on failure dispatch this one."
 
 Then there are two follow-up handlers, each pure:
 
 ```clojure
 (rf/reg-event-db :user/login-success
-  (fn [db [_ resp]]
+  (fn [db [_ {:keys [value]}]]
     (-> db
         (assoc :auth/loading? false)
-        (assoc :auth/user (:user resp)))))
+        (assoc :auth/user (:user value)))))
 
 (rf/reg-event-db :user/login-error
-  (fn [db [_ err]]
+  (fn [db [_ {:keys [failure]}]]
     (-> db
         (assoc :auth/loading? false)
-        (assoc :auth/error err))))
+        (assoc :auth/error failure))))
 ```
 
-The runtime is what actually *does* the HTTP request. It looks at the effect map, sees `[:http {...}]`, looks up the registered `:http` fx handler, hands it the args. When the request resolves, the registered fx handler dispatches `[:user/login-success {...}]` or `[:user/login-error {...}]`. Those events go through the queue exactly like any other event. The cycle runs.
+The runtime is what actually *does* the HTTP request. It looks at the effect map, sees `[:rf.http/managed {...}]`, looks up the registered fx, and hands it the args. When the request resolves, the fx dispatches `[:user/login-success {:kind :success :value v}]` or `[:user/login-error {:kind :failure :failure m}]`. Those events go through the queue exactly like any other event. The cycle runs.
+
+`:rf.http/managed` is the canonical HTTP fx — managed decoding, retry-with-backoff, abort, schema-driven decode, frame-aware reply addressing — and it's covered in detail in [chapter 06 — Doing HTTP requests](06-doing-http-requests.md). This chapter uses it to make the effects-as-data shape concrete; the full surface lives there.
 
 This shape makes the dynamic story tractable again. You can trace the login flow by reading three handlers, in order, top to bottom. There are no callbacks. There are no `.then` chains. There's data going in, data going out, data going in again.
 
 ## The standard effect map
 
-The standard keys an `reg-event-fx` handler can return:
+The shape an `reg-event-fx` handler returns is intentionally narrow: two top-level keys.
 
 | Key | Meaning |
 |---|---|
 | `:db` | Replace `app-db` with this value. |
-| `:dispatch` | Dispatch a single event vector. |
-| `:dispatch-later` | After `n` ms, dispatch this event. (Vector of `{:ms ... :dispatch ...}`.) |
-| `:fx` | A vector of arbitrary `[fx-id args]` pairs. The recommended form for any non-trivial set of effects. |
+| `:fx` | A vector of `[fx-id args]` pairs. Every other effect — dispatch, dispatch-later, HTTP, navigation, your own — goes through here. |
 
-You also use `:fx` for user-registered effects. Anything you've registered with `reg-fx` is reachable from here:
+That's all. Top-level `:dispatch`, `:dispatch-later`, `:dispatch-n` from re-frame v1 are gone — they fold into `:fx` as `[:dispatch ...]` / `[:dispatch-later {...}]` rows. The single shape across every effect is the load-bearing piece: tooling, tests, and the runtime each see one consistent grammar instead of two parallel ones. (This consolidation is migration rule M-8 in [`spec/MIGRATION.md`](../../spec/MIGRATION.md).)
 
 ```clojure
 {:db (assoc db :saved? true)
- :fx [[:http       {:url "/api/save" :method :post}]
-      [:localstorage/set {:key "last-saved" :value (now)}]
-      [:rf.nav/push-url     "/saved"]
-      [:dispatch         [:notification/show "Saved!"]]]}
+ :fx [[:rf.http/managed
+       {:request {:method :post :url "/api/save" :body (:draft db)
+                  :request-content-type :json}}]
+      [:localstorage/set  {:key "last-saved" :value (now)}]
+      [:rf.nav/push-url   "/saved"]
+      [:dispatch          [:notification/show "Saved!"]]]}
 ```
 
-Five effects in one handler, including a state change, an HTTP request, a localStorage write, a navigation, and a follow-up event. The order of these effects is well-defined (the runtime applies `:db` first, then walks the `:fx` vector in order), and crucially, *the handler itself is still pure*. Tested as a function: `(handler {:db {...}} [:event-id])` returns the map above. Done.
+Four effects in one handler, including a state change, an HTTP request, a localStorage write, a navigation, and a follow-up event. The order is well-defined (the runtime applies `:db` first, then walks `:fx` top-to-bottom), and crucially, *the handler itself is still pure*. Tested as a function: `(handler {:db {...}} [:event-id])` returns the map above. Done.
 
 ## Registering your own effects
 
-You're not limited to the standard set. Any side-effect you need can be registered:
+You're not limited to the framework-supplied set. Any side-effect you need can be registered:
 
 ```clojure
-(rf/reg-fx :http
-  {:doc       "Issue an HTTP request."
-   :platforms #{:client :server}}
-  (fn [m args]
-    ;; This is the one place where the network call actually happens.
-    (let [{:keys [method url body on-success on-error]} args]
-      (-> (js/fetch url #js {:method (name method) :body (when body (js/JSON.stringify body))})
-          (.then  (fn [resp] (rf/dispatch (conj on-success (json->clj resp)) {:frame (:frame m)})))
-          (.catch (fn [err]  (rf/dispatch (conj on-error err)               {:frame (:frame m)})))))))
+(rf/reg-fx :localstorage/set
+  {:doc       "Write a value to localStorage."
+   :platforms #{:client}}
+  (fn [_frame-ctx {:keys [key value]}]
+    (.setItem js/localStorage key (pr-str value))))
 ```
 
 Three things to notice:
 
-1. **`reg-fx` is the *only* place in your codebase that actually calls `js/fetch`.** The handler that triggered the request didn't. The success-handler that processes the response doesn't either. The line `js/fetch` appears once. That's the entire surface for the effect.
+1. **`reg-fx` is the *only* place in your codebase that calls `js/localStorage`.** The handler that triggered the write didn't. The handler that reads the value back later doesn't either. The browser-side imperative call appears once. That's the entire surface for the effect.
 
-2. **The fx receives args (the value the event handler put in the effect map) and an envelope `m` (the dispatch envelope, which carries the originating frame).** It uses both to dispatch follow-up events on the right frame.
+2. **The fx receives a frame context (carrying `:frame`, `:event`, etc.) and the args the event handler put in the effect map.** Most fxs only use the args; ones that re-dispatch follow-up events thread the frame through so the dispatch lands in the right frame.
 
-3. **`:platforms` says where this effect is allowed to run.** `#{:client :server}` means it works in the browser and in server-side rendering. A `:localstorage/set` effect would be `#{:client}` only — the runtime skips it during SSR with a logged trace event. We'll come back to this in [chapter 06](06-server-side.md).
+3. **`:platforms` says where this effect is allowed to run.** `#{:client}` means it's skipped during SSR with a `:rf.fx/skipped-on-platform` trace event; the handler doesn't have to branch. We'll come back to this in [chapter 07](07-server-side.md).
 
-You'll register a handful of effects in any non-trivial app. `:http` for the network. `:localstorage/get` and `:localstorage/set` for persistence. `:rf.nav/push-url` for navigation. `:notify` for toasts. Each is registered once; every event handler describes its effects by id.
+You'll register a handful of effects in any non-trivial app: `:localstorage/get` and `:localstorage/set` for persistence, `:rf.nav/push-url` for navigation, `:notify` for toasts. Each is registered once; every event handler describes its effects by id.
+
+For HTTP, the framework already ships `:rf.http/managed` — managed decoding, retry-with-backoff, abort, frame-aware reply addressing, schema-driven decode. You don't write your own HTTP fx; you use that one. [Chapter 06 — Doing HTTP requests](06-doing-http-requests.md) walks through it end-to-end.
 
 ## Why effects-as-data is worth the verbosity
 
@@ -133,16 +135,18 @@ The benefits:
 
 **Tests don't need a network.** The handler that produces the effect map can be tested as a pure function. The success/error handlers similarly. The fx itself can be tested by stubbing the HTTP call. None of these tests need React, JSDOM, or a running server.
 
-**You can swap the implementation.** A test wants the `:http` fx to return a canned response? Override it for that test:
+**You can swap the implementation.** A test wants `:rf.http/managed` to return a canned response? Override it for that test:
 
 ```clojure
-(rf/with-frame [f (rf/make-frame
-                   {:on-create [:user/login {:email "a@b.c" :password "..."}]
-                    :fx-overrides {:http :http.canned-success}})]
-  (is (= "test@example.com" (-> @(rf/get-frame-db f) :auth/user :email))))
+(rf/with-managed-request-stubs
+  {[:post "/api/login"] {:reply {:ok {:user {:email "test@example.com"}}}}}
+  (rf/with-frame [f (rf/make-frame
+                     {:on-create [:user/login {:email "a@b.c" :password "..."}]})]
+    (is (= "test@example.com"
+           (-> (rf/get-frame-db f) :auth/user :email)))))
 ```
 
-The override is **id-valued** — `:http` is replaced by `:http.canned-success`, another registered fx. No mocking. No interceptors. Just a registry pointer redirected.
+The framework ships `with-managed-request-stubs` (and the lower-level `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs) precisely so tests can synthesise managed-HTTP replies without a network. It's a registry redirect, not a mock — the same dispatch shape the real fx produces lands in the test handler.
 
 **You can record what happened.** Because effects are data, the runtime can log them, replay them, ship them across the wire, store them in a fixture file. re-frame2's trace stream surfaces every effect that fired, with its args, in order. Debugging an asynchronous interaction stops being archaeology.
 
@@ -209,7 +213,7 @@ The pattern docs are themselves human-readable — closer in voice to this guide
 
 ## A note on revertibility
 
-One consequence of the discipline above worth pausing on: because state lives in one place and updates atomically, **the entire frame's state at any moment is a single value**. That value can be captured, stored, compared, restored. The framework's [Goal 2](../../spec/000-Vision.md#frame-state-revertibility) — *frame state revertibility* — turns this from an implementation detail into a contract: any prior frame value can be restored as a pointer swap, with no out-of-band state left behind. App-level undo is a thin interceptor. Time-travel debugging records values, not events. SSR ships a value. AI experimentation can try a change, observe, revert, retry without registry pollution. Each of these is a consequence of "state is a value"; the architecture commits to that discipline so the consequences are real.
+One consequence of the discipline above worth pausing on: because state lives in one place and updates atomically, **the entire frame's state at any moment is a single value**. That value can be captured, stored, compared, restored. The framework's [Goal 3](../../spec/000-Vision.md#frame-state-revertibility) — *frame state revertibility* — turns this from an implementation detail into a contract: any prior frame value can be restored as a pointer swap, with no out-of-band state left behind. App-level undo is a thin interceptor. Time-travel debugging records values, not events. SSR ships a value. AI experimentation can try a change, observe, revert, retry without registry pollution. Each of these is a consequence of "state is a value"; the architecture commits to that discipline so the consequences are real.
 
 ## A note on naming
 
@@ -224,4 +228,4 @@ You don't have to follow this. But every re-frame2 codebase that does looks the 
 ## Next
 
 - [04 — Views and frames](04-views-and-frames.md) — what's on the screen and how to keep different parts isolated.
-- The same pattern that handles `:http` handles every external-world interaction. Once you've internalised "side-effects are data the runtime interprets," you're ready for everything else.
+- The same pattern that handles `:rf.http/managed` handles every external-world interaction. Once you've internalised "side-effects are data the runtime interprets," you're ready for everything else.

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -184,7 +184,7 @@ A top-level key per *feature*. Each feature owns its own slice. No feature reach
 
 This **id-prefix-as-namespace** convention extends to the registry: events for the cart feature live under `:cart/...` and `:cart.item/...`; subs that read the cart's slice live under `:cart/items`, `:cart/total`; views live under `:cart/summary`. The whole feature is identifiable by its prefix. Adding or removing a feature is a `git mv` away from being a single coherent unit.
 
-For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev. We'll see this in [chapter 06](06-server-side.md) when SSR enters the picture.
+For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev. We'll see this in [chapter 07](07-server-side.md) when SSR enters the picture.
 
 ### Computed values as state — the flow escape hatch
 

--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -22,16 +22,18 @@ Without state machines, the login flow looks something like this:
 
       (>= (:auth/attempts db) 3)
       {:db (assoc db :auth/state :locked-out)
-       :fx [[:http {:url "/api/lock-account"}]]}
+       :fx [[:rf.http/managed
+             {:request {:method :post :url "/api/lock-account"}}]]}
 
       :else
       {:db (-> db
                (assoc :auth/state :submitting)
                (update :auth/attempts inc))
-       :fx [[:http {:url "/api/login"
-                    :body creds
-                    :on-success [:auth/login-success]
-                    :on-error   [:auth/login-error]}]]})))
+       :fx [[:rf.http/managed
+             {:request    {:method :post :url "/api/login" :body creds
+                           :request-content-type :json}
+              :on-success [:auth/login-success]
+              :on-failure [:auth/login-error]}]]})))
 
 (rf/reg-event-db :auth/login-success
   (fn [db [_ resp]]
@@ -80,11 +82,13 @@ The fix isn't to write better `cond` clauses. The fix is to step back and notice
 
     :issue-request
     (fn [_data [_ creds]]
-      {:fx [[:http {:method     :post
-                    :url        "/api/login"
-                    :body       creds
-                    :on-success [:auth.login/flow [:auth.login/success]]
-                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+      {:fx [[:rf.http/managed
+             {:request    {:method :post
+                           :url    "/api/login"
+                           :body   creds
+                           :request-content-type :json}
+              :on-success [:auth.login/flow [:auth.login/success]]
+              :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
     :record-error
     (fn [data [_ err]]
@@ -93,7 +97,9 @@ The fix isn't to write better `cond` clauses. The fix is to step back and notice
                  (assoc :error (or (:message err) "Login failed.")))})
 
     :lock-account
-    (fn [_ _] {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+    (fn [_ _]
+      {:fx [[:rf.http/managed
+             {:request {:method :post :url "/api/auth/lock"}}]]})
 
     :store-session
     (fn [_data [_ {:keys [token]}]]
@@ -194,21 +200,23 @@ Sub-events route via the machine's id and an inner event vector:
 
 The outer keyword is the machine; the inner vector is the event the machine sees. The runtime resolves the inner event against the current state's `:on` map, runs the guard, fires the action, and writes the new snapshot back to `[:rf/machines :auth.login/flow]`.
 
-For HTTP / async callbacks, the convention "build a 2-element template, conj the result on resolve" works as in any other re-frame fx:
+For HTTP / async callbacks, the convention "build a 2-element template, conj the reply on resolve" works as in any other re-frame fx:
 
 ```clojure
 ;; The :issue-request action returns this fx vector:
-[:http {:url        "/api/login"
-        :on-success [:auth.login/flow [:auth.login/success]]   ;; 2-element template
-        :on-error   [:auth.login/flow [:auth.login/failure]]}]
+[:rf.http/managed
+ {:request    {:method :post :url "/api/login"
+               :request-content-type :json}
+  :on-success [:auth.login/flow [:auth.login/success]]   ;; 2-element template
+  :on-failure [:auth.login/flow [:auth.login/failure]]}]
 
-;; The :http fx implementation does (rf/dispatch (conj on-success response)),
-;; producing [:auth.login/flow [:auth.login/success] response].
-;; The runtime folds the trailing response onto the inner event so the action
-;; sees [:auth.login/success response].
+;; :rf.http/managed appends the reply payload as the last argument, producing
+;;   [:auth.login/flow [:auth.login/success] {:kind :success :value v}]
+;; The runtime folds the trailing reply onto the inner event so the action
+;; sees [:auth.login/success {:kind :success :value v}].
 ```
 
-This "extras-fold" makes the standard fx-callback convention work without ceremony — every async callback ships a value into the machine the same way.
+This "extras-fold" makes the standard fx-callback convention work without ceremony — every async callback ships a value into the machine the same way. (The reply-payload shape — `{:kind :success :value v}` / `{:kind :failure :failure m}` — is the canonical envelope `:rf.http/managed` produces; see [chapter 06 — Doing HTTP requests](06-doing-http-requests.md).)
 
 ## Guards and actions
 
@@ -234,11 +242,13 @@ Actions are functions that produce data updates and / or effects. They live in `
 
  :issue-request
  (fn [_data [_ creds]]
-   {:fx [[:http {:method     :post
-                 :url        "/api/login"
-                 :body       creds
-                 :on-success [:auth.login/flow [:auth.login/success]]
-                 :on-error   [:auth.login/flow [:auth.login/failure]]}]]})}
+   {:fx [[:rf.http/managed
+          {:request    {:method :post
+                        :url    "/api/login"
+                        :body   creds
+                        :request-content-type :json}
+           :on-success [:auth.login/flow [:auth.login/success]]
+           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})}
 ```
 
 An action sees `(fn [data event] effects)` and returns either:
@@ -366,7 +376,7 @@ The complete login flow from this chapter — including the runnable smoke tests
 
 ## The deeper claim
 
-State machines are a small example of the broader thesis [chapter 08](08-the-dynamic-model.md) makes: **constrained execution models are easier to reason about than free-form ones**.
+State machines are a small example of the broader thesis [chapter 09](09-the-dynamic-model.md) makes: **constrained execution models are easier to reason about than free-form ones**.
 
 A finite state machine has, by construction, a small set of reachable states. You can enumerate them. You can prove things about transitions. You can render the whole flow as a diagram. You can ask "from this state, what can happen?" and the answer is bounded.
 
@@ -378,4 +388,5 @@ When the flow has the shape of a machine, write a machine.
 
 ## Next
 
-- [06 — The server side](06-server-side.md) — server-side rendering, hydration, and the `:platforms` story for fx that should only run in one place.
+- [06 — Doing HTTP requests](06-doing-http-requests.md) — `:rf.http/managed`, the canonical request fx, end-to-end.
+- [07 — The server side](07-server-side.md) — server-side rendering, hydration, and the `:platforms` story for fx that should only run in one place.

--- a/docs/guide/06-doing-http-requests.md
+++ b/docs/guide/06-doing-http-requests.md
@@ -1,0 +1,333 @@
+# 06 — Doing HTTP requests
+
+Most SPAs spend their lives talking to a server. A handler dispatches; a fetch goes out; some milliseconds later a reply lands; the handler integrates the reply; the view re-renders. Repeat a few thousand times per session.
+
+[Chapter 03](03-events-state-cycle.md) introduced the *shape* of that interaction: side-effects are data, the runtime interprets, the handler stays pure. This chapter narrows in on **the canonical mechanism re-frame2 ships for HTTP** — the `:rf.http/managed` fx — and walks through the contract end-to-end.
+
+The full normative contract lives in [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md). This chapter is the human-track companion: what the fx is, what it does, why it's shaped the way it is, and how the runnable examples exercise it.
+
+## What `:rf.http/managed` is
+
+A registered fx whose args map describes an HTTP request *as data*, and whose runtime side issues the request, decodes the body, runs retry-with-backoff if you asked for it, classifies failures into a closed set of `:rf.http/*` categories, and dispatches the reply back into the runtime.
+
+You don't write the fetch. You don't write the `.then` chain. You don't reach for `js/fetch` or `java.net.http.HttpClient` directly. You return a map, the runtime does the rest.
+
+A first taste, in the simplest possible form:
+
+```clojure
+(rf/reg-event-fx :ping
+  (fn [{:keys [db]} [_ msg]]
+    (if-let [reply (:rf/reply msg)]
+      ;; Reply branch — same handler, different role.
+      {:db (assoc db :pinged-at (:elapsed-at reply))}
+
+      ;; Initial branch — issue the managed request.
+      {:fx [[:rf.http/managed
+             {:request {:url "/ping"}}]]})))
+```
+
+Two lines of fx, no decode, no accept, no retry. Default `:method` is `:get`. Default decode is `:auto` (sniff the response Content-Type). Default reply addressing dispatches *back to this same event id* with `:rf/reply` merged into the original message — so one handler covers both roles, distinguishable by `(:rf/reply msg)`.
+
+This default — co-located request and reply — is the whole reason `:rf.http/managed` exists as a distinct surface from "register your own `:http` fx and roll your own conventions." The shape is uniform across applications. Tooling can introspect. Tests can stub. Pair tools, retry policy, error projection, and frame-aware reply addressing all compose against one canonical envelope.
+
+## Why it exists (vs raw `js/fetch` + ad-hoc effects)
+
+If you're coming from re-frame v1, the obvious thing is to register your own `:http` fx (chapter 03 sketches one), have it call `js/fetch`, and dispatch user-named follow-up events on resolution. That works. It's also what every team using re-frame v1 ended up reinventing, with subtly incompatible answers to:
+
+- **Where does the response shape live?** Some teams put `{:status 200 :body ...}`; some unwrap `:body` immediately; some hand the raw `Response` to the success handler.
+- **How are 4xx and 5xx classified?** Some teams treat any non-2xx as failure; some forward 401 specially; some let the success handler branch on status.
+- **What's a transport error vs a decode error vs an HTTP error?** Usually nothing — `(.catch ...)` swallows them all into `:on-error` with a string.
+- **Do retries exist?** Sometimes, hand-rolled, often inconsistent across endpoints.
+- **How do you abort a stale request?** Often not at all.
+- **How do you stub it for tests?** Each team grows its own.
+
+Spec 014 picks one canonical answer for each of those, locks it, and ships. Apps that adopt it get retry, abort, frame-aware reply addressing, schema-driven decode, the closed `:rf.http/*` failure category set, status-before-decode classification, and test stubs *as a single uniform surface*. Pair tools introspect that surface; conformance fixtures grade against it; AI scaffolds emit code that fits it.
+
+The lower-level option (write your own fx) is still there for wire-level control — custom transport, raw bytes, idiosyncratic protocols. `:rf.http/managed` covers the common case, ergonomically, and pair tools can rely on it.
+
+## The request map
+
+The args map for `:rf.http/managed` is small. The required keys are `:request` (with `:url` inside it). Everything else has a sensible default.
+
+```clojure
+{:request    {:method  :post
+              :url     "/api/articles"
+              :params  {:tag "clojure"}
+              :body    {:title "..."}
+              :request-content-type :json
+              :headers {"X-Trace" "abc"}}
+ :decode     ArticleResponse           ;; Malli schema, kw, fn, or :auto
+ :accept     (fn [decoded] {:ok decoded})  ;; default = success-on-2xx
+ :retry      {:on #{:rf.http/transport :rf.http/http-5xx}
+              :max-attempts 4
+              :backoff      {:base-ms 250 :factor 2 :max-ms 5000 :jitter true}}
+ :timeout-ms 30000
+ :on-success [:articles/loaded]        ;; default = back to originator
+ :on-failure [:articles/load-error]    ;; default = back to originator
+ :request-id :articles/load            ;; for abort + supersede
+ :abort-signal external-controller-signal}
+```
+
+The full table — every key, every type, every default — is in [Spec 014 §The args map](../../spec/014-HTTPRequests.md#the-args-map). Two pieces are worth highlighting in narrative.
+
+### `:request` carries the wire shape
+
+`:method` defaults to `:get`. `:url` is required. `:params` get URL-encoded and merged onto the URL. `:body` may be a Clojure collection (encoded per `:request-content-type`), a string, a `Blob` / `FormData` / `ArrayBuffer`, or **a thunk `(fn [] body)`**. The thunk is called at request-send time — useful for very-large payloads you don't want to hold in memory between dispatch and send, and for retries that need a fresh body handle.
+
+Headers, credentials, redirect mode, and the CLJS-only Fetch passthroughs (`:mode`, `:cache`, `:referrer`, `:integrity`) all live inside `:request`. On the JVM, the per-row CLJS-only keys are no-ops with a single `:rf.http/cljs-only-key-ignored-on-jvm` trace per occurrence.
+
+### Default reply addressing — co-located handler
+
+```clojure
+{:fx [[:rf.http/managed {:request {...}}]]}
+```
+
+When you don't specify `:on-success` / `:on-failure`, the fx captures the originating event id from the dispatch envelope's cofx. On reply, it dispatches:
+
+```clojure
+[<originating-event-id> (assoc original-msg :rf/reply <reply-payload>)]
+```
+
+So your handler ends up looking like:
+
+```clojure
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ;; Reply path
+      (case (:kind reply)
+        :success
+        {:db (-> db
+                 (assoc-in [:article :status] :loaded)
+                 (assoc-in [:article :data]   (:value reply)))}
+
+        :failure
+        {:db (-> db
+                 (assoc-in [:article :status] :error)
+                 (assoc-in [:article :error]  (:failure reply)))})
+
+      ;; Initial path
+      {:db (-> db
+               (assoc-in [:article :status] :loading)
+               (assoc-in [:article :error]  nil))
+       :fx [[:rf.http/managed
+             {:request {:url (str "/articles/" slug)}
+              :decode  ArticleResponse}]]})))
+```
+
+One handler, two roles, distinguishable by the `:rf/reply` sentinel. The reply payload's outer shape is `{:kind :success :value v}` or `{:kind :failure :failure m}`; the inner `:kind` (under `:failure`) names the `:rf.http/*` category.
+
+When the co-located shape doesn't fit — typical for auth flows that already live in a state machine, or for endpoints whose success and failure paths diverge dramatically — supply explicit `:on-success` / `:on-failure` event vectors and the reply payload appends as the last argument. Pass `nil` to silence (fire-and-forget telemetry beacons).
+
+### Failure shapes are closed-set
+
+Every failure carries a `:kind` keyword in the framework-reserved `:rf.http/*` namespace plus category-specific tags:
+
+| `:kind` | When |
+|---|---|
+| `:rf.http/transport` | Network / DNS / connection error before the HTTP transaction completed. |
+| `:rf.http/cors` | CORS preflight rejected. CLJS-only. |
+| `:rf.http/timeout` | Per-attempt timeout fired. |
+| `:rf.http/http-4xx` | 4xx response. The raw body is at `:body` (decode is skipped on non-2xx). |
+| `:rf.http/http-5xx` | 5xx response. Same shape as `:http-4xx`. |
+| `:rf.http/decode-failure` | A 2xx response whose body the decode pipeline rejected. |
+| `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. |
+| `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal`. |
+
+The vocabulary is **closed for v1** — additions require a Spec change. See [Spec 014 §Failure categories](../../spec/014-HTTPRequests.md#failure-categories-closed-set) for the full table.
+
+## Decode pipeline
+
+The `:decode` key controls how the response body is parsed.
+
+**Decode runs only on 2xx responses.** This is the load-bearing classification rule: status is checked *before* the body is touched. A JSON endpoint that returns an HTML 404 from a load balancer surfaces as `:rf.http/http-4xx` with the raw HTML at `:body`, not as `:rf.http/decode-failure`. The HTTP failure category is the load-bearing piece of information for the caller; if you want to see the structured error body that an API might return alongside a 4xx, you decode the raw `:body` yourself in the failure-handling branch. (Spec 014 §Classification order.)
+
+The `:decode` key takes:
+
+- **A Malli schema** (the canonical form): `:decode ArticleResponse`. The fx parses the body by content-type, runs Malli's `decode`, hands the validated value to `:accept`. A 2xx body that fails to decode classifies as `:rf.http/decode-failure`.
+- **A keyword**: `:decode :json` (force JSON), `:text`, `:blob`, `:array-buffer`, `:form-data`. No Malli step.
+- **A function** `(fn [body-text headers] decoded)` — full control. Throwing on a 2xx classifies as `:rf.http/decode-failure`.
+- **`:auto`** (the default): sniff the response Content-Type. `application/json*` → JSON. `text/*` → text. Otherwise blob. Whenever `:auto` resolves and the user did NOT explicitly supply `:decode`, the runtime emits a single `:rf.warning/decode-defaulted` trace per request — informational, not an error, just visible in tooling so you can choose to be explicit.
+
+### Schema reflection
+
+Pair tools and AI generators want to know which schemas a handler expects from the wire — without invoking the handler. Declare them at registration time via the `:rf.http/decode-schemas` metadata key:
+
+```clojure
+(rf/reg-event-fx :article/load
+  {:doc                    "Load an article."
+   :rf.http/decode-schemas [ArticleResponse]}     ;; declared up-front for tooling
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ...
+      {:fx [[:rf.http/managed
+             {:request {:url (str "/articles/" slug)}
+              :decode  ArticleResponse}]]})))     ;; same schema at the call site
+```
+
+Then `(rf/handler-meta :event :article/load)` returns metadata carrying `:rf.http/decode-schemas [ArticleResponse]`, which tools introspect. **Optional, never enforced** — the runtime does not cross-check that the call-site `:decode` matches the declared schemas. The metadata is reflective sugar; runtime enforcement would want a `defmanaged-event-fx` macro that DRYs the declaration, which is out of v1 scope.
+
+## Retry and backoff
+
+```clojure
+:retry {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
+        :max-attempts 4
+        :backoff      {:base-ms 250
+                       :factor  2
+                       :max-ms  5000
+                       :jitter  true}}
+```
+
+`:max-attempts` is the total including the first; `1` means no retry. `:on` names which failure categories trigger a retry — `:rf.http/aborted` is never retried regardless. Backoff is exponential with optional ±25% jitter, capped at `:max-ms`.
+
+**Only the final exhausted-retries failure dispatches `:on-failure`.** Intermediate attempts that match `:retry :on` do NOT dispatch the failure handler — the user sees the success reply if any attempt succeeds, and exactly one failure reply (with `:max-attempts` reached) if every attempt fails. For debugging visibility, each intermediate attempt emits a `:rf.http/retry-attempt` trace event. Pair tools and 10x panels surface the per-attempt trace; user code only sees the final outcome.
+
+A common shape in real apps: declare a shared retry policy for read-only data fetches, and *don't* retry user-initiated actions (login, submit, delete — single user-initiated action per click).
+
+```clojure
+(def data-fetch-retry
+  {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
+   :max-attempts 3
+   :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
+
+;; Apply to reads:
+[:rf.http/managed {:request {:url "/articles"} :decode ArticleListResponse :retry data-fetch-retry}]
+
+;; Don't apply to writes:
+[:rf.http/managed {:request {:method :post :url "/articles" :body draft :request-content-type :json}
+                   :decode  ArticleResponse}]
+```
+
+The realworld example does exactly this — see `examples/realworld/http.cljs`.
+
+## Abort by `:request-id`
+
+A stable id on the request lets a subsequent `:rf.http/managed-abort` fx cancel the in-flight request. The id can be anything `=`-comparable: a keyword, a string, a vector, a uuid.
+
+```clojure
+(rf/reg-event-fx :search/query
+  (fn [{:keys [db]} [_ {:keys [q] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ;; ...handle results...
+      {:fx [[:rf.http/managed-abort :search]                 ;; cancel previous
+            [:rf.http/managed
+             {:request    {:url "/search" :params {:q q}}
+              :request-id :search
+              :decode     SearchResponse}]]})))
+```
+
+When two in-flight requests share an id, issuing a new one with the same id supersedes the old one — the previous request aborts with `:reason :request-id-superseded`. A manual `:rf.http/managed-abort` aborts whichever request currently holds the id with `:reason :user`. Aborted requests dispatch `:on-failure` (or the default reply path) with `:kind :rf.http/aborted`.
+
+The external-handle alternative — `:abort-signal (.-signal my-controller)` — threads a user-owned `AbortController.signal` directly through to the underlying transport. CLJS-only (Fetch supports it). The two mechanisms are mutually exclusive — pick one.
+
+## Lazy `:body` thunk
+
+If `:body` is a thunk `(fn [] body)`, the fx invokes it *just before sending* (after `:retry :backoff` delays elapse). Each retry re-invokes the thunk to obtain a fresh handle.
+
+This is useful when:
+
+- The body is expensive to serialise and you don't want to pay the cost until the request is actually about to ship.
+- The body is a single-shot stream that can't be replayed — a thunk lets retries obtain a fresh handle each time.
+- The body's contents depend on something computable only at send time (a fresh CSRF token, a current timestamp).
+
+```clojure
+:body (fn [] (build-large-payload (current-state)))
+```
+
+## Frame awareness
+
+The reply dispatch lands in the **same frame** the request was issued from. The fx captures `:frame` from the dispatch envelope's cofx and threads it through to the reply dispatch's `{:frame ...}` opt. Multi-frame apps (story tools, SSR, multi-window) work without extra ceremony — the request that originated in `:left` replies into `:left`; the request that originated in the per-request SSR frame replies into that same per-request SSR frame and the drain settles before render.
+
+## Test stubs
+
+Tests want managed-HTTP requests to resolve against canned data, not the network. The framework ships **two canonical stub fxs** plus a higher-level helper.
+
+### Per-request stubs via `:fx-overrides`
+
+```clojure
+;; Success stub — synthesises a success reply.
+(rf/dispatch-sync [:article/load {:slug "hello"}]
+                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+
+;; Failure stub — synthesises a failure reply.
+(rf/dispatch-sync [:article/load {:slug "missing"}]
+                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+```
+
+The args map is the same shape; the canned-success stub takes a `:value` key (the payload to put under `:rf/reply :value`); the canned-failure stub takes `:kind` and `:tags` for the failure shape. Both stubs reuse the canonical reply envelope, so the test handler's reply branch sees what the live fx would produce.
+
+### `with-managed-request-stubs`
+
+For test suites that exercise many requests:
+
+```clojure
+(rf/with-managed-request-stubs
+  {[:get  "/articles/hello"]   {:reply {:ok hello-article}}
+   [:get  "/articles/missing"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
+   [:post "/articles"]         {:reply {:ok new-article}}}
+  (rf/dispatch-sync [:article/load {:slug "hello"}])
+  (rf/dispatch-sync [:article/load {:slug "missing"}])
+  (rf/dispatch-sync [:article/create {:title "..."}]))
+```
+
+The helper inspects each `:rf.http/managed` invocation's `:request :method` + `:request :url` and routes through the configured reply. Wrap a test, run dispatches, assert against the resulting `app-db`. No browser, no network.
+
+The canned-stub fxs gate on `interop/debug-enabled?` — they elide in production builds, so tests pay no production cost.
+
+## Worked example — `examples/managed_http_counter/`
+
+The runnable demo of every contract above lives in [`examples/managed_http_counter/`](https://github.com/day8/re-frame2/tree/main/examples/managed_http_counter). It's a counter where each button issues a managed HTTP request and the reply lands back in app-db.
+
+Five buttons, each exercising a different slice of the contract:
+
+- **+1** — `GET /api/inc.json`. A static asset; the response `{"delta": 1}` decodes as JSON via default `:auto` decoding; the reply lands at the originating `:counter/+1` handler via default reply addressing; the handler branches on `(:rf/reply msg)` to apply the increment. *Real round-trip through Fetch.*
+
+- **Fail** — `GET /api/does-not-exist`. The endpoint 404s with HTML; per the status-before-decode classification rule, the failure category is `:rf.http/http-4xx` (with the raw HTML at `:body`), not `:rf.http/decode-failure`. The handler's failure branch records the error.
+
+- **Retry-recover** — exercises the `:rf.http/managed-canned-success` stub at app level. The :counter/retry-recover handler issues `[:rf.http/managed-canned-success {... :value {:delta 5}}]` directly; the stub synthesises the success reply with `{:delta 5}`; the handler increments by 5. Same reply shape as a live retry-recover would produce.
+
+- **Start long** — issues a `GET /api/long` with `:request-id :counter/long`. The request stays in flight; clicking **Cancel** issues `[:rf.http/managed-abort :counter/long]` which aborts the in-flight handle. The aborted reply dispatches `:rf.http/aborted` via the default reply path back to `:counter/start-long`, which clears `:status`.
+
+The whole example is ~200 lines of CLJS. Drop it in front of you while reading; tweak the request shape and watch the reply path adapt.
+
+## Worked example — `examples/realworld/`
+
+For breadth across the contract — auth, routing, optimistic updates, pagination, forms, SSR-relevant payload concerns — see [`examples/realworld/`](https://github.com/day8/re-frame2/tree/main/examples/realworld). It's the canonical Spec 014 demo, built on the [RealWorld Conduit spec](https://github.com/gothinkster/realworld).
+
+What it specifically exercises from this chapter:
+
+- **Default reply addressing** — `realworld.comments/:article/load` issues `:rf.http/managed` with no explicit `:on-success` / `:on-failure` and branches on `(:rf/reply msg)`. One handler, two roles.
+- **Explicit `:on-success` / `:on-failure`** — every other endpoint (auth, articles list, profile, comments, favourites, follow, settings, editor) uses the separate-handler shape: a small DB-only handler per success / failure.
+- **Schema-driven decode** — every request passes a Malli schema as `:decode`. Decode runs only on 2xx; a 4xx HTML page never produces `:rf.http/decode-failure`.
+- **Schema reflection** — every event handler that issues a managed request declares `:rf.http/decode-schemas` in its registration metadata. Tooling can introspect via `(rf/handler-meta :event :articles/load)` without invoking the handler.
+- **Retry + backoff** — read-only data fetches share a `data-fetch-retry` policy; user-initiated writes (login, submit, delete) deliberately do NOT retry.
+- **Abort by `:request-id`** — `:articles/load` and `:feed/load` use stable `:request-id` keywords; `(:articles/cancel)` and `(:feed/cancel)` issue `:rf.http/managed-abort` to cancel an in-flight load when the user navigates away or re-issues mid-fetch.
+- **Frame awareness** — replies route back to the originating frame automatically; the test fixtures spin per-test frames via `make-frame` and assert against `(get-frame-db f)`.
+- **Failure projection** — `realworld.http/failure->message` projects the closed-set `:rf.http/*` failure categories to human-readable messages, surfacing the Conduit `{:errors {:body [...]}}` shape when present.
+
+The realworld example is a worked sketch — broader than the counter demo, narrower than a polished production clone, deliberately exercising every Spec 014 affordance one place at a time.
+
+## Migrating from re-frame v1's ad-hoc HTTP
+
+If you're coming from a re-frame v1 codebase that registered its own `:http` fx — or used `re-frame-http-fx`, `re-frame-fetch-fx`, or one of their cousins — the migration is mechanical:
+
+1. Replace your `[:http {:url ... :on-success ... :on-error ...}]` fx vectors with `[:rf.http/managed {:request {:url ...} :on-success ... :on-failure ...}]`.
+2. Move wire-shape keys (`:method`, `:url`, `:body`, `:headers`, `:params`) inside `:request`.
+3. Rename `:on-error` → `:on-failure`. The reply payload appends as the last argument; destructure `{:keys [value]}` for success, `{:keys [failure]}` for failure.
+4. Adopt the closed `:rf.http/*` failure category set in your error-handling branches — your code that branched on `(:status err)` becomes branching on `(:kind failure)`.
+5. (Optional) Convert per-call success handlers to default reply addressing if the pre-request and post-reply logic naturally co-locate.
+
+The migration is detailed in [`spec/MIGRATION.md` §M-23 (alpha removed)](../../spec/MIGRATION.md#m-23-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn) for callers that depended on the alpha namespace's now-removed query/registration shape, and the per-fx migration is mechanical (Type A) for the standard cases.
+
+## Cross-references
+
+- [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md) — the normative contract: every key, every default, every failure shape.
+- [`spec/Pattern-RemoteData.md`](../../spec/Pattern-RemoteData.md) — the 5-key request-lifecycle slice; managed-HTTP writes through this slice.
+- [`spec/Pattern-AsyncEffect.md`](../../spec/Pattern-AsyncEffect.md) — the generic six-step async shape that managed-HTTP specialises.
+- [`spec/Pattern-StaleDetection.md`](../../spec/Pattern-StaleDetection.md) — epoch carry; managed requests inherit it.
+- [`examples/managed_http_counter/`](https://github.com/day8/re-frame2/tree/main/examples/managed_http_counter) — the runnable per-button demo of every contract row.
+- [`examples/realworld/`](https://github.com/day8/re-frame2/tree/main/examples/realworld) — the canonical breadth demo across auth, routing, forms, machines, optimistic updates, and SSR-relevant payload concerns.
+
+## Next
+
+- [07 — The server side](07-server-side.md) — SSR and hydration; the `:platforms` story for fx that should only run in one place; how the per-request frame composes with managed-HTTP for setup fetches.

--- a/docs/guide/07-server-side.md
+++ b/docs/guide/07-server-side.md
@@ -1,4 +1,4 @@
-# 06 — The server side
+# 07 — The server side
 
 For most of the SPA era, "server-side rendering" has been an awkward retrofit. You built your client app with React, then later — when SEO mattered, or first-paint was too slow, or social-media link previews didn't render — you bolted on Next.js or its equivalent. The server-rendered code path was different from the client-rendered one. Subtle bugs lived in the seam.
 
@@ -34,7 +34,7 @@ It works because the architecture has been *structurally* SSR-friendly from the 
 
 **Render-tree as serialisable data.** Hiccup is just nested vectors and maps. There's a pure function — `(rf/render-to-string hiccup-tree)` — that turns any hiccup into a string. No React. No DOM. No JavaScript runtime. It's a function from data to string, and it runs on the JVM.
 
-These three properties aren't accidents. They're consequences of the broader pattern decisions ([chapter 08](08-the-dynamic-model.md) covers the philosophy). The same constraints that make handlers testable, debuggable, and AI-amenable also make them *runnable on a server without a browser*.
+These three properties aren't accidents. They're consequences of the broader pattern decisions ([chapter 09](09-the-dynamic-model.md) covers the philosophy). The same constraints that make handlers testable, debuggable, and AI-amenable also make them *runnable on a server without a browser*.
 
 ## The hydration handshake
 
@@ -46,13 +46,13 @@ The re-frame2 approach: the server **serialises the final state** and ships it d
 
 ```clojure
 ;; Server side
-(let [final-db @(rf/get-frame-db request-frame)
-      hiccup   ((rf/view :app/root))
+(let [final-db (rf/get-frame-db request-frame)
+      hiccup   [(rf/view :app/root)]
       html     (rf/render-to-string hiccup {:frame request-frame})
       payload  {:rf/version    "1.0"
                 :rf/frame-id   :app/main
                 :rf/app-db     final-db
-                :rf/render-hash (hash hiccup)}]
+                :rf/render-hash (rf/render-tree-hash hiccup)}]
   ;; ... ship html + payload to the client
   )
 
@@ -63,6 +63,8 @@ The re-frame2 approach: the server **serialises the final state** and ships it d
       (rf/dispatch-sync [:rf/hydrate payload] {:frame :app/main}))
     (rdc/render root [(rf/view :app/root)])))
 ```
+
+`get-frame-db` returns the current `app-db` *value* — a plain map, not a deref-able container — so there's no `@` in front. `(rf/view :id)` looks up the registered render fn by id; the canonical hiccup head is the looked-up fn placed inside a vector (`[(rf/view :app/root)]`), so Reagent / the SSR emitter treats the call as a component. `render-tree-hash` is the framework's stable structural hash — both server and client compute it from the same canonical-EDN representation, which is what makes the mismatch detection below reliable.
 
 The framework's default `:rf/hydrate` handler is **`:replace-app-db`**: the server's serialised slice replaces whatever the client bootstrap had pre-seeded. This is locked. The reasoning: the server is authoritative for the initial app-db, and a defaulting merge policy would leave subtle ordering bugs (which slice wins?) under the rug.
 
@@ -190,16 +192,21 @@ A server handling concurrent requests can't have one global frame — each reque
 
 ```clojure
 (defn handle-request [request]
-  (let [frame-id (gensym "ssr-")]
-    (rf/with-frame [f (rf/make-frame {:id frame-id
-                                      :on-create [:rf/server-init request]})]
-      ;; with-frame creates the frame, runs the body, destroys the frame at end
-      (let [final-db @(rf/get-frame-db f)
-            hiccup   ((rf/view :app/root))
-            html     (rf/render-to-string hiccup {:frame f})]
-        {:status  200
-         :headers {"Content-Type" "text/html"}
-         :body    (page-template html (pr-str (build-payload f hiccup)))}))))
+  (rf/with-frame [f (rf/make-frame {:on-create [:rf/server-init request]})]
+    ;; make-frame returns the gensym'd frame id (a keyword under :rf.frame/);
+    ;; with-frame binds *current-frame* to it for the body. The frame's
+    ;; :on-create dispatches synchronously when the frame is created, so by
+    ;; the time the let-body runs the frame is already initialised.
+    (let [final-db (rf/get-frame-db f)
+          hiccup   [(rf/view :app/root)]
+          html     (rf/render-to-string hiccup {:frame f})]
+      {:status  200
+       :headers {"Content-Type" "text/html"}
+       :body    (page-template html (pr-str (build-payload f hiccup)))})))
+
+;; Test fixtures destroy the frame between runs via (rf/destroy-frame f);
+;; long-lived servers typically destroy after the response is shipped to free
+;; the per-frame caches.
 ```
 
 The pattern from [chapter 04](04-views-and-frames.md) — frames as isolated runtime boundaries — is what makes this clean. Each request lives in its own frame; the frames don't share state. Concurrent requests don't pollute each other.
@@ -213,11 +220,12 @@ The `:on-create` event for the per-request frame typically dispatches setup via 
     {:db (-> db
              (assoc :session (:session request))
              (assoc :route (parse-url (:uri request))))
-     :fx [[:http {:url "/api/initial-data"
-                  :on-success [:initial-data/loaded]}]]}))
+     :fx [[:rf.http/managed
+           {:request    {:method :get :url "/api/initial-data"}
+            :on-success [:initial-data/loaded]}]]}))
 ```
 
-The drain settles before `with-frame` returns: the HTTP fetch resolves (server-side `:http` is synchronous in the JVM; or async with a `<!!` block to wait), the response arrives, the `:initial-data/loaded` handler runs, state is final. *Then* `render-to-string` runs, against the now-stable state.
+The drain settles before `with-frame` returns: the managed-HTTP request runs (on the JVM the fx uses `java.net.http.HttpClient`; the per-spec contract is a single drain that completes before render), the reply lands, the `:initial-data/loaded` handler runs, state is final. *Then* `render-to-string` runs, against the now-stable state.
 
 This is why run-to-completion drain matters for SSR: the server can't render half-resolved state. Drain ensures it doesn't.
 
@@ -283,4 +291,4 @@ For non-Clojure hosts entirely (a TypeScript port of re-frame2), the exact same 
 
 ## Next
 
-- [07 — From re-frame v1](07-from-re-frame-v1.md) — what changes (and what doesn't) if you're already a re-frame user.
+- [08 — From re-frame v1](08-from-re-frame-v1.md) — what changes (and what doesn't) if you're already a re-frame user.

--- a/docs/guide/08-from-re-frame-v1.md
+++ b/docs/guide/08-from-re-frame-v1.md
@@ -1,4 +1,4 @@
-# 07 — From re-frame v1
+# 08 — From re-frame v1
 
 If you've been writing re-frame for a while — say, since 2015, when re-frame v0.something was already a real thing — most of re-frame2 will feel familiar. The dominoes are still six. `app-db` is still one atom. `reg-event-db` and `reg-event-fx` still take an id and a handler. `subscribe` and `dispatch` still do what they always did.
 
@@ -12,7 +12,7 @@ Most of re-frame2 is re-frame v1 with cleaner edges. The unchanged parts:
 - **The six dominoes.** Event dispatch → event handler → effect handling → query → view → DOM. Same pipeline, same semantics.
 - **Pure handlers.** `reg-event-db` and `reg-event-fx` still take pure functions. The argument shapes are unchanged.
 - **Subscriptions, including `:<-` chained subs.** The signal-graph composition rules are the same.
-- **Effects-as-data.** The effect map keys (`:db`, `:dispatch`, `:dispatch-later`, `:fx`, `:http` if you've written that fx, etc.) are unchanged.
+- **Effects-as-data.** The effect map keeps the `:db` slot and the `:fx` slot. v1's top-level `:dispatch`/`:dispatch-later`/`:dispatch-n` shorthands fold into `:fx` — see M-8 in [`spec/MIGRATION.md`](../../spec/MIGRATION.md). The `:fx` shape `[[fx-id args] ...]` is unchanged. The HTTP fx becomes the framework-shipped `:rf.http/managed` (see [chapter 06](06-doing-http-requests.md)); apps that hand-rolled their own `:http` keep working but should adopt managed for the closed-set failure shapes, retry, and reply addressing.
 - **Reagent for the view layer.** Hiccup is hiccup. Form-1, Form-2, and Form-3 components all still work.
 - **The event queue and run-to-completion semantics.** The drain still runs to completion before the view re-renders.
 - **`re-frame-10x`, `re-frame-test`, `re-frame-undo`, and friends** — they still work. The trace API they consume is preserved.
@@ -47,7 +47,7 @@ In re-frame2 it can also be a metadata map. The metadata map carries reflection 
   (fn my-foo-handler [m] ...))
 ```
 
-All three forms — bare `(id handler)`, `(id [interceptors] handler)`, and `(id metadata [interceptors] handler)` — work. The function dispatches on the type of each non-id argument: a map is metadata, a vector is interceptors. Putting `:interceptors` inside the metadata-map is an authoring mistake; the runtime emits `:rf.warning/interceptors-in-metadata-map` and the chain is silently ignored. (See [Conventions §`:interceptors` is positional, not metadata](../specification/Conventions.md#interceptors-is-positional-not-metadata-reg-event-).)
+All three forms — bare `(id handler)`, `(id [interceptors] handler)`, and `(id metadata [interceptors] handler)` — work. The function dispatches on the type of each non-id argument: a map is metadata, a vector is interceptors. Putting `:interceptors` inside the metadata-map is an authoring mistake; the runtime emits `:rf.warning/interceptors-in-metadata-map` and the chain is silently ignored. (See [Conventions §`:interceptors` is positional, not metadata](../../spec/Conventions.md#interceptors-is-positional-not-metadata-reg-event-).)
 
 The new form gets you:
 
@@ -148,7 +148,7 @@ Multi-instance state, with shared handlers. See [chapter 04](04-views-and-frames
 
 In v1, there was effectively one frame, but it wasn't a first-class concept; `app-db` was a top-level Reagent atom. In re-frame2, `app-db` is a property of a frame. For most apps this is a relabelling; for apps that wanted multi-instance behaviour, it's a structural enabler.
 
-The migration agent handles the renamings. Your code that does `@rf/app-db` is updated to `@(rf/get-frame-db :rf/default)`. (Direct access to `re-frame.db/app-db` was always off-contract; it's even more so now.)
+The migration agent handles the renamings. Your code that does `@rf/app-db` is updated to `(rf/get-frame-db :rf/default)` — the new accessor returns the `app-db` value (a plain map), not a deref-able container. (Direct access to `re-frame.db/app-db` was always off-contract; it's even more so now.)
 
 ### Registered views
 
@@ -164,7 +164,7 @@ The xstate-flavoured pattern in [chapter 05](05-state-machines.md). Entirely opt
 
 ### Server-side rendering
 
-[Chapter 06](06-server-side.md). Also entirely opt-in for clients-only apps; the architecture changes that make SSR possible are present whether or not you use SSR. If you don't, you don't notice them.
+[Chapter 07](07-server-side.md). Also entirely opt-in for clients-only apps; the architecture changes that make SSR possible are present whether or not you use SSR. If you don't, you don't notice them.
 
 ### Schemas everywhere (CLJS reference)
 
@@ -206,16 +206,16 @@ If your code uses any of these, the migration agent will find them and either re
 
 ### The structured error contract
 
-[Spec 009 §Error contract](../../spec/009-Instrumentation.md) defines structured error trace events: `:rf.error/handler-exception`, `:rf.error/schema-validation-failure`, etc. These ride the same trace stream that 10x and re-frame-pair already consume. You can register an error-handler that decides recovery policy:
+[Spec 009 §Error contract](../../spec/009-Instrumentation.md) defines structured error trace events: `:rf.error/handler-exception`, `:rf.error/schema-validation-failure`, `:rf.error/machine-action-exception`, and the closed `:rf.http/*` failure-category set ([Spec 014](../../spec/014-HTTPRequests.md)). These ride the same trace stream that 10x and re-frame-pair already consume. You hook in via the trace callback surface:
 
 ```clojure
-(rf/reg-event-error-handler
-  (fn [error-event]
-    (sentry/capture (sentry-shape error-event))
-    nil))                                          ;; nil = use default recovery
+(rf/register-trace-cb! ::sentry-fwd
+  (fn [trace-event]
+    (when (= :error (:op-type trace-event))
+      (sentry/capture (sentry-shape trace-event)))))
 ```
 
-In v1, errors propagated unstructured. In re-frame2, every error has a category, a payload, a recovery hint, and rides the trace stream. Tools can categorise; monitoring can integrate; users can decide.
+In v1, errors propagated unstructured. In re-frame2, every error has a category, a payload, a recovery hint, and rides the trace stream. Tools can categorise; monitoring can integrate; users can decide. Production builds elide the trace surface entirely via `interop/debug-enabled?`, so the cost is dev-only.
 
 ## How to migrate
 

--- a/docs/guide/09-the-dynamic-model.md
+++ b/docs/guide/09-the-dynamic-model.md
@@ -1,4 +1,4 @@
-# 08 — The dynamic-model story
+# 09 — The dynamic-model story
 
 > *Our intellectual powers are rather geared to master static relations and our powers to visualise processes evolving in time are relatively poorly developed.*
 > — E. W. Dijkstra
@@ -55,7 +55,7 @@ re-frame2 takes the position that **most parts of an SPA should be deliberately 
 
 - **Event handlers** are restricted to pure functions of `(state, event) → effects`. They can't call out to the network. They can't read globals. They can't mutate state. They can't suspend. They take in data and return data. That's it.
 - **Subscriptions** are restricted to pure derivations of `state → value`. Same constraints, even tighter.
-- **Effects** are described as data, not performed. An event handler that wants to fire an HTTP request returns `{:fx [[:http {:url ...}]]}`. The runtime interprets. The handler stays pure.
+- **Effects** are described as data, not performed. An event handler that wants to fire an HTTP request returns `{:fx [[:rf.http/managed {:request {:url ...}}]]}`. The runtime interprets. The handler stays pure.
 - **State machines** (when used) are explicit FSMs. Discrete states. Discrete transitions. No backdoors.
 - **The drain semantics** are run-to-completion. Events don't interleave. State doesn't change while a handler is running.
 - **Views** are pure functions of state to render-tree. They can't mutate. They can't have side-effects. They produce data describing what should be on the screen.
@@ -93,7 +93,7 @@ What you gain:
 - **Tests that don't need a runtime.** Pure functions are testable as pure functions, full stop.
 - **Time-travel debugging.** Because state is one value updated atomically, every value can be recorded.
 - **Replay.** Because events are data and state is a value, you can replay any session.
-- **Revertibility as a contract.** Because the *whole* of a frame's runtime state — `app-db`, frame-local registrations, machine snapshots, router state, sub-cache — is a single persistent value, reverting to any prior point is a pointer swap. App-level undo is a thin interceptor. AI experimentation can try-revert-retry without registry pollution. SSR ships a value, not a sequence of mutations. The architecture commits to "frame state is a value" so these consequences are real, not aspirational. (See [Goal 2 — Frame state revertibility](../../spec/000-Vision.md#frame-state-revertibility).)
+- **Revertibility as a contract.** Because the *whole* of a frame's runtime state — `app-db`, frame-local registrations, machine snapshots, router state, sub-cache — is a single persistent value, reverting to any prior point is a pointer swap. App-level undo is a thin interceptor. AI experimentation can try-revert-retry without registry pollution. SSR ships a value, not a sequence of mutations. The architecture commits to "frame state is a value" so these consequences are real, not aspirational. (See [Goal 3 — Frame state revertibility](../../spec/000-Vision.md#frame-state-revertibility).)
 - **AI assistance.** Because the registry is queryable, the contracts are stable, and the dynamic model is small.
 - **Predictable concurrency.** Because run-to-completion drain rules out the interleaving classes of bug.
 - **Server-side rendering.** Because the runtime is just data interpretation, not browser-coupled.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -15,9 +15,10 @@ If you're an AI agent or implementor, you want the [specification](../../spec/) 
 | 03 | [Events, state, and the cycle](03-events-state-cycle.md) | The core loop, with side-effects-as-data. |
 | 04 | [Views and frames](04-views-and-frames.md) | What you put on the screen, and how you isolate state. |
 | 05 | [State machines](05-state-machines.md) | When the answer to a flow is a finite state machine. |
-| 06 | [The server side](06-server-side.md) | SSR and hydration without losing your mind. |
-| 07 | [From re-frame v1](07-from-re-frame-v1.md) | What's the same, what's different, what to do. |
-| 08 | [The dynamic-model story](08-the-dynamic-model.md) | The deeper essay on *why* less-powerful is more. |
+| 06 | [Doing HTTP requests](06-doing-http-requests.md) | `:rf.http/managed` — the canonical request fx, end-to-end. |
+| 07 | [The server side](07-server-side.md) | SSR and hydration without losing your mind. |
+| 08 | [From re-frame v1](08-from-re-frame-v1.md) | What's the same, what's different, what to do. |
+| 09 | [The dynamic-model story](09-the-dynamic-model.md) | The deeper essay on *why* less-powerful is more. |
 
 After the chapters: read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login), then benchmarks (7GUIs, nine-states), then the RealWorld scaffold.
 


### PR DESCRIPTION
## Summary

Reconciliation pass on `docs/guide/*` against current spec/impl, plus a new chapter 06 on managed HTTP.

### Drift sweep (chapters 01-09)

- **02 — Your first app**: test code uses `(rf/get-frame-db f)` as a value (not `@(rf/get-frame-db f)`); narration explains `make-frame` returns a gensym'd id and `with-frame [sym expr]` binding shape.
- **03 — Events, state, and the cycle**: login example off legacy `:http` onto `:rf.http/managed`; standard-effect-map table reflects M-8 (only `:db` / `:fx` at top level — no top-level `:dispatch` / `:dispatch-later`); custom-fx example switched to `:localstorage/set` so `:rf.http/managed` remains the canonical HTTP surface; test override switched onto the framework's `with-managed-request-stubs`; Goal 2 → Goal 3 anchor corrected.
- **04 — Views and frames**: chapter cross-reference renumber (06 → 07).
- **05 — State machines**: every machine action that issued `[:http {...}]` now issues `[:rf.http/managed {...}]` with `:on-failure` and the canonical reply-payload envelope; extras-fold narration tightened.
- **07 — The server side** (was 06): SSR examples use `get-frame-db` without `@`, `[(rf/view :id)]` for the hiccup head, `rf/render-tree-hash`; per-request `make-frame` example drops the spurious `{:id ...}` (make-frame generates the id); `:rf/server-init` fx switched off `:http` onto `:rf.http/managed`.
- **08 — From re-frame v1** (was 07): broken `../specification/Conventions.md` link fixed; effects-as-data section describes M-8 + the `:rf.http/managed` upgrade path; `reg-event-error-handler` (which doesn't exist) replaced with `register-trace-cb!`; `@rf/app-db` migration corrected.
- **09 — The dynamic-model story** (was 08): `:http` → `:rf.http/managed`; Goal 2 → Goal 3 anchor.
- **01 — Why re-frame2** + **README**: cross-reference renumber + nav-table updated.

### New chapter 06 — Doing HTTP requests

Human-track companion to Spec 014. Walks through `:rf.http/managed` end-to-end: why it exists vs ad-hoc fxs; the request map shape; default reply addressing (one handler, two roles via `(:rf/reply msg)`); the closed `:rf.http/*` failure category set; status-before-decode classification (rf2-lokk); the decode pipeline (Malli / keyword / fn / `:auto`); `:rf.http/decode-schemas` reflection; retry + backoff with `:rf.http/retry-attempt` traces; abort by `:request-id` (with supersede); lazy `:body` thunk; frame-aware reply addressing; test stubs (`with-managed-request-stubs`, `:rf.http/managed-canned-success` / `-canned-failure`); worked examples pointing at `examples/managed_http_counter/` and `examples/realworld/`; migration narrative for callers updating from re-frame v1's ad-hoc `:http`.

### Renames

- `06-server-side.md` → `07-server-side.md`
- `07-from-re-frame-v1.md` → `08-from-re-frame-v1.md`
- `08-the-dynamic-model.md` → `09-the-dynamic-model.md`
- New: `06-doing-http-requests.md`

## Test plan

- [x] `cd implementation && clojure -M:test` — green (225 tests, 1062 assertions, 0 failures)
- [x] All cross-chapter links resolve to existing files
- [x] All `../../spec/` references point at real spec files
- [x] No remaining `[:http {` legacy effect (apart from the migration narrative in 06 and 08)
- [x] No remaining `@(rf/get-frame-db ...)`, `(rf/h ...)`, `rf/get-view`, `(reg-view :keyword ...)` drift
- [x] Bead status updated to `in_progress`