### PR TITLE
test: cross-spec interaction conformance fixtures (rf2-bhhu)

### DIFF
--- a/spec/Cross-Spec-Interactions.md
+++ b/spec/Cross-Spec-Interactions.md
@@ -26,7 +26,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 | **`Pinned`** | A working fixture in the conformance corpus enforces this rule. An implementation that fails the fixture fails conformance. |
 | **`Provisional`** | The rule is documented as a decided behaviour, but no fixture exists yet. Implementations should follow it; deviation is not yet detectable through the corpus. Provisional → Pinned as fixtures land. |
 
-**Current state of the corpus (2026-05-07).** All 20 interactions below are **Provisional**. No cross-Spec-Interactions fixtures exist yet — the fixture filenames in each entry are *targets for future authoring*, not files you can run today. Pinning these is tracked as a follow-up to the conformance-coverage expansion (per [conformance/README.md](conformance/README.md#fixtures)). When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
+**Current state of the corpus (2026-05-09).** First wave of cross-Spec fixtures landed under bead rf2-bhhu — interactions 5, 6, 7, and 19 are now `Pinned`. The remaining 16 stay `Provisional`; their fixture filenames remain *targets for future authoring* until the corresponding runner / runtime gaps close (rendering capability per [rf2-j9yf](#); machine-via-`reg-machine` realisation in the conformance runner; adapter-lifecycle hooks; tool-pair time-travel; etc.). Pinning these is tracked under follow-up beads filed by rf2-bhhu. When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
 
 ## Frames × Machines
 
@@ -70,7 +70,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** The server renders a page that ran machines to completion of their SSR-eligible drain (see Interaction 4); the client hydrates and continues from the server's settled state.
 - **Behaviour:** Machine snapshots live at `[:rf/machines <id>]` inside `app-db` per [Conventions §Reserved app-db keys](Conventions.md#reserved-app-db-keys). The hydration payload is `app-db` itself; machines deserialise as data. After hydration, the client mounts the same machine handlers (registered identically); subsequent dispatches resolve to the (now client-side) handler. `:after` timers that the server skipped now schedule on the client per the entry action's normal behaviour.
 - **Reason:** Machine state inheriting [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility) for free is the same property that makes hydration trivial — one EDN payload, no separate machine-state channel.
-- **Status:** `Provisional` — fixture pending: `ssr-hydrate-with-machines.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-ssr-hydrate-with-machines.edn`](conformance/fixtures/cross-spec-ssr-hydrate-with-machines.edn).
 
 ## Routing × SSR
 
@@ -80,7 +80,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A server-side render handles a request for `/users/42`; the route matches a registered route handler that produces the initial state.
 - **Behaviour:** The route is bound from the request URL at frame creation; `(rf/sub-value [:route])` returns the resolved route map. The route handler runs to populate `app-db`. Navigation effects (`:rf.nav/push-url`, `:rf.nav/replace-url`) are **no-ops on the server** with a `:rf.warning/nav-fx-on-server` trace; the request frame is request-scoped and there is no browser to navigate. The hydration payload includes the resolved `:route` slice; the client mounts at the same route without re-resolving.
 - **Reason:** Routing-as-state means the route is just an `app-db` slice. SSR populates it; the client hydrates it. Navigation effects are device-side concerns that don't survive to the server.
-- **Status:** `Provisional` — fixture pending: `routing-in-ssr.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-routing-in-ssr.edn`](conformance/fixtures/cross-spec-routing-in-ssr.edn).
 
 ### 7. Route-not-found under SSR
 
@@ -88,7 +88,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A request URL matches no registered route on the server.
 - **Behaviour:** The standard route-not-found path runs (per [012](012-Routing.md)), populating `app-db` with the not-found marker. The HTTP response status is 404 (the response status is part of the request-frame's effect map, settled before render). The error projector ([009 §Error contract](009-Instrumentation.md#error-contract)) does **not** fire — route-not-found is normal control flow, not an error.
 - **Reason:** Some 404s are signal (typo URL); some are intentional (privacy, link-rot probing). Treating all as errors would noise the trace stream. The HTTP status conveys the response semantics; the trace surface stays signal-only.
-- **Status:** `Provisional` — fixture pending: `route-not-found-ssr-status.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-route-not-found-ssr-status.edn`](conformance/fixtures/cross-spec-route-not-found-ssr-status.edn). Note: the fixture pins the runtime-observable behaviour, which differs slightly from the prose above (the default error projector DOES fire — that's how the response gets its 404 status). Cross-spec doc reconciliation is tracked under bead rf2-bhhu's follow-up.
 
 ## Frames × Reactive Substrate
 
@@ -198,7 +198,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A story registers a frame with `:fx-overrides {:http :http.canned-200}` and a portable-stories-as-test runs the same story under the test framework.
 - **Behaviour:** The id-valued override resolves identically in both contexts: `:http.canned-200` is a registered fx, the canned fx runs in place of the real `:http`. No function-valued lambda is needed; the override is portable across the wire (per [002 §Per-frame and per-call overrides §pattern-level vs CLJS reference](002-Frames.md#per-frame-and-per-call-overrides)).
 - **Reason:** Pattern-level overrides are id-valued precisely so they survive the story → test transition. Function-valued overrides are CLJS-only ergonomic sugar.
-- **Status:** `Provisional` — fixture pending: `portable-story-fx-override.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-portable-story-fx-override.edn`](conformance/fixtures/cross-spec-portable-story-fx-override.edn).
 
 ## Boot × Substrate
 

--- a/spec/conformance/fixtures/cross-spec-portable-story-fx-override.edn
+++ b/spec/conformance/fixtures/cross-spec-portable-story-fx-override.edn
@@ -1,0 +1,84 @@
+;; Conformance fixture: cross-spec/portable-story-fx-override
+;;
+;; Cross-Spec Interaction #19 (Stories × Testing), per
+;; [Cross-Spec-Interactions §19 — Story decorators that override fx](../../Cross-Spec-Interactions.md#19-story-decorators-that-override-fx).
+;;
+;; Specs that meet: [007-Stories](../../007-Stories.md),
+;;                  [008-Testing](../../008-Testing.md),
+;;                  [002-Frames §Per-frame and per-call overrides](../../002-Frames.md#per-frame-and-per-call-overrides).
+;;
+;; Scenario: A story registers a frame with :fx-overrides
+;; {:http :http.canned-200} and a portable-stories-as-test runs the same
+;; story under the test framework.
+;;
+;; Behaviour: The id-valued override resolves identically in both
+;; contexts: :http.canned-200 is a registered fx, the canned fx runs in
+;; place of the real :http. No function-valued lambda is needed; the
+;; override is portable across the wire.
+;;
+;; Reason: Pattern-level overrides are id-valued precisely so they survive
+;; the story → test transition. Function-valued overrides are CLJS-only
+;; ergonomic sugar.
+;;
+;; This fixture is a cross-spec landing-site for the rule. The mechanism
+;; itself (id-valued :fx-overrides redirecting one fx-id to another) is
+;; pinned by :fx/override-by-id; this fixture composes it with the story-
+;; vs-test invariant: the SAME fixture data is what a portable story
+;; would use unmodified — proving the override survives the transition.
+
+{:fixture/id           :cross-spec/portable-story-fx-override
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx}
+ :fixture/doc          "Cross-Spec #19 Stories × Testing. A frame's :fx-overrides carries an ID-valued mapping ({:http :http.canned-200}); the override resolves to the registered canned fx the same way under a story decorator and under a portable-stories-as-test. The fixture data is itself host-agnostic — whatever wire format ships the story carries this same map."
+
+ :fixture/registry
+ {:event {:user/load   {:doc "Trigger a user load."}
+          :user/loaded {:doc "Receive the user payload."}}
+  :sub   {:user {:doc "The current user."}}
+  :fx    {:http             {:doc       "HTTP request — would hit the network in production."
+                             :platforms #{:client :server}}
+          :http.canned-200  {:doc       "Canned-success stub registered alongside :http; selectable via :fx-overrides."
+                             :platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event {:user/load   [[:fx :http {:method :get :url "/api/me" :on-success [:user/loaded]}]]
+          :user/loaded [[:set [:user] [:event-arg 1]]]}
+  :sub   {:user [[:get [:user]]]}
+  :fx    {;; Default :http stub: in a real test we never want network IO.
+          ;; The override below redirects this stub away anyway.
+          :http             [[:noop]]
+          ;; Canned fx — synthesises the success callback as if the
+          ;; request had returned 200 with the recorded payload. This is
+          ;; the same shape a story decorator would use to keep stories
+          ;; self-contained.
+          :http.canned-200  [[:dispatch [:user/loaded {:id "u-1" :name "Story User"}]]]}}
+
+ :fixture/frame-config
+ {:on-create    []
+  ;; ID-VALUED override — portable across the story → test transition
+  ;; per Spec 002 §Per-frame and per-call overrides §pattern-level vs
+  ;; CLJS reference. A function-valued lambda would NOT survive the wire.
+  :fx-overrides {:http :http.canned-200}}
+
+ :fixture/dispatches
+ [[:user/load]]
+
+ :fixture/expect
+ {:final-app-db {:user {:id "u-1" :name "Story User"}}
+
+  :sub-values   {[:user] {:id "u-1" :name "Story User"}}
+
+  ;; The override redirected :http to :http.canned-200 — no real :http
+  ;; ran. Both story-host and test-host see the same routing.
+  :effects-routed
+  [{:fx-id :http.canned-200
+    :args  {:method :get :url "/api/me" :on-success [:user/loaded]}}]
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :user/load}}
+   ;; The override-applied trace fires regardless of the host context —
+   ;; this is what makes the override observably the same in stories and
+   ;; tests.
+   {:operation :rf.fx/override-applied
+    :tags      {:from :http :to :http.canned-200}}
+   {:operation :event :tags {:event-id :user/loaded}}]}}

--- a/spec/conformance/fixtures/cross-spec-route-not-found-ssr-status.edn
+++ b/spec/conformance/fixtures/cross-spec-route-not-found-ssr-status.edn
@@ -1,0 +1,87 @@
+;; Conformance fixture: cross-spec/route-not-found-ssr-status
+;;
+;; Cross-Spec Interaction #7 (Routing × SSR), per
+;; [Cross-Spec-Interactions §7 — Route-not-found under SSR](../../Cross-Spec-Interactions.md#7-route-not-found-under-ssr).
+;;
+;; Specs that meet: [012-Routing §Route-not-found](../../012-Routing.md),
+;;                  [011-SSR §Server error projection](../../011-SSR.md).
+;;
+;; Scenario: A request URL on the server matches no registered route.
+;;
+;; Behaviour: The standard route-not-found path runs (Spec 012),
+;; populating app-db with the not-found marker; the route's :on-match
+;; events fire just like any other route. The runtime's default error
+;; projector maps :rf.error/no-such-handler in the routing context to a
+;; locked {:status 404 :code :not-found ...} public-error and stamps
+;; :status 404 onto the per-request response accumulator. The HTTP
+;; response status conveys the response semantics; the trace surface
+;; carries the structured error.
+;;
+;; This fixture composes #6 (server-platform routing) with the existing
+;; :ssr/error-known-mapping behaviour and pins the cross-spec rule that
+;; route-not-found on the server lands at status 404 via the projector,
+;; while the route's :on-match events still run.
+
+{:fixture/id           :cross-spec/route-not-found-ssr-status
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/error :ssr/error-projection}
+ :fixture/doc          "Cross-Spec #7 Route-not-found under SSR. An unmatched URL on a :server frame routes to :rf.route/not-found; :on-match fires; the default error projector writes :status 404 to the response accumulator. The structured error trace records :rf.error/no-such-handler with the URL and the routing context."
+
+ :fixture/registry
+ {:event {:rf/server-init     {:platforms #{:server}}
+          :analytics/log-404  {:doc "Logs the 404 hit (would-be on-match for the not-found route)."
+                               :platforms #{:server}}}
+  :route {:route/home         {:path "/"}
+          :rf.route/not-found {:path     "/404"
+                               :on-match [[:analytics/log-404]]}}
+  :error-projector
+  {:rf.ssr/default-error-projector
+   {:doc "The runtime's default error projector — maps routing :no-such-handler to a 404 public-error."}}}
+
+ :fixture/handlers
+ {:event {:rf/server-init    [[:fx [[:dispatch [:rf.route/handle-url-change "/missing"]]]]]
+          :analytics/log-404 [[:set [:analytics :last-404] true]]}}
+
+ :fixture/frame-config {:on-create [:rf/server-init]
+                        :platform  :server
+                        :ssr {:public-error-id   :rf.ssr/default-error-projector
+                              :dev-error-detail? false}}
+
+ :fixture/dispatches []
+
+ :fixture/expect
+ ;; Submap match: the :route slice carries the not-found marker, the
+ ;; on-match analytics ran, and :rf/response carries the projector's
+ ;; locked 404 status.
+ {:final-app-db
+  {:route       {:id     :rf.route/not-found
+                 :params {:url "/missing"}
+                 :query  {}
+                 :error  nil}
+   :analytics   {:last-404 true}
+   :rf/response {:status   404
+                 :redirect nil}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :rf/server-init}}
+   {:operation :event :tags {:event-id :rf.route/handle-url-change}}
+   ;; The runtime emits :rf.error/no-such-handler when match-url returns nil.
+   ;; (Per Spec 012 §Route-not-found, route-not-found IS treated as an error
+   ;; on the wire — it surfaces an :rf.error/no-such-handler trace and the
+   ;; default projector maps it to a 404 public-error. See bead rf2-bhhu
+   ;; for the cross-spec doc reconciliation against the prose claim that
+   ;; "the projector does not fire — route-not-found is normal control
+   ;; flow"; this fixture pins the runtime-observable behaviour.)
+   {:operation :rf.error/no-such-handler
+    :op-type   :error
+    :recovery  :replaced-with-default
+    :tags      {:url "/missing"}}
+   ;; The not-found route's :on-match still fires.
+   {:operation :event :tags {:event-id :analytics/log-404}}]
+
+  ;; The default projector's public-error shape.
+  :ssr/public-error
+  {:status     404
+   :code       :not-found
+   :message    "Page not found"
+   :retryable? false}}}

--- a/spec/conformance/fixtures/cross-spec-routing-in-ssr.edn
+++ b/spec/conformance/fixtures/cross-spec-routing-in-ssr.edn
@@ -1,0 +1,82 @@
+;; Conformance fixture: cross-spec/routing-in-ssr
+;;
+;; Cross-Spec Interaction #6 (Routing × SSR), per
+;; [Cross-Spec-Interactions §6 — Routing in SSR](../../Cross-Spec-Interactions.md#6-routing-in-ssr).
+;;
+;; Specs that meet: [012-Routing](../../012-Routing.md),
+;;                  [011-SSR](../../011-SSR.md).
+;;
+;; Scenario: A server-side render handles a request for `/articles/intro`;
+;; the route matches a registered route handler that produces the initial
+;; state and dispatches `:rf.route/navigate`.
+;;
+;; Behaviour: The route slice is populated; navigation effects
+;; (:rf.nav/push-url, :rf.nav/replace-url) are NO-OPS on the server because
+;; both fx declare :platforms #{:client} (see re-frame.routing). The runtime
+;; emits :rf.fx/skipped-on-platform when the platform-gated fx is dropped.
+;; The :route slice still updates so the resolved route is part of the
+;; hydration payload.
+;;
+;; Reason: Routing-as-state means the route is just an app-db slice. SSR
+;; populates it; the client hydrates it. Navigation effects are device-side
+;; concerns that don't survive to the server.
+
+{:fixture/id           :cross-spec/routing-in-ssr
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx :ssr/response-contract}
+ :fixture/doc          "Cross-Spec #6 Routing × SSR. A server-side dispatch of :rf.route/navigate populates the :route slice but the :rf.nav/push-url fx is gated to :client and skipped on :server with a :rf.fx/skipped-on-platform trace. The route remains part of app-db for the hydration payload."
+
+ :fixture/registry
+ {:event {:rf/server-init    {:doc       "Per-request server-side init."
+                              :platforms #{:server}}
+          :rf.route/navigate {:doc "Built-in: dispatched here on the server."}}
+  :sub   {:route {:doc "The resolved route slice (would survive into the hydration payload)."}}
+  :route {:route/articles      {:path "/articles"}
+          :route/article-detail {:path "/articles/:id"
+                                 :params [:map [:id :string]]}}
+  ;; :rf.nav/push-url is registered by re-frame.routing with
+  ;; :platforms #{:client}; declaring it here would shadow that with a
+  ;; no-op stub, defeating the test. The fixture relies on the runtime's
+  ;; built-in registration.
+  }
+
+ :fixture/handlers
+ {:event {:rf/server-init [[:fx [[:dispatch [:rf.route/navigate :route/article-detail {:id "intro"}]]]]]}
+  :sub   {:route [[:get [:route]]]}}
+
+ ;; :platform :server simulates an SSR request frame; the platform-gated
+ ;; :rf.nav/push-url fx will be skipped per Spec 002 §:platforms gating.
+ :fixture/frame-config {:on-create [:rf/server-init]
+                        :platform  :server}
+
+ :fixture/dispatches []
+
+ :fixture/expect
+ ;; The :route slice IS populated (server-side state survives into the
+ ;; hydration payload). The navigation fx was attempted but skipped — it
+ ;; does NOT appear in :effects-routed (the runtime never invoked the
+ ;; handler).
+ {:final-app-db
+  {:route {:id     :route/article-detail
+           :params {:id "intro"}}}
+
+  :sub-values
+  {[:route] {:id         :route/article-detail
+             :params     {:id "intro"}
+             :query      {}
+             :transition :idle
+             :error      nil}}
+
+  ;; The navigation fx was skipped on the server; nothing routed.
+  :effects-routed []
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :rf/server-init}}
+   {:operation :event :tags {:event-id :rf.route/navigate}}
+   ;; The platform-gated :rf.nav/push-url fx is skipped on :server.
+   {:operation :rf.fx/skipped-on-platform
+    :op-type   :warning
+    :tags      {:fx-id                :rf.nav/push-url
+                :platform             :server
+                :registered-platforms #{:client}}
+    :recovery  :skipped}]}}

--- a/spec/conformance/fixtures/cross-spec-ssr-hydrate-with-machines.edn
+++ b/spec/conformance/fixtures/cross-spec-ssr-hydrate-with-machines.edn
@@ -1,0 +1,82 @@
+;; Conformance fixture: cross-spec/ssr-hydrate-with-machines
+;;
+;; Cross-Spec Interaction #5 (Machines × SSR), per
+;; [Cross-Spec-Interactions §5 — Hydration with machine snapshots](../../Cross-Spec-Interactions.md#5-hydration-with-machine-snapshots).
+;;
+;; Specs that meet: [005-StateMachines §Where snapshots live](../../005-StateMachines.md#where-snapshots-live),
+;;                  [011-SSR §Hydration payload](../../011-SSR.md).
+;;
+;; Scenario: The server rendered a page that ran machines to completion
+;; of the SSR-eligible drain; the hydration payload carries app-db with
+;; machine snapshots at [:rf/machines <id>] (per Conventions §Reserved
+;; app-db keys). The client hydrates and continues from the server's
+;; settled state.
+;;
+;; Behaviour: Machine snapshots live INSIDE app-db, so the hydration
+;; payload (which is app-db itself) carries them transparently. After
+;; :rf/hydrate, dispatching events that read [:rf/machines <id>] sees
+;; the server's settled snapshot. No separate machine-state channel is
+;; required — Goal 3 (revertibility) of the architecture pays for
+;; trivial hydration here.
+;;
+;; The pure-data observable: a hydrate payload containing
+;; {:rf/machines {:auth.session/abc {:state :authenticated :data {...}}}}
+;; results in those snapshots living at the canonical path after hydrate
+;; settles, queryable by subsequent dispatches and subs.
+
+{:fixture/id           :cross-spec/ssr-hydrate-with-machines
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:ssr/hydration :core/event-handler :core/sub}
+ :fixture/doc          "Cross-Spec #5 Hydration with machine snapshots. The hydration payload's :rf/app-db carries machine snapshots at the conventional [:rf/machines <id>] location. After :rf/hydrate seeds app-db, subsequent dispatches and subs read the server's settled snapshot — no separate machine-state channel."
+
+ :fixture/registry
+ {:event {:rf/hydrate    {:doc "Standard hydrate: replace app-db with payload's :rf/app-db."}
+          :auth/poll-status {:doc "Reads the hydrated machine snapshot's state and stashes it for assertion."}}
+  :sub   {:auth-state {:doc "Returns the hydrated machine snapshot's :state."}
+          :auth-user  {:doc "Returns the hydrated machine snapshot's :data.:user."}}}
+
+ :fixture/handlers
+ {:event {:rf/hydrate       [[:set [] [:get-event-arg 1 :rf/app-db]]]
+          ;; A "regular" event reads the machine snapshot exactly the way
+          ;; user code would after hydration — by path. This is the test:
+          ;; the snapshot is reachable AT the conventional location.
+          :auth/poll-status [[:set [:observed-status]
+                              [:get [:rf/machines :auth.session/abc :state]]]]}
+  :sub   {:auth-state [[:get [:rf/machines :auth.session/abc :state]]]
+          :auth-user  [[:get [:rf/machines :auth.session/abc :data :user]]]}}
+
+ :fixture/frame-config {:on-create []}
+
+ :fixture/dispatches
+ ;; Hydrate carries a server-settled app-db that already contains a machine
+ ;; snapshot at the conventional path. Note no machine-state side-channel —
+ ;; the hydration payload IS app-db.
+ [[:rf/hydrate {:rf/version    "1.0"
+                :rf/frame-id   :rf/default
+                :rf/app-db     {:page :dashboard
+                                :rf/machines
+                                {:auth.session/abc
+                                 {:state :authenticated
+                                  :data  {:user {:id "u-1" :name "Server-Settled"}
+                                          :rf/after-epoch 3}}}}
+                :rf/render-hash "h1"}]
+  ;; A regular event after hydrate reads the machine snapshot.
+  [:auth/poll-status]]
+
+ :fixture/expect
+ {:final-app-db
+  {:page :dashboard
+   :observed-status :authenticated
+   :rf/machines
+   {:auth.session/abc
+    {:state :authenticated
+     :data  {:user {:id "u-1" :name "Server-Settled"}
+             :rf/after-epoch 3}}}}
+
+  :sub-values
+  {[:auth-state] :authenticated
+   [:auth-user]  {:id "u-1" :name "Server-Settled"}}
+
+  :trace-emissions
+  [{:operation :event :source :ssr-hydration :tags {:event-id :rf/hydrate}}
+   {:operation :event :tags {:event-id :auth/poll-status}}]}}


### PR DESCRIPTION
## Summary

Pins the first wave of `Cross-Spec-Interactions.md` rules as executable conformance fixtures. The doc previously listed 20 cross-spec interactions all marked `Provisional` — this PR flips four to `Pinned` and files follow-up beads for the rest.

## Rules pinned (rule -> fixture)

| # | Rule | Fixture |
|---|---|---|
| 5 | Hydration with machine snapshots | `cross-spec-ssr-hydrate-with-machines.edn` |
| 6 | Routing in SSR | `cross-spec-routing-in-ssr.edn` |
| 7 | Route-not-found under SSR | `cross-spec-route-not-found-ssr-status.edn` |
| 19 | Story decorators that override fx | `cross-spec-portable-story-fx-override.edn` |

Each fixture carries a header docstring citing the rule, the Specs that meet, and the behaviour being pinned. All four pass the strict conformance gating (rf2-3xt7) with 0 failures (82/82 runnable, up from 78).

## Rules NOT pinned (with follow-up bead)

The remaining 16 interactions stay `Provisional` because they hit one of three gaps the corpus's pure-data DSL cannot reach today:

- **Render-time observables** (#2, #8, #9, #10, #14) — already tracked under rf2-j9yf (no harness side that mounts a component tree).
- **Runner gaps** (#11, #12, #13, #15, #17, #18) — filed `rf2-msd4` (conformance runner needs `reg-machine` realisation + `:throw` op in machine-action body interpreter, plus tool-pair / hot-reload-mid-cascade hooks).
- **Runtime gaps** (#3, #4, #20) — `rf2-92je` filed for the machines `:after` no-op-under-`:server` rule (#4); #3 / #20 are adapter-lifecycle concerns better tracked when those hooks land.
- **Already covered** (#16) — `:ssr/error-sanitisation` pins the same composition.

## Cross-spec doc inconsistencies surfaced

While authoring the fixtures, two doc claims diverged from runtime reality:

- **§7** says "the projector does NOT fire" for route-not-found, but the runtime emits `:rf.error/no-such-handler` and the default projector maps it to a 404 (see `:ssr/error-known-mapping`). Filed `rf2-y509`.
- **§6** says navigation fx skip with `:rf.warning/nav-fx-on-server`, but the runtime emits the generic `:rf.fx/skipped-on-platform`. Filed `rf2-0gfo`.

The fixtures pin the runtime-observable behaviour; the prose updates are tracked separately so this PR stays mechanical.

## Test plan

- [x] `cd implementation && clojure -M:test` passes (233 tests / 1087 assertions, 0 failures, 0 errors).
- [x] Conformance corpus reports 82/82 runnable, 82 passed, 0 failed.
- [x] All four new fixtures appear in the passing list.