### PR TITLE
feat: mkdocs hook rewrites cross-tree links to GitHub URLs (rf2-jtkc)

### DIFF
--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -1,4 +1,4 @@
-# MkDocs build-time hooks (rf2-qvlf).
+# MkDocs build-time hooks (rf2-qvlf, rf2-jtkc).
 #
 # The narrative guide lives at docs/guide/*.md. Many guide pages cross-link
 # to the normative spec under spec/*.md using the path ../../spec/ — that
@@ -17,21 +17,63 @@
 # rewrite the markdown at build time. Source on disk remains correct for
 # both contexts.
 #
-# Scope deliberately narrow: only the ../../spec/ -> ../spec/ rewrite,
-# applied only to pages whose source path is under guide/. Other
-# repo-relative paths in the guide (e.g. ../../examples/, ../../README.md)
-# are out of scope for this hook — those targets are not staged into
-# docs/ and require a separate decision (link to GitHub instead, or stage
-# additional trees).
+# Two rewrite cases (rf2-jtkc):
+#
+#   1. guide -> spec      ../../spec/       -> ../spec/
+#                         (spec is staged into docs/spec/, so it IS in the
+#                         site; the relative-path depth changes)
+#
+#   2. cross-tree refs to trees that are NOT staged into the site:
+#        - examples/   (CLJS apps; not docs to render)
+#        - root README.md
+#      These are rewritten to absolute GitHub blob URLs so the published
+#      site links to the source-tree view on github.com. Source files
+#      keep their GitHub-friendly relative paths.
 
 import re
 
-_SPEC_LINK = re.compile(r'\]\(\.\./\.\./spec/')
+GH_BLOB_BASE = "https://github.com/day8/re-frame2/blob/main"
+
+# Case 1: guide/* pages link to spec via ../../spec/ — collapse one level.
+_GUIDE_TO_SPEC = re.compile(r'\]\(\.\./\.\./spec/')
+
+# Case 2: cross-tree refs that don't exist in the staged docs tree.
+# These rewrites apply to ALL pages (guide/ and spec/), since both trees
+# reference examples/ and root README.md from their own depth in the source
+# layout.
+#
+# From guide/ source (docs/guide/X.md), the path to repo-root is ../../
+# From spec/  source (spec/X.md, staged at docs/spec/X.md), it is ../
+#
+# Both depths are rewritten to the same absolute GitHub URL.
+_REWRITES = (
+    # examples/ tree (anchor or no anchor; trailing path captured greedily
+    # up to the closing paren or whitespace).
+    (re.compile(r'\]\(\.\./\.\./examples/([^)\s]*)\)'),
+     rf']({GH_BLOB_BASE}/examples/\1)'),
+    (re.compile(r'\]\(\.\./examples/([^)\s]*)\)'),
+     rf']({GH_BLOB_BASE}/examples/\1)'),
+    # root README.md
+    (re.compile(r'\]\(\.\./\.\./README\.md(#[^)\s]*)?\)'),
+     rf']({GH_BLOB_BASE}/README.md\1)'),
+    (re.compile(r'\]\(\.\./README\.md(#[^)\s]*)?\)'),
+     rf']({GH_BLOB_BASE}/README.md\1)'),
+)
 
 
 def on_page_markdown(markdown, page, config, files):
-    """Rewrite ../../spec/ -> ../spec/ in guide/* pages."""
+    """Rewrite cross-tree links in guide/* and spec/* pages.
+
+    1. ../../spec/ -> ../spec/   (only on guide/* pages; spec IS staged)
+    2. ../../examples/ and ../examples/  -> https://github.com/.../examples/
+    3. ../../README.md and ../README.md  -> https://github.com/.../README.md
+    """
     src = page.file.src_path.replace('\\', '/')
+
     if src.startswith('guide/'):
-        markdown = _SPEC_LINK.sub('](../spec/', markdown)
+        markdown = _GUIDE_TO_SPEC.sub('](../spec/', markdown)
+
+    for pattern, replacement in _REWRITES:
+        markdown = pattern.sub(replacement, markdown)
+
     return markdown


### PR DESCRIPTION
## Summary

Extends `mkdocs_hooks.py` with two additional rewrite rules so the published site no longer 404s on cross-tree references from `guide/` and `spec/` source pages.

Per the rf2-jtkc bead, this is **path 2**: rewrite to GitHub URLs (chosen over staging `examples/` and the root README into `docs/`). The `examples/` tree contains CLJS apps, not docs to render; pointing the published site at the GitHub source-tree view is the right destination.

## Rewrites added

| Source pattern | Rewritten to |
| --- | --- |
| `](../../examples/X)` (from `guide/`) | `](https://github.com/day8/re-frame2/blob/main/examples/X)` |
| `](../examples/X)` (from `spec/`) | `](https://github.com/day8/re-frame2/blob/main/examples/X)` |
| `](../../README.md)` (from `guide/`) | `](https://github.com/day8/re-frame2/blob/main/README.md)` |
| `](../README.md)` (from `spec/`) | `](https://github.com/day8/re-frame2/blob/main/README.md)` |

Anchor variants (`#section`) are preserved in the rewritten URL — GitHub honours `#anchor` on rendered Markdown.

Source files in `spec/` and `docs/guide/` are unchanged: they keep GitHub-friendly relative paths so the trees still browse cleanly on github.com.

## Build warnings: before vs after

Local `mkdocs build` (with `cp -r spec docs/spec` first):

| | WARNINGs |
| --- | --- |
| Before | 33 |
| After  | 0 |

The 33 baseline warnings split as: 4 from `guide/*` (`../../README.md`, `../../examples/...`) and 29 from `spec/*` (`../examples/...`). All cleared.

(There are still ~50 INFO-level messages about missing in-page anchors inside spec — those are unrelated content issues, separately tracked, and not affected by this hook.)

## Test plan

- [x] `python -m mkdocs build` after `cp -r spec docs/spec` produces 0 link WARNINGs.
- [x] Spot-checked rendered HTML: `site/guide/02-your-first-app/index.html` and `site/spec/Pattern-Forms/index.html` show absolute `https://github.com/day8/re-frame2/blob/main/...` URLs for examples.
- [x] Existing `../../spec/` -> `../spec/` rewrite still works (`site/guide/01-why-re-frame2/index.html` shows `href="../spec/"`).
- [x] No source-tree files modified (only `mkdocs_hooks.py`).