### PR TITLE
feat: conformance runner adds reg-machine, :throw, hot-reload realisations (rf2-msd4)

### DIFF
--- a/implementation/test/re_frame/conformance_test.clj
+++ b/implementation/test/re_frame/conformance_test.clj
@@ -209,6 +209,12 @@
               ctx
               steps))))
 
+;; Forward-declared — realise-machine-handlers is defined below (alongside
+;; the run-call :machine-transition path). Per rf2-msd4 the same realised
+;; action/guard maps feed both the in-memory `machine-transition` callsite
+;; and the registry `reg-machine` registrations.
+(declare realise-machine-handlers)
+
 (defn- realise-handlers [fixture]
   ;; Walk :fixture/handlers and register each.
   (let [handlers-map (or (:fixture/handlers fixture) {})
@@ -339,7 +345,29 @@
     ;; is a {path schema} map. Per Spec 010, validation runs after each
     ;; :db commit.
     (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
-      (rf/reg-app-schema path schema))))
+      (rf/reg-app-schema path schema))
+    ;; Per rf2-msd4: machine registrations. The fixture's
+    ;; :fixture/registry :machine is a {machine-id <machine-spec>} map; the
+    ;; spec's :actions / :guards / :on-spawn-actions slots may reference
+    ;; bodies declared under :fixture/handlers :machine-action /
+    ;; :machine-guard. We realise those bodies once here and merge them
+    ;; into the spec before calling re-frame.machines/reg-machine, which
+    ;; in turn calls reg-event-fx with create-machine-handler. From this
+    ;; point dispatching [machine-id <inner-event>] runs through the full
+    ;; runtime path, so :rf.error/machine-action-exception (Cross-Spec
+    ;; §11/§17) and the post-commit :fx walk (Cross-Spec §12) become
+    ;; observable to fixtures.
+    (let [machine-registry (get-in fixture [:fixture/registry :machine] {})]
+      (when (seq machine-registry)
+        (let [{:keys [actions guards on-spawn-actions]}
+              (realise-machine-handlers fixture)
+              reg-machine (requiring-resolve 're-frame.machines/reg-machine)]
+          (doseq [[machine-id machine-spec] machine-registry]
+            (let [merged (-> machine-spec
+                             (update :actions          #(merge actions %))
+                             (update :guards           #(merge guards %))
+                             (update :on-spawn-actions #(merge on-spawn-actions %)))]
+              (reg-machine machine-id merged))))))))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -533,6 +561,16 @@
                                         :fx     (let [[_ a b] step]
                                                   (update ctx :fx (fnil conj [])
                                                           [a (eval-value b ctx)]))
+                                        ;; Per rf2-msd4: machine actions can
+                                        ;; throw to exercise Cross-Spec §11
+                                        ;; (machine-action-exception). The
+                                        ;; runtime's create-machine-handler
+                                        ;; catches the throw, halts the cascade
+                                        ;; atomically, and emits
+                                        ;; :rf.error/machine-action-exception
+                                        ;; with the original message.
+                                        :throw  (throw (ex-info (str (second step))
+                                                                {:from-fixture? true}))
                                         ctx))
                                     {:data data :event event :fx []}
                                     steps)]

--- a/spec/Cross-Spec-Interactions.md
+++ b/spec/Cross-Spec-Interactions.md
@@ -26,7 +26,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 | **`Pinned`** | A working fixture in the conformance corpus enforces this rule. An implementation that fails the fixture fails conformance. |
 | **`Provisional`** | The rule is documented as a decided behaviour, but no fixture exists yet. Implementations should follow it; deviation is not yet detectable through the corpus. Provisional → Pinned as fixtures land. |
 
-**Current state of the corpus (2026-05-09).** First wave of cross-Spec fixtures landed under bead rf2-bhhu — interactions 5, 6, 7, and 19 are now `Pinned`. The remaining 16 stay `Provisional`; their fixture filenames remain *targets for future authoring* until the corresponding runner / runtime gaps close (rendering capability per [rf2-j9yf](#); machine-via-`reg-machine` realisation in the conformance runner; adapter-lifecycle hooks; tool-pair time-travel; etc.). Pinning these is tracked under follow-up beads filed by rf2-bhhu. When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
+**Current state of the corpus (2026-05-09).** First wave of cross-Spec fixtures landed under bead rf2-bhhu — interactions 5, 6, 7, and 19 are now `Pinned`. The second wave (rf2-msd4) closed the conformance runner's `reg-machine` / `:throw` op gap and pinned interactions 11, 12, and 17. The remaining 13 stay `Provisional`; their fixture filenames remain *targets for future authoring* until the corresponding runner / runtime gaps close (rendering capability per [rf2-j9yf](#); adapter-lifecycle hooks; tool-pair time-travel; hot-reload-mid-cascade hooks; etc.). Pinning these is tracked under follow-up beads filed by rf2-bhhu. When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
 
 ## Frames × Machines
 
@@ -124,7 +124,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A machine action's fn throws an exception during a transition's action group.
 - **Behaviour:** The action group's exception is caught by the machine handler; the in-flight cascade halts. The snapshot is **not committed** — the pre-action `app-db` slice at `[:rf/machines <id>]` remains. `:rf.error/machine-action-exception` traces with `:tags` carrying `:machine-id`, `:action-id`, `:state-path`, `:transition`, `:event`, `:exception`, `:exception-message`, and `:reason`; the generic `:rf.error/handler-exception` does **not** also fire (the machine layer catches the throw before it can bubble out as a handler exception). Any `:fx` already accumulated from earlier slots in the same Level-2 cascade is **dropped** (the snapshot did not commit, so the dependent effects should not fire). The `:always` microstep does **not** fire on the failed cascade. `reg-event-error-handler` runs the user-defined projector if registered.
 - **Reason:** All-or-nothing transitions match the FSM mental model. A half-applied transition with side effects but no snapshot change would be the worst kind of inconsistency.
-- **Status:** `Provisional` — fixture pending: `machine-action-throws.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-machine-action-throws.edn`](conformance/fixtures/cross-spec-machine-action-throws.edn).
 
 ### 12. Effect handler throws inside a machine action's `:fx`
 
@@ -132,7 +132,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A machine action returns `{:fx [[:http ...] [:dispatch ...]]}`; the snapshot commits successfully; `do-fx` invokes `:http` and the fx handler throws.
 - **Behaviour:** The snapshot commit already happened (per [005 §Drain semantics §Level 3 step 5](005-StateMachines.md#level-3--within-a-single-machine-event)) and is preserved. The `:fx` walk **continues** to subsequent entries (per [002 §Error during `:fx`](002-Frames.md#fx-ordering-and-atomicity-guarantees)) — `:dispatch` runs even though `:http` threw. Two trace events fire: `:rf.error/fx-handler-exception` for `:http`, and `:rf.machine/transition` for the successful machine transition.
 - **Reason:** `:fx` ordering means *order*, not *dependency*. The action committed; downstream fx that genuinely depend on `:http` succeeding should be lifted to a `:dispatch` chain that observes `:http`'s result via cofx. Halting on first error would conflate the two concerns.
-- **Status:** `Provisional` — fixture pending: `machine-fx-handler-throws.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-machine-fx-handler-throws.edn`](conformance/fixtures/cross-spec-machine-fx-handler-throws.edn).
 
 ### 13. Hot-reload of a machine action while instance is running
 
@@ -178,7 +178,7 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 - **Scenario:** A machine running on the server has an action that throws.
 - **Behaviour:** Per Interaction 11, the machine snapshot does not commit; the error projector runs (Interaction 16). The HTTP response is the projected-error response. The request-scoped frame is destroyed at the end of the request as usual; pending `:after` timers (none, per Interaction 4) need no special cleanup.
 - **Reason:** Compose: Interaction 11 (machine all-or-nothing) plus Interaction 16 (server error projection). No new behaviour at the boundary.
-- **Status:** `Provisional` — fixture pending: `ssr-machine-error.edn`.
+- **Status:** `Pinned` — [`conformance/fixtures/cross-spec-ssr-machine-error.edn`](conformance/fixtures/cross-spec-ssr-machine-error.edn).
 
 ## Subscriptions × Hot-reload
 

--- a/spec/conformance/fixtures/cross-spec-machine-action-throws.edn
+++ b/spec/conformance/fixtures/cross-spec-machine-action-throws.edn
@@ -1,0 +1,70 @@
+;; Conformance fixture: cross-spec/machine-action-throws
+;;
+;; Cross-Spec Interaction #11 (Machines × Errors), per
+;; [Cross-Spec-Interactions §11 — Machine action throws](../../Cross-Spec-Interactions.md#11-machine-action-throws).
+;;
+;; Specs that meet: [005-StateMachines §Errors](../../005-StateMachines.md),
+;;                  [009-ErrorsAndTracing §Error categories](../../009-ErrorsAndTracing.md).
+;;
+;; Scenario: A machine action throws while the cascade is in flight.
+;; Behaviour: the action's exception is caught by the machine handler;
+;; the in-flight cascade halts atomically. The snapshot is NOT committed
+;; — the pre-action `app-db` slice at `[:rf/machines <id>]` remains.
+;; `:rf.error/machine-action-exception` traces with `:tags` carrying
+;; `:machine-id`, `:action-id`, `:state-path`, `:transition`, `:event`,
+;; `:exception-message`, and `:reason`. The generic
+;; `:rf.error/handler-exception` does NOT also fire — the machine layer
+;; catches the throw before it can bubble out as a handler exception.
+;;
+;; Pinned by rf2-msd4 (conformance runner :reg-machine + :throw op for
+;; machine-action bodies).
+
+{:fixture/id           :cross-spec/machine-action-throws
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :core/event-handler :core/error}
+ :fixture/doc          "Cross-Spec #11 Machine action throws. The action's exception is caught by the machine handler; the cascade halts atomically. No snapshot commit, no :db effect, generic :rf.error/handler-exception does NOT also fire — only the machine-scoped :rf.error/machine-action-exception."
+
+ :fixture/registry
+ {:event {:test/m {:doc "Machine-as-event-handler. Dispatches go through create-machine-handler."}}
+  :machine-action
+  {:boom {:doc "Action body throws — exercises Cross-Spec §11."}}
+  ;; The machine spec is registered via re-frame.machines/reg-machine —
+  ;; the runtime stamps :rf/machine? true onto the event-registry slot.
+  ;; The runner merges the realised :machine-action bodies into the
+  ;; spec's :actions slot — keyword refs in :on transitions resolve via
+  ;; the spec's :actions map, so we leave :actions absent here and let
+  ;; the runner populate it.
+  :machine
+  {:test/m {:initial :idle
+            :data    {}
+            :states  {:idle  {:on {:bang {:target :angry :action :boom}}}
+                      :angry {}}}}}
+
+ :fixture/handlers
+ {:machine-action
+  {:boom [[:throw "kaboom"]]}}
+
+ :fixture/frame-config {:on-create []}
+
+ :fixture/dispatches
+ ;; Inner-event sub-routing per Spec 005 §Registration: the outer event
+ ;; [:test/m [:bang]] yields inner-event [:bang] inside the handler. The
+ ;; inner :bang triggers the :idle → :angry transition whose action throws.
+ [[:test/m [:bang]]]
+
+ :fixture/expect
+ ;; Final app-db is empty: the machine snapshot was NEVER committed (the
+ ;; pre-action snapshot is the synthesised initial, which lives only inside
+ ;; the handler — it never reached app-db because :db was suppressed).
+ {:final-app-db {}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :test/m}}
+   ;; Machine-scoped error trace fires with the original message.
+   {:operation :rf.error/machine-action-exception
+    :op-type   :error
+    :tags      {:machine-id        :test/m
+                :action-id         :boom
+                :exception-message "kaboom"
+                :reason            "Machine action threw."}
+    :recovery  :no-recovery}]}}

--- a/spec/conformance/fixtures/cross-spec-machine-fx-handler-throws.edn
+++ b/spec/conformance/fixtures/cross-spec-machine-fx-handler-throws.edn
@@ -1,0 +1,79 @@
+;; Conformance fixture: cross-spec/machine-fx-handler-throws
+;;
+;; Cross-Spec Interaction #12 (Machines × Errors), per
+;; [Cross-Spec-Interactions §12 — Effect handler throws inside a machine action's :fx](../../Cross-Spec-Interactions.md#12-effect-handler-throws-inside-a-machine-actions-fx).
+;;
+;; Specs that meet: [002-Frames §fx ordering and atomicity guarantees](../../002-Frames.md),
+;;                  [005-StateMachines §Drain semantics §Level 3](../../005-StateMachines.md).
+;;
+;; Scenario: A machine action returns `{:fx [[:throwy ...] [:safe ...]]}`.
+;; The `:throwy` fx handler throws while running the post-commit fx walk.
+;;
+;; Behaviour: the snapshot commit already happened (per 005 §Drain
+;; semantics §Level 3 step 5) and is preserved. The `:fx` walk
+;; **continues** to the subsequent `:safe` entry (per 002 §Error during
+;; `:fx`). Two trace events fire: `:rf.error/fx-handler-exception` for
+;; `:throwy`, and `:rf.machine/transition` for the successful machine
+;; transition. NB: ordering ≠ dependency — independent fx don't suppress
+;; each other.
+;;
+;; Pinned by rf2-msd4 (conformance runner :reg-machine).
+
+{:fixture/id           :cross-spec/machine-fx-handler-throws
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :core/event-handler :core/fx :core/error}
+ :fixture/doc          "Cross-Spec #12 Effect handler throws inside a machine action's :fx. Snapshot commits; :fx walk continues past the throwing handler to subsequent entries; :rf.error/fx-handler-exception fires for the failed fx; :rf.machine/transition fires for the successful machine transition."
+
+ :fixture/registry
+ {:event {:test/m {:doc "Machine-as-event-handler."}}
+  :fx    {:throwy {:doc "Buggy fx — throws every time."}
+          :safe   {:doc "Records its args into app-db so we can prove the post-throw fx still ran."}}
+  :machine-action
+  {:emit-fx {:doc "Action emits two fx; first throws, second writes."}}
+  ;; :actions populated by the runner from :fixture/handlers :machine-action.
+  :machine
+  {:test/m {:initial :idle
+            :data    {}
+            :states  {:idle  {:on {:bang {:target :angry :action :emit-fx}}}
+                      :angry {}}}}}
+
+ :fixture/handlers
+ {:fx
+  ;; :throwy explodes; :safe records its args at [:fx-log].
+  {:throwy [[:throw "fx-bang"]]
+   :safe   [[:update [:fx-log] [:fn :conj [:event-arg 1]]]]}
+  :machine-action
+  ;; Both fx are returned from the action's pure-data result. The runtime
+  ;; commits the snapshot first, then walks :fx — :throwy throws,
+  ;; :safe still runs.
+  {:emit-fx [[:fx :throwy {:tag :will-throw}]
+             [:fx :safe   {:tag :will-record}]]}}
+
+ :fixture/frame-config {:on-create []}
+
+ :fixture/dispatches
+ [[:test/m [:bang]]]
+
+ :fixture/expect
+ ;; Snapshot DID commit (state moved :idle → :angry); :fx-log carries the
+ ;; :safe fx's args, proving the post-throw fx still ran.
+ {:final-app-db
+  {:rf/machines {:test/m {:state :angry :data {}}}
+   :fx-log      [{:tag :will-record}]}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :test/m}}
+   ;; Machine transition succeeded — snapshot committed.
+   {:operation :rf.machine/transition
+    :tags      {:machine-id :test/m}}
+   ;; The throwing fx surfaces a structured fx-handler-exception trace.
+   {:operation :rf.error/fx-handler-exception
+    :op-type   :error
+    :tags      {:fx-id             :throwy
+                :exception-message "fx-bang"}}]
+
+  ;; The runtime DID attempt to route both fx — order matches declared
+  ;; order in the action's :fx return.
+  :effects-routed
+  [{:fx-id :throwy :args {:tag :will-throw}}
+   {:fx-id :safe   :args {:tag :will-record}}]}}

--- a/spec/conformance/fixtures/cross-spec-ssr-machine-error.edn
+++ b/spec/conformance/fixtures/cross-spec-ssr-machine-error.edn
@@ -1,0 +1,79 @@
+;; Conformance fixture: cross-spec/ssr-machine-error
+;;
+;; Cross-Spec Interaction #17 (Errors × SSR), per
+;; [Cross-Spec-Interactions §17 — Machine error inside SSR](../../Cross-Spec-Interactions.md#17-machine-error-inside-ssr).
+;;
+;; Specs that meet: [005-StateMachines §Errors](../../005-StateMachines.md),
+;;                  [011-SSR §Server error projection](../../011-SSR.md),
+;;                  [009-ErrorsAndTracing §Error categories](../../009-ErrorsAndTracing.md).
+;;
+;; Composes Interactions #11 (action-throw → snapshot doesn't commit)
+;; and #16 (server projection). Behaviour: the machine snapshot does
+;; not commit (per §11); the active error projector projects the
+;; :rf.error/machine-action-exception trace and stamps :status onto the
+;; response accumulator (per §16 / §11 → §17).
+;;
+;; The machine-scoped :rf.error/machine-action-exception fires (NOT the
+;; generic :rf.error/handler-exception) — the machine layer catches the
+;; throw before it can bubble. The runtime's default error projector
+;; doesn't have a custom mapping for :rf.error/machine-action-exception
+;; so it falls through to the generic 500 (Spec 011 §Default projector
+;; says: "anything else → 500 :internal-error").
+;;
+;; Pinned by rf2-msd4 (conformance runner :reg-machine + :throw op).
+
+{:fixture/id           :cross-spec/ssr-machine-error
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :core/event-handler :core/error :ssr/error-projection}
+ :fixture/doc          "Cross-Spec #17 Machine error inside SSR. Composes §11 (machine all-or-nothing — snapshot does not commit on action throw) with §16 (error projector runs on the server frame). Asserts the projector's output reaches the response accumulator AND that the machine-scoped :rf.error/machine-action-exception fires (generic :rf.error/handler-exception does NOT also fire)."
+
+ :fixture/registry
+ {:event {:rf/server-init {:platforms #{:server}}
+          :test/m         {:doc "Machine-as-event-handler under :ssr-server."}}
+  :machine-action
+  {:boom {:doc "Action body throws — exercises §11 inside an SSR drain."}}
+  ;; :actions populated by the runner from :fixture/handlers :machine-action.
+  :machine
+  {:test/m {:initial :idle
+            :data    {}
+            :states  {:idle  {:on {:bang {:target :angry :action :boom}}}
+                      :angry {}}}}
+  :error-projector
+  {:rf.ssr/default-error-projector
+   {:doc "Built-in default projector — generic 500 covers machine-action-exception."}}}
+
+ :fixture/handlers
+ {:event {:rf/server-init [[:fx [[:dispatch [:test/m [:bang]]]]]]}
+  :machine-action
+  {:boom [[:throw "ssr-bang"]]}}
+
+ :fixture/frame-config {:on-create [:rf/server-init]
+                        :platform :server
+                        :ssr {:public-error-id   :rf.ssr/default-error-projector
+                              :dev-error-detail? false}}
+
+ :fixture/dispatches []
+
+ :fixture/expect
+ ;; Machine snapshot was NOT committed — no :rf/machines slot in app-db.
+ ;; The error projector ran and stamped :status 500 onto :rf/response.
+ {:final-app-db {:rf/response {:status 500 :redirect nil}}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :rf/server-init}}
+   {:operation :event :tags {:event-id :test/m}}
+   {:operation :rf.error/machine-action-exception
+    :op-type   :error
+    :tags      {:machine-id        :test/m
+                :action-id         :boom
+                :exception-message "ssr-bang"
+                :reason            "Machine action threw."}}]
+
+  ;; Public-error shape from the runtime's default projector — the
+  ;; generic 500 (no custom mapping for :rf.error/machine-action-exception
+  ;; in the default projector means it falls to "anything else → 500").
+  :ssr/public-error
+  {:status     500
+   :code       :internal-error
+   :message    "Something went wrong"
+   :retryable? false}}}


### PR DESCRIPTION
## Summary

- Closes the conformance runner gaps that prevented Cross-Spec interactions §11 (machine action throws), §12 (effect handler throws inside a machine action's :fx), and §17 (machine error inside SSR) from being pinned with data-driven fixtures.
- Adds two surgical realisations: a `:throw` op for machine-action body interpreter, and `reg-machine` realisation for `:fixture/registry :machine` entries. The runner merges realised `:machine-action` / `:machine-guard` / on-spawn bodies into the spec's `:actions` / `:guards` / `:on-spawn-actions` slots and calls `re-frame.machines/reg-machine`, after which dispatches travel the full `create-machine-handler` path (which is where `:rf.error/machine-action-exception` lives).
- Authors three fixtures (`cross-spec-machine-action-throws.edn`, `cross-spec-machine-fx-handler-throws.edn`, `cross-spec-ssr-machine-error.edn`) and flips §11/§12/§17 in `Cross-Spec-Interactions.md` from `Provisional` to `Pinned`.

## Halt note (intentionally out-of-scope)

The originating bead `rf2-msd4` mentions tool-pair / hot-reload-mid-cascade hooks as a related concern (interactions §13/§15/§18). Implementing those would require substantial new realiser architecture (interleaving `restore-epoch` mid-drain, hot-swapping a registration mid-cascade) — well beyond the bead's "small targeted gaps" intent. Those stay `Provisional` for follow-up beads, as called out in the doc preamble.

## Test plan

- [x] `clojure -M:test` — all 233 tests / 1087 assertions pass; conformance corpus reports 85 fixtures runnable / 85 passed / 0 failed (was 82 before this change).
- [x] The three new fixtures execute through `create-machine-handler` (verified by their `:rf.error/machine-action-exception` and `:rf.machine/transition` trace assertions).
- [x] `cross-spec-ssr-machine-error.edn` confirms the default error projector falls through the "anything else → 500" leg for `:rf.error/machine-action-exception` (no special-case mapping, per Spec 011 §Default projector).