### PR TITLE
docs: add Information for AIs section + tighten Ownership.md (rf2-fc8i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,42 @@ implementation/                CLJS reference implementation — split into per-
 skills/                        Claude skills (planned; pair-improver and friends)
 ```
 
+## Information for AIs
+
+re-frame2 is spec-first and AI-implementable. If you're an LLM landing here to implement, port, scaffold, or audit the pattern, this section is the map you need. The narrative above is for humans; this section is for tools.
+
+**Spec is the artefact.** [`spec/`](spec/) is the contract. [`docs/guide/`](docs/guide/) is narrative for humans. The `Pattern-*.md` files are worked-example conventions, not normative. The reference implementation in [`implementation/`](implementation/) is downstream of the spec, not the source of truth.
+
+### Reading order
+
+1. **The corpus index** — [spec/README.md](spec/README.md). Foundation / Capability / Companion layering.
+2. **The contract, in normative order**:
+   - [spec/000-Vision.md](spec/000-Vision.md) — goals, hard constraints, host-profile matrix, minimal core.
+   - [spec/001-Registration.md](spec/001-Registration.md) — `reg-*` grammar, metadata-map shape, hot-reload.
+   - [spec/002-Frames.md](spec/002-Frames.md) — frame model, dispatch envelope, drain semantics, machines-as-event-handlers hooks.
+   - [spec/004-Views.md](spec/004-Views.md) through [spec/014-HTTPRequests.md](spec/014-HTTPRequests.md) — per-area capabilities.
+3. **Naming + packaging** — [spec/Conventions.md](spec/Conventions.md) — reserved namespaces, fx-ids, `app-db` keys, artefact naming.
+4. **Surface-to-spec map** — [spec/Ownership.md](spec/Ownership.md) — every public surface's canonical home spec, plus informational cross-references.
+5. **Consolidated public API** — [spec/API.md](spec/API.md) — every shipped fn / macro / fx / cofx with signatures.
+6. **Spec-internal shapes** — [spec/Spec-Schemas.md](spec/Spec-Schemas.md) — Malli-shaped definitions of every internal map (effect-map, registration-metadata, hydration-payload, trace-event, machine snapshot, etc.).
+7. **AI-first audit** — [spec/AI-Audit.md](spec/AI-Audit.md) — every spec scored against the AI-first practical principles.
+8. **Migration prompt** — [spec/MIGRATION.md](spec/MIGRATION.md) — mechanical re-frame v1.x → re-frame2 rewrite rules.
+9. **Implementor checklist** — [spec/Implementor-Checklist.md](spec/Implementor-Checklist.md) — porting to a new host; decision-ordered companion to the host-profile matrix.
+10. **Tool-Pair contract** — [spec/Tool-Pair.md](spec/Tool-Pair.md) — runtime surfaces that pair-shaped AI tools (re-frame-pair and equivalents) consume.
+
+### Quick lookups
+
+- "Where does `<surface>` live?" → [spec/Ownership.md](spec/Ownership.md).
+- "What's the contract for `<topic>`?" → `spec/<NNN>-<topic>.md`.
+- "How is this tested?" → [spec/conformance/](spec/conformance/) (executable EDN fixtures).
+- "Does the implementation actually do what the spec says?" → [`implementation/core/`](implementation/core/) + [`implementation/reagent/`](implementation/reagent/) + the conformance suite.
+- "What's the public API?" → [spec/API.md](spec/API.md).
+- "How do I scaffold a `<kind>`?" → [spec/Construction-Prompts.md](spec/Construction-Prompts.md).
+
+### When porting to a new host
+
+Start at [spec/Implementor-Checklist.md](spec/Implementor-Checklist.md). Part 1 is the capability-declaration list; Part 2 walks technology choices with options-by-host; Part 3 is conformance against the claimed list. The host-profile matrix in [spec/000-Vision.md §Host-profile matrix](spec/000-Vision.md#host-profile-matrix) tells you what's pattern-required vs. host-discretion vs. CLJS-only.
+
 ## Licence
 
 re-frame2 is [MIT licensed](license.txt).

--- a/spec/Ownership.md
+++ b/spec/Ownership.md
@@ -1,29 +1,32 @@
 # Ownership Matrix
 
 > **Type:** Reference
-> The single source for "where does X live?" — every contract surface in re-frame2 is owned by exactly one normative Spec; companion docs cite the owner without redefining the contract. Use this matrix to navigate, and to detect drift if a definition ever appears in a non-owning doc.
+> The single source for "where does X live?" — every contract surface in re-frame2 has exactly one **canonical home spec**; other specs may *reference* the surface, but those references are informational and must not redefine the contract. Use this matrix to navigate, and to detect drift if a definition ever appears in a non-owning doc.
 
-Every contract surface in re-frame2 is **owned** by exactly one normative Spec. Companion docs cite the owner; they do not redefine the contract. This matrix is the single source for "where does X live?" — use it to navigate, and to detect drift if a definition ever appears in a non-owning doc.
+Every contract surface in re-frame2 has exactly one **canonical home spec**. Other specs may reference the surface, but those references are non-normative — they cite the canonical home rather than redefining the contract. The "Referenced in" column lists those informational mentions.
 
-| Contract surface | Owning Spec | Companion citations |
+| Contract surface | Canonical home spec | Referenced in (informational) |
 |---|---|---|
 | Goals, hard constraints, host-profile matrix, identity primitive, minimal-core contract | [000-Vision](000-Vision.md) | [Principles](Principles.md), [Implementor-Checklist](Implementor-Checklist.md), [API](API.md) |
 | Registration grammar (`reg-*` shape, metadata map, two-form middle slot) | [001-Registration](001-Registration.md) | [API](API.md), [Spec-Schemas §`:rf/registration-metadata`](Spec-Schemas.md#rfregistration-metadata), [Construction-Prompts](Construction-Prompts.md) |
 | Registry kind taxonomy (the canonical `kind` keyword set) | [001-Registration](001-Registration.md) | [API](API.md), [Spec-Schemas](Spec-Schemas.md) |
 | Source-coordinate capture (macro-driven, CLJS reference) | [001-Registration](001-Registration.md) | [Tool-Pair](Tool-Pair.md), [009-Instrumentation](009-Instrumentation.md) (trace events carry coords) |
 | Hot-reload semantics for registrations | [001-Registration](001-Registration.md) | [002-Frames](002-Frames.md) (sub-cache invalidation) |
-| Registry query API | [001-Registration](001-Registration.md), [002-Frames](002-Frames.md) (runtime side) | [Tool-Pair](Tool-Pair.md), [007-Stories](007-Stories.md) |
+| Registry query API (`handlers`, `handler-meta`, `frame-ids`, `frame-meta` — registrar contract) | [001-Registration](001-Registration.md) | [002-Frames §The public registrar query API](002-Frames.md#the-public-registrar-query-api) (re-tabulates alongside frame-runtime queries), [Tool-Pair](Tool-Pair.md), [007-Stories](007-Stories.md) |
+| Frame-runtime queries (`get-frame-db`, `snapshot-of`, `sub-topology`, `sub-cache`) | [002-Frames](002-Frames.md) | [Tool-Pair](Tool-Pair.md), [008-Testing](008-Testing.md) |
 | Frame model, identity, lifecycle, `:rf/default` fallback | [002-Frames](002-Frames.md) | [API](API.md), [Spec-Schemas](Spec-Schemas.md) |
 | Event handlers (`reg-event-fx`, `reg-event-db`, the `(state, event) → effects-map` contract) | [002-Frames](002-Frames.md) | [API](API.md), [Construction-Prompts CP-1](Construction-Prompts.md), [Pattern-AsyncEffect](Pattern-AsyncEffect.md) |
-| Dispatch envelope (explicit-frame addressing, two-arg dispatch form) | [002-Frames](002-Frames.md) | [API](API.md), [Tool-Pair](Tool-Pair.md) |
+| Dispatch envelope (`dispatch`, `dispatch-sync`, explicit-frame addressing, two-arg form) | [002-Frames](002-Frames.md) | [API](API.md), [Tool-Pair](Tool-Pair.md) |
+| `subscribe` (frame-bound and global forms; `reg-sub` *registration* surface) | [002-Frames](002-Frames.md) | [006-ReactiveSubstrate](006-ReactiveSubstrate.md) (the runtime cache & derivation graph the surface consumes), [API](API.md), [Construction-Prompts CP-2](Construction-Prompts.md) |
+| Subscription runtime — derivation graph, sub-cache, invalidation, change tracking, layer-1/2/3 semantics | [006-ReactiveSubstrate](006-ReactiveSubstrate.md) | [002-Frames](002-Frames.md) (registration & call-site surface), [008-Testing](008-Testing.md) (`compute-sub`) |
+| `frame-provider` (CLJS reference; React-context plumbing of frame keyword to subtree) | [002-Frames](002-Frames.md) | [004-Views](004-Views.md), [007-Stories](007-Stories.md) |
 | Effect-map shape (closed `:db` + `:fx` at top level) | [002-Frames](002-Frames.md) | [Spec-Schemas §`:rf/effect-map`](Spec-Schemas.md#rfeffect-map), [API](API.md) |
 | Effects (`reg-fx`) and coeffects (`reg-cofx`) | [002-Frames](002-Frames.md) | [API](API.md), [Pattern-AsyncEffect](Pattern-AsyncEffect.md), [011-SSR](011-SSR.md) (`:platforms`) |
 | Run-to-completion drain semantics | [002-Frames](002-Frames.md) | [005-StateMachines](005-StateMachines.md) (drain interaction), [008-Testing](008-Testing.md) (synchronous triggers) |
 | Per-frame and per-call overrides (`:fx-overrides`, `:interceptor-overrides`, `:interceptors`) | [002-Frames](002-Frames.md) | [008-Testing](008-Testing.md), [007-Stories](007-Stories.md) |
 | Machines-as-event-handlers foundation hooks | [002-Frames](002-Frames.md) | [005-StateMachines](005-StateMachines.md) (full grammar) |
-| View contract (`(state, props) → render-tree`, Form-1/2/3, `reg-view`) | [004-Views](004-Views.md) | [API](API.md), [011-SSR](011-SSR.md), [Construction-Prompts CP-4](Construction-Prompts.md) |
-| Subscriptions (`reg-sub`, derivation graph) | [002-Frames](002-Frames.md) (registration & contract) + [006-ReactiveSubstrate](006-ReactiveSubstrate.md) (cache, invalidation, change tracking) | [API](API.md), [Construction-Prompts CP-2](Construction-Prompts.md) |
-| State machine grammar (transition table, `:always`, `:after`, `:invoke`, hierarchical states, snapshot shape) | [005-StateMachines](005-StateMachines.md) | [CP-5-MachineGuide](CP-5-MachineGuide.md), [Pattern-WebSocket](Pattern-WebSocket.md), [Pattern-Boot](Pattern-Boot.md), [Pattern-LongRunningWork](Pattern-LongRunningWork.md) |
+| View contract and `reg-view` (pure `(state, props) → render-tree`, Form-1/2/3) | [004-Views](004-Views.md) | [API](API.md), [011-SSR](011-SSR.md), [Construction-Prompts CP-4](Construction-Prompts.md) |
+| State machine grammar and `reg-machine` (transition table, `:always`, `:after`, `:invoke`, hierarchical states, snapshot shape) | [005-StateMachines](005-StateMachines.md) | [CP-5-MachineGuide](CP-5-MachineGuide.md), [Pattern-WebSocket](Pattern-WebSocket.md), [Pattern-Boot](Pattern-Boot.md), [Pattern-LongRunningWork](Pattern-LongRunningWork.md) |
 | Reactive substrate adapter contract (Reagent default, plain-atom for JVM) | [006-ReactiveSubstrate](006-ReactiveSubstrate.md) | [008-Testing](008-Testing.md), [011-SSR](011-SSR.md) |
 | Stories / Variants / Workspaces | [007-Stories](007-Stories.md) | [008-Testing](008-Testing.md) (portable-stories-as-tests) |
 | Testing infrastructure (fixtures, synchronous triggers, per-test stubs, headless evaluation, framework adapters, JVM-runnable suites) | [008-Testing](008-Testing.md) | [API](API.md), [007-Stories](007-Stories.md), [conformance/](conformance/README.md) |
@@ -33,9 +36,10 @@ Every contract surface in re-frame2 is **owned** by exactly one normative Spec. 
 | SSR flow (server frame lifecycle, hydration payload, `:rf/hydrate`, hydration-mismatch detection) | [011-SSR](011-SSR.md) | [004-Views](004-Views.md), [008-Testing](008-Testing.md), [012-Routing](012-Routing.md) |
 | `:platforms` metadata on `reg-fx`/`reg-cofx`; pure hiccup → HTML emitter | [011-SSR](011-SSR.md) | [002-Frames](002-Frames.md), [API](API.md) |
 | Route grammar, `:route` sub, navigation events, route-not-found, navigation-blocking, fragments, scroll restoration | [012-Routing](012-Routing.md) | [011-SSR](011-SSR.md), [API](API.md) |
+| Flows (`reg-flow` / `:rf.fx/reg-flow` / `:rf.fx/clear-flow`, computed-state declarations materialised into `app-db`) | [013-Flows](013-Flows.md) | [API](API.md), [Conventions](Conventions.md) (`:rf.fx/*` reserved) |
 | Managed HTTP requests (`:rf.http/managed` fx, args-map shape, decode pipeline, `:accept` normalisation, retry-with-backoff, abort surface, frame-aware reply addressing, eight-category `:rf.http/*` failure taxonomy, schema-reflection metadata, canned stubs, `with-managed-request-stubs`) | [014-HTTPRequests](014-HTTPRequests.md) | [API](API.md), [Spec-Schemas](Spec-Schemas.md), [Conventions](Conventions.md) (`:rf.http/*` reserved), [Pattern-AsyncEffect](Pattern-AsyncEffect.md), [Pattern-RemoteData](Pattern-RemoteData.md), [Pattern-StaleDetection](Pattern-StaleDetection.md), [009-Instrumentation](009-Instrumentation.md) (`:rf.http/retry-attempt` trace) |
-| Runtime shapes (Malli, CLJS reference) — `:rf/effect-map`, `:rf/registration-metadata`, `:rf/hydration-payload`, `:rf/trace-event`, etc. | per-Spec owner; [Spec-Schemas](Spec-Schemas.md) is the *projection* (collected EDN forms) | every Spec that owns a shape |
-| API signatures (consolidated) | [API](API.md) is the *projection*; canonical content lives in the per-Spec owner | per-Spec owners |
+| Runtime shapes (Malli, CLJS reference) — `:rf/effect-map`, `:rf/registration-metadata`, `:rf/hydration-payload`, `:rf/trace-event`, etc. | the per-Spec owner of each shape; [Spec-Schemas](Spec-Schemas.md) is the *projection* (collected EDN forms) — non-canonical | every Spec that owns a shape |
+| API signatures (consolidated) | the per-Spec owner of each surface; [API](API.md) is the *projection* — non-canonical | per-Spec owners |
 | Migration rules (re-frame v1.x → re-frame2, CLJS reference) | [MIGRATION](MIGRATION.md) | per-Spec owners (contract content); Migration owns the rules |
 | Pair-tool runtime contract (inspect, dispatch, hot-swap, time-travel, fx-stub, source-map) | [Tool-Pair](Tool-Pair.md) | [001-Registration](001-Registration.md), [009-Instrumentation](009-Instrumentation.md) |
 | Reserved-namespace policy, reserved fx-ids and `app-db` keys | [Conventions](Conventions.md) | every Spec that uses a reserved id cites the Conventions list |


### PR DESCRIPTION
## Summary

Two doc-only changes addressing rf2-fc8i (front-door doc-map simplification + ownership clarity):

- **`README.md`** — append a new `## Information for AIs` section at the bottom. The README's existing narrative is human-targeted; this section is the tools-targeted map (reading order, quick lookups, porting entry point) that the repo previously lacked. The narrative above is unchanged.
- **`spec/Ownership.md`** — tighten so every surface has exactly one canonical home spec.
  - Right-hand column renamed `Companion citations` → `Referenced in (informational)` to mark non-normative tier explicitly.
  - Subscriptions split: `subscribe` / `reg-sub` registration surface canonical to 002; subscription runtime (cache, derivation graph, invalidation, layer-1/2/3) canonical to 006.
  - Registry-query split: registrar query API canonical to 001 (per 001's existing ownership claim); frame-runtime queries (`get-frame-db`, `snapshot-of`, `sub-topology`, `sub-cache`) canonical to 002.
  - Added previously-missing rows: `frame-provider` (canonical: 002), Flows / `reg-flow` (canonical: 013), `reg-machine` and `dispatch` surfaced explicitly.
  - Lead paragraph restated in canonical-home / informational-reference terms.

No spec-prose rewrites needed — existing cross-references in 001 / 002 / 006 already point the right way; the matrix tightening matches the prose that's already there.

## Test plan

- [x] `clojure -M:test` in `implementation/core` — 252 tests / 1127 assertions, 0 failures (doc-only PR; safety check)
- [x] README narrative unchanged above the new section
- [x] No new doc tiers introduced (no "Tier 1 / Tier 2" language)
- [x] `spec/README.md` prose unchanged