### PR TITLE
fix: nine-states-runs-end-to-end browser test (rf2-6r59)

### DIFF
--- a/examples/nine_states/README.md
+++ b/examples/nine_states/README.md
@@ -8,7 +8,7 @@ single small domain: a **todos list**.
 
 | # | Name | What it shows | Trigger |
 |---|---|---|---|
-| 1 | **Nothing**   | Blank initial slate; never fetched. "Get started" CTA. | `[:app/initialise]` |
+| 1 | **Nothing**   | Blank initial slate; never fetched. "Get started" CTA. | `[:nine-states.app/initialise]` |
 | 2 | **Loading**   | First fetch in flight; no `:data` yet. Spinner / skeleton. | `[:todos/load {:n N}]` (transient) |
 | 3 | **Empty**     | Fetched, but the result is the empty list. "No results" CTA. | `[:todos/load {:n 0}]` |
 | 4 | **One**       | Exactly one item; focused single-item layout. | `[:todos/load {:n 1}]` |

--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -160,7 +160,7 @@
 ;; EVENTS — Pattern-RemoteData lifecycle  (states 1-6)
 ;; ============================================================================
 
-(rf/reg-event-db :app/initialise
+(rf/reg-event-db :nine-states.app/initialise
   {:doc "Seed both slices to defaults. Drives the app to State 1 (Nothing)."}
   (fn handler-app-initialise [db _]
     (-> db
@@ -518,7 +518,7 @@
   (let [done? @(subscribe [:ui.state/done?])]
     [:div.control-panel
      [:h3 "Drive the demo"]
-     [:button {:on-click #(dispatch [:app/initialise])
+     [:button {:on-click #(dispatch [:nine-states.app/initialise])
                :disabled done?} "1. Nothing"]
      [:button {:on-click #(dispatch [:todos/load-with-failure])
                :disabled done?} "Trigger error"]
@@ -590,7 +590,7 @@
 
 (defn test-state-1-nothing []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (is (in-state? f :ui.state/nothing?))
     (is (not (in-state? f :ui.state/loading?)))
@@ -598,7 +598,7 @@
 
 (defn test-state-2-loading []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     ;; Set status directly to :loading (the actual stub resolves synchronously,
     ;; so we assert against an explicit pre-loaded shape).
@@ -613,7 +613,7 @@
 
 (defn test-state-3-empty []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 0}] {:frame f})
     (is       (in-state? f :ui.state/empty?))
@@ -623,7 +623,7 @@
 
 (defn test-state-4-one []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 1}] {:frame f})
     (is       (in-state? f :ui.state/one?))
@@ -632,7 +632,7 @@
 
 (defn test-state-5-some []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
     (is       (in-state? f :ui.state/some?))
@@ -641,14 +641,14 @@
 
 (defn test-state-6-too-many []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 25}] {:frame f})
     (is       (in-state? f :ui.state/too-many?))
     (is (not (in-state? f :ui.state/some?)))))
 
 (defn test-state-7-incorrect []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame {:on-create [:nine-states.app/initialise]})]
     ;; Type a too-short title, then submit — should land in :error / :incorrect?
     (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
     (rf/dispatch-sync [:new-todo/submit]                {:frame f})
@@ -657,7 +657,7 @@
 
 (defn test-state-8-correct []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 0}]                  {:frame f})
     (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
@@ -668,7 +668,7 @@
 
 (defn test-state-9-done []
   (with-frame [f (rf/make-frame
-                   {:on-create    [:app/initialise]
+                   {:on-create    [:nine-states.app/initialise]
                     :fx-overrides demo-overrides})]
     (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
     (rf/dispatch-sync [:todos/editor [:todos.editor/archive {:now 1}]] {:frame f})
@@ -714,6 +714,6 @@
   (rf/reg-frame :rf/default
     {:doc          "Nine-states demo frame."
      :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
-  (rf/dispatch-sync [:app/initialise])
+  (rf/dispatch-sync [:nine-states.app/initialise])
   (when react-root
     (rdc/render react-root [root-view])))

--- a/examples/nine_states/nine_states.spec.cjs
+++ b/examples/nine_states/nine_states.spec.cjs
@@ -1,7 +1,7 @@
 /*
  * Nine-states example — smoke test (rf2-lyj0).
  *
- * The example dispatches :app/initialise on startup, putting the app in
+ * The example dispatches :nine-states.app/initialise on startup, putting the app in
  * State 1 (Nothing). The control panel has buttons that drive it through
  * the other states. Smoke test transitions through a few:
  *


### PR DESCRIPTION
## Root cause

The browser-test build loads every `*_cljs_test.cljs` ns, which in turn loads its example's `core.cljs` at namespace-load time. Three example cores happened to register the same generic event id `:app/initialise` (`nine-states`, `routing`, `realworld`). The last loader wins; under alphabetical ns load order `realworld` shadowed `nine-states`.

When `test-state-1-nothing` called

    (rf/make-frame {:on-create [:app/initialise]})

the `:on-create` event resolved to realworld's handler — which seeds `:tags`/`:feed`/`:articles`/`:auth`/etc., not `:todos`. The `:ui.state/nothing?` sub then failed because `:todos/status` was nil. Confirmed by instrumenting the test and observing the realworld-shaped initial db.

## Introducing commit

`d64e78f` — *Phase 3: realworld example runnable + Playwright*. Before that commit, realworld's namespaces had broken paths and didn't compile, so the registration never ran and the collision was latent.

## Fix direction — example

Rename nine-states's event id from `:app/initialise` to `:nine-states.app/initialise` everywhere inside `examples/nine_states/core.cljs`. The change is local to the example: the standalone DOM mount fn still dispatches the renamed id; the headless test fixtures inside the file pass through to the renamed id.

The broader concern — shared registries across examples in the cross-example test runtime — is tracked under rf2-gkf9 (browser test harness isolation).

## Test plan

- [x] `clojure -M:test`: 223 tests / 1047 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs`: 94 tests / 295 assertions, 0 failures, 0 errors
- [x] `npm run test:browser`: 94 tests / 295 assertions, 0/0 — verified 3/3 runs green
- [x] `npm run test:elision`: PASS
- [x] `npm run test:examples`: 13/13 PASS (including nine-states Playwright spec)