### PR TITLE
docs(spec): fold-in additive recommendations for Tool-Pair (rf2-ehpu / rf2-toolpair-readability)

### DIFF
--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -86,9 +86,54 @@ The runtime contract for time-travel:
 
 All six failures have `:op-type :error` and `:recovery :no-recovery`. Pair tools display the `:operation` and `:tags` to the user; the reserved `:rf.epoch/*` namespace lets tools route restore failures distinctly from frame-lookup errors. The failure surface is closed for v1 — additional categories require a Spec-ulation increment.
 
+> **Note on the unknown-frame row.** Five of the six failures fire under the reserved `:rf.epoch/*` namespace; the sixth (**Unknown frame**) rides the framework-wide `:rf.error/no-such-handler` op-type with `:kind :frame` because it is a registry-lookup failure that predates the restore call (the same op-type fires for any registrar lookup that names a missing frame). A pair tool routing restore failures should therefore match on either `:rf.epoch/*` or `(:rf.error/no-such-handler ∧ :kind = :frame)` to catch the full failure surface; the audit-found drift between the reserved-namespace prose and the table's heterogeneous first row is preserved-by-design, not a contradiction.
+
 **Restore caveat.** Even a *successful* restore rewinds `app-db` only; effects already fired (HTTP requests sent, navigation pushed, localStorage written) are not reversed. Pair-shaped tools surface this caveat in their UI before applying a restore.
 
 **Production elision.** Per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) the trace surface, schema validation, registrar trace emit, and epoch-history machinery share a single compile-time gate (`re-frame.interop/debug-enabled?`, alias of `goog.DEBUG`); production builds (`:advanced` + `goog.DEBUG=false`) elide all of it. CI's `npm run test:elision` job (Spec 009 §Production-elision verification) asserts the contract holds for every gated surface, including the epoch-history primitives once they land.
+
+### Worked example: walking history and restoring
+
+A pair tool that wants to render a per-frame undo affordance walks `epoch-history`, picks a target epoch (typically by index, by `:event-id`, or by user click on a visualised list), and calls `restore-epoch`. The round-trip below covers the dev-shape consumption pattern end-to-end, including the listener wiring that catches restore failure traces:
+
+```clojure
+;; A pair tool's "rewind to before that event" affordance.
+;; - Walks the per-frame epoch history (oldest-first vector).
+;; - Picks the most recent epoch BEFORE a target event-id.
+;; - Calls restore-epoch and listens for either
+;;   :rf.epoch/restored (success) or any :rf.epoch/restore-* error.
+
+(defn epoch-before-event
+  "Return the epoch-id of the most recent epoch in `frame-id`'s history
+   that precedes `target-event-id`, or nil if none exists."
+  [frame-id target-event-id]
+  (let [history (rf/epoch-history frame-id)            ;; oldest-first vector of :rf/epoch-record
+        before  (take-while #(not= target-event-id (:event-id %)) history)]
+    (when (seq before)
+      (:epoch-id (last before)))))
+
+;; Listener: catch restore success / failure traces and fan out to UI.
+(rf/register-trace-cb!
+  :my-tool/restore-watcher
+  (fn [ev]
+    (case (:operation ev)
+      :rf.epoch/restored                    (notify-ui :restored ev)
+      :rf.epoch/restore-unknown-epoch       (notify-ui :error ev)
+      :rf.epoch/restore-schema-mismatch     (notify-ui :error ev)
+      :rf.epoch/restore-missing-handler     (notify-ui :error ev)
+      :rf.epoch/restore-version-mismatch    (notify-ui :error ev)
+      :rf.epoch/restore-during-drain        (notify-ui :error ev)
+      ;; Unknown-frame rides :rf.error/no-such-handler (kind :frame); see note above.
+      nil)))
+
+;; Trigger the rewind. restore-epoch returns nil on failure (the failure mode
+;; is delivered via the trace stream); on success, app-db has been rewound and
+;; :rf.epoch/restored has fired with the new :db-after.
+(when-let [target (epoch-before-event :app/main :checkout/submit)]
+  (rf/restore-epoch :app/main target))
+```
+
+The walk-history-then-restore shape is the canonical pair-tool gesture; render-tree visualisers, "what did this event do?" probes, and conformance harnesses all build on the same primitives. Tools that want post-restore confirmation without registering a trace listener can re-call `(rf/get-frame-db :app/main)` and diff against the pre-restore snapshot.
 
 ## Performance API consumption
 
@@ -219,6 +264,8 @@ The full attachment surface, from the tool's point of view:
 | Hot-swap a handler | Re-call `(rf/reg-event-fx id ...)`; `:rf.registry/handler-replaced` trace fires | [001 §Hot-reload semantics](001-Registration.md#hot-reload-semantics) |
 | REPL eval against the runtime | The host's REPL (nREPL+CIDER for CLJS); private namespaces are off-contract | [§REPL-eval](#repl-eval) |
 
+> **Platform-availability note.** Rows tagged "(CLJS-only)" — `(rf/sub-cache frame-id)` is the load-bearing example — are CLJS-host-only surfaces; JVM hosts (SSR, headless tests, conformance runners) ship no equivalent. Pair tools driving JVM-side test runs MUST gate the call (e.g. `(when (cljs-host?) (rf/sub-cache frame-id))`) — JVM-host return shape is not yet specified (tracked separately) and consumers should not assume nil-vs-throw across hosts. Surfaces NOT tagged "(CLJS-only)" are portable by design.
+
 The consumption pattern is therefore:
 
 > **A pair-shaped tool registers as a trace listener (and/or as an epoch listener for assembled per-cascade records), reads recent history from the trace buffer, queries the registrar for shape, walks the epoch history for time-travel, and dispatches into frames to drive experiments. That's the entire surface.**
@@ -255,6 +302,47 @@ This is **dev-only** end-to-end — every primitive listed above elides in produ
 The same pattern works for any subsystem with a dedicated op-type — `:machine` for state-machine activity, `:event` for the dispatch / drain stream, `:sub/run` and `:sub/create` for subscription work, `:fx` for effect handlers. New op-types are additive (per [009 §Open shape; new fields are additive](009-Instrumentation.md#open-shape-new-fields-are-additive)); tools ignore op-types they don't understand.
 
 For per-cascade structured projections (sub-cache hit/miss, render attribution, effect outcome), tools route off `register-epoch-cb`'s assembled `:rf/epoch-record` instead — the §[Time-travel](#time-travel-epoch-snapshots-and-undo) projection slots already pre-fold the per-cascade trace into the `:sub-runs` / `:renders` / `:effects` shape. The raw-stream filter pattern above is the right shape for fine-grained per-event consumption.
+
+### Subscribing to assembled epoch records
+
+`register-epoch-cb` callbacks fire **once per drain-settle**, with the cascade's `:sub-runs` / `:renders` / `:effects` projections already computed. Pair-shaped tools, post-mortem dashboards, and "what just happened?" probes typically consume this shape rather than re-folding the raw trace stream:
+
+```clojure
+;; A pair-tool dashboard routing diagnostics off the assembled per-cascade record.
+;; - One callback per drain-settle (NOT per emitted trace event).
+;; - The record is fully shaped: :db-before, :db-after, :sub-runs, :renders, :effects.
+;; - The record has already been appended to (rf/epoch-history (:frame ev)).
+
+(rf/register-epoch-cb
+  :my-tool/dashboard
+  (fn [{:keys [frame event-id epoch-id sub-runs renders effects] :as record}]
+    ;; Cache-hit-vs-rerun: every entry in :sub-runs is a recompute (rf2-7e2y);
+    ;; cache-hit subs are absent. Counting :sub-runs answers
+    ;; "how many subs moved this cascade?"
+    (record-recomputes! frame event-id (count sub-runs))
+
+    ;; Render attribution: :renders[*].:render-key is [<view-id> <instance-token>].
+    ;; Aggregate by first slot to count "view X re-rendered N times this cascade."
+    (doseq [{:keys [render-key elapsed-ms]} renders]
+      (record-render! frame (first render-key) elapsed-ms))
+
+    ;; Fx outcome: every dispatched fx surfaces exactly one :effects entry.
+    ;; :outcome ∈ {:ok :error :skipped-on-platform}; route :error entries to UI.
+    (doseq [{:keys [fx-id outcome error-trace]} effects]
+      (when (= :error outcome)
+        (surface-fx-error! frame epoch-id fx-id error-trace)))
+
+    ;; The epoch is already in (rf/epoch-history frame); no need to re-query
+    ;; unless the dashboard wants the full vector for context.
+    nil))
+```
+
+Edge-case behaviour the example does not exercise but consumers should know about:
+
+- **Listener exceptions are caught.** A throw inside the callback does not propagate to the framework or other listeners (per [009 §register-epoch-cb invocation rules](009-Instrumentation.md#register-epoch-cb--assembled-epoch-listener)). The framework does **not** auto-evict the throwing listener — repeated throws keep the registration in place; eviction is the consumer's call.
+- **Re-entrant dispatch from a callback.** A callback that calls `(rf/dispatch …)` enqueues the new event; the new dispatch's drain begins on stack-unwind from the current callback fan-out, not before. Other registered epoch listeners still receive the *current* record before the re-entrant dispatch begins.
+- **`(rf/configure :epoch-history {:depth 0})` and listeners.** Setting depth to 0 disables the per-frame ring buffer (so `(rf/epoch-history frame-id)` returns `[]`) but does **not** stop epoch listeners from firing — `register-epoch-cb` callbacks continue to receive the assembled record on every drain-settle. Tools that need the assembled stream without retaining history should set depth `0` and consume via `register-epoch-cb` only.
+- **Frame-destroyed mid-observation.** Tool-Pair surface behaviour against destroyed frames (epoch-history reads, in-flight epoch-cb deliveries, restore against a now-destroyed frame) is tracked separately (bd rf2-d656) and not yet specified; consumers should defensively handle nil returns and missing-frame error traces until the contract is closed.
 
 ### Implications for downstream tools
 


### PR DESCRIPTION
Fifth (and final) fold-in under the additive-only rule. Folds findings from the two Tool-Pair audits — `findings/audit-tool-pair-2026-05-09.md` (spec-precision, rf2-ehpu) and `findings/audit-tool-pair-readability-2026-05-09.md` — into `spec/Tool-Pair.md`.

**Net diff: +88 / -0 lines.** Pure additions. Zero deletions. No structural moves. No edits to §4 Strengths-to-preserve.

## Applied (additive)

Two worked examples plus two clarifying notes — all purely insertional, all sit alongside (not in place of) existing prose.

1. **Worked example — Time-travel round-trip** (resolves audit **R5**, "missing example"). New `### Worked example: walking history and restoring` subsection inside §Time-travel showing `epoch-history` → walk → `restore-epoch` plus the `register-trace-cb!` wiring that catches `:rf.epoch/restored` and the five `:rf.epoch/restore-*` failure traces. The pilot's high-value-additive priority — Tool-Pair's headline novel content (time-travel) shipped without a single code block until now.

2. **Worked example — `register-epoch-cb`** (resolves the audit's no-worked-example finding for `register-epoch-cb`; partially closes **F7**). New `### Subscribing to assembled epoch records` subsection after §Subscribing-to-a-slice (preserves the §4-protected slice example, doesn't touch it). Shows assembled-record consumption with `:sub-runs` / `:renders` / `:effects` projection routing, plus an edge-case bullet list per F7's recommendation: listener-exceptions-caught (cross-ref to 009), re-entrant-dispatch-from-callback semantics (enqueue, current fan-out completes, new drain on stack-unwind), `:depth 0` listener firing (continues), and frame-destroyed-mid-observation pointing at bd rf2-d656.

3. **Clarifying note — restore-failure unknown-frame row** (resolves **F3**, internal contradiction). One blockquote under the §Time-travel failure-mode table explaining that five of six failures are under `:rf.epoch/*` while the sixth (Unknown frame) rides the framework-wide `:rf.error/no-such-handler` op-type — with routing guidance for consumers wanting to catch the full failure surface. Prose-level fix to the audit's "consumer cannot tell which" finding without rewording the existing prose.

4. **Clarifying note — `(CLJS-only)` rows** (resolves **F10**, layering violation). One blockquote under the §How-AI-tools-attach table calling out that `(CLJS-only)`-tagged rows (load-bearing example: `(rf/sub-cache frame-id)`) need a host gate from JVM-driving consumers, with the open JVM-host return-shape gap explicitly flagged.

## Rewords

**None.** All four applied edits are pure insertions. Cap unused (3 slots available, 0 spent).

## Strengths-conflict

**None.** Verified by inspection: §Subscribing-to-a-slice trace example, bolded short-form lead-ins in §Time-travel, §What-pair-shaped-tools-NOT-to-ship, cross-reference footer, and §Future-compat commitments are all byte-identical to `origin/main`. The `+88 / -0` diff stat confirms zero modifications to existing prose.

## Mike-review-needed

### Already-beaded (don't action — listed for tracking)
- **F1 / R10-adjacent (rf2-q7r0)** — Tool-Pair §Source-mapping "opaque + parseable" + missing Spec-Schemas schema + 3-spec format drift (`:ns/:line/:file` vs `:ns/:sym/:line/:col`). Audit-recommended fix is a contract decision (commit format vs ship parser helper).
- **F6 (rf2-d656)** — Frame-destroyed-mid-observation contract for `epoch-history` / `restore-epoch` / `get-frame-db` / `register-epoch-cb`. Surfaced as a defensive-coding note in the new epoch-cb example bullets, but the actual contract decision is the bead's job.
- **F8 (rf2-zq55)** — "Complete and self-contained" claim vs pair2 reaching past `(rf/handler-meta :frame …) :app-db` to mutate. Architectural decision (commit a `reset-frame-db!` write surface, or document the escape hatch, or drop the claim).

### Spec-precision (rf2-ehpu) — judgment-required
- **F2 — listener bang-asymmetry rename** (`register-epoch-cb` → `register-epoch-cb!`). Cross-spec rename touching Tool-Pair / 009 / API.md / soft-deprecated-synonyms table; not strictly additive (existing-name removal needed). Recommend Mike action with a separate one-line-rename PR.
- **F4 — API.md `:rf.epoch/restore-schema-mismatch` tag drift.** Tool-Pair is canonical (`:schema-digest-recorded` + `:schema-digest-current` + `:failing-paths`); API.md row has only the third. API.md sweep, not Tool-Pair edit.
- **F5 — 009 §Subscription/consumption "in registration order" contradiction.** Tool-Pair's "Listener ordering is not contract" line is correct; 009's upstream prose is the problem. Out-of-Tool-Pair-scope.
- **F9 — `handler-meta` `:column` key cross-spec inconsistency.** Tool-Pair line 54 promises `:ns/:line/:file/:column`; Spec 001 source-coord-capture table lists only `:ns/:line/:file`. Spec 001 add (canonical-shape sweep), not Tool-Pair edit.

### Readability — structural (forbidden under additive-only)
- **R1 + R2 — Buried lede** (move §What-pair-shaped-tools-do to top, demote audit-lineage / source-of-truth blockquotes to a §Spec-maintenance footer).
- **R3 — Two-surface-tables redundancy** (drop one of the §What-re-frame2-commits-to or §How-AI-tools-attach tables; doc itself flags the duplication at line 43).
- **R4 — Dense paragraph 1 of §Time-travel** (split single 8-line sentence into lede + bullets + tool-consumption sentence).
- **R6 — Voice mismatch in failure-table** (table breaks the bolded-lead-ins rhythm).
- **R7 — Four-of-six "What" headings** (rename to noun-shaped: Scope / Capability surface / Runtime contract / Out-of-scope). Borderline-additive but technically modifies existing headings; surfaced for Mike per pilot-lessons "heading-clarity wins are cheap."
- **R8 — Section ordering** (promote §Source-mapping to sit immediately after §Time-travel; move §REPL-eval).
- **R9 — Density bloat in §Where-DOM-to-source-helpers-live** (lead with the one-sentence commitment, collapse audit-discovery framing).
- **R10 — "infrastructure-complete" overclaim** (line 310; voice-mismatch in Reference-typed doc).
- **R11 — "decoupled from 10x" repetition** (said three times: lines 14, 16, 196).

### Large architectural (audit S/M/L "Large")
- Spec-author decision: pick a primary reader profile (Profile 1 narrative vs Profile 2 reference) and structure for it. Out-of-fold-in scope.

## Diff balance

```
spec/Tool-Pair.md | 88 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
1 file changed, 88 insertions(+)
```

Net positive (insertions only). Zero lines deleted.

## Verification

- [x] Diff-line review — all `+` lines, zero `-` lines (confirmed by `git diff --stat`).
- [x] Strengths-to-preserve untouched — §Subscribing-to-a-slice, bolded lead-ins, §What-NOT-to-ship, cross-reference footer, §Future-compat all byte-identical to origin/main.
- [x] `MIGRATION.md` untouched.
- [x] No edits outside `spec/Tool-Pair.md`.
- [x] Markdown shape — code blocks fenced, blockquote callouts well-formed, no broken table separators.
- [x] No AI attribution (no `Co-Authored-By`, no Claude Code trailer).

## Lessons-learned

- The two worked examples (epoch-history round-trip, `register-epoch-cb`) are the most consequential additions: Tool-Pair's headline novel content shipped without code, and the pilot's high-value-additive heuristic was directly actionable.
- F7's recommended-but-not-yet-decided semantics (re-entry, listener eviction, depth=0) sit cleanly inside the new epoch-cb example as edge-case bullets that match the audit's recommendations — a clean fit for additive-only.
- The §Subscribing-to-a-slice example (§4 strength) provided a stylistic template the new examples could mirror exactly (case-dispatch on `:operation`, comments above key lines), which kept the diff cohesive with the existing voice.
- Almost-did-but-didn't: a §What-headings rename (R7) — the pilot's "heading clarity wins are cheap" hint suggested it, but heading rename strictly modifies existing prose, so I surfaced it as Mike-review.
