### PR TITLE
test: restore-epoch reactive surfaces after rewind (rf2-2fat)

### DIFF
--- a/implementation/core/test/re_frame/epoch_test.clj
+++ b/implementation/core/test/re_frame/epoch_test.clj
@@ -31,6 +31,12 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  ;; Per smoke_test.clj fixture (rf2-xsfj): flows.cljc keeps a private
+  ;; last-inputs atom for dirty-checking. Clear it so a prior test's
+  ;; flow registration can't leak its last-inputs into a same-keyed
+  ;; flow in a subsequent test.
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
@@ -768,3 +774,222 @@
     (is (= 7 (:depth (epoch/current-config))))
     (rf/configure :epoch-history {:depth 12})
     (is (= 12 (:depth (epoch/current-config))))))
+
+;; ---- restore-epoch reactive surfaces (rf2-2fat) ---------------------------
+;;
+;; Bead rf2-2fat coverage. Tool-Pair §Time-travel says restore "rewinds the
+;; frame's app-db to the named epoch's :db-after value." Spec 006 §Subscription
+;; cache pins invalidation to :replace-container! — and restore-epoch goes
+;; through the same adapter/replace-container! choke point used by the drain
+;; loop's :db commit. The two together imply: every reactive surface that
+;; observes app-db (subscriptions, flows materialised at :path, route slice
+;; reads) must reflect the rewound value after restore-epoch returns true,
+;; without a separate cache-invalidation call.
+;;
+;; These tests pin that downstream contract on the JVM with the plain-atom
+;; adapter. The plain-atom adapter recomputes derived values on every deref
+;; (no cache), so subscribe-value before/after restore is a clean read of
+;; the post-restore container. The CLJS Reagent counterpart in
+;; runtime_cljs_test.cljs covers the reactive-graph case where a held
+;; reaction must observe the rewound value.
+
+(deftest restore-rewinds-subscriptions-via-subscribe-value
+  (testing "after restore-epoch, subscribe-value reflects the restored db
+  for both layer-1 and layer-2 subs (no manual cache invalidation)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n   (fn [db _] (:n db)))
+    (rf/reg-sub :n*2 :<- [:n] (fn [n _] (* 2 (or n 0))))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})  ;; n=0
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=1
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=2
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=3
+
+    (is (= 3 (rf/subscribe-value :test/main [:n])))
+    (is (= 6 (rf/subscribe-value :test/main [:n*2])))
+
+    (let [history (rf/epoch-history :test/main)
+          ;; Pick the epoch where :n landed at 1 (second :inc dispatch).
+          target  (some (fn [r] (when (= 1 (:n (:db-after r))) r)) history)]
+      (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
+      (is (= 1 (rf/subscribe-value :test/main [:n]))
+          "layer-1 sub now sees the restored value (no manual invalidation)")
+      (is (= 2 (rf/subscribe-value :test/main [:n*2]))
+          "layer-2 sub recomputes against the restored input"))))
+
+(deftest restore-rewinds-pinned-reaction
+  (testing "a subscription held across restore re-derefs to the restored
+  value. Pins the contract that restore-epoch goes through the same
+  app-db write path as the drain loop, so any consumer holding a
+  subscription before the restore observes the rewind on the next deref
+  without re-subscribing."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=1
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=2
+
+    (let [pinned  (rf/subscribe :test/main [:n])
+          _       (is (= 2 @pinned) "pinned reaction sees current value")
+          history (rf/epoch-history :test/main)
+          target  (some (fn [r] (when (= 1 (:n (:db-after r))) r)) history)]
+      (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
+      (is (= 1 @pinned)
+          "the same reaction handle now derefs to the restored value")
+      (rf/unsubscribe :test/main [:n]))))
+
+(deftest restore-frame-isolation
+  (testing "restoring frame A leaves frame B's app-db and subscriptions
+  untouched. Per Tool-Pair §Time-travel: time-travel is a frame-local
+  primitive — there is no global epoch sequence."
+    (rf/reg-frame :frame/a {})
+    (rf/reg-frame :frame/b {})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    ;; Drive A through 0 → 1 → 2; B through 100 → 101.
+    (rf/dispatch-sync [:seed 0]   {:frame :frame/a})
+    (rf/dispatch-sync [:inc]      {:frame :frame/a})
+    (rf/dispatch-sync [:inc]      {:frame :frame/a})
+    (rf/dispatch-sync [:seed 100] {:frame :frame/b})
+    (rf/dispatch-sync [:inc]      {:frame :frame/b})
+
+    (let [a-history (rf/epoch-history :frame/a)
+          ;; The epoch where A's n landed at 1 (first :inc).
+          a-target  (some (fn [r] (when (= 1 (:n (:db-after r))) r)) a-history)]
+      (is (true? (rf/restore-epoch :frame/a (:epoch-id a-target))))
+      (is (= 1   (rf/subscribe-value :frame/a [:n]))
+          "frame A's sub sees the rewound value")
+      (is (= 101 (rf/subscribe-value :frame/b [:n]))
+          "frame B's sub is unchanged by the cross-frame restore")
+      (is (= 101 (:n (rf/get-frame-db :frame/b)))
+          "frame B's app-db is unchanged"))))
+
+(deftest restore-fixed-point-same-epoch-twice
+  (testing "restoring twice to the same epoch is a no-op semantically:
+  the second call lands on the same db-after, every observable surface
+  reads the same value, and the call still returns true."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=1
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=2
+    (rf/dispatch-sync [:inc]  {:frame :test/main})  ;; n=3
+
+    (let [history (rf/epoch-history :test/main)
+          target  (some (fn [r] (when (= 1 (:n (:db-after r))) r)) history)
+          target-eid (:epoch-id target)]
+      (is (true? (rf/restore-epoch :test/main target-eid)) "first restore ok")
+      (let [db-after-1 (rf/get-frame-db :test/main)
+            sub-1      (rf/subscribe-value :test/main [:n])]
+        (is (= {:n 1} db-after-1))
+        (is (= 1     sub-1))
+
+        ;; Restore again to the SAME epoch.
+        (is (true? (rf/restore-epoch :test/main target-eid)) "second restore ok")
+        (is (= db-after-1 (rf/get-frame-db :test/main))
+            "app-db unchanged across the second restore")
+        (is (= sub-1 (rf/subscribe-value :test/main [:n]))
+            "sub value unchanged across the second restore")))))
+
+(deftest restore-rewinds-flow-output-in-app-db
+  (testing "Per Spec 013 — a flow's value lives in app-db at :path, where
+  it 'survives ... time-travel revert.' After restore-epoch, the flow's
+  output reads through the restored db match the recorded epoch's output."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :init (fn [_ _]      {:w 2 :h 3}))
+    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    (rf/reg-event-db :h!   (fn [db [_ h]] (assoc db :h h)))
+    (rf/reg-flow {:id     :rect/area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :test/main})
+
+    (rf/dispatch-sync [:init]    {:frame :test/main})  ;; area=6
+    (rf/dispatch-sync [:w! 5]    {:frame :test/main})  ;; area=15
+    (rf/dispatch-sync [:h! 10]   {:frame :test/main})  ;; area=50
+    (is (= 50 (get-in (rf/get-frame-db :test/main) [:rect :area])))
+
+    (let [history (rf/epoch-history :test/main)
+          ;; Find the epoch whose db-after has area=15 (after :w! 5).
+          target  (some (fn [r] (when (= 15 (get-in (:db-after r) [:rect :area])) r))
+                        history)]
+      (is (some? target))
+      (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
+      (is (= 15 (get-in (rf/get-frame-db :test/main) [:rect :area]))
+          "the restored db carries the flow's value at :path"))))
+
+(deftest restore-then-dispatch-recomputes-flow-correctly
+  (testing "After restore, the next event drain re-runs flows correctly.
+  The dirty-check operates on observed inputs (:w, :h) vs last-inputs;
+  even if last-inputs holds a pre-restore tuple, a real input change
+  in the next dispatch triggers recomputation. Pins that flow recompute
+  state does not silently miss after a restore."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :init (fn [_ _]      {:w 1 :h 1}))
+    (rf/reg-event-db :w!   (fn [db [_ w]] (assoc db :w w)))
+    (rf/reg-flow {:id     :rect/area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :test/main})
+
+    (rf/dispatch-sync [:init]   {:frame :test/main})  ;; area=1
+    (rf/dispatch-sync [:w! 4]   {:frame :test/main})  ;; area=4
+    (rf/dispatch-sync [:w! 7]   {:frame :test/main})  ;; area=7
+    (rf/dispatch-sync [:w! 9]   {:frame :test/main})  ;; area=9
+
+    (let [history (rf/epoch-history :test/main)
+          target  (some (fn [r] (when (= 4 (get-in (:db-after r) [:rect :area])) r))
+                        history)]
+      (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
+      (is (= 4 (get-in (rf/get-frame-db :test/main) [:rect :area]))
+          "restored db carries the flow output value at :path")
+
+      ;; Drive a new event that changes :w. The flow must recompute
+      ;; against the post-restore inputs, not against any leftover
+      ;; last-inputs cache from the pre-restore history.
+      (rf/dispatch-sync [:w! 6] {:frame :test/main})
+      (is (= 6 (get-in (rf/get-frame-db :test/main) [:w])))
+      (is (= 6 (get-in (rf/get-frame-db :test/main) [:rect :area]))
+          "flow recomputed correctly post-restore (6 * 1 = 6)"))))
+
+(deftest restore-rewinds-route-slice-and-route-sub
+  (testing "Per the bead: when a restored epoch changes :route, the
+  observable routing state follows. A sub keyed on the :route slice
+  returns the restored route id without manual cache invalidation."
+    (rf/reg-frame :test/main {})
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-route :route/article {:path "/articles/:id"})
+    (rf/reg-event-db :go-home
+      (fn [db _] (assoc db :route {:id :route/home :params {}})))
+    (rf/reg-event-db :go-article
+      (fn [db [_ id]] (assoc db :route {:id :route/article :params {:id id}})))
+    (rf/reg-sub :current-route (fn [db _] (get-in db [:route :id])))
+
+    (rf/dispatch-sync [:go-home]               {:frame :test/main})
+    (rf/dispatch-sync [:go-article "intro"]    {:frame :test/main})
+    (is (= :route/article (rf/subscribe-value :test/main [:current-route])))
+
+    (let [history (rf/epoch-history :test/main)
+          ;; The epoch whose db-after carries :route/home in :route :id.
+          target  (some (fn [r]
+                          (when (= :route/home (get-in (:db-after r) [:route :id]))
+                            r))
+                        history)]
+      (is (some? target))
+      (is (true? (rf/restore-epoch :test/main (:epoch-id target))))
+      (is (= :route/home (get-in (rf/get-frame-db :test/main) [:route :id]))
+          "the :route slice is rewound by restore")
+      (is (= :route/home (rf/subscribe-value :test/main [:current-route]))
+          "a sub keyed on :route returns the restored value"))))

--- a/implementation/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -641,3 +641,72 @@
                         [[:n] :pending-dispose]))
           "resubscribe cancels the pending-dispose"))
     (rf/configure :sub-cache {:grace-period-ms 50})))
+
+;; ---- restore-epoch reactive surfaces (Tool-Pair §Time-travel, rf2-2fat) ---
+;;
+;; Per Tool-Pair §Time-travel + Spec 006 §Subscription cache:
+;; restore-epoch goes through adapter/replace-container! — the same
+;; choke point used by the drain loop's :db commit. On the Reagent
+;; substrate, that means a reaction held across a restore observes
+;; the rewound value through Reagent's reactive graph, exactly as
+;; it does for a normal event commit.
+;;
+;; The JVM-side epoch_test.clj covers subscribe-value / pinned-reaction
+;; semantics under the plain-atom adapter (every deref recomputes,
+;; so observable equivalence is straightforward). This test pins the
+;; same contract under the Reagent reactive substrate where the
+;; reaction itself caches and only re-runs when its source changes
+;; by =.
+
+(deftest restore-rewinds-reagent-reaction
+  (testing "a Reagent-backed reaction held across restore-epoch derefs
+  to the restored value — proving the restore goes through the same
+  reactive-graph notification path as a drain :db commit."
+    (rf/reg-frame :restore/cljs {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed] {:frame :restore/cljs})  ;; n=0
+    (rf/dispatch-sync [:inc]  {:frame :restore/cljs})  ;; n=1
+    (rf/dispatch-sync [:inc]  {:frame :restore/cljs})  ;; n=2
+    (rf/dispatch-sync [:inc]  {:frame :restore/cljs})  ;; n=3
+
+    (let [r       (rf/subscribe :restore/cljs [:n])
+          _       (is (= 3 @r) "the reaction sees current value before restore")
+          history (rf/epoch-history :restore/cljs)
+          target  (some (fn [rec] (when (= 1 (:n (:db-after rec))) rec))
+                        history)]
+      (is (true? (rf/restore-epoch :restore/cljs (:epoch-id target))))
+      (is (= 1 @r)
+          "the same reaction handle observes the rewound value after restore")
+      (rf/unsubscribe :restore/cljs [:n]))))
+
+(deftest restore-reagent-frame-isolation
+  (testing "restoring frame A does not cause frame B's reactions to
+  re-derive to a different value. Frame-isolation under the reactive
+  substrate."
+    (rf/reg-frame :restore/a {})
+    (rf/reg-frame :restore/b {})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed 0]   {:frame :restore/a})
+    (rf/dispatch-sync [:inc]      {:frame :restore/a})  ;; a-n=1
+    (rf/dispatch-sync [:inc]      {:frame :restore/a})  ;; a-n=2
+    (rf/dispatch-sync [:seed 100] {:frame :restore/b})
+    (rf/dispatch-sync [:inc]      {:frame :restore/b})  ;; b-n=101
+
+    (let [a-r       (rf/subscribe :restore/a [:n])
+          b-r       (rf/subscribe :restore/b [:n])
+          _         (is (= 2   @a-r))
+          _         (is (= 101 @b-r))
+          a-history (rf/epoch-history :restore/a)
+          a-target  (some (fn [rec] (when (= 1 (:n (:db-after rec))) rec))
+                          a-history)]
+      (is (true? (rf/restore-epoch :restore/a (:epoch-id a-target))))
+      (is (= 1   @a-r) "frame A's reaction sees the rewound value")
+      (is (= 101 @b-r) "frame B's reaction is unaffected by the cross-frame restore")
+      (rf/unsubscribe :restore/a [:n])
+      (rf/unsubscribe :restore/b [:n]))))


### PR DESCRIPTION
## Summary

Add downstream-surface coverage for `restore-epoch`. Existing
`epoch_test.clj` covers epoch recording and the basic restore happy /
failure paths, but stops at raw app-db replacement. For Tool-Pair and
time-travel debugging, the load-bearing question is whether materialised
runtime surfaces observe the rewind correctly.

Per Tool-Pair §Time-travel + Spec 006 §Subscription cache: restore-epoch
goes through `adapter/replace-container!` — the same write path used by
the drain `:db` commit — so reactive consumers should see the rewind
without manual cache invalidation. These tests pin that contract.

JVM (`implementation/core/test/re_frame/epoch_test.clj`):

- subscriptions re-derive after restore (layer-1 + layer-2)
- a pinned reaction held across restore derefs to the restored value
- frame-isolation: restoring A leaves B's app-db and subs untouched
- fixed-point: restoring twice to the same epoch is a no-op
- a flow's value at `:path` is rewound (Spec 013 contract)
- post-restore dispatch recomputes flows correctly even when
  `last-inputs` holds a pre-restore tuple
- a sub keyed on the `:route` slice returns the restored route id

CLJS (`implementation/reagent/test/re_frame/runtime_cljs_test.cljs`):

- a Reagent-backed reaction held across restore observes the rewound
  value (the reactive-graph notification path under the Reagent adapter)
- frame-isolation under the reactive substrate

The `epoch_test.clj` fixture also now clears `flows/last-inputs` —
mirrors `smoke_test.clj` per rf2-xsfj.

## Test plan

- [x] `clojure -M:test` (core) — 241 tests, 0 failures
- [x] `npm run test:cljs` — 101 tests, 0 failures
- [x] `npm run test:browser` — 99 tests, 0 failures
- [x] `npm run test:elision` — pass (probe sentinels confirm
  restore-epoch traces elide in production)
- [x] `npm run test:examples` — pass (15 example apps)