### PR TITLE
feat: (rf/sub-topology) — close v1-✓ documentation/implementation drift (rf2-8nzo / discovered-from rf2-nfyf)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1017,6 +1017,12 @@
   ([frame-id]
    (subs/sub-cache-snapshot frame-id)))
 
+;; sub-topology is the **static** counterpart to sub-cache — pure data
+;; derived from the registrar at registration time, JVM-runnable. Per
+;; Spec 002 §The public registrar query API and Spec 006 §Subscription
+;; topology vs subscription tracking.
+(def sub-topology subs/sub-topology)
+
 ;; ---- interceptors ---------------------------------------------------------
 
 (def ->interceptor   interceptor/->interceptor)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -491,6 +491,56 @@
               (catch #?(:clj Throwable :cljs :default) _ nil))))
      (reset! cache {}))))
 
+;; ---- static topology ------------------------------------------------------
+;;
+;; Per Spec 002 §The public registrar query API and Spec 006 §Subscription
+;; topology vs subscription tracking. `sub-topology` is the static ":<- chain"
+;; you can derive from registrations alone — pure data over the registrar,
+;; no app-db, no reactive runtime, no per-frame cache. JVM-runnable.
+;;
+;; Shape (per Spec 002 §The public registrar query API row): a map of
+;;   sub-id → {:inputs [<input-sub-ids>] :doc <str?> :ns sym :line int :file str}
+;; with :inputs always present (empty vector for layer-1 / direct-app-db subs)
+;; and the source-coord / :doc keys included only when the registration
+;; carries them.
+
+(defn sub-topology
+  "Return the static dependency graph of every registered subscription.
+
+  Pure data over the registrar — no app-db, no per-frame cache, no
+  reactive runtime. Per Spec 002 §The public registrar query API and
+  Spec 006 §Subscription topology vs subscription tracking.
+
+  Shape: `{sub-id {:inputs [<input-sub-ids>] :doc ... :ns ... :line ... :file ...}}`.
+
+  - `:inputs` is the vector of upstream sub-ids declared via `:<-` at
+    registration time. It is always present; layer-1 subs (which read
+    `app-db` directly) report `:inputs []`. The order matches the
+    declaration order so that downstream tools can reconstruct the
+    chain shape the body fn expects.
+  - `:doc`, `:ns`, `:line`, `:file` are present when the registration
+    carried them (`:ns` / `:line` / `:file` are auto-captured by the
+    `reg-sub` macro per Spec 001 §Source-coordinate capture; `:doc`
+    is user-supplied via the meta-map first arg).
+
+  Returns `{}` when no subs are registered.
+
+  JVM-runnable. The runtime cache state (`sub-cache`) is the dynamic
+  counterpart and is CLJS-only."
+  []
+  (let [subs-meta (registrar/handlers :sub)]
+    (reduce-kv
+      (fn [acc sub-id meta]
+        (let [inputs (mapv first (:input-signals meta))
+              entry  (cond-> {:inputs inputs}
+                       (contains? meta :doc)  (assoc :doc  (:doc  meta))
+                       (contains? meta :ns)   (assoc :ns   (:ns   meta))
+                       (contains? meta :line) (assoc :line (:line meta))
+                       (contains? meta :file) (assoc :file (:file meta)))]
+          (assoc acc sub-id entry)))
+      {}
+      subs-meta)))
+
 (defn sub-cache-snapshot
   "Public read-only snapshot of a frame's sub-cache, projected to a
   Tool-Pair-friendly shape: `{query-v {:value v :ref-count n}}`.

--- a/implementation/core/test/re_frame/sub_topology_test.clj
+++ b/implementation/core/test/re_frame/sub_topology_test.clj
@@ -1,0 +1,174 @@
+(ns re-frame.sub-topology-test
+  "Tests for the public `(rf/sub-topology)` static dependency-graph
+  query (rf2-8nzo). Per Spec 002 §The public registrar query API and
+  Spec 006 §Subscription topology vs subscription tracking.
+
+  `sub-topology` returns a map of
+    `sub-id → {:inputs [<input-sub-ids>] :doc :ns :line :file}`
+  derived purely from the registrar at registration time. No app-db,
+  no per-frame cache, no reactive runtime — JVM-runnable.
+
+  These tests exercise the contract end-to-end: empty registry,
+  layer-1 / layer-2 / layer-3 chains, multi-input fanout, source-coord
+  capture, doc passthrough, declaration-order preservation, and a
+  declared self-reference cycle (which is allowed by registration —
+  the topology surface reports the static :<- chain regardless of
+  whether the resulting sub would resolve at runtime)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init!)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- empty / shape contract ----------------------------------------------
+
+(deftest empty-registry-returns-empty-map
+  (testing "(sub-topology) returns {} (not nil) when no subs are registered"
+    ;; clear-all! ran in the fixture; the registrar holds zero :sub
+    ;; entries. Returning {} (not nil) lets callers compose with
+    ;; reduce-kv / get-in / count without nil-pun special cases.
+    (registrar/clear-all!)
+    (is (= {} (rf/sub-topology)))
+    (is (map? (rf/sub-topology)))))
+
+(deftest layer-1-sub-has-empty-inputs
+  (testing "a layer-1 sub (reads app-db directly) reports :inputs []"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (let [topo (rf/sub-topology)]
+      (is (contains? topo :n))
+      (is (= [] (:inputs (topo :n)))
+          ":inputs is always present and is the empty vector for layer-1 subs"))))
+
+;; ---- :<- chain capture ---------------------------------------------------
+
+(deftest single-input-layer-2-sub-reports-the-upstream-id
+  (testing "a layer-2 sub with one :<- declares one upstream input"
+    (rf/reg-sub :n  (fn [db _] (:n db)))
+    (rf/reg-sub :n2 :<- [:n] (fn [n _] (* 2 n)))
+    (let [topo (rf/sub-topology)]
+      (is (= [] (:inputs (topo :n))))
+      (is (= [:n] (:inputs (topo :n2)))))))
+
+(deftest multi-input-layer-2-sub-preserves-declaration-order
+  (testing "multi-input :<- chain order is preserved (matters for body fn arity)"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :c (fn [db _] (:c db)))
+    (rf/reg-sub :sum :<- [:a] :<- [:b] :<- [:c]
+                (fn [[a b c] _] (+ a b c)))
+    (is (= [:a :b :c] (:inputs ((rf/sub-topology) :sum)))
+        "declaration order is preserved so tools can reconstruct the body's input shape")))
+
+(deftest deeper-chain-each-link-recorded
+  (testing "layer-3 chain — every node carries its direct upstreams"
+    (rf/reg-sub :raw   (fn [db _] (:n db)))
+    (rf/reg-sub :step1 :<- [:raw]   (fn [r _] (inc r)))
+    (rf/reg-sub :step2 :<- [:step1] (fn [s _] (* 10 s)))
+    (let [topo (rf/sub-topology)]
+      (is (= []       (:inputs (topo :raw))))
+      (is (= [:raw]   (:inputs (topo :step1))))
+      (is (= [:step1] (:inputs (topo :step2)))))))
+
+(deftest input-sub-ids-strip-query-args
+  (testing ":inputs reports sub-ids only — query-vector args are stripped"
+    ;; The registration form is `:<- [:upstream arg1 arg2]`; the static
+    ;; topology is keyed by sub-id, so :inputs reports just :upstream.
+    ;; Per Spec 002 §The public registrar query API row.
+    (rf/reg-sub :upstream (fn [db [_ _arg]] (:n db)))
+    (rf/reg-sub :downstream :<- [:upstream :some-arg]
+                (fn [u _] (str u)))
+    (is (= [:upstream] (:inputs ((rf/sub-topology) :downstream)))
+        "the per-input-vector args don't change the topology — sub-ids only")))
+
+;; ---- :doc and source-coord passthrough -----------------------------------
+
+(deftest source-coords-are-included
+  (testing ":ns / :line / :file are auto-captured by reg-sub and surface in topology"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (let [entry ((rf/sub-topology) :n)]
+      (is (some? (:ns entry))   ":ns captured at the call site")
+      (is (number? (:line entry)) ":line captured at the call site")
+      (is (some? (:file entry)) ":file captured at the call site"))))
+
+(deftest user-supplied-doc-passes-through
+  (testing ":doc supplied via the meta-map first arg surfaces in topology"
+    (rf/reg-sub :counter
+                {:doc "Counter sub — a layer-1 sub that reads :n from app-db."}
+                (fn [db _] (:n db)))
+    (is (= "Counter sub — a layer-1 sub that reads :n from app-db."
+           (:doc ((rf/sub-topology) :counter))))))
+
+(deftest no-doc-key-when-not-supplied
+  (testing ":doc is absent when the registration didn't supply one"
+    ;; Don't surface a nil :doc — match the spec row's "keys present
+    ;; when the registration carries them" semantics.
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (is (not (contains? ((rf/sub-topology) :n) :doc)))))
+
+;; ---- registry semantics --------------------------------------------------
+
+(deftest unregistered-ids-absent
+  (testing "subs that were never registered don't appear"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (let [topo (rf/sub-topology)]
+      (is (contains? topo :a))
+      (is (not (contains? topo :ghost))))))
+
+(deftest cleared-subs-are-removed
+  (testing "(rf/clear-sub id) removes the sub from the topology"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (let [topo (rf/sub-topology)]
+      (is (contains? topo :a))
+      (is (contains? topo :b)))
+    (subs/clear-sub :a)
+    (let [topo (rf/sub-topology)]
+      (is (not (contains? topo :a)))
+      (is (contains? topo :b)))))
+
+(deftest reregistration-replaces-the-entry
+  (testing "re-registering a sub replaces its topology entry"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (is (= [] (:inputs ((rf/sub-topology) :a))))
+    ;; Re-register :a as a layer-2 sub composing :b. The topology
+    ;; reports the new :<- chain (last-write-wins per Spec 001
+    ;; §Hot-reload semantics).
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :a :<- [:b] (fn [b _] (str b)))
+    (is (= [:b] (:inputs ((rf/sub-topology) :a))))))
+
+;; ---- self-reference / cycle handling -------------------------------------
+
+(deftest declared-self-reference-is-reported-verbatim
+  (testing "a sub declaring :<- [:itself] is reported with that input — no cycle detection at the topology layer"
+    ;; The topology surface is a literal projection of the registrar's
+    ;; :<- declarations. Cycle detection is a debugger / tool concern,
+    ;; not a property of the static topology query — the same way the
+    ;; registrar accepts the registration without complaint. Keeping
+    ;; sub-topology as a verbatim projection means tools can detect
+    ;; cycles by traversing the returned graph; sub-topology itself
+    ;; just reports what was registered.
+    (rf/reg-sub :loop :<- [:loop] (fn [v _] v))
+    (is (= [:loop] (:inputs ((rf/sub-topology) :loop)))))
+
+  (testing "a 2-node cycle :<- declarations are similarly verbatim"
+    (rf/reg-sub :a :<- [:b] (fn [b _] b))
+    (rf/reg-sub :b :<- [:a] (fn [a _] a))
+    (let [topo (rf/sub-topology)]
+      (is (= [:b] (:inputs (topo :a))))
+      (is (= [:a] (:inputs (topo :b)))))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -775,7 +775,9 @@ Other CLJS adapters (UIx, Helix) plug in via the same shape, replacing only the 
 
 A subtle distinction worth pulling out: **the static topology of the sub graph is core; the runtime tracking is adapter**.
 
-The topology is "what depends on what" — the static `:<-` chain you can derive from registrations alone, without running any code. `(rf/sub-topology)` returns this graph as data. JVM-runnable. No adapter needed.
+The topology is "what depends on what" — the static `:<-` chain you can derive from registrations alone, without running any code. `(rf/sub-topology)` returns this graph as data, shaped `{sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}` per [002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api). `:inputs` is always present (empty for layer-1 / direct-app-db subs) and lists the upstream sub-ids in declaration order; `:doc` and the source-coord keys are present when the registration carries them. JVM-runnable. No adapter needed.
+
+`sub-topology` is a *literal projection* of the registrar — it does not validate the resulting graph. Cycle detection, "this `:<-` references an unregistered sub", and similar diagnostics are debugger / tool-pair concerns that traverse the returned map; the topology query itself reports verbatim what was registered. (Cycles in `:<-` are not legal at runtime — the resolved sub will throw — but the topology query stays a static projection.)
 
 The tracking is "when source X changes, recompute everyone who depends on X" — the runtime mechanism that makes views update reactively. This requires the adapter's `make-derived-value` and is substrate-specific.
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -263,7 +263,7 @@ For tooling, agents, story tools, 10x.
 | `frame-meta` | Fn | `(frame-meta frame-id)` | v1 | ✓ | 002 |
 | `get-frame-db` | Fn | `(get-frame-db frame-id)` → app-db value (plain map) | v1 | ✓ | 002 |
 | `snapshot-of` | Fn | `(snapshot-of path)` / `(snapshot-of path opts)` | v1 | ✓ | 002 |
-| `sub-topology` | Fn | `(sub-topology)` → static dependency graph | v1 | ✓ | 002 |
+| `sub-topology` | Fn | `(sub-topology)` → `{sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}` — static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them. | v1 | ✓ | 002 |
 | `sub-cache` | Fn | `(sub-cache frame-id)` → live cache state | v1 | ✗ (CLJS-only) | 002 |
 | `app-schemas` | Fn | `(app-schemas)` / `(app-schemas {:frame frame-id})` → map of path → schema | v1 | ✓ | 010 |
 | `app-schema-at` | Fn | `(app-schema-at path)` / `(app-schema-at path {:frame frame-id})` | v1 | ✓ | 010 |

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1037,7 +1037,7 @@ rf/trace-api-version                             ;; version slot, never wired
 
 **Why:** each of these v1 surfaces had a v2-canonical equivalent that subsumed the use case (trace listeners, point-event tracing, fx-shaped lifecycle, run-to-completion drain, frame-level error policy). Carrying the v1 names as separate documented entries created drift between the API table and the actual v2 surfaces.
 
-For `make-restore-fn`, `init-platform`, the SSR-head trio (`reg-head` / `render-head` / `active-head`), and `sub-topology` — these were also flagged in the rf2-gr0n triage but carry post-v1 ergonomic value; they are deferred (not dropped) and tracked as separate beads. Migration tooling should not attempt to rewrite these.
+For `make-restore-fn`, `init-platform`, and the SSR-head trio (`reg-head` / `render-head` / `active-head`) — these were also flagged in the rf2-gr0n triage but carry post-v1 ergonomic value; they are deferred (not dropped) and tracked as separate beads. Migration tooling should not attempt to rewrite these. (`sub-topology` was flagged the same way and has since been implemented as part of the v1-✓ public registrar query API — see [O-12](#o-12-introspect-the-static-sub-graph-via-rfsub-topology) for opt-in adoption.)
 
 ---
 
@@ -1406,6 +1406,17 @@ The opt-in modernisation, when it applies:
 2. **Conformance harnesses** registering machines from EDN fixtures already use the plain-fn surface (via `requiring-resolve`); the late-bind hook key (`:machines/reg-machine`) now points at `reg-machine*`. No change required.
 
 Do not apply unless the user has explicitly asked to surface the per-element coord index for tooling, or to clean up code-gen call sites.
+
+### O-12. Introspect the static sub-graph via `(rf/sub-topology)`
+
+re-frame v1 had no public way to query the static sub-dependency graph; tooling that wanted to draw it walked private state. re-frame2 ships `(rf/sub-topology)` as a v1-✓ public surface (per [002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api) and [006 §Subscription topology vs subscription tracking](006-ReactiveSubstrate.md#subscription-topology-vs-subscription-tracking)) returning `{sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}` — pure data, JVM-runnable, no app-db, no per-frame cache.
+
+Adoption is opt-in:
+
+- **Tools and dev overlays** that previously read private subs state should switch to `(rf/sub-topology)` for the static graph and `(rf/sub-cache frame-id)` (CLJS-only, see M-26) for the runtime view.
+- **Tests** asserting on which subs depend on which can replace ad-hoc fixtures with a single `(rf/sub-topology)` projection.
+
+No application-code rewrite is required. The surface is additive; existing `reg-sub` registrations populate the topology automatically.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the documentation/implementation drift identified by the rf2-nfyf Tool-Pair audit: `(rf/sub-topology)` is documented v1-✓ in `spec/API.md` and cross-referenced from `000-Vision`, `002-Frames`, `006-ReactiveSubstrate`, `007-Stories`, `008-Testing`, `009-Instrumentation`, `AI-Audit`, `Construction-Prompts`, and `Principles` — but no `defn` existed. AI agents implementing re-frame2 from the spec corpus would assume the surface exists.

This PR ships the surface, lands tests, and grounds the spec row.

## Shape decision

Per [`spec/002-Frames.md` §The public registrar query API](../blob/master/spec/002-Frames.md#the-public-registrar-query-api) row 1109:

> `(rf/sub-topology)` — Static dependency graph from `:<-` declarations: a map of `sub-id → {:inputs [<input-sub-ids>], :doc, :ns/:line/:file}`. Pure data derived from the registrar at registration time.

The implementation is a literal projection over `(registrar/handlers :sub)`:
- `:inputs` is the vector of upstream sub-ids extracted from each registration's `:input-signals` (per-input query-vector args are stripped — `:inputs` reports sub-ids only).
- `:inputs` is **always** present; layer-1 subs (which read `app-db` directly) report `:inputs []`.
- Order matches the `:<-` declaration order — multi-input bodies depend on it.
- `:doc` / `:ns` / `:line` / `:file` are present when the registration carries them (`:ns` / `:line` / `:file` are auto-captured by the `reg-sub` macro per Spec 001 §Source-coordinate capture; `:doc` is user-supplied via the meta-map first arg).
- Empty registry returns `{}` (not nil).
- The surface is a literal projection — cycle detection is a debugger / tool-pair concern that traverses the returned map.

## Example output

Test fixture:

```clojure
(rf/reg-sub :n (fn [db _] (:n db)))
(rf/reg-sub :doubled
            {:doc "Double :n."}
            :<- [:n]
            (fn [n _] (* 2 n)))
(rf/reg-sub :a (fn [db _] (:a db)))
(rf/reg-sub :b (fn [db _] (:b db)))
(rf/reg-sub :sum :<- [:a] :<- [:b]
            (fn [[a b] _] (+ a b)))

(rf/sub-topology)
;; =>
{:a       {:inputs [],     :ns user, :line 1, :file "..."},
 :b       {:inputs [],     :ns user, :line 1, :file "..."},
 :doubled {:inputs [:n],
           :doc "Double :n.",
           :ns user, :line 1, :file "..."},
 :n       {:inputs [],     :ns user, :line 1, :file "..."},
 :sum     {:inputs [:a :b], :ns user, :line 1, :file "..."}}
```

## Tests

`implementation/core/test/re_frame/sub_topology_test.clj` — 13 tests / 27 assertions:

- empty registry → `{}` (not nil)
- layer-1 → `:inputs []`
- single-input layer-2 → `[:upstream]`
- multi-input — declaration order preserved
- layer-3 chain — every node carries direct upstreams
- per-input query-vector args stripped
- source-coords auto-captured (`:ns`/`:line`/`:file`)
- user `:doc` passes through; absent when not supplied
- unregistered ids absent; `clear-sub` removes
- re-registration replaces (last-write-wins)
- self-reference and 2-node cycles reported verbatim

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 232 tests / 1008 assertions, 0 failures
- [x] `cd implementation/routing && clojure -M:test` — 6 / 33, 0 failures
- [x] `cd implementation/flows && clojure -M:test` — 24 / 89, 0 failures
- [x] `cd implementation/http && clojure -M:test` — 15 / 32, 0 failures
- [x] `cd implementation/schemas && clojure -M:test` — 27 / 109, 0 failures
- [x] `cd implementation/machines && clojure -M:test` — 0 failures
- [x] `npm run test:cljs` — 117 / 370, 0 failures
- [x] `npm run test:elision` — PASS
- [ ] `npm run test:browser` — running
- [ ] `npm run test:examples` — running

## Spec changes

- `spec/API.md` — sub-topology row replaced with the concrete return shape.
- `spec/006-ReactiveSubstrate.md §Subscription topology vs subscription tracking` — expanded the `(rf/sub-topology)` paragraph with the same shape + the literal-projection note.
- `spec/MIGRATION.md` — sub-topology removed from M-26's deferred list (it has shipped); new opt-in rule **O-11** Introspect the static sub-graph via `(rf/sub-topology)` for tools and tests.

## Discovered from

rf2-nfyf (Tool-Pair audit) — promoted from rf2-gr0n's P3 defer to P1.