### PR TITLE
docs: trace contract follow-up sweep (rf2-2dd5)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -169,7 +169,7 @@ The CLJS reference makes the following bindings to the language-agnostic pattern
 | Source-coord capture | macros |
 | Registration symbol style | Vars defined via `reg-*` macros |
 | Effect resolver | `reg-fx` registered handlers |
-| Trace listener delivery | batched, debounced (50ms default) |
+| Trace listener delivery | synchronous, in-order, event-at-a-time (per [009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules)) |
 | Macro-vs-function bias | macros where source-coord capture or compile-time elision matters; functions otherwise |
 | Test framework | `cljs.test` / `clojure.test` re-exports plus `re-frame.test` helpers |
 | Build/dev tooling | shadow-cljs (test fixtures, hot reload, release elision) |

--- a/spec/Implementor-Checklist.md
+++ b/spec/Implementor-Checklist.md
@@ -256,9 +256,9 @@ For each capability included in Part 1, the implementor makes the per-capability
 
 #### T1. Trace-event delivery
 
-- **Why it matters.** Trace events flow into a single per-application stream; subscribers listen. Batched, debounced delivery (50ms default) per [009 §Subscription / consumption](009-Instrumentation.md#subscription--consumption). Plus a retain-N ring buffer (per [009 §Retain-N trace ring buffer](009-Instrumentation.md#retain-n-trace-ring-buffer-dev-only)) for tools that attach after events have fired.
-- **Options by host.** Hand-rolled per host; the contract is just "deliver collections of trace maps to registered callbacks at a debounced cadence."
-- **Reference-impl picks.** CLJS uses a single atom (the listener registry) + a setTimeout-driven debounce + a separate ring-buffer atom.
+- **Why it matters.** Trace events flow into a single per-application stream; subscribers listen. Synchronous, in-order, event-at-a-time delivery per [009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules). Plus a retain-N ring buffer (per [009 §Retain-N trace ring buffer](009-Instrumentation.md#retain-n-trace-ring-buffer-dev-only)) for tools that attach after events have fired.
+- **Options by host.** Hand-rolled per host; the contract is just "deliver each emitted trace map to every registered callback synchronously, in registration order, on the runtime's emit call stack."
+- **Reference-impl picks.** CLJS uses a single atom (the listener registry) plus a separate ring-buffer atom; each emit walks the registry inline.
 - **Trade-offs.** Hot path: trace allocation must be cheap; listener invocation must short-circuit when no listeners are registered.
 
 #### T2. Performance API equivalent

--- a/spec/Runtime-Architecture.md
+++ b/spec/Runtime-Architecture.md
@@ -23,7 +23,7 @@ The runtime is eight components plus a host-side **interop layer** that the CLJS
 | 5 | **Effect interpreter (`do-fx`)** | Walks the `:fx` vector in source order, dispatching each entry to its registered fx handler. | [002-Frames §`:fx` ordering](002-Frames.md#fx-ordering-and-atomicity-guarantees) |
 | 6 | **Sub-cache** | Per-frame derivation graph + memoised values. Invalidates on `app-db` change; disposes on frame destroy. | [006-ReactiveSubstrate §Subscription cache invalidation](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics) |
 | 7 | **Reactive substrate adapter** | Bridges the core to a reactivity library (Reagent in CLJS reference). Turns container reads into view re-renders. | [006-ReactiveSubstrate](006-ReactiveSubstrate.md) |
-| 8 | **Trace bus** | Per-process event stream; listeners notified after debounce window. Carries every dispatch, fx, machine transition, error, and registry mutation. | [009-Instrumentation](009-Instrumentation.md) |
+| 8 | **Trace bus** | Per-process event stream; listeners notified synchronously, in registration order, on each emit. Carries every dispatch, fx, machine transition, error, and registry mutation. | [009-Instrumentation](009-Instrumentation.md) |
 
 The **interop layer** (`re-frame.interop` in the CLJS reference) is not a runtime component — it is the host-abstraction surface the components call into for `next-tick`, `after-render`, mutable references, host-clock `now-ms`. Other hosts implement it natively; the interface stays small (per [Spec 002 §Interop layer](002-Frames.md#interop-layer--clock-primitives--see-spec-005)).
 
@@ -53,7 +53,7 @@ External event ingress to settled view, in one diagram:
                                    │      [:rf/machines <id>]   │  │            │
                                    └─────────┬──────────────────┘  │            ▼
                                              │                     │   listener delivery
-                                             │ container.replace!  │   (debounced batches)
+                                             │ container.replace!  │   (synchronous, in-order)
                                              ▼                     │
                                    ┌────────────────────────────┐  │
                                    │ Frame container            │  │
@@ -213,12 +213,12 @@ The Reagent-specific bridging pseudocode — which Reagent primitive realises wh
 
 **Inputs.** Emit calls from every other component — registrar (mutations), router (enqueue/drain markers), drain loop (event lifecycle), `do-fx` (per-fx events), sub-cache (recompute markers), substrate (render markers, adapter lifecycle), error projector ([009 §Error contract](009-Instrumentation.md#error-contract)).
 
-**Outputs.** Batched delivery to listeners ([009 §Listener API](009-Instrumentation.md#the-listener-api)). Listener-side: 10x panel, re-frame-pair, agent tools.
+**Outputs.** Synchronous, event-at-a-time delivery to listeners ([009 §The listener API](009-Instrumentation.md#the-listener-api)). Listener-side: 10x panel, re-frame-pair, agent tools.
 
 **Invariants.**
 - Open shape ([009 §Open shape; new fields are additive](009-Instrumentation.md#open-shape-new-fields-are-additive)).
 - Compile-time elidable in production ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
-- Listener invocation is async (debounce window batched) by default; opt-in per-event delivery for tools that need it.
+- Listener invocation is synchronous, in registration order, on the runtime's emit call stack — every emit returns once every listener has run ([009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules)).
 
 ## Lifecycles
 
@@ -263,7 +263,7 @@ Two sub-cases: per-frame teardown and per-process teardown.
 
 1. Every frame is destroyed in reverse-creation order.
 2. The adapter's `dispose-adapter!` runs ([006 §Adapter disposal lifecycle](006-ReactiveSubstrate.md#adapter-disposal-lifecycle)).
-3. The trace bus drains its pending batch to listeners; subscriptions are released.
+3. Trace listeners are released; the retain-N ring buffer is dropped (no pending batch — listeners were already invoked synchronously on each emit).
 4. The registrar is held by the host; in a long-lived process it persists across test runs (per [008-Testing](008-Testing.md) fixture conventions).
 
 ## What is new versus re-frame v1


### PR DESCRIPTION
## Summary

rf2-j7kv (PR #107) reconciled the bulk of the Spec 009 trace contract — `register-trace-cb!` (2-arity, bang form), event-at-a-time `:time` shape, synchronous in-order delivery, no `with-trace`/`merge-trace!`/`finish-trace` macro suite, no `trace-api-version` — but three companion docs still described the unshipped batched/debounced shape. This PR brings them into alignment.

The bead's specific line references (`spec/009-Instrumentation.md:21` and `spec/API.md:247`) are now at correctly-aligned content — those lines were fixed by rf2-j7kv; the residue lived in the companion docs below.

## Sites fixed (per file)

**`spec/000-Vision.md` — 1 fix**
- Row "Trace listener delivery" in the reference-implementation choices table: `batched, debounced (50ms default)` -> `synchronous, in-order, event-at-a-time` (links to [009 §Listener invocation rules]).

**`spec/Implementor-Checklist.md` — 1 fix**
- T1 Trace-event delivery (§Why it matters / §Options by host / §Reference-impl picks): rewrote the three bullets to describe synchronous-on-emit-stack delivery; dropped the setTimeout-driven debounce reference-impl claim.

**`spec/Runtime-Architecture.md` — 3 fixes**
- Components table row 8 (Trace bus): `listeners notified after debounce window` -> `listeners notified synchronously, in registration order, on each emit`.
- Data-flow diagram callout next to listener delivery: `(debounced batches)` -> `(synchronous, in-order)`.
- §8 Trace bus invariants (Outputs and Listener invocation bullets): rewrote to pin the synchronous-on-emit-stack contract.
- Per-process shutdown step 3: `trace bus drains its pending batch to listeners` -> `Trace listeners are released; the retain-N ring buffer is dropped (no pending batch — listeners were already invoked synchronously on each emit)`.

## Files re-swept and confirmed clean post-rf2-j7kv

`spec/009-Instrumentation.md`, `spec/API.md`, `spec/Spec-Schemas.md`, `spec/Tool-Pair.md` — all sites mentioning span / batched / debounced / 50ms / `register-trace-cb` (3-arity) / `:start` / `:end` / `:duration` / `:child-of` / `with-trace` / `merge-trace!` / `finish-trace` / `trace-api-version` are either correctly disclaiming those shapes ("not span-shaped", "no batching, debounce window, or background delivery loop") or sit in the §Removed/not shipped section.

## Test plan

- [x] `clojure -M:test` (implementation): 239 tests, 1103 assertions, 0 failures, 0 errors.
- [x] `grep -i 'batch\|debounce\|50ms\|span-shaped\|with-trace\|merge-trace\|finish-trace\|trace-api-version'` over `spec/` re-run after edits — only legitimate matches remain (sub-cache `:grace-period-ms`, long-running-work batching pattern, 009's correctly-disclaimed prose, API.md §Removed section).