### PR TITLE
docs(spec): fold-in additive recommendations for Conventions (first additive-only pilot)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -30,6 +30,10 @@ The previous v1-and-early-v2 scheme used 14 separate top-level prefixes (`:regis
 | `:rf.test/*` | Test-runner-internal events and fx-stub ids | 008 |
 | `:rf.http/*` | Managed-HTTP fx ids (`:rf.http/managed`, `:rf.http/managed-abort`, `:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure`); reply-payload `:kind` values for the closed eight-category failure taxonomy (`:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/accept-failure`, `:rf.http/aborted`); registration metadata key `:rf.http/decode-schemas`; trace operations (`:rf.http/retry-attempt`). Reserved whether or not the implementation ships Spec 014 — ports that omit `:rf.http/managed` MUST NOT register the namespace for any other purpose. | 014 |
 
+### Error-id and warning-id grammar
+
+Error and warning ids follow `:rf.error/<kebab-id>` and `:rf.warning/<kebab-id>` — a single-segment kebab-case category under the reserved sub-namespace. The `:rf.error/*` and `:rf.warning/*` table rows above reserve the namespaces; the per-category vocabulary (the closed set of `<category>` values, what each one means, and which trace `:operation` it maps to) is enumerated in [009 §Error namespace convention](009-Instrumentation.md#error-namespace-convention). The same `:rf.<prefix>/<category>` shape applies to `:rf.fx/*` advisories, `:rf.ssr/*` advisories, and `:rf.epoch/*` operations — Conventions reserves the prefixes; 009 owns the per-prefix grammar.
+
 ### v1-compat alias
 
 | Compat namespace | Status |
@@ -69,6 +73,7 @@ re-frame2 reserves a small set of *unqualified* fx-ids — the runtime, the mach
 | `:dispatch-later` | runtime `do-fx` | Delayed dispatch | 002 |
 | `:raise` | machine handler (`create-machine-handler`) | Self-event addressed to the same machine; processed atomically pre-commit. **Outside a machine action's `:fx`, `:raise` is unbound** and `:rf.error/no-such-handler` is the failure mode. | 005 |
 | `:spawn` | machine handler (`create-machine-handler`) | Spawn a dynamic actor; record its id into the parent's `:data` via `:on-spawn`. **Outside a machine action's `:fx`, `:spawn` is unbound.** Args per `:rf.fx/spawn-args`. | 005 |
+| `:destroy-machine` | machine handler (`create-machine-handler`) | Destroy a dynamic actor: runs the actor's `:exit` action, dissociates its snapshot at `[:rf/machines <actor-id>]`, and clears its event handler from the frame-local registry. Symmetric counterpart to `:spawn`. **Outside a machine action's `:fx`, `:destroy-machine` is unbound.** Per [005 §`:raise`, `:spawn`, and `:destroy-machine` are reserved fx-ids inside `:fx`](005-StateMachines.md#raise-spawn-and-destroy-machine-are-reserved-fx-ids-inside-fx). | 005 |
 | `:rf.fx/reg-flow` | runtime `do-fx` | Register a flow at runtime (per [013 §Dynamic toggle via fx](013-Flows.md#dynamic-toggle-via-fx)). Args: a flow map. | 013 |
 | `:rf.fx/clear-flow` | runtime `do-fx` | Clear a registered flow; `dissoc-in` on its `:path`. Args: a flow id. | 013 |
 
@@ -101,6 +106,7 @@ A small set of keys at the root of every frame's `app-db` are **reserved** — t
 | `:rf/machines` | machine runtime | Map of `<machine-id> → :rf/machine-snapshot`. Each registered machine's snapshot lives at `[:rf/machines <id>]`; per-frame isolation is automatic (each frame's `app-db` has its own `:rf/machines`). Locating snapshots inside `app-db` is the named mechanism by which machine state inherits [000 §Frame state revertibility](000-Vision.md#frame-state-revertibility) (Goal 2). | 005 |
 | `:rf/system-ids` | machine runtime | Per-frame reverse index for `:system-id` named-machine addressing — a map of `<system-id> → <gensym'd-machine-id>`. A spawn whose args carry `:system-id` writes a slot here; destroy clears it. `(rf/machine-by-system-id sid)` reads against this slot. Allocated lazily — absent until the first system-id-bound spawn. Per [005 §Named addressing via `:system-id`](005-StateMachines.md#named-addressing-via-system-id) and rf2-suue. | 005 |
 | `:rf/route` | routing runtime | The current route slice `{:id :params :query :transition :error}`. | 012 |
+| `:rf/pending-navigation` | routing runtime | The pending-navigation slot, populated by the runtime when a `:can-leave` guard rejects a navigation; cleared by `:rf.route/continue` or `:rf.route/cancel`. Schema `:rf/pending-navigation`. Allocated lazily — absent until the first guard rejection. Per [012 §Navigation blocking — pending-nav protocol](012-Routing.md#navigation-blocking--pending-nav-protocol). | 012 |
 
 User registrations and writes must avoid the reserved keys. The migration agent flags any user-registered `app-db` schema or write under `:rf/machines` as a Type-B migration. Schema-bearing implementations (re-frame2 reference) register the reserved keys' schemas at boot — `(rf/app-schema-at [:rf/machines])` returns `[:map-of :keyword :rf/machine-snapshot]`, with per-machine refinements composed from registered machines' `:data` shapes.
 
@@ -320,4 +326,4 @@ A consumer picks their substrate by adding the matching adapter alongside the co
 - [000-Vision.md](000-Vision.md) — goals, constraints, the pattern's minimal core.
 - [Principles.md](Principles.md) — the discipline principles that motivate these conventions.
 - [001-Registration.md](001-Registration.md) — registration metadata-map shape; what each `reg-*` accepts.
-- [MIGRATION.md](MIGRATION.md) — the collision-audit migration rule.
+- [MIGRATION.md](MIGRATION.md) — framework-keyword consolidation under `:rf/*` ([§M-20](MIGRATION.md#m-20-framework-keyword-consolidation--rf-as-the-single-root-prefix)) and the Type-A vs Type-B migration classification.


### PR DESCRIPTION
First fold-in under the additive-only rule. Consumes findings from the AI-precision audit (rf2-smpt, 23 findings) and the parallel readability audit (12 findings). Cuts and structural edits surfaced for manual judgment.

## Applied — additive

- **F2 (rf2-smpt)** — §Reserved fx-ids: added `:destroy-machine` row. 005-StateMachines.md:348 cites Conventions §Reserved fx-ids as listing `:raise`, `:spawn`, **and** `:destroy-machine`; only `:raise` and `:spawn` were in the table. Closes a dangling inbound citation.
- **F5 (rf2-smpt)** — §Reserved app-db keys: added `:rf/pending-navigation` row. 012-Routing.md:807 puts the pending-nav slot at the app-db root; without a row, user code told "MUST NOT write under reserved keys" cannot enumerate the set.
- **F6 (rf2-smpt) / F11 (readability)** — added §Error-id and warning-id grammar sub-section directly under the §Reserved namespaces table. Single paragraph stating `:rf.error/<kebab-id>` / `:rf.warning/<kebab-id>` shape, delegating per-category vocabulary to 009. Conventions previously reserved the prefixes without ever stating the format — the most surprising absence in the audit.

## Rewords (for correctness)

- **F18 (rf2-smpt)** — doc-tail §Cross-references entry. Old → new:
  - Old: `- [MIGRATION.md](MIGRATION.md) — the collision-audit migration rule.`
  - New: `- [MIGRATION.md](MIGRATION.md) — framework-keyword consolidation under :rf/* (§M-20) and the Type-A vs Type-B migration classification.`
  - Canonical source: MIGRATION.md:719 has heading "M-20. Framework keyword consolidation — `:rf/*` as the single root prefix"; MIGRATION.md:1198 lists Type-A (mechanical) vs Type-B (judgment) classification. No "collision-audit" heading exists in MIGRATION.md.
  - Length note: -8 words / +14 words is above the ±20% guidance, but the change replaces a single short noun-phrase with a short noun-phrase plus a concrete §-link, which is the smallest correct fix — flagging here so reviewer can shorten if preferred.

(Reword cap: 3. Used: 1. Two further reword candidates — F4 `:rf/route` vs `:route` and F22 `:rf.machine` vs `:rf/machine` — surfaced as Mike-review because the canonical fix touches the strengths-protected §Reserved namespaces table.)

## Mike review needed — out of additive scope

### From rf2-smpt audit

- **F1** — "Conventions.md §Reading machines" cited from 005:1446; section doesn't exist. Recommended fix is in 005 (re-target the link), not Conventions; out of scope for a Conventions fold-in.
- **F3** — `:story.*` / `:Workspace.*` reservation status. 007:39 claims them as "reserved (see Conventions §Reserved namespaces)"; not in the table. Decision needed: extend the "single root" claim with documented exceptions, or fix 007's wording to "library-owned". Either way changes prose in §Reserved namespaces (strength-protected).
- **F4** — `:rf/route` vs `:route`. Conventions is the outlier (line 16 in §Reserved namespaces table, line 103 in §Reserved app-db keys, line 114 in §Reserved sub-ids). 012-Routing, API.md, Runtime-Architecture.md all use `:route`. The canonical fix touches the strengths-protected table at line 16, and a partial fix (only lines 103/114) creates new internal inconsistency with line 16.
- **F7** — "Owner" column terminology in §Reserved app-db keys uses "machine runtime" / "routing runtime"; no Conventions section names the runtimes. Reword needed; structural choice.
- **F8** — "User code MUST NOT register handlers, fx, subs, or **frames** under `:rf/*`" — sentence is technically correct but reads as if it covers ids the framework also doesn't use. Recommended rewrite is a sentence-replacement, not additive.
- **F9** — `:rf.fx/spawn-args` cross-link tighter. The current line cross-links to Spec-Schemas already; the audit's complaint is that the §Reserved namespaces row characterises `:rf.fx/*` as advisory (which `spawn-args` is not). Touches strength-protected row at line 19.
- **F10** — Move/merge the duplicate "fixed-and-additive" paragraph at line 93 into the §Reserved fx-ids subsection. Recommendation is structural movement (cut from one place, paste in another). Both occurrences are in §4 Strengths-to-preserve.
- **F11 (rf2-smpt)** — Substrate-test-matrix policy CI gate aspirational/enforced ambiguity. Section is in §Substrate-adapter shipping convention which is locked alongside §Packaging conventions territory.
- **F12** — "Tooling and migration agents check for collisions" / linter stated as fact. Reword to forward-looking; touches strength-protected line 8.
- **F13** — §`re-frame.alpha` is dissolved (lines 39-48). Recommended cut to a one-line cross-link; cuts not in remit.
- **F14** — Split the muddy `:rf/*` row in §Reserved namespaces into typed sub-rows. Restructure of strength-protected table.
- **F15** — `:rf/url-changed` vs `:rf.route/url-changed` reconcile. Touches strength-protected row at line 24.
- **F16** — cofx and sub reservation policy decision. Either add `:rf.cofx/*` / `:rf.sub/*` rows (additive) OR narrow the opening paragraph at line 8 to drop "cofx" (cut from strength-protected text). Decision-shaped.
- **F17** — Separate qualified vs unqualified fx-ids in §Reserved fx-ids. Restructure.
- **F19** — late-bind hook table cross-reference (rf2-0hxm). The applicable site (§Independence rule under §Packaging conventions) is rf2-uo7v territory.
- **F20** — "Unused by v1" parenthetical at line 75. Aspirational language; cut or anchor needed.
- **F21** — "Capability axis" column needs explicit cross-link to 005's capability matrix. Existing cross-link present at line 79 — borderline; may not need additional clause.
- **F22** — Sub-id is `:rf/machine` not `:rf.machine`. Two sites: line 22 in strength-protected §Reserved namespaces table, line 113 in §Reserved sub-ids. The canonical fix touches the strength-protected line 22; a line-113-only fix leaves the doc internally inconsistent.
- **F23** — Schema-registration aside at line 105 belongs in 010-Schemas. Cut/move.

### From readability audit

- **F1 (read.)** — Promote §Reserved sub-ids out of §Reserved app-db keys. Restructure.
- **F2 (read.)** — Promote §Reserved state-node keys to H2; delete duplicate "fixed-and-additive" closing paragraph at line 93. Restructure + cut from §4 Strengths.
- **F3 (read.)** — Slim the `:rf.http/*` row. Cut from strength-protected table.
- **F4 (read.) + F5 (read.)** — Merge §Substrate-adapter shipping convention into §Packaging conventions; replace the 460-word rationale paragraph at line 308 with a five-bullet list. **Out of scope: §Packaging is rf2-uo7v territory**, and large structural rewrite besides.
- **F6 (read.)** — Section re-ordering. Restructure.
- **F7 (read.)** — Rewrite the §`:interceptors` H2 heading. Stylistic reword that doesn't fit the strict reword-for-correctness criteria.
- **F8 (read.)** — Convert the §Reserved namespaces / Discipline list to rule-then-example shape. Restructure of strength-adjacent prose.
- **F9 (read.)** — Restructure §Lockstep versioning into Rule / Mechanism / Enforcement / Post-1.0 micro-sections. **Out of scope: §Packaging territory**.
- **F10 (read.)** — Split the multi-namespace row at line 23. Restructure of strength-protected table.
- **F12 (read.)** — Drop or reformat the doc-tail §Cross-references. Cut/restructure (note: the F18 reword above touches one item in this section, but the structural decision about the section's existence is yours).

## §Packaging conventions excluded

Confirmation: I did not touch §Packaging conventions (lines 217 onward) nor §Substrate-adapter shipping convention (treated as packaging-adjacent territory, conservative interpretation of the rf2-uo7v boundary). `git diff` grep for `Packaging` and `Substrate-adapter` against my changes returns zero hits.

## Diff balance

- Lines added: 8 (4 new content + 4 blank-line spacing)
- Lines removed: 1 (F18 reword target)
- Lines changed: 1 file
- Net: +7

## Verification

- Strengths-to-preserve check: PASS. §Reserved namespaces table (lines 14-31), all four "fixed-and-additive" sentences, §Feature-modularity, §`:interceptors` example block, `reg-view` examples, voice — all untouched.
- §Packaging exclusion: PASS. No edits to §Packaging conventions nor §Substrate-adapter shipping convention.
- Markdown lint: PASS (no tool available locally; verified table structure visually — pipe alignment, header-row separators, no orphaned cells).

## Caught-on-self

- Initially planned to apply F4 reword (`:rf/route` → `:route`). Stopped because the canonical fix would require editing line 16 in the §Reserved namespaces table, which is in §4 Strengths-to-preserve. Partial fix (only lines 103/114) would create new internal inconsistency with line 16. Surfaced to Mike review.
- Same logic for F22 (`:rf.machine` → `:rf/machine` for sub-id) — line 22 is in the strength-protected table.

## Tensions between audits and §4 Strengths-to-preserve

Several findings would require editing strength-protected passages:

- F4 (`:rf/route` vs `:route`) — touches line 16 in the strength table.
- F14 (split muddy `:rf/*` row) — restructures the strength table.
- F15 (`:rf/url-changed` reconcile) — touches line 24 in the strength table.
- F22 (`:rf.machine` sub-id form) — touches line 22 in the strength table.
- F8 (MUST-NOT sentence rewrite) — touches strength-protected line 8 voice.
- F12 (linter aspirational language) — touches strength-protected line 8 voice.
- F10 (move duplicate "fixed-and-additive" paragraph) — touches the framing-phrase strengths.
- F2 readability (promote state-node keys H2; delete duplicate paragraph) — touches the framing-phrase strengths.

These are genuine cases where audit-found defects sit inside passages flagged as load-bearing for human readers. Worth deciding case-by-case.
