### PR TITLE
docs(spec): fx-handler binary contract preserved; drain-loop pseudocode passes context map (rf2-gmr1)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -568,6 +568,8 @@ The mechanism is symmetric with how event handlers receive their context: **fx h
 
 For sync fx that dispatch (or otherwise need to know the frame), the pattern is `(rf/dispatch event {:frame (:frame m)})`.
 
+The runtime needs to resolve fx-handlers against the frame record (for `:fx-overrides`) and to thread the originating envelope through to reserved fxs that queue children (`:dispatch`, `:dispatch-later`, per [§Cascade propagation](#cascade-propagation)). Both reach the fx-handler as fields of `m` (`:frame` is already documented above; the parent envelope is available at `(:envelope m)` for reserved-fx implementations). User fxs typically read only `(:frame m)`; the `(:envelope m)` slot is a runtime-internal handle that the four reserved fx defmethods consume — see [§Drain-loop pseudocode](#drain-loop-pseudocode).
+
 #### Async fx capture the frame in a closure
 
 When the actual dispatching happens after the fx handler has returned (HTTP callback, websocket message, timer, deferred promise), the fx handler captures `(:frame m)` into the closure that fires later:
@@ -851,16 +853,23 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
 
       ;; 3. Walk :fx in source order. Each entry's handler returns
       ;;    synchronously before the next begins. Errors trace and continue.
-      ;;    The originating envelope is threaded so reserved fxs that queue
-      ;;    children (`:dispatch`, `:dispatch-later`) can copy envelope fields
-      ;;    onto the child envelope, per [§Cascade propagation](#cascade-propagation).
-      (doseq [[fx-id args] (:fx effects)]
-        (try
-          (let [fx-handler (lookup-fx frame fx-id)]    ;; honors :fx-overrides
-            (fx-handler frame envelope args))
-          (catch :default e
-            (raise! :rf.error/fx-handler-exception
-                    {:fx-id fx-id :event event :frame (:id frame) :ex e}))))
+      ;;    The fx-handler is invoked with the binary `(m args)` contract
+      ;;    documented in [§The binary fx-handler signature](#the-binary-fx-handler-signature):
+      ;;    `m` is the same context map the originating event handler received,
+      ;;    carrying `:frame`, `:envelope`, `:event`, plus cofx. The runtime
+      ;;    needs the frame record (to resolve `:fx-overrides`) and the parent
+      ;;    envelope (so reserved fxs that queue children — `:dispatch`,
+      ;;    `:dispatch-later` — can copy envelope fields onto the child envelope,
+      ;;    per [§Cascade propagation](#cascade-propagation)); both reach the
+      ;;    fx-handler as fields of `m`, not as separate positional arguments.
+      (let [m (handler-context frame envelope)]      ;; same `m` the event handler saw
+        (doseq [[fx-id args] (:fx effects)]
+          (try
+            (let [fx-handler (lookup-fx frame fx-id)]  ;; honors :fx-overrides
+              (fx-handler m args))                     ;; binary contract: (m, args)
+            (catch :default e
+              (raise! :rf.error/fx-handler-exception
+                      {:fx-id fx-id :event event :frame (:id frame) :ex e})))))
 
       (trace! :event/run-end {:event event :frame (:id frame)}))))
 
@@ -888,11 +897,21 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
   (-> (select-keys parent-envelope inheritable-envelope-keys)
       (assoc :event event)))
 
-(defmethod do-fx :dispatch [frame parent-envelope ev]
-  (dispatch frame (child-envelope parent-envelope ev))) ;; back of queue, FIFO
+;; Reserved-fx defmethods follow the same binary `(m args)` contract as
+;; user fxs. They reach the frame record and the parent envelope through
+;; `m` — `(:frame m)` and `(:envelope m)` — rather than as separate
+;; positional arguments. This keeps reserved and user fxs uniform: they
+;; are all `(fn [m args] ...)` to the resolver.
 
-(defmethod do-fx :dispatch-later [frame parent-envelope {:keys [ms event]}]
-  (let [child (child-envelope parent-envelope event)]
+(defmethod do-fx :dispatch [m ev]
+  (let [frame           (:frame m)
+        parent-envelope (:envelope m)]
+    (dispatch frame (child-envelope parent-envelope ev)))) ;; back of queue, FIFO
+
+(defmethod do-fx :dispatch-later [m {:keys [ms event]}]
+  (let [frame           (:frame m)
+        parent-envelope (:envelope m)
+        child           (child-envelope parent-envelope event)]
     (interop/set-timeout!
       (fn [] (dispatch frame child))
       ms)))


### PR DESCRIPTION
## Summary

Fixes the spec/002-Frames.md fx-handler signature contradiction surfaced by audit-002 finding F5 (rf2-gmr1, top-3 most load-bearing). Two parts of the same spec disagreed on the calling convention for fx-handlers:

- §The binary fx-handler signature documents the user-facing contract as `(fn [m args])` where `m` is the originating event handler's context map.
- §Drain-loop pseudocode invoked fx-handlers as `(fx-handler frame envelope args)` — three positional arguments, none of them `m`.

These cannot both be the contract — an AI implementor reading the pseudocode would write user fxs against `m = frame` and `(:frame m)` reads would silently fail.

Resolution per Mike's decision (2026-05-09): **Option (a)** — the binary `(m args)` contract is canonical; the pseudocode is the outlier and is reworded to construct `m` at the call site and invoke `(fx-handler m args)`.

## The contradiction (quoted)

### Binary contract — kept (002 §The binary fx-handler signature)

L540 / L553-559:
> `reg-fx`'s primary signature in re-frame2 is binary:
> ```clojure
> (reg-fx :dispatch
>   (fn [m event]
>     (rf/dispatch event {:frame (:frame m)})))
> ```

L567:
> `m` is the same map the originating event handler received — same `:db`, `:event`, `:frame`, `:trace-id`, `:source`, plus any cofx.

L573 (Async fx subsection):
> the fx handler captures `(:frame m)` into the closure that fires later

### Old pseudocode — fixed (002 §Drain-loop pseudocode, L857-863 and L891-898 pre-edit)

```clojure
(doseq [[fx-id args] (:fx effects)]
  (try
    (let [fx-handler (lookup-fx frame fx-id)]    ;; honors :fx-overrides
      (fx-handler frame envelope args))
    (catch :default e
      (raise! :rf.error/fx-handler-exception
              {:fx-id fx-id :event event :frame (:id frame) :ex e}))))
```

```clojure
(defmethod do-fx :dispatch [frame parent-envelope ev]
  (dispatch frame (child-envelope parent-envelope ev)))

(defmethod do-fx :dispatch-later [frame parent-envelope {:keys [ms event]}]
  (let [child (child-envelope parent-envelope event)]
    (interop/set-timeout!
      (fn [] (dispatch frame child))
      ms)))
```

### New pseudocode (post-edit)

Call site builds `m` from frame + envelope, then invokes the binary contract:

```clojure
;; 3. Walk :fx in source order. Each entry's handler returns
;;    synchronously before the next begins. Errors trace and continue.
;;    The fx-handler is invoked with the binary `(m args)` contract
;;    documented in [§The binary fx-handler signature](#the-binary-fx-handler-signature):
;;    `m` is the same context map the originating event handler received,
;;    carrying `:frame`, `:envelope`, `:event`, plus cofx. The runtime
;;    needs the frame record (to resolve `:fx-overrides`) and the parent
;;    envelope (so reserved fxs that queue children — `:dispatch`,
;;    `:dispatch-later` — can copy envelope fields onto the child envelope,
;;    per [§Cascade propagation](#cascade-propagation)); both reach the
;;    fx-handler as fields of `m`, not as separate positional arguments.
(let [m (handler-context frame envelope)]      ;; same `m` the event handler saw
  (doseq [[fx-id args] (:fx effects)]
    (try
      (let [fx-handler (lookup-fx frame fx-id)]  ;; honors :fx-overrides
        (fx-handler m args))                     ;; binary contract: (m, args)
      (catch :default e
        (raise! :rf.error/fx-handler-exception
                {:fx-id fx-id :event event :frame (:id frame) :ex e})))))
```

Reserved-fx defmethods now also use the binary `(m args)` shape and pull what they need from `m`:

```clojure
(defmethod do-fx :dispatch [m ev]
  (let [frame           (:frame m)
        parent-envelope (:envelope m)]
    (dispatch frame (child-envelope parent-envelope ev))))

(defmethod do-fx :dispatch-later [m {:keys [ms event]}]
  (let [frame           (:frame m)
        parent-envelope (:envelope m)
        child           (child-envelope parent-envelope event)]
    (interop/set-timeout!
      (fn [] (dispatch frame child))
      ms)))
```

## PR #150 interaction

PR #150 (rf2-574o) added envelope-forwarding for `:dispatch` and `:dispatch-later` so that `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:origin`, `:source` propagate transitively at depth-2+. That mechanism is preserved verbatim — `inheritable-envelope-keys` and `child-envelope` are unchanged. The only change is *how* the parent envelope reaches the reserved-fx defmethod: previously a separate positional argument, now `(:envelope m)`.

## Reconciliation prose (additive)

A short paragraph after L569 of §The binary fx-handler signature names the runtime-needs-frame / user-fx-receives-m reconciliation: user fxs typically read only `(:frame m)`; `(:envelope m)` is a runtime-internal handle that the four reserved fx defmethods consume.

## Cross-spec sanity check

Grep across `spec/` for `(fx-handler frame ...)` / `defmethod do-fx [frame ...]` patterns: no other call sites echo the wrong shape. The only remaining reference to `frame` at the call site is `(lookup-fx frame fx-id)` — correct, since lookup needs the frame record (to honor `:fx-overrides`).

Implementation directory (`implementation/`) was also grepped: no `defmethod do-fx [frame ...]` drift; only `:rf.error/fx-handler-exception` references in `epoch.cljc`, which are unaffected.

## Scope

- Pseudocode reword in `spec/002-Frames.md` only (one code-fenced block, plus the new paragraph at L571 and updated header comment for the reserved-fx defmethods).
- §Async effects section structure preserved.
- §Cascade propagation prose untouched.
- No MIGRATION.md change — this is a spec-internal contradiction, not a user-visible breakage change.
- 1 file, 34 insertions, 15 deletions.

## Test plan

- [x] Markdown lints clean (code fences balanced).
- [x] L540 / L553 / L564 / L567 binary-contract prose still reads correctly.
- [x] Pseudocode now matches the binary contract.
- [x] PR #150's envelope-forwarding still works in the new wording — `child-envelope` and `inheritable-envelope-keys` unchanged.
- [x] Cross-spec grep — no other drift surfaced.