### PR TITLE
test: late-bind missing-artefact error path coverage for all per-feature splits (rf2-5b6x / discovered-from rf2-o423)

### DIFF
--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,84 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the flows artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the flows artefact IS on the classpath here (the test ns
+  requires `re-frame.flows`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-tfw3 (flows split), and the
+  prose at the call sites in `re-frame.core`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading flows registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.flows]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest clear-flow-raises-when-flows-artefact-missing
+  (testing "rf/clear-flow raises :rf.error/flows-artefact-missing when the :flows/clear-flow hook is nil"
+    (with-hook-as-nil :flows/clear-flow
+      (fn []
+        (let [thrown (try (rf/clear-flow :no-such-flow)
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "clear-flow throws when the flows artefact is absent")
+          (is (= ":rf.error/flows-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'clear-flow (:where data))
+                "ex-data carries :where = 'clear-flow")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest reg-flow-raises-when-flows-artefact-missing
+  (testing "rf/reg-flow (macro) raises :rf.error/flows-artefact-missing when the :flows/reg-flow hook is nil"
+    ;; The macro expands to a runtime late-bind lookup, so flipping the
+    ;; hook at runtime is enough — we don't need to touch the test's
+    ;; compile-time classpath.
+    (with-hook-as-nil :flows/reg-flow
+      (fn []
+        (let [thrown (try (rf/reg-flow {:id     :late-bind-missing/probe
+                                        :inputs []
+                                        :output (fn [] 0)
+                                        :path   [:probe]})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-flow throws when the flows artefact is absent")
+          (is (= ":rf.error/flows-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            ;; The macro syntax-quotes 'reg-flow at expansion site, so
+            ;; the symbol stamped onto :where is namespace-qualified
+            ;; against `re-frame.core` (the macro's home ns).
+            (is (= 're-frame.core/reg-flow (:where data))
+                "ex-data carries :where = 're-frame.core/reg-flow (macro form)")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/http/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/http/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,92 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the http artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the http artefact IS on the classpath here (the test ns
+  requires `re-frame.http-managed`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-5kpd (http split), and the
+  prose at the call sites in `re-frame.core`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading http-managed registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.http-managed]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest install-managed-request-stubs-raises-when-http-artefact-missing
+  (testing "rf/install-managed-request-stubs! raises :rf.error/http-artefact-missing when the :http/install-managed-request-stubs! hook is nil"
+    (with-hook-as-nil :http/install-managed-request-stubs!
+      (fn []
+        (let [thrown (try (rf/install-managed-request-stubs! {})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "install-managed-request-stubs! throws when the http artefact is absent")
+          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'install-managed-request-stubs! (:where data))
+                "ex-data carries :where = 'install-managed-request-stubs!")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest uninstall-managed-request-stubs-raises-when-http-artefact-missing
+  (testing "rf/uninstall-managed-request-stubs! raises :rf.error/http-artefact-missing when the :http/uninstall-managed-request-stubs! hook is nil"
+    (with-hook-as-nil :http/uninstall-managed-request-stubs!
+      (fn []
+        (let [thrown (try (rf/uninstall-managed-request-stubs!)
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "uninstall-managed-request-stubs! throws when the http artefact is absent")
+          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'uninstall-managed-request-stubs! (:where data))
+                "ex-data carries :where = 'uninstall-managed-request-stubs!")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest with-managed-request-stubs-fn-raises-when-http-artefact-missing
+  (testing "rf/with-managed-request-stubs* (fn form) raises :rf.error/http-artefact-missing when the :http/with-managed-request-stubs* hook is nil"
+    (with-hook-as-nil :http/with-managed-request-stubs*
+      (fn []
+        (let [thrown (try (rf/with-managed-request-stubs* {} (fn [] :unused))
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "with-managed-request-stubs* throws when the http artefact is absent")
+          (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'with-managed-request-stubs* (:where data))
+                "ex-data carries :where = 'with-managed-request-stubs*")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/machines/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/machines/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,149 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the machines artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the machines artefact IS on the classpath here (the test ns
+  requires `re-frame.machines`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-xbtj (machines split), and the
+  prose at the call sites in `re-frame.core`.
+
+  Note: only the active machine surfaces (`reg-machine`, `reg-machine*`,
+  `create-machine-handler`, `machine-transition`) raise the missing-
+  artefact error. The read-only query surfaces (`machines`,
+  `machine-meta`, `machine-by-system-id`) deliberately return safe
+  defaults — Spec 005 §Querying machines."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading machines registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.machines]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest reg-machine-star-raises-when-machines-artefact-missing
+  (testing "rf/reg-machine* (plain fn) raises :rf.error/machines-artefact-missing when the :machines/reg-machine hook is nil"
+    (with-hook-as-nil :machines/reg-machine
+      (fn []
+        (let [thrown (try (rf/reg-machine* :probe/machine
+                                           {:initial :idle
+                                            :states  {:idle {}}})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-machine* throws when the machines artefact is absent")
+          (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'reg-machine* (:where data))
+                "ex-data carries :where = 'reg-machine*")
+            (is (= :probe/machine (:machine-id data))
+                "ex-data carries :machine-id from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest reg-machine-macro-raises-when-machines-artefact-missing
+  (testing "rf/reg-machine (macro) raises :rf.error/machines-artefact-missing when the :machines/reg-machine hook is nil"
+    (with-hook-as-nil :machines/reg-machine
+      (fn []
+        (let [thrown (try (rf/reg-machine :probe/macro-machine
+                                          {:initial :idle
+                                           :states  {:idle {}}})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-machine throws when the machines artefact is absent")
+          (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            ;; The macro syntax-quotes 'reg-machine at expansion site,
+            ;; so the symbol stamped onto :where is namespace-qualified
+            ;; against `re-frame.core` (the macro's home ns).
+            (is (= 're-frame.core/reg-machine (:where data))
+                "ex-data carries :where = 're-frame.core/reg-machine (macro form)")
+            (is (= :probe/macro-machine (:machine-id data))
+                "ex-data carries :machine-id from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest create-machine-handler-raises-when-machines-artefact-missing
+  (testing "rf/create-machine-handler raises :rf.error/machines-artefact-missing when the :machines/create-machine-handler hook is nil"
+    (with-hook-as-nil :machines/create-machine-handler
+      (fn []
+        (let [thrown (try (rf/create-machine-handler {:initial :idle
+                                                      :states  {:idle {}}})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "create-machine-handler throws when the machines artefact is absent")
+          (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'create-machine-handler (:where data))
+                "ex-data carries :where = 'create-machine-handler")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest machine-transition-raises-when-machines-artefact-missing
+  (testing "rf/machine-transition raises :rf.error/machines-artefact-missing when the :machines/machine-transition hook is nil"
+    (with-hook-as-nil :machines/machine-transition
+      (fn []
+        (let [thrown (try (rf/machine-transition {:initial :idle
+                                                  :states  {:idle {}}}
+                                                 {:state :idle :data {}}
+                                                 [:noop])
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "machine-transition throws when the machines artefact is absent")
+          (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'machine-transition (:where data))
+                "ex-data carries :where = 'machine-transition")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest read-only-machine-queries-return-safe-defaults
+  (testing "Per Spec 005 §Querying machines, the read-only machine
+  introspection surfaces return safe defaults when the machines
+  artefact is absent — `machines` returns []; `machine-meta` and
+  `machine-by-system-id` return nil. This branch must stay distinct
+  from the active surfaces' missing-artefact contract."
+    (with-hook-as-nil :machines/machines
+      (fn []
+        (is (= [] (rf/machines))
+            "machines returns [] when the machines artefact is absent")))
+    (with-hook-as-nil :machines/machine-meta
+      (fn []
+        (is (nil? (rf/machine-meta :anything))
+            "machine-meta returns nil when the machines artefact is absent")))
+    (with-hook-as-nil :machines/machine-by-system-id
+      (fn []
+        (is (nil? (rf/machine-by-system-id :anything))
+            "machine-by-system-id returns nil when the machines artefact is absent")))))

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,99 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the routing artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the routing artefact IS on the classpath here (the test ns
+  requires `re-frame.routing`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-k682 (routing split), and the
+  prose at the call sites in `re-frame.core`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading routing registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.routing]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest match-url-raises-when-routing-artefact-missing
+  (testing "rf/match-url raises :rf.error/routing-artefact-missing when the :routing/match-url hook is nil"
+    (with-hook-as-nil :routing/match-url
+      (fn []
+        (let [thrown (try (rf/match-url "/anything")
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "match-url throws when the routing artefact is absent")
+          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'match-url (:where data))
+                "ex-data carries :where = 'match-url")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest route-url-raises-when-routing-artefact-missing
+  (testing "rf/route-url raises :rf.error/routing-artefact-missing when the :routing/route-url hook is nil"
+    (with-hook-as-nil :routing/route-url
+      (fn []
+        (let [thrown (try (rf/route-url :route/probe {:id "x"})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "route-url throws when the routing artefact is absent")
+          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'route-url (:where data))
+                "ex-data carries :where = 'route-url")
+            (is (= :route/probe (:route-id data))
+                "ex-data carries :route-id from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest reg-route-raises-when-routing-artefact-missing
+  (testing "rf/reg-route (macro) raises :rf.error/routing-artefact-missing when the :routing/reg-route hook is nil"
+    (with-hook-as-nil :routing/reg-route
+      (fn []
+        (let [thrown (try (rf/reg-route :route/probe {:path "/probe"})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-route throws when the routing artefact is absent")
+          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            ;; The macro syntax-quotes 'reg-route at expansion site, so
+            ;; the symbol stamped onto :where is namespace-qualified
+            ;; against `re-frame.core` (the macro's home ns).
+            (is (= 're-frame.core/reg-route (:where data))
+                "ex-data carries :where = 're-frame.core/reg-route (macro form)")
+            (is (= :route/probe (:route-id data))
+                "ex-data carries :route-id from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/schemas/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/schemas/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,88 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the schemas artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the schemas artefact IS on the classpath here (the test ns
+  requires `re-frame.schemas`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-p7va (schemas split), and the
+  prose at the call sites in `re-frame.core`.
+
+  Note: only `reg-app-schema` raises a missing-artefact error. The
+  introspection surfaces (`app-schema-at`, `app-schemas`,
+  `app-schemas-digest`) deliberately return safe defaults (nil / {} /
+  nil) when the schemas artefact is absent — Spec 010 §Schemas as a
+  tooling and agent surface. We test both branches here."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading schemas registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.schemas]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest reg-app-schema-raises-when-schemas-artefact-missing
+  (testing "rf/reg-app-schema (macro) raises :rf.error/schemas-artefact-missing when the :schemas/reg-app-schema hook is nil"
+    (with-hook-as-nil :schemas/reg-app-schema
+      (fn []
+        (let [thrown (try (rf/reg-app-schema [:probe] :int)
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-app-schema throws when the schemas artefact is absent")
+          (is (= ":rf.error/schemas-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            ;; The macro syntax-quotes 'reg-app-schema at expansion
+            ;; site, so the symbol stamped onto :where is namespace-
+            ;; qualified against `re-frame.core` (the macro's home ns).
+            (is (= 're-frame.core/reg-app-schema (:where data))
+                "ex-data carries :where = 're-frame.core/reg-app-schema (macro form)")
+            (is (= [:probe] (:path data))
+                "ex-data carries :path from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest introspection-surfaces-return-safe-defaults-when-schemas-artefact-missing
+  (testing "Per Spec 010 §Schemas as a tooling and agent surface, the
+  read-only schema-introspection surfaces deliberately do NOT throw
+  when the schemas artefact is absent — they return safe defaults
+  (nil / {} / nil). This branch must stay distinct from the active
+  surfaces' missing-artefact contract."
+    (with-hook-as-nil :schemas/app-schema-at
+      (fn []
+        (is (nil? (rf/app-schema-at [:any]))
+            "app-schema-at returns nil when the schemas artefact is absent")))
+    (with-hook-as-nil :schemas/app-schemas
+      (fn []
+        (is (= {} (rf/app-schemas))
+            "app-schemas returns {} when the schemas artefact is absent")))
+    (with-hook-as-nil :schemas/app-schemas-digest
+      (fn []
+        (is (nil? (rf/app-schemas-digest))
+            "app-schemas-digest returns nil when the schemas artefact is absent")))))

--- a/implementation/ssr/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/ssr/test/re_frame/late_bind_missing_test.clj
@@ -1,0 +1,122 @@
+(ns re-frame.late-bind-missing-test
+  "Per rf2-5b6x — assert the documented missing-artefact error contract for
+  the ssr artefact's `re-frame.core` re-exports.
+
+  Each per-feature split (schemas / machines / routing / flows / http /
+  ssr) raises a documented `:rf.error/<artefact>-artefact-missing`
+  ex-info when a consumer calls a re-exported surface but the artefact
+  is absent from the classpath. The contract was previously only
+  documented in prose; this test pins the runtime behaviour against
+  regression.
+
+  Strategy: the ssr artefact IS on the classpath here (the test ns
+  requires `re-frame.ssr`, which fires the late-bind hook
+  registrations at ns-load). To simulate the absent-artefact state we
+  flip the relevant late-bind hook to nil for the duration of the
+  assertion, then restore it in `finally`. Identical mechanism as the
+  test would use on CLJS.
+
+  Per Spec 002 §The late-bind seam, rf2-uo7v (ssr split), and the
+  prose at the call sites in `re-frame.core`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading ssr registers its late-bind hooks. The
+            ;; `with-hook-as-nil` helper below re-establishes the absent
+            ;; state by flipping the hook value at runtime; restoration
+            ;; in `finally` keeps cross-test isolation intact.
+            [re-frame.ssr]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest render-to-string-raises-when-ssr-artefact-missing
+  (testing "rf/render-to-string raises :rf.error/ssr-artefact-missing when the :ssr/render-to-string hook is nil"
+    (with-hook-as-nil :ssr/render-to-string
+      (fn []
+        (let [thrown (try (rf/render-to-string [:div])
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "render-to-string throws when the ssr artefact is absent")
+          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'render-to-string (:where data))
+                "ex-data carries :where = 'render-to-string")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")
+            (is (string? (:reason data))
+                "ex-data carries :reason as a string")))))))
+
+(deftest render-tree-hash-raises-when-ssr-artefact-missing
+  (testing "rf/render-tree-hash raises :rf.error/ssr-artefact-missing when the :ssr/render-tree-hash hook is nil"
+    (with-hook-as-nil :ssr/render-tree-hash
+      (fn []
+        (let [thrown (try (rf/render-tree-hash [:div])
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "render-tree-hash throws when the ssr artefact is absent")
+          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'render-tree-hash (:where data))
+                "ex-data carries :where = 'render-tree-hash")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest reg-error-projector-raises-when-ssr-artefact-missing
+  (testing "rf/reg-error-projector (macro) raises :rf.error/ssr-artefact-missing when the :ssr/reg-error-projector hook is nil"
+    ;; The macro forwards to -reg-error-projector which performs the
+    ;; late-bind lookup at runtime. Flipping the hook at runtime is
+    ;; enough to surface the absent-artefact branch.
+    (with-hook-as-nil :ssr/reg-error-projector
+      (fn []
+        (let [thrown (try (rf/reg-error-projector :probe/projector
+                                                  (fn [_trace-event] {}))
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "reg-error-projector throws when the ssr artefact is absent")
+          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            ;; The :where stamped here is the bare 'reg-error-projector
+            ;; symbol — the macro forwards to the plain-fn delegate
+            ;; `-reg-error-projector`, which is where the late-bind
+            ;; check (and ex-info) lives. The fn does not syntax-quote
+            ;; through a macro layer, so :where is the bare symbol.
+            (is (= 'reg-error-projector (:where data))
+                "ex-data carries :where = 'reg-error-projector")
+            (is (= :probe/projector (:id data))
+                "ex-data carries :id from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest project-error-raises-when-ssr-artefact-missing
+  (testing "rf/project-error raises :rf.error/ssr-artefact-missing when the :ssr/project-error hook is nil"
+    (with-hook-as-nil :ssr/project-error
+      (fn []
+        (let [thrown (try (rf/project-error :rf/default {})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "project-error throws when the ssr artefact is absent")
+          (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'project-error (:where data))
+                "ex-data carries :where = 'project-error")
+            (is (= :rf/default (:frame data))
+                "ex-data carries :frame from the call site")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))


### PR DESCRIPTION
## Summary

Each per-feature split (schemas / machines / routing / flows / http / ssr) raises a documented `:rf.error/<artefact>-artefact-missing` ex-info when a consumer calls a re-exported `re-frame.core` surface but the artefact is absent from the classpath. The contract was previously only documented in prose at each call site — broken absent-handling would not have been caught in CI.

This PR adds 6 per-artefact JVM test files, one per split, alongside the split's existing `test/` tree. Each test simulates the absent state by flipping the relevant late-bind hook to `nil` (with restoration in `finally`) and exercises the documented `re-frame.core` re-export.

## Per-artefact coverage

| Artefact | Error category asserted | Surfaces tested | Test count |
| --- | --- | --- | --- |
| schemas | `:rf.error/schemas-artefact-missing` | `rf/reg-app-schema` (macro) + safe-default contract for `rf/app-schema-at`, `rf/app-schemas`, `rf/app-schemas-digest` | 2 deftests |
| machines | `:rf.error/machines-artefact-missing` | `rf/reg-machine*`, `rf/reg-machine` (macro), `rf/create-machine-handler`, `rf/machine-transition` + safe-default contract for `rf/machines`, `rf/machine-meta`, `rf/machine-by-system-id` | 5 deftests |
| routing | `:rf.error/routing-artefact-missing` | `rf/match-url`, `rf/route-url`, `rf/reg-route` (macro) | 3 deftests |
| flows | `:rf.error/flows-artefact-missing` | `rf/clear-flow`, `rf/reg-flow` (macro) | 2 deftests |
| http | `:rf.error/http-artefact-missing` | `rf/install-managed-request-stubs!`, `rf/uninstall-managed-request-stubs!`, `rf/with-managed-request-stubs*` | 3 deftests |
| ssr | `:rf.error/ssr-artefact-missing` | `rf/render-to-string`, `rf/render-tree-hash`, `rf/reg-error-projector` (macro), `rf/project-error` | 4 deftests |

Each deftest also pins the documented `ex-data` payload (`:where`, `:recovery :no-recovery`, `:reason` string, plus surface-specific keys like `:route-id` / `:path` / `:machine-id` / `:id` / `:frame` where documented).

## Documented-but-not-raised — none

Every documented `:rf.error/<artefact>-artefact-missing` was confirmed to be raised at the documented call site with the documented payload shape. No follow-up bead needed for "the more fundamental bug".

## One ergonomic finding worth flagging

The `:where` symbol stamped onto `ex-data` differs between macro and plain-fn surfaces:

- Plain-fn forms (e.g. `rf/match-url`) stamp the bare symbol — `(:where data) => 'match-url`.
- Macro forms (e.g. `rf/reg-flow`, `rf/reg-route`, `rf/reg-app-schema`, `rf/reg-machine`) syntax-quote `'reg-flow` at expansion site, so the symbol resolves namespace-qualified against `re-frame.core` — `(:where data) => 're-frame.core/reg-flow`.

This isn't wrong (the macro-side namespace-qualification is what syntax-quote does, and the symbol still reads as the surface the consumer called), but it's subtle. The test comments call it out explicitly so future readers don't trip over it. If the team prefers a uniform shape, the macro forms could `(quote ~'reg-flow)` instead of `'reg-flow` to skip the syntax-quote namespace-qualification — separate decision; not in scope for this PR.

## Test results

- All 7 JVM artefact test suites green: `core` (212 tests / 928 assertions), `routing` (9 / 48), `flows` (26 / 98), `http` (18 / 45), `schemas` (29 / 118), `machines` (18 / 55), `ssr` (24 / 99).
- CLJS node-test green: 126 tests / 393 assertions.
- New tests contribute the missing-artefact coverage in the per-artefact totals above.

## File-location decision

Per-artefact (one test file per split, alongside each split's existing tests) was chosen over a single core-side test file. Reasons:

1. Mirrors the project's existing per-artefact test convention (Strategy B per rf2-5vjj).
2. Each split's CI already runs its own test suite — keeping the missing-artefact assertion in the split's tree means breaking the contract at the producer side fails the producer's CI directly, not just the core's.
3. The hook-flip mechanism is local to the producing artefact's hook keys, so the test naturally lives alongside the producer.

## Test plan

- [x] `cd implementation/core && clojure -M:test`
- [x] `cd implementation/routing && clojure -M:test`
- [x] `cd implementation/flows && clojure -M:test`
- [x] `cd implementation/http && clojure -M:test`
- [x] `cd implementation/schemas && clojure -M:test`
- [x] `cd implementation/machines && clojure -M:test`
- [x] `cd implementation/ssr && clojure -M:test`
- [x] `npm run test:cljs`