### PR TITLE
test: reg-view gaps sweep — auto-inject / warn-once / parity (rf2-d4v7 / discovered-from rf2-o423)

### DIFF
--- a/implementation/reagent/test/re_frame/auto_inject_form2_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/auto_inject_form2_cljs_test.cljs
@@ -1,0 +1,186 @@
+(ns re-frame.auto-inject-form2-cljs-test
+  "Per Spec 004 §reg-view (rf2-d0pi) and §Form-2: the `reg-view` macro
+  auto-injects lexical bindings `dispatch` and `subscribe` around the
+  body. The injection is a single OUTER `let`:
+
+      (fn outer [args]
+        (let [dispatch  (rf/dispatcher)
+              subscribe (rf/subscriber)]
+          body))
+
+  For Form-1 (body is plain hiccup), `dispatch` / `subscribe` are
+  available straight in the body — covered by the existing macro
+  tests (views-macros-test).
+
+  For Form-2 (body returns an inner render fn), the outer `let`
+  encloses the inner `(fn ... )`, so the inner fn captures the SAME
+  `dispatch` / `subscribe` lexical bindings via Clojure closure. Both
+  the outer body AND the inner-render fn see the auto-injected names —
+  the bindings are NOT re-injected per inner call; they're the same
+  closed-over values. Per Spec 004 §Form-2:
+
+    'The dispatch and subscribe in both the outer body and the inner
+     fn refer to the same lexical bindings — Clojure lexical closure
+     does the right thing.'
+
+  This is the pre-beta gap that rf2-o423 surfaced (rf2-d4v7 sub-gap 1):
+  the Form-1 happy path is covered by views-macros-test, but the
+  Form-2 boundary — does the inner fn see the injected names? — was
+  only documented in Spec 004 §Form-2 and the macro source comment,
+  never asserted by a test. This file pins the contract.
+
+  Reference Mike's feedback memory: 'target Reagent v2; don't invest
+  in 1.2 back-compat.' Form-2's expansion is identical under v1 and
+  v2 Reagent (lexical closure is Clojure semantics, not a Reagent
+  feature)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- Form-1 baseline: dispatch / subscribe are auto-injected -------------
+
+(deftest form-1-auto-inject-baseline
+  (testing "Form-1 body sees auto-injected `dispatch` / `subscribe`. The
+            outer `let` makes both names lex-scoped over the body — if
+            either name were not in scope, the CLJS compiler would
+            error at macro-expansion time. The runtime check below
+            asserts both names resolve to fns and the captured
+            dispatcher routes against the registered :rf/default frame."
+    (let [captured (atom {})]
+      (reg-view ^{:rf/id :rf.f2-inject/form-1-view} f1-view []
+        ;; Capture the auto-injected bindings as fn values. We don't
+        ;; invoke them here — invocation behaviour belongs to the
+        ;; dispatcher / subscriber tests in events_cljs_test. The point
+        ;; is: the names are bound, in scope, and bound to fns.
+        (swap! captured assoc
+               :dispatch  dispatch
+               :subscribe subscribe)
+        [:p "ok"])
+      (let [render (rf/view :rf.f2-inject/form-1-view)
+            out    (render)]
+        (is (vector? out) "Form-1 returns hiccup")
+        (is (fn? (:dispatch  @captured))
+            "Form-1: `dispatch` auto-injected as a fn")
+        (is (fn? (:subscribe @captured))
+            "Form-1: `subscribe` auto-injected as a fn")))))
+
+;; ---- Form-2 boundary: inner fn captures the SAME dispatch / subscribe ----
+
+(deftest form-2-inner-fn-captures-auto-injected-bindings
+  (testing "Form-2: when the body returns a fn, the inner fn closes over
+            the SAME `dispatch` / `subscribe` lexical bindings the outer
+            let injected. The macro expansion is:
+
+                (fn outer [args]
+                  (let [dispatch  (rf/dispatcher)
+                        subscribe (rf/subscriber)]
+                    body))               ;; body = `(fn inner [...] ...)`
+
+            Clojure lexical closure means `inner` sees `dispatch` /
+            `subscribe` from the surrounding `let` — they are NOT
+            re-injected per inner call. Per Spec 004 §Form-2:
+            'The dispatch and subscribe in both the outer body and
+            the inner fn refer to the same lexical bindings — Clojure
+            lexical closure does the right thing.'
+
+            Asserts: from the inner fn's body, both `dispatch` and
+            `subscribe` resolve (no compile error), and they are the
+            SAME (===) fn values the outer body saw."
+    (let [outer-captured (atom {})
+          inner-captured (atom {})]
+      (reg-view ^{:rf/id :rf.f2-inject/form-2-view} f2-view []
+        ;; Outer body — the auto-inject `let`'s body. Stashes the
+        ;; injected names from the OUTER scope.
+        (swap! outer-captured assoc
+               :dispatch  dispatch
+               :subscribe subscribe)
+        ;; Inner render fn — the body of `(fn inner ...)`. References
+        ;; `dispatch` / `subscribe` from the SURROUNDING `let`. If
+        ;; lexical closure didn't carry them through, the CLJS
+        ;; compiler would fail to resolve the symbols here.
+        (fn inner-render []
+          (swap! inner-captured assoc
+                 :dispatch  dispatch
+                 :subscribe subscribe)
+          [:p "ok"]))
+      (let [wrapper       (rf/view :rf.f2-inject/form-2-view)
+            ;; First wrapper invocation: runs the outer body (records
+            ;; outer-captured) and returns the inner fn (which the
+            ;; substrate's source-coord wrapper has wrapped per Spec
+            ;; 006 §Form-2 handling — the wrapped fn delegates to
+            ;; the inner render).
+            inner-or-fn   (wrapper)]
+        (is (fn? inner-or-fn)
+            "Form-2 wrapper returns a fn (the inner render — Spec 004
+             §Form-2 / Spec 006 §Form-2 handling)")
+        (let [inner-out (inner-or-fn)]
+          (is (vector? inner-out) "inner fn returns hiccup")
+          (is (= :p (first inner-out)) "inner fn root tag preserved"))
+        ;; Both layers captured fn values for `dispatch` and `subscribe`.
+        (is (fn? (:dispatch  @outer-captured))
+            "outer body: `dispatch` auto-injected as a fn")
+        (is (fn? (:subscribe @outer-captured))
+            "outer body: `subscribe` auto-injected as a fn")
+        (is (fn? (:dispatch  @inner-captured))
+            "inner fn: `dispatch` resolves via lexical closure")
+        (is (fn? (:subscribe @inner-captured))
+            "inner fn: `subscribe` resolves via lexical closure")
+        ;; The inner fn sees the SAME fn instances the outer body saw —
+        ;; this is the Spec 004 §Form-2 contract: 'refer to the same
+        ;; lexical bindings'. If the macro had re-injected per inner
+        ;; call (a bug shape), the values would be fresh fn objects
+        ;; minted by `(rf/dispatcher)` / `(rf/subscriber)` per call,
+        ;; not identical to the outer body's.
+        (is (identical? (:dispatch  @outer-captured)
+                        (:dispatch  @inner-captured))
+            "inner fn's `dispatch` is the SAME closed-over fn as the
+             outer body's — confirming the auto-inject is the outer
+             let, lexically captured by the inner fn (Spec 004 §Form-2)")
+        (is (identical? (:subscribe @outer-captured)
+                        (:subscribe @inner-captured))
+            "inner fn's `subscribe` is the SAME closed-over fn as the
+             outer body's — confirming lexical-closure semantics")))))
+
+;; ---- Form-2: bindings persist across inner re-renders --------------------
+
+(deftest form-2-inner-fn-binding-stable-across-renders
+  (testing "A Form-2 view's auto-inject is the OUTER `let`, run once
+            per outer-body invocation. Subsequent inner-fn calls see
+            the SAME captured `dispatch` / `subscribe` — they are NOT
+            re-resolved per render. Per Spec 004 §Form-2 lexical-
+            closure contract.
+
+            Asserts: the captured `dispatch` is identical (===) across
+            three inner-fn invocations — the binding is the closed-
+            over value, not freshly resolved per render."
+    (let [captures (atom [])]
+      (reg-view ^{:rf/id :rf.f2-inject/identity-view} id-view []
+        ;; Outer body: stash the auto-injected dispatch.
+        (swap! captures conj dispatch)
+        (fn inner-render []
+          ;; Inner body: stash the captured dispatch on each render.
+          (swap! captures conj dispatch)
+          [:span "ok"]))
+      (let [wrapper   (rf/view :rf.f2-inject/identity-view)
+            inner-fn  (wrapper)]
+        (inner-fn)        ;; first inner render
+        (inner-fn)        ;; second inner render
+        (let [captured @captures]
+          ;; Three captures: outer + 2× inner.
+          (is (= 3 (count captured))
+              "outer body and 2 inner renders all stashed `dispatch`")
+          ;; All three are the SAME object — proving the inner fn
+          ;; closed over the same lexical binding the outer let
+          ;; created.
+          (is (apply identical? captured)
+              "all three captures are the same fn instance —
+               confirming the inner fn's `dispatch` is the outer
+               let's binding, closed over, NOT re-resolved per inner
+               call (Spec 004 §Form-2 lexical-closure contract)"))))))

--- a/implementation/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
@@ -1,0 +1,92 @@
+(ns re-frame.source-coord-parity-cljs-test
+  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and Spec
+  011 §Source-coord annotation under SSR: the CLJS-side Reagent
+  adapter's `format-source-coord` (in `re-frame.views`) and the JVM-
+  side SSR emitter's `format-view-source-coord` (in `re-frame.ssr`)
+  MUST produce byte-identical attribute values for the same input —
+  same id, same captured `:line` / `:column`. Pair tools that consume
+  the `data-rf2-source-coord` attribute parse the same shape regardless
+  of whether the HTML came from server-side rendering or client-side
+  Reagent — divergent formats would silently break the source-mapping
+  contract.
+
+  The parser fix in rf2-7g2q's pair2 work assumed both sides produce
+  the same `<ns>:<sym>:<line>:<col>` string for the same registration.
+  No test exercises both paths against a single fixture to confirm.
+  This file pins parity from the CLJS side (rf2-d4v7 sub-gap 3 /
+  rf2-o423 audit); the JVM-side counterpart lives at
+  `implementation/ssr/test/re_frame/source_coord_parity_test.clj`
+  and pins the same canonical literal against
+  `format-view-source-coord`.
+
+  Strategy: each helper is `defn-` (private), but the var is
+  reachable via `#'ns/sym`. This CLJS test exercises
+  `re-frame.views/format-source-coord` against fixture inputs and
+  asserts it produces a single canonical literal. The companion JVM
+  test exercises `re-frame.ssr/format-view-source-coord` against the
+  SAME fixture and asserts the SAME canonical literal. If either
+  helper drifts from the canonical shape, the corresponding host's
+  test fails. The literal IS the byte-comparison point — both sides
+  pin it independently."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.views]))
+
+;; ---- the canonical attribute-value shape (shared spec) -------------------
+;;
+;; These three values mirror the JVM-side parity test exactly. The
+;; literal `expected-attr` IS the cross-host byte-comparison point —
+;; if either helper diverges from this shape, the corresponding host's
+;; test fails.
+
+(def fixture-id :rf.parity-test/sample-view)
+
+(def fixture-meta {:ns         'rf.parity-test
+                   :line       42
+                   :column     7
+                   :file       "rf/parity_test.cljs"
+                   :handler-id fixture-id})
+
+;; Canonical: <ns>=rf.parity-test, <sym>=sample-view, <line>=42, <col>=7.
+(def expected-attr "rf.parity-test:sample-view:42:7")
+
+;; Degraded canonical: programmatic registration with no macro coords.
+(def fixture-meta-no-line-no-col
+  {:ns         'rf.parity-test
+   :file       "rf/parity_test.cljs"
+   :handler-id fixture-id})
+
+(def expected-attr-no-line-no-col
+  "rf.parity-test:sample-view:?:?")
+
+;; ---- CLJS side: format-source-coord pins the canonical literal -----------
+
+(deftest cljs-format-source-coord-byte-identical-to-canonical
+  (testing "CLJS `format-source-coord` consumes the fixture
+            (id + line + column + file) and produces the canonical
+            <ns>:<sym>:<line>:<col> string — bytes match the literal
+            the JVM-side companion test pins. The literal IS the
+            cross-host byte-comparison point."
+    (let [cljs-format #'re-frame.views/format-source-coord
+          cljs-output (cljs-format fixture-id fixture-meta)]
+      (is (= expected-attr cljs-output)
+          (str "CLJS `format-source-coord` MUST produce the canonical "
+               "<ns>:<sym>:<line>:<col> shape. Expected: "
+               (pr-str expected-attr) " — got: " (pr-str cljs-output))))))
+
+;; ---- CLJS side: degraded shape (no line / col) pins the canonical -------
+
+(deftest cljs-format-source-coord-degraded-shape-byte-identical
+  (testing "When :line / :column are absent (programmatic reg-view*
+            without macro coords), the CLJS helper degrades to
+            <ns>:<sym>:?:? — byte-identical to the SSR-side helper's
+            degraded shape. Per Spec 006 §Source-coord annotation:
+            'A registration that bypassed the macro path … still
+            annotates with <ns>:<sym>:?:? — degrading gracefully so
+            pair tools can still resolve <ns>/<sym> via the
+            registrar's :rf/id lookup.'"
+    (let [cljs-format #'re-frame.views/format-source-coord
+          cljs-output (cljs-format fixture-id fixture-meta-no-line-no-col)]
+      (is (= expected-attr-no-line-no-col cljs-output)
+          (str "CLJS degraded shape: expected "
+               (pr-str expected-attr-no-line-no-col)
+               " — got: " (pr-str cljs-output))))))

--- a/implementation/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs
@@ -1,0 +1,139 @@
+(ns re-frame.source-coord-warn-once-cljs-test
+  "Per Spec 006 §Documented exemption: non-DOM roots (rf2-z7f7 / rf2-z9n1):
+
+    'A registered view whose root element is one of [Fragment, host-
+     component head, function/component head] is exempt from the
+     annotation. The adapter MUST emit a one-shot warning per id (so
+     the developer learns the pair-tool footgun without spamming the
+     console on re-render) and MUST NOT inject the attribute in
+     these cases.'
+
+  Coverage gap before this file (rf2-d4v7 sub-gap 2 / rf2-o423 audit):
+  the attribute-emission path has tests in
+  `source_coord_dom_cljs_test` (Fragment-root exempt, interop-root
+  exempt, attribute-format shape) — the WARNING-FIRES-ONLY-ONCE
+  contract has no test. This file pins the warn-once-per-id semantic.
+
+  Mechanism: `re-frame.views/warn-non-dom-root!` (private) consults a
+  process-wide `defonce` set `warned-non-dom-roots`. First call for an
+  id `swap!`s the id into the set and emits `js/console.warn`;
+  subsequent calls for the same id are silenced. The atom is a
+  `defonce` so the first warning per id sticks for the lifetime of
+  the JS process — re-rendering the same view repeatedly emits the
+  warning exactly ONCE."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.substrate.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helper: capture console.warn calls ----------------------------------
+
+(defn- with-captured-console-warn
+  "Replace js/console.warn with a recording shim around `thunk`. Returns
+  a vector of the messages observed (each message is the joined string
+  of the call's args). Restores the original on the way out, even if
+  thunk throws."
+  [thunk]
+  (let [calls    (atom [])
+        original (.-warn js/console)]
+    (try
+      (set! (.-warn js/console)
+            (fn [& args]
+              (swap! calls conj (apply str args))))
+      (thunk)
+      @calls
+      (finally
+        (set! (.-warn js/console) original)))))
+
+;; ---- Fragment root: warning fires exactly once per id ---------------------
+
+(deftest fragment-root-warn-fires-once-across-multiple-renders
+  (testing "A Fragment-headed reg-view'd component renders without the
+            data-rf2-source-coord attribute (existing coverage) and
+            ALSO emits the documented warning EXACTLY ONCE — the
+            second through fifth re-render do NOT re-emit. Per Spec
+            006 §Documented exemption: 'one-shot warning per id (so
+            the developer learns the pair-tool footgun without
+            spamming the console on re-render)'.
+
+            Note: the warned-set is a `defonce` atom in re-frame.views,
+            so the first warning across the whole test process sticks
+            per-id. We use a unique id per test to avoid cross-test
+            contamination."
+    ;; Unique id — the warned-non-dom-roots set is process-wide
+    ;; defonce, so a different id per test is the safe shape.
+    (rf/reg-view* :rf.warn-once-test/fragment-multi
+                  (fn [] [:<> [:p "a"] [:p "b"]]))
+    (let [render   (rf/view :rf.warn-once-test/fragment-multi)
+          warnings (with-captured-console-warn
+                     (fn []
+                       ;; Render 5 times — the warning must fire on
+                       ;; the FIRST render and stay silent on the
+                       ;; subsequent four.
+                       (dotimes [_ 5] (render))))]
+      (is (= 1 (count warnings))
+          (str "expected EXACTLY ONE warning across 5 renders of the "
+               "Fragment-rooted view; got " (count warnings) ": "
+               (pr-str warnings)))
+      (is (str/includes? (first warnings)
+                         "rf.warn-once-test/fragment-multi")
+          "the single warning names the offending view-id")
+      (is (str/includes? (first warnings) "data-rf2-source-coord")
+          "the warning mentions the attribute that was skipped")
+      (is (or (str/includes? (first warnings) "Spec 006")
+              (str/includes? (first warnings) "fall back"))
+          "the warning points the user at the documented contract"))))
+
+;; ---- Per-id silencing is independent across ids --------------------------
+
+(deftest warn-once-is-per-id-not-global
+  (testing "The warn-once contract is keyed by view-id. Two different
+            non-DOM-rooted views each emit their OWN one-shot warning
+            (not a single global gate)."
+    (rf/reg-view* :rf.warn-once-test/fragment-id-a
+                  (fn [] [:<> [:p "a"]]))
+    (rf/reg-view* :rf.warn-once-test/fragment-id-b
+                  (fn [] [:<> [:p "b"]]))
+    (let [warnings (with-captured-console-warn
+                     (fn []
+                       ;; Render each twice. Each id should warn once
+                       ;; — total 2 warnings, not 1 (per-id silencing,
+                       ;; not global), not 4 (one-shot, not per-render).
+                       (let [render-a (rf/view :rf.warn-once-test/fragment-id-a)
+                             render-b (rf/view :rf.warn-once-test/fragment-id-b)]
+                         (render-a) (render-b)
+                         (render-a) (render-b))))]
+      (is (= 2 (count warnings))
+          (str "expected EXACTLY TWO warnings (one per id) across 4 "
+               "renders; got " (count warnings) ": "
+               (pr-str warnings)))
+      (is (some #(str/includes? % "fragment-id-a") warnings)
+          "id-a's warning fired")
+      (is (some #(str/includes? % "fragment-id-b") warnings)
+          "id-b's warning fired"))))
+
+;; ---- Interop / fn-headed roots also warn-once -----------------------------
+
+(deftest interop-root-warn-fires-once
+  (testing "A `:>` interop-headed root is on the same exemption list as
+            Fragments; it MUST warn exactly once per id across renders.
+            Pair tools fall back to :rf/id for these roots. Per Spec
+            006 §Documented exemption: non-DOM roots."
+    (rf/reg-view* :rf.warn-once-test/interop-multi
+                  (fn [] [:> "div" {} "body"]))
+    (let [render   (rf/view :rf.warn-once-test/interop-multi)
+          warnings (with-captured-console-warn
+                     (fn [] (dotimes [_ 5] (render))))]
+      (is (= 1 (count warnings))
+          (str "expected EXACTLY ONE warning across 5 renders of the "
+               "interop-rooted view; got " (count warnings) ": "
+               (pr-str warnings)))
+      (is (str/includes? (first warnings) "interop-multi")
+          "the single warning names the interop-rooted view-id"))))

--- a/implementation/ssr/test/re_frame/source_coord_parity_test.clj
+++ b/implementation/ssr/test/re_frame/source_coord_parity_test.clj
@@ -1,0 +1,130 @@
+(ns re-frame.source-coord-parity-test
+  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and Spec
+  011 §Source-coord annotation under SSR: the JVM-side SSR emitter's
+  `format-view-source-coord` (in `re-frame.ssr`) and the CLJS-side
+  Reagent adapter's `format-source-coord` (in `re-frame.views`) MUST
+  produce byte-identical attribute values for the same input — same
+  id, same captured `:line` / `:column`. Pair tools that consume the
+  `data-rf2-source-coord` attribute parse the same shape regardless
+  of whether the HTML came from server-side rendering or client-side
+  Reagent — divergent formats would silently break the source-mapping
+  contract.
+
+  The parser fix in rf2-7g2q's pair2 work assumed both sides produce
+  the same `<ns>:<sym>:<line>:<col>` string for the same registration.
+  No test exercises both paths against a single fixture to confirm.
+  This file pins parity from the JVM side (rf2-d4v7 sub-gap 3 /
+  rf2-o423 audit); the CLJS-side counterpart lives at
+  `implementation/reagent/test/re_frame/source_coord_parity_cljs_test.cljs`
+  and pins the same canonical literal against `format-source-coord`.
+
+  Strategy: each helper is `defn-` (private), but Clojure exposes
+  private vars via `#'ns/sym`. This JVM test exercises
+  `re-frame.ssr/format-view-source-coord` against fixture inputs and
+  asserts it produces a single canonical literal. The companion CLJS
+  test exercises `re-frame.views/format-source-coord` against the
+  SAME fixture and asserts the SAME canonical literal. If either
+  helper drifts from the canonical shape, the corresponding host's
+  test fails. The literal IS the byte-comparison point — both sides
+  pin it independently."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr]))
+
+;; ---- the canonical attribute-value shape (shared spec) -------------------
+;;
+;; Per Spec 006 §Source-coord annotation: `<ns>:<sym>:<line>:<col>`.
+;; <ns> is the registry id keyword's namespace; <sym> is its name;
+;; <line> / <col> come from `(meta &form)` at reg-view macro-expansion
+;; time. The fixture below is the same "stamped meta" shape both
+;; helpers consume; the expected string is the canonical literal.
+
+(def fixture-id :rf.parity-test/sample-view)
+
+(def fixture-meta {:ns         'rf.parity-test
+                   :line       42
+                   :column     7
+                   :file       "rf/parity_test.cljs"
+                   ;; :handler-id is the slot's id key in the registrar
+                   ;; — neither helper consumes it, but the audit's
+                   ;; bead lists it among the stamped-meta keys so we
+                   ;; carry it for shape-fidelity.
+                   :handler-id fixture-id})
+
+;; The byte-string both helpers MUST produce for the fixture above.
+;; <ns>=rf.parity-test, <sym>=sample-view, <line>=42, <col>=7.
+(def expected-attr "rf.parity-test:sample-view:42:7")
+
+;; The degraded-shape canonical literal — a programmatic registration
+;; that bypassed the macro path (no :line / :column captured) but
+;; still carried :ns. Per Spec 006 §Source-coord annotation: 'A
+;; registration that bypassed the macro path … still annotates with
+;; <ns>:<sym>:?:? — degrading gracefully so pair tools can still
+;; resolve <ns>/<sym> via the registrar's :rf/id lookup.'
+(def fixture-meta-no-line-no-col
+  {:ns         'rf.parity-test
+   :file       "rf/parity_test.cljs"
+   ;; :line and :column intentionally absent.
+   :handler-id fixture-id})
+
+(def expected-attr-no-line-no-col
+  "rf.parity-test:sample-view:?:?")
+
+;; ---- JVM SSR side: format-view-source-coord pins the canonical literal ---
+
+(deftest ssr-format-view-source-coord-byte-identical-to-canonical
+  (testing "JVM SSR `format-view-source-coord` consumes the fixture
+            (id + line + column + file) and produces the canonical
+            <ns>:<sym>:<line>:<col> string — bytes match the literal
+            the CLJS-side companion test pins. The literal IS the
+            cross-host byte-comparison point."
+    (let [ssr-format #'re-frame.ssr/format-view-source-coord
+          ssr-output (ssr-format fixture-id fixture-meta)]
+      (is (= expected-attr ssr-output)
+          (str "JVM SSR `format-view-source-coord` MUST produce the "
+               "canonical <ns>:<sym>:<line>:<col> shape. Expected: "
+               (pr-str expected-attr) " — got: " (pr-str ssr-output))))))
+
+;; ---- JVM SSR side: degraded shape (no line / col) pins the canonical -----
+
+(deftest ssr-format-view-source-coord-degraded-shape-byte-identical
+  (testing "When :line / :column are absent (programmatic reg-view*
+            with :ns stamped from a sibling macro registration in the
+            same compilation unit), the SSR helper degrades to
+            <ns>:<sym>:?:? — byte-identical to the CLJS-side helper's
+            degraded shape. Per Spec 006 §Source-coord annotation."
+    (let [ssr-format #'re-frame.ssr/format-view-source-coord
+          ssr-output (ssr-format fixture-id fixture-meta-no-line-no-col)]
+      (is (= expected-attr-no-line-no-col ssr-output)
+          (str "SSR degraded shape: expected "
+               (pr-str expected-attr-no-line-no-col)
+               " — got: " (pr-str ssr-output))))))
+
+;; ---- end-to-end byte parity: SSR-rendered HTML carries the canonical ----
+
+(deftest ssr-rendered-html-attribute-byte-identical-to-canonical
+  (testing "The SSR-emitted HTML for a fixture-shape registered view
+            carries the canonical attribute value — verifying parity
+            extends through the full render path, not just the helper.
+
+            Note: this test cannot use `reg-view` (the macro), because
+            macro-captured :line / :column are call-site-dependent.
+            We use `reg-view*` and stamp the slot meta directly — the
+            registry slot has the same shape it would have under the
+            macro path."
+    (require '[re-frame.registrar :as registrar]
+             '[re-frame.ssr      :as ssr])
+    (let [registrar         (resolve 're-frame.registrar/register!)
+          ssr-render        (resolve 're-frame.ssr/render-to-string)
+          ;; Programmatically register with the fixture meta — same
+          ;; slot shape the reg-view macro would produce, but with
+          ;; control over the :line / :column values so the canonical
+          ;; literal is reachable.
+          _ (registrar :view fixture-id
+                       (assoc fixture-meta
+                              :handler-fn (fn [] [:p "body"])))
+          html (ssr-render [fixture-id] {})]
+      (is (.contains html (str "data-rf2-source-coord=\""
+                               expected-attr
+                               "\""))
+          (str "SSR-emitted HTML must carry the canonical attribute "
+               "value `" expected-attr "`; got: " (pr-str html))))))


### PR DESCRIPTION
## Summary

Three reg-view-related test gaps surfaced by the rf2-o423 pre-beta
audit, bundled together because each is small individually. All
three sub-gaps PASS with the asserted contracts already met by the
implementation — these are pure coverage additions; no production
code changes.

### Sub-gap 1 — Auto-inject Form-2 boundary

Per Spec 004 §reg-view (rf2-d0pi) and §Form-2: the `reg-view` macro
auto-injects lexical bindings `dispatch` and `subscribe` as a single
outer `let` around the body. For Form-2 (body returns an inner
render fn), the inner fn closes over the SAME bindings via Clojure
lexical closure — the macro does NOT re-inject per inner call.

The Form-1 happy path is covered by `views-macros-test` on JVM.
Form-2 was only documented in Spec 004 §Form-2 ('the dispatch and
subscribe in both the outer body and the inner fn refer to the same
lexical bindings — Clojure lexical closure does the right thing')
and the macro source (`views_macros.clj:140-144`), never asserted
by a test.

New file:
`implementation/reagent/test/re_frame/auto_inject_form2_cljs_test.cljs`

Asserts that the inner fn's captured `dispatch` is `identical?` to
the outer body's, across multiple inner-fn renders — pinning the
lexical-closure contract.

**Status: PASS — contract met as documented.**

### Sub-gap 2 — Source-coord warn-once contract

Per Spec 006 §Documented exemption: non-DOM roots (rf2-z7f7 /
rf2-z9n1): a Fragment / `:>` interop / fn-headed root MUST emit a
'one-shot warning per id'. The attribute-emission path has tests
(source_coord_dom_cljs_test, ssr_source_coord_test); the
warning-fires-only-once contract had none.

The implementation (`re-frame.views/warn-non-dom-root!`,
`views.cljs:227-242`) gates on a `defonce` set
`warned-non-dom-roots`. First call for an id `swap!`s the id in and
emits `js/console.warn`; subsequent calls are silenced.

New file:
`implementation/reagent/test/re_frame/source_coord_warn_once_cljs_test.cljs`

Captures `js/console.warn` via a try/finally shim and asserts:
- Fragment-rooted view rendered 5 times → exactly 1 warning;
- Per-id silencing (two ids → 2 warnings, not 1, not 4);
- Interop-rooted `:>` views warn once on the same contract.

**Status: PASS — contract met as documented.**

### Sub-gap 3 — SSR/CLJS source-coord parity

Per Spec 006 §Source-coord annotation and Spec 011 §Source-coord
annotation under SSR: the CLJS Reagent path (`format-source-coord`
in `views.cljs:211-225`) and the JVM SSR path
(`format-view-source-coord` in `ssr.cljc:137-151`, ssr artefact
post-PR #145) MUST produce byte-identical attribute values. The
pair2 parser fix in rf2-7g2q assumed parity but no test verified it.

Each helper is `defn-` private but reachable via `#'ns/sym`. Two
test files pin the SAME canonical literal:

- `implementation/ssr/test/re_frame/source_coord_parity_test.clj`
  (JVM) — `format-view-source-coord` produces the canonical literal.
- `implementation/reagent/test/re_frame/source_coord_parity_cljs_test.cljs`
  (CLJS) — `format-source-coord` produces the same canonical literal.

The literal IS the cross-host byte-comparison point; if either
helper drifts, the corresponding host's test fails.

**Byte comparison result: PASS — byte-identical.**

For canonical fixture
`{:ns 'rf.parity-test :line 42 :column 7}` with id
`:rf.parity-test/sample-view`, both helpers emit
`\"rf.parity-test:sample-view:42:7\"`. For the degraded fixture (no
`:line`/`:column`, `:ns` only), both emit
`\"rf.parity-test:sample-view:?:?\"`.

The JVM test additionally exercises the full SSR render path —
`render-to-string` over a fixture-shape registered view — and
confirms the rendered HTML carries the canonical attribute value
verbatim. Parity holds through the full render path, not just the
helper.

**Status: PASS — byte-identical, no follow-up needed.**

## Test plan

- [x] `clojure -M:test` in `implementation/core` — 212 tests, 928 assertions, 0 failures.
- [x] `clojure -M:test` in `implementation/ssr` — 23 tests, 83 assertions, 0 failures (was 22 before).
- [x] `clojure -M:test` in `implementation/reagent` — 0 tests (CLJS-only artefact).
- [x] `npm run test:cljs` (node-test build) — 134 tests, 418 assertions, 0 failures (was 132 before — 2 new parity-cljs assertions inline).
- [x] `npm run test:browser` — 134 tests, 418 assertions, 0 failures.