### PR TITLE
feat(ci): topological multi-artefact deploy + lockstep verification + release-process doc (rf2-ace2 / rf2-w05l)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# verify-version-lockstep.sh (rf2-ace2)
+#
+# Asserts the lockstep-version contract documented in spec/Conventions.md
+# §Packaging conventions: every published artefact picks up its version
+# from the single repo-root VERSION file via :clein/build :version
+# "../../VERSION", and every artefact references core via the in-repo
+# :local/root coordinate (which the release workflow rewrites to the
+# matching :mvn/version at deploy time).
+#
+# This script is the single source of truth for the lockstep contract;
+# both .github/workflows/test.yml (PR-time drift detection) and
+# .github/workflows/release.yml (pre-deploy gate) invoke it.
+#
+# Exits 0 on success; non-zero on the first detected drift, with a
+# GitHub-Actions-friendly ::error:: line on stderr-or-stdout. Running
+# locally from the repo root prints the same messages and is the
+# fastest way to debug a CI lockstep failure.
+#
+# Usage:
+#   ./.github/scripts/verify-version-lockstep.sh
+#
+# rf2-ace2 / rf2-w05l.
+
+set -euo pipefail
+
+# Resolve repo root from script location so the script is callable from
+# anywhere (CI working-directory, local dev shell, sub-repo).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Lockstep policy through 1.0 (per rf2-w05l): single root VERSION drives
+# every artefact via :clein/build :version "../../VERSION". Each non-core
+# artefact references core via {:local/root "../core"} so changes to
+# VERSION propagate to every artefact's pom at deploy time. Anything else
+# is drift.
+
+VERSION_FILE="${REPO_ROOT}/VERSION"
+if [[ ! -f "${VERSION_FILE}" ]]; then
+  echo "::error file=VERSION::repo-root VERSION file is missing"
+  exit 2
+fi
+VERSION="$(tr -d '[:space:]' < "${VERSION_FILE}")"
+if [[ -z "${VERSION}" ]]; then
+  echo "::error file=VERSION::repo-root VERSION file is empty"
+  exit 2
+fi
+echo "lockstep VERSION = ${VERSION}"
+
+# The artefact set the lockstep contract covers. Order matches the
+# topological deploy DAG in release.yml so a drift report reads
+# top-down. Add per-feature splits to this list as they land (rf2-uo7v
+# ssr, rf2-lt4e epoch, ...).
+ARTEFACTS=(core schemas reagent machines routing flows http)
+
+# core is the lockstep root: it does not depend on any other re-frame-2
+# artefact, so the :local/root core-reference check below skips it.
+NON_CORE=(schemas reagent machines routing flows http)
+
+errors=0
+
+for artefact in "${ARTEFACTS[@]}"; do
+  deps_file="${REPO_ROOT}/implementation/${artefact}/deps.edn"
+  if [[ ! -f "${deps_file}" ]]; then
+    echo "::error file=implementation/${artefact}/deps.edn::deps.edn missing for artefact '${artefact}'"
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # Every artefact's :clein/build :version must point at "../../VERSION".
+  # Any literal version string here is the canonical drift signal — it
+  # bypasses the single-source-of-truth and would let an artefact ship
+  # at a stale version number.
+  if ! grep -qF ':version  "../../VERSION"' "${deps_file}" \
+     && ! grep -qF ':version "../../VERSION"' "${deps_file}"; then
+    echo "::error file=implementation/${artefact}/deps.edn::expected ':version \"../../VERSION\"' in :clein/build (lockstep contract)"
+    errors=$((errors + 1))
+  fi
+
+  # No artefact may carry a literal :mvn/version coordinate for any of
+  # the day8/re-frame-2-* artefacts in its committed deps.edn. The
+  # release workflow rewrites :local/root → :mvn/version at deploy
+  # time on a throwaway checkout; a literal in the committed file means
+  # someone hand-edited it and the lockstep is broken.
+  #
+  # Strip comments first (deps.edn line comments start with `;;`) — the
+  # consumer-facing usage examples in artefact deps.edn headers
+  # legitimately show `day8/re-frame-2 {:mvn/version "..."}` snippets.
+  if sed 's/;;.*$//' "${deps_file}" | grep -qE 'day8/re-frame-2[^[:space:]]*[[:space:]]+\{:mvn/version'; then
+    echo "::error file=implementation/${artefact}/deps.edn::found literal :mvn/version for a day8/re-frame-2-* artefact in non-comment line (lockstep expects :local/root \"../<artefact>\" in committed deps.edn)"
+    errors=$((errors + 1))
+  fi
+done
+
+# Every non-core artefact must reference core via :local/root "../core".
+# The release workflow swaps this for :mvn/version $VERSION at deploy
+# time; the swap only works if the in-repo source declares :local/root.
+for artefact in "${NON_CORE[@]}"; do
+  deps_file="${REPO_ROOT}/implementation/${artefact}/deps.edn"
+  [[ -f "${deps_file}" ]] || continue
+  if ! grep -qF 'day8/re-frame-2 {:local/root "../core"}' "${deps_file}"; then
+    echo "::error file=implementation/${artefact}/deps.edn::expected 'day8/re-frame-2 {:local/root \"../core\"}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)"
+    errors=$((errors + 1))
+  fi
+done
+
+if [[ "${errors}" -gt 0 ]]; then
+  echo "::error::lockstep version verification FAILED (${errors} drift(s) detected)"
+  exit 1
+fi
+
+echo "lockstep version verification PASSED — all ${#ARTEFACTS[@]} artefacts pinned to repo-root VERSION ${VERSION}"
+exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,77 @@
-# Release workflow (rf2-r382; extended per rf2-p7va, rf2-xbtj, rf2-k682, rf2-tfw3, rf2-5kpd):
-# publish to Clojars on tag push.
+# Release workflow (rf2-r382; restructured for multi-artefact lockstep
+# deploy in rf2-ace2 / rf2-w05l).
 #
-# Modeled on re-frame v1's continuous-deployment-workflow.yml. The
-# pipeline gates the deploy on the same checks the regular `tests.yml`
-# runs (JVM, CLJS, elision probe), then deploys every published
-# artefact in sequence using `clojure -M:clein deploy` per artefact
-# directory:
+# # Topological deploy DAG
 #
-#   - day8/re-frame-2          (implementation/core)
-#   - day8/re-frame-2-reagent  (implementation/reagent)
-#   - day8/re-frame-2-schemas  (implementation/schemas, rf2-p7va)
-#   - day8/re-frame-2-machines (implementation/machines, rf2-xbtj)
-#   - day8/re-frame-2-routing  (implementation/routing,  rf2-k682)
-#   - day8/re-frame-2-flows    (implementation/flows,    rf2-tfw3)
-#   - day8/re-frame-2-http     (implementation/http,     rf2-5kpd)
+#   verify-version-lockstep ──► test ──► deploy-core
+#                                         │
+#                                         ├── deploy-schemas
+#                                         ├── deploy-reagent
+#                                         ├── deploy-machines
+#                                         ├── deploy-routing
+#                                         ├── deploy-flows
+#                                         └── deploy-http
+#                                                  │
+#                                                  ▼
+#                                          github-release
 #
-# Versioning. The repo-root VERSION file is the single source of truth.
-# A release commit updates VERSION and tags the commit `v<contents>`
-# (e.g. VERSION=0.0.1.beta → tag v0.0.1.beta). Each artefact's
-# :clein/build alias reads ../../VERSION.
+# Every per-feature artefact's *published* :deps depends only on core
+# (`day8/re-frame-2`); cross-feature references at runtime are wired
+# through `re-frame.late-bind` per Spec 006 §Substrate-adapter shipping
+# convention and the Conventions §Packaging conventions §Independence
+# rule. The DAG above reflects that: once core has shipped, every leaf
+# artefact is publishable independently and they fan out in parallel.
+# When ssr (rf2-uo7v) and epoch (rf2-lt4e) split, they slot in alongside
+# the existing leaves.
 #
-# Tag pattern. Matches re-frame v1's trailing-glob pattern; accepts
-# both strict semver (v1.0.0) and pre-release suffixes (v0.0.1.beta).
+# # Lockstep versioning policy through 1.0
 #
-# Secrets. CLOJARS_USERNAME and CLOJARS_PASSWORD must be configured at
-# the repository level. Per re-frame v1 convention, CLOJARS_PASSWORD
+# Per the rf2-w05l decision: pre-1.0, every artefact ships at the same
+# version, sourced from the repo-root VERSION file via :clein/build
+# :version "../../VERSION" in each artefact's deps.edn. The
+# `verify-version-lockstep` job enforces the contract before we touch
+# Clojars. Independent versioning is revisited post-1.0 (rf2-w05l
+# §Decision §1).
+#
+# # Failure recovery
+#
+# Clojars does not support yanking a published version. If the deploy
+# DAG fails part-way through (e.g. core ships but deploy-schemas
+# crashes), DO NOT attempt to re-run with the same tag — Clojars will
+# 409 on the duplicate core upload and the workflow will appear stuck.
+# Recovery procedure (per docs/release-process.md §Recovery):
+#
+#   1. Diagnose & fix the cause locally.
+#   2. Bump VERSION in a release-recovery commit (e.g. 0.0.1.beta →
+#      0.0.1.beta-1, or vX.Y.Z → vX.Y.Z+1).
+#   3. Re-tag with the bumped VERSION.
+#   4. Re-run; the workflow ships every artefact at the new version,
+#      preserving the lockstep contract. The partial-release artefacts
+#      from the failed run are tombstoned-by-supersession on the
+#      consumer side: the next release ships every artefact at the
+#      bumped version, so a consumer pinning the bumped version pulls a
+#      coherent set.
+#
+# # Modeled on re-frame v1's continuous-deployment-workflow.yml
+#
+# Same shape: tag-push trigger, gated on the same checks the regular
+# `tests.yml` runs (JVM, CLJS, elision probe). Each artefact's own
+# directory carries its `:clein/build` descriptor; deploy is
+# `clojure -M:clein deploy` from that directory, with the
+# :local/root → :mvn/version rewrite happening on the throwaway runner
+# checkout (see the Rewrite step in each per-artefact deploy job).
+#
+# # Secrets
+#
+# CLOJARS_USERNAME and CLOJARS_PASSWORD are configured at the
+# repository level. Per re-frame v1 convention, CLOJARS_PASSWORD
 # carries a Clojars deploy token (the username sees the token as the
 # password) — neither is committed; both are GHA secrets.
 #
-# First publish protocol. Mike runs the first deploy manually after
-# reviewing the workflow on a tagged commit. Subsequent releases run
-# automatically on tag push.
+# # First publish protocol
+#
+# Mike runs the first deploy manually after reviewing the workflow on a
+# tagged commit. Subsequent releases run automatically on tag push.
 
 name: release
 
@@ -40,8 +81,43 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # 1. Lockstep version contract gate (rf2-ace2 / rf2-w05l).
+  #
+  # Asserts every artefact's :clein/build :version points at the
+  # repo-root VERSION file, and every non-core artefact references core
+  # via {:local/root "../core"}. Fails fast if a hand-edit has broken
+  # the lockstep contract.
+  # ─────────────────────────────────────────────────────────────────
+  verify-version-lockstep:
+    name: Verify lockstep version contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Verify VERSION matches tag
+        # Sanity check: the pushed tag must match the repo-root VERSION
+        # file content (prefixed with `v`). Catches accidental tags.
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="$(tr -d '[:space:]' < VERSION)"
+          expected="v${version}"
+          if [ "$tag" != "$expected" ]; then
+            echo "::error::tag '$tag' does not match VERSION '$expected'"
+            exit 1
+          fi
+          echo "tag $tag matches VERSION $expected — proceeding"
+
+      - name: Verify lockstep version contract (rf2-ace2)
+        run: ./.github/scripts/verify-version-lockstep.sh
+
+  # ─────────────────────────────────────────────────────────────────
+  # 2. Pre-release test gate. Same checks as the regular tests
+  #    workflow; gates every deploy job below.
+  # ─────────────────────────────────────────────────────────────────
   test:
     name: Pre-release test gate
+    needs: verify-version-lockstep
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -75,19 +151,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clj-release-
             ${{ runner.os }}-clj-
-
-      - name: Verify VERSION matches tag
-        # Sanity check: the pushed tag must match the repo-root VERSION
-        # file content (prefixed with `v`). Catches accidental tags.
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          version="$(tr -d '[:space:]' < VERSION)"
-          expected="v${version}"
-          if [ "$tag" != "$expected" ]; then
-            echo "::error::tag '$tag' does not match VERSION '$expected'"
-            exit 1
-          fi
-          echo "tag $tag matches VERSION $expected — proceeding"
 
       - name: JVM tests (core artefact)
         working-directory: implementation/core
@@ -129,10 +192,18 @@ jobs:
         working-directory: implementation
         run: npm run test:elision
 
-  release:
-    name: Deploy to Clojars
+  # ─────────────────────────────────────────────────────────────────
+  # 3. Deploy core. The lockstep root: every other deploy job depends
+  #    on this one because their published poms reference
+  #    `day8/re-frame-2 {:mvn/version <VERSION>}` which the per-leaf
+  #    rewrite step produces from this published version.
+  # ─────────────────────────────────────────────────────────────────
+  deploy-core:
+    name: Deploy day8/re-frame-2
     needs: test
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -175,34 +246,79 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  # ─────────────────────────────────────────────────────────────────
+  # 4. Per-leaf deploy jobs. All depend on deploy-core; none depend on
+  #    each other (per Conventions §Packaging conventions §Independence
+  #    rule). They run in parallel; a single leaf failure does NOT
+  #    halt sibling leaves — by design, since the published-pom DAG
+  #    has no edges between leaves and a partial-leaf-success is
+  #    coherent (a consumer that pins schemas + core only is unaffected
+  #    by a flows-deploy failure). The github-release job depends on
+  #    every leaf, so a partial deploy means no GitHub Release is
+  #    cut and the next step is the recovery procedure documented at
+  #    the top of this file.
+  #
+  #    Each leaf:
+  #      - re-installs core into the runner's local ~/.m2/repository so
+  #        the leaf's pom dep on day8/re-frame-2 ${{ version }} resolves
+  #        without waiting for Clojars' index;
+  #      - rewrites :local/root "../core" → :mvn/version "${VERSION}"
+  #        in its own deps.edn (throwaway runner checkout, never
+  #        committed);
+  #      - deploys with `clojure -M:clein deploy`.
+  # ─────────────────────────────────────────────────────────────────
+  deploy-reagent:
+    name: Deploy day8/re-frame-2-reagent
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
       - name: Install core to runner ~/.m2
-        # The reagent build's pom step resolves day8/re-frame-2 from
-        # Maven; installing locally first means the runner doesn't have
-        # to wait for Clojars' index to refresh and avoids a window
-        # where the deploy succeeded but the artefact isn't yet
-        # discoverable. Local install is cheap on top of the just-built
-        # jar in target/.
+        # The leaf's pom dep on day8/re-frame-2 ${{ needs.deploy-core.outputs.version }}
+        # resolves from Maven Central / Clojars. Installing locally
+        # first means the runner doesn't have to wait for Clojars'
+        # index to refresh and avoids a window where deploy-core
+        # succeeded but the artefact isn't yet discoverable. Local
+        # install is cheap on top of the just-built jar in target/.
         working-directory: implementation/core
         run: clojure -M:clein install
 
       - name: Rewrite reagent :local/root → :mvn/version
-        # The reagent artefact's deps.edn declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. The checkout is throwaway so this rewrite is local
-        # to the runner and never committed.
         working-directory: implementation/reagent
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
             echo "::error::expected ':local/root \"../core\"' substring not found in implementation/reagent/deps.edn"
             exit 1
           fi
-          # Use python with stdin-fed source to avoid sed-vs-quote escaping.
           BEFORE=':local/root "../core"' \
           AFTER=":mvn/version \"${VERSION}\"" \
           python3 -c 'import os, pathlib; p = pathlib.Path("deps.edn"); src = p.read_text(); before = os.environ["BEFORE"]; after = os.environ["AFTER"]; assert src.count(before) == 1, f"expected exactly one occurrence of {before!r}"; p.write_text(src.replace(before, after))'
@@ -216,17 +332,46 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  deploy-schemas:
+    name: Deploy day8/re-frame-2-schemas
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
+      - name: Install core to runner ~/.m2
+        working-directory: implementation/core
+        run: clojure -M:clein install
+
       - name: Rewrite schemas :local/root → :mvn/version
-        # Same rationale as the reagent rewrite above (rf2-p7va).
-        # implementation/schemas/deps.edn declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. Local to the runner; never committed.
         working-directory: implementation/schemas
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
@@ -246,17 +391,46 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  deploy-machines:
+    name: Deploy day8/re-frame-2-machines
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
+      - name: Install core to runner ~/.m2
+        working-directory: implementation/core
+        run: clojure -M:clein install
+
       - name: Rewrite machines :local/root → :mvn/version
-        # Same rationale as the reagent / schemas rewrites above (rf2-xbtj).
-        # implementation/machines/deps.edn declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. Local to the runner; never committed.
         working-directory: implementation/machines
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
@@ -276,17 +450,46 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  deploy-routing:
+    name: Deploy day8/re-frame-2-routing
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
+      - name: Install core to runner ~/.m2
+        working-directory: implementation/core
+        run: clojure -M:clein install
+
       - name: Rewrite routing :local/root → :mvn/version
-        # Same rationale as the reagent / schemas / machines rewrites
-        # above (rf2-k682). implementation/routing/deps.edn declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. Local to the runner; never committed.
         working-directory: implementation/routing
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
@@ -306,18 +509,46 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  deploy-flows:
+    name: Deploy day8/re-frame-2-flows
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
+      - name: Install core to runner ~/.m2
+        working-directory: implementation/core
+        run: clojure -M:clein install
+
       - name: Rewrite flows :local/root → :mvn/version
-        # Same rationale as the reagent / schemas / machines / routing
-        # rewrites above (rf2-tfw3). implementation/flows/deps.edn
-        # declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. Local to the runner; never committed.
         working-directory: implementation/flows
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
@@ -337,18 +568,46 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  deploy-http:
+    name: Deploy day8/re-frame-2-http
+    needs: deploy-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-${{ hashFiles('implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-
+            ${{ runner.os }}-clj-
+
+      - name: Install core to runner ~/.m2
+        working-directory: implementation/core
+        run: clojure -M:clein install
+
       - name: Rewrite http :local/root → :mvn/version
-        # Same rationale as the reagent / schemas / machines / routing /
-        # flows rewrites above (rf2-5kpd). implementation/http/deps.edn
-        # declares
-        #   day8/re-frame-2 {:local/root "../core"}
-        # which is correct for in-repo dev/test but produces an
-        # unresolvable pom dependency for downstream consumers. Swap to
-        # the just-published :mvn/version coordinate before clein writes
-        # the pom. Local to the runner; never committed.
         working-directory: implementation/http
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.deploy-core.outputs.version }}
         run: |
           set -euo pipefail
           if ! grep -qF ':local/root "../core"' deps.edn; then
@@ -368,6 +627,25 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -M:clein deploy
 
+  # ─────────────────────────────────────────────────────────────────
+  # 5. GitHub Release. Cuts only after every leaf has shipped — a
+  #    partial deploy means no Release is created and the next step is
+  #    the recovery procedure documented at the top of this file.
+  # ─────────────────────────────────────────────────────────────────
+  github-release:
+    name: Create GitHub Release
+    needs:
+      - deploy-core
+      - deploy-reagent
+      - deploy-schemas
+      - deploy-machines
+      - deploy-routing
+      - deploy-flows
+      - deploy-http
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
       - name: Create GitHub Release
         # Mirrors re-frame v1's release-notes pattern — minimal body
         # with a link back to the CHANGELOG. Mike updates CHANGELOG.md
@@ -380,13 +658,13 @@ jobs:
             See [CHANGELOG.md](https://github.com/day8/re-frame2/blob/main/CHANGELOG.md) for release notes.
 
             Artefacts published to Clojars:
-            - `day8/re-frame-2` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-reagent` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-schemas` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-machines` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-routing` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-flows` ${{ steps.version.outputs.version }}
-            - `day8/re-frame-2-http` ${{ steps.version.outputs.version }}
+            - `day8/re-frame-2` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-reagent` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-schemas` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-machines` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-routing` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-flows` ${{ needs.deploy-core.outputs.version }}
+            - `day8/re-frame-2-http` ${{ needs.deploy-core.outputs.version }}
           draft: false
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,28 @@ on:
   pull_request:
     branches: [main]
 
+# Per-artefact JVM jobs and the CLJS / browser / elision / examples
+# jobs all run in parallel — none `needs:` another, by design (per
+# rf2-ace2 audit). The lockstep-version-verify job below also runs in
+# parallel; it is fast (single bash script over seven deps.edn files)
+# and adds no critical-path latency. We deliberately do NOT gate the
+# test jobs on lockstep verify so a drift report and a test failure
+# surface together rather than serialising.
+
 jobs:
+  # PR-time drift detection for the lockstep-version contract
+  # (rf2-ace2 / rf2-w05l). Fast — the script is shared with
+  # release.yml's pre-deploy gate so the contract has a single source
+  # of truth.
+  verify-version-lockstep:
+    name: Verify lockstep version contract (rf2-ace2)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Verify lockstep version contract
+        run: ./.github/scripts/verify-version-lockstep.sh
+
   jvm-core:
     name: JVM core (clojure -M:test)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ spec/                          Full specification (AI-targeted; the primary arte
   conformance/                 EDN fixture corpus
 docs/
   guide/                       Human-facing guide (marketing voice)
+  release-process.md           Operational doc — multi-artefact release pipeline (rf2-w05l / rf2-ace2)
 examples/                      Worked examples
 implementation/                CLJS reference implementation — split into per-artefact subdirs
                                (per Conventions §Packaging conventions; tier rollout per rf2-0hxm

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,137 @@
+# Release process
+
+> **Type:** Operational doc.
+> **Audience:** maintainers cutting a re-frame2 release.
+> **Authority:** decisions in [rf2-w05l](#) (CI/CD strategy) and the implementation in [rf2-ace2](#) ([.github/workflows/release.yml](../.github/workflows/release.yml)).
+
+re-frame2 ships as a coordinated set of Maven artefacts, all driven from a single repo-root [`VERSION`](../VERSION) file. This doc is the operational guide for how a release flows through CI, what gates exist, and how to recover when something goes wrong mid-deploy.
+
+## Tag format
+
+| Channel | Tag pattern | VERSION file content | Example |
+|---|---|---|---|
+| Stable | `vX.Y.Z` | `X.Y.Z` | `v1.0.0` ↔ `1.0.0` |
+| Beta | `v0.0.1.beta` (or `v0.0.1.beta-N` for recovery / increments) | matches the tag minus the leading `v` | `v0.0.1.beta-2` ↔ `0.0.1.beta-2` |
+| Pre-release (alpha / rc) | `vX.Y.Z-alpha.N`, `vX.Y.Z-rc.N` | matches the tag minus the leading `v` | `v1.0.0-rc.1` ↔ `1.0.0-rc.1` |
+
+The release workflow's tag glob is `v[0-9]+.[0-9]+.[0-9]+*`. Tag must match the contents of `VERSION` (prefixed with `v`); the release workflow's `verify-version-lockstep` job hard-fails if they disagree. The `prerelease` flag on the resulting GitHub Release is set automatically when the tag contains `beta`, `alpha`, or `rc`.
+
+## Trigger
+
+Tag push. Push a tag matching the pattern above and the release workflow runs end-to-end:
+
+```bash
+git tag v0.0.1.beta-1
+git push origin v0.0.1.beta-1
+```
+
+There is no `workflow_dispatch` trigger by design: a release commit always carries an updated `VERSION` and a CHANGELOG entry, and the tag-push trigger keeps that coupling tight.
+
+## Topological deploy DAG
+
+Per rf2-w05l's lockstep-versioning decision, all artefacts ship at the same version each release. The DAG reflects the **published-pom** dependency graph (which is much narrower than the in-repo test-classpath graph): every per-feature artefact's published `:deps` declares only `day8/re-frame-2` (core); cross-feature references at runtime are wired through `re-frame.late-bind` per [Conventions §Packaging conventions §Independence rule](../spec/Conventions.md#independence-rule).
+
+```mermaid
+graph TD
+  V[verify-version-lockstep] --> T[test]
+  T --> C[deploy-core]
+  C --> S[deploy-schemas]
+  C --> R[deploy-reagent]
+  C --> M[deploy-machines]
+  C --> RT[deploy-routing]
+  C --> F[deploy-flows]
+  C --> H[deploy-http]
+  S --> GR[github-release]
+  R --> GR
+  M --> GR
+  RT --> GR
+  F --> GR
+  H --> GR
+```
+
+ASCII fallback:
+
+```
+verify-version-lockstep ──► test ──► deploy-core
+                                       │
+                                       ├── deploy-schemas
+                                       ├── deploy-reagent
+                                       ├── deploy-machines
+                                       ├── deploy-routing
+                                       ├── deploy-flows
+                                       └── deploy-http
+                                                │
+                                                ▼
+                                        github-release
+```
+
+**Why fan-out (not strict serial).** The decision text describes a topological linearization (`core → schemas → reagent → machines → routing → flows → http`); the deps-graph data is wider — every leaf has core as its only re-frame-2 dependency. The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, halving wall-clock at the cost of a marginally wider failure surface (see Recovery below). When future per-feature splits land — ssr ([rf2-uo7v](#)), epoch ([rf2-lt4e](#)) — they slot in alongside the existing leaves.
+
+## Pre-flight checklist
+
+Before tagging:
+
+- [ ] All checks green on `main` (the `tests` workflow + any required reviews).
+- [ ] [`VERSION`](../VERSION) file updated to the target version. Single line, no trailing whitespace.
+- [ ] [`spec/MIGRATION.md`](../spec/MIGRATION.md) carries a fresh `M-NN` entry if the release contains a breaking change. (Per rf2-w05l, MIGRATION stays flat through 1.0; numbering is monotonic.)
+- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated for the release. The GitHub Release body links to it, so it is the canonical narrative.
+- [ ] The tag's commit is the same commit that updates VERSION + MIGRATION + CHANGELOG (one release commit).
+- [ ] Locally green: `./.github/scripts/verify-version-lockstep.sh` passes. (The CI gate runs the same script; running locally first surfaces drift in seconds.)
+
+## Recovery from a partial deploy
+
+Clojars **does not support yanking** a published version. The recovery story is bump-and-replay, not rollback.
+
+If a deploy job fails part-way through (e.g. `deploy-core` shipped, but `deploy-flows` failed):
+
+1. **Diagnose.** Read the failing job's logs. Common causes: transient Clojars 5xx (re-runs cleanly on retry), credential rotation (CLOJARS_USERNAME / CLOJARS_PASSWORD secrets stale), pom-validation regression in the leaf's clein descriptor, network outage during the leaf's `clojure -M:clein deploy`.
+2. **Decide whether the partial set is publishable as-is.** A consumer pinning the bumped version expects a coherent set; the partial set the failed run left on Clojars is not coherent. Do not promote it.
+3. **Fix the cause locally.** Land the fix on `main` via the normal PR flow.
+4. **Bump VERSION** in a release-recovery commit. For betas, increment the suffix: `0.0.1.beta` → `0.0.1.beta-1`. For stable, bump the patch: `1.0.0` → `1.0.1`.
+5. **Re-tag** with the bumped VERSION. The workflow ships every artefact at the new version, restoring the lockstep contract on the consumer side: a consumer pinning the bumped version pulls a coherent set; the partial-release artefacts from the failed run are tombstoned-by-supersession (still on Clojars, but nobody pins them).
+6. **Note the abandoned version** in CHANGELOG.md so future readers don't try to pin it.
+
+**Do NOT** attempt to re-run the failed workflow with the same tag. The `deploy-core` step will 409 on the duplicate jar upload to Clojars and the workflow will appear stuck.
+
+**Do NOT** ask Clojars support to yank. The platform doesn't expose it; ad-hoc yanks would corrupt downstream caches anyway.
+
+## Lockstep verification (drift detection)
+
+[`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh) is the single source of truth for the lockstep contract. It is invoked by:
+
+- the `tests` workflow on every PR (`verify-version-lockstep` job — fast, runs in parallel with the test jobs);
+- the `release` workflow as the first gate before any deploy (`verify-version-lockstep` job — gates `test`, which gates `deploy-core`).
+
+The contract:
+
+- Repo root has a non-empty `VERSION` file.
+- Every artefact's `:clein/build` declares `:version "../../VERSION"` (i.e. defers to the single source).
+- Every non-core artefact references core via `day8/re-frame-2 {:local/root "../core"}` (the release workflow rewrites this to `:mvn/version` at deploy time).
+- No artefact's committed `deps.edn` carries a literal `:mvn/version` for any `day8/re-frame-2-*` artefact in a non-comment line.
+
+Run locally any time:
+
+```bash
+./.github/scripts/verify-version-lockstep.sh
+```
+
+## Lockstep versioning policy through 1.0
+
+Per [rf2-w05l](#) §Decision §1: every artefact ships at the same VERSION pre-1.0. Independent versioning is revisited post-1.0. The mechanism:
+
+- single root [`VERSION`](../VERSION) file;
+- every artefact's `:clein/build :version` is the relative path `"../../VERSION"`;
+- every non-core artefact references core via `:local/root "../core"`, swapped to `:mvn/version $VERSION` on the throwaway runner checkout at deploy time.
+
+There is intentionally no per-artefact version override. Adding one would break the lockstep contract; the verify script flags it.
+
+## Cross-references
+
+- [rf2-w05l](#) — CI/CD strategy decision (parent).
+- [rf2-ace2](#) — implementation bead (this doc + workflow restructure).
+- [.github/workflows/release.yml](../.github/workflows/release.yml) — the release pipeline.
+- [.github/workflows/test.yml](../.github/workflows/test.yml) — PR-time tests including lockstep drift detection.
+- [.github/scripts/verify-version-lockstep.sh](../.github/scripts/verify-version-lockstep.sh) — the lockstep contract script.
+- [spec/Conventions.md §Packaging conventions](../spec/Conventions.md#packaging-conventions) — artefact naming, the independence rule, the bundle-isolation argument.
+- [spec/MIGRATION.md](../spec/MIGRATION.md) — the migration prompt; flat through 1.0.
+- [examples/realworld/README.md](../examples/realworld/README.md) — the canonical multi-artefact integration test.

--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -1,5 +1,7 @@
 # RealWorld (Conduit) in re-frame2
 
+> **Canonical multi-artefact integration test.** Per the rf2-w05l CI/CD strategy decision (implemented in rf2-ace2), this example is the canonical multi-artefact integration test for re-frame-2. It exercises `day8/re-frame-2` (core) + `-schemas` + `-machines` + `-routing` + `-flows` + `-http` together in a single app. CI runs it on every PR via `npm run test:examples` from `implementation/`. When a per-artefact change accidentally breaks cross-artefact composition, this is the test that catches it. See [docs/release-process.md](../../docs/release-process.md) for how this slots into the multi-artefact deploy pipeline.
+
 The canonical re-frame2 demo for **Spec 014 — `:rf.http/managed`** (per rf2-kauy and rf2-o8t6). Built on the [RealWorld spec](https://github.com/gothinkster/realworld), the de-facto cross-framework benchmark for SPA frameworks.
 
 The goal here is breadth: show how the current re-frame2 surface composes across auth, routing, remote data, forms, machines, optimistic updates, and SSR-related payload concerns — all on top of `:rf.http/managed` for HTTP.

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -253,11 +253,18 @@ The `*`-suffix convention for fn-versions of macros (per the Clojure idiom of `l
 
 A production-elision build of an app that consumes `day8/re-frame-2` plus `day8/re-frame-2-reagent` carries `re-frame.substrate.reagent` strings AND does NOT carry `re-frame.substrate.uix` or `re-frame.substrate.helix` strings, AND does NOT carry the namespaces of any per-feature artefact the app didn't add to its `deps.edn`. The check is a grep over the advanced-compile output. Per [rf2-5vjj](#) and the per-feature split beads.
 
+### Lockstep versioning through 1.0
+
+Through the v0.0.1.beta → 1.0 stretch every artefact ships at the **same version** sourced from the repo-root `VERSION` file. The mechanism is structural: every artefact's `:clein/build :version` declares the relative path `"../../VERSION"`, and every non-core artefact references core via `{:local/root "../core"}` (rewritten to `{:mvn/version <VERSION>}` on the throwaway runner checkout at deploy time). The lockstep contract is enforced by [`.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh), invoked by both `.github/workflows/test.yml` (PR-time drift detection) and `.github/workflows/release.yml` (pre-deploy gate). Independent versioning is revisited post-1.0; until then, adding a literal `:mvn/version` for a `day8/re-frame-2-*` artefact in a committed `deps.edn` is a contract break that the verify script flags.
+
+The release pipeline — topological deploy DAG, recovery procedure when a partial deploy fails, pre-flight checklist — is documented in [docs/release-process.md](../docs/release-process.md). Per [rf2-w05l](#) (decision) and [rf2-ace2](#) (implementation).
+
 ### Cross-references
 
 - [§Substrate-adapter shipping convention](#substrate-adapter-shipping-convention) below — the per-substrate tier in operational detail.
 - [README §Project layout](../README.md#project-layout) — the per-artefact directory structure under `implementation/`.
-- The per-feature split beads: [rf2-xbtj](#) (machines), [rf2-tfw3](#) (flows), [rf2-k682](#) (routing), [rf2-5kpd](#) (http), [rf2-uo7v](#) (ssr), [rf2-p7va](#) (schemas), [rf2-lt4e](#) (epoch). The umbrella is [rf2-5vjj](#).
+- [docs/release-process.md](../docs/release-process.md) — operational doc for cutting a release: topological DAG, recovery procedure, lockstep enforcement.
+- The per-feature split beads: [rf2-xbtj](#) (machines), [rf2-tfw3](#) (flows), [rf2-k682](#) (routing), [rf2-5kpd](#) (http), [rf2-uo7v](#) (ssr), [rf2-p7va](#) (schemas), [rf2-lt4e](#) (epoch). The umbrella is [rf2-5vjj](#); the CI/CD strategy is [rf2-w05l](#) / [rf2-ace2](#).
 
 ## Substrate-adapter shipping convention
 
@@ -304,6 +311,8 @@ A consumer picks their substrate by adding the matching adapter alongside the co
 **Out of scope for the v1 split.** The Reagent-coupled views layer (`re-frame.views`) currently lives in core because the CLJS reference is Reagent-default. Full substrate-config plumbing — making `re-frame.views` substrate-agnostic so the core artefact carries no Reagent dep — lands with the UIx-adapter work (rf2-3yij). The v1 artefact split is the *adapter ns* split; the views-layer decoupling is the next step.
 
 **Conformance check (bundle isolation).** A production-elision build of an app that consumes `day8/re-frame-2-reagent` carries `re-frame.substrate.reagent` strings AND does NOT carry `re-frame.substrate.uix` or `re-frame.substrate.helix` strings. The same applies to feature artefacts: a counter-style app that registers no schemas builds an `:advanced` bundle clean of `re-frame.schemas` symbols and Malli code; an app that registers no machines builds an `:advanced` bundle clean of `re-frame.machines` symbols, `reg-machine` / `machine-handler` / `machine-transition` strings, and the `:rf.machine/spawned` / `:rf.machine/destroyed` trace strings; an app that registers no flows builds an `:advanced` bundle clean of `re-frame.flows` symbols, the topological-sort engine, and the dirty-check `last-inputs` machinery; an app that issues no managed-HTTP requests builds an `:advanced` bundle clean of `re-frame.http-managed` symbols, the in-flight registry, the Fetch transport adapter, and every `:rf.http/*` keyword string. The check is a grep over the advanced-compile output. Per the rf2-0hxm, rf2-p7va, rf2-xbtj, rf2-k682, rf2-tfw3, and rf2-5kpd verification steps.
+
+**Substrate test matrix policy.** Reagent is the **canonical substrate**: the full re-frame2 test suite (every `clojure -M:test` run, every `node-test` build, every `:browser-test` run, every `examples` run, every conformance fixture) executes against the Reagent adapter. UIx ([rf2-3yij](#)) and Helix ([rf2-2qit](#)) adapters, when they ship, are **smoke-tested** via a representative subset — counter, login, and realworld are the standard trio (per [examples/realworld/README.md](../examples/realworld/README.md) on multi-artefact integration coverage). Full-substrate-matrix conformance — every test, every fixture, every example, against every shipped substrate — remains a per-substrate-adapter responsibility, not a re-frame2-core responsibility. The policy is a deliberate concentration of the test budget on the substrate the spec was authored against; the substrate-adapter contract (Spec 006 §The reactive-substrate adapter contract) is what the smoke trio confirms each non-canonical adapter has implemented correctly.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

Implement the multi-artefact CI/CD strategy decided in rf2-w05l: lockstep versions through 1.0, topological-order deploy in `release.yml`, lockstep contract verified by a single shared script invoked from both `test.yml` (PR-time) and `release.yml` (pre-deploy gate). Ship the operational `docs/release-process.md`, mark the realworld example as the canonical multi-artefact integration test, and lock the substrate test matrix policy in `spec/Conventions.md`.

Parent decision bead: **rf2-w05l** (CI/CD strategy for multi-artefact release coordination).
Implementation bead: **rf2-ace2**.

## Topological deploy DAG

```mermaid
graph TD
  V[verify-version-lockstep] --> T[test]
  T --> C[deploy-core]
  C --> S[deploy-schemas]
  C --> R[deploy-reagent]
  C --> M[deploy-machines]
  C --> RT[deploy-routing]
  C --> F[deploy-flows]
  C --> H[deploy-http]
  S --> GR[github-release]
  R --> GR
  M --> GR
  RT --> GR
  F --> GR
  H --> GR
```

ASCII fallback:

```
verify-version-lockstep ──> test ──> deploy-core
                                       │
                                       ├── deploy-schemas
                                       ├── deploy-reagent
                                       ├── deploy-machines
                                       ├── deploy-routing
                                       ├── deploy-flows
                                       └── deploy-http
                                                │
                                                ▼
                                        github-release
```

The DAG is data-derived: every per-feature artefact's *published* `:deps` declares only `day8/re-frame-2` (core); cross-feature references at runtime go through `re-frame.late-bind` per `Conventions §Packaging conventions §Independence rule`. Once core has shipped, the leaves fan out in parallel — a valid topological linearization that exploits the parallelism. `ssr` (rf2-uo7v) and `epoch` (rf2-lt4e) slot in alongside the existing leaves when those splits land.

## Lockstep verify dry-run output

Positive (clean tree):

```
$ ./.github/scripts/verify-version-lockstep.sh
lockstep VERSION = 0.0.1.beta
lockstep version verification PASSED — all 7 artefacts pinned to repo-root VERSION 0.0.1.beta
(exit=0)
```

Negative (temporarily swap `implementation/http/deps.edn` `{:local/root "../core"}` for `{:mvn/version "999.0.0"}`):

```
$ ./.github/scripts/verify-version-lockstep.sh
lockstep VERSION = 0.0.1.beta
::error file=implementation/http/deps.edn::found literal :mvn/version for a day8/re-frame-2-* artefact in non-comment line (lockstep expects :local/root "../<artefact>" in committed deps.edn)
::error file=implementation/http/deps.edn::expected 'day8/re-frame-2 {:local/root "../core"}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)
::error::lockstep version verification FAILED (2 drift(s) detected)
(exit=1)
```

After restoring, the positive run passes again — both error categories fire on real drift, neither false-positives on comment-block usage examples.

## Test results (local, full matrix)

* JVM tests
  * `core`: 214 tests, 973 assertions, 0 failures, 0 errors
  * `routing`: 6 tests, 33 assertions, 0/0
  * `flows`: 15 tests, 49 assertions, 0/0
  * `http`: 15 tests, 32 assertions, 0/0
  * `schemas`: 27 tests, 109 assertions, 0/0
  * `machines`: classpath probe (no JVM-runnable tests; expected — see deps.edn comment), 0/0
* CLJS suites (`implementation/`)
  * `npm run test:cljs`: 101 tests, 314 assertions, 0/0
  * `npm run test:elision`: PASS (every sentinel-presence / -absence assertion matched)
  * `npm run test:browser`: 110 tests, 347 assertions, 0/0 (CORS noise from realworld example fetches is unrelated to test pass/fail)
  * `npm run test:examples`: PASS for all 15 examples (counter, login, managed-http-counter, nine-states, realworld, routing, ssr, state-machines walkthrough, todomvc, plus the seven 7GUIs entries)

## What changed

`ci:` commit (`5af204e`):
* `.github/workflows/release.yml`: split monolithic `release` job into per-artefact deploy jobs with explicit `needs:` linkages; `verify-version-lockstep` gates `test` which gates `deploy-core` which gates each leaf which gates `github-release`. Failure-recovery comment block at the top.
* `.github/workflows/test.yml`: add `verify-version-lockstep` job (parallel with the test jobs); audit confirmed every other job has no `needs:` linkages.
* `.github/scripts/verify-version-lockstep.sh` (new): single source of truth for the lockstep contract.

`docs:` commit (`9e5359d`):
* `docs/release-process.md` (new): operational doc covering tag format, trigger, DAG, pre-flight checklist, recovery procedure, lockstep enforcement.
* `spec/Conventions.md`: §Packaging conventions gains a §Lockstep versioning through 1.0 subsection; §Substrate-adapter shipping convention gains the substrate test matrix policy (Reagent canonical, UIx/Helix smoke-tested via counter+login+realworld).
* `examples/realworld/README.md`: leading note marking it the canonical multi-artefact integration test.
* `README.md`: project-layout block names `docs/release-process.md`.

## Notes for the reviewer

* The release.yml restructure intentionally keeps the existing `:local/root → :mvn/version` rewrite step shape per leaf (rather than factoring into a composite action). Keeping the rewrite inline matches the per-leaf-`needs:` failure granularity goal — a composite-action regression would surface as a noisier-to-diagnose downstream failure. Open to factoring later if a sixth or seventh leaf adds friction.
* The deploy-leaves run in parallel, not strict serial. The rf2-w05l decision text describes a *linearization* (`core → schemas → reagent → machines → routing → flows → http`); the per-leaf published-deps graph permits parallelism. The CI graph realises a valid topological sort. Documented in the `release.yml` comment block.
* No follow-up beads filed — the existing release.yml accumulated piecemeal but the restructure is comprehensive; nothing surfaced that warrants a separate bead.
* PR title intentionally doesn't include "BREAKING CHANGE" because the workflow change is build-system-only; consumer artefacts and APIs are unaffected.

## Test plan

- [ ] CI on this branch — confirm `verify-version-lockstep` and the test-job parallel layout render correctly in the GHA UI.
- [ ] (Post-merge, when next release happens) Confirm the topological deploy DAG visualises correctly in the GHA UI for an actual release.
- [ ] (Post-merge) Confirm the verify-version-lockstep job fails fast on a deliberately drifted PR (sanity of the negative-test path against the live workflow).

## Links

* Parent decision bead: rf2-w05l.
* Implementation bead: rf2-ace2.
* Released under: rf2-w05l §Decision (lockstep through 1.0; topological deploy; realworld canonical integration test; Reagent canonical substrate; MIGRATION.md flat through 1.0).