### PR TITLE
fix(skills/re-frame-pair2): app-db/reset uses canonical rf/reset-frame-db! surface (rf2-mzn7)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -103,7 +103,7 @@ Each op below is a short `scripts/eval-cljs.sh` invocation wrapping a call into 
 | `dispatch` | `scripts/dispatch.sh '[:cart/apply-coupon "SPRING25"]'` | Queued by default; `--sync` forces `dispatch-sync`. Skill-issued dispatches carry `:origin :pair` (Spec 002 §Dispatch origin tagging) so `:event/dispatched` traces can be filtered by who fired them. |
 | `dispatch --frame` | `scripts/dispatch.sh '[:foo]' --frame :stories` | Targets a specific frame via the `:frame` opt on `rf/dispatch`. |
 | `reg-event` / `reg-sub` / `reg-fx` | `scripts/eval-cljs.sh '<full reg-* form>'` | Re-registration replaces; emits `:rf.registry/handler-replaced` trace (Spec 001 §Hot-reload semantics). Ephemeral. |
-| `app-db/reset` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-reset! ...)'` | Logged explicitly via `tap>` so the user sees what the agent changed. Use sparingly. |
+| `app-db/reset` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-reset! ...)'` | Delegates to `rf/reset-frame-db!` (Tool-Pair §Pair-tool writes, rf2-zq55) — replaces app-db, records a synthetic `:rf.epoch/db-replaced` epoch, validates against schema, refuses during a drain. Logged explicitly via `tap>` so the user sees what the agent changed. Use sparingly. |
 | `repl/eval` | `scripts/eval-cljs.sh '<arbitrary form>'` | Escape hatch. Prefer structured ops first. |
 | `fx-overrides/with` | `scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http` | Per-call `:fx-overrides` (Spec 002 §Per-frame and per-call overrides) — redirect a registered fx to a stub for one experiment, restore on completion. |
 

--- a/skills/re-frame-pair2/docs/capabilities.md
+++ b/skills/re-frame-pair2/docs/capabilities.md
@@ -83,7 +83,7 @@ What re-frame-pair2 can see inside a live re-frame2 app.
 
 | Guardrail | Status | Notes |
 |---|---|---|
-| `app-db/reset` is logged via `tap>` | *done* | Previous + next + timestamp are tap'd so the human sees the change |
+| `app-db/reset` is logged via `tap>` | *done* | Previous + next + timestamp are tap'd so the human sees the change. Delegates to `rf/reset-frame-db!` (Tool-Pair §Pair-tool writes, rf2-zq55) so the synthetic `:rf.epoch/db-replaced` record is appended and `restore-epoch` can rewind past the injection. |
 | `repl/eval` treated as full-authority | *guardrail* | SKILL.md instructs Claude to prefer structured ops; the escape hatch is acknowledged |
 | Mutating ops refuse on `:ambiguous-frame` | *done* | Reads proceed against `:rf/default` after warning |
 | Watches and background processes always stop cleanly | *done* | Auto-terminate on disconnect, idle (default 30s), hard-cap (default 5min), or count cap (default 5) |

--- a/skills/re-frame-pair2/scripts/runtime.cljs
+++ b/skills/re-frame-pair2/scripts/runtime.cljs
@@ -119,9 +119,22 @@
   "Replace the operating frame's app-db with v. Logged explicitly via
    `tap>` so the human sees what the agent changed.
 
-   This bypasses the dispatch loop (no event, no cascade, no recorded
-   epoch). Use sparingly — prefer `dispatch` for any change you want
-   the data loop to see."
+   Delegates to the canonical Tool-Pair write surface
+   `(rf/reset-frame-db! frame-id v)` (Tool-Pair §Pair-tool writes,
+   rf2-zq55). That surface bypasses the dispatch loop (no event, no
+   cascade) but DOES record a synthetic `:rf/epoch-record` with
+   `:event-id :rf.epoch/db-replaced` so that `restore-epoch` can
+   rewind past the injection. Use sparingly — prefer `dispatch` for
+   any change you want the data loop to see.
+
+   Returns `{:ok? true :frame frame-id}` on success.
+
+   Failure modes (each is a no-op on app-db; corresponding
+   `:rf.epoch/*` or `:rf.error/*` trace fires per Spec 009):
+     :no-such-frame                — frame not registered
+     :reset-frame-db-during-drain  — drain in flight
+     :schema-mismatch              — v fails the frame's app-schema
+     :epoch-artefact-missing       — re-frame-2-epoch artefact not loaded"
   ([v] (app-db-reset! v (current-frame)))
   ([v frame-id]
    (tap> {:re-frame-pair2/op :app-db/reset
@@ -129,13 +142,27 @@
           :previous           (rf/get-frame-db frame-id)
           :next               v
           :t                  (js/Date.now)})
-   ;; Reach through the Tool-Pair-pinned container surface. We read the
-   ;; container ref via the registry-query API (frame/get-frame-db
-   ;; returns the container in re-frame2; the deref is the value, the
-   ;; container itself is what gets reset!).
-   (when-let [container (some-> (rf/handler-meta :frame frame-id) :app-db)]
-     (reset! container v))
-   {:ok? true :frame frame-id}))
+   (try
+     (if (rf/reset-frame-db! frame-id v)
+       {:ok? true :frame frame-id}
+       ;; reset-frame-db! returns false on the soft-failure modes
+       ;; (unknown frame, in-drain, schema-mismatch). The structured
+       ;; reason is in the trace stream (`:rf.error/no-such-handler`,
+       ;; `:rf.epoch/reset-frame-db-during-drain`,
+       ;; `:rf.epoch/reset-frame-db-schema-mismatch`); we surface a
+       ;; `:reset-rejected` umbrella so callers know the call did
+       ;; not land without having to interpret the trace.
+       {:ok?    false
+        :frame  frame-id
+        :reason :reset-rejected
+        :hint   "rf/reset-frame-db! returned false. Inspect (rf/trace-buffer {:op-type :error}) and {:op-type :rf.epoch} for the structured reason — :rf.error/no-such-handler, :rf.epoch/reset-frame-db-during-drain, or :rf.epoch/reset-frame-db-schema-mismatch."})
+     (catch :default e
+       (let [{:keys [reason] :as data} (ex-data e)]
+         {:ok?     false
+          :frame   frame-id
+          :reason  (or reason :reset-throw)
+          :message (.-message e)
+          :data    data})))))
 
 (defn schemas
   "All registered app-schemas for the operating frame.

--- a/skills/re-frame-pair2/tests/runtime/app_db_reset_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/app_db_reset_test.clj
@@ -1,0 +1,215 @@
+;;;; tests/runtime/app_db_reset_test.clj
+;;;;
+;;;; Babashka-runnable structural verification of `app-db-reset!` from
+;;;; `scripts/runtime.cljs`.
+;;;;
+;;;; Why this test exists (rf2-mzn7):
+;;;;
+;;;;   `app-db-reset!` previously reached into `(rf/handler-meta :frame
+;;;;   frame-id)` looking for an `:app-db` key — not the canonical
+;;;;   Tool-Pair write surface — and could plausibly return
+;;;;   `{:ok? true}` without mutating state or appending the synthetic
+;;;;   epoch that `restore-epoch` depends on. The fix delegates to
+;;;;   `rf/reset-frame-db!` (Tool-Pair §Pair-tool writes, rf2-zq55).
+;;;;
+;;;; Why a structural test rather than a runtime test:
+;;;;
+;;;;   `scripts/runtime.cljs` is CLJS-only — injected into the browser
+;;;;   app over nREPL — so it can't run under bb. The semantic contract
+;;;;   of `rf/reset-frame-db!` (mutates app-db, appends a synthetic
+;;;;   `:rf.epoch/db-replaced` epoch, schema-validates, drain-checks,
+;;;;   emits trace, fires listeners) is already covered by the JVM
+;;;;   tests at
+;;;;   implementation/epoch/test/re_frame/epoch_test.clj
+;;;;     reset-frame-db!-replaces-container
+;;;;     reset-frame-db!-records-undo-epoch         (also covers the
+;;;;       restore-epoch-rewinds-past-injection case)
+;;;;     reset-frame-db!-emits-trace                (`:rf.epoch/db-replaced`)
+;;;;     reset-frame-db!-fires-listeners
+;;;;     reset-frame-db!-failure-unknown-frame
+;;;;     reset-frame-db!-failure-during-drain
+;;;;     reset-frame-db!-failure-schema-mismatch
+;;;;
+;;;;   What we MUST verify here is that pair2's `app-db-reset!` actually
+;;;;   delegates to that surface — not to some other API that won't
+;;;;   record the epoch. This file parses `scripts/runtime.cljs`,
+;;;;   locates the `app-db-reset!` defn form, and asserts the structural
+;;;;   contract:
+;;;;
+;;;;     1. The body invokes `rf/reset-frame-db!` (the canonical
+;;;;        Tool-Pair write surface — guarantees app-db mutation +
+;;;;        synthetic-epoch append per rf2-zq55).
+;;;;     2. The body does NOT reach into `rf/handler-meta` to grab
+;;;;        an `:app-db` key (the bug we just fixed).
+;;;;     3. The success branch returns `{:ok? true ...}`, the
+;;;;        soft-failure branch returns `{:ok? false :reason
+;;;;        :reset-rejected ...}`.
+;;;;     4. The body still tap>s the change so the human sees it
+;;;;        (existing safety guardrail per docs/capabilities.md:86).
+;;;;
+;;;; Run:    bb tests/runtime/app_db_reset_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns app-db-reset-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is run-tests testing]]
+            [clojure.walk :as walk]))
+
+;; ---------------------------------------------------------------------------
+;; Locate runtime.cljs relative to this test file. Test runs from the
+;; skill root, so the path is scripts/runtime.cljs. We try a couple of
+;; likely paths to stay robust to where bb is invoked from.
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-cljs-path
+  (some (fn [p] (when (.exists (io/file p)) p))
+        ["scripts/runtime.cljs"
+         "skills/re-frame-pair2/scripts/runtime.cljs"
+         "../scripts/runtime.cljs"]))
+
+(when-not runtime-cljs-path
+  (binding [*out* *err*]
+    (println "ERROR: cannot locate scripts/runtime.cljs from" (System/getProperty "user.dir")))
+  (System/exit 2))
+
+;; ---------------------------------------------------------------------------
+;; Read & parse all top-level forms. Use a CLJS-tolerant reader: the file
+;; uses `js/Date.now`, `:default`, etc., which Clojure's reader tolerates
+;; as symbols / keywords; we never evaluate the forms.
+;; ---------------------------------------------------------------------------
+
+(defn- read-all-forms [^String src]
+  (let [pbr (java.io.PushbackReader.
+             (java.io.StringReader. src))]
+    (loop [acc []]
+      (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+                      (catch Exception _ ::eof))]
+        (if (= ::eof form)
+          acc
+          (recur (conj acc form)))))))
+
+(def ^:private all-forms
+  (read-all-forms (slurp runtime-cljs-path)))
+
+(def ^:private app-db-reset-form
+  (some (fn [form]
+          (when (and (seq? form)
+                     (= 'defn (first form))
+                     (= 'app-db-reset! (second form)))
+            form))
+        all-forms))
+
+;; ---------------------------------------------------------------------------
+;; Tree-walk helpers — answer "does this form contain a sub-form
+;; matching pred?".
+;; ---------------------------------------------------------------------------
+
+(defn- form-contains? [pred form]
+  (let [hit? (atom false)]
+    (walk/postwalk
+     (fn [node]
+       (when (pred node) (reset! hit? true))
+       node)
+     form)
+    @hit?))
+
+(defn- calls? [sym form]
+  (form-contains?
+   (fn [node] (and (seq? node) (= sym (first node))))
+   form))
+
+;; ---------------------------------------------------------------------------
+;; Structural assertions
+;; ---------------------------------------------------------------------------
+
+(deftest app-db-reset-form-is-defined
+  (testing "scripts/runtime.cljs defines app-db-reset!"
+    (is (some? app-db-reset-form)
+        "the defn form is present in the source")))
+
+(deftest delegates-to-canonical-tool-pair-surface
+  (testing "app-db-reset! delegates to rf/reset-frame-db! — the canonical
+            Tool-Pair §Pair-tool writes surface (rf2-zq55) that mutates
+            app-db, appends a synthetic :rf.epoch/db-replaced epoch,
+            schema-validates, and drain-checks"
+    (is (calls? 'rf/reset-frame-db! app-db-reset-form)
+        "(rf/reset-frame-db! frame-id v) appears in the body")))
+
+(deftest does-not-reach-through-handler-meta
+  (testing "app-db-reset! does NOT use the buggy `(rf/handler-meta :frame
+            frame-id) :app-db` path that returned {:ok? true} without
+            mutating state or recording an epoch — that was rf2-mzn7's
+            offending pattern"
+    (is (not (form-contains?
+              (fn [node]
+                (and (seq? node)
+                     (= 'rf/handler-meta (first node))
+                     (some #{:frame} node)))
+              app-db-reset-form))
+        "no `(rf/handler-meta :frame ...)` lookup")
+    (is (not (form-contains?
+              (fn [node]
+                (and (seq? node)
+                     (= 'reset! (first node))
+                     ;; reset! container — the only reset! the previous
+                     ;; impl did was on the frame container ref. Any
+                     ;; reset! at all here would be suspicious.
+                     ))
+              app-db-reset-form))
+        "no `(reset! container ...)` — delegating to rf/reset-frame-db!
+         means the container is replaced inside that surface, not here")))
+
+(deftest preserves-tap-log-guardrail
+  (testing "the human-visible tap> log stays in place per
+            docs/capabilities.md §Safety / guardrails — Previous + next
+            + timestamp tap'd so the human sees what the agent changed"
+    (is (calls? 'tap> app-db-reset-form)
+        "tap> call survives in the body")
+    (is (form-contains?
+         (fn [node] (= :re-frame-pair2/op node))
+         app-db-reset-form)
+        ":re-frame-pair2/op tag in the tap> payload")
+    (is (form-contains?
+         (fn [node] (= :app-db/reset node))
+         app-db-reset-form)
+        ":app-db/reset op id in the tap> payload")))
+
+(deftest success-shape
+  (testing "success branch returns {:ok? true :frame frame-id}"
+    (is (form-contains?
+         (fn [node]
+           (and (map? node)
+                (= true (get node :ok?))
+                (contains? node :frame)))
+         app-db-reset-form)
+        "{:ok? true :frame ...} literal in the body")))
+
+(deftest soft-failure-shape
+  (testing "soft-failure branch surfaces the rejection rather than
+            silently claiming success — {:ok? false :reason :reset-rejected ...}"
+    (is (form-contains?
+         (fn [node]
+           (and (map? node)
+                (= false (get node :ok?))
+                (= :reset-rejected (get node :reason))))
+         app-db-reset-form)
+        "{:ok? false :reason :reset-rejected ...} literal in the body")))
+
+(deftest catches-throw
+  (testing "the :rf.error/epoch-artefact-missing throw from
+            rf/reset-frame-db! (when the day8/re-frame-2-epoch artefact
+            isn't loaded) is caught and surfaced — the caller sees the
+            failure rather than a stack trace"
+    (is (calls? 'try app-db-reset-form)
+        "(try ...) wraps the delegating call")
+    (is (form-contains?
+         (fn [node] (and (seq? node) (= 'catch (first node))))
+         app-db-reset-form)
+        "(catch ...) clause is present")))
+
+;; ---------------------------------------------------------------------------
+;; Run.
+;; ---------------------------------------------------------------------------
+
+(let [{:keys [fail error]} (run-tests 'app-db-reset-test)]
+  (System/exit (if (and (zero? fail) (zero? error)) 0 1)))


### PR DESCRIPTION
## Summary

Fixes rf2-mzn7. `re-frame-pair2`'s `app-db-reset!` reached into `(rf/handler-meta :frame frame-id)` looking for an `:app-db` key — that's not the canonical Tool-Pair write surface. Per rf2-zq55 (PR #170), `(rf/reset-frame-db! frame-id new-db)` is the canonical surface: it drain-checks, schema-validates, replaces the container, records a synthetic `:rf/epoch-record` with `:event-id :rf.epoch/db-replaced`, emits the matching trace, and fans the assembled record out to `register-epoch-cb` listeners.

The previous implementation could plausibly return `{:ok? true}` without ever mutating state or recording the synthetic epoch — meaning a subsequent `restore-epoch` would silently fail to rewind past the (non-existent) injection.

## The offending lines

`skills/re-frame-pair2/scripts/runtime.cljs:118-138` (before):

```clojure
(defn app-db-reset!
  ([v] (app-db-reset! v (current-frame)))
  ([v frame-id]
   (tap> {:re-frame-pair2/op :app-db/reset
          :frame              frame-id
          :previous           (rf/get-frame-db frame-id)
          :next               v
          :t                  (js/Date.now)})
   ;; Reach through the Tool-Pair-pinned container surface. We read the
   ;; container ref via the registry-query API (frame/get-frame-db
   ;; returns the container in re-frame2; the deref is the value, the
   ;; container itself is what gets reset!).
   (when-let [container (some-> (rf/handler-meta :frame frame-id) :app-db)]
     (reset! container v))
   {:ok? true :frame frame-id}))
```

`(rf/handler-meta :frame frame-id)` returns config/lifecycle metadata, not a frame container — there is no `:app-db` key on that map, so the `when-let` clause is a no-op and the function silently returns `{:ok? true}` while `app-db` stays unchanged.

## The new body

```clojure
(defn app-db-reset!
  ([v] (app-db-reset! v (current-frame)))
  ([v frame-id]
   (tap> {:re-frame-pair2/op :app-db/reset
          :frame              frame-id
          :previous           (rf/get-frame-db frame-id)
          :next               v
          :t                  (js/Date.now)})
   (try
     (if (rf/reset-frame-db! frame-id v)
       {:ok? true :frame frame-id}
       {:ok?    false
        :frame  frame-id
        :reason :reset-rejected
        :hint   "rf/reset-frame-db! returned false. Inspect (rf/trace-buffer {:op-type :error}) and {:op-type :rf.epoch} for the structured reason — :rf.error/no-such-handler, :rf.epoch/reset-frame-db-during-drain, or :rf.epoch/reset-frame-db-schema-mismatch."})
     (catch :default e
       (let [{:keys [reason] :as data} (ex-data e)]
         {:ok?     false
          :frame   frame-id
          :reason  (or reason :reset-throw)
          :message (.-message e)
          :data    data})))))
```

Soft failures (unknown frame, in-drain, schema-mismatch) come back as `{:ok? false :reason :reset-rejected ...}` with a hint pointing at the structured trace; the `:rf.error/epoch-artefact-missing` ExceptionInfo is caught and surfaced as `{:ok? false :reason :epoch-artefact-missing ...}`. The `tap>` guardrail (previous + next + timestamp) is preserved.

## Documentation updates

- `skills/re-frame-pair2/SKILL.md:106` — describes the new contract.
- `skills/re-frame-pair2/docs/capabilities.md:86` — same, plus the rf2-zq55 reference.

## Test plan

`scripts/runtime.cljs` is CLJS-only (injected over nREPL), so it can't run under bb. The semantic contract of `rf/reset-frame-db!` itself — mutates app-db, appends a synthetic `:rf.epoch/db-replaced` epoch, drain-checks, schema-validates, emits trace, fires listeners, restore-epoch rewinds past the injection — is exhaustively covered by the JVM tests at `implementation/epoch/test/re_frame/epoch_test.clj` (`reset-frame-db!-*` family).

What pair2 needs to verify on its own side is that `app-db-reset!` actually *delegates* to that surface. The new bb test `tests/runtime/app_db_reset_test.clj` parses `scripts/runtime.cljs`, locates the defn form, and asserts:

- the body invokes `rf/reset-frame-db!` (the canonical write surface)
- the body does NOT use the buggy `(rf/handler-meta :frame _) :app-db` pattern
- success returns `{:ok? true ...}`, soft-failure returns `{:ok? false :reason :reset-rejected ...}` — never silently claims success
- the human-visible `tap>` log is preserved
- the missing-artefact throw is caught and surfaced

Test results:

```
$ bb tests/runtime/app_db_reset_test.clj
Testing app-db-reset-test
Ran 7 tests containing 11 assertions.
0 failures, 0 errors.

$ bb tests/runtime/parse_rf2_coord_test.clj
Testing parse-rf2-coord-test
Ran 12 tests containing 21 assertions.
0 failures, 0 errors.
```

## Refs

- rf2-mzn7 (this bead)
- rf2-zq55 / PR #170 — `rf/reset-frame-db!` surface
- Tool-Pair §Pair-tool writes
- Spec 009 §Listener ordering