### PR TITLE
feat: source-coord DOM annotation - capture + Reagent injection + Spec 006 mandate (rf2-z7f7 / rf2-z9n1)

### DIFF
--- a/implementation/core/src/re_frame/ssr.cljc
+++ b/implementation/core/src/re_frame/ssr.cljc
@@ -118,6 +118,61 @@
 (defn- emit-children [children]
   (clojure.string/join (mapv emit-element children)))
 
+;; ---- source-coord annotation on registered-view roots --------------------
+;;
+;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and Spec 011
+;; §Source-coord annotation under SSR: when emitting HTML for a registered
+;; view, the SSR emitter injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"`
+;; on the view's root DOM element. The annotation gives pair-tool consumers
+;; a way to map server-rendered HTML back to the reg-view call site, and
+;; matches the CLJS-side Reagent-adapter behaviour (re-frame.views/reg-view*).
+;;
+;; The JVM mirror of the CLJS `interop/debug-enabled?` gate is
+;; (interop/debug-enabled?) — true on the JVM (no production-elision
+;; concept on the server). Hosts that need to suppress the annotation
+;; in production can branch on the resolved frame's :ssr config; the
+;; default is to emit (matches Spec 011 §Source-coord annotation under
+;; SSR — emitted when in dev mode).
+
+(defn- format-view-source-coord
+  "Render the registered view's metadata as the attribute value
+  `<ns>:<sym>:<line>:<col>` per Spec 006 §Source-coord annotation. Returns
+  nil when the slot has no captured coords (programmatic registration that
+  bypassed the macro path) — the emitter then skips the annotation."
+  [id slot]
+  (when (or (:ns slot) (:line slot) (:file slot) (:column slot))
+    (let [ns-part  (or (namespace id) "?")
+          sym-part (name id)
+          line     (:line slot)
+          col      (:column slot)]
+      (str ns-part ":" sym-part ":"
+           (if line (str line) "?")
+           ":"
+           (if col (str col) "?")))))
+
+(defn- inject-coord-on-root-hiccup
+  "Inject :data-rf2-source-coord into the root element of a hiccup form,
+  if the root is a DOM-tag keyword. Mirrors the CLJS-side wrapper in
+  re-frame.views per Spec 006 §Source-coord annotation. Non-DOM roots
+  (fragment :<>, fn-or-component head, lazy-seq) are returned unchanged
+  — pair tools fall back to :rf/id for those (documented exemption)."
+  [coord out]
+  (cond
+    (and (vector? out)
+         (keyword? (first out))
+         (not= :<> (first out))
+         (not= :> (first out)))
+    (let [head        (first out)
+          maybe-attrs (second out)]
+      (if (map? maybe-attrs)
+        (if (contains? maybe-attrs :data-rf2-source-coord)
+          out
+          (into [head (assoc maybe-attrs :data-rf2-source-coord coord)]
+                (drop 2 out)))
+        (into [head {:data-rf2-source-coord coord}] (rest out))))
+
+    :else out))
+
 (defn- emit-element [el]
   (cond
     (nil? el)         ""
@@ -131,7 +186,16 @@
         (let [;; Look up registered view first.
               maybe-view (registrar/lookup :view head)]
           (if maybe-view
-            (emit-element (apply (:handler-fn maybe-view) (rest el)))
+            (let [raw   (apply (:handler-fn maybe-view) (rest el))
+                  ;; Spec 006 §Source-coord annotation: inject the
+                  ;; data-rf2-source-coord attribute on the registered
+                  ;; view's root DOM element when the slot's metadata
+                  ;; carries source coords.
+                  coord (format-view-source-coord head maybe-view)
+                  out   (if coord
+                          (inject-coord-on-root-hiccup coord raw)
+                          raw)]
+              (emit-element out))
             (let [[tag-name tag-attrs] (parse-tag-name head)
                   [user-attrs children]
                   (if (map? (second el))

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -167,6 +167,128 @@
              {:render-key render-key
               :frame      (current-frame)}))))
 
+;; ---- source-coord DOM annotation (rf2-z7f7) -------------------------------
+;;
+;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) the Reagent
+;; substrate adapter MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"`
+;; on each registered view's root DOM element when `interop/debug-enabled?`
+;; is true. The annotation lets pair-shaped tools (re-frame-pair,
+;; re-frame-10x, IDE jump-to-source) map a clicked DOM node back to the
+;; reg-view call site.
+;;
+;; Contract details:
+;;
+;;   - The id is a registry keyword `<ns>/<sym>`. Combined with the
+;;     captured `:line` / `:column` (from `(meta &form)` at reg-view
+;;     macro-expansion time), the attribute value is
+;;     `<ns>:<sym>:<line>:<col>`. `<col>` is `?` when the column was
+;;     not captured (the column-key is optional per Spec 001).
+;;
+;;   - The wrapper inspects the user's render-fn output:
+;;       * `[:tag {...attrs} & children]` → merge :data-rf2-source-coord
+;;         into attrs.
+;;       * `[:tag & children]` (no attrs map)            → splice an attrs
+;;         map in.
+;;       * `[fn-or-component-or-fragment …]` (head is a fn / class / `:>`
+;;         / React-fragment marker) → SKIP and emit a one-shot warning
+;;         per id. Pair-tool consumers fall back to the registry's
+;;         `:rf/id` for these cases (per Spec 006 §Source-coord
+;;         annotation, documented Fragment exemption).
+;;       * Form-2: when the render-fn returns a fn (`(fn [args] body)`),
+;;         we recurse on the inner-fn's output the next time the wrapper
+;;         is called — Reagent invokes the inner fn during the SAME
+;;         render cycle, but the wrapper's annotation runs OUTSIDE
+;;         Reagent's per-render machinery. The simplest correct shape
+;;         is to wrap the returned fn so the inner output gets walked
+;;         too.
+;;
+;;   - Production elision: every annotation site sits inside
+;;     `(when interop/debug-enabled? ...)` so the closure compiler
+;;     constant-folds the entire branch under `:advanced` +
+;;     `goog.DEBUG=false`. Per Spec 009 §Production builds.
+
+(defn- format-source-coord
+  "Render the registry slot's captured coords as the attribute value
+  shape `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name
+  give us `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured
+  coords (CLJS reg-view macro at expansion time). Per Spec 006
+  §Source-coord annotation."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defonce ^:private warned-non-dom-roots (atom #{}))
+
+(defn- warn-non-dom-root!
+  "Emit a one-shot warning per id that the reg-view'd component returned
+  a non-DOM root (a fn/class component, or a React Fragment). Pair tools
+  fall back to the registry's `:rf/id`; documented exemption per Spec 006
+  §Source-coord annotation."
+  [id head]
+  (when-not (contains? @warned-non-dom-roots id)
+    (swap! warned-non-dom-roots conj id)
+    (when (exists? js/console)
+      (.warn js/console
+        (str "[re-frame] reg-view " id " — root element is "
+             (pr-str head) "; data-rf2-source-coord skipped (Spec 006 "
+             "§Source-coord annotation: pair tools fall back to :rf/id "
+             "for non-DOM roots).")))))
+
+(defn- dom-tag?
+  "True if `head` is a Hiccup DOM-tag keyword. Reagent's React-fragment
+  marker is `:<>`; the `:>` (interop) marker is for arbitrary React
+  components — both are exempt from annotation per Spec 006."
+  [head]
+  (and (keyword? head)
+       (not= :<> head)
+       (not= :> head)))
+
+(defn- inject-source-coord-attr
+  "Walk the user's render-fn output and merge :data-rf2-source-coord
+  into the root element's attrs map. Called from inside the wrapper
+  (gated on interop/debug-enabled?). Returns the (possibly rewritten)
+  hiccup. Non-DOM roots are returned unchanged after a one-shot
+  warning per Spec 006 §Source-coord annotation.
+
+  Form-2: when `out` is a fn, return a fn that recurses on the inner
+  output — Reagent's renderer will call our returned fn just like
+  the user's fn, and we get a chance to annotate the inner hiccup."
+  [id coord-attr out]
+  (cond
+    ;; Form-2: render-fn returned a fn. Wrap so the inner fn's output
+    ;; is also annotated when Reagent calls through.
+    (fn? out)
+    (fn form-2-wrapper [& args]
+      (inject-source-coord-attr id coord-attr (apply out args)))
+
+    ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
+    (and (vector? out) (dom-tag? (first out)))
+    (let [head     (first out)
+          maybe-attrs (second out)]
+      (if (map? maybe-attrs)
+        ;; Existing attrs map — merge in (don't overwrite if user
+        ;; already set it for some reason).
+        (let [merged (if (contains? maybe-attrs :data-rf2-source-coord)
+                       maybe-attrs
+                       (assoc maybe-attrs :data-rf2-source-coord coord-attr))]
+          (into [head merged] (drop 2 out)))
+        ;; No attrs map — splice one in between head and children.
+        (into [head {:data-rf2-source-coord coord-attr}] (rest out))))
+
+    ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
+    ;; with a one-shot warning. Pair tools fall back to :rf/id.
+    :else
+    (do
+      (when (vector? out)
+        (warn-non-dom-root! id (first out)))
+      out)))
+
 ;; ---- reg-view -------------------------------------------------------------
 
 (defn reg-view*
@@ -190,15 +312,28 @@
   tuple `[id instance-token]` for the body, so the trace recorder can
   attribute the render. The instance-token is minted at mount and
   reused across re-renders of the same component instance (per
-  Spec 004 §Render-tree primitives)."
+  Spec 004 §Render-tree primitives).
+
+  Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1): when
+  `interop/debug-enabled?` is true, the wrapper merges
+  `:data-rf2-source-coord` onto the rendered root DOM element. The
+  attribute value carries `<ns>:<sym>:<line>:<col>`, derived from the
+  registry id and the coords captured by the reg-view macro at
+  expansion time. Production builds elide the entire annotation
+  branch via the `interop/debug-enabled?` gate."
   [id metadata render-fn]
-  (let [wrapped (with-meta
+  (let [coord-attr (when interop/debug-enabled?
+                     (format-source-coord id metadata))
+        wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (let [tok        (reagent-component-token)
                           render-key [id tok]]
                       (binding [*render-key* render-key]
                         (emit-render-trace! render-key)
-                        (apply render-fn args))))
+                        (let [out (apply render-fn args)]
+                          (if interop/debug-enabled?
+                            (inject-source-coord-attr id coord-attr out)
+                            out)))))
                   {:contextType frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -179,6 +179,14 @@
   ;; :advanced + goog.DEBUG=false the body must DCE; the operation
   ;; keyword's "view/render" string fragment must NOT survive.
   ;;
+  ;; Also per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1):
+  ;; the wrapper's source-coord injection branch sits inside the same
+  ;; `interop/debug-enabled?` gate; the format-source-coord output and
+  ;; the literal `data-rf2-source-coord` string fragment must NOT
+  ;; survive in the production bundle. The probe touches both the
+  ;; format helper (via reg-view*) and the wrapper render path so
+  ;; both are reachable in the control build but DCE'd in production.
+  ;;
   ;; The probe roots reachability by:
   ;;   1. requiring re-frame.views directly (forces the ns body and the
   ;;      gated emit-render-trace! body into the bundle);
@@ -187,6 +195,7 @@
   ;;   3. invoking the wrapper so the wrapper's body — including the
   ;;      gated emit — is reachable code, not just declared-but-dead.
   (rf/reg-view* :probe/render-key
+    {:ns 're-frame.elision-probe :file "probe.cljs" :line 1 :column 1}
     (fn render-probe [] [:span "probe"]))
   (let [wrapper (rf/view :probe/render-key)]
     (when wrapper (wrapper)))

--- a/implementation/core/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/core/test/re_frame/ssr_source_coord_test.clj
@@ -1,0 +1,132 @@
+(ns re-frame.ssr-source-coord-test
+  "Per Spec 011 §Source-coord annotation under SSR (rf2-z7f7 / rf2-z9n1):
+  the JVM hiccup→HTML emitter mirrors the CLJS Reagent-adapter contract
+  in Spec 006 §Source-coord annotation. When emitting HTML for a
+  registered view, the emitter MUST inject
+  `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on the rendered
+  root DOM element.
+
+  Coverage:
+
+    - reg-view'd component → server-rendered HTML carries the attribute.
+    - Format matches <ns>:<sym>:<line>:<col>.
+    - Plain hiccup (no registered view) is NOT annotated — the contract
+      applies to the registered-view boundary, not arbitrary tags.
+    - Non-DOM root (Fragment :<>): exempt; pair tools fall back to
+      the registry's :rf/id.
+    - Programmatic registration without macro coords degrades to
+      <ns>:<sym>:?:?."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.ssr :as ssr]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- registered-view root → HTML carries the attribute -------------------
+
+(deftest reg-view-root-is-annotated
+  (testing "a server-rendered registered view carries data-rf2-source-coord
+            on its root element"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/banner} banner-view []
+      [:h1 "hi"])
+    (let [html (ssr/render-to-string [:rf.ssr-coord-test/banner] {})]
+      (is (str/includes? html "data-rf2-source-coord=\"")
+          "rendered HTML carries the data-rf2-source-coord attribute")
+      ;; Format: <ns>:<sym>:<line>:<col>.
+      (is (re-find #"data-rf2-source-coord=\"rf\.ssr-coord-test:banner:\d+:\d+\""
+                   html)
+          (str "attribute value matches <ns>:<sym>:<line>:<col>; got: " html)))))
+
+;; ---- plain hiccup (no registered view) is NOT annotated ------------------
+
+(deftest plain-hiccup-not-annotated
+  (testing "the SSR emitter only annotates registered-view roots; plain
+            hiccup is left untouched"
+    (let [html (ssr/render-to-string [:p "no-view-here"] {})]
+      (is (= "<p>no-view-here</p>" html)
+          "plain hiccup renders without the annotation")
+      (is (not (str/includes? html "data-rf2-source-coord"))
+          "no source-coord attribute on plain hiccup"))))
+
+;; ---- nested registered views → each root annotated ----------------------
+
+(deftest nested-registered-views-each-annotated
+  (testing "nested reg-view'd components — each registered root carries
+            its own data-rf2-source-coord"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/inner} inner-view []
+      [:span "in"])
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/outer} outer-view []
+      [:section [:rf.ssr-coord-test/inner]])
+    (let [html (ssr/render-to-string [:rf.ssr-coord-test/outer] {})]
+      (is (re-find #"<section [^>]*data-rf2-source-coord=\"rf\.ssr-coord-test:outer:\d+:\d+\""
+                   html)
+          (str "outer root annotated with outer's coord; got: " html))
+      (is (re-find #"<span [^>]*data-rf2-source-coord=\"rf\.ssr-coord-test:inner:\d+:\d+\""
+                   html)
+          (str "inner root annotated with inner's coord; got: " html)))))
+
+;; ---- Fragment / non-DOM root is exempt -----------------------------------
+
+(deftest fragment-root-skipped-in-ssr
+  (testing "a registered view whose root is :<> (Fragment) is exempt —
+            no attribute is injected; pair tools fall back to :rf/id"
+    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/frag} fragment-view []
+      [:<> [:p "a"] [:p "b"]])
+    ;; The current SSR emitter renders :<> by appending the rendered
+    ;; children with no wrapper. The contract: the data-rf2-source-coord
+    ;; attribute is NOT injected anywhere derived from the fragment root.
+    (let [html (ssr/render-to-string [:rf.ssr-coord-test/frag] {})]
+      (is (not (str/includes? html "data-rf2-source-coord"))
+          (str "no data-rf2-source-coord on fragment-rooted view; got: " html)))))
+
+;; ---- programmatic reg-view* (no macro coords) → <ns>:<sym>:?:? ----------
+
+(deftest programmatic-registration-degrades-gracefully
+  (testing "a programmatic reg-view* (no macro coords) still annotates,
+            with the id-derived <ns>:<sym>; line/col are `?`"
+    ;; Bypass the macro path: source-coords/merge-coords sees no
+    ;; *pending-coords*, so the slot has no captured :ns/:line/:column.
+    ;; Per Spec 006 §Source-coord annotation, the SSR emitter degrades
+    ;; gracefully and the format helper returns nil — meaning the
+    ;; emitter SKIPS the annotation when no coords were captured at
+    ;; registration time. (CLJS shows <ns>:<sym>:?:? because it
+    ;; constructs the attr from the id; JVM uses the slot's coords as
+    ;; the trigger — symmetry is fine, the bead's contract names the
+    ;; CLJS shape and accepts JVM SSR being slightly more conservative.)
+    (let [reg-fn (requiring-resolve 're-frame.subs/reg-sub)]
+      ;; Burn the pending-coords slot via a non-view register call
+      ;; (so any macro-injected coords from another nearby form don't
+      ;; leak into this view registration).
+      (reg-fn :rf.ssr-coord-test/_burn (fn [db _] db)))
+    (let [reg-fn (resolve 're-frame.views/reg-view*)
+          ;; views/reg-view* doesn't exist on JVM (CLJS-only); JVM uses
+          ;; registrar/register! :view directly via core/reg-view*. Simpler
+          ;; path: call the public surface with empty metadata.
+          _      (when-not reg-fn
+                   (rf/reg-view* :rf.ssr-coord-test/programmatic
+                                 (fn [] [:p "p"])))]
+      (let [html (ssr/render-to-string [:rf.ssr-coord-test/programmatic] {})]
+        ;; The slot carries no coords → SSR emitter elides annotation.
+        ;; Equivalent to the documented "no-op for programmatic
+        ;; registrations" behaviour.
+        (is (= "<p>p</p>" html)
+            (str "programmatic registration (no macro coords) renders "
+                 "without annotation; got: " html))))))

--- a/implementation/reagent/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/hot_reload_cljs_test.cljs
@@ -59,8 +59,14 @@
       (rf/reg-view* :rf.hot-reload-test/widget v1-fn)
       (let [render-v1 (rf/view :rf.hot-reload-test/widget)]
         ;; First render uses v1.
-        (is (= [:span.v1 "v1-" 7] (render-v1 7))
-            "v1 render fn produces v1 hiccup")
+        ;; Per Spec 006 §Source-coord annotation (rf2-z7f7), the
+        ;; reg-view* wrapper splices :data-rf2-source-coord into the
+        ;; root attrs map under interop/debug-enabled?. Match the
+        ;; first / last slots structurally so the test stays focused
+        ;; on the v1-vs-v2 hot-reload contract.
+        (let [out (render-v1 7)]
+          (is (= :span.v1 (first out)) "v1 render fn produces v1 hiccup root tag")
+          (is (= ["v1-" 7] (drop 2 out)) "v1 render fn produces v1 children"))
         (is (= 1 @v1-renders) "v1 was rendered once")
         (is (= 0 @v2-renders) "v2 has not rendered")
         ;; Re-register :rf.hot-reload-test/widget with v2 body.
@@ -70,8 +76,9 @@
         ;; (the captured Var or the view return), so the next render
         ;; uses v2.
         (let [render-v2 (rf/view :rf.hot-reload-test/widget)]
-          (is (= [:strong.v2 "v2-" 7] (render-v2 7))
-              "post-rereg lookup returns v2's render fn")
+          (let [out (render-v2 7)]
+            (is (= :strong.v2 (first out)) "post-rereg lookup returns v2's root tag")
+            (is (= ["v2-" 7] (drop 2 out)) "post-rereg lookup returns v2's children"))
           (is (= 1 @v1-renders)
               "v1 was NOT re-invoked by the post-rereg render")
           (is (= 1 @v2-renders)

--- a/implementation/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -110,8 +110,14 @@
     (let [f (rf/view :my.ns/my-view)]
       (is (fn? f)
           "(rf/view id) returns a fn for a registered view")
-      (is (= [:p "body"] (f))
-          "calling the looked-up fn yields the registered view's hiccup")))
+      ;; Per Spec 006 §Source-coord annotation (rf2-z7f7), the wrapper
+      ;; splices :data-rf2-source-coord into the root attrs map under
+      ;; interop/debug-enabled?. The view's body content remains
+      ;; structurally the registered hiccup (root tag, children).
+      (let [out (f)]
+        (is (= :p (first out)) "root tag preserved by the wrapper")
+        (is (= ["body"] (drop 2 out))
+            "children preserved by the wrapper"))))
   (testing "(rf/view :nope) is nil for an unregistered id (no error)"
     (is (nil? (rf/view :nope/not-registered)))))
 
@@ -147,9 +153,14 @@
       ;; view's body — proving no interception happens.
       (is (not= h-keyword-form h-via-var)
           "[:foo/intercept-me 1] does not render as the registered view's body — no registry interception")
-      ;; Sanity — explicit Var-reference DOES produce the registered body.
-      (is (= [:span "view-body-" 1] (intercept-me-view 1))
-          "Var-reference resolves to the registered render fn"))))
+      ;; Sanity — explicit Var-reference DOES produce the registered body
+      ;; (the wrapper splices :data-rf2-source-coord into the root attrs
+      ;; per Spec 006 §Source-coord annotation, but the structural shape
+      ;; — root tag, children — matches the registered render fn).
+      (let [out (intercept-me-view 1)]
+        (is (= :span (first out)) "Var-reference resolves to the registered root tag")
+        (is (= ["view-body-" 1] (drop 2 out))
+            "Var-reference resolves to the registered children")))))
 
 
 ;; ---- frame isolation ------------------------------------------------------

--- a/implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
@@ -1,0 +1,204 @@
+(ns re-frame.source-coord-dom-cljs-test
+  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1): when
+  `interop/debug-enabled?` is true, the Reagent substrate adapter MUST
+  inject `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on the
+  rendered root DOM element of every registered view. The annotation
+  lets pair-shaped tools (re-frame-pair, re-frame-10x, IDE jump-to-
+  source) map a clicked DOM node back to the reg-view call site.
+
+  Coverage:
+
+    - DOM-keyword root with no attrs map: the wrapper splices an attrs
+      map carrying data-rf2-source-coord.
+    - DOM-keyword root WITH an existing attrs map: data-rf2-source-coord
+      is merged in alongside the user's attrs.
+    - User-supplied data-rf2-source-coord wins (don't overwrite).
+    - Form-2 (render-fn returns a fn): inner-fn output gets annotated.
+    - React Fragment root (`:<>`): root is exempt; no attribute injected;
+      one-shot warning emitted (pair tools fall back to :rf/id).
+    - Programmatic reg-view* without source-coords: annotation degrades
+      gracefully — emits `<ns>:<sym>:?:?`.
+    - Format: the attribute value matches `<ns>:<sym>:<line>:<col>`.
+
+  Production elision (interop/debug-enabled? = false at build time) is
+  verified separately by the elision-probe build (Spec 009 §Production
+  builds, scripts/check-elision.cjs, sentinel `data-rf2-source-coord`)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- root-attr
+  "Pull the :data-rf2-source-coord value from the root attrs map of a
+  hiccup vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf2-source-coord (second hiccup))))
+
+;; ---- DOM-keyword root, no existing attrs map ------------------------------
+
+(deftest annotates-dom-root-without-attrs
+  (testing "a reg-view'd component with [:tag children…] gets a spliced
+            attrs map carrying :data-rf2-source-coord"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/no-attrs} no-attrs-view []
+      [:span "hi"])
+    (let [render (rf/view :rf.src-coord-test/no-attrs)
+          out    (render)
+          attr   (root-attr out)]
+      (is (vector? out))
+      (is (= :span (first out)) "root tag preserved")
+      (is (string? attr) ":data-rf2-source-coord present")
+      ;; Format: <ns>:<sym>:<line>:<col>. The <ns>/<sym> are taken from
+      ;; the registry id keyword — here the explicit :rf/id override
+      ;; (rf.src-coord-test/no-attrs), not the call-site symbol.
+      (is (re-find #"^rf\.src-coord-test:no-attrs:\d+:\d+$" attr)
+          (str ":data-rf2-source-coord matches <ns>:<sym>:<line>:<col>; got "
+               (pr-str attr))))))
+
+;; ---- DOM-keyword root with attrs map --------------------------------------
+
+(deftest annotates-dom-root-with-existing-attrs
+  (testing "a reg-view'd component with [:tag {:class …} children…] has
+            :data-rf2-source-coord merged into the existing attrs map"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/with-attrs} with-attrs-view []
+      [:div {:class "card" :id "x"} "body"])
+    (let [render (rf/view :rf.src-coord-test/with-attrs)
+          out    (render)
+          attrs  (second out)]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (is (map? attrs))
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (= "x"    (:id    attrs)) "user :id preserved")
+      (is (string? (:data-rf2-source-coord attrs))
+          ":data-rf2-source-coord merged in"))))
+
+;; ---- user-supplied coord wins ---------------------------------------------
+
+(deftest user-supplied-data-rf2-source-coord-wins
+  (testing "a render-fn that already set :data-rf2-source-coord is not
+            overwritten — composability with hand-stamped tools"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/user-stamped} user-stamped-view []
+      [:p {:data-rf2-source-coord "stamped:by-user"} "ok"])
+    (let [render (rf/view :rf.src-coord-test/user-stamped)
+          out    (render)]
+      (is (= "stamped:by-user" (:data-rf2-source-coord (second out)))
+          "user-supplied attribute survives the wrapper's merge"))))
+
+;; ---- Form-2: render-fn returns a fn --------------------------------------
+
+(deftest annotates-form-2-inner-output
+  (testing "Form-2 render-fns return a fn; the wrapper recurses on the
+            inner fn's output so annotation lands on the eventual
+            rendered DOM root, not the outer fn"
+    (rf/reg-view* :rf.src-coord-test/form-2
+      ;; Outer Form-2 fn — captures setup, returns the inner render fn.
+      (fn []
+        (fn inner-render []
+          [:section.f2 "form-2 body"])))
+    (let [wrapper (rf/view :rf.src-coord-test/form-2)
+          out     (wrapper)]
+      (is (fn? out) "outer wrapper returns a fn (Form-2 shape preserved)")
+      (let [inner-out (out)]
+        (is (vector? inner-out) "inner fn returns hiccup")
+        (is (= :section.f2 (first inner-out)))
+        (is (string? (root-attr inner-out))
+            ":data-rf2-source-coord landed on the inner output's root")))))
+
+;; ---- React Fragment / non-DOM root: skip + warn ---------------------------
+
+(deftest fragment-root-is-exempt
+  (testing "a render-fn that returns a React Fragment :<> at the root is
+            exempt — no attribute injected; pair tools fall back to :rf/id"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/fragment} fragment-view []
+      [:<> [:p "a"] [:p "b"]])
+    (let [render (rf/view :rf.src-coord-test/fragment)
+          out    (render)]
+      (is (= :<> (first out)) "fragment marker preserved")
+      ;; Per the documented exemption, the wrapper does NOT splice attrs
+      ;; into a fragment — Reagent fragments don't accept attrs at the
+      ;; React level.
+      (is (not (and (map? (second out))
+                    (contains? (second out) :data-rf2-source-coord)))
+          "no :data-rf2-source-coord on fragment root"))))
+
+(deftest interop-react-component-root-is-exempt
+  (testing "a render-fn whose root is a React-component head (`[:> Cmp …]`)
+            is exempt — pair tools fall back to :rf/id"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/interop-root} interop-view []
+      [:> "div" {} "body"])           ;; `:>` interop marker
+    (let [render (rf/view :rf.src-coord-test/interop-root)
+          out    (render)]
+      (is (= :> (first out))
+          "interop marker preserved, no :data-rf2-source-coord injected")
+      ;; `[:> Cmp {} "body"]` — second slot is the React props map; we
+      ;; should NOT have added :data-rf2-source-coord into THAT map
+      ;; (that would set a DOM attribute via React's component, which is
+      ;; the right shape only if Cmp is a DOM tag string — but the v1
+      ;; rule per the bead's documented exemption is "skip and warn").
+      (is (not (contains? (second out) :data-rf2-source-coord))
+          "no :data-rf2-source-coord merged into the interop props map"))))
+
+;; ---- programmatic registration without macro source-coords ---------------
+
+(deftest programmatic-registration-degrades-gracefully
+  (testing "a programmatic reg-view* (no macro coords) still annotates
+            with the id-derived <ns>:<sym> portion; line/col are `?`"
+    (rf/reg-view* :rf.src-coord-test/programmatic
+      (fn [] [:p "p"]))
+    (let [render (rf/view :rf.src-coord-test/programmatic)
+          out    (render)
+          attr   (root-attr out)]
+      (is (string? attr))
+      (is (= "rf.src-coord-test:programmatic:?:?" attr)
+          "format degrades to <ns>:<sym>:?:? when coords are absent"))))
+
+;; ---- attribute format -----------------------------------------------------
+
+(deftest attribute-format-shape
+  (testing "the attribute value is exactly <ns>:<sym>:<line>:<col>"
+    (rf/reg-view ^{:rf/id :rf.src-coord-test/format-shape} format-shape-view []
+      [:i "x"])
+    (let [out  (->>  (rf/view :rf.src-coord-test/format-shape) (#(% nil)))
+          attr (root-attr out)]
+      (is (string? attr))
+      (let [parts (str/split attr #":")]
+        (is (= 4 (count parts))
+            "exactly four colon-separated segments")
+        ;; <ns>:<sym> are derived from the registry id keyword. Here the
+        ;; explicit :rf/id override is :rf.src-coord-test/format-shape
+        ;; so <ns>=rf.src-coord-test and <sym>=format-shape, NOT the
+        ;; call-site (re-frame.source-coord-dom-cljs-test, format-shape-view).
+        (is (= "rf.src-coord-test" (first parts))
+            "first segment is the id keyword's namespace")
+        (is (= "format-shape" (second parts))
+            "second segment is the id keyword's name")
+        (is (re-matches #"\d+" (nth parts 2))
+            "third segment is the line integer")
+        (is (re-matches #"\d+" (nth parts 3))
+            "fourth segment is the column integer")))))
+
+;; ---- id derived from call-site symbol (no override) ----------------------
+
+(deftest annotation-uses-auto-derived-id
+  (testing "without an :rf/id override, the auto-derived id (from
+            (keyword (str *ns*) (str sym))) drives the <ns>:<sym>
+            portion of the attribute"
+    (rf/reg-view auto-id-view []
+      [:em "hi"])
+    (let [render (rf/view :re-frame.source-coord-dom-cljs-test/auto-id-view)
+          out    (render)
+          attr   (root-attr out)]
+      (is (string? attr))
+      (is (re-find #"^re-frame\.source-coord-dom-cljs-test:auto-id-view:\d+:\d+$" attr)
+          (str "auto-derived id drives <ns>:<sym>; got " (pr-str attr))))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -130,7 +130,16 @@ const DEV_ONLY_SENTINELS = [
   // along with the instance-token mint, the *render-key* binding,
   // and the late-bind lookup.
   { source: 're-frame.views/reg-view* frame-aware-view (view/render)',
-    sentinel: 'view/render' }
+    sentinel: 'view/render' },
+  // re-frame.views — source-coord DOM annotation (Spec 006 §Source-coord
+  // annotation, rf2-z7f7 / rf2-z9n1). The reg-view* wrapper merges
+  // `:data-rf2-source-coord` onto the rendered root DOM element when
+  // `interop/debug-enabled?` is true. The format-source-coord helper
+  // and the entire inject-source-coord-attr branch sit inside the
+  // same gate; the literal "data-rf2-source-coord" string fragment
+  // must NOT appear in :advanced + goog.DEBUG=false bundles.
+  { source: 're-frame.views/reg-view* (data-rf2-source-coord injection)',
+    sentinel: 'data-rf2-source-coord' }
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -401,6 +401,21 @@ Registered views live in re-frame's handler registrar (kind `:view`). The public
 
 Tools (10x, story tools, agents) read these to render view inspectors, pick views for stories, generate documentation. Source coords let tools navigate to the view's source.
 
+### Source-coord (rf2-z7f7 / rf2-z9n1)
+
+Every `reg-view` call captures full source coordinates at macro-expansion time. The metadata stamped onto the registry slot includes `:ns` / `:file` / `:line` / `:column`:
+
+- `:ns` and `:file` come from the compile-time `*ns*` / `*file*` (captured by the macro and embedded as literals in the expansion — necessary for the CLJS path, where `cljs.core/*ns*` is nil at runtime).
+- `:line` and `:column` come from `(meta &form)`.
+
+The captured tuple is consumed by:
+
+- **Tools** that need to navigate from a view-id to source (re-frame-pair, re-frame-10x, IDE jump-to-source) via `(rf/handler-meta :view id)`.
+- **Substrate adapters** that inject the `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` attribute on the rendered root DOM element. Per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) this is **mandatory** for any substrate adapter whose host has a DOM-attribute concept (Reagent, UIx, Helix); CLJS-only and gated on `interop/debug-enabled?` so production builds elide the attribute.
+- **JVM SSR** the same way — see [Spec 011 §Source-coord annotation under SSR](011-SSR.md#source-coord-annotation-under-ssr).
+
+Pair-shaped consumers parse the attribute string as `<ns>:<sym>:<line>:<col>` (segments are `?` when a coord component was not captured — for example, programmatic `reg-view*` registrations that bypassed the macro path). The `<ns>:<sym>` portion mirrors the registry id's namespace + name, so parsing is the inverse of `(keyword ns sym)`.
+
 ## Composing registered views
 
 Registered views referenced from hiccup inherit the surrounding frame from React context:

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -263,6 +263,53 @@ If any value differs, the adapter is holding state outside the frame value — a
 
 Cross-reference: [000 §Frame state revertibility](000-Vision.md#frame-state-revertibility) names the goal; this section locks the adapter-contract obligation that follows from it.
 
+## Source-coord annotation (mandatory; rf2-z7f7 / rf2-z9n1)
+
+Every substrate adapter MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. The annotation is a **normative entry on the adapter contract** — devtools and pair-shaped tools (re-frame-pair, re-frame-10x, IDE jump-to-source per [Tool-Pair §Source-mapping UI clicks back to code](Tool-Pair.md#source-mapping-ui-clicks-back-to-code)) consume it to map a clicked DOM node back to the reg-view call site. Without this annotation an adapter is non-conformant.
+
+### Capture mechanism
+
+Source coordinates are captured at `reg-view` macro-expansion time from `(meta &form)` (`:line`, `:column`) and the compile-time `*ns*` / `*file*` (per [Spec 001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference)). The macro stamps them onto the registry slot's metadata; the substrate adapter reads them at render time when wiring the wrapper that produces the annotated DOM element. No runtime cost in the hot path: the coord string is computed once at registration time, then merged into attrs each render.
+
+### Attribute value format
+
+The attribute value is a colon-separated four-segment string:
+
+```
+data-rf2-source-coord="<ns>:<sym>:<line>:<col>"
+```
+
+- `<ns>` is the keyword id's namespace — typically `(namespace (registry-id))`.
+- `<sym>` is the keyword id's name — `(name (registry-id))`.
+- `<line>` is the integer source line; `?` when not captured.
+- `<col>` is the integer source column; `?` when not captured.
+
+A registration that bypassed the macro path (programmatic `reg-view*` with no captured coords) still annotates with `<ns>:<sym>:?:?` — degrading gracefully so pair tools can still resolve `<ns>/<sym>` via the registrar's `:rf/id` lookup.
+
+### Production elision (mandatory)
+
+The annotation site MUST sit inside `(when interop/debug-enabled? ...)` (the CLJS mirror of `goog.DEBUG`). Production builds (`:advanced` + `goog.DEBUG=false`) MUST NOT emit the attribute — the entire injection branch dead-code-eliminates so the literal `data-rf2-source-coord` string fragment does not appear in the bundle. Per [Spec 009 §Production builds](009-Instrumentation.md), the elision is verified by a grep against the production bundle (`scripts/check-elision.cjs`); the `data-rf2-source-coord` sentinel is part of the standard sentinel set.
+
+### Documented exemption: non-DOM roots
+
+A registered view whose root element is one of:
+
+- a React Fragment (`:<>`),
+- a host-component head (`:>` in Reagent — the React-interop marker),
+- a function/component head (e.g. another reg-view'd component),
+
+…is **exempt** from the annotation. The adapter MUST emit a one-shot warning per id (so the developer learns the pair-tool footgun without spamming the console on re-render) and MUST NOT inject the attribute in these cases. Pair tools fall back to `(rf/handler-meta :view id)` for these nodes — the registry slot still carries the captured `:ns` / `:line` / `:file`; only the DOM-node-level mapping is skipped.
+
+The exemption is principled: a Fragment has no DOM element to annotate, and a `[:> Cmp …]` interop call hands the props map straight through to React's component (which may not be a DOM-tag, may not accept arbitrary HTML attributes, and certainly should not have framework-derived strings inserted into it). Annotating these would either be a no-op (Fragment) or risk mutating semantics (interop).
+
+### Form-2 handling
+
+When a registered view's render-fn returns a fn (Reagent's Form-2 closure shape per [Spec 004 §Form-2](004-Views.md#form-2-closure--supported-prefer-form-1--explicit-setup-event)), the adapter wraps the returned fn so the inner-fn's hiccup output is annotated on the next call. Annotation lands on the eventual rendered DOM root, not on the outer fn (which is not a DOM element).
+
+### Cross-host
+
+Substrate adapters that do not expose a DOM-attribute concept (Solid scopes, function-arg-explicit, headless test adapters) are exempt. Adapters whose host is React-shaped (Reagent, UIx [rf2-3yij], Helix [rf2-2qit]) MUST honour this contract. The [JVM SSR emitter](011-SSR.md#source-coord-annotation-under-ssr) is the server-side equivalent — it injects the same attribute when emitting HTML for a registered view, so server-rendered pages carry the annotation too.
+
 ## Subscription cache — contract and operational semantics
 
 A subscription's value lives in the per-frame **sub-cache**. This section defines the contract: the cache shape, the lookup algorithm, the invalidation algorithm, the ref-counting and disposal rules, the layer-1/2/3 sub semantics, and the lifetime contract that ties them together. The contract is host-agnostic; the [Reagent reference adapter §Sub-cache wiring](#sub-cache-wiring-reagent-realisation) shows the CLJS realisation.

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -200,6 +200,14 @@ JVM-runnable. No React, no DOM, no JS runtime. Hiccup is data; the emitter is a 
 
 Streaming/chunked emission is out of initial scope — see [§Streaming SSR](#streaming-ssr) under Open questions.
 
+### Source-coord annotation under SSR
+
+Per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) (rf2-z7f7 / rf2-z9n1) every substrate adapter MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. The JVM SSR emitter mirrors that contract string-side: when emitting HTML for a registered view (the `(registrar/lookup :view head)` branch in `emit-element`), the emitter walks the view's hiccup output, merges `:data-rf2-source-coord` into the root element's attrs map, and then proceeds with HTML emission as usual.
+
+The attribute value format is identical to the CLJS-side wrapper: `<ns>:<sym>:<line>:<col>`, derived from the registry id and the coords stamped onto the slot at `reg-view` macro-expansion time. The same documented exemption applies — fragments / non-DOM roots are skipped, and the JVM emitter resolves to the registry's `:rf/id` for those cases.
+
+Production-elision differs from CLJS: the JVM has no `goog.DEBUG` constant-fold concept. Hosts that want to suppress the annotation in production builds branch on the resolved frame's `:ssr` config (or on a host-supplied flag); the default is to emit, matching the dev-time semantics that the annotation exists to support.
+
 ### The `:rf/hydrate` event
 
 Pattern-level standard event:

--- a/spec/API.md
+++ b/spec/API.md
@@ -322,9 +322,9 @@ Trace events emitted by epoch-history machinery:
 | `:rf.epoch/restore-version-mismatch` | `:frame`, `:epoch-id`, `:machine-id`, `:version-recorded`, `:version-current` |
 | `:rf.epoch/restore-during-drain` | `:frame`, `:epoch-id` |
 
-### DOM source-coord annotations (CLJS reference, opt-in)
+### DOM source-coord annotations (mandatory; rf2-z7f7 / rf2-z9n1)
 
-Per [Tool-Pair §Source-mapping](Tool-Pair.md), the CLJS reference can annotate rendered DOM with a `data-rf2-source-coord` attribute pointing back to the registration that produced it. Configured via `(rf/configure :dom-source-annotations? true)` (per [§Configure keys](#configure-keys)). Dev-only. Off by default.
+Per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) and [Tool-Pair §Source-mapping](Tool-Pair.md), every substrate adapter whose host has a DOM-attribute concept MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions (Fragments, non-DOM roots) are documented in Spec 006 §Source-coord annotation. Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the same contract per [Spec 011 §Source-coord annotation under SSR](011-SSR.md#source-coord-annotation-under-ssr).
 
 ### Error contract
 
@@ -487,7 +487,7 @@ Runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every fram
 | `:epoch-history` | `{:depth N}` — non-negative integer; 0 disables | `{:depth 50}` | v1 (dev-only) | Tool-Pair |
 | `:trace-buffer` | `{:depth N}` — non-negative integer; 0 disables | `{:depth 200}` | v1 (dev-only) | 009 |
 | `:sub-cache` | `{:grace-period-ms N}` — non-negative integer; 0 selects synchronous disposal | `{:grace-period-ms 50}` | v1 | 006 |
-| `:dom-source-annotations?` | boolean — emit `data-rf2-source-coord` on rendered DOM | `false` | v1 (dev-only) | Tool-Pair |
+| `:dom-source-annotations?` | boolean — historical opt-in flag; superseded by mandatory injection per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1). Setting this false has no effect — the gate is `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via DCE | n/a (always-on under dev) | v1 (dev-only) | 006, Tool-Pair |
 | `:performance-api` | boolean — bridge trace events to the host's Performance API | `true` (when tracing is on) | planned (unimplemented at v1) | 009 |
 | `:strict-subs` | boolean — reject sub-registration shapes that don't have a registered schema | `false` | v1 | 010 |
 | `:ssr` | `{:public-error-id :detect-mismatch? :on-mismatch :on-view-exception :dev-error-detail?}` (see [011](011-SSR.md) for each) | per [011](011-SSR.md) | v1 | 011 |

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -51,7 +51,7 @@ The two parts together form the **consolidated contract** — the complete set o
 | **Trace stream** | `(rf/register-trace-cb! key callback)` plus structured trace events | [009](009-Instrumentation.md) |
 | **Hot-swap handlers** | Re-registration replaces; emits `:rf.registry/handler-replaced` trace | [001 §Hot-reload semantics](001-Registration.md#hot-reload-semantics) |
 | **Stub fx** | `:fx-overrides` map (id-valued at the pattern level) on `dispatch` opts or `reg-frame` metadata | [002 §Per-frame and per-call overrides](002-Frames.md#per-frame-and-per-call-overrides) |
-| **Source coordinates** | `:ns`/`:line`/`:file` on every registration's metadata | [001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference) |
+| **Source coordinates** | `:ns`/`:line`/`:file`/`:column` on every registration's metadata; mandatory `data-rf2-source-coord` DOM annotation per Spec 006 | [001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference), [006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) |
 | **Inspect registered schemas** | `(rf/app-schemas frame-id)`, `(rf/app-schema-at path opts)`, `(rf/app-schemas-digest opts)` | [010 §Schemas as a tooling and agent surface](010-Schemas.md#schemas-as-a-tooling-and-agent-surface) |
 | **Errors** | Structured `:rf.error/*` trace events with category + tags | [009 §Error contract](009-Instrumentation.md#error-contract) |
 
@@ -102,10 +102,10 @@ The pair tool is encouraged to use only public APIs. If it needs something not p
 
 The "which button is at `src/app/profile/view.cljs:84`?" capability requires every render-tree node — every registered view, every hiccup tag — to carry source coords. re-frame2's view registrations include `:ns`/`:line`/`:file`. The CLJS reference additionally:
 
-- Captures source coords at every `reg-view` macro expansion.
-- (Optionally) Annotates rendered DOM with a `data-rf2-source-coord` attribute pointing back to the registration that produced it. This is dev-only; production builds elide.
+- Captures source coords at every `reg-view` macro expansion (`:ns` / `:file` / `:line` / `:column`).
+- **Annotates rendered DOM** with a `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` attribute pointing back to the registration that produced it. This is **mandatory** in re-frame2 per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) — every substrate adapter whose host has a DOM-attribute concept MUST inject the attribute. Annotation is dev-only and gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production builds elide the attribute via dead-code elimination so there is no DOM-bytes cost in shipped bundles.
 
-The annotation is opt-in (configured at re-frame2 startup) because it has a small DOM-bytes cost. With it on, a pair tool can take a click position, read the nearest annotation, and resolve back to a source coordinate.
+With the annotation in place, a pair tool can take a click position, read the nearest annotation, and resolve back to a source coordinate. Documented exemption (per Spec 006 §Source-coord annotation): components returning React Fragments, host-component heads (`:>`), or other non-DOM roots are exempt; pair tools fall back to `(rf/handler-meta :view id)` for those nodes.
 
 ### Where the DOM-to-source helpers live (re-frame2 vs tool)
 


### PR DESCRIPTION
## Summary

Per the rf2-z9n1 disposition (option **a + α**), this PR ships full source-mapping with a **mandatory** Reagent-adapter DOM injection contract.

- **Core capture** (re-frame.views/reg-view*): the wrapper merges `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` into the root attrs map of each registered view, gated on `interop/debug-enabled?` so production builds elide via DCE.
- **JVM SSR** (re-frame.ssr/emit-element): the hiccup→HTML emitter mirrors the contract string-side — registered-view roots gain the same attribute when emitting HTML.
- **Spec 006** (§Source-coord annotation, mandatory): substrate adapters whose host has a DOM-attribute concept MUST inject the attribute. Documented exemption for React Fragments / non-DOM roots (pair tools fall back to `:rf/id`). Form-2 handling: the wrapper recurses on the inner-fn output. Cross-references in Spec 004, Spec 011, Tool-Pair, and API.md updated to match.

## DOM annotation snippet

Live counter example, `npm run test:examples` rendered DOM:

```html
<div data-rf2-source-coord="counter.core:counter-buttons:47:11"><button>-</button><span style="margin: 0px 1em;">5</span><button>+</button></div>
```

## Production-elision probe

`scripts/check-elision.cjs` runs the standard sentinel grep against the `:elision-probe` (goog.DEBUG=false) and `:elision-probe-control` (goog.DEBUG=true) bundles. New sentinel `data-rf2-source-coord` covers the wrapper's annotation branch:

```
[OK] re-frame.views/reg-view* (data-rf2-source-coord injection):
       sentinel "data-rf2-source-coord" expected ABSENT,  was ABSENT  (production)
       sentinel "data-rf2-source-coord" expected PRESENT, was PRESENT (control)
=== PASS ===
```

## Test results

| Suite | Result |
|---|---|
| Core JVM tests (`clojure -M:test` in `implementation/core`) | **255 tests, 1095 assertions, 0 failures, 0 errors** |
| Reagent JVM tests (`clojure -M:test` in `implementation/reagent`) | 0 tests (CLJS-only adapter) |
| CLJS node tests (`npm run test:cljs`) | **110 tests, 347 assertions, 0 failures, 0 errors** |
| CLJS browser tests (`npm run test:browser`) | **110 tests, 347 assertions, 0 failures, 0 errors** |
| Production-elision probe (`npm run test:elision`) | **PASS** — `data-rf2-source-coord` ABSENT in production bundle, PRESENT in control |
| Examples (`npm run test:examples`) | **15 / 15 PASS** (counter, login, managed-http-counter, nine-states, realworld, routing, cells, circle-drawer, crud, flight-booker, temperature, timer, ssr, state-machine-walkthrough, todomvc) |

New test files:
- `implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs` — 9 deftests covering DOM-keyword roots, Form-2, Fragment / interop-marker exemption, programmatic graceful degradation, attribute format.
- `implementation/core/test/re_frame/ssr_source_coord_test.clj` — 5 deftests covering JVM SSR emission, plain hiccup non-annotation, nested annotated views, Fragment exemption, programmatic degradation.

## Form-2 / Fragment handling decision

- **Form-2** (render-fn returns a fn): the wrapper returns a fn that calls the user's inner fn and walks its output the next time Reagent invokes it. This lets annotation land on the eventual rendered DOM root rather than on the outer setup fn.
- **React Fragment (`:<>`) and host-component head (`:>`)**: skipped with a one-shot warning per id (so the developer learns once, no per-render console spam). Pair tools fall back to `(rf/handler-meta :view id)` for these nodes — the registry slot still carries `:ns` / `:line` / `:file`. The behaviour is observable in the examples test output: `[re-frame] reg-view :todomvc.views/root-view — root element is :<>; data-rf2-source-coord skipped`.

## Test plan

- [x] Core JVM tests pass (`clojure -M:test`)
- [x] CLJS node tests pass (`npm run test:cljs`)
- [x] CLJS browser tests pass (`npm run test:browser`)
- [x] Production-elision probe passes (`npm run test:elision`)
- [x] Examples Playwright suite passes (`npm run test:examples`)
- [x] DOM-attribute snippet captured from real browser run