### PR TITLE
fix(skills/re-frame-pair2): align watch-op modes + predicate docs with implementation (rf2-gy3n)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -153,7 +153,7 @@ Each op below is a short `scripts/eval-cljs.sh` invocation wrapping a call into 
 | `watch/stream` | `scripts/watch-epochs.sh --stream --event-id-prefix :cart/` | Streams until disconnect, idle-timeout, or `watch/stop` |
 | `watch/stop` | `scripts/watch-epochs.sh --stop` | Terminates any active watch for this session |
 
-Predicates (any combination): `--event-id`, `--event-id-prefix`, `--effects`, `--timing-ms '>100'`, `--touches-path`, `--sub-ran`, `--render`, `--origin :pair|:app|:ui|:timer|:http`, `--frame :foo`, `--custom` (arbitrary CLJS predicate form).
+Predicates (any combination): `--event-id`, `--event-id-prefix`, `--effects`, `--timing-ms '>100'`, `--touches-path`, `--sub-ran`, `--render`, `--origin :pair|:app|:ui|:timer|:http`, `--frame :foo`.
 
 Mode rules:
 
@@ -307,7 +307,7 @@ When the user mentions a state machine (Spec 005), chain:
 1. `machines/list` — confirm it's registered.
 2. `machines/describe :auth` — return the spec map (`:initial`, `:states`, `:guards`, `:actions`, source coords).
 3. `machines/state :auth` — current snapshot, including `:rf/snapshot-version`.
-4. To watch transitions live: `watch/stream --custom '(fn [e] (some #(= :rf.machine/transition (:operation %)) (:trace-events e)))'`.
+4. To watch transitions live: `watch/stream` and inspect each emitted epoch's `:trace-events` for `:rf.machine/transition` entries — `(some #(= :rf.machine/transition (:operation %)) (:trace-events e))`. Arbitrary-predicate filtering at the watch layer is not currently supported; combine `--event-id-prefix` (to narrow by trigger) with caller-side filtering of the streamed epochs.
 5. Subscribe to the canonical machine sub: `subs/sample [:rf/machine :auth]`.
 
 ### "Dead code scan"

--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -155,6 +155,10 @@ Each op below is a short `scripts/eval-cljs.sh` invocation wrapping a call into 
 
 Predicates (any combination): `--event-id`, `--event-id-prefix`, `--effects`, `--timing-ms '>100'`, `--touches-path`, `--sub-ran`, `--render`, `--origin :pair|:app|:ui|:timer|:http`, `--frame :foo`, `--custom` (arbitrary CLJS predicate form).
 
+Mode rules:
+
+- `--window-ms` and `--count` are independent. `--window-ms` alone runs for N ms with no count limit; `--count` alone runs until N matches with no window timeout. If both are set, the first condition to fire wins. With neither flag (and no `--stream`), the default is a 30 s window.
+
 The watch transport polls the assembled-epoch stream by tracking the last seen `:epoch-id` in the operating frame's history and asking for everything since. See `docs/initial-spec.md` §4.4.
 
 ### Hot-reload coordination

--- a/skills/re-frame-pair2/scripts/ops.clj
+++ b/skills/re-frame-pair2/scripts/ops.clj
@@ -441,15 +441,22 @@
       (= a "--origin")          (recur (rest more) (assoc pred :origin (->kw (first more))))
       (= a "--frame")           (recur (rest more) (assoc pred :frame (->kw (first more))))
 
+      ;; rf2-gy3n: --custom (arbitrary CLJS predicate form) was advertised
+      ;; in earlier docs but never implemented. Implementing it requires
+      ;; designing the predicate-fn surface (security implications: the
+      ;; transport would eval untrusted CLJS), so it is removed from the
+      ;; documented surface for now. The flag is rejected with an
+      ;; explanatory error rather than silently skipped, so any stale
+      ;; caller surfaces clearly.
       (= a "--custom")
       (do
         (emit {:ok? false
-               :reason :not-yet-supported
+               :reason :unsupported-flag
                :flag :--custom
-               :hint (str "Arbitrary CLJS predicate filters are reserved "
-                          "but not yet implemented. Use --event-id-prefix, "
+               :hint (str "--custom (arbitrary CLJS predicate form) is "
+                          "not supported. Use --event-id, --event-id-prefix, "
                           "--effects, --touches-path, --sub-ran, --render, "
-                          "--origin, or --frame instead.")})
+                          "--origin, or --frame.")})
         (System/exit 1))
 
       :else                     (recur more pred))))

--- a/skills/re-frame-pair2/scripts/ops.clj
+++ b/skills/re-frame-pair2/scripts/ops.clj
@@ -461,17 +461,29 @@
 
 (defn- watch-op [args]
   (ensure-port!)
-  (let [build-id   (build-id-from-args args)
-        stream?    (has-flag? args "--stream")
-        stop?      (has-flag? args "--stop")
-        window-ms  (Long/parseLong (flag-value args "--window-ms" "30000"))
-        count-n    (Long/parseLong (flag-value args "--count" "5"))
-        frame      (frame-from-args args)
-        pred       (parse-predicate-args args)
-        idle-ms    (Long/parseLong (flag-value args "--idle-ms" "30000"))
-        hard-ms    (Long/parseLong (flag-value args "--hard-ms" "300000"))
-        poll-ms    (Long/parseLong (flag-value args "--poll-ms" "100"))
-        frame-arg  (if frame (str " " (pr-str frame)) "")]
+  (let [build-id     (build-id-from-args args)
+        stream?      (has-flag? args "--stream")
+        stop?        (has-flag? args "--stop")
+        ;; rf2-gy3n: --window-ms and --count are independent modes.
+        ;;   --window-ms alone: run for N ms, no count limit.
+        ;;   --count alone:     run until N matches, no window timeout.
+        ;;   both set:          first to fire wins (race).
+        ;;   neither set:       default to a 30s window (back-compat).
+        window-raw   (flag-value args "--window-ms" nil)
+        count-raw    (flag-value args "--count" nil)
+        window-ms    (when window-raw (Long/parseLong window-raw))
+        count-n      (when count-raw  (Long/parseLong count-raw))
+        ;; If neither is set, fall back to the documented 30s window so
+        ;; an argument-less `watch-epochs.sh` still terminates.
+        window-ms    (if (and (nil? window-ms) (nil? count-n) (not stream?))
+                       30000
+                       window-ms)
+        frame        (frame-from-args args)
+        pred         (parse-predicate-args args)
+        idle-ms      (Long/parseLong (flag-value args "--idle-ms" "30000"))
+        hard-ms      (Long/parseLong (flag-value args "--hard-ms" "300000"))
+        poll-ms      (Long/parseLong (flag-value args "--poll-ms" "100"))
+        frame-arg    (if frame (str " " (pr-str frame)) "")]
     (cond
       stop?
       (emit {:ok? true :stopped? true
@@ -491,10 +503,16 @@
                                 elapsed  (- now start)
                                 idle     (- now @last-hit)]
                             (cond
-                              (and (not stream?) (>= elapsed window-ms))     [:done :window]
-                              (and (not stream?) (>= @emitted count-n))      [:done :count]
-                              (>= elapsed hard-ms)                           [:done :hard-cap]
-                              (and stream? (>= idle idle-ms))                [:done :idle]
+                              ;; window-ms is only checked when the user
+                              ;; (or the default fallback) actually set it.
+                              (and (not stream?) window-ms
+                                   (>= elapsed window-ms))                 [:done :window]
+                              ;; count-n is only checked when the user
+                              ;; actually set --count.
+                              (and (not stream?) count-n
+                                   (>= @emitted count-n))                  [:done :count]
+                              (>= elapsed hard-ms)                         [:done :hard-cap]
+                              (and stream? (>= idle idle-ms))              [:done :idle]
                               :else nil)))
               fetch-form (fn [since-id]
                            (format

--- a/skills/re-frame-pair2/scripts/watch-epochs.sh
+++ b/skills/re-frame-pair2/scripts/watch-epochs.sh
@@ -4,9 +4,12 @@
 #
 # Emits one edn line per matching epoch, plus a final {:finished?} summary.
 #
-# Modes:
-#   --window-ms N    Run for N ms, report matches, summarise.
-#   --count N        Run until N matches emitted.
+# Modes (pick one or combine; first to fire wins):
+#   --window-ms N    Run for N ms with no count limit.
+#   --count N        Run until N matches with no window timeout.
+#   --window-ms N --count M
+#                    Race: terminate when N ms elapse OR M matches emit.
+#   (neither flag)   Defaults to a 30 s window.
 #   --stream         Run until disconnect, idle (default 30s), or --hard-ms.
 #   --stop           No-op for pull-mode; simply terminate the running shell.
 #
@@ -20,7 +23,7 @@
 #   --origin :pair|:app|:ui|:timer|:http
 #   --frame  :stories
 #
-# Stopping defaults: idle-ms 30000, hard-ms 300000, count 5.
+# Stopping defaults: idle-ms 30000, hard-ms 300000.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 command -v bb >/dev/null 2>&1 || {

--- a/skills/re-frame-pair2/tests/runtime/watch_op_modes_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/watch_op_modes_test.clj
@@ -1,0 +1,290 @@
+;;;; tests/runtime/watch_op_modes_test.clj
+;;;;
+;;;; Babashka-runnable verification of `watch-op` mode-termination
+;;;; semantics and predicate-flag handling in `scripts/ops.clj`.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `scripts/ops.clj` is a babashka entry point that opens nREPL
+;;;;   sockets, calls `System/exit`, and prints edn to stdout. None of
+;;;;   that is friendly to in-process unit testing. The functions of
+;;;;   interest — the mode-termination cond and the flag-parsing loop —
+;;;;   are pure logic embedded inside `watch-op` / `parse-predicate-args`.
+;;;;
+;;;;   This file mirrors that logic and asserts behaviour against the
+;;;;   contract documented in `SKILL.md` §"Live watch (push-mode)" and
+;;;;   the inline rf2-gy3n notes in `scripts/ops.clj`. Format drift in
+;;;;   the production cond shows up under bb until a richer test
+;;;;   harness lands.
+;;;;
+;;;;   KEEP IN SYNC WITH scripts/ops.clj: the mirror functions and the
+;;;;   real ones must agree on flag set, default fallbacks, and stop
+;;;;   ordering.
+;;;;
+;;;; Run:    bb tests/runtime/watch_op_modes_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns watch-op-modes-test
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of `flag-value` from scripts/ops.clj.
+;; ---------------------------------------------------------------------------
+
+(defn- flag-value [args flag default]
+  (if-let [idx (->> args (keep-indexed (fn [i v] (when (= v flag) i))) first)]
+    (nth args (inc idx) default)
+    default))
+
+(defn- has-flag? [args flag]
+  (boolean (some #(= % flag) args)))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of the mode-resolution prelude inside `watch-op`.
+;;
+;; Returns the resolved {:window-ms :count-n :stream?} after applying
+;; the rf2-gy3n distinct-modes rules.
+;; ---------------------------------------------------------------------------
+
+(defn resolve-modes [args]
+  (let [stream?    (has-flag? args "--stream")
+        window-raw (flag-value args "--window-ms" nil)
+        count-raw  (flag-value args "--count" nil)
+        window-ms  (when window-raw (Long/parseLong window-raw))
+        count-n    (when count-raw  (Long/parseLong count-raw))
+        ;; If neither is set and we're not streaming, fall back to a
+        ;; 30 s window so an argument-less watch still terminates.
+        window-ms  (if (and (nil? window-ms) (nil? count-n) (not stream?))
+                     30000
+                     window-ms)]
+    {:window-ms window-ms
+     :count-n   count-n
+     :stream?   stream?}))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of the `done?` cond inside `watch-op`.
+;;
+;; Returns [:done <reason>] or nil. The contract under test is:
+;;   - window-ms is checked only when set.
+;;   - count-n is checked only when set.
+;;   - hard-ms is always a backstop.
+;;   - stream + idle is a stop only when stream? is true.
+;;   - Order: window > count > hard-cap > idle (matches scripts/ops.clj).
+;; ---------------------------------------------------------------------------
+
+(defn decide-stop
+  [{:keys [window-ms count-n stream?]} elapsed emitted idle hard-ms]
+  (cond
+    (and (not stream?) window-ms (>= elapsed window-ms))  [:done :window]
+    (and (not stream?) count-n   (>= emitted count-n))    [:done :count]
+    (>= elapsed hard-ms)                                  [:done :hard-cap]
+    (and stream? (>= idle (or 30000 idle)))               [:done :idle]
+    :else                                                 nil))
+
+;; The (or 30000 idle) above is a guard rail: in production, idle-ms
+;; defaults to 30000 via flag-value. Tests that exercise the stream
+;; branch pass a concrete idle-ms below.
+
+(defn decide-stop*
+  "Variant that takes idle-ms explicitly so the stream branch is testable."
+  [{:keys [window-ms count-n stream?]} elapsed emitted idle hard-ms idle-ms]
+  (cond
+    (and (not stream?) window-ms (>= elapsed window-ms))  [:done :window]
+    (and (not stream?) count-n   (>= emitted count-n))    [:done :count]
+    (>= elapsed hard-ms)                                  [:done :hard-cap]
+    (and stream? (>= idle idle-ms))                       [:done :idle]
+    :else                                                 nil))
+
+;; ---------------------------------------------------------------------------
+;; Behaviour matrix — rf2-gy3n contract.
+;; ---------------------------------------------------------------------------
+
+(deftest window-ms-alone-no-count-limit
+  (testing "--window-ms 30000 alone: count limit is unbounded"
+    (let [m (resolve-modes ["--window-ms" "30000"])]
+      (is (= 30000 (:window-ms m)))
+      (is (nil?    (:count-n m)))
+      ;; 100 matches accumulated, only 5 s elapsed: must keep running.
+      (is (nil?    (decide-stop m 5000 100 0 300000)))
+      ;; 30 s elapsed: stops on :window regardless of count.
+      (is (= [:done :window] (decide-stop m 30000 100 0 300000)))
+      (is (= [:done :window] (decide-stop m 30001 0   0 300000))))))
+
+(deftest count-alone-no-window-timeout
+  (testing "--count 5 alone: window timeout is unbounded"
+    (let [m (resolve-modes ["--count" "5"])]
+      (is (nil? (:window-ms m)))
+      (is (= 5  (:count-n m)))
+      ;; 5 minutes elapsed, only 4 matches: keep running.
+      (is (nil? (decide-stop m 300001 4 0 600000)))
+      ;; 5 matches: stop on :count.
+      (is (= [:done :count] (decide-stop m 0      5 0 600000)))
+      (is (= [:done :count] (decide-stop m 999999 5 0 (* 60 60 1000))))
+      ;; 6 matches: still :count (>=).
+      (is (= [:done :count] (decide-stop m 0      6 0 600000))))))
+
+(deftest both-flags-race
+  (testing "--window-ms N --count M: first to fire wins"
+    (let [m (resolve-modes ["--window-ms" "10000" "--count" "5"])]
+      (is (= 10000 (:window-ms m)))
+      (is (= 5     (:count-n m)))
+      ;; Window fires first.
+      (is (= [:done :window] (decide-stop m 10000 0 0 300000)))
+      ;; Count fires first.
+      (is (= [:done :count]  (decide-stop m 0     5 0 300000)))
+      ;; Neither fires.
+      (is (nil? (decide-stop m 9999 4 0 300000)))
+      ;; Both fire simultaneously: window wins (cond order).
+      (is (= [:done :window] (decide-stop m 10000 5 0 300000))))))
+
+(deftest neither-flag-defaults-to-30s-window
+  (testing "neither --window-ms nor --count (no --stream): default 30 s window"
+    (let [m (resolve-modes [])]
+      (is (= 30000 (:window-ms m)))
+      (is (nil?    (:count-n m)))
+      (is (false?  (:stream? m)))
+      ;; Stops at 30 s on :window.
+      (is (= [:done :window] (decide-stop m 30000 0 0 300000))))))
+
+(deftest stream-mode-ignores-window-and-count
+  (testing "--stream: window/count limits are ignored, idle/hard backstop"
+    (let [m (resolve-modes ["--stream"])]
+      (is (nil? (:window-ms m)))
+      (is (nil? (:count-n m)))
+      (is (true? (:stream? m)))
+      ;; 5 minutes elapsed, 1000 matches, no idle: keeps running.
+      (is (nil? (decide-stop* m 300000 1000 0 600000 30000)))
+      ;; 30 s idle: stops on :idle.
+      (is (= [:done :idle] (decide-stop* m 60000 1 30000 600000 30000)))
+      ;; Hard-cap regardless of stream.
+      (is (= [:done :hard-cap] (decide-stop* m 600000 1 0 600000 30000))))))
+
+(deftest hard-cap-applies-to-all-modes
+  (testing "--hard-ms is the global backstop for every mode"
+    (let [m-win   (resolve-modes ["--window-ms" "999999999"])
+          m-cnt   (resolve-modes ["--count" "999999999"])
+          m-strm  (resolve-modes ["--stream"])]
+      (is (= [:done :hard-cap] (decide-stop m-win  600000 0 0 600000)))
+      (is (= [:done :hard-cap] (decide-stop m-cnt  600000 0 0 600000)))
+      (is (= [:done :hard-cap] (decide-stop* m-strm 600000 0 0 600000 30000))))))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of `parse-predicate-args` from scripts/ops.clj.
+;;
+;; Production version calls (emit ...) + (System/exit 1) on --custom.
+;; The mirror returns a sentinel so the test can assert rejection
+;; without exiting the JVM. KEEP IN SYNC.
+;; ---------------------------------------------------------------------------
+
+(defn- ->kw [s]
+  (when s
+    (if (str/starts-with? s ":")
+      (keyword (subs s 1))
+      (keyword s))))
+
+(defn parse-predicate-args
+  "Mirror of scripts/ops.clj `parse-predicate-args`. On --custom returns
+   {:rejected :--custom :reason :unsupported-flag}. On unknown flags
+   continues (matches production: unknown flags are skipped — they may
+   be mode/predicate flags handled elsewhere)."
+  [args]
+  (loop [[a & more] args pred {}]
+    (cond
+      (nil? a) pred
+      (= a "--event-id")        (recur (rest more) (assoc pred :event-id (->kw (first more))))
+      (= a "--event-id-prefix") (recur (rest more)
+                                       (let [raw (first more)]
+                                         (assoc pred :event-id-prefix
+                                                (if (str/starts-with? raw ":") raw (str ":" raw)))))
+      (= a "--effects")         (recur (rest more) (assoc pred :effects (->kw (first more))))
+      (= a "--touches-path")    (recur (rest more) (assoc pred :touches-path
+                                                           (edn/read-string (first more))))
+      (= a "--sub-ran")         (recur (rest more) (assoc pred :sub-ran (->kw (first more))))
+      (= a "--render")          (recur (rest more) (assoc pred :render (first more)))
+      (= a "--origin")          (recur (rest more) (assoc pred :origin (->kw (first more))))
+      (= a "--frame")           (recur (rest more) (assoc pred :frame (->kw (first more))))
+      (= a "--custom")          {:rejected :--custom :reason :unsupported-flag}
+      :else                     (recur more pred))))
+
+;; ---------------------------------------------------------------------------
+;; Predicate-flag tests — supported set + rejected --custom.
+;; ---------------------------------------------------------------------------
+
+(deftest predicate-supported-flags
+  (testing "supported predicate flags parse into the predicate map"
+    (is (= {:event-id :foo}
+           (parse-predicate-args ["--event-id" ":foo"])))
+    (is (= {:event-id-prefix ":cart/"}
+           (parse-predicate-args ["--event-id-prefix" ":cart/"])))
+    (is (= {:event-id-prefix ":cart/"}
+           (parse-predicate-args ["--event-id-prefix" "cart/"]))
+        "--event-id-prefix should auto-prefix `:` if missing")
+    (is (= {:effects :http}
+           (parse-predicate-args ["--effects" ":http"])))
+    (is (= {:touches-path [:user :name]}
+           (parse-predicate-args ["--touches-path" "[:user :name]"])))
+    (is (= {:sub-ran :cart/total}
+           (parse-predicate-args ["--sub-ran" ":cart/total"])))
+    (is (= {:render "my.ns/foo"}
+           (parse-predicate-args ["--render" "my.ns/foo"])))
+    (is (= {:origin :pair}
+           (parse-predicate-args ["--origin" ":pair"])))
+    (is (= {:frame :stories}
+           (parse-predicate-args ["--frame" ":stories"])))))
+
+(deftest predicate-flags-can-combine
+  (testing "multiple predicate flags AND together into one map"
+    (is (= {:event-id-prefix ":cart/" :origin :pair :effects :http}
+           (parse-predicate-args ["--event-id-prefix" ":cart/"
+                                  "--origin" ":pair"
+                                  "--effects" ":http"])))))
+
+(deftest predicate-custom-rejected
+  (testing "--custom is explicitly rejected (rf2-gy3n: not implemented)"
+    (let [r (parse-predicate-args ["--custom" "(fn [_] true)"])]
+      (is (= :--custom            (:rejected r)))
+      (is (= :unsupported-flag    (:reason r)))))
+  (testing "--custom is rejected even when other valid flags are present"
+    (let [r (parse-predicate-args ["--event-id" ":foo" "--custom" "(fn [_] true)"])]
+      (is (= :--custom         (:rejected r))))))
+
+(deftest predicate-unknown-flags-skipped
+  (testing "unknown flags are skipped (consistent with production loop)"
+    ;; Mode flags like --window-ms / --count / --stream are NOT predicates
+    ;; — the predicate loop must not choke on them.
+    (is (= {:event-id :foo}
+           (parse-predicate-args ["--window-ms" "30000" "--event-id" ":foo"])))
+    (is (= {:event-id :foo}
+           (parse-predicate-args ["--count" "5" "--event-id" ":foo"])))
+    (is (= {:event-id :foo}
+           (parse-predicate-args ["--stream" "--event-id" ":foo"])))))
+
+;; ---------------------------------------------------------------------------
+;; Documented predicate set — must match SKILL.md §"Live watch (push-mode)".
+;; If you add or remove a flag from the production parse-predicate-args,
+;; update both this set and the SKILL.md predicate list.
+;; ---------------------------------------------------------------------------
+
+(def ^:private documented-predicate-flags
+  #{"--event-id" "--event-id-prefix" "--effects" "--touches-path"
+    "--sub-ran" "--render" "--origin" "--frame"})
+
+(deftest documented-predicates-cover-the-flag-set
+  (testing "every documented predicate flag is parsed"
+    (doseq [flag documented-predicate-flags]
+      (let [r (parse-predicate-args [flag ":x"])]
+        (is (and (map? r) (not (contains? r :rejected)))
+            (str "flag " flag " should parse, got: " (pr-str r)))))))
+
+(deftest custom-not-in-documented-set
+  (testing "--custom is no longer in the documented flag set"
+    (is (not (contains? documented-predicate-flags "--custom")))))
+
+;; ---------------------------------------------------------------------------
+;; Run.
+;; ---------------------------------------------------------------------------
+
+(let [{:keys [fail error]} (run-tests 'watch-op-modes-test)]
+  (System/exit (if (and (zero? fail) (zero? error)) 0 1)))


### PR DESCRIPTION
## Summary

Aligns `re-frame-pair2`'s `watch/*` surface with what its docs claim. Closes the two gaps called out in **rf2-gy3n**:

1. `--window-ms` and `--count` were not actually distinct modes — `watch-op` defaulted `count-n` to 5 and checked **both** stop conditions, so `watch-epochs.sh --window-ms 30000` terminated after 5 matches instead of running for 30 s.
2. `--custom` was advertised in `SKILL.md` (predicate list + machine-transition recipe) but `ops.clj` returned `:not-yet-supported` whenever it was passed.

## Options chosen

| Part | Option | Rationale |
|---|---|---|
| 1 — distinct modes | **1b**: set the inactive mode's limit to unbounded; both can coexist as a race; neither flag falls back to a 30 s window | Composes naturally, matches the docs, preserves bounded termination for argument-less watches. |
| 2 — `--custom` | **2b**: remove from docs + examples; keep an explicit `:unsupported-flag` error in the parser so stale callers surface clearly | Implementing it requires designing a predicate-fn surface with security implications (the transport would eval untrusted CLJS). Defer; remove from docs. |

## Behaviour matrix

| Invocation | Stops on |
|---|---|
| `--window-ms 30000` (alone) | `:window` after 30 s, regardless of match count |
| `--count 5` (alone) | `:count` after 5 matches, regardless of elapsed time |
| `--window-ms N --count M` | Race — `:window` if N ms elapse first, `:count` if M matches arrive first (ties go to `:window`, matching cond order) |
| neither flag, no `--stream` | `:window` after the default 30 s |
| `--stream` | `:idle` after 30 s of inactivity, or `:hard-cap` at 5 minutes; window/count are ignored |
| `--custom <form>` | rejected with `{:ok? false :reason :unsupported-flag :flag :--custom}` and exit 1 |

`--hard-ms` (default 5 min) is the global backstop for every mode.

## Changes

- `skills/re-frame-pair2/scripts/ops.clj`
  - `watch-op`: `--window-ms` / `--count` only checked when set; default 30 s window applies only when neither flag is present (and not `--stream`).
  - `parse-predicate-args`: `--custom` rejection re-tagged `:unsupported-flag` (was `:not-yet-supported`); hint updated.
- `skills/re-frame-pair2/scripts/watch-epochs.sh`: rewritten Modes section + dropped `count 5` from the defaults note.
- `skills/re-frame-pair2/SKILL.md`: explicit Mode rules block; `--custom` removed from the predicate list and the machine-transition recipe (recipe now uses `watch/stream` plus caller-side filtering of `:trace-events`).
- `skills/re-frame-pair2/tests/runtime/watch_op_modes_test.clj` — new bb-runnable test, mirrors `parse_rf2_coord_test.clj` pattern. Covers the full behaviour matrix above plus the documented predicate-flag set.

## Test results

```
$ bb skills/re-frame-pair2/tests/runtime/watch_op_modes_test.clj
Testing watch-op-modes-test
Ran 12 tests containing 55 assertions.
0 failures, 0 errors.

$ bb skills/re-frame-pair2/tests/runtime/parse_rf2_coord_test.clj
Testing parse-rf2-coord-test
Ran 12 tests containing 21 assertions.
0 failures, 0 errors.