### PR TITLE
docs(guide): flesh out — 3 priority new chapters + 3 chapter updates (rf2-m8np)

### DIFF
--- a/docs/guide/02-your-first-app.md
+++ b/docs/guide/02-your-first-app.md
@@ -4,6 +4,39 @@ The smallest interesting program is a counter: a number, two buttons, the number
 
 The full source is in [`examples/reagent/counter/core.cljs`](../../examples/reagent/counter/core.cljs). This chapter walks through it section by section, explaining what each piece is doing and *why it's shaped the way it is*. By the end you'll have seen every load-bearing primitive in re-frame2 at least once.
 
+## Choose your substrate
+
+Before the code, one decision: **which view substrate is rendering this?** re-frame2's runtime — the registry, the dispatch loop, events, fx, subs, machines — is substrate-agnostic. The primitives you use in `app-db`, in event handlers, and in subs are identical regardless. What differs is how the view layer is wired into React.
+
+Three substrate adapters are available today:
+
+- **Reagent** — the canonical CLJS reference. Hiccup-shaped views, deref-tracking subscriptions (`@(subscribe ...)`), the substrate the rest of this guide uses. Pick this if you have no other constraint.
+- **UIx** — a CLJS adapter targeting React function components and hooks idiomatically. Useful if you're integrating with a JS-side codebase that expects React fn-components, or if you want UIx's compile-time JSX-style ergonomics.
+- **Helix** — same shape as UIx in spirit; pick it if your team already uses Helix.
+
+Each ships as its own Maven artefact alongside core (per Strategy B — see [rf2-5vjj](../../spec/MIGRATION.md)):
+
+```clojure
+;; deps.edn — Reagent (the canonical "first app" stack)
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-reagent  {:mvn/version "2.0.0"}
+        reagent                   {:mvn/version "2.0.0"}}}
+
+;; deps.edn — UIx
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-uix      {:mvn/version "2.0.0"}
+        com.pitch/uix.core       {:mvn/version "..."}}}
+
+;; deps.edn — Helix
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-helix    {:mvn/version "2.0.0"}
+        lilactown/helix          {:mvn/version "..."}}}
+```
+
+Per the [feature-opt-in story](../../spec/MIGRATION.md), core ships with **none** of the substrate adapters baked in — you add the artefact for the substrate you've picked. The same pattern applies to optional capabilities (state machines, routing, HTTP, schemas, SSR, time-travel) — each ships as its own artefact, and an app that doesn't use a feature doesn't bundle its code.
+
+This chapter uses Reagent throughout. The `dispatch`, `subscribe`, and `reg-view` primitives are identical across substrates; the difference shows up in the mount call (`reagent.dom.client/render` vs `uix.dom/render-root` vs Helix's mount fn) and in how the view body composes — Reagent uses hiccup, UIx and Helix use their own component DSLs. The pattern survives.
+
 ## What we're building
 
 A page with a `+` button, a `-` button, and a number between them. Click `+`: the number goes up. Click `-`: it goes down. Default value: `5`.
@@ -194,7 +227,31 @@ This is the part that's not really re-frame2 — it's the React/Reagent runtime 
 >   (rdc/render root [counter]))
 > ```
 >
-> Requiring `re-frame.substrate.reagent` fires its ns-load side-effect, which registers the Reagent adapter as the default-resolution candidate (per [rf2-84po](#)); `(rf/init!)` with no args picks it up. Mixed-substrate apps that require both Reagent and UIx disambiguate via `(rf/init! :reagent)` / `(rf/init! :uix)`. `dispatch-sync` fires the initialisation event synchronously so `app-db` is populated *before* the first render — otherwise the view briefly sees an empty `app-db`. (In the chapter's example we wired `:on-create [:counter/initialise]` into `reg-frame` instead, which seeds `app-db` at frame-creation time; either form works.) The runnable [`examples/reagent/counter/core.cljs`](https://github.com/day8/re-frame2/blob/main/examples/reagent/counter/core.cljs) shows the full mount, including both lines. They were elided above to keep the narrative focused on `reg-view`; everything else in the chapter assumes they're present.
+> Requiring `re-frame.substrate.reagent` fires its ns-load side-effect, which registers the Reagent adapter as the default-resolution candidate (per [rf2-84po](#)); `(rf/init!)` with no args picks it up. `dispatch-sync` fires the initialisation event synchronously so `app-db` is populated *before* the first render — otherwise the view briefly sees an empty `app-db`. (In the chapter's example we wired `:on-create [:counter/initialise]` into `reg-frame` instead, which seeds `app-db` at frame-creation time; either form works.) The runnable [`examples/reagent/counter/core.cljs`](https://github.com/day8/re-frame2/blob/main/examples/reagent/counter/core.cljs) shows the full mount, including both lines. They were elided above to keep the narrative focused on `reg-view`; everything else in the chapter assumes they're present.
+
+### `init!` and how the substrate gets wired
+
+The line `(rf/init!)` deserves a closer look — it's where the substrate adapter is bound to the runtime.
+
+There are two shapes:
+
+```clojure
+;; Option 1 — explicit. Pass the adapter you want.
+(rf/init! re-frame.substrate.reagent/adapter)
+
+;; Option 2 — no-arg. Resolve from the registry.
+(rf/init!)
+```
+
+**Option 2 is the canonical form** — and it works because the substrate adapter ns has a side-effect when it loads. Inside `re-frame.substrate.reagent`, a top-level `defonce` calls `(register-default-adapter! ...)` at ns-load time. So as soon as you `(:require [re-frame.substrate.reagent])` anywhere in your app's require graph, the Reagent adapter is registered as a default-resolution candidate. `(rf/init!)` with no args looks up the registered default and uses it.
+
+The benefit is "you require it, it's wired." The first-app boilerplate is exactly four lines: a require, an `init!`, a seeding `dispatch-sync`, and a `render`. No threading-an-adapter-object through the run fn.
+
+For mixed-substrate cases — say a build that requires both `re-frame.substrate.reagent` and `re-frame.substrate.uix` because it has Reagent stories AND a UIx production view tree — the no-arg `init!` raises a structured error (`:rf.error/multiple-default-adapters`) so the call site can't accidentally pick the wrong one. The fix is to pass the adapter explicitly, or, equivalently, init by adapter id: `(rf/init! :reagent)` / `(rf/init! :uix)`.
+
+If no substrate adapter has been required, `(rf/init!)` raises `:rf.error/no-adapter-registered` with a message that names the artefact you probably want (`day8/re-frame-2-reagent`). That error is the canonical signal that you forgot the substrate dep.
+
+The same shape applies to UIx and Helix. Each adapter ns ns-load-registers itself; `(rf/init!)` resolves; if you've required exactly one, it picks that one.
 
 ## What just happened
 

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -53,6 +53,45 @@ Two things change:
 
 For a single-frame app, plain views are fine. For anything else — and "anything else" includes story tools, SSR, devcards, and multi-window apps — register your views. The cost is a few extra characters; the win is that the view-side architecture supports the multi-frame case as soon as you need it.
 
+### `dispatch` and `subscribe` are auto-injected
+
+Inside a `reg-view` body, two names are available that you didn't import: `dispatch` and `subscribe`. They look like the global functions but are **lexically bound**, frame-aware versions that the macro injects.
+
+```clojure
+(rf/reg-view counter []
+  [:div
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]
+   [:span @(subscribe [:count])]])
+;; ↑                  ↑
+;; injected           injected
+```
+
+What that buys you: the view's body never says "this frame" out loud. The injected `dispatch`/`subscribe` capture the surrounding frame from the React tree (when wrapped by `frame-provider`) or fall back to the dynamic-var tier or `:rf/default`. The view fn doesn't know which frame it's been instantiated under; the framework routes correctly.
+
+Form-1 views — render fns whose body is a literal hiccup expression — get the auto-inject via the macro's expansion. Form-2 views — render fns that return another fn (the "outer fn closes over args, inner fn does the work" Reagent idiom) — also work, and are the canonical shape when the view needs to capture per-instance state in the closure or maintain a Reagent-local atom for transient UI state. Both shapes are documented in [Spec 004](../../spec/004-Views.md).
+
+```clojure
+;; Form-1 — direct render
+(rf/reg-view counter []
+  [:div @(subscribe [:count])])
+
+;; Form-2 — captures args; useful for setup-once-then-render
+(rf/reg-view greeting [name]
+  (let [greeted-at (js/Date.now)]
+    (fn render [name]
+      [:div "Hello, " name " (at " greeted-at ")"])))
+```
+
+The macro errors at compile time if you hand it a Form-3 (`reagent.core/create-class`) or a non-literal-fn body — the message points you at the underlying fn `reg-view*` for those rare cases. The compile-time check is the load-bearing piece: it stops the auto-inject from silently doing the wrong thing when the body shape isn't what the macro can rewrite.
+
+### How frames propagate through the view tree
+
+The architecture above assumes a view inside a `frame-provider` subtree picks up the surrounding frame. The CLJS reference uses **React context** to carry this — when you wrap a subtree with `[rf/frame-provider {:frame :left} ...]`, every registered view rendered underneath receives the frame id through context, and the auto-injected `dispatch`/`subscribe` resolves against it.
+
+In practice, the propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` will dispatch to `:left`. **Caveat:** as of today the CLJS implementation has a partial gap here — the resolution chain spec/002 §3 documents (dynamic-var → React context → `:rf/default`) is not fully wired in the current CLJS reference. Subscribe consults the dynamic-var tier and falls back to `:rf/default`; the React-context tier is documented but not yet connected in the read path. The split-counter example below works in the canonical case (one frame-per-mount, set up via `frame-provider` plus dispatch-sync seed events) because the dynamic-var tier carries the frame for each render, but more elaborate cases — sibling views under different frame-providers within a single render pass that BOTH need to read state — should be tested against your specific shape.
+
+The behaviour is tracked at [rf2-d4sf](#); the contract in this guide describes what works today, not what spec/002 §3 promises long-term. When the gap closes, the resolution is automatic — your code does not change. The chapter's example (and the runnable [`examples/reagent/counter/core.cljs`](../../examples/reagent/counter/core.cljs)) exercises only the part that works today.
+
 ### The Var-reference idiom
 
 `reg-view` is defn-shape: it auto-defs the symbol you supply. Reference that var like any other Reagent component:
@@ -163,6 +202,25 @@ In CLJS, the way to put a registered view inside a particular frame's subtree is
 Two instances of the same registered view, different frames. Each subtree's `dispatch`/`subscribe` resolves to its own frame. The view fn doesn't know it's been instantiated twice with different state.
 
 `frame-provider` is a Reagent-specific (React context-driven) construct. The pattern itself doesn't require it — what the *pattern* requires is that every dispatch/subscribe targets a specific frame, by whatever mechanism the host language provides. In TypeScript, you might use a hooks-flavoured `useFrame()`. In Python, you might pass the frame as an argument. In Clojure, React context happens to be ergonomic. The contract — every view targets a specific frame — is the part that survives across hosts.
+
+## Source coordinates on rendered DOM
+
+A small but load-bearing detail: every `reg-view`-rendered DOM element receives a `data-rf2-source-coord` attribute pointing back to the registration that produced it.
+
+```html
+<button data-rf2-source-coord="counter.core:counter:48:5" ...>+</button>
+```
+
+The four colon-separated segments are `<ns>:<sym>:<line>:<col>` — the registration's namespace, the registered symbol, and the source line/column captured at macro-expansion time. (To recover the file path too, look it up via `(rf/handler-meta :view <id>)`; the registration metadata carries `:rf/source-coord-meta` with `:ns`/`:line`/`:column`/`:file`.)
+
+The annotation is **mandatory** in the CLJS reference per [Spec 006](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) — every substrate adapter whose host has a DOM-attribute concept injects it. It exists so pair-tools and devtools can take a clicked DOM node and resolve it back to the source line that produced the view; [chapter 11](11-devtools-and-pair-tools.md) walks through what tools do with it.
+
+Two production-elision details matter:
+
+- The annotation is **dev-only** — gated on the universal `re-frame.interop/debug-enabled?` flag (the CLJS mirror of `goog.DEBUG`). `:advanced` builds with `goog.DEBUG=false` strip the attribute via Closure DCE; the rendered HTML in production carries no `data-rf2-source-coord` bytes.
+- Components whose outermost return is a React Fragment, a `:>`-prefixed host component, or another non-DOM root are exempt — the runtime can't attach an attribute to a fragment. Pair-tools fall back to the registration's metadata for those nodes.
+
+You don't need to do anything to get the annotation. `reg-view` does it. The mention here is so you recognise the attribute when you see it in the inspector.
 
 ## What lives in app-db
 

--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -189,6 +189,10 @@ If you don't need any other registration metadata (no `:doc`, no `:interceptors`
 
 This is exactly `(reg-event-fx machine-id (create-machine-handler machine))` — same effect, less ceremony.
 
+`reg-machine` is a **macro** (since [rf2-8bp3](../../spec/005-StateMachines.md#source-coord-stamping-rf2-8bp3)). At expansion time it walks the literal spec form and stamps a flat coord index under `:rf.machine/source-coords` on the machine's metadata, keyed by spec-path tuples like `[:guards :form-valid?]`, `[:actions :commit]`, `[:states :form :on :submit]`. The coord index is what lets pair-tools take a clicked transition arrow in a state-diagram visualisation and jump to the source line that wrote it. It's dev-only — production builds elide the index alongside other source-coord annotations.
+
+In day-to-day code you will not see the coord index unless you go looking for it. `(rf/machine-meta :auth.login/flow)` returns it under the `:rf.machine/source-coords` key.
+
 ## Dispatching to a machine
 
 Sub-events route via the machine's id and an inner event vector:
@@ -369,6 +373,98 @@ Real apps have more than one machine: an auth machine, a checkout-wizard machine
 When machines need to talk to each other, they do so through dispatch — the auth machine's `:auth.login/success` action might dispatch `[:user/load-profile]`, which is handled by a regular `reg-event-fx` handler that updates the user-profile slice. There's no special inter-machine messaging. It's all events, all going through the same queue, all running to completion.
 
 The drain semantics matter here. If an action dispatches a child event, that child event runs *before* subscriptions update. So if a state machine moves through `:idle → :submitting → :authed → :loading-profile → :ready` in a single user click, the view sees only `:idle` (before) and `:ready` (after) — never any in-between flicker. The pattern's commitment to atomic state changes pays off most strongly in flows like this.
+
+### Spawning child machines: `:rf.machine/spawn` and `:rf.machine/destroy`
+
+Some machines aren't long-lived singletons. A protocol machine that owns one HTTP request lives only as long as the request. A websocket-pump machine spawns when the connection comes up and exits when it closes. A wizard's per-step subprocess starts and stops with the step. These are **dynamic actors** — gensym'd ids, lifecycle scoped to the parent.
+
+The canonical fxs for the lifecycle are:
+
+```clojure
+[:rf.machine/spawn   {:machine-id :request/protocol
+                      :data       {...}}]    ;; create — runtime gensyms an id
+[:rf.machine/destroy actor-id]                ;; tear down by id
+```
+
+`:rf.machine/spawn` registers a fresh actor (a copy of the spec keyed by a gensym'd id), seeds its `:data`, runs `:on-spawn` against the new id, and queues the optional `:start` event to it. `:rf.machine/destroy` runs the actor's `:exit` action, dissociates its snapshot at `[:rf/machines <actor-id>]`, and clears its handler from the frame-local registry.
+
+These are the **only** spelling for lifecycle fx since [PR #175](https://github.com/day8/re-frame2/pull/175). The earlier internal-only `:spawn` / `:destroy-machine` ids are gone — every spawn and destroy uses the `:rf.machine/...` namespace, in alignment with the framework's `:rf.<feature>/...` convention. (If you have a code-search habit of finding `:spawn` strings, switch to `:rf.machine/spawn` — `:spawn` no longer matches.)
+
+For most apps, you do not call `:rf.machine/spawn` directly. The declarative `:invoke` slot on a state node spawns a child on entry and destroys it on exit:
+
+```clojure
+:states
+{:authenticating
+ {:invoke {:machine-id :auth/oauth-flow
+           :data       {:provider :github}
+           :on-spawn   :stash-actor-id}
+  :on {:auth.oauth/success {:target :authenticated
+                            :action :store-session}}}
+
+ :authenticated
+ {:entry :clear-actor-id
+  ;; ... no :invoke — no child to manage in this state
+  }}
+```
+
+`:invoke` is **registration-time sugar.** `create-machine-handler` walks the spec at construction time and rewrites every `:invoke` slot into entry/exit actions emitting `:rf.machine/spawn` and `:rf.machine/destroy`. The runtime sees only the desugared form — no new mechanics, no new lifecycle event.
+
+#### The runtime-tracked spawn registry
+
+Earlier drafts of the spec asked the user to write the spawned actor-id into a chosen `:data` key (e.g. `:auth-actor`) inside their `:on-spawn` action, then read that key on destroy to pass it to `:rf.machine/destroy`. That contract had a worked-example bug ([rf2-t07u](#)): if you wrote the id into `:auth-actor` but the runtime hardcoded a magic `:pending` key when destroying, your actor would silently leak on every state exit.
+
+That is fixed (per PR #172). The runtime now keeps an internal **spawn registry** at `[:rf/spawned <parent-id> <invoke-id>]` in the spawning frame's `app-db`. When a state with `:invoke` is entered, the runtime writes the spawned actor-id there. On exit, the runtime reads it back and emits the destroy fx with the right id. **You don't have to track the actor-id yourself.**
+
+`:on-spawn` is now **advisory** — you can still write the id into `:data` if your transition table needs it for something, but the runtime no longer relies on you doing so. The auth-flow worked example in this chapter — and in [Spec 005](../../spec/005-StateMachines.md) — works as written, no per-user-bookkeeping required.
+
+```clojure
+;; The runtime tracks this for you. Visible via:
+(get-in (rf/get-frame-db) [:rf/spawned :auth.login/flow :auth-actor])
+;; → :auth/oauth-flow#g42  (the gensym'd actor id)
+```
+
+The slot is sibling to `[:rf/system-ids]` (next section): same per-frame isolation, same revertibility (the slot walks back atomically with `app-db` on a frame revert), same lazy allocation (absent until the first declarative `:invoke` spawn).
+
+### Naming machines across the frame: `:system-id`
+
+Sometimes a spawned actor needs to be reached by name from somewhere else — a sibling machine, an event handler, a REPL session — without threading the gensym'd id through `:data`. The opt-in `:system-id` key on a spawn binds the actor to a frame-level reverse index:
+
+```clojure
+;; Imperative spawn (action :fx) with a :system-id binding.
+{:fx [[:rf.machine/spawn {:machine-id :request/protocol
+                          :data       {...}
+                          :system-id  :primary-request}]]}
+
+;; The same key works on declarative :invoke:
+:states
+{:requesting
+ {:invoke {:machine-id :request/protocol
+           :system-id  :primary-request
+           :data       {...}}}}
+
+;; Look it up later:
+(rf/machine-by-system-id :primary-request)
+;; → :request/protocol#g42  (the gensym'd actor-id), or nil if no actor is currently bound
+```
+
+`:system-id` is a **frame-level reverse index** that resolves to whichever spawned actor currently owns the name. It lives at `[:rf/system-ids <name>]` in the spawning frame's `app-db` — same place as the snapshot, so it inherits frame revertibility for free.
+
+Lifecycle:
+
+- **On spawn** with a `:system-id`, the runtime writes `[:rf/system-ids <name>] = <gensym'd-id>` and emits `:rf.machine/system-id-bound`.
+- **On destroy**, the runtime clears the slot AND emits `:rf.machine/system-id-released`.
+- **A spawn under an already-bound name rebinds** (last-write-wins) and emits `:rf.error/system-id-collision` so observers can see the displacement. The previously-bound machine's snapshot stays at its `[:rf/machines <id>]` slot — just unnamed.
+
+The standard cross-machine pattern still works — `[:fx [[:dispatch [<other-id> [:event]]]]]` addresses any registered id. With `:system-id` bound, the addressing call site becomes a name lookup:
+
+```clojure
+{:fx [[:dispatch [(rf/machine-by-system-id :primary-request)
+                  [:protocol/cancel]]]]}
+```
+
+This is **opt-in** and **orthogonal** to gensym'd ids. Most spawns won't need it. Reach for `:system-id` when you have a stable role (one auth flow, one primary request, one wizard) that other parts of the frame need to talk to by name.
+
+A note on the 3-arity escape hatch covered earlier: the runtime detects "this fn declared three positional parameters" by inspecting the fn's arglist. **Variadic fns** like `(constantly nil)` or `(fn [& args] ...)` are detected as 2-arity (per [rf2-1e0n](#) and follow-up rf2-l04j). If you actually want the introspection slot, write a real 3-arity fn rather than reaching for a variadic shorthand — the variadic case is a footgun, not a clever shortcut.
 
 ## A runnable example
 

--- a/docs/guide/10-testing.md
+++ b/docs/guide/10-testing.md
@@ -1,0 +1,428 @@
+# 10 — Testing
+
+re-frame2's pattern is shaped to be tested. Pure event handlers, pure machine transitions, sub bodies that compute against an `app-db` value, an effect map that's just data — every load-bearing piece is a function from values to values. There's nothing in the runtime that requires a browser, a network, or a clock to evaluate.
+
+This chapter is about how you write that down as test code: the `re-frame.test-support` artefact, the per-test fixture patterns, the JVM-vs-CLJS boundary, and the conformance harness that grades implementations against the same fixtures used by the framework's own tests.
+
+You'll know how to:
+
+- Spin up an isolated frame for a test and tear it down cleanly.
+- Test event handlers, fxs, and subs without a browser.
+- Test state machines as pure transitions, no frame required.
+- Use `dispatch-sequence` and `assert-state` to keep test bodies short.
+- Decide what runs on the JVM and what needs CLJS.
+- Use the host-agnostic conformance fixtures.
+- Understand what the bundle-isolation CI gate enforces.
+
+## The artefact
+
+Testing helpers ship in `re-frame.test-support`, alongside re-exports of the foundation primitives (`make-frame`, `dispatch-sync`, `with-frame`, etc.) so a test file needs one require:
+
+```clojure
+(ns my-app.auth-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as ts]))
+```
+
+The artefact is dev-only and cleanly separated from the runtime — the testing surface is built entirely from foundation primitives in [Spec 002](../../spec/002-Frames.md). Nothing in `re-frame.test-support` is a special-case mechanism; it's all sugar over `make-frame`/`destroy-frame`/`reset-frame`/`dispatch-sync`/`compute-sub`.
+
+## Fixtures: getting a fresh frame for each test
+
+The hardest part of testing imperative code is **isolation** — making sure test 1 doesn't leak state into test 2. re-frame v1 papered over this with global `app-db`-resetting helpers; re-frame2 makes it explicit through frames.
+
+Three patterns, ranked roughly by frequency:
+
+### Pattern 1 — `with-frame` for tighter blocks
+
+```clojure
+(deftest auth-flow
+  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+    (rf/dispatch-sync [:auth/login-pressed])
+    (is (= :validating (get-in (rf/get-frame-db f) [:auth :state])))))
+```
+
+`with-frame` binds `f` to the freshly-created frame for the body's duration, sets it as the implicit `*current-frame*` (so `dispatch-sync` and `subscribe` inside the body resolve to it without a `{:frame ...}` opt), and on exit (success or exception) destroys the frame. One block; no try/finally.
+
+### Pattern 2 — anonymous fixture per test
+
+The shape `with-frame` desugars into, useful when you want explicit teardown logic:
+
+```clojure
+(deftest auth-flow
+  (let [f (rf/make-frame {:on-create [:auth/init-idle]})]
+    (try
+      (rf/dispatch-sync [:auth/login-pressed] {:frame f})
+      (is (= :validating (get-in (rf/get-frame-db f) [:auth :state])))
+      (finally
+        (rf/destroy-frame f)))))
+```
+
+Functionally equivalent to Pattern 1; reach for it when the body is doing something the macro can't see — running a generator over many frames, threading the frame into a helper that takes its own teardown, etc.
+
+### Pattern 3 — named fixture across many tests
+
+For a test group sharing setup, register a named test frame once and reset between tests:
+
+```clojure
+(use-fixtures :each
+  (fn [test-fn]
+    (rf/reg-frame :test-fixture {:on-create [:auth/init-idle]})
+    (try
+      (test-fn)
+      (finally
+        (rf/reset-frame :test-fixture)))))
+
+(deftest one-thing
+  (rf/dispatch-sync [:auth/login-pressed] {:frame :test-fixture})
+  (is (= :validating (get-in (rf/get-frame-db :test-fixture) [:auth :state]))))
+```
+
+`reset-frame` (per [Spec 002](../../spec/002-Frames.md)) clears `app-db` to `{}` and re-fires `:on-create`. State is fresh between tests; the registration cost is paid once.
+
+### Registrar isolation: `with-fresh-registrar`
+
+The patterns above isolate `app-db`. They don't isolate the **registrar** — the global registry of events, fxs, subs, machines. If one test registers `:my-feature/event` and another test registers a different version of the same id, the second wins, regardless of test order. That's a recipe for tests that pass alone and fail together.
+
+`re-frame.test-support/with-fresh-registrar` snapshots the registrar around the body and restores on exit:
+
+```clojure
+(use-fixtures :each
+  (fn [test-fn]
+    (ts/with-fresh-registrar (test-fn))))
+```
+
+The companion fn `reset-runtime-fixture` is the same shape extended to per-process state — frames, flows, schemas, trace listeners — and is the standard `:each` fixture for re-frame2 test suites. Use `with-fresh-registrar` when only the registrar might change; use `reset-runtime-fixture` when tests touch trace listeners, schemas, or other process-wide state.
+
+## What you actually test
+
+### Event handlers
+
+A `reg-event-db` handler is a pure function of `(db, event) → db`. Test it as a pure function:
+
+```clojure
+(deftest counter-inc-test
+  (let [handler (:handler-fn (rf/handler-meta :event :counter/inc))
+        before  {:count 5}
+        after   (handler before [:counter/inc])]
+    (is (= 6 (:count after)))))
+```
+
+For `reg-event-fx` handlers, you test the **effect map shape**:
+
+```clojure
+(deftest login-handler-produces-http-fx
+  (let [handler (:handler-fn (rf/handler-meta :event :user/login))
+        result  (handler {:db {}} [:user/login {:email "a@b.c" :password "x"}])]
+    (is (= true (get-in result [:db :auth/loading?])))
+    (is (= :rf.http/managed (ffirst (:fx result))))))
+```
+
+The handler doesn't fire the HTTP request. The runtime would. The test doesn't need a runtime — it asserts that the handler **describes** the right request.
+
+### End-to-end through a frame
+
+For tests that exercise multiple events in sequence and want to assert at the end, drive the whole flow through `dispatch-sync`:
+
+```clojure
+(deftest auth-happy-path
+  (rf/with-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+    (rf/dispatch-sync [:auth/email-changed "alice@example.com"])
+    (rf/dispatch-sync [:auth/password-changed "hunter2"])
+    (rf/dispatch-sync [:auth/login-pressed]
+                      {:fx-overrides {:rf.http/managed
+                                      (fn [_ _] {:status 200 :body {:user/id 42}})}})
+    (is (= :authed (get-in (rf/get-frame-db f) [:auth :state])))))
+```
+
+Two pieces are doing work here:
+
+- **`dispatch-sync` drains synchronously to fixed point.** The whole event cascade — including any follow-up `:dispatch` fxs — settles before `dispatch-sync` returns. Assertions immediately after see committed state, no race.
+- **`:fx-overrides`** redirects a registered fx for one dispatch (or one frame, if specified on `reg-frame`). The override is an id-redirect, not a mock — the same dispatch shape the real `:rf.http/managed` produces lands in the test handler. No JSDOM, no fake fetch.
+
+### Subscriptions
+
+Two ways to test a sub:
+
+```clojure
+;; 1. compute-sub against a literal app-db value
+(deftest pending-todos-sub-pure
+  (is (= 2 (count (rf/compute-sub [:pending-todos]
+                                  {:items [{:id 1 :status :pending}
+                                           {:id 2 :status :done}
+                                           {:id 3 :status :pending}]})))))
+
+;; 2. compute-sub against a frame's app-db, after dispatching events
+(deftest pending-todos-sub-via-events
+  (rf/with-frame [f (rf/make-frame {})]
+    (rf/dispatch-sync [:todos/add {:id 1 :status :pending}])
+    (rf/dispatch-sync [:todos/add {:id 2 :status :done}])
+    (rf/dispatch-sync [:todos/add {:id 3 :status :pending}])
+    (is (= 2 (count (rf/compute-sub [:pending-todos] (rf/get-frame-db f)))))))
+```
+
+The dispatch-driven form is preferred — it tests the sub against state produced by the same code paths the application uses, and it survives `app-db` schema changes. If `:items` becomes `:todos`, the events update, the sub updates, the test keeps working unmodified.
+
+`compute-sub` is **pure** — same `(query-v, db)` always returns the same value. Composed subs (`:<-`) are computed transitively: inputs first, then outputs, all without spinning up the reactive cache.
+
+### State machines
+
+Three levels of machine testing, in order of unit-cost:
+
+**Level 1 — pure `machine-transition`.** No frame, no `app-db`, no router. Test the transition rules in isolation:
+
+```clojure
+(deftest login-flow-happy-path
+  (let [s0 {:state :idle :data {:attempts 0 :error nil}}
+        [s1 _fx] (rf/machine-transition login-flow s0
+                                        [:auth.login/submit {:email "a@b.c"
+                                                             :password "..."}])]
+    (is (= :submitting (:state s1)))))
+
+(deftest login-flow-lockout
+  (let [snap {:state :submitting :data {:attempts 3}}
+        [s _fx] (rf/machine-transition login-flow snap
+                                       [:auth.login/failure {:message "wrong"}])]
+    (is (= :locked-out (:state s)))))
+```
+
+**Level 2 — unregistered handler fn.** `(rf/create-machine-handler login-flow)` returns a regular event-handler fn. Call it directly with a synthetic cofx map:
+
+```clojure
+(let [handler (rf/create-machine-handler login-flow)
+      result  (handler {:db {:rf/machines {:auth.login/flow {:state :idle :data {}}}}}
+                       [:auth.login/flow [:auth.login/submit {...}]])]
+  (is (= :submitting (get-in result [:db :rf/machines :auth.login/flow :state]))))
+```
+
+**Level 3 — registered in test frame.** Register the machine in a frame, dispatch events, assert against the frame's `app-db`:
+
+```clojure
+(rf/with-frame [f (rf/make-frame {})]
+  (rf/reg-machine :auth.login/flow login-flow)
+  (rf/dispatch-sync [:auth.login/flow [:auth.login/submit {...}]])
+  (is (= :submitting (get-in (rf/get-frame-db f)
+                              [:rf/machines :auth.login/flow :state]))))
+```
+
+Use Level 1 for transition logic. Use Level 2 when you want to verify the handler boundary's effect-lifting. Use Level 3 for the integration shape — that the machine wires correctly into a frame's dispatch loop. Most machine bugs are caught at Level 1; the levels exist so each layer's failure mode is unambiguous.
+
+## Test-flavoured helpers
+
+`re-frame.test-support` ships a few small helpers that read better than hand-rolling the same shape:
+
+### `dispatch-sequence`
+
+Fires each event via `dispatch-sync` in order. Returns the final `app-db`:
+
+```clojure
+(deftest counter-walk
+  (rf/dispatch-sync [:counter/init])
+  (let [final (ts/dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])]
+    (is (= 1 (:n final)))))
+```
+
+Capturing intermediate states between dispatches:
+
+```clojure
+(let [seen (atom [])]
+  (ts/dispatch-sequence [[:counter/inc] [:counter/inc]]
+                        {:after-each (fn [db ev] (swap! seen conj [ev db]))}))
+```
+
+Equivalent to a `doseq` of `dispatch-sync` calls; reads better in tests.
+
+### `assert-state`
+
+A `clojure.test`-aware assertion that doubles as the path-or-full-db check:
+
+```clojure
+(rf/dispatch-sync [:auth/login-pressed])
+(ts/assert-state [:auth :state] :validating)
+;; or full-db form:
+(ts/assert-state {:auth {:state :validating}})
+;; with a non-default frame:
+(ts/assert-state [:auth :state] :validating {:frame :test/auth-flow})
+```
+
+Mismatch fires a `clojure.test/is`-style failure via `do-report`. The path form is the common case; the full-db form is for "the whole thing should equal this" assertions in small fixtures.
+
+### `run-test-sync` (compatibility shim)
+
+For mechanical migration of v1 tests written against `day8/re-frame-test`'s `run-test-sync`:
+
+```clojure
+(deftest legacy-flow
+  (ts/run-test-sync
+    (rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:counter/inc])
+    (is (= 1 (:n (rf/get-frame-db :rf/default))))))
+```
+
+The macro snapshots the registrar before the body and restores on exit (success or exception). v2's `dispatch-sync` already drains synchronously, so the macro is a body wrapper — its job is registrar isolation, not synchronicity. New tests don't need it; existing v1 test suites get a name-rename and keep working.
+
+## JVM vs CLJS — what runs where
+
+A defining property of re-frame2's testing surface: **almost everything runs on the JVM**. You don't need a browser, JSDOM, a CLJS test runner, or a headless Chrome to test event handlers, fxs, subs, machine transitions, or whole event cascades.
+
+What's JVM-runnable:
+
+- ✓ `make-frame` / `destroy-frame` / `reset-frame` / `with-frame`
+- ✓ `dispatch-sync` and the entire dispatch pipeline (router, drain, interceptors)
+- ✓ All `reg-event-*` handler invocation
+- ✓ Override application (`:fx-overrides`, `:interceptor-overrides`, `:interceptors`)
+- ✓ Cofx injection
+- ✓ `machine-transition` (pure function)
+- ✓ `compute-sub` (sub computation against an `app-db` value)
+- ✓ Public registrar queries (`handlers`, `frame-meta`, `sub-topology`, etc.)
+- ✓ **Hiccup → HTML emission** via `render-to-string` (per [Spec 011](../../spec/011-SSR.md)) — pure function, JVM-runnable. Snapshot tests, SSR conformance tests, and visual-regression diffs all run headlessly.
+
+What's CLJS-only:
+
+- ✗ React-actually-mounting (the mount lifecycle, `:on-click` firing into the real DOM, scroll events).
+- ✗ Reactive subscription **tracking** (auto-subscribe-on-deref, Reagent's dispose lifecycle). Subscription **computation** is JVM-runnable via `compute-sub`.
+
+The split is clean: every business-logic test runs on the JVM. View **content** tests — does the rendered hiccup contain the expected text? does the structure match the schema? — also run on the JVM via `render-to-string`. Only tests that exercise actual React mounting or scroll-position-style interactive DOM behaviour need CLJS.
+
+In practice, a typical re-frame2 codebase ends up with hundreds of JVM tests for handlers/fxs/subs/machines, and a small handful of CLJS-or-Playwright tests for actual click-through-DOM behaviour. The proportion is opposite to what most React codebases get used to.
+
+### Per-artefact `clojure -M:test`
+
+Each per-feature artefact in re-frame2's Strategy B layout — core, machines, routing, flows, http, ssr, schemas, epoch — has its own test alias:
+
+```bash
+cd implementation/core      && clojure -M:test    # JVM tests for core
+cd implementation/machines  && clojure -M:test    # JVM tests for machines
+cd implementation/routing   && clojure -M:test
+# ... and so on
+```
+
+The alias runs `clojure.test` against the artefact's `test/` directory. The CI matrix runs each in parallel; if you've changed core, run core's suite plus any consumer artefact's suite to catch downstream regressions.
+
+The CLJS-side tests (browser-runner integration tests) run separately — `npm run test:cljs` from the repo root drives a shadow-cljs build into a headless browser.
+
+## Stubbing fxs, recording events, replacing interceptors
+
+Three more shapes show up frequently enough to be worth naming.
+
+### Stubbing an fx for a whole frame
+
+Per-frame `:fx-overrides`:
+
+```clojure
+(rf/reg-frame :test/auth-flow
+  {:on-create   [:auth/init-idle]
+   :fx-overrides {:rf.http/managed (fn [_m _args] {:status 200 :body {:user/id 42}})}})
+;; every event handled in :test/auth-flow uses the stub :rf.http/managed
+```
+
+Or a one-shot per-call override:
+
+```clojure
+(rf/dispatch-sync [:auth/load-user]
+                  {:frame :test/auth-flow
+                   :fx-overrides {:rf.http/managed (fn [_ _] {:status 401})}})
+```
+
+The override is a **redirect**, not a mock. The same dispatch shape the real fx produces lands in the test handler.
+
+### Recording dispatched events without firing them
+
+```clojure
+(def recorded (atom []))
+
+(def event-recorder
+  (rf/->interceptor
+    :id :test/event-recorder
+    :before (fn [ctx]
+              (swap! recorded conj (-> ctx :coeffects :event))
+              ctx)))
+
+(rf/reg-frame :test/recorder-frame
+  {:interceptors [event-recorder]})
+```
+
+After running a test sequence, `@recorded` carries the events that fired, in order. Useful for verifying control flow without checking every state transition.
+
+### Disabling a logging interceptor
+
+```clojure
+(rf/reg-frame :test/silent
+  {:on-create             [:test/init]
+   :interceptor-overrides {:my-app/logger nil}})       ;; nil removes the interceptor
+```
+
+Same shape as `:fx-overrides`; same per-frame / per-call duality. The `nil` value removes the interceptor entirely; a non-nil value substitutes it.
+
+## Conformance fixtures
+
+The framework ships a **conformance corpus** — host-agnostic EDN fixtures under `spec/conformance/` — that grades implementations against a single source of truth. Each fixture describes a scenario as data: registrations, an event sequence, expected `app-db` shape, expected trace events. A conformance harness reads the fixture, replays it against an implementation, and asserts the results.
+
+You don't typically write conformance fixtures. They exist to:
+
+- **Pin a contract.** Ranked-route precedence, machine spawn/destroy lifecycle, schema validation failure modes — every behaviour the spec calls "the answer" has a fixture asserting that answer.
+- **Grade ports.** A new-language port (TypeScript, Python, Kotlin) doesn't need to re-derive what's correct — it runs the conformance corpus against its own implementation and gets a pass/fail per behaviour.
+- **Catch drift.** A spec change that says one thing but an implementation that does another fails conformance — the test surface is structural, not implementation-specific.
+
+When you'd reach for a conformance fixture in your own codebase: when you have a behaviour you want **multiple implementations** to agree on. Most app-side tests are not conformance tests; they verify your app's logic, not the framework's contract. The fixtures are framework infrastructure.
+
+If you want to know what your implementation supports, look at the `:capabilities` declaration in the implementation's manifest and cross-reference against `spec/conformance/README.md`. Each fixture lists the capabilities it exercises; the harness skips fixtures whose capabilities the implementation hasn't claimed.
+
+## Bundle-isolation: the gate that keeps core clean
+
+A subtle but load-bearing testing concern: re-frame2's Strategy B layout puts every optional feature in its own artefact. **Core does not require any per-feature artefact.** That's the whole point of feature opt-in — apps that don't use machines don't bundle machine code; apps that don't use routing don't bundle routing code.
+
+The risk is silent regression: a future change to core that accidentally `(:require [re-frame.machines])` for a default-fallback path would silently re-include the machines artefact in every consumer's bundle. The change wouldn't fail any existing test; it'd just balloon production bundle size by the per-feature payload.
+
+The framework's CI runs a **bundle-isolation gate** ([rf2-51x5](#)) on every PR:
+
+1. `shadow-cljs release` the **counter** example (the canonical no-feature app).
+2. Grep the produced `main.js` for each per-feature artefact's namespace markers.
+3. Assert **0 hits** per artefact (or a stable allow-list of consumer-side preset-map keywords).
+
+If a future PR re-imports a split-out namespace into core, the counter bundle suddenly carries `re-frame.machines`-shaped strings, and the gate fails. The contract is enforced at PR time, not discovered three releases later.
+
+You don't write bundle-isolation tests for your own app. The gate runs on the framework. The mention here is to explain *why* core is so spartan in its requires — the absence is the contract.
+
+## Property-based testing
+
+`test.check` fits cleanly into re-frame2 — `make-frame` is cheap, generators produce event sequences, properties check invariants:
+
+```clojure
+(require '[clojure.test.check :as tc]
+         '[clojure.test.check.generators :as gen]
+         '[clojure.test.check.properties :as prop])
+
+(def counter-never-negative
+  (prop/for-all [evs (gen/vector (gen/elements [[:counter/inc] [:counter/dec]]) 0 50)]
+    (rf/with-frame [f (rf/make-frame {:on-create [:counter/initialise]})]
+      (doseq [ev evs] (rf/dispatch-sync ev))
+      (let [{:keys [count]} (rf/get-frame-db f)]
+        (or (>= count 0)
+            ;; design choice: maybe negative IS allowed; the property is whatever
+            ;; we want to assert. The cheap fixture lets us assert it across
+            ;; thousands of generated sequences.
+            true)))))
+
+(tc/quick-check 1000 counter-never-negative)
+```
+
+The cheap fixture is the load-bearing piece — `make-frame` plus `dispatch-sync` lets a property exercise hundreds of full event cascades per second. Generators produce the event sequences; the property asserts whatever invariant matters; a thousand-trial run takes milliseconds. This shape is documented in [Spec 008](../../spec/008-Testing.md) as one of the natural extensions of the foundation primitives.
+
+For machines specifically, the `machine-transition` purity opens a path to `@xstate/test`-style coverage: enumerate paths through the transition graph, generate event sequences that visit every transition, run them as test cases. That's library territory rather than framework, and out of scope for this guide; the spec's [§Future](../../spec/008-Testing.md#open-questions) notes it as an open area.
+
+## What you should expect
+
+A re-frame2 codebase that's been built with the patterns in this guide tends to acquire a particular testing shape:
+
+- **Many small JVM unit tests.** Hundreds of them. Each runs in milliseconds. Together they cover almost all business logic.
+- **A handful of CLJS browser tests.** Click-through interaction, focus management, the parts that genuinely need a real DOM. Slow, fewer, focused.
+- **Conformance grading**, if you're maintaining a port. Read fixtures, replay, assert.
+- **Property-based runs**, if your domain has invariants worth asserting structurally.
+
+The split is the inverse of what most React-side test suites accumulate over time. The reason is structural: re-frame2's primitives are functions, and functions test cheaply.
+
+## Next
+
+- [11 — Devtools and pair tools](11-devtools-and-pair-tools.md) — the trace stream, time-travel, source-coords, and how AI/REPL companions attach.
+- [Spec 008 — Testing](../../spec/008-Testing.md) — the full normative surface, JVM/CLJS boundary, and adapter notes.

--- a/docs/guide/11-devtools-and-pair-tools.md
+++ b/docs/guide/11-devtools-and-pair-tools.md
@@ -1,0 +1,437 @@
+# 11 — Devtools and pair tools
+
+A re-frame2 app is **inspectable**. Every event the runtime processes, every fx that fires, every render, every error — they all emit structured trace events. Every drain-to-empty-queue settles into an epoch record with a `:db-before`, a `:db-after`, and the cascade's structured `:sub-runs`/`:renders`/`:effects` projections. Every registration carries source coordinates. Every rendered DOM node carries a back-pointer to the registration that produced it. Every frame's last N epochs are kept in a ring buffer, queryable and restorable.
+
+These surfaces exist so **tools** — not the framework — can build inspection, debugging, and AI-pairing experiences on top.
+
+This chapter is about that contract: what re-frame2 commits to, what tools consume it, and what you do at the keyboard to attach.
+
+You'll know how to:
+
+- Subscribe to the trace stream from a REPL or tool.
+- Walk a frame's epoch history and restore an earlier state.
+- Inject a synthetic `app-db` value (state injection) for repros and experiments.
+- Parse the source-coord DOM attribute back to a code location.
+- Read the static sub-graph topology.
+- Understand what tools see when a frame is destroyed mid-observation.
+- Recognise where the contract ends and where the consuming tool begins.
+
+## What "pair tools" are
+
+A pair tool is an AI/REPL companion that attaches to a running re-frame2 app. The canonical examples:
+
+- **[day8/re-frame-pair](https://github.com/day8/re-frame-pair)** — an nREPL middleware + Claude integration that lets an agent inspect, dispatch, hot-swap handlers, time-travel, and stub fxs against a live app.
+- **A future re-frame-10x v2** — a renderer of the same surfaces; trace listener, epoch-history consumer, registry inspector, all wrapped in a UI.
+- **Custom debug panels** built into your app's dev build.
+
+Each consumes the same runtime contract — the trace stream, the registrar query API, the epoch ring buffer, source coordinates. Multiple tools can attach simultaneously; listener ordering isn't contract.
+
+re-frame2's commitment is the **contract**, not the tool. Two tools can disagree on UX, prompt design, or visualisation without disagreeing on the API.
+
+## The trace stream
+
+Every event the runtime emits — dispatch boundaries, handler invocations, fx applications, sub computations, errors, machine transitions, registrations, hot-swaps — flows through one channel: the trace stream.
+
+Subscribe to it with `register-trace-cb!`:
+
+```clojure
+(rf/register-trace-cb!
+  :my-tool/watcher
+  (fn [ev]
+    ;; ev is a structured trace map with :op-type, :operation, :tags, :timestamp, ...
+    (println (:operation ev) (:tags ev))))
+```
+
+The callback fires once per emitted event — fine-grained, raw. The shape of the event is documented in [Spec 009 §Trace event](../../spec/009-Instrumentation.md). The load-bearing field is `:op-type` — the universal discriminator. Tools that only care about a single subsystem filter inside the callback:
+
+```clojure
+(rf/register-trace-cb!
+  :my-tool/flow-panel
+  (fn [ev]
+    (when (= :flow (:op-type ev))
+      (case (:operation ev)
+        :rf.flow/registered  (track-flow-registration! ev)
+        :rf.flow/computed    (record-flow-computation! ev)
+        :rf.flow/skip        (note-skip! ev)
+        :rf.flow/cleared     (drop-flow-state! ev)
+        :rf.flow/failed      (surface-flow-error! ev)
+        nil))))
+```
+
+The same pattern works for `:machine`, `:event`, `:sub/run`, `:fx`, etc. New op-types are additive (per [Spec 009](../../spec/009-Instrumentation.md)); a tool that doesn't recognise an op-type ignores it without breaking.
+
+To unsubscribe:
+
+```clojure
+(rf/remove-trace-cb! :my-tool/watcher)
+```
+
+The trace surface is **dev-only** — gated on `re-frame.interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`). Production builds (`:advanced` + `goog.DEBUG=false`) elide every emit via Closure DCE. A shipped binary carries no trace bytes and no listener machinery.
+
+### The retain-N trace ring buffer
+
+For tools that want to read **recent history** without having been registered earlier, the runtime keeps a configurable ring buffer of the last N trace events:
+
+```clojure
+(rf/trace-buffer)                        ;; → vector of recent trace events, oldest-first
+(rf/trace-buffer {:op-type :event})      ;; with optional filter map
+(rf/configure :trace-buffer {:depth 1000})
+```
+
+Default depth is per-implementation. The buffer is dev-only and elides under production build flags.
+
+## Per-cascade epoch records
+
+`register-trace-cb!` is the **raw** stream. For tools that route diagnostics off "what just happened in this drain?", a complementary listener fires once per **drain-settle**, with the cascade's structured projections already computed:
+
+```clojure
+(rf/register-epoch-cb
+  :my-tool/dashboard
+  (fn [{:keys [frame event-id epoch-id sub-runs renders effects] :as record}]
+    (record-recomputes! frame event-id (count sub-runs))
+    (doseq [{:keys [render-key elapsed-ms]} renders]
+      (record-render! frame (first render-key) elapsed-ms))
+    (doseq [{:keys [fx-id outcome error-trace]} effects]
+      (when (= :error outcome)
+        (surface-fx-error! frame epoch-id fx-id error-trace)))
+    nil))
+```
+
+The record (per [Spec-Schemas §`:rf/epoch-record`](../../spec/Spec-Schemas.md#rfepoch-record)) carries:
+
+- `:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`
+- `:db-before`, `:db-after`
+- `:sub-runs` — every sub recomputation in this cascade (cache-hit subs are absent)
+- `:renders` — every view that re-rendered, keyed `[<view-id> <instance-token>]`
+- `:effects` — every fx that fired, with `:outcome` ∈ `{:ok :error :skipped-on-platform}`
+- `:trace-events` — the raw trace slice, optionally
+
+Two listener shapes coexist by design:
+
+- **`register-trace-cb!`** is the raw stream — used by tools that need per-emit detail (custom recorders, error-monitor forwarders, timing aggregators).
+- **`register-epoch-cb`** is the assembled stream — one fully-shaped record per drain-settle, used by tools that route diagnostics off "what happened in this cascade" rather than re-folding the raw stream each time.
+
+Most pair-shaped tools prefer the assembled stream and reach for the raw stream only when they need detail the projection drops.
+
+A throw inside an epoch-cb does not propagate to the framework or other listeners — the framework catches and continues. The throwing listener is **not** auto-evicted; eviction is the consumer's call.
+
+## Epoch history and time-travel
+
+Per frame, the runtime keeps a ring buffer of the last N epoch records. The default is 50; configure with `(rf/configure :epoch-history {:depth N})`.
+
+```clojure
+(rf/epoch-history :app/main)
+;; → vector of epoch records, oldest-first
+;;   each carries :epoch-id, :event-id, :db-before, :db-after, :sub-runs, ...
+
+(rf/restore-epoch :app/main some-epoch-id)
+;; rewinds the frame's app-db to the named epoch's :db-after
+;; emits :rf.epoch/restored on success
+;; returns true on success, false on any failure
+```
+
+`restore-epoch` rewinds the frame's `app-db` only — **effects already fired** (HTTP requests sent, navigation pushed, localStorage written) are not reversed. Pair tools surface this caveat in their UI before applying a restore.
+
+Six failure modes are enumerated and named, each emitting a structured error trace event under the reserved `:rf.epoch/*` namespace:
+
+| Failure | When |
+|---|---|
+| **Unknown frame** | The frame-id doesn't name a registered frame. |
+| **Unknown epoch** | The epoch-id isn't in the frame's current history (aged out, or never recorded). |
+| **Schema mismatch** | The recorded `:db-after` doesn't validate against the currently-registered schemas (someone added a stricter schema since the snapshot). |
+| **Missing handler** | The recorded `app-db` references a registered id (a machine, a route) that's no longer in the registrar. |
+| **Version mismatch** | The frame's recorded `:rf/snapshot-version` is incompatible with the currently-loaded machine definition. |
+| **Concurrent-drain rejection** | Called while the frame's drain is still in flight; retry after settle. |
+
+Pair tools display the `:operation` and `:tags` to the user and route from the failure to a remediation. The full table with `:tags` schemas is in [Tool-Pair §Time-travel](../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo).
+
+### Walking history and restoring — worked example
+
+A pair tool's "rewind to before that event" affordance:
+
+```clojure
+(defn epoch-before-event
+  "Return the epoch-id of the most recent epoch in `frame-id`'s history
+   that precedes `target-event-id`, or nil."
+  [frame-id target-event-id]
+  (let [history (rf/epoch-history frame-id)
+        before  (take-while #(not= target-event-id (:event-id %)) history)]
+    (when (seq before)
+      (:epoch-id (last before)))))
+
+;; Listen for restore success / failure traces.
+(rf/register-trace-cb!
+  :my-tool/restore-watcher
+  (fn [ev]
+    (case (:operation ev)
+      :rf.epoch/restored                    (notify-ui :restored ev)
+      :rf.epoch/restore-unknown-epoch       (notify-ui :error ev)
+      :rf.epoch/restore-schema-mismatch     (notify-ui :error ev)
+      :rf.epoch/restore-missing-handler     (notify-ui :error ev)
+      :rf.epoch/restore-version-mismatch    (notify-ui :error ev)
+      :rf.epoch/restore-during-drain        (notify-ui :error ev)
+      nil)))
+
+;; Trigger.
+(when-let [target (epoch-before-event :app/main :checkout/submit)]
+  (rf/restore-epoch :app/main target))
+```
+
+The walk-then-restore pattern is the canonical pair-tool gesture; render-tree visualisers, "what did this event do?" probes, and conformance harnesses all build on the same primitives.
+
+### Where the time-travel surface lives
+
+Per Strategy B, the time-travel surface ships in the artefact `day8/re-frame-2-epoch`. Apps that want time-travel add it alongside core:
+
+```clojure
+{:deps {day8/re-frame-2        {...}
+        day8/re-frame-2-epoch  {...}}}
+```
+
+When the artefact is on the classpath and `re-frame.epoch` is required at boot, the late-bind hooks publish so the public re-exports in `re-frame.core` (`epoch-history`, `restore-epoch`, `register-epoch-cb`, `reset-frame-db!`) reach into the hook table at call time.
+
+When the artefact is **not** on the classpath, the read-shaped surfaces (`epoch-history`, `register-epoch-cb`) degrade silently — empty vector / no-op. A production build that omits the artefact does not raise. Mutating surfaces (`reset-frame-db!`) raise `:rf.error/epoch-artefact-missing` — the caller's invariant is "this changes state" and a silent no-op would lie.
+
+## Direct state injection: `reset-frame-db!`
+
+Sometimes you need to put a frame in a state the runtime never recorded. A pair-tool agent has just hot-swapped a handler that operates on an evolved `app-db` shape; running a real cascade would re-trigger broken handlers. A story tool wants to render the cart in a specific snapshot without authoring a setup event for every variant. A bug repro arrives as a serialised `app-db` from a user; the agent needs to load it.
+
+`reset-frame-db!` is the supported write surface ([rf2-zq55](#), shipped in PR #170):
+
+```clojure
+(rf/reset-frame-db! :app/main {:cart {:items [{:sku "abc" :qty 2}]}
+                                :checkout/state :ready})
+;; Returns true on success, false on failure.
+```
+
+It bypasses the dispatch loop, replaces the frame's `app-db` container directly, and **records a synthetic epoch** so `restore-epoch` can rewind past the injection. The synthetic epoch carries:
+
+- `:event-id :rf.epoch/db-replaced`
+- `:trigger-event [:rf.epoch/db-replaced]`
+- `:db-before` (the pre-reset value)
+- `:db-after` (`new-db`)
+- empty `:sub-runs` / `:renders` / `:effects` projections — no cascade ran
+
+It also fires a `:rf.epoch/db-replaced` trace event and delivers the assembled record to every registered epoch listener — same shape as a cascade-settle delivery. Pair-tool dashboards filter on the operation to route pair-tool injections distinctly from cascade-driven epochs.
+
+The empty projections are the **visible signal** that no cascade ran. If your tool routes off `:sub-runs`, `:renders`, or `:effects`, an empty entry tells you the epoch came from a direct write rather than dispatch.
+
+Three failure modes:
+
+| Failure | When |
+|---|---|
+| **Unknown frame** | `frame-id` doesn't name a registered frame. |
+| **Drain in flight** | Called while the frame's drain is in progress; retry after settle. |
+| **Schema mismatch** | `new-db` fails the frame's currently-registered `app-schema` set. With no schemas registered, every `new-db` is accepted. |
+
+`reset-frame-db!` is **not** a substitute for `dispatch`. Use it only when bypass-the-cascade is required (the four use cases above); for anything you want the data loop to see, dispatch a real event.
+
+```clojure
+;; A pair-tool agent has hot-swapped a handler that needs a new app-db shape.
+;; Inject the shape directly; then drive a single dispatch to verify.
+(when (rf/reset-frame-db! :app/main {:cart {:items [{:sku "abc" :qty 2}]}
+                                      :checkout/state :ready})
+  (rf/dispatch [:checkout/submit] {:frame :app/main}))
+
+;; Rewind PAST the injection: pick the epoch BEFORE the synthetic one.
+(let [history (rf/epoch-history :app/main)
+      pre     (last (filter #(not= :rf.epoch/db-replaced (:event-id %)) history))]
+  (when pre
+    (rf/restore-epoch :app/main (:epoch-id pre))))
+```
+
+## Source coordinates: clicking a button back to its source line
+
+A pair tool gestures at a button on screen and asks "where in the code did this come from?" That requires every rendered DOM node to carry a back-pointer to the registration that produced it.
+
+re-frame2's CLJS reference does this two ways, layered:
+
+### 1. The `data-rf2-source-coord` DOM attribute
+
+Every `reg-view`-rendered DOM element receives:
+
+```html
+<button data-rf2-source-coord="counter.core:counter:48:5" ...>+</button>
+```
+
+The four colon-separated segments are `<ns>:<sym>:<line>:<col>`:
+
+- `<ns>` — the registration's namespace (`counter.core`)
+- `<sym>` — the **registered handler-id** (the symbol passed to `reg-view`, here `counter`). Not a file path.
+- `<line>` — source line at `reg-view` macro-expansion time
+- `<col>` — source column
+
+The format is a **public, parseable contract** ([rf2-q7r0](#), per [Spec-Schemas §`:rf/source-coord-attr`](../../spec/Spec-Schemas.md#rfsource-coord-attr)). Tools split on the colon and recover the four pieces directly.
+
+To recover the file path too, follow the parsed handler-id back to the registration metadata:
+
+```clojure
+(:rf/source-coord-meta (rf/handler-meta :view :counter.core/counter))
+;; → {:ns "counter.core", :file "counter/core.cljs", :line 48, :column 5}
+```
+
+`:rf/source-coord-meta` (per [Spec-Schemas](../../spec/Spec-Schemas.md)) carries all four keys including `:file`. The DOM attribute is the cheap-on-the-wire form; the registration metadata is the rich form.
+
+The annotation is **dev-only** — gated on the universal `re-frame.interop/debug-enabled?`. Production builds elide via DCE; the rendered HTML in production carries no `data-rf2-source-coord` bytes.
+
+Documented exemption: components whose outermost return is a React Fragment, a `:>` host-component head, or another non-DOM root are exempt. Pair tools fall back to `(rf/handler-meta :view id)` for those nodes.
+
+### 2. State-machine source-coord stamping
+
+A complementary surface for state-machines: `reg-machine` is a macro that walks its literal spec form at expansion time and attaches a flat coord index under `:rf.machine/source-coords`, keyed by spec-path tuples:
+
+```clojure
+(:rf.machine/source-coords (rf/machine-meta :auth/login))
+;; {[:guards :form-valid?]                {:ns ... :line ... :column ... :file ...}
+;;  [:actions :commit]                    {...}
+;;  [:states :form :on :submit]           {...}
+;;  [:states :form :on :submit :action]   {...}}
+```
+
+Pair tools use this index for two distinct gestures:
+
+- **Jump to definition.** A click on a guard or action name in a state-diagram visualisation reads `[:guards <id>]` / `[:actions <id>]` to find where the fn is implemented.
+- **Jump to call site.** A click on a transition arrow or state node reads the deepest stamped path-tuple matching the node (e.g. `[:states :idle :on :submit]`); for keyword-named slots (`{:guard :form-valid?}`) the slot itself isn't stamped — the tool falls back to the enclosing transition's coord, which IS stamped.
+
+The framework commits to **the index shape and the keyword-reference rule** (definition-site only for keyword refs, reference-site for inline-fn literals). Pair tools ship their own UI affordance over the index. Like `data-rf2-source-coord`, the stamping is gated on debug-enabled and elides under production build flags.
+
+### Where the helpers live
+
+The audit found upstream pair tools ship `dom/source-at`, `dom/find-by-src`, and `dom/fire-click-at-src` helpers. **re-frame2's commitment is the attribute, not the helpers.**
+
+The runtime emits the attribute; the attribute's value format is a committed public contract. Consumers read it via their own host's DOM access (`document.querySelector` in CLJS, `page.locator` in Playwright-driven flows) and parse the four segments locally. The framework does **not** ship `dom-source-at` / `find-by-src` / `fire-click-at-src` helpers — those depend on host-specific DOM access that re-frame2 the framework doesn't assume. A future minor version may introduce framework-side helpers if the ecosystem converges; the attribute contract is forward-compatible.
+
+## The static sub-graph: `sub-topology`
+
+Subscriptions chain — `:count-doubled` depends on `:count`. The framework knows the dependency graph at registration time (built from `:<-` declarations). For visualisation, dependency analysis, and "what depends on this sub?" navigation, the static graph is exposed:
+
+```clojure
+(rf/sub-topology)
+;; → a static dependency graph
+;;   {:nodes #{:count :count-doubled :auth/state ...}
+;;    :edges #{[:count-doubled :count] ...}}
+```
+
+This is **static** — no runtime, no live cache, no Reagent. It reads off the registry. Use it to:
+
+- Render a graph of "everything in the app that's derived."
+- Find the leaves (subs nothing else depends on) — the stuff views actually read.
+- Find the roots (subs that read `app-db` directly) — the ground truth.
+- Spot dead subs (registered but no consumers).
+
+The shape lives in [Spec 006 §Subscription topology](../../spec/006-ReactiveSubstrate.md). The function shipped in PR #142 ([rf2-8nzo](#)).
+
+## What happens when a frame is destroyed mid-observation
+
+Multi-frame architectures make frame churn ordinary — story tools mount and unmount frames freely; pair tools probe ephemeral test frames. A pair tool watching a frame's epoch history is guaranteed to encounter destroyed-frame races.
+
+The runtime commits to a **closed contract** for these races so a tool can route them deterministically:
+
+| Surface | Shape | Behaviour against destroyed frame |
+|---|---|---|
+| `(rf/epoch-history frame-id)` | read | Returns `[]`. Identical to "no epochs yet recorded"; consumers that want to distinguish a destroyed frame from a fresh one consult `(rf/frame-meta frame-id)` separately. |
+| `(rf/get-frame-db frame-id)` | read | Returns `nil`. Consumers consult `(rf/frame-meta frame-id)` for destroyed-vs-unknown. |
+| `(rf/restore-epoch frame-id epoch-id)` | mutate | Emits `:rf.error/no-such-handler` (kind `:frame`) and returns `false`. |
+| `(rf/reset-frame-db! frame-id new-db)` | mutate | Emits `:rf.error/no-such-handler` (kind `:frame`) and returns `false`. |
+| Pre-registered `register-epoch-cb` callback whose observed frame is later destroyed | listener silencing | Runtime emits `:rf.epoch.cb/silenced-on-frame-destroy` once per `(frame-id, cb-id)` pair, with `:tags {:frame-id <id>, :cb-id <id>}`. The callback registration stays in place — eviction is the consumer's call. |
+
+The pattern: **read-shaped surfaces return an empty shape** (so a defensive `(when ...)` is sufficient); **mutating-shaped surfaces raise structurally** (so a tool that intended a write learns the write did not happen); **listener fan-out emits a one-shot trace** when a previously-registered callback is silenced because its observed frame was destroyed.
+
+Why "silencing" is a trace and not a return value: the `register-epoch-cb` callback never sees a record from a destroyed frame — the runtime stops producing records the moment the destroy walks. A tool that didn't know its observed frame was destroyed would see a callback that simply *stopped firing*, with no signal to route off. The silencing trace closes that gap.
+
+The full contract is in [Tool-Pair §Surface behaviour against destroyed frames](../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames). Pattern source: rf2-d656.
+
+## What you don't get from re-frame2
+
+The contract above is sized to the framework's responsibility. Things explicitly **not** part of re-frame2:
+
+- **The Claude integration itself** — prompts, retrieval, model selection. Lives in the pair tool.
+- **The nREPL middleware** that bridges agent-to-runtime. Specific to the host.
+- **The conversational interface** ("Tell me about every `:checkout/*` event"). The pair tool's job to prompt-engineer; re-frame2 ships data.
+- **Skill-shaped retrospective analysis** of pair sessions. That's a separate, post-v1 artefact (`re-frame-pair-improver`) — a Claude skill that reviews sessions and proposes improvements to the pair tool itself.
+- **DOM-to-source helpers** (`source-at`, `find-by-src`). Tool-side; depends on host-specific DOM access.
+
+The split is deliberate: the framework commits to **stable data shapes and query APIs**; tools own **presentation and orchestration**. Multiple tools can coexist on the same contract without coordinating with each other or with the framework.
+
+## Performance API consumption — the prod-friendly channel
+
+A separate channel from the dev-only trace stream: the runtime emits **User Timing API** entries that any consumer with a `PerformanceObserver` can read. No re-frame2 API call needed.
+
+Names are stable and namespaced under `rf:`:
+
+```
+rf:event:<event-id>
+rf:sub:<sub-id>
+rf:fx:<fx-id>
+rf:render:<view-id>
+```
+
+```javascript
+// Pull every re-frame entry from the recent run
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'))
+  .forEach(e => {
+    const [_rf, bucket, ...idParts] = e.name.split(':');
+    const id = idParts.join(':');
+    sendToAPM(e);
+  });
+
+// Live: PerformanceObserver fires per emitted entry
+new PerformanceObserver((list) => {
+  for (const e of list.getEntriesByType('measure')) {
+    if (e.name.startsWith('rf:')) {
+      sendToAPM(e);
+    }
+  }
+}).observe({ type: 'measure', buffered: true });
+```
+
+The channel is gated on `re-frame.performance/enabled?` — a `goog-define` boolean defaulting to `false`. When the flag is off (default), Closure DCE elides every bracket; `getEntriesByType` returns no `rf:`-prefixed entries because none were emitted. This is **opt-in for prod**; timing instrumentation has measurable cost on heavy hot paths and consumers should choose to pay it.
+
+Flip the flag in your build:
+
+```edn
+;; consumer's shadow-cljs.edn
+{:builds {:app {:target           :browser
+                :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
+```
+
+The Performance API surface is **CLJS-only**. JVM artefacts (SSR, headless tests) emit no perf entries; tools running there use the host's profilers (clj-async-profiler, JFR).
+
+## Putting it together — a minimal "trace + epoch" debug panel
+
+A small in-app panel that prints the last 10 events and the current frame's last 5 epochs:
+
+```clojure
+(ns my-app.debug-panel
+  (:require [re-frame.core :as rf]
+            [reagent.core :as r]))
+
+(defonce recent-events (r/atom []))
+
+(rf/register-trace-cb!
+  :my-app/debug-panel
+  (fn [ev]
+    (when (= :event (:op-type ev))
+      (swap! recent-events (fn [evs] (->> (cons ev evs) (take 10) vec))))))
+
+(rf/reg-view debug-panel []
+  (let [events @recent-events
+        epochs (take-last 5 (rf/epoch-history :rf/default))]
+    [:aside.debug-panel
+     [:h3 "Recent events"]
+     [:ul (for [e events] ^{:key (:dispatch-id e)} [:li (str (:operation e))])]
+     [:h3 "Recent epochs"]
+     [:ul (for [ep epochs] ^{:key (:epoch-id ep)}
+            [:li
+             [:button {:on-click #(rf/restore-epoch :rf/default (:epoch-id ep))}
+              (str (:event-id ep))]])]]))
+```
+
+That's the whole shape. The trace listener is a fn; the epoch list is a query; the restore is a single call. No framework extension, no plugin contract. The panel composes from the same surfaces the upstream pair tool consumes — the tool is just a richer renderer of the same data.
+
+## Next
+
+- [12 — Routing](12-routing.md) — the URL ↔ state contract.
+- [Tool-Pair](../../spec/Tool-Pair.md) — the full normative contract for pair-shaped tools.
+- [Spec 009 — Instrumentation](../../spec/009-Instrumentation.md) — the trace stream's full shape and the error contract.

--- a/docs/guide/12-routing.md
+++ b/docs/guide/12-routing.md
@@ -1,0 +1,547 @@
+# 12 — Routing
+
+Routing in re-frame2 is **state plus events**, not a separate subsystem.
+
+The URL is a derivable view of `app-db`. Navigation is an event. Browser back/forward is an event. Deep links and SSR feed the same `:rf.route/handle-url-change` handler that client-side popstate does. The current route lives at the `:rf/route` slice; views read it through subs; the root view dispatches on `:rf.route/id`.
+
+There is no separate routing runtime. There are no route-aware components. There is no "router context." It's just data that happens to be reflected in the address bar.
+
+This chapter walks through the routing surface: registering routes, navigating, reading the route in views, the navigation token that suppresses stale loads, the `:can-leave` protocol for unsaved-changes prompts, and how multi-frame apps handle routes that don't push to the URL.
+
+You'll know how to:
+
+- Register a route with path params, query params, defaults, and retain keys.
+- Trigger navigation programmatically and from links.
+- Read the active route in views.
+- Block navigation with a `:can-leave` guard and resume it from a confirmation dialog.
+- Avoid stale-result clobber with `:rf/url-changed`'s nav-token epoch.
+- Run the same route resolution server- and client-side.
+- Give a non-default frame its own route without touching the browser URL.
+
+## The artefact
+
+Routing ships as a separate per-feature artefact (`day8/re-frame-2-routing`):
+
+```clojure
+{:deps {day8/re-frame-2          {...}
+        day8/re-frame-2-routing  {...}}}
+```
+
+Per Strategy B, an app that doesn't use routing doesn't bundle routing code. The bundle-isolation gate ([rf2-51x5](#)) asserts that core's release build carries zero routing namespace markers — re-importing `re-frame.routing` from core is a CI failure.
+
+Once the artefact is on the classpath, `(:require [re-frame.routing])` once at app boot wires the late-bind hooks; `reg-route`, `:rf.route/navigate`, the `:rf/route` sub, and the `:rf.route/...` family of fxs are then available through `re-frame.core`.
+
+## Registering a route
+
+Routes are registry entries — same shape as events, fxs, subs:
+
+```clojure
+(rf/reg-route :route/home
+  {:doc  "The landing page."
+   :path "/"})
+
+(rf/reg-route :route/cart
+  {:doc      "The cart page."
+   :path     "/cart"
+   :on-match [[:cart/load-items]]})
+
+(rf/reg-route :route/cart.item-detail
+  {:doc    "Detail page for a single cart item."
+   :path   "/cart/items/:id"
+   :params [:map [:id :uuid]]})
+
+(rf/reg-route :route/article
+  {:doc    "An article. Optional slug suffix."
+   :path   "/articles/:id{/:slug}?"
+   :params [:map [:id :uuid] [:slug {:optional true} :string]]})
+
+(rf/reg-route :route/files
+  {:doc   "A files browser; matches /files and any sub-path."
+   :path  "/files/*rest"
+   :params [:map [:rest :string]]})
+```
+
+The grammar is small — five productions. **Literal segment** (`/articles`), **named param** (`:id`), **optional segment group** (`{/:slug}?`), **catch-all/splat** (`*rest`), and **root** (`/`). The full grammar with rules is in [Spec 012 §Path-pattern grammar](../../spec/012-Routing.md#path-pattern-grammar-canonical) — it's a strict subset of RFC 6570 Level 1 plus a splat extension, parseable by hand in any host.
+
+When two routes can match the same URL, [a six-rule cascade](../../spec/012-Routing.md#route-ranking-algorithm) decides which wins. More static segments beat fewer; longer paths beat shorter; named params beat splats; exact patterns beat optional-group patterns. The cascade is **structural** — the score is computable from each pattern's parsed shape, no URL needed. Implementations pre-compute the score at registration time.
+
+## The `:rf/route` slice
+
+The runtime maintains a single slice in `app-db`:
+
+```clojure
+{:rf/route
+  {:id           :route/article             ;; current route id
+   :params       {:id #uuid "..."}          ;; path params (matches :params schema)
+   :query        {:q "clojure" :page 2}     ;; query/search params (matches :query schema)
+   :fragment     "section-2"                ;; URL #fragment, or nil
+   :transition   :idle                      ;; :idle | :loading | :error
+   :error        nil                        ;; populated when :transition = :error
+   :nav-token    "nav-42"}}                 ;; per-navigation epoch token
+```
+
+The `:rf/route` key is reserved (per [rf2-ljw6](#) reconciliation). Path params (`:params`) and query params (`:query`) are distinct maps — captured separately, validated against separate schemas, kept separate in the slice. Consumers that prefer a merged map build one in a derived sub.
+
+`:fragment` carries the URL `#fragment` part. `:nav-token` is the runtime-allocated navigation epoch (see [§Navigation tokens](#navigation-tokens-stale-result-suppression)). Both are runtime-managed; user code reads them through subs.
+
+`:transition` is a tiny FSM driven by the runtime: `:idle` when no navigation is in flight; `:loading` while the active route's `:on-match` events are draining; `:error` if any errors. A global progress bar reads `:rf.route/transition` and renders when it's `:loading`; an error banner reads `:rf.route/error`.
+
+Schema for the slice: `:rf/route-slice` (per [Spec-Schemas](../../spec/Spec-Schemas.md#rfroute-slice)).
+
+## Navigation is an event
+
+```clojure
+;; Programmatic navigation by route-id
+(rf/dispatch [:rf.route/navigate :route/cart])
+
+;; With path params
+(rf/dispatch [:rf.route/navigate :route/cart.item-detail {:id "abc-123"}])
+
+;; With query params
+(rf/dispatch [:rf.route/navigate :route/search {} {:q "clojure" :page 2}])
+
+;; With a fragment
+(rf/dispatch [:rf.route/navigate :route/docs {:page "routing"} {} "scroll-restoration"])
+
+;; Replace rather than push (login redirects, redirects-on-load)
+(rf/dispatch [:rf.route/navigate :route/login {} {} nil {:replace? true}])
+
+;; URL-string escape hatch (for dynamic / user-supplied URLs)
+(rf/dispatch [:rf.route/navigate {:url "/some/path"}])
+```
+
+The route-id form is preferred — the route-id is enumerable, refactorable, and queryable through the registrar. URL-strings are stringly-typed escape-hatchy by nature; tools can flag them as candidates for migration.
+
+When the navigation event fires, three things happen, in order:
+
+1. The `:rf/route` slice is updated (id, params, query, fragment, transition, nav-token).
+2. The browser URL is pushed via `:rf.nav/push-url` (registered fx; `:platforms #{:client}`).
+3. The route's `:on-match` events dispatch, in order, and the route's `:scroll` strategy is emitted as a `:rf.nav/scroll` effect.
+
+The order is locked: state changes first, URL update second, then `:on-match` and scroll. If the URL update fails (browser denies, user is offline) the state is still consistent.
+
+## URL changes are events
+
+When the user clicks a link, presses Back/Forward, or arrives via a deep link, the runtime fires `:rf/url-changed` — the canonical event for "the URL is now different." The default handler is `:rf.route/handle-url-change`, which:
+
+1. Calls `match-url` to resolve the URL against the registered route table.
+2. Sets the `:rf/route` slice with the matched id, params, query, fragment, transition, and a fresh `:nav-token`.
+3. Dispatches the matched route's `:on-match` events.
+
+```clojure
+;; Run for popstate, initial load, and SSR alike — same handler everywhere
+(rf/reg-event-fx :rf.route/handle-url-change ...)
+```
+
+The same handler runs **on the server during SSR** — the request URL is fed in, the route slice is set, the view renders against it. The `:on-match` events also fire server-side, populating server-rendered data the same way they do client-side. There is **no SSR-specific routing code**. (See [chapter 07](07-server-side.md) for the SSR story.)
+
+### Two URL-change events you'll see
+
+Two named events surface in the trace stream:
+
+- **`:rf/url-changed`** — the runtime event fired on every URL transition. Default handler is `:rf.route/handle-url-change`. Users can override by re-registering — to log analytics, run an auth-check, or apply per-app routing policy.
+- **`:rf.route/url-changed`** — a **trace event** (not a runtime event) fired when the URL changes only in its `#fragment`. Distinct from the runtime event above; the runtime emits the trace and updates `:fragment` in the slice but does NOT re-fire `:on-match`. The reason: `:on-match` exists to re-load route-scoped data when path or query changes; a fragment-only change does not change loaded data, only the in-page anchor target.
+
+If your view subscribes to `:rf.route/fragment` and re-renders when the fragment changes, you'll see the update. If your view subscribes only to `:rf.route/id` or `:rf.route/params`, fragment changes don't ripple through.
+
+## Reading the route is a sub
+
+```clojure
+@(rf/subscribe [:rf/route])               ;; the full slice map
+@(rf/subscribe [:rf.route/id])            ;; just the route id
+@(rf/subscribe [:rf.route/params])        ;; path params
+@(rf/subscribe [:rf.route/query])         ;; query params
+@(rf/subscribe [:rf.route/fragment])      ;; #fragment string or nil
+@(rf/subscribe [:rf.route/transition])    ;; :idle | :loading | :error
+@(rf/subscribe [:rf.route/error])         ;; structured error map when :error
+@(rf/subscribe [:rf.route/chain])         ;; :parent chain for nested layouts
+@(rf/subscribe [:rf/pending-navigation])  ;; pending-nav slot when blocked
+```
+
+Views derive UI from the route the same way they derive UI from any other state — no special routing API in views.
+
+The root view dispatches on `:rf.route/id`:
+
+```clojure
+(rf/reg-view app-root []
+  (case @(subscribe [:rf.route/id])
+    :route/home              [home-page]
+    :route/cart              [cart-page]
+    :route/cart.item-detail  [cart-item-detail]
+    :route/article           [article-page]
+    :rf.route/not-found      [not-found-page]))
+```
+
+Per-route views can subscribe to `:rf.route/params` for their own data needs:
+
+```clojure
+(rf/reg-view article-page []
+  (let [{:keys [id slug]} @(subscribe [:rf.route/params])]
+    [:article
+     [:h1 "Article " id]
+     (when slug [:p.slug slug])]))
+```
+
+## Linking from views
+
+```clojure
+[rf/route-link {:to :route/cart} "Cart"]
+[rf/route-link {:to :route/article :params {:id "abc"}} "Read more"]
+[rf/route-link {:to :route/search :query {:q "clojure"}} "Search"]
+```
+
+`route-link` renders an `<a href="...">` and intercepts plain primary-button clicks itself: it calls `.preventDefault` and dispatches `:rf/url-requested`. **Modifier keys** (cmd-click, middle-click, shift-click) defer to the browser — the link follows the `href` natively, opening in a new tab the way users expect.
+
+Plain anchors (`[:a {:href "..."}]`) in user view code are **not** intercepted by the framework. They cause native browser navigation. Apps that want SPA-style interception on plain anchors install it at the host adapter layer (a top-level `click` listener on the document that consults `match-url`); the runtime's contract stops at `route-link` plus `:rf/url-requested`. Why: a global `click` listener is host-bound and conflicts with non-routed `<a>` tags inside iframes, shadow DOM, or third-party widgets — the host adapter has the context to install it appropriately.
+
+## Per-route data loading: `:on-match`
+
+A route declares a vector of events the runtime dispatches whenever the route becomes active:
+
+```clojure
+(rf/reg-route :route/cart
+  {:doc      "The cart page."
+   :path     "/cart"
+   :on-match [[:cart/load-items]
+              [:user/load-prefs]]})
+```
+
+Semantics:
+
+1. When the route becomes active (URL-driven via `:rf.route/handle-url-change`, or programmatic via `:rf.route/navigate`), the runtime dispatches each `:on-match` event in order, after writing the `:rf/route` slice and before any view renders that depend on the loaded data.
+2. The runtime sets `:rf.route/transition` to `:loading` while the dispatches drain, and back to `:idle` when they complete.
+3. Same-route-id navigations with **changed `:params` or `:query`** *do* re-fire `:on-match` (the route is becoming active again under new inputs). Same-route-id navigations with identical params do **not** re-fire — the runtime compares the post-update `:rf/route` slice against the pre-update slice and skips dispatch when nothing relevant changed.
+4. `:on-match` events run server- and client-side. SSR populates server-rendered data via the same vector. Hydration does **not** re-fire `:on-match` events — the seeded `app-db` already contains the data.
+5. Each `:on-match` event is an ordinary event vector. Handlers may emit any `:fx` (typically `:rf.http/managed`). The events are also enumerable: `(rf/handler-meta :route :route/cart)` returns the metadata so tooling can render route-loading dependency graphs.
+
+The `:on-match` list is the **enumerable, machine-readable** answer to "what loads when this route is active?"
+
+## Per-route error handling: `:on-error`
+
+If any event in `:on-match` errors, the runtime:
+
+1. Sets `:rf.route/transition` to `:error`.
+2. Populates `:rf.route/error` with the structured error map.
+3. If the route declares an `:on-error` event, dispatches it. The error map is available via `(:error (:rf/route db))`.
+
+```clojure
+(rf/reg-route :route/cart
+  {:path     "/cart"
+   :on-match [[:cart/load-items]]
+   :on-error [:route/cart-load-failed]})
+
+(rf/reg-event-fx :route/cart-load-failed
+  (fn [{:keys [db]} _]
+    (let [error (get-in db [:rf/route :error])]
+      {:db (assoc-in db [:cart :load-error] (:rf.error/message error))})))
+```
+
+`:on-error` is **route-scoped** error handling, layered over [Spec 009](../../spec/009-Instrumentation.md)'s structured error contract — it doesn't replace it. The structured error trace event still fires; `:on-error` is the route's response to it.
+
+## The `:rf.route/not-found` route
+
+Apps **must** register a `:rf.route/not-found` route. The id is special-cased in one direction: when a URL fails to match any registered route, the runtime sets `:rf/route` to `{:id :rf.route/not-found :params {:url <url>} ...}` and proceeds with that route's `:on-match` events.
+
+```clojure
+(rf/reg-route :rf.route/not-found
+  {:doc      "404 page."
+   :path     "/404"
+   :on-match [[:analytics/log-404]]
+   :scroll   :top})
+```
+
+It's an ordinary `reg-route` — `:on-match`, `:on-error`, `:scroll`, `:tags` all behave normally. The view tree's `case` over `:rf.route/id` renders the not-found view from the leaf:
+
+```clojure
+(rf/reg-view app-root []
+  (case @(subscribe [:rf.route/id])
+    ;; ... matched routes ...
+    :rf.route/not-found  [not-found-page]))
+```
+
+If no `:rf.route/not-found` is registered, the runtime emits a `:rf.warning/no-not-found-route` trace and falls back to a built-in placeholder view (a minimal `<h1>Not Found</h1>` page) so the request still produces a response. Test fixtures and the conformance corpus assume the user-registered shape.
+
+URL-validation failures (a route's path matches but its `:params` schema rejects the captured values) also route here, with `:reason :validation` in the `:params` slice.
+
+## Navigation tokens — stale-result suppression
+
+When a route is loading and the user navigates away before the load completes, the older load's result can land **after** the user has moved on, clobbering newer state. Re-frame2's answer is the **navigation-token (nav-token) epoch**: a per-navigation token allocated when a route becomes active, carried by every async result, and validated on receipt.
+
+```clojure
+;; cofx of :on-match handlers carries the current :nav-token
+{:db        ...
+ :event     [:cart/load-items]
+ :nav-token "nav-42"}                       ;; the token at scheduling time
+```
+
+Async completions either carry the token in their follow-up event payload, or use the framework-supplied `:rf.route/with-nav-token` fx wrapper which threads the token into the dispatched continuation:
+
+```clojure
+{:fx [[:rf.route/with-nav-token
+       {:do        [:dispatch [:cart/items-loaded items]]
+        :nav-token (:nav-token cofx)}]]}
+```
+
+When the receiving handler runs, the framework-provided `:nav-token` cofx checks the carried token against the *current* `:rf/route` slice's `:nav-token`:
+
+- **Match** — the token is current; the result is committed normally.
+- **Mismatch** — the token has been superseded; the runtime emits `:route.nav-token/stale-suppressed` and the handler does NOT run. No `:db` write, no `:fx`, no transition.
+
+```clojure
+;; Step 1: User navigates to article id="A". nav-token = "nav-1".
+{:rf/route {:id :route/article :params {:id "A"} :transition :loading :nav-token "nav-1"}}
+
+;; Step 2: While the load is in flight, user navigates to article id="B".
+;; A fresh nav-token is allocated.
+{:rf/route {:id :route/article :params {:id "B"} :transition :loading :nav-token "nav-2"}}
+
+;; Step 3: The "A" load completes; its dispatched [:article/loaded "A" payload] carries
+;; nav-token "nav-1". Current is "nav-2". Mismatch → suppressed; trace fires; no commit.
+
+;; Step 4: The "B" load completes; carries "nav-2". Match → commit.
+{:rf/route {:id :route/article :params {:id "B"} :transition :idle :nav-token "nav-2"}}
+```
+
+Suppression alone fixes the user-visible bug. Hosts that support abortable fetches (`AbortController` in JS, etc.) MAY *additionally* abort in-flight work for superseded tokens to save bandwidth — but the conformance contract only requires suppression, not cancellation. Same shape as the `:after` timer story for state-machines (see [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md)).
+
+Two trace events surround the nav-token lifecycle:
+
+- **`:route.nav-token/allocated`** — emitted when a navigation cascade allocates a fresh token.
+- **`:route.nav-token/stale-suppressed`** — emitted when an async result arrives carrying a now-superseded token.
+
+## Navigation blocking — the `:can-leave` protocol
+
+Real product needs — unsaved forms, interrupted checkouts, destructive multi-step workflows — require navigation to be **blockable**. Re-frame2 makes this a first-class named-event/state protocol instead of a hook-based router thing. Pending-nav state lives in `app-db`; UI renders confirm dialogs from ordinary subs; user choices are dispatched as standard events. All testable.
+
+### Declare the guard on the route
+
+```clojure
+(rf/reg-route :editor/article
+  {:doc       "Editing an article."
+   :path      "/editor/articles/:id"
+   :params    [:map [:id :string]]
+   :can-leave [:editor/can-leave?]})
+
+(rf/reg-sub :editor/can-leave?
+  :<- [:editor/dirty?]
+  (fn [dirty? _] (not dirty?)))             ;; true means "OK to leave"
+```
+
+The sub returns `true` when the route is OK to leave; `false` to block. Convention: the sub's name describes the **positive** case (`:can-leave?`), so `false` means "can NOT leave."
+
+### What happens on a blocked navigation
+
+1. `:rf/url-requested` fires (link click, programmatic call, popstate).
+2. The runtime evaluates the **current** route's `:can-leave` sub.
+3. **Guard returns `true`** (or no guard) → proceed normally. The new URL becomes active; nav-token allocates; `:on-match` runs.
+4. **Guard returns `false`** → BLOCK:
+   - Generate a `pending-nav-id`.
+   - Write `:rf/pending-navigation` with `{:id <id> :requested-by-event <ev> :requested-url <url> :rejecting-route <id> :rejecting-guard <sub-id>}`.
+   - **The URL does not change.** No `pushState`, no `:rf/route` update, no `:on-match`.
+   - Dispatch `[:rf.route/navigation-blocked pending-nav]` and emit the trace.
+
+The pending-nav slot's shape (per [Spec-Schemas](../../spec/Spec-Schemas.md#rfpending-navigation)):
+
+```clojure
+{:rf/pending-navigation
+ {:id                  "pn-7"
+  :requested-by-event  [:rf/url-requested {:url "/editor/articles/42"}]
+  :requested-url       "/editor/articles/42"
+  :reason              "Form has unsaved changes"
+  :rejecting-route     :editor/article
+  :rejecting-guard     :editor/can-leave?}}
+```
+
+### The dialog
+
+UI renders the confirm dialog by subscribing to `:rf/pending-navigation`:
+
+```clojure
+(rf/reg-view leave-confirmation []
+  (when-let [pn @(subscribe [:rf/pending-navigation])]
+    [:dialog.confirm-leave
+     [:p (:reason pn)]
+     [:p "Leaving will discard your changes."]
+     [:button {:on-click #(dispatch [:rf.route/cancel   (:id pn)])} "Stay"]
+     [:button {:on-click #(dispatch [:rf.route/continue (:id pn)])} "Leave"]]))
+```
+
+User choice:
+
+- **Continue** → `[:rf.route/continue pending-nav-id]` clears the slot and re-dispatches the original navigation **bypassing** the leave-guard for this one shot.
+- **Cancel** → `[:rf.route/cancel pending-nav-id]` clears the slot. Nothing else changes.
+
+### Why this shape (and not a hook-based router)
+
+The hook version (`useBlocker`) is convenient but tied to component lifecycle. Re-frame2's strengths are explicit state and dispatched events; the named-event/slot shape preserves them. Slightly more verbose at the call site; far more testable.
+
+A test fires `[:rf/url-requested {:url "/cart"}]` against a frame whose `:editor/can-leave?` sub returns `false`, asserts `:rf/pending-navigation` is set, asserts `:rf.nav/push-url` did NOT fire, dispatches `[:rf.route/continue pending-nav-id]`, asserts the navigation completes. No DOM, no hook-mock, no event simulation.
+
+## Query strings and fragments
+
+Path syntax is the *primary* binding. Query strings are bound separately via the route's `:query` metadata key:
+
+```clojure
+(rf/reg-route :route/search
+  {:path            "/search"
+   :query           [:map [:q :string] [:page {:optional true} :int]]
+   :query-defaults  {:page 1}
+   :query-retain    #{:theme :locale}})
+
+;; URL: /search?q=clojure&page=2
+;; match-url yields {:route-id :route/search :params {} :query {:q "clojure" :page 2}}
+
+;; URL: /search?q=clojure  (page absent; default applied)
+;; match-url yields {:route-id :route/search :params {} :query {:q "clojure" :page 1}}
+```
+
+`:query-defaults` populates absent query keys at match time. `:query-retain` carries keys through subsequent navigations even when the caller didn't supply them — useful for global state encoded in the URL (`:theme`, `:locale`, `:debug`). The merge happens inside `:rf.route/navigate`'s handler (which has access to `app-db` and the current query slice) before the URL is built. The result: a `[:rf.route/navigate :route/cart]` from a search page preserves `?theme=dark`.
+
+Coercion is data-shaped (the `:query` schema is the coercion specification — `:int` coerces `"2"` → `2`). No per-key middleware functions — data over functions.
+
+The URL `#fragment` is a first-class part of the routing contract — anchor navigation, scroll-to-section, settings-tab selection. Read it via `:rf.route/fragment`. Fragment-only changes update the slice and emit `:rf.route/url-changed` trace but do NOT re-fire `:on-match` (the data didn't change; only the in-page target did).
+
+## Multi-frame routing
+
+Each frame may have its own `:rf/route` slice — it's a regular `app-db` path, not a special concept. **Only one frame is URL-bound.**
+
+| Frame | URL-bound? | Behaviour |
+|---|---|---|
+| `:rf/default` | yes (default) | `:rf.route/navigate` events fire `:rf.nav/push-url`; popstate dispatches into this frame. The browser URL reflects this frame's route. |
+| Non-default | no (default) | `:rf.route/navigate` updates the frame's `:rf/route` slice but does **not** fire `:rf.nav/push-url`. The browser URL is unchanged. |
+| Non-default with `(rf/reg-frame :my-frame {:url-bound? true})` | yes (opt-in) | The runtime enforces "only one frame can own the URL at a time" — re-registering a second URL-bound frame is a `:rf.error/duplicate-url-binding` trace event. |
+
+The story tools / devcards / SSR cases all benefit:
+
+- **Stories / devcards.** Each story-variant frame has its own `:rf/route` independent of the page URL. A "show me the cart in the loaded state at `/cart/items/abc`" variant doesn't push to the browser bar.
+- **Per-test fixtures.** Each test frame has its own route; tests don't accidentally hit `pushState`.
+- **SSR per-request frames.** The request URL is fed in via `:rf.route/handle-url-change`; no client-side `pushState` (which doesn't exist server-side anyway).
+
+## Pure helpers
+
+Two pure functions are part of the public surface:
+
+```clojure
+(rf/match-url url)
+;; → {:route-id :route/search :params {} :query {:q "clojure"} :fragment nil
+;;    :validation-failed? false}
+;; or nil if no route matches at all.
+
+(rf/route-url :route/cart)
+(rf/route-url :route/cart.item-detail {:id "abc"})
+(rf/route-url :route/search {} {:q "clojure"})
+(rf/route-url :route/docs {:page "routing"} {} "scroll-restoration")
+;; → URL string, e.g. "/docs/routing#scroll-restoration"
+```
+
+Both are pure; both run on JVM and CLJS; both work against the same registered route table so adding/removing a route updates both directions automatically. `route-url` is a string-builder — it does NOT navigate, does NOT read `app-db`, does NOT push or dispatch.
+
+To navigate, dispatch `:rf.route/navigate` (which uses `route-url` internally). To resolve a URL incoming from outside, call `match-url` (which `:rf.route/handle-url-change` uses internally).
+
+## Worked example — the realworld scaffold
+
+The [`examples/reagent/realworld/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld) example is a re-frame2 implementation of the [RealWorld example app spec](https://github.com/gothinkster/realworld). Its routing setup is the canonical end-to-end shape:
+
+```clojure
+(ns realworld.routes
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-route :route/home
+  {:path     "/"
+   :on-match [[:articles/load-feed]]})
+
+(rf/reg-route :route/login
+  {:path "/login"})
+
+(rf/reg-route :route/register
+  {:path "/register"})
+
+(rf/reg-route :route/article
+  {:path     "/article/:slug"
+   :params   [:map [:slug :string]]
+   :on-match [[:article/load]
+              [:article/load-comments]]})
+
+(rf/reg-route :route/profile
+  {:path     "/profile/:username"
+   :params   [:map [:username :string]]
+   :on-match [[:profile/load]]})
+
+(rf/reg-route :route/editor
+  {:path      "/editor"
+   :tags      #{:requires-auth}
+   :can-leave [:editor/can-leave?]})
+
+(rf/reg-route :route/editor-edit
+  {:path      "/editor/:slug"
+   :params    [:map [:slug :string]]
+   :tags      #{:requires-auth}
+   :on-match  [[:editor/load-for-edit]]
+   :can-leave [:editor/can-leave?]})
+
+(rf/reg-route :route/settings
+  {:path "/settings"
+   :tags #{:requires-auth}})
+
+(rf/reg-route :rf.route/not-found
+  {:path "/404"})
+```
+
+The root view dispatches on `:rf.route/id`:
+
+```clojure
+(rf/reg-view app-root []
+  (let [route-id @(subscribe [:rf.route/id])]
+    [:div.app
+     [navbar]
+     [leave-confirmation]              ;; renders pending-nav dialog
+     (case route-id
+       :route/home          [home-page]
+       :route/login         [login-page]
+       :route/register      [register-page]
+       :route/article       [article-page]
+       :route/profile       [profile-page]
+       :route/editor        [editor-page]
+       :route/editor-edit   [editor-page]
+       :route/settings      [settings-page]
+       :rf.route/not-found  [not-found-page])
+     [footer]]))
+```
+
+An auth guard (regular interceptor on `:rf.route/navigate`) consults `:tags` and redirects to `/login` when the user isn't authed:
+
+```clojure
+(def auth-guard
+  (rf/->interceptor
+    :id     :rf.route/auth-guard
+    :before (fn [ctx]
+              (let [event       (get-in ctx [:coeffects :event])
+                    target      (second event)
+                    route-meta  (rf/handler-meta :route target)
+                    needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
+                    logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
+                (if (and needs-auth? (not logged-in?))
+                  (assoc-in ctx [:coeffects :event]
+                            [:rf.route/navigate :route/login {} {} nil
+                             {:return-to target}])
+                  ctx)))))
+```
+
+Guards are interceptors, not a special routing mechanism. They compose; multiple guards can layer.
+
+The editor's `:can-leave` guard plus a confirmation dialog are wired exactly as described above — the dirty-flag drives the sub; the dialog renders from `:rf/pending-navigation`; user clicks dispatch `:rf.route/continue` or `:rf.route/cancel`.
+
+The same routing setup runs **server-side under SSR** without modification. The request URL is fed to `:rf.route/handle-url-change`; `:on-match` events fire and populate the route's data; the view renders against the populated state; HTML + serialised state ship to the client; hydration restores the route along with everything else.
+
+## Tooling and AI-amenability
+
+- `(rf/handlers :route)` enumerates every registered route. AI scaffolds consult this before generating new routes to avoid collisions.
+- `(rf/handler-meta :route :route/cart)` returns the route's metadata: path, params shape, query shape, `:on-match`, `:on-error`, `:scroll`, `:parent`, tags, source coords. The `:on-match` slot is enumerable — tools render route-loading dependency graphs without parsing handler bodies.
+- `:rf.route/navigate`, `:rf.route/handle-url-change`, `:rf/url-changed`, `:rf/url-requested` are stable, named events; trace events surface every navigation and every URL request.
+- A registered `:rf.route/not-found` is required by contract; tools surface the `:rf.warning/no-not-found-route` trace event for apps missing the registration.
+
+## Next
+
+- [Spec 012 — Routing](../../spec/012-Routing.md) — the full normative surface, including the path-pattern grammar's productions, the route ranking cascade, scroll restoration, and the SSR integration story in detail.
+- [chapter 07](07-server-side.md) — how routing folds into SSR.
+- [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) — why nav-tokens are the same shape as `:after`-timer epochs, and the cross-cutting pattern.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -19,6 +19,9 @@ If you're an AI agent or implementor, you want the [specification](../../spec/) 
 | 07 | [The server side](07-server-side.md) | SSR and hydration without losing your mind. |
 | 08 | [From re-frame v1](08-from-re-frame-v1.md) | What's the same, what's different, what to do. |
 | 09 | [The dynamic-model story](09-the-dynamic-model.md) | The deeper essay on *why* less-powerful is more. |
+| 10 | [Testing](10-testing.md) | `re-frame.test-support`, frame fixtures, JVM-vs-CLJS boundary, conformance. |
+| 11 | [Devtools and pair tools](11-devtools-and-pair-tools.md) | Trace stream, epoch history, time-travel, source-coords, `reset-frame-db!`. |
+| 12 | [Routing](12-routing.md) | URL ↔ state contract, `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
 
 After the chapters: read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login, routing, ssr, managed-http-counter, state-machine-walkthrough), then benchmarks (todomvc, 7GUIs, nine-states), then the RealWorld scaffold. Fifteen examples total, each with a Playwright smoke spec; the catalogue maps each one to the Specs it exercises.
 


### PR DESCRIPTION
## Summary

Expands `docs/guide/` to cover this session's substantial additions. Three new priority chapters; three existing-chapter updates. Lower-priority chapters (Schemas, Flows, Production, From-xstate, ch 08/09 updates) are explicitly out of scope here — follow-up dispatch.

## Per-chapter breakdown

### Phase 1 — chapter updates

- **`docs/guide/02-your-first-app.md`** — 319 lines (was 262, +57)
  - New "Choose your substrate" section: Reagent / UIx / Helix with deps.edn snippets each.
  - Expanded `(rf/init!)` Option 2 walkthrough — adapter ns side-effect registration, no-arg shape, multi-adapter error case (`:rf.error/multiple-default-adapters`), `:rf.error/no-adapter-registered`. References rf2-84po (PR #165).
  - Per-artefact deps.edn for the smallest sensible "first app." References Strategy B (rf2-5vjj).

- **`docs/guide/04-views-and-frames.md`** — 323 lines (was 265, +58)
  - "`dispatch` and `subscribe` are auto-injected" section — Form-1 / Form-2 boundary, compile-time error on Form-3 and non-literal-fn bodies, escape via `reg-view*`. References rf2-d0pi.
  - "How frames propagate through the view tree" — frame-provider + React context (rf2-sixo / Path 1). Documents the rf2-d4sf caveat honestly: dispatch/subscribe consult the dynamic-var tier today; the React-context tier of spec/002 §3 is partially dead-code; describes what works rather than what spec promises long-term.
  - "Source coordinates on rendered DOM" — `data-rf2-source-coord` 4-segment format, production-elision contract, fragment exemption. References rf2-z7f7 / Spec 006 §Source-coord annotation. Cross-links to chapter 11.

- **`docs/guide/05-state-machines.md`** — 488 lines (was 392, +96)
  - `reg-machine` is a macro now (rf2-8bp3, PR #140) — source-coord stamping, per-element coord index.
  - "Spawning child machines: `:rf.machine/spawn` and `:rf.machine/destroy`" — the canonical lifecycle fx names per rf2-m83v / PR #175; the earlier `:spawn` / `:destroy-machine` are gone.
  - "The runtime-tracked spawn registry" (rf2-t07u, PR #172) — `[:rf/spawned <parent> <invoke-id>]`; `:on-spawn` is now advisory; auth-flow worked example works as written.
  - "Naming machines across the frame: `:system-id`" — opt-in named-machine addressing per rf2-suue / PR #136; cross-machine messaging by name; `:rf.machine/system-id-bound` / `-released` traces.
  - 3-arity escape hatch footnote (rf2-1e0n / rf2-l04j) — variadic-fn footgun.

### Phase 2 — new chapters

- **`docs/guide/10-testing.md`** — 428 lines (NEW)
  - `re-frame.test-support` artefact + `with-fresh-registrar` / `reset-runtime-fixture` patterns (rf2-hkr5 / rf2-0l3s).
  - Three fixture-lifecycle patterns; testing event handlers, fxs, subs against an isolated frame; three-level machine testing.
  - `dispatch-sequence` / `assert-state` / `run-test-sync` (v1 compat) helper coverage.
  - JVM vs CLJS test boundaries; per-artefact `clojure -M:test`.
  - Stubbing, recording, conformance fixtures, property-based testing.
  - Bundle-isolation CI gate (rf2-51x5 / PR #149) — the contract that core stays clean of per-feature artefacts.

- **`docs/guide/11-devtools-and-pair-tools.md`** — 437 lines (NEW)
  - What pair-tooling means; re-frame-pair2 + 10x v2 as canonical consumers; framework commits to the contract, not the tool.
  - `register-trace-cb!` raw stream; `register-epoch-cb` assembled per-cascade stream.
  - `epoch-history` + `restore-epoch` + the six failure modes; time-travel `:rf.epoch/restored` trace.
  - `reset-frame-db!` (rf2-zq55 / PR #170) — direct write surface; drain-check + epoch-record + `:rf.epoch/db-replaced` trace.
  - Source-coord parsing — `<ns>:<sym>:<line>:<col>` 4-segment contract (rf2-q7r0 / PR #174); `:rf/source-coord-meta` for full meta via `(handler-meta :view id)`.
  - Sub-topology (rf2-8nzo / PR #142) — `(rf/sub-topology)` for the static sub-graph.
  - Frame-destroyed semantics (rf2-d656 / PR #177) — read returns empty/nil; mutate raises; listener silenced with one-shot trace.
  - Performance API channel (CLJS-only, opt-in for prod).
  - Worked example: a minimal trace + epoch debug panel.

- **`docs/guide/12-routing.md`** — 547 lines (NEW)
  - The `day8/re-frame-2-routing` artefact (Strategy B).
  - `reg-route` + path-pattern grammar (5 productions); the 6-rule ranking cascade.
  - `:rf/route` reserved app-db slot (rf2-ljw6 corpus alignment, PR #179).
  - Navigation events (`:rf.route/navigate`, `:rf/url-changed`, `:rf/url-requested`); `:on-match` data loading; `:on-error` route-scoped error handling; canonical `:rf.route/not-found` registration.
  - `:rf/url-changed` runtime event vs `:rf.route/url-changed` trace event — fragment-only URL update doesn't re-fire `:on-match`.
  - Navigation tokens (stale-result suppression) — same shape as `:after`-timer epochs.
  - `:can-leave` guard + `:rf/pending-navigation` slot; full block / continue / cancel lifecycle.
  - Query strings (`:query-defaults`, `:query-retain`); fragments; multi-frame routing (URL-bound vs not).
  - Worked example: realworld-app-style routing setup (auth guard via interceptor, leave-confirmation, root view dispatching on `:rf.route/id`).

### `docs/guide/README.md` — chapter list updated to include 10 / 11 / 12.

## Cross-reference verification

- No broken inter-chapter links (`grep -nE '\]\(\.\./|\]\(#' docs/guide/*.md` clean).
- Spec-relative references cross-checked against existing files:
  - 10 → `spec/002-Frames.md`, `spec/008-Testing.md`, `spec/011-SSR.md`.
  - 11 → `spec/006-ReactiveSubstrate.md`, `spec/009-Instrumentation.md`, `spec/Spec-Schemas.md` (`#rfepoch-record`, `#rfsource-coord-attr`), `spec/Tool-Pair.md` (`#time-travel-epoch-snapshots-and-undo`, `#surface-behaviour-against-destroyed-frames`).
  - 12 → `spec/009-Instrumentation.md`, `spec/012-Routing.md` (`#path-pattern-grammar-canonical`, `#route-ranking-algorithm`), `spec/Pattern-StaleDetection.md`, `spec/Spec-Schemas.md` (`#rfpending-navigation`, `#rfroute-slice`).
- All anchors verified to exist in the linked-to files.

## Honest documentation calls

- Chapter 04's frame-provider section explicitly documents the rf2-d4sf gap (subscribe consults dynamic-var only; React-context tier is partially dead code in the current CLJS impl). The chapter describes what works today rather than overselling spec/002 §3's full chain.

## Out of scope (follow-up dispatch)

The lower-priority chapters from the post-session catch-up are explicitly **not** addressed by this PR:

- Schemas chapter (Spec 010 surface).
- Flows chapter (Spec 013 surface).
- Production chapter (production-elision, bundle-size, CI gate from a user's perspective).
- From-xstate chapter (a "how this maps if you're an xstate user" companion to chapter 05).
- Chapter 08 and 09 updates (v1 → v2 migration deltas; dynamic-model essay refresh).

Each is a separate, smaller dispatch; this PR's scope is the 6 deliverables in the rf2-m8np scope ladder.

## Test plan

- [ ] Markdown renders correctly via mkdocs (existing repo pattern).
- [ ] `grep -nE '\]\(\.\./|\]\(#' docs/guide/*.md` shows no broken file references.
- [ ] All cross-referenced spec files and anchors exist.
- [ ] `wc -l docs/guide/*.md` shows expected per-chapter line counts.