### PR TITLE
docs(spec): strict elision ratification — drop (prod) recovery row + land C-000.35 (rf2-wq0a, Option a)

### DIFF
--- a/spec/000-Vision.md
+++ b/spec/000-Vision.md
@@ -566,6 +566,8 @@ This summary captures the small set of clauses that introduce checkable obligati
 >
 > - **C-000.27** (MUST). The CLJS reference's `core` artefact MUST NOT transitively `:require` any per-feature or per-substrate namespace. Bundle isolation MUST be structural (absent from the classpath), not a property dependent on dead-code elimination.
 >
+> - **C-000.35** (MUST). Production elision of dev-time instrumentation (trace, schema/type validation) MUST NOT alter the value of a frame's state nor the order or identity of dispatched events. Elision is a build-time substitution, not a behavioural change. Grounded by [Spec 009](009-Instrumentation.md)'s strict-elision contract — production builds contain zero trace and zero validation code, so the recovery dispositions in [009 §Default behaviour by category](009-Instrumentation.md#default-behaviour-by-category) apply only in dev.
+>
 > - **C-000.45** (MUST). Runtime data shapes that flow on the wire — dispatch envelopes, effect maps, registration metadata, trace events, hydration payloads — MUST be open: producers MAY add new keys, and consumers MUST tolerate unknown keys (ignore-or-pass-through; a consumer that destructures and rejects on unknown keys is non-conformant).
 >
 > - **C-000.49** (MUST). At the pattern level, every view call MUST be addressable to a specific frame at the call site (frame as parameter or property). React-context-driven view injection is a CLJS-reference-specific optimisation and MUST NOT be required of any other host implementation.

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -793,6 +793,8 @@ Each frame has at most one `:on-error` handler. Re-registering the frame replace
 
 #### Default behaviour by category
 
+(Every recovery in this table applies in dev only — trace emission and schema/type validation are both production-elided per the lead claim above, so production builds never reach these recovery paths. See [Spec 000 §Contract C-000.35](000-Vision.md) for the production-elision-equivalence clause this section grounds.)
+
 | Category | Default `:recovery` | Notes |
 |---|---|---|
 | `:rf.error/handler-exception` | `:no-recovery` | The exception propagates; the cascade halts. |
@@ -800,7 +802,7 @@ Each frame has at most one `:on-error` handler. Re-registering the frame replace
 | `:rf.error/fx-handler-exception` | `:no-recovery` | The fx is skipped; cascade continues if other fx independent. |
 | `:rf.error/sub-exception` | `:replaced-with-default` | The sub returns `nil`; views see no value. |
 | `:rf.error/no-such-sub` | `:replaced-with-default` | The unresolved input is substituted with `nil`; the sub's body still runs. Strict mode (`:strict-subs` config) escalates to a thrown exception. |
-| `:rf.error/schema-validation-failure` | `:no-recovery` (dev) / `:replaced-with-default` (prod) | Dev: hard-fail to surface bugs early. Prod: log and proceed with the offending value (validation at boundaries should already have rejected it). |
+| `:rf.error/schema-validation-failure` | `:no-recovery` | Hard-fail to surface bugs early. Production builds elide the validation entirely (per the lead claim — see C-000.35), so this row applies only in dev. |
 | `:rf.error/drain-depth-exceeded` | `:no-recovery` | Always indicates a bug; halt the cascade. |
 | `:rf.error/no-such-handler` | `:replaced-with-default` | No-op; emit the trace. |
 | `:rf.error/dispatch-sync-in-handler` | `:no-recovery` | The call is rejected. Use `:fx [[:dispatch event]]` in the effect map. |

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -807,7 +807,7 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
 
 Pattern-level: every implementation registers an equivalent set of schemas. The category vocabulary is fixed-and-additive per [Spec-ulation](Principles.md): existing categories cannot be renamed or removed; new categories appear additively.
 
-The schemas above are *open* (Malli's default `[:map ...]`) — consumers receive payloads that conform to the listed keys plus any additive keys the implementation adds. Validation against these schemas is non-fatal in production: a `validate` failure is logged via the same trace stream (per [009](009-Instrumentation.md)) but does not abort the consumer.
+The schemas above are *open* (Malli's default `[:map ...]`) — consumers receive payloads that conform to the listed keys plus any additive keys the implementation adds. Validation against these schemas is non-fatal in dev: a `validate` failure is logged via the same trace stream (per [009](009-Instrumentation.md)) but does not abort the consumer. In production, both validation and the trace stream are compile-time elided (per [009](009-Instrumentation.md) lead claim and [Spec 000 C-000.35](000-Vision.md)) — there is no runtime validation cost and no trace emission.
 
 ### `:rf/handler-body-dsl`
 


### PR DESCRIPTION
## Summary

Mike's 2026-05-09 decision (Option (a) — strict elision): the lead claim in spec/009-Instrumentation.md L13 ("All tracing is compile-time eliminated in production builds. No exceptions.") is canonical. The `(prod)` recovery segment that had crept into the §Default behaviour by category table for `:rf.error/schema-validation-failure` was fictional — schema validation does not run in production at all, so there is no production recovery path to specify.

This PR strips the fictional split, lands the previously-held **C-000.35** clause in the 000-Vision summary Contract block (held since the rf2-04sm review pending 009 ratification of strict elision), and corrects one drift sentence in Spec-Schemas. Additive-only spirit honoured: 1 reword slot (the row), 1 additive parenthetical (above the table), 1 additive Contract clause (C-000.35), 1 reword in Spec-Schemas L810.

## A. The fictional `(prod)` row in 009 (L803, now L805)

**Before:**

```
| `:rf.error/schema-validation-failure` | `:no-recovery` (dev) / `:replaced-with-default` (prod) | Dev: hard-fail to surface bugs early. Prod: log and proceed with the offending value (validation at boundaries should already have rejected it). |
```

**After:**

```
| `:rf.error/schema-validation-failure` | `:no-recovery` | Hard-fail to surface bugs early. Production builds elide the validation entirely (per the lead claim — see C-000.35), so this row applies only in dev. |
```

An additive parenthetical introduces the table:

> (Every recovery in this table applies in dev only — trace emission and schema/type validation are both production-elided per the lead claim above, so production builds never reach these recovery paths. See [Spec 000 §Contract C-000.35](000-Vision.md) for the production-elision-equivalence clause this section grounds.)

## B. C-000.35 lands in 000-Vision summary Contract block

Inserted between C-000.27 and C-000.45 (preserving the established numbering — missing numbers are intentional per the block's preamble):

> **C-000.35** (MUST). Production elision of dev-time instrumentation (trace, schema/type validation) MUST NOT alter the value of a frame's state nor the order or identity of dispatched events. Elision is a build-time substitution, not a behavioural change. Grounded by [Spec 009](009-Instrumentation.md)'s strict-elision contract — production builds contain zero trace and zero validation code, so the recovery dispositions in [009 §Default behaviour by category](009-Instrumentation.md#default-behaviour-by-category) apply only in dev.

**History (rf2-uuoj review):** C-000.35 was held back from the rf2-04sm Contract-block summarisation pass because 009 had not yet ratified production-elision-equivalence. The rf2-uuoj review flagged the held clause; with this PR ratifying L13 as canonical (and removing the contradictory recovery row), the clause is now ratifiable and lands.

## C. Spec-Schemas drift correction (L810)

The error-tags-schemas section said "Validation against these schemas is non-fatal in production" — that implies validation runs in production. Reworded to "non-fatal in dev" with an explicit production-elision clause referencing 009's lead claim and C-000.35.

## Drift surfaced — follow-up bead candidates (not edited in this PR; out of scope)

These are residual phrasings in spec/010-Schemas.md that imply a "prod (when re-enabled)" path for global validation, which contradicts strict elision (C-000.35). They should likely be reworded so only the boundary-validation interceptor remains as the production validation surface (which is the legitimate exception per 010 L134):

- spec/010-Schemas.md L92 — `reg-app-schema` row of the summary table: "Dev: roll back the `:db` effect, treat dispatch as failed; **prod (when re-enabled): log and proceed.**"
- spec/010-Schemas.md L94 — narrative repeats: "post-handler `app-db` failures roll back in dev"; the "in dev" qualifier reads as if there's a "in prod" alternative.
- spec/010-Schemas.md L118 — Per-step recovery table step 4: "**Prod (when validation re-enabled):** log and proceed with the offending value (cf. [009 §Per-category recovery defaults]…)."

Boundary-validation prose at L130-148 is fine — that's the documented production exception. The "(when re-enabled)" framing for global validation is the drift; it is inconsistent with C-000.35 and with the strict-elision lead claim. **Mike-review item.**

SPEC-AUTHORING SA-N entries (rf2-04sm) do not reference C-000.35 — no edits needed there.

## Verification

- [x] `grep -nE 'no-recovery \(dev\)' spec/009-Instrumentation.md` → 0 matches.
- [x] `grep -nE 'C-000\.35' spec/000-Vision.md` → 1 match (L569, the new clause).
- [x] Cross-references resolve (009 → 000 C-000.35; 000 → 009 §Default behaviour by category; Spec-Schemas → 009 lead + 000 C-000.35).
- [x] Markdown clean (no list/table-shape changes; only one row's middle column edited).

## Test plan

- [ ] Skim 009 §Default behaviour by category — table reads coherently with the new parenthetical above it; the `:rf.error/schema-validation-failure` row reads cleanly.
- [ ] Skim 000-Vision Contract block — C-000.35 sits sensibly between C-000.27 and C-000.45.
- [ ] Skim Spec-Schemas L808-812 — the prod-elision sentence reads correctly.
- [ ] Confirm 010-Schemas drift items above are tracked as a follow-up bead.

## Rebase status

Plan to rebase if conflicts arise on table rows in 009 from concurrent agents (rf2-zq55-impl epoch + Tool-Pair, rf2-t07u runtime spawn registry, rf2-m83v machines fx rename, rf2-d3k3 views ns+006/009, rf2-fhb9 spec/005). Conflicts on table rows are expected to be additive — both sides win. This PR's 009 edit touches one existing row and adds one parenthetical line above the table — minimal collision surface.

bd: rf2-wq0a moved to in_progress.