### PR TITLE
fix: validate machine snapshots on epoch restore (rf2-ocg1)

### DIFF
--- a/implementation/src/re_frame/epoch.cljc
+++ b/implementation/src/re_frame/epoch.cljc
@@ -439,20 +439,61 @@
                     path)))
               schemas)))))
 
+(defn- machine-registration
+  "Resolve a machine-id against the public machine registry. Per
+  Spec 005 §Registration / §Querying machines, machines are event
+  handlers whose registration metadata carries `:rf/machine? true`
+  and `:rf/machine` (the spec map). Returns the registration map
+  when machine-id names a registered machine, nil otherwise.
+
+  Per rf2-ocg1: epoch restore validates against this public surface,
+  not against the internal `:head` registrar kind that machines
+  never used."
+  [machine-id]
+  (let [reg (registrar/lookup :event machine-id)]
+    (when (:rf/machine? reg)
+      reg)))
+
+(defn- snapshot-version
+  "Read the recorded snapshot's `:rf/snapshot-version`. Per
+  Spec-Schemas §`:rf/machine-snapshot` and Spec 005 §Snapshot shape,
+  the canonical slot is `[:meta :rf/snapshot-version]`. Tolerates
+  the legacy top-level `:rf/snapshot-version` slot for snapshots
+  written before the meta-nesting was finalised."
+  [snapshot]
+  (or (get-in snapshot [:meta :rf/snapshot-version])
+      (:rf/snapshot-version snapshot)))
+
+(defn- machine-definition-version
+  "Read the currently-registered machine definition's
+  `:rf/snapshot-version`. Per Spec 005 §Snapshot shape — the
+  definition's `:meta :rf/snapshot-version` is the canonical slot."
+  [machine-id]
+  (when-let [reg (machine-registration machine-id)]
+    (let [machine (:rf/machine reg)]
+      (get-in machine [:meta :rf/snapshot-version]))))
+
 (defn- missing-references
   "Walk the recorded db for ids that are no longer present in the
-  registrar. Closed v1 surface — `:rf/machines` (machine-id keys must
-  reference a registered :head/machine snapshot via the machine
-  registry) and `:route` (`:id` must reference a registered :route).
+  registrar. Closed v1 surface — `:rf/machines` (each machine-id
+  must reference a registered machine via the public event registry,
+  per Spec 005 §Registration — machines are event handlers tagged
+  with `:rf/machine?`) and `:route` (`:id` must reference a registered
+  :route).
+
+  Per rf2-ocg1: machine lookup goes through the event registry, NOT
+  the internal `:head` registrar kind. The latter is unrelated to
+  the public machine contract.
 
   Returns a vector of {:kind <kind> :id <id>} entries. Empty when
   every reference resolves."
   [db]
   (let [missing (atom [])]
-    ;; Machines under :rf/machines: re-frame.machines registers under :head.
+    ;; Machines under :rf/machines: registered as event handlers with
+    ;; :rf/machine? true (per Spec 005 §Registration).
     (doseq [[machine-id _snapshot] (:rf/machines db)]
-      (when-not (registrar/lookup :head machine-id)
-        (swap! missing conj {:kind :head :id machine-id})))
+      (when-not (machine-registration machine-id)
+        (swap! missing conj {:kind :machine :id machine-id})))
     ;; Active route
     (when-let [route-id (get-in db [:route :id])]
       (when-not (registrar/lookup :route route-id)
@@ -461,17 +502,23 @@
 
 (defn- machine-version-mismatch
   "Walk the recorded db's `:rf/machines` for snapshot version drift.
-  Each snapshot may carry `:rf/snapshot-version`; the currently-
-  registered machine carries `:version` in its meta. When they
-  differ, return the first mismatch as
+  The recorded snapshot may carry `:rf/snapshot-version` under
+  `:meta`; the registered machine definition carries
+  `:rf/snapshot-version` under its own `:meta`. When they differ,
+  return the first mismatch as
   `{:machine-id <id> :recorded <int> :current <int>}`. nil when no
-  mismatch is found."
+  mismatch is found.
+
+  Per rf2-ocg1: both versions are read through the public Spec 005
+  §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`
+  and the registered machine's `[:meta :rf/snapshot-version]`. The
+  legacy top-level `:rf/snapshot-version` slot on the snapshot is
+  tolerated for back-compat."
   [db]
   (some (fn [[machine-id snapshot]]
-          (let [recorded (:rf/snapshot-version snapshot)]
+          (let [recorded (snapshot-version snapshot)]
             (when (some? recorded)
-              (let [meta    (registrar/lookup :head machine-id)
-                    current (:version meta)]
+              (let [current (machine-definition-version machine-id)]
                 (when (and (some? current) (not= recorded current))
                   {:machine-id machine-id
                    :recorded   recorded

--- a/implementation/test/re_frame/epoch_test.clj
+++ b/implementation/test/re_frame/epoch_test.clj
@@ -340,8 +340,8 @@
         (is (some? ev) ":rf.epoch/restore-schema-mismatch fired")
         (is (vector? (:failing-paths (:tags ev))))))))
 
-(deftest restore-failure-missing-handler
-  (testing "restore-epoch on a db referencing a now-unregistered head/route fires :rf.epoch/restore-missing-handler"
+(deftest restore-failure-missing-handler-route
+  (testing "restore-epoch on a db referencing a now-unregistered route fires :rf.epoch/restore-missing-handler"
     (rf/reg-frame :test/main {})
     ;; Register a route so the recorded :route reference resolves; we'll
     ;; later unregister it to trigger the missing-handler failure.
@@ -370,23 +370,98 @@
                             (= :route/users (:id %)))
                       missing))))))))
 
-(deftest restore-failure-version-mismatch
-  (testing "restore-epoch on a db whose machine snapshot version drifts fires :rf.epoch/restore-version-mismatch"
+(deftest restore-failure-missing-handler-machine
+  (testing "restore-epoch on a db referencing a machine snapshot whose machine
+  is no longer registered fires :rf.epoch/restore-missing-handler. Per
+  rf2-ocg1: machine resolution goes through the public event registry
+  (:rf/machine? metadata), NOT the internal :head registrar kind."
     (rf/reg-frame :test/main {})
-    ;; Register a machine head with version 1, then commit a snapshot
-    ;; carrying :rf/snapshot-version 1.
-    (registrar/register! :head :machine/tl
-      {:version 1 :handler-fn (fn [_ _] nil)})
+    ;; Register a machine via the public reg-machine path. This installs an
+    ;; :event handler with :rf/machine? metadata.
+    (rf/reg-machine :machine/tl
+      {:initial :red
+       :states  {:red    {:on {:tick :green}}
+                 :green  {:on {:tick :red}}}})
+    ;; Drive the machine so :rf/machines :machine/tl gets a snapshot.
+    (rf/dispatch-sync [:machine/tl [:tick]] {:frame :test/main})
+
+    (let [target (last (rf/epoch-history :test/main))]
+      (is (some? (get-in (:db-after target) [:rf/machines :machine/tl]))
+          "snapshot recorded under :rf/machines")
+
+      ;; Unregister the machine so the recorded snapshot's id no longer resolves.
+      (registrar/unregister! :event :machine/tl)
+
+      (let [recorded (record-trace!)
+            pre      (rf/get-frame-db :test/main)
+            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+        (is (false? ok?))
+        (is (= pre (rf/get-frame-db :test/main)) "app-db unchanged")
+        (let [ev (some (fn [ev]
+                         (when (= :rf.epoch/restore-missing-handler (:operation ev))
+                           ev))
+                       @recorded)]
+          (is (some? ev) ":rf.epoch/restore-missing-handler fired")
+          (let [missing (:missing (:tags ev))]
+            (is (vector? missing))
+            (is (some #(and (= :machine (:kind %))
+                            (= :machine/tl (:id %)))
+                      missing)
+                "missing entry surfaces the machine id under :machine kind")))))))
+
+(deftest restore-failure-missing-handler-non-machine-event-not-confused
+  (testing "an event handler under the same id as a recorded machine snapshot —
+  but NOT marked :rf/machine? — does not satisfy the machine reference. Per
+  rf2-ocg1, the registry probe gates on :rf/machine? metadata."
+    (rf/reg-frame :test/main {})
+    ;; Register a machine, drive it, then replace its registration with a
+    ;; plain event handler (no :rf/machine? metadata). The recorded snapshot
+    ;; should still surface as missing, since the public contract says the
+    ;; reference must resolve to a registered MACHINE — not a same-id event.
+    (rf/reg-machine :machine/tl
+      {:initial :red
+       :states  {:red {:on {:tick :green}} :green {}}})
+    (rf/dispatch-sync [:machine/tl [:tick]] {:frame :test/main})
+
+    (let [target (last (rf/epoch-history :test/main))]
+      (rf/reg-event-db :machine/tl (fn [db _] db)) ;; replace with non-machine handler
+
+      (let [recorded (record-trace!)
+            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+        (is (false? ok?))
+        (let [ev (some (fn [ev]
+                         (when (= :rf.epoch/restore-missing-handler (:operation ev))
+                           ev))
+                       @recorded)]
+          (is (some? ev))
+          (is (some #(and (= :machine (:kind %))
+                          (= :machine/tl (:id %)))
+                    (:missing (:tags ev)))))))))
+
+(deftest restore-failure-version-mismatch
+  (testing "restore-epoch on a db whose machine snapshot version drifts fires
+  :rf.epoch/restore-version-mismatch. Per rf2-ocg1: the recorded snapshot's
+  [:meta :rf/snapshot-version] is compared against the registered machine's
+  [:meta :rf/snapshot-version], both via the public Spec 005 surface."
+    (rf/reg-frame :test/main {})
+    ;; Register a versioned machine via the public path.
+    (rf/reg-machine :machine/tl
+      {:initial :red
+       :meta    {:rf/snapshot-version 1}
+       :states  {:red {:on {:tick :green}} :green {}}})
+    ;; Commit a snapshot carrying matching :meta :rf/snapshot-version.
     (rf/reg-event-db :put-snap
       (fn [db _]
         (assoc-in db [:rf/machines :machine/tl]
-                  {:state :red :data {} :rf/snapshot-version 1})))
+                  {:state :red :data {} :meta {:rf/snapshot-version 1}})))
     (rf/dispatch-sync [:put-snap] {:frame :test/main})
 
     (let [target (last (rf/epoch-history :test/main))]
-      ;; Hot-reload bumps the machine version.
-      (registrar/register! :head :machine/tl
-        {:version 2 :handler-fn (fn [_ _] nil)})
+      ;; Hot-reload bumps the machine definition's version.
+      (rf/reg-machine :machine/tl
+        {:initial :red
+         :meta    {:rf/snapshot-version 2}
+         :states  {:red {:on {:tick :green}} :green {}}})
 
       (let [recorded (record-trace!)
             pre      (rf/get-frame-db :test/main)
@@ -399,6 +474,40 @@
                        @recorded)]
           (is (some? ev) ":rf.epoch/restore-version-mismatch fired")
           (is (= :machine/tl (:machine-id (:tags ev))))
+          (is (= 1 (:version-recorded (:tags ev))))
+          (is (= 2 (:version-current  (:tags ev)))))))))
+
+(deftest restore-version-legacy-snapshot-slot-tolerated
+  (testing "snapshots written before :rf/snapshot-version moved into :meta
+  remain comparable. The legacy top-level slot resolves to the same recorded
+  version. Per rf2-ocg1 (back-compat tolerance)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-machine :machine/tl
+      {:initial :red
+       :meta    {:rf/snapshot-version 1}
+       :states  {:red {} :green {}}})
+    ;; Commit a snapshot with the LEGACY top-level slot.
+    (rf/reg-event-db :put-snap
+      (fn [db _]
+        (assoc-in db [:rf/machines :machine/tl]
+                  {:state :red :data {} :rf/snapshot-version 1})))
+    (rf/dispatch-sync [:put-snap] {:frame :test/main})
+
+    (let [target (last (rf/epoch-history :test/main))]
+      ;; Bump definition version.
+      (rf/reg-machine :machine/tl
+        {:initial :red
+         :meta    {:rf/snapshot-version 2}
+         :states  {:red {} :green {}}})
+
+      (let [recorded (record-trace!)
+            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
+        (is (false? ok?))
+        (let [ev (some (fn [ev]
+                         (when (= :rf.epoch/restore-version-mismatch (:operation ev))
+                           ev))
+                       @recorded)]
+          (is (some? ev))
           (is (= 1 (:version-recorded (:tags ev))))
           (is (= 2 (:version-current  (:tags ev)))))))))
 


### PR DESCRIPTION
## Summary

`re-frame.epoch`'s restore-time validation looked machines up under the
registrar's `:head` kind, but machines register as **event handlers**
tagged with `:rf/machine?` metadata (per Spec 005 §Registration / §Querying
machines). Restore would either silently miss real drift, or surface
unregistered machines as `{:kind :head ...}` — neither matched the
public contract.

- `missing-references` now resolves machine refs through `(registrar/lookup :event id)` gated on `:rf/machine?` metadata; the missing-entry kind becomes `:machine`.
- `machine-version-mismatch` reads the recorded snapshot's version from `[:meta :rf/snapshot-version]` and the registered definition's version from `[:meta :rf/snapshot-version]`, both per Spec 005 §Snapshot shape. The legacy top-level snapshot slot is tolerated for back-compat.
- Tests rewritten to drive the public `reg-machine` surface; new fixtures cover the machine-missing path, the version-drift path, the same-id-non-machine-event distinction, and legacy snapshot tolerance.

The six closed-for-v1 `:rf.epoch/*` failure modes from Tool-Pair §Time-travel are unchanged — this PR only corrects which registry the existing `:rf.epoch/restore-missing-handler` / `:rf.epoch/restore-version-mismatch` checks consult.

Closes rf2-ocg1.

## Test plan

- [x] `clojure -M:test` (228 tests, 1075 assertions, 0 fail / 0 err)
- [x] `npm run test:cljs` (98 tests, 303 assertions, 0 fail / 0 err)
- [x] `npm run test:browser` (98 tests, 303 assertions, 0 fail / 0 err)
- [x] `npm run test:elision` (PASS — all `:rf.epoch/*` sentinel checks both directions)
- [x] `npm run test:examples` (all 7guis / todomvc / lockout / ssr PASS)
- [x] New tests: `restore-failure-missing-handler-route`, `restore-failure-missing-handler-machine`, `restore-failure-missing-handler-non-machine-event-not-confused`, `restore-failure-version-mismatch` (rewritten), `restore-version-legacy-snapshot-slot-tolerated`