### PR TITLE
test(epoch): fix late-bind publication for restore-* tests (rf2-v6z0 / discovered-from rf2-lt4e)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -22,7 +22,14 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.trace :as trace]
-            [re-frame.epoch :as epoch]))
+            [re-frame.epoch :as epoch]
+            ;; rf2-v6z0: machines is a separate artefact whose late-bind
+            ;; hook publishes `rf/reg-machine` only when the namespace is
+            ;; loaded. Several restore-* tests register machines via
+            ;; `rf/reg-machine` in their bodies; without this require they
+            ;; throw `:rf.error/machines-artefact-missing`. Side-effect
+            ;; require — the namespace alias is unused.
+            [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `[re-frame.machines]` as a side-effect-only require to `implementation/epoch/test/re_frame/epoch_test.clj` so the machines late-bind hook publishes `rf/reg-machine` before the restore-* tests register machines via `rf/reg-machine` in their bodies.

Test-only change. Runtime is unaffected. Mirrors the pattern already used for `re-frame.http-managed` in `implementation/core/test/re_frame/conformance_test.clj` (per rf2-suue's wiring work).

## Tests fixed (previously failing)

- `restore-failure-version-mismatch`
- `restore-failure-missing-handler-machine`
- `restore-version-legacy-snapshot-slot-tolerated`
- `restore-failure-missing-handler-non-machine-event-not-confused`

All four threw `:rf.error/machines-artefact-missing` because the late-bind hook in `re-frame.machines` had not been published.

## Before / After

`cd implementation/epoch && clojure -M:test`

**Before:**
```
Ran 38 tests containing 132 assertions.
0 failures, 4 errors.
```

**After:**
```
Ran 38 tests containing 147 assertions.
0 failures, 0 errors.
```

Sibling artefact sanity runs:
- `implementation/core` — 174 tests, 781 assertions, 0 failures, 0 errors
- `implementation/machines` — 28 tests, 79 assertions, 0 failures, 0 errors

## Bead

rf2-v6z0 (discovered from rf2-lt4e)