### PR TITLE
docs(spec): Conventions dangling cross-refs — additive fixes (rf2-sjnf, scope: dangling-refs)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1569,7 +1569,7 @@ User-facing call sites:
 ;;    ...)
 ```
 
-See also [API.md §Machines](API.md#machines) and Conventions.md §Reading machines.
+See also [API.md §Machines](API.md#machines).
 
 ## Subscribing to machines via `sub-machine`
 

--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -36,7 +36,7 @@ The story / variant / workspace id syntax is **locked** and used consistently th
 
 Rules:
 
-1. The `:story.<...>` and `:Workspace.<...>` prefixes are reserved (see [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)).
+1. The `:story.<...>` and `:Workspace.<...>` prefixes are **library-owned** by the post-v1 stories library — they are not framework-reserved under `:rf/*` (see [Conventions §Library-owned prefixes](Conventions.md#library-owned-prefixes)). User code MUST NOT register stories/workspaces under conflicting prefixes when this library is loaded.
 2. The dotted path segments organise the tree the story tool renders — split on `.` to build the navigator.
 3. Variant names go after `/`. A variant id always belongs to exactly one story; the story id is everything before `/`.
 4. Tools enumerate via `(rf/handlers :story)`, `(rf/handlers :variant)`, `(rf/handlers :workspace)`. The hierarchy is recoverable from the id alone — no separate `:title` field is required.

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -55,6 +55,17 @@ Migration entries: [MIGRATION §M-23](MIGRATION.md#m-23-re-framealpha-is-removed
 
 User-defined route ids are **not** namespaced under any framework prefix. Routes are user-facing names; pick a feature prefix per the [feature-modularity convention](#feature-modularity-prefix-convention) below — `:cart/show`, `:auth/login-page`, `:account.profile/show`. The framework's routing concerns (events that drive navigation, subs that read the route slice) live under `:rf.route/*`; user route ids share the user-feature namespace with their adjacent events and subs. This stops the framework prefix from leaking into app code and removes the `:route/*` ambiguity (was it a framework operation or a user route-id? — the v2 answer is unambiguously the latter has no `:route/*` prefix at all).
 
+### Library-owned prefixes
+
+A handful of canonical libraries reserve prefixes outside the framework `:rf/*` root. These prefixes are **library-owned** (canonical when the library is loaded), not **framework-reserved** (closed by Spec change). The distinction matters: framework-reserved names are fixed-and-additive in the table above; library-owned prefixes belong to the library's own surface and would only collide with user code that loads the library and ignores its convention.
+
+| Library-owned prefix | Library | Used for | Spec |
+|---|---|---|---|
+| `:story.<...>` | post-v1 stories library | Story ids (`:story.auth.login-form`) and variant ids (`:story.auth.login-form/empty`) | [007](007-Stories.md) |
+| `:Workspace.<...>` | post-v1 stories library | Workspace ids (`:Workspace.Auth/all-states`) | [007](007-Stories.md) |
+
+Library-owned prefixes do **not** violate the single-root invariant on framework-reserved ids (the rule that framework names live under `:rf/*` only) — they are user-space names that the library claims by convention. The framework's own assertion-event vocabulary used by the stories library's play functions and test runner is `:rf.assert/*` (per the table above) and remains framework-reserved.
+
 ### Discipline
 
 - **User-registered ids must not collide.** A user may not `(reg-event-fx :rf/hydrate ...)` to override a framework event without going through the documented `:on-create` / re-registration extension points. The linter rule is: `:rf/*` and any `:rf.X/*` sub-namespace is reserved.


### PR DESCRIPTION
## Summary

Closes the two remaining dangling cross-references identified by the rf2-smpt Conventions audit (`findings/audit-conventions-2026-05-09.md` F1 and F3). Both fixes are additive and do not touch §Reserved namespaces' protected centerpiece table (§Strengths-protected per `findings/audit-conventions-readability-2026-05-09.md` §4).

PR #141 already merged the bead's other items (F2 `:destroy-machine`, F5 `:rf/pending-navigation`, F6/F11 error-id grammar, F18 collision-audit cross-ref). Bead rf2-sjnf remains open because the F15/F22 naming-inconsistency portions are halt-pending Mike's rf2-ljw6 decision.

## Per dangling-ref — inbound site → fix applied

- **F1** — `005-StateMachines.md:1572` cited `Conventions.md §Reading machines`; the section does not exist. **Fix (b):** dropped the dangling reference. The same line already linked `API.md §Machines`, which is the canonical home for the read API. Per audit R-S1.

- **F3** — `007-Stories.md:39` claimed `:story.<...>` and `:Workspace.<...>` prefixes are "reserved (see Conventions §Reserved namespaces)"; neither prefix appears in the table, and both violate the single-root `:rf/*` invariant if treated as framework-reserved. **Fix (a + b):** rephrased 007 to call them **library-owned** by the post-v1 stories library, and added a new §Library-owned prefixes subsection in Conventions (sibling to §User-defined route ids and §Discipline) that records the prefixes in their own table and explicitly distinguishes library-owned (canonical when the library is loaded) from framework-reserved (fixed-and-additive table). The protected centerpiece table is unchanged. Per audit R-M1.

## Naming-inconsistency findings deferred (out-of-scope)

The following items remain pending Mike's rf2-ljw6 decision on the broader `:rf/route` vs `:route` corpus disagreement; they all live inside the §Strengths-protected reserved-namespaces table:

- **F22** — `:rf.machine <id>` vs `:rf/machine` (Conventions table line 22 cell vs 005:1453 + API.md:61).
- **F15** — `:rf/url-changed` vs `:rf.route/url-changed` (Conventions table line 24 cell vs API.md:102-103 + Substrate-adapter section).
- **F4** (out-of-task per the bead but listed for context) — `:rf/route` vs `:route` is the parent rf2-ljw6 disagreement.

## §Strengths-protected cases skipped

- The audit's R-M1 alternative would have added rows to the §Reserved namespaces table itself; that approach was rejected to preserve the protected centerpiece. The new §Library-owned prefixes subsection is the additive substitute.

## Test plan

- [ ] Anchor links resolve: `Conventions.md#library-owned-prefixes` — present (heading `### Library-owned prefixes`).
- [ ] `005-StateMachines.md:1572` no longer references the missing Conventions section; `API.md#machines` link still valid (heading `## Machines` at API.md:531).
- [ ] No edits within Conventions.md lines 14-31 (the protected §Reserved namespaces table).
- [ ] Markdown lints clean.