### PR TITLE
feat: mkdocs hook rewrites guide→spec links at build time (rf2-qvlf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 /site/
 # spec/ is staged into docs/spec/ at build time; never commit the staged copy.
 /docs/spec/
+# Python bytecode from mkdocs_hooks.py (rf2-qvlf).
+/__pycache__/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,14 @@ copyright: Copyright &copy; 2014-2026 Michael Thompson
 docs_dir: docs
 site_dir: site
 
+# Build-time hooks. mkdocs_hooks.py rewrites guide/* cross-references
+# from ../../spec/ (correct for GitHub source-tree browsing, where spec/
+# lives at the repo root) to ../spec/ (correct for the staged docs tree
+# this build sees, where spec/ has been copied to docs/spec/). See
+# rf2-qvlf and the comment block at the top of mkdocs_hooks.py.
+hooks:
+  - mkdocs_hooks.py
+
 theme:
   name: material
   icon:

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -1,0 +1,37 @@
+# MkDocs build-time hooks (rf2-qvlf).
+#
+# The narrative guide lives at docs/guide/*.md. Many guide pages cross-link
+# to the normative spec under spec/*.md using the path ../../spec/ — that
+# is correct when the guide is browsed via the GitHub source tree (where
+# spec/ lives at the repo root, two levels up from docs/guide/).
+#
+# At MkDocs build time the spec tree is staged under docs/spec/ (see the
+# `Stage spec/ into docs/spec/` step in .github/workflows/docs.yml, and
+# the equivalent local `cp -r spec docs/spec`). From a guide page the
+# correct relative path to the staged spec is therefore ../spec/, not
+# ../../spec/. Without rewriting, every guide -> spec link 404s on the
+# published site and emits a WARNING during `mkdocs build`.
+#
+# Rather than rewrite the source files (which would break GitHub
+# source-tree browsing for anyone reading the guide on github.com), we
+# rewrite the markdown at build time. Source on disk remains correct for
+# both contexts.
+#
+# Scope deliberately narrow: only the ../../spec/ -> ../spec/ rewrite,
+# applied only to pages whose source path is under guide/. Other
+# repo-relative paths in the guide (e.g. ../../examples/, ../../README.md)
+# are out of scope for this hook — those targets are not staged into
+# docs/ and require a separate decision (link to GitHub instead, or stage
+# additional trees).
+
+import re
+
+_SPEC_LINK = re.compile(r'\]\(\.\./\.\./spec/')
+
+
+def on_page_markdown(markdown, page, config, files):
+    """Rewrite ../../spec/ -> ../spec/ in guide/* pages."""
+    src = page.file.src_path.replace('\\', '/')
+    if src.startswith('guide/'):
+        markdown = _SPEC_LINK.sub('](../spec/', markdown)
+    return markdown


### PR DESCRIPTION
## Summary

Many `docs/guide/*.md` cross-references to spec docs use `../../spec/` paths — correct for GitHub source-tree browsing (where `spec/` sits at the repo root, two levels up from `docs/guide/`) but wrong for the staged MkDocs tree (where `spec/` is staged at `docs/spec/`, so the relative path from a guide page is `../spec/`, only one `..` up).

Result on `main` today: 54 broken-link `WARNING` lines in `mkdocs build` and 404s on the published site for every guide→spec cross-reference.

## Approach

Add an `on_page_markdown` hook (`mkdocs_hooks.py` at the repo root) that rewrites `](../../spec/` to `](../spec/` only for pages whose source path is under `guide/`. Source markdown is untouched, so GitHub source-tree browsing of the same guide pages keeps working.

`mkdocs.yml` gets a small `hooks:` block referencing the file. `.gitignore` picks up `/__pycache__/` (generated next to the hook on Python import).

## Verification

Local with Python 3.14 + `pip install -r requirements.txt`:

```bash
rm -rf docs/spec && cp -r spec docs/spec
python -m mkdocs build 2>&1 | grep -c "^WARNING"
```

- Without hook: **87** warnings
- With hook: **33** warnings (delta of 54, all guide→spec)

The remaining 33 warnings are unrelated and out of scope for this bead — they are `../../examples/` and `../../README.md` references coming from both `spec/*` and a few `guide/*` files. Those targets are not staged into `docs/` at all (only `spec/` is staged per `.github/workflows/docs.yml`), so they need a separate decision: stage additional trees, link to GitHub absolute URLs, or extend the hook with a different rewrite. Filing as a follow-up rather than expanding the scope here.

## Test plan

- [x] `mkdocs build` locally produces zero broken-link WARNINGs for guide→spec references
- [x] GitHub source-tree browsing of `docs/guide/*.md` still resolves `../../spec/*` correctly (source files unchanged)
- [ ] CI `docs` workflow stays green on the next push to `main`
- [ ] After merge, sanity-check the deployed site's guide pages cross-link correctly to spec pages