### PR TITLE
feat(views): emit plain-fn-under-non-default-frame-once warning + close rf2-o83z gap (rf2-d3k3)

### DIFF
--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -88,6 +88,8 @@
     :ssr/reg-error-projector     re-frame.ssr/reg-error-projector
     :ssr/project-error           re-frame.ssr/project-error
     :reagent/set-hiccup-emitter! re-frame.substrate.reagent/set-hiccup-emitter!
+    :views/maybe-warn-plain-fn-under-non-default-frame!  re-frame.views/maybe-warn-plain-fn-under-non-default-frame!
+    :views/clear-plain-fn-warned-pairs!                  re-frame.views/clear-plain-fn-warned-pairs!
     :epoch/settle!            re-frame.epoch/settle!
     :epoch/discard-buffer!    re-frame.epoch/discard-buffer!
     :epoch/in-flight-buffer   re-frame.epoch/in-flight-buffer

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -287,8 +287,27 @@
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity form resolves
   the active frame via re-frame.frame/current-frame so subscribe
-  inside a with-frame or under a frame-provider auto-routes."
-  ([query-v] (subscribe (frame/current-frame) query-v))
+  inside a with-frame or under a frame-provider auto-routes.
+
+  Per Spec 006 §Plain-fn-under-non-default-frame warning (rf2-d3k3):
+  the 1-arity form runs the plain-fn detection check — if the
+  surrounding React-context Provider names a non-default frame and the
+  rendering component is NOT reg-view-wrapped (so its subscribe call
+  has fallen through to :rf/default), `:rf.warning/plain-fn-under-
+  non-default-frame-once` fires once per (component-id, frame-id)
+  pair. The check is late-bound through re-frame.views (CLJS-only) so
+  the JVM build never loads it; production (`:advanced` +
+  `goog.DEBUG=false`) elides via `interop/debug-enabled?`."
+  ([query-v]
+   #?(:cljs
+      (let [frame-id (frame/current-frame)]
+        (when interop/debug-enabled?
+          (when-let [warn! (late-bind/get-fn
+                            :views/maybe-warn-plain-fn-under-non-default-frame!)]
+            (warn! frame-id query-v)))
+        (subscribe frame-id query-v))
+      :clj
+      (subscribe (frame/current-frame) query-v)))
   ([frame-id query-v]
    (let [frame-record (frame/frame frame-id)]
      (cond

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -15,12 +15,14 @@
   to obtain the wrapped fn and use `[(rf/view :id) args]` as the
   hiccup head."
   (:require [reagent.core   :as r]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
-            [re-frame.substrate.context :as substrate-context]))
+            [re-frame.substrate.context :as substrate-context]
+            [re-frame.trace :as trace]))
 
 ;; ---- the React context for frame propagation -----------------------------
 ;;
@@ -353,3 +355,177 @@
                   {:contextType frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
+
+;; ---- plain-fn-under-non-default-frame warning (rf2-d3k3) -----------------
+;;
+;; Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-default-
+;; frame warning: a plain Reagent fn (not registered via `reg-view`, so
+;; without the `^{:contextType frame-context}` metadata `reg-view` attaches)
+;; cannot read the surrounding React-context frame. When such a fn renders
+;; inside a non-default `frame-provider` and calls `(rf/subscribe ...)` or
+;; `(rf/dispatch ...)`, the resolution chain falls through to `:rf/default`
+;; — almost certainly not what the author intended.
+;;
+;; The runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` at
+;; most once per `(component-id, non-default-frame-id)` pair, per Spec 004
+;; §The footgun is loud, but at most once per (component, non-default-frame)
+;; pair. Detection sits at subscribe-time per Spec 006 §706: subscribe
+;; consults this helper through the late-bind hook table; the JVM build
+;; never sees this ns and the lookup returns nil there.
+;;
+;; Suppression: a process-wide `defonce` atom set keyed by [component-id
+;; frame-id] pairs. The suppression cache survives hot-reload (`defonce`)
+;; so repeated re-renders of the same plain fn produce exactly one
+;; warning per pair across the JS process. Per Spec 004 §The suppression
+;; cache: destroying and re-creating a frame resets the warning history
+;; for that frame — implemented by `clear-plain-fn-warned-pairs-for-frame!`
+;; which the frame-destroy path can call (today the cache is process-wide
+;; and the helper is exported for tests / future destroy-frame integration).
+;;
+;; Production-elision: every code path is gated on `interop/debug-enabled?`.
+;; Under :advanced + `goog.DEBUG=false` the closure compiler constant-folds
+;; the gate and the entire detection branch, the trace emission, and the
+;; `console.warn` fallback are dead-code-eliminated. Per Spec 009
+;; §Production builds.
+
+(defonce ^:private warned-plain-fn-frame-pairs
+  ;; Set of `[component-id frame-id]` pairs already warned about. Per
+  ;; Spec 004 §The suppression cache.
+  (atom #{}))
+
+(defn clear-plain-fn-warned-pairs!
+  "Reset the warn-once suppression cache. Tests use this between cases
+  so each case starts from a clean slate. Per Spec 004 §The suppression
+  cache."
+  []
+  (reset! warned-plain-fn-frame-pairs #{})
+  nil)
+
+(defn- plain-fn-component-id
+  "Identify the rendering component for warn-once keying. Reagent
+  components carry the user's render-fn as `.-cljsLegacyRender` (form-1)
+  or as the bound fn proper. We prefer `displayName` (which Reagent /
+  React tend to set for named fns), then fall back to the constructor's
+  `name`, then a string repr. The id is opaque text used only as the
+  cache key and the warning's `:fn-name` payload — stable across renders
+  of the same component, distinct across different component fns."
+  [cmp]
+  (or (when-let [n (.-displayName ^js cmp)]
+        (when (and (string? n) (not= "" n)) n))
+      (let [c (.-constructor ^js cmp)
+            n (when c (.-name ^js c))]
+        (when (and (string? n) (not= "" n) (not= "Object" n)) n))
+      (pr-str cmp)))
+
+(defn- read-react-context-frame
+  "Read the value the closest enclosing frame-provider has pushed onto the
+  shared React context. Reagent's class-component machinery only surfaces
+  context to components whose `:contextType` matches the context object;
+  plain fns lack that wiring, so `(.-context cmp)` is the React empty
+  default. We bypass the per-component view by reading the context's
+  current value directly — React maintains `_currentValue` on the context
+  object as it pushes / pops Provider boundaries during render.
+
+  Reagent's `convert-prop-value` (reagent.impl.template) stringifies
+  named values (keywords, symbols) when they are passed as React
+  prop values: `[:> Provider {:value :foo} ...]` reaches React with
+  `value=\"foo\"`, not the keyword. We undo that conversion here so the
+  detection logic (and consumers reading off the context value) see a
+  keyword regardless of whether the closest Provider was reached via
+  `[:> ...]` interop (stringified) or through a plain-CLJS object path
+  (preserved). The createContext default — `:rf/default` — survives as
+  a keyword because it never passed through Reagent's prop-conversion."
+  []
+  (let [v (.-_currentValue ^js substrate-context/frame-context)]
+    (cond
+      (keyword? v) v
+      (string?  v) (keyword v))))
+
+(defn maybe-warn-plain-fn-under-non-default-frame!
+  "Detection per Spec 006 §706 (plain-fn-under-non-default-frame
+  warning). Called from `re-frame.subs/subscribe` after frame
+  resolution; `resolved-frame-id` is the frame the subscribe call
+  routed to.
+
+  Conditions for the warning to fire (all must hold):
+    1. We are mid-render — `(r/current-component)` returns a component.
+    2. The component is NOT a reg-view-wrapped one — its `contextType`
+       is not the shared `frame-context`. (reg-view-wrapped components
+       carry the `:contextType` so they read the surrounding Provider's
+       value into `(.-context cmp)`; plain fns do not.)
+    3. The closest enclosing Provider names a non-default frame.
+    4. The dynamic `*current-frame*` tier is unset — i.e. no `with-frame`
+       binding shadows the React-context read. When `with-frame` IS set,
+       the plain fn picks up the frame correctly via the dynamic var,
+       and no warning is needed.
+
+  Suppression: warn-once per `[component-id non-default-frame-id]` pair.
+  Subsequent renders of the same plain fn under the same Provider stay
+  silent. Per Spec 004 §at most once per (component, non-default-frame)
+  pair.
+
+  Returns nil. Production builds elide the entire body via the
+  `interop/debug-enabled?` gate the trace surface itself rides — the
+  call site in subs already pays a `(when interop/debug-enabled? ...)`
+  test, so this fn is reached only in dev / JVM (where it is unbound
+  via late-bind and not called)."
+  [resolved-frame-id _query-v]
+  (when interop/debug-enabled?
+    (let [cmp (r/current-component)]
+      ;; Condition 1: must be mid-render.
+      (when (some? cmp)
+        ;; Condition 2: component must NOT be reg-view-wrapped. The
+        ;; sentinel is the `contextType` static — reg-view's wrapper
+        ;; sets it to `frame-context`; plain fns leave it unset (or
+        ;; React's empty default).
+        (let [ctx-type (some-> ^js cmp .-constructor .-contextType)]
+          (when-not (identical? ctx-type substrate-context/frame-context)
+            ;; Condition 3: closest enclosing Provider names a
+            ;; non-default frame.
+            (let [provider-frame (read-react-context-frame)]
+              (when (and (keyword? provider-frame)
+                         (not= :rf/default provider-frame))
+                ;; Condition 4: no with-frame binding shadowing the
+                ;; React-context read.
+                (when (nil? frame/*current-frame*)
+                  (let [fn-id (plain-fn-component-id cmp)
+                        pair  [fn-id provider-frame]]
+                    (when-not (contains? @warned-plain-fn-frame-pairs pair)
+                      (swap! warned-plain-fn-frame-pairs conj pair)
+                      (let [reason (str "Plain Reagent fns do not pick "
+                                        "up the surrounding frame; their "
+                                        "dispatch/subscribe targets "
+                                        ":rf/default. To capture the "
+                                        "surrounding frame, register the "
+                                        "view via reg-view.")]
+                        (trace/emit! :warning
+                                     :rf.warning/plain-fn-under-non-default-frame-once
+                                     {:fn-name        fn-id
+                                      :rendered-under provider-frame
+                                      :routed-to      resolved-frame-id
+                                      :reason         reason
+                                      :recovery       :warned-and-replaced})
+                        ;; Per Spec 004 §The footgun is loud: in dev,
+                        ;; the runtime also `console.warn`s the first
+                        ;; occurrence. The trace event is the
+                        ;; programmatic surface (10x, re-frame-pair);
+                        ;; the console message is the human-eyeballs
+                        ;; surface.
+                        (when (exists? js/console)
+                          (.warn js/console
+                            (str "[re-frame] :rf.warning/plain-fn-under-"
+                                 "non-default-frame-once — " fn-id
+                                 " rendered under " provider-frame
+                                 "; subscribe/dispatch routed to "
+                                 resolved-frame-id ". " reason)))))))))))))
+    nil))
+
+;; Publish through the late-bind hook table so re-frame.subs (a leaf
+;; namespace, .cljc, JVM-runnable) can call the helper without
+;; statically requiring this CLJS-only ns. JVM builds never load this
+;; file; the lookup returns nil there and subs no-ops the warning
+;; check. Per re-frame.late-bind §Hook keys.
+(late-bind/set-fn! :views/maybe-warn-plain-fn-under-non-default-frame!
+                   maybe-warn-plain-fn-under-non-default-frame!)
+(late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
+                   clear-plain-fn-warned-pairs!)

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -205,6 +205,25 @@
   ;; gated branches dead; the public surface itself remains).
   (let [_t (views/mint-instance-token!)
         _k (views/current-render-key)]
+    nil)
+  ;; Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-
+  ;; default-frame warning (rf2-d3k3): the warn-once helper sits inside
+  ;; `(when interop/debug-enabled? ...)`. Touch the helper's public
+  ;; entry points so the reachability graph keeps the ns body — the
+  ;; trace-emit branch itself is gated on `(some? (r/current-component))`
+  ;; which is nil at probe time (no Reagent render in flight), so the
+  ;; emit-site keyword is DCE'd from BOTH bundles by closure dataflow.
+  ;; The browser-runner test
+  ;; (re-frame.cross-spec-cljs-test/plain-fn-under-non-default-frame) is
+  ;; the load-bearing assertion that the gate fires under DEBUG=true;
+  ;; production elision rests on the surrounding
+  ;; `(when interop/debug-enabled? ...)` constant-folding to false the
+  ;; same way every other warn site does.
+  (rf/reg-sub :probe/sub (fn [_db _q] nil))
+  (let [_r (rf/subscribe [:probe/sub])]
+    (views/clear-plain-fn-warned-pairs!)
+    (views/maybe-warn-plain-fn-under-non-default-frame!
+      :rf/default [:probe/sub])
     nil))
 
 ;; ---- Spec 005 §Source-coord stamping — reg-machine macro (rf2-8bp3) -------

--- a/implementation/reagent/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/reagent/test/re_frame/cross_spec_cljs_test.cljs
@@ -19,6 +19,7 @@
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.late-bind]
             ;; rf2-k682: routing ships in day8/re-frame-2-routing.
             ;; Required here so its load-time hook + reg-sub
             ;; registrations fire before this ns's reg-route calls.
@@ -419,27 +420,165 @@
 ;; spec/Cross-Spec-Interactions.md#10-plain-reagent-fn-under-a-non-default-frame
 ;; ---------------------------------------------------------------------------
 
-(deftest plain-fn-under-non-default-frame-placeholder
+(deftest plain-fn-under-non-default-frame
   "#10 Plain Reagent fn under a non-default frame —
-   ;; HALTED for rf2-o83z: this is a runtime gap, NOT a browser-test
-   ;; gap. Spec 004 §Plain Reagent fns and Spec 009 §Trace catalog define
-   ;; the warning operation `:rf.warning/plain-fn-under-non-default-frame
-   ;; -once` (with `:fn-name`, `:rendered-under`, `:routed-to` tags),
-   ;; emitted at most once per `(component-id, non-default-frame-id)`
-   ;; pair when a plain (non-`reg-view`) Reagent fn renders inside a
-   ;; non-default frame-provider. The runtime does NOT yet emit this
-   ;; trace; promoting the placeholder to a real assertion would have
-   ;; nothing to assert against. Tracking under the rf2-o83z follow-up
-   ;; bead (filed by the same PR that promoted #4 and #8) — the
-   ;; emission must land in re-frame.views' resolution chain at the
-   ;; point a plain fn falls through to :rf/default while a non-default
-   ;; React-context frame is in scope. Once emission lands, the test
-   ;; here can become a real browser assertion (mount under
-   ;; frame-provider, render a plain fn that subscribes, capture
-   ;; traces, assert exactly one warning per (fn, frame) pair across
-   ;; multiple renders)."
-  (is true
-      "placeholder; HALTED on runtime gap — see comment above (rf2-o83z follow-up)"))
+   a plain (non-`reg-view`) Reagent fn that renders inside a non-default
+   `frame-provider` lacks the `:contextType` wiring `reg-view` attaches,
+   so its `(rf/subscribe ...)` call cannot read the surrounding React-
+   context frame and falls through to `:rf/default`. Per Spec 004
+   §Plain Reagent fns and Spec 006 §Plain-fn-under-non-default-frame
+   warning (rf2-d3k3): the runtime emits
+   `:rf.warning/plain-fn-under-non-default-frame-once` at most once per
+   `(component-id, non-default-frame-id)` pair across renders.
+
+   Browser-only — requires a real React render so the React-context
+   tier actually pushes the Provider's value. Promoted from the
+   rf2-o83z placeholder once rf2-d3k3 landed the runtime emission."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target-frame :tenant-plain-fn-warn]
+      (rf/reg-frame target-frame {:doc "non-default frame for plain-fn warn-once test"})
+      (rf/reg-event-db :seed-plain-fn (fn [_ _] {:n 7}))
+      (rf/dispatch-sync [:seed-plain-fn] {:frame target-frame})
+      (rf/reg-sub :plain-fn-test/n (fn [db _] (:n db)))
+      ;; Reset the warn-once cache so this test starts from a clean
+      ;; slate. Per Spec 004 §The suppression cache is per-frame-instance.
+      (when-let [clear! (re-frame.late-bind/get-fn
+                          :views/clear-plain-fn-warned-pairs!)]
+        (clear!))
+      (let [render-counts (atom {})
+            ;; Two distinct plain Reagent fns. Neither is registered via
+            ;; reg-view, so neither carries the `:contextType` wiring;
+            ;; both will fall through to :rf/default at subscribe time.
+            plain-fn-a   (fn plain-fn-a-impl []
+                           (swap! render-counts update :a (fnil inc 0))
+                           (let [_ @(rf/subscribe [:plain-fn-test/n])]
+                             [:div.plain-a "a"]))
+            plain-fn-b   (fn plain-fn-b-impl []
+                           (swap! render-counts update :b (fnil inc 0))
+                           (let [_ @(rf/subscribe [:plain-fn-test/n])]
+                             [:div.plain-b "b"]))
+            mount-node   (make-mount-node!)
+            traces       (collect-traces ::xspec-10)
+            root         (rdc/create-root mount-node)]
+        (try
+          ;; Render the tree multiple times so the warn-once contract is
+          ;; exercised across re-renders. The Provider scopes the
+          ;; non-default frame; both plain fns subscribe inside that
+          ;; subtree on every render.
+          (dotimes [_ 3]
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root
+                            [rf/frame-provider {:frame target-frame}
+                             [:div
+                              [plain-fn-a]
+                              [plain-fn-b]]]))))
+          (stop-traces ::xspec-10)
+          (let [warns (filter #(= :rf.warning/plain-fn-under-non-default-frame-once
+                                   (:operation %))
+                              @traces)]
+            (is (>= (get @render-counts :a 0) 1)
+                "plain-fn-a rendered at least once")
+            (is (>= (get @render-counts :b 0) 1)
+                "plain-fn-b rendered at least once")
+            ;; Two distinct plain fns under the same non-default frame
+            ;; → two warnings (one per pair), regardless of how many
+            ;; times each rendered.
+            (is (= 2 (count warns))
+                (str "expected EXACTLY TWO :rf.warning/plain-fn-under-"
+                     "non-default-frame-once events (one per (fn, frame) "
+                     "pair, not per render); got " (count warns)
+                     " across " (apply + (vals @render-counts))
+                     " total renders"))
+            ;; Each warning carries the documented payload keys per
+            ;; Spec 009 §Error categories.
+            (is (every? #(contains? (:tags %) :fn-name) warns)
+                "every warning carries :fn-name")
+            (is (every? #(= target-frame (get-in % [:tags :rendered-under])) warns)
+                "every warning carries :rendered-under = the non-default frame id")
+            (is (every? #(= :rf/default (get-in % [:tags :routed-to])) warns)
+                "every warning records :routed-to = :rf/default (the frame the subscribe call actually used)")
+            (is (= :warning (-> warns first :op-type))
+                "the trace event uses op-type :warning"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+(deftest plain-fn-under-default-frame-no-warning
+  "Negative case — a plain Reagent fn rendered under the :rf/default
+   frame (or no frame-provider at all) must NOT trigger the warning.
+   Per Spec 004 §Plain Reagent fns: 'plain fns are safe in single-frame
+   apps (no different from today) and in default-frame portions of
+   multi-frame apps.' The warning is reserved for the non-default-
+   frame case."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (do
+      (rf/reg-event-db :seed-plain-default (fn [_ _] {:m 9}))
+      (rf/dispatch-sync [:seed-plain-default])
+      (rf/reg-sub :plain-default-test/m (fn [db _] (:m db)))
+      (when-let [clear! (re-frame.late-bind/get-fn
+                          :views/clear-plain-fn-warned-pairs!)]
+        (clear!))
+      (let [plain-default (fn plain-default-impl []
+                            (let [_ @(rf/subscribe [:plain-default-test/m])]
+                              [:div "default"]))
+            mount-node (make-mount-node!)
+            traces     (collect-traces ::xspec-10b)
+            root       (rdc/create-root mount-node)]
+        (try
+          (dotimes [_ 2]
+            (react-dom/flushSync
+              (fn []
+                ;; No frame-provider — the React-context tier resolves
+                ;; to :rf/default (the context's default value).
+                (rdc/render root [plain-default]))))
+          (stop-traces ::xspec-10b)
+          (let [warns (filter #(= :rf.warning/plain-fn-under-non-default-frame-once
+                                   (:operation %))
+                              @traces)]
+            (is (empty? warns)
+                "no warning fires for plain fns rendered under :rf/default"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+(deftest reg-view-under-non-default-frame-no-warning
+  "Negative case — a properly-registered view (reg-view*) renders inside
+   a non-default frame-provider WITHOUT triggering the warning. The
+   warning targets the plain-fn footgun specifically; reg-view'd
+   components carry the `:contextType` wiring that lets them read the
+   Provider's frame, so their subscribe calls route correctly."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target-frame :tenant-reg-view-no-warn]
+      (rf/reg-frame target-frame {:doc "non-default frame for reg-view negative test"})
+      (rf/reg-event-db :seed-reg-view (fn [_ _] {:k 11}))
+      (rf/dispatch-sync [:seed-reg-view] {:frame target-frame})
+      (rf/reg-sub :reg-view-test/k (fn [db _] (:k db)))
+      (when-let [clear! (re-frame.late-bind/get-fn
+                          :views/clear-plain-fn-warned-pairs!)]
+        (clear!))
+      (rf/reg-view* :rf.cross-spec-10/registered-view
+                    (fn registered-impl []
+                      (let [_ @(rf/subscribe [:reg-view-test/k])]
+                        [:div "reg-view"])))
+      (let [render-fn  (rf/view :rf.cross-spec-10/registered-view)
+            mount-node (make-mount-node!)
+            traces     (collect-traces ::xspec-10c)
+            root       (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root [rf/frame-provider {:frame target-frame}
+                                [render-fn]])))
+          (stop-traces ::xspec-10c)
+          (let [warns (filter #(= :rf.warning/plain-fn-under-non-default-frame-once
+                                   (:operation %))
+                              @traces)]
+            (is (empty? warns)
+                "no warning fires for reg-view'd components — the wiring lets them read the surrounding frame"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Interaction 11 — Machine action throws

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -150,6 +150,18 @@ const DEV_ONLY_SENTINELS = [
   // production bundles.
   { source: 're-frame.core/reg-machine (rf.machine/source-coords stamping)',
     sentinel: 'rf.machine/source-coords' }
+  // Note (rf2-d3k3): re-frame.views/maybe-warn-plain-fn-under-non-
+  // default-frame! emits :rf.warning/plain-fn-under-non-default-frame-
+  // once gated on interop/debug-enabled?. We do NOT add a sentinel
+  // entry here because the elision-probe runs outside Reagent's render
+  // cycle — `(r/current-component)` is nil — and closure compiler's
+  // dataflow analysis under :advanced determines the inner emit branch
+  // is unreachable, so the keyword's literal string is dropped from
+  // the control build too. The methodology check would be vacuous.
+  // The browser-test (re-frame.cross-spec-cljs-test/plain-fn-under-
+  // non-default-frame) is the load-bearing assertion that the gate is
+  // wired up under DEBUG=true; under :advanced + goog.DEBUG=false the
+  // gate is constant-folded false and the body DCE's regardless.
 ];
 
 // ----- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-default-frame warning: a plain (non-`reg-view`) Reagent fn that renders inside a non-default `frame-provider` cannot read the surrounding React-context frame — its `(rf/subscribe ...)` call falls through to `:rf/default`, almost certainly not what the author intended. The runtime now emits `:rf.warning/plain-fn-under-non-default-frame-once` at most once per `(component-id, non-default-frame-id)` pair. Closes the runtime gap left by rf2-o83z PR #166 (browser-test placeholder for cross-spec interaction #10) and promotes that placeholder to a real assertion.

Implements rf2-d3k3.

## Resolution-chain location of the new emission

The detection sits in `re-frame.subs/subscribe`'s 1-arity form (the documented call site per Spec 006 §706). After resolving the frame via `frame/current-frame`, subscribe consults a CLJS-only helper through `re-frame.late-bind`:

- Helper: `re-frame.views/maybe-warn-plain-fn-under-non-default-frame!` — gated on `interop/debug-enabled?`; the JVM build never loads `re-frame.views.cljs` and the late-bind lookup returns `nil` there.
- Detection conditions (all must hold to fire):
  1. We are mid-render — `(reagent.core/current-component)` returns a component.
  2. The component is NOT `reg-view`-wrapped — its `contextType` static is not the shared `frame-context`.
  3. The closest enclosing Provider names a non-default frame (read off the React context's `_currentValue`).
  4. The dynamic `*current-frame*` tier is unset (no `with-frame` shadow).
- Suppression: warn-once per `[component-id, frame-id]` pair via a `defonce` atom set, mirroring the rf2-z7f7 source-coord warn-once contract.

## Warn-once-per-pair behaviour (sample trace stream)

For two distinct plain fns rendered three times each under the same non-default `frame-provider`, exactly two `:rf.warning/plain-fn-under-non-default-frame-once` events fire (one per pair, not per render):

```clojure
{:operation :rf.warning/plain-fn-under-non-default-frame-once
 :op-type   :warning
 :id        ...
 :time      ...
 :tags      {:fn-name        "re-frame.cross-spec-cljs-test/plain-fn-a-impl"
             :rendered-under :tenant-plain-fn-warn
             :routed-to      :rf/default
             :reason         "Plain Reagent fns do not pick up the surrounding frame; their dispatch/subscribe targets :rf/default. To capture the surrounding frame, register the view via reg-view."}
 :recovery  :warned-and-replaced}

{:operation :rf.warning/plain-fn-under-non-default-frame-once
 :op-type   :warning
 :id        ...
 :time      ...
 :tags      {:fn-name        "re-frame.cross-spec-cljs-test/plain-fn-b-impl"
             :rendered-under :tenant-plain-fn-warn
             :routed-to      :rf/default
             :reason         "..."}
 :recovery  :warned-and-replaced}
```

Tag keys match Spec 009 §Error categories: `:fn-name`, `:rendered-under`, `:routed-to`. Plus a structured `:reason` with the migration hint to `reg-view`. In dev, the runtime also `console.warn`s the first occurrence so the footgun lands in front of human eyes; the trace event is the programmatic surface (10x, re-frame-pair).

## Production-elision

Every code path is gated on `interop/debug-enabled?` (`^boolean goog/DEBUG`). Bundle-grep for the keyword's literal string fragment:

```
$ grep -c "plain-fn-under-non-default-frame-once" out/examples/counter/main.js
0
```

Zero occurrences in shipped binaries (`:advanced` + `goog.DEBUG=false`). The detection branch, the trace emit, and the `console.warn` fallback all DCE.

(Note: an elision-check sentinel was considered but not added — the elision-probe runs outside Reagent's render cycle, so closure dataflow under `:advanced` determines the inner emit branch unreachable in BOTH probe bundles, making the methodology check vacuous. The new browser-runner test is the load-bearing assertion that the gate fires under `goog.DEBUG=true`.)

## Browser-runner test (cross-spec #10)

Promoted from the `(is true)` placeholder rf2-o83z left:

- `plain-fn-under-non-default-frame` — three renders × two distinct plain fns under the same non-default frame; asserts exactly two warnings fire (one per pair, not per render); asserts each warning's payload keys.
- `plain-fn-under-default-frame-no-warning` — negative case: plain fn under no frame-provider (`:rf/default`-tier) produces zero warnings.
- `reg-view-under-non-default-frame-no-warning` — negative case: a properly `reg-view*`-registered component under the same non-default `frame-provider` produces zero warnings (the `:contextType` wiring exempts it).

Each test gates on `(browser?)`; under `:node-test` they return `(is true)`; under `:browser-test` they mount through React via `rdc/create-root` + `react-dom/flushSync`.

## Test results

- core JVM:        184 tests, 834 assertions, 0 failures, 0 errors
- flows JVM:        26 tests,  98 assertions, 0 failures
- routing JVM:       9 tests,  48 assertions, 0 failures
- schemas JVM:      29 tests, 118 assertions, 0 failures
- ssr JVM:          27 tests, 102 assertions, 0 failures
- epoch JVM:        38 tests, 147 assertions, 0 failures
- http JVM:         18 tests,  45 assertions, 0 failures
- machines JVM:     30 tests,  81 assertions, 0 failures
- `npm run test:cljs` (node-test):  154 tests, 466 assertions, 0 failures
- `npm run test:browser`:           154 tests, 476 assertions, 0 failures
- `npm run test:elision`:           PASS (every existing sentinel still elides)
- `npm run test:bundle-isolation`:  PASS
- `npm run test:examples`:          PASS (18 examples)
- Bundle-grep `out/examples/counter/main.js`: 0 occurrences of `plain-fn-under-non-default-frame-once`

(`npm run test:perf-bundle` was failing before this branch — pre-existing unrelated failure on master.)

## Discovered while implementing

Filed rf2-d4sf (P2, follow-up): the existing reg-view + frame-provider integration is dead code — `re-frame.subs/subscribe` calls `re-frame.frame/current-frame` (dynamic-var only), never `re-frame.views/current-frame` (which has the React-context tier), so even properly-registered views under a non-default `frame-provider` route subscribes to `:rf/default`. Compounding issue: Reagent's `convert-prop-value` stringifies named values when passed as React props, so `(.-context cmp)` would be a string anyway — `views/current-frame`'s `(when (keyword? ctx) ctx)` returns nil. This PR's `re-frame.views/read-react-context-frame` adds the string→keyword fallback for the warning's detection logic; the broader subscribe-side fix is rf2-d4sf's scope. The plain-fn warning's contract (`:routed-to :rf/default`) is currently always true for ANY fn (registered or not) under a non-default frame-provider — but that's the correct observable behaviour the warning surfaces today.

## Test plan

- [x] Run `cd implementation/core && clojure -M:test`
- [x] Run `cd implementation/{flows,routing,schemas,ssr,epoch,http,machines} && clojure -M:test`
- [x] Run `npm run test:cljs`
- [x] Run `npm run test:browser`
- [x] Run `npm run test:elision`
- [x] Run `npm run test:bundle-isolation`
- [x] Run `npm run test:examples`
- [x] Bundle-grep production for the warning's literal string fragment