### PR TITLE
docs: refresh example catalog and run stories (rf2-0h9n)

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -20,7 +20,7 @@ If you're an AI agent or implementor, you want the [specification](../../spec/) 
 | 08 | [From re-frame v1](08-from-re-frame-v1.md) | What's the same, what's different, what to do. |
 | 09 | [The dynamic-model story](09-the-dynamic-model.md) | The deeper essay on *why* less-powerful is more. |
 
-After the chapters: read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login), then benchmarks (7GUIs, nine-states), then the RealWorld scaffold.
+After the chapters: read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login, routing, ssr, managed-http-counter, state-machine-walkthrough), then benchmarks (todomvc, 7GUIs, nine-states), then the RealWorld scaffold. Fifteen examples total, each with a Playwright smoke spec; the catalogue maps each one to the Specs it exercises.
 
 If you're impatient, read [01](01-why-re-frame2.md) and skip to [02](02-your-first-app.md). If you're skeptical, [01](01-why-re-frame2.md) is where the argument lives.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,19 +15,33 @@ Each example carries one of three maturity tags. New readers should pick example
 | **Benchmark** | Exhaustive demonstration of a class of UI tasks. Useful for "what does the pattern look like across a wide surface?" |
 | **Worked scaffold** | Substantial app. Shows how the primitives compose into a real-world codebase, even when some parts are still sketch-level rather than production-polished. The README inside each scaffold is the source of truth for what is demonstrated concretely. |
 
-## The examples
+## The catalogue
 
-| Example | Maturity | What it demonstrates |
-|---|---|---|
-| [`counter/`](counter/) | Pedagogical sketch | The smallest possible app — one event, one sub, one view. The "hello world" of the pattern. |
-| [`login/`](login/) | Pedagogical sketch | Single-feature scaffold — events + subs + views + machine + tests, all in one file, for a typical login flow. |
-| [`todomvc/`](todomvc/README.md) | Benchmark | Canonical cross-framework todo app: persistence, editing, bulk actions, remaining count, and hash-routing filters. |
-| [`routing/`](routing/) | Pedagogical sketch | Three-page app demonstrating `reg-route`, `:rf.route/navigate`, and route-not-found handling. The CP-7 worked example. |
-| [`ssr/`](ssr/) | Pedagogical sketch | Minimal SSR + hydration walkthrough. The CP-9 worked example. JVM-runnable; the browser side hydrates against a baked `<script id="__rf_payload">` block in the static index.html (standing in for a real Clojure server in front). |
-| [`state_machine_walkthrough/`](state_machine_walkthrough/) | Pedagogical sketch | Runnable companion to [docs/guide/05-state-machines.md](../docs/guide/05-state-machines.md). The chapter's login flow as code; the browser layer drives the canonical lockout scenario (three failures → `:locked-out`). |
-| [`seven_guis/`](seven_guis/README.md) | Benchmark | The full [7GUIs](https://eugenkiss.github.io/7guis/) cross-framework UI benchmark — counter, temperature converter, flight booker, timer, CRUD, circle drawer, cells. Exhaustive demonstration that the pattern's primitives compose across difficulty levels. |
-| [`nine_states/`](nine_states/README.md) | Benchmark | The nine canonical UI states (nothing / loading / empty / one / some / too many / incorrect / correct / done) for a single domain. Pedagogically exhaustive. |
-| [`realworld/`](realworld/README.md) | Worked scaffold | [RealWorld (Conduit)](https://github.com/gothinkster/realworld) — the de-facto cross-framework benchmark. Auth, feeds, routing, comments, editor, profile, favorites, settings, and SSR-hydration glue are all sketched on the current API surface. |
+Fifteen examples ship in this directory. Each is paired with a Playwright smoke spec (`<name>.spec.cjs`) and a shadow-cljs build id; the orchestrator at [`implementation/scripts/serve-and-run-examples-tests.cjs`](../implementation/scripts/serve-and-run-examples-tests.cjs) compiles every build, stages the example's hand-written `index.html`, serves the lot, and runs the specs against a real Chromium. Run the full sweep from `implementation/`:
+
+```bash
+npm run test:examples
+```
+
+| # | Example | Maturity | Build id | Spec(s) it exercises | What it demonstrates |
+|---|---|---|---|---|---|
+| 1 | [`counter/`](counter/) | Pedagogical sketch | `examples/counter` | [002 Frames](../spec/002-Frames.md), [004 Views](../spec/004-Views.md) | The smallest possible app — one event, one sub, one view. The "hello world" of the pattern. |
+| 2 | [`login/`](login/) | Pedagogical sketch | `examples/login` | [005 StateMachines](../spec/005-StateMachines.md), [014 HTTPRequests](../spec/014-HTTPRequests.md), [010 Schemas](../spec/010-Schemas.md), [008 Testing](../spec/008-Testing.md) | Single-feature scaffold — events + subs + views + machine + tests, all in one file, for a typical login flow. |
+| 3 | [`todomvc/`](todomvc/README.md) | Benchmark | `examples/todomvc` | [002 Frames](../spec/002-Frames.md), [004 Views](../spec/004-Views.md), [012 Routing](../spec/012-Routing.md) | Canonical cross-framework todo app: persistence (localStorage), editing, bulk actions, remaining count, and hash-routing filters. |
+| 4 | [`routing/`](routing/) | Pedagogical sketch | `examples/routing` | [012 Routing](../spec/012-Routing.md) | Three-page app demonstrating `reg-route`, `:rf.route/navigate`, anchor clicks via `:rf/url-requested`, and route-not-found handling. The CP-7 worked example. |
+| 5 | [`ssr/`](ssr/) | Pedagogical sketch | `examples/ssr` | [011 SSR](../spec/011-SSR.md), [004 Views](../spec/004-Views.md) | Minimal SSR + hydration walkthrough. The CP-9 worked example. JVM-runnable; the browser side hydrates against a baked `<script id="__rf_payload">` block in the static `index.html` (standing in for a real Clojure server in front). |
+| 6 | [`managed_http_counter/`](managed_http_counter/) | Pedagogical sketch | `examples/managed-http-counter` | [014 HTTPRequests](../spec/014-HTTPRequests.md), [Pattern-AsyncEffect](../spec/Pattern-AsyncEffect.md) | A counter where each button issues a `:rf.http/managed` request: success, 4xx failure, retry-recover (canned-stub), and abort. The compact, single-feature complement to RealWorld for Spec 014. |
+| 7 | [`state_machine_walkthrough/`](state_machine_walkthrough/) | Pedagogical sketch | `examples/state-machine-walkthrough` | [005 StateMachines](../spec/005-StateMachines.md), [014 HTTPRequests](../spec/014-HTTPRequests.md), [008 Testing](../spec/008-Testing.md) | Runnable companion to [docs/guide/05-state-machines.md](../docs/guide/05-state-machines.md). The chapter's login flow as code; the browser layer drives the canonical lockout scenario (three failures → `:locked-out`). |
+| 8 | [`nine_states/`](nine_states/README.md) | Benchmark | `examples/nine-states` | [Pattern-NineStates](../spec/Pattern-NineStates.md), [Pattern-RemoteData](../spec/Pattern-RemoteData.md), [Pattern-Forms](../spec/Pattern-Forms.md), [005 StateMachines](../spec/005-StateMachines.md) | The nine canonical UI states (nothing / loading / empty / one / some / too many / incorrect / correct / done) for a single domain. Pedagogically exhaustive. |
+| 9 | [`seven_guis/temperature.cljs`](seven_guis/temperature.cljs) | Benchmark | `examples/temperature` | [004 Views](../spec/004-Views.md), [006 ReactiveSubstrate](../spec/006-ReactiveSubstrate.md) | 7GUIs #2 — Temperature converter. Bidirectional derivations; one source of truth. |
+| 10 | [`seven_guis/flight_booker.cljs`](seven_guis/flight_booker.cljs) | Benchmark | `examples/flight-booker` | [004 Views](../spec/004-Views.md), [Pattern-Forms](../spec/Pattern-Forms.md) | 7GUIs #3 — Flight booker. Form validation; layered subs deriving the Book button's enabled state. |
+| 11 | [`seven_guis/timer.cljs`](seven_guis/timer.cljs) | Benchmark | `examples/timer` | [002 Frames](../spec/002-Frames.md), [004 Views](../spec/004-Views.md) | 7GUIs #4 — Timer. `:dispatch-later` periodic tick; controlled slider; one source of truth for elapsed time. |
+| 12 | [`seven_guis/crud.cljs`](seven_guis/crud.cljs) | Benchmark | `examples/crud` | [004 Views](../spec/004-Views.md) | 7GUIs #5 — CRUD. List operations (add / update / delete), selection-as-state, derived filtered list. |
+| 13 | [`seven_guis/circle_drawer.cljs`](seven_guis/circle_drawer.cljs) | Benchmark | `examples/circle-drawer` | [004 Views](../spec/004-Views.md), [002 Frames](../spec/002-Frames.md) | 7GUIs #6 — Circle drawer. Undo/redo via an interceptor that snapshots `:circles`; modal dialog as state. |
+| 14 | [`seven_guis/cells.cljs`](seven_guis/cells.cljs) | Benchmark | `examples/cells` | [006 ReactiveSubstrate](../spec/006-ReactiveSubstrate.md), [004 Views](../spec/004-Views.md) | 7GUIs #7 — Cells. Formula evaluation; subscription-graph propagation; cycle detection; pure parser+evaluator. |
+| 15 | [`realworld/`](realworld/README.md) | Worked scaffold | `examples/realworld` | [014 HTTPRequests](../spec/014-HTTPRequests.md), [012 Routing](../spec/012-Routing.md), [005 StateMachines](../spec/005-StateMachines.md), [011 SSR](../spec/011-SSR.md), [Pattern-RemoteData](../spec/Pattern-RemoteData.md), [Pattern-Forms](../spec/Pattern-Forms.md) | [RealWorld (Conduit)](https://github.com/gothinkster/realworld) — the de-facto cross-framework benchmark. Auth, feeds, routing, comments, editor, profile, favorites, settings, and SSR-hydration glue are all sketched on the current API surface. |
+
+For the 7GUIs cluster's own narrative (entries 9–14 above plus the counter from entry 1), see the cluster README at [`seven_guis/README.md`](seven_guis/README.md).
 
 ## Reading order
 
@@ -36,13 +50,46 @@ If you've finished the guide and want to see code:
 1. **Start with [`counter/`](counter/)** — the smallest possible app. Establishes the basic shape.
 2. **Then [`login/`](login/)** — adds a state machine, async effects, and form handling. Single-feature scope; full shape.
 3. **Then [`todomvc/`](todomvc/README.md)** — classic benchmark shape: persistence, editing, filters, and browser routing pressure.
-4. **Then [`routing/`](routing/)** or [`ssr/`](ssr/)** — pick whichever is closer to your interest.
-5. **Then [`seven_guis/`](seven_guis/)** — survey of the pattern across many UI shapes.
-6. **Then [`realworld/`](realworld/)** — substantial-app shape across the widest surface in the repo.
+4. **Then [`routing/`](routing/)** or [`ssr/`](ssr/) — pick whichever is closer to your interest.
+5. **Then [`managed_http_counter/`](managed_http_counter/)** — the smallest possible Spec 014 demo, before the broader RealWorld surface.
+6. **Then [`state_machine_walkthrough/`](state_machine_walkthrough/)** — the ch.05 prose as runnable code, with smoke tests for every section.
+7. **Then [`seven_guis/`](seven_guis/)** — survey of the pattern across many UI shapes.
+8. **Then [`nine_states/`](nine_states/README.md)** — the page-level cardinality / lifecycle conventions wired together.
+9. **Then [`realworld/`](realworld/)** — substantial-app shape across the widest surface in the repo.
 
 ## End-to-end verification
 
-Every example listed above is verified end-to-end by a Playwright spec — each spec navigates a real browser to the example's URL, asserts the initial render, drives at least one interaction, and asserts the post-interaction user-visible state. The orchestrator at [`implementation/scripts/serve-and-run-examples-tests.cjs`](../implementation/scripts/serve-and-run-examples-tests.cjs) compiles every example, stages its `index.html`, serves the output over HTTP, and runs the spec runner at [`implementation/scripts/run-examples-tests.cjs`](../implementation/scripts/run-examples-tests.cjs). Specs sit alongside each example as `<name>.spec.cjs`. Run the full sweep with `npm run test:examples` from `implementation/`.
+Every example listed above is verified end-to-end by a Playwright spec — each spec navigates a real browser to the example's URL, asserts the initial render, drives at least one interaction, and asserts the post-interaction user-visible state. The orchestrator at [`implementation/scripts/serve-and-run-examples-tests.cjs`](../implementation/scripts/serve-and-run-examples-tests.cjs) compiles every example, stages its `index.html`, serves the output over HTTP on port 8030, and runs the spec runner at [`implementation/scripts/run-examples-tests.cjs`](../implementation/scripts/run-examples-tests.cjs). Specs sit alongside each example as `<name>.spec.cjs`. Run the full sweep with `npm run test:examples` from `implementation/`.
+
+### How the orchestrator wires an example up
+
+The orchestrator file declares one entry per example and walks through three steps for the whole set:
+
+1. **Compile.** A single `shadow-cljs compile <build-id> ...` invocation runs every build at once, sharing one JVM warmup. Each build's `:output-dir` is `out/examples/<name>/`.
+2. **Stage.** Each example's hand-written `index.html` (and any extra static assets — TodoMVC's CSS, the managed-HTTP counter's `/api/inc.json`) is copied next to the compiled `main.js` under `out/examples/<name>/`.
+3. **Serve and run.** `http-server` is launched against `out/examples` on port 8030, then `run-examples-tests.cjs` walks the tree, picks up every `*.spec.cjs`, and runs each spec against `http://127.0.0.1:8030/<mount>/`.
+
+Each spec module exports `{name, url, run}`; `run` is an `async (page) => ...` that issues Playwright assertions. URL mounts match the orchestrator's `outDir` directory name (e.g. `/counter/`, `/managed-http-counter/`, `/state-machine-walkthrough/`).
+
+### Adding a new example
+
+1. Create `examples/<name>/` with the source, a hand-written `index.html`, and a Playwright spec `<name>.spec.cjs`.
+2. Add a shadow-cljs build target to `implementation/shadow-cljs.edn` under the existing `:examples/...` block.
+3. Append an entry to the `EXAMPLES` array in `implementation/scripts/serve-and-run-examples-tests.cjs` declaring `{build, htmlSrc, outDir, extraFiles?}`.
+4. Update this catalogue and any per-Spec cross-references that the new example exercises.
+
+The spec runner discovers specs by filesystem walk under `examples/`, so no additional registration is needed beyond the orchestrator entry.
+
+### Running a single example interactively
+
+If you want to iterate on one example without re-running the whole sweep:
+
+```bash
+# From implementation/ — pick the build id from the catalogue above.
+shadow-cljs watch examples/counter
+```
+
+Then serve the same `out/examples/counter/` directory (after staging its `index.html` once by hand, or by running `npm run test:examples` once first to populate the layout). The orchestrator is the canonical end-to-end runner; this loop is purely for source-code iteration.
 
 ## What examples are *not*
 

--- a/examples/nine_states/README.md
+++ b/examples/nine_states/README.md
@@ -58,13 +58,23 @@ views.cljs / machines.cljs / events_test.cljs`).
 
 ## How to run
 
+The example is wired into the canonical examples harness. From `implementation/`:
+
 ```bash
-# From the project root
-shadow-cljs watch nine-states
-# then open the served page (per the example harness setup)
+npm run test:examples
 ```
 
-The headless test suite runs JVM-side:
+That compiles every example (this one builds under shadow-cljs id `examples/nine-states`), stages its `index.html` into `out/examples/nine-states/`, serves the lot, and runs the Playwright smoke spec at [`nine_states.spec.cjs`](nine_states.spec.cjs).
+
+To iterate on the source alone, watch the build directly from `implementation/`:
+
+```bash
+shadow-cljs watch examples/nine-states
+```
+
+(Run `npm run test:examples` at least once first so `out/examples/nine-states/index.html` is staged; subsequent watch builds reuse it.)
+
+The headless tests run JVM-side from a CLJS REPL:
 
 ```clojure
 (nine-states.core/run-all-tests)

--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -58,14 +58,22 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../spec/014-HTTP
 
 ## How to run
 
-The example assumes a shadow-cljs build aliased `examples/realworld` (typical
-`:modules {:realworld {:entries [realworld.core] :init-fn realworld.core/run}}`).
+The example is wired into the canonical examples harness. From `implementation/`:
+
+```bash
+npm run test:examples
+```
+
+That compiles every example (this one builds under shadow-cljs id `examples/realworld`), stages its `index.html` into `out/examples/realworld/`, serves the lot on port 8030, and runs [`realworld.spec.cjs`](realworld.spec.cjs) against it.
 
 In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`. The demo entry installs an in-process `:rf.http/managed` override (`:rf.http/managed.realworld-demo`) that synthesises canned responses for the common reads (global feed, tags, profile) — Spec 014 §Testing — so the headless smoke and Playwright run without a network.
 
+To iterate on the source alone, watch the build directly from `implementation/`:
+
 ```bash
 shadow-cljs watch examples/realworld
-# then open the served HTML and click around
+# then visit http://127.0.0.1:8030/realworld/ once the harness is running, or
+# stage the index.html into out/examples/realworld/ by running the harness once first.
 ```
 
 ## Headless tests

--- a/spec/README.md
+++ b/spec/README.md
@@ -90,7 +90,7 @@ Worked examples:
 
 | Title | Type | One-liner |
 |---|---|---|
-| [Worked examples](../examples/) | Reference | The [7GUIs series](../examples/seven_guis/README.md), a [login feature](../examples/login/core.cljs), the [Nine States of UI](../examples/nine_states/README.md) pedagogical exhaustive-states demo, and a [RealWorld (Conduit)](../examples/realworld/README.md) cross-framework benchmark app. Demonstrates every construction prompt in working code. |
+| [Worked examples](../examples/) | Reference | Fifteen browser-runnable apps spanning the construction-prompt surface — [counter](../examples/counter/), [login](../examples/login/core.cljs), [todomvc](../examples/todomvc/README.md), [routing](../examples/routing/), [ssr](../examples/ssr/), [managed_http_counter](../examples/managed_http_counter/), [state_machine_walkthrough](../examples/state_machine_walkthrough/), [nine_states](../examples/nine_states/README.md), the [7GUIs cluster](../examples/seven_guis/README.md) (temperature / flight booker / timer / crud / circle drawer / cells), and [realworld](../examples/realworld/README.md). Each is paired with a Playwright smoke spec; the catalogue at [examples/README.md](../examples/README.md) maps each example to the Specs it exercises. |
 
 ## Reading paths
 


### PR DESCRIPTION
## Summary

- Rewrote `examples/README.md` to enumerate every example currently shipped — fifteen entries with maturity, shadow-cljs build id, the Specs/Patterns each one exercises, and a short summary. The previous catalogue omitted `managed_http_counter` and folded the 7GUIs cluster into a single row.
- Documented the orchestrator (`implementation/scripts/serve-and-run-examples-tests.cjs`): compile, stage, serve, run; how the spec discovery walk picks up `*.spec.cjs` automatically; how to add a new example; how to iterate on a single example with `shadow-cljs watch`.
- Fixed the broken `shadow-cljs watch nine-states` invocation in `examples/nine_states/README.md` (the build id is `examples/nine-states`); both `nine_states` and `realworld` READMEs now lead with `npm run test:examples` as the canonical run path.
- Refreshed cross-links in `spec/README.md` (worked-examples row) and `docs/guide/README.md` (after-the-chapters pointer) so they match the expanded catalogue.

No example source code touched; doc-only PR.

## Test plan

- [x] `clojure -M:test` from `implementation/` — 233 tests, 1087 assertions, 0 failures, 0 errors.
- [ ] Spot-check the rendered Markdown on GitHub for layout (table widths, nested links).