### PR TITLE
chore: consolidate Day8 skills under skills/ (re-frame-pair2 + re-frame-pair-improver2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ Thumbs.db
 /docs/spec/
 # Python bytecode from mkdocs_hooks.py (rf2-qvlf).
 /__pycache__/
+
+# Skills build artefacts
+skills/*/node_modules/
+skills/*/.shadow-cljs/
+skills/*/out/
+skills/*/target/

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# skills/
+
+This directory holds Claude Code / agent-shaped skills for re-frame2. Each
+subdirectory is a self-contained skill with its own `SKILL.md`, scripts,
+and packaging metadata.
+
+These skills were consolidated here from formerly-standalone repositories
+during the `v0.0.1.beta` prep — keeping the skill source colocated with the
+re-frame2 surfaces it consumes, so the spec, implementation, and tooling
+travel together.
+
+## Current skills
+
+- **[`re-frame-pair2/`](./re-frame-pair2/)** — pair-program with a live
+  re-frame2 application. Attach to a running shadow-cljs build via nREPL,
+  inspect `app-db`, dispatch events, hot-swap handlers, trace the six
+  dominoes, and consume re-frame2's Tool-Pair surfaces directly. No
+  re-frame-10x dependency.
+
+- **[`re-frame-pair-improver2/`](./re-frame-pair-improver2/)** — meta-skill
+  for `re-frame-pair2`. Reviews a pair-programming session, identifies
+  friction and wasted effort, and proposes improvements to `re-frame-pair2`
+  itself (or routes upstream beads to re-frame2 when the friction is
+  framework-shaped rather than tool-shaped).
+
+## Layout convention
+
+Each skill subdir contains, at minimum:
+
+- `SKILL.md` — the skill description Claude loads on invocation.
+- `README.md` — human-facing overview.
+- `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata.
+- `package.json` — npm packaging metadata (skill is also distributable as
+  an Agent Skill via `npx skills add`).
+
+Skills do not run independently of re-frame2's CI; their workflows have
+been removed in favour of release coordination through re-frame2's own
+release pipeline. See each skill's `RELEASING.md` (where present) for
+historical npm publish mechanics.

--- a/skills/re-frame-pair-improver2/.claude-plugin/plugin.json
+++ b/skills/re-frame-pair-improver2/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "re-frame-pair-improver2",
+  "version": "0.1.0-alpha.1",
+  "description": "Review a re-frame-pair2 session, identify workflow friction, and propose improvements or bead drafts.",
+  "skills": [
+    "./SKILL.md"
+  ],
+  "status": "alpha"
+}

--- a/skills/re-frame-pair-improver2/.gitignore
+++ b/skills/re-frame-pair-improver2/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+Thumbs.db
+node_modules/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/skills/re-frame-pair-improver2/LICENSE
+++ b/skills/re-frame-pair-improver2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michael Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/re-frame-pair-improver2/README.md
+++ b/skills/re-frame-pair-improver2/README.md
@@ -1,0 +1,83 @@
+# re-frame-pair-improver2
+
+`re-frame-pair-improver2` is a Claude ***meta-skill*** for [`re-frame-pair2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2). It reviews a user's `re-frame-pair2` session, identifies friction and wasted effort, and suggests how `re-frame-pair2` itself could be improved to become a better pair programmer.
+
+It is the re-frame2 sibling of [`re-frame-pair-improver`](https://github.com/day8/re-frame-pair-improver), which targets the v1 [`re-frame-pair`](https://github.com/day8/re-frame-pair) tool against [`re-frame`](https://github.com/day8/re-frame) v1.
+
+It is designed for retrospectives like:
+
+- "What was frustrating about this re-frame-pair2 session?"
+- "What took longer than it should have?"
+- "Which parts of this workflow should re-frame-pair2 absorb?"
+- "Can you draft or file a bead for the best improvement idea?"
+
+It focuses on evidence from the session itself: retries, confusion, workarounds, stale or empty results, missing observability, brittle platform behavior, hidden prerequisites, and trust gaps. It then proposes improvements at the right layer: `SKILL.md`, scripts/runtime ops, warnings/results, tests/fixtures, or — when the friction is caused by the framework rather than the pair tool — an upstream bead against `re-frame2`.
+
+It can draft a `bd` bead (or a GitHub issue, if the target repo prefers that), but only if the user wants that.
+
+It is intentionally diagnosis-first: the default outcome is a better understanding of what went wrong and which improvements would matter most, not pressure to contribute code or file beads.
+
+## Repo contents
+
+- `SKILL.md` — the skill itself
+- `references/analysis-lenses.md` — friction taxonomy and prioritization prompts (re-frame2-aware)
+- `references/known-frictions.md` — recurring classes of product friction to pattern-match against
+- `references/issue-template.md` — bead drafting structure (also usable as a GitHub issue body)
+- `.claude-plugin/plugin.json` — plugin packaging metadata
+- `agents/openai.yaml` — UI metadata for skill lists and invocation
+
+## Relationship to other repos
+
+- [`re-frame-pair2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) — the pair tool this skill reviews. Sessions with that tool are this skill's input.
+- [`re-frame2`](https://github.com/day8/re-frame2) — the framework. When friction is caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings), beads route here, not to `re-frame-pair2`.
+- [`re-frame-pair-improver`](https://github.com/day8/re-frame-pair-improver) — the v1 sibling that targets v1 `re-frame-pair`.
+
+This skill does **not** depend on or reference `re-frame-10x`. re-frame2's Tool-Pair surfaces (`register-trace-cb`, `register-epoch-cb`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation) replace the v1 reliance on the 10x dev tool.
+
+## Typical output
+
+A good run of the skill produces:
+
+1. the user's actual goal
+2. the main friction points observed in the session
+3. likely root causes
+4. 2-5 high-leverage improvement ideas
+5. optional bead candidates (against `re-frame-pair2` and/or `re-frame2`), with draft text or direct filing only after approval
+
+## Status
+
+Pre-alpha. Ports the v1 `re-frame-pair-improver` skill structure to target re-frame2. Expected to evolve as `re-frame-pair2` matures and as more re-frame2 sessions surface novel friction patterns.
+
+## Install
+
+> Not yet published to npm. There is no package install path for this skill yet.
+
+To use it now, install it straight from a clone of this repo.
+
+### Install the skill in Claude Code
+
+#### Global — for you, across any repo
+
+Clone the re-frame2 repo somewhere stable, then symlink the skill subdirectory into your user Claude config:
+
+```bash
+git clone https://github.com/day8/re-frame2.git ~/src/re-frame2
+mkdir -p ~/.claude/skills
+ln -s ~/src/re-frame2/skills/re-frame-pair-improver2 ~/.claude/skills/re-frame-pair-improver2
+```
+
+Best when you want the skill available everywhere and are happy to `git pull` updates in one place.
+
+#### Project-local — for your whole team via the repo
+
+Install into the project's own `.claude/skills/re-frame-pair-improver2/` directory and commit it. Teammates who clone the repo and open Claude Code there get the same pinned version.
+
+Because there is no npm package yet, do this by vendoring the repo contents or adding it as a submodule under `.claude/skills/re-frame-pair-improver2/`.
+
+For the plugin variant, check in the packaged files from this repo and reference the local plugin from the project's Claude configuration rather than a published package name.
+
+#### Which to choose
+
+- **Global** if you're the only person using Claude Code here, or you want one install shared across repos.
+- **Project-local** if your team wants one pinned, shared version.
+- **Both** is fine — the project-local install takes precedence when both are present.

--- a/skills/re-frame-pair-improver2/SKILL.md
+++ b/skills/re-frame-pair-improver2/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: re-frame-pair-improver2
+description: Analyze a user's recent work with re-frame-pair2 to identify friction, wasted effort, missing observability, workflow mismatches, and high-leverage improvement opportunities. Use when the user asks how re-frame-pair2 could better support their workflow, wants a retrospective on a debugging or pairing session, or wants concrete improvement ideas or bead drafts for re-frame-pair2.
+---
+
+# re-frame-pair-improver2
+
+Study the current or just-finished session and turn it into a product retrospective for `re-frame-pair2`.
+
+This is a conversation, not an automated report. Surface findings, let the user steer which ones matter, and only then converge on improvements.
+
+## Core job
+
+Deliver:
+- what the user was trying to do
+- where the workflow dragged, confused, or frustrated them
+- which problems were one-off environment issues vs recurring product gaps
+- 2-5 concrete improvement ideas, prioritized by leverage, including 1-2 bolder options when they would materially improve the workflow
+- an opt-in bead draft or filed bead only after explicit user approval
+
+## Guard rails
+
+- Always start with session analysis. Do not jump straight to fixes.
+- Present friction points before root causes. Let the user choose which ones to dig into.
+- Default to diagnosis, not contribution. Do not assume the user wants to file a bead or propose a patch.
+- Never file a bead or edit another repo without explicit user approval.
+- If the user invoked the skill with a specific complaint, focus there first but still notice other background friction.
+
+## Working style
+
+- Prefer evidence over vibes. Cite concrete moments from the session: retries, clarifications, fallbacks, stale outputs, empty outputs, mismatched docs, waits, or manual workarounds.
+- Separate symptom from cause. "We had to retry the attach three times" is the symptom; "discovery was brittle on this platform" is the likely cause.
+- Notice both direct and indirect friction.
+  - Direct: the user says something was frustrating, confusing, slow, brittle, or surprising.
+  - Indirect: repeated commands, repeated explanations, fallback to lower-level tools, manual reconstruction, hidden prerequisites, brittle environment assumptions, partial results, confusing contracts, or missing trust signals.
+- Notice positive gaps too.
+  - What almost worked?
+  - What required too much expert knowledge?
+  - What capability existed but was undiscoverable?
+  - What should have been the default?
+- Be creatively ambitious after the diagnosis is clear.
+  - Start with grounded fixes supported directly by the session.
+  - Then ask what would make this workflow feel nearly automatic, self-explaining, or hard to misuse.
+  - Include 1-2 higher-upside ideas when warranted, even if they require reshaping the workflow rather than patching a local symptom.
+  - Label speculative ideas clearly; creative does not mean vague.
+- Stay focused on improving `re-frame-pair2`. If the best fix belongs upstream in `re-frame2` itself (its Tool-Pair surfaces, trace stream, epoch-history, schema reflection, or source-coordinate annotation), say so explicitly and route the proposal there as a `bd` bead against the `re-frame2` repo, not against `re-frame-pair2`.
+- Read [references/analysis-lenses.md](references/analysis-lenses.md) when the session has multiple plausible causes or you need a sharper taxonomy.
+- Read [references/known-frictions.md](references/known-frictions.md) when the session resembles a recurring class of `re-frame-pair2` pain and you want to sanity-check whether it is a one-off or a pattern.
+
+## Analysis workflow
+
+1. Reconstruct the session goal.
+   - Identify the user's intended outcome, not just the last command.
+   - Capture the important environment facts: platform, target repo, live runtime state (which frame, which epoch depth), and tooling constraints.
+
+2. Build a short timeline.
+   - List the turns or actions where progress stalled, restarted, detoured, or required a workaround.
+   - Include tool errors, empty outputs, stale outputs, retries, and clarification loops.
+
+3. Extract friction.
+   - Present a numbered list of friction points first.
+   - For each point, note:
+     - what happened
+     - where it showed up in the session
+     - the initial category guess
+   - Ask:
+     - which of these should we dig into?
+     - did I miss anything important?
+
+4. Classify the root cause.
+   - Work through these lenses briefly:
+
+     | Lens | Question | Typical improvement |
+     |------|----------|---------------------|
+     | Skill structure | Was the right guidance present but buried or too low-signal? | Promote to guard rail, shorten, reorder, add examples |
+     | Skill gap | Was key guidance missing entirely? | Add a new recipe, anti-pattern, or decision rule |
+     | Misleading docs | Did the docs suggest the wrong action or wrong trust model? | Correct wording, add warnings, align contracts |
+     | Missing structured op | Did the workflow need a first-class command or result shape? | Add a script/runtime op or a structured field |
+     | Unreliable op | Did an existing op behave too ambiguously or too brittlely? | Fix behavior, add warnings, strengthen validation |
+     | Default or fallback | Was the default path wrong, silent, or unsafe? | Change defaults or automate the safer fallback |
+     | Platform bug | Did the workflow break on a specific shell, OS, or browser setup? | Add platform-aware handling or explicit detection |
+     | Validation gap | Did this ship because the right fixture, smoke test, or regression test is missing? | Add test coverage or fixture support |
+     | Upstream limitation | Is `re-frame-pair2` working around the wrong abstraction in `re-frame2` itself? | File a `bd` bead against the `re-frame2` repo |
+     | Context-window issue | Did long context or low-salience guidance cause forgetfulness? | Make the guard rail shorter, earlier, and stronger |
+
+   - Prefer one primary cause per finding, but allow multiple contributing causes when needed.
+
+5. Generate improvements at the right layer.
+   - Consider several layers before choosing one:
+     - tighten `SKILL.md` instructions or recipes
+     - add or reshape a shell, script, or runtime op
+     - enrich structured results, warnings, or failure modes
+     - improve cross-platform behavior
+     - add validation, fixture coverage, or smoke tests
+     - expose new runtime instrumentation
+     - file a `bd` bead against `re-frame2` when the right fix is in the framework's Tool-Pair contract rather than the pair tool
+   - Prefer proposals that remove repeated effort, not just this session's exact symptom.
+   - Ask a broader design question before finalizing ideas:
+     - what should the tool have noticed automatically?
+     - what manual decision or reconstruction step should disappear?
+     - what would make this workflow feel obvious to a first-time user?
+     - what would prevent this class of failure earlier?
+   - Offer options when there is more than one credible path:
+     - no action
+     - docs or skill edit
+     - tool/runtime change
+     - bead draft against `re-frame-pair2`
+     - upstream escalation as a `bd` bead against `re-frame2`
+   - If the workflow itself seems wrong, include a redesign option instead of only polishing the current path.
+
+6. Prioritize.
+   - Favor ideas that are:
+     - high impact on common workflows
+     - specific enough to implement
+     - supported by session evidence
+     - likely to improve trust, speed, or debuggability
+   - Usually return 2-5 improvements, not a long brainstorm.
+   - A good default mix is 1-3 grounded improvements plus 0-2 bolder ideas.
+
+## Output format
+
+Use a compact retrospective with these sections when the session has enough evidence:
+- `Goal`
+- `Observed friction`
+- `Likely root causes`
+- `Improvement ideas`
+- `Bolder ideas` if there are credible higher-upside options worth separating from the grounded fixes
+- `Bead candidates` if the user wants them
+- `Other possibilities` if there were good lower-priority ideas
+
+For each improvement idea, include:
+- the friction it addresses
+- why `re-frame-pair2` was not enough
+- the proposed change
+- the likely layer of change: skill, script/runtime, tests/docs, or upstream `re-frame2`
+- a short impact statement
+
+If the session is too thin, say so plainly and ask for either a recap or permission to use a longer conversation as input.
+
+## Filing improvements
+
+Never file a bead without explicit user approval.
+
+After presenting the retrospective, only offer filing work if it is useful:
+- draft bead text
+- file the bead directly via `bd create` against the appropriate repo (`re-frame-pair2` for tool changes, `re-frame2` for upstream contract changes), if the user asks
+- split the ideas into multiple focused beads, if that would be cleaner
+
+Default routing:
+- `re-frame-pair2` — friction inside the pair tool: SKILL.md, scripts, recipes, structured results, attach/discovery brittleness, cross-platform handling.
+- `re-frame2` — friction caused by the framework's Tool-Pair contract: missing trace events, gaps in `epoch-history` or `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings.
+
+Before filing:
+- redact secrets, tokens, internal URLs, and unnecessary local file paths
+- avoid dumping the raw transcript; summarize the evidence instead
+- search for an existing bead with `bd list` / `bd ready` or `bd show <id>` before creating a new one
+- prefer one bead per materially distinct improvement
+- use [references/issue-template.md](references/issue-template.md) for structure
+
+If filing is not possible (e.g. `bd` is not configured in the target repo), produce a ready-to-paste bead body and say that it is a draft, not a filed bead. If the user prefers a GitHub Issue, the same template works — just paste it there.
+
+## What to avoid
+
+- Do not reduce every problem to "write more docs". Consider product behavior, tooling, defaults, and instrumentation first.
+- Do not confuse a transient local outage with a product gap unless the workflow made recovery harder than it should have.
+- Do not propose vague improvements like "better UX" without naming the concrete missing behavior.
+- Do not confuse creativity with hand-waving. Bold ideas still need a concrete change and a believable path to value.
+- Do not force every retro into a code contribution or bead.
+- Do not file speculative beads unsupported by the session.
+- Do not pressure the user to file anything.
+- Do not propose fixes that route through `re-frame-10x` — re-frame2's pair tooling does not depend on it. Time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces (`register-trace-cb`, `register-epoch-cb`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation).

--- a/skills/re-frame-pair-improver2/agents/openai.yaml
+++ b/skills/re-frame-pair-improver2/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "re-frame-pair2 improver"
+  short_description: "Find re-frame-pair2 workflow friction."
+  default_prompt: "Use $re-frame-pair-improver2 to review this session, identify where re-frame-pair2 made the workflow harder than it should have been, and propose concrete improvements before drafting any bead."

--- a/skills/re-frame-pair-improver2/package.json
+++ b/skills/re-frame-pair-improver2/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@day8/re-frame-pair-improver2",
+  "version": "0.1.0-alpha.1",
+  "description": "Analyze re-frame-pair2 sessions for friction and propose concrete product improvements.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "re-frame-pair2",
+    "re-frame2",
+    "retrospective",
+    "workflow-analysis",
+    "product-feedback"
+  ],
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2",
+  "bugs": {
+    "url": "https://github.com/day8/re-frame2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame-pair-improver2"
+  },
+  "license": "MIT",
+  "author": "day8 (https://github.com/day8)",
+  "files": [
+    "SKILL.md",
+    "README.md",
+    "LICENSE",
+    "agents/",
+    "references/",
+    ".claude-plugin/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/skills/re-frame-pair-improver2/references/analysis-lenses.md
+++ b/skills/re-frame-pair-improver2/references/analysis-lenses.md
@@ -1,0 +1,99 @@
+# Analysis lenses
+
+Use this file when the session has enough detail that a loose summary is not enough.
+
+## Friction signals
+
+Look for:
+
+- repeated retries or "try again" loops
+- repeated explanation of the same context
+- fallback from a high-level workflow to low-level commands
+- missing or empty outputs where the user expected an answer
+- stale outputs that required manual verification
+- unclear contracts between docs and actual behavior
+- hidden prerequisites or environment assumptions
+- long waits with weak progress signals
+- workarounds that the tool should have encoded
+- user uncertainty about whether to trust the result
+
+Also notice:
+
+- hidden capabilities that should have been discoverable
+- expert-only knowledge that should have been embodied in the tool
+- places where the workflow nearly worked but failed late
+- places where the user had to choose between speed and safety
+
+## re-frame2-specific friction signals
+
+These signals are unique to or amplified by re-frame2's Tool-Pair surfaces. Watch for them in addition to the generic list above.
+
+- ambiguity about which **frame** an inspection or dispatch targeted (multi-frame is first-class in re-frame2)
+- confusion between the **raw trace stream** (`register-trace-cb`) and the **assembled epoch stream** (`register-epoch-cb`) — wrong listener choice for the question being asked
+- manual reconstruction of `:sub-runs`, `:renders`, or `:effects` from raw traces when the structured projections on `:rf/epoch-record` already carry them
+- `restore-epoch` calls that fail with one of the six named failure modes (`:rf.epoch/restore-unknown-epoch`, `restore-schema-mismatch`, `restore-missing-handler`, `restore-version-mismatch`, `restore-during-drain`, or `:rf.error/no-such-handler`) without a clear next-best-action
+- silent loss of history because `:epoch-history :depth` is too low for the user's workflow, with no warning when the target epoch ages out
+- stale or empty result because the build is `:advanced` (production-elided): the trace surface, schema validation, and epoch machinery are gated by `re-frame.interop/debug-enabled?` and elide entirely
+- source-coordinate workflows that assume `data-rf2-source-coord` is present when the runtime opt is off
+- private-namespace reach-through (`re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`) — these are off-contract per Tool-Pair §REPL-eval and may move
+- hot-swap that fired but the user could not tell because `:rf.registry/handler-replaced` was not surfaced
+- dispatch correlation gaps: cascade walks where `:dispatch-id` / `:parent-dispatch-id` were available but the tool did not stitch them
+- machine-snapshot version skew (`:rf/snapshot-version`) silently breaking restore after a hot reload
+- effect overrides (`:fx-overrides`) that lingered or leaked across experiments
+
+## Root-cause categories
+
+Map each finding to one primary cause:
+
+- `docs/discoverability` — the feature or prerequisite existed, but the user could not find or trust it
+- `workflow-gap` — the instructions or recipes did not guide the user through a common task
+- `missing-op` — the workflow needed a first-class operation that does not exist
+- `unreliable-op` — an existing operation was too brittle or ambiguous
+- `default/fallback` — the default behavior was wrong, silent, or unsafe
+- `platform-bug` — the workflow behaved differently on a specific OS, shell, or browser setup
+- `validation-gap` — the bug shipped because the repo lacks the right smoke test, fixture, or warning
+- `upstream-gap` — the best fix belongs in `re-frame2` itself (Tool-Pair contract, instrumentation surface, schema reflection, epoch machinery, or source-coord annotation)
+- `out-of-scope` — the user wanted something `re-frame-pair2` should probably not own
+
+## Improvement patterns
+
+Prefer proposals that remove repeated effort:
+
+- tighten `SKILL.md` wording or add a recipe
+- add a stronger warning or a more explicit failure mode
+- add a structured result field instead of forcing manual interpretation
+- add a runtime/script op for a repeated manual step
+- make a platform-specific fallback automatic
+- add a fixture or regression test for the observed failure mode
+- file a `bd` bead against `re-frame2` when the pair tool is working around a missing surface in the Tool-Pair contract
+
+Also consider higher-upside redesigns:
+
+- collapse a multi-step troubleshooting loop into one guided operation
+- make the tool detect and explain the problem before the user asks
+- remove an expert-only decision by choosing or validating the safe default automatically
+- turn a late failure into an early warning or preflight check
+- add instrumentation that makes the next debugging step obvious instead of manual
+- rethink the interaction shape if the current command flow is fighting the user's mental model
+- prefer the assembled epoch stream by default for "what happened in this cascade" routing; reach for the raw trace stream only when the question demands per-emit detail
+
+## Routing the fix
+
+Decide where the bead lives before drafting:
+
+- **`re-frame-pair2`** — the friction is in the tool's SKILL.md, scripts, attach logic, recipe selection, structured-result shape, cross-platform handling, or any concern that is not part of the framework's commitment.
+- **`re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself: a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation, or a private-namespace reach-through that should be promoted to public.
+- **Both** — sometimes the fastest path is a tool-side workaround now plus an upstream bead for the long-term fix. File both, and reference one from the other.
+
+## Prioritization
+
+Prioritize improvements that score well on most of these:
+
+- common: likely to help many sessions
+- leverage: removes a whole class of manual effort
+- specific: easy to describe and implement
+- trustworthy: improves confidence in results
+- local-first: can be fixed in `re-frame-pair2` without waiting on upstream
+
+If many ideas surface, return the top 2-5 and demote the rest to "other possibilities".
+Include 0-2 bolder ideas when they are concrete, high-leverage, and clearly labeled as redesigns or speculative bets.

--- a/skills/re-frame-pair-improver2/references/issue-template.md
+++ b/skills/re-frame-pair-improver2/references/issue-template.md
@@ -1,0 +1,96 @@
+# Bead / issue template
+
+Use this structure when drafting or filing an improvement. Keep it evidence-based and concise.
+
+The default filing path for the re-frame2 ecosystem is `bd` (beads) — both for `re-frame-pair2` (the pair tool) and for `re-frame2` (the framework). The body shape below works equally well as a GitHub issue if a repo prefers that path.
+
+## Routing first
+
+Before drafting, decide the target repo:
+
+- **`re-frame-pair2`** — friction in the pair tool itself: SKILL.md, scripts, recipes, attach logic, structured results, cross-platform handling.
+- **`re-frame2`** — friction caused by a gap in the framework's Tool-Pair contract: missing trace event category, under-specified `:rf.epoch/*` failure mode, missing registrar query, source-coord shape question, schema-reflection limitation, private-namespace reach-through that should be promoted.
+
+When unsure, ask the user. Sometimes both: a tool-side workaround now and an upstream bead for the long-term fix; cross-link them.
+
+## Title patterns
+
+- `Improve <workflow> when <condition>`
+- `Add <op/result/warning> for <workflow>`
+- `Fix <platform> behavior in <script/op>`
+- `Make <workflow> self-validating instead of manual`
+- `Surface <signal> instead of requiring manual reconstruction`
+- `Promote <private-ns reach-through> to a public Tool-Pair surface` (upstream)
+
+## Body
+
+```md
+## Problem
+
+Describe the workflow the user was trying to complete and the friction they hit.
+
+## Evidence from a real session
+
+- What happened
+- What had to be retried, worked around, or manually verified
+- Why the current workflow was slower or less trustworthy than it should have been
+
+## Why re-frame-pair2 was not enough
+
+Explain the missing behavior, missing data, brittle assumption, or misleading contract. If the gap is upstream in re-frame2, name the Tool-Pair surface (or the missing surface) explicitly.
+
+## Proposed improvement
+
+Describe the change concretely. Name the likely layer:
+- `SKILL.md`
+- script/runtime op
+- result/warning shape
+- tests/fixture
+- upstream `re-frame2` bead (Tool-Pair contract, trace event, epoch machinery, schema reflection, source-coord annotation)
+
+## Expected impact
+
+Explain what effort, confusion, or risk this would remove in future sessions.
+
+## Open questions
+
+List any remaining uncertainty, especially if the best fix might belong upstream.
+```
+
+## Filing with bd
+
+Once the body is drafted and the user has approved:
+
+```bash
+# In the target repo (re-frame-pair2 or re-frame2)
+bd create \
+  --title "<title>" \
+  --type task \
+  --priority <P0|P1|P2|P3> \
+  --body "<body>"
+```
+
+For an upstream bead against re-frame2:
+
+```bash
+cd /c/Users/miket/code/re-frame2
+bd create --title "..." --type task --priority P2 --body "..."
+```
+
+For a tool-side bead:
+
+```bash
+cd /c/Users/miket/code/re-frame-pair2
+bd create --title "..." --type task --priority P2 --body "..."
+```
+
+Always run `bd list` or `bd ready` first to check for an existing bead on the same friction; reference it instead of duplicating.
+
+## Filing rules
+
+- File only after explicit user approval.
+- Redact secrets, tokens, and internal-only details.
+- Prefer one bead per distinct improvement.
+- Search for an existing bead first (`bd list`, `bd ready`, `bd show <id>`).
+- Cross-link tool-side and upstream beads when both are filed for the same friction.
+- If the target repo does not have `bd` configured, paste the same body as a GitHub issue and tell the user it is a draft.

--- a/skills/re-frame-pair-improver2/references/known-frictions.md
+++ b/skills/re-frame-pair-improver2/references/known-frictions.md
@@ -1,0 +1,167 @@
+# Known recurring frictions
+
+Use this file as a pattern-check, not as a substitute for session evidence.
+
+If the current session resembles one of these classes, mention that it may be part of a recurring product gap rather than a one-off.
+
+## Common classes (framework-agnostic)
+
+### Runtime discovery and attachment brittleness
+
+Signals:
+- repeated attach attempts
+- discovery works on one platform or shell but not another
+- the user has to bypass the documented path and connect manually
+- the tool can reach the runtime indirectly, but the documented helper fails
+
+Typical improvements:
+- platform-aware discovery logic
+- explicit fallback behavior
+- stronger structured errors naming the next best action
+- regression coverage for platform-specific connection paths
+
+### Docs and behavior drift
+
+Signals:
+- the documented command exists but behaves differently
+- the recipe is conceptually right but the exact method, flag, or expectation is wrong
+- the user follows docs and still gets misleading results
+
+Typical improvements:
+- tighten contracts between docs and code
+- add smoke checks for documented commands and result shapes
+- promote volatile facts into generated or verified references
+
+### Weak trust signals
+
+Signals:
+- the user cannot tell whether the result is fresh, partial, stale, or inferred
+- the tool succeeds structurally but returns too little information to trust
+- the user has to manually verify whether the action really landed
+
+Typical improvements:
+- add explicit freshness, completeness, or warning fields
+- distinguish "worked but partial" from "fully landed"
+- add better default summaries around retries, misses, and fallback paths
+
+### Hidden prerequisite burden
+
+Signals:
+- too much expert knowledge is needed before the happy path works
+- the user has to know environment quirks, shell behavior, fixture setup, or instrumentation assumptions
+- a missing prerequisite is only discovered late
+
+Typical improvements:
+- earlier prerequisite checks
+- clearer discovery output
+- safer defaults
+- stronger recipes for environment setup and recovery
+
+### Missing first-class workflows
+
+Signals:
+- the user repeatedly falls back to raw commands or ad hoc reasoning
+- the same multi-step workaround appears in more than one session
+- the tool has the necessary low-level primitives but not the right composed recipe
+
+Typical improvements:
+- add a new structured op
+- add a higher-level recipe to the skill
+- reshape result fields so downstream reasoning is less manual
+
+### Validation and fixture gaps
+
+Signals:
+- a regression clearly could have been caught by a smoke test, fixture, or cross-platform check
+- confidence in the tool depends on manual dogfooding
+- behavior is documented as supported but not actually exercised in CI
+
+Typical improvements:
+- add fixture coverage
+- add targeted regression tests
+- narrow the documented contract until tests exist
+
+## re-frame2-specific classes
+
+### Frame ambiguity
+
+Signals:
+- the user dispatches or inspects without specifying a frame and the result confuses them
+- the tool defaults to "the" frame in a multi-frame app
+- the timeline of events is correct but the user cannot tell which frame produced which row
+
+Typical improvements:
+- require an explicit `:frame` opt where ambiguity is possible, or surface the implicit choice prominently in the result
+- add a "current operating frame" indicator in retrospective output
+- list `(rf/frame-ids)` and recently-active frames at session start
+
+### Wrong listener for the question
+
+Signals:
+- the user reaches for raw trace events to answer "what happened in this cascade" — a job for the assembled epoch stream
+- the tool re-derives `:sub-runs` / `:renders` / `:effects` per epoch instead of reading the structured projections on `:rf/epoch-record`
+- the user wants per-emit detail (live timing, in-flight events) but is reading post-hoc epoch records
+
+Typical improvements:
+- recipe that names the listener for each question shape
+- default to `register-epoch-cb` for cascade-shaped questions; reach for `register-trace-cb` only for per-emit detail
+- short prose in SKILL.md naming the two streams and when each wins
+
+### Time-travel restore failures
+
+Signals:
+- `restore-epoch` returned a `:rf.epoch/*` error and the user did not know how to recover
+- the target epoch aged out silently because `:depth` was at default
+- a hot-swapped handler or evolved schema invalidated an older snapshot, but the failure tag was not surfaced helpfully
+
+Typical improvements:
+- structured presentation of the six named failure modes with a next-best-action per mode
+- preflight check before restore (depth, schema digest, machine version)
+- surface `:history-size` and `:schema-digest-recorded`/`:current` in the tool's output
+
+### Production-elision confusion
+
+Signals:
+- the trace stream, epoch history, or schema reflection returned empty and the user thought the tool was broken
+- the build is `:advanced` and `goog.DEBUG=false`, so every Tool-Pair surface elides
+- the user cannot tell whether they hit an elision wall or a tool bug
+
+Typical improvements:
+- preflight check that reads `re-frame.interop/debug-enabled?` and reports the answer
+- make "I am attached to a production-elided build" a first-class result state
+- recipe for switching to a dev build before continuing
+
+### Source-coordinate availability
+
+Signals:
+- "where in the source did this come from?" returned nothing
+- `data-rf2-source-coord` annotation is off because it is opt-in
+- the user expected DOM-to-source even though re-frame2 commits to the attribute, not the helpers
+
+Typical improvements:
+- preflight that reports whether source-coord annotation is enabled
+- include the recipe for turning it on at startup
+- recipe for parsing the attribute via the host's DOM access (CDP, querySelector, Playwright locator)
+
+### Private-namespace reach-through
+
+Signals:
+- the tool or a recipe reaches into `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, or `re-frame.registrar`
+- a re-frame2 minor version moves something and the recipe breaks
+
+Typical improvements:
+- audit reach-throughs and replace with public APIs from Tool-Pair
+- file a `bd` bead against `re-frame2` if the public surface is missing the needed capability
+- add a lint or smoke test that flags private-namespace usage
+
+### Multi-tool coexistence
+
+Signals:
+- the pair tool's listener key collides with re-frame-10x v2 (or another tool's) listener
+- listener-ordering assumptions fail (per Spec 009 listener ordering is not contract)
+- multiple tools writing to the same trace consumer step on each other
+
+Typical improvements:
+- always register with a tool-specific key namespace
+- never assume listener-ordering
+- recipe for "I am attached alongside another tool" coexistence

--- a/skills/re-frame-pair2/.claude-plugin/plugin.json
+++ b/skills/re-frame-pair2/.claude-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "re-frame-pair2",
+  "version": "0.1.0-alpha.1",
+  "description": "Pair-program with a live re-frame2 application. A Claude Code Skill consuming re-frame2's Tool-Pair surfaces directly. No re-frame-10x dependency.",
+  "author": {
+    "name": "day8",
+    "url": "https://github.com/day8"
+  },
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame-pair2"
+  },
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "re-frame",
+    "re-frame2",
+    "re-com",
+    "shadow-cljs",
+    "clojurescript",
+    "pair-programming",
+    "day8"
+  ],
+  "skills": [
+    "./SKILL.md"
+  ],
+  "scripts": [
+    "./scripts/discover-app.sh",
+    "./scripts/eval-cljs.sh",
+    "./scripts/inject-runtime.sh",
+    "./scripts/dispatch.sh",
+    "./scripts/trace-window.sh",
+    "./scripts/watch-epochs.sh",
+    "./scripts/tail-build.sh",
+    "./scripts/ops.clj",
+    "./scripts/runtime.cljs"
+  ],
+  "requirements": {
+    "babashka": ">=1.3.0"
+  },
+  "status": "pre-alpha"
+}

--- a/skills/re-frame-pair2/.gitignore
+++ b/skills/re-frame-pair2/.gitignore
@@ -1,0 +1,27 @@
+# editors
+.idea/
+.vscode/
+*.iml
+.nrepl-history
+
+# OS
+.DS_Store
+Thumbs.db
+
+# CLJS build outputs
+target/
+.shadow-cljs/
+out/
+public/js/compiled/
+resources/public/js/compiled/
+node_modules/
+.cpcache/
+
+# logs / tmp
+*.log
+tmp/
+.tmp/
+
+# Claude Code working files (agent state, not project artefacts)
+.claude/
+CLAUDE.local.md

--- a/skills/re-frame-pair2/LICENSE
+++ b/skills/re-frame-pair2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/re-frame-pair2/README.md
+++ b/skills/re-frame-pair2/README.md
@@ -1,0 +1,256 @@
+# re-frame-pair2
+
+A `Skill` which makes `Claude Code` a better pair programmer by allowing it to **interact with your running [re-frame2](https://github.com/day8/re-frame2) application**.
+
+This is the **re-frame2 sibling** of [`re-frame-pair`](https://github.com/day8/re-frame-pair) (the v1 skill, which targeted re-frame + re-frame-10x). re-frame-pair2 is **decoupled from re-frame-10x entirely** — it consumes only re-frame2's own runtime contract (the [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md)).
+
+A coding agent working with just the **static code** is working with a limited perspective. This Skill makes Claude Code more capable by giving it read/write access to:
+  - the **internal state** of the application
+  - the **dynamics of your running application**
+
+It can:
+
+- use the REPL
+- consume re-frame2's Tool-Pair surfaces directly: the trace stream (`register-trace-cb`), the retain-N trace buffer (`trace-buffer`), the per-frame epoch history (`epoch-history`), the registered handler/sub/fx/machine introspection API (`handlers`, `handler-meta`, `frame-ids`, `frame-meta`, `machines`, `machine-meta`, `app-schemas`, `sub-cache`), and first-class time-travel via `restore-epoch`
+- use re-frame2's source-coord annotation (`data-rf2-source-coord`) — and re-com's `data-rc-src` as a fallback — to bridge live DOM elements back to source `{:ns :line :file}`
+
+With these capabilities, Claude Code can iteratively perform experiments by patching parts of the system, restoring state to a recorded epoch, retrying events and seeing the results.
+
+## Status
+
+**Pre-alpha — code is written, but not yet exercised against a running re-frame2 app.** The repository contains the SKILL.md, the `scripts/runtime.cljs` injection payload, a babashka-based ops dispatcher (`scripts/ops.clj`) behind thin shell shims, the plugin manifest, the npm package manifest, and a GitHub Actions workflow that publishes to npm on tag.
+
+What's **not** done: a fixture app and end-to-end exercise. See [`STATUS.md`](STATUS.md) and [`docs/initial-spec.md`](docs/initial-spec.md) §8a for the per-phase implementation state and the spike deliverables.
+
+Read [`STATUS.md`](STATUS.md) for the per-phase implementation state; [`docs/initial-spec.md`](docs/initial-spec.md) for the full design; [`docs/TESTING.md`](docs/TESTING.md) for the test plan; [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md) for running from a clone without waiting for an npm release; [`RELEASING.md`](RELEASING.md) for the release flow.
+
+## Why a separate skill (vs. extending re-frame-pair)?
+
+re-frame-pair (v1) reaches into re-frame-10x internals to read the epoch buffer, drive undo, and time-travel. re-frame2 supersedes both that pattern and that dependency: epoch recording, querying, and restore are first-class surfaces in re-frame2 itself (per the [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md) §Time-travel and §How AI tools attach). Trying to reuse the v1 skill against re-frame2 would mean carrying a re-frame-10x dep that doesn't need to exist.
+
+re-frame-pair2 is a clean port: same vocabulary (read / write / trace / watch / hot-reload / time-travel), same recipes, but every surface translated to re-frame2's own primitives. The two skills can coexist — pick the one that matches your app's framework version. A future merge is possible if/when re-frame and re-frame2 converge, but isn't a goal.
+
+## Cross-link
+
+- [re-frame-pair](https://github.com/day8/re-frame-pair) — the v1 skill (re-frame + re-frame-10x; this is its source).
+- [re-frame-pair-improver2](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2) — the post-session retrospective skill that reviews pair sessions and proposes improvements to re-frame-pair2 itself. Sibling to v1's [re-frame-pair-improver](https://github.com/day8/re-frame-pair-improver).
+- [re-frame2 Tool-Pair Spec](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md) — the canonical surface contract this skill consumes.
+
+## Which technical stack?
+
+Designed for web apps built from the following stack — in pre-alpha, it has not yet been exercised end-to-end against a running app of any shape:
+
+- A [re-frame2](https://github.com/day8/re-frame2) application (reference implementation: CLJS + Reagent v2)
+- `re-frame.interop/debug-enabled?` true (the `goog.DEBUG` mirror — set automatically in dev builds; production elides the trace and epoch surfaces per [Spec 009 §Production builds](https://github.com/day8/re-frame2/blob/master/docs/specification/009-Instrumentation.md))
+- Optional: re-frame2's source-coord annotation enabled (`(rf/configure :source-coords {:annotate-dom? true})`) — and/or [`re-com`](https://github.com/day8/re-com) with debug instrumentation + `:src (at)` at call sites. Without one of these, the `dom/*` ops degrade gracefully.
+- [shadow-cljs](https://shadow-cljs.github.io/) as the build tool, with nREPL enabled on the dev build
+
+You don't need to make any changes to your code/project to use it, but you will need [`babashka`](https://babashka.org) installed because the skill's shell shims use it. See the [babashka install guide](https://github.com/babashka/babashka#installation).
+
+## No re-frame-10x dependency
+
+re-frame-pair2 does not require, recommend, or fall back to re-frame-10x. Where v1 read 10x's epoch buffer, v2 reads `(rf/epoch-history frame-id)`. Where v1 stepped through 10x's internal navigation events, v2 calls `(rf/restore-epoch frame-id epoch-id)`. Where v1 detected a 10x trace callback, v2 registers its own listener under id `:re-frame-pair2` (multi-tool coexistence is the expected default per [Spec 009 §Listener ordering](https://github.com/day8/re-frame2/blob/master/docs/specification/009-Instrumentation.md)).
+
+If your app uses both re-frame2 *and* a re-frame-10x v2 (when one ships), this skill and that tool will coexist as parallel listeners. Neither depends on the other.
+
+## Two modes
+
+Without this `Skill`, `Claude Code` writes edits to source files and shadow-cljs hot-reloads them into the running program.
+
+`re-frame-pair2` adds a second mode: Claude can also make **ephemeral** changes to application code via the REPL — hot-swap an event handler or a subscription, try it, discard if it didn't work.
+
+The difference between the two modes is that REPL changes last until the next full page reload whereas source edits stick.
+
+
+## Examples
+
+Here's the kinds of conversations you can have with Claude.
+
+### Inspect the last change
+
+> **You**: What changes did the last event make to `app-db` under `:shopping-cart`?
+>
+> **Claude**: 2 items, subtotal 47.50, no coupon.
+> `{:items [{:sku "BK-42" :qty 2} {:sku "TS-9" :qty 1}] :total 47.50 :coupon nil}`
+
+### Ask why a view didn't update
+
+> **You**: I dispatched `[:profile/save ...]` but the name in the header isn't changing.
+>
+> **Claude**: The header reads `[:user/display-name]`. The last epoch's `:sub-runs` has `[:user/profile]` in it — that one re-ran — but `[:user/display-name]` is absent, so it cache-hit (rf2-719e value-equal recompute suppression). Your handler wrote to `[:user :pending-profile]`, not `[:user :profile]`. The upstream sub returned `=`, the equality gate held, the header didn't re-render. Want me to hot-swap the handler to write the intended path?
+
+### Jump from a click to the line of code
+
+> **You**: I just clicked the "Save" button and nothing happened. Where is that button and why doesn't it work?
+>
+> **Claude**: `src/app/profile/view.cljs:84`. It's a `re-com/button` with `:on-click #(rf/dispatch [:profile/save])`. The click *did* dispatch — the latest epoch shows `:trigger-event [:profile/save]` and `:db-after` differs from `:db-before`, but `:profile/form-dirty?` didn't flip. What feedback were you expecting: toast, spinner, redirect?
+
+### Trace the full cascade of an event
+
+> **You**: What happens when I dispatch `[:cart/apply-coupon "SPRING25"]`?
+>
+> **Claude**: Interceptors: `inject-cofx :now`, `path :shopping-cart`, handler. Effects map: `{:db ...}` only — no HTTP, no further dispatches. app-db diff: `:coupon` `nil` → `"SPRING25"`, `:total` `47.50` → `35.62`. Subs that re-ran (from `:sub-runs`): `[:cart/total]`, `[:cart/coupon-status]`. `[:cart/items]` is absent — cache-hit. One render in `:renders`: the total badge at `cart_view.cljs:23`. Pure handler, nothing outside the cart subtree touched.
+
+### Watch events as they fire
+
+> **You**: Tell me about every `:checkout/*` event as I click through.
+>
+> **Claude**: *(watches in the background; narrates each matching epoch as it fires, one short paragraph, with effect cascade)* — idle timeout after 30s of silence, so you don't need to remember to stop it.
+
+### Hot-swap a handler mid-session
+
+> **You**: Make `:cart/apply-coupon` reject expired coupons instead of silently accepting them.
+>
+> **Claude**: Proposed change:
+> ```clojure
+> (rf/reg-event-db :cart/apply-coupon
+>   (fn [db [_ code]]
+>     (if (contains? (:expired-coupons db) code)
+>       (assoc db :cart/coupon-error (str code " is expired"))
+>       (assoc-in db [:shopping-cart :coupon] code))))
+> ```
+> Registered. The runtime emitted `:rf.registry/handler-replaced` so I know it took. Try clicking apply — I'll watch the next epoch.
+
+
+### Ask a question that doesn't have a pre-baked op
+
+> **You**: Are there any items in the cart with `:qty <= 0`?
+>
+> **Claude**: *[at the REPL]* `(->> (rf/snapshot-of [:shopping-cart :items]) (filter #(<= (:qty %) 0)))` — returns `()`. None right now, but the invariant isn't enforced by the `:cart/add-item` handler, and there's no `:app-schema` registered for `[:shopping-cart :items]`. Want me to propose a guard, or register a malli schema?
+
+### Post-mortem — how did I get into this state?
+
+> **You**: I notice that sometime in the last few events the "Done" button got disabled. I don't remember which action did it. Can you figure out when that happened?
+>
+> **Claude**: *[walks back through the operating frame's `epoch-history`, looking for the transition]* Three epochs ago, the event `[:cart/apply-coupon "EXPIRED"]` flipped `:session-state` from `:authenticated` to `:unauthenticated` — that's what greyed the button. The cascade also cleared `:user/profile`. Looks like a bug in the coupon handler, not an intended side-effect. Want me to fix it?
+
+
+### Iterate against the same starting state
+
+> **You**: When I first enter the Dashboard panel, the global reset button doesn't work. Fix it, then return to the previous state and fire the same event again, iterating until it works.
+>
+> **Claude**: I called `(rf/restore-epoch :rf/default <pre-click-epoch-id>)` — the restore returned `true`, so `app-db` is back. (Caveat: any HTTP requests or navigation that already fired during the original cascade are *not* reversed — restore rewinds `app-db` only.) The panel-level subscription was wrong; I patched it. Re-ran the event, `app-db` now updates as expected. Want me to put the patch into the source code?
+
+### Stub an effect for a what-if
+
+> **You**: What would happen if the checkout HTTP request returned a 500?
+>
+> **Claude**: I'll dispatch `[:cart/checkout]` with `:fx-overrides {:http :stub-http}`, where `:stub-http` is a registered fx that fires the canonical `:rf.http/managed` failure trace with status 500. Watch — *(reports the resulting epoch's cascade, including the error-projector path through `reg-error-projector`)*
+
+### Commit a change via source edit
+
+> **You**: Transfer the patch to the source code.
+>
+> **Claude**: That change has been made to the source code.
+
+
+## Install
+
+> Not yet published. The first tagged release (`v0.1.0-alpha.1`+) will appear on npm as `@day8/re-frame-pair2`.
+
+To run it *before* then — straight from a clone, with edits live — see [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md). Symlink the repo into `~/.claude/skills/re-frame-pair2/`, install babashka, done.
+
+`re-frame-pair2` adds nothing to the host project beyond what re-frame2 already requires. On first connect, the skill injects its runtime helpers into your app over the REPL — no extra deps, no extra preloads, no extra closure-defines attributable to `re-frame-pair2`.
+
+### Install the skill in Claude Code
+
+Both distributions (Agent Skill and Claude Code Plugin) ship the same `SKILL.md` and `scripts/*` shims. Choose a scope.
+
+#### Global — for you, across any re-frame2 project
+
+As an Agent Skill (recommended; portable across Claude clients):
+
+```bash
+npx skills add day8/re-frame-pair2
+```
+
+As a Claude Code Plugin:
+
+```bash
+/plugin install re-frame-pair2@day8
+```
+
+Lands in your user Claude config (`~/.claude/`). Best when you work on several re-frame2 apps, or you're the only Claude Code user on this project.
+
+#### Project-local — for your whole team via the repo
+
+Install into the project's own `.claude/skills/re-frame-pair2/` directory and commit it. Teammates who clone the repo and open Claude Code there get the skill on first use, pinned to the committed version.
+
+```bash
+cd your-re-frame2-project
+npx skills add --scope project day8/re-frame-pair2    # planned syntax
+git add .claude/skills/re-frame-pair2
+```
+
+For the plugin variant, reference `re-frame-pair2@day8` in a checked-in `.claude/plugin.json`.
+
+#### Which to choose
+
+- **Global** if you're the only person using Claude Code here, or you hop between re-frame2 apps.
+- **Project-local** if your team wants one pinned, shared version.
+- **Both** is fine — the project-local install takes precedence when both are present.
+
+### How the connection works
+
+On first use in a session:
+
+1. The skill locates your shadow-cljs nREPL port.
+2. It sends a handful of ClojureScript forms over nREPL to create a `re-frame-pair2.runtime` namespace in your app, populated with helpers and convenience wrappers around re-frame2's public Tool-Pair surfaces. The runtime also calls `(rf/register-trace-cb :re-frame-pair2 ...)` and `(rf/register-epoch-cb :re-frame-pair2-epoch ...)` so live-watch ops have a push-style stream.
+3. Live-watch ops (`watch/*`) consume the assembled-epoch stream by tracking the last seen `:epoch-id` per frame and asking for everything since (see [`docs/initial-spec.md`](docs/initial-spec.md) §4.4). Hot-reload confirmation is probe-based: after an edit, the skill polls a short CLJS form (typically against `(rf/handler-meta ...)`) that changes when the new code has landed in the browser. The script is named `tail-build.sh` for historical reasons — it does not actually tail the shadow-cljs server log.
+
+On full page refresh, the skill detects that its session sentinel is gone and re-injects automatically.
+
+## Invoking it in Claude
+
+Once the skill is installed, there are two ways to reach it from a Claude Code conversation.
+
+### Implicit — just ask
+
+The skill's description auto-matches when you talk about the running re-frame2 app. Ask in natural language:
+
+> What's in `app-db` under `:shopping-cart`?
+>
+> Why didn't the header update after `[:profile/save ...]`?
+>
+> Fire the delete button on the first row of the table.
+
+Claude connects on first use of the session and stays connected until you exit.
+
+### Explicit — slash command
+
+```
+/re-frame-pair2
+```
+
+…or name it in a prompt:
+
+> Using re-frame-pair2, trace `[:cart/apply-coupon "SPRING25"]` and show me the cascade.
+
+Useful when you want to force the tool, or when the phrasing of your question doesn't obviously lean on the running app.
+
+### What happens on first use
+
+The skill's first op in a session is `discover-app.sh`, which:
+
+1. Finds the running shadow-cljs nREPL (from `target/shadow-cljs/nrepl.port`, falling back to `.shadow-cljs/nrepl.port` or the `SHADOW_CLJS_NREPL_PORT` env var — the exact location depends on shadow-cljs version and config).
+2. Verifies a browser runtime is attached to that build.
+3. Checks that `re-frame.core` is loaded and `re-frame.interop/debug-enabled?` is true.
+4. Reports `connected` or names the single failing check with a one-line fix suggestion.
+
+Once verified, the skill injects its runtime namespace (`re-frame-pair2.runtime`) into the app over nREPL. All subsequent ops reuse that connection.
+
+## How it works
+
+The pieces (design; see *Status* above):
+
+1. `discover-app.sh` finds the running shadow-cljs build and its nREPL port, switches the session into `:cljs` mode for that build, and verifies re-frame2 + `debug-enabled?`.
+2. `eval-cljs.sh` sends short ClojureScript forms over nREPL into the browser runtime and returns edn.
+3. `inject-runtime.sh` creates the `re-frame-pair2.runtime` namespace in the app on connect, populating it with helpers over re-frame2's public Tool-Pair surfaces. The session sentinel (a UUID) is interned here so full-page-refresh detection is a simple lookup. The injection also registers exactly one trace listener (`:re-frame-pair2`) and one epoch listener (`:re-frame-pair2-epoch`).
+4. `SKILL.md` teaches Claude a verb vocabulary (read / write / trace / watch / hot-reload / time-travel) mapped onto those forms, plus diagnostic recipes composed from them.
+5. All trace and epoch reads come from re-frame2's own surfaces — `register-trace-cb`, `trace-buffer`, `register-epoch-cb`, `epoch-history`. Render entries are projected by re-frame2 itself in `:renders`, with `:ns` / `:line` / `:file` resolvable through the registrar's source-coord capture (Spec 001).
+
+See [`docs/initial-spec.md`](docs/initial-spec.md) for the full operation catalogue, architecture, error surfaces, versioning, and phased delivery plan.
+
+## License
+
+MIT

--- a/skills/re-frame-pair2/RELEASING.md
+++ b/skills/re-frame-pair2/RELEASING.md
@@ -1,0 +1,94 @@
+# Releasing re-frame-pair2
+
+> **Note (consolidation):** As of re-frame2 `v0.0.1.beta` prep, this skill lives at
+> `re-frame2/skills/re-frame-pair2/`. The standalone `day8/re-frame-pair2`
+> repo is no longer the source of truth. The standalone `release.yml`
+> workflow described below has been removed from this copy; release flow
+> now happens (or will happen) as part of re-frame2's release pipeline.
+> This document is retained as historical reference for the npm publish
+> mechanics and version-bump checklist.
+
+Releases go out through the `release.yml` GitHub Actions workflow when
+a semver tag is pushed. This doc captures the checklist and the expected
+tag formats.
+
+## Prerequisites
+
+- `NPM_TOKEN` secret set on the repo, with publish scope on `@day8` (npm Automation token).
+- Locally: a checkout of `main`, npm-cli installed (only needed if you want to dry-run `npm pack` before tagging).
+- You have maintainer rights on the `day8` npm scope.
+
+## Version numbers
+
+Single source of truth: `package.json` `version`. One other file must match:
+
+- `package.json`
+- `.claude-plugin/plugin.json`
+
+The release workflow cross-checks these at publish time and fails if they drift.
+
+## Cutting a release
+
+1. **Decide the version.** Follow semver. Pre-1.0, everything is pre-release: use `0.x.y-alpha.N`, `0.x.y-beta.N`, `0.x.y-rc.N`.
+2. **Update the two version strings** (package.json, plugin.json):
+   ```bash
+   npm version 0.1.0-alpha.2 --no-git-tag-version
+   # then bump .claude-plugin/plugin.json's "version" by hand to match
+   ```
+3. **Commit the version bump** on `main`:
+   ```bash
+   git add package.json .claude-plugin/plugin.json
+   git commit -m "Release v0.1.0-alpha.2"
+   ```
+4. **Tag and push:**
+   ```bash
+   git tag v0.1.0-alpha.2
+   git push origin main --tags
+   ```
+5. **Watch the workflow.** `release.yml` will:
+   - verify tag == package.json version
+   - verify plugin.json matches
+   - smoke-test the babashka shims
+   - (future) run CLJS unit tests against the fixture
+   - `npm publish` with public access under `@day8` scope
+   - create a GitHub release with auto-generated notes; marked prerelease for `-alpha`/`-beta`/`-rc`
+6. **Verify publish:** `npm view @day8/re-frame-pair2 versions --json` should list the new version.
+7. **Smoke-test install** from a clean machine:
+   ```bash
+   npx skills add day8/re-frame-pair2
+   # or, when using the plugin path:
+   # /plugin install re-frame-pair2@day8
+   ```
+
+## Tag format
+
+Regex the workflow accepts: `v[0-9]+.[0-9]+.[0-9]+*`
+
+Examples:
+- `v0.1.0-alpha.1`
+- `v0.1.0-rc.1`
+- `v1.0.0`
+
+## Rolling back a bad release
+
+npm doesn't allow unpublishing published versions after 72 hours, and even inside 72 hours it's discouraged. The normal path is:
+
+1. Publish a patched version (e.g., `v0.1.0-alpha.2` -> `v0.1.0-alpha.3`).
+2. `npm deprecate @day8/re-frame-pair2@0.1.0-alpha.2 "Superseded by 0.1.0-alpha.3 — bug X"`.
+
+## Release notes
+
+Generated automatically from commits + PRs since the previous tag by `action-gh-release`. To shape them, use conventional-commit-ish prefixes on PR titles (`feat:`, `fix:`, `docs:`, `chore:`).
+
+## Pre-1.0 release cadence
+
+While pre-alpha:
+
+- Tag `v0.1.0-alpha.N` for major surface changes.
+- Tag `v0.1.0-beta.N` once the surfaces are validated against a fixture re-frame2 app.
+- Tag `v0.1.0-rc.N` once there's a working end-to-end path.
+- `v0.1.0` when the full v1 scope is implemented and tested.
+
+## Distributing via Claude Code's plugin path
+
+`npm publish` handles the Agent Skill distribution (`npx skills add day8/re-frame-pair2`). For Claude Code Plugin distribution (`/plugin install`), the plugin discovery currently pulls from the same repo — no separate publish step needed.

--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: re-frame-pair2
+description: >
+  Pair-program with a live re-frame2 application. Attach to a running
+  shadow-cljs build via nREPL, inspect any frame's app-db, dispatch
+  events, hot-swap handlers, trace the six dominoes, and read the
+  per-frame epoch history — all through re-frame2's own runtime
+  contract (Tool-Pair Spec). No re-frame-10x dependency. Use this
+  skill whenever the user asks about their running re-frame2 app or
+  uses any of: re-frame2, app-db, dispatch, subscribe, reg-event,
+  reg-sub, reg-fx, reg-machine, frame, epoch, interceptor, sub-cache,
+  trace-buffer, register-trace-cb, register-epoch-cb, restore-epoch,
+  re-com, shadow-cljs.
+allowed-tools:
+  - Bash(scripts/discover-app.sh *)
+  - Bash(scripts/eval-cljs.sh *)
+  - Bash(scripts/inject-runtime.sh *)
+  - Bash(scripts/dispatch.sh *)
+  - Bash(scripts/trace-window.sh *)
+  - Bash(scripts/watch-epochs.sh *)
+  - Bash(scripts/tail-build.sh *)
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+---
+
+# re-frame-pair2
+
+You are pair-programming with a developer on a **live, running re-frame2 application**. The app is running in a browser tab behind `shadow-cljs watch`. Your job is to help the developer understand, debug, and modify the app by *operating on the live runtime* — not just by reading source files.
+
+Your agency runs through three coupled primitives, all part of re-frame2's own [Tool-Pair contract](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md):
+
+1. **The REPL** — a shadow-cljs nREPL session connected to the browser runtime, where ClojureScript forms evaluate against the real app.
+2. **The trace stream** — `(rf/register-trace-cb id cb)` for live trace events; `(rf/trace-buffer opts)` for the retain-N ring of recent events. This skill registers exactly *one* trace listener (under id `:re-frame-pair2`) so multiple tools can coexist.
+3. **The epoch history** — `(rf/epoch-history frame-id)` returns the per-frame ring of `:rf/epoch-record` values, each carrying the cascade's `:db-before`, `:db-after`, `:trace-events`, and the structured `:sub-runs` / `:renders` / `:effects` projections. `(rf/register-epoch-cb id cb)` is the assembled-stream listener.
+
+Every operation below eventually becomes a short ClojureScript form evaluated through the REPL, usually against a helper function in the `re-frame-pair2.runtime` namespace that the skill injects on connect.
+
+---
+
+## Cardinal rule — two modes of changing the app
+
+- **REPL changes** (hot-swap a handler, evaluate a form, reset a frame's `app-db`) are **ephemeral**. They survive hot-reloads of unaffected namespaces, but are lost on full page reload. Use them for **probes, experiments, and throwaway fixes**.
+- **Source edits** (using `Edit` / `Write`) are **permanent**. After any source edit, you *must* call `hot-reload/wait` before dispatching or tracing. Otherwise you'll interact with the pre-reload code and get misleading results.
+
+Know which mode you're in and why.
+
+---
+
+## Connect first, every session
+
+Before any other op, run:
+
+```
+scripts/discover-app.sh
+```
+
+This locates the shadow-cljs nREPL port, connects, switches the session to `:cljs` mode for the running build, verifies re-frame2 is loaded with `interop/debug-enabled?` true, and injects the runtime namespace.
+
+If any precondition fails, the script returns a structured edn error like `{:ok? false :missing :re-frame2}`. Report the failing check to the user verbatim; do *not* guess at workarounds.
+
+Between user turns, the nREPL session persists, but a full page refresh in the browser drops the injected namespace. Every op checks the **session sentinel** (`re-frame-pair2.runtime/session-id`) and re-injects if it's gone. You don't usually need to do this by hand.
+
+---
+
+## Multi-frame model — set the operating frame
+
+re-frame2 supports multiple, named frames (Spec 002). Most apps run with one frame (`:rf/default`); larger apps may run several (a stories build, an SSR slot, a sub-app island). Every read/write op below takes an implicit operating frame; you can override per-call with `--frame :foo`.
+
+- `frames/list` — `(rf/frame-ids)` — set of registered, non-destroyed frame ids.
+- `frames/select` — set the session's default operating frame (the runtime caches it).
+- `frames/meta` — `(rf/frame-meta id)` — config + lifecycle for one frame.
+
+When the operating frame is ambiguous (more than one is registered and the session hasn't selected one), **mutating ops refuse with `:ambiguous-frame`** and read ops proceed against `:rf/default` after warning. This mirrors the Spec 002 §Frame presets / lifecycle convention.
+
+---
+
+## Operations (the vocabulary)
+
+Each op below is a short `scripts/eval-cljs.sh` invocation wrapping a call into `re-frame-pair2.runtime`, or a dedicated script when the concern is broader than one form. Prefer the **structured ops** over `repl/eval` whenever a structured op fits.
+
+### Read
+
+| Op | Invocation | Returns |
+|---|---|---|
+| `app-db/snapshot` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/snapshot)'` | Current app-db value for the operating frame (via `rf/get-frame-db`) |
+| `app-db/get` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-at [:path :to :value])'` | Path-scoped value (via `rf/snapshot-of`) |
+| `app-db/schemas` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/schemas)'` | Map of `path → schema` from `rf/app-schemas` |
+| `registrar/list` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/registrar-list :event)'` | Ids registered under `:event` / `:sub` / `:fx` / `:cofx` (via `rf/handlers`) |
+| `registrar/describe` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/registrar-describe :event :cart/apply-coupon)'` | Full handler metadata: kind, interceptor ids, `:ns` / `:line` / `:file`, `:rf/machine?`, retained source form when present |
+| `subs/cache` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/sub-cache)'` | `rf/sub-cache` — `{query-v {:value v :ref-count n}}` for every materialised subscription (CLJS-only) |
+| `subs/sample` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/subs-sample [:cart/total])'` | One-shot value via `rf/compute-sub` (no cache mutation) or `@(rf/subscribe ...)` |
+| `machines/list` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/machines-list)'` | Machine ids (`rf/machines`) |
+| `machines/describe` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/machine-describe :auth)'` | The registered spec map (`rf/machine-meta`) |
+| `machines/state` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/machine-state :auth)'` | Current snapshot from `(rf/snapshot-of [:rf/machines :auth])` |
+
+### Write
+
+| Op | Invocation | Notes |
+|---|---|---|
+| `dispatch` | `scripts/dispatch.sh '[:cart/apply-coupon "SPRING25"]'` | Queued by default; `--sync` forces `dispatch-sync`. Skill-issued dispatches carry `:origin :pair` (Spec 002 §Dispatch origin tagging) so `:event/dispatched` traces can be filtered by who fired them. |
+| `dispatch --frame` | `scripts/dispatch.sh '[:foo]' --frame :stories` | Targets a specific frame via the `:frame` opt on `rf/dispatch`. |
+| `reg-event` / `reg-sub` / `reg-fx` | `scripts/eval-cljs.sh '<full reg-* form>'` | Re-registration replaces; emits `:rf.registry/handler-replaced` trace (Spec 001 §Hot-reload semantics). Ephemeral. |
+| `app-db/reset` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-reset! ...)'` | Logged explicitly via `tap>` so the user sees what the agent changed. Use sparingly. |
+| `repl/eval` | `scripts/eval-cljs.sh '<arbitrary form>'` | Escape hatch. Prefer structured ops first. |
+| `fx-overrides/with` | `scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http` | Per-call `:fx-overrides` (Spec 002 §Per-frame and per-call overrides) — redirect a registered fx to a stub for one experiment, restore on completion. |
+
+### Trace (read-only from the trace stream + epoch history)
+
+| Op | Invocation | Returns |
+|---|---|---|
+| `trace/buffer` | `scripts/eval-cljs.sh '(rf/trace-buffer)'` | Recent N trace events from the retain-N ring (Spec 009 §Retain-N trace ring buffer). Optional `{:operation _ :op-type _ :since _ :frame _}` filter. |
+| `trace/last-epoch` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/last-epoch)'` | Most recent `:rf/epoch-record` for the operating frame |
+| `trace/last-pair-epoch` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/last-pair-epoch)'` | Most recent epoch whose `:trigger-event`'s top-level dispatch carried `:origin :pair` (i.e. *this skill* fired it) |
+| `trace/epoch` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/epoch-by-id <id>)'` | The named epoch from the frame's history |
+| `trace/dispatch-and-collect` | `scripts/dispatch.sh --trace '[:foo ...]'` | Fire + wait for drain-settle + return the resulting `:rf/epoch-record` |
+| `trace/recent` | `scripts/trace-window.sh <ms>` | Epochs whose `:committed-at` falls inside the last N ms |
+| `trace/find-where` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/find-where <pred>)'` | Most recent epoch matching a predicate — primary forensic op for "when did X happen?" post-mortems |
+| `trace/find-all-where` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/find-all-where <pred>)'` | Every matching epoch, newest first — for trajectories rather than single transitions |
+| `trace/cascade` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/cascade-of <dispatch-id>)'` | Walk `:dispatch-id` / `:parent-dispatch-id` (Spec 009 §Dispatch correlation) to reconstruct the full cascade tree from a root dispatch |
+
+### DOM ↔ source bridge
+
+**Why this family matters — read first.** When the runtime is configured to annotate rendered DOM (`(rf/configure :source-coords {:annotate-dom? true})` per Tool-Pair §Source-mapping), every rendered DOM node carries a `data-rf2-source-coord` attribute pointing back to the registration that produced it. The attribute's value resolves via `re-frame-pair2.runtime/parse-rf2-coord` to a structured `{:ns ... :line ... :file ...}` map keyed off the registration's source coords (auto-captured by `reg-*` macros, per Spec 001 §Source-coordinate capture). This gives you a direct, two-way bridge between a live DOM element and the exact line of source code that rendered it.
+
+**Two attribute formats are recognised:**
+
+- `data-rf2-source-coord` — re-frame2's own annotation when `:annotate-dom?` is on. Stable, preferred.
+- `data-rc-src` — re-com's debug-instrumentation attribute. The runtime parses both; if both are present on a node, `data-rf2-source-coord` wins.
+
+**Prerequisites — at least one of:**
+
+- re-frame2 source-coord annotation enabled (`(rf/configure :source-coords {:annotate-dom? true})` at startup), *or*
+- re-com debug instrumentation enabled and the call site passed `:src (at)`.
+
+**Degradation is per-element.** When neither is present on a given element, the bridge returns `{:src nil :reason :no-coord-at-this-element}`. When neither annotation is enabled app-wide, every element returns `{:src nil :reason :source-coord-annotation-disabled}`. Tell the user which case they're hitting.
+
+| Op | Invocation | Returns |
+|---|---|---|
+| `dom/source-at` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/dom-source-at "#save-button")'` or `'(... :last-clicked)'` | `{:ns :line :file}` for a CSS selector, or for the most recently clicked element |
+| `dom/find-by-src` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/dom-find-by-src "view.cljs" 84)'` | Live DOM elements rendered by that source line |
+| `dom/fire-click-at-src` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/dom-fire-click "view.cljs" 84)'` | Synthesise a click on the element rendered by that line |
+| `dom/describe` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/dom-describe "#save-button")'` | Tag, classes, both source-coord attributes, and any registration metadata they resolve to |
+
+### Live watch (push-mode)
+
+| Op | Invocation | Behaviour |
+|---|---|---|
+| `watch/window` | `scripts/watch-epochs.sh --window-ms 30000 --event-id-prefix :checkout/` | Runs for N ms, reports every matching epoch, summarises at end |
+| `watch/count` | `scripts/watch-epochs.sh --count 5` | Runs until N epochs match |
+| `watch/stream` | `scripts/watch-epochs.sh --stream --event-id-prefix :cart/` | Streams until disconnect, idle-timeout, or `watch/stop` |
+| `watch/stop` | `scripts/watch-epochs.sh --stop` | Terminates any active watch for this session |
+
+Predicates (any combination): `--event-id`, `--event-id-prefix`, `--effects`, `--timing-ms '>100'`, `--touches-path`, `--sub-ran`, `--render`, `--origin :pair|:app|:ui|:timer|:http`, `--frame :foo`, `--custom` (arbitrary CLJS predicate form).
+
+The watch transport polls the assembled-epoch stream by tracking the last seen `:epoch-id` in the operating frame's history and asking for everything since. See `docs/initial-spec.md` §4.4.
+
+### Hot-reload coordination
+
+After any source edit, before the next dispatch or trace:
+
+```
+scripts/tail-build.sh --wait-ms 5000 --probe '(some/probe-form)'
+```
+
+`--probe` is a CLJS form chosen to change when the edited code reloads. Good probes for re-frame2:
+
+- After editing a `reg-*` handler: `(rf/handler-meta :event :foo)` — the `:line` / `:column` / `:handler-fn` change after re-registration. Capture the meta map's hash before the edit, compare after.
+- After editing a `reg-machine`: `(rf/machine-meta :auth)` — same comparison.
+- After editing a view: pick a CLJS form that derefs the view's namespace var (e.g. `(some-ns/my-view)` or `(meta #'some-ns/my-view)`).
+- If you don't know a good probe, omit `--probe` and the script falls back to a 300ms timer; the result includes `:soft? true` so you know it's timer-based.
+
+A successful probe-flip also coincides with a `:rf.registry/handler-replaced` trace event arriving in the buffer, so an alternative confirmation is `(filter #(= :rf.registry/handler-replaced (:operation %)) (rf/trace-buffer {:since <pre-edit-id>}))`. Use whichever fits — they're not exclusive.
+
+### Time-travel (epoch restore)
+
+re-frame2 ships first-class time-travel as part of the Tool-Pair contract — no adapter, no internal poking. These ops are **fully implemented** and use only public surfaces.
+
+| Op | Invocation | Purpose |
+|---|---|---|
+| `epoch/history` | `scripts/eval-cljs.sh '(rf/epoch-history :rf/default)'` | The full ring of `:rf/epoch-record` values for the frame, oldest-first |
+| `epoch/restore` | `scripts/eval-cljs.sh '(rf/restore-epoch :rf/default <epoch-id>)'` | Rewind the frame's `app-db` to the named epoch's `:db-after`. Returns `true` on success, `false` on any documented failure mode (see below). |
+| `epoch/configure` | `scripts/eval-cljs.sh '(rf/configure :epoch-history {:depth 200})'` | Bump the ring depth (default 50). |
+| `undo/step-back` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/undo-step-back)'` | Sugar: restore the previous epoch in the operating frame |
+| `undo/to-epoch` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/undo-to-epoch <id>)'` | Sugar over `restore-epoch` for the operating frame |
+
+**Documented failure modes** (Tool-Pair §Time-travel — restore is a no-op on failure):
+
+| Failure | Trace operation | When |
+|---|---|---|
+| Unknown frame | `:rf.error/no-such-handler` (kind `:frame`) | `frame-id` not registered |
+| Unknown epoch | `:rf.epoch/restore-unknown-epoch` | `epoch-id` not in current history (aged out or never recorded) |
+| Schema mismatch | `:rf.epoch/restore-schema-mismatch` | `:db-after` no longer validates against currently-registered schemas (a schema was tightened since the snapshot) |
+| Missing handler | `:rf.epoch/restore-missing-handler` | DB references a registration id no longer in the registrar (e.g. a machine snapshot whose machine was unregistered) |
+| Version mismatch | `:rf.epoch/restore-version-mismatch` | Recorded `:rf/snapshot-version` of an active machine is incompatible with the currently-loaded definition (hot-reload bumped it) |
+| Concurrent drain | `:rf.epoch/restore-during-drain` | Called while the frame's run-to-completion drain is in flight |
+
+When `restore-epoch` returns `false`, read the matching trace event from `(rf/trace-buffer {:op-type :error})` to get the structured `:tags`, then report to the user.
+
+**Caveat (always tell the user before restoring):** restore rewinds `app-db` only. Side effects that already fired (HTTP requests sent, navigation pushed, localStorage written, `:dispatch-later` already landed) are *not* undone.
+
+---
+
+## Hot-reload protocol
+
+Editing source is legitimate and often correct. The protocol is strict:
+
+1. Make the edit with `Edit` / `Write`.
+2. Call `scripts/tail-build.sh` with a `--probe` that verifies the browser has the new code:
+   - If you edited a `reg-*` handler, the probe is `(re-frame-pair2.runtime/registrar-handler-ref <kind> <id>)` — compares a hash over `handler-meta`.
+   - If you edited a `reg-machine`, the probe is the same shape against `:event` (machines register under `:event` per Spec 005).
+   - If you edited a view or helper, the probe is a short form that derefs a value depending on the edited code.
+   - If no good probe is available, omit `--probe` and accept the soft/timer-based confirmation.
+3. Only after the probe succeeds do you proceed to `dispatch`, `trace/*`, etc.
+4. If the probe times out, treat that as a compile error in the user's code — read the tail output, report it to the user, do *not* retry dispatching.
+
+---
+
+## Recipes (named procedures the user may ask for)
+
+When the user asks a matching question, run the procedure below rather than improvising.
+
+### "What's in `app-db`?" / "What did the last event do?"
+
+- Snapshot or get: `app-db/snapshot`, `app-db/get`, or for a diff between an epoch's `:db-before` and `:db-after`: `trace/last-epoch` and compute the diff with `clojure.data/diff`. The runtime helper `(re-frame-pair2.runtime/epoch-diff <epoch>)` returns a pre-computed `{:only-before :only-after :common}` map.
+
+### "Why didn't my view update?"
+
+1. Identify the sub the view reads (ask the user if it's not in the view file).
+2. `trace/last-epoch` (or `trace/last-pair-epoch`) — find the recent dispatch that should have updated it.
+3. Walk the epoch's `:sub-runs` projection. **A sub that re-ran appears in the vector; a sub that cache-hit does not** (Spec-Schemas §`:rf/epoch-record` — the rf2-719e value-equal recompute suppression is enforced by the runtime, so cache-hit subs do not emit `:sub/run`).
+4. If the sub the view depends on isn't in `:sub-runs` for the cascade, the equality gate held; report the upstream sub whose return value was `=` to its previous value.
+5. If the sub did re-run but the view didn't re-render, check `:renders` — the projection lists every render in the cascade with its `:render-key` and `:triggered-by`.
+
+### "Explain this dispatch"
+
+Run `trace/dispatch-and-collect`, then narrate the six dominoes against the resulting `:rf/epoch-record`:
+
+- Event vector + interceptor chain (from `(rf/handler-meta :event id)`)
+- Coeffects injected (visible as `:event/run` tags in `:trace-events`)
+- Effects map (visible as `:event/do-fx` plus per-fx warning/error traces; the `:effects` projection only carries warning/error outcomes — successful fx executions live in the raw `:trace-events` slot, see Spec-Schemas note)
+- `app-db` diff between `:db-before` and `:db-after`
+- Subs that re-ran (the `:sub-runs` projection); the absence of a sub from this list means it cache-hit
+- Components that re-rendered (the `:renders` projection), with `:ns` / `:line` / `:file` resolvable via `(rf/handler-meta :view <render-key>)` for registered views
+
+Keep it short. One compact paragraph per domino.
+
+### "Post-mortem — how did we get here?"
+
+**When the user is stuck in a broken state and can't describe how they got there.** Every cascade since page load is in the operating frame's `epoch-history` (subject to retention — default depth 50, configurable). You don't need the user to remember the sequence; you can walk it back.
+
+Procedure:
+
+1. Ask the user what's wrong in *observable* terms ("the save button is grey", "the dashboard is empty"). Resolve any UI references to source via `dom/source-at` if possible.
+2. Identify the **app-db key(s) or sub(s)** that govern the observation. If the user can't, trace the recent render for the offending component and walk its sub inputs.
+3. Use `trace/find-where` to pinpoint the epoch where the governing key last changed to its current (bad) value. Example:
+   ```
+   scripts/eval-cljs.sh '(re-frame-pair2.runtime/find-where
+                           (fn [e] (= :expired (get-in (:db-after e)
+                                                        [:auth-state]))))'
+   ```
+4. Report that epoch as the culprit: its `:trigger-event`, the diff between `:db-before` and `:db-after`, and (crucially) the cascade tree. Often the root-cause dispatch is a child of another event — follow `:parent-dispatch-id` upstream via `trace/cascade <dispatch-id>`.
+5. If no single epoch is responsible — the state drifted over many events — use `find-all-where` to get the trajectory. Narrate the 3–5 most relevant transitions rather than all of them.
+6. Propose a fix. Usually one of: a handler that shouldn't have fired, a handler that did fire but was wrong, or a missing guard.
+
+**Retention caveat.** The epoch ring is bounded (default 50, configurable via `(rf/configure :epoch-history {:depth N})`). Events that happened "a long time ago" may have aged out. If the user describes a state change you can't find in the ring, say so explicitly: *"I can see the last N events but the change you're describing happened before that."* Then propose reproducing the path from a known state — or `(rf/configure :epoch-history {:depth 500})` and re-trigger.
+
+### "What effects fired?"
+
+Walk the epoch's `:effects` projection — but note its asymmetry (Spec-Schemas §`:rf/epoch-record`): the projection captures *visible outcomes* (skipped-on-platform, fx-handler-exception, no-such-fx). Successful fx execution is observable only in the raw `:trace-events` slot (look for `:event/do-fx` plus the absence of an error trace for that fx-id). If you need successful-fx attribution, walk `:trace-events` directly and group by `:fx-id` tag.
+
+For cascaded dispatches: follow `:dispatch-id` / `:parent-dispatch-id` (Spec 009 §Dispatch correlation) into child epochs. `trace/cascade <dispatch-id>` returns the tree.
+
+### "What caused this re-render?"
+
+Given a component name or render key, find the latest epoch whose `:renders` includes it. Reverse from there: the sub inputs that invalidated its outputs (visible in `:sub-runs`), then the event that invalidated the sub inputs (the `:trigger-event` of that epoch). For machine-driven renders, also check `:rf/machine` reg-sub activity — machine state changes flow through the sub graph like any other.
+
+### "Where in the code does this come from?"
+
+Call `dom/source-at` on the element (or on `:last-clicked`). Return `{:ns :line :file}` resolved against the source-coord registry. If `:src` is nil, report which prerequisite is missing (`:annotate-dom?` is off, no `:src (at)` on this re-com call site, or no registered view at this DOM position).
+
+### "Understand this component" / "What is this thing?"
+
+When the user points at a UI element (CSS selector, *"the thing I last clicked"*, or a description), chain:
+
+1. `dom/source-at` — resolve to `{:ns :line :file}`.
+2. `Read` the source file at that line, with ~30 lines of context.
+3. Narrate: what the component is, what props it takes, which event(s) its interactions dispatch, and (if you can see them nearby) which subscriptions it reads. Cross-check against `(rf/handler-meta :view <id>)` for registered views.
+4. If the source-coord lookup fails, fall back to `dom/describe` to report tag/class/listeners, and ask the user to point at the source instead.
+
+This is one of the most grounding moves you can make — it turns *"that button"* into *"`re-com/button` at `app/cart/view.cljs:84`, dispatching `[:cart/checkout]`"* in one step.
+
+### "Fire the button at file:line"
+
+Use `dom/fire-click-at-src`. Report the resulting epoch. Distinctive to re-frame-pair2 — exercise a specific call site by its source location rather than picking a CSS path.
+
+### "Inspect this machine"
+
+When the user mentions a state machine (Spec 005), chain:
+
+1. `machines/list` — confirm it's registered.
+2. `machines/describe :auth` — return the spec map (`:initial`, `:states`, `:guards`, `:actions`, source coords).
+3. `machines/state :auth` — current snapshot, including `:rf/snapshot-version`.
+4. To watch transitions live: `watch/stream --custom '(fn [e] (some #(= :rf.machine/transition (:operation %)) (:trace-events e)))'`.
+5. Subscribe to the canonical machine sub: `subs/sample [:rf/machine :auth]`.
+
+### "Dead code scan"
+
+`registrar/list :event`, `registrar/list :sub`, etc. Then `trace/recent` with a large window (e.g. 60s) — or ask the user to exercise the app first. Report registered ids that never appeared in any epoch's `:trigger-event` or `:sub-runs`. *Caveat: trace coverage is bounded by epoch-history depth and trace-buffer depth.*
+
+### Experiment loop
+
+**Why this works:** the same starting `app-db`, the same event, only the code changes — so any difference in the resulting epoch is attributable to *your edit*, nothing else. That makes it a controlled experiment rather than a fix-and-pray. Reach for this loop whenever you're unsure whether a change has the intended effect.
+
+re-frame2's first-class `restore-epoch` makes this loop fully closed — no adapter caveats.
+
+Canonical procedure:
+
+1. `trace/dispatch-and-collect [:foo ...]` → observe baseline. Capture the `:epoch-id` from the resulting record.
+2. **Tell the user** which side effects in the cascade can't be rewound. Walk `:trace-events` for `:event/do-fx` involving non-pure fx (`:http`, navigation, localStorage, `:dispatch-later` that already landed) and warn before restoring.
+3. `epoch/restore <epoch-id>` → rewind `app-db`. Watch for `false` return + check `(rf/trace-buffer {:op-type :error})` for the failure reason.
+4. **Modify the part of the system you're iterating on.**
+   - *Handlers / subs / fx:* `(rf/reg-event-fx :foo ...)` / `(rf/reg-sub :bar ...)` / `(rf/reg-fx :baz ...)` via `repl/eval`. The registrar replaces; `:rf.registry/handler-replaced` fires.
+   - *Machines:* `(rf/reg-machine :auth ...)` — bumps the machine's `:version` if one is supplied. Old snapshots may now `:rf.epoch/restore-version-mismatch` against this machine.
+   - *Views / helpers (plain `defn`s):* redefine the var via `repl/eval`. Subsequent renders pick up the new fn.
+   - *Permanent change:* `Edit` the source file, then `scripts/tail-build.sh --probe '...'` to wait for the reload to land.
+5. **Verify the patch took before re-dispatching.** `registrar/describe :event :foo` should now return different `:line` / `:column` (or a different `:handler-fn` hash) than what you captured at step 1. If the patch didn't land, re-dispatching will silently test the old code.
+6. `trace/dispatch-and-collect [:foo ...]` → observe the new behaviour.
+7. Compare the two epochs (`epoch-diff` between their `:db-after` values; cross-check `:sub-runs` and `:renders` projections). Repeat until satisfied.
+8. If the change was REPL-only and the user wants to keep it, *commit via source edit* — REPL changes are lost on full page reload.
+
+### Stub an effect for an experiment
+
+Per Spec 002 §Per-frame and per-call overrides, dispatches can carry `:fx-overrides` to redirect a registered fx to a stub for one cascade. Used to run "what if the HTTP request returned X" experiments without hitting the network.
+
+```
+scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http
+```
+
+The stub must already be registered via `(rf/reg-fx :stub-http (fn [v] ...))`. The override applies for this dispatch only; subsequent dispatches use the canonical `:http` again.
+
+For `:rf.http/managed` failure-category experiments (Spec 014 §Failure categories), stub `:http` to fire one of the canonical failure traces directly.
+
+### "Narrate the next N events"
+
+`watch/count N` with no filter. Report each epoch as a short paragraph (event id, `:trigger-event`, key entries from `:effects` and `:sub-runs`, `app-db` diff summary) as it fires.
+
+### "Alert me on slow events"
+
+`watch/stream --timing-ms '>100'`. Silent until a match; report with the `:event/run` duration plus per-interceptor timings from the raw trace.
+
+### "Watch for X while I interact"
+
+`watch/stream --event-id-prefix :checkout/` (or other predicate). Narrate each match; summarise when idle.
+
+---
+
+## Error handling
+
+Every script returns structured edn like `{:ok? false :reason ...}` rather than raising. Translate to plain English for the user and suggest the fix named in `:reason`.
+
+Common cases:
+
+- `:nrepl-port-not-found` → tell the user to start their dev build with `shadow-cljs watch <build>`.
+- `:browser-runtime-not-attached` → tell the user to open the app in a browser tab.
+- `:debug-disabled` → re-frame2's `interop/debug-enabled?` is false (production build, or `goog.DEBUG` was set false). The trace stream and epoch history are elided in this build.
+- `:ns-not-loaded :missing :re-frame2` → re-frame2 isn't loaded; check the user's deps.
+- `:no-frames-registered` → no frame is up yet. Tell the user to call `(rf/init!)` (or wait for app boot).
+- `:ambiguous-frame` → multiple frames; ask the user to `frames/select` or pass `--frame :foo`.
+- `:handler-error` inside an epoch → the user's handler threw; surface the `:rf.error/handler-exception` trace event from `(rf/trace-buffer {:op-type :error})`.
+- `:timed-out? true` on a `dispatch-and-collect` → drain didn't settle in the wait window (a long-running async cascade, or a stuck `:dispatch-later`). Inspect the in-flight cascade via the trace buffer.
+- `:connection :lost` → reconnect by calling `scripts/discover-app.sh` again.
+- Restore failures (`:rf.epoch/restore-*`) → see the Time-travel table above.
+
+---
+
+## Style guidance
+
+- **Read before you write.** Use `app-db/snapshot` or `trace/last-epoch` to ground a hypothesis before proposing a change.
+- **Prefer structured ops over `repl/eval`.** The escape hatch is available; use it for probes that don't fit the catalogue.
+- **Keep it in re-frame2's vocabulary.** Dispatch, reg-event-fx, reg-sub, reg-machine, frame, epoch — speak the same language the app speaks. Avoid `reset!` of a frame's app-db except when surgically needed, and say so when you do.
+- **Experiment, don't speculate.** When an answer isn't obvious, probe at the REPL against live data.
+- **Validate before proposing.** When a hot-swap or suggestion is on the table, compose the form and run it against current state first.
+- **Narrow detail as you go.** Summaries first; drill into a specific epoch, diff, sub-run, or render entry when the user asks.
+- **Always resolve UI references to source first.** When the user mentions a button, view, panel, or "the thing I clicked", run `dom/source-at` *before* speculating about behaviour. Reporting `re-com/button at app/cart/view.cljs:84` grounds the conversation in a file the user can open; reporting *"probably the Save button somewhere in the profile view"* doesn't.
+- **Surface restore limits.** Before any time-travel experiment, walk the cascade's effects and tell the user which effects already fired and cannot be reversed.
+- **Use the assembled epoch stream by default; reach for the raw trace stream when you need detail the projection drops.** `:sub-runs`, `:renders`, `:effects` are the routing surface; `:trace-events` is the escape hatch when the projection is incomplete (e.g. successful-fx attribution).
+- **One trace listener per skill.** This skill registers exactly one listener (`:re-frame-pair2`) and one epoch listener (`:re-frame-pair2-epoch`). Multi-tool coexistence is the expected default — don't worry about other listeners; per Spec 009 §Listener ordering, ordering is not contract.
+
+---
+
+## Dropped from v1 (10x-specific surfaces with no re-frame2 equivalent)
+
+The v1 `re-frame-pair` skill carried a few surfaces that have no direct re-frame2 equivalent today. They have been **dropped** rather than ported:
+
+- **`subs/live` (10x's "currently subscribed query vectors" view)** — replaced by `subs/cache` (`rf/sub-cache`), which is the public Tool-Pair-pinned shape `{query-v {:value v :ref-count n}}`. Same need, different surface.
+- **10x's internal epoch-buffer accessor + ring-rollover detection** — gone; replaced by `(rf/epoch-history frame-id)` which is bounded and self-describing (size = `(count history)`, depth = `(:depth (epoch/current-config))`).
+- **10x's internal undo / step-back navigation** — gone; replaced by first-class `(rf/restore-epoch frame-id epoch-id)` with six documented failure modes.
+- **`re-com-debug-disabled` heuristic** — kept (re-com is still a valid source-coord source), but the source-coord story now leads with re-frame2's own `:annotate-dom?` annotation; re-com's `data-rc-src` is a fallback rather than the only path.
+- **`trace-enabled?` discovery check** — replaced by `interop/debug-enabled?` (the `goog.DEBUG` mirror per Spec 009 §Production builds). Same gate, framework-canonical name.
+- **Version-floor enforcement against re-frame-10x / re-com / re-frame** — gone (no re-frame-10x dependency; re-com is optional; re-frame2's version is implicit in the loaded ns).
+
+If during real-world use a surface re-frame2 currently lacks would unblock a recipe (e.g. successful-fx attribution in `:effects` projection, or a stable `:render-key` shape per rf2-t5tx), file a `bd` bead against the spec rather than working around in this skill.

--- a/skills/re-frame-pair2/STATUS.md
+++ b/skills/re-frame-pair2/STATUS.md
@@ -1,0 +1,103 @@
+# Implementation status
+
+A living record of what's actually implemented, what's scaffolded, and what's blocked. Updated per release. See `docs/initial-spec.md` for the design this is measured against.
+
+**Last updated:** 2026-05-09 (initial port from v1)
+
+---
+
+## TL;DR
+
+| Area | State |
+|---|---|
+| Design spec | Complete (see `docs/initial-spec.md`) |
+| `SKILL.md` | Written — the full vocabulary Claude learns |
+| `scripts/runtime.cljs` | Written — helpers over re-frame2's public Tool-Pair surfaces |
+| `scripts/ops.clj` + shell shims | Written — babashka dispatches every op |
+| `.claude-plugin/plugin.json` | Written |
+| `package.json` + GH Actions (CI + release) | Written |
+| Fixture app | Not yet — see `docs/initial-spec.md` §8a |
+| End-to-end against a live re-frame2 app | Not done — this is the spike |
+
+**Nothing in this repo has been exercised against a running re-frame2 + shadow-cljs build yet.** Pre-alpha. See *Known unknowns* below.
+
+---
+
+## Per-phase status (against `docs/initial-spec.md` §6)
+
+| Phase | Deliverable | State | Notes |
+|---|---|---|---|
+| 0 | `eval-cljs.sh` round-trips a form | **Coded, not yet run** | `scripts/eval-cljs.sh` + `ops.clj` implement it; needs a live nREPL to verify. |
+| 1 | Read surface (§4.1) | **Coded** | `app-db/snapshot`, `app-db/get`, `app-db/schemas`, `registrar/list`, `registrar/describe`, `subs/cache`, `subs/sample`, `machines/*` — all over `rf/get-frame-db`, `rf/snapshot-of`, `rf/handlers`, `rf/handler-meta`, `rf/sub-cache`, `rf/machines`, `rf/machine-meta`, `rf/app-schemas`. |
+| 2 | Dispatch + trace (§4.2–§4.3) | **Coded** | `pair-dispatch!` / `pair-dispatch-sync!` / `dispatch-and-collect`; trace consumed via `rf/register-trace-cb`, `rf/trace-buffer`, `rf/register-epoch-cb`, `rf/epoch-history`. No 10x dependency. |
+| 3 | Live watch (§4.4) | **Coded, pull-mode only** | `scripts/watch-epochs.sh` runs repeated short evals at 100ms cadence against `epochs-since`; assembled-stream listener feeds an internal stash. Streaming-via-`:out` deferred. |
+| 4 | Hot-swap (REPL) | **Coded** | Delivered by `reg-event-fx`/`reg-sub`/`reg-fx`/`reg-machine` via `eval-cljs.sh`. Re-registration emits `:rf.registry/handler-replaced` per Spec 001 §Hot-reload semantics. |
+| 5 | Hot-reload coordination (§4.5) | **Coded** | `tail-build.sh` implements the probe-based protocol — preferred probes target `(rf/handler-meta ...)` since the meta map's `:line` / `:column` / `:handler-fn` change after re-registration. |
+| 6 | Time-travel (§4.6) | **Coded — first-class** | `restore-epoch`, `undo-step-back`, `undo-to-epoch` all delegate to `rf/restore-epoch`. Six documented failure modes per Tool-Pair §Time-travel. No adapter — re-frame2 ships this directly. |
+| 7 | Diagnostics recipes (§4.7) | **Coded as SKILL.md procedures** | Listed; will be refined as real usage surfaces needed ops. |
+| 8 | Packaging | **Coded** | `package.json`, `plugin.json`, GH Actions for CI + npm release on tag. See `RELEASING.md`. |
+
+---
+
+## Known unknowns — the §8a spike deliverables
+
+Three things need to be proven against a fixture before calling this beyond pre-alpha.
+
+### 1. Runtime discovery
+
+`scripts/discover-app.sh` needs to actually connect against a real re-frame2 app. Specific unknowns:
+
+- nREPL port location across shadow-cljs versions (we try `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`, and `$SHADOW_CLJS_NREPL_PORT` in that order).
+- CLJS-mode switch — does `(shadow.cljs.devtools.api/cljs-eval <build-id> <form-str> {})` return the `:value` in a parseable edn form, or wrapped in a shadow-specific result map?
+- `re-frame.interop/debug-enabled?` — verify the symbol is reachable post-init. The current health check reads the var directly, which works in CLJS but may need adjustment if the symbol is moved.
+
+### 2. CLJS eval round-trip
+
+Does `scripts/eval-cljs.sh '(+ 1 2)'` return `{:ok? true :value 3}`? If not, `ops.clj`'s `cljs-eval-value` parsing needs adjustment.
+
+### 3. `data-rf2-source-coord` format — RESOLVED 2026-05-09 (rf2-7g2q)
+
+Resolved against re-frame2 rf2-z7f7 (PR #135). Per [Spec 006 §Source-coord annotation](https://github.com/day8/re-frame2/blob/master/spec/006-ReactiveSubstrate.md) and [Tool-Pair §Source-mapping](https://github.com/day8/re-frame2/blob/master/spec/Tool-Pair.md) the emitted attribute value is:
+
+```
+data-rf2-source-coord="<ns>:<handler-id>:<line>:<col>"
+```
+
+Four colon-separated segments, where `<ns>` and `<handler-id>` derive from the registry id keyword (`(namespace id)` / `(name id)`). Either coord segment may be the literal `?` for programmatic `reg-view*` calls that bypassed the macro path. Non-DOM roots (Fragment `:<>`, `:>` interop, fn-component head) are exempt — pair tools fall back to `(rf/handler-meta :view id)` for those.
+
+`scripts/runtime.cljs/parse-rf2-coord` now returns `{:ns :handler-id :line :col}` (or nil for malformed / non-4-segment input). Verified by `tests/runtime/parse_rf2_coord_test.clj` (run via `bb`).
+
+> **Compatibility note.** Tool-Pair.md declares the attribute's value format opaque to consumers — pair2 parses it pragmatically so the DOM-to-source bridge can be useful, but skill consumers MUST NOT depend on the parsed shape's stability across re-frame2 versions. If the format shifts, update the parser (and these tests) in one place.
+
+---
+
+## What's genuinely verified
+
+- `re-frame.core` exposes the Tool-Pair surfaces this skill consumes — `register-trace-cb`, `trace-buffer`, `register-epoch-cb`, `epoch-history`, `restore-epoch`, `configure`, `handlers`, `handler-meta`, `frame-ids`, `frame-meta`, `get-frame-db`, `snapshot-of`, `sub-cache`, `machines`, `machine-meta`, `app-schemas` — confirmed in `re-frame2/implementation/src/re_frame/core.cljc`.
+- Epoch records carry the documented `:rf/epoch-record` shape — confirmed in `re-frame2/implementation/src/re_frame/epoch.cljc` (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, `:trace-events`, `:sub-runs`, `:renders`, `:effects`).
+- `restore-epoch` implements the six documented failure modes per Tool-Pair §Time-travel.
+- shadow-cljs nREPL accepts JVM `(shadow.cljs.devtools.api/cljs-eval ...)` calls (well-known).
+
+Everything else is structurally correct per the Tool-Pair Spec but not runtime-verified.
+
+---
+
+## Next actions
+
+In order:
+
+1. Stand up a fixture re-frame2 app (minimal Reagent v2 + shadow-cljs).
+2. Ground-truth the three items under *Known unknowns*.
+3. Adjust `runtime.cljs` and `ops.clj` to match.
+4. Wire `tests/runtime/` into an actual shadow-cljs test build.
+5. Graduate out of pre-alpha and cut `v0.1.0-beta.1`.
+
+---
+
+## Asymmetries to monitor in the spec
+
+These are documented gaps in re-frame2's `:rf/epoch-record` projection that affect what recipes can return today. Each is a candidate `bd` bead if real usage shows it materially blocks a recipe:
+
+- **`:effects` projection captures only warning/error outcomes** — successful fx execution is not in the projection (Spec-Schemas §`:rf/epoch-record`). The skill's "What effects fired?" recipe falls back to walking `:trace-events` directly when successful-fx attribution is needed.
+- **`:render-key` shape is TBD** (Spec-Schemas §`:rf/epoch-record`, rf2-t5tx). Treated as opaque by the skill; recipes that route by render-key compare via `str` until the shape stabilises.
+- **`:sub-runs` `:result-changed?` is currently always true when the sub recomputed** — the raw trace doesn't yet carry the prior value. Tools requiring fine-grained change-tracking consume the raw trace stream.

--- a/skills/re-frame-pair2/docs/LOCAL_DEV.md
+++ b/skills/re-frame-pair2/docs/LOCAL_DEV.md
@@ -1,0 +1,158 @@
+# Running re-frame-pair2 locally (no npm needed)
+
+npm publishing is for distribution to other people. While developing the skill itself — or dogfooding it against a real re-frame2 app before the first release — you run it straight from a clone. Three install paths, most to least convenient.
+
+> **Note (consolidation):** This skill now lives under
+> `re-frame2/skills/re-frame-pair2/`. The example paths below assume you have
+> a re-frame2 clone at `~/code/re-frame2` (or `%USERPROFILE%\code\re-frame2`)
+> and are linking the `skills/re-frame-pair2/` subdirectory. Adjust the source
+> path if your clone is elsewhere.
+
+## Prerequisites on your machine
+
+Same as the README's *Requirements*:
+
+- [`babashka`](https://babashka.org) on `PATH` — the shell shims exec `bb` regardless of how the skill is installed.
+- [Claude Code](https://docs.claude.com/en/docs/claude-code).
+- A re-frame2 + shadow-cljs app to exercise it against. (Optional: re-com — used as a fallback source-coord source, not required.)
+
+## 1. Symlink (recommended for dev)
+
+Edits you make in the repo are live immediately — no copy to keep in sync.
+
+### macOS / Linux
+
+```bash
+mkdir -p ~/.claude/skills
+ln -s "$HOME/code/re-frame2/skills/re-frame-pair2" ~/.claude/skills/re-frame-pair2
+```
+
+### Windows
+
+With Developer Mode or admin:
+
+```powershell
+New-Item -ItemType SymbolicLink `
+  -Path "$env:USERPROFILE\.claude\skills\re-frame-pair2" `
+  -Target "$env:USERPROFILE\code\re-frame2\skills\re-frame-pair2"
+```
+
+Without admin, use a directory junction:
+
+```cmd
+mklink /J %USERPROFILE%\.claude\skills\re-frame-pair2 %USERPROFILE%\code\re-frame2\skills\re-frame-pair2
+```
+
+Junctions behave like symlinks for read purposes; fine for skill loading.
+
+## 2. Copy (snapshot the current state)
+
+```bash
+cp -r ~/code/re-frame2/skills/re-frame-pair2 ~/.claude/skills/re-frame-pair2
+```
+
+Simple, but you have to re-copy after every change. Useful if you want to pin a specific commit and keep iterating on the repo itself without affecting Claude's view of the skill.
+
+## 3. Project-local (only active in one app)
+
+Same content, but under a specific target project rather than your home directory:
+
+```bash
+cd ~/some-re-frame2-app
+mkdir -p .claude/skills
+ln -s "$HOME/code/re-frame2/skills/re-frame-pair2" .claude/skills/re-frame-pair2
+```
+
+Useful if you only want the skill loaded when you open the specific app you're debugging — and useful for testing what the project-local install flow feels like before anyone ships the skill.
+
+## Invoking it in Claude Code
+
+Once the skill directory is in place:
+
+- **Implicit**: ask about your running re-frame2 app in natural language (*"what's in `app-db` under `:cart`?"*). Claude auto-matches the skill's description.
+- **Explicit**: type `/re-frame-pair2` or name it in a prompt (*"Using re-frame-pair2, trace `[:cart/apply-coupon ...]`"*).
+
+First use of a session runs `scripts/discover-app.sh` — that connects to your shadow-cljs nREPL, verifies prerequisites, and injects the runtime namespace.
+
+## Dev loop: iterating on the skill itself
+
+The power of the symlink approach is that editing `SKILL.md` / `scripts/runtime.cljs` / `scripts/ops.clj` in the repo takes effect immediately:
+
+| You edited... | What Claude sees after your next prompt |
+|---|---|
+| `SKILL.md` frontmatter or body | New vocabulary / recipes on next invocation (may need to restart the Claude Code session for the description change to be re-indexed). |
+| `scripts/ops.clj` | Next `bb` invocation picks it up — no action needed. |
+| `scripts/runtime.cljs` | The injected code in the browser is **stale** until you explicitly re-push it. Run `scripts/inject-runtime.sh` in the connected session; it now force-reinjects regardless of the session sentinel so your edits land without a full page refresh. |
+| Shell shims (`*.sh`) | Next invocation picks them up. |
+
+## Troubleshooting
+
+### The skill doesn't appear in `/` completion
+
+- Confirm the directory landed where Claude Code looks: `ls ~/.claude/skills/re-frame-pair2/` (or the project-local equivalent).
+- Confirm `SKILL.md` is at the top level of that directory, not nested.
+- Restart Claude Code — it reads the skill registry at session start.
+- Check the skill name in `SKILL.md`'s frontmatter — it must match the directory name (`re-frame-pair2`).
+
+### `babashka-missing` error from `discover-app.sh`
+
+`bb` isn't on `PATH`. Verify with `which bb` (macOS/Linux) or `where bb` (Windows). Install:
+
+- macOS: `brew install borkdude/brew/babashka`
+- Linux / Windows: [babashka install guide](https://github.com/babashka/babashka#installation)
+
+Restart the shell (and Claude Code) so the new `PATH` takes effect.
+
+### `:nrepl-port-not-found`
+
+`discover-app.sh` couldn't locate `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, or `$SHADOW_CLJS_NREPL_PORT`. Start your dev build:
+
+```bash
+npx shadow-cljs watch <build-id>
+```
+
+...and make sure nREPL is enabled for the build.
+
+### `:debug-disabled`
+
+`re-frame.interop/debug-enabled?` is false (production build, or `goog.DEBUG` was forced off). Trace and epoch surfaces are elided. For a dev build this should be true automatically; for a release/staging build you'll need to flip the closure-define.
+
+### `:no-frames-registered`
+
+The app hasn't called `(rf/init!)` yet (or the only frame was destroyed). Wait for boot or call `(rf/init!)` manually.
+
+### `:ambiguous-frame`
+
+Multiple frames are registered and the session hasn't selected one. Use `frames/select` or pass `--frame :foo` per call. Reads proceed against `:rf/default` after warning; mutating ops refuse.
+
+### Watch ops don't stream anything
+
+Two likely causes:
+
+- **No epoch history yet.** `(rf/epoch-history :rf/default)` returns `[]` until the app dispatches at least one event. Click around or fire one synthetic dispatch.
+- **No activity matches the predicate**. Try `scripts/watch-epochs.sh --count 5` with no predicate to confirm the transport works, then add filters.
+
+### DOM ops return `{:src nil}`
+
+Two preconditions, at least one must hold:
+
+- `(rf/configure :source-coords {:annotate-dom? true})` enabled at startup, *or*
+- re-com debug instrumentation enabled and the call site passed `:src (at)`.
+
+If neither, `dom/source-at` returns `:reason :source-coord-annotation-disabled` for every element.
+
+### Changes to `runtime.cljs` aren't taking effect
+
+The session sentinel fast-path in `discover-app.sh` skips re-injection if the runtime is already present. To push edits into a live session, run `scripts/inject-runtime.sh` — it force-reinjects regardless.
+
+## Uninstall / reset
+
+```bash
+# symlink or junction:
+rm ~/.claude/skills/re-frame-pair2
+
+# copy:
+rm -rf ~/.claude/skills/re-frame-pair2
+```
+
+Restart Claude Code. The skill disappears from completion; no residual state.

--- a/skills/re-frame-pair2/docs/TESTING.md
+++ b/skills/re-frame-pair2/docs/TESTING.md
@@ -1,0 +1,91 @@
+# Testing plan
+
+Four surfaces need coverage at different fidelities. See `docs/initial-spec.md` §9 for the architectural split.
+
+## 1. Runtime unit tests (`tests/runtime/`)
+
+**Status: not yet written.**
+
+`runtime_test.cljs` (planned) covers pure fns in `scripts/runtime.cljs` — `parse-rf2-coord`, `parse-rc-src`, `epoch-matches?`, `current-frame` resolution, `epochs-since` semantics, the session-sentinel shape, time-travel sugar. These can run via `shadow-cljs compile test` + `node out/test.js` without a browser or live re-frame2 app.
+
+**To run (once set up):**
+
+```bash
+shadow-cljs compile test
+node out/test.js
+```
+
+Failing points to flag on first run:
+
+- ~~`parse-rf2-coord` assumes a `'<ns>|<file>:<line>:<col>'` shape for `data-rf2-source-coord`.~~ Resolved 2026-05-09 (rf2-7g2q): parser updated to the canonical `<ns>:<handler-id>:<line>:<col>` shape per Spec 006 §Source-coord annotation. Bb-runnable tests at `tests/runtime/parse_rf2_coord_test.clj` until the shadow-cljs harness lands.
+- `parse-rc-src` assumes a `"file:line"` or `"file:line:column"` format for `data-rc-src`. Real re-com attribute format needs verification.
+
+## 2. Bash-shim integration (`tests/shim/`)
+
+**Status: not yet written.**
+
+End-to-end against the fixture app. For each shell script in `scripts/*.sh`, assert:
+
+- exit code matches the documented contract
+- stdout is parseable as edn
+- structured result has expected keys
+
+Recommended approach: [`bats`](https://bats-core.readthedocs.io/) or a simple bash test harness. One `.bats` file per script; the fixture is started/stopped per test suite (not per test).
+
+## 3. End-to-end in-browser (`tests/e2e/`)
+
+**Status: not yet written. Blocked on the fixture app.**
+
+Drives a headless Chrome via [playwright](https://playwright.dev/) against the fixture. Exercises:
+
+- `watch-epochs.sh` against the assembled-epoch stream
+- `tail-build.sh` probe-based confirmation after a live source edit
+- `dom/source-at`, `dom/find-by-src`, `dom/fire-click-at-src` against an annotated DOM (`:annotate-dom? true`)
+- `restore-epoch` against each of the six documented failure modes
+- Full page refresh -> re-injection via session-sentinel miss
+- Multi-frame routing: dispatch with `--frame :stories` lands in the right history
+
+This is where uncertainty about `data-rf2-source-coord` format and the `cljs-eval` round-trip gets flushed out.
+
+## 4. Skill-prompt regression (`tests/prompts/`)
+
+**Status: not yet written.**
+
+A fixture app plus a harness that feeds representative Claude conversations and asserts the set of `scripts/*` invocations (and optionally the shape of Claude's reply). This catches silent drift in the skill's description and recipes as Claude's behaviour changes.
+
+Candidate prompts:
+
+- "What's in `app-db` under `:user/profile`?" -> should call `app-db/get`
+- "Trace `[:cart/apply-coupon "SPRING25"]`" -> should call `dispatch.sh --trace`
+- "Why didn't the header update after `[:profile/save ...]`?" -> should walk `:sub-runs`, identify the equality gate
+- "Iterate on the cart handler until expired coupons are rejected" -> should use the experiment-loop recipe (dispatch-and-collect, restore-epoch, reg-event-fx, repeat)
+
+## CI gating
+
+| Surface | Runs on |
+|---|---|
+| Runtime unit tests | every push |
+| Bash-shim integration | every push (once fixture exists) |
+| End-to-end in-browser | `main` + nightly |
+| Prompt regression | `main` + nightly |
+
+Release gates on all four passing.
+
+### Known coverage gap — probe-based reload
+
+`hot-reload/wait`'s probe-based confirmation (§4.5) is *safety-critical* — Claude uses it to gate dispatches after a source edit, and a false positive means Claude interacts with stale code. Yet the only way to genuinely exercise it requires a real browser + real shadow-cljs + real edit + real compile pipeline — i.e. the E2E surface, which runs nightly and on `main`, not per-push.
+
+Mitigation until we can run E2E per-push:
+
+- **Unit-test the probe-selection heuristics** (which probe to pick for a `reg-*` edit vs a view edit vs no-good-probe-available). Cheap; catches drift in the selection logic without needing a browser.
+- **Soft-confirmation signalling**: when no probe is available, `hot-reload/wait` returns `:soft? true`; SKILL.md asks Claude to surface this to the user rather than trust it as a hard landing confirmation.
+- **Never force release on a broken probe path.**
+
+## What's explicitly **not** tested yet
+
+- Connection against a real shadow-cljs build with nREPL enabled
+- Multi-frame routing under real concurrency
+- `restore-epoch` failure-mode traces
+- Hot-reload probe-form selection heuristics
+
+These are §8a spike deliverables.

--- a/skills/re-frame-pair2/docs/capabilities.md
+++ b/skills/re-frame-pair2/docs/capabilities.md
@@ -1,0 +1,126 @@
+# Capabilities — what re-frame-pair2 covers
+
+A scorecard against the real-world surface of re-frame2 + SPA development, mapped to concrete features. Two goals: (1) tell a prospective user honestly what the skill will and won't help with, (2) give the project a living matrix against which progress can be measured. Complements [`STATUS.md`](../STATUS.md) (per-phase implementation state).
+
+## Status legend
+
+- *done* — implemented and exercisable (caveats noted inline)
+- *partial* — designed but limited
+- *spike* — code path in place; depends on §8a spike items landing
+- *not yet*
+- *guardrail* — a *safety property*, encoded in design or protocol rather than a concrete op
+
+---
+
+## Context: what re-frame2 programmers face
+
+Most failure modes carry over from v1 (path mismatches, destructive merge, shape drift, init order, wrong handler args, sub identity instability, etc.). re-frame2 introduces a few new ones:
+
+- **Frame routing errors** — wrong dispatch landed in `:rf/default` because the call forgot `:frame :stories`.
+- **Machine snapshot version drift** — hot-reload bumped a machine's version; old snapshots in app-db now reject restore.
+- **Schema validation tightening** — a new app-schema added since the last snapshot, so `restore-epoch` fails with `:rf.epoch/restore-schema-mismatch`.
+- **`:origin` mis-attribution** — UI handler dispatches without setting `:origin` to the right tag, the trace shows everything from `:app`.
+
+re-frame-pair2 surfaces all of these via the documented restore-failure modes and the `:origin` filter on watch.
+
+---
+
+## Core runtime visibility
+
+What re-frame-pair2 can see inside a live re-frame2 app.
+
+| Capability | Status | Notes |
+|---|---|---|
+| Read all of `app-db` for any frame | *done* | `app-db/snapshot` via `rf/get-frame-db` |
+| Read a specific path | *done* | `app-db/get` via `rf/snapshot-of` |
+| Diff `app-db` before/after one event | *done* | Each `:rf/epoch-record` carries `:db-before` and `:db-after`; `epoch-diff` returns the projected `{:only-before :only-after :common}` |
+| List registered handlers | *done* | `registrar/list <kind>` over `rf/handlers` |
+| Inspect handler + interceptor chain + source coords | *done* | `registrar/describe :event <id>` over `rf/handler-meta` (returns `:ns` / `:line` / `:file` / `:column` / `:handler-fn`) |
+| Sample a subscription on demand | *done* | `subs/sample [:query-v]` |
+| Inspect the live sub cache | *done* | `subs/cache` returns `{query-v {:value v :ref-count n}}` (CLJS-only) |
+| Show subs that re-ran for one epoch | *done* | `:sub-runs` projection per epoch (Spec-Schemas) |
+| Show effects fired for one epoch | *partial* | `:effects` projection captures warning/error outcomes; successful-fx attribution requires walking `:trace-events` |
+| Follow cascaded dispatch chains | *done* | `:dispatch-id` / `:parent-dispatch-id` correlation; `trace/cascade` walks the tree |
+| Show components that re-rendered | *done* | `:renders` projection per epoch |
+| Attach source location to renders | *done* | Source coords flow from registrar metadata; `:render-key` is opaque pending rf2-t5tx |
+| List registered machines, see their state | *done* | `machines/list`, `machines/describe`, `machines/state` over `rf/machines` / `rf/machine-meta` / `rf/snapshot-of` |
+| List registered app-schemas | *done* | `schemas` over `rf/app-schemas` |
+| Frame enumeration / metadata | *done* | `frames/list`, `frames/meta` over `rf/frame-ids` / `rf/frame-meta` |
+
+---
+
+## Typical re-frame2 mistakes the tool supports
+
+| Mistake | Status | How |
+|---|---|---|
+| Wrong write path in `app-db` | *done* | `epoch-diff` shows the exact path(s) mutated; compare to what the sub reads |
+| Event fired but no visible UI change | *done* | "Why didn't my view update?" recipe walks `:sub-runs` and identifies the equality gate |
+| View didn't update because sub result stayed `=` | *done* | Same recipe — the sub's *absence* from `:sub-runs` is the equality-gate evidence (rf2-719e suppression) |
+| View re-rendered too broadly | *done* | `:renders` per epoch + `:sub-runs` shows which over-broad sub recomputed |
+| Async effects make the app look "wrong for a moment" | *partial* | `:effects` flags non-pure outcomes; for successful-fx attribution, walk `:trace-events` directly |
+| Interceptor order changes behaviour | *done* | `registrar/describe` lists ordered interceptor ids; `:event/run` traces carry per-step timing |
+| Hot reload leaves stale registrations behind | *done* | Probe-based `tail-build.sh` against `(rf/handler-meta ...)`; `:rf.registry/handler-replaced` trace fires on every replace |
+| Wrong frame routing | *done* | `--frame :foo` on dispatch + `--frame :foo` on watch; `:ambiguous-frame` refuses unsafe ops |
+| Machine snapshot drift after hot-reload | *done* | `restore-epoch` returns false with `:rf.epoch/restore-version-mismatch`; recipe explains and proposes fix |
+| Form bug mixes edit / validation / saved state | *not yet* | General re-frame pattern; not a specific recipe |
+
+---
+
+## Time-travel
+
+| Capability | Status | Notes |
+|---|---|---|
+| List recorded epochs per frame | *done* | `epoch/history` over `rf/epoch-history` |
+| Restore an epoch | *done* | `epoch/restore` over `rf/restore-epoch` |
+| Step back one epoch | *done* | `undo/step-back` (sugar) |
+| Restore failure surfaces | *done* | Six modes, all documented (Tool-Pair §Time-travel); `(rf/trace-buffer {:op-type :error})` carries the structured tags |
+| Configure ring depth | *done* | `(rf/configure :epoch-history {:depth N})` |
+| Reverse side effects | *guardrail* | Restore rewinds `app-db` only; SKILL.md asks Claude to enumerate non-pure effects from the cascade and warn before restoring |
+
+---
+
+## Safety / guardrails
+
+| Guardrail | Status | Notes |
+|---|---|---|
+| `app-db/reset` is logged via `tap>` | *done* | Previous + next + timestamp are tap'd so the human sees the change |
+| `repl/eval` treated as full-authority | *guardrail* | SKILL.md instructs Claude to prefer structured ops; the escape hatch is acknowledged |
+| Mutating ops refuse on `:ambiguous-frame` | *done* | Reads proceed against `:rf/default` after warning |
+| Watches and background processes always stop cleanly | *done* | Auto-terminate on disconnect, idle (default 30s), hard-cap (default 5min), or count cap (default 5) |
+| Restore-failure traces are structured | *done* | Six `:rf.epoch/*` operations with `:tags` — Tool-Pair contract |
+| Time-travel rewinds app-db only — surface limit | *guardrail* | SKILL.md style guidance + recipe text |
+
+---
+
+## Debugging recipes
+
+All in SKILL.md's Recipes section.
+
+| Recipe | Status |
+|---|---|
+| "Why didn't this view update?" | *done* — walks `:sub-runs`, names the equality gate (rf2-719e) |
+| "Why did this view re-render?" | *done* — reverses from `:renders` to `:sub-runs` to `:trigger-event` |
+| "What changed in app-db after this event?" | *done* — `epoch-diff` |
+| "What effects fired?" | *partial* — successful-fx attribution requires `:trace-events` walk |
+| "What event caused this render?" | *done* |
+| "Where in source did this DOM element come from?" | *done* — `dom/source-at` reads `data-rf2-source-coord` first, `data-rc-src` second |
+| "Replay this bug from the same starting state" | *done* — first-class via `restore-epoch` |
+| "Watch all `:foo/*` events while I click around" | *done* |
+| "Post-mortem — how did I get into this state?" | *done* — bounded by `epoch-history` depth |
+| "Inspect this machine" | *done* — `machines/list`, `machines/describe`, `machines/state` |
+| "Stub an effect for an experiment" | *done* — `:fx-overrides` per call |
+
+---
+
+## What re-frame-pair2 does *not* address
+
+- **Visual / pixel-level inspection.** No screenshots, no layout reasoning. Pair with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp).
+- **Cross-browser / mobile testing.** Single browser runtime at a time.
+- **Intermittent / race-condition bugs** that don't reproduce on command.
+- **Third-party widget internals** not exposed through the DOM or a public JS API.
+- **Ambient "watch for anything weird"** observation. `watch/*` is predicate-scoped.
+- **UX judgment.** Whether a flow *feels* right is beyond scope.
+
+---
+
+*Last updated: 2026-05-09.*

--- a/skills/re-frame-pair2/docs/initial-spec.md
+++ b/skills/re-frame-pair2/docs/initial-spec.md
@@ -1,0 +1,210 @@
+# re-frame-pair2 — Initial Specification
+
+**Status:** Draft 1
+**Date:** 2026-05-09
+**Owner:** mike.thompson@day8.com.au
+
+---
+
+## 1. Purpose
+
+`re-frame-pair2` is a Claude Code Skill (and Plugin) that lets Claude act as a pair programmer for a **live, running [re-frame2](https://github.com/day8/re-frame2) application**. It attaches to the application's runtime via shadow-cljs nREPL and exposes a small set of operations that map directly onto re-frame2's primitives: frames, `app-db`, events, subscriptions, effects, interceptors, machines.
+
+This is the re-frame2 sibling of v1 [`re-frame-pair`](https://github.com/day8/re-frame-pair). It consumes only re-frame2's own [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md) surfaces. **It has no re-frame-10x dependency.**
+
+### Why this shape
+
+re-frame is a reactive dataflow system — a DAG of derived values rooted in mutable state. `app-db` is the single source of truth; events are the only legal writes; subscriptions recompute as derived values; views re-render when their subs change. A coding agent that only edits `.cljs` files works against the static shape of that system and has no view of its dynamics at runtime.
+
+re-frame-pair2 inverts this. It operates on the live browser runtime *and* on source files — but deliberately, with a protocol: REPL changes are ephemeral probes; source edits are committed changes coordinated with shadow-cljs hot-reload (§4.5). Every read and write runs through re-frame2's own vocabulary, so the data loop, the trace stream, the assembled epoch records, and the user's own instincts about the app all see the same thing Claude sees.
+
+### Non-goals
+
+- Not a replacement for re-frame-10x or any future v2 of it. 10x is a human-facing devtool; re-frame-pair2 is an agent-facing back-channel reading from re-frame2's public surfaces. They coexist as parallel listeners (Spec 009 §Listener ordering).
+- Not a test runner, linter, or static analysis tool. Those operate on source; re-frame-pair2 operates on runtime.
+- Not a production feature. Dev/debug only — `interop/debug-enabled?` gates the entire trace-and-epoch substrate.
+
+### Assumed stack
+
+- **re-frame2** — the subject. The reference implementation targets Reagent v2 + shadow-cljs.
+- **`re-frame.interop/debug-enabled?` true** — automatic in dev builds; production elides per Spec 009 §Production builds. Without this, the trace stream and epoch history are no-ops and this skill has nothing to read.
+- **Optional: re-frame2 source-coord annotation** (`(rf/configure :source-coords {:annotate-dom? true})`) — populates `data-rf2-source-coord` on rendered DOM nodes. Without this, the DOM->source bridge degrades; with it, every annotated element resolves to `{:ns :line :file :column}`.
+- **Optional: re-com with debug instrumentation + `:src (at)`** at call sites — populates `data-rc-src`. Either annotation source unlocks the bridge; both can be present (re-frame2's wins).
+- **shadow-cljs** as the build tool, with nREPL enabled.
+
+re-frame-pair2 itself contributes **zero** additional host-project configuration.
+
+### Terminology
+
+- **Trace stream** — `(rf/register-trace-cb)` listeners + `(rf/trace-buffer)` retain-N ring. The fine-grained, per-emit stream (Spec 009).
+- **Assembled epoch** — one `:rf/epoch-record` per drain-settle, with structured `:sub-runs` / `:renders` / `:effects` projections plus `:trace-events`. Consumed via `(rf/register-epoch-cb)` and `(rf/epoch-history frame-id)`.
+- **Frame** — a re-frame2 isolated runtime instance (Spec 002). Most apps have one (`:rf/default`); larger apps have several.
+- **Origin** — the Spec 002 §Dispatch origin tagging keyword on every dispatch (`:app`, `:pair`, `:story`, `:ui`, `:timer`, `:http`...). The skill stamps `:pair` on its own dispatches.
+- **Session sentinel** — a UUID the skill interns on injection; its absence after a REPL lookup means the browser has refreshed and re-injection is needed.
+
+---
+
+## 2. Key concepts at a glance
+
+- **Live runtime.** The browser JS runtime behind `shadow-cljs watch`.
+- **Reactive graph.** re-frame2's subscription signal graph, with rf2-719e value-equal recompute suppression.
+- **Per-frame state.** Each frame's `app-db` is reachable via `(rf/get-frame-db frame-id)` and `(rf/snapshot-of path opts)`.
+- **Writes.** `dispatch` (with `:origin :pair` opt), `reg-*` re-registration, `restore-epoch`, container reset (rare).
+- **Runtime introspection API.** Every Tool-Pair surface listed in [Tool-Pair §How AI tools attach](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md#how-ai-tools-attach).
+- **Connection mechanism.** nREPL -> shadow-cljs -> browser runtime.
+- **Packaging.** `SKILL.md` + bash shim scripts + babashka ops dispatcher.
+- **Cardinal rule.** Two modes — REPL (ephemeral) vs source edit (permanent via hot-reload). See §3.
+
+---
+
+## 3. Architecture
+
+**Cardinal rule.** Two modes of changing the app, one protocol:
+
+- **REPL changes** (hot-swap a handler, evaluate a form) are *ephemeral* — lost on full page reload. Preferred for probes and experiments.
+- **Source edits** are *permanent* and pass through shadow-cljs hot-reload. After any source edit, the skill must `hot-reload/wait` before dispatching, or it risks interacting with the pre-reload code.
+
+Source edits are not forbidden — they're the right tool for committed changes. See §4.5 for the reload-coordination protocol.
+
+### 3.1 Connection path
+
+shadow-cljs nREPL into the connected browser runtime. Same as v1.
+
+### 3.2 Listening, not adapting
+
+Where v1 reached into re-frame-10x's internal epoch buffer, v2 consumes re-frame2's own surfaces:
+
+- `(rf/register-trace-cb :re-frame-pair2 cb)` — raw trace stream. The skill's listener id is fixed (one listener per skill per Spec 009).
+- `(rf/register-epoch-cb :re-frame-pair2-epoch cb)` — assembled-epoch stream. Mirrors `register-trace-cb`'s contract.
+- `(rf/trace-buffer opts)` — retain-N trace ring (default 200, configurable via `(rf/configure :trace-buffer {:depth N})`).
+- `(rf/epoch-history frame-id)` — per-frame epoch ring (default 50, configurable via `(rf/configure :epoch-history {:depth N})`).
+- `(rf/restore-epoch frame-id epoch-id)` — first-class time-travel with six documented failure modes (Tool-Pair §Time-travel).
+
+No adapter layer; no internal-state introspection; no second source of truth. If a feature isn't in the Tool-Pair contract, the skill doesn't ship it (and the gap becomes a `bd` bead candidate — see "Asymmetries to monitor in the spec" in `STATUS.md`).
+
+### 3.3 Component layout
+
+```
+re-frame-pair2/
+├── .claude-plugin/
+│   └── plugin.json                 # Claude Code Plugin manifest
+├── SKILL.md                        # Skill body
+├── README.md
+├── STATUS.md
+├── RELEASING.md
+├── package.json
+├── docs/
+│   ├── initial-spec.md             # this file
+│   ├── LOCAL_DEV.md
+│   ├── TESTING.md
+│   └── capabilities.md
+├── scripts/
+│   ├── discover-app.sh             # connect + verify + inject
+│   ├── eval-cljs.sh                # raw CLJS eval
+│   ├── inject-runtime.sh           # force re-inject runtime.cljs
+│   ├── dispatch.sh                 # pair-tagged dispatch
+│   ├── trace-window.sh             # last-N-ms epoch window
+│   ├── watch-epochs.sh             # pull-mode live watch
+│   ├── tail-build.sh               # probe-based hot-reload wait
+│   ├── ops.clj                     # babashka dispatcher (every op)
+│   └── runtime.cljs                # injected helper namespace
+└── .github/
+    └── workflows/
+        ├── ci.yml
+        └── release.yml
+```
+
+### 3.4 Session sentinel
+
+Same as v1: a UUID interned on injection. Every op reads it; absence triggers re-injection. Survives hot-reloads of the running CLJS code; lost on full page refresh.
+
+### 3.5 Watch transport
+
+Pull-mode (same as v1, with Spec-Schemas-aware decoding). The watch loop polls `epochs-since` against the operating frame, tracks the last seen `:epoch-id`, and surfaces an `:id-aged-out?` warning when the tracking id falls off the ring. Streaming-via-`:out` is deferred.
+
+### 3.6 Error surfaces
+
+Structured `{:ok? false :reason ...}` — every script. Recognised reasons:
+
+| Reason | Cause |
+|---|---|
+| `:nrepl-port-not-found` | shadow-cljs not running, or port file in an unexpected location |
+| `:debug-disabled` | `interop/debug-enabled?` is false (production build) |
+| `:ns-not-loaded` | `:missing :re-frame2` — re-frame2 isn't loaded into the runtime |
+| `:no-frames-registered` | App hasn't called `(rf/init!)` yet |
+| `:ambiguous-frame` | Multiple frames; mutating ops require explicit selection |
+| `:eval-error`, `:cljs-eval-error` | nREPL or CLJS-eval surfaced an exception |
+| `:no-epoch-recorded` | `dispatch-sync` returned but no record landed; recording disabled or frame destroyed |
+| `:rf.epoch/restore-*` | One of six restore failure modes (Tool-Pair §Time-travel) |
+| `:timed-out?` | Probe form didn't flip in `--wait-ms` (likely a compile error) |
+| `:no-element-at-src` | `dom/fire-click-at-src` couldn't find a matching DOM node |
+| `:source-coord-annotation-disabled` | Neither `:annotate-dom?` nor re-com debug is producing attributes |
+
+### 3.7 Versioning / floors
+
+re-frame2 itself is the only required dep. The Tool-Pair contract is additive across versions per Spec-ulation; the skill targets re-frame2 v1+ (the version that ships the contract).
+
+---
+
+## 4. Operation catalogue
+
+See `SKILL.md` for the full vocabulary. Subsections at-a-glance:
+
+- §4.1 Read — `app-db/snapshot`, `app-db/get`, `app-db/schemas`, `registrar/list`, `registrar/describe`, `subs/cache`, `subs/sample`, `machines/*`.
+- §4.2 Write — `dispatch` (queued / sync / trace), `reg-*` re-registration, `app-db/reset`, `repl/eval`, `fx-overrides/with`.
+- §4.3 Trace — `trace/buffer`, `trace/last-epoch`, `trace/last-pair-epoch`, `trace/epoch`, `trace/dispatch-and-collect`, `trace/recent`, `trace/find-where`, `trace/find-all-where`, `trace/cascade`.
+- §4.3b DOM bridge — `dom/source-at`, `dom/find-by-src`, `dom/fire-click-at-src`, `dom/describe`. Reads `data-rf2-source-coord` first, `data-rc-src` second.
+- §4.4 Watch — `watch/window`, `watch/count`, `watch/stream`, `watch/stop`. Predicates include `--origin`, `--frame`.
+- §4.5 Hot-reload coordination — `tail-build.sh --probe '...'`. Recommended probe: `(rf/handler-meta kind id)` hash.
+- §4.6 Time-travel — `epoch/history`, `epoch/restore`, `epoch/configure`, `undo/step-back`, `undo/to-epoch`. Six documented failure modes.
+- §4.7 Recipes — see SKILL.md.
+
+---
+
+## 6. Phased delivery
+
+| Phase | Deliverable | State |
+|---|---|---|
+| 0 | nREPL round-trip | Coded, not yet run |
+| 1 | Read surface | Coded |
+| 2 | Dispatch + trace | Coded |
+| 3 | Live watch (pull-mode) | Coded |
+| 4 | Hot-swap | Coded |
+| 5 | Hot-reload coordination | Coded |
+| 6 | Time-travel | Coded — first-class via re-frame2 |
+| 7 | Diagnostics recipes | SKILL.md complete |
+| 8 | Packaging | Coded |
+| 9 | Fixture + spike | Not yet |
+
+See `STATUS.md` for the per-phase state.
+
+---
+
+## 8. The §8a spike
+
+Before graduating from pre-alpha, three things must be ground-truthed against a fixture re-frame2 app:
+
+1. **Runtime discovery** — `discover-app.sh` connects, verifies `interop/debug-enabled?`, reports frames cleanly.
+2. **CLJS-eval round-trip** — `cljs-eval-value` parses shadow's response shape correctly.
+3. **`data-rf2-source-coord` format** — `parse-rf2-coord` matches whatever re-frame2's `:annotate-dom?` actually emits.
+
+See `STATUS.md` for the full known-unknowns list.
+
+---
+
+## 9. Test architecture
+
+Four surfaces — see `docs/TESTING.md`.
+
+---
+
+## 10. What changed from v1
+
+- **No re-frame-10x dependency.** Every 10x reach has been replaced with a re-frame2 Tool-Pair surface. See `SKILL.md`'s "Dropped from v1" section for the exhaustive substitution table.
+- **First-class time-travel.** `restore-epoch` is shipped by re-frame2; no adapter, no stubs, six documented failure modes.
+- **Multi-frame.** Every op carries an operating-frame concept; reads use `:rf/default` when unambiguous; mutating ops refuse on `:ambiguous-frame`.
+- **Origin tagging.** Pair dispatches carry `:origin :pair` so they can be filtered out of a trace stream that also carries `:app` / `:ui` / `:timer` / `:http` events.
+- **Render projection consumed verbatim.** `:renders` and `:sub-runs` are projected by re-frame2 itself; no re-com classifier in the runtime (Spec-Schemas owns the projection shape).
+- **Source-coord bridge takes re-frame2's annotation first, re-com's as a fallback.**
+
+The skill's vocabulary is preserved end-to-end. A user familiar with v1 lands in the same place: same recipes, same op names where they make sense, same protocol around REPL vs source edits.

--- a/skills/re-frame-pair2/package.json
+++ b/skills/re-frame-pair2/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@day8/re-frame-pair2",
+  "version": "0.1.0-alpha.1",
+  "description": "Pair-program with a live re-frame2 application. A Claude Code Skill consuming re-frame2's Tool-Pair surfaces. No re-frame-10x dependency.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "claude-code-plugin",
+    "re-frame",
+    "re-frame2",
+    "re-com",
+    "shadow-cljs",
+    "clojurescript",
+    "pair-programming",
+    "day8"
+  ],
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2",
+  "bugs": {
+    "url": "https://github.com/day8/re-frame2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame-pair2"
+  },
+  "license": "MIT",
+  "author": "day8 (https://github.com/day8)",
+  "files": [
+    "SKILL.md",
+    "README.md",
+    "LICENSE",
+    "scripts/",
+    ".claude-plugin/",
+    "docs/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/skills/re-frame-pair2/scripts/discover-app.sh
+++ b/skills/re-frame-pair2/scripts/discover-app.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# discover-app.sh — locate shadow-cljs nREPL, verify prerequisites,
+# inject re-frame-pair2.runtime. Prints a structured edn result.
+#
+# Usage:
+#   scripts/discover-app.sh [--build=:app]
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" discover "$@"

--- a/skills/re-frame-pair2/scripts/dispatch.sh
+++ b/skills/re-frame-pair2/scripts/dispatch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# dispatch.sh — fire a re-frame2 event in the connected app, tagged
+# with :origin :pair (Spec 002 §Dispatch origin tagging).
+#
+# Default mode is queued dispatch (`rf/dispatch`).
+# --sync  forces `rf/dispatch-sync` for deterministic before/after.
+# --trace dispatches synchronously and returns the assembled
+#         `:rf/epoch-record` for the cascade.
+#
+# Targeting:
+#   --frame :foo                   target a specific frame
+#   --fx-override :http=:stub-http per-call fx redirect (repeatable)
+#
+# Usage:
+#   scripts/dispatch.sh '[:cart/apply-coupon "SPRING25"]'
+#   scripts/dispatch.sh '[:cart/apply-coupon "SPRING25"]' --sync
+#   scripts/dispatch.sh '[:cart/apply-coupon "SPRING25"]' --trace
+#   scripts/dispatch.sh '[:foo]' --frame :stories
+#   scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" dispatch "$@"

--- a/skills/re-frame-pair2/scripts/eval-cljs.sh
+++ b/skills/re-frame-pair2/scripts/eval-cljs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# eval-cljs.sh — evaluate a ClojureScript form in the connected browser
+# runtime via shadow-cljs's cljs-eval. Prints edn on stdout.
+#
+# Usage:
+#   scripts/eval-cljs.sh '(+ 1 2)' [--build=:app]
+#   scripts/eval-cljs.sh '(re-frame-pair2.runtime/snapshot)'
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" eval "$@"

--- a/skills/re-frame-pair2/scripts/inject-runtime.sh
+++ b/skills/re-frame-pair2/scripts/inject-runtime.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# inject-runtime.sh — (re-)inject scripts/runtime.cljs into the running
+# browser runtime. Returns the health map from
+# `re-frame-pair2.runtime/health`.
+#
+# Usage:
+#   scripts/inject-runtime.sh [--build=:app]
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" inject "$@"

--- a/skills/re-frame-pair2/scripts/ops.clj
+++ b/skills/re-frame-pair2/scripts/ops.clj
@@ -1,0 +1,585 @@
+#!/usr/bin/env bb
+;;;; scripts/ops.clj — babashka entry point for all re-frame-pair2 ops.
+;;;;
+;;;; Each `scripts/*.sh` is a thin wrapper that exec's:
+;;;;     bb ops.clj <subcommand> [args...]
+;;;;
+;;;; Subcommands:
+;;;;   discover     — locate shadow-cljs nREPL, verify prerequisites,
+;;;;                  inject runtime, report {:ok? ...}
+;;;;   eval         — cljs-eval a form, return edn result
+;;;;   inject       — (re-)inject re-frame-pair2.runtime
+;;;;   dispatch     — fire an event with :origin :pair; --sync / --trace
+;;;;                  variants, --frame / --fx-override flags
+;;;;   trace-recent — epochs added in the last N ms (operating frame)
+;;;;   watch        — pull-mode live streaming of matching epochs
+;;;;   tail-build   — wait for hot-reload to land; probe-form gated
+;;;;
+;;;; All ops return edn on stdout. Shells capture and forward.
+
+(ns ops
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import (java.net Socket)
+           (java.io PushbackInputStream)))
+
+;; ---------------------------------------------------------------------------
+;; Minimal bencode + nREPL socket client
+;; ---------------------------------------------------------------------------
+;;
+;; bb doesn't ship a built-in nREPL client and we don't want a classpath
+;; dep just for this. Bencode is a 40-line protocol and nREPL speaks it
+;; directly over TCP; inline is simpler than bolting on Maven deps.
+
+(defn- bencode ^String [v]
+  (cond
+    (integer? v)   (str "i" v "e")
+    (string? v)    (let [bs (.getBytes ^String v "UTF-8")]
+                     (str (alength bs) ":" v))
+    (keyword? v)   (bencode (name v))
+    (map? v)       (str "d"
+                        (apply str (mapcat (fn [[k v]] [(bencode k) (bencode v)])
+                                           (sort-by (fn [[k _]] (if (keyword? k) (name k) (str k))) v)))
+                        "e")
+    (sequential? v) (str "l" (apply str (map bencode v)) "e")
+    (nil? v)       (bencode "")
+    :else          (bencode (pr-str v))))
+
+(defn- read-char [^PushbackInputStream in]
+  (let [b (.read in)]
+    (when (neg? b) (throw (ex-info "unexpected EOF" {})))
+    (char b)))
+
+(defn- bdecode [^PushbackInputStream in]
+  (let [c (read-char in)]
+    (case c
+      \i (let [sb (StringBuilder.)]
+           (loop [ch (read-char in)]
+             (if (= ch \e)
+               (Long/parseLong (.toString sb))
+               (do (.append sb ch) (recur (read-char in))))))
+      \l (loop [acc []]
+           (let [b (.read in)]
+             (cond (neg? b)          (throw (ex-info "unexpected EOF in list" {}))
+                   (= b (int \e))    acc
+                   :else             (do (.unread in b) (recur (conj acc (bdecode in)))))))
+      \d (loop [acc {}]
+           (let [b (.read in)]
+             (cond (neg? b)          (throw (ex-info "unexpected EOF in dict" {}))
+                   (= b (int \e))    acc
+                   :else             (do (.unread in b)
+                                         (let [k (bdecode in)
+                                               v (bdecode in)]
+                                           (recur (assoc acc k v)))))))
+      ;; digit — byte string of length N
+      (let [sb (StringBuilder.)]
+        (.append sb c)
+        (loop [ch (read-char in)]
+          (if (= ch \:)
+            (let [len (Long/parseLong (.toString sb))
+                  buf (byte-array len)]
+              (loop [read 0]
+                (when (< read len)
+                  (let [n (.read in buf read (- len read))]
+                    (when-not (pos? n) (throw (ex-info "EOF in string body" {})))
+                    (recur (+ read n)))))
+              (String. buf "UTF-8"))
+            (do (.append sb ch) (recur (read-char in)))))))))
+
+(defn- nrepl-eval-raw
+  "Open a socket to nREPL at port, send an op eval of code-str, read
+   responses until :status contains \"done\", close, return responses."
+  [port code-str]
+  (with-open [sock (Socket. "127.0.0.1" (int port))]
+    (let [out (.getOutputStream sock)
+          in  (PushbackInputStream. (.getInputStream sock))
+          id  (str (random-uuid))
+          msg (bencode {"op" "eval" "code" code-str "id" id})]
+      (.write out (.getBytes ^String msg "UTF-8"))
+      (.flush out)
+      (loop [responses []]
+        (let [resp (bdecode in)
+              responses' (conj responses resp)
+              done? (and (= id (get resp "id"))
+                         (some #{"done"} (get resp "status" [])))]
+          (if done?
+            responses'
+            (recur responses')))))))
+
+(defn- combine-responses
+  "Collapse a sequence of nREPL responses into a single result map."
+  [responses]
+  (reduce (fn [acc r]
+            (cond-> acc
+              (contains? r "value") (assoc :value (get r "value"))
+              (contains? r "out")   (update :out str (get r "out"))
+              (contains? r "err")   (update :err str (get r "err"))
+              (contains? r "ex")    (assoc :ex (get r "ex"))
+              (contains? r "status") (update :status (fnil into #{}) (get r "status"))))
+          {:out "" :err ""}
+          responses))
+
+;; ---------------------------------------------------------------------------
+;; Config / env
+;; ---------------------------------------------------------------------------
+
+(def default-build-id
+  (keyword (or (System/getenv "SHADOW_CLJS_BUILD_ID") "app")))
+
+(def port-file-candidates
+  ["target/shadow-cljs/nrepl.port"
+   ".shadow-cljs/nrepl.port"
+   ".nrepl-port"])
+
+(defn- read-port []
+  (or (when-let [p (System/getenv "SHADOW_CLJS_NREPL_PORT")]
+        (Integer/parseInt p))
+      (some (fn [path]
+              (let [f (io/file path)]
+                (when (.exists f)
+                  (Integer/parseInt (str/trim (slurp f))))))
+            port-file-candidates)))
+
+(defn- runtime-cljs-path []
+  (.getPath (io/file (.getParent (io/file *file*)) "runtime.cljs")))
+
+;; ---------------------------------------------------------------------------
+;; Output helpers
+;; ---------------------------------------------------------------------------
+
+(defn- emit [m]
+  (binding [*out* *out*]
+    (pr m)
+    (println))
+  (flush))
+
+(defn- die [reason & {:as extra}]
+  (emit (merge {:ok? false :reason reason} extra))
+  (System/exit 1))
+
+;; ---------------------------------------------------------------------------
+;; nREPL conveniences
+;; ---------------------------------------------------------------------------
+
+(defn- jvm-eval
+  "Evaluate a Clojure (JVM-side) form over nREPL and return the combined
+   response map."
+  [form-str]
+  (let [port (or (read-port)
+                 (throw (ex-info "nREPL port not found" {:reason :nrepl-port-not-found})))]
+    (combine-responses (nrepl-eval-raw port form-str))))
+
+(defn- cljs-eval
+  "Evaluate a ClojureScript form in the connected browser runtime via
+   shadow-cljs's `cljs-eval` API. Returns the raw nREPL response."
+  [build-id form-str]
+  (let [wrapped (format "(shadow.cljs.devtools.api/cljs-eval %s %s {})"
+                        (pr-str build-id)
+                        (pr-str form-str))]
+    (jvm-eval wrapped)))
+
+(defn- safe-edn [s]
+  (try (edn/read-string s) (catch Exception _ s)))
+
+(defn- cljs-eval-value
+  "Like cljs-eval but unwraps to the actual CLJS value."
+  [build-id form-str]
+  (let [res (cljs-eval build-id form-str)]
+    (cond
+      (some? (:ex res))
+      (throw (ex-info "nREPL eval error" {:reason :eval-error
+                                          :ex (:ex res)
+                                          :err (:err res)}))
+
+      (str/blank? (str (:value res)))
+      nil
+
+      :else
+      (let [outer (safe-edn (str (:value res)))]
+        (cond
+          (and (map? outer) (vector? (:results outer)))
+          (when-let [last-result (peek (:results outer))]
+            (safe-edn last-result))
+
+          (and (map? outer) (:err outer))
+          (throw (ex-info "cljs eval error"
+                          {:reason :cljs-eval-error
+                           :err (:err outer)}))
+
+          :else outer)))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: discover
+;; ---------------------------------------------------------------------------
+
+(defn- ensure-port! []
+  (or (read-port)
+      (die :nrepl-port-not-found
+           :hint "Start your shadow-cljs dev build (`shadow-cljs watch <build>`).")))
+
+(defn- build-id-from-args [args]
+  (or (some-> (some #(when (str/starts-with? % "--build=") %) args)
+              (str/replace-first "--build=" "")
+              keyword)
+      default-build-id))
+
+(defn- frame-from-args [args]
+  ;; --frame :foo  -or-  --frame=:foo
+  (or (some-> (some #(when (str/starts-with? % "--frame=") %) args)
+              (str/replace-first "--frame=" "")
+              edn/read-string)
+      (let [idx (->> args (keep-indexed (fn [i v] (when (= v "--frame") i))) first)]
+        (when idx
+          (some-> (nth args (inc idx) nil) edn/read-string)))))
+
+(defn- runtime-already-injected?
+  "Fast-path check: if the session sentinel var exists, the runtime is
+   already injected in this browser runtime."
+  [build-id]
+  (try
+    (let [v (cljs-eval-value build-id "re-frame-pair2.runtime/session-id")]
+      (and (string? v) (seq v)))
+    (catch Exception _ false)))
+
+(defn- inject-runtime!
+  "Ensure scripts/runtime.cljs is loaded in the connected runtime."
+  [build-id]
+  (when-not (runtime-already-injected? build-id)
+    (let [source (slurp (runtime-cljs-path))]
+      (cljs-eval build-id source)))
+  (cljs-eval-value build-id "(re-frame-pair2.runtime/health)"))
+
+(defn- discover [args]
+  (ensure-port!)
+  (let [build-id (build-id-from-args args)]
+    (try
+      (let [health (inject-runtime! build-id)]
+        (cond
+          (not (:ok? health))
+          (emit health)
+
+          (not (:debug-enabled? health))
+          (emit {:ok? false :reason :debug-disabled
+                 :hint (str "re-frame.interop/debug-enabled? is false. "
+                            "This is a production build (or goog.DEBUG was forced "
+                            "off). Trace and epoch surfaces are elided.")})
+
+          (empty? (:frames health))
+          (emit {:ok? false :reason :no-frames-registered
+                 :hint "Call (rf/init!) to register :rf/default, or wait for app boot."})
+
+          (:ambiguous-frame? health)
+          (emit (assoc health :ok? true
+                              :warning :ambiguous-frame
+                              :note (str "Multiple frames registered: "
+                                         (vec (:frames health))
+                                         ". Mutating ops require --frame :foo "
+                                         "or run `frames/select` first.")))
+
+          (not (:coord-annotation-enabled? health))
+          (emit (assoc health :ok? true
+                              :warning :no-source-coord-annotation
+                              :note (str "Neither data-rf2-source-coord nor "
+                                         "data-rc-src is on any element. The "
+                                         "DOM->source ops will degrade. Enable "
+                                         "(rf/configure :source-coords {:annotate-dom? true}) "
+                                         "or use re-com with :src (at).")))
+
+          :else
+          (emit (assoc health :ok? true :build-id build-id))))
+      (catch Exception e
+        (emit {:ok? false
+               :reason (or (:reason (ex-data e)) :unknown)
+               :message (.getMessage e)})))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: eval
+;; ---------------------------------------------------------------------------
+
+(defn- eval-op [args]
+  (ensure-port!)
+  (when (empty? args) (die :missing-form :hint "usage: eval '<form>' [--build :app]"))
+  (let [form     (first args)
+        build-id (build-id-from-args (rest args))]
+    (try
+      (emit {:ok? true :value (cljs-eval-value build-id form)})
+      (catch Exception e
+        (emit {:ok? false
+               :reason (or (:reason (ex-data e)) :eval-error)
+               :message (.getMessage e)
+               :data (dissoc (ex-data e) :reason)})))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: inject
+;; ---------------------------------------------------------------------------
+
+(defn- inject-runtime-force!
+  "Like inject-runtime! but *always* re-ships scripts/runtime.cljs."
+  [build-id]
+  (let [source (slurp (runtime-cljs-path))]
+    (cljs-eval build-id source))
+  (cljs-eval-value build-id "(re-frame-pair2.runtime/health)"))
+
+(defn- inject-op [args]
+  (ensure-port!)
+  (let [build-id (build-id-from-args args)]
+    (try
+      (emit (assoc (inject-runtime-force! build-id)
+                   :build-id build-id
+                   :forced? true
+                   :note "Source re-shipped regardless of sentinel. Use this after editing scripts/runtime.cljs."))
+      (catch Exception e
+        (emit {:ok? false :reason :inject-failed :message (.getMessage e)})))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: dispatch
+;; ---------------------------------------------------------------------------
+
+(defn- has-flag? [args flag]
+  (boolean (some #(= % flag) args)))
+
+(defn- fx-override-from-args
+  "--fx-override :http=:stub-http  (repeatable)
+   Returns a map {:http :stub-http ...} or nil."
+  [args]
+  (let [pairs (->> args
+                   (keep-indexed (fn [i v] (when (= v "--fx-override") (nth args (inc i) nil))))
+                   (keep (fn [s]
+                           (when (string? s)
+                             (let [[k v] (str/split s #"=" 2)]
+                               (when (and k v)
+                                 [(edn/read-string k) (edn/read-string v)]))))))]
+    (when (seq pairs)
+      (into {} pairs))))
+
+(defn- dispatch-op [args]
+  (ensure-port!)
+  (when (empty? args) (die :missing-event :hint "usage: dispatch '[:ev/id args...]' [--sync] [--trace] [--frame :foo] [--fx-override :http=:stub-http]"))
+  (let [event-str    (first args)
+        rest-args    (rest args)
+        build-id     (build-id-from-args rest-args)
+        sync?        (has-flag? rest-args "--sync")
+        trace?       (has-flag? rest-args "--trace")
+        frame        (frame-from-args rest-args)
+        fx-overrides (fx-override-from-args rest-args)
+        opts-form    (cond-> {}
+                       frame        (assoc :frame frame)
+                       fx-overrides (assoc :fx-overrides fx-overrides))]
+    (try
+      (cond
+        ;; --trace: dispatch-and-collect returns the epoch synchronously
+        ;; once drain settles (run-to-completion guarantees this).
+        trace?
+        (emit (merge {:mode :trace}
+                     (cljs-eval-value
+                       build-id
+                       (format "(re-frame-pair2.runtime/dispatch-and-collect %s %s)"
+                               event-str (pr-str opts-form)))))
+
+        sync?
+        (emit (merge {:mode :sync}
+                     (cljs-eval-value
+                       build-id
+                       (format "(re-frame-pair2.runtime/pair-dispatch-sync! %s %s)"
+                               event-str (pr-str opts-form)))))
+
+        :else
+        (emit (merge {:mode :queued}
+                     (cljs-eval-value
+                       build-id
+                       (format "(re-frame-pair2.runtime/pair-dispatch! %s %s)"
+                               event-str (pr-str opts-form))))))
+      (catch Exception e
+        (emit {:ok? false :reason :dispatch-failed :message (.getMessage e)
+               :ex-data (ex-data e)})))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: trace-recent
+;; ---------------------------------------------------------------------------
+
+(defn- trace-recent-op [args]
+  (ensure-port!)
+  (when (empty? args) (die :missing-window :hint "usage: trace-recent <ms> [--frame :foo]"))
+  (let [ms       (Integer/parseInt (first args))
+        rest-args (rest args)
+        build-id (build-id-from-args rest-args)
+        frame    (frame-from-args rest-args)]
+    (try
+      (let [form (if frame
+                   (format "(re-frame-pair2.runtime/epochs-in-last-ms %d %s)" ms (pr-str frame))
+                   (format "(re-frame-pair2.runtime/epochs-in-last-ms %d)" ms))
+            epochs (cljs-eval-value build-id form)]
+        (emit {:ok? true :window-ms ms :count (count epochs) :epochs epochs}))
+      (catch Exception e
+        (emit {:ok? false :reason :trace-failed :message (.getMessage e)})))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: watch (pull-mode)
+;; ---------------------------------------------------------------------------
+
+(defn- ->kw [s]
+  (when s
+    (if (str/starts-with? s ":")
+      (keyword (subs s 1))
+      (keyword s))))
+
+(defn- parse-predicate-args [args]
+  (loop [[a & more] args pred {}]
+    (cond
+      (nil? a) pred
+      (= a "--event-id")        (recur (rest more) (assoc pred :event-id (->kw (first more))))
+      (= a "--event-id-prefix") (recur (rest more)
+                                       (let [raw (first more)]
+                                         (assoc pred :event-id-prefix
+                                                (if (str/starts-with? raw ":") raw (str ":" raw)))))
+      (= a "--effects")         (recur (rest more) (assoc pred :effects (->kw (first more))))
+      (= a "--touches-path")    (recur (rest more) (assoc pred :touches-path
+                                                           (edn/read-string (first more))))
+      (= a "--sub-ran")         (recur (rest more) (assoc pred :sub-ran (->kw (first more))))
+      (= a "--render")          (recur (rest more) (assoc pred :render (first more)))
+      (= a "--origin")          (recur (rest more) (assoc pred :origin (->kw (first more))))
+      (= a "--frame")           (recur (rest more) (assoc pred :frame (->kw (first more))))
+
+      (= a "--custom")
+      (do
+        (emit {:ok? false
+               :reason :not-yet-supported
+               :flag :--custom
+               :hint (str "Arbitrary CLJS predicate filters are reserved "
+                          "but not yet implemented. Use --event-id-prefix, "
+                          "--effects, --touches-path, --sub-ran, --render, "
+                          "--origin, or --frame instead.")})
+        (System/exit 1))
+
+      :else                     (recur more pred))))
+
+(defn- flag-value [args flag default]
+  (if-let [idx (->> args (keep-indexed (fn [i v] (when (= v flag) i))) first)]
+    (nth args (inc idx) default)
+    default))
+
+(defn- watch-op [args]
+  (ensure-port!)
+  (let [build-id   (build-id-from-args args)
+        stream?    (has-flag? args "--stream")
+        stop?      (has-flag? args "--stop")
+        window-ms  (Long/parseLong (flag-value args "--window-ms" "30000"))
+        count-n    (Long/parseLong (flag-value args "--count" "5"))
+        frame      (frame-from-args args)
+        pred       (parse-predicate-args args)
+        idle-ms    (Long/parseLong (flag-value args "--idle-ms" "30000"))
+        hard-ms    (Long/parseLong (flag-value args "--hard-ms" "300000"))
+        poll-ms    (Long/parseLong (flag-value args "--poll-ms" "100"))
+        frame-arg  (if frame (str " " (pr-str frame)) "")]
+    (cond
+      stop?
+      (emit {:ok? true :stopped? true
+             :note "watch/stop is a no-op in pull-mode; simply terminate the running watch shell."})
+
+      :else
+      (try
+        (let [start     (System/currentTimeMillis)
+              last-id   (atom (cljs-eval-value
+                                build-id
+                                (format "(some-> (re-frame-pair2.runtime/last-epoch%s) :epoch-id)"
+                                        frame-arg)))
+              emitted   (atom 0)
+              last-hit  (atom (System/currentTimeMillis))
+              done?     (fn []
+                          (let [now      (System/currentTimeMillis)
+                                elapsed  (- now start)
+                                idle     (- now @last-hit)]
+                            (cond
+                              (and (not stream?) (>= elapsed window-ms))     [:done :window]
+                              (and (not stream?) (>= @emitted count-n))      [:done :count]
+                              (>= elapsed hard-ms)                           [:done :hard-cap]
+                              (and stream? (>= idle idle-ms))                [:done :idle]
+                              :else nil)))
+              fetch-form (fn [since-id]
+                           (format
+                            "(let [r (re-frame-pair2.runtime/epochs-since %s%s)
+                                   matches (filterv #(re-frame-pair2.runtime/epoch-matches? %s %%) (:epochs r))]
+                               {:matches matches
+                                :id-aged-out? (:id-aged-out? r)
+                                :head-id (:head-id r)})"
+                            (pr-str since-id)
+                            frame-arg
+                            (pr-str pred)))
+              aged-warned? (atom false)]
+          (loop []
+            (Thread/sleep poll-ms)
+            (let [result    (try (cljs-eval-value build-id (fetch-form @last-id))
+                                 (catch Exception _ nil))
+                  matches   (or (:matches result) [])
+                  head-id   (:head-id result)
+                  aged-out? (:id-aged-out? result)]
+              (when head-id (reset! last-id head-id))
+              (when (and aged-out? (not @aged-warned?))
+                (reset! aged-warned? true)
+                (emit {:ok? true :warning :id-aged-out
+                       :note (str "The id we were tracking fell off the frame's "
+                                  "epoch-history ring between polls — some matching "
+                                  "epochs may have been missed. Bump depth via "
+                                  "(rf/configure :epoch-history {:depth N}).")}))
+              (doseq [m matches]
+                (swap! emitted inc)
+                (reset! last-hit (System/currentTimeMillis))
+                (emit {:ok? true :epoch m}))
+              (if-let [[_ why] (done?)]
+                (emit {:ok? true :finished? true :reason why :emitted @emitted})
+                (recur)))))
+        (catch Exception e
+          (emit {:ok? false :reason :watch-failed :message (.getMessage e)}))))))
+
+;; ---------------------------------------------------------------------------
+;; Subcommand: tail-build (hot-reload/wait)
+;; ---------------------------------------------------------------------------
+
+(defn- tail-build-op [args]
+  (ensure-port!)
+  (let [build-id (build-id-from-args args)
+        wait-ms  (Long/parseLong (flag-value args "--wait-ms" "5000"))
+        probe    (flag-value args "--probe" nil)
+        poll-ms  100]
+    (cond
+      (nil? probe)
+      (do (Thread/sleep 300)
+          (emit {:ok? true :t (System/currentTimeMillis) :soft? true
+                 :note "No probe supplied; waited a 300ms fixed delay."}))
+
+      :else
+      (let [before (try (cljs-eval-value build-id probe) (catch Exception _ ::error))
+            start  (System/currentTimeMillis)]
+        (loop []
+          (Thread/sleep poll-ms)
+          (let [elapsed (- (System/currentTimeMillis) start)
+                now     (try (cljs-eval-value build-id probe) (catch Exception _ ::error))]
+            (cond
+              (and (not= now ::error) (not= now before))
+              (emit {:ok? true :t (System/currentTimeMillis) :soft? false})
+
+              (>= elapsed wait-ms)
+              (emit {:ok? false :reason :timed-out :timed-out? true
+                     :note "Probe did not change within --wait-ms. Likely a compile error; check your dev build output."})
+
+              :else
+              (recur))))))))
+
+;; ---------------------------------------------------------------------------
+;; Dispatcher
+;; ---------------------------------------------------------------------------
+
+(defn -main [& args]
+  (case (first args)
+    "discover"     (discover (rest args))
+    "eval"         (eval-op (rest args))
+    "inject"       (inject-op (rest args))
+    "dispatch"     (dispatch-op (rest args))
+    "trace-recent" (trace-recent-op (rest args))
+    "watch"        (watch-op (rest args))
+    "tail-build"   (tail-build-op (rest args))
+    (die :unknown-subcommand :arg (first args)
+         :valid #{"discover" "eval" "inject" "dispatch" "trace-recent" "watch" "tail-build"})))
+
+(apply -main *command-line-args*)

--- a/skills/re-frame-pair2/scripts/runtime.cljs
+++ b/skills/re-frame-pair2/scripts/runtime.cljs
@@ -1,0 +1,839 @@
+;;;; re-frame-pair2.runtime — injected helper namespace
+;;;;
+;;;; This file is evaluated by `scripts/inject-runtime.sh` on first
+;;;; connect. It creates the `re-frame-pair2.runtime` namespace inside
+;;;; the running browser app and populates it with helpers that the
+;;;; skill's ops call through `eval-cljs.sh`.
+;;;;
+;;;; Design invariants (see docs/initial-spec.md):
+;;;;   - All trace and epoch reads consume re-frame2's public Tool-Pair
+;;;;     surfaces (`re-frame.core/register-trace-cb`, `trace-buffer`,
+;;;;     `register-epoch-cb`, `epoch-history`, `restore-epoch`). No
+;;;;     reaching into private namespaces.
+;;;;   - Exactly one trace listener (`:re-frame-pair2`) and one epoch
+;;;;     listener (`:re-frame-pair2-epoch`) are registered. Multi-tool
+;;;;     coexistence is the expected default; per Spec 009 §Listener
+;;;;     ordering, listener ordering is not contract.
+;;;;   - The `session-id` sentinel below is re-read on every op. If
+;;;;     it's gone, a full page refresh happened and the shim
+;;;;     re-injects this file.
+;;;;
+;;;; This file is source-of-truth for injection. The shell shim reads
+;;;; it and ships the forms over nREPL — so keep it self-contained.
+
+(ns re-frame-pair2.runtime
+  (:require [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [clojure.data :as data]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Session sentinel
+;; ---------------------------------------------------------------------------
+;;
+;; A random UUID set once per injection. Every subsequent op reads it
+;; through `eval-cljs.sh`. If a full page refresh has wiped the
+;; browser-side runtime, reading the var throws and the shim knows to
+;; re-inject.
+
+(def session-id
+  (str (random-uuid)))
+
+(defn sentinel
+  "Return the session sentinel. Used by the shim to confirm the runtime
+   is still alive in the current browser runtime."
+  []
+  {:ok?        true
+   :session-id session-id
+   :installed  (js/Date.now)})
+
+;; ---------------------------------------------------------------------------
+;; Operating frame
+;; ---------------------------------------------------------------------------
+;;
+;; re-frame2 is multi-frame (Spec 002). Every read/write op resolves an
+;; *operating frame* — the session-cached default, overridable per call.
+;; Mutating ops refuse with :ambiguous-frame when more than one frame is
+;; registered and the session hasn't selected one. Reads proceed against
+;; :rf/default and emit a warning.
+
+(defonce ^:private selected-frame (atom nil))
+
+(defn select-frame!
+  "Pin the operating frame for this session. Subsequent ops use it
+   unless an explicit `:frame` opt is passed."
+  [frame-id]
+  (reset! selected-frame frame-id)
+  {:ok? true :frame frame-id})
+
+(defn current-frame
+  "Resolve the operating frame: explicit override -> session pin ->
+   :rf/default if it's the only registered frame -> nil (ambiguous)."
+  ([] (current-frame nil))
+  ([override]
+   (or override
+       @selected-frame
+       (let [fids (rf/frame-ids)]
+         (cond
+           (= 1 (count fids)) (first fids)
+           (contains? fids :rf/default) :rf/default
+           :else nil)))))
+
+(defn frames-list
+  "All registered, non-destroyed frame ids plus the operating frame."
+  []
+  {:ok?              true
+   :frames           (vec (rf/frame-ids))
+   :selected         @selected-frame
+   :operating        (current-frame)})
+
+(defn frames-meta
+  "Frame metadata (config, lifecycle) for `id` — `(rf/frame-meta id)`."
+  [id]
+  (or (rf/frame-meta id)
+      {:ok? false :reason :no-such-frame :frame-id id}))
+
+;; ---------------------------------------------------------------------------
+;; app-db read/write
+;; ---------------------------------------------------------------------------
+;;
+;; All app-db access is via the public Tool-Pair surfaces:
+;;   (rf/get-frame-db frame-id)        — current value
+;;   (rf/snapshot-of path opts)        — path-scoped read with :frame opt
+
+(defn snapshot
+  "Full current app-db value for the operating frame. No-arg form uses
+   the session's operating frame; arity-1 takes an explicit frame-id."
+  ([] (snapshot (current-frame)))
+  ([frame-id]
+   (rf/get-frame-db frame-id)))
+
+(defn app-db-at
+  "Read a path in app-db for the operating frame.
+   Sugar over (rf/snapshot-of path {:frame frame-id})."
+  ([path] (app-db-at path (current-frame)))
+  ([path frame-id]
+   (rf/snapshot-of path {:frame frame-id})))
+
+(defn app-db-reset!
+  "Replace the operating frame's app-db with v. Logged explicitly via
+   `tap>` so the human sees what the agent changed.
+
+   This bypasses the dispatch loop (no event, no cascade, no recorded
+   epoch). Use sparingly — prefer `dispatch` for any change you want
+   the data loop to see."
+  ([v] (app-db-reset! v (current-frame)))
+  ([v frame-id]
+   (tap> {:re-frame-pair2/op :app-db/reset
+          :frame              frame-id
+          :previous           (rf/get-frame-db frame-id)
+          :next               v
+          :t                  (js/Date.now)})
+   ;; Reach through the Tool-Pair-pinned container surface. We read the
+   ;; container ref via the registry-query API (frame/get-frame-db
+   ;; returns the container in re-frame2; the deref is the value, the
+   ;; container itself is what gets reset!).
+   (when-let [container (some-> (rf/handler-meta :frame frame-id) :app-db)]
+     (reset! container v))
+   {:ok? true :frame frame-id}))
+
+(defn schemas
+  "All registered app-schemas for the operating frame.
+   Map of `path → schema`. (rf/app-schemas frame-id)"
+  ([] (schemas (current-frame)))
+  ([frame-id]
+   (rf/app-schemas frame-id)))
+
+;; ---------------------------------------------------------------------------
+;; Registrar introspection
+;; ---------------------------------------------------------------------------
+
+(defn registrar-list
+  "Enumerate registered ids under a kind. (rf/handlers kind) returns
+   `{id meta}`; we return the sorted id vector."
+  [kind]
+  (-> (rf/handlers kind) keys sort vec))
+
+(defn- handler-fn-hash
+  "Opaque hash for hot-reload probe comparisons. Function refs aren't
+   reliably `=`, so hash a stringified form."
+  [meta-map]
+  (some-> meta-map :handler-fn str hash))
+
+(defn registrar-describe
+  "Return public handler metadata for kind+id. (rf/handler-meta kind id)
+   already gives the source coords (:ns :line :file :column), the
+   :handler-fn, the :rf/machine? flag where applicable, and any extra
+   keys the registrar carries (e.g. retained source forms when present).
+
+   Augments with :handler-fn-hash for use as a probe over hot-reload."
+  [kind id]
+  (if-let [m (rf/handler-meta kind id)]
+    (assoc m :handler-fn-hash (handler-fn-hash m))
+    {:ok? false :reason :not-registered :kind kind :id id}))
+
+(defn registrar-handler-ref
+  "Stable opaque identifier for the currently-registered handler. Used
+   as a hot-reload probe: capture before edit, compare after. The hash
+   changes on every re-registration (new fn ref, new source coords)."
+  [kind id]
+  (handler-fn-hash (rf/handler-meta kind id)))
+
+;; ---------------------------------------------------------------------------
+;; Subscriptions
+;; ---------------------------------------------------------------------------
+
+(defn sub-cache
+  "(rf/sub-cache frame-id) — public Tool-Pair surface returning
+   `{query-v {:value v :ref-count n}}` for every materialised
+   subscription in the operating frame. CLJS-only; nil on JVM."
+  ([] (sub-cache (current-frame)))
+  ([frame-id]
+   (rf/sub-cache frame-id)))
+
+(defn subs-sample
+  "Subscribe to query-v and deref once. Goes through `rf/subscribe` so
+   the cache lifecycle is the standard one — fine for one-shot probes,
+   not for repeated polling outside a reactive context."
+  [query-v]
+  (try
+    @(rf/subscribe query-v)
+    (catch :default e
+      {:ok? false :reason :sub-error :message (.-message e)})))
+
+;; ---------------------------------------------------------------------------
+;; Machines (Spec 005)
+;; ---------------------------------------------------------------------------
+
+(defn machines-list
+  "(rf/machines) — all registered machine ids."
+  []
+  (vec (rf/machines)))
+
+(defn machine-describe
+  "(rf/machine-meta id) — registered spec map for one machine, or
+   `{:ok? false :reason :not-a-machine}`."
+  [machine-id]
+  (or (rf/machine-meta machine-id)
+      {:ok? false :reason :not-a-machine :id machine-id}))
+
+(defn machine-state
+  "Snapshot of one machine in the operating frame. Per Spec 005, machine
+   snapshots live at `[:rf/machines machine-id]` in app-db."
+  ([machine-id] (machine-state machine-id (current-frame)))
+  ([machine-id frame-id]
+   (rf/snapshot-of [:rf/machines machine-id] {:frame frame-id})))
+
+;; ---------------------------------------------------------------------------
+;; Epoch history & assembled-stream listener
+;; ---------------------------------------------------------------------------
+;;
+;; re-frame2 ships first-class epoch recording. The listener fires once
+;; per drain-settle with the assembled `:rf/epoch-record`. We register
+;; ours under id :re-frame-pair2-epoch — multi-tool coexistence per
+;; Spec 009 §Listener ordering.
+;;
+;; The stash atom retains the last N records observed via the listener,
+;; even though `(rf/epoch-history frame-id)` already returns the ring.
+;; Two reasons: (a) we can stash *only* this skill's perspective, useful
+;; for last-pair-epoch; (b) it gives the watch loop a cheap "what's
+;; new since I last checked" without re-walking the framework's ring.
+
+(defonce ^:private observed-epochs
+  ;; frame-id -> vector of records (oldest first), capped to 500
+  (atom {}))
+
+(defonce ^:private pair-epoch-ids
+  ;; Set of epoch-ids that this skill itself dispatched (used by
+  ;; last-pair-epoch). Populated by the dispatch helpers below.
+  (atom #{}))
+
+(defn- on-epoch [record]
+  (swap! observed-epochs
+         (fn [m]
+           (let [frame-id (:frame record)
+                 v        (or (get m frame-id) [])
+                 v+       (conj v record)
+                 n        (count v+)]
+             (assoc m frame-id (if (> n 500) (subvec v+ (- n 500)) v+))))))
+
+(defn- ensure-epoch-listener!
+  "Register the assembled-epoch listener if it isn't already. Idempotent —
+   passing the same id twice replaces (per `register-epoch-cb` contract)."
+  []
+  (rf/register-epoch-cb :re-frame-pair2-epoch on-epoch))
+
+(defn epoch-history
+  "Pass-through to (rf/epoch-history frame-id) — the framework's
+   per-frame ring, oldest-first."
+  ([] (epoch-history (current-frame)))
+  ([frame-id]
+   (vec (rf/epoch-history frame-id))))
+
+(defn last-epoch
+  "Most recent epoch in the operating frame's history."
+  ([] (last-epoch (current-frame)))
+  ([frame-id]
+   (peek (rf/epoch-history frame-id))))
+
+(defn last-pair-epoch
+  "Most recent epoch this skill dispatched. Walks the operating frame's
+   history backward, filtering by epoch-id membership in pair-epoch-ids."
+  ([] (last-pair-epoch (current-frame)))
+  ([frame-id]
+   (let [ours @pair-epoch-ids]
+     (->> (rf/epoch-history frame-id)
+          reverse
+          (some (fn [r] (when (contains? ours (:epoch-id r)) r)))))))
+
+(defn epoch-by-id
+  "Look up an epoch by id in the operating frame's history."
+  ([epoch-id] (epoch-by-id epoch-id (current-frame)))
+  ([epoch-id frame-id]
+   (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
+         (rf/epoch-history frame-id))))
+
+(defn epochs-since
+  "Records appended *after* the given epoch-id in the operating frame.
+   Returns `{:epochs [...] :id-aged-out? bool :head-id <last-id>}`.
+
+   Semantics:
+     - `id` nil                  -> all records, :id-aged-out? false
+     - `id` matches current head -> [], :id-aged-out? false
+     - `id` matches some record  -> records strictly after it
+     - `id` not found            -> [], :id-aged-out? true"
+  ([epoch-id] (epochs-since epoch-id (current-frame)))
+  ([epoch-id frame-id]
+   (let [history (vec (rf/epoch-history frame-id))
+         head-id (some-> history peek :epoch-id)]
+     (cond
+       (nil? epoch-id)
+       {:epochs history :id-aged-out? false :head-id head-id}
+
+       (some #(= epoch-id (:epoch-id %)) history)
+       {:epochs (vec (rest (drop-while #(not= epoch-id (:epoch-id %)) history)))
+        :id-aged-out? false
+        :head-id head-id}
+
+       :else
+       {:epochs [] :id-aged-out? true :head-id head-id :requested-id epoch-id}))))
+
+(defn epochs-in-last-ms
+  "Records whose `:committed-at` falls inside the last N ms in the
+   operating frame's history."
+  ([ms] (epochs-in-last-ms ms (current-frame)))
+  ([ms frame-id]
+   (let [cutoff (- (js/Date.now) ms)]
+     (->> (rf/epoch-history frame-id)
+          (filterv #(>= (or (:committed-at %) 0) cutoff))))))
+
+(defn find-where
+  "Walk the operating frame's epoch-history in reverse chronological
+   order and return the first record matching the predicate, or nil.
+
+   Primary forensic op — 'find the epoch where X happened'. Examples:
+
+     ;; find the epoch where :auth-state flipped to :expired
+     (find-where
+       (fn [e] (= :expired (get-in (:db-after e) [:auth-state]))))
+
+     ;; find the epoch that triggered a specific event id
+     (find-where
+       (fn [e] (= :user/sign-out (:event-id e))))
+
+   Most recent match wins — usually what you want for 'how did I get
+   into this state?' post-mortems."
+  ([pred] (find-where pred (current-frame)))
+  ([pred frame-id]
+   (->> (rf/epoch-history frame-id)
+        reverse
+        (filter pred)
+        first)))
+
+(defn find-all-where
+  "Like find-where but returns every matching epoch, newest first.
+   Use when you want the trajectory of a path — 'every epoch where
+   :cart changed' — not just the most recent transition."
+  ([pred] (find-all-where pred (current-frame)))
+  ([pred frame-id]
+   (->> (rf/epoch-history frame-id)
+        reverse
+        (filterv pred))))
+
+(defn epoch-diff
+  "Pre-computed diff between an epoch's `:db-before` and `:db-after`,
+   shaped to match the v1 vocabulary the skill uses:
+       {:only-before <map> :only-after <map> :common <map>}"
+  [{:keys [db-before db-after]}]
+  (let [[ob oa c] (data/diff db-before db-after)]
+    {:only-before ob :only-after oa :common c}))
+
+;; ---------------------------------------------------------------------------
+;; Trace stream listener (raw-trace, retain-N buffer is in framework)
+;; ---------------------------------------------------------------------------
+;;
+;; The framework already maintains a retain-N ring buffer accessible via
+;; `(rf/trace-buffer opts)`. We register one listener here for callers
+;; that want a programmatic side-channel (e.g. a watch loop's idle
+;; detector); the buffer remains the canonical query surface.
+
+(defonce ^:private last-trace-id (atom 0))
+
+(defn- on-trace [event]
+  (when-let [id (:id event)]
+    (when (number? id) (reset! last-trace-id id))))
+
+(defn- ensure-trace-listener!
+  "Register the raw-trace listener if it isn't already."
+  []
+  (rf/register-trace-cb :re-frame-pair2 on-trace))
+
+(defn last-trace-event-id
+  "Last trace event id observed by the skill's listener. Useful as a
+   `:since` cursor for `(rf/trace-buffer {:since N})`."
+  []
+  @last-trace-id)
+
+;; ---------------------------------------------------------------------------
+;; Dispatch correlation (Spec 009 §Dispatch correlation)
+;; ---------------------------------------------------------------------------
+
+(defn cascade-of
+  "Reconstruct the cascade tree from a root `:dispatch-id` by walking
+   `:event/dispatched` traces in the buffer for matching :parent links.
+   Returns a tree of {:dispatch-id <id> :event <ev> :children [...]}.
+
+   Note: this walks the in-memory trace buffer (default depth 200 events
+   per `(rf/configure :trace-buffer {:depth N})`). For long cascades use
+   `(rf/configure :trace-buffer {:depth ...})` to widen the window."
+  [root-dispatch-id]
+  (let [events     (rf/trace-buffer {:operation :event/dispatched})
+        by-parent  (group-by #(get-in % [:tags :parent-dispatch-id]) events)
+        node       (fn node [did]
+                     (let [ev (some (fn [e] (when (= did (get-in e [:tags :dispatch-id])) e))
+                                    events)]
+                       {:dispatch-id did
+                        :event       (get-in ev [:tags :event])
+                        :origin      (get-in ev [:tags :origin])
+                        :children    (mapv #(node (get-in % [:tags :dispatch-id]))
+                                           (get by-parent did []))}))]
+    (node root-dispatch-id)))
+
+;; ---------------------------------------------------------------------------
+;; Pair-tagged dispatch
+;; ---------------------------------------------------------------------------
+;;
+;; Per Spec 002 §Dispatch origin tagging, dispatches carry an :origin opt
+;; (default :app). The skill stamps :pair so `:event/dispatched` traces
+;; can be filtered by who fired them. Pair-epoch tracking populates
+;; `pair-epoch-ids` from the assembled-epoch listener.
+
+(defn- mark-pair! [epoch-id]
+  (when epoch-id (swap! pair-epoch-ids conj epoch-id)))
+
+(defn pair-dispatch!
+  "Queued dispatch with `:origin :pair`. Returns
+   `{:ok? true :queued? true :event ...}`. The epoch-id appears once
+   the cascade settles; callers can read it via `last-pair-epoch`."
+  ([event-v] (pair-dispatch! event-v {}))
+  ([event-v opts]
+   (rf/dispatch event-v (merge {:origin :pair} opts))
+   {:ok? true :queued? true :event event-v :opts opts}))
+
+(defn pair-dispatch-sync!
+  "Synchronous dispatch with `:origin :pair`. Reads the operating
+   frame's epoch-history before and after; the new head is reported
+   as the pair-attributed epoch.
+
+   On real success returns {:ok? true :epoch-id <id> :event ...}.
+   When epoch-history depth is 0 (recording disabled) or the frame
+   isn't registered, reports the failure mode rather than claiming
+   success."
+  ([event-v] (pair-dispatch-sync! event-v {}))
+  ([event-v opts]
+   (let [frame-id  (or (:frame opts) (current-frame))
+         _         (when-not frame-id
+                     (throw (ex-info "ambiguous frame" {:reason :ambiguous-frame})))
+         before-id (some-> (rf/epoch-history frame-id) peek :epoch-id)]
+     (rf/dispatch-sync event-v (merge {:origin :pair} opts))
+     (let [after-id (some-> (rf/epoch-history frame-id) peek :epoch-id)]
+       (cond
+         (and after-id (not= before-id after-id))
+         (do (mark-pair! after-id)
+             {:ok? true :epoch-id after-id :event event-v :frame frame-id})
+
+         (and (nil? before-id) (nil? after-id))
+         {:ok? false
+          :reason :no-epoch-recorded
+          :event event-v
+          :frame frame-id
+          :hint (str "epoch-history is empty after dispatch. Either depth "
+                     "is 0 (disabled), the frame is destroyed, or "
+                     "interop/debug-enabled? is false (production build).")}
+
+         :else
+         {:ok? false
+          :reason :no-new-epoch
+          :event event-v
+          :frame frame-id
+          :hint "dispatch-sync returned, but epoch-history head did not advance."})))))
+
+;; ---------------------------------------------------------------------------
+;; Effect stubs (per-call :fx-overrides)
+;; ---------------------------------------------------------------------------
+
+(defn pair-dispatch-with-fx-overrides!
+  "Dispatch with a Spec 002 §Per-frame and per-call overrides
+   `:fx-overrides` map. `overrides` is `{fx-id stub-id ...}` where
+   `stub-id` is a separately-registered `reg-fx`. Each stub redirects
+   for this dispatch only."
+  [event-v overrides & {:keys [sync? frame]}]
+  (let [opts {:origin :pair :fx-overrides overrides :frame frame}]
+    (if sync?
+      (pair-dispatch-sync! event-v opts)
+      (pair-dispatch! event-v opts))))
+
+;; ---------------------------------------------------------------------------
+;; Time-travel — first-class via re-frame2
+;; ---------------------------------------------------------------------------
+
+(defn restore-epoch
+  "(rf/restore-epoch frame-id epoch-id). Returns true on success, false
+   on any failure mode. Failure traces fire under :rf.epoch/* — read
+   them with `(rf/trace-buffer {:op-type :error})`."
+  ([epoch-id] (restore-epoch epoch-id (current-frame)))
+  ([epoch-id frame-id]
+   (rf/restore-epoch frame-id epoch-id)))
+
+(defn undo-step-back
+  "Restore the previous epoch in the operating frame. Returns
+   {:ok? true :epoch-id <previous> :restored? true|false} or
+   {:ok? false :reason :no-prior-epoch} when there is no previous
+   record."
+  ([] (undo-step-back (current-frame)))
+  ([frame-id]
+   (let [history (vec (rf/epoch-history frame-id))
+         n       (count history)]
+     (if (< n 2)
+       {:ok? false :reason :no-prior-epoch :history-size n :frame frame-id}
+       (let [prior (nth history (- n 2))
+             epoch-id (:epoch-id prior)
+             ok?   (rf/restore-epoch frame-id epoch-id)]
+         {:ok? true :epoch-id epoch-id :restored? ok? :frame frame-id})))))
+
+(defn undo-to-epoch
+  "Restore a specific epoch by id."
+  ([epoch-id] (undo-to-epoch epoch-id (current-frame)))
+  ([epoch-id frame-id]
+   {:ok? true
+    :epoch-id epoch-id
+    :restored? (rf/restore-epoch frame-id epoch-id)
+    :frame frame-id}))
+
+;; ---------------------------------------------------------------------------
+;; DOM ↔ source bridge
+;; ---------------------------------------------------------------------------
+;;
+;; Two attribute sources, in priority order:
+;;   1. data-rf2-source-coord (re-frame2's own annotation when
+;;      :annotate-dom? is on — Tool-Pair §Source-mapping;
+;;      Spec 006 §Source-coord annotation, rf2-z7f7)
+;;   2. data-rc-src (re-com's debug attribute, fallback)
+;;
+;; The two attributes resolve to different schemas — re-frame2's
+;; carries the registry-id derived <ns>/<handler-id> with <line>/<col>;
+;; re-com's carries <file>/<line>/<column>. The runtime returns
+;; whichever map the first present attribute parses to.
+
+(defn- parse-rf2-coord
+  "Parse re-frame2's `data-rf2-source-coord` attribute.
+
+   Per Spec 006 §Source-coord annotation (rf2-z7f7) and Tool-Pair
+   §Source-mapping the attribute value is a four-segment colon-
+   separated string:
+
+       <ns>:<handler-id>:<line>:<col>
+
+   where <ns> and <handler-id> derive from the registry id keyword
+   (`(namespace id)` and `(name id)`) and <line>/<col> are the
+   captured source coords from the reg-view macro. Either coord
+   segment may be the literal `?` for programmatic registrations
+   that bypassed the macro path (Spec 006 §Attribute value format).
+
+   Returns
+       {:ns          <string>
+        :handler-id  <string>
+        :line        <int|nil>
+        :col         <int|nil>}
+
+   - :line and :col are nil when the corresponding segment is `?`
+     or otherwise non-numeric.
+   - Returns nil for blank input, non-strings, or fewer than four
+     segments. Pair-shaped consumers fall back to (rf/handler-meta
+     :view id) for those cases (Spec 006 §Documented exemption).
+
+   Tool-Pair.md declares the value format opaque to consumers; this
+   parser exists so pair2's DOM-to-source bridge can be useful, but
+   downstream callers MUST NOT depend on the parsed shape's
+   stability across re-frame2 versions."
+  [attr-val]
+  (when (and (string? attr-val) (seq attr-val))
+    (let [parts (str/split attr-val #":")]
+      (when (= 4 (count parts))
+        (let [[ns-part sym-part line-part col-part] parts
+              parse-int (fn [s]
+                          (when (and (string? s) (re-matches #"\d+" s))
+                            (js/parseInt s 10)))]
+          (when (and (seq ns-part) (seq sym-part))
+            {:ns         ns-part
+             :handler-id sym-part
+             :line       (parse-int line-part)
+             :col        (parse-int col-part)}))))))
+
+(defn- parse-rc-src
+  "Parse re-com's `data-rc-src` attribute into {:file :line :column}.
+   Expected shapes: 'app/cart.cljs:42', 'app/cart.cljs:42:8'."
+  [attr-val]
+  (when (and (string? attr-val) (seq attr-val))
+    (let [parts (str/split attr-val #":")
+          valid-line? (fn [s] (and s (re-matches #"\d+" s)))]
+      (when (and (>= (count parts) 2) (valid-line? (nth parts 1 nil)))
+        {:file   (first parts)
+         :line   (js/parseInt (nth parts 1) 10)
+         :column (when (and (>= (count parts) 3) (valid-line? (nth parts 2 nil)))
+                   (js/parseInt (nth parts 2) 10))}))))
+
+(defn- read-coord-from-element
+  "Try data-rf2-source-coord first, then data-rc-src. Returns the
+   parsed map or nil."
+  [el]
+  (or (some-> (.getAttribute el "data-rf2-source-coord") parse-rf2-coord)
+      (some-> (.getAttribute el "data-rc-src") parse-rc-src)))
+
+(defn coord-annotation-enabled?
+  "Heuristic: at least one element on the page carries either
+   `data-rf2-source-coord` or `data-rc-src`. False when neither
+   annotation source is producing attributes (re-frame2's
+   :annotate-dom? off and no re-com :src (at) call sites). Reads
+   may be unreliable on a freshly-loaded page that hasn't rendered."
+  []
+  (or (some? (.querySelector js/document "[data-rf2-source-coord]"))
+      (some? (.querySelector js/document "[data-rc-src]"))))
+
+;; Last-clicked capture — passive listener that records the element
+;; most recently clicked anywhere on the page. Installed once by
+;; `install-last-click-capture!` during injection so ops like
+;; `dom/source-at :last-clicked` have something to resolve.
+
+(defonce ^:private last-clicked (atom nil))
+
+(defn install-last-click-capture!
+  "Install a single capturing click listener on document that records
+   the most recently clicked element. Idempotent — calling twice does
+   not double-register (guard via a marker on window)."
+  []
+  (when-not (aget js/window "__rfp2_click_capture__")
+    (aset js/window "__rfp2_click_capture__" true)
+    (.addEventListener
+     js/document
+     "click"
+     (fn [e] (reset! last-clicked (.-target e)))
+     #js {:capture true :passive true})))
+
+(defn last-clicked-element
+  "Return the DOM element most recently clicked, or nil if nothing has
+   been clicked yet this session."
+  []
+  @last-clicked)
+
+(defn- selector-or-last-clicked [selector]
+  (cond
+    (or (= selector :last-clicked) (= selector "last-clicked"))
+    (last-clicked-element)
+
+    (string? selector)
+    (.querySelector js/document selector)
+
+    :else nil))
+
+(defn dom-source-at
+  "Given a CSS selector (or `:last-clicked`), return the source coord
+   attached by re-frame2's annotation or re-com's debug path. Shape
+   depends on which attribute matched:
+     - re-frame2: {:ns :handler-id :line :col}  (Spec 006 §Source-coord
+       annotation)
+     - re-com:    {:file :line :column}
+   Returns a structured result wrapping the coord under :src."
+  [selector]
+  (if-let [el (selector-or-last-clicked selector)]
+    (if-let [coord (read-coord-from-element el)]
+      {:ok? true :src coord :selector selector}
+      {:ok? true :src nil :selector selector
+       :reason (if (coord-annotation-enabled?)
+                 :no-coord-at-this-element
+                 :source-coord-annotation-disabled)})
+    {:ok? false :reason :no-element :selector selector
+     :hint (when (or (= selector :last-clicked) (= selector "last-clicked"))
+             "Nothing clicked this session; interact with the page first, or pass a CSS selector instead.")}))
+
+(defn dom-find-by-src
+  "Find live DOM elements whose source-coord attributes mention the
+   needle `<file-or-id>:<line>`. Searches both `data-rf2-source-coord`
+   and `data-rc-src`.
+
+   For `data-rc-src` the needle pairs the source file and line.
+   For `data-rf2-source-coord` (whose value is `<ns>:<handler-id>:<line>:<col>`,
+   per Spec 006 §Source-coord annotation) callers typically pass the
+   handler-id as the first argument so the substring match hits the
+   handler-id segment. Pair-shaped consumers wanting <ns>-scoped
+   queries should construct their own selector."
+  [file-or-id line]
+  (let [needle (str file-or-id ":" line)
+        nodes  (.querySelectorAll js/document
+                                  (str "[data-rf2-source-coord*='" needle "'],"
+                                       "[data-rc-src*='" needle "']"))]
+    (->> (array-seq nodes)
+         (mapv (fn [node]
+                 {:tag   (.toLowerCase (.-tagName node))
+                  :id    (not-empty (.-id node))
+                  :class (not-empty (.-className node))
+                  :src   (read-coord-from-element node)})))))
+
+(defn dom-fire-click
+  "Synthesise a click on the element whose source-coord attribute
+   contains the substring `<file-or-id>:<line>`. Picks the first
+   match if multiple. Returns {:ok? true :clicked {...}} — the
+   resulting epoch lands asynchronously, fetch it with `last-epoch`.
+   See `dom-find-by-src` for the needle semantics."
+  [file-or-id line]
+  (let [needle   (str file-or-id ":" line)
+        selector (str "[data-rf2-source-coord*='" needle "'],"
+                      "[data-rc-src*='" needle "']")
+        el       (.querySelector js/document selector)]
+    (if el
+      (let [ev (js/Event. "click" #js {:bubbles true :cancelable true})]
+        (.dispatchEvent el ev)
+        {:ok?     true
+         :clicked {:tag (.toLowerCase (.-tagName el))
+                   :id  (not-empty (.-id el))}})
+      {:ok? false :reason :no-element-at-src :file-or-id file-or-id :line line})))
+
+(defn dom-describe
+  "Summarise a DOM element."
+  [selector]
+  (if-let [el (.querySelector js/document selector)]
+    {:ok?      true
+     :tag      (.toLowerCase (.-tagName el))
+     :id       (not-empty (.-id el))
+     :class    (not-empty (.-className el))
+     :src      (read-coord-from-element el)
+     :rf2-src  (some-> (.getAttribute el "data-rf2-source-coord") parse-rf2-coord)
+     :rc-src   (some-> (.getAttribute el "data-rc-src") parse-rc-src)
+     :text     (let [t (.-textContent el)]
+                 (when (and t (< (count t) 200)) t))}
+    {:ok? false :reason :no-element :selector selector}))
+
+;; ---------------------------------------------------------------------------
+;; Watch predicate matching
+;; ---------------------------------------------------------------------------
+;;
+;; Translated for re-frame2's :rf/epoch-record shape — :event-id and
+;; :trigger-event are top-level slots; :sub-runs / :renders / :effects
+;; are pre-projected; the trace-events vector carries everything else.
+
+(defn epoch-matches?
+  "Test an epoch record against a predicate map built from
+   `watch-epochs.sh` CLI args.
+
+   Recognised keys: :event-id, :event-id-prefix, :effects (matches
+   :fx-id in the projection), :touches-path (anywhere in db-before /
+   db-after), :sub-ran (matches :sub-id or first of :query-v),
+   :render (matches :render-key as a string), :origin (matches
+   :origin in :event/dispatched trace events), :frame.
+
+   Prefix matching uses `str` on both sides so `:cart` matches
+   `:cart/apply-coupon`."
+  [pred {:keys [event-id trigger-event sub-runs renders effects
+                trace-events frame db-before db-after] :as epoch}]
+  (let [{p-eid    :event-id
+         p-prefix :event-id-prefix
+         p-fx     :effects
+         p-path   :touches-path
+         p-sub    :sub-ran
+         p-render :render
+         p-origin :origin
+         p-frame  :frame} pred]
+    (boolean
+     (and
+      (if p-eid    (= p-eid event-id) true)
+      (if p-prefix (some-> event-id str (str/starts-with? (str p-prefix))) true)
+      (if p-fx     (some #(= p-fx (:fx-id %)) effects) true)
+      (if p-path   (or (some? (get-in db-before p-path))
+                       (some? (get-in db-after p-path)))
+                   true)
+      (if p-sub    (some #(or (= p-sub (:sub-id %))
+                              (= p-sub (first (:query-v %))))
+                         sub-runs) true)
+      (if p-render (some #(= p-render (str (:render-key %))) renders) true)
+      (if p-origin (some (fn [t] (and (= :event/dispatched (:operation t))
+                                      (= p-origin (get-in t [:tags :origin]))))
+                         trace-events)
+                   true)
+      (if p-frame  (= p-frame frame) true)))))
+
+;; ---------------------------------------------------------------------------
+;; Dispatch-and-collect
+;; ---------------------------------------------------------------------------
+
+(defn dispatch-and-collect
+  "Synchronously dispatch (origin :pair) and return the resulting
+   epoch record. Drain-settle is synchronous in re-frame2's
+   `dispatch-sync`, so the new epoch is in the frame's history by the
+   time this call returns."
+  ([event-v] (dispatch-and-collect event-v {}))
+  ([event-v opts]
+   (let [result (pair-dispatch-sync! event-v opts)]
+     (if (:ok? result)
+       (assoc result :epoch (epoch-by-id (:epoch-id result)
+                                         (:frame result)))
+       result))))
+
+;; ---------------------------------------------------------------------------
+;; Health check
+;; ---------------------------------------------------------------------------
+
+(defn debug-enabled?
+  "Probe `re-frame.interop/debug-enabled?`. False in production builds;
+   trace and epoch surfaces elide entirely when this is false."
+  []
+  (boolean interop/debug-enabled?))
+
+(defn health
+  "One-call summary of the runtime's view of the world. Used by
+   `discover-app.sh` to confirm the environment is healthy.
+
+   Side effects: installs the last-click capture listener; registers
+   the trace and epoch listeners. All idempotent."
+  []
+  (install-last-click-capture!)
+  (ensure-trace-listener!)
+  (ensure-epoch-listener!)
+  (let [fids (rf/frame-ids)]
+    {:ok?                       true
+     :session-id                session-id
+     :debug-enabled?            (debug-enabled?)
+     :coord-annotation-enabled? (coord-annotation-enabled?)
+     :last-click-capture?       true
+     :frames                    (vec fids)
+     :selected-frame            @selected-frame
+     :operating-frame           (current-frame)
+     :ambiguous-frame?          (and (> (count fids) 1)
+                                     (nil? @selected-frame))
+     :epoch-history-depth       (try
+                                  (let [requiring (resolve 're-frame.epoch/current-config)]
+                                    (when requiring (:depth (requiring))))
+                                  (catch :default _ nil))
+     :epoch-counts              (into {} (map (fn [fid]
+                                                [fid (count (rf/epoch-history fid))])
+                                              fids))
+     :pair-epoch-count          (count @pair-epoch-ids)}))

--- a/skills/re-frame-pair2/scripts/tail-build.sh
+++ b/skills/re-frame-pair2/scripts/tail-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# tail-build.sh — coordinate with shadow-cljs hot-reload after a source
+# edit.
+#
+# --wait-ms N       how long to wait for the reload to land (default 5000)
+# --probe '<form>'  a CLJS form whose return value changes after the edit is
+#                   live. When the form's return value flips, reload has
+#                   landed. Without --probe, falls back to a fixed 300ms
+#                   timer delay and returns :soft? true.
+#
+# Recommended probes for re-frame2:
+#   - reg-* edits:        --probe '(re-frame-pair2.runtime/registrar-handler-ref :event :foo)'
+#   - reg-machine edits:  --probe '(re-frame-pair2.runtime/registrar-handler-ref :event :auth)'
+#   - view edits:         --probe '<form that derefs the edited code>'
+#
+# A successful probe-flip also coincides with a `:rf.registry/handler-replaced`
+# trace event arriving in the buffer; that event's presence is an
+# alternative confirmation.
+#
+# Note on the name: despite being called tail-build, this does NOT tail
+# shadow-cljs's server stdout. Both the server-side "Build complete" event
+# and the browser-side reload landing are driven through the probe-based
+# pattern. See docs/initial-spec.md §4.5 for rationale.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" tail-build "$@"

--- a/skills/re-frame-pair2/scripts/trace-window.sh
+++ b/skills/re-frame-pair2/scripts/trace-window.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# trace-window.sh — return epochs added to the operating frame's
+# epoch-history in the last N ms.
+#
+# Usage:
+#   scripts/trace-window.sh 3000           # last 3 seconds of epochs
+#   scripts/trace-window.sh 30000 --frame :stories
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" trace-recent "$@"

--- a/skills/re-frame-pair2/scripts/watch-epochs.sh
+++ b/skills/re-frame-pair2/scripts/watch-epochs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# watch-epochs.sh — pull-mode live watch of the operating frame's
+# epoch-history.
+#
+# Emits one edn line per matching epoch, plus a final {:finished?} summary.
+#
+# Modes:
+#   --window-ms N    Run for N ms, report matches, summarise.
+#   --count N        Run until N matches emitted.
+#   --stream         Run until disconnect, idle (default 30s), or --hard-ms.
+#   --stop           No-op for pull-mode; simply terminate the running shell.
+#
+# Predicates (any combination, AND-ed):
+#   --event-id :foo
+#   --event-id-prefix :cart/
+#   --effects :http
+#   --touches-path [:a :b]
+#   --sub-ran :cart/total
+#   --render 'my.ns/foo'
+#   --origin :pair|:app|:ui|:timer|:http
+#   --frame  :stories
+#
+# Stopping defaults: idle-ms 30000, hard-ms 300000, count 5.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v bb >/dev/null 2>&1 || {
+  echo '{:ok? false :reason :babashka-missing :hint "Install babashka: https://babashka.org"}' >&2
+  exit 1
+}
+exec bb "$HERE/ops.clj" watch "$@"

--- a/skills/re-frame-pair2/tests/runtime/parse_rf2_coord_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/parse_rf2_coord_test.clj
@@ -1,0 +1,210 @@
+;;;; tests/runtime/parse_rf2_coord_test.clj
+;;;;
+;;;; Babashka-runnable verification of `parse-rf2-coord` from
+;;;; `scripts/runtime.cljs`.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `scripts/runtime.cljs` is a CLJS-only file injected into the
+;;;;   browser app over nREPL. It uses `js/parseInt`, so it can't run
+;;;;   under bb directly. The real shadow-cljs test build (planned per
+;;;;   `docs/TESTING.md` §1) will exercise the `.cljs` source in place
+;;;;   under Node — that's the canonical home for these tests once the
+;;;;   build is wired up.
+;;;;
+;;;;   Until then, this file mirrors the parser logic and asserts
+;;;;   behaviour against samples cribbed from re-frame2's own tests
+;;;;   (`implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs`
+;;;;   and `implementation/core/test/re_frame/ssr_source_coord_test.clj`)
+;;;;   so format drift in `runtime.cljs` shows up under `bb` until the
+;;;;   shadow-cljs harness lands.
+;;;;
+;;;; Run:    bb tests/runtime/parse_rf2_coord_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns parse-rf2-coord-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of scripts/runtime.cljs `parse-rf2-coord`.
+;;
+;; KEEP IN SYNC WITH scripts/runtime.cljs. Logic is identical except
+;; for `js/parseInt` -> `Long/parseLong` (bb runtime). The regex,
+;; segment count, and shape are the contract under test.
+;; ---------------------------------------------------------------------------
+
+(defn- parse-int-str [s]
+  (when (and (string? s) (re-matches #"\d+" s))
+    (Long/parseLong s)))
+
+(defn parse-rf2-coord
+  "See scripts/runtime.cljs for the canonical version.
+   Returns {:ns :handler-id :line :col} or nil."
+  [attr-val]
+  (when (and (string? attr-val) (seq attr-val))
+    (let [parts (str/split attr-val #":")]
+      (when (= 4 (count parts))
+        (let [[ns-part sym-part line-part col-part] parts]
+          (when (and (seq ns-part) (seq sym-part))
+            {:ns         ns-part
+             :handler-id sym-part
+             :line       (parse-int-str line-part)
+             :col        (parse-int-str col-part)}))))))
+
+;; ---------------------------------------------------------------------------
+;; Canonical case — the DOM snippet from PR #135 (rf2-z7f7).
+;; ---------------------------------------------------------------------------
+
+(deftest canonical-form-1
+  (testing "canonical 4-segment shape from PR #135"
+    (is (= {:ns         "counter.core"
+            :handler-id "counter-buttons"
+            :line       47
+            :col        11}
+           (parse-rf2-coord "counter.core:counter-buttons:47:11")))))
+
+;; ---------------------------------------------------------------------------
+;; Real Form-1 sample shape — derived from
+;; re-frame2/implementation/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+;; (annotates-dom-root-without-attrs). The real test asserts the regex
+;; `^rf\.src-coord-test:no-attrs:\d+:\d+$` — concrete sample below.
+;; ---------------------------------------------------------------------------
+
+(deftest form-1-rf2-test-sample
+  (testing "Form-1 sample matching the rf2 test regex"
+    (is (= {:ns         "rf.src-coord-test"
+            :handler-id "no-attrs"
+            :line       54
+            :col        7}
+           (parse-rf2-coord "rf.src-coord-test:no-attrs:54:7")))))
+
+;; ---------------------------------------------------------------------------
+;; Form-2 sample shape — re-frame2 tests confirm the inner output is
+;; annotated using the SAME 4-segment format (the wrapper recurses on
+;; the inner fn's hiccup; the attribute value is identical to Form-1).
+;; Sample: rf.src-coord-test/form-2 from source_coord_dom_cljs_test.cljs.
+;; ---------------------------------------------------------------------------
+
+(deftest form-2-inner-output
+  (testing "Form-2 wrapper annotates inner hiccup with the same 4-segment shape"
+    (is (= {:ns         "rf.src-coord-test"
+            :handler-id "form-2"
+            :line       104
+            :col        5}
+           (parse-rf2-coord "rf.src-coord-test:form-2:104:5")))))
+
+;; ---------------------------------------------------------------------------
+;; SSR sample — derived from
+;; re-frame2/implementation/core/test/re_frame/ssr_source_coord_test.clj
+;; (reg-view-root-is-annotated). Test asserts the regex
+;; `data-rf2-source-coord="rf\.ssr-coord-test:banner:\d+:\d+"`.
+;; ---------------------------------------------------------------------------
+
+(deftest ssr-sample
+  (testing "SSR-rendered registered view carries the same 4-segment format"
+    (is (= {:ns         "rf.ssr-coord-test"
+            :handler-id "banner"
+            :line       48
+            :col        13}
+           (parse-rf2-coord "rf.ssr-coord-test:banner:48:13")))))
+
+;; ---------------------------------------------------------------------------
+;; Programmatic-registration degradation — Spec 006 §Attribute value
+;; format: <line>/<col> may be `?` when the macro path was bypassed.
+;; The CLJS test (programmatic-registration-degrades-gracefully)
+;; asserts the literal value "rf.src-coord-test:programmatic:?:?".
+;; ---------------------------------------------------------------------------
+
+(deftest degraded-line-col
+  (testing "programmatic registration with `?` placeholders parses the id portion;
+            line/col are nil"
+    (is (= {:ns         "rf.src-coord-test"
+            :handler-id "programmatic"
+            :line       nil
+            :col        nil}
+           (parse-rf2-coord "rf.src-coord-test:programmatic:?:?"))))
+
+  (testing "partial degradation — only column missing"
+    (is (= {:ns         "ns.x"
+            :handler-id "view"
+            :line       42
+            :col        nil}
+           (parse-rf2-coord "ns.x:view:42:?")))))
+
+;; ---------------------------------------------------------------------------
+;; Malformed / edge cases — must never throw; return nil.
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-too-few-segments
+  (testing "too few segments returns nil"
+    (is (nil? (parse-rf2-coord "ns:view:42")))
+    (is (nil? (parse-rf2-coord "ns:view")))
+    (is (nil? (parse-rf2-coord "ns")))
+    (is (nil? (parse-rf2-coord "")))))
+
+(deftest malformed-too-many-segments
+  (testing "more than 4 segments returns nil — strict 4-segment shape"
+    (is (nil? (parse-rf2-coord "a:b:c:d:e")))
+    (is (nil? (parse-rf2-coord "a:b:1:2:3")))))
+
+(deftest empty-segments
+  (testing "empty <ns> or <handler-id> segments return nil"
+    (is (nil? (parse-rf2-coord ":handler:1:2")))
+    (is (nil? (parse-rf2-coord "ns::1:2")))))
+
+(deftest non-string-input
+  (testing "non-string input returns nil — never throws"
+    (is (nil? (parse-rf2-coord nil)))
+    (is (nil? (parse-rf2-coord 42)))
+    (is (nil? (parse-rf2-coord :keyword)))
+    (is (nil? (parse-rf2-coord ["v" "e" "c"])))))
+
+;; ---------------------------------------------------------------------------
+;; Hyphenated / dotted ids — re-frame's namespace and registry-id
+;; conventions allow dots in the namespace and hyphens in the symbol.
+;; ---------------------------------------------------------------------------
+
+(deftest dotted-and-hyphenated
+  (testing "dotted ns and hyphenated handler-id parse cleanly"
+    (is (= {:ns         "my-app.cart.view"
+            :handler-id "apply-coupon-button"
+            :line       125
+            :col        4}
+           (parse-rf2-coord "my-app.cart.view:apply-coupon-button:125:4")))))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip (idempotence) — re-formatting a parsed coord and parsing
+;; that string back yields equivalent shape (line/col only meaningful
+;; when both were captured numerically).
+;; ---------------------------------------------------------------------------
+
+(defn- format-coord
+  "Mirror of re-frame2/views.cljs/format-source-coord: emits the
+   <ns>:<sym>:<line>:<col> shape, with `?` for nil line/col."
+  [{:keys [ns handler-id line col]}]
+  (str ns ":" handler-id ":"
+       (if line (str line) "?")
+       ":"
+       (if col (str col) "?")))
+
+(deftest round-trip-numeric
+  (testing "parse -> format -> parse is idempotent for numeric coords"
+    (let [s     "counter.core:counter-buttons:47:11"
+          once  (parse-rf2-coord s)
+          twice (parse-rf2-coord (format-coord once))]
+      (is (= once twice)))))
+
+(deftest round-trip-degraded
+  (testing "parse -> format -> parse is idempotent for ?:? coords"
+    (let [s     "rf.x:programmatic:?:?"
+          once  (parse-rf2-coord s)
+          twice (parse-rf2-coord (format-coord once))]
+      (is (= once twice)))))
+
+;; ---------------------------------------------------------------------------
+;; Run.
+;; ---------------------------------------------------------------------------
+
+(let [{:keys [fail error]} (run-tests 'parse-rf2-coord-test)]
+  (System/exit (if (and (zero? fail) (zero? error)) 0 1)))


### PR DESCRIPTION
## Summary

Consolidates two Day8 Claude-shaped skills into `skills/` so they live alongside the re-frame2 surfaces they consume. Per Mike's choice (Option A): copy contents in without `.git/`, leave the standalone repos in place for the transition, future updates happen here.

## Pre-copy: pair2 PR #1 merged

`day8/re-frame-pair2#1` (the `parse-rf2-coord` parser fix for rf2-7g2q, aligning with rf2-z7f7's emitted source-coord format) was open and `MERGEABLE` at start of task. Merged via `gh pr merge --rebase --admin --delete-branch` immediately before the copy, so the consolidated `skills/re-frame-pair2/` carries the fix from the start. `tests/runtime/parse_rf2_coord_test.clj` is included.

## Per-skill

### `re-frame-pair2`

- **Source**: `C:/Users/miket/code/re-frame-pair2/` (public repo `day8/re-frame-pair2`)
- **Target**: `skills/re-frame-pair2/`
- **Files moved**: 22 (~3,305 LoC across `*.md`, `*.cljs`, `*.clj`, `*.json`, `*.sh`, `*.yml`)
- **Dropped**: `.git/`, `.github/workflows/` (`ci.yml`, `release.yml`), `node_modules/`, `.shadow-cljs/`, `out/`, `target/` (last four were already absent in source)
- **Edited for new layout**:
  - `package.json` `homepage` / `bugs` / `repository` retargeted at `day8/re-frame2/tree/main/skills/re-frame-pair2`, with `repository.directory` set so monorepo subdir publishes work when releases resume.
  - `.claude-plugin/plugin.json` `homepage` / `repository` likewise retargeted.
  - `README.md` cross-link to improver2 retargeted at the new monorepo path.
  - `RELEASING.md` keeps the npm publish mechanics as historical reference and gains a banner noting the standalone `release.yml` is gone.
  - `docs/LOCAL_DEV.md` symlink/copy/junction examples rewritten to reflect skill living under `re-frame2/skills/re-frame-pair2/`.

### `re-frame-pair-improver2`

- **Source**: `C:/Users/miket/code/re-frame-pair-improver2/` (verified: no public GitHub repo — `gh repo view day8/re-frame-pair-improver-improver2` returns "Could not resolve")
- **Target**: `skills/re-frame-pair-improver2/`
- **Files moved**: 10 (~668 LoC)
- **Dropped**: `.git/` (no `.github/`, no build dirs in source)
- **Edited for new layout**:
  - `package.json` `homepage` / `bugs` / `repository` retargeted at `day8/re-frame2/tree/main/skills/re-frame-pair-improver2` with `repository.directory` set.
  - `README.md` sibling reference to `re-frame-pair2` retargeted at the new monorepo path; standalone-clone install instructions rewritten to clone re-frame2 and symlink the subdir.
  - `.claude-plugin/plugin.json` had no remote URLs to update.

## Top-level

- `skills/README.md` (new) — explains the directory's role, lists current skills with one-line descriptions, documents the per-skill layout convention, and notes that release coordination has shifted off the standalone-repo CI.
- `.gitignore` — added `skills/*/node_modules/`, `skills/*/.shadow-cljs/`, `skills/*/out/`, `skills/*/target/`.

## Standalone repos

Per Mike's instruction: leaving the source dirs (`C:/Users/miket/code/re-frame-pair2/`, `C:/Users/miket/code/re-frame-pair-improver2/`) and the GitHub repo `day8/re-frame-pair2` in place. Mike will delete them later when satisfied with the consolidated layout. The standalone `day8/re-frame-pair2` no longer accepts new work — but it still exists as the historical record of pre-consolidation activity (including the parser-fix PR that was merged here just before the copy).

## Verification

- No nested `.git` directories under `skills/`: `find skills -name '.git' -type d` returns empty.
- JVM test suite still passes: `cd implementation/core && clojure -M:test` -> `Ran 182 tests containing 822 assertions. 0 failures, 0 errors.`
- CLJS test suite (`cd implementation && npm run test:cljs`) was not run in this PR — change set is purely additive under `skills/`, no implementation/ files were touched.

## Follow-ups

- The `Install` sections in both READMEs still mention `npx skills add day8/<skill>` and `/plugin install <skill>@day8` — those external distribution paths assumed the standalone GitHub repos. When release coordination is wired into re-frame2's pipeline, those install commands need to be updated (or removed). Out of scope for this consolidation PR — Mike to decide release strategy.

## Test plan

- [x] `find skills -name '.git' -type d` returns empty
- [x] `clojure -M:test` from `implementation/core` passes
- [ ] Smoke-load `skills/re-frame-pair2/SKILL.md` from a fresh Claude Code session against a re-frame2 fixture app (manual; deferred until first standalone-repo deletion to confirm layout works)
- [ ] Confirm `skills/README.md` renders correctly on GitHub once merged