### PR TITLE
fix(skills/re-frame-pair2): tighten multi-frame operating-frame semantics (rf2-19xl)

### DIFF
--- a/skills/re-frame-pair2/scripts/runtime.cljs
+++ b/skills/re-frame-pair2/scripts/runtime.cljs
@@ -68,16 +68,22 @@
 
 (defn current-frame
   "Resolve the operating frame: explicit override -> session pin ->
-   :rf/default if it's the only registered frame -> nil (ambiguous)."
+   the sole registered frame -> nil (ambiguous).
+
+   Returns nil whenever more than one frame is registered AND the
+   session hasn't selected one (and the caller didn't pass an override).
+   Mutating ops then refuse via the `:ambiguous-frame` path in
+   `pair-dispatch-sync!`. Reads that nil-default to `:rf/default` would
+   silently land in the wrong frame, so the resolver is deliberately
+   conservative — callers either pin via `select-frame!`, pass an
+   explicit override, or get a clear refusal."
   ([] (current-frame nil))
   ([override]
    (or override
        @selected-frame
        (let [fids (rf/frame-ids)]
-         (cond
-           (= 1 (count fids)) (first fids)
-           (contains? fids :rf/default) :rf/default
-           :else nil)))))
+         (when (= 1 (count fids))
+           (first fids))))))
 
 (defn frames-list
   "All registered, non-destroyed frame ids plus the operating frame."
@@ -192,14 +198,29 @@
    (rf/sub-cache frame-id)))
 
 (defn subs-sample
-  "Subscribe to query-v and deref once. Goes through `rf/subscribe` so
-   the cache lifecycle is the standard one — fine for one-shot probes,
-   not for repeated polling outside a reactive context."
-  [query-v]
-  (try
-    @(rf/subscribe query-v)
-    (catch :default e
-      {:ok? false :reason :sub-error :message (.-message e)})))
+  "Subscribe to query-v in the operating frame and deref once. Goes
+   through `rf/subscribe` so the cache lifecycle is the standard one —
+   fine for one-shot probes, not for repeated polling outside a
+   reactive context.
+
+   Threads the resolved operating frame through `(rf/subscribe
+   frame-id query-v)` so a prior `select-frame!` (or an explicit
+   `frame-id` arg) actually steers the read. Returns
+   `{:ok? false :reason :ambiguous-frame}` if no frame can be
+   resolved — read ops shouldn't silently fall back to `:rf/default`
+   in a multi-frame session."
+  ([query-v] (subs-sample query-v (current-frame)))
+  ([query-v frame-id]
+   (cond
+     (nil? frame-id)
+     {:ok? false :reason :ambiguous-frame
+      :hint "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}
+
+     :else
+     (try
+       @(rf/subscribe frame-id query-v)
+       (catch :default e
+         {:ok? false :reason :sub-error :message (.-message e) :frame frame-id})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Machines (Spec 005)

--- a/skills/re-frame-pair2/tests/runtime/multi_frame_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/multi_frame_test.clj
@@ -1,0 +1,299 @@
+;;;; tests/runtime/multi_frame_test.clj
+;;;;
+;;;; Babashka-runnable verification of the multi-frame operating-frame
+;;;; semantics in `scripts/runtime.cljs` — `current-frame` ambiguity
+;;;; resolution, the `:ambiguous-frame` refusal path used by
+;;;; `pair-dispatch-sync!`, and `subs-sample` frame-threading.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `scripts/runtime.cljs` is a CLJS-only file injected into the
+;;;;   browser app over nREPL. It depends on the live re-frame2 frame
+;;;;   registry (`re-frame.core/frame-ids`, `register-epoch-cb`, ...)
+;;;;   so it can't run under bb directly. The real shadow-cljs test
+;;;;   build (planned per `docs/TESTING.md` §1) will exercise the
+;;;;   `.cljs` source in place under Node — that's the canonical home
+;;;;   for these tests once the build is wired up.
+;;;;
+;;;;   Until then, this file mirrors the resolver, the subscribe
+;;;;   threading, and the dispatch-sync refusal path with stub frame
+;;;;   APIs and asserts behaviour against the contracts at
+;;;;   `SKILL.md:76`, `docs/initial-spec.md:205`, and
+;;;;   `docs/capabilities.md:88`. KEEP IN SYNC WITH scripts/runtime.cljs.
+;;;;
+;;;; Run:    bb tests/runtime/multi_frame_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns multi-frame-test
+  (:require [clojure.test :refer [deftest is run-tests testing use-fixtures]]))
+
+;; ---------------------------------------------------------------------------
+;; Stub frame registry — stands in for `re-frame.core/frame-ids` and
+;; `re-frame.core/subscribe`. The CLJS runtime calls these directly;
+;; under bb we model their observable shape so the resolver and the
+;; refusal path can be exercised end-to-end.
+;; ---------------------------------------------------------------------------
+
+(def frame-registry
+  "Mutable set of registered frame-ids. The CLJS runtime reads this
+   via `(rf/frame-ids)` — set semantics, no order contract."
+  (atom #{}))
+
+(def frame-dbs
+  "frame-id -> atom holding the frame's app-db. Stand-in for the real
+   container behind `rf/get-frame-db` and the targets of `rf/subscribe`."
+  (atom {}))
+
+(defn register-frame!
+  ([frame-id] (register-frame! frame-id {}))
+  ([frame-id initial-db]
+   (swap! frame-registry conj frame-id)
+   (swap! frame-dbs assoc frame-id (atom initial-db))
+   frame-id))
+
+(defn unregister-frame! [frame-id]
+  (swap! frame-registry disj frame-id)
+  (swap! frame-dbs dissoc frame-id))
+
+(defn frame-ids [] @frame-registry)
+
+(defn get-frame-db [frame-id]
+  (some-> (get @frame-dbs frame-id) deref))
+
+(defn subscribe
+  "Mirrors `re-frame.core/subscribe`'s 2-arity form `(subscribe
+   frame-id query-v)`. The CLJS runtime calls this in `subs-sample`.
+   Returns a deref-able stand-in (an atom whose value derives from
+   the frame-db) so `@(subscribe frame-id query-v)` works."
+  [frame-id query-v]
+  (let [container (get @frame-dbs frame-id)]
+    (when container
+      ;; Project the query against the frame-db. For the test we
+      ;; treat query-v as a path into the db.
+      (atom (get-in @container query-v)))))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of scripts/runtime.cljs `selected-frame`, `select-frame!`,
+;; and `current-frame`.
+;;
+;; KEEP IN SYNC WITH scripts/runtime.cljs lines 60-86. Logic must be
+;; identical to the CLJS version: explicit override -> session pin ->
+;; sole registered frame -> nil (ambiguous).
+;; ---------------------------------------------------------------------------
+
+(def selected-frame (atom nil))
+
+(defn select-frame! [frame-id]
+  (reset! selected-frame frame-id)
+  {:ok? true :frame frame-id})
+
+(defn current-frame
+  ([] (current-frame nil))
+  ([override]
+   (or override
+       @selected-frame
+       (let [fids (frame-ids)]
+         (when (= 1 (count fids))
+           (first fids))))))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of `subs-sample` — threads the resolved frame through
+;; `subscribe` and refuses on :ambiguous-frame.
+;;
+;; KEEP IN SYNC WITH scripts/runtime.cljs lines 194-218.
+;; ---------------------------------------------------------------------------
+
+(defn subs-sample
+  ([query-v] (subs-sample query-v (current-frame)))
+  ([query-v frame-id]
+   (cond
+     (nil? frame-id)
+     {:ok? false :reason :ambiguous-frame
+      :hint "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}
+
+     :else
+     (try
+       @(subscribe frame-id query-v)
+       (catch Throwable e
+         {:ok? false :reason :sub-error :message (.getMessage e) :frame frame-id})))))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of the `pair-dispatch-sync!` refusal path. We don't model the
+;; full dispatch loop — just the entry guard at runtime.cljs:454-456,
+;; which is the contract under test (mutating ops refuse on ambiguous
+;; frame).
+;;
+;; KEEP IN SYNC WITH scripts/runtime.cljs lines 443-479.
+;; ---------------------------------------------------------------------------
+
+(defn pair-dispatch-sync!
+  ([event-v] (pair-dispatch-sync! event-v {}))
+  ([event-v opts]
+   (let [frame-id (or (:frame opts) (current-frame))]
+     (when-not frame-id
+       (throw (ex-info "ambiguous frame" {:reason :ambiguous-frame})))
+     ;; Real impl runs `dispatch-sync` and walks epoch-history; for the
+     ;; test the guard is the contract — return a success shape so the
+     ;; non-ambiguous case still asserts something meaningful.
+     {:ok? true :event event-v :frame frame-id})))
+
+;; ---------------------------------------------------------------------------
+;; Per-test reset. Each test owns its frame-registry state.
+;; ---------------------------------------------------------------------------
+
+(defn reset-state! []
+  (reset! frame-registry #{})
+  (reset! frame-dbs {})
+  (reset! selected-frame nil))
+
+(use-fixtures :each (fn [t] (reset-state!) (t) (reset-state!)))
+
+;; ---------------------------------------------------------------------------
+;; current-frame resolution
+;; ---------------------------------------------------------------------------
+
+(deftest current-frame-no-frames
+  (testing "no frames registered, no selection, no override -> nil"
+    (is (nil? (current-frame)))))
+
+(deftest current-frame-single-frame-default
+  (testing "single :rf/default frame registered -> :rf/default"
+    (register-frame! :rf/default {:counter 0})
+    (is (= :rf/default (current-frame)))))
+
+(deftest current-frame-single-non-default-frame
+  (testing "single non-default frame registered -> that frame"
+    (register-frame! :stories {})
+    (is (= :stories (current-frame)))))
+
+(deftest current-frame-ambiguous-no-selection
+  (testing "multiple frames registered, no selection -> nil (ambiguous)"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (is (nil? (current-frame))
+        "must NOT silently fall back to :rf/default just because it's registered")))
+
+(deftest current-frame-ambiguous-three-frames
+  (testing "three frames, no selection -> nil"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (register-frame! :sandbox {})
+    (is (nil? (current-frame)))))
+
+(deftest current-frame-session-pin-resolves-ambiguity
+  (testing "select-frame! resolves ambiguity -> selected frame"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (select-frame! :stories)
+    (is (= :stories (current-frame)))))
+
+(deftest current-frame-explicit-override-beats-session-pin
+  (testing "explicit override takes precedence over session pin"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (select-frame! :stories)
+    (is (= :rf/default (current-frame :rf/default)))))
+
+(deftest current-frame-explicit-override-with-no-frames-registered
+  (testing "explicit override returns even if frame isn't registered (resolver is naive)"
+    (is (= :ghost (current-frame :ghost)))))
+
+;; ---------------------------------------------------------------------------
+;; pair-dispatch-sync! refuses on :ambiguous-frame
+;; ---------------------------------------------------------------------------
+
+(deftest pair-dispatch-sync-refuses-on-ambiguous-frame
+  (testing "ambiguous multi-frame session: pair-dispatch-sync! raises :ambiguous-frame"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (try
+      (pair-dispatch-sync! [:cart/apply-coupon "SPRING25"])
+      (is false "expected ex-info :ambiguous-frame to be thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :ambiguous-frame (:reason (ex-data e))))))))
+
+(deftest pair-dispatch-sync-succeeds-on-single-frame
+  (testing "single-frame session: pair-dispatch-sync! succeeds against :rf/default"
+    (register-frame! :rf/default {:counter 0})
+    (let [result (pair-dispatch-sync! [:counter/inc])]
+      (is (:ok? result))
+      (is (= :rf/default (:frame result))))))
+
+(deftest pair-dispatch-sync-succeeds-after-select-frame
+  (testing "ambiguous session, then select-frame! -> dispatch lands on selected"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (select-frame! :stories)
+    (let [result (pair-dispatch-sync! [:demo/click])]
+      (is (:ok? result))
+      (is (= :stories (:frame result))))))
+
+(deftest pair-dispatch-sync-explicit-frame-opt-wins
+  (testing "explicit :frame opt routes the dispatch even in ambiguous session"
+    (register-frame! :rf/default {})
+    (register-frame! :stories {})
+    (let [result (pair-dispatch-sync! [:demo/click] {:frame :stories})]
+      (is (:ok? result))
+      (is (= :stories (:frame result))))))
+
+;; ---------------------------------------------------------------------------
+;; subs-sample threads the operating frame
+;; ---------------------------------------------------------------------------
+
+(deftest subs-sample-refuses-on-ambiguous-frame
+  (testing "ambiguous session: subs-sample returns :ambiguous-frame instead of silently reading :rf/default"
+    (register-frame! :rf/default {:counter 99})
+    (register-frame! :stories {:counter 1})
+    (let [result (subs-sample [:counter])]
+      (is (false? (:ok? result)))
+      (is (= :ambiguous-frame (:reason result))))))
+
+(deftest subs-sample-reads-selected-frame
+  (testing "select-frame! steers subs-sample to the chosen frame"
+    (register-frame! :rf/default {:counter 99})
+    (register-frame! :stories {:counter 1})
+    (select-frame! :stories)
+    ;; Stories has :counter 1, default has :counter 99. Reading the
+    ;; right frame is the only way to land on 1.
+    (is (= 1 (subs-sample [:counter]))
+        "subs-sample must read from the selected frame, not :rf/default")))
+
+(deftest subs-sample-explicit-frame-arg
+  (testing "explicit frame-id arg overrides session pin"
+    (register-frame! :rf/default {:counter 99})
+    (register-frame! :stories {:counter 1})
+    (select-frame! :stories)
+    (is (= 99 (subs-sample [:counter] :rf/default)))))
+
+(deftest subs-sample-single-frame-session
+  (testing "single-frame session: subs-sample reads from that frame"
+    (register-frame! :rf/default {:counter 7})
+    (is (= 7 (subs-sample [:counter])))))
+
+;; ---------------------------------------------------------------------------
+;; Cross-cutting — the contract together
+;; ---------------------------------------------------------------------------
+
+(deftest contract-mutating-refuses-reads-thread
+  (testing "ambiguous session: mutating refuses; selecting a frame steers reads"
+    (register-frame! :rf/default {:greeting "hello"})
+    (register-frame! :stories {:greeting "world"})
+    ;; Mutating refuses.
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ambiguous"
+                          (pair-dispatch-sync! [:noop])))
+    ;; Read refuses too (no silent default fallback).
+    (is (= :ambiguous-frame (:reason (subs-sample [:greeting]))))
+    ;; Select a frame; reads now resolve.
+    (select-frame! :stories)
+    (is (= "world" (subs-sample [:greeting])))
+    ;; And mutating succeeds.
+    (let [result (pair-dispatch-sync! [:noop])]
+      (is (:ok? result))
+      (is (= :stories (:frame result))))))
+
+;; ---------------------------------------------------------------------------
+;; Run.
+;; ---------------------------------------------------------------------------
+
+(let [{:keys [fail error]} (run-tests 'multi-frame-test)]
+  (System/exit (if (and (zero? fail) (zero? error)) 0 1)))


### PR DESCRIPTION
## Summary

Closes [rf2-19xl]. Two multi-frame inconsistencies in `skills/re-frame-pair2/scripts/runtime.cljs` let mutating ops silently land in `:rf/default` when the operating frame was actually ambiguous, and let `subs-sample` ignore the session's frame pin entirely. Docs at `SKILL.md:76`, `docs/initial-spec.md:205`, and `docs/capabilities.md:88` all promise mutating ops refuse with `:ambiguous-frame`. The capabilities matrix marks wrong-frame routing as done. Reality: not enforced.

## The bug

### `current-frame` (was runtime.cljs:69-80)

```clojure
(defn current-frame
  "Resolve the operating frame: explicit override -> session pin ->
   :rf/default if it's the only registered frame -> nil (ambiguous)."
  ([] (current-frame nil))
  ([override]
   (or override
       @selected-frame
       (let [fids (rf/frame-ids)]
         (cond
           (= 1 (count fids)) (first fids)
           (contains? fids :rf/default) :rf/default
           :else nil)))))
```

The `(contains? fids :rf/default) :rf/default` clause fired whenever `:rf/default` was registered — including in multi-frame sessions with no explicit/session pick. `pair-dispatch-sync!`'s ambiguity guard at runtime.cljs:454-456 only triggers when `current-frame` returns nil, so mutating ops silently routed to `:rf/default` instead of refusing.

### `subs-sample` (was runtime.cljs:194-200)

```clojure
(defn subs-sample
  "Subscribe to query-v and deref once. Goes through `rf/subscribe` so
   the cache lifecycle is the standard one — fine for one-shot probes,
   not for repeated polling outside a reactive context."
  [query-v]
  (try
    @(rf/subscribe query-v)
    (catch :default e
      {:ok? false :reason :sub-error :message (.-message e)})))
```

No frame threading. A prior `select-frame!` had zero effect on `subs-sample`'s read — the call fell through to `rf/subscribe`'s 1-arity default-resolution path, which has its own (different) frame-resolution semantics.

## The fix

### `current-frame`

```clojure
(defn current-frame
  "Resolve the operating frame: explicit override -> session pin ->
   the sole registered frame -> nil (ambiguous).

   Returns nil whenever more than one frame is registered AND the
   session hasn't selected one (and the caller didn't pass an override).
   Mutating ops then refuse via the `:ambiguous-frame` path in
   `pair-dispatch-sync!`. Reads that nil-default to `:rf/default` would
   silently land in the wrong frame, so the resolver is deliberately
   conservative — callers either pin via `select-frame!`, pass an
   explicit override, or get a clear refusal."
  ([] (current-frame nil))
  ([override]
   (or override
       @selected-frame
       (let [fids (rf/frame-ids)]
         (when (= 1 (count fids))
           (first fids))))))
```

The `:rf/default`-fallback clause is gone. Ambiguous multi-frame sessions return nil so the existing `:ambiguous-frame` guard fires.

### `subs-sample`

```clojure
(defn subs-sample
  "Subscribe to query-v in the operating frame and deref once. ..."
  ([query-v] (subs-sample query-v (current-frame)))
  ([query-v frame-id]
   (cond
     (nil? frame-id)
     {:ok? false :reason :ambiguous-frame
      :hint "Multi-frame session with no selected frame — pass `frame-id` or call `select-frame!` first."}

     :else
     (try
       @(rf/subscribe frame-id query-v)
       (catch :default e
         {:ok? false :reason :sub-error :message (.-message e) :frame frame-id})))))
```

Threads the resolved frame through `(rf/subscribe frame-id query-v)` and refuses on ambiguity instead of silently reading whichever frame the default-resolution lands on.

## Test cases

`tests/runtime/multi_frame_test.clj` — bb-runnable, mirrors the resolver and refusal-guard logic against stub frame APIs (same pattern as `parse_rf2_coord_test.clj` until the shadow-cljs harness lands per docs/TESTING.md §1).

- `current-frame` returns nil with no frames registered, returns the sole frame for single-frame sessions (`:rf/default` and non-default), returns nil for ambiguous multi-frame, resolves via `select-frame!`, and respects explicit override over session pin.
- `pair-dispatch-sync!` raises `:ambiguous-frame` on ambiguous sessions, succeeds against `:rf/default` in single-frame, succeeds on the selected frame after `select-frame!`, and routes via the explicit `:frame` opt.
- `subs-sample` returns `{:ok? false :reason :ambiguous-frame}` in ambiguous sessions; reads steered by `select-frame!` and explicit `frame-id` land on the correct frame's app-db; single-frame sessions read normally.
- Combined contract: ambiguous -> both reads and writes refuse; `select-frame!` -> both resolve.

17 tests, 25 assertions, all passing under `bb tests/runtime/multi_frame_test.clj`.

## Test plan

- [x] `bb tests/runtime/multi_frame_test.clj` passes (17 tests, 25 assertions, 0 failures, 0 errors)
- [x] `bb tests/runtime/parse_rf2_coord_test.clj` still passes (no regressions in adjacent tests)
- [ ] CLJS-side runtime exercise once the shadow-cljs harness ships (docs/TESTING.md §1) — for now the bb mirror is the contract gate.