### PR TITLE
docs(release): rf2-r382 policy capture — tag-triggered CD, manual recovery, all-artefacts-ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ All notable changes to re-frame2 are recorded in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses pre-release suffixes (`.beta`, `.alpha`, `.rc`) on its way to a stable v1.0.0 line. Once stable, releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Artefacts published per release (in lock-step):
+Artefacts published per release (in lock-step — all 10 artefacts ship together at the same VERSION per [rf2-w05l](#) and [docs/release-process.md §Policy](docs/release-process.md#policy)):
 
-- `day8/re-frame-2` — core (registry, drain, machines, flows, routing, fx, schemas, trace, headless plain-atom adapter)
-- `day8/re-frame-2-reagent` — Reagent substrate adapter
-- `day8/re-frame-2-uix` *(planned, [rf2-3yij](https://github.com/day8/re-frame2/issues))*
-- `day8/re-frame-2-helix` *(planned, [rf2-2qit](https://github.com/day8/re-frame2/issues))*
+| Artefact | Tier | Role |
+|---|---|---|
+| `day8/re-frame-2` | core | Registry, drain, fx, dispatch, subscribe, frame-provider, trace, the substrate-adapter contract, the headless plain-atom adapter |
+| `day8/re-frame-2-schemas` | per-feature | Spec 010 — Malli-backed schema-attachment surface |
+| `day8/re-frame-2-machines` | per-feature | Spec 005 — state machines |
+| `day8/re-frame-2-routing` | per-feature | Spec 012 — routing |
+| `day8/re-frame-2-flows` | per-feature | Spec 013 — flows |
+| `day8/re-frame-2-http` | per-feature | Spec 014 — managed HTTP |
+| `day8/re-frame-2-ssr` | per-feature | Spec 011 — SSR & hydration |
+| `day8/re-frame-2-epoch` | per-feature | Tool-Pair §Time-travel — epoch / time-travel |
+| `day8/re-frame-2-reagent` | per-substrate | Spec 006 — Reagent adapter (browser default) |
+| `day8/re-frame-2-uix` | per-substrate | Spec 006 — UIx adapter ([rf2-3yij](#)) |
+
+A future Helix adapter (`day8/re-frame-2-helix`, [rf2-2qit](#)) slots in alongside the existing per-substrate leaves when it ships.
 
 Spec changes are tracked separately under `spec/` and referenced from each entry.
 
@@ -35,7 +45,7 @@ First public pre-release. Mike fills in the release notes manually before taggin
 - `:rf.http/managed` effect family with retry / decode / abort semantics (Spec 014).
 - Multi-instance frames and the `frame-provider` substrate boundary that lets adapters ship independently of the core (Spec 006 §Substrate-adapter shipping convention).
 - Production-elision contract (Spec 009): dev-only diagnostics drop out of advanced-compile bundles; CI gates on the elision probe (rf2-11hn).
-- Artefact split (rf2-0hxm): `day8/re-frame-2` ships substrate-agnostic; `day8/re-frame-2-reagent` ships the Reagent adapter as a separate Maven coordinate so a UIx- or Helix-only app does not transitively pull in Reagent.
+- Artefact split (rf2-0hxm + rf2-5vjj): `day8/re-frame-2` ships substrate-agnostic; the seven per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) ship as separate Maven coordinates so a consumer who omits a feature does not pay for it on the classpath; the per-substrate artefacts (`-reagent`, `-uix`) keep substrate code out of any app that has chosen the other substrate. All 10 artefacts ship in lockstep at the same VERSION per [rf2-w05l](#).
 - `MIGRATION.md` (`spec/MIGRATION.md`) for agent-driven migration of v1 codebases to v2.
 
 ### Changed

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,6 +6,16 @@
 
 re-frame2 ships as a coordinated set of Maven artefacts, all driven from a single repo-root [`VERSION`](../VERSION) file. This doc is the operational guide for how a release flows through CI, what gates exist, and how to recover when something goes wrong mid-deploy.
 
+## Policy
+
+The release pipeline reflects a small set of decisions Mike made up front (rf2-r382). They are recorded here so future contributors don't have to re-derive them from the workflow.
+
+1. **Mechanism — tag-triggered CD, modeled on re-frame v1.** Push a tag matching the [tag glob](#tag-format); the [`release` workflow](../.github/workflows/release.yml) runs end-to-end. Same shape as [re-frame v1's `continuous-deployment-workflow.yml`](https://github.com/day8/re-frame/blob/master/.github/workflows/continuous-deployment-workflow.yml): tag-push trigger, gated test job, `clojure -M:clein deploy`, `softprops/action-gh-release` for the GitHub Release. The differences are structural — re-frame v1 ships one artefact, re-frame2 ships ten — and are documented in [§Topological deploy DAG](#topological-deploy-dag).
+2. **Channel gating — pre-1.0 = beta, post-1.0 = stable.** Pre-1.0 releases tag as `v0.0.1.beta` (and `v0.0.1.beta-N` / `v0.0.2.beta` etc. for subsequent betas). Post-1.0 releases tag as `vX.Y.Z` per Semantic Versioning. The release workflow flags any tag containing `beta`, `alpha`, or `rc` as a GitHub `prerelease` automatically.
+3. **First publish — manual cut, all artefacts together.** Mike triggers the first `v0.0.1.beta` deploy by hand once the policy text and the workflow have been reviewed against an actual tag. After the first cut, subsequent releases run automatically on tag push. The first cut ships the **full ten-artefact set** (core + schemas + reagent + uix + machines + routing + flows + http + ssr + epoch); no artefact "comes later" — they all ship together at every release per the lockstep contract below.
+4. **Atomic rollback — NOT POLICY.** Clojars does not support yanking a published version, and re-frame2 does not invest in machinery that would make it look like it does. If a deploy fails part-way through, recovery is **bump VERSION + re-tag + re-run** (see [§Recovery from a partial deploy](#recovery-from-a-partial-deploy) for the procedure). The partial-release artefacts from a failed run remain on Clojars, tombstoned-by-supersession; consumers pin the bumped version and pull a coherent set. Manual recovery is acceptable; we do not build atomic-rollback or partial-deploy-replay machinery.
+5. **Artefact set ships together at lockstep VERSION.** All 10 artefacts ship at every release at the same VERSION, sourced from the repo-root [`VERSION`](../VERSION) file. The lockstep contract (rf2-w05l) is enforced before any deploy by [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh). Independent versioning is revisited post-1.0; until then, every published Maven coord moves in lockstep.
+
 ## Tag format
 
 | Channel | Tag pattern | VERSION file content | Example |
@@ -37,16 +47,22 @@ graph TD
   T --> C[deploy-core]
   C --> S[deploy-schemas]
   C --> R[deploy-reagent]
+  C --> U[deploy-uix]
   C --> M[deploy-machines]
   C --> RT[deploy-routing]
   C --> F[deploy-flows]
   C --> H[deploy-http]
+  C --> SS[deploy-ssr]
+  C --> E[deploy-epoch]
   S --> GR[github-release]
   R --> GR
+  U --> GR
   M --> GR
   RT --> GR
   F --> GR
   H --> GR
+  SS --> GR
+  E --> GR
 ```
 
 ASCII fallback:
@@ -56,16 +72,19 @@ verify-version-lockstep ──► test ──► deploy-core
                                        │
                                        ├── deploy-schemas
                                        ├── deploy-reagent
+                                       ├── deploy-uix
                                        ├── deploy-machines
                                        ├── deploy-routing
                                        ├── deploy-flows
-                                       └── deploy-http
+                                       ├── deploy-http
+                                       ├── deploy-ssr
+                                       └── deploy-epoch
                                                 │
                                                 ▼
                                         github-release
 ```
 
-**Why fan-out (not strict serial).** The decision text describes a topological linearization (`core → schemas → reagent → machines → routing → flows → http`); the deps-graph data is wider — every leaf has core as its only re-frame-2 dependency. The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, halving wall-clock at the cost of a marginally wider failure surface (see Recovery below). When future per-feature splits land — ssr ([rf2-uo7v](#)), epoch ([rf2-lt4e](#)) — they slot in alongside the existing leaves.
+**Why fan-out (not strict serial).** The decision text describes a topological linearization (`core → schemas → reagent → machines → routing → flows → http → ssr → epoch → uix`); the deps-graph data is wider — every leaf has core as its only re-frame-2 dependency. The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The per-feature split set is now closed at seven (schemas, machines, routing, flows, http, ssr, epoch — per [rf2-5vjj](#) Strategy B); the substrate-adapter set is two (reagent default, uix per [rf2-3yij](#)); a future Helix adapter ([rf2-2qit](#)) slots in as another leaf when it ships.
 
 ## Pre-flight checklist
 


### PR DESCRIPTION
## Summary

Captures the policy decisions for the multi-artefact CD pipeline into `docs/release-process.md` and aligns `CHANGELOG.md` with the actual ten-artefact set. No workflow, verifier, or spec changes — release.yml + verify-version-lockstep.sh already cover all 10 artefacts; this PR just writes down the policy that motivated their shape.

### Confirmation: release.yml has all 10 deploy jobs

`.github/workflows/release.yml` carries deploy jobs for every artefact: `deploy-core`, `deploy-reagent`, `deploy-uix`, `deploy-schemas`, `deploy-machines`, `deploy-routing`, `deploy-flows`, `deploy-http`, `deploy-ssr`, `deploy-epoch`. The terminal `github-release` job depends on all ten. Topological DAG is correct (every leaf depends on `deploy-core`, no leaf-to-leaf edges).

### Confirmation: recovery comment block is present

The top of `release.yml` (lines 43–60) carries the recovery procedure: "Clojars does not support yanking… DO NOT attempt to re-run with the same tag… bump VERSION in a release-recovery commit, re-tag, re-run." Pointing at `docs/release-process.md §Recovery`.

### Confirmation: re-frame v1 mechanism matches

re-frame v1's `continuous-deployment-workflow.yml` shape:
- Tag-push trigger on `v[0-9]+.[0-9]+.[0-9]+*`.
- Test job gates the release job.
- `clojure -M:clein deploy` for the actual upload.
- `actions/create-release` (re-frame v1) / `softprops/action-gh-release` (re-frame2) for the GitHub Release.

re-frame2's release.yml is the same shape, fanned out to ten parallel deploy jobs (one per artefact) plus a lockstep-version gate before the test job. The trigger glob, the deploy command, and the test gating are unchanged.

### Drift surfaced (note for Mike)

1. **release-process.md DAG diagrams were stale.** The mermaid + ASCII fallback under §Topological deploy DAG predated the `uix`, `ssr`, `epoch` leaves and showed only six per-feature artefacts. Fixed in this PR — they now reflect what `release.yml` actually runs.
2. **CHANGELOG.md artefact list was stale.** The "Artefacts published per release (in lock-step)" header listed only `core`, `reagent`, plus two "planned" entries (`uix`, `helix`). Replaced with the full 10-row table aligned to the lockstep contract; the `v0.0.1.beta §Added` entry now references the seven per-feature splits + the per-substrate splits.
3. **README.md has no Installation section.** The repo root `README.md` does not have an "Adding to your project" / "Installation" section, by design (the README explicitly says "Still a work in progress but getting close to beta"). Adding installation guidance for an unpublished artefact would be misleading; left as-is. **Suggest** adding one when Mike triggers `v0.0.1.beta` — the table in CHANGELOG.md can be the source for it.
4. **`spec/Conventions.md §Packaging conventions` is current.** All 10 artefacts documented; cross-references already point at `docs/release-process.md`. No edits needed (and rf2-t07u + rf2-m83v are touching that file in parallel; declined to add a third toucher).

### Policy decisions documented

`docs/release-process.md` now carries a §Policy section (lines 9–17) capturing all five decisions:
1. Mechanism — tag-triggered CD modeled on re-frame v1.
2. Channel gating — pre-1.0 beta, post-1.0 stable, automatic prerelease flag.
3. First publish — manual cut by Mike when ready.
4. Atomic rollback — **NOT POLICY**; recovery is bump-and-replay; manual is acceptable.
5. Artefact set — all 10 ship together at lockstep VERSION; rf2-w05l contract enforced before any deploy.

### CHANGELOG.md: augmented (not new)

`CHANGELOG.md` already existed; this PR augments it (full artefact table; v0.0.1.beta Added entry updated) rather than overwriting.

## Test plan

- [x] `./.github/scripts/verify-version-lockstep.sh` passes locally (all 10 artefacts pinned to repo-root VERSION 0.0.1.beta).
- [x] No code / deps.edn / workflow / verifier / spec changes — only `docs/release-process.md` + `CHANGELOG.md`. Heavy CI matrix not informative for this scope.
- [ ] CI: `tests` workflow green on the PR (lockstep + JVM + CLJS + elision + bundle-isolation gates).
- [ ] No conflicts with rf2-t07u / rf2-m83v (they touch `spec/Conventions.md`; this PR does not).