### PR TITLE
feat: public re-frame.test-support helpers — dispatch-sequence, assert-state, run-test-sync (rf2-0l3s / rf2-hkr5)

### DIFF
--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -34,20 +34,33 @@
 
   ## Public API
 
+  ### Fixture machinery
   - [[snapshot-registrar]] — capture the current registrar state.
   - [[restore-registrar!]] — restore the registrar to a captured snapshot.
   - [[with-fresh-registrar]] — bracket a thunk with snapshot + restore.
   - [[reset-runtime-fixture]] — `clojure.test`/`cljs.test` `:each`
     fixture that snapshot/restores the registrar AND resets the
     per-process state held by frames / flows / adapter / machine
-    counters / trace listeners."
+    counters / trace listeners.
+
+  ### Test-flavoured helpers (rf2-0l3s / rf2-hkr5)
+  - [[dispatch-sequence]] — fire a vector of events synchronously,
+    optionally observing intermediate state via `:after-each`.
+  - [[assert-state]] — assert against the current frame's app-db (full
+    db or `path` form); failure is reported via `clojure.test/is`.
+  - [[run-test-sync]] — v1 compatibility shim. v2's `dispatch-sync`
+    drain is already synchronous so the macro is largely a body
+    wrapper; included for mechanical migration of v1 test code."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.schemas :as schemas]
             [re-frame.trace :as trace]
-            [re-frame.substrate.adapter :as adapter]))
+            [re-frame.router :as router]
+            [re-frame.substrate.adapter :as adapter]
+            #?(:clj  [clojure.test :as ctest]
+               :cljs [cljs.test :as ctest :include-macros true])))
 
 ;; ---- registrar snapshot/restore -------------------------------------------
 
@@ -194,3 +207,151 @@
            (reset! schemas/schemas-by-frame schemas-snap)
            (reset! frame/frames {})
            (reset! flows/flows {})))))))
+
+;; ---- test-flavoured helpers (rf2-0l3s / rf2-hkr5) -------------------------
+;;
+;; Three thin wrappers over `dispatch-sync!` and `frame-app-db-value` for
+;; ergonomic test code. The fixture machinery above carries the heavy
+;; lifting; these helpers are composition sugar.
+;;
+;; Per Spec 008 §Built-in test-runner namespace, all three live under
+;; re-frame.test-support so users `(:require [re-frame.test-support :as t])`
+;; once and reach the full testing surface — including dispatch-sequence,
+;; assert-state, run-test-sync — without an additional require.
+
+(defn- resolve-frame
+  "Frame-resolution chain shared by the helpers below:
+     1. `:frame` key in opts when supplied;
+     2. `(frame/current-frame)` — picks up `with-frame` bindings,
+        defaults to `:rf/default`."
+  [opts]
+  (or (:frame opts) (frame/current-frame)))
+
+(defn dispatch-sequence
+  "Fire each event in `events` synchronously, in order, against the
+  resolved frame. Returns the final app-db value.
+
+  Each event is delivered via `dispatch-sync!`, which runs the handler
+  and drains the queue to fixed point before returning. The drain
+  settles between events, so observable state between calls reflects
+  committed effects.
+
+  Options (all optional):
+    :after-each — fn of `(db, event)` invoked after each event's drain
+                  settles. Useful for capturing intermediate states or
+                  per-step assertions.
+    :frame      — frame id. Defaults to `(current-frame)`, which is
+                  `:rf/default` outside a `with-frame` binding.
+
+  Per Spec 008 §Normative surface and the rf2-hkr5 / rf2-0l3s decision.
+
+  Example — assert final state:
+
+      (dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])
+      ;; => {:counter/value 1}
+
+  Example — capture intermediate states:
+
+      (let [seen (atom [])]
+        (dispatch-sequence [[:counter/inc] [:counter/inc]]
+                           {:after-each (fn [db ev] (swap! seen conj [ev db]))})
+        @seen)"
+  ([events] (dispatch-sequence events {}))
+  ([events {:keys [after-each] :as opts}]
+   (let [frame-id (resolve-frame opts)
+         dispatch-opts (cond-> {:frame frame-id}
+                         (contains? opts :origin) (assoc :origin (:origin opts)))]
+     (doseq [ev events]
+       (router/dispatch-sync! ev dispatch-opts)
+       (when after-each
+         (after-each (frame/frame-app-db-value frame-id) ev)))
+     (frame/frame-app-db-value frame-id))))
+
+(defn assert-state
+  "Assert against the resolved frame's `app-db`. Mismatch is reported
+  via `clojure.test/is` — the failure carries the actual value so the
+  diagnostic is one line.
+
+  Two call shapes:
+
+    (assert-state expected-db)
+    ;; full-db form: (= expected-db (frame-app-db-value frame))
+
+    (assert-state path expected-val)
+    ;; path form:    (= expected-val (get-in (frame-app-db-value frame) path))
+
+  Both shapes accept a trailing options map:
+
+    (assert-state expected-db {:frame :test/foo})
+    (assert-state path expected-val {:frame :test/foo})
+
+  Frame-resolution chain matches `dispatch-sequence`: `:frame` opt →
+  `(current-frame)` → `:rf/default`.
+
+  Returns `true` when the assertion passes, `false` otherwise — the
+  `clojure.test` failure has already been reported in either case, so
+  callers rarely care about the boolean.
+
+  Per Spec 008 §Normative surface and the rf2-hkr5 / rf2-0l3s decision."
+  ([expected-db]
+   (assert-state expected-db nil))
+  ([path-or-expected expected-or-opts]
+   ;; Disambiguate by shape of the second arg:
+   ;; - if path-or-expected is a vector (path), the second arg is the
+   ;;   expected value;
+   ;; - otherwise the second arg, if a map, is opts (full-db form).
+   (cond
+     (and (vector? path-or-expected)
+          (not (map? expected-or-opts)))
+     (assert-state path-or-expected expected-or-opts nil)
+
+     :else
+     (let [opts        (or expected-or-opts {})
+           frame-id    (resolve-frame opts)
+           actual      (frame/frame-app-db-value frame-id)
+           expected-db path-or-expected
+           pass?       (= expected-db actual)]
+       (ctest/do-report
+         {:type     (if pass? :pass :fail)
+          :message  (str "assert-state full-db mismatch on frame " frame-id)
+          :expected expected-db
+          :actual   actual})
+       pass?)))
+  ([path expected-val opts]
+   (let [opts     (or opts {})
+         frame-id (resolve-frame opts)
+         actual   (get-in (frame/frame-app-db-value frame-id) path)
+         pass?    (= expected-val actual)]
+     (ctest/do-report
+       {:type     (if pass? :pass :fail)
+        :message  (str "assert-state mismatch at path " (pr-str path)
+                       " on frame " frame-id)
+        :expected expected-val
+        :actual   actual})
+     pass?)))
+
+#?(:clj
+   (defmacro run-test-sync
+     "v1 compatibility shim for `re-frame-test/run-test-sync`. In v2
+     `dispatch-sync` already drains synchronously to fixed point, so this
+     macro is largely a body wrapper — it exists so v1 test code that
+     called `re-frame.test/run-test-sync` ports to v2 by a mechanical
+     namespace rename (per [MIGRATION §M-25](MIGRATION.md), and rf2-8hcb's
+     `re-frame.test` → `re-frame.test-support` rename).
+
+     The macro snapshots and restores the registrar around `body` so
+     test-local registrations are rolled back even if the body throws.
+     This matches v1's `run-test-sync` behaviour of giving each test
+     block a fresh registrar baseline.
+
+     Example:
+
+         (deftest legacy-flow
+           (run-test-sync
+             (rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+             (rf/dispatch-sync [:counter/inc])
+             (is (= 1 (:n (rf/get-frame-db :rf/default))))))
+
+     Per Spec 008 §`re-frame-test` library compatibility."
+     [& body]
+     `(with-fresh-registrar (fn [] ~@body))))

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -1,0 +1,180 @@
+(ns re-frame.test-support-test
+  "Coverage for the public test-flavoured helpers landed under rf2-0l3s
+  (resolves rf2-hkr5):
+
+    - dispatch-sequence
+    - assert-state
+    - run-test-sync
+
+  The fixture machinery (snapshot-registrar / with-fresh-registrar /
+  reset-runtime-fixture) is exercised transitively by the rest of the
+  test suite — these tests pin the helper *signatures* and the
+  per-helper contract in Spec 008 §Built-in test-runner namespace."
+  (:require [clojure.test :refer [deftest is testing use-fixtures
+                                  do-report report]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
+            [re-frame.test-support :as ts]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-reports
+  "Run `body-fn` with `clojure.test/report` rebound to record into the
+  returned atom. The recorded value is the seq of `:type` keys in the
+  order they fired so tests can assert pass/fail outcomes from
+  helpers that emit through `do-report`."
+  [body-fn]
+  (let [recorded (atom [])]
+    (with-redefs [report (fn [m] (swap! recorded conj (:type m)))]
+      (body-fn))
+    @recorded))
+
+(defn- register-counter-handlers! []
+  (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
+  (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+  (rf/reg-event-db :counter/dec  (fn [db _] (update db :n dec)))
+  (rf/reg-event-db :counter/add
+    (fn [db [_ amt]] (update db :n + amt))))
+
+;; ---- dispatch-sequence ----------------------------------------------------
+
+(deftest dispatch-sequence-runs-each-event-in-order
+  (testing "events fire in order; final app-db reflects the cumulative result"
+    (register-counter-handlers!)
+    (rf/dispatch-sync [:counter/init])
+    (let [final (ts/dispatch-sequence
+                  [[:counter/inc]
+                   [:counter/inc]
+                   [:counter/inc]
+                   [:counter/dec]])]
+      (is (= 2 (:n final))
+          "three incs and one dec leave :n at 2")
+      (is (= final (rf/get-frame-db :rf/default))
+          "return value matches the live app-db value"))))
+
+(deftest dispatch-sequence-after-each-captures-intermediate-states
+  (testing ":after-each fires once per event with (db, event)"
+    (register-counter-handlers!)
+    (rf/dispatch-sync [:counter/init])
+    (let [seen (atom [])]
+      (ts/dispatch-sequence
+        [[:counter/inc] [:counter/inc] [:counter/dec]]
+        {:after-each (fn [db ev] (swap! seen conj [(:n db) ev]))})
+      (is (= [[1 [:counter/inc]]
+              [2 [:counter/inc]]
+              [1 [:counter/dec]]]
+             @seen)
+          ":after-each observed each step's committed state"))))
+
+(deftest dispatch-sequence-frame-opt
+  (testing ":frame opt routes dispatches to a non-default frame"
+    ;; Register handlers first so :on-create can resolve them at
+    ;; reg-frame time (Spec 002 §Frame lifecycle).
+    (register-counter-handlers!)
+    (rf/dispatch-sync [:counter/init])
+    (rf/reg-frame :test-support/seq-frame {:on-create [:counter/init]})
+    (let [final (ts/dispatch-sequence
+                  [[:counter/inc] [:counter/add 5]]
+                  {:frame :test-support/seq-frame})]
+      (is (= 6 (:n final)))
+      (is (= 6 (:n (rf/get-frame-db :test-support/seq-frame))))
+      (is (= {:n 0} (rf/get-frame-db :rf/default))
+          ":rf/default is unaffected"))))
+
+;; ---- assert-state ---------------------------------------------------------
+
+(deftest assert-state-path-form-pass
+  (register-counter-handlers!)
+  (rf/dispatch-sync [:counter/init])
+  (rf/dispatch-sync [:counter/add 7])
+  (let [outcomes (record-reports
+                   (fn [] (ts/assert-state [:n] 7)))]
+    (is (= [:pass] outcomes)
+        "matching path form fires a clojure.test :pass")))
+
+(deftest assert-state-path-form-fail
+  (register-counter-handlers!)
+  (rf/dispatch-sync [:counter/init])
+  (let [outcomes (record-reports
+                   (fn [] (ts/assert-state [:n] 99)))]
+    (is (= [:fail] outcomes)
+        "mismatching path form fires a clojure.test :fail")))
+
+(deftest assert-state-full-db-form
+  (register-counter-handlers!)
+  (rf/dispatch-sync [:counter/init])
+  (let [pass-outcomes (record-reports
+                        (fn [] (ts/assert-state {:n 0})))
+        fail-outcomes (record-reports
+                        (fn [] (ts/assert-state {:n 42})))]
+    (is (= [:pass] pass-outcomes))
+    (is (= [:fail] fail-outcomes))))
+
+(deftest assert-state-frame-opt
+  (testing ":frame opt selects which frame's app-db is asserted against"
+    (register-counter-handlers!)
+    (rf/dispatch-sync [:counter/init])
+    (rf/reg-frame :test-support/assert-frame {:on-create [:counter/init]})
+    (rf/dispatch-sync [:counter/add 3] {:frame :test-support/assert-frame})
+    (let [outcomes (record-reports
+                     (fn []
+                       (ts/assert-state [:n] 3 {:frame :test-support/assert-frame})
+                       (ts/assert-state [:n] 0 {:frame :rf/default})))]
+      (is (= [:pass :pass] outcomes)
+          ":rf/default and the named frame each carry their own state"))))
+
+;; ---- run-test-sync --------------------------------------------------------
+
+(deftest run-test-sync-wraps-body
+  (testing "body executes; assertions inside fire normally"
+    (register-counter-handlers!)
+    (rf/dispatch-sync [:counter/init])
+    (ts/run-test-sync
+      (rf/dispatch-sync [:counter/inc])
+      (rf/dispatch-sync [:counter/inc])
+      (is (= 2 (:n (rf/get-frame-db :rf/default)))))))
+
+(deftest run-test-sync-rolls-back-test-local-registrations
+  (testing "registrations made inside the body are rolled back on exit"
+    (let [id-before (registrar/lookup :event :test-support.run-sync/in-body)]
+      (is (nil? id-before)
+          "sanity: the test-local event id is not registered up front")
+      (ts/run-test-sync
+        (rf/reg-event-db :test-support.run-sync/in-body (fn [db _] db))
+        (is (some? (registrar/lookup :event :test-support.run-sync/in-body))
+            "registration is visible inside the body"))
+      (is (nil? (registrar/lookup :event :test-support.run-sync/in-body))
+          "registration was rolled back after the body returned"))))
+
+(deftest run-test-sync-rolls-back-on-exception
+  (testing "rollback fires even when the body throws"
+    (let [thrown? (atom false)]
+      (try
+        (ts/run-test-sync
+          (rf/reg-event-db :test-support.run-sync/throw-id (fn [db _] db))
+          (throw (ex-info "boom" {})))
+        (catch Throwable _
+          (reset! thrown? true)))
+      (is @thrown? "the body's exception propagated")
+      (is (nil? (registrar/lookup :event :test-support.run-sync/throw-id))
+          "registration was rolled back despite the throw"))))

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -12,7 +12,7 @@ The testing surface is built entirely from foundation primitives in [002-Frames.
 
 ## Normative surface
 
-The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runtime)](000-Vision.md#goals). Every entry below is a re-export from `re-frame.core` and re-exported again from the convenience namespace `re-frame.test` (per [§Built-in test-runner namespace](#built-in-test-runner-namespace)) — the inventory is single-source-of-truth.
+The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runtime)](000-Vision.md#goals). Every entry below is a re-export from `re-frame.core` and gathered alongside the test-flavoured helpers in the convenience namespace `re-frame.test-support` (per [§Built-in test-runner namespace](#built-in-test-runner-namespace)) — the inventory is single-source-of-truth.
 
 | Need | API |
 |---|---|
@@ -29,7 +29,7 @@ The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runti
 | Machine cleanup on destroy | `(rf/destroy-frame f)` — disposes sub-cache, stops router, clears overrides |
 | Static sub-graph inspection | `(rf/sub-topology)` |
 | Sub computation against an `app-db` | `(rf/compute-sub query-v db)` — query-v is `[:sub-id arg1 arg2]`, JVM-runnable |
-| Test-flavoured helpers | `(rf/dispatch-sequence frame events)` — chained `dispatch-sync`; `(rf/assert-state frame path expected)` — assertion macro. Both ship with `re-frame.test`. |
+| Test-flavoured helpers | `(ts/dispatch-sequence events)` — chained `dispatch-sync`; `(ts/assert-state path expected)` — clojure.test-aware assertion; `(ts/run-test-sync body...)` — v1 compatibility wrapper. All ship with `re-frame.test-support`. |
 
 ### `with-frame` call shapes
 
@@ -337,7 +337,7 @@ No special integration — works because `cljs.test` and `clojure.test` work. Ka
 
 ### `re-frame-test` (existing community library)
 
-The `day8/re-frame-test` library provides `run-test-sync` and similar helpers. re-frame2 ships a *re-frame2-aware* version: `run-test-sync` is a thin wrapper over `with-frame` + `dispatch-sync`. Migration of existing `re-frame-test` users is mechanical — same API shape, frame-aware under the hood.
+The `day8/re-frame-test` library provides `run-test-sync` and similar helpers. re-frame2 ships a *re-frame2-aware* version: `re-frame.test-support/run-test-sync` is a thin macro over the registrar snapshot/restore bracket. Because v2's `dispatch-sync` already drains synchronously to fixed point, the macro is largely a body wrapper — its job is registrar isolation, not synchronicity. Migration of existing `re-frame-test` users is mechanical — same API shape, frame-aware under the hood; v1's `re-frame.test/run-test-sync` becomes `re-frame.test-support/run-test-sync` per [MIGRATION §M-25](MIGRATION.md#m-25-re-frametest-helpers-renamed-to-re-frametest-support).
 
 ## Forward compatibility with stories
 
@@ -400,19 +400,64 @@ This is library territory, not framework. See [005 §Future](005-StateMachines.m
 
 ### Built-in test-runner namespace
 
-re-frame2 ships a `re-frame.test` convenience namespace. The canonical helper inventory is:
+re-frame2 ships a `re-frame.test-support` convenience namespace (renamed from v1's `re-frame.test` per rf2-8hcb). Users `(:require [re-frame.test-support :as ts])` once and reach the full testing surface. The canonical helper inventory is:
 
 | Helper | Origin | Purpose |
 |---|---|---|
 | `with-frame`, `make-frame`, `destroy-frame`, `reset-frame`, `dispatch-sync`, `get-frame-db`, `snapshot-of`, `compute-sub`, `sub-topology`, `machine-transition` | re-export from `re-frame.core` | Same primitives the rest of the framework uses; gathered here for one require. |
-| `dispatch-sequence` | test-flavoured | `(dispatch-sequence frame [event-1 event-2 ...])` — dispatch-syncs each event in order against `frame`. Equivalent to a `doseq` of `dispatch-sync` calls; reads better in tests. |
-| `assert-state` | test-flavoured macro | `(assert-state frame [:auth :state] :validating)` — assertion macro reading `(get-in (get-frame-db frame) path)` and checking equality. Reports the actual value on failure. |
+| `dispatch-sequence` | test-flavoured fn | `(dispatch-sequence events)` / `(dispatch-sequence events opts)` — fires each event via `dispatch-sync` in order against the resolved frame. Returns the final `app-db` value. Optional `:after-each (fn [db ev] ...)` runs after each event's drain settles, useful for capturing intermediate state. Optional `:frame` defaults to `(current-frame)` (typically `:rf/default`). Equivalent to a `doseq` of `dispatch-sync` calls; reads better in tests. |
+| `assert-state` | test-flavoured fn | `(assert-state expected-db)` for a full-db check, or `(assert-state path expected-val)` for a path check. Both shapes accept a trailing `{:frame ...}` opt. Mismatch fires a `clojure.test/is`-style failure (delivered via `do-report`). |
+| `run-test-sync` | test-flavoured macro | `(run-test-sync body...)` — v1 compatibility shim for `re-frame-test/run-test-sync`. v2's `dispatch-sync` already drains synchronously to fixed point, so the macro is largely a body wrapper that snapshots/restores the registrar around the body. Included for mechanical migration of v1 test code; new tests don't need it. |
+| `snapshot-registrar`, `restore-registrar!`, `with-fresh-registrar`, `reset-runtime-fixture` | fixture machinery | Snapshot/restore the registrar (and per-process state — frames, flows, schemas, trace listeners) around a test or fixture. The standard `:each` fixture for re-frame2 test suites. |
 
 This is the full surface. Anything else a test needs is composed from `dispatch-sync` / `get-frame-db` / `compute-sub` / `machine-transition` directly — there is no hidden helper layer.
 
+#### `dispatch-sequence` example
+
+```clojure
+(rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+(rf/reg-event-db :counter/dec (fn [db _] (update db :n dec)))
+
+(deftest counter-walk
+  (rf/dispatch-sync [:counter/init])
+  (let [final (ts/dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])]
+    (is (= 1 (:n final)))))
+```
+
+Capturing intermediate states:
+
+```clojure
+(let [seen (atom [])]
+  (ts/dispatch-sequence [[:counter/inc] [:counter/inc]]
+                        {:after-each (fn [db ev] (swap! seen conj [ev db]))}))
+```
+
+#### `assert-state` example
+
+```clojure
+(rf/dispatch-sync [:auth/login-pressed])
+(ts/assert-state [:auth :state] :validating)
+;; or full-db form:
+(ts/assert-state {:auth {:state :validating}})
+;; with a non-default frame:
+(ts/assert-state [:auth :state] :validating {:frame :test/auth-flow})
+```
+
+#### `run-test-sync` example (v1 mechanical port)
+
+```clojure
+(deftest legacy-flow
+  (ts/run-test-sync
+    (rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:counter/inc])
+    (is (= 1 (:n (rf/get-frame-db :rf/default))))))
+```
+
+The macro snapshots the registrar before the body and restores it on exit (success or exception), so test-local registrations don't leak into the next test.
+
 ### `re-frame-test` library compatibility
 
-re-frame2 ships a compatibility wrapper for `day8/re-frame-test`'s `run-test-sync` API. The wrapper delegates to `with-frame` + `dispatch-sync`. Existing test suites built against `re-frame-test` work unchanged after the migration; new tests use the API directly.
+re-frame2 ships a compatibility wrapper for `day8/re-frame-test`'s `run-test-sync` API as `re-frame.test-support/run-test-sync` (rf2-0l3s / rf2-hkr5). The macro snapshots the registrar around the body and restores on exit; v2's `dispatch-sync` already drains synchronously, so the macro is largely a body wrapper. Existing test suites built against `re-frame-test` work after a mechanical `re-frame.test → re-frame.test-support` namespace rename (per [MIGRATION §M-25](MIGRATION.md#m-25-re-frametest-helpers-renamed-to-re-frametest-support)); new tests use the API directly.
 
 ### Headless rendering for visual regression
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -413,13 +413,15 @@ Schemas are **open** by default (consumers tolerate unknown keys; producers grow
 
 ## Testing
 
-`re-frame.test-support` re-exports `make-frame`/`destroy-frame`/`with-frame`/`dispatch-sync`. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
+`re-frame.test-support` ships the test-flavoured helpers below alongside re-exports of `make-frame`/`destroy-frame`/`with-frame`/`dispatch-sync` for one-stop import. See [008-Testing.md](008-Testing.md) for fixtures, framework adapters, and `re-frame-test` compatibility.
 
-| API | M/Fn | Signature | Status | Spec |
-|---|---|---|---|---|
-| `dispatch-sequence` | Fn | `(dispatch-sequence frame events)` | v1 | 008 |
-| `assert-state` | M | `(assert-state frame path expected-value)` | v1 | 008 |
-| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | 008 |
+| API | M/Fn | Signature | Status | Spec | Notes |
+|---|---|---|---|---|---|
+| `dispatch-sequence` | Fn | `(dispatch-sequence events)` / `(dispatch-sequence events opts)` | v1 | 008 | `opts`: `:after-each (fn [db ev] ...)`, `:frame`. Returns final `app-db`. Lives in `re-frame.test-support`. |
+| `assert-state` | Fn | `(assert-state expected-db)` / `(assert-state path expected-val)` / either form `+ {:frame ...}` opts | v1 | 008 | Mismatch fires `clojure.test/is`-style failure via `do-report`. Lives in `re-frame.test-support`. |
+| `run-test-sync` | M | `(run-test-sync body...)` | v1 | 008 | v1 compatibility shim. Snapshots/restores the registrar around `body`; v2's `dispatch-sync` is already synchronous so synchronicity is not added. Lives in `re-frame.test-support`. |
+| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | 008 | Pure sub computation against an `app-db` value. Lives in `re-frame.core`. |
+| `snapshot-registrar` / `restore-registrar!` / `with-fresh-registrar` / `reset-runtime-fixture` | Fn | per docstring | v1 | 008 | Fixture machinery. Lives in `re-frame.test-support`. |
 
 ---
 

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -961,15 +961,54 @@ The agent rewrites mechanically. For the Var-ref form (the common case), the nam
 
 **Why?** Two view call-site forms is enough; three was drifty (P1 violation flagged in [AI-Audit §G-E](AI-Audit.md#g-e-view-invocation-has-two-forms--var-canonical-view-id-for-late-binding)). Same surface-shrinking principle as rf2-7cb2 (drop alpha) and rf2-iyzm (Var-ref canonical for views): when two surfaces cover every case the third was solving, the third is excess.
 
+### M-25. `re-frame.test` helpers renamed to `re-frame.test-support`
+
+**Type A** (mechanical).
+
+Per rf2-8hcb / rf2-0l3s / rf2-hkr5: v1's `re-frame.test` namespace (the `day8/re-frame-test` library's helpers) is renamed to `re-frame.test-support` in v2 and ships as part of the core artefact. The three test-flavoured helpers — `dispatch-sequence`, `assert-state`, `run-test-sync` — keep their v1 names and ship under the new ns; the move is a mechanical require-rewrite.
+
+**What to look for** in the codebase:
+
+```clojure
+(:require [re-frame.test :as rf-test])
+(:require [re-frame.test :refer [run-test-sync dispatch-sequence assert-state]])
+;; or referencing day8/re-frame-test directly:
+(:require [day8.re-frame.test :as rf-test])
+```
+
+**What to do:**
+
+```clojure
+;; before
+(:require [re-frame.test :as rf-test])
+(rf-test/run-test-sync ...)
+(rf-test/dispatch-sequence ...)
+(rf-test/assert-state ...)
+
+;; after — single mechanical require-rewrite; helper names unchanged
+(:require [re-frame.test-support :as ts])
+(ts/run-test-sync ...)
+(ts/dispatch-sequence ...)
+(ts/assert-state ...)
+```
+
+**Signature notes** (the v2 helpers are frame-aware; v1 helpers were single-frame implicit):
+
+- `(dispatch-sequence events)` / `(dispatch-sequence events {:after-each f :frame f-id})` — v1's frame-implicit form maps to the no-opts arity; tests targeting a non-default frame supply `{:frame ...}`.
+- `(assert-state expected-db)` / `(assert-state path expected-val)` / either form `+ {:frame ...}` — v1's two-arg `(assert-state path expected)` is the path form; the full-db form and `:frame` opt are v2 additions.
+- `(run-test-sync body...)` — v2's `dispatch-sync` already drains synchronously, so the macro is largely a body wrapper that snapshots/restores the registrar. v1 callers see no behavioural difference.
+
+If the project depended on `day8/re-frame-test` as a Maven coordinate, drop the dependency — v2 ships the helpers in the core artefact (no separate coordinate to require).
+
 ---
 
-**Reporting M-12 through M-24.** These thirteen rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing thirteen separate preambles.
+**Reporting M-12 through M-25.** These fourteen rules are smaller-surface concerns. The agent aggregates them into a single "review notes" section in the migration report rather than producing fourteen separate preambles.
 
 ---
 
 ## Type-tag summary
 
-- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: **M-0** (deps-coord swap to `day8/re-frame-2` — target is unambiguous per rf2-5sqd), M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**, **M-22**, **M-23 (registration / subscribe shape rewrites only — lifecycle annotations are dropped with a flag, not silently rewritten)**, **M-24** (`h` macro removal).
+- **Type A — fully mechanical.** Agent applies the rewrite without asking. Rules: **M-0** (deps-coord swap to `day8/re-frame-2` — target is unambiguous per rf2-5sqd), M-1 (with the documented private-namespace exceptions), M-4, M-5, M-6, M-7, M-8, M-9, M-16, **M-17 (single-frame app variant only)**, **M-20** (framework keyword consolidation under `:rf/*`), **M-21 (`debug` and `trim-v` portions only)**, **M-22**, **M-23 (registration / subscribe shape rewrites only — lifecycle annotations are dropped with a flag, not silently rewritten)**, **M-24** (`h` macro removal), **M-25** (`re-frame.test` → `re-frame.test-support` ns rename).
 - **Type B — flag for human review.** Agent identifies hit sites, explains the change, but does NOT rewrite without explicit approval — the rewrite depends on intent that static analysis can't recover. Rules: **M-3** (run-to-completion drain semantics; timing-sensitive code may depend on the old async-dispatch behaviour and silent reordering would break it); **M-10** (reserved-namespace collisions; the rewrite depends on whether the user intended to override a framework event or accidentally collided); **M-11** (plain Reagent fns rendered under non-default frames; the rewrite depends on whether the component should follow its surrounding frame or pin to the default); **M-12** (render-count test re-baselining); **M-13** (error-handler ownership); **M-14** (`:rf.route/not-found` requirement when adopting Spec 012); **M-15** (app-db seeding move); **M-17 (multi-frame app variant)** (rewrite path depends on whether the global interceptor was meant to apply to every frame, was observer-shaped, or only belonged on the default frame); **M-18** (`reg-sub-raw` removal; rewrite path depends on what the raw body does — app-db read, non-app-db source, lifecycle management, or side-effects-from-subs anti-pattern); **M-19 (opt-in)** (multi-positional dispatch/subscribe → map-payload; the rewrite is mechanical given handler-side parameter names, but the trigger is the codebase owner's choice — multi-positional is tolerated indefinitely); **M-21 (`on-changes`, `enrich`, `after` portions)** (rewrite path depends on whether the interceptor's body is computing derived state, validating, side-effecting, or escape-hatching; agent suggests flow / schema / fx / custom `->interceptor` based on body shape).
 
 Per [000-Vision §C1](000-Vision.md#c1-mechanical-migration-via-ai-agent), Type B rules require human review precisely because side-effects can be silently reordered with observable consequences.


### PR DESCRIPTION
## Summary

Per rf2-hkr5 Option A and rf2-0l3s, ship the v1 `re-frame-test` helpers under the v2 `re-frame.test-support` namespace, frame-aware and `clojure.test`-aware. Three additions, all in `implementation/core/src/re_frame/test_support.cljc`:

- `dispatch-sequence` — fires each event in a vector via `dispatch-sync!` in order; optional `:after-each (fn [db ev] ...)` observes intermediate state per step; optional `:frame` opt; returns the final app-db value.
- `assert-state` — full-db form `(assert-state expected-db)` and path form `(assert-state path expected-val)`; both accept a trailing `{:frame ...}` opt; mismatch fires a `clojure.test/is`-style failure via `do-report`.
- `run-test-sync` — v1 compatibility macro. v2's `dispatch-sync` already drains synchronously, so the macro is largely a body wrapper that snapshots/restores the registrar across the body — included for mechanical migration of v1 test code.

All three are frame-aware via the resolution chain `:frame opt → (current-frame) → :rf/default`.

Spec edits land alongside:

- `spec/008-Testing.md` — refresh §Built-in test-runner namespace with the full helper inventory, signatures, and per-helper examples; correct stale `re-frame.test` references.
- `spec/API.md` — replace the testing table with actual signatures and the correct namespace.
- `spec/MIGRATION.md` — add `M-25` (`re-frame.test → re-frame.test-support` mechanical require-rewrite), update the Type-A summary.

Resolves rf2-hkr5; closes the add-or-drop question on `dispatch-sequence` and `assert-state` from rf2-gr0n.

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 252 tests, 1127 assertions, 0 failures, 0 errors (10 new tests in `re-frame.test-support-test`).
- [x] `npm run test:cljs` — 98 tests, 303 assertions, 0 failures.
- [x] `npm run test:browser` — 99 tests, 306 assertions, 0 failures (CORS warnings against realworld.io are pre-existing environmental noise).
- [x] `npm run test:elision` — PASS, every sentinel present in dev / absent in prod as expected.
- [x] `npm run test:examples` — all 15 examples PASS.