### PR TITLE
feat: MkDocs docs publishing pipeline (rf2-h09k)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,75 @@
+# Builds and publishes the re-frame2 docs site (rf2-h09k).
+#
+# Source: docs/guide/ (narrative) + spec/ (normative) + spec/API.md (reference).
+# Sink:   https://day8.github.io/re-frame2/
+#
+# PREREQUISITE: the repository's Pages source must be set to "GitHub Actions"
+# (Settings → Pages → Build and deployment → Source). If it is still set to
+# "Deploy from a branch" the deploy-pages step below will fail.
+#
+# This workflow only triggers on push to `main` or via manual dispatch. The
+# first publish is a deliberate manual step (run via the Actions tab once
+# Pages is configured) — see PR description for rf2-h09k.
+
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow only one concurrent Pages deployment, but do not cancel an
+# in-progress run so it can finish before the next starts.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: MkDocs build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f  # v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install MkDocs + plugins
+        run: pip install -r requirements.txt
+
+      # Stage the spec/ tree under docs/spec/ so MkDocs (which requires
+      # docs_dir to be a child of the config file) can see it. The local
+      # equivalent is `cp -r spec docs/spec` before `mkdocs build`. The
+      # staged copy is .gitignored — never commit it.
+      - name: Stage spec/ into docs/spec/
+        run: |
+          rm -rf docs/spec
+          cp -r spec docs/spec
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ Thumbs.db
 .dolt/
 *.db
 .beads-credential-key
+
+# MkDocs build artefacts (rf2-h09k)
+/site/
+# spec/ is staged into docs/spec/ at build time; never commit the staged copy.
+/docs/spec/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# re-frame2
+
+> *This, milord, is my family's axe. We have owned it for almost nine hundred years, see. Of course, sometimes it needed a new blade. And sometimes it has required a new handle, new designs on the metalwork, a little refreshing of the ornamentation ... but is this not the nine hundred-year-old axe of my family? And because it has changed gently over time, it is still a pretty good axe, y'know. Pretty good.*
+>
+> — Terry Pratchett, *The Fifth Elephant*
+
+re-frame2 is a pattern for building web apps (specifically SPAs), probably in ClojureScript, which is:
+
+- **[re-frame](https://github.com/day8/re-frame)-first**
+- **AI-first**
+
+The published artefact is the **specification**. A reference implementation in Clojure/ClojureScript exists to validate it.
+
+## Three doors into this site
+
+| Door | When | Start |
+|---|---|---|
+| **[Guide](guide/README.md)** | You're a human and you want the story. | [01 — Why re-frame2](guide/01-why-re-frame2.md) |
+| **[Spec](spec/README.md)** | You're an AI agent or implementor. You want the contract. | [000 — Vision](spec/000-Vision.md) |
+| **[API](spec/API.md)** | You know what you're looking for. | [API reference](spec/API.md) |
+
+The Guide gives you the story; the Spec gives you the system; the API gives you the symbols. Each links to the others.
+
+## Status
+
+Still a **work in progress** but getting close to beta. The repository [README](https://github.com/day8/re-frame2#readme) tracks the latest status and what ships today.
+
+## Source
+
+- Repository: [day8/re-frame2](https://github.com/day8/re-frame2)
+- Issues / discussion: [GitHub issues](https://github.com/day8/re-frame2/issues)
+- Reference implementation: [`implementation/`](https://github.com/day8/re-frame2/tree/main/implementation) (Clojure/ClojureScript, Reagent v2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,115 @@
+site_name: "re-frame2"
+site_description: "AI-first, re-frame-first pattern for SPAs — specification, guide, and API reference."
+site_author: Mike Thompson
+site_url: https://day8.github.io/re-frame2/
+
+repo_name: day8/re-frame2
+repo_url: https://github.com/day8/re-frame2
+
+copyright: Copyright &copy; 2014-2026 Michael Thompson
+
+# All published markdown lives under docs/ at build time. The narrative
+# guide already lives under docs/guide/. The normative spec lives at the
+# repo root in spec/ (rf2-9hft) — `bb stage-docs` (or the docs.yml CI
+# step) copies spec/ into docs/spec/ before `mkdocs build` runs. The
+# staged copies are ignored by git (see .gitignore).
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  icon:
+    logo: material/home
+    repo: fontawesome/brands/git-alt
+  language: en
+  palette:
+    primary: blue
+    accent: blue
+  font:
+    text: IBM Plex Sans
+    code: Source Code Pro
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - content.code.annotate
+    - content.code.copy
+
+extra:
+  social:
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/day8
+
+nav:
+  - Home: index.md
+
+  - Guide:
+    - Overview: guide/README.md
+    - "01 — Why re-frame2": guide/01-why-re-frame2.md
+    - "02 — Your first app": guide/02-your-first-app.md
+    - "03 — Events, state, the cycle": guide/03-events-state-cycle.md
+    - "04 — Views and frames": guide/04-views-and-frames.md
+    - "05 — State machines": guide/05-state-machines.md
+    - "06 — Doing HTTP requests": guide/06-doing-http-requests.md
+    - "07 — The server side": guide/07-server-side.md
+    - "08 — From re-frame v1": guide/08-from-re-frame-v1.md
+    - "09 — The dynamic model": guide/09-the-dynamic-model.md
+
+  - Spec:
+    - Overview: spec/README.md
+    - Foundation:
+      - "000 — Vision": spec/000-Vision.md
+      - "001 — Registration": spec/001-Registration.md
+      - "002 — Frames": spec/002-Frames.md
+    - Capability:
+      - "004 — Views": spec/004-Views.md
+      - "005 — State machines": spec/005-StateMachines.md
+      - "006 — Reactive substrate": spec/006-ReactiveSubstrate.md
+      - "007 — Stories": spec/007-Stories.md
+      - "008 — Testing": spec/008-Testing.md
+      - "009 — Instrumentation": spec/009-Instrumentation.md
+      - "010 — Schemas": spec/010-Schemas.md
+      - "011 — SSR": spec/011-SSR.md
+      - "012 — Routing": spec/012-Routing.md
+      - "013 — Flows": spec/013-Flows.md
+      - "014 — HTTP requests": spec/014-HTTPRequests.md
+    - Companion:
+      - Principles: spec/Principles.md
+      - Conventions: spec/Conventions.md
+      - Migration: spec/MIGRATION.md
+      - Construction prompts: spec/Construction-Prompts.md
+      - "CP-5 — Machine guide": spec/CP-5-MachineGuide.md
+      - AI audit: spec/AI-Audit.md
+      - "Tool — pair": spec/Tool-Pair.md
+      - Implementor checklist: spec/Implementor-Checklist.md
+      - Runtime architecture: spec/Runtime-Architecture.md
+      - Cross-spec interactions: spec/Cross-Spec-Interactions.md
+      - Ownership: spec/Ownership.md
+      - Spec schemas: spec/Spec-Schemas.md
+      - Conformance corpus: spec/conformance/README.md
+    - Patterns:
+      - Async effect: spec/Pattern-AsyncEffect.md
+      - Boot: spec/Pattern-Boot.md
+      - Forms: spec/Pattern-Forms.md
+      - Long-running work: spec/Pattern-LongRunningWork.md
+      - Nine states: spec/Pattern-NineStates.md
+      - Remote data: spec/Pattern-RemoteData.md
+      - Stale detection: spec/Pattern-StaleDetection.md
+      - WebSocket: spec/Pattern-WebSocket.md
+
+  - API:
+    - Reference: spec/API.md
+
+markdown_extensions:
+  - meta
+  - admonition
+  - footnotes
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Python dependencies for building the re-frame2 docs site (rf2-h09k).
+#
+# Pinned for reproducibility. Bump deliberately and verify the build still
+# resolves the cross-tree nav (docs/guide + spec/) cleanly.
+mkdocs==1.6.1
+mkdocs-material==9.5.44
+pymdown-extensions==10.11.2


### PR DESCRIPTION
Sets up the docs publishing pipeline for re-frame2 — Material-themed MkDocs site that publishes the **guide**, **spec**, and **API reference** to GitHub Pages.

## What ships

- `mkdocs.yml` — Material theme. Three nav sections:
  - **Guide** — `docs/guide/01-09` (narrative, human-facing).
  - **Spec** — `spec/` corpus, organised into Foundation (000–002), Capability (004–014), Companion (Principles, Conventions, Migration, …), and Patterns (`Pattern-*`).
  - **API** — `spec/API.md` as a single reference page (per-symbol pages are a follow-up; bead in scoping).
- `requirements.txt` — pinned `mkdocs 1.6.1`, `mkdocs-material 9.5.44`, `pymdown-extensions 10.11.2`.
- `.github/workflows/docs.yml` — two-job pipeline (build → deploy) using `actions/upload-pages-artifact` + `actions/deploy-pages`. Triggers on push to `main` plus `workflow_dispatch` for manual control.
- `docs/index.md` — published home page; three-doors landing (Guide / Spec / API).

## How the cross-tree publishing works

`spec/` lives at the repo root (rf2-9hft) but MkDocs requires `docs_dir` to be a child of the config file. The build stages `spec/` into `docs/spec/` (`cp -r spec docs/spec`) before running `mkdocs build`. The staged copy is `.gitignored`. Local previews need the same one-liner.

## Deferred

- **First publish.** The workflow only fires on push to `main` (or manual dispatch). Before the first publish, the repository's Pages source must be set to **GitHub Actions** (Settings → Pages → Build and deployment → Source). This PR does **not** trigger a publish — first publish is yours, manually, after review.
- **Per-symbol API pages.** `spec/API.md` ships as a single page. v1's per-symbol auto-generation pipeline (the `bb release-docs` step that emits per-namespace API markdown) is out of scope here; follow-up bead.
- **Custom theme overrides.** v1 ships a `docs/theme/` directory with a custom home page. Skipped — keeping the default Material chrome until the content stabilises.

## v1 things skipped (deliberate)

| v1 piece | Why skipped |
|---|---|
| `docs/theme/` (custom 404, header, footer overrides) | Scope creep; default Material is fine for v0. |
| `bb release-docs` API generation | Follow-up; not blocking first publish. |
| `squidfunk/mkdocs-material:5.5.9` Docker image | Pinned to 2020 versions; missing modern features. Replaced with `setup-python` + `pip install -r requirements.txt` for control over versions. |
| Highlight.js CDN includes | Material has built-in syntax highlighting via `pymdownx.highlight`. |

## Verification

- `python -m mkdocs build` completes locally in ~4s with **zero errors**. ~30 WARNINGs flag pre-existing link drift in `docs/guide/*.md` (uses `../../spec/*` paths designed for GitHub source-tree browsing; correct relative path on the published site is `../spec/*`). Tracked as follow-up bead **rf2-qvlf**.
- `mkdocs.yml` and `.github/workflows/docs.yml` round-trip cleanly through `yaml.safe_load`.
- All nav entries resolve to existing files.

## Files added

- `mkdocs.yml`
- `requirements.txt`
- `docs/index.md`
- `.github/workflows/docs.yml`
- `.gitignore` (added `/site/` and `/docs/spec/`)

## Follow-up beads

- **rf2-qvlf** — rewrite `../../spec/*` cross-references in `docs/guide/*.md` (or hook them at build time) so the published site has no dead links.
- (in scope of a future bead) per-symbol API pages — drive from registration metadata + docstrings.