### PR TITLE
docs(spec): document reg-machine public surface in 005 + CP-5 (rf2-wv7a / discovered-from rf2-goxn)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -517,6 +517,36 @@ The fn `create-machine-handler` returns is the event handler. Crucially, the fac
 
 This is a real constraint on the implementation, not just a testing affordance — it's what makes the singleton vs spawned symmetry clean (the registration happens *outside* the factory in both cases) and what makes Level-2 testing (per [§Testing](#testing)) possible without a test frame.
 
+### `reg-machine` — public registration surface
+
+Alongside the underlying `reg-event-fx + create-machine-handler` form (per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler)), the framework ships **`reg-machine`** as the standard public registration entry point for machines. Both forms register the same thing — an event handler whose body interprets the transition table — and they reach the same registry slot. `reg-machine` is the surface that tools, examples, and CP-5-generated scaffolds default to.
+
+```clojure
+(rf/reg-machine :auth.login/flow
+  {:initial :idle
+   :data    {:attempts 0 :error nil}
+   :guards  {:under-retry-limit (fn [data _] (< (:attempts data) 3))}
+   :actions {:begin-submit       (fn [_ [_ creds]] {:fx [[:http {...}]]})
+             :record-failure     (fn [data _]      {:data {:attempts (inc (:attempts data))}})}
+   :states  { ... }})
+```
+
+**Surface signature.** Two arities of two forms:
+
+- `(rf/reg-machine machine-id machine)` — **macro**. Walks the literal spec form at expansion time and stamps a per-element source-coord index onto the spec's `:rf.machine/source-coords` key (per [§Source-coord stamping](#source-coord-stamping-rf2-8bp3)). The macro emits `(reg-machine* …)` after stamping; the runtime call site is the plain-fn surface.
+- `(rf/reg-machine* machine-id machine)` — **plain fn**. Equivalent to `(reg-event-fx machine-id (create-machine-handler machine))` plus the registration-metadata stamp. No source-coord walking — the spec is opaque data at the call site.
+
+Both forms live in `re-frame.machines` (the `day8/re-frame-2-machines` artefact, per [Conventions.md](Conventions.md)) and are re-exported under `re-frame.core` for both JVM and CLJS callers. See [API.md §Machines](API.md#machines) for the canonical API table.
+
+**Registration-metadata stamp.** Both forms record two keys on the registry slot's metadata map (per [001 §Metadata-map shape](001-Registration.md)):
+
+- `:rf/machine? true` — the discriminator. `(rf/machines)` filters `(handlers :event)` by this flag (per [§Querying machines](#querying-machines)). User-written event handlers do not set this key.
+- `:rf/machine <spec>` — the spec map passed to `reg-machine`. `(rf/machine-meta id)` reads this back; tools that walk the transition table (visualisers, conformance harnesses, CP-5-time scaffolders) consume the spec via this key. When the macro path stamps source coords, the `:rf.machine/source-coords` index lives inside this spec map.
+
+Source-coord stamping on the call site (`:ns` / `:line` / `:column` / `:file`) follows the standard rules from [001 §Source-coord stamping](001-Registration.md): the macro stamps; programmatic registration via `reg-machine*` does not. See [§Source-coord stamping](#source-coord-stamping-rf2-8bp3) for the per-element index.
+
+`reg-machine` is itself **late-bound** — `re-frame.core` carries the macro and a stub fn that resolves the producer through the late-bind hook table at registration time. Apps that use `reg-machine` MUST add `day8/re-frame-2-machines` to their deps and require `re-frame.machines` at app boot; without it, the lookup throws `:rf.error/machines-artefact-missing`.
+
 ### `reg-machine` vs `reg-machine*`
 
 The `reg-machine` convenience surface splits along Clojure's `let` / `let*`, `fn` / `fn*` idiom:

--- a/spec/CP-5-MachineGuide.md
+++ b/spec/CP-5-MachineGuide.md
@@ -5,6 +5,32 @@
 
 This file is intentionally **kept separate** from Construction-Prompts.md so that CP-5 reads as a parallel sibling to CP-1/CP-2/CP-3/CP-4 rather than a doc-within-a-doc. Read CP-5 first; consult this file when the prompt's checklist sends you here.
 
+## Registration — `reg-machine` and `reg-machine*`
+
+Two equivalent surfaces register a machine; CP-5-generated scaffolds default to **`reg-machine`** (the macro). Both register the same thing — an event handler whose body interprets the transition table — and both stamp the registry slot with `:rf/machine? true` and `:rf/machine <spec>` so that `(rf/machines)` and `(rf/machine-meta id)` see the registration (per [005 §Querying machines](005-StateMachines.md#querying-machines)).
+
+```clojure
+;; Standard form — the macro (preferred).
+(rf/reg-machine :auth.login/flow
+  {:initial :idle
+   :data    {...}
+   :guards  {...}
+   :actions {...}
+   :states  {...}})
+
+;; Plain-fn surface — for code-gen, REPL, fixture-synthesised specs.
+(rf/reg-machine* machine-id (build-spec-from-edn fixture))
+```
+
+| Form | Shape | Source-coord stamping | Use case |
+|---|---|---|---|
+| `(rf/reg-machine machine-id machine-spec)` | **macro** | Yes — call-site coords on the registry slot AND per-element coord index walked from the literal spec form (per [005 §Source-coord stamping](005-StateMachines.md#source-coord-stamping-rf2-8bp3)) | The default. Use whenever the spec is a literal map at the call site. |
+| `(rf/reg-machine* machine-id machine-spec)` | plain fn | None — the spec is opaque data at the call site | Code-gen pipelines, REPL exploration, conformance harnesses that synthesise specs from EDN fixtures. |
+
+Both forms live in `re-frame.machines` (the `day8/re-frame-2-machines` artefact) and are re-exported under `re-frame.core`. See [API.md §Machines](API.md#machines) and [005 §`reg-machine` — public registration surface](005-StateMachines.md#reg-machine--public-registration-surface) for the canonical contract.
+
+The older `reg-event-fx + create-machine-handler` form (visible in [Construction-Prompts.md §CP-5](Construction-Prompts.md#cp-5-scaffold-a-state-machine) examples) registers the *same* slot — `reg-machine` is the convenience surface that wraps it and adds the metadata stamp.
+
 ## The inline-fn escape hatch
 
 CP-5 says: **default to named guards and actions**; inline fns are an escape hatch for trivial logic, not the default form. The test for "trivial" is **single non-branching expression**.


### PR DESCRIPTION
## Summary

Closes audit-005 finding #6 (rf2-goxn): `reg-machine` / `reg-machine*` are shipped public surfaces (re-exported from `re-frame.core`, used internally by `spawn-fx`) but the spec narrative only taught `reg-event-fx + create-machine-handler` as the registration form. The macro/plain-fn split (rf2-8bp3) made the gap larger — readers of 005 / CP-5 had no entry point that named `reg-machine` as the standard public surface.

This change is **additive**. No prose was deleted or restructured.

## Where the new sections live

- **spec/005-StateMachines.md** — new `### reg-machine — public registration surface` H3 inserted under `## Registration — the machine IS the event handler`, just before the existing `### reg-machine vs reg-machine*` comparison. The new section frames `reg-machine` as the standard surface; the existing comparison remains as the macro/plain-fn detail and the source-coord section remains untouched.

- **spec/CP-5-MachineGuide.md** — new `## Registration — reg-machine and reg-machine*` H2 inserted near the top, just after the appendix introduction and before `## The inline-fn escape hatch`. Cross-links to API.md §Machines and to the new 005 section.

## Quote — 005 §`reg-machine` — public registration surface (~50 words)

> Alongside the underlying `reg-event-fx + create-machine-handler` form, the framework ships **`reg-machine`** as the standard public registration entry point for machines. Both forms register the same thing — an event handler whose body interprets the transition table — and they reach the same registry slot. `reg-machine` is the surface that tools, examples, and CP-5-generated scaffolds default to.

Plus a Registration-metadata stamp bullet documenting `:rf/machine? true` and `:rf/machine <spec>`, a Surface-signature bullet documenting the macro vs plain-fn split, and a late-bind callout (apps need `day8/re-frame-2-machines` on the classpath; missing-artefact lookup throws `:rf.error/machines-artefact-missing`).

## Quote — CP-5-MachineGuide §Registration (~40 words)

> Two equivalent surfaces register a machine; CP-5-generated scaffolds default to **`reg-machine`** (the macro). Both register the same thing — an event handler whose body interprets the transition table — and both stamp the registry slot with `:rf/machine? true` and `:rf/machine <spec>` so that `(rf/machines)` and `(rf/machine-meta id)` see the registration.

Plus a side-by-side example (macro form for literal specs; plain-fn for code-gen / REPL / fixtures), the form-comparison table, and a closing pointer noting that the older `reg-event-fx + create-machine-handler` form (still visible in Construction-Prompts.md §CP-5 examples) registers the same slot.

## Test plan

- [ ] mkdocs build sanity-check (no broken anchors).
- [ ] Spec-internal cross-references resolve: 005's new section links forward to `#source-coord-stamping-rf2-8bp3`, `#querying-machines`, `#registration--the-machine-is-the-event-handler`; CP-5 links to `005-StateMachines.md#reg-machine--public-registration-surface` and `API.md#machines`.