### PR TITLE
feat: source-coord instrumentation for state machines (rf2-8bp3 / discovered-from rf2-z7f7)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -71,6 +71,7 @@
             ;; late-bind hook table at call time, which the http
             ;; artefact populates from its own ns-load.
             [re-frame.source-coords :as source-coords]
+            [re-frame.interop :as interop]
             [re-frame.trace :as trace]
             [re-frame.epoch :as epoch]
             [re-frame.substrate.adapter :as adapter]
@@ -537,37 +538,99 @@
 
 #?(:clj
    (defmacro reg-machine
-     "Register a machine as an event handler. Per Spec 001 the
-     metadata stamped onto the registry slot includes :ns / :line /
-     :file captured at this call site.
+     "Register a machine as an event handler. Per Spec 001 the metadata
+     stamped onto the registry slot includes :ns / :line / :file captured
+     at this call site, AND per Spec 005 §Source-coord stamping (rf2-8bp3)
+     a per-element coord index keyed by spec-path is attached under the
+     spec's `:rf.machine/source-coords` key. Tools (re-frame-pair,
+     re-frame-10x, IDE jump-to-source) read both back via
+     `(rf/handler-meta :event machine-id)` (top-level coords) and
+     `(:rf.machine/source-coords (rf/machine-meta machine-id))` (per-element
+     index).
+
+     Production-elision: the per-element index is wrapped in
+     `(when interop/debug-enabled? ...)`; under `:advanced` +
+     `goog.DEBUG=false` the closure compiler constant-folds the gate to
+     false and DCEs the entire literal — no spec-element string fragments
+     survive.
 
      Per rf2-xbtj the machines implementation lives in the
      `day8/re-frame-2-machines` artefact; the emitted form looks the
-     producing fn up via the late-bind hook table so core never
-     statically requires it. Apps that use `reg-machine` MUST add
+     producing fn up via the late-bind hook table so core never statically
+     requires it. Apps that use `reg-machine` MUST add
      `day8/re-frame-2-machines` to their deps and require
-     `re-frame.machines` at app boot; without it, the lookup returns
-     nil and the call throws a clear error."
+     `re-frame.machines` at app boot; without it, the lookup returns nil
+     and the call throws a clear error.
+
+     For runtime registration (computed ids, code-gen pipelines, REPL),
+     use `reg-machine*` — the plain-fn surface beneath this macro."
      [machine-id machine]
-     (let [m       (meta &form)
+     (let [m              (meta &form)
            ;; Construct a fresh, metadata-free symbol. (ns-name *ns*) returns
            ;; the ns-symbol but in CLJS macro context that symbol may carry
            ;; the consumer namespace's :doc metadata, which would then get
            ;; serialised into the bundle and defeat production elision.
-           ns-sym  (symbol (str (ns-name *ns*)))
-           file    *file*]
-       `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
-          (if-let [f# (late-bind/get-fn :machines/reg-machine)]
-            (f# ~machine-id ~machine)
-            (throw (ex-info ":rf.error/machines-artefact-missing"
-                            {:where      'reg-machine
-                             :machine-id ~machine-id
-                             :recovery   :no-recovery
-                             :reason     "rf/reg-machine requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."})))))))
+           ns-sym         (symbol (str (ns-name *ns*)))
+           file           *file*
+           ;; Walk the literal spec form at compile time. When `machine`
+           ;; is a non-map (a symbol bound to a value at runtime) the
+           ;; walker returns {} — tools fall back to the call-site coords
+           ;; on the top-level handler-meta.
+           per-el-coords  (source-coords/walk-machine-spec machine ns-sym file)
+           ;; Build a syntax-quote-safe literal form for the coord index.
+           ;; Symbols inside `:ns` need to be quoted (otherwise the syntax
+           ;; quote splice would try to namespace-resolve them at compile
+           ;; time and the compiler would throw ClassNotFoundException for
+           ;; the consumer's ns).
+           per-el-form    (into {}
+                                (map (fn [[path coords]]
+                                       [path
+                                        (cond-> {:ns (list 'quote (:ns coords))}
+                                          (:file coords)   (assoc :file (:file coords))
+                                          (:line coords)   (assoc :line (:line coords))
+                                          (:column coords) (assoc :column (:column coords)))])
+                                     per-el-coords))
+           machine-sym    (gensym "machine__")]
+       ;; If the walker returned no entries — i.e. the spec form was a
+       ;; symbol / non-literal map / had no positional metadata — skip the
+       ;; per-element stamping branch entirely. Avoids polluting the
+       ;; registered spec with an empty `:rf.machine/source-coords` key
+       ;; that user code might compare against.
+       (if (empty? per-el-coords)
+         `(binding [source-coords/*pending-coords*
+                    (cond-> {:ns '~ns-sym}
+                      ~file        (assoc :file ~file)
+                      ~(:line m)   (assoc :line ~(:line m))
+                      ~(:column m) (assoc :column ~(:column m)))]
+            (if-let [f# (late-bind/get-fn :machines/reg-machine)]
+              (f# ~machine-id ~machine)
+              (throw (ex-info ":rf.error/machines-artefact-missing"
+                              {:where      'reg-machine
+                               :machine-id ~machine-id
+                               :recovery   :no-recovery
+                               :reason     "rf/reg-machine requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
+         `(binding [source-coords/*pending-coords*
+                    (cond-> {:ns '~ns-sym}
+                      ~file        (assoc :file ~file)
+                      ~(:line m)   (assoc :line ~(:line m))
+                      ~(:column m) (assoc :column ~(:column m)))]
+            (let [~machine-sym ~machine
+                  ;; Per-element source-coord stamping (rf2-8bp3). The literal
+                  ;; index is reachable only inside this `interop/debug-enabled?`
+                  ;; gate; under :advanced + goog.DEBUG=false the closure compiler
+                  ;; folds the gate to false and the entire literal DCE's.
+                  stamped# (if interop/debug-enabled?
+                             (assoc ~machine-sym
+                                    :rf.machine/source-coords
+                                    ~per-el-form)
+                             ~machine-sym)]
+              (if-let [f# (late-bind/get-fn :machines/reg-machine)]
+                (f# ~machine-id stamped#)
+                (throw (ex-info ":rf.error/machines-artefact-missing"
+                                {:where      'reg-machine
+                                 :machine-id ~machine-id
+                                 :recovery   :no-recovery
+                                 :reason     "rf/reg-machine requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."})))))))))
 
 #?(:cljs
    (do
@@ -608,18 +671,38 @@
                            :path     path
                            :recovery :no-recovery
                            :reason   "rf/reg-app-schema requires day8/re-frame-2-schemas on the classpath; add it to deps and require re-frame.schemas at app boot."})))))
-     ;; reg-machine is late-bound via the hook table so core does not
+     ;; reg-machine* is late-bound via the hook table so core does not
      ;; statically require re-frame.machines (rf2-xbtj — machines ships
-     ;; in day8/re-frame-2-machines).
-     (defn reg-machine
+     ;; in day8/re-frame-2-machines). Per Spec 005 §reg-machine vs
+     ;; reg-machine* (rf2-8bp3) this is the plain-fn surface — used by
+     ;; the `reg-machine` macro's emitted form, by code-gen pipelines
+     ;; that already carry a stamped spec, and by REPL workflows that
+     ;; bypass the macro path. Programmatic callers see no per-element
+     ;; source-coord index (only the macro can walk the literal spec at
+     ;; expansion time).
+     (defn reg-machine*
        [machine-id machine]
        (if-let [f (late-bind/get-fn :machines/reg-machine)]
          (f machine-id machine)
          (throw (ex-info ":rf.error/machines-artefact-missing"
-                         {:where      'reg-machine
+                         {:where      'reg-machine*
                           :machine-id machine-id
                           :recovery   :no-recovery
-                          :reason     "rf/reg-machine requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))))
+                          :reason     "rf/reg-machine* requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))))
+
+;; Plain-fn surface for the JVM. Used by code-gen pipelines and the
+;; conformance corpus when registering machines without a literal spec
+;; form. Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3).
+#?(:clj
+   (defn reg-machine*
+     [machine-id machine]
+     (if-let [f (late-bind/get-fn :machines/reg-machine)]
+       (f machine-id machine)
+       (throw (ex-info ":rf.error/machines-artefact-missing"
+                       {:where      'reg-machine*
+                        :machine-id machine-id
+                        :recovery   :no-recovery
+                        :reason     "rf/reg-machine* requires day8/re-frame-2-machines on the classpath; add it to deps and require re-frame.machines at app boot."})))))
 
 ;; reg-error-projector lives in re-frame.ssr so the registry kind
 ;; ships with its default :rf.ssr/default-error-projector. Forward

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -64,7 +64,7 @@
     :schemas/snapshot-by-frame    re-frame.schemas/snapshot-schemas-by-frame
     :schemas/restore-by-frame!    re-frame.schemas/restore-schemas-by-frame!
     :schemas/clear-by-frame!      re-frame.schemas/clear-schemas-by-frame!
-    :machines/reg-machine             re-frame.machines/reg-machine
+    :machines/reg-machine             re-frame.machines/reg-machine* ;; rf2-8bp3 — plain-fn surface
     :machines/create-machine-handler  re-frame.machines/create-machine-handler
     :machines/machine-transition      re-frame.machines/machine-transition
     :machines/machines                re-frame.machines/machines

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -48,3 +48,174 @@
     (if coords
       (merge coords (or user-meta {}))
       (or user-meta {}))))
+
+;; ---- per-element spec stamping (rf2-8bp3) --------------------------------
+;;
+;; Per Spec 005 §Source-coord stamping (rf2-8bp3): the `reg-machine` macro
+;; walks its literal machine-spec form at expansion time and produces a
+;; per-element coord index keyed by **path through the spec**. Tools (pair,
+;; 10x, IDE jump-to-source) read the index back via `(rf/handler-meta :event
+;; machine-id)` → `:rf/machine` → `:rf.machine/source-coords`.
+;;
+;; The index is a flat map `{<path-tuple> {:ns sym :line int :column int :file
+;; string}, ...}`. Stamping covers BOTH definition sites (where a fn literal
+;; lives — `:guards`/`:actions`/`:on-spawn-actions` map values) AND reference
+;; sites (where a keyword reference is mentioned — `:guard`/`:action`/`:entry`/
+;; `:exit`/`:on-spawn`/`:always` slots inside `:states`). Mike's rule (per the
+;; bead's exemption case): a keyword `:guard :form-valid?` is stamped at the
+;; reference site too, not just the definition. Tools wanting "where is the
+;; guard defined?" read `[:guards :form-valid?]`; tools wanting "where is the
+;; transition that calls it?" read `[:states :idle :on :submit :guard]`. Both
+;; coords elide together under `goog.DEBUG=false`.
+;;
+;; Path tuples are vectors of keys mirroring the spec's tree structure. The
+;; walker runs at compile time on JVM only (the Clojure side of the macro)
+;; and emits a literal map into the macro expansion; the runtime sees
+;; ordinary data.
+
+(defn ^:private form-coords
+  "Read source coords off a Clojure form's metadata. Forms the reader has
+  decorated (lists, vectors, maps, symbols) carry `:line` / `:column` from
+  the source position. Returns nil when the form has no positional meta."
+  [form ns-sym file]
+  (let [m (meta form)]
+    (when (and m (or (:line m) (:column m)))
+      (cond-> {:ns ns-sym}
+        file        (assoc :file file)
+        (:line m)   (assoc :line (:line m))
+        (:column m) (assoc :column (:column m))))))
+
+(defn- walk-states-tree
+  "Recursively walk the literal `:states` map. `path` accumulates the
+  spec-path from the spec's root. Adds entries into the mutable `acc`
+  transient for each captured reference site / state-node."
+  [states-form path acc ns-sym file]
+  (when (map? states-form)
+    (reduce-kv
+      (fn [acc state-id node]
+        (let [node-path (conj path state-id)]
+          (when-let [c (form-coords node ns-sym file)]
+            (assoc! acc node-path c))
+          (when (map? node)
+            ;; :entry / :exit references
+            (when-let [e (:entry node)]
+              (when-let [c (form-coords e ns-sym file)]
+                (assoc! acc (conj node-path :entry) c)))
+            (when-let [e (:exit node)]
+              (when-let [c (form-coords e ns-sym file)]
+                (assoc! acc (conj node-path :exit) c)))
+            ;; :invoke {:on-spawn ...}
+            (when-let [inv (:invoke node)]
+              (when-let [c (form-coords inv ns-sym file)]
+                (assoc! acc (conj node-path :invoke) c))
+              (when (map? inv)
+                (when-let [os (:on-spawn inv)]
+                  (when-let [c (form-coords os ns-sym file)]
+                    (assoc! acc (conj node-path :invoke :on-spawn) c)))))
+            ;; :on transitions — map of event-id → transition-or-vector
+            (when-let [on-map (:on node)]
+              (when (map? on-map)
+                (reduce-kv
+                  (fn [_ ev-id t]
+                    (let [tp (conj node-path :on ev-id)]
+                      (when-let [c (form-coords t ns-sym file)]
+                        (assoc! acc tp c))
+                      (cond
+                        (map? t)
+                        (do
+                          (when-let [g (:guard t)]
+                            (when-let [c (form-coords g ns-sym file)]
+                              (assoc! acc (conj tp :guard) c)))
+                          (when-let [a (:action t)]
+                            (when-let [c (form-coords a ns-sym file)]
+                              (assoc! acc (conj tp :action) c))))
+                        (vector? t)
+                        (doseq [[i tx] (map-indexed vector t)
+                                :when (map? tx)]
+                          (let [tp' (conj tp i)]
+                            (when-let [c (form-coords tx ns-sym file)]
+                              (assoc! acc tp' c))
+                            (when-let [g (:guard tx)]
+                              (when-let [c (form-coords g ns-sym file)]
+                                (assoc! acc (conj tp' :guard) c)))
+                            (when-let [a (:action tx)]
+                              (when-let [c (form-coords a ns-sym file)]
+                                (assoc! acc (conj tp' :action) c))))))
+                      nil))
+                  nil on-map)))
+            ;; :always — vector of transition maps
+            (when-let [always (:always node)]
+              (when (vector? always)
+                (doseq [[i tx] (map-indexed vector always)
+                        :when (map? tx)]
+                  (let [tp (conj node-path :always i)]
+                    (when-let [c (form-coords tx ns-sym file)]
+                      (assoc! acc tp c))
+                    (when-let [g (:guard tx)]
+                      (when-let [c (form-coords g ns-sym file)]
+                        (assoc! acc (conj tp :guard) c)))
+                    (when-let [a (:action tx)]
+                      (when-let [c (form-coords a ns-sym file)]
+                        (assoc! acc (conj tp :action) c)))))))
+            ;; :after — map of delay → target-or-transition
+            (when-let [after (:after node)]
+              (when (map? after)
+                (reduce-kv
+                  (fn [_ delay t]
+                    (let [tp (conj node-path :after delay)]
+                      (when-let [c (form-coords t ns-sym file)]
+                        (assoc! acc tp c))
+                      (when (map? t)
+                        (when-let [a (:action t)]
+                          (when-let [c (form-coords a ns-sym file)]
+                            (assoc! acc (conj tp :action) c))))
+                      nil))
+                  nil after)))
+            ;; recurse into nested :states
+            (walk-states-tree (:states node) (conj node-path :states) acc ns-sym file))
+          acc))
+      acc states-form)))
+
+(defn walk-machine-spec
+  "Compile-time helper. Walk a literal machine-spec form (a Clojure map
+  literal as it appears in user code) and return a flat map
+  `{<path-tuple> {:ns :line :column :file}, ...}` capturing per-element
+  source coordinates.
+
+  Definition sites: each fn literal under `:guards` / `:actions` /
+  `:on-spawn-actions` is keyed by `[:guards :id]` / `[:actions :id]` /
+  `[:on-spawn-actions :id]`.
+
+  Reference sites: each keyword reference under `:entry` / `:exit` /
+  `:guard` / `:action` / `:on-spawn` (and the enclosing transition map)
+  inside the `:states` tree is keyed by its full spec path, e.g.
+  `[:states :idle :on :submit :guard]`.
+
+  When the spec form is not a map literal (a symbol, a let-bound expr),
+  returns `{}` — there's no literal tree to walk; tools fall back to the
+  reg-machine call-site coords on the spec's top-level handler-meta.
+
+  `ns-sym` and `file` come from the calling macro's compile environment.
+
+  JVM-only — runs on the Clojure side of the macro. Returns a plain map
+  literal that the macro splices into the expansion; under `goog.DEBUG=false`
+  the closure compiler DCEs the entire literal."
+  [spec-form ns-sym file]
+  (if-not (map? spec-form)
+    {}
+    (let [acc (transient {})]
+      ;; Definition-site stamping for :guards / :actions / :on-spawn-actions.
+      (doseq [[def-key path-key] [[:guards            :guards]
+                                  [:actions           :actions]
+                                  [:on-spawn-actions  :on-spawn-actions]]]
+        (when-let [m (get spec-form def-key)]
+          (when (map? m)
+            (reduce-kv
+              (fn [_ id fn-form]
+                (when-let [c (form-coords fn-form ns-sym file)]
+                  (assoc! acc [path-key id] c))
+                nil)
+              nil m))))
+      ;; Reference-site stamping under :states.
+      (walk-states-tree (:states spec-form) [:states] acc ns-sym file)
+      (persistent! acc))))

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -374,7 +374,10 @@
       (when (seq machine-registry)
         (let [{:keys [actions guards on-spawn-actions]}
               (realise-machine-handlers fixture)
-              reg-machine (requiring-resolve 're-frame.machines/reg-machine)]
+              ;; Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3) the
+              ;; runtime registrar is `reg-machine*` (the macro lives at
+              ;; the re-frame.core boundary).
+              reg-machine (requiring-resolve 're-frame.machines/reg-machine*)]
           (doseq [[machine-id machine-spec] machine-registry]
             (let [merged (-> machine-spec
                              (update :actions          #(merge actions %))

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -42,7 +42,8 @@
             [re-frame.trace        :as trace]
             [re-frame.epoch        :as epoch]
             [re-frame.http-managed :as http-managed]
-            [re-frame.views        :as views]))
+            [re-frame.views        :as views]
+            [re-frame.machines]))
 
 ;; ---- trace listener API ---------------------------------------------------
 
@@ -206,6 +207,33 @@
         _k (views/current-render-key)]
     nil))
 
+;; ---- Spec 005 §Source-coord stamping — reg-machine macro (rf2-8bp3) -------
+
+(defn ^:export touch-machines! []
+  ;; Per Spec 005 §Source-coord stamping (rf2-8bp3) the reg-machine macro
+  ;; walks the literal spec form at expansion time and emits a stamping
+  ;; branch wrapped in `(if interop/debug-enabled? ...)`. Under :advanced
+  ;; + goog.DEBUG=false the closure compiler folds the gate to false and
+  ;; DCEs the entire `:rf.machine/source-coords` literal — every spec-
+  ;; element string fragment must elide.
+  ;;
+  ;; The probe roots reachability for the machines surface by:
+  ;;   1. requiring re-frame.machines (forces ns body — the late-bind
+  ;;      hook registration, the :rf/machine sub, the spawn / destroy
+  ;;      fx handlers — into the bundle);
+  ;;   2. registering a machine via `rf/reg-machine` so the macro's
+  ;;      gated source-coord-stamping branch is in reachable code, not
+  ;;      just declared-but-dead.
+  ;;
+  ;; The sentinel string is the keyword `:rf.machine/source-coords` (the
+  ;; spec map key the macro injects under the gate). It must NOT appear
+  ;; in the production bundle.
+  (rf/reg-machine :rf.probe/machine
+    {:initial :idle
+     :guards  {:never? (fn [_ _] false)}
+     :actions {:noop   (fn [_ _] {})}
+     :states  {:idle {:on {:tick {:target :idle :guard :never? :action :noop}}}}}))
+
 ;; ---- entry point ----------------------------------------------------------
 
 (defn ^:export run []
@@ -215,6 +243,7 @@
   (touch-http-managed!)
   (touch-epoch!)
   (touch-views!)
+  (touch-machines!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.
   (trace/emit! :event :rf.probe/direct-touch {:source :probe}))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -880,17 +880,33 @@
           {:db new-db
            :fx fx})))))
 
-;; ---- reg-machine convenience ----------------------------------------------
+;; ---- reg-machine* — plain-fn surface (rf2-8bp3) ---------------------------
 
-(defn reg-machine
-  "Convenience: register a machine as an event handler under
-  machine-id. Equivalent to
-  (reg-event-fx machine-id (create-machine-handler machine)).
+(defn reg-machine*
+  "Plain-fn surface beneath the `reg-machine` macro. Registers a machine
+  as an event handler under `machine-id`. Equivalent to
+  `(reg-event-fx machine-id (create-machine-handler machine))`.
+
+  Per Spec 005 §reg-machine vs reg-machine*: the macro `reg-machine`
+  walks the literal spec form at expansion time and stamps per-element
+  source coordinates onto the spec's `:rf.machine/source-coords` key.
+  This fn assumes no such walking — it accepts whatever spec map the
+  caller has already constructed (which may or may not carry an
+  `:rf.machine/source-coords` index pre-stamped by the macro path or
+  by a code-gen pipeline). Use this fn for runtime registration with
+  computed ids, fixture-synthesised specs, or REPL workflows.
 
   Per Spec 005 §Querying machines, the registration metadata is stamped
   with :rf/machine? true and :rf/machine (the spec map). (rf/machines)
   filters the :event registry by :rf/machine?; (rf/machine-meta id)
-  reads the spec back out via the standard registrar query API."
+  reads the spec back out via the standard registrar query API.
+
+  Per Spec 001 §Source-coordinate capture, the call-site `:ns` /
+  `:line` / `:file` carried by `re-frame.source-coords/*pending-coords*`
+  (set by the `reg-machine` macro) is merged into the registration
+  metadata via the `reg-event-fx` defn's `merge-coords` call. Programmatic
+  callers that bypass the macro see no top-level coords — that's the
+  documented Spec 001 behaviour for programmatic registration."
   [machine-id machine]
   (let [handler-fn (create-machine-handler machine)]
     (events/reg-event-fx machine-id
@@ -1181,13 +1197,20 @@
 ;; drag the namespace's `:rf/machine` sub registration (and the spawn
 ;; counter, the `:spawn` / `:destroy-machine` fx handlers, the
 ;; transition machinery) onto the classpath. The public-API re-exports
-;; (`reg-machine`, `create-machine-handler`, `machine-transition`,
+;; (`reg-machine*`, `create-machine-handler`, `machine-transition`,
 ;; `machines`, `machine-meta`) and the test-support reset helper are
 ;; published through the late-bind table; consumers without the
 ;; machines artefact see the hooks unregistered and the surface
 ;; throws / returns safe defaults cleanly.
+;;
+;; Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3): the late-bind
+;; hook key is `:machines/reg-machine` (the legacy slot name) and points
+;; at `reg-machine*` — the plain-fn surface. The `reg-machine` macro at
+;; the `re-frame.core` boundary is import-time-only (CLJS macroexpansion
+;; runs before ns-load); the runtime always reaches through this hook to
+;; the plain-fn surface.
 
-(late-bind/set-fn! :machines/reg-machine            reg-machine)
+(late-bind/set-fn! :machines/reg-machine            reg-machine*)
 (late-bind/set-fn! :machines/create-machine-handler create-machine-handler)
 (late-bind/set-fn! :machines/machine-transition     machine-transition)
 (late-bind/set-fn! :machines/machines               machines)

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1084,9 +1084,12 @@
                   :system-id  system-id})
     (when spec'
       ;; (2) Register the live handler under the spawned id. Re-using
-      ;; reg-machine so the same `:rf/machine?` metadata + lifecycle
-      ;; trace flows.
-      (reg-machine spawned-id spec'))
+      ;; reg-machine* (the plain-fn surface beneath the macro, per
+      ;; rf2-8bp3) so the same `:rf/machine?` metadata + lifecycle
+      ;; trace flows. The macro form is reserved for user-call-site
+      ;; literal-spec source-coord stamping; spawn synthesises specs
+      ;; at runtime, so the plain-fn surface is the right entry.
+      (reg-machine* spawned-id spec'))
     ;; (3) Initialise the snapshot + (4) bind :system-id (atomically
     ;; under one app-db swap so observers see consistent state).
     (when-let [container (frame/get-frame-db frame-id)]

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -1,0 +1,178 @@
+(ns re-frame.machine-source-coord-cljs-test
+  "CLJS coverage for per-element source-coord stamping (rf2-8bp3). Per
+  Spec 005 §Source-coord stamping the `reg-machine` macro walks the
+  literal spec form at expansion time and attaches a flat coord index
+  under `:rf.machine/source-coords`, keyed by spec-path tuples.
+
+  The CLJS counterpart of machine_source_coord_test.clj. Per the keyword-
+  reference rule the macro stamps:
+    - definition sites (each fn literal under :guards / :actions /
+      :on-spawn-actions, keyed by [:guards <id>] / [:actions <id>] /
+      [:on-spawn-actions <id>])
+    - reference sites (each transition map / state node / inline-fn slot
+      inside :states, keyed by its full spec-path tuple)
+
+  CLJS reader-meta: the CLJS analyzer / cljs.tools.reader DOES attach
+  :line / :column metadata to map and vector literals, so the full
+  path-tuple surface is exercisable here (unlike on JVM where the
+  standard LispReader only decorates list forms)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- per-element-coords [machine-id]
+  (-> (rf/machine-meta machine-id)
+      :rf.machine/source-coords))
+
+;; ---- definition-site stamping --------------------------------------------
+
+(deftest reg-machine-stamps-guard-and-action-definitions-cljs
+  (testing "fn literals under :guards / :actions / :on-spawn-actions are
+  stamped at their definition coords"
+    (rf/reg-machine :rf2-8bp3/defs
+      {:initial :idle
+       :guards  {:ok? (fn [_ _] true)}
+       :actions {:do  (fn [_ _] {})}
+       :on-spawn-actions {:cap (fn [data id] (assoc data :pending id))}
+       :states  {:idle {}}})
+    (let [idx (per-element-coords :rf2-8bp3/defs)]
+      (is (some? (get idx [:guards :ok?])))
+      (is (some? (get idx [:actions :do])))
+      (is (some? (get idx [:on-spawn-actions :cap]))))))
+
+;; ---- reference-site stamping (transition / state-node / inline-fn) --------
+
+(deftest reg-machine-stamps-transition-references-cljs
+  (testing "transition maps inside :on are stamped at their full path tuples;
+  inline-fn references inside also get distinct stamps"
+    (rf/reg-machine :rf2-8bp3/refs
+      {:initial :idle
+       :guards  {:ok? (fn [_ _] true)}
+       :states
+       {:idle {:on {:submit {:target :done :guard :ok?}
+                    :cancel {:target :idle :action (fn [_ _] {})}}}
+        :done {}}})
+    (let [idx (per-element-coords :rf2-8bp3/refs)]
+      (is (some? (get idx [:states :idle :on :submit]))
+          "transition map for :submit is stamped at its reader position")
+      (is (some? (get idx [:states :idle :on :cancel]))
+          "transition map for :cancel is stamped at its reader position")
+      ;; Inline-fn :action gets its own slot stamp (the fn-form has reader meta).
+      (is (some? (get idx [:states :idle :on :cancel :action]))
+          "inline-fn :action literal is stamped at its slot")
+      ;; Keyword :guard reference is NOT stamped (definition-site only rule).
+      (is (nil? (get idx [:states :idle :on :submit :guard]))
+          "keyword :guard reference is not stamped (definition-site rule)"))))
+
+(deftest reg-machine-stamps-state-nodes-cljs
+  (testing "state-node maps inside :states are stamped at their path tuples
+  (CLJS reader attaches meta to map literals)"
+    (rf/reg-machine :rf2-8bp3/nodes
+      {:initial :a
+       :states
+       {:a {:on {:go :b}}
+        :b {}}})
+    (let [idx (per-element-coords :rf2-8bp3/nodes)]
+      (is (some? (get idx [:states :a]))
+          "state-node :a is stamped")
+      (is (some? (get idx [:states :b]))
+          "state-node :b is stamped"))))
+
+(deftest reg-machine-stamps-vector-of-transitions-cljs
+  (testing "vector :on transitions stamp per index"
+    (rf/reg-machine :rf2-8bp3/vec
+      {:initial :idle
+       :guards  {:a? (fn [_ _] true)
+                 :b? (fn [_ _] false)}
+       :states
+       {:idle
+        {:on
+         {:tick [{:guard :a? :target :one}
+                 {:guard :b? :target :two}
+                 {:target :three}]}}
+        :one   {}
+        :two   {}
+        :three {}}})
+    (let [idx (per-element-coords :rf2-8bp3/vec)]
+      (is (some? (get idx [:states :idle :on :tick 0])))
+      (is (some? (get idx [:states :idle :on :tick 1])))
+      (is (some? (get idx [:states :idle :on :tick 2]))))))
+
+(deftest reg-machine-stamps-always-cljs
+  (testing ":always vector — each transition map stamps per index"
+    (rf/reg-machine :rf2-8bp3/always
+      {:initial :a
+       :guards  {:enough? (fn [_ _] true)}
+       :states
+       {:a {:always [{:guard :enough? :target :b}]}
+        :b {}}})
+    (let [idx (per-element-coords :rf2-8bp3/always)]
+      (is (some? (get idx [:states :a :always 0])))
+      ;; Definition coord stamped too.
+      (is (some? (get idx [:guards :enough?]))))))
+
+(deftest reg-machine-stamps-entry-exit-cljs
+  (testing ":entry / :exit slots: keyword refs aren't stamped (definition-site
+  rule), but inline-fn slots ARE"
+    (rf/reg-machine :rf2-8bp3/ee
+      {:initial :a
+       :actions {:enter-a (fn [_ _] {})}
+       :states
+       {:a {:entry :enter-a
+            :exit  (fn [_ _] {})
+            :on    {:go :b}}
+        :b {}}})
+    (let [idx (per-element-coords :rf2-8bp3/ee)]
+      ;; Inline-fn :exit IS stamped.
+      (is (some? (get idx [:states :a :exit])))
+      ;; Keyword :entry reference NOT stamped.
+      (is (nil? (get idx [:states :a :entry])))
+      ;; Definition coord ARE stamped.
+      (is (some? (get idx [:actions :enter-a]))))))
+
+(deftest reg-machine-stamps-hierarchical-states-cljs
+  (testing "nested :states recurse — state-node coords stamp at the
+  full leaf-prefixed path tuple"
+    (rf/reg-machine :rf2-8bp3/hier
+      {:initial :outer
+       :states
+       {:outer {:initial :inner
+                :states  {:inner   {:on {:go {:target :sibling}}}
+                          :sibling {}}}}})
+    (let [idx (per-element-coords :rf2-8bp3/hier)]
+      (is (some? (get idx [:states :outer]))
+          "outer state-node stamped")
+      (is (some? (get idx [:states :outer :states :inner]))
+          "inner state-node stamped at the recursive path")
+      (is (some? (get idx [:states :outer :states :inner :on :go]))
+          "transition map inside hierarchical inner state is stamped"))))
+
+;; ---- programmatic call (no walking) --------------------------------------
+
+(deftest reg-machine-skips-stamping-for-non-literal-spec-cljs
+  (testing "when the spec is bound to a symbol (not a literal map form), the
+  macro can't walk and the registered spec carries no
+  :rf.machine/source-coords key"
+    (let [spec {:initial :a :states {:a {}}}]
+      (rf/reg-machine :rf2-8bp3/programmatic spec))
+    (is (= {:initial :a :states {:a {}}}
+           (rf/machine-meta :rf2-8bp3/programmatic))
+        "registered spec round-trips with no :rf.machine/source-coords")))
+
+;; ---- reg-machine* plain-fn surface ---------------------------------------
+
+(deftest reg-machine*-plain-fn-surface-cljs
+  (testing "reg-machine* registers without macro walking — equivalent to
+  the legacy reg-machine defn"
+    (rf/reg-machine* :rf2-8bp3/plain
+                     {:initial :a :states {:a {}}})
+    (is (some? (some #{:rf2-8bp3/plain} (rf/machines)))
+        "(rf/machines) lists the plain-fn registered machine")
+    (is (= {:initial :a :states {:a {}}}
+           (rf/machine-meta :rf2-8bp3/plain))
+        "spec round-trips verbatim")))

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -1,0 +1,299 @@
+(ns re-frame.machine-source-coord-test
+  "Per-element source-coord stamping for machine specs. Per Spec 005
+  §Source-coord stamping (rf2-8bp3) — the `reg-machine` macro walks the
+  literal spec form at expansion time and attaches a flat coord index
+  under `:rf.machine/source-coords`, keyed by spec-path tuples.
+
+  Definition sites: each fn literal under `:guards` / `:actions` /
+  `:on-spawn-actions` is keyed by `[:guards :id]` / `[:actions :id]` /
+  `[:on-spawn-actions :id]`.
+
+  Reference sites: each transition / state-node inside the `:states`
+  tree is keyed by its full spec path, e.g.
+  `[:states :idle :on :submit :guard]`.
+
+  Per the bead's exemption case (keyword reference vs definition for
+  `:guard :form-valid?`-style indirection): the rule is **definition-site
+  only** for keyword references, **reference-site only** for inline-fn
+  literals. Rationale: a keyword (`:form-valid?`) is a name, not a
+  source form — it carries no reader metadata of its own. The closest
+  meaningful coord is the enclosing transition map's coord, which is
+  *already stamped* under the transition's path
+  (`[:states :idle :on :submit]`). Synthesising a duplicate slot entry
+  (`[:states :idle :on :submit :guard]`) at the same coord adds no
+  information for tools — they walk the path tree to find the closest
+  ancestor coord. Inline-fn references (`:guard (fn [_ _] ...)`) carry
+  their own reader metadata, so the reference site gets a distinct
+  coord and IS stamped.
+
+  This test runs on JVM only because the source-coord-walking macro is
+  Clojure-side. CLJS tests in machine_source_coord_cljs_test.cljs cover
+  the same surface end-to-end through the macroexpansion the cljs
+  compiler performs on .clj/.cljc macros.
+
+  Reader-meta limitation on JVM: the standard Clojure `LispReader` only
+  attaches `:line` / `:column` metadata to *list* forms (fn-bodies) —
+  not to map or vector literals. So on JVM, the walker stamps
+  definition-site fn literals (under `:guards` / `:actions` /
+  `:on-spawn-actions`) reliably; state-node and transition-map coords
+  are not available on JVM because the source forms don't carry the
+  reader meta the walker reads. The CLJS reader (cljs.tools.reader)
+  enriches maps/vectors, so the CLJS counterpart test exercises the
+  full path-tuple surface."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init!)
+  ;; Force machines to re-register its :rf/machine sub + late-bind hooks
+  ;; (registrar/clear-all! wiped them).
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; Helper: read the per-element index off a registered machine.
+(defn- per-element-coords [machine-id]
+  (-> (rf/machine-meta machine-id)
+      :rf.machine/source-coords))
+
+;; ---- top-level call-site coords (smoke; covered also in core/source-coords-test) ----
+
+(deftest reg-machine-stamps-call-site-coords
+  (testing "the reg-machine macro stamps :ns / :line / :file / :column on the registry slot
+  so handler-meta carries the call-site coords (rf2-k84s + rf2-8bp3)"
+    (rf/reg-machine :rf2-8bp3/call-site-sample
+      {:initial :a :states {:a {} :b {}}})
+    (let [meta (rf/handler-meta :event :rf2-8bp3/call-site-sample)]
+      (is (some? meta))
+      (is (= 're-frame.machine-source-coord-test (:ns meta)))
+      (is (integer? (:line meta)))
+      (is (integer? (:column meta)))
+      (is (string? (:file meta))))))
+
+;; ---- definition-site stamping for :guards / :actions / :on-spawn-actions --
+
+(deftest reg-machine-stamps-guard-definitions
+  (testing "each fn literal under :guards is stamped with the source-coord at the
+  fn-form's reader position; key in the index is [:guards <id>]"
+    (rf/reg-machine :rf2-8bp3/guard-defs
+      {:initial :idle
+       :data    {}
+       :guards  {:always-true (fn [_ _] true)
+                 :n-positive? (fn [data _] (pos? (or (:n data) 0)))}
+       :states  {:idle {}}})
+    (let [idx (per-element-coords :rf2-8bp3/guard-defs)]
+      (is (some? idx) "the spec carries :rf.machine/source-coords")
+      (is (some? (get idx [:guards :always-true]))
+          "the :always-true guard fn-form is keyed by [:guards :always-true]")
+      (is (some? (get idx [:guards :n-positive?]))
+          "the :n-positive? guard fn-form is keyed by [:guards :n-positive?]")
+      (let [c (get idx [:guards :always-true])]
+        (is (= 're-frame.machine-source-coord-test (:ns c)))
+        (is (integer? (:line c)))
+        (is (integer? (:column c)))))))
+
+(deftest reg-machine-stamps-action-definitions
+  (testing "each fn literal under :actions is stamped, keyed by [:actions <id>]"
+    (rf/reg-machine :rf2-8bp3/action-defs
+      {:initial :idle
+       :data    {}
+       :actions {:bump   (fn [data _] {:data (update data :n (fnil inc 0))})
+                 :reset  (fn [data _] {:data (assoc data :n 0)})}
+       :states  {:idle {}}})
+    (let [idx (per-element-coords :rf2-8bp3/action-defs)]
+      (is (some? (get idx [:actions :bump])))
+      (is (some? (get idx [:actions :reset])))
+      (let [c (get idx [:actions :bump])]
+        (is (= 're-frame.machine-source-coord-test (:ns c)))
+        (is (integer? (:line c)))))))
+
+(deftest reg-machine-stamps-on-spawn-action-definitions
+  (testing "each fn literal under :on-spawn-actions is stamped, keyed by
+  [:on-spawn-actions <id>]"
+    (rf/reg-machine :rf2-8bp3/on-spawn-defs
+      {:initial :idle
+       :data    {}
+       :on-spawn-actions {:capture-id (fn [data id] (assoc data :pending id))}
+       :states  {:idle {}}})
+    (let [idx (per-element-coords :rf2-8bp3/on-spawn-defs)]
+      (is (some? (get idx [:on-spawn-actions :capture-id]))
+          "the :capture-id on-spawn-action fn-form is keyed by
+          [:on-spawn-actions :capture-id]"))))
+
+;; ---- reference-site stamping inside the :states tree ----------------------
+
+(deftest reg-machine-stamps-on-transition-keyword-references-via-definition
+  (testing "On JVM the LispReader doesn't attach line/column meta to map
+  literals, so transition-map reference-site coords aren't available
+  here. The definition coords for the named guard / action ARE present
+  (fn-forms are lists, which the reader does decorate)."
+    (rf/reg-machine :rf2-8bp3/on-refs
+      {:initial :idle
+       :data    {}
+       :guards  {:ok? (fn [_ _] true)}
+       :actions {:do  (fn [_ _] {})}
+       :states
+       {:idle
+        {:on
+         {:submit {:target :done :guard :ok? :action :do}}}
+        :done {}}})
+    (let [idx (per-element-coords :rf2-8bp3/on-refs)]
+      ;; Definition sites are stamped (they carry the fn-literal's meta).
+      (is (some? (get idx [:guards :ok?]))
+          "definition site is stamped for keyword references")
+      (is (some? (get idx [:actions :do]))))))
+
+(deftest reg-machine-stamps-inline-fn-references
+  (testing "an inline fn literal in :guard / :action / :entry slot DOES get
+  stamped at the reference site, since the fn-form is a list (which the
+  Clojure LispReader does decorate with line/column meta) — distinct from
+  any enclosing transition's coord. Inline-fn references work on JVM
+  even though their enclosing map literals don't."
+    (rf/reg-machine :rf2-8bp3/inline-refs
+      {:initial :idle
+       :data    {}
+       :states
+       {:idle
+        {:entry (fn [_ _] {})
+         :on    {:submit {:target :done
+                          :guard  (fn [_ _] true)
+                          :action (fn [_ _] {})}}}
+        :done {}}})
+    (let [idx (per-element-coords :rf2-8bp3/inline-refs)]
+      (is (some? (get idx [:states :idle :entry]))
+          "inline-fn :entry literal is stamped at the slot path")
+      (is (some? (get idx [:states :idle :on :submit :guard]))
+          "inline-fn :guard literal is stamped at the slot path")
+      (is (some? (get idx [:states :idle :on :submit :action]))
+          "inline-fn :action literal is stamped at the slot path"))))
+
+(deftest reg-machine-stamps-vector-of-transitions
+  (testing "an :on entry whose value is a vector of guarded-transition maps:
+  on JVM the transition maps don't carry reader meta (LispReader limitation)
+  but the named guards' definition coords ARE stamped (they're fn lists,
+  which the reader does decorate)."
+    (rf/reg-machine :rf2-8bp3/on-vec
+      {:initial :idle
+       :data    {}
+       :guards  {:a? (fn [_ _] true)
+                 :b? (fn [_ _] false)}
+       :states
+       {:idle
+        {:on
+         {:tick [{:guard :a? :target :one}
+                 {:guard :b? :target :two}
+                 {:target :three}]}}
+        :one   {}
+        :two   {}
+        :three {}}})
+    (let [idx (per-element-coords :rf2-8bp3/on-vec)]
+      ;; Definition coords are stamped.
+      (is (some? (get idx [:guards :a?])))
+      (is (some? (get idx [:guards :b?]))))))
+
+(deftest reg-machine-stamps-entry-and-exit-via-definition
+  (testing "keyword :entry / :exit references resolve to their definition
+  coords under [:actions <id>] — on JVM the slot itself isn't stamped (the
+  keyword carries no meta) and the enclosing state-node map literal also
+  doesn't (LispReader doesn't decorate maps), but the action fn-forms ARE
+  stamped at their definition sites under [:actions <id>] which is what
+  tools need to find the implementation."
+    (rf/reg-machine :rf2-8bp3/entry-exit
+      {:initial :a
+       :data    {}
+       :actions {:enter-a (fn [_ _] {})
+                 :exit-a  (fn [_ _] {})}
+       :states
+       {:a {:entry :enter-a
+            :exit  :exit-a
+            :on    {:go :b}}
+        :b {}}})
+    (let [idx (per-element-coords :rf2-8bp3/entry-exit)]
+      ;; Definition coords for the named actions present.
+      (is (some? (get idx [:actions :enter-a])))
+      (is (some? (get idx [:actions :exit-a]))))))
+
+(deftest reg-machine-stamps-always-via-definition
+  (testing ":always transitions reference named guards by keyword. On JVM
+  the transition map itself doesn't carry reader meta, but the guard's
+  fn-form definition coord IS stamped under [:guards <id>] — that's
+  what tools navigate to."
+    (rf/reg-machine :rf2-8bp3/always
+      {:initial :a
+       :data    {}
+       :guards  {:enough? (fn [_ _] true)}
+       :states
+       {:a {:always [{:guard :enough? :target :b}]}
+        :b {}}})
+    (let [idx (per-element-coords :rf2-8bp3/always)]
+      (is (some? (get idx [:guards :enough?]))))))
+
+(deftest reg-machine-stamps-invoke-on-spawn-via-definition
+  (testing ":invoke {:on-spawn :id}: keyword references resolve through
+  the [:on-spawn-actions <id>] definition coord, where the fn-form lives"
+    (rf/reg-machine :rf2-8bp3/invoke-os
+      {:initial :idle
+       :data    {}
+       :on-spawn-actions {:cap (fn [data id] (assoc data :pending id))}
+       :states
+       {:idle {:invoke {:machine-id :child :on-spawn :cap}}}})
+    (let [idx (per-element-coords :rf2-8bp3/invoke-os)]
+      ;; Definition coord present.
+      (is (some? (get idx [:on-spawn-actions :cap]))))))
+
+(deftest reg-machine-stamps-hierarchical-via-definition
+  (testing "nested :states recurse — on JVM, state-node maps carry no
+  reader meta so direct path-tuple lookups for state nodes are absent.
+  Definition coords for inline-fn references inside hierarchical states
+  ARE stamped, since fn-forms always carry meta."
+    (rf/reg-machine :rf2-8bp3/hier
+      {:initial :outer
+       :data    {}
+       :states
+       {:outer {:initial :inner
+                :states
+                {:inner   {:entry (fn [_ _] {})
+                           :on    {:go {:target :sibling}}}
+                 :sibling {}}}}})
+    (let [idx (per-element-coords :rf2-8bp3/hier)]
+      (is (some? (get idx [:states :outer :states :inner :entry]))
+          "deeply-nested inline-fn :entry literal is stamped at the
+          full path-tuple — recursion works on JVM for fn-forms"))))
+
+;; ---- programmatic call (no literal walk possible) -------------------------
+
+(deftest reg-machine-skips-stamping-for-non-literal-spec
+  (testing "when reg-machine receives a symbol bound to a spec value (not a
+  literal map form), the macro can't walk the literal — falls through to
+  call-site-only stamping; :rf.machine/source-coords is absent rather than
+  empty (avoids polluting the registered spec)"
+    (let [my-spec {:initial :a :states {:a {}}}]
+      (rf/reg-machine :rf2-8bp3/programmatic my-spec))
+    ;; The spec itself round-trips; no per-element coord index attached.
+    (is (= {:initial :a :states {:a {}}}
+           (rf/machine-meta :rf2-8bp3/programmatic))
+        "round-tripped spec carries no :rf.machine/source-coords key")
+    ;; Top-level handler-meta still carries the macro's call-site coords.
+    (let [meta (rf/handler-meta :event :rf2-8bp3/programmatic)]
+      (is (some? (:line meta)))
+      (is (some? (:ns meta))))))
+
+;; ---- reg-machine* programmatic plain-fn surface ---------------------------
+
+(deftest reg-machine*-plain-fn-surface
+  (testing "reg-machine* (the plain-fn surface) registers a machine without
+  any macro walking — equivalent to the legacy reg-machine defn. Used by
+  code-gen pipelines that already carry a stamped spec."
+    (rf/reg-machine* :rf2-8bp3/plain
+                     {:initial :a :states {:a {}}})
+    (is (= :rf2-8bp3/plain
+           (some #{:rf2-8bp3/plain} (rf/machines)))
+        "plain-fn registration shows up in (rf/machines) like macro registrations")
+    (is (= {:initial :a :states {:a {}}}
+           (rf/machine-meta :rf2-8bp3/plain))
+        "spec round-trips verbatim")))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -139,7 +139,17 @@ const DEV_ONLY_SENTINELS = [
   // same gate; the literal "data-rf2-source-coord" string fragment
   // must NOT appear in :advanced + goog.DEBUG=false bundles.
   { source: 're-frame.views/reg-view* (data-rf2-source-coord injection)',
-    sentinel: 'data-rf2-source-coord' }
+    sentinel: 'data-rf2-source-coord' },
+  // re-frame.core/reg-machine — per-element source-coord stamping
+  // (Spec 005 §Source-coord stamping, rf2-8bp3). The reg-machine macro
+  // emits an `(if interop/debug-enabled? (assoc spec :rf.machine/
+  // source-coords {...}) spec)` branch; under :advanced +
+  // goog.DEBUG=false the closure compiler constant-folds the gate to
+  // false and DCEs the entire literal coord index. The keyword's
+  // `rf.machine/source-coords` string fragment must NOT survive in
+  // production bundles.
+  { source: 're-frame.core/reg-machine (rf.machine/source-coords stamping)',
+    sentinel: 'rf.machine/source-coords' }
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -508,6 +508,86 @@ The fn `create-machine-handler` returns is the event handler. Crucially, the fac
 
 This is a real constraint on the implementation, not just a testing affordance — it's what makes the singleton vs spawned symmetry clean (the registration happens *outside* the factory in both cases) and what makes Level-2 testing (per [§Testing](#testing)) possible without a test frame.
 
+### `reg-machine` vs `reg-machine*`
+
+The `reg-machine` convenience surface splits along Clojure's `let` / `let*`, `fn` / `fn*` idiom:
+
+| Form | Shape | Source-coord stamping | Use case |
+|---|---|---|---|
+| `(rf/reg-machine machine-id machine-spec)` | **macro** | Yes — call-site coords on the registry slot, AND per-element coord index walked from the literal spec form (per [§Source-coord stamping](#source-coord-stamping-rf2-8bp3)) | Standard form. The literal-spec contract enables the macro to walk and stamp at expansion time. |
+| `(rf/reg-machine* machine-id machine-spec)` | plain fn | None — the call-site predates the registration; the spec is opaque data | Code-gen pipelines that produce specs at runtime, REPL exploration, conformance harnesses that synthesise machines from EDN fixtures. |
+
+The macro lives at the `re-frame.core` boundary; the plain-fn surface lives in `re-frame.machines/reg-machine*` and is exposed publicly under `re-frame.core/reg-machine*` for both JVM and CLJS programmatic callers. The macro emits `(reg-machine* …)` after stamping; the runtime never reaches both surfaces independently.
+
+### Source-coord stamping (rf2-8bp3)
+
+When the `reg-machine` macro receives a literal-map spec form, it walks the form at expansion time and attaches a flat coord index under the spec's `:rf.machine/source-coords` key. Tools (re-frame-pair, re-frame-10x, IDE jump-to-source) read the index back via `(:rf.machine/source-coords (rf/machine-meta machine-id))`.
+
+#### What gets stamped
+
+The index is a flat map of **path-tuple → coord-map**:
+
+```clojure
+{[:guards :form-valid?]
+ {:ns sym :file "path/login.cljs" :line 47 :column 13}
+
+ [:actions :commit]
+ {:ns sym :file "path/login.cljs" :line 52 :column 13}
+
+ [:states :idle :on :submit]
+ {:ns sym :file "path/login.cljs" :line 80 :column 23}
+
+ [:states :idle :on :submit :guard]
+ {:ns sym :file "path/login.cljs" :line 80 :column 35}}    ; only when slot is an inline-fn literal
+```
+
+Two axes are stamped:
+
+1. **Definition sites** — each fn literal under `:guards` / `:actions` / `:on-spawn-actions` is keyed by `[:guards <id>]` / `[:actions <id>]` / `[:on-spawn-actions <id>]`. This is the coord tools navigate to for "jump to definition."
+
+2. **Reference sites** — each transition map / state-node / inline-fn slot inside `:states` is keyed by its full spec-path tuple, e.g. `[:states :idle :on :submit]`. This is the coord tools navigate to for "jump to call site."
+
+#### Keyword reference rule (the exemption case)
+
+For a keyword reference like `:guard :form-valid?` inside a transition, the **definition-site is stamped, the reference-site slot is not**. Rationale: a keyword (`:form-valid?`) is a name, not a source form — it carries no reader metadata of its own. The closest meaningful coord is the **enclosing transition map's** coord, which IS stamped under the transition's path. Synthesising a duplicate slot entry at the same coord adds no information for tools — they walk the path tree to find the closest ancestor coord.
+
+For an **inline-fn reference** like `:guard (fn [_ _] ...)`, the fn-form carries its own reader meta, so the reference-site slot IS stamped at the full path with a distinct coord.
+
+Concretely for `{:on {:submit {:target :done :guard :form-valid? :action (fn [_ _] {})}}}`:
+
+| Path | Stamped? | Why |
+|---|---|---|
+| `[:guards :form-valid?]` | ✓ (when defined) | fn literal carries reader meta |
+| `[:states :idle :on :submit]` | ✓ | transition map carries reader meta |
+| `[:states :idle :on :submit :guard]` | — | `:form-valid?` is a keyword — no meta |
+| `[:states :idle :on :submit :action]` | ✓ | inline-fn literal carries reader meta |
+
+Tools walking the index pick the deepest stamped path-tuple matching their UI gesture; for a "jump to call site" click on a state's `:guard`, they fall back to the enclosing transition's coord (which is the same source line).
+
+#### Reading the index back
+
+```clojure
+(:rf.machine/source-coords (rf/machine-meta :auth/login))
+;; {[:guards :form-valid?]                {:ns ... :line ... :column ... :file ...}
+;;  [:actions :commit]                    {...}
+;;  [:states :form :on :submit]           {...}
+;;  [:states :form :on :submit :action]   {...}}
+```
+
+The top-level call-site coords (the position of the `(rf/reg-machine ...)` form itself) live on the registry slot as `:ns` / `:line` / `:column` / `:file`, queryable via `(rf/handler-meta :event machine-id)`. The two surfaces are independent: a tool that wants to highlight the `reg-machine` declaration uses `handler-meta`; a tool that wants to highlight a transition's source line uses `machine-meta`'s coord index.
+
+#### Production elision
+
+The macro emits an `(if interop/debug-enabled? (assoc spec :rf.machine/source-coords {...}) spec)` branch. Under `:advanced` + `goog.DEBUG=false` the closure compiler constant-folds the gate to `false` and DCEs the entire literal coord index. The keyword `:rf.machine/source-coords` and every spec-element string fragment (the `:ns` symbol values, the `:file` strings) are absent from the production bundle. Verified by the `npm run test:elision` sentinel grep.
+
+#### JVM caveat
+
+Clojure's `LispReader` only attaches `:line` / `:column` metadata to *list* forms (function calls, `(fn …)` bodies). Map and vector literals do NOT carry reader meta on JVM. So on JVM the walker stamps definition-site fn literals reliably (under `:guards` / `:actions` / `:on-spawn-actions`) but state-node and transition-map coords are unavailable — those need the CLJS reader (cljs.tools.reader, which DOES decorate maps/vectors). Per Goal 1 (CLJS reference) the tooling-facing path is CLJS-side; the JVM caveat affects only JVM-side tooling that walks the index directly.
+
+#### Programmatic registration
+
+`reg-machine*` (the plain-fn surface) and any `reg-machine` macro call where the spec arg is a non-literal (a symbol, a let-bound expression) skip the per-element walk: there's no literal tree to walk at expansion time. The registered spec carries no `:rf.machine/source-coords` key in those cases — tools fall back to the call-site coords on `handler-meta`.
+
 ## Design rule — data DSLs vs functions
 
 > **Use data DSLs** for *deferred function calls* (`:fx [[fx-id args]]`), *named effects* (`:on-match [event]`), *declarative shape descriptions* (schemas, hiccup), and *static dependency declarations* (`:<-`, `:platforms`).

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -310,6 +310,12 @@ When a registered view's render-fn returns a fn (Reagent's Form-2 closure shape 
 
 Substrate adapters that do not expose a DOM-attribute concept (Solid scopes, function-arg-explicit, headless test adapters) are exempt. Adapters whose host is React-shaped (Reagent, UIx [rf2-3yij], Helix [rf2-2qit]) MUST honour this contract. The [JVM SSR emitter](011-SSR.md#source-coord-annotation-under-ssr) is the server-side equivalent — it injects the same attribute when emitting HTML for a registered view, so server-rendered pages carry the annotation too.
 
+### Source-coord stamping for state machines (rf2-8bp3)
+
+The view-side annotation above is one half of the tool-pair source-mapping contract. The other half is **the spec-side stamping for state machines**: per [Spec 005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping-rf2-8bp3), the `reg-machine` macro walks its literal spec form at expansion time and attaches a `:rf.machine/source-coords` index keyed by spec-path tuples (`[:guards :form-valid?]`, `[:states :idle :on :submit]`, etc.). Pair tools that surface a "click on a transition's call site" gesture read the index back via `(:rf.machine/source-coords (rf/machine-meta machine-id))` — symmetric to how they consume `data-rf2-source-coord` for views.
+
+Both surfaces share the production-elision contract: the stamping branch is gated on `interop/debug-enabled?`, so under `:advanced` + `goog.DEBUG=false` the closure compiler folds it away. The `rf.machine/source-coords` keyword is part of the standard `scripts/check-elision.cjs` sentinel set (verified ABSENT in the production bundle, PRESENT in the control bundle).
+
 ## Subscription cache — contract and operational semantics
 
 A subscription's value lives in the per-frame **sub-cache**. This section defines the contract: the cache shape, the lookup algorithm, the invalidation algorithm, the ref-counting and disposal rules, the layer-1/2/3 sub semantics, and the lifetime contract that ties them together. The contract is host-agnostic; the [Reagent reference adapter §Sub-cache wiring](#sub-cache-wiring-reagent-realisation) shows the CLJS realisation.

--- a/spec/API.md
+++ b/spec/API.md
@@ -31,6 +31,8 @@
 | `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | 002 | Anonymous frame; gensym'd id. |
 | `reg-view` | M | `(reg-view sym [args] body+)` / `(reg-view sym docstring [args] body+)` / `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | 004 | Defn-shape; auto-defs the symbol; auto-derives id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. |
 | `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | 004 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. The `*` follows Clojure's `let`/`let*`, `fn`/`fn*` idiom (per [Conventions](Conventions.md)). |
+| `reg-machine` | M | `(reg-machine machine-id machine-spec)` | v1 | 005 | Walks the literal spec form at expansion time; stamps per-element source coords under `:rf.machine/source-coords` (rf2-8bp3). Top-level call-site coords land on `handler-meta`. |
+| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | 005 | Plain-fn surface beneath `reg-machine`. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data. |
 | `reg-app-schema` | M | `(reg-app-schema path schema)` | v1 | 010 | |
 | `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 | 013 | |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |
@@ -512,11 +514,13 @@ Split between the v1 machine-as-event-handler foundation and the post-v1 `re-fra
 
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
+| `reg-machine` | M | `(reg-machine machine-id machine-spec)` — registers a machine as an event handler. Walks the literal spec form at expansion time and stamps per-element source coords under `:rf.machine/source-coords` (rf2-8bp3). | v1 | 005 |
+| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` — plain-fn surface beneath the macro. No source-coord walking. | v1 | 005 |
 | `create-machine-handler` | Fn | `(create-machine-handler spec)` → event-handler fn | v1 | 005 |
 | `machine-transition` | Fn | `(machine-transition definition snapshot event)` → `[next-snapshot effects]` | v1 | 005 |
 | `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot | v1 | 005 |
 | `machines` | Fn | `(machines)` → seq of registered machine-ids | v1 | 005 |
-| `machine-meta` | Fn | `(machine-meta machine-id)` → registration metadata | v1 | 005 |
+| `machine-meta` | Fn | `(machine-meta machine-id)` → registration metadata; carries `:rf.machine/source-coords` index when registered via the macro | v1 | 005 |
 | `:spawn` (fx) | — | Reserved fx-id inside a machine action's `:fx`. Args per `:rf.fx/spawn-args`. | v1 | 005 |
 | `:raise` (fx) | — | Reserved fx-id inside a machine action's `:fx`. Args: an event vector. | v1 | 005 |
 | `:child-machine` (transition-table key) | — | Declarative state-scoped child-machine binding. | post-v1 lib | 005 |

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1393,6 +1393,20 @@ This is a meaningful migration of consumer code, not a mechanical rewrite. Do no
 
 Spec 000 now carries a summary [Contract block](000-Vision.md#contract--pattern-obligations) — a small set of formal `C-000.NN` clauses that capture checkable obligations the prose did not previously make explicit (PDS revert is O(1); the explicit-frame view contract; identity-primitive anti-patterns; and a handful of others). The block is implementor-facing — it does not change the migration of an existing re-frame app, but a port author auditing a re-frame2 implementation against its conformance fixtures should grep for `C-000.NN` references and verify each kept clause holds. Spec-authoring and conformance-harness obligations live in [SPEC-AUTHORING.md](SPEC-AUTHORING.md) under the parallel `SA-N` id scheme. There is no rewrite for an application codebase; this is orientation only.
 
+### O-11. Source-coord stamping for state machines (rf2-8bp3)
+
+re-frame2 turns `reg-machine` into a macro that walks the literal spec form at expansion time and stamps per-element source coordinates under the spec's `:rf.machine/source-coords` key (per [Spec 005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping-rf2-8bp3)). This gives pair tools (re-frame-pair, re-frame-10x, IDE jump-to-source) a structured surface for "click on a guard, jump to its definition" and "click on a transition, jump to its source line" gestures.
+
+This is **additive** for consumers — the macro is fully back-compatible with the v1 plain-fn `reg-machine` shape, and the stamping branch elides under `:advanced` + `goog.DEBUG=false`. No migration step is required for v1 → v2.
+
+The opt-in modernisation, when it applies:
+
+1. **Code-gen pipelines that synthesise machine specs from data** SHOULD switch to `reg-machine*` (the plain-fn surface) rather than calling `reg-machine` with a non-literal spec arg. Both paths register correctly; the explicit `*` documents that the call site has no literal spec to walk and no per-element stamping is expected. The `*` follows Clojure's `let`/`let*`, `fn`/`fn*` idiom.
+
+2. **Conformance harnesses** registering machines from EDN fixtures already use the plain-fn surface (via `requiring-resolve`); the late-bind hook key (`:machines/reg-machine`) now points at `reg-machine*`. No change required.
+
+Do not apply unless the user has explicitly asked to surface the per-element coord index for tooling, or to clean up code-gen call sites.
+
 ---
 
 ## What stays the same (do not change these)

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -157,6 +157,27 @@ The "which button is at `src/app/profile/view.cljs:84`?" capability requires eve
 
 With the annotation in place, a pair tool can take a click position, read the nearest annotation, and resolve back to a source coordinate. Documented exemption (per Spec 006 §Source-coord annotation): components returning React Fragments, host-component heads (`:>`), or other non-DOM roots are exempt; pair tools fall back to `(rf/handler-meta :view id)` for those nodes.
 
+### State-machine source-coord stamping (rf2-8bp3)
+
+The DOM-attribute annotation above maps clicked DOM nodes to view registration call sites. A complementary surface maps state-machine spec elements (guards / actions / transitions / state-nodes) back to their source positions.
+
+Per [Spec 005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping-rf2-8bp3), the `reg-machine` macro walks its literal spec form at expansion time and attaches a flat coord index under `:rf.machine/source-coords`, keyed by spec-path tuples:
+
+```clojure
+(:rf.machine/source-coords (rf/machine-meta :auth/login))
+;; {[:guards :form-valid?]                {:ns ... :line ... :column ... :file ...}
+;;  [:actions :commit]                    {...}
+;;  [:states :form :on :submit]           {...}
+;;  [:states :form :on :submit :action]   {...}}
+```
+
+Pair tools use this index for two distinct UI gestures:
+
+- **Jump to definition.** A click on a guard/action name in the visualisation reads `[:guards <id>]` / `[:actions <id>]` / `[:on-spawn-actions <id>]` to find where the fn is implemented.
+- **Jump to call site.** A click on a transition arrow or state node reads the deepest stamped path-tuple matching the node (e.g. `[:states :idle :on :submit]`); for keyword-named slots (`{:guard :form-valid?}`) the slot itself isn't stamped — the tool falls back to the enclosing transition's coord, which IS stamped.
+
+The framework commits to **the index shape and the keyword-reference rule** (definition-site only for keyword refs, reference-site for inline-fn literals). Pair tools ship their own UI affordance over the index. Like `data-rf2-source-coord`, the stamping is gated on `interop/debug-enabled?` and elides under `:advanced` + `goog.DEBUG=false`.
+
 ### Where the DOM-to-source helpers live (re-frame2 vs tool)
 
 The audit found the upstream pair tool ships `dom/source-at`, `dom/find-by-src`, and `dom/fire-click-at-src` helpers (it currently parses re-com's `data-rc-src` attribute, but the shape is general). Pair-shaped tools need *some* DOM-to-source bridge; the question is whether the helpers themselves are part of re-frame2's contract or live in the consuming tool.


### PR DESCRIPTION
## Summary

Mirror the rf2-z7f7 view source-coord pattern, applied to state machines. `reg-machine` becomes a macro that walks the literal machine spec at expansion time and stamps a per-element coord index under `:rf.machine/source-coords`. The plain-fn surface beneath the macro is renamed `reg-machine*` (Clojure's `let`/`let*`, `fn`/`fn*` idiom).

- **Macro**: `(rf/reg-machine machine-id machine-spec)` walks the literal spec, builds a `{<path-tuple> {:ns :line :column :file}}` index, and emits `(reg-machine* machine-id stamped-spec)` wrapped in DEBUG-gated injection.
- **Plain fn**: `re-frame.core/reg-machine*` and `re-frame.machines/reg-machine*` for code-gen pipelines, conformance harnesses, REPL.
- **Stamping axes**: definition sites (each fn literal under `:guards` / `:actions` / `:on-spawn-actions`) and reference sites (each transition map / state-node / inline-fn slot inside `:states`).
- **Keyword-reference rule** (the bead's exemption case): definition-site only for keyword refs, reference-site for inline-fn literals. Rationale: a keyword carries no reader meta — the closest meaningful coord is the enclosing transition map's coord, which IS stamped at the transition's path. Tools walk the path tree to find the closest stamped ancestor.

## Stamped meta snippet

From a real `(rf/reg-machine :auth/login {...})` registration, read back via `(:rf.machine/source-coords (rf/machine-meta :auth/login))`:

```clojure
{[:guards :form-valid?]
 {:ns user :file ".../auth-login.clj" :line 8  :column 27}

 [:actions :commit]
 {:ns user :file ".../auth-login.clj" :line 11 :column 28}

 [:actions :clear-error]
 {:ns user :file ".../auth-login.clj" :line 12 :column 28}}
```

(JVM run; map / vector / state-node / transition coords also populate on CLJS where the cljs reader decorates collection literals — see CLJS test for the full path-tuple surface.)

## Production-elision

The macro emits `(if interop/debug-enabled? (assoc spec :rf.machine/source-coords {...}) spec)`. Under `:advanced` + `goog.DEBUG=false` the closure compiler folds the gate to false and DCEs the entire literal coord index. New sentinel `rf.machine/source-coords` added to `scripts/check-elision.cjs`:

```
[OK] re-frame.core/reg-machine (rf.machine/source-coords stamping):
       sentinel "rf.machine/source-coords" expected ABSENT,  was ABSENT  (production)
       sentinel "rf.machine/source-coords" expected PRESENT, was PRESENT (control)
=== PASS ===
```

## Test results

| Suite | Result |
|---|---|
| Core JVM (`clojure -M:test` in `implementation/core`) | **219 tests, 981 assertions, 0 failures, 0 errors** |
| Machines JVM (new `machine_source_coord_test.clj`) | **13 tests, 33 assertions, 0 failures, 0 errors** |
| Routing JVM | **6 tests, 33 assertions, 0 / 0** |
| Flows JVM | **15 tests, 49 assertions, 0 / 0** |
| HTTP JVM | **15 tests, 32 assertions, 0 / 0** |
| Schemas JVM | **27 tests, 109 assertions, 0 / 0** |
| CLJS node (`npm run test:cljs`) | **119 tests, 370 assertions, 0 / 0** (incl. new `machine_source_coord_cljs_test.cljs` — 8 deftests covering full path-tuple surface) |
| Production-elision (`npm run test:elision`) | **PASS** — `rf.machine/source-coords` ABSENT in production, PRESENT in control |
| Examples Playwright (`npm run test:examples`) | **15 / 15 PASS** |

`npm run test:browser` was port-blocked by another in-flight worktree on `localhost:8021`; the production-elision verifier and node test compile through the same shadow-cljs config and all 119 CLJS tests pass under node, so the surface is exercised.

## Keyword-reference rule (chosen rule)

For a keyword `:guard :form-valid?` reference inside a transition: **definition site is stamped, reference site slot is not**. The transition map IS stamped at its path, so a tool's "jump to call site" gesture walks the path tree to find the closest stamped ancestor — the transition's coord IS the call-site coord. Inline-fn references (`:guard (fn [_ _] ...)`) DO get distinct slot stamps because the fn-form has its own reader meta. Documented in Spec 005 §Source-coord stamping; tested both in the JVM and CLJS test files.

## JVM caveat

Clojure's `LispReader` only attaches `:line` / `:column` metadata to *list* forms (function calls, fn-bodies). Map and vector literals don't carry reader meta on JVM. So on JVM the walker stamps definition-site fn literals reliably under `:guards` / `:actions` / `:on-spawn-actions`, but state-node and transition-map coords are unavailable until the cljs reader decorates them. Per Goal 1 (CLJS reference) the tooling-facing path is CLJS-side; the JVM caveat affects only JVM-side tooling that walks the index directly. Documented in Spec 005 §JVM caveat.

## Sequencing note: rf2-suue overlap

rf2-suue (Option B `:system-id` impl) is in flight against `implementation/machines/src/re_frame/machines.cljc` — extending `spawn-fx` and `destroy-machine-fx` near the end of the file. This PR's only edits to `machines.cljc` are at lines 876-915 (`reg-machine` rename to `reg-machine*` + docstring) and the late-bind hook table at the file's tail (the hook key now points at `reg-machine*`). The two PRs touch distinct sections; rebase should be clean.

## Test plan

- [x] JVM tests pass for all 6 modules (core / machines / routing / flows / http / schemas)
- [x] CLJS node tests pass (`npm run test:cljs`)
- [x] Production-elision probe passes (`npm run test:elision`) — `rf.machine/source-coords` sentinel ABSENT in production, PRESENT in control
- [x] Examples Playwright suite passes (`npm run test:examples`)
- [x] Stamped-meta snippet captured from a real registration