### PR TITLE
feat: examples HTTP migration to :rf.http/managed (rf2-wdu8)

### DIFF
--- a/examples/login/core.cljs
+++ b/examples/login/core.cljs
@@ -6,7 +6,10 @@
    - Schema attachment (CP-8)              — Malli schema for the machine snapshot
    - Event handlers (CP-1)                 — pure (state, event) → effects
    - Subscriptions (CP-2)                  — pure derivations, including a :<- chain
-   - Registered fx (CP-3)                  — :http with :platforms metadata
+   - Managed HTTP (Spec 014)                — :rf.http/managed plus a per-app
+                                                demo stub that resolves the
+                                                request locally so the example
+                                                runs without a backend.
    - Registered view (CP-4)                — Var reference (canonical), Form-1 only
    - State machine (CP-5)                  — login flow as a transition table
                                               read via [:rf/machines :auth.login/flow]
@@ -24,6 +27,7 @@
    Kept as a single file here for brevity."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.reagent :as reagent-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
@@ -57,40 +61,21 @@
 (rf/reg-app-schema [:rf/machines :auth.login/flow] AuthLoginSnapshot)
 
 ;; ============================================================================
-;; FX  (CP-3)
+;; FX  (Spec 014 + per-app demo stub)
 ;; ============================================================================
 ;;
-;; :http is server-and-client; the :platforms metadata gates SSR per [011].
-;; :auth.session/store is client-only — localStorage is a browser API.
+;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
+;; The example demo would normally hit `/api/login`, which we don't ship —
+;; instead we register a per-app demo stub at `:rf.http/managed.login-demo`
+;; and override `:rf.http/managed` to it on the default frame in `run`. The
+;; stub inspects the request body's `:password` and synthesises either a
+;; success or failure reply via the framework-shipped canned-success /
+;; canned-failure fxs (Spec 014 §Testing) so the canonical reply shape is
+;; preserved end-to-end.
+;;
+;; `:auth.session/store` is client-only — localStorage is a browser API.
 
-;; The example demo runs against a canned in-process stub so it can be
-;; opened standalone (no backend required). Treat any login with a
-;; password matching :good-password as a success; anything else fails.
-;; The stub mirrors the shape a real :http effect would have.
 (def good-password "correct-horse")
-
-(rf/reg-fx :http
-  {:doc       "Demo stub of an HTTP request. In a real app this would issue a fetch;
-               here we synthesise a canned response so the example is runnable
-               standalone."
-   :platforms #{:server :client}}
-  (fn fx-http [{:keys [frame]} {:keys [body on-success on-error]}]
-    (let [success? (= good-password (:password body))]
-      ;; Simulate a small request latency so the :submitting state is
-      ;; observable in the UI before the response lands.
-      (js/setTimeout
-        (fn []
-          (cond
-            (and success? on-success)
-            (rf/dispatch (conj on-success {:user  {:id    (random-uuid)
-                                                   :email (:email body)}
-                                           :token "demo-token-123"})
-                         {:frame frame})
-
-            on-error
-            (rf/dispatch (conj on-error {:message "Invalid credentials."})
-                         {:frame frame})))
-        50))))
 
 (rf/reg-fx :auth.session/store
   {:doc       "Persist the session token in localStorage. Client only."
@@ -99,16 +84,50 @@
     (when-let [ls (.-localStorage js/globalThis)]
       (.setItem ls "auth/token" token))))
 
-;; Test stub — id-valued override, the canonical pattern-level form.
-(rf/reg-fx :http.canned-success
-  {:doc       "Test stub: every :http call resolves to a canned success response."
-   :platforms #{:client :server}}
-  (fn fx-http-canned-success [{:keys [frame]} {:keys [on-success]}]
-    (when on-success
-      (rf/dispatch (conj on-success {:user  {:id    (random-uuid)
-                                             :email "test@example.com"}
-                                     :token "test-token-123"})
-                   {:frame frame}))))
+(rf/reg-fx :rf.http/managed.login-demo
+  {:doc       "Demo override for `:rf.http/managed`: routes by URL +
+               request body to canned login responses so the example runs
+               standalone without a backend.
+
+               POST /api/login with `:password good-password` → success
+                 with `{:user {...} :token \"demo-token-123\"}`.
+               POST /api/login otherwise → 401 failure.
+               Anything else (e.g. /api/auth/lock) → empty success.
+
+               Delegates to the framework-shipped
+               `:rf.http/managed-canned-success` /
+               `:rf.http/managed-canned-failure` per Spec 014 §Testing,
+               so the reply shape (`{:kind :success :value ...}` /
+               `{:kind :failure :failure ...}`) lands at the inner
+               `:auth.login/success` / `:auth.login/failure` sub-events
+               via the explicit `:on-success` / `:on-failure` form."
+   :platforms #{:server :client}}
+  (fn fx-managed-login-demo [frame-ctx args-map]
+    (let [{:keys [url body]} (:request args-map)
+          login?    (= "/api/login" url)
+          success?  (and login? (= good-password (:password body)))
+          ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
+          fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      ;; Simulate a small request latency so the :submitting state is
+      ;; observable in the UI before the response lands.
+      (js/setTimeout
+        (fn []
+          (cond
+            success?
+            (ok-stub frame-ctx (assoc args-map
+                                      :value {:user  {:id    (random-uuid)
+                                                      :email (:email body)}
+                                              :token "demo-token-123"}))
+
+            login?
+            (fail-stub frame-ctx (assoc args-map
+                                        :kind :rf.http/http-4xx
+                                        :tags {:status 401
+                                               :message "Invalid credentials."}))
+
+            :else
+            (ok-stub frame-ctx (assoc args-map :value {}))))
+        50))))
 
 ;; ============================================================================
 ;; STATE MACHINE  (CP-5)
@@ -141,29 +160,36 @@
 
       :issue-request
       ;; Issue the login HTTP request. Returns effects, not side-effects.
+      ;; Spec 014 reply: explicit :on-success / :on-failure events have the
+      ;; reply payload (`{:kind :success :value ...}` / `{:kind :failure
+      ;; :failure ...}`) appended as their last arg by the runtime.
       (fn [_data [_ creds]]
-        {:fx [[:http {:method     :post
-                      :url        "/api/login"
-                      :body       creds
-                      :on-success [:auth.login/flow [:auth.login/success]]
-                      :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+        {:fx [[:rf.http/managed
+               {:request    {:method :post
+                             :url    "/api/login"
+                             :body   creds
+                             :request-content-type :json}
+                :decode     :json
+                :on-success [:auth.login/flow [:auth.login/success]]
+                :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
       :record-error
       ;; Record the failure into :data and bump the attempt counter.
-      (fn [data [_ err]]
+      (fn [data [_ {:keys [failure]}]]
         {:data (-> data
                    (update :attempts inc)
-                   (assoc :error (or (:message err) "Login failed.")))})
+                   (assoc :error (or (:message failure) "Login failed.")))})
 
       :lock-account
       ;; Mark the account as locked after too many failed attempts.
       (fn [_data _event]
-        {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+        {:fx [[:rf.http/managed
+               {:request {:method :post :url "/api/auth/lock"}}]]})
 
       :store-session
       ;; Persist the session token returned by a successful login.
-      (fn [_data [_ {:keys [token]}]]
-        {:fx [[:auth.session/store {:token token}]]})}
+      (fn [_data [_ {:keys [value]}]]
+        {:fx [[:auth.session/store {:token (:token value)}]]})}
 
      :states
      {:idle
@@ -283,15 +309,42 @@
 ;; ============================================================================
 ;;
 ;; Browserless. No DOM, no React. Drives the machine via dispatch-sync and
-;; asserts on app-db. Uses the id-valued override seam (:http →
-;; :http.canned-success) so the test doesn't issue real network requests.
-;; Because this file is .cljs, the test runs in a CLJS host (Node, browser
-;; without a DOM, shadow-cljs node-test target); to run it on the JVM, lift
-;; the events / subs / machine into a .cljc namespace.
+;; asserts on app-db. Uses the id-valued override seam (`:rf.http/managed`
+;; → per-test stub) so the test doesn't issue real network requests. The
+;; per-test stubs delegate to the framework-shipped
+;; `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`
+;; fxs (Spec 014 §Testing), so the canonical reply shape (`{:kind :success
+;; :value ...}` / `{:kind :failure :failure ...}`) is preserved.
+;;
+;; Because this file is .cljs, the test runs in a CLJS host (Node,
+;; browser without a DOM, shadow-cljs node-test target); to run it on
+;; the JVM, lift the events / subs / machine into a .cljc namespace.
+
+(rf/reg-fx :auth.login/test-canned-success
+  {:doc "Test stub: every :rf.http/managed call resolves :success with a
+         canned user/token payload."
+   :platforms #{:client :server}}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (stub frame-ctx
+            (assoc args-map :value {:user  {:id    (random-uuid)
+                                            :email "test@example.com"}
+                                    :token "test-token-123"})))))
+
+(rf/reg-fx :auth.login/test-canned-failure
+  {:doc "Test stub: every :rf.http/managed call resolves :failure with a
+         401 reply."
+   :platforms #{:client :server}}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (stub frame-ctx (assoc args-map
+                             :kind :rf.http/http-4xx
+                             :tags {:status 401 :message "bad creds"})))))
 
 (defn login-feature-happy-path-test []
   ;; The machine self-initialises on first dispatch — no :on-create needed.
-  (with-frame [f (rf/make-frame {:fx-overrides {:http :http.canned-success}})]
+  (with-frame [f (rf/make-frame
+                   {:fx-overrides {:rf.http/managed :auth.login/test-canned-success}})]
     ;; Submit credentials. Dispatches synchronously; drain settles before return.
     ;; Sub-events route via the machine id (per [005 §Registration]).
     (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
@@ -304,12 +357,8 @@
     (assert (rf/compute-sub [:auth.login/authenticated?] (rf/get-frame-db f)))))
 
 (defn login-feature-retry-then-lockout-test []
-  (rf/reg-fx :http.canned-failure
-    {:platforms #{:client :server}}
-    (fn [{:keys [frame]} {:keys [on-error]}]
-      (rf/dispatch (conj on-error {:message "bad creds"}) {:frame frame})))
-
-  (with-frame [f (rf/make-frame {:fx-overrides {:http :http.canned-failure}})]
+  (with-frame [f (rf/make-frame
+                   {:fx-overrides {:rf.http/managed :auth.login/test-canned-failure}})]
     ;; Three failures → locked-out.
     (dotimes [_ 3]
       (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
@@ -333,4 +382,10 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
+  ;; Install the demo override so `:rf.http/managed` calls route to the
+  ;; in-process login stub above. The example runs standalone — no
+  ;; backend required.
+  (rf/reg-frame :rf/default
+    {:doc          "Login demo frame."
+     :fx-overrides {:rf.http/managed :rf.http/managed.login-demo}})
   (rdc/render react-root [root-view]))

--- a/examples/login/login.spec.cjs
+++ b/examples/login/login.spec.cjs
@@ -5,8 +5,10 @@
  *
  *   :idle -> :submitting -> :authed
  *
- * The example registers a stub :http effect that resolves :on-success
- * after a 50ms timeout when the password matches `correct-horse`.
+ * The example registers a stub `:rf.http/managed.login-demo` fx and
+ * overrides `:rf.http/managed` to it on the default frame. The stub
+ * resolves :on-success after a 50ms timeout when the password matches
+ * `correct-horse`, otherwise it synthesises a 401 :on-failure reply.
  *
  * Flow:
  *   - Initial render: form visible, "Sign in" button enabled, no error.

--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -48,6 +48,7 @@
   (:require [cljs.test :refer-macros [is]]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [re-frame.views]
             [re-frame.substrate.reagent :as reagent-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
@@ -121,29 +122,39 @@
 ;; FX  (test-friendly stubs)
 ;; ============================================================================
 ;;
-;; Real apps would register a single `:http` fx and override at test time via
-;; the id-valued seam (per Spec 002). For this self-contained example we
-;; ship two canned-success stubs that synthesise different list sizes so the
-;; control panel can drive the lifecycle into Empty / One / Some / Too Many
-;; without a server.
+;; Real apps would issue a single `:rf.http/managed` request (Spec 014) and
+;; override at test time via the id-valued seam (per Spec 002). For this
+;; self-contained example we ship two per-app stubs that delegate to the
+;; framework-shipped canned-success / canned-failure fxs (Spec 014 §Testing)
+;; so the control panel can drive the lifecycle into Empty / One / Some /
+;; Too Many without a server.
 
 (defn- gen-todos [n]
   (vec (for [i (range n)]
          {:id (random-uuid) :title (str "Todo #" (inc i)) :done? false})))
 
-(rf/reg-fx :http.canned-todos
-  {:doc       "Test stub: dispatches :on-success with a list of N synthetic todos."
+(rf/reg-fx :nine-states.http/managed-demo
+  {:doc       "Demo override for `:rf.http/managed`. Routes by URL:
+               `/api/todos` → success with N synthetic todos (N from
+               `:request :query :n`); `/api/todos/fail` → transport
+               failure. Delegates to the framework-shipped
+               `:rf.http/managed-canned-success` /
+               `:rf.http/managed-canned-failure` per Spec 014 §Testing
+               so the canonical reply shape is preserved."
    :platforms #{:client :server}}
-  (fn fx-http-canned-todos [{:keys [frame]} {:keys [n on-success]}]
-    (when on-success
-      (rf/dispatch (conj on-success (gen-todos n)) {:frame frame}))))
+  (fn fx-managed-demo [frame-ctx args-map]
+    (let [url (-> args-map :request :url str)]
+      (cond
+        (= url "/api/todos/fail")
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+          (stub frame-ctx (assoc args-map
+                                 :kind :rf.http/transport
+                                 :tags {:message "Network unreachable."})))
 
-(rf/reg-fx :http.canned-failure
-  {:doc       "Test stub: dispatches :on-error with a canned error message."
-   :platforms #{:client :server}}
-  (fn fx-http-canned-failure [{:keys [frame]} {:keys [on-error]}]
-    (when on-error
-      (rf/dispatch (conj on-error {:message "Network unreachable."}) {:frame frame}))))
+        :else
+        (let [n    (or (-> args-map :request :query :n) 0)
+              stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx (assoc args-map :value (gen-todos n))))))))
 
 ;; ============================================================================
 ;; EVENTS — Pattern-RemoteData lifecycle  (states 1-6)
@@ -158,15 +169,20 @@
 
 (rf/reg-event-fx :todos/load
   {:doc "Trigger a list load. Sets :loading (no prior data) or :fetching
-         (revalidate); dispatches :todos/loaded or :todos/load-failed."}
+         (revalidate); the `:rf.http/managed` reply lands as `:todos/loaded`."}
   (fn handler-todos-load [{:keys [db]} [_ {:keys [n]}]]
     (let [has-data? (some? (get-in db [:todos :data]))]
       {:db (-> db
                (assoc-in  [:todos :status]  (if has-data? :fetching :loading))
                (assoc-in  [:todos :error]   nil)
                (update-in [:todos :attempt] inc))
-       :fx [[:http.canned-todos {:n          (or n 0)
-                                 :on-success [:todos/loaded]}]]})))
+       :fx [[:rf.http/managed
+             {:request    {:method :get
+                           :url    "/api/todos"
+                           :query  {:n (or n 0)}}
+              :decode     :json
+              :on-success [:todos/loaded]
+              :on-failure [:todos/load-failed]}]]})))
 
 (rf/reg-event-fx :todos/load-with-failure
   {:doc "Trigger a load that always fails. Drives the slice into :error."}
@@ -174,23 +190,29 @@
     {:db (-> db
              (assoc-in  [:todos :status]  :loading)
              (update-in [:todos :attempt] inc))
-     :fx [[:http.canned-failure {:on-error [:todos/load-failed]}]]}))
+     :fx [[:rf.http/managed
+           {:request    {:method :get :url "/api/todos/fail"}
+            :decode     :json
+            :on-success [:todos/loaded]
+            :on-failure [:todos/load-failed]}]]}))
 
 (rf/reg-event-db :todos/loaded
-  {:doc "Successful fetch. Sets :status :loaded, :data, :loaded-at."}
-  (fn handler-todos-loaded [db [_ todos]]
+  {:doc "Successful fetch. Reads the list from the `:rf.http/managed`
+         reply payload's `:value`."}
+  (fn handler-todos-loaded [db [_ {:keys [value]}]]
     (-> db
         (assoc-in [:todos :status]    :loaded)
-        (assoc-in [:todos :data]      (vec todos))
+        (assoc-in [:todos :data]      (vec value))
         (assoc-in [:todos :error]     nil)
         (assoc-in [:todos :loaded-at] 0))))
 
 (rf/reg-event-db :todos/load-failed
-  {:doc "Fetch failed. Keeps any prior :data; sets :status :error and :error."}
-  (fn handler-todos-load-failed [db [_ err]]
+  {:doc "Fetch failed. Reads the failure category from the
+         `:rf.http/managed` reply payload's `:failure`."}
+  (fn handler-todos-load-failed [db [_ {:keys [failure]}]]
     (-> db
         (assoc-in [:todos :status] :error)
-        (assoc-in [:todos :error]  err))))
+        (assoc-in [:todos :error]  failure))))
 
 (rf/reg-event-db :todos/reset
   {:doc "Reset to :idle. Drives the slice back to State 1 (Nothing)."}
@@ -561,27 +583,38 @@
   [frame state-sub]
   (rf/compute-sub [state-sub] (rf/get-frame-db frame)))
 
+(def ^:private demo-overrides
+  "Per-test :fx-overrides map that routes `:rf.http/managed` to the in-process
+   demo stub so tests run without a backend."
+  {:rf.http/managed :nine-states.http/managed-demo})
+
 (defn test-state-1-nothing []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (is (in-state? f :ui.state/nothing?))
     (is (not (in-state? f :ui.state/loading?)))
     (is (not (in-state? f :ui.state/empty?)))))
 
 (defn test-state-2-loading []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     ;; Set status directly to :loading (the actual stub resolves synchronously,
     ;; so we assert against an explicit pre-loaded shape).
-    (rf/dispatch-sync [:todos/loaded []] {:frame f}) ;; loaded with no data
+    (rf/dispatch-sync [:todos/loaded {:kind :success :value []}] {:frame f}) ;; loaded with no data
     (rf/dispatch-sync [:todos/reset]      {:frame f})
     (rf/dispatch-sync [:todos/load-with-failure] {:frame f})
-    ;; The failure stub fires :on-error synchronously, so :status ends in :error;
+    ;; The failure stub fires :on-failure synchronously, so :status ends in :error;
     ;; the `loading?` predicate is false at the *end* of the drain — which is
     ;; the correct semantic. We instead assert that the lifecycle visited
     ;; :loading by checking :attempt was bumped.
     (is (pos? (:attempt (rf/compute-sub [:todos] (rf/get-frame-db f)))))))
 
 (defn test-state-3-empty []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 0}] {:frame f})
     (is       (in-state? f :ui.state/empty?))
     (is (not (in-state? f :ui.state/one?)))
@@ -589,21 +622,27 @@
     (is (not (in-state? f :ui.state/too-many?)))))
 
 (defn test-state-4-one []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 1}] {:frame f})
     (is       (in-state? f :ui.state/one?))
     (is (not (in-state? f :ui.state/empty?)))
     (is (not (in-state? f :ui.state/some?)))))
 
 (defn test-state-5-some []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
     (is       (in-state? f :ui.state/some?))
     (is (not (in-state? f :ui.state/one?)))
     (is (not (in-state? f :ui.state/too-many?)))))
 
 (defn test-state-6-too-many []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 25}] {:frame f})
     (is       (in-state? f :ui.state/too-many?))
     (is (not (in-state? f :ui.state/some?)))))
@@ -617,7 +656,9 @@
     (is (not (in-state? f :ui.state/correct?)))))
 
 (defn test-state-8-correct []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 0}]                  {:frame f})
     (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit]                    {:frame f})
@@ -626,7 +667,9 @@
     (is       (in-state? f :ui.state/one?))))    ;; correctness side-effect
 
 (defn test-state-9-done []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:app/initialise]
+                    :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
     (rf/dispatch-sync [:todos/editor [:todos.editor/archive {:now 1}]] {:frame f})
     ;; Snapshot lives at [:rf/machines :todos/editor].
@@ -665,6 +708,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
+  ;; Install the demo override so `:rf.http/managed` calls route to the
+  ;; in-process canned-stub fxs above. The example runs standalone — no
+  ;; backend required.
+  (rf/reg-frame :rf/default
+    {:doc          "Nine-states demo frame."
+     :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
   (rf/dispatch-sync [:app/initialise])
   (when react-root
     (rdc/render react-root [root-view])))

--- a/examples/ssr/core.cljc
+++ b/examples/ssr/core.cljc
@@ -23,6 +23,7 @@
      diffs server vs. client hashes after first render and emits
      :rf.ssr/hydration-mismatch on disagreement"
   (:require [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             #?(:cljs [reagent.dom.client :as rdc])))
 
 ;; ============================================================================
@@ -38,28 +39,12 @@
 ;; ============================================================================
 ;; FX
 ;; ============================================================================
-
-(rf/reg-fx :http/get
-  {:doc       "GET request. Returns to dispatch on success/error.
-                Thread the active frame through to dispatch so the
-                continuation lands in the right frame's app-db."
-   :platforms #{:server :client}}
-  (fn fx-http-get [{:keys [frame]} {:keys [url on-success on-error]}]
-    #?(:cljs (-> (js/fetch url)
-                 (.then  #(.json %))
-                 (.then  #(when on-success
-                            (rf/dispatch (conj on-success (js->clj % :keywordize-keys true))
-                                         {:frame frame})))
-                 (.catch #(when on-error
-                            (rf/dispatch (conj on-error %) {:frame frame}))))
-       :clj  (try
-               (let [resp (slurp url)
-                     data (clojure.edn/read-string resp)]
-                 (when on-success
-                   (rf/dispatch (conj on-success data) {:frame frame})))
-               (catch Exception e
-                 (when on-error
-                   (rf/dispatch (conj on-error e) {:frame frame})))))))
+;;
+;; HTTP requests go via the framework-shipped `:rf.http/managed` (Spec 014).
+;; The example deliberately doesn't register an HTTP-side fx of its own —
+;; the SSR test below uses the `:fx-overrides` seam to redirect
+;; `:rf.http/managed` to a per-frame canned-success stub so the JVM-side
+;; render exercises the full domino loop without real network traffic.
 
 (rf/reg-fx :auth.session/store
   {:doc       "Persist a session token in localStorage."
@@ -78,11 +63,14 @@
    :platforms #{:server}}
   (fn handler-rf-server-init [{:keys [db]} [_ request]]
     {:db (assoc db :route {:id :route/articles :params {}})
-     :fx [[:http/get {:url "/api/articles" :on-success [:articles/loaded]}]]}))
+     :fx [[:rf.http/managed
+           {:request    {:method :get :url "/api/articles"}
+            :decode     :json
+            :on-success [:articles/loaded]}]]}))
 
 (rf/reg-event-db :articles/loaded
-  (fn handler-articles-loaded [db [_ articles]]
-    (assoc db :articles articles)))
+  (fn handler-articles-loaded [db [_ {:keys [value]}]]
+    (assoc db :articles value)))
 
 ;; The runtime ships a default :rf/hydrate handler that uses the locked
 ;; :replace-app-db policy (per Spec 011 §The :rf/hydrate event): server is
@@ -130,7 +118,8 @@
 ;; The server flow:
 ;;   1. Accept request.
 ;;   2. make-frame; :on-create dispatches :rf/server-init with the request.
-;;   3. Drain settles (HTTP fetches resolve via the JVM-side :http/get).
+;;   3. Drain settles (HTTP fetches resolve via :rf.http/managed; the JVM
+;;      transport uses java.net.http.HttpClient under the hood).
 ;;   4. Render to string via the pure hiccup → HTML emitter.
 ;;   5. Serialise app-db; ship in the HTML.
 
@@ -216,22 +205,23 @@
      ;; Boot the runtime (idempotent) — installs the plain-atom adapter
      ;; and the :rf/default frame.
      (rf/init!)
-     ;; Stub :http/get so the test doesn't make real network calls. The
-     ;; per-frame :fx-overrides redirect :http/get to this canned stub.
-     ;; Note: fx handlers receive {:frame frame-id} as their first arg —
-     ;; thread it through to dispatch so the :on-success continuation
-     ;; lands in the right frame's app-db.
-     (rf/reg-fx :http/get.canned-articles
+     ;; Stub `:rf.http/managed` so the test doesn't make real network
+     ;; calls. The per-frame `:fx-overrides` redirect `:rf.http/managed`
+     ;; to a per-test stub that delegates to the framework-shipped
+     ;; `:rf.http/managed-canned-success` (Spec 014 §Testing) with a
+     ;; canned `:value` payload — the same reply shape a live request
+     ;; would produce.
+     (rf/reg-fx :ssr.http/canned-articles
        {:platforms #{:server :client}}
-       (fn [{:keys [frame]} {:keys [on-success]}]
-         (when on-success
-           (rf/dispatch (conj on-success
-                              [{:id "a" :title "Article A" :body "Body A"}
-                               {:id "b" :title "Article B" :body "Body B"}])
-                        {:frame frame}))))
+       (fn [frame-ctx args-map]
+         (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+           (stub frame-ctx
+                 (assoc args-map
+                        :value [{:id "a" :title "Article A" :body "Body A"}
+                                {:id "b" :title "Article B" :body "Body B"}])))))
 
      (let [f           (rf/make-frame {:on-create    [:rf/server-init {:uri "/articles"}]
-                                       :fx-overrides {:http/get :http/get.canned-articles}})
+                                       :fx-overrides {:rf.http/managed :ssr.http/canned-articles}})
            final-db    (rf/get-frame-db f)
            ;; The root view's body invokes the articles-page render fn,
            ;; which calls (rf/subscribe-value [:articles]). Both run

--- a/examples/state_machine_walkthrough/core.cljc
+++ b/examples/state_machine_walkthrough/core.cljc
@@ -8,11 +8,13 @@
 
   Why .cljc: the chapter promises 'runs in microseconds on the JVM, no
   browser, no network.' The same code runs under shadow-cljs node-test
-  for the CLJS surface. The HTTP side is exercised via the id-valued
-  override seam (`:fx-overrides`) so no real network traffic happens.
+  for the CLJS surface. The HTTP side is exercised via the framework-
+  shipped `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`
+  stubs (Spec 014 §Testing) so no real network traffic happens.
 
   Read alongside docs/guide/05-state-machines.md."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]))
 
 ;; ============================================================================
 ;; THE TRANSITION TABLE — chapter §The same flow as a machine
@@ -40,29 +42,35 @@
     (fn [_data _event] {:data {:error nil}})
 
     :issue-request
-    ;; Returns effects, not side-effects. The :http fx implementation
-    ;; conj's the response onto the :on-success template; the runtime
-    ;; folds the trailing arg onto the inner event.
+    ;; Returns effects, not side-effects. The `:rf.http/managed` fx
+    ;; (Spec 014) issues the request; the framework dispatches the
+    ;; explicit `:on-success` / `:on-failure` events with the reply
+    ;; payload appended as the last arg, so the inner sub-event lands
+    ;; back in this machine via :auth.login/flow's machine-id routing.
     (fn [_data [_ creds]]
-      {:fx [[:http {:method     :post
-                    :url        "/api/login"
-                    :body       creds
-                    :on-success [:auth.login/flow [:auth.login/success]]
-                    :on-error   [:auth.login/flow [:auth.login/failure]]}]]})
+      {:fx [[:rf.http/managed
+             {:request    {:method :post
+                           :url    "/api/login"
+                           :body   creds
+                           :request-content-type :json}
+              :decode     :json
+              :on-success [:auth.login/flow [:auth.login/success]]
+              :on-failure [:auth.login/flow [:auth.login/failure]]}]]})
 
     :record-error
-    (fn [data [_ err]]
+    (fn [data [_ {:keys [failure]}]]
       {:data (-> data
                  (update :attempts inc)
-                 (assoc :error (or (:message err) "Login failed.")))})
+                 (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
     (fn [_data _event]
-      {:fx [[:http {:method :post :url "/api/auth/lock"}]]})
+      {:fx [[:rf.http/managed
+             {:request {:method :post :url "/api/auth/lock"}}]]})
 
     :store-session
-    (fn [_data [_ {:keys [token]}]]
-      {:fx [[:auth.session/store {:token token}]]})}
+    (fn [_data [_ {:keys [value]}]]
+      {:fx [[:auth.session/store {:token (:token value)}]]})}
 
    :states
    {:idle
@@ -90,33 +98,15 @@
 ;; FX — chapter §Wiring a machine into the rest of re-frame
 ;; ============================================================================
 ;;
-;; The :http and :auth.session/store fx are stubs for the example: they
-;; show the shape, not real network/storage. The smoke test below uses
-;; the id-valued override seam (`:fx-overrides`) to swap :http for a
-;; canned-success or canned-failure stub at frame-creation time.
-
-(rf/reg-fx :http
-  {:doc "Stub: a real implementation would call (js/fetch ...)."}
-  (fn [_m _args] nil))
+;; The `:auth.session/store` fx is a stub for the example: it shows the
+;; shape, not real localStorage. The smoke tests below exercise the
+;; managed-HTTP path via the framework-shipped canned-success /
+;; canned-failure stubs (Spec 014 §Testing), routed in via the
+;; `:fx-overrides` seam at frame creation.
 
 (rf/reg-fx :auth.session/store
   {:doc "Stub: a real implementation would write localStorage."}
   (fn [_m _args] nil))
-
-(rf/reg-fx :http.canned-success
-  {:doc "Test stub: every :http call resolves to a canned success."}
-  (fn [{:keys [frame]} {:keys [on-success]}]
-    (when on-success
-      (rf/dispatch (conj on-success {:user  {:id "test-user"}
-                                     :token "test-token"})
-                   {:frame frame}))))
-
-(rf/reg-fx :http.canned-failure
-  {:doc "Test stub: every :http call resolves to a canned failure."}
-  (fn [{:keys [frame]} {:keys [on-error]}]
-    (when on-error
-      (rf/dispatch (conj on-error {:message "bad creds"})
-                   {:frame frame}))))
 
 ;; ============================================================================
 ;; REGISTRATION — chapter §Wiring a machine into the rest of re-frame
@@ -148,6 +138,35 @@
   (fn [state _] (= :authed state)))
 
 ;; ============================================================================
+;; TEST STUBS — per-test wrappers that delegate to the framework-shipped
+;; canned-success / canned-failure stubs.
+;; ============================================================================
+;;
+;; Per Spec 014 §Testing, the framework ships `:rf.http/managed-canned-success`
+;; and `:rf.http/managed-canned-failure` fxs that synthesise the canonical
+;; reply shape. Per-test wrappers delegate to those stubs while supplying
+;; the test-specific `:value` (success) / failure category.
+
+(rf/reg-fx :auth.login/canned-success
+  {:doc "Test stub: every `:rf.http/managed` call resolves :success with a
+         canned user/token payload. Delegates to the framework-shipped
+         `:rf.http/managed-canned-success` per Spec 014 §Testing."}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+      (stub frame-ctx (assoc args-map :value {:user  {:id "test-user"}
+                                              :token "test-token"})))))
+
+(rf/reg-fx :auth.login/canned-failure
+  {:doc "Test stub: every `:rf.http/managed` call resolves :failure.
+         Delegates to the framework-shipped `:rf.http/managed-canned-failure`
+         per Spec 014 §Testing."}
+  (fn [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (stub frame-ctx (assoc args-map
+                             :kind :rf.http/http-4xx
+                             :tags {:message "bad creds" :status 401})))))
+
+;; ============================================================================
 ;; HEADLESS TESTS — chapter §Headless testing
 ;; ============================================================================
 ;;
@@ -156,10 +175,11 @@
 ;; 1. Pure machine-transition: pass a snapshot + event, get back the
 ;;    next snapshot. No frame, no app-db, no fx execution. JVM-runnable.
 ;;
-;; 2. Drain-level: spin up a frame with a fx-override, dispatch into
+;; 2. Drain-level: spin up a frame with a `:fx-overrides` map that
+;;    redirects `:rf.http/managed` to a per-test stub, dispatch into
 ;;    the machine id, read the resulting app-db slice. Exercises the
 ;;    full registration → drain → snapshot-write path including the
-;;    :on-success / :on-error callback fold.
+;;    :on-success / :on-failure callback fold.
 
 (defn pure-happy-path-test
   "Drives the transition table directly via machine-transition. No
@@ -172,11 +192,12 @@
     (assert (= :submitting (:state s1))
             (str "expected :submitting, got " (:state s1)))
     ;; Entering :submitting fires the :issue-request action's :fx.
-    (assert (= 1 (count fx1)) (str "expected one :http fx, got " fx1))
-    (assert (= :http (ffirst fx1)) (str "expected :http fx-id, got " (ffirst fx1)))
+    (assert (= 1 (count fx1)) (str "expected one :rf.http/managed fx, got " fx1))
+    (assert (= :rf.http/managed (ffirst fx1))
+            (str "expected :rf.http/managed fx-id, got " (ffirst fx1)))
 
     (let [[s2 _] (rf/machine-transition login-flow s1
-                                        [:auth.login/success {:token "t"}])]
+                                        [:auth.login/success {:value {:token "t"}}])]
       (assert (= :authed (:state s2))
               (str "expected :authed, got " (:state s2))))
     :ok))
@@ -190,17 +211,19 @@
   []
   (let [snapshot {:state :submitting :data {:attempts 3 :error nil}}
         [s _fx] (rf/machine-transition login-flow snapshot
-                                       [:auth.login/failure {:message "bad creds"}])]
+                                       [:auth.login/failure
+                                        {:failure {:kind :rf.http/http-4xx
+                                                   :message "bad creds"}}])]
     (assert (= :locked-out (:state s))
             (str "expected :locked-out at attempts=3, got " (:state s)))
     :ok))
 
 (defn drain-happy-path-test
   "Full drain: registers the machine, dispatches into it, asserts the
-  app-db landed at :authed. Uses the fx-overrides seam to swap :http
-  for a canned-success stub."
+  app-db landed at :authed. Uses the `:fx-overrides` seam to swap
+  `:rf.http/managed` for the per-test canned-success stub."
   []
-  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-success}})]
+  (let [f (rf/make-frame {:fx-overrides {:rf.http/managed :auth.login/canned-success}})]
     (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                           {:email "a@b.com"
                                            :password "secret"}]]
@@ -214,7 +237,7 @@
   "Three failures cycle :submitting → :error-shown → :idle ×3, then a
   fourth :submit fails the guard and lands at :locked-out."
   []
-  (let [f (rf/make-frame {:fx-overrides {:http :http.canned-failure}})]
+  (let [f (rf/make-frame {:fx-overrides {:rf.http/managed :auth.login/canned-failure}})]
     (dotimes [_ 3]
       (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
                                             {:email "x@y.z" :password "wrong"}]]

--- a/implementation/test/re_frame/examples_test.clj
+++ b/implementation/test/re_frame/examples_test.clj
@@ -13,6 +13,13 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (rf/init!)
+  ;; clear-all! also drops the framework-shipped fxs that register at
+  ;; namespace load time (e.g. :rf.http/managed and its canned-stub
+  ;; siblings). Reload the relevant ns so the toplevel reg-fx forms run
+  ;; again and the framework substrate is back in place — the examples
+  ;; routinely route :rf.http/managed via :fx-overrides to those stubs
+  ;; (Spec 014 §Testing).
+  (require 're-frame.http-managed :reload)
   ;; Drop any cached require of example namespaces so each test re-evaluates
   ;; their namespace-level handlers against a fresh registrar.
   (remove-ns 'ssr.core)


### PR DESCRIPTION
## Summary

Sweeps the remaining legacy `:http` / `:http.canned-*` fxs in the
example apps to the Spec 014 `:rf.http/managed` surface. The realworld
retrofit (rf2-o8t6) landed the canonical demo; this PR catches the
stragglers — login, nine-states, ssr, and the state-machine walkthrough.

Per Spec 014 §Testing, per-test stubs delegate to the framework-shipped
`:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure`
handlers via `registrar/handler` lookup, so the canonical reply shape
(`{:kind :success :value ...}` / `{:kind :failure :failure ...}`) is
preserved end-to-end.

- Login uses an `:fx-overrides` demo stub that routes by URL + body so
  the example runs standalone (no `/api/login` server).
- Nine-states collapses two custom stubs into one URL-routing
  `:rf.http/managed` override; `:todos/loaded` / `:todos/load-failed`
  now read the canonical reply shape.
- SSR retires `:http/get`; `:rf/server-init` issues `:rf.http/managed`.
  The JVM SSR test redirects to a per-frame canned-success stub.
- `state_machine_walkthrough` matches the `:issue-request` action and
  drain-level tests to Spec 014.

A small accompanying fixture fix in `examples_test.clj`: the per-test
`registrar/clear-all!` also wipes the framework-shipped
`:rf.http/managed*` fxs (registered at ns load time), so the fixture
now reloads `re-frame.http-managed` to bring them back — matching the
pattern in `re-frame.http-managed-test`.

## Test plan

- [x] `clojure -M:test` (JVM): 225 tests, 1062 assertions, 0 failures, 0 errors.
- [x] `npm run test:cljs`: pre-existing nine-states flake (rf2-6r59 in
      flight) is the only failure; everything else green.
- [x] `npm run test:browser`: 94 tests, 295 assertions, all green.
- [x] `npm run test:elision`: PASS.
- [x] `npm run test:examples`: all 13 Playwright specs green (counter,
      login, managed-http-counter, nine-states, realworld, routing,
      cells, circle-drawer, crud, flight-booker, temperature, timer,
      todomvc).

Closes rf2-wdu8.