### PR TITLE
docs(spec): drain-loop pseudocode forwards :dispatch envelope per cascade contract (rf2-574o)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -851,10 +851,13 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
 
       ;; 3. Walk :fx in source order. Each entry's handler returns
       ;;    synchronously before the next begins. Errors trace and continue.
+      ;;    The originating envelope is threaded so reserved fxs that queue
+      ;;    children (`:dispatch`, `:dispatch-later`) can copy envelope fields
+      ;;    onto the child envelope, per [§Cascade propagation](#cascade-propagation).
       (doseq [[fx-id args] (:fx effects)]
         (try
           (let [fx-handler (lookup-fx frame fx-id)]    ;; honors :fx-overrides
-            (fx-handler frame args))
+            (fx-handler frame envelope args))
           (catch :default e
             (raise! :rf.error/fx-handler-exception
                     {:fx-id fx-id :event event :frame (:id frame) :ex e}))))
@@ -872,13 +875,27 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
 ;; :raise / :spawn — machine-internal; routed by create-machine-handler
 ;;                   BEFORE :fx reaches do-fx (see machine pseudocode below).
 
-(defmethod do-fx :dispatch [frame ev]
-  (dispatch frame {:event ev}))                        ;; back of queue, FIFO
+;; Inheritable envelope fields — copied from parent to child when :dispatch /
+;; :dispatch-later queue a new envelope. This is the "envelope-field-copying
+;; when queueing children" mechanism named in [§Cascade propagation]
+;; (#cascade-propagation). `:event` and `:dispatched-at` are NOT inherited —
+;; the child gets its own. `:source` is preserved unless the queueing fx
+;; sets a more specific value (e.g. a timer fx might set `:source :timer`).
+(def ^:private inheritable-envelope-keys
+  [:frame :fx-overrides :interceptor-overrides :trace-id :origin :source])
 
-(defmethod do-fx :dispatch-later [frame {:keys [ms event]}]
-  (interop/set-timeout!
-    (fn [] (dispatch frame {:event event}))
-    ms))
+(defn- child-envelope [parent-envelope event]
+  (-> (select-keys parent-envelope inheritable-envelope-keys)
+      (assoc :event event)))
+
+(defmethod do-fx :dispatch [frame parent-envelope ev]
+  (dispatch frame (child-envelope parent-envelope ev))) ;; back of queue, FIFO
+
+(defmethod do-fx :dispatch-later [frame parent-envelope {:keys [ms event]}]
+  (let [child (child-envelope parent-envelope event)]
+    (interop/set-timeout!
+      (fn [] (dispatch frame child))
+      ms)))
 ```
 
 For machine events, `process-event!` step 1 lands inside the machine handler, which runs the Level-3 cascade before returning effects. The cascade is Level 3 in [005 §Drain semantics §Level 3](005-StateMachines.md#level-3--within-a-single-machine-event):


### PR DESCRIPTION
## Summary

Fixes spec/002-Frames.md §Drain-loop pseudocode where the `do-fx :dispatch` and `do-fx :dispatch-later` defmethods built a child envelope with only `:event`, losing every other envelope field. That literal pseudocode contradicts §Cascade propagation in the same spec, which mandates that overrides and routing/tagging fields propagate transitively at every depth.

Closes [rf2-574o] / audit-002 finding F18 (top-3 most load-bearing).

## The contradiction

### Cascade propagation contract (002 §Cascade propagation, line 1072 pre-edit / 1087 post-edit)

> All three override types propagate transitively through any depth of `:fx [:dispatch ...]` cascade. When a handler returns an effect map containing `:dispatch`, the dispatched child inherits the parent envelope's overrides (and `:frame`, `:trace-id`, etc.). One mechanism: envelope-field-copying when queueing children; same as `:frame` propagation.

### Old pseudocode (002 §Drain-loop pseudocode, lines 875-881 pre-edit)

```clojure
(defmethod do-fx :dispatch [frame ev]
  (dispatch frame {:event ev}))                        ;; back of queue, FIFO

(defmethod do-fx :dispatch-later [frame {:keys [ms event]}]
  (interop/set-timeout!
    (fn [] (dispatch frame {:event event}))
    ms))
```

The child envelope is a fresh map with just `:event` (`:dispatch-later` doesn't even forward `:frame`). An AI literally implementing this produces a runtime where `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:origin`, and `:source` only apply at depth-0 — directly violating the cascade contract above.

The call site upstream also dropped `m` — `(fx-handler frame args)` — so even a binary fx-handler couldn't recover the parent envelope.

### New pseudocode (post-edit)

Call site (process-event! step 3) now threads the parent envelope:

```clojure
;; 3. Walk :fx in source order. Each entry's handler returns
;;    synchronously before the next begins. Errors trace and continue.
;;    The originating envelope is threaded so reserved fxs that queue
;;    children (`:dispatch`, `:dispatch-later`) can copy envelope fields
;;    onto the child envelope, per [§Cascade propagation](#cascade-propagation).
(doseq [[fx-id args] (:fx effects)]
  (try
    (let [fx-handler (lookup-fx frame fx-id)]    ;; honors :fx-overrides
      (fx-handler frame envelope args))
    (catch :default e
      (raise! :rf.error/fx-handler-exception
              {:fx-id fx-id :event event :frame (:id frame) :ex e}))))
```

Reserved `do-fx` methods now copy the inheritable envelope subset:

```clojure
;; Inheritable envelope fields — copied from parent to child when :dispatch /
;; :dispatch-later queue a new envelope. This is the "envelope-field-copying
;; when queueing children" mechanism named in [§Cascade propagation]
;; (#cascade-propagation). `:event` and `:dispatched-at` are NOT inherited —
;; the child gets its own. `:source` is preserved unless the queueing fx
;; sets a more specific value (e.g. a timer fx might set `:source :timer`).
(def ^:private inheritable-envelope-keys
  [:frame :fx-overrides :interceptor-overrides :trace-id :origin :source])

(defn- child-envelope [parent-envelope event]
  (-> (select-keys parent-envelope inheritable-envelope-keys)
      (assoc :event event)))

(defmethod do-fx :dispatch [frame parent-envelope ev]
  (dispatch frame (child-envelope parent-envelope ev))) ;; back of queue, FIFO

(defmethod do-fx :dispatch-later [frame parent-envelope {:keys [ms event]}]
  (let [child (child-envelope parent-envelope event)]
    (interop/set-timeout!
      (fn [] (dispatch frame child))
      ms)))
```

## Scope

- Pseudocode-only edit inside the `Drain-loop pseudocode` code-fenced block, plus a one-line clarifying comment at the call site naming the cascade-propagation cross-reference.
- No prose restructuring; surrounding §Run-to-completion / §Drain semantics text unchanged.
- §Cascade propagation prose untouched.
- No spec content beyond what was already implied by the cascade contract.

## Test plan

- [ ] Markdown renders cleanly (code fences balanced, anchor `#cascade-propagation` resolves).
- [ ] Cross-spec references in 002 still resolve.
- [ ] Conformance corpus depth-2+ override-propagation fixtures still pass (or are filed as a follow-up if they don't yet exist — see bead notes).