### PR TITLE
docs(spec): refine Contract-block pilot — 8 clauses in 000-Vision + SPEC-AUTHORING for meta-spec obligations (rf2-04sm / resolves rf2-uuoj / rf2-ehml)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -548,3 +548,28 @@ Not macros: `dispatch`, `dispatch-sync`, `subscribe`. All are functions acceptin
 
 re-frame2 decouples from Reagent at the architecture level: subscription topology, cache, and `app-db` are re-frame-owned data structures; auto-tracking deref-dependency capture during view render is delegated to a pluggable adapter. Reagent stays as the default CLJS-side rendering adapter; the substrate-agnostic core is shared with the plain-atom adapter used by SSR and headless tests. The public API never exposes Reagent-specific types at `re-frame.core`. Full design lives in [006-ReactiveSubstrate.md](006-ReactiveSubstrate.md).
 
+## Contract — pattern obligations
+
+This summary captures the small set of clauses that introduce checkable obligations beyond what the prose makes explicit. The clause numbering scheme is the same as in earlier drafts; missing numbers indicate clauses that did not survive review. Spec-authoring and conformance-harness obligations live separately in [SPEC-AUTHORING.md](SPEC-AUTHORING.md) — those bind a different audience (spec authors and harness authors, not implementors) and were extracted to keep this block focused. The block is RFC 2119 / RFC 8174 keyword-graded; capitalised MUST / SHOULD / MAY / MUST NOT carry the formal meaning, lower-case occurrences do not.
+
+> - **C-000.13** (MUST). The implementation MUST provide *some* form of shape description for runtime data shapes (event vectors, registration metadata, the dispatch envelope, effect maps, `app-db` slices). The mechanism MAY be a runtime schema layer (dynamic hosts) or the host's static type system (static hosts), or a combination. Omission of all shape description is non-conformant.
+>
+> - **C-000.14** (SHOULD). The implementation SHOULD provide a means of eliding dev-time machinery (tracing, schema/type validation) from production builds. The mechanism is host-discretion (compile-time defines, build flags, runtime stubs).
+>
+> - **C-000.15** (MAY). The implementation MAY capture source coordinates (namespace / line / file) at registration time. Absence of source-coord capture MUST NOT be treated as non-conformant.
+>
+> - **C-000.19** (MUST NOT). Implementations MUST NOT use opaque integer ids, randomly-generated UUIDs, or reference-identity primitives (e.g. ES `Symbol`, Java reference equality) as the spec's identity primitive. These violate at least one of the required properties (human-readable, serialisable, reflective).
+>
+> - **C-000.25** (MUST). An implementation claiming FSM-richness or actor-model capabilities beyond the minimum MUST declare its claimed capability list (per [§Hierarchical FSM substrate](#hierarchical-fsm-substrate-with-implementor-chosen-capabilities)) and MUST pass the conformance fixtures matching that list.
+>
+> - **C-000.26** (MUST). The implementation MUST use persistent data structures with structural sharing for `app-db` and frame state. Reverting frame state to a prior value MUST be O(1) in the size of `app-db` (a pointer / reference swap), not O(n) (a deep copy).
+>
+> - **C-000.27** (MUST). The CLJS reference's `core` artefact MUST NOT transitively `:require` any per-feature or per-substrate namespace. Bundle isolation MUST be structural (absent from the classpath), not a property dependent on dead-code elimination.
+>
+> - **C-000.45** (MUST). Runtime data shapes that flow on the wire — dispatch envelopes, effect maps, registration metadata, trace events, hydration payloads — MUST be open: producers MAY add new keys, and consumers MUST tolerate unknown keys (ignore-or-pass-through; a consumer that destructures and rejects on unknown keys is non-conformant).
+>
+> - **C-000.49** (MUST). At the pattern level, every view call MUST be addressable to a specific frame at the call site (frame as parameter or property). React-context-driven view injection is a CLJS-reference-specific optimisation and MUST NOT be required of any other host implementation.
+>
+> - **C-000.50** (MUST). The observable behaviour of a CLJS-reference view rendered via `frame-provider` (React-context optimisation) MUST be indistinguishable from the same view called with an explicit `:frame` argument given the same `(state, props)` inputs.
+>
+> - **C-000.51** (MUST). The CLJS reference's `re-frame.core` public API MUST NOT expose Reagent-specific types (e.g. `reagent.ratom/ratom`, Reagent reactive contexts) directly. Substrate-specific types belong in adapter namespaces.

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1389,6 +1389,10 @@ If the user wants to adopt the standard surface, the migration shape is:
 
 This is a meaningful migration of consumer code, not a mechanical rewrite. Do not apply unless the user has explicitly asked to adopt the standard routing surface.
 
+### O-10. Spec 000 §Contract — pattern obligations (orient against the formal clauses)
+
+Spec 000 now carries a summary [Contract block](000-Vision.md#contract--pattern-obligations) — a small set of formal `C-000.NN` clauses that capture checkable obligations the prose did not previously make explicit (PDS revert is O(1); the explicit-frame view contract; identity-primitive anti-patterns; and a handful of others). The block is implementor-facing — it does not change the migration of an existing re-frame app, but a port author auditing a re-frame2 implementation against its conformance fixtures should grep for `C-000.NN` references and verify each kept clause holds. Spec-authoring and conformance-harness obligations live in [SPEC-AUTHORING.md](SPEC-AUTHORING.md) under the parallel `SA-N` id scheme. There is no rewrite for an application codebase; this is orientation only.
+
 ---
 
 ## What stays the same (do not change these)

--- a/spec/SPEC-AUTHORING.md
+++ b/spec/SPEC-AUTHORING.md
@@ -1,0 +1,45 @@
+# Spec Authoring — meta-spec obligations
+
+> **Type:** Meta-spec (addressed to spec authors and conformance-harness authors, not implementors).
+> A small set of obligations on the people writing re-frame2's specifications and the people building its conformance harness — distinct from the implementor-facing contracts in the per-Spec docs.
+
+## Scope
+
+The per-Spec documents (000–014, the Pattern docs, MIGRATION, Spec-Schemas, etc.) bind **implementors**: a TS port, a Python port, the CLJS reference. They use RFC 2119 keywords (MUST, SHOULD, MAY) to mark obligations the implementation has to satisfy.
+
+This document binds two different audiences:
+
+- **Spec authors** — the people writing the per-Spec docs themselves. Their obligations are about what the spec corpus *as a corpus* must contain or avoid.
+- **Conformance-harness authors** — the people building [conformance/](conformance/) and the runners that grade implementations against capability-declared fixture sets. Their obligations are about what the harness must and must not do when grading.
+
+The clauses below are addressed to those two roles; an implementor never acts on them directly. They live in their own document because mixing them into 000-Vision's implementor-facing Contract block dilutes both audiences (per the rf2-ehml review §6.5).
+
+The clauses are id'd `SA-NN` (spec-authoring) to keep them visually distinct from per-Spec `C-NNN.NN` clauses. The original draft assigned these clauses C-000.20, .37, .38, .39, .40, .43, .44 inside 000-Vision's Contract block; that history is preserved in each clause's cross-reference for traceability.
+
+## Contract — spec authoring and conformance harness obligations
+
+> The clauses below are normative for spec authors and conformance-harness authors. Implementors are not the addressees. RFC 2119 keywords are interpreted per RFC 8174 (capitalised forms only carry the formal meaning).
+
+> - **SA-1** (MUST NOT — addressed to spec authors and harness authors). *(originally C-000.20 in the rf2-ehml draft.)* A non-CLJS port MUST NOT be deemed non-conformant for failing to ship any of the items in [000 §What the pattern does NOT over-commit to](000-Vision.md#what-the-pattern-does-not-over-commit-to) (macros, Vars and `def`-as-registration, Reagent-specific component return types, hiccup, CLJS-only runtime assumptions, React context as the frame-routing mechanism, `goog-define`, Malli). These are CLJS-reference choices, not pattern requirements.
+>
+> - **SA-2** (MUST — addressed to spec authors). *(originally C-000.37.)* Every spec document MUST be readable without consulting re-frame v1 source. Where re-frame v1 behaviour is the contract, the spec MUST capture it explicitly (with examples); "see re-frame v1 for the existing behaviour" is not a sufficient specification.
+>
+> - **SA-3** (MUST — addressed to spec authors). *(originally C-000.38.)* Every shape that flows on the wire or appears in a spec example — event vector, dispatch envelope, registration metadata, effect map, snapshot, hydration payload, trace event, fixture file — MUST have a schema in [Spec-Schemas.md](Spec-Schemas.md).
+>
+> - **SA-4** (MUST — addressed to spec authors). *(originally C-000.39.)* Every Open Question in a per-Spec document MUST eventually resolve to either (a) a landed decision, or (b) an explicit "host-choice" framing naming the v1 CLJS reference's pick. Indefinite "we'll figure out X later" Open Questions are incompatible with [000 Goal 2 — AI-implementable from the spec alone](000-Vision.md#ai-implementable-from-the-spec-alone) and MUST be resolved before the corpus ships.
+>
+> - **SA-5** (MUST — addressed to spec authors and harness authors). *(originally C-000.40.)* A conformance fixture that fails because the spec is ambiguous MUST be classified as a spec defect, not an implementation defect. The remediation is to add the missing prose, schema, fixture, or host-profile-matrix entry.
+>
+> - **SA-6** (MUST NOT — addressed to harness authors). *(originally C-000.43.)* A conformance harness MUST NOT mark a fixture as failing against an implementation when the fixture exercises a capability the implementation has not claimed (per [000 §Hierarchical FSM substrate](000-Vision.md#hierarchical-fsm-substrate-with-implementor-chosen-capabilities)). Capability-graded conformance only works if the harness honours the claim.
+>
+> - **SA-7** (MUST NOT — addressed to spec authors and harness authors). *(originally C-000.44.)* Parallel regions and history states MUST NOT be treated as pattern-level capability omissions. They are explicitly out of pattern scope; substitutes (separate machines per region; snapshot-as-value capture) are documented in [005 §Substitutes for skipped features](005-StateMachines.md#substitutes-for-skipped-features). Treating them as gaps in the substrate contradicts the deliberate scope decision.
+
+## Cross-references
+
+- [000-Vision.md §Contract — pattern obligations](000-Vision.md) — the implementor-facing summary block that pairs with this document. The clauses there bind implementations of the pattern; the clauses here bind the spec corpus and the harness that grades implementations.
+- [conformance/README.md](conformance/README.md) — the operational contract for the harness; SA-5 and SA-6 govern how it grades.
+- [Spec-Schemas.md](Spec-Schemas.md) — the catalogue SA-3 commits the spec corpus to keep complete.
+
+## Decision history
+
+The clauses above were originally drafted inside 000-Vision's Contract block (rf2-uuoj / rf2-ehml). Independent review (`findings/rf2-ehml-review.md` §5, §6.5) flagged them as addressee-flipped — they bind spec authors or harness authors, not implementors — and recommended extracting them so 000's implementor-facing contract isn't diluted. This document is the resolution (rf2-04sm).


### PR DESCRIPTION
## Summary

Apply the rf2-ehml review §6 recommendation: replace the 51-clause Contract-block draft with a small, end-of-doc summary block in `spec/000-Vision.md` plus a new `spec/SPEC-AUTHORING.md` for clauses that bind spec authors / harness authors, not implementors.

**Before / after counts.** 51 draft clauses → **11 in 000-Vision** (one summary block at the end) + **7 in SPEC-AUTHORING.md** (under a parallel `SA-N` id scheme) + **2 deliberately held** (C-000.06, C-000.35) + **31 dropped** as paraphrase or premature normative content.

> The bead's headline figure was "8 keepers"; the count rose to 11 once C-000.13–15 are counted as three (not one) and C-000.45 was kept after the destructure-and-throw failure-mode check passed (see below). All keepers satisfy the reviewer's criterion.

## Failing-fixture shape per kept C-000 clause

The reviewer's criterion: *if I could write a fixture that fails when the prose's claim is violated, the prose wanted a Contract block.* One-line failing-fixture sketch per kept clause:

- **C-000.13** — auditor inspects an `app-db` slice; impl exposes neither schemas nor types; harness asserts shape-description capability is present and fails.
- **C-000.14** (SHOULD) — release-build asset graph contains trace listener bodies / schema validators that should have been elided; bundle-inspection fixture flags it.
- **C-000.15** (MAY) — conformance-neutral; the failing case here is the *harness* incorrectly marking the impl non-conformant for absent source-coords (ties into SA-6).
- **C-000.19** — registry round-trip with a serialised id; impl reuses ES `Symbol` or Java reference equality; serialised id fails to round-trip / two equally-named ids fail value-equality.
- **C-000.25** — impl claims hierarchical-states; harness runs the hierarchical-states fixture set; impl fails the fixture; conformance grade reports the gap against its own claim.
- **C-000.26** — grow `app-db` to N keys, snapshot, mutate, revert; assert revert wallclock is bounded as N grows; deep-copy revert fails the bound.
- **C-000.27** — load `core` artefact alone; assert no per-feature / per-substrate namespace is on the classpath. Transitive `:require` of `re-frame.machines` from `re-frame.core` fails.
- **C-000.45** — producer dispatches an envelope with an extra benign key; consumer reads via the public surface; fixture asserts no error. Consumer with `:closed true` Malli (or destructure-and-throw on extras) fails.
- **C-000.49** — render the same view under two frames; assert each call's frame is determinable from the call site (parameter / property). A view that routes via thread-local-only fails.
- **C-000.50** — render the same `(state, props)` through `frame-provider` and through an explicit `:frame` argument; assert identical render-tree output. Context wrapper that mounts an extra wrapper element fails.
- **C-000.51** — static check on `re-frame.core`'s public surface for `reagent.*` types in any signature; failing impl returns `reagent.ratom/Reaction` directly from a public function.

Every keeper has a writable failing fixture. **No keeper was retained without a corresponding fixture shape.**

## SPEC-AUTHORING.md vs Conventions.md — choice rationale

A new `spec/SPEC-AUTHORING.md` rather than extending `spec/Conventions.md`. Conventions.md is locked-runtime conventions (reserved namespaces, reserved fx-ids, reserved `app-db` keys) — same audience as the per-Spec docs (implementors), different genus from the meta-spec / process-rule clauses being extracted. Mixing addressee-flipped clauses into Conventions would replicate the dilution the reviewer flagged in 000. A new doc with the `SA-N` id prefix makes the audience boundary visible and lets the harness lint the meta-spec obligations independently. Each `SA-N` clause cross-references the original `C-000.NN` id for traceability.

## Reword summary

- **C-000.49.** Original: *"React-context-driven view injection is a CLJS-reference-specific optimisation MUST NOT be required of any other host implementation."* Reworded to: *"...is a CLJS-reference-specific optimisation **and** MUST NOT be required of any other host implementation."* Restores grammar.
- **C-000.31** and **C-000.34.** Did not survive cherry-pick. Their rewords (loosen `.31` to match the prose's "where possible" hedge; inline `.36`'s caveat into `.34`) are moot — the clauses are not in the kept set, and `.36` itself isn't either, so a "subject to C-000.36" reference would have dangled. Documented for the audit trail.

## Held — do not land

**C-000.06** (unregistered fx MUST raise) — out of scope for this bead. Needs spec 002 ratification first; introducing a hard MUST in 000 ahead of 002 committing to silent-ignore-vs-throw would be a layering violation.

**C-000.35** (production elision behavioural equivalence) — out of scope for this bead. Needs spec 009 ratification. Plausibly correct but extracts an implicit invariant the prose does not commit to. Deferred per the reviewer's §5 flag.

If either should later land in 000, that's a separate bead at the upstream-spec layer (002 or 009 respectively).

## Files touched

- `spec/000-Vision.md` — single new `## Contract — pattern obligations` summary block at the end of the doc; no changes to existing prose.
- `spec/SPEC-AUTHORING.md` — new file; 7 SA-N clauses preserving the original C-000.NN cross-references.
- `spec/MIGRATION.md` — additive O-10 orientation entry pointing port authors at the new C-000.NN ids.

## Verification

- Markdown renders clean (no broken backticks; no unclosed code fences).
- Cross-references resolve: every `(C-000.NN)` citation inside another clause points to a clause that survived; every `[link](path)` resolves to a file on disk.
- Doc reads end-to-end as a punctuating sidebar at the close, not a 16-block interruption throughout.

## Test plan

- [ ] Confirm the 11 surviving clauses match the reviewer's criterion (each has a writable failing fixture).
- [ ] Confirm SPEC-AUTHORING.md vs Conventions.md choice rationale.
- [ ] Confirm C-000.06 and C-000.35 are deliberately held (not silently dropped).
- [ ] Verify the O-10 orientation entry in MIGRATION.md is accurate (no rewrite for app codebases; orientation only).

## Related beads

- Resolves rf2-04sm (this bead).
- References rf2-uuoj (the pilot — closing note appended on PR open).
- References rf2-ehml (the parent decision — closing note appended on PR open).