### PR TITLE
fix(scripts): browser-test harness resilient to occupied port 8021 (rf2-nuv7)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -165,6 +165,11 @@ Exits 0 on green, 1 on red. Use this when verifying anything that
 depends on a real DOM, real browser timing, or React's DOM-rendering
 pipeline.
 
+If port 8021 is already in use (e.g. another local repo's dev server),
+the harness logs a warning and falls back to a free OS-chosen port.
+Set `BROWSER_TEST_PORT` to pin a specific port (CI determinism); the
+harness still falls back if that port is busy too.
+
 ## What's not in scope
 
 - The migration agent (re-frame v1 → v2). That's a separate

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Orchestrator: spawn http-server over out/browser-test on port 8021,
+ * Orchestrator: spawn http-server over out/browser-test on a port,
  * wait for it to be reachable, then run the Playwright runner.
  * Always tear the server down (success or failure).
  *
@@ -8,14 +8,28 @@
  * `http-server ... & sleep 2 && node ...`. That works on POSIX but not
  * on Windows, and `sleep 2` is a brittle race. This script is the same
  * idea but cross-platform and with a real readiness probe.
+ *
+ * Port selection (rf2-nuv7):
+ *   1. If $BROWSER_TEST_PORT is set, try that port. If it's busy, fall
+ *      back to a free port chosen by the OS.
+ *   2. If unset, default to 8021 (historical behaviour). If 8021 is
+ *      busy, fall back to a free port chosen by the OS.
+ *   3. Either way, log clearly which port was used and thread it
+ *      through to the Playwright runner via $BROWSER_TEST_URL.
+ *
+ * Early-exit detection: listen for the http-server child's `'exit'`
+ * event during the readiness window. If it dies before becoming
+ * reachable (typically EADDRINUSE), fail fast with a direct message
+ * instead of waiting out the full readiness timeout.
  */
 
 const { spawn } = require('child_process');
 const fs = require('fs');
 const http = require('http');
+const net = require('net');
 const path = require('path');
 
-const PORT = 8021;
+const DEFAULT_PORT = 8021;
 const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test');
 const INDEX = path.join(ROOT, 'index.html');
 const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
@@ -42,6 +56,65 @@ function ensureMountPoint() {
   }
 }
 
+// True if the given TCP port is currently free on 127.0.0.1.
+// We bind a temporary listener and immediately release it. EADDRINUSE
+// on the bind attempt means it's busy; any other error is treated as
+// "not free" so we fall back to OS-chosen port.
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.once('listening', () => {
+      srv.close(() => resolve(true));
+    });
+    srv.listen(port, '127.0.0.1');
+  });
+}
+
+// Ask the OS for a free port (listen on 0, capture, close).
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Resolve the port to use, honouring $BROWSER_TEST_PORT first, then
+// the historical default 8021, then a free OS-chosen port.
+async function resolvePort() {
+  const envRaw = process.env.BROWSER_TEST_PORT;
+  if (envRaw && envRaw.trim() !== '') {
+    const parsed = parseInt(envRaw, 10);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
+      console.error(
+        `BROWSER_TEST_PORT="${envRaw}" is not a valid TCP port; ignoring and choosing a free port.`
+      );
+      return await findFreePort();
+    }
+    if (await isPortFree(parsed)) {
+      return parsed;
+    }
+    const fallback = await findFreePort();
+    console.warn(
+      `BROWSER_TEST_PORT=${parsed} is busy; falling back to free port ${fallback}.`
+    );
+    return fallback;
+  }
+  if (await isPortFree(DEFAULT_PORT)) {
+    return DEFAULT_PORT;
+  }
+  const fallback = await findFreePort();
+  console.warn(
+    `Default port ${DEFAULT_PORT} is busy; falling back to free port ${fallback}. ` +
+      `Set BROWSER_TEST_PORT to pin a specific port.`
+  );
+  return fallback;
+}
+
 function probe(port) {
   return new Promise((resolve) => {
     const req = http.get({ host: '127.0.0.1', port, path: '/', timeout: 1000 }, (res) => {
@@ -56,9 +129,15 @@ function probe(port) {
   });
 }
 
-async function waitForReady(port, deadline) {
+// Race-style readiness wait: resolves true on first successful probe,
+// false on timeout, false-with-cause on early child exit. The caller
+// distinguishes between timeout and early-exit via the supplied
+// state object.
+async function waitForReady(port, deadline, state) {
   while (Date.now() < deadline) {
+    if (state.exited) return false;
     if (await probe(port)) return true;
+    if (state.exited) return false;
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
   return false;
@@ -66,38 +145,55 @@ async function waitForReady(port, deadline) {
 
 (async () => {
   ensureMountPoint();
+
+  const port = await resolvePort();
+  console.log(`Serving ${ROOT} on http://127.0.0.1:${port}`);
+
   const isWin = process.platform === 'win32';
   // On Windows, npx is a .cmd shim — must go through the shell.
   const httpServerCmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['http-server', ROOT, '-p', String(PORT), '-s', '-c-1'];
+  const args = ['http-server', ROOT, '-p', String(port), '-s', '-c-1'];
   const server = spawn(httpServerCmd, args, {
     stdio: ['ignore', 'inherit', 'inherit'],
     shell: isWin,
   });
 
-  let serverDown = false;
+  // Track the server's lifecycle so the readiness loop can fail fast
+  // if http-server dies before becoming reachable. With pre-binding via
+  // isPortFree() this should be rare, but a slow-to-release socket or a
+  // race against a sibling spawner can still trigger EADDRINUSE.
+  const state = { exited: false, exitCode: null, exitSignal: null };
   server.on('exit', (code, signal) => {
-    serverDown = true;
-    if (code !== 0 && code !== null) {
-      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
-    }
+    state.exited = true;
+    state.exitCode = code;
+    state.exitSignal = signal;
   });
 
-  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
-  if (!ready || serverDown) {
-    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
-    if (!serverDown) server.kill();
+  const ready = await waitForReady(port, Date.now() + READY_TIMEOUT_MS, state);
+  if (!ready) {
+    if (state.exited) {
+      console.error(
+        `http-server exited before becoming reachable on :${port} ` +
+          `(code=${state.exitCode}, signal=${state.exitSignal}). ` +
+          `Likely cause: port already in use or http-server failed to start.`
+      );
+    } else {
+      console.error(
+        `http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`
+      );
+      server.kill();
+    }
     process.exit(1);
   }
 
   const runner = spawn(process.execPath, [RUNNER], {
     stdio: 'inherit',
-    env: { ...process.env, BROWSER_TEST_URL: `http://127.0.0.1:${PORT}` },
+    env: { ...process.env, BROWSER_TEST_URL: `http://127.0.0.1:${port}` },
   });
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  if (!serverDown) {
+  if (!state.exited) {
     server.kill();
   }
   process.exit(code == null ? 1 : code);


### PR DESCRIPTION
## Why

`implementation/scripts/serve-and-run-browser-tests.cjs` hard-coded `const PORT = 8021` and assumed the port was available. When a sibling repo or prior dev server holds 8021, `http-server` exits with `EADDRINUSE` but the harness keeps polling its readiness probe for the full 30s timeout before failing — brittle across concurrent local sessions and slow to diagnose.

Bead: `rf2-nuv7` (P2 BUG).

## What

**Option (a)** from the bead: env var preferred, fallback to free-port discovery.

- Honour `BROWSER_TEST_PORT` env var (for CI determinism — set it to `8021` to pin historical behaviour).
- Pre-bind a probe socket via `net.createServer()` to detect whether the requested port is free; if not, fall back to an OS-chosen port via `listen(0)`. This applies to both the env-var path and the historical `8021` default.
- Listen for the `http-server` child's `'exit'` event during the readiness window; if it dies before becoming reachable, log the exit code/signal and fail fast in `<1s` (typically one poll cycle, ~200ms) instead of waiting out the 30s readiness timeout.
- Thread the resolved port through to `BROWSER_TEST_URL` so `run-browser-tests.cjs` and Playwright need no changes.
- README: document the env var and free-port fallback.

## Behaviour matrix

| scenario                                | outcome                                                |
|-----------------------------------------|--------------------------------------------------------|
| port 8021 free, no env var              | uses 8021 (historical default)                         |
| `BROWSER_TEST_PORT=N`, N free           | uses N                                                 |
| `BROWSER_TEST_PORT=N`, N busy           | warns, falls back to OS-chosen free port               |
| port 8021 busy, no env var              | warns, falls back to OS-chosen free port               |
| `http-server` dies during readiness     | fail-fast with code/signal logged, ~1 poll cycle (<1s) |
| `BROWSER_TEST_PORT="not-a-port"`        | warns, falls back to OS-chosen free port               |

## Before vs after

**Before**: port 8021 busy → `http-server` exits immediately with EADDRINUSE, harness polls for 30s, then prints `did not become reachable on :8021 within 30000ms`.

**After**: port 8021 busy → `isPortFree(8021)` returns false up front, harness logs `Default port 8021 is busy; falling back to free port <N>` and the test run proceeds on `<N>`. If a child still races into EADDRINUSE somehow (slow socket release), the readiness loop sees the `'exit'` event and reports `http-server exited before becoming reachable on :<port> (code=1, signal=null). Likely cause: port already in use or http-server failed to start.` in well under 1s.

## Test plan

Standalone harness scripts exercised the four port-resolution scenarios + early-exit detection (results below). All four pass; early-exit detection fired in 219ms (well under the 1s target).

```
Scenario 1 OK: free default -> 8021
Scenario 2 OK: env=51993 -> 51993
Scenario 3 OK: env=51994 (busy) -> fallback 51995
Scenario 4 OK: invalid env -> free 51996
OK: detected early-exit in 219ms
```

- [x] Lints / no JS errors (`node -c` clean).
- [x] Default 8021 path unchanged when port is free.
- [x] `BROWSER_TEST_PORT` honoured when set + free.
- [x] Free-port fallback when env-var port busy.
- [x] Free-port fallback when default 8021 busy.
- [x] Invalid env-var value rejected with warning + fallback.
- [x] Early-exit detection fires <1s on simulated EADDRINUSE.
- [ ] Full `npm run test:browser` end-to-end on green test tree (operator verification).

## Scope

- `implementation/scripts/serve-and-run-browser-tests.cjs` only.
- `implementation/README.md` doc update.
- No change to Playwright config, `run-browser-tests.cjs`, or `npm run test:browser` invocation shape.