### PR TITLE
chore: examples best-practice audit (rf2-zuwz)

### DIFF
--- a/examples/nine_states/core.cljs
+++ b/examples/nine_states/core.cljs
@@ -295,16 +295,17 @@
      {:has-todos?
       ;; Only allow archive if there is at least one todo to freeze.
       ;; Named — a non-trivial guard reading two slices of app-db.
-      (fn guard-has-todos? [_snapshot _event]
-        ;; The machine sees its own snapshot's :data; for cross-slice guards
-        ;; we typically pass the predicate result IN via the event payload.
-        ;; Here the event itself carries the count.
+      (fn guard-has-todos? [_data _event]
+        ;; The machine's 2-arity sees `data` (the snapshot's :data slot)
+        ;; directly. For cross-slice guards we typically pass the predicate
+        ;; result IN via the event payload. Here the event itself carries
+        ;; the count.
         true)}
 
      :actions
      {:stamp-archived
       ;; Mark the moment of archival in the machine's :data. Inspectable.
-      (fn action-stamp-archived [_snapshot [_ {:keys [now]}]]
+      (fn action-stamp-archived [_data [_ {:keys [now]}]]
         {:data {:archived-at (or now 0)}})}
 
      :states

--- a/examples/realworld/auth.cljs
+++ b/examples/realworld/auth.cljs
@@ -75,7 +75,7 @@
      :data    {:error nil}
      :guards
      {:has-token?
-      (fn [_snapshot [_ token]]
+      (fn [_data [_ token]]
         (not (str/blank? token)))}
      :actions
      {:clear-error

--- a/examples/routing/core.cljs
+++ b/examples/routing/core.cljs
@@ -43,7 +43,7 @@
 ;; APP DATA
 ;; ============================================================================
 
-(rf/reg-event-db :app/initialise
+(rf/reg-event-db :routing.app/initialise
   (fn [_ _]
     {:articles [{:id "intro" :title "Intro to re-frame2" :body "..."}
                 {:id "ssr"   :title "Server rendering"  :body "..."}]}))
@@ -137,7 +137,7 @@
 ;; ============================================================================
 
 (defn routing-tests []
-  (with-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-frame [f (rf/make-frame {:on-create [:routing.app/initialise]})]
     (rf/dispatch-sync [:rf.route/navigate :route/articles] {:frame f})
     (assert (= :route/articles (rf/compute-sub [:rf.route/id] (rf/get-frame-db f))))
 
@@ -162,6 +162,6 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:app/initialise])
+  (rf/dispatch-sync [:routing.app/initialise])
   (install-router!)
   (rdc/render react-root [root-view]))


### PR DESCRIPTION
## Summary

Audit of every example under `examples/` against the current re-frame2 idiom checklist (rf2-zuwz). Most examples are already canonical; two small drift items were found and fixed.

## Per-example findings

Idiom checklist sweeps performed:

- **reg-view defn-shape** (rf2-d0pi) — every example uses defn-shape; no `(reg-view :keyword (fn ...))` calls present.
- **`view` not `get-view`** (rf2-sx7t / rf2-heo2) — no `get-view` calls present.
- **Form 2 canonical** (rf2-iyzm) — all render trees use `[my-view ...]` form.
- **`rf/frame-provider` canonical** (rf2-41la / rf2-sixo) — no direct `build-frame-provider` calls.
- **No `h` macro** (rf2-n4um / rf2-u33b) — no `(rf/h ...)` wrappers.
- **Spec 014 for HTTP** (rf2-z1mw / rf2-cfig / rf2-wdu8) — every HTTP request goes via `:rf.http/managed`; no ad-hoc `js/fetch`.
- **M-8 effect-map shape** (rf2-ooc5) — every `:dispatch` / `:dispatch-later` is inside `:fx`.
- **No `re-frame.alpha`** (rf2-7cb2) — clean.
- **No `re-frame-10x`** — clean.
- **`:interceptors` positional** (rf2-bbea) — verified `circle_drawer.cljs`'s use is positional.
- **No `:context`** (rf2-hbt1) — clean.

Two issues fixed:

- **Machine guard/action `_data` naming** (rf2-qppo). `nine_states/core.cljs` and `realworld/auth.cljs` had three guard/action fns whose first param was named `_snapshot`. Per Spec 005 §Guards/§Actions and `re_frame/machines.cljc`'s `call-guard`/`call-action`, the runtime invokes the 2-arity body with `data` (the snapshot's `:data` slot), not the whole snapshot. The misnomer made the example contradict the spec it demonstrated; renamed to `_data` and amended a misleading inline comment.
- **Event-id namespacing** (rf2-6r59 lesson). `routing/core.cljs` registered an unnamespaced `:app/initialise`. The realworld example also registers `:app/initialise` (intentional for its test fixtures); to keep the routing example safe to compose into the cross-example browser-test runtime, renamed to `:routing.app/initialise`.

The realworld example was deliberately not touched beyond the auth.cljs `_data` rename — per the bead's out-of-scope note ("realworld just retrofitted (rf2-o8t6); audit but don't re-architect"), and because renaming `:app/initialise` there would cascade through every test fixture without changing behaviour.

No real implementation bug surfaced; no follow-up bead filed.

## Test plan

- [x] `clojure -M:test` — 225 tests / 1062 assertions, 0 failures.
- [x] `npm run test:cljs` — 98 tests / 303 assertions, 0 failures.
- [x] `npm run test:browser` — 98 tests / 303 assertions, 0 failures.
- [x] `npm run test:elision` — PASS (advanced compile DCEs dev sentinels; control build retains them).
- [x] `npm run test:examples` — 13 specs, all PASS (counter, login, managed-http-counter, nine-states, realworld, routing, cells, circle-drawer, crud, flight-booker, temperature, timer, todomvc).