### PR TITLE
feat: Performance API instrumentation behind compile-time flag (rf2-du3i / discovered-from rf2-nfyf)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -95,6 +95,29 @@ If a deploy job fails part-way through (e.g. `deploy-core` shipped, but `deploy-
 
 **Do NOT** ask Clojars support to yank. The platform doesn't expose it; ad-hoc yanks would corrupt downstream caches anyway.
 
+## Performance-instrumented prod bundles
+
+Per [Spec 009 §Performance instrumentation](../spec/009-Instrumentation.md#performance-instrumentation), re-frame2 ships a default-off Performance API channel gated on the `re-frame.performance/enabled?` `goog-define`. Releases land both shapes:
+
+- The published **artefact** (the `day8/re-frame-2-*` Maven jars driven through this release pipeline) carries the bracket sites in source. Apps consuming the artefact decide at *their* `:advanced` build time whether to flip the flag.
+- The **release verification** in CI runs `npm run test:perf-bundle`, which builds two `:examples/counter` variants under `:advanced` (one with the flag off, the default; one with it on via `:closure-defines {re-frame.performance/enabled? true}`) and asserts:
+  - the off bundle carries zero `performance.mark` / `performance.measure` / `re-frame.performance` strings (bundle-isolation: shipped binaries that don't ask for timing have no User-Timing cost);
+  - the on bundle carries those strings (bundle-presence: the toggle actually produces the measure entries).
+
+The grep methodology mirrors `npm run test:elision` (the trace-surface elision contract). Both jobs run on every push/PR; either failing blocks merge.
+
+Apps that ship a perf-instrumented prod bundle alongside their default release set their own consumer config:
+
+```edn
+;; consumer's shadow-cljs.edn — perf-on prod build
+{:builds {:app-perf {:target           :browser
+                     :output-dir       "..."
+                     :compiler-options {:closure-defines {goog.DEBUG                       false
+                                                          re-frame.performance/enabled?    true}}}}}
+```
+
+`goog.DEBUG=false` elides the trace surface (per [Spec 009 §Production builds](../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code)); `re-frame.performance/enabled?=true` keeps the User-Timing brackets live. The two flags are independent — apps freely combine them per build target.
+
 ## Lockstep verification (drift detection)
 
 [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh) is the single source of truth for the lockstep contract. It is invoked by:

--- a/examples/counter/core.cljs
+++ b/examples/counter/core.cljs
@@ -21,8 +21,32 @@
 
 ;; -- Events / subs (handler registry is app-global) --------------------------
 
-(rf/reg-event-db :counter/initialise
-  (fn [_db _event] {:count 5}))
+;; A user-registered fx so the perf-instrumented variant of this
+;; example (out/examples/counter-perf — see shadow-cljs.edn and rf2-du3i)
+;; exercises the `rf:fx:<id>` perf bucket too. The default counter spec
+;; doesn't observe any user fx; this fx fires on init and records its
+;; calls into a process-local atom so the regular counter spec is
+;; unaffected. The perf-on counter spec
+;; (examples/counter/counter-perf.spec.cjs) reads
+;; `performance.getEntriesByType('measure')` and asserts an entry under
+;; `rf:fx:counter/log` is present.
+
+(defonce counter-log (atom []))
+
+(rf/reg-fx :counter/log
+  (fn [_ctx args]
+    (swap! counter-log conj args)))
+
+;; reg-event-fx so the handler can return both `:db` and a `:fx` walk.
+;; Mixing :db and :fx in one handler makes the example exercise every
+;; perf bucket (event handler, sub recompute, fx walk, render) on a
+;; single dispatch — which is what the counter-perf browser smoke
+;; observes. Per Spec 002 §`:fx` ordering: :db commits first, then :fx
+;; walks in source order.
+(rf/reg-event-fx :counter/initialise
+  (fn [_ctx _event]
+    {:db {:count 5}
+     :fx [[:counter/log :initialised]]}))
 
 (rf/reg-event-db :counter/inc
   (fn [db _event] (update db :count inc)))

--- a/examples/counter/counter-perf.spec.cjs
+++ b/examples/counter/counter-perf.spec.cjs
@@ -1,0 +1,94 @@
+/*
+ * Counter (perf-instrumented) — browser smoke for rf2-du3i.
+ *
+ * Spec 009 §Performance instrumentation: when a build sets
+ * `re-frame.performance/enabled? true`, the runtime brackets event
+ * dispatch / sub recompute / fx execution / view render in
+ * `performance.mark` + `performance.measure` calls so the User-Timing
+ * stream carries `rf:event:*` / `rf:sub:*` / `rf:fx:*` / `rf:render:*`
+ * entries.
+ *
+ * This spec runs against `examples/counter-perf` — the same counter
+ * source, same `:advanced` compilation, but with the goog-define flag
+ * flipped via `:closure-defines`. After a real dispatch (the +1 click),
+ * it reads `performance.getEntriesByType('measure')` and asserts that
+ * the four expected `rf:` buckets are populated.
+ *
+ * The counter source itself is unchanged; the perf surface is purely a
+ * compile-time toggle exercised through the same code path as the
+ * default counter spec.
+ */
+
+const { expectTextEquals } = require('../scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'counter-perf',
+  url:  '/counter-perf/',
+  run:  async (page) => {
+    // Make sure the app booted and the initial render landed before we
+    // sample the User-Timing stream — `dispatch-sync :counter/initialise`
+    // and the first reagent render must have run.
+    const span = page.locator('span').first();
+    await expectTextEquals(span, '5', 10000);
+
+    // Drive a real dispatch through the +/- buttons so every bucket
+    // (event handler, sub recompute, fx, render) fires at least once.
+    await page.getByRole('button', { name: '+' }).click();
+    await expectTextEquals(span, '6');
+
+    // Read every recorded `measure` entry whose name starts `rf:` and
+    // group by bucket. Returned to Node as a plain object so the
+    // Playwright report carries the per-bucket totals.
+    const buckets = await page.evaluate(() => {
+      const entries = performance.getEntriesByType('measure');
+      const out = { event: [], sub: [], fx: [], render: [], other: [] };
+      for (const e of entries) {
+        if (typeof e.name !== 'string' || !e.name.startsWith('rf:')) continue;
+        const parts = e.name.split(':');         // ["rf", "<bucket>", "<id>"...]
+        const bucket = parts[1];
+        if (out[bucket] !== undefined) {
+          out[bucket].push(e.name);
+        } else {
+          out.other.push(e.name);
+        }
+      }
+      return {
+        counts: {
+          event:  out.event.length,
+          sub:    out.sub.length,
+          fx:     out.fx.length,
+          render: out.render.length,
+          other:  out.other.length,
+        },
+        // Sample one name from each populated bucket so the spec runner
+        // log carries a concrete `rf:` entry per bucket — useful in CI
+        // and as the entries listed in the rf2-du3i PR body.
+        samples: {
+          event:  out.event[0]  || null,
+          sub:    out.sub[0]    || null,
+          fx:     out.fx[0]     || null,
+          render: out.render[0] || null,
+        },
+      };
+    });
+
+    console.log('  rf2-du3i perf-on counter — User Timing entries:');
+    console.log(`    rf:event   count=${buckets.counts.event}   sample=${buckets.samples.event}`);
+    console.log(`    rf:sub     count=${buckets.counts.sub}     sample=${buckets.samples.sub}`);
+    console.log(`    rf:fx      count=${buckets.counts.fx}      sample=${buckets.samples.fx}`);
+    console.log(`    rf:render  count=${buckets.counts.render}  sample=${buckets.samples.render}`);
+
+    if (buckets.counts.event === 0) {
+      throw new Error('Expected at least one rf:event:* measure entry; got 0.');
+    }
+    if (buckets.counts.sub === 0) {
+      throw new Error('Expected at least one rf:sub:* measure entry; got 0.');
+    }
+    if (buckets.counts.fx === 0) {
+      throw new Error('Expected at least one rf:fx:* measure entry; got 0.');
+    }
+    if (buckets.counts.render === 0) {
+      throw new Error('Expected at least one rf:render:* measure entry; got 0.');
+    }
+  },
+};

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -47,6 +47,17 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'counter', 'index.html'),
     outDir: path.join(OUT_ROOT, 'counter'),
   },
+  // Performance-API instrumented variant of the counter (rf2-du3i).
+  // Same source, same :advanced compilation, but with the
+  // `re-frame.performance/enabled?` goog-define flipped to true. The
+  // paired counter-perf.spec.cjs asserts that a real dispatch through
+  // the perf-on bundle produces `rf:event:*` / `rf:sub:*` / `rf:fx:*` /
+  // `rf:render:*` measure entries on `performance.getEntriesByType`.
+  {
+    build: 'examples/counter-perf',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'counter', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'counter-perf'),
+  },
   {
     build: 'examples/temperature',
     htmlSrc: path.join(REPO_ROOT, 'examples', '7Guis', 'temperature', 'temperature.html'),

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -23,6 +23,8 @@
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.performance :as performance
+             #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -116,7 +118,18 @@
   to the originator without a separate cofx-injection step."
   [frame-id [original-fx-id args] active-platform overrides origin-event]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)]
-   (case fx-id
+   ;; Per Spec 009 §Performance instrumentation (rf2-du3i): every fx
+   ;; invocation — reserved or user-registered — runs inside a perf
+   ;; bracket so prod builds with the perf flag enabled produce a
+   ;; `rf:fx:<fx-id>` measure entry per fx walk-step. Default-off: the
+   ;; bracket DCEs under :advanced + `re-frame.performance/enabled?=false`.
+   ;; The bracket sits at the top of `handle-one-fx` so it covers reserved
+   ;; fx-ids too (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`,
+   ;; `:rf.fx/clear-flow`) — without that, an app whose handlers only
+   ;; emit `:dispatch` produces zero `rf:fx:*` entries even with the perf
+   ;; flag on.
+   (performance/mark-and-measure :fx fx-id
+    (case fx-id
     :dispatch
     (do
       ;; Append to back of the frame's router queue.
@@ -185,7 +198,7 @@
                          {:fx-id    fx-id
                           :fx-args  args
                           :frame    frame-id
-                          :recovery :no-recovery})))))
+                          :recovery :no-recovery}))))))
 
 (defn do-fx
   "Walk the :fx vector in source order. Per Spec 002 §`:fx` ordering rule 3:

--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -1,0 +1,148 @@
+(ns re-frame.performance
+  "Performance API instrumentation — prod timing, default off (rf2-du3i).
+
+  Per Spec 009 §Performance instrumentation. Distinct from the trace
+  surface: trace runs in dev (and is too noisy to keep on in prod);
+  the Performance API path is intended for **production timing** and is
+  default-off behind a compile-time `goog-define` flag so Closure DCE
+  elides every call site under `:advanced` unless the consumer opts in.
+
+  Mechanism:
+
+    - `enabled?` is a `goog-define`d boolean, default `false`. A consumer
+      flips it via `:closure-defines {re-frame.performance/enabled? true}`
+      in their shadow-cljs.edn / compiler-options.
+    - `mark-and-measure` is a **macro** that expands to
+      `(if enabled? <gated-bracket> (do ~@body))`. With the flag false
+      at compile time, Closure constant-folds the gate; the gated
+      branch DCEs and every helper string (the entry name, the
+      `performance.mark` / `performance.measure` call sites, the helper
+      ns code) elides. The macro shape — rather than a fn — is what
+      keeps the entry-name construction inside the gate too: a
+      function-shaped helper would force its arg expressions to evaluate
+      regardless, which would leave the `\"rf:\"` prefix string surviving
+      DCE in the off bundle.
+    - The runtime call sites (event dispatch, sub recompute, fx
+      execution, render) wrap their hot-path work via `mark-and-measure`
+      with a stable `rf:<bucket>:<id>` name. Consumers read entries via
+      `(.getEntriesByType js/performance \"measure\")` and filter by
+      the `rf:` prefix.
+
+  Naming convention (per Spec 009 §Performance instrumentation):
+    rf:event:<event-id>     — event handler invocation
+    rf:sub:<sub-id>          — subscription recompute
+    rf:fx:<fx-key>           — fx handler invocation
+    rf:render:<view-id>      — view render (when substrate exposes a hook)
+
+  JVM is a no-op — the Performance API is browser-only.
+
+  This is **separate from trace** by design. Trace is dev-only (gated on
+  `re-frame.interop/debug-enabled?` / `goog.DEBUG`); the perf surface is
+  prod-friendly and gated on `re-frame.performance/enabled?`. The two
+  flags compose: a build that wants both flips both. A typical prod
+  build has `goog.DEBUG=false` and `re-frame.performance/enabled?` either
+  true or false depending on whether timing instrumentation is wanted."
+  #?(:cljs (:require-macros [re-frame.performance])))
+
+;; ---- the compile-time flag -------------------------------------------------
+
+#?(:cljs
+   (goog-define ^boolean enabled? false))
+
+#?(:clj
+   ;; JVM has no `:advanced` and no DCE. Two scopes use this var:
+   ;;
+   ;;   1. The CLJS macro body, expanded at compile time on the JVM —
+   ;;      it reads this var to decide whether to emit the gated bracket
+   ;;      or just the body. Default: emit the gated bracket so the CLJS
+   ;;      compiler then has the full closed-over body to constant-fold
+   ;;      against the goog-define value at :advanced time.
+   ;;
+   ;;   2. JVM-runtime callers (headless tests, SSR). The CLJC fn forms
+   ;;      below treat the JVM as a permanent no-op — the Performance API
+   ;;      is browser-only — so the JVM expansion is just `(do body...)`.
+   (def ^:const enabled? false))
+
+;; ---- name builder (used by the macro expansion at the call site) ----------
+
+#?(:clj
+   (defn build-name
+     "Build a `rf:<bucket>:<id>` entry name from the bucket keyword and
+     the registered id keyword/symbol/string. Stable shape across every
+     emit site so consumers filter on the `rf:` prefix without parsing
+     per-bucket shapes.
+
+     Per Spec 009 §Performance instrumentation §Naming convention."
+     [bucket id]
+     (str "rf:" (name bucket) ":"
+          (cond
+            (keyword? id) (if-let [n (namespace id)]
+                            (str n "/" (name id))
+                            (name id))
+            (symbol? id)  (str id)
+            :else         (str id)))))
+
+#?(:cljs
+   (defn build-name
+     "Build a `rf:<bucket>:<id>` entry name. Mirror of the JVM fn above
+     so it is callable at runtime when the gate is on (the macro
+     embeds a call to it inside the gated branch). At expansion time
+     under :advanced + enabled?=false, every call to this fn lives
+     inside the gated dead branch and DCEs."
+     [bucket id]
+     (str "rf:" (name bucket) ":"
+          (cond
+            (keyword? id) (if-let [n (namespace id)]
+                            (str n "/" (name id))
+                            (name id))
+            (symbol? id)  (str id)
+            :else         (str id)))))
+
+;; ---- the macro -------------------------------------------------------------
+
+#?(:clj
+   (defmacro mark-and-measure
+     "Macro form. Expands to a `(if enabled? <gated-bracket> (do body...))`
+     so that under :advanced + `re-frame.performance/enabled?=false`,
+     Closure constant-folds the gate, DCEs the gated branch, and the
+     surviving form is just `(do body...)`. The bucket / id arguments are
+     evaluated *inside* the gated branch — when the flag is off at
+     compile time, even the entry-name construction is dead code.
+
+     Usage at the call site:
+
+         (perf/mark-and-measure :event event-id
+           (interceptor/execute-chain full-chain initial-ctx))
+
+     Three args: a `:bucket` keyword (`:event` / `:sub` / `:fx` /
+     `:render` per Spec 009 §Performance instrumentation), an `id` value
+     (keyword/symbol/string), and one or more body forms. Returns the
+     last body form's value. JVM expansion is `(do body...)` — the
+     Performance API is browser-only.
+
+     Exception isolation: when the flag is on, the bracket is wrapped in
+     try/finally so the `:end` mark and the `measure` entry land even if
+     the body throws. The exception still propagates."
+     [bucket id & body]
+     (if (:ns &env)
+       ;; CLJS expansion. Constant-fold-able shape:
+       ;;   (if enabled? <gated> (do body...))
+       ;; Closure replaces `enabled?` with the goog-define value and
+       ;; eliminates the dead branch under :advanced.
+       `(if re-frame.performance/enabled?
+          (let [nm#         (re-frame.performance/build-name ~bucket ~id)
+                start-name# (str nm# ":start")
+                end-name#   (str nm# ":end")]
+            (.mark js/performance start-name#)
+            (try
+              (do ~@body)
+              (finally
+                (.mark js/performance end-name#)
+                (try
+                  (.measure js/performance nm# start-name# end-name#)
+                  (catch :default _# nil)))))
+          (do ~@body))
+       ;; JVM expansion: pure pass-through. The Performance API is
+       ;; browser-only; JVM-runtime callers (headless tests, SSR) get
+       ;; the body run with no instrumentation overhead.
+       `(do ~@body))))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -15,6 +15,8 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.performance :as performance
+             #?@(:cljs [:include-macros true])]
             [re-frame.trace :as trace]))
 
 ;; ---- dispatch-id allocation -----------------------------------------------
@@ -156,8 +158,16 @@
                 ;; If event-payload validation failed, skip the handler
                 ;; entirely. Per Spec 010 §Per-step recovery step 1:
                 ;; "Handler is not invoked"; downstream queue continues.
+                ;;
+                ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
+                ;; bracket the handler invocation in performance marks so
+                ;; prod builds with the perf flag enabled produce a
+                ;; `rf:event:<event-id>` measure entry. Default-off; under
+                ;; `:advanced` + `re-frame.performance/enabled?=false` the
+                ;; bracket DCEs and the call collapses to the chain run.
                 final-ctx    (if event-ok?
-                               (interceptor/execute-chain full-chain initial-ctx)
+                               (performance/mark-and-measure :event event-id
+                                 (interceptor/execute-chain full-chain initial-ctx))
                                initial-ctx)
                 effects      (:effects final-ctx)
                 error        (:rf/interceptor-error final-ctx)]

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -32,6 +32,8 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.performance :as performance
+             #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -209,14 +211,23 @@
                                               {:sub-id  query-id
                                                :query-v query-v
                                                :frame   frame-id})
+                               ;; Per Spec 009 §Performance instrumentation
+                               ;; (rf2-du3i): bracket the sub recompute in
+                               ;; performance marks so prod builds with the
+                               ;; perf flag enabled produce a
+                               ;; `rf:sub:<sub-id>` measure entry. Default-
+                               ;; off; under `:advanced` +
+                               ;; `re-frame.performance/enabled?=false` the
+                               ;; bracket DCEs.
                                v (try
-                                   (let [v (if (empty? input-signals)
-                                             (body-fn (first in-vals) query-v)
-                                             ;; Layer-2+: deliver inputs as a coll if many,
-                                             ;; or singleton when only one chain entry.
-                                             (if (= 1 (count input-signals))
+                                   (let [v (performance/mark-and-measure :sub query-id
+                                             (if (empty? input-signals)
                                                (body-fn (first in-vals) query-v)
-                                               (body-fn (vec in-vals) query-v)))]
+                                               ;; Layer-2+: deliver inputs as a coll if many,
+                                               ;; or singleton when only one chain entry.
+                                               (if (= 1 (count input-signals))
+                                                 (body-fn (first in-vals) query-v)
+                                                 (body-fn (vec in-vals) query-v))))]
                                      ;; Per Spec 010 §step 6: validate sub-return
                                      ;; post-compute against the sub's :spec.
                                      ;; Failures emit :rf.error/schema-validation-failure

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -18,6 +18,7 @@
             [reagent.core   :as r]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]))
 
@@ -330,7 +331,17 @@
                           render-key [id tok]]
                       (binding [*render-key* render-key]
                         (emit-render-trace! render-key)
-                        (let [out (apply render-fn args)]
+                        ;; Per Spec 009 §Performance instrumentation
+                        ;; (rf2-du3i): every render of a registered view
+                        ;; brackets the user render-fn in performance
+                        ;; marks so prod builds with the perf flag
+                        ;; enabled produce a `rf:render:<view-id>`
+                        ;; measure entry. Default-off; under :advanced +
+                        ;; `re-frame.performance/enabled?=false` the
+                        ;; bracket DCEs and the form collapses to the
+                        ;; bare `(apply render-fn args)` call.
+                        (let [out (performance/mark-and-measure :render id
+                                    (apply render-fn args))]
                           (if interop/debug-enabled?
                             (inject-source-coord-attr id coord-attr out)
                             out)))))

--- a/implementation/core/test/re_frame/performance_cljs_test.cljs
+++ b/implementation/core/test/re_frame/performance_cljs_test.cljs
@@ -1,0 +1,100 @@
+(ns re-frame.performance-cljs-test
+  "Spec 009 §Performance instrumentation — `re-frame.performance/mark-and-measure`
+  round-trip (rf2-du3i).
+
+  CLJS-only: the macro's only platform behaviour is the
+  `performance.mark` / `performance.measure` bracket; on JVM it expands
+  to `(do body...)` with no instrumentation overhead.
+
+  This file covers:
+
+   1. Naming convention (`build-name`).
+   2. Helper round-trip with `enabled?` either branch — when false (the
+      default :node-test build) no entry lands; when true (a bundle that
+      flips the goog-define) exactly one entry per call lands.
+   3. Macro shape — body forms run, return value preserved.
+
+  Bundle-isolation / bundle-presence under `:advanced` lives in
+  `scripts/check-perf-bundle.cjs`. The browser smoke landing the four
+  `rf:` measure entries from a real drain lives in
+  `examples/counter/counter-perf.spec.cjs`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.performance :as performance :include-macros true]))
+
+(defn- count-measures
+  "Count entries in `performance.getEntriesByType('measure')` whose
+  `.name` matches `nm`."
+  [nm]
+  (->> (.getEntriesByType js/performance "measure")
+       (filter #(= nm (.-name %)))
+       count))
+
+(defn- clear-measures!
+  []
+  (when (exists? js/performance.clearMeasures)
+    (.clearMeasures js/performance))
+  (when (exists? js/performance.clearMarks)
+    (.clearMarks js/performance)))
+
+;; ---- naming convention -----------------------------------------------------
+
+(deftest build-name-shape
+  (testing "Per Spec 009 §Naming convention — bucket and id render as
+            `rf:<bucket>:<id>` with the keyword's namespace preserved."
+    (is (= "rf:event:user/login"  (performance/build-name :event :user/login)))
+    (is (= "rf:sub:cart/total"    (performance/build-name :sub   :cart/total)))
+    (is (= "rf:fx:dispatch"       (performance/build-name :fx    :dispatch)))
+    (is (= "rf:render:my.app/page"
+           (performance/build-name :render :my.app/page)))))
+
+;; ---- macro round-trip ------------------------------------------------------
+
+(deftest mark-and-measure-returns-body-value
+  (testing "Regardless of the perf flag, mark-and-measure returns whatever
+            its body returned (the macro expands to a value-yielding
+            form on both branches of the `if`)."
+    (is (= :result (performance/mark-and-measure :test :return :result)))
+    (is (= 42      (performance/mark-and-measure :test :return-num
+                     (+ 40 2))))
+    (is (= [1 2 3] (performance/mark-and-measure :test :return-vec
+                     (let [a 1 b 2]
+                       [a b 3]))))))
+
+(deftest mark-and-measure-on-path-when-enabled
+  (testing "When `enabled?` is true at compile time, mark-and-measure
+            produces exactly one measure entry under the
+            `rf:<bucket>:<id>` name per call."
+    (when performance/enabled?
+      (clear-measures!)
+      (let [nm "rf:test:roundtrip-on"]
+        (performance/mark-and-measure :test :roundtrip-on :ok)
+        (is (= 1 (count-measures nm))
+            "exactly one measure entry under the constructed name")))))
+
+(deftest mark-and-measure-off-path-when-disabled
+  (testing "When `enabled?` is false at compile time, mark-and-measure is
+            shape-equivalent to `(do body...)` — no measure entries land.
+            This is the runtime expression of the elision contract: a
+            broken DCE would leave the body live and this assertion
+            would still be the runtime signal."
+    (when-not performance/enabled?
+      (clear-measures!)
+      (dotimes [_ 5]
+        (performance/mark-and-measure :test :off nil))
+      (is (zero? (count-measures "rf:test:off"))))))
+
+(deftest mark-and-measure-propagates-thrown-exceptions
+  (testing "When the body throws, the exception propagates AFTER the
+            `:end` mark fires (the try/finally ensures a partial measure
+            entry still lands when the perf flag is on)."
+    (clear-measures!)
+    (let [thrown (atom nil)]
+      (try
+        (performance/mark-and-measure :test :throws
+          (throw (ex-info "boom" {})))
+        (catch :default e
+          (reset! thrown e)))
+      (is @thrown "the exception propagates")
+      (when performance/enabled?
+        (is (= 1 (count-measures "rf:test:throws"))
+            "the bracket still produced a measure entry on the partial run")))))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -16,6 +16,7 @@
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
+    "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs"
   }
 }

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/*
+ * Performance-API bundle-isolation / bundle-presence verifier
+ * (Spec 009 §Performance instrumentation, bead rf2-du3i).
+ *
+ * Asserts the production-elision contract for the perf flag, the dual
+ * of scripts/check-elision.cjs:
+ *
+ *   1. The default counter bundle (`:examples/counter` — `:advanced`,
+ *      `re-frame.performance/enabled? false` — the implicit goog-define
+ *      default) does NOT contain `performance.mark` / `performance.measure`
+ *      strings or the `re-frame.performance` namespace fragment. This is
+ *      the bundle-isolation proof: shipped binaries with the perf flag
+ *      off carry zero User-Timing instrumentation.
+ *
+ *   2. The perf-on counter bundle (`:examples/counter-perf` — `:advanced`,
+ *      `re-frame.performance/enabled? true`) DOES contain those strings.
+ *      Without the perf-on bundle, the bundle-isolation assertion would
+ *      be vacuous: a refactor that *moved* the strings would silently
+ *      turn the negative grep into a false pass.
+ *
+ * Strategy: grep, not parse. The closure compiler may rename symbols
+ * but does not rewrite string literals. Matching `performance.mark`
+ * proves the JS-interop call site (from `(.mark js/performance ...)`)
+ * survived; matching the bracketed entry-name shape `rf:` proves the
+ * helper's name-building survived too.
+ *
+ * Exit 0 on PASS, 1 on FAIL.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// ----- the perf-flag elision contract ---------------------------------------
+
+// Each sentinel is a string fragment that appears ONLY when the perf
+// flag is on at compile time AND the namespace's call sites are reached.
+// If any of these appear in the OFF bundle, the (if performance/enabled?
+// ...) bracket survived dead-code elimination — the perf elision contract
+// is broken. If any are MISSING from the ON bundle, the strings have
+// moved and the negative assertion is now vacuous.
+//
+// The first three are the JS-interop strings the helper emits via
+// `(.mark js/performance ...)` / `(.measure js/performance ...)`; the
+// fourth is the namespace fragment (load-order proof — the ns is in the
+// bundle but every body-form should DCE on the OFF build).
+const PERF_SENTINELS = [
+  { source: 're-frame.performance/mark-and-measure (performance.mark)',
+    sentinel: 'performance.mark' },
+  { source: 're-frame.performance/mark-and-measure (performance.measure)',
+    sentinel: 'performance.measure' },
+  { source: 're-frame.performance/build-name (rf: name prefix)',
+    sentinel: '"rf:' },
+];
+
+// ----- helpers ---------------------------------------------------------------
+
+function readAllJs(dir) {
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+  const out = [];
+  const walk = (d) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        out.push(fs.readFileSync(full, 'utf8'));
+      }
+    }
+  };
+  walk(dir);
+  return out.join('\n');
+}
+
+function checkBundle(label, bundlePath, mustContain) {
+  const blob = readAllJs(bundlePath);
+  if (blob == null) {
+    console.error(`[perf-bundle] ${label}: bundle path missing — ${bundlePath}`);
+    console.error('              Did you run the matching shadow-cljs release?');
+    return false;
+  }
+  console.log(`[perf-bundle] ${label}: ${bundlePath}`);
+  console.log(`              bundle size: ${blob.length} chars`);
+
+  let ok = true;
+  for (const { source, sentinel } of PERF_SENTINELS) {
+    const present = blob.includes(sentinel);
+    const expected = mustContain ? 'PRESENT' : 'ABSENT';
+    const actual   = present     ? 'PRESENT' : 'ABSENT';
+    const passed   = present === mustContain;
+    const tag      = passed ? 'OK' : 'FAIL';
+    console.log(`              [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (!passed) ok = false;
+  }
+  return ok;
+}
+
+// Count `performance.mark|performance.measure|re-frame.performance` for
+// the report. The PR body wants the raw count number for both bundles,
+// per the bead's bundle-grep contract.
+function countOccurrences(blob, patterns) {
+  if (blob == null) return null;
+  const re = new RegExp(patterns.join('|'), 'g');
+  const m  = blob.match(re);
+  return m ? m.length : 0;
+}
+
+// ----- main ------------------------------------------------------------------
+
+function main() {
+  console.log('=== Performance-API bundle isolation / presence (Spec 009 §Performance instrumentation) ===');
+
+  const offDir = path.join(ROOT, 'out', 'examples', 'counter');
+  const onDir  = path.join(ROOT, 'out', 'examples', 'counter-perf');
+
+  // OFF bundle: sentinels MUST be absent.
+  const offOk = checkBundle('perf-off (default counter, enabled?=false)',
+                            offDir, false);
+
+  // ON bundle: sentinels MUST be present.
+  const onOk  = checkBundle('perf-on  (counter-perf,  enabled?=true) ',
+                            onDir,  true);
+
+  // Report the counts the bead asks for.
+  const offBlob = readAllJs(offDir);
+  const onBlob  = readAllJs(onDir);
+  const patterns = ['performance\\.mark',
+                    'performance\\.measure',
+                    're-frame\\.performance'];
+  const offCount = countOccurrences(offBlob, patterns);
+  const onCount  = countOccurrences(onBlob,  patterns);
+  console.log('');
+  console.log('=== Bundle-grep counts ===');
+  console.log(`  perf-off counter (must be 0):     ${offCount}`);
+  console.log(`  perf-on  counter (must be > 0):   ${onCount}`);
+
+  const countsOk = (offCount === 0) && (onCount > 0);
+
+  if (offOk && onOk && countsOk) {
+    console.log('=== PASS ===');
+    process.exit(0);
+  } else {
+    console.error('=== FAIL ===');
+    if (!offOk || offCount !== 0) {
+      console.error('Perf-off bundle isolation broke: a Performance API call');
+      console.error('site or the re-frame.performance ns survived advanced');
+      console.error('compilation with re-frame.performance/enabled?=false.');
+      console.error('Per Spec 009 §Performance instrumentation, the bracket');
+      console.error('site must collapse to (f) so DCE removes the gated body.');
+    }
+    if (!onOk || !(onCount > 0)) {
+      console.error('Perf-on bundle missing expected sentinels — the grep');
+      console.error('test would be vacuous. The helper or its call sites');
+      console.error('may have been refactored without updating sentinels.');
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -102,6 +102,30 @@
    :asset-path "."
    :modules    {:main {:init-fn counter.core/run}}}
 
+  ;; Performance-API instrumented variant of the counter example
+  ;; (rf2-du3i). Same source, same :advanced compilation, but with the
+  ;; `re-frame.performance/enabled?` goog-define flipped to `true`. Used
+  ;; by:
+  ;;
+  ;;   1. The bundle-presence assertion in scripts/check-perf-bundle.cjs:
+  ;;      `performance.mark` / `performance.measure` and the helper's
+  ;;      bracketing strings MUST appear in this bundle.
+  ;;   2. The browser-smoke spec at examples/counter/counter-perf.spec.cjs:
+  ;;      after a dispatch, `performance.getEntriesByType('measure')`
+  ;;      returns at least one entry per bucket (`rf:event:*`, `rf:sub:*`,
+  ;;      `rf:fx:*`, `rf:render:*`).
+  ;;
+  ;; Per Spec 009 §Performance instrumentation: the flag is the consumer's
+  ;; surface. Default :examples/counter is the shape every other example
+  ;; ships in (perf elided); this counter-perf variant proves the toggle
+  ;; produces the expected bracket entries when consumers want them.
+  :examples/counter-perf
+  {:target           :browser
+   :output-dir       "out/examples/counter-perf"
+   :asset-path       "."
+   :compiler-options {:closure-defines {re-frame.performance/enabled? true}}
+   :modules          {:main {:init-fn counter.core/run}}}
+
   :examples/temperature
   {:target     :browser
    :output-dir "out/examples/temperature"

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -341,13 +341,122 @@ Dev iteration matters; you don't want trace machinery to slow ordinary feedback 
 - **No string formatting or other expensive work** happens in framework emit code; tools format if they want to.
 - **Listener invocation cost scales with listener count.** Zero registered listeners means zero per-emit dispatch overhead beyond the registry deref. The retain-N ring buffer always pushes (its append is `swap!` plus a slot check), so the floor is one map allocation, one buffer push, and one deref per emit.
 
-## Chrome Performance API integration
+## Performance instrumentation
 
-> **Status:** unimplemented at the v1 reference runtime. The bridge described below is forward-looking — see [API.md §Configure keys](API.md#configure-keys) for the `:performance-api` placeholder. Production builds will elide the bridge along with the rest of tracing once it lands.
+The trace stream above is dev-only — too noisy for prod, gated on `re-frame.interop/debug-enabled?` (an alias of `goog.DEBUG`). Many apps still want a *separate*, default-off, prod-friendly timing channel: one that surfaces in Chrome DevTools' Performance panel alongside React renders, network, and paint, and that consumers (the host's APM, a custom `PerformanceObserver`, an in-app perf overlay) can read via the standard browser [User Timing](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing) surface.
 
-The Chrome Performance API ([User Timing](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing)) lets dev tools see custom timing alongside React renders, network, paint, etc. A future re-frame2 release may ship a built-in bridge between trace emission and `performance.mark` / `performance.measure`. The intended shape: a hardcoded emit-path side-effect, gated on the same `re-frame.interop/debug-enabled?` flag as the rest of trace, with a per-runtime `(rf/configure :performance-api {:enabled? false})` to turn it off without disabling the trace stream itself.
+re-frame2 ships that channel through the browser's `performance.mark` / `performance.measure`, gated on a **second** compile-time constant — `re-frame.performance/enabled?` — that is independent of `goog.DEBUG`. The default is off; consumers opt in by flipping the `goog-define` via `:closure-defines`. Closure DCE then either keeps the bracket sites or elides them entirely; production binaries that don't ask for timing carry zero User-Timing instrumentation.
 
-The bridge will be CLJS-only — the Chrome Performance API is browser-specific. JVM tooling uses the host's own profilers (clj-async-profiler, JFR).
+This is **distinct from** the trace surface above:
+
+| Axis | Trace stream | Performance instrumentation |
+|---|---|---|
+| Compile-time gate | `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`) | `re-frame.performance/enabled?` |
+| Default | on in dev (`goog.DEBUG=true`), off in prod | **off** in both (`enabled?=false`) |
+| Consumer | `register-trace-cb!` listeners, the retain-N ring buffer, `register-epoch-cb` | `performance.getEntriesByType('measure')`, `PerformanceObserver`, Chrome DevTools Performance |
+| Shape | structured trace events (open maps with `:operation` / `:op-type` / `:tags`) | `User Timing` measure entries (`name`, `startTime`, `duration`) |
+| Where it runs | both platforms (dev) | CLJS only — JVM is a no-op |
+
+The two flags compose: a build that wants both flips both. A typical prod build has `goog.DEBUG=false` and either `re-frame.performance/enabled?` true (perf timing kept; trace elided) or false (everything elided).
+
+### The compile-time flag
+
+```clojure
+;; src/re_frame/performance.cljc
+(goog-define ^boolean enabled? false)
+```
+
+A consumer flips it in their shadow-cljs.edn / compiler-options:
+
+```edn
+{:builds {:app {:target           :browser
+                :output-dir       "..."
+                :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
+```
+
+Like `goog.DEBUG`, `:advanced` constant-folds the value, the gated branch DCEs, and the body collapses to its un-bracketed shape — for the perf surface that means each call site becomes a direct invocation of the body it brackets.
+
+### What gets bracketed
+
+The reference runtime brackets four hot-path call sites. Each runs inside a `(performance/mark-and-measure :<bucket> <id> <body>)` macro form so the bracket is a compile-time decision (the macro expands to `(if enabled? <gated-bracket> (do <body>))`, which Closure constant-folds):
+
+| Bucket | Where | Entry name |
+|---|---|---|
+| `:event`  | Event handler invocation (router's `process-event*` step that runs the interceptor chain) | `rf:event:<event-id>` |
+| `:sub`    | Subscription recompute (the body fn inside `compute-and-cache!`'s reaction) | `rf:sub:<sub-id>` |
+| `:fx`     | Per-fx walk-step (every entry processed by `handle-one-fx`, including reserved fx-ids `:dispatch` / `:dispatch-later` / `:rf.fx/reg-flow` / `:rf.fx/clear-flow` and user-registered fx) | `rf:fx:<fx-id>` |
+| `:render` | Per-`reg-view` render (the wrapper emitted by `reg-view*`) | `rf:render:<view-id>` |
+
+The bracket shape (when the flag is on at compile time):
+
+```
+performance.mark(<name>:start)
+try    <body>
+finally
+  performance.mark(<name>:end)
+  performance.measure(<name>, <name>:start, <name>:end)
+```
+
+The `try/finally` ensures a partial measure entry still lands when the body throws — observability does not become silent on the unhappy path. The thrown exception still propagates after the `:end` mark fires.
+
+### Naming convention
+
+Every entry name uses the shape `rf:<bucket>:<id>`, so consumers filter by the `rf:` prefix without parsing per-bucket shapes. Keyword ids preserve their namespace:
+
+```
+rf:event:user/login
+rf:sub:cart/total
+rf:fx:dispatch
+rf:fx:rf.http/managed
+rf:render:my.app/page-header
+```
+
+Tools that want a per-bucket view split on the second `:`. The shape is **stable**: new buckets adopt the `rf:<bucket>:<id>` convention and are additive.
+
+### Consumer access
+
+```javascript
+// All re-frame entries from the most recent run.
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'));
+
+// Live: a PerformanceObserver fires per emitted entry.
+new PerformanceObserver((list) => {
+  for (const e of list.getEntriesByType('measure')) {
+    if (e.name.startsWith('rf:')) {
+      // entry: { name, startTime, duration, ... }
+      sendToAPM(e);
+    }
+  }
+}).observe({ type: 'measure', buffered: true });
+```
+
+Chrome DevTools' Performance panel renders the measures as named tracks alongside React renders, network, and paint — no custom UI required.
+
+The `User Timing` entry buffer is bounded by the host (Chrome's default is 10000 entries); long-running pages that want every entry should attach a `PerformanceObserver` and offload to durable storage rather than rely on the buffer.
+
+### Production-elision verification
+
+The bundle-isolation contract is enforced in CI by `npm run test:perf-bundle` (the dual of `npm run test:elision`):
+
+1. `:examples/counter` builds the standard counter example under `:advanced` with the perf flag off (the goog-define default).
+2. `:examples/counter-perf` builds the same source under `:advanced` with `:closure-defines {re-frame.performance/enabled? true}`.
+3. `scripts/check-perf-bundle.cjs` greps both bundles. The contract:
+   - **Off bundle** MUST NOT contain `performance.mark`, `performance.measure`, or any `"rf:` entry-name fragment.
+   - **On bundle** MUST contain all three.
+
+Without the on bundle the off-bundle assertion would be vacuous — a refactor that *moved* the strings out of the gated branch would silently turn the negative grep into a false pass. The same dual-bundle methodology that gives the trace-surface elision contract its teeth (per [§Production-elision verification](#production-elision-verification)) extends to the perf surface here.
+
+The browser smoke at `examples/counter/counter-perf.spec.cjs` complements the grep: it serves the perf-on bundle, drives a real dispatch through the +/- buttons, and reads `performance.getEntriesByType('measure')` to confirm at least one entry per bucket lands. A passing grep is necessary but not sufficient; the smoke proves the four call sites actually fire under a real cascade.
+
+### JVM scope
+
+The Performance API is browser-only. The JVM half of `re-frame.performance`:
+
+- Defines `enabled?` as `^:const false` so the macro expansion's `(if enabled? ...)` is statically dead and the JVM body runs as if instrumentation were absent.
+- Expands `mark-and-measure` to `(do body...)` — pure pass-through, no instrumentation overhead.
+
+JVM artefacts (headless tests, SSR, Pedestal/Ring services using re-frame2 for state) that want timing should reach for the host's profilers (clj-async-profiler, JFR, async-profiler).
 
 ## Forward compatibility for tools
 
@@ -394,7 +503,7 @@ All trace functionality is **dev-build only** — production builds elide the en
 | `register-epoch-cb` / `remove-epoch-cb` | ✓ | ✓ |
 | Trace ring buffer (`trace-buffer`) | ✓ | ✓ |
 | Hot-reload trace events | ✓ | ✓ |
-| Chrome Performance API integration | ✗ | (planned, see §Chrome Performance API integration) |
+| Performance API instrumentation (`rf:event:*` / `rf:sub:*` / `rf:fx:*` / `rf:render:*` measures) | ✗ | ✓ (default-off; see [§Performance instrumentation](#performance-instrumentation)) |
 | 10x panel itself | ✗ | ✓ |
 | re-frame-pair attachment | ✓ | ✓ |
 
@@ -650,7 +759,7 @@ Tracing is the connective tissue between the runtime and every tool that observe
 - Locks the data shape independently of any specific tool.
 - Documents the forward-compat commitments tools depend on.
 - Separates "framework emits events" (002 territory) from "framework provides a tap surface" (this Spec).
-- Carves space for a future Chrome Performance API integration (currently unimplemented, see §Chrome Performance API integration).
+- Documents the prod-side Performance API instrumentation channel (gated on `re-frame.performance/enabled?`, default-off) alongside the dev-side trace stream — two compile-time-elidable surfaces with distinct gates and distinct consumers (see [§Performance instrumentation](#performance-instrumentation)).
 
 ## Open questions
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -294,6 +294,7 @@ All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Inst
 | `remove-trace-cb!` | Fn | `(remove-trace-cb! key)` → nil | v1 (dev-only) | 009 |
 | `emit-trace!` | Fn | `(emit-trace! op-type operation tags)` → nil | v1 (dev-only) | 009 |
 | `re-frame.interop/debug-enabled?` | Var | `^boolean` (alias of `goog.DEBUG` on CLJS; `true` on JVM) | v1 | 009 |
+| `re-frame.performance/enabled?` | Var | `^boolean` `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op. See [009 §Performance instrumentation](009-Instrumentation.md#performance-instrumentation) and [Tool-Pair §Performance API consumption](Tool-Pair.md#performance-api-consumption) | v1 | 009 |
 | `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | 009 |
 | `clear-trace-buffer!` | Fn | `(clear-trace-buffer!)` → nil | v1 (dev-only) | 009 |
 | `(rf/configure :trace-buffer {:depth N})` | — | See [§Configure keys](#configure-keys). | v1 (dev-only) | 009 |
@@ -488,7 +489,6 @@ Runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every fram
 | `:trace-buffer` | `{:depth N}` — non-negative integer; 0 disables | `{:depth 200}` | v1 (dev-only) | 009 |
 | `:sub-cache` | `{:grace-period-ms N}` — non-negative integer; 0 selects synchronous disposal | `{:grace-period-ms 50}` | v1 | 006 |
 | `:dom-source-annotations?` | boolean — historical opt-in flag; superseded by mandatory injection per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1). Setting this false has no effect — the gate is `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via DCE | n/a (always-on under dev) | v1 (dev-only) | 006, Tool-Pair |
-| `:performance-api` | boolean — bridge trace events to the host's Performance API | `true` (when tracing is on) | planned (unimplemented at v1) | 009 |
 | `:strict-subs` | boolean — reject sub-registration shapes that don't have a registered schema | `false` | v1 | 010 |
 | `:ssr` | `{:public-error-id :detect-mismatch? :on-mismatch :on-view-exception :dev-error-detail?}` (see [011](011-SSR.md) for each) | per [011](011-SSR.md) | v1 | 011 |
 
@@ -567,7 +567,7 @@ See [007-Stories.md](007-Stories.md).
 | `dispatch-to` (proposed earlier) | Use `(dispatch event {:frame :todo})` | 002 |
 | `subscribe-to` (proposed earlier) | Use `(subscribe query-v {:frame :todo})` | 002 |
 | `frame-dispatcher` (proposed earlier) | Renamed to `bound-dispatcher` | 002 |
-| `enable-performance-api-tracing!` (proposed earlier) | Performance-API bridge is forward-looking and unimplemented at v1 (see [009 §Chrome Performance API integration](009-Instrumentation.md#chrome-performance-api-integration)) | 009 |
+| `enable-performance-api-tracing!` (proposed earlier) | Performance-API instrumentation is gated on the compile-time `re-frame.performance/enabled?` `goog-define`, not a runtime toggle (see [009 §Performance instrumentation](009-Instrumentation.md#performance-instrumentation)) | 009 |
 | `add-trace-listener` / `remove-trace-listener` (proposed earlier) | Use `register-trace-cb!` / `remove-trace-cb!` | 009 |
 | `register-trace-cb` / `remove-trace-cb` (no-bang, proposed earlier) | Renamed to `register-trace-cb!` / `remove-trace-cb!` (bang form matches the side-effecting nature of listener registration) | 009 |
 | Bare `[:my-view "args"]` keyword-tagged hiccup | Use the Var form `[my-view "args"]` (canonical) or `[(rf/view :my-view) "args"]` for late-binding by id | 004 |

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -90,6 +90,56 @@ All six failures have `:op-type :error` and `:recovery :no-recovery`. Pair tools
 
 **Production elision.** Per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) the trace surface, schema validation, registrar trace emit, and epoch-history machinery share a single compile-time gate (`re-frame.interop/debug-enabled?`, alias of `goog.DEBUG`); production builds (`:advanced` + `goog.DEBUG=false`) elide all of it. CI's `npm run test:elision` job (Spec 009 §Production-elision verification) asserts the contract holds for every gated surface, including the epoch-history primitives once they land.
 
+## Performance API consumption
+
+The Performance API channel (per [009 §Performance instrumentation](009-Instrumentation.md#performance-instrumentation)) is the prod-friendly counterpart to the dev-only trace stream. Pair-shaped tools that want timing data — an in-app perf overlay, an APM forwarder, a custom `PerformanceObserver` watching for slow renders — read it via the standard browser User Timing surface. No re-frame2 API call is needed; the runtime emits `User Timing` `measure` entries and any consumer that knows about `performance.getEntriesByType` can read them.
+
+Names are stable and namespaced under `rf:`:
+
+```
+rf:event:<event-id>
+rf:sub:<sub-id>
+rf:fx:<fx-id>
+rf:render:<view-id>
+```
+
+Consumer pattern — pull every re-frame entry from the recent run:
+
+```javascript
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'))
+  .forEach(e => {
+    const [_rf, bucket, ...idParts] = e.name.split(':');
+    const id = idParts.join(':');
+    // e: { name, startTime, duration, ... }
+    // bucket: 'event' | 'sub' | 'fx' | 'render'
+  });
+```
+
+Live: `PerformanceObserver` fires per emitted entry (the canonical shape for a tool that wants to react in real time):
+
+```javascript
+new PerformanceObserver((list) => {
+  for (const e of list.getEntriesByType('measure')) {
+    if (e.name.startsWith('rf:')) {
+      sendToAPM(e);  // or update an overlay, or buffer for a flush
+    }
+  }
+}).observe({ type: 'measure', buffered: true });
+```
+
+The channel is gated on `re-frame.performance/enabled?` — a `goog-define` boolean that defaults to `false`. Pair tools that depend on the channel **MUST** document the consumer's responsibility to flip the flag in their build:
+
+```edn
+;; consumer's shadow-cljs.edn
+{:builds {:app {:target           :browser
+                :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
+```
+
+When the flag is off (the default), Closure DCE elides every bracket; `performance.getEntriesByType('measure')` returns no `rf:`-prefixed entries because none were ever emitted. This is by design: the perf channel is *opt-in for prod* (timing instrumentation has measurable cost on heavy hot paths and consumers should choose to pay it).
+
+The Performance API surface is **CLJS-only**. JVM artefacts (SSR, headless tests) emit no perf entries; tools running there use the host's profilers (clj-async-profiler, JFR).
+
 ## REPL-eval
 
 The pair tool's "execute arbitrary expression" capability is the **host's REPL** (CLJS: nREPL via cider; Python: IPython; etc.) — re-frame2 doesn't ship an evaluator, just exposes its data structures. An nREPL session attached to a running re-frame2 app can already see `re-frame.db/app-db` (or its substrate-agnostic equivalent), the registrar, and any namespace-resolvable function.


### PR DESCRIPTION
## Summary

Per [Spec 009 §Performance instrumentation](../blob/rf2-du3i-performance-api/spec/009-Instrumentation.md#performance-instrumentation) (this PR lands the section), re-frame2 ships a default-off, prod-friendly Performance API channel that brackets event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls. Consumers flip a `goog-define` (`re-frame.performance/enabled?`) to opt in; under `:advanced` + the default value Closure DCE elides every bracket.

This is **distinct from** the trace surface — different gate (`re-frame.performance/enabled?` vs `goog.DEBUG`), different consumer (Chrome DevTools Performance / `PerformanceObserver` / `performance.getEntriesByType` vs `register-trace-cb!`), different default (off vs on-in-dev). The two flags compose: a typical perf-on prod build sets `goog.DEBUG=false` AND `re-frame.performance/enabled?=true`.

Naming convention: `rf:<bucket>:<id>` so consumers filter on the `rf:` prefix:

```
rf:event:counter/initialise
rf:sub:count
rf:fx:counter/log
rf:render:counter.core/counter-app
```

Decision per Mike 2026-05-09: replace the v1 span-shape with the browser User Timing API; debug builds skip (browsers too noisy); prod builds default-off behind a goog-define so DCE owns the elision.

## Bundle-grep contract

`npm run test:perf-bundle` builds two `:advanced` `:examples/counter` variants (one with the flag off, one with it on) and asserts:

- **Off bundle** (`out/examples/counter`, `:closure-defines {re-frame.performance/enabled? false}` — the default): every `performance.mark` / `performance.measure` / `re-frame.performance` string is absent.
- **On bundle** (`out/examples/counter-perf`, `:closure-defines {re-frame.performance/enabled? true}`): those strings are present.

Without the on bundle the off-bundle assertion would be vacuous (a refactor moving the strings would silently turn the negative grep into a false pass) — same dual-bundle methodology that gives `npm run test:elision` its teeth.

```
=== Bundle-grep counts ===
  perf-off counter (must be 0):     0
  perf-on  counter (must be > 0):   12
=== PASS ===
```

Both individual sentinels' contracts pass:

```
[perf-bundle] perf-off (default counter, enabled?=false)
              [OK] performance.mark    expected ABSENT, was ABSENT
              [OK] performance.measure expected ABSENT, was ABSENT
              [OK] "rf:                expected ABSENT, was ABSENT
[perf-bundle] perf-on  (counter-perf,  enabled?=true)
              [OK] performance.mark    expected PRESENT, was PRESENT
              [OK] performance.measure expected PRESENT, was PRESENT
              [OK] "rf:                expected PRESENT, was PRESENT
```

## Browser smoke — four `rf:` measure entries per cascade

`examples/counter/counter-perf.spec.cjs` serves the perf-on counter, drives a real dispatch (the +/- buttons), and reads `performance.getEntriesByType('measure')`. After `dispatch-sync :counter/initialise` + a `+1` click, every bucket is populated:

```
rf2-du3i perf-on counter — User Timing entries:
  rf:event   count=2   sample=rf:event:counter/initialise
  rf:sub     count=2   sample=rf:sub:count
  rf:fx      count=1   sample=rf:fx:counter/log
  rf:render  count=3   sample=rf:render:counter.core/counter-app
```

(The counter source picks up a small `reg-fx :counter/log` so the `:fx` walk fires under the existing dispatch — `reg-event-db` handlers don't naturally produce `:fx` entries.)

## Test results

| Suite | Result |
|---|---|
| `implementation/core` (`clojure -M:test`) | 219 tests / 981 assertions / 0 failures / 0 errors |
| `implementation/machines` | 0 tests (suite empty) |
| `implementation/routing` | 6 tests / 33 assertions / 0 failures / 0 errors |
| `implementation/flows` | 15 tests / 49 assertions / 0 failures / 0 errors |
| `implementation/http` | 15 tests / 32 assertions / 0 failures / 0 errors |
| `implementation/schemas` | 27 tests / 109 assertions / 0 failures / 0 errors |
| `npm run test:cljs` (node-test) | 115 tests / 356 assertions / 0 failures / 0 errors |
| `npm run test:browser` | 110 tests / 347 assertions / 0 failures / 0 errors |
| `npm run test:elision` | PASS (every dev-only sentinel ABSENT in prod, PRESENT in control) |
| `npm run test:perf-bundle` | PASS (off=0, on=12 — see above) |
| `npm run test:examples` | 16 / 16 PASS (counter-perf included) |

## Render-cycle status

Render bracketing is wired: `reg-view*`'s frame-aware-view wrapper in `views.cljs` calls `performance/mark-and-measure :render id` around the user `render-fn`. Reagent v2's `reg-view` machinery is the substrate hook — every registered view produces a `rf:render:<view-id>` measure entry on each render. Plain Reagent fns that bypass `reg-view*` are not bracketed (documented in the spec section: tools fall back to the `:rf.view/anonymous` shape there too).

## Files

### Code

- `implementation/core/src/re_frame/performance.cljc` (new) — the `goog-define` flag, the `mark-and-measure` macro, the `build-name` helper.
- `implementation/core/src/re_frame/router.cljc` — bracket the event handler invocation in `process-event*`.
- `implementation/core/src/re_frame/subs.cljc` — bracket the sub recompute body fn in `compute-and-cache!`.
- `implementation/core/src/re_frame/fx.cljc` — bracket every fx walk-step in `handle-one-fx` (covers reserved fx-ids and user-registered fx).
- `implementation/core/src/re_frame/views.cljs` — bracket the user `render-fn` invocation in `reg-view*`'s wrapper.

### Tests

- `implementation/core/test/re_frame/performance_cljs_test.cljs` (new) — helper round-trip / build-name / exception propagation.
- `implementation/scripts/check-perf-bundle.cjs` (new) — the dual-bundle grep script.
- `implementation/shadow-cljs.edn` — `:examples/counter-perf` build.
- `implementation/package.json` — `test:perf-bundle` npm script.
- `examples/counter/core.cljs` — small `reg-fx` so the perf smoke covers the fx bucket.
- `examples/counter/counter-perf.spec.cjs` (new) — browser-smoke spec.
- `examples/scripts/serve-and-run-examples-tests.cjs` — picks up `examples/counter-perf`.

### Spec

- `spec/009-Instrumentation.md` — replaces the forward-looking "Chrome Performance API integration" stub with a real §Performance instrumentation section.
- `spec/Tool-Pair.md` — adds §Performance API consumption.
- `spec/API.md` — promotes `re-frame.performance/enabled?` to a v1 row in §Tracing; updates the Removed table.
- `docs/release-process.md` — adds §Performance-instrumented prod bundles.

## Test plan

- [x] `clojure -M:test` for every artefact (core / machines / routing / flows / http / schemas)
- [x] `npm run test:cljs` (node-test build)
- [x] `npm run test:browser`
- [x] `npm run test:elision` (dev-only sentinels still elide; perf addition does not break trace elision)
- [x] `npm run test:perf-bundle` (off=0, on=12; per-sentinel ABSENT/PRESENT contracts pass)
- [x] `npm run test:examples` (16/16; counter-perf produces all four `rf:` buckets)