### PR TITLE
fix: API.md clean reconciliations (rf2-8hcb partial)

### DIFF
--- a/implementation/src/re_frame/core.cljc
+++ b/implementation/src/re_frame/core.cljc
@@ -588,7 +588,7 @@
 (def handler-meta registrar/handler-meta)
 (def handler-ids  registrar/ids)
 (def registry-summary registrar/all-kinds-with-counts)
-(def frames       (fn [] (frame/frame-ids)))
+(def frame-ids    frame/frame-ids)
 (def frame-meta   frame/frame-meta)
 (def get-frame-db frame/frame-app-db-value)
 
@@ -704,6 +704,7 @@
 
 (def install-adapter!  adapter/install-adapter!)
 (def dispose-adapter!  adapter/dispose-adapter!)
+(def current-adapter   adapter/current-adapter)
 
 ;; ---- boot -----------------------------------------------------------------
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -9,11 +9,11 @@
   - Base values: `v1` (ships in v1), `v1 (preserved)` (exists in current re-frame; preserved unchanged), `v1 (preserved + extended)` (exists today; v1 adds new arity or behaviour), `post-v1 lib` (design spec in v1 Specs but ships in a post-v1 library).
   - Qualifier: `dev-only` (elided in production builds — the macro emit site or runtime body, depending on the API).
   - Examples: `v1`, `v1 (preserved)`, `v1 (dev-only)`, `v1 (preserved, dev-only)`, `post-v1 lib`.
-  - The `re-frame.alpha` namespace is dissolved (rf2-7cb2 / rf2-s9dn) — no APIs in this reference live outside `re-frame.core` (with the documented per-namespace exceptions: `re-frame.test`, `re-frame.views-macros`).
+  - The `re-frame.alpha` namespace is dissolved (rf2-7cb2 / rf2-s9dn) — no APIs in this reference live outside `re-frame.core` (with the documented per-namespace exceptions: `re-frame.test-support`, `re-frame.views-macros`).
 - **Macro/Fn:** marked `M` (macro) or `Fn`.
 - **Spec column** — names exactly the **canonical owning Spec** (the per-Spec doc whose contract this API implements). Migration rules and other cross-references are NOT in the Spec column; they appear in the Notes column when relevant.
 - **Configure keys** — runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every `<key>` is enumerated in [§Configure keys](#configure-keys) below; per-area tables call out which keys their APIs read but do not redefine the key's vocabulary.
-- All APIs live in `re-frame.core` unless otherwise noted (`re-frame.test`, `re-frame.views-macros`).
+- All APIs live in `re-frame.core` unless otherwise noted (`re-frame.test-support`, `re-frame.views-macros`).
 
 ---
 
@@ -80,6 +80,8 @@
 | `view` | Fn | `(view view-id)` → render-fn (runtime-lookup handle) | v1 | 001, 004 |
 
 `with-frame`'s two shapes (bare keyword vs let-binding) are documented in [002 §with-frame](002-Frames.md#with-frame).
+
+`bound-fn` lives in `re-frame.views-macros`, one of the documented per-namespace exceptions to "all APIs live in `re-frame.core`" (see [Conventions](#conventions)). Users `:require-macros [re-frame.views-macros :refer [bound-fn]]`.
 
 ---
 
@@ -244,8 +246,8 @@ All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Inst
 
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
-| `register-trace-cb` | Fn | `(register-trace-cb key callback)` / `(register-trace-cb key callback opts)` | v1 (preserved) | 009 |
-| `remove-trace-cb` | Fn | `(remove-trace-cb key)` | v1 (preserved) | 009 |
+| `register-trace-cb!` | Fn | `(register-trace-cb! key callback)` / `(register-trace-cb! key callback opts)` | v1 (preserved) | 009 |
+| `remove-trace-cb!` | Fn | `(remove-trace-cb! key)` | v1 (preserved) | 009 |
 | `re-frame.interop/debug-enabled?` | Var | `^boolean` (alias of `goog.DEBUG` on CLJS; `true` on JVM) | v1 | 009 |
 | `trace-api-version` | Fn | `(trace-api-version)` → integer | v1 | 009 |
 | `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | 009 |
@@ -365,7 +367,7 @@ Schemas are **open** by default (consumers tolerate unknown keys; producers grow
 
 ## Testing
 
-`re-frame.test` re-exports `make-frame`/`destroy-frame`/`with-frame`/`dispatch-sync`. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
+`re-frame.test-support` re-exports `make-frame`/`destroy-frame`/`with-frame`/`dispatch-sync`. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
 
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
@@ -529,10 +531,10 @@ See [007-Stories.md](007-Stories.md).
 | `subscribe-to` (proposed earlier) | Use `(subscribe query-v {:frame :todo})` | 002 |
 | `frame-dispatcher` (proposed earlier) | Renamed to `bound-dispatcher` | 002 |
 | `enable-performance-api-tracing!` (proposed earlier) | Bridge always active when tracing is on; production elides everything | 009 |
-| `add-trace-listener` / `remove-trace-listener` (proposed earlier) | Use `register-trace-cb` / `remove-trace-cb` | 009 |
+| `add-trace-listener` / `remove-trace-listener` (proposed earlier) | Use `register-trace-cb!` / `remove-trace-cb!` | 009 |
 | Bare `[:my-view "args"]` keyword-tagged hiccup | Use the Var form `[my-view "args"]` (canonical) or `[(rf/view :my-view) "args"]` for late-binding by id | 004 |
 | `h` macro (proposed earlier) | Removed (rf2-n4um). Use the Var form `[my-view "args"]` or `[(rf/view :my-view) "args"]` | 004 |
-| `reg-global-interceptor` | Use `reg-frame :interceptors` (frame-level is the canonical "global within this frame"). For cross-frame observation use `register-trace-cb`. | MIGRATION M-17 |
+| `reg-global-interceptor` | Use `reg-frame :interceptors` (frame-level is the canonical "global within this frame"). For cross-frame observation use `register-trace-cb!`. | MIGRATION M-17 |
 | `clear-global-interceptor` | No replacement needed — re-register `reg-frame` with an updated `:interceptors` vector (absent-key semantics clear it). | MIGRATION M-17 |
 | `reg-sub-raw` | Use `reg-sub` (app-db reads), Pattern-AsyncEffect (non-app-db sources), state machines (lifecycle), or the [006](006-ReactiveSubstrate.md) adapter contract (bridging external reactivity). | MIGRATION M-18 |
 | `re-frame.alpha/reg` | Per-kind macros: `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` / `reg-flow`. | MIGRATION M-23 |

--- a/spec/API.md
+++ b/spec/API.md
@@ -45,7 +45,6 @@
 | `clear-event` | Fn | `(clear-event)` / `(clear-event id)` | v1 (preserved) |
 | `clear-sub` | Fn | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) |
 | `clear-fx` | Fn | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) |
-| `clear-cofx` | Fn | `(clear-cofx)` / `(clear-cofx id)` | v1 (preserved) |
 | `clear-flow` | Fn | `(clear-flow)` / `(clear-flow id)` | v1 |
 | `destroy-frame` | Fn | `(destroy-frame frame-id)` | v1 |
 | `reset-frame` | Fn | `(reset-frame frame-id)` | v1 |
@@ -417,7 +416,6 @@ Removed in v2 (see [MIGRATION §M-21](MIGRATION.md#m-21-drop-debug-trim-v-on-cha
 | `assoc-coeffect` | Fn | `(assoc-coeffect ctx key value)` | v1 (preserved) |
 | `get-effect` | Fn | `(get-effect ctx)` / `(get-effect ctx key)` / `(get-effect ctx key not-found)` | v1 (preserved) |
 | `assoc-effect` | Fn | `(assoc-effect ctx key value)` | v1 (preserved) |
-| `enqueue` | Fn | `(enqueue ctx interceptors)` | v1 (preserved) |
 
 ---
 
@@ -429,8 +427,6 @@ Removed in v2 (see [MIGRATION §M-21](MIGRATION.md#m-21-drop-debug-trim-v-on-cha
 | `add-post-event-callback` | Fn | `(add-post-event-callback f)` / `(add-post-event-callback id f)` / `(add-post-event-callback frame-id id f)` | v1 (preserved + extended) | 002 |
 | `remove-post-event-callback` | Fn | `(remove-post-event-callback id)` / `(remove-post-event-callback frame-id id)` | v1 (preserved + extended) | 002 |
 | `purge-event-queue` | Fn | `(purge-event-queue)` / `(purge-event-queue frame-id)` | v1 (preserved + extended) | 002 |
-| `set-loggers!` | Fn | `(set-loggers! new-loggers)` | v1 (preserved) | — |
-| `console` | Fn | `(console level & args)` | v1 (preserved) | — |
 | `install-adapter!` | Fn | `(install-adapter! adapter-or-keyword)` — must be called before any frame is created | v1 | 006 |
 | `current-adapter` | Fn | `(current-adapter)` → `:reagent` / `:plain-atom` / `:custom` | v1 | 006 |
 | `init-platform` | Fn | `(init-platform :server \| :client)` — sets the active platform; defaults from build target | v1 | 011 |
@@ -517,7 +513,6 @@ See [007-Stories.md](007-Stories.md).
 | `variants-with-tags` | Fn | `(variants-with-tags tag-set)` → seq of variant ids | post-v1 lib | 007 |
 | `snapshot-identity` | Fn | `(snapshot-identity variant-id)` → `{:variant-id ... :content-hash "..."}` | post-v1 lib | 007 |
 | `story-view` | Fn | `(story-view variant-id)` → hiccup | post-v1 lib | 007 |
-| `frame-doc` | Fn | `(frame-doc frame-id)` | v1 | 002 / 007 |
 
 ---
 


### PR DESCRIPTION
Partial landing of rf2-8hcb. The earlier agent halted after finding 18
of 31 missing-symbol items ambiguous. This PR lands 11 of the 13
cleanly-classifiable items; 2 turned ambiguous on closer look and are
being re-filed.

## Aliases / rename (`re-frame.core`)

| # | Item | Disposition |
|---|---|---|
| 1 | `current-adapter` | Added `(def current-adapter adapter/current-adapter)` |
| 2 | `frame-ids` | Renamed the alias `frames` -> `frame-ids` (no callers of `rf/frames`; pre-1.0, no deprecation needed) |

## Doc fixes (impl is canonical; API.md drifted)

| # | Item | Disposition |
|---|---|---|
| 3 | `register-trace-cb` -> `register-trace-cb!` | Updated row + cross-references |
| 4 | `remove-trace-cb` -> `remove-trace-cb!` | Updated row + cross-references |
| 5 | `bound-fn` | Added explanatory note: lives in `re-frame.views-macros` (one of the documented per-namespace exceptions) |
| 6 | `re-frame.test` -> `re-frame.test-support` | Updated all three references in API.md (008-Testing.md / 000-Vision.md still discuss a `re-frame.test` convenience namespace; out of scope here) |

## Removals (only existed in API.md, no other usage)

| # | Item | Disposition |
|---|---|---|
| 7 | `set-loggers!` | Removed |
| 8 | `console` | Removed |
| 9 | `enqueue` | Removed |
| 10 | `frame-doc` | Removed |
| 13 | `clear-cofx` | Removed |

## Re-classified as ambiguous (filing follow-ups)

| # | Item | Why ambiguous |
|---|---|---|
| 11 | `sub-topology` | Heavily referenced in 000-Vision, 002-Frames, 006, 007, 008, 009, AI-Audit, Construction-Prompts, Principles. Removing only the API.md row would worsen the drift. |
| 12 | `app-schemas-digest` | Referenced in 010-Schemas (with code samples) and Tool-Pair. Same reasoning. |

`route-link` (the agent's earlier "remove" candidate) is referenced
from 012-Routing, Construction-Prompts, MIGRATION, 000-Vision,
Implementor-Checklist, and used in the routing and realworld examples.
Kept.

## Verification

- `clojure -M:test` -> 233 tests / 1087 assertions / 0 failures / 0 errors
- `npm run test:cljs` -> 98 tests / 303 assertions / 0 failures / 0 errors
- `npm run test:browser` -> 98 tests / 303 assertions / 0 failures / 0 errors
- `npm run test:elision` -> PASS
- `npm run test:examples` -> 15 / 15 PASS