### PR TITLE
docs: refresh stale spec and status references (rf2-rdx0)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -436,24 +436,27 @@ The above sections (Abstract, Constraints and goals, Pattern, Hard constraints, 
 
 | Spec | Title | Notes |
 |---|---|---|
-| 001 | Capture Handler Metadata | Registration calls accept a metadata map. Foundation for everything below. |
+| 001 | Registration | Registration calls accept a metadata map. Foundation for everything below. |
 | 002 | Frames | Isolated runtime boundaries; one global handler registrar; explicit-frame addressing at the pattern level. CLJS reference uses React context as an optimisation. |
-| 003 | Reusable Components | Subsumed by 002 + 004. |
-| 004 | View Registration | Pure `(state, props) → render-tree`; render-tree is serialisable data. CLJS reference: `reg-view` + hiccup + Reagent. |
+| 004 | Views | Pure `(state, props) → render-tree`; render-tree is serialisable data. CLJS reference: `reg-view` + hiccup + Reagent. |
+| 006 | Reactive Substrate | Substrate-agnostic core + adapter contract; Reagent default; plain-atom for JVM/SSR/headless. v1-required for the CLJS reference; pattern-level for any host. |
 | 008 | Testing | Test fixtures, sync triggers, per-test stubbing, headless sub/machine evaluation, framework adapters. |
 | 009 | Instrumentation, Tracing, Performance | Trace event stream, listener API, Performance API integration; tools depend on traces. |
 | 010 | Schemas (CLJS reference) | Malli on every `reg-*` and `app-db` paths; validation timing and dev-vs-prod elision. Other-language hosts use their type system. |
 | 011 | SSR & Hydration | Server frame lifecycle, render-to-string contract, state-shipping, hydration handshake. Forces the id-valued override seam. |
 | 012 | Routing | URL ↔ frame-state; routes are registry entries; navigation is an event. |
+| 013 | Flows | Registered, runtime-toggleable computed-state declarations that materialise into `app-db`. v2 incarnation of v1's `on-changes` interceptor. |
+
+> Slot 003 is intentionally vacant — reserved for a future Spec on cross-frame composition (frame supervisors, parent/child frame relationships, frame-graph topology); see [README §About Spec 003](README.md). The slot is held open so existing Spec numbers do not need to renumber when 003 lands.
+
+### v1-optional capabilities
+
+- **Spec 014 — HTTP requests.** Implementations MAY ship `:rf.http/managed`; when they do, the contract in [014-HTTPRequests.md](014-HTTPRequests.md) is fixed. The CLJS reference ships it. Other-language ports decide independently.
 
 ### Post-v1 (foundation hooks ship in v1; ergonomic libraries land later)
 
 - **Spec 005 — State Machines.** Builds on foundation hooks in 002 (machines as event handlers, pure factory `create-machine-handler`, pure `machine-transition`, reserved `:raise`/`:spawn` fx-ids). Pattern adopted from xstate.
 - **Spec 007 — Stories, Variants, Workspaces.** Storybook-class tooling. Layered on Specs 002 and 008.
-
-### Feasibility-gated → likely v1 territory
-
-- **Spec 006 — Reactive Substrate.** Substrate-agnostic core (and possibly cooperative rendering substrate). Pulled toward v1 by Spec 011 — SSR demands substrate-agnostic rendering.
 
 ### New / deferred
 

--- a/spec/Pattern-Forms.md
+++ b/spec/Pattern-Forms.md
@@ -281,7 +281,7 @@ Forms typically don't need SSR-rendered hydration; the form is interactive clien
 - [examples/login/core.cljs](../examples/login/core.cljs) — login form built on this convention plus a state machine
 - [Pattern-NineStates.md](Pattern-NineStates.md) — the page-level convention that turns form validation and success into explicit `Incorrect` / `Correct` UI states.
 - [examples/nine_states/](../examples/nine_states/) — worked example whose Incorrect state exercises this form lifecycle (validation errors, touched-field display, recovery to Correct).
-- [examples/realworld/auth.cljs](../examples/realworld/auth.cljs) — RealWorld's login and register forms exercise the full convention; the article editor (TODO) and comment form (TODO) extend it across more shapes.
+- [examples/realworld/auth.cljs](../examples/realworld/auth.cljs) — RealWorld's login and register forms exercise the full convention; [article_editor.cljs](../examples/realworld/article_editor.cljs) and [comments.cljs](../examples/realworld/comments.cljs) extend it across more shapes.
 
 ## Conformance checklist
 

--- a/spec/Runtime-Architecture.md
+++ b/spec/Runtime-Architecture.md
@@ -146,7 +146,7 @@ Each section below states **inputs**, **outputs**, **invariants**, and **who cal
 
 **Outputs.** Side-effects. New `app-db` value committed to the frame container. `:fx` entries dispatched to `do-fx`. Trace events emitted at every phase boundary.
 
-**Invariants — the four Levels** (the drain-loop pseudocode itself is tracked separately and will land as a section in 002):
+**Invariants — the four Levels** (the drain-loop pseudocode itself lives in [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode)):
 
 | Level | Scope | Locked by |
 |---|---|---|
@@ -180,7 +180,7 @@ If an `:fx` entry's handler throws, subsequent entries **continue** ([002 §Erro
 
 ### 6. Sub-cache
 
-**Role.** Per-frame memoised derivation graph. Each `(subscribe q)` call returns a value; if the underlying `app-db` slice changes, dependents recompute on the next deref. The full contract — invalidation algorithm, ref-counting, layer-1/2/3 sub semantics, disposal — is tracked separately and will be locked in [006 §Subscription cache invalidation](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics).
+**Role.** Per-frame memoised derivation graph. Each `(subscribe q)` call returns a value; if the underlying `app-db` slice changes, dependents recompute on the next deref. The full contract — invalidation algorithm, ref-counting, layer-1/2/3 sub semantics, disposal — is locked in [006 §Subscription cache — contract and operational semantics](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics).
 
 **Inputs.** Sub registrations from the registrar (`reg-sub`). `replace-container!` calls from the drain loop (cache-invalidation hook). `subscribe` calls from views.
 
@@ -205,7 +205,7 @@ If an `:fx` entry's handler throws, subsequent entries **continue** ([002 §Erro
 - One adapter per process ([006 §Single adapter per process](006-ReactiveSubstrate.md#single-adapter-per-process)).
 - The adapter is replaceable. The CLJS reference ships Reagent-default; SSR uses a plain-atom adapter; tests use headless.
 
-The Reagent-specific bridging pseudocode — which Reagent primitive realises which contract function — is tracked separately and will land as a Reference-adapter appendix in [006-ReactiveSubstrate](006-ReactiveSubstrate.md).
+The Reagent-specific bridging pseudocode — which Reagent primitive realises which contract function — lives in [006 §CLJS reference: Reagent as default adapter](006-ReactiveSubstrate.md#cljs-reference-reagent-as-default-adapter).
 
 ### 8. Trace bus
 


### PR DESCRIPTION
## Summary

Drift sweep across `spec/` for stale or contradictory references — old goal numbers, outdated implementation status counts, and the phantom Spec 003 row in the v1-required table flagged in `rf2-rdx0`.

Three categories of edit:

- **Status-table refresh** (`000-Vision.md`): the v1-required Specs table named Spec 003 ("Reusable Components, subsumed by 002 + 004") but the README reserves slot 003 for a future cross-frame composition Spec. The table also lagged the per-Spec headers — 006 is v1-required for the CLJS reference (not feasibility-gated), 013 ships in v1, and 014 is a v1-optional capability. Aligned the table with each Spec's own status header, removed the phantom 003 row, added a note pointing at the README's reserved-slot prose, and added a v1-optional capabilities subsection covering Spec 014.
- **Forward-promises now fulfilled** (`Runtime-Architecture.md`): three "tracked separately and will land in 002 / 006" forward-promises pointed at material that has since landed — drain-loop pseudocode now lives in 002 §Drain-loop pseudocode, the sub-cache contract in 006 §Subscription cache, and the Reagent adapter realisation in 006 §CLJS reference: Reagent as default adapter. Replaced each with a direct citation.
- **Closed-bead prose updates / forward-promises fulfilled** (`Pattern-Forms.md`): the RealWorld article editor and comment form were marked "(TODO)"; both have since landed in `examples/realworld/` as `article_editor.cljs` and `comments.cljs`. Replaced with direct links.

Sweep counts:

- v1-required Specs table: 1 phantom row removed, 4 rows updated/added (006 promoted, 013 added, 014 added in new subsection), 1 README cross-reference inserted.
- Runtime-Architecture forward-promises: 3 tightened to landed-section citations.
- Pattern-Forms TODO refs: 2 replaced with worked-example links.

Resolved-bead descriptions in spec prose were spot-checked against `bd show` for every bead listed in the rdx0 task — every closed-bead reference (rf2-7cb2, rf2-n4um, rf2-iyzm, rf2-d0pi, rf2-qppo, rf2-smba, rf2-t5tx, rf2-sx7t, rf2-lokk) already reads as resolved-state prose. Open beads (rf2-9hft, rf2-jp75, rf2-rrgq, rf2-7e2y, rf2-8hi7, rf2-zhkw, rf2-xfa2, rf2-bhhu, rf2-j9yf) are left alone per the rdx0 constraints.

Doc-only; no MIGRATION.md v1→v2 entries were touched; no closed-bead descriptions were touched.

## Test plan

- [x] `clojure -M:test` (in `implementation/`): 233 tests, 1087 assertions, 0 failures, 0 errors.
- [ ] mkdocs build (optional; touches no rendered TOC entries).