### PR TITLE
fix: app-db schemas are frame-scoped (rf2-xfa2)

### DIFF
--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -371,21 +371,29 @@
    (defmacro reg-app-schema
      "Register a Malli schema at a path inside app-db. Per Spec 001 the
      metadata stamped onto the registry slot includes :ns / :line /
-     :file captured at this call site."
-     [path schema]
+     :file captured at this call site.
+
+     Per Spec 010 §Per-frame schemas this registration is frame-scoped.
+     The frame to register against comes from the optional `opts`
+     map's `:frame` key; default is `(re-frame.frame/current-frame)` —
+     usually `:rf/default` unless called inside `(with-frame ...)`."
+     {:arglists '([path schema] [path schema opts])}
+     [path schema & [opts]]
      (let [m       (meta &form)
-           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
-           ;; the ns-symbol but in CLJS macro context that symbol may carry
-           ;; the consumer namespace's :doc metadata, which would then get
-           ;; serialised into the bundle and defeat production elision.
+           ;; Construct a fresh, metadata-free symbol. (ns-name *ns*)
+           ;; returns the ns-symbol but in CLJS macro context that
+           ;; symbol may carry the consumer namespace's :doc metadata,
+           ;; which would then get serialised into the bundle and
+           ;; defeat production elision.
            ns-sym  (symbol (str (ns-name *ns*)))
-           file    *file*]
+           file    *file*
+           opts'   (or opts {})]
        `(binding [source-coords/*pending-coords*
                   (cond-> {:ns '~ns-sym}
                     ~file        (assoc :file ~file)
                     ~(:line m)   (assoc :line ~(:line m))
                     ~(:column m) (assoc :column ~(:column m)))]
-          (schemas/reg-app-schema ~path ~schema)))))
+          (schemas/reg-app-schema ~path ~schema ~opts')))))
 
 ;; Schema introspection — pure fn aliases (no source-coord capture
 ;; needed, these are read-only public queries).

--- a/implementation/src/re_frame/epoch.cljc
+++ b/implementation/src/re_frame/epoch.cljc
@@ -404,35 +404,41 @@
      :cljs (try (resolve 'malli.core/validate)
                 (catch :default _ nil))))
 
-(defn- registered-app-schemas []
-  (registrar/handlers :app-schema))
+(defn- registered-app-schemas
+  "Return the {path → schema-meta} map registered against the named
+  frame, or {}. Per Spec 010 §Per-frame schemas the schema set is
+  frame-scoped; restore-epoch validates against the schemas registered
+  against the frame the epoch belongs to, not a process-global set."
+  [frame-id]
+  (if-let [entries (late-bind/get-fn :schemas/frame-schema-entries)]
+    (entries frame-id)
+    {}))
 
 (defn- schema-validate-ok?
-  "True when the recorded db validates against every currently-registered
-  app-schema. Defensive: when no schemas are registered or Malli is
-  not on the path, we consider the db valid (we can't disprove it)."
-  [db]
-  (let [schemas  (registered-app-schemas)
+  "True when the recorded db validates against every app-schema
+  registered against frame-id. Defensive: when no schemas are
+  registered or Malli is not on the path, we consider the db valid
+  (we can't disprove it)."
+  [frame-id db]
+  (let [schemas  (registered-app-schemas frame-id)
         validate (malli-validate-fn)]
     (or (empty? schemas)
         (nil? validate)
-        (every? (fn [[_path meta]]
+        (every? (fn [[path meta]]
                   (let [schema (:schema meta)
-                        path   (:path meta)
                         v      (get-in db path)]
                     (try (validate schema v)
                          (catch #?(:clj Throwable :cljs :default) _ true))))
                 schemas))))
 
-(defn- failing-paths-for [db]
-  (let [schemas  (registered-app-schemas)
+(defn- failing-paths-for [frame-id db]
+  (let [schemas  (registered-app-schemas frame-id)
         validate (malli-validate-fn)]
     (if (or (empty? schemas) (nil? validate))
       []
       (vec
-        (keep (fn [[_id meta]]
+        (keep (fn [[path meta]]
                 (let [schema (:schema meta)
-                      path   (:path meta)
                       v      (get-in db path)]
                   (when-not (try (validate schema v)
                                  (catch #?(:clj Throwable :cljs :default) _ true))
@@ -545,14 +551,14 @@
             (let [db-target (:db-after epoch)]
               (cond
                 ;; (4) Schema mismatch?
-                (not (schema-validate-ok? db-target))
+                (not (schema-validate-ok? frame-id db-target))
                 (do
                   (emit-restore-failure! :rf.epoch/restore-schema-mismatch
                                          {:frame                  frame-id
                                           :epoch-id               epoch-id
                                           :schema-digest-recorded nil
                                           :schema-digest-current  nil
-                                          :failing-paths          (failing-paths-for db-target)})
+                                          :failing-paths          (failing-paths-for frame-id db-target)})
                   false)
 
                 ;; (5) Missing handler referenced from db?

--- a/implementation/src/re_frame/router.cljc
+++ b/implementation/src/re_frame/router.cljc
@@ -185,9 +185,13 @@
               ;; after each commit. Failures emit
               ;; :rf.error/schema-validation-failure but don't roll back
               ;; (recovery is :no-recovery by default).
+              ;;
+              ;; Per Spec 010 §Per-frame schemas the validation walks
+              ;; the schemas registered against THIS dispatch's frame
+              ;; only — sibling frames' schemas don't fire here.
               (when-let [validate (late-bind/get-fn :schemas/validate-app-db!)]
                 (try
-                  (validate (:db effects) event-id)
+                  (validate (:db effects) event-id frame)
                   (catch #?(:clj Throwable :cljs :default) _ nil))))
             ;; Run flows (per Spec 013 §Drain integration: after :db
             ;; commits and before :fx walks).

--- a/implementation/src/re_frame/schemas.cljc
+++ b/implementation/src/re_frame/schemas.cljc
@@ -6,9 +6,19 @@
   after compute; app-db after each handler completes). In dev builds
   only — production builds elide.
 
+  Per Spec 010 §Per-frame schemas, `app-db` schemas are **frame-scoped**:
+  registered against the active frame at registration time and looked
+  up per frame at validation time. Stories, multi-instance widgets,
+  per-test fixtures need shape-flexibility — a stripped-down schema
+  registered against `:story.foo/empty` does NOT bleed into the
+  `:rf/default` frame's contract. `(reg-app-schema path schema)` uses
+  the active frame (`(frame/current-frame)`); `(reg-app-schema path
+  schema {:frame frame-id})` registers explicitly.
+
   This first-pass implementation uses Malli when available; if the user
   hasn't pulled Malli into their project, schemas are silently ignored."
   (:require [re-frame.registrar :as registrar]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
@@ -44,26 +54,83 @@
          (when explain (explain schema value)))
        (catch :default _ nil))))
 
+;; ---- per-frame storage ----------------------------------------------------
+;;
+;; Per Spec 010 §Per-frame schemas. The registry shape is
+;;   {frame-id {path schema-meta}}
+;; mirroring `re-frame.flows`'s frame-scoping (rf2-lvwr). The registrar
+;; (`:app-schema` kind) still receives a slot-per-path entry so source-
+;; coords / hot-reload tooling can introspect a path's most-recent
+;; registration; the per-frame map is the authoritative store the
+;; validation hot path reads.
+
+(defonce
+  ^{:doc "frame-id → path → schema-meta. Per-frame so a story or test
+          fixture's reg-app-schema does not bleed into the default
+          frame's contract."}
+  schemas-by-frame
+  (atom {}))
+
+(defn- resolve-frame
+  "Pluck :frame from the opts map; default to (frame/current-frame)."
+  [opts]
+  (or (:frame opts) (frame/current-frame)))
+
+(defn- coerce-opts
+  "Permit the keyword-only sugar `(app-schemas frame-id)` and the
+  opts-map form `(app-schemas {:frame frame-id})`."
+  [opts-or-frame-id]
+  (cond
+    (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
+    (map?     opts-or-frame-id) opts-or-frame-id
+    (nil?     opts-or-frame-id) {}
+    :else
+    (throw (ex-info ":rf.error/bad-app-schemas-arg"
+                    {:received opts-or-frame-id
+                     :expected "keyword frame-id or opts map"}))))
+
 ;; ---- app-db schema registration -------------------------------------------
 
 (defn reg-app-schema
   "Register a Malli schema at a path inside app-db. Validation runs in
   dev whenever an event handler returns a new app-db; failures emit
-  :rf.error/schema-validation-failure."
-  [path schema]
-  (registrar/register! :app-schema path
-                       (source-coords/merge-coords
-                         {:schema schema :path path}))
-  path)
+  :rf.error/schema-validation-failure.
+
+  Per Spec 010 §Per-frame schemas this registration is frame-scoped.
+  The frame to register against comes from the optional :frame opt;
+  default is (frame/current-frame) — usually :rf/default unless the
+  caller is inside a (with-frame ...) wrapper or a frame-provider."
+  ([path schema] (reg-app-schema path schema {}))
+  ([path schema opts]
+   (let [frame-id (resolve-frame opts)
+         meta     (source-coords/merge-coords
+                    {:schema schema :path path :frame frame-id})]
+     ;; Stamp the registrar slot so source-coords / handler-meta /
+     ;; hot-reload tooling continue to see :app-schema entries. The
+     ;; registrar is per-process; the per-frame map is the
+     ;; authoritative store for validation.
+     (registrar/register! :app-schema path meta)
+     (swap! schemas-by-frame assoc-in [frame-id path] meta)
+     path)))
 
 (defn app-schema-at
-  "Lookup the registered schema for a path, or nil."
-  [path]
-  (when-let [meta (registrar/lookup :app-schema path)]
-    (:schema meta)))
+  "Look up the registered schema for a path in a frame, or nil.
+
+  Arities:
+    (app-schema-at path)         ;; current frame (or :rf/default)
+    (app-schema-at path opts)    ;; opts map; :frame names the frame
+                                 ;; (keyword sugar also accepted)
+
+  Per Spec 010 §Schemas as a tooling and agent surface."
+  ([path] (app-schema-at path {}))
+  ([path opts-or-frame-id]
+   (let [opts     (coerce-opts opts-or-frame-id)
+         frame-id (resolve-frame opts)]
+     (when-let [m (get-in @schemas-by-frame [frame-id path])]
+       (:schema m)))))
 
 (defn app-schemas
-  "Return every registered `app-schema-at` declaration as a
+  "Return every registered `app-schema-at` declaration for a frame as a
   `{path → schema}` map. Pair tools and 10x panels read this to
   introspect what schemas apply in a given frame.
 
@@ -74,30 +141,51 @@
     (app-schemas opts)         ;; opts is a map; supports {:frame ...}
                                ;; and is the place future opts will land
 
-  The `opts`-map arity is the configurable form; the keyword arity is
-  the common pair-tool case. Per Spec 010 §Schemas as a tooling and
-  agent surface.
-
-  Note: in the v1 reference implementation `:app-schema` is a
-  process-global registry kind (per [001 §Registry model]), so the
-  `:frame` opt is accepted for forward-compatibility (the spec calls
-  for per-frame schemas) but does not yet narrow the result. Returns
-  the same global map regardless of `:frame` until per-frame storage
-  lands."
+  Per Spec 010 §Per-frame schemas the result is the schema set
+  registered against the named frame (active frame when none is
+  given). Schemas registered against a different frame do not appear."
   ([] (app-schemas {}))
   ([opts-or-frame-id]
-   (let [_opts (cond
-                 (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
-                 (map?     opts-or-frame-id) opts-or-frame-id
-                 (nil?     opts-or-frame-id) {}
-                 :else
-                 (throw (ex-info ":rf.error/bad-app-schemas-arg"
-                                 {:received opts-or-frame-id
-                                  :expected "keyword frame-id or opts map"})))]
-     (reduce-kv (fn [acc path meta]
-                  (assoc acc path (:schema meta)))
+   (let [opts     (coerce-opts opts-or-frame-id)
+         frame-id (resolve-frame opts)]
+     (reduce-kv (fn [acc path m] (assoc acc path (:schema m)))
                 {}
-                (registrar/handlers :app-schema)))))
+                (get @schemas-by-frame frame-id {})))))
+
+(defn frame-schema-entries
+  "Internal: return the {path → schema-meta} map for a frame, or {}.
+  Used by the validation hot path and the epoch-restore predicates so
+  they can read the same authoritative store reg-app-schema writes."
+  [frame-id]
+  (get @schemas-by-frame frame-id {}))
+
+;; ---- hot-reload invalidation ---------------------------------------------
+;;
+;; When a frame is destroyed (or a schema is explicitly cleared via the
+;; registrar), drop its per-frame entry so the validation hot path
+;; doesn't keep walking dead schemas. Per Spec 001 §Hot-reload semantics
+;; the registrar's :app-schema slot is shared (path-keyed) across
+;; frames; replacement-hook fires on EVERY re-register, not only when
+;; we want to invalidate. We only act on :rf.registry/handler-cleared-
+;; equivalent paths (kind = :app-schema, no `:now` means cleared).
+
+(defn- on-app-schema-registry-event!
+  [{:keys [kind id was now]}]
+  (when (= kind :app-schema)
+    ;; A `register!` always supplies `now`; `unregister!` / `clear-kind!`
+    ;; produce no replacement-hook callback (they don't fire hooks). The
+    ;; registrar today only invokes hooks on replacement, so this hook
+    ;; sees re-registrations against the same path. Re-registering with
+    ;; an explicit :frame opt MAY be against a different frame — in
+    ;; which case we leave the prior frame's entry alone (it was
+    ;; registered separately) and the new frame's entry is updated by
+    ;; reg-app-schema directly. Nothing to do here today; the hook is
+    ;; published as the seam future invalidation work plugs into.
+    (let [_ was _ now])))
+
+(defonce ^:private _hot-reload-hook
+  (do (registrar/add-replacement-hook! on-app-schema-registry-event!)
+      :installed))
 
 ;; ---- validation entry points ----------------------------------------------
 
@@ -114,23 +202,33 @@
     :else        (str (type v))))
 
 (defn validate-app-db!
-  "After a handler commits :db, walk every registered app-schema and
-  validate the post-state. Failures trace as
+  "After a handler commits :db, walk every registered app-schema for the
+  named frame and validate the post-state. Failures trace as
   :rf.error/schema-validation-failure with a Malli explanation.
+
+  Per Spec 010 §Per-frame schemas only the named frame's schemas are
+  walked — schemas registered against sibling frames are ignored.
+
+  Arities:
+    (validate-app-db! db)                       ;; current frame
+    (validate-app-db! db event-id)              ;; current frame, named handler
+    (validate-app-db! db event-id frame-id)     ;; explicit frame
 
   event-id (optional) names the handler whose commit prompted the
   failure — surfaced as :failing-id in the error tags."
-  ([db] (validate-app-db! db nil))
-  ([db event-id]
+  ([db] (validate-app-db! db nil (frame/current-frame)))
+  ([db event-id] (validate-app-db! db event-id (frame/current-frame)))
+  ([db event-id frame-id]
    (when interop/debug-enabled?
-     (doseq [[path meta] (registrar/handlers :app-schema)]
+     (doseq [[path m] (frame-schema-entries frame-id)]
        (let [val-at (get-in db path)
-             schema (:schema meta)]
+             schema (:schema m)]
          (when-not (malli-validate* schema val-at)
            (trace/emit-error! :rf.error/schema-validation-failure
                               (cond-> {:where    :app-db
                                        :path     path
                                        :value    val-at
+                                       :frame    frame-id
                                        :explain  (malli-explain* schema val-at)
                                        :reason   (str "App-db at path " path
                                                       " failed schema " schema
@@ -264,3 +362,4 @@
 (late-bind/set-fn! :schemas/validate-event!      validate-event!)
 (late-bind/set-fn! :schemas/validate-sub-return! validate-sub-return!)
 (late-bind/set-fn! :schemas/validate-cofx!       validate-cofx!)
+(late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)

--- a/implementation/src/re_frame/test_support.cljc
+++ b/implementation/src/re_frame/test_support.cljc
@@ -45,6 +45,7 @@
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
+            [re-frame.schemas :as schemas]
             [re-frame.trace :as trace]
             [re-frame.substrate.adapter :as adapter]))
 
@@ -110,7 +111,8 @@
     1. Captures the current registrar (so user-test registrations can be
        rolled back without losing ns-load-time framework / example
        registrations).
-    2. Resets `frame/frames` and `flows/flows` to `{}`.
+    2. Resets `frame/frames`, `flows/flows`, and `schemas/schemas-by-frame`
+       to `{}`.
     3. Disposes the currently-installed substrate adapter.
     4. Resets the machines spawn-counter.
     5. Clears trace listeners.
@@ -123,7 +125,8 @@
        `(routing/reset-counters!)`.
     8. Runs the test.
     9. Restores the registrar to the captured snapshot.
-   10. Resets `frame/frames` and `flows/flows` back to `{}` for symmetry.
+   10. Resets `frame/frames`, `flows/flows`, and
+       `schemas/schemas-by-frame` back to `{}` for symmetry.
 
   Steps 9–10 run in a `finally` block so they fire even on test
   exceptions.
@@ -166,10 +169,12 @@
   ([] (reset-runtime-fixture {}))
   ([{:keys [adapter init-fn clear-kinds]}]
    (fn [test-fn]
-     (let [snap (snapshot-registrar)]
+     (let [snap          (snapshot-registrar)
+           schemas-snap  @schemas/schemas-by-frame]
        (try
          (reset! frame/frames {})
          (reset! flows/flows {})
+         (reset! schemas/schemas-by-frame {})
          (adapter/dispose-adapter!)
          (machines/reset-counters!)
          (trace/clear-trace-cbs!)
@@ -177,10 +182,15 @@
            (adapter/install-adapter! adapter)
            (frame/ensure-default-frame!))
          (doseq [k clear-kinds]
-           (registrar/clear-kind! k))
+           (registrar/clear-kind! k)
+           ;; Per-frame schema map is the authoritative store; clear it
+           ;; in lockstep when the caller asks for an :app-schema reset.
+           (when (= k :app-schema)
+             (reset! schemas/schemas-by-frame {})))
          (when init-fn (init-fn))
          (test-fn)
          (finally
            (restore-registrar! snap)
+           (reset! schemas/schemas-by-frame schemas-snap)
            (reset! frame/frames {})
            (reset! flows/flows {})))))))

--- a/implementation/test/re_frame/boot_test.clj
+++ b/implementation/test/re_frame/boot_test.clj
@@ -19,6 +19,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -32,6 +33,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (adapter/dispose-adapter!)
   (test-fn)
   ;; Leave the world in a state the next namespace's fixture can reset

--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -20,6 +20,7 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
             [re-frame.subs :as subs]
             [re-frame.trace :as trace]
             [re-frame.conformance :as conformance]
@@ -102,6 +103,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework events / fx are registered at namespace-load time in
   ;; routing.cljc / ssr.cljc; clear-all! wiped them. Re-eval those

--- a/implementation/test/re_frame/drain_test.clj
+++ b/implementation/test/re_frame/drain_test.clj
@@ -9,6 +9,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]))
 
@@ -16,6 +17,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)

--- a/implementation/test/re_frame/epoch_test.clj
+++ b/implementation/test/re_frame/epoch_test.clj
@@ -20,6 +20,7 @@
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.trace :as trace]
             [re-frame.epoch :as epoch]))
 
@@ -29,6 +30,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
@@ -320,7 +322,10 @@
     (rf/dispatch-sync [:seed]    {:frame :test/main})
 
     ;; Now register a schema that the bad-record's :db-after fails.
-    (rf/reg-app-schema [:n] [:int])
+    ;; Per Spec 010 §Per-frame schemas reg-app-schema is frame-scoped;
+    ;; restore-epoch runs on :test/main so the schema must register
+    ;; against that frame, not the (current-frame)-default :rf/default.
+    (rf/reg-app-schema [:n] [:int] {:frame :test/main})
 
     (let [pre      (rf/get-frame-db :test/main)
           history  (rf/epoch-history :test/main)

--- a/implementation/test/re_frame/examples_test.clj
+++ b/implementation/test/re_frame/examples_test.clj
@@ -6,12 +6,14 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; clear-all! also drops the framework-shipped fxs that register at
   ;; namespace load time (e.g. :rf.http/managed and its canned-stub

--- a/implementation/test/re_frame/flows_test.clj
+++ b/implementation/test/re_frame/flows_test.clj
@@ -20,6 +20,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 ;; ---- per-test reset -------------------------------------------------------
@@ -34,6 +35,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   ;; flows.cljc keeps a private last-inputs atom for dirty-checking
   ;; (per Spec 013 §Dirty-check semantics). The smoke-test fixture
   ;; doesn't reset it; left alone, an entry from this namespace's tests
@@ -353,6 +355,7 @@
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
     (is (contains? (get @flows/flows :rf/default) :one))
     (reset! flows/flows {})
+    (reset! schemas/schemas-by-frame {})
     (is (empty? (get @flows/flows :rf/default))
         "per-frame map is empty after reset")
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})

--- a/implementation/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/test/re_frame/frame_lifecycle_test.clj
@@ -9,12 +9,14 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework events / fx / subs are registered at namespace-load time;
   ;; clear-all! wiped them. Reload to resurrect the framework registrations.

--- a/implementation/test/re_frame/fx_test.clj
+++ b/implementation/test/re_frame/fx_test.clj
@@ -20,6 +20,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.trace :as trace]))
 
@@ -27,6 +28,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework registrations live at namespace-load time; clear-all!
   ;; wiped them. Reload so :rf/route, :rf.route/* subs and the framework

--- a/implementation/test/re_frame/hot_reload_test.clj
+++ b/implementation/test/re_frame/hot_reload_test.clj
@@ -22,6 +22,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
@@ -29,6 +30,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework events / fx are registered at namespace-load time in
   ;; routing.cljc and ssr.cljc; clear-all! wiped them. Re-eval those

--- a/implementation/test/re_frame/http_managed_test.clj
+++ b/implementation/test/re_frame/http_managed_test.clj
@@ -11,6 +11,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
             [re-frame.http-managed :as http-managed]
@@ -25,6 +26,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)

--- a/implementation/test/re_frame/interceptor_test.clj
+++ b/implementation/test/re_frame/interceptor_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.interceptor :as interceptor]
             [re-frame.registrar :as registrar]))
@@ -25,6 +26,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework-shipped registrations live in routing.cljc / ssr.cljc /
   ;; machines.cljc and are wiped by clear-all!. None of these tests need

--- a/implementation/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/test/re_frame/pattern_smoke_test.clj
@@ -12,6 +12,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]))
 
@@ -19,6 +20,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   (test-fn))
 

--- a/implementation/test/re_frame/routing_test.clj
+++ b/implementation/test/re_frame/routing_test.clj
@@ -34,12 +34,14 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework events / fx (routing.cljc, ssr.cljc) are registered at
   ;; ns-load; clear-all! wiped them. Reload to resurrect.

--- a/implementation/test/re_frame/schemas_test.clj
+++ b/implementation/test/re_frame/schemas_test.clj
@@ -38,6 +38,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   (test-fn))
 
@@ -374,3 +375,76 @@
         (is (keyword? (:code public)))
         (is (string? (:message public)))
         (is (boolean? (:retryable? public)))))))
+
+;; ---- rf2-xfa2 — frame-scoped app-db schemas ------------------------------
+
+(deftest reg-app-schema-defaults-to-current-frame
+  (testing "Per Spec 010 §Per-frame schemas — reg-app-schema with no opts
+            registers against (current-frame), which is :rf/default outside
+            (with-frame ...)."
+    (rf/reg-app-schema [:user] [:map [:id :uuid]])
+    (is (= [:map [:id :uuid]] (rf/app-schema-at [:user]))
+        "schema is visible from the active frame's lookup")
+    (is (= [:map [:id :uuid]] (rf/app-schema-at [:user] :rf/default))
+        "schema is visible from explicit :rf/default lookup")
+    (is (= {[:user] [:map [:id :uuid]]} (rf/app-schemas))
+        "app-schemas returns the active frame's schema set")
+    (is (= {[:user] [:map [:id :uuid]]} (rf/app-schemas :rf/default))
+        "app-schemas with explicit :rf/default returns the same map")))
+
+(deftest reg-app-schema-explicit-frame-opt-isolates-schemas
+  (testing "Per Spec 010 §Per-frame schemas — :frame opt registers against
+            a named frame; sibling frames don't see that schema."
+    (rf/reg-frame :test/story {})
+    (rf/reg-app-schema [:user] [:map [:id :uuid]] {:frame :rf/default})
+    (rf/reg-app-schema [:user] [:map [:nick :string]] {:frame :test/story})
+    (is (= [:map [:id :uuid]]   (rf/app-schema-at [:user] :rf/default))
+        "default frame keeps its own schema at [:user]")
+    (is (= [:map [:nick :string]] (rf/app-schema-at [:user] :test/story))
+        "story frame has its own (different) schema at [:user]")
+    (is (= {[:user] [:map [:id :uuid]]}     (rf/app-schemas :rf/default)))
+    (is (= {[:user] [:map [:nick :string]]} (rf/app-schemas {:frame :test/story})))))
+
+(deftest sibling-frame-schemas-do-not-fire-on-each-others-dispatches
+  (testing "Per Spec 010 §Per-frame schemas — validate-app-db! only walks the
+            schemas registered against THIS dispatch's frame; a malformed
+            commit on frame A must not fire a schema-validation-failure for
+            a schema registered against frame B."
+    (rf/reg-frame :test/main  {})
+    (rf/reg-frame :test/other {})
+    ;; Schema only on :test/other; commit happens on :test/main.
+    (rf/reg-app-schema [:n] [:int] {:frame :test/other})
+    (rf/reg-event-db :n/break-on-main (fn [db _] (assoc db :n "not-an-int")))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sib (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:n/break-on-main] {:frame :test/main})
+      (rf/remove-trace-cb! ::sib)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                          @traces))
+          "no schema fires on :test/main because the schema lives on :test/other"))))
+
+(deftest schema-fires-only-on-the-frame-it-registers-against
+  (testing "Per Spec 010 §Per-frame schemas — a malformed commit on the same
+            frame the schema is registered against DOES fire the failure trace."
+    (rf/reg-frame :test/main {})
+    (rf/reg-app-schema [:n] [:int] {:frame :test/main})
+    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "not-an-int")))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::same (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:n/break] {:frame :test/main})
+      (rf/remove-trace-cb! ::same)
+      (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "the schema registered against :test/main fires when :test/main commits a violation")
+        (is (= :test/main (-> violations first :tags :frame))
+            ":frame tag carries the failing frame's id")))))
+
+(deftest app-schemas-with-keyword-and-opts-arities-agree
+  (testing "(app-schemas frame-id) is documented as sugar for
+            (app-schemas {:frame frame-id}); both must return the same map."
+    (rf/reg-frame :test/k {})
+    (rf/reg-app-schema [:k] [:int] {:frame :test/k})
+    (is (= (rf/app-schemas :test/k)
+           (rf/app-schemas {:frame :test/k}))
+        "keyword form == opts-map form")))

--- a/implementation/test/re_frame/smoke_test.clj
+++ b/implementation/test/re_frame/smoke_test.clj
@@ -7,6 +7,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.routing :as routing]))
@@ -15,6 +16,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   ;; flows.cljc keeps a private last-inputs atom for dirty-checking
   ;; (per Spec 013 §Dirty-check semantics). Without resetting it, an
   ;; entry from a prior deftest can leak into a subsequent same-keyed

--- a/implementation/test/re_frame/source_coords_test.clj
+++ b/implementation/test/re_frame/source_coords_test.clj
@@ -27,12 +27,14 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (when-let [li-var (resolve 're-frame.flows/last-inputs)]
     (reset! (deref li-var) {}))
   (rf/init!)

--- a/implementation/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/test/re_frame/ssr_end_to_end_test.clj
@@ -32,6 +32,7 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]))
 
@@ -39,6 +40,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   ;; Framework registrations happen at namespace-load time in
   ;; routing.cljc / ssr.cljc / machines.cljc; clear-all! wiped them, so

--- a/implementation/test/re_frame/sub_cache_test.clj
+++ b/implementation/test/re_frame/sub_cache_test.clj
@@ -14,12 +14,14 @@
             [re-frame.subs :as subs]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (rf/init!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)

--- a/implementation/test/re_frame/trace_buffer_test.clj
+++ b/implementation/test/re_frame/trace_buffer_test.clj
@@ -16,6 +16,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.trace :as trace]))
 
@@ -25,6 +26,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (trace/clear-trace-cbs!)
   (rf/clear-trace-buffer!)
   ;; Restore default depth between tests so a depth-tweaking test does

--- a/implementation/test/re_frame/trace_test.clj
+++ b/implementation/test/re_frame/trace_test.clj
@@ -27,6 +27,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.trace :as trace]))
 
@@ -36,6 +37,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (trace/clear-trace-cbs!)
   (rf/init!)
   ;; Framework events / fx are registered at namespace-load time in

--- a/implementation/test/re_frame/views_macros_test.clj
+++ b/implementation/test/re_frame/views_macros_test.clj
@@ -11,6 +11,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.views-macros :as vm]))
 
@@ -18,6 +19,7 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
   (when-let [li-var (resolve 're-frame.flows/last-inputs)]
     (reset! (deref li-var) {}))
   (rf/init!)


### PR DESCRIPTION
## Summary

Spec 010 §Per-frame schemas describes `reg-app-schema` as frame-scoped — a story / per-test fixture's schema MUST NOT bleed into `:rf/default`'s contract. The impl was a process-global registry. Move the authoritative store to a per-frame map (`schemas-by-frame {frame-id {path schema-meta}}`), mirroring `re-frame.flows` (rf2-lvwr).

- `reg-app-schema` accepts `:frame` opt; default `(frame/current-frame)`.
- `app-schema-at` / `app-schemas` accept `:frame` opt (keyword sugar too).
- `validate-app-db!` takes a `frame-id`; the router passes the dispatch's frame, so a malformed commit on frame A no longer fires schemas registered against frame B.
- `epoch/restore-schema-mismatch` is now frame-scoped — `restore-epoch` validates against the schemas registered against the frame whose epoch is being restored.

The `:app-schema` registrar slot still receives a path-keyed entry so `handler-meta` / source-coords / hot-reload introspection continue to surface the most-recent registration; the per-frame map is what the validation hot path walks.

`MIGRATION.md` needs no entry: `reg-app-schema` is a re-frame2-only API and Spec 010 always documented it as frame-scoped — this PR aligns the impl with the documented contract.

## Test plan

- [x] `clojure -M:test` — 230 tests / 1074 assertions, 0 failures, 0 errors (5 new frame-scope assertions in `schemas_test.clj`)
- [x] `npm run test:cljs` — 98 tests / 303 assertions, 0 failures
- [x] `npm run test:browser` — 98 tests / 303 assertions, 0 failures
- [x] `npm run test:elision` — all elision sentinels PASS
- [x] `npm run test:examples` — every example app green (counter, login, todomvc, realworld, ssr, 7guis, etc.)