### PR TITLE
docs(spec): align 002 reg-frame metadata grammar with Spec-Schemas (rf2-5r0m / discovered-from rf2-8syd)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -205,7 +205,7 @@ A `:preset` key on the metadata expands at registration time into a fixed bundle
    :drain-depth 1000})        ;; overrides the :test preset's drain-depth default
 ```
 
-The closed canonical set of four presets, with their exact expansions:
+The closed canonical set of four presets, with their exact expansions. The expansion *table itself* is normatively captured in [Spec-Schemas §`:rf/preset-expansion`](Spec-Schemas.md#rfpreset-expansion); the four sub-sections below mirror that schema for human readability.
 
 #### `:default`
 
@@ -253,7 +253,7 @@ At registration time, the runtime:
 1. Reads the `:preset` key from the user's metadata (if any).
 2. Looks up the expansion table (above).
 3. Constructs an effective metadata map: `(merge expansion user-supplied-metadata)`. **User keys win on conflict** — the preset is a default, not a closed bundle.
-4. The effective metadata is what `(frame-meta <id>)` returns; the original `:preset` is preserved as a metadata field for inspection.
+4. The effective metadata is what `(frame-meta <id>)` returns; the original `:preset` is preserved as a metadata field for inspection. The returned shape conforms to [Spec-Schemas §`:rf/frame-meta`](Spec-Schemas.md#rfframe-meta); the table-itself shape is [§`:rf/preset-expansion`](Spec-Schemas.md#rfpreset-expansion).
 
 Reading `(rf/frame-meta :test/auth-flow)` returns the *effective* map; the `:preset` key is preserved verbatim so tools can inspect which preset was applied:
 


### PR DESCRIPTION
## Summary

Bead [rf2-5r0m](https://github.com/day8/re-frame2/issues?q=rf2-5r0m) bundled three independent drifts of inline reg-frame / trace-event grammars from Spec-Schemas as canonical (audit-002 F1, F4, plus 009 F-10).

**All three drifts were already resolved by prior fold-in commits.** No inline grammar edits remain.

This PR adds two **additive cross-references** in spec/002-Frames.md §Frame presets — pointing the section that mirrors the preset expansion table at the canonical [Spec-Schemas §`:rf/preset-expansion`](../blob/master/spec/Spec-Schemas.md#rfpreset-expansion) and §`:rf/frame-meta` schemas. This makes Spec-Schemas's canonicity explicit at the second-largest grammar-mirror site in 002 and helps future drift get caught.

## Per-drift status

| Drift | Spec-Schemas (canonical) | spec/002 / 009 (pre-fix) | Post-fix | Already-resolved-by |
|---|---|---|---|---|
| F1 — `:on-error` / `:platform` ghost-keys missing from 002 reg-frame canonical grammar | `:rf/frame-meta` carries both keys (Spec-Schemas L1421-1422) | 002 canonical grammar list omitted both keys | Both keys present in worked example (002 L101-102), enumerated in canonical-surface paragraph (002 L106), and called out in §`:ssr-server` preset table (002 L242-243) | b126043 (rf2-8syd 002 fold-in) — F1 additively |
| F4 — `:source` enum drift (5 vs 6 vs 8 values across three sites) | `:rf/dispatch-envelope` ships 8 values: `:ui :timer :http :machine :repl :ssr-hydration :test :other` (Spec-Schemas L94) | 002 L330 listed 5; 002 L366 listed 6 | Both 002 sites (now L340, L376) replaced inline enums with cross-link to canonical `:rf/dispatch-envelope` schema | b126043 (rf2-8syd 002 fold-in) — F4 reword (proximate-fanout: two adjacent sites, single edit) |
| 009 F-10 — `:operation` type drift | `:rf/trace-event` field is `:keyword` (Spec-Schemas L183) | 009 L25 prior text said `<kw-or-vec>` | 009 L25 now reads `:operation <kw>` with `;; Per Spec-Schemas §:rf/trace-event` cross-ref | a04deb3 (rf2-ra02 009 fold-in) — aligned `:operation` to `:keyword` |

## Rewords applied in this PR

Zero — all three rewords called out by the bead were already executed by the prior fold-in commits. The audit cap of 3 distinct rewords has already been spent (against this bead's three drifts) by those commits.

## Additive supports applied (STEP 3)

Two single-line cross-reference additions to spec/002-Frames.md §Frame presets:

1. After "The closed canonical set of four presets, with their exact expansions" — add: "The expansion *table itself* is normatively captured in [Spec-Schemas §`:rf/preset-expansion`]; the four sub-sections below mirror that schema for human readability."
2. After step 4 of §Expansion algorithm — add: "The returned shape conforms to [Spec-Schemas §`:rf/frame-meta`]; the table-itself shape is [§`:rf/preset-expansion`]."

Both are length-extending; no prose deleted.

## Test plan

- [x] `git diff --stat` — only spec/002-Frames.md, +2/-2 lines
- [x] Cross-ref anchors verified against Spec-Schemas headings (`#rfpreset-expansion`, `#rfframe-meta` — match existing slug convention used elsewhere in 002)
- [x] Post-edit: `grep -nE '(:on-error|:platform|:source|:operation)' spec/002-Frames.md` — values match `:rf/frame-meta` and `:rf/dispatch-envelope` in Spec-Schemas
- [x] No edits to MIGRATION.md