### PR TITLE
docs(spec): 012 fragment-change trace op alignment to :rf.route/url-changed (rf2-7zz0)

### DIFF
--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -80,7 +80,7 @@ Defined per the [009 Error contract](009-Instrumentation.md#error-contract):
 
 - `:route.nav-token/allocated` — fresh nav-token cascade begins.
 - `:route.nav-token/stale-suppressed` — async result carrying a now-superseded token.
-- `:route.url/fragment-changed` — fragment-only URL update (the URL changed only in its `#fragment`; `:on-match` did not re-fire). Distinct from the runtime event `:rf/url-changed`, which fires on every URL transition.
+- `:rf.route/url-changed` — fragment-only URL update (the URL changed only in its `#fragment`; `:on-match` did not re-fire). Distinct from the runtime event `:rf/url-changed`, which fires on every URL transition.
 - `:rf.route/navigation-blocked` — `:can-leave` guard rejected a navigation.
 - `:rf.error/duplicate-url-binding` — second frame attempted `:url-bound? true` while another already owns the URL.
 - `:rf.warning/route-shadowed-by-equal-score` — registration-time warning when ranking ties on rule 6.
@@ -333,13 +333,13 @@ When the user clicks a link, presses Back/Forward, or arrives via a deep link, t
                                :transition :idle :error nil
                                :nav-token nav-token})}
 
-        ;; Fragment-only change — update the slice; emit :route.url/fragment-changed
+        ;; Fragment-only change — update the slice; emit :rf.route/url-changed
         ;; trace; do NOT re-fire :on-match. See "Fragments" below.
         fragment-only?
         {:db (assoc-in db [:route :fragment] fragment)
-         :fx [[:rf/trace [:route.url/fragment-changed {:route-id route-id
-                                                       :prev-fragment (:fragment prev-route)
-                                                       :next-fragment fragment}]]]}
+         :fx [[:rf/trace [:rf.route/url-changed {:route-id route-id
+                                                 :prev-fragment (:fragment prev-route)
+                                                 :next-fragment fragment}]]]}
 
         :else
         {:db (assoc db :route {:id         route-id
@@ -703,7 +703,7 @@ Read it via the `:rf.route/fragment` sub. Fragment is **populated by `match-url`
 When the new URL differs from the current URL **only** in its fragment (same `:route-id`, same `:params`, same `:query`, but different `:fragment`), the runtime:
 
 1. Updates `:fragment` in the `:route` slice.
-2. Emits a `:route.url/fragment-changed` trace event with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s>}`.
+2. Emits a `:rf.route/url-changed` trace event with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s>}`.
 3. Does **NOT** allocate a new `:nav-token`.
 4. Does **NOT** re-fire `:on-match`.
 
@@ -753,7 +753,7 @@ The server does NOT scroll (no DOM); `:rf.nav/scroll` is `:platforms #{:client}`
 
 Fixture `route-fragment-change.edn` exercises:
 1. Navigate to `/docs/routing#scroll-restoration`. Verify the slice's `:fragment` is `"scroll-restoration"`.
-2. Navigate to `/docs/routing#caching` (same path/query, different fragment). Verify `:on-match` does NOT re-fire and `:route.url/fragment-changed` trace event fires.
+2. Navigate to `/docs/routing#caching` (same path/query, different fragment). Verify `:on-match` does NOT re-fire and `:rf.route/url-changed` trace event fires.
 3. Navigate to `/docs/instrumentation#scroll-restoration` (different path, same fragment). Verify `:on-match` DOES re-fire (path changed; fragment-only rule does not apply).
 
 ## Nested layouts


### PR DESCRIPTION
## Summary

Aligns spec/012-Routing.md fragment-change trace op name to the canonical `:rf.route/url-changed`, matching the runtime (`routing.cljc`), test (`trace_test.clj`), Spec-Schemas, conformance fixture, MIGRATION, and the just-merged spec/009 alignment (PR #162). spec/012 was the lone remaining outlier still using the older `:route.url/fragment-changed`.

Mechanical token swap only — no restructuring, no prose compression. Per the bead direction, the canonical merged op `:rf.route/url-changed` covers both full URL transitions and fragment-only navigation; consumers discriminate on `:tags`.

## Per-site fix

Bead description noted 3 sites (lines 83, 336, 706); on inspection the swap actually touched **5 sites** in 4 hunks — lines 336 and 340 are part of the same code-example hunk, and there were two further occurrences the bead's grep didn't enumerate (line 340 in the same `:fx` example, and line 756 in the conformance description).

| Line (pre-edit) | Old | New |
| --- | --- | --- |
| 83  | `:route.url/fragment-changed` (table row) | `:rf.route/url-changed` |
| 336 | `;; emit :route.url/fragment-changed` (comment in code example) | `;; emit :rf.route/url-changed` |
| 340 | `[:rf/trace [:route.url/fragment-changed ...]]` (code example body) | `[:rf/trace [:rf.route/url-changed ...]]` |
| 706 | `:route.url/fragment-changed trace event` (contract bullet) | `:rf.route/url-changed trace event` |
| 756 | `:route.url/fragment-changed trace event fires` (conformance fixture description) | `:rf.route/url-changed trace event fires` |

All 5 sites are normative documentation (table row, runtime-canonical code example, contract bullet, fixture description). None are pedagogical examples teaching the older form — no halts.

The line-83 wording ("Distinct from the runtime event `:rf/url-changed`") remains factually accurate: the trace op `:rf.route/url-changed` (dotted namespace) is still distinct from the runtime event `:rf/url-changed` (single-segment namespace).

## Verification

```bash
$ grep -nE ':route\.url/fragment-changed' spec/
# 0 matches across spec/
```

Confirmed: 0 remaining `:route.url/fragment-changed` mentions anywhere under `spec/`. Remaining repo-wide hits are confined to `implementation/routing/src/re_frame/routing.cljc` (legacy alongside-emission, tracked separately as rf2-hyxg) and `implementation/core/test/re_frame/trace_test.clj` (test comments referencing the legacy name) — out of scope for this spec-doc alignment.

## Test plan

- [x] grep `spec/` for `:route.url/fragment-changed` returns 0 matches
- [x] Diff is token-swap only (7 insertions / 7 deletions, single file)
- [x] Code example at lines 336-342 still renders as valid Clojure