### PR TITLE
fix(machines): CLJS arity-3 check + initial-snapshot meta propagation (rf2-l04j / discovered-from rf2-1e0n)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -86,10 +86,15 @@
 
 (defn- declares-3-arity?
   "True iff f explicitly declares a 3-fixed-arg invocation. Distinguishes
-  user opt-in 3-arity from variadic helpers like (constantly ...). On the
-  JVM, walks the fn class's declared invoke methods (variadics are
-  RestFns with no declared invoke(O,O,O) on the fn class itself); on
-  CLJS, looks for the multi-arity dispatch slot or matches .-length."
+  user opt-in 3-arity from variadic helpers like (constantly ...) or
+  (fn [data event & rest] ...). On the JVM, walks the fn class's
+  declared invoke methods (variadics are RestFns with no declared
+  invoke(O,O,O) on the fn class itself); on CLJS, inspects the compiled
+  fn surface — `cljs$lang$maxFixedArity` is set on every variadic and
+  records its max-fixed-arg count, so a variadic with max-fixed < 3 is a
+  2-plus-rest helper and is NOT a 3-arity declaration. A non-variadic fn
+  whose `.-length` is 3, or a multi-arity fn carrying an explicit
+  `cljs$core$IFn$_invoke$arity$3` dispatch slot, IS a 3-arity declaration."
   [f]
   #?(:clj  (boolean
              (some
@@ -97,8 +102,30 @@
                  (and (= "invoke" (.getName m))
                       (= 3 (.getParameterCount m))))
                (.getDeclaredMethods (class f))))
-     :cljs (or (= 3 (.-length f))
-               (some? (unchecked-get f "cljs$core$IFn$_invoke$arity$3")))))
+     :cljs (let [variadic? (some? (.-cljs$lang$maxFixedArity f))]
+             (cond
+               ;; Variadic of any flavour — (constantly ...), 2-plus-rest,
+               ;; 3-plus-rest. RestFns on the JVM don't expose a declared
+               ;; `invoke(O,O,O)` on the user's class, so the JVM check
+               ;; classifies all variadics as non-3-arity. To converge,
+               ;; CLJS treats every variadic the same way: routes through
+               ;; the 2-arity path per the docstring's "distinguishes
+               ;; variadic helpers" promise. The previously-buggy CLJS
+               ;; check matched 2-plus-rest as 3-arity via the auto-
+               ;; generated `cljs$core$IFn$_invoke$arity$3` rest-dispatch
+               ;; slot — that's what this branch fixes (rf2-l04j).
+               variadic?
+               false
+               ;; Plain 3-fixed-arity (e.g. `(fn [a b c] ...)`).
+               (= 3 (.-length f))
+               true
+               ;; Multi-arity fn with an explicit 3-arity dispatch case
+               ;; — `(fn ([a] ...) ([a b c] ...))`. The user IS opting
+               ;; in to a 3-arity surface; route through it.
+               (some? (unchecked-get f "cljs$core$IFn$_invoke$arity$3"))
+               true
+               :else
+               false))))
 
 (defn- call-guard
   "Invoke a resolved guard fn against a snapshot + event with the

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -832,7 +832,18 @@
           initial-decl  (:initial machine)
           initial-path  (initial-cascade machine (state-path initial-decl))
           initial-state (denormalise-state initial-path initial-decl)
-          initial    {:state initial-state :data (or (:data machine) {})}
+          ;; Per Spec 005 §Snapshot shape (`{:state :data :meta?}`) and
+          ;; §Versioned via :meta: a machine's spec-level :meta (e.g.
+          ;; `:rf/snapshot-version`, user introspection tags) propagates
+          ;; into the lazily-synthesised initial snapshot so the 3-arity
+          ;; ctx (and any downstream version-check) sees the same :meta
+          ;; the spec declares. Without this, a `:meta` declared on the
+          ;; spec is invisible until a transition explicitly seeds it
+          ;; via an action's `:meta` write — divergent with the
+          ;; pure-surface harness which receives the spec :meta directly.
+          initial    (cond-> {:state initial-state
+                              :data  (or (:data machine) {})}
+                       (some? (:meta machine)) (assoc :meta (:meta machine)))
           snapshot   (or (get-in db path) initial)
           ;; Sub-event routing per Spec 005 §Registration. The outer
           ;; event is [:machine-id <inner-event> & extra-args]. Extra

--- a/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
@@ -1,6 +1,7 @@
 (ns re-frame.three-arity-guards-cljs-test
   "Coverage for the machine guard / action 3-arity escape hatch (rf2-1e0n,
-  discovered-from rf2-o423; CLJS arity convergence rf2-l04j).
+  discovered-from rf2-o423; CLJS arity + initial-snapshot meta
+  convergence rf2-l04j).
 
   Per Spec 005 and `re-frame.machines`'s contract documented at
   `machines.cljc` lines 74-121, guards and actions accept two canonical
@@ -32,6 +33,12 @@
   previously-divergent assertions below are now consistent across
   platforms.
 
+  rf2-l04j also fixes the live initial-snapshot synthesis at
+  `machines.cljc:808` so a spec-level `:meta` propagates into the
+  initial snapshot. The CLJS live tests can now assert a non-nil
+  user-tagged `:meta` in ctx — the same payload the JVM pure-surface
+  tests pin.
+
   This file uses reader conditionals so its assertions run on both
   JVM and CLJS:
 
@@ -40,13 +47,9 @@
       a snapshot's :meta directly so the 3-arity ctx assertion can
       pin the full {:state :meta} payload.
     - CLJS uses the live `reg-machine` + `dispatch-sync` surface, which
-      is the same path real apps use. Because the runtime synthesises
-      the initial snapshot from `{:state ... :data ...}` only — it
-      never propagates a spec's `:meta` (machines.cljc:808) — the live
-      tests assert `:meta` is `nil` rather than user-tagged. The
-      documented behaviour holds either way: ctx is always
-      `{:state ... :meta ...}`; whether `:meta` is non-nil depends on
-      the snapshot, not the spec.
+      is the same path real apps use. With the rf2-l04j initial-
+      snapshot fix, a spec-level `:meta` is reflected in the synthesised
+      snapshot, so the live ctx now carries the user's tag.
 
   The file is named `*-cljs-test.cljc` so it's discovered by both:
     - cognitect.test-runner's default `.*-test$` regex (JVM).
@@ -150,10 +153,17 @@
   "Build a machine whose :go transition's :guard slot IS exactly
   `guard-fn` (no wrapper) — so the dispatcher classifies it on its real
   arity surface. The :action is a plain 2-arity bumper so the snapshot's
-  :data evolves observably when the transition fires."
+  :data evolves observably when the transition fires.
+
+  A spec-level `:meta {:user-tag :probe}` is seeded so the live CLJS
+  tests can assert that the rf2-l04j initial-snapshot fix propagates
+  the spec's `:meta` into the synthesised snapshot — the 3-arity ctx
+  thus carries `{:state ... :meta {:user-tag :probe}}` rather than a
+  nil :meta."
   [guard-fn]
   {:initial :idle
    :data    {:bumps 0}
+   :meta    {:user-tag :probe}
    :states
    {:idle {:on {:go {:target :gone
                      :guard  guard-fn
@@ -164,10 +174,14 @@
 (defn- machine-with-action
   "Build a machine whose :go transition's :action slot IS exactly
   `action-fn` — so the dispatcher classifies it on its real arity
-  surface. The :guard is omitted (defaults to `(constantly true)`)."
+  surface. The :guard is omitted (defaults to `(constantly true)`).
+
+  A spec-level `:meta {:user-tag :probe}` is seeded for the same
+  reason as `machine-with-guard`."
   [action-fn]
   {:initial :idle
    :data    {:bumps 0}
+   :meta    {:user-tag :probe}
    :states
    {:idle {:on {:go {:target :gone
                      :action action-fn}}}
@@ -183,11 +197,11 @@
 ;; `declares-3-arity?` check itself, which IS platform-specific and is
 ;; covered by the unit tests above.
 ;;
-;; The pure surface also lets us seed `:meta` directly on the snapshot,
-;; which the live event handler doesn't do (machines.cljc:808
-;; synthesises only `{:state :data}`). That's why the JVM tests below
-;; pin a non-nil :meta in ctx, while the CLJS live tests assert :meta
-;; is nil.
+;; The pure surface also lets us seed `:meta` directly on the snapshot.
+;; Post-rf2-l04j the live event handler also propagates a spec-level
+;; `:meta` into the synthesised initial snapshot, so the JVM-pure and
+;; CLJS-live assertions both pin the same `{:state ... :meta {...}}`
+;; ctx shape — platform parity.
 
 #?(:clj
    (deftest plain-3-arity-guard-receives-ctx
@@ -312,11 +326,11 @@
 ;; runtime path real apps use. The machine spec is value-identical to
 ;; the JVM cases above.
 ;;
-;; Note on :meta: the live initial-snapshot synthesis (machines.cljc:808)
-;; builds `{:state ... :data ...}` and does NOT propagate a spec-level
-;; `:meta` into the snapshot. So the 3-arity ctx's `:meta` is `nil` in
-;; these live tests — which is itself a documented-vs-actual divergence
-;; recorded under "behaviour-vs-docstring observations" in the PR body.
+;; Note on :meta: per rf2-l04j, the live initial-snapshot synthesis
+;; (`machines.cljc:808`) now propagates a spec-level `:meta` into the
+;; synthesised snapshot. The 3-arity ctx therefore carries the spec's
+;; `:meta {:user-tag :probe}` (seeded by `machine-with-guard` /
+;; `machine-with-action`), matching the JVM pure-surface assertions.
 
 #?(:cljs
    (defn- snapshot-of
@@ -343,12 +357,13 @@
            (is (= 1 (get-in snap [:data :bumps])))
            (is (= {:bumps 0} data))
            (is (= [:go] event))
-           ;; Live initial-snapshot synthesis seeds {:state :data}
-           ;; only — :meta is nil in the ctx (machines.cljc:808).
-           (is (= {:state :idle :meta nil} ctx)
+           ;; Per rf2-l04j the live initial-snapshot synthesis now
+           ;; propagates the spec's `:meta` into the snapshot, so the
+           ;; 3-arity ctx carries the user-tagged :meta — matching the
+           ;; JVM pure-surface assertions.
+           (is (= {:state :idle :meta {:user-tag :probe}} ctx)
                "live event surface: the 3-arity guard saw {:state :meta}
-                ctx; :meta is nil because the live initial-snapshot
-                builder doesn't propagate a spec-level :meta"))))))
+                ctx; :meta carries the spec-level :meta after rf2-l04j"))))))
 
 #?(:cljs
    (deftest plain-3-arity-action-cljs-receives-ctx
@@ -371,7 +386,9 @@
            (let [{:keys [data event ctx]} @seen]
              (is (= {:bumps 0} data))
              (is (= [:go] event))
-             (is (= {:state :idle :meta nil} ctx))))))))
+             (is (= {:state :idle :meta {:user-tag :probe}} ctx)
+                 "live event surface: 3-arity action's ctx carries the
+                  spec-level :meta after rf2-l04j")))))))
 
 #?(:cljs
    (deftest variadic-from-zero-guard-cljs-routes-as-2-arity

--- a/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.three-arity-guards-cljs-test
   "Coverage for the machine guard / action 3-arity escape hatch (rf2-1e0n,
-  discovered-from rf2-o423).
+  discovered-from rf2-o423; CLJS arity convergence rf2-l04j).
 
   Per Spec 005 and `re-frame.machines`'s contract documented at
   `machines.cljc` lines 74-121, guards and actions accept two canonical
@@ -14,24 +14,23 @@
   The dispatcher (`declares-3-arity?`) inspects the fn's declared
   invocation surface at runtime and routes 3-fixed-arg fns through the
   3-arity path; everything else (including variadic helpers like
-  `(constantly ...)`) is INTENDED to route through the 2-arity path.
-  The docstring explicitly flags variadics as a footgun: a user who
-  expects `& rest` to receive the ctx will silently see it called as
-  2-arity instead.
+  `(constantly ...)` and 2-plus-rest fns) routes through the 2-arity
+  path. The docstring flags variadics as a footgun: a user who expects
+  `& rest` to receive the ctx will silently see it called as 2-arity
+  instead.
 
   Before this file, not a single test in the suite exercised 3-arity
   guards or actions. A `declares-3-arity?` refactor — especially around
   variadics — would have been invisible.
 
-  ***Behaviour-vs-docstring divergence found while writing these tests***:
-  on CLJS the dispatcher mis-classifies a 2-plus-rest fn
-  `(fn [data event & rest] ...)` as 3-arity (`true`), so it IS called
-  with `(g data event ctx)` and the user's `& rest` receives `(ctx)`.
-  On JVM the same fn classifies as 2-arity (`false`) per the docstring.
-  This is a real footgun the docstring doesn't cover — see the
-  `declares-3-arity-classifies-2-plus-rest-divergent-by-platform` test
-  and the PR body. The tests here pin the actual current behaviour on
-  each platform; a follow-up bead can track the convergence work.
+  rf2-l04j convergence: previously the CLJS check classified a
+  2-plus-rest fn `(fn [data event & rest] ...)` as 3-arity, so the
+  user's `& rest` silently received `(ctx)`. JVM matched the docstring
+  (returns false). The fix at `machines.cljc:declares-3-arity?` consults
+  `cljs$lang$maxFixedArity` to detect variadicity: every variadic now
+  routes through the 2-arity path on CLJS, matching JVM. The
+  previously-divergent assertions below are now consistent across
+  platforms.
 
   This file uses reader conditionals so its assertions run on both
   JVM and CLJS:
@@ -98,46 +97,48 @@
     (is (false? (boolean (declares-3-arity? (constantly true)))))
     (is (false? (boolean (declares-3-arity? (constantly nil)))))))
 
-(deftest declares-3-arity-classifies-2-plus-rest-divergent-by-platform
+(deftest declares-3-arity-classifies-2-plus-rest-as-false
   (testing "a 2-fixed-plus-rest fn (fn [data event & extras]) is
-            classified differently on JVM vs CLJS — a documented
-            divergence between this implementation and the docstring's
+            classified as non-3-arity on BOTH JVM and CLJS (rf2-l04j).
+
+            Previously CLJS classified this as 3-arity because the
+            compiled variadic surfaces a `cljs$core$IFn$_invoke$arity$3`
+            slot used by the rest dispatcher; the user's `& extras`
+            silently received `(ctx)` as a single element. The fix at
+            `declares-3-arity?` consults `cljs$lang$maxFixedArity` to
+            detect variadicity — a variadic with max-fixed < 3 is a
+            2-plus-rest helper and is NOT a 3-arity declaration, so
+            CLJS now matches the JVM behaviour and the docstring's
             'distinguishes user opt-in 3-arity from variadic helpers'
-            promise (machines.cljc:88-90).
-
-            JVM behaviour: false (correct per docstring). RestFns don't
-            declare invoke(O,O,O) on the user's class — the variadic is
-            routed through the 2-arity path and the user's `& extras`
-            stays empty.
-
-            CLJS behaviour: true (DIVERGENT). The cljs check
-              (or (= 3 (.-length f))
-                  (some? (unchecked-get f \"cljs$core$IFn$_invoke$arity$3\")))
-            mis-classifies a 2-plus-rest fn as 3-arity because the
-            compiled fn surfaces an arity-3 invoke slot for the rest
-            entry path. Net effect: the dispatcher CALLS the variadic
-            with three args, and `& extras` receives `(ctx)` rather
-            than being empty. This is a candidate for a follow-up
-            bead — see PR body."
-    #?(:clj  (is (false? (boolean (declares-3-arity? (fn [_ _ & _] :ok))))
-                 "JVM: 2-plus-rest classifies as non-3-arity (per docstring)")
-       :cljs (is (true?  (boolean (declares-3-arity? (fn [_ _ & _] :ok))))
-                 "CLJS: 2-plus-rest classifies as 3-arity — divergent with
-                  JVM and with the docstring's 'distinguishes variadic
-                  helpers' promise. Pin the actual behaviour here so
-                  future refactors don't accidentally 'fix' it without
-                  also fixing the JVM side and the docstring."))))
+            promise."
+    (is (false? (boolean (declares-3-arity? (fn [_ _ & _] :ok))))
+        "2-plus-rest classifies as non-3-arity on both JVM and CLJS")))
 
 (deftest declares-3-arity-classifies-3-plus-rest-as-false
-  (testing "a 3-fixed-plus-rest fn (fn [data event ctx & extras]) is
-            also a RestFn and is classified as non-3-arity — symmetric
-            with the 2+rest case. A user who writes this signature
-            expecting the 3-arity surface will instead be called as
-            2-arity (and on JVM that's an arity-mismatch since the
-            2-arity call is missing the third REQUIRED fixed arg).
-            This is the sharper footgun the docstring's variadic
-            warning covers."
+  (testing "a 3-fixed-plus-rest fn (fn [data event ctx & extras]) is a
+            RestFn; on JVM it doesn't expose a declared `invoke(O,O,O)`
+            on the user's class, so it classifies as non-3-arity. To
+            keep the rule simple and platform-consistent, CLJS treats
+            ANY variadic as non-3-arity (rf2-l04j) — including
+            3-plus-rest. A user who wants the 3-arity surface should
+            declare three FIXED args without `& rest`, as the canonical
+            shape `(fn [data event ctx] ...)`."
     (is (false? (boolean (declares-3-arity? (fn [_ _ _ & _] :ok)))))))
+
+(deftest declares-3-arity-classifies-multi-arity-with-3-as-true
+  (testing "a multi-arity fn that includes a 3-arity case — e.g.
+            `(fn ([a] :one) ([a b c] :three))` — has an explicit 3-arity
+            dispatch slot and IS a 3-arity declaration on both JVM and
+            CLJS. The dispatcher routes through the user's 3-arity case."
+    (let [f (fn ([_a] :one) ([_a _b _c] :three))]
+      (is (true? (boolean (declares-3-arity? f)))))))
+
+(deftest declares-3-arity-classifies-multi-arity-without-3-as-false
+  (testing "a multi-arity fn whose only fixed cases are 1 and 2
+            (no 3-arity case) is NOT a 3-arity declaration on either
+            platform."
+    (let [f (fn ([_a] :one) ([_a _b] :two))]
+      (is (false? (boolean (declares-3-arity? f)))))))
 
 ;; ---- (2) shared machine spec for guard / action exercises -----------------
 ;;
@@ -385,20 +386,20 @@
                "transition fired under the variadic-from-zero guard"))))))
 
 #?(:cljs
-   (deftest variadic-2-plus-rest-guard-cljs-receives-ctx-in-rest
+   (deftest variadic-2-plus-rest-guard-cljs-routes-as-2-arity
      (testing "Case (4) live-CLJS: a variadic 2-plus-rest guard.
 
-               Documented intent (machines.cljc:88-90): variadics
-               classify as non-3-arity, so the dispatcher would call
-               `(g data event)` and `& rest` would be empty.
+               Documented intent (machines.cljc:declares-3-arity?):
+               variadics with max-fixed < 3 classify as non-3-arity, so
+               the dispatcher calls `(g data event)` and `& rest` stays
+               empty.
 
-               ACTUAL CLJS behaviour: the dispatcher classifies
-               2-plus-rest as 3-arity (see
-               declares-3-arity-classifies-2-plus-rest-divergent-by-platform
-               above) and calls `(g data event ctx)`, so `& rest`
-               receives `(ctx)` — i.e. one element, the {:state :meta}
-               map. We pin the actual current CLJS behaviour and flag
-               the divergence in the PR body for follow-up."
+               After rf2-l04j, CLJS now agrees with JVM here (the check
+               consults `cljs$lang$maxFixedArity` to detect the variadic
+               and ignore the auto-generated arity-3 dispatch slot). The
+               assertion below is now consistent across platforms — the
+               same shape pinned by `variadic-2-plus-rest-guard-routes-
+               as-2-arity` on JVM."
        (let [seen-rest (atom :unset)
              guard     (fn [_data _event & rest]
                          (reset! seen-rest rest)
@@ -410,14 +411,12 @@
          (let [snap (snapshot-of :rf2-1e0n/v2)]
            (is (= :gone (:state snap))
                "transition fired (guard returned true)")
-           (is (sequential? @seen-rest))
-           (is (= 1 (count @seen-rest))
-               "CLJS dispatcher classified 2-plus-rest as 3-arity →
-                `& rest` received exactly one element (the ctx)")
-           (is (= {:state :idle :meta nil} (first @seen-rest))
-               "the lone rest element is the same {:state :meta} ctx
-                a fixed-3-arity guard would have seen as its third arg
-                — confirming the dispatcher took the 3-arity path"))))))
+           (is (or (nil? @seen-rest)
+                   (and (sequential? @seen-rest) (empty? @seen-rest)))
+               "post-rf2-l04j: `& rest` is empty / nil — the dispatcher
+                routed the variadic through the 2-arity path, matching
+                JVM and the docstring's 'distinguishes variadic helpers'
+                promise"))))))
 
 #?(:cljs
    (deftest plain-2-arity-guard-cljs-still-works


### PR DESCRIPTION
## Summary

Two related fixes to `re-frame.machines` (rf2-l04j) discovered while writing the 3-arity escape-hatch coverage in rf2-1e0n (PR #156).

### 1. CLJS `declares-3-arity?` mis-classified variadic 2-plus-rest fns

The CLJS check at `re-frame.machines/declares-3-arity?` was:

```clojure
(or (= 3 (.-length f))
    (some? (unchecked-get f \"cljs$core$IFn$_invoke$arity$3\")))
```

Compiled variadics surface a `cljs$core$IFn$_invoke$arity$3` slot for the rest-dispatcher path, so a 2-plus-rest fn `(fn [data event & rest] ...)` mis-classified as 3-arity on CLJS. The runtime then called it with three args and the user's `& rest` silently received `(ctx)`. JVM matched the docstring (false for any RestFn).

Fixed by consulting `cljs$lang$maxFixedArity` — set on every variadic — to detect variadicity and route ALL variadics through the 2-arity path. CLJS now matches JVM and the docstring's "distinguishes user opt-in 3-arity from variadic helpers" promise.

### 2. Live initial-snapshot synthesis dropped spec `:meta`

The live event handler synthesises the initial snapshot lazily on first dispatch: previously `{:state :data}` only, dropping any spec-level `:meta`. The 3-arity ctx therefore saw `:meta nil` on CLJS while the JVM pure-surface tests saw whatever `:meta` was seeded — divergence that obscured legitimate uses of spec `:meta` (versioning, tooling tags). Per Spec 005 §Snapshot shape (`{:state :data :meta?}`) and §Versioned via `:meta`, the spec's `:meta` is part of the canonical snapshot shape; it now propagates into the synthesised initial snapshot.

## Edge cases asserted in `three_arity_guards_cljs_test.cljc`

| Fn shape | JVM | CLJS (was) | CLJS (now) |
|---|---|---|---|
| `(fn [_ _ _] :ok)`            (plain 3-arity)            | true  | true  | true  |
| `(fn [_ _] :ok)`              (canonical 99% case)       | false | false | false |
| `(constantly true)` / `nil`   (variadic-from-zero)       | false | false | false |
| `(fn [_ _ & _] :ok)`          (2-plus-rest — was the bug)| false | **true** | **false** |
| `(fn [_ _ _ & _] :ok)`        (3-plus-rest variadic)     | false | n/a   | false |
| `(fn ([_] _) ([_ _ _] _))`    (multi-arity with 3-arity) | true  | n/a   | true  |
| `(fn ([_] _) ([_ _] _))`      (multi-arity without)      | false | n/a   | false |

The `declares-3-arity-classifies-2-plus-rest-divergent-by-platform` test is renamed to `declares-3-arity-classifies-2-plus-rest-as-false` and now asserts a single platform-shared expectation. `variadic-2-plus-rest-guard-cljs-receives-ctx-in-rest` is renamed to `...-routes-as-2-arity` and asserts `& rest` is empty/nil — matching the JVM `variadic-2-plus-rest-guard-routes-as-2-arity` test.

The live CLJS tests for `plain-3-arity-guard-cljs-receives-ctx` / `plain-3-arity-action-cljs-receives-ctx` now seed `:meta {:user-tag :probe}` on the spec via the `machine-with-guard` / `machine-with-action` helpers and assert ctx receives `{:state :idle :meta {:user-tag :probe}}` — same payload the JVM pure-surface tests pin.

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 174 tests / 781 assertions / 0 failures
- [x] `cd implementation/machines && clojure -M:test` — 30 tests / 81 assertions / 0 failures
- [x] `npm run test:cljs` — 146 tests / 444 assertions / 0 failures
- [x] `npm run test:browser` — 146 tests / 444 assertions / 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:examples` — all 18 example builds PASS

## References

- bead `rf2-l04j` (this PR moves it `OPEN → IN_PROGRESS`).
- discovered-from bead `rf2-1e0n` (PR #156) — the test file authored there pinned the platform divergence; this PR resolves it.