### PR TITLE
feat: :flow op-type + :rf.flow/* trace vocabulary (rf2-2s1o / discovered-from rf2-nfyf)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -153,6 +153,16 @@
          (registrar/unregister! :flow flow-id)
          (throw e)))
      (invalidate-topo!)
+     ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires after
+     ;; reg-flow successfully completes (including post-cycle-detection).
+     ;; Tools observe this to track the flow population over hot reloads /
+     ;; toggles. Op-type :flow is the discriminator for the whole flow
+     ;; trace stream (per Spec 009 §:op-type vocabulary, §Flow tracing).
+     (trace/emit! :flow :rf.flow/registered
+                  {:flow-id flow-id
+                   :inputs  (:inputs flow)
+                   :path    (:path flow)
+                   :frame   frame-id})
      flow-id)))
 
 (defn clear-flow
@@ -188,7 +198,15 @@
          (when (every? (fn [[_ frame-flows]] (not (contains? frame-flows id)))
                        @flows)
            (registrar/unregister! :flow id))
-         (invalidate-topo!)))
+         (invalidate-topo!)
+         ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
+         ;; clear-flow has removed the flow from the per-frame registry
+         ;; and dissoc-in'd its output path. Tools observe this to drop
+         ;; their per-flow display state.
+         (trace/emit! :flow :rf.flow/cleared
+                      {:flow-id id
+                       :path    path
+                       :frame   frame-id})))
      nil)))
 
 ;; ---- fx hooks (called from re-frame.fx) --------------------------------
@@ -231,17 +249,64 @@
   (mapv (fn [path] (get-in db path)) (:inputs flow)))
 
 (defn- evaluate-flow!
-  "Evaluate one flow against the given db. Returns the [new-db dirty?] tuple."
+  "Evaluate one flow against the given db. Returns the [new-db dirty?] tuple.
+
+  Emits one of the per-flow `:rf.flow/*` traces per call (per Spec 009
+  §:op-type vocabulary, §Flow tracing): `:rf.flow/skip` when value-equal
+  recompute suppression triggers, `:rf.flow/computed` on a successful
+  recompute, or `:rf.flow/failed` when the flow's `:output` fn throws.
+  On the failure path the in-flight db is returned unchanged and `dirty?`
+  is `false` so downstream flows still walk."
   [frame-id db flow]
-  (let [k         [frame-id (:id flow)]
+  (let [flow-id    (:id flow)
+        k          [frame-id flow-id]
         new-inputs (read-inputs db flow)
         old-inputs (get @last-inputs k)]
     (if (= new-inputs old-inputs)
-      [db false]
-      (let [new-output (apply (:output flow) new-inputs)
-            new-db     (assoc-in db (:path flow) new-output)]
-        (swap! last-inputs assoc k new-inputs)
-        [new-db true]))))
+      (do
+        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/skip records the
+        ;; suppressed recompute (per rf2-719e value-equal recompute
+        ;; suppression). Tools use this to surface "flow ran but inputs
+        ;; were stable" — distinct from "flow didn't fire at all because
+        ;; nothing wrote".
+        (trace/emit! :flow :rf.flow/skip
+                     {:flow-id flow-id
+                      :reason  :inputs-value-equal
+                      :frame   frame-id})
+        [db false])
+      (try
+        (let [new-output (apply (:output flow) new-inputs)
+              new-db     (assoc-in db (:path flow) new-output)]
+          (swap! last-inputs assoc k new-inputs)
+          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/computed records
+          ;; a successful recompute. :input-values are raw values (not
+          ;; hashed) — the trace surface is dev-only and elided in
+          ;; production, and downstream tools (10x flow panel) display
+          ;; them. Per rf2-719e the dirty-check is =-equality so this
+          ;; only fires when inputs actually changed.
+          (trace/emit! :flow :rf.flow/computed
+                       {:flow-id      flow-id
+                        :input-values new-inputs
+                        :result       new-output
+                        :path         (:path flow)
+                        :frame        frame-id})
+          [new-db true])
+        (catch #?(:clj Throwable :cljs :default) e
+          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/failed fires
+          ;; when the flow's :output fn throws. last-inputs is NOT
+          ;; advanced — so the flow will retry on the next drain rather
+          ;; than silently caching a stale-or-missing output. We re-
+          ;; throw so the router's outer catch (router.cljc) emits the
+          ;; cascade-level :rf.error/flow-eval-exception per Spec 009
+          ;; §Error contract; the per-flow `:rf.flow/failed` trace
+          ;; emitted here adds the flow-attributed detail tools (10x
+          ;; flow panel) consume.
+          (trace/emit! :flow :rf.flow/failed
+                       {:flow-id flow-id
+                        :ex      e
+                        :inputs  new-inputs
+                        :frame   frame-id})
+          (throw e))))))
 
 (defn run-flows!
   "Per Spec 013 §Drain integration: walk THIS FRAME'S registered flows

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -1,0 +1,235 @@
+(ns re-frame.flows-trace-test
+  "JVM coverage for Spec 009 §Flow trace events / Spec 013 §Flow tracing
+  — verifies the five `:rf.flow/*` lifecycle events fire with the
+  documented payloads. The conformance fixture
+  `flow-lifecycle-emits-traces.edn` describes the same shapes as data;
+  this file exercises them against the JVM reference implementation
+  directly so a regression surfaces as a unit-test failure even when the
+  conformance harness is skipping the fixture (the reference harness
+  skips `:flow/basic` capability fixtures until the runner wires the
+  flow-body realiser through).
+
+  Per rf2-2s1o: `:flow` op-type and `:rf.flow/*` operation vocabulary
+  added for re-frame-10x v2's flow panel."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.trace :as trace]))
+
+;; ---- per-test reset / trace recorder -------------------------------------
+
+(def ^:dynamic ^:private *captured* nil)
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (let [captured (atom [])]
+    (binding [*captured* captured]
+      (trace/register-trace-cb!
+        ::flow-trace-recorder
+        (fn [ev]
+          ;; Filter to flow op-type only — keeps assertions tight.
+          (when (= :flow (:op-type ev))
+            (swap! captured conj ev))))
+      (try
+        (test-fn)
+        (finally
+          (trace/remove-trace-cb! ::flow-trace-recorder))))))
+
+(use-fixtures :each reset-runtime)
+
+(defn- by-op
+  "Filter the captured trace events by :operation, returning the matching
+  events in capture order."
+  [op]
+  (filterv #(= op (:operation %)) @*captured*))
+
+;; ---------------------------------------------------------------------------
+;; 1. :rf.flow/registered fires after reg-flow successfully registers
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-emits-registered-trace
+  (testing "reg-flow fires :rf.flow/registered with :flow-id, :inputs, :path, :frame"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (let [evs (by-op :rf.flow/registered)]
+      (is (= 1 (count evs))
+          "exactly one :rf.flow/registered fired for the reg-flow call")
+      (let [ev (first evs)]
+        (is (= :flow (:op-type ev))                      "op-type :flow")
+        (is (= :rf.flow/registered (:operation ev))      "operation :rf.flow/registered")
+        (let [tags (:tags ev)]
+          (is (= :area              (:flow-id tags))     ":flow-id in tags")
+          (is (= [[:w] [:h]]        (:inputs tags))      ":inputs in tags")
+          (is (= [:rect :area]      (:path tags))        ":path in tags")
+          (is (= :rf/default        (:frame tags))       ":frame in tags"))))))
+
+(deftest reg-flow-cycle-does-NOT-emit-registered
+  (testing "when reg-flow throws cycle, no :rf.flow/registered fires for the rejected flow"
+    (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
+    ;; one event so far for :a
+    (is (= 1 (count (by-op :rf.flow/registered))))
+    (is (thrown? Throwable
+                 (rf/reg-flow {:id :b :inputs [[:a]] :output identity :path [:b]})))
+    ;; Still just the one — :b's registration unwound before the trace.
+    (is (= 1 (count (by-op :rf.flow/registered)))
+        "only :a's register trace; :b's was rolled back")))
+
+;; ---------------------------------------------------------------------------
+;; 2. :rf.flow/computed fires when a flow recomputes
+;; ---------------------------------------------------------------------------
+
+(deftest flow-computed-fires-on-input-change
+  (testing "first drain after registration emits :rf.flow/computed with :input-values, :result, :path, :frame"
+    (rf/reg-event-db :init (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:init])
+    (let [computes (by-op :rf.flow/computed)]
+      (is (pos? (count computes))
+          "first drain after init computes the flow at least once")
+      (let [ev (last computes)]
+        (is (= :flow (:op-type ev)))
+        (let [tags (:tags ev)]
+          (is (= :area         (:flow-id tags)))
+          (is (= [3 4]         (:input-values tags))     ":input-values are the raw vec")
+          (is (= 12            (:result tags))           ":result is the computed value")
+          (is (= [:rect :area] (:path tags)))
+          (is (= :rf/default   (:frame tags))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. :rf.flow/skip fires when value-equal input rewrite suppresses recompute
+;; ---------------------------------------------------------------------------
+
+(deftest flow-skip-fires-on-value-equal-rewrite
+  (testing "writing :n with =-equal value emits :rf.flow/skip not :rf.flow/computed"
+    (rf/reg-event-db :init       (fn [_ _] {:n 5}))
+    (rf/reg-event-db :replace-n  (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:init])
+    ;; Reset capture so we look only at the :replace-n drain.
+    (reset! *captured* [])
+    (rf/dispatch-sync [:replace-n 5])
+    (let [skips    (by-op :rf.flow/skip)
+          computes (by-op :rf.flow/computed)]
+      (is (= 1 (count skips))
+          ":n was replaced with =-equal value; one :rf.flow/skip fired")
+      (is (zero? (count computes))
+          "the value-equal rewrite did NOT trigger a recompute trace")
+      (let [tags (:tags (first skips))]
+        (is (= :double             (:flow-id tags)))
+        (is (= :inputs-value-equal (:reason tags))
+            ":reason names the suppression cause (rf2-719e value-equal recompute suppression)")
+        (is (= :rf/default         (:frame tags)))))))
+
+(deftest flow-skip-then-computed-on-real-change
+  (testing "skip fires on equal rewrite; subsequent real change fires :rf.flow/computed"
+    (rf/reg-event-db :init      (fn [_ _] {:n 5}))
+    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:derived :doubled]})
+    (rf/dispatch-sync [:init])
+    (reset! *captured* [])
+    (rf/dispatch-sync [:replace-n 5])    ;; same value → skip
+    (rf/dispatch-sync [:replace-n 7])    ;; new value  → compute
+    (is (= 1 (count (by-op :rf.flow/skip))))
+    (is (= 1 (count (by-op :rf.flow/computed))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. :rf.flow/cleared fires when clear-flow runs
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-emits-cleared-trace
+  (testing "clear-flow emits :rf.flow/cleared with :flow-id, :path, :frame"
+    (rf/reg-event-db :seed (fn [_ _] {:rect {:w 3 :h 4}}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:rect :w] [:rect :h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:seed])
+    (reset! *captured* [])
+    (rf/clear-flow :area)
+    (let [evs (by-op :rf.flow/cleared)]
+      (is (= 1 (count evs)))
+      (let [tags (:tags (first evs))]
+        (is (= :area         (:flow-id tags)))
+        (is (= [:rect :area] (:path tags)))
+        (is (= :rf/default   (:frame tags)))))))
+
+(deftest clear-flow-on-unknown-id-emits-nothing
+  (testing "clear-flow on an unregistered id is a no-op and emits no trace"
+    (rf/clear-flow :no-such-flow)
+    (is (zero? (count (by-op :rf.flow/cleared))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. :rf.flow/failed fires when the :output fn throws
+;; ---------------------------------------------------------------------------
+
+(deftest flow-failed-fires-when-output-throws
+  (testing "a flow whose :output fn throws emits :rf.flow/failed; the exception propagates"
+    (rf/reg-event-db :init       (fn [_ _] {:n 1}))
+    (rf/reg-event-db :bump       (fn [db _] (update db :n inc)))
+    (rf/reg-flow {:id     :boom
+                  :inputs [[:n]]
+                  :output (fn [_] (throw (ex-info "boom" {:why :test})))
+                  :path   [:doomed]})
+    (reset! *captured* [])
+    ;; The router catches the cascade-level throw and emits
+    ;; :rf.error/flow-eval-exception per Spec 009 §Error contract; our
+    ;; concern is that the per-flow :rf.flow/failed fired before that.
+    (rf/dispatch-sync [:init])
+    (let [evs (by-op :rf.flow/failed)]
+      (is (= 1 (count evs))
+          ":rf.flow/failed fires once on the first drain (initial evaluation throws)")
+      (let [tags (:tags (first evs))]
+        (is (= :boom (:flow-id tags)))
+        (is (some? (:ex tags))     ":ex carries the thrown exception")
+        (is (= :rf/default (:frame tags)))
+        (is (= [1] (:inputs tags)) ":inputs records what was read just before the throw")))
+    ;; Driving another input change re-attempts (last-inputs was not
+    ;; advanced on the failed path) — :rf.flow/failed fires again.
+    (reset! *captured* [])
+    (rf/dispatch-sync [:bump])
+    (is (= 1 (count (by-op :rf.flow/failed)))
+        "subsequent input change re-attempts and :rf.flow/failed fires again")))
+
+;; ---------------------------------------------------------------------------
+;; 6. End-to-end sample: all five events fire across a typical lifecycle
+;; ---------------------------------------------------------------------------
+
+(deftest typical-lifecycle-fires-all-five-events
+  (testing "register → first compute → skip on equal rewrite → real recompute → clear"
+    (rf/reg-event-db :init      (fn [_ _] {:n 3}))
+    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:replace-n 3])     ;; same → skip
+    (rf/dispatch-sync [:replace-n 4])     ;; change → compute
+    (rf/clear-flow :double)
+    (is (= 1 (count (by-op :rf.flow/registered))))
+    (is (pos?  (count (by-op :rf.flow/computed))))
+    (is (= 1 (count (by-op :rf.flow/skip))))
+    (is (= 1 (count (by-op :rf.flow/cleared))))
+    (is (zero? (count (by-op :rf.flow/failed))))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -88,6 +88,7 @@ Additional values for re-frame2 concerns:
 - `:route.nav-token/allocated` / `:route.nav-token/stale-suppressed` — navigation-token lifecycle (per [012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression)). `*-allocated` fires when a navigation cascade begins; `*-stale-suppressed` fires when an async result arrives carrying a now-superseded token. Same epoch idiom as the machine-`:after` timer events.
 - `:route.url/fragment-changed` / `:rf.route/navigation-blocked` — fragment-only URL change emission (per [012 §Fragments](012-Routing.md#fragments); distinct from the runtime event `:rf/url-changed` which fires on every URL transition) and pending-nav protocol blockage (per [012 §Navigation blocking](012-Routing.md#navigation-blocking--pending-nav-protocol)).
 - `:rf.registry/handler-registered` / `:rf.registry/handler-cleared` / `:rf.registry/handler-replaced` — registration changes (hot reload). The canonical trio: `-registered` for a fresh id, `-cleared` for an explicit removal, `-replaced` when re-registration overwrote an existing id (the typical hot-reload case).
+- `:flow` — flow lifecycle and evaluation events (per [013 §Flow tracing](013-Flows.md#flow-tracing)). The op-type for the whole flow trace stream; per-flow events live under `:rf.flow/*` operations (`:rf.flow/registered`, `:rf.flow/computed`, `:rf.flow/skip`, `:rf.flow/cleared`, `:rf.flow/failed` — see [§Flow trace events](#flow-trace-events) below). Tools filter `op-type :flow` to subscribe to the whole flow stream.
 - `:error` / `:warning` — universal severity discriminators for failure events. The category-specific identity lives in `:operation` (e.g. `:rf.error/handler-exception`); see [§Error contract](#error-contract) for the authoritative model.
 
 Consumers filter by `:op-type` (or `:source`, or `(get-in ev [:tags :frame])`) to get the slice they care about. Adding new `:op-type` values is non-breaking — tools ignore what they don't understand.
@@ -104,6 +105,26 @@ The map is open. New fields can be added by future versions without breaking con
 - **Re-frame2 additions hoisted to top level** (`:source`, `:recovery`) are stable once shipped; they are present on every event whose tags carry them.
 - **Op-type-specific fields inside `:tags`** are stable within their op-type — including `:frame`, which every emit site supplies under `:tags`. New optional tag keys are additive; existing keys don't change shape.
 - **New `:op-type` values** can be added without breaking existing tools — tools filter the values they recognise.
+
+### Flow trace events
+
+Five trace events constitute the flow lifecycle stream (per [013 §Flow tracing](013-Flows.md#flow-tracing)). All five carry `:op-type :flow`; consumers filter by `:op-type` to subscribe to the whole stream and branch on `:operation` to discriminate. Every event's `:tags` carries `:flow-id` and `:frame` so tools can attribute and route per-frame.
+
+| `:operation` | When it fires | `:tags` payload (in addition to `:flow-id` and `:frame`) |
+|---|---|---|
+| `:rf.flow/registered` | After `reg-flow` (or `:rf.fx/reg-flow`) successfully registers a flow against a frame, including post-cycle-detection. | `:inputs` (the flow's input paths), `:path` (the flow's output path) |
+| `:rf.flow/computed` | A flow's `:output` fn ran and the result was assoc-in'd at `:path`. Fires only when the dirty-check observed an input value-difference. | `:input-values` (raw values read from the input paths), `:result` (the new output value), `:path` |
+| `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (per [013 §Dirty-check semantics](013-Flows.md#dirty-check-semantics) and rf2-719e value-equal recompute suppression). | `:reason` (currently `:inputs-value-equal`; the keyword is open for future skip reasons) |
+| `:rf.flow/cleared` | After `clear-flow` (or `:rf.fx/clear-flow`) removes the flow from the per-frame registry and dissoc-in's its output path. | `:path` (the path that was vacated) |
+| `:rf.flow/failed` | The flow's `:output` fn threw during recompute. The exception is re-thrown after this trace fires so the router's outer catch emits the cascade-level `:rf.error/flow-eval-exception` (per [§Error contract](#error-contract)); tools see the per-flow detail here and the cascade halt there. | `:ex` (the exception), `:inputs` (the input values that were read just before the throw) |
+
+Payload-shape decisions:
+
+- **`:input-values` / `:result` are the actual values, not hashes.** The trace surface is dev-only (per [§Production builds](#production-builds-zero-overhead-zero-code)) and downstream tools — re-frame-10x's flow panel, custom dashboards — display the values. Hashing would force consumers to consult an out-of-band side table; raw values keep the stream self-contained.
+- **`:rf.flow/skip` carries `:reason :inputs-value-equal`** rather than always being implicit. The keyword is the future extension point if additional skip reasons land (e.g. flow disabled mid-walk, frame in restore).
+- **`:rf.flow/failed` re-throws** so cascade-level error-handling (Spec 009 §Error contract's `:rf.error/flow-eval-exception`) still fires; the per-flow `:rf.flow/failed` adds the per-flow attribution.
+
+Pair-shaped tools and 10x v2's flow panel filter `op-type :flow` (per [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach)) to subscribe to the whole stream.
 
 ## Subscription / consumption
 
@@ -225,6 +246,7 @@ The framework emits trace events from these call sites:
 - `registrar.cljc` — `:rf.registry/handler-registered`, `:rf.registry/handler-replaced`, `:rf.registry/handler-cleared`.
 - `machines.cljc` — `:rf.machine/event-received`, `:rf.machine/transition`, `:rf.machine/snapshot-updated`, `:rf.machine.lifecycle/created`, `:rf.machine.timer/scheduled`, `:rf.machine.timer/fired`, `:rf.machine.timer/stale-after`, plus the machine-error categories.
 - `routing.cljc` — `:route.url/fragment-changed`, `:rf.route/url-changed`, `:rf.route/navigation-blocked`, `:route.nav-token/allocated`, `:route.nav-token/stale-suppressed`, `:rf.fx/skipped-on-platform` (route-fx platform skips), `:warning :rf.warning/route-shadowed-by-equal-score`.
+- `flows.cljc` — `:rf.flow/registered`, `:rf.flow/computed`, `:rf.flow/skip`, `:rf.flow/cleared`, `:rf.flow/failed` (per [013 §Flow tracing](013-Flows.md#flow-tracing)). All carry `:op-type :flow`.
 - `schemas.cljc` — `:rf.error/schema-validation-failure` (from `validate-app-db!` / `validate-event!` / `validate-cofx!` / `validate-sub-return!`).
 - `ssr.cljc` — `:warning :rf.warning/multiple-status-set`, `:warning :rf.warning/multiple-redirects`, `:rf.error/sanitised-on-projection`.
 - `epoch.cljc` — `:rf.epoch/snapshotted` per drain-settle, `:rf.epoch/restored` on restore success, plus the six restore-failure categories.

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -171,6 +171,22 @@ Three implications:
 2. **Path-overlap is sufficient, not necessary, for re-firing.** A flow whose inputs sit at `[:user :profile :name]` does not re-fire when an unrelated path like `[:cart :items]` changes. The dirty-check is per-flow, not per-app-db-change.
 3. **First evaluation always fires.** A newly-registered flow's `last-inputs` is uninitialised; its first walk recomputes unconditionally and produces the initial output value.
 
+## Flow tracing
+
+Every flow lifecycle event emits a structured trace event under op-type `:flow`. The full taxonomy lives in [009 §Flow trace events](009-Instrumentation.md#flow-trace-events); the summary:
+
+| `:operation` | Fires when |
+|---|---|
+| `:rf.flow/registered` | `reg-flow` (or `:rf.fx/reg-flow`) successfully registers a flow against a frame, after cycle detection passes. |
+| `:rf.flow/computed` | A flow's `:output` fn ran and the result was written to `:path` (dirty-check observed input value-difference). |
+| `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (§[Dirty-check semantics](#dirty-check-semantics) above; rf2-719e value-equal recompute suppression). |
+| `:rf.flow/cleared` | `clear-flow` (or `:rf.fx/clear-flow`) removed the flow from the per-frame registry and dissoc-in'd its output path. |
+| `:rf.flow/failed` | A flow's `:output` fn threw during recompute. The exception is re-thrown after the trace fires so the router's outer catch emits the cascade-level `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). |
+
+Every event carries `:flow-id` and `:frame` under `:tags`. Pair-shaped tools, 10x v2's flow panel, and custom dashboards filter `op-type :flow` to subscribe to the whole flow stream — see [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach) and [009 §Flow trace events](009-Instrumentation.md#flow-trace-events) for the consumer-side pattern.
+
+The whole flow trace surface, like the rest of trace, is compile-time eliminated in production builds (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
+
 ## Dynamic toggle via fx
 
 Two reserved fx-ids let event handlers register and clear flows during normal event processing:
@@ -279,5 +295,6 @@ No opt-out. Stale derived values are confusing; vacating the slot is the natural
 - [002-Frames §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode) — where the flow after-interceptor sits.
 - [006-ReactiveSubstrate](006-ReactiveSubstrate.md) — sub-cache invalidation; flows trigger sub-cache invalidation when they write.
 - [009-Instrumentation §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/flow-cycle` namespace.
+- [009-Instrumentation §Flow trace events](009-Instrumentation.md#flow-trace-events) — full taxonomy and payloads for the `:rf.flow/*` event vocabulary; cross-referenced from [§Flow tracing](#flow-tracing) above.
 - [Conventions](Conventions.md) — `:rf.fx/reg-flow` and `:rf.fx/clear-flow` reserved fx-ids.
 - [MIGRATION §M-19](MIGRATION.md) — generic call-shape migration; `:inputs` is positional vector matching the v1 `on-changes` form.

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -156,6 +156,35 @@ Two listener shapes coexist by design: `register-trace-cb!` is the **raw** strea
 
 This is **dev-only** end-to-end — every primitive listed above elides in production builds (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)). Pair-shaped tools do not ship in production binaries.
 
+### Subscribing to a slice of the trace stream
+
+`register-trace-cb!` callbacks see *every* trace event. Tools that only care about a single subsystem filter inside the callback by `:op-type` — the universal discriminator (per [009 §`:op-type` vocabulary](009-Instrumentation.md#op-type-vocabulary)). The pattern is one-key dispatch on the event:
+
+```clojure
+;; A tool (re-frame-10x v2's flow panel, a pair-tool flow inspector,
+;; a custom dashboard) subscribes to JUST the flow trace stream.
+;; Per Spec 009 §Flow trace events, every flow lifecycle event carries
+;; :op-type :flow with the per-event identity in :operation
+;; (:rf.flow/registered, :rf.flow/computed, :rf.flow/skip,
+;; :rf.flow/cleared, :rf.flow/failed).
+
+(rf/register-trace-cb!
+  :my-tool/flow-panel
+  (fn [ev]
+    (when (= :flow (:op-type ev))
+      (case (:operation ev)
+        :rf.flow/registered  (track-flow-registration! ev)
+        :rf.flow/computed    (record-flow-computation! ev)
+        :rf.flow/skip        (note-skip! ev)               ;; (per rf2-719e value-equal recompute suppression)
+        :rf.flow/cleared     (drop-flow-state! ev)
+        :rf.flow/failed      (surface-flow-error! ev)
+        nil))))
+```
+
+The same pattern works for any subsystem with a dedicated op-type — `:machine` for state-machine activity, `:event` for the dispatch / drain stream, `:sub/run` and `:sub/create` for subscription work, `:fx` for effect handlers. New op-types are additive (per [009 §Open shape; new fields are additive](009-Instrumentation.md#open-shape-new-fields-are-additive)); tools ignore op-types they don't understand.
+
+For per-cascade structured projections (sub-cache hit/miss, render attribution, effect outcome), tools route off `register-epoch-cb`'s assembled `:rf/epoch-record` instead — the §[Time-travel](#time-travel-epoch-snapshots-and-undo) projection slots already pre-fold the per-cascade trace into the `:sub-runs` / `:renders` / `:effects` shape. The raw-stream filter pattern above is the right shape for fine-grained per-event consumption.
+
 ### Implications for downstream tools
 
 - **re-frame-pair** (the upstream nREPL companion) consumes only the surfaces above. It depends on re-frame2; it does not depend on re-frame-10x.

--- a/spec/conformance/fixtures/flow-lifecycle-emits-traces.edn
+++ b/spec/conformance/fixtures/flow-lifecycle-emits-traces.edn
@@ -1,0 +1,76 @@
+;; Conformance fixture: flow/lifecycle-emits-traces
+;; Per Spec 009 §Flow trace events / Spec 013 §Flow tracing — every flow
+;; lifecycle event emits a :op-type :flow trace event with its operation
+;; under the :rf.flow/* namespace. This fixture exercises the canonical
+;; lifecycle and asserts each of the five events fires with the documented
+;; payload shape.
+;;
+;; Event vocabulary (rf2-2s1o):
+;;   :rf.flow/registered  — reg-flow ran successfully
+;;   :rf.flow/computed    — recompute ran (inputs differed by =-equality)
+;;   :rf.flow/skip        — recompute suppressed (inputs =-equal — rf2-719e)
+;;   :rf.flow/cleared     — clear-flow ran
+;;   :rf.flow/failed      — :output fn threw (re-raised after this trace)
+;;
+;; Required for re-frame-10x v2's flow panel (per the rf2-2s1o discovery
+;; from the rf2-nfyf Tool-Pair audit).
+
+{:fixture/id           :flow/lifecycle-emits-traces
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :flow/basic :flow/trace}
+ :fixture/doc          "Drive the canonical flow lifecycle (register → first compute → no-op equal rewrite → real recompute → clear) and assert each lifecycle action emits the documented :rf.flow/* trace event with op-type :flow. The harness records every emitted trace event and checks the captured stream for the expected entries in order."
+
+ :fixture/registry
+ {:event {:n/init     {:doc "Seed :n to 3."}
+          :n/replace  {:doc "Replace :n with the event's arg."}}
+  :flow  {:double
+          {:doc    "Materialised :doubled — twice :n."
+           :inputs [[:n]]
+           :path   [:doubled]}}}
+
+ :fixture/handlers
+ {:event {:n/init    [[:set [:n] 3]]
+          :n/replace [[:set [:n] [:event-arg 1]]]}}
+
+ ;; The :output fn realised by the harness as `(fn [n] (* 2 n))`.
+ :fixture/flow-bodies
+ {:double [[:fn :* 2 [:event-arg 0]]]}
+
+ :fixture/dispatches
+ [;; first drain: flow first-fires
+  [:n/init]
+  ;; rewrite with =-equal value: skip
+  [:n/replace 3]
+  ;; rewrite with new value: compute
+  [:n/replace 7]]
+
+ :fixture/expect
+ {:final-app-db
+  {:n       7
+   :doubled 14}
+
+  ;; Trace stream slice — only events with :op-type :flow are matched;
+  ;; the harness asserts each expected event appears in the captured
+  ;; stream in the order listed. :tags entries are subset-matched
+  ;; (the harness checks each listed key/value but ignores extras).
+  :expect-trace-stream
+  [{:op-type   :flow
+    :operation :rf.flow/registered
+    :tags      {:flow-id :double
+                :inputs  [[:n]]
+                :path    [:doubled]}}
+   {:op-type   :flow
+    :operation :rf.flow/computed
+    :tags      {:flow-id      :double
+                :input-values [3]
+                :result       6
+                :path         [:doubled]}}
+   {:op-type   :flow
+    :operation :rf.flow/skip
+    :tags      {:flow-id :double
+                :reason  :inputs-value-equal}}
+   {:op-type   :flow
+    :operation :rf.flow/computed
+    :tags      {:flow-id      :double
+                :input-values [7]
+                :result       14}}]}}


### PR DESCRIPTION
## Summary

Adds the `:flow` op-type and the five `:rf.flow/*` lifecycle trace events
required for re-frame-10x v2's flow panel. Discovered from rf2-nfyf
(Tool-Pair audit against re-frame-10x).

The five events:

| Operation | Fires when |
|---|---|
| `:rf.flow/registered` | `reg-flow` ran successfully (post-cycle-detection) |
| `:rf.flow/computed` | recompute ran (inputs differed by =-equality) |
| `:rf.flow/skip` | recompute suppressed (=-equal inputs per rf2-719e) |
| `:rf.flow/cleared` | `clear-flow` ran |
| `:rf.flow/failed` | `:output` fn threw (re-raised so the router's outer catch still fires `:rf.error/flow-eval-exception`) |

All five carry `:op-type :flow`. Consumers filter by op-type to subscribe
to the whole flow stream.

## Trace-stream sample

Captured from a typical lifecycle:

```clojure
(rf/reg-flow {:id :doubled :inputs [[:n]]
              :output (fn [n] (* 2 n)) :path [:derived :doubled]})
(rf/dispatch-sync [:init])             ;; sets {:n 3}
(rf/dispatch-sync [:replace-n 3])      ;; same value -> skip
(rf/dispatch-sync [:replace-n 7])      ;; new value  -> compute
(rf/clear-flow :doubled)
```

```clojure
{:op-type :flow, :operation :rf.flow/registered,
 :tags {:flow-id :doubled, :inputs [[:n]],
        :path [:derived :doubled], :frame :rf/default}}
{:op-type :flow, :operation :rf.flow/computed,
 :tags {:flow-id :doubled, :input-values [3], :result 6,
        :path [:derived :doubled], :frame :rf/default}}
{:op-type :flow, :operation :rf.flow/skip,
 :tags {:flow-id :doubled, :reason :inputs-value-equal,
        :frame :rf/default}}
{:op-type :flow, :operation :rf.flow/computed,
 :tags {:flow-id :doubled, :input-values [7], :result 14,
        :path [:derived :doubled], :frame :rf/default}}
{:op-type :flow, :operation :rf.flow/cleared,
 :tags {:flow-id :doubled, :path [:derived :doubled],
        :frame :rf/default}}
```

Failed-path sample:

```clojure
{:op-type :flow, :operation :rf.flow/failed,
 :tags {:flow-id :boom, :inputs [99],
        :ex #error {:cause "kaboom" ...}, :frame :rf/default}}
```

## Bundle-isolation grep

```
$ npx shadow-cljs release examples/counter
$ grep -cE 'rf\.flow' out/examples/counter/main.js
0
```

Counter doesn't import flows; the `:rf.flow` strings stay out of its bundle. (Counter's `main` had 0 hits before this change too — unchanged.) The full trace surface elides in production via `goog.DEBUG=false` per Spec 009 §Production builds; the elision-probe build (`npm run test:elision`) passes.

## Test results

| Suite | Result |
|---|---|
| `implementation/core` | 219 tests / 981 assertions, 0 failures, 0 errors |
| `implementation/flows` | 24 tests / 89 assertions, 0 failures, 0 errors (10 new in `flows-trace-test`) |
| `implementation/routing` | 6 tests / 33 assertions, 0 failures, 0 errors |
| `implementation/http` | 15 tests / 32 assertions, 0 failures, 0 errors |
| `implementation/schemas` | 27 tests / 109 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | 110 tests / 347 assertions, 0 failures, 0 errors |
| `npm run test:browser` | 112 tests / 361 assertions, 0 failures, 0 errors |
| `npm run test:elision` | PASS (probe and control bundles both green) |
| `npm run test:examples` | All 16 examples PASS |

## Payload-shape decisions

- **`:input-values` / `:result` are raw values, not hashes.** The trace surface is dev-only and downstream tools (10x's flow panel) display the values; hashing would force consumers to consult an out-of-band side table.
- **`:rf.flow/skip` carries `:reason :inputs-value-equal`** rather than being implicit — keeps the keyword as the future extension point if more skip reasons land.
- **`:rf.flow/failed` re-throws** so the router's outer catch still emits the cascade-level `:rf.error/flow-eval-exception` (Spec 009 §Error contract). The per-flow `:rf.flow/failed` adds the per-flow attribution; the cascade-level error retains its existing semantics.

## Files

- `implementation/flows/src/re_frame/flows.cljc` — emit calls in `reg-flow`, `clear-flow`, and `evaluate-flow!`.
- `implementation/flows/test/re_frame/flows_trace_test.clj` — new test namespace.
- `spec/009-Instrumentation.md` — `:flow` op-type row + new §Flow trace events section.
- `spec/013-Flows.md` — new §Flow tracing section cross-referencing 009.
- `spec/Tool-Pair.md` — new §Subscribing to a slice of the trace stream with consumer-side code sketch.
- `spec/conformance/fixtures/flow-lifecycle-emits-traces.edn` — new conformance fixture.

## Test plan

- [x] `clojure -M:test` in core / flows / routing / http / schemas
- [x] `npm run test:cljs`
- [x] `npm run test:browser`
- [x] `npm run test:elision` (production-elision verifier)
- [x] `npm run test:examples`
- [x] Bundle grep on `examples/counter` (`:rf.flow` count = 0; counter doesn't import flows)
- [x] Manual trace-stream capture confirming all five events fire on a typical lifecycle