### PR TITLE
fix(subs): sub-cache lifecycle — rf2-l9u5 + rf2-79tl investigation

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -177,7 +177,16 @@
   `in-vals` against the previous invocation and short-circuits to the
   cached return value when equal. Reagent's dependency tracking still
   observes every `deref` because the wrapper *is* the compute fn — only
-  the user's body is suppressed."
+  the user's body is suppressed.
+
+  Per Spec 006 §What happens when a sub references an unknown sub
+  (rf2-l9u5): when the registrar lookup misses, emit
+  `:rf.error/no-such-sub` and build a nil-yielding reaction, but
+  DO NOT store it in the cache. The miss is transient — a later
+  registration (boot order, lazy load) must let the next subscribe
+  build a fresh reaction against the real body. v1 had the same
+  semantic by virtue of not caching the nil path; v2 preserves it
+  by branching here on nil meta."
   [frame-id query-v]
   (let [query-id     (first query-v)
         meta         (registrar/lookup :sub query-id)
@@ -255,7 +264,12 @@
                            v)))))
         cache (:sub-cache (frame/frame frame-id))
         k     (cache-key query-v)]
-    (when cache
+    ;; Skip caching the no-such-sub miss — see the rf2-l9u5 note in the
+    ;; docstring. The reaction is built so callers that hold a reference
+    ;; deref to nil (per Spec 009 §Error contract recovery
+    ;; :replaced-with-default), but the cache slot stays empty so a later
+    ;; registration is observed by the next subscribe.
+    (when (and cache meta)
       (swap! cache assoc k {:reaction        reaction
                             :inputs          input-signals
                             :ref-count       1

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -196,3 +196,122 @@
     (rf/reg-sub :n (fn [db _] (* 2 (:n db))))
     (is (not (contains? (cache-keys) [:n]))
         "hot-reload evicts the slot regardless of pending-dispose")))
+
+;; ---- subscribe-before-register does NOT cache (rf2-l9u5) -----------------
+;;
+;; Per Spec 006 §What happens when a sub references an unknown sub:
+;; subscribing to an unregistered sub-id emits :rf.error/no-such-sub and
+;; returns a nil-yielding reaction. Crucially, that miss is NOT cached —
+;; the cache slot stays empty so that a later registration (boot order,
+;; lazy-loaded namespace) is observed by the next subscribe, which builds
+;; a fresh reaction against the real body.
+
+(deftest subscribe-before-register-does-not-cache
+  (testing "subscribing before reg-sub does not cache; later registration is observed"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/dispatch-sync [:init])
+
+    ;; Subscribe BEFORE the sub is registered.
+    (let [r1 (rf/subscribe [:my-sub])]
+      (is (some? r1)
+          "subscribe still returns a (nil-yielding) reaction so callers don't deref nil")
+      (is (nil? @r1)
+          "the reaction yields nil per :replaced-with-default recovery")
+      (is (not (contains? (cache-keys) [:my-sub]))
+          "the no-such-sub miss MUST NOT be cached (rf2-l9u5)"))
+
+    ;; Now register the sub. First-time registration does NOT fire the
+    ;; replacement hook — the boot-order fix is "don't cache on miss",
+    ;; not "invalidate on first register".
+    (rf/reg-sub :my-sub (fn [db _] (:n db)))
+    (is (not (contains? (cache-keys) [:my-sub]))
+        "first registration leaves the cache untouched")
+
+    ;; Next subscribe builds a fresh reaction against the real body.
+    (let [r2 (rf/subscribe [:my-sub])]
+      (is (= 7 @r2)
+          "post-registration subscribe yields the real value")
+      (is (contains? (cache-keys) [:my-sub])
+          "the post-registration reaction IS cached"))))
+
+(deftest subscribe-before-register-survives-multiple-misses
+  (testing "repeated subscribe-before-register calls do not poison the cache"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 11}))
+    (rf/dispatch-sync [:init])
+
+    (dotimes [_ 3]
+      (let [r (rf/subscribe [:lazy-sub])]
+        (is (nil? @r))
+        (is (not (contains? (cache-keys) [:lazy-sub])))))
+
+    (rf/reg-sub :lazy-sub (fn [db _] (:n db)))
+    (is (= 11 @(rf/subscribe [:lazy-sub]))
+        "after registration, the cache is fresh and the real body runs")))
+
+;; ---- clear-sub does NOT clear the per-frame cache (rf2-79tl) -------------
+;;
+;; v2 preserves v1's contract: clear-sub removes the registration but
+;; leaves cached reactions in place. Cache eviction is a separate
+;; concern, owned by clear-subscription-cache!, hot-reload (re-register)
+;; and frame disposal. This split keeps clear-sub a pure registry op
+;; (no per-frame side effects) and matches v1's documented behaviour
+;; (per spec/API.md §Clearing registrations: clear-sub is "v1
+;; (preserved)") and the v1 docstring's explicit caller-responsibility
+;; note ("Depending on the usecase, it may be necessary to call
+;; clear-subscription-cache! afterwards").
+;;
+;; If you want both effects in one call: clear-sub then
+;; clear-subscription-cache! — or use re-registration if you have a
+;; replacement body.
+
+(deftest clear-sub-id-leaves-cache-intact
+  (testing "(clear-sub id) removes the registration but does not evict cache slots"
+    (subs/configure! {:grace-period-ms 60000})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (let [r1 (rf/subscribe [:n])]
+      (is (= 7 @r1))
+      (is (contains? (cache-keys) [:n])))
+
+    (rf/clear-sub :n)
+    ;; Cache slot survives clear-sub — this is the documented v1 contract.
+    (is (contains? (cache-keys) [:n])
+        "clear-sub leaves the cache slot in place; use clear-subscription-cache! to evict")
+    (is (nil? (registrar/lookup :sub :n))
+        "the registration is gone")
+
+    ;; Subsequent subscribe inside the grace-period reuses the cached reaction
+    ;; (reading the still-derived value), even though the registration is gone.
+    (let [r2 (rf/subscribe [:n])]
+      (is (= 7 @r2)
+          "cache hit serves the previously-derived value"))
+
+    ;; clear-subscription-cache! is the explicit follow-up that fully resets.
+    (rf/clear-subscription-cache! :rf/default)
+    (is (empty? (cache-keys))
+        "clear-subscription-cache! is the cache-eviction half of the pair")))
+
+(deftest clear-sub-no-arg-leaves-cache-intact
+  (testing "(clear-sub) clears every registration but leaves the cache untouched"
+    (subs/configure! {:grace-period-ms 60000})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :a (fn [db _] (:n db)))
+    (rf/reg-sub :b (fn [db _] (* 2 (:n db))))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:a])
+    (rf/subscribe [:b])
+    (is (= #{[:a] [:b]} (cache-keys)))
+
+    (rf/clear-sub)
+    (is (= #{[:a] [:b]} (cache-keys))
+        "clear-sub with no args wipes registrations but not cache slots")
+    (is (= {} (registrar/handlers :sub))
+        "every :sub registration is gone")
+
+    (rf/clear-subscription-cache! :rf/default)
+    (is (empty? (cache-keys)))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -506,6 +506,7 @@ Three contract guarantees this enforces:
 - **Drain-loop integration** ([002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode)): invalidation fires once per `process-event!` step 2, after the `:db` write and before the `:fx` walk. A handler can rely on subscriptions reflecting the new `app-db` from inside `do-fx`.
 - **Hot reload** ([001-Registration](001-Registration.md)): re-registering a sub disposes the cache slot for that query (regardless of ref-count); next subscribe rebuilds with the new body. Tracked with the rest of hot-reload semantics in the bead-tracked work.
 - **Machine subscriptions** ([005 §Subscribing to machines via `sub-machine`](005-StateMachines.md#subscribing-to-machines-via-sub-machine)): a machine's snapshot lives at `[:rf/machines <id>]` and is read like any other slice of `app-db`; `sub-machine` is a thin convenience over `reg-sub`. Sub-cache invalidation works the same.
+- **`clear-sub` is a registry-only operation** (rf2-79tl): `(clear-sub id)` and `(clear-sub)` remove `:sub` registrations but leave already-materialised per-frame cache slots in place. Caching is governed by the disposal contract above (ref-count + grace-period, hot-reload eviction, frame-destroy eviction); cache eviction independent of those triggers is `clear-subscription-cache!`'s job. This split preserves v1's documented contract — see the `clear-sub` docstring's note: "Depending on the usecase, it may be necessary to call `clear-subscription-cache!` afterwards."
 
 ### Per-host implementation notes
 
@@ -532,6 +533,8 @@ The behaviour is environment-specific:
 - **In strict mode** (`:strict-subs` config), the unresolved-input error escalates to a thrown exception so the bug is loud during dev.
 
 The subscription's body still runs with `nil` substituted for the unresolved input. This is intentional: it keeps the trace stream readable (the agent sees one error event rather than a chain of cascading throws) and lets the caller handle the missing data gracefully if it can.
+
+A related case is `subscribe` itself naming an unregistered sub-id — most often a boot-order or lazy-load race where the consumer subscribes before the registering namespace has loaded. The runtime emits the same `:rf.error/no-such-sub` trace event, returns a nil-yielding reaction (recovery `:replaced-with-default`), and **does not** populate the per-frame sub-cache. Skipping the cache on miss preserves the v1 semantic that a later registration is observed by the next subscribe — no stale `nil`-reaction lingers (rf2-l9u5).
 
 ## CLJS reference: Reagent as default adapter
 


### PR DESCRIPTION
Investigation of two sub-cache lifecycle questions raised against `re-frame.subs`.

## rf2-l9u5 — stale nil cache path when subscribing before a sub is registered

**Category: (a) — bug confirmed.**

**Finding.** v2's `compute-and-cache!` always builds a reaction and stores it in the per-frame cache, even when the registrar lookup misses. The miss path emits `:rf.error/no-such-sub` and the resulting reaction yields nil, but the entry sits in the cache. A later first-time `reg-sub` for that id does NOT fire the registrar's replacement hook (the replacement hook only fires when there was a previous registration), so the stale nil-yielding reaction stays in the cache. Boot-order / lazy-load flows where a consumer subscribes before the registering namespace has loaded leave the early subscriber permanently stuck on nil.

This is a regression vs v1 (`re-frame.subs/subscribe` lines 115-118 in v1 source: nil handler-fn → log + nil return, **no caching**).

**Action.** Branch on nil registrar meta in `compute-and-cache!` to skip the cache write. The reaction is still built (preserves caller call-shape — those who deref it still get nil per `:replaced-with-default` recovery), the trace event still fires, but the per-frame cache stays empty so the next subscribe (after registration lands) builds a fresh reaction against the real body.

Spec 006 §"What happens when a sub references an unknown sub" was extended with a paragraph making the no-cache-on-miss invariant explicit for the entry-point sub-id case. (The existing paragraph there covers `:<-` input misses; the entry-point case shares the same trace event but is a different code path.)

## rf2-79tl — clear-sub and the materialised cache

**Category: (b) — not a bug; pin behaviour + document.**

**Finding.** `(clear-sub id)` and `(clear-sub)` only touch the registrar; they do not evict per-frame cache slots for the cleared sub-id(s). A consumer that holds a subscription reference (or has one pinned by a pending grace-period timer) continues observing the previously-derived value until ref-counting / grace-period / hot-reload / frame-destroy disposes it.

This matches v1's documented contract:
- v1 `re-frame.core/clear-sub` docstring: *"NOTE: Depending on the usecase, it may be necessary to call `clear-subscription-cache!` afterwards"*
- v2 `spec/API.md` §Clearing registrations tags `clear-sub` as `v1 (preserved)`

The split is deliberate: `clear-sub` is registry-only, `clear-subscription-cache!` is cache-only. Hot-reload (re-registration) is the path that does both atomically.

**Action.** Two pin-behaviour tests in `re-frame.sub-cache-test`:
- `clear-sub-id-leaves-cache-intact` — after `(clear-sub :id)` the cache slot survives; subsequent subscribe serves the prior derived value; `clear-subscription-cache!` is the explicit follow-up
- `clear-sub-no-arg-leaves-cache-intact` — `(clear-sub)` wipes registrations but not cache slots

Spec 006 §"Cross-spec interactions" gained a `clear-sub` bullet pinning the contract.

## Test results

All green:
- `clojure -M:test` from `implementation/core` — **178 tests, 804 assertions, 0 failures, 0 errors** (4 new tests, 23 new assertions)
- `npm run test:cljs` (shadow-cljs `:node-test`) — **146 tests, 444 assertions, 0 failures, 0 errors**
- `npm run test:browser` — **146 tests, 444 assertions, 0 failures, 0 errors**
- `npm run test:elision` — all dev sentinels stripped under `:advanced` + `goog.DEBUG=false`; PASS

## Files touched

- `implementation/core/src/re_frame/subs.cljc` — branch on nil meta to skip cache write (rf2-l9u5 fix)
- `implementation/core/test/re_frame/sub_cache_test.clj` — four new tests
- `spec/006-ReactiveSubstrate.md` — two additive sentences

## Beads

Both updated to `in_progress` pending merge.