### PR TITLE
docs(spec): 005 transition resolution precedence alignment (rf2-fhb9)

### DIFF
--- a/implementation/machines/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_cljs_test.cljs
@@ -159,6 +159,66 @@
           "internal transition — snapshot unchanged")
       (is (= [:leaf] @log) "leaf's :help action fired; parent shadowed"))))
 
+;; ---- (1b) wildcard precedence in hierarchical machines (rf2-fhb9) ---------
+;; Per Spec 005 §Wildcard transitions and §Transition resolution: at each
+;; level, explicit-event match beats `:*`; only if neither matches does the
+;; runtime walk up to the parent. So a leaf's `:*` SHADOWS a parent's
+;; explicit handler for the same event — wildcard wins at the deeper level
+;; before parent fallthrough kicks in. This is the divergence point that
+;; the §Wildcard transitions list at L213-218 used to muddle (rf2-fhb9).
+(deftest machine-hierarchical-wildcard-precedence-cljs
+  (testing "leaf :* shadows parent's explicit handler for the same event"
+    (let [log (atom [])
+          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:parent-explicit (tag :parent-explicit)
+                     :leaf-wildcard   (tag :leaf-wildcard)}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:help {:action :parent-explicit}}    ;; explicit at parent
+             :states
+             {:dashboard
+              {:on {:* {:action :leaf-wildcard}}}}}}}]      ;; :* at leaf
+      (rf/reg-machine :rf2-fhb9/precedence machine)
+      (reset! log [])
+      (rf/dispatch-sync [:rf2-fhb9/precedence [:help]])
+      ;; At leaf [:authenticated :dashboard]: explicit miss → :* hit. The
+      ;; runtime stops walking; parent's explicit :help is shadowed.
+      (is (= [:leaf-wildcard] @log)
+          "leaf-level :* fired, parent's explicit :help shadowed (per-level rule)")
+      (is (not (some #{:parent-explicit} @log))
+          "parent's explicit handler must NOT fire when leaf :* matched")))
+
+  (testing "parent fallthrough still works when leaf has neither explicit nor :*"
+    (let [log (atom [])
+          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          machine
+          {:initial :authenticated
+           :data    {}
+           :actions {:parent-explicit (tag :parent-explicit)
+                     :parent-wildcard (tag :parent-wildcard)}
+           :states
+           {:authenticated
+            {:initial :dashboard
+             :on      {:help {:action :parent-explicit}
+                       :*    {:action :parent-wildcard}}    ;; both at parent
+             :states
+             {:dashboard {}}}}}]                            ;; leaf has no :on
+      (rf/reg-machine :rf2-fhb9/parent-walk machine)
+      (reset! log [])
+      ;; :help at parent — explicit beats parent's own :*.
+      (rf/dispatch-sync [:rf2-fhb9/parent-walk [:help]])
+      (is (= [:parent-explicit] @log)
+          "explicit at the matching level beats :* at the same level")
+      ;; :unknown at parent — falls through to parent's :*.
+      (reset! log [])
+      (rf/dispatch-sync [:rf2-fhb9/parent-walk [:unknown]])
+      (is (= [:parent-wildcard] @log)
+          "no explicit anywhere — parent's :* fires"))))
+
 ;; ---- (2) :always microsteps -----------------------------------------------
 ;; Mirrors always-single-microstep.edn (single guarded fire, atomic commit)
 ;; and always-depth-exceeded.edn (cycle hits the bounded depth limit).

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -210,14 +210,12 @@ Transition slots:
                   :*        {:action (fn [_ ev] {:fx [[:log/unknown ev]]})}}}}
 ```
 
-Precedence inside the standard transition lookup:
+Precedence inside the standard transition lookup, **at each level**:
 
-1. State-local explicit event match.
-2. State-local `:*` wildcard.
-3. Top-level (machine root) explicit match.
-4. Top-level `:*` wildcard.
+1. Explicit event match at this level.
+2. `:*` wildcard at this level.
 
-The wildcard fires after specific matches at the same level. If no transition matches at any level, the snapshot is unchanged and the runtime emits a single `:rf.warning/machine-unhandled-event` trace (see [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough) for the canonical name; consistent with the other `:rf.warning/machine-*` advisory categories).
+The wildcard fires after specific matches **at the same level**. Only if neither matches does the runtime walk up to the next level and try again — so `:*` at the leaf shadows an explicit match on the parent for the same event. The full leaf-up-to-root walk is canonically specified at [§Transition resolution — deepest-wins with parent fallthrough](#transition-resolution--deepest-wins-with-parent-fallthrough); for a flat machine the path is one level deep and the two-step rule above is the whole story. If no level matches, the snapshot is unchanged and the runtime emits a single `:rf.warning/machine-unhandled-event` trace (see [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough) for the canonical name; consistent with the other `:rf.warning/machine-*` advisory categories).
 
 ### Self-transitions (external vs internal)
 

--- a/spec/conformance/fixtures/hierarchical-wildcard-precedence.edn
+++ b/spec/conformance/fixtures/hierarchical-wildcard-precedence.edn
@@ -1,0 +1,94 @@
+;; Conformance fixture: machine/hierarchical-wildcard-precedence
+;;
+;; Per-level transition resolution with wildcards. Verifies the rule that
+;; was clarified for rf2-fhb9: at each level, an explicit-event match beats
+;; `:*`; only if neither matches does the runtime walk up to the parent. So
+;; a leaf's `:*` SHADOWS a parent's explicit handler for the same event,
+;; because the leaf level's `:*` lookup happens before the runtime walks
+;; up to the parent.
+;;
+;; This fixture pins the divergence point between the (now reworded)
+;; §Wildcard transitions list at L213 and the canonical §Transition
+;; resolution list at L877. Per rf2-fhb9 / rf2-goxn audit finding #9.
+;;
+;; Per [005 §Wildcard transitions]
+;; (../../005-StateMachines.md#wildcard-transitions) and
+;; [005 §Transition resolution — deepest-wins with parent fallthrough]
+;; (../../005-StateMachines.md#transition-resolution--deepest-wins-with-parent-fallthrough).
+
+{:fixture/id           :machine/hierarchical-wildcard-precedence
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :fsm/hierarchical}
+ :fixture/doc          "Per-level wildcard precedence in a hierarchical machine. (1) Leaf has `:*`, parent has explicit `:help` — leaf `:*` wins, parent shadowed. (2) Leaf has neither, parent has explicit `:help` and `:*` — explicit wins at parent. (3) Leaf has neither, parent has `:*` only — parent `:*` fires."
+
+ :fixture/registry
+ {:machine-action
+  {:wp/leaf-wildcard   {:doc "Action declared at the leaf for `:*`."}
+   :wp/parent-explicit {:doc "Action declared at the parent for explicit `:help`."}
+   :wp/parent-wildcard {:doc "Action declared at the parent for `:*`."}}}
+
+ :fixture/handlers
+ {:machine-action
+  {:wp/leaf-wildcard   [[:fx :log {:msg "leaf :* fired"}]]
+   :wp/parent-explicit [[:fx :log {:msg "parent explicit :help fired"}]]
+   :wp/parent-wildcard [[:fx :log {:msg "parent :* fired"}]]}}
+
+ :fixture/calls
+ ;; Case 1: leaf `:*` SHADOWS parent's explicit `:help`. The runtime checks
+ ;; leaf-explicit (miss) then leaf-`:*` (hit) and stops walking — parent's
+ ;; explicit handler does NOT fire.
+ [{:call         :machine-transition
+   :definition
+   {:initial :authenticated
+    :data    {}
+    :states
+    {:authenticated
+     {:initial :dashboard
+      :on      {:help {:action :wp/parent-explicit}}      ;; explicit at parent
+      :states
+      {:dashboard
+       {:on {:* {:action :wp/leaf-wildcard}}}}}}}         ;; :* at leaf
+   :snapshot     {:state [:authenticated :dashboard] :data {}}
+   :event        [:help]
+   ;; Walk: leaf [:authenticated :dashboard] — explicit :help miss, :* hit.
+   ;; Stop. Parent's explicit :help is shadowed by the leaf's :*.
+   :expect-next-snapshot {:state [:authenticated :dashboard] :data {}}
+   :expect-effects       [[:log {:msg "leaf :* fired"}]]}
+
+  ;; Case 2: leaf has nothing; parent has explicit AND `:*`. At the parent
+  ;; level, explicit beats `:*`, so the parent's explicit handler fires.
+  {:call         :machine-transition
+   :definition
+   {:initial :authenticated
+    :data    {}
+    :states
+    {:authenticated
+     {:initial :dashboard
+      :on      {:help {:action :wp/parent-explicit}
+                :*    {:action :wp/parent-wildcard}}
+      :states
+      {:dashboard {}}}}}                                  ;; leaf has no :on
+   :snapshot     {:state [:authenticated :dashboard] :data {}}
+   :event        [:help]
+   ;; Walk: leaf — no :on, miss; walk up. Parent — explicit :help hit; stop.
+   :expect-next-snapshot {:state [:authenticated :dashboard] :data {}}
+   :expect-effects       [[:log {:msg "parent explicit :help fired"}]]}
+
+  ;; Case 3: leaf has nothing; parent has only `:*`. Falls through to it.
+  {:call         :machine-transition
+   :definition
+   {:initial :authenticated
+    :data    {}
+    :states
+    {:authenticated
+     {:initial :dashboard
+      :on      {:help {:action :wp/parent-explicit}
+                :*    {:action :wp/parent-wildcard}}
+      :states
+      {:dashboard {}}}}}
+   :snapshot     {:state [:authenticated :dashboard] :data {}}
+   :event        [:unknown-event]
+   ;; Walk: leaf — no :on, miss; walk up. Parent — explicit :unknown-event
+   ;; miss; parent :* hit. Stop.
+   :expect-next-snapshot {:state [:authenticated :dashboard] :data {}}
+   :expect-effects       [[:log {:msg "parent :* fired"}]]}]}


### PR DESCRIPTION
## Summary

Spec 005 had two precedence lists for transition resolution that disagreed for hierarchical machines. Per audit-005 finding #9 (rf2-goxn), the §Wildcard transitions list shipped a 4-step rule that omitted the level-walk; the canonical §Transition resolution list spells out the leaf-up-to-root walk that the impl actually performs.

The drift was contained to one paragraph — same canonical behaviour, no impl change.

## The two pre-fix lists

**§Wildcard transitions (L213-218, drifted):**

```
1. State-local explicit event match.
2. State-local `:*` wildcard.
3. Top-level (machine root) explicit match.
4. Top-level `:*` wildcard.
```

This reads as "leaf, then root" — skipping intermediate levels in a hierarchical machine. A reader following this list expects a leaf `:*` to fall through to the root's explicit handler, leaving the parent unconsulted.

**§Transition resolution — deepest-wins with parent fallthrough (L877-887, canonical):**

```
1. Leaf state's :on — explicit match.
2. Leaf state's :on — :* wildcard.
3. Parent state's :on — explicit match.
4. Parent state's :on — :* wildcard.
5. ... continue walking up ...
6. Top-level (root) :on — explicit match.
7. Top-level :on — :* wildcard.
```

## Impl is canonical

`implementation/machines/src/re_frame/machines.cljc:330-343` (`pick-transition`):

```clojure
(loop [i (dec (count path))]
  (when (>= i 0)
    (let [prefix (vec (take (inc i) path))
          n      (node-at machine prefix)
          cands  (normalise-on-clause
                   (or (get-in n [:on event-id])
                       (get-in n [:on :*])))
          ...]
      (if hit
        {:transition hit :decl-path prefix}
        (recur (dec i))))))
```

At each level (each prefix from leaf to root): try `[:on event-id]`, else `[:on :*]`. If either matches, stop. Otherwise walk up. This matches §Transition resolution exactly.

## Aligned post-fix list

Reworded §Wildcard transitions to a per-level rule that cross-links to the canonical leaf-up-to-root walk:

> Precedence inside the standard transition lookup, **at each level**:
>
> 1. Explicit event match at this level.
> 2. `:*` wildcard at this level.
>
> The wildcard fires after specific matches **at the same level**. Only if neither matches does the runtime walk up to the next level and try again — so `:*` at the leaf shadows an explicit match on the parent for the same event. The full leaf-up-to-root walk is canonically specified at §Transition resolution; for a flat machine the path is one level deep and the two-step rule above is the whole story. ...

For flat machines the two-step rule is the whole story (path length = 1, "this level" is the only level). For hierarchical machines the canonical §Transition resolution list spells out the walk; the cross-link removes the contradiction.

## Test pin

The drift landed because no fixture/test exercised the divergence case (leaf `:*` AND parent explicit for the same event). `hierarchical-parent-fallthrough.edn` covers leaf-empty fallthrough, which both lists agreed on.

Added:

- **`spec/conformance/fixtures/hierarchical-wildcard-precedence.edn`** — three cases. (1) Leaf `:*` SHADOWS parent's explicit `:help` (the divergence the old list muddled). (2) Leaf empty, parent has explicit + `:*` — explicit beats `:*` at the same level. (3) Leaf empty, parent `:*` only — `:*` fires.
- **`implementation/machines/test/re_frame/machines_cljs_test.cljs` — `machine-hierarchical-wildcard-precedence-cljs`** — CLJS-side mirror via `reg-machine` + `dispatch-sync`.

## Test plan

- [x] `clojure -M:test` in `implementation/core` (184 tests, 834 assertions, 0 failures — new fixture appears in "Conforms" list).
- [x] `clojure -M:test` in `implementation/machines` (30 tests, 81 assertions, 0 failures).
- [x] `npm run test:cljs` (153 tests, 468 assertions, 0 failures).
- [x] `npm run test:browser` (153 tests, 472 assertions, 0 failures).
- [x] `npm run test:elision` (PASS).
- [x] `npm run test:examples` (all examples PASS).