### PR TITLE
fix: UIx/Helix derived-value baseline + regression coverage (rf2-66hb)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -83,16 +83,23 @@
     ;; Wire one watch per source so the listener registry surface
     ;; (subscribe-container) on the derived container fires whenever
     ;; any source changes.
-    (doseq [s source-containers]
-      (let [k (gensym "rf-helix-derived-")
-            prev-state (atom (deref s))]
-        (swap! own-keys assoc s k)
-        (add-watch s k
-          (fn [_ _ _ _]
-            (let [new-derived (recompute)
-                  prev-derived @prev-state]
-              (reset! prev-state new-derived)
-              (notify prev-derived new-derived))))))
+    ;; Seed the baseline from the *derived* value at construction time,
+    ;; not the raw source. The watch callback compares prev-derived
+    ;; against the recomputed derived value; if we seeded from
+    ;; `(deref s)` (the raw source), the first source change would
+    ;; spuriously notify whenever the derived projection differs in
+    ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
+    ;; lookups, projections — even when the derived value itself is `=`.
+    (let [prev-state (atom (recompute))]
+      (doseq [s source-containers]
+        (let [k (gensym "rf-helix-derived-")]
+          (swap! own-keys assoc s k)
+          (add-watch s k
+            (fn [_ _ _ _]
+              (let [new-derived (recompute)
+                    prev-derived @prev-state]
+                (reset! prev-state new-derived)
+                (notify prev-derived new-derived)))))))
     (reify
       IDeref
       (-deref [_] (recompute))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_derived_value_baseline_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_derived_value_baseline_cljs_test.cljs
@@ -1,0 +1,139 @@
+(ns re-frame.adapter.helix-derived-value-baseline-cljs-test
+  "Regression coverage for rf2-66hb — Helix adapter's derived-value
+  watch baseline.
+
+  The bug: in re-frame.adapter.helix/make-derived-value the watch
+  baseline (`prev-state`) was seeded from the *raw source* container
+  (`(deref s)`) instead of from the *derived* value the watch callback
+  later compares against. On the first source update, any derived
+  projection that stays value-equal but differs in identity from the
+  raw source — e.g. `(odd? x)`, `(count xs)`, `(:k m)`, `(boolean
+  ...)`, vector projections — would spuriously notify subscribers.
+
+  These tests drive `make-derived-value` directly through the adapter
+  map. They count notifications received by a `subscribe-container`
+  callback wired to the derived container, replace the source via
+  `replace-container!`, and assert that when the derived value remains
+  `=` the subscriber receives ZERO notifications. They also confirm
+  that real changes still notify exactly once.
+
+  Note: this file is intentionally identical in shape to the matching
+  UIx test (re-frame.adapter.uix), with the namespace hoisted under a
+  distinct file name. Both adapters share the same internals shape for
+  derived-value watch baselines (rf2-66hb)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.helix :as adapter]))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(defn- subscribe [container]
+  (let [calls (atom [])
+        unsub ((:subscribe-container adapter/adapter)
+               container
+               (fn [prev nu] (swap! calls conj [prev nu])))]
+    {:calls calls :unsub unsub}))
+
+;; ---- tests ----------------------------------------------------------------
+
+(deftest helix-first-update-no-op-odd?-cljs-test
+  (testing "source moves 1 → 3; (odd? x) stays true; ZERO notifications"
+    (let [src     (make-source 1)
+          derived (derive [src] odd?)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src 3)
+      (is (= [] @calls)
+          "first source update where derived stays = must NOT notify")
+      (write! src 4)
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [true false] (first @calls)))
+      (unsub))))
+
+(deftest helix-first-update-no-op-count-cljs-test
+  (testing "source moves [1 2 3] → [4 5 6]; (count xs) stays 3; ZERO notifications"
+    (let [src     (make-source [1 2 3])
+          derived (derive [src] count)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src [4 5 6])
+      (is (= [] @calls)
+          "first source update where count stays = must NOT notify")
+      (write! src [4 5 6 7])
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [3 4] (first @calls)))
+      (unsub))))
+
+(deftest helix-first-update-no-op-key-projection-cljs-test
+  (testing "source moves {:k 1 :other 2} → {:k 1 :other 99}; (:k m) stays 1; ZERO notifications"
+    (let [src     (make-source {:k 1 :other 2})
+          derived (derive [src] :k)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:k 1 :other 99})
+      (is (= [] @calls)
+          "first source update where (:k m) stays = must NOT notify")
+      (write! src {:k 2 :other 99})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [1 2] (first @calls)))
+      (unsub))))
+
+(deftest helix-first-update-no-op-boolean-projection-cljs-test
+  (testing "source moves {:logged-in? true} → {:logged-in? true :name \"x\"}; (boolean ...) stays true; ZERO notifications"
+    (let [src     (make-source {:logged-in? true})
+          derived (derive [src] (fn [m] (boolean (:logged-in? m))))
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:logged-in? true :name "x"})
+      (is (= [] @calls)
+          "first source update where boolean projection stays = must NOT notify")
+      (write! src {:logged-in? false})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [true false] (first @calls)))
+      (unsub))))
+
+(deftest helix-first-update-no-op-vector-projection-cljs-test
+  (testing "source moves {:items [1 2] :n 5} → {:items [1 2] :n 6}; (:items m) stays [1 2]; ZERO notifications"
+    (let [src     (make-source {:items [1 2] :n 5})
+          derived (derive [src] :items)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:items [1 2] :n 6})
+      (is (= [] @calls)
+          "first source update where vector projection stays = must NOT notify")
+      (write! src {:items [1 2 3] :n 6})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [[1 2] [1 2 3]] (first @calls)))
+      (unsub))))
+
+(deftest helix-first-update-no-op-then-change-cljs-test
+  (testing "the contract holds across a sequence of updates: only real = changes emit"
+    (let [src     (make-source 0)
+          derived (derive [src] odd?)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src 2)   ;; even → even, no emit
+      (write! src 4)   ;; even → even, no emit
+      (write! src 5)   ;; even → odd, emit once
+      (write! src 7)   ;; odd → odd, no emit
+      (write! src 8)   ;; odd → even, emit once
+      (is (= 2 (count @calls)))
+      (is (= [false true]  (first @calls)))
+      (is (= [true false]  (second @calls)))
+      (unsub))))
+
+(deftest helix-multi-source-derived-cljs-test
+  (testing "multi-source derived: each source's update recomputes; only = changes emit"
+    (let [a       (make-source 1)
+          b       (make-source 2)
+          derived (derive [a b] (fn [x y] (+ x y)))
+          {:keys [calls unsub]} (subscribe derived)]
+      ;; baseline derived = 3
+      (write! a 2)    ;; new sum 4, prev 3 → emit
+      (write! b 1)    ;; new sum 3, prev 4 → emit
+      (is (= 2 (count @calls)))
+      (is (= [3 4] (first @calls)))
+      (is (= [4 3] (second @calls)))
+      (unsub))))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -79,16 +79,23 @@
     ;; Wire one watch per source so the listener registry surface
     ;; (subscribe-container) on the derived container fires whenever
     ;; any source changes.
-    (doseq [s source-containers]
-      (let [k (gensym "rf-uix-derived-")
-            prev-state (atom (deref s))]
-        (swap! own-keys assoc s k)
-        (add-watch s k
-          (fn [_ _ _ _]
-            (let [new-derived (recompute)
-                  prev-derived @prev-state]
-              (reset! prev-state new-derived)
-              (notify prev-derived new-derived))))))
+    ;; Seed the baseline from the *derived* value at construction time,
+    ;; not the raw source. The watch callback compares prev-derived
+    ;; against the recomputed derived value; if we seeded from
+    ;; `(deref s)` (the raw source), the first source change would
+    ;; spuriously notify whenever the derived projection differs in
+    ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
+    ;; lookups, projections — even when the derived value itself is `=`.
+    (let [prev-state (atom (recompute))]
+      (doseq [s source-containers]
+        (let [k (gensym "rf-uix-derived-")]
+          (swap! own-keys assoc s k)
+          (add-watch s k
+            (fn [_ _ _ _]
+              (let [new-derived (recompute)
+                    prev-derived @prev-state]
+                (reset! prev-state new-derived)
+                (notify prev-derived new-derived)))))))
     (reify
       IDeref
       (-deref [_] (recompute))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_derived_value_baseline_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_derived_value_baseline_cljs_test.cljs
@@ -1,0 +1,135 @@
+(ns re-frame.adapter.uix-derived-value-baseline-cljs-test
+  "Regression coverage for rf2-66hb — UIx adapter's derived-value watch
+  baseline.
+
+  The bug: in re-frame.adapter.uix/make-derived-value the watch
+  baseline (`prev-state`) was seeded from the *raw source* container
+  (`(deref s)`) instead of from the *derived* value the watch callback
+  later compares against. On the first source update, any derived
+  projection that stays value-equal but differs in identity from the
+  raw source — e.g. `(odd? x)`, `(count xs)`, `(:k m)`, `(boolean
+  ...)`, vector projections — would spuriously notify subscribers.
+
+  These tests drive `make-derived-value` directly through the adapter
+  map. They count notifications received by a `subscribe-container`
+  callback wired to the derived container, replace the source via
+  `replace-container!`, and assert that when the derived value remains
+  `=` the subscriber receives ZERO notifications. They also confirm
+  that real changes still notify exactly once."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.uix :as adapter]))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(defn- subscribe [container]
+  (let [calls (atom [])
+        unsub ((:subscribe-container adapter/adapter)
+               container
+               (fn [prev nu] (swap! calls conj [prev nu])))]
+    {:calls calls :unsub unsub}))
+
+;; ---- tests ----------------------------------------------------------------
+
+(deftest first-update-no-op-odd?-cljs-test
+  (testing "source moves 1 → 3; (odd? x) stays true; ZERO notifications"
+    (let [src     (make-source 1)
+          derived (derive [src] odd?)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src 3)
+      (is (= [] @calls)
+          "first source update where derived stays = must NOT notify")
+      (write! src 4)
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [true false] (first @calls)))
+      (unsub))))
+
+(deftest first-update-no-op-count-cljs-test
+  (testing "source moves [1 2 3] → [4 5 6]; (count xs) stays 3; ZERO notifications"
+    (let [src     (make-source [1 2 3])
+          derived (derive [src] count)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src [4 5 6])
+      (is (= [] @calls)
+          "first source update where count stays = must NOT notify")
+      (write! src [4 5 6 7])
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [3 4] (first @calls)))
+      (unsub))))
+
+(deftest first-update-no-op-key-projection-cljs-test
+  (testing "source moves {:k 1 :other 2} → {:k 1 :other 99}; (:k m) stays 1; ZERO notifications"
+    (let [src     (make-source {:k 1 :other 2})
+          derived (derive [src] :k)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:k 1 :other 99})
+      (is (= [] @calls)
+          "first source update where (:k m) stays = must NOT notify")
+      (write! src {:k 2 :other 99})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [1 2] (first @calls)))
+      (unsub))))
+
+(deftest first-update-no-op-boolean-projection-cljs-test
+  (testing "source moves {:logged-in? true} → {:logged-in? true :name \"x\"}; (boolean ...) stays true; ZERO notifications"
+    (let [src     (make-source {:logged-in? true})
+          derived (derive [src] (fn [m] (boolean (:logged-in? m))))
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:logged-in? true :name "x"})
+      (is (= [] @calls)
+          "first source update where boolean projection stays = must NOT notify")
+      (write! src {:logged-in? false})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [true false] (first @calls)))
+      (unsub))))
+
+(deftest first-update-no-op-vector-projection-cljs-test
+  (testing "source moves {:items [1 2] :n 5} → {:items [1 2] :n 6}; (:items m) stays [1 2]; ZERO notifications"
+    (let [src     (make-source {:items [1 2] :n 5})
+          derived (derive [src] :items)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src {:items [1 2] :n 6})
+      (is (= [] @calls)
+          "first source update where vector projection stays = must NOT notify")
+      (write! src {:items [1 2 3] :n 6})
+      (is (= 1 (count @calls)) "real change notifies once")
+      (is (= [[1 2] [1 2 3]] (first @calls)))
+      (unsub))))
+
+(deftest first-update-no-op-then-change-cljs-test
+  (testing "the contract holds across a sequence of updates: only real = changes emit"
+    (let [src     (make-source 0)
+          derived (derive [src] odd?)
+          {:keys [calls unsub]} (subscribe derived)]
+      (write! src 2)   ;; even → even, no emit
+      (write! src 4)   ;; even → even, no emit
+      (write! src 5)   ;; even → odd, emit once
+      (write! src 7)   ;; odd → odd, no emit
+      (write! src 8)   ;; odd → even, emit once
+      (is (= 2 (count @calls)))
+      (is (= [false true]  (first @calls)))
+      (is (= [true false]  (second @calls)))
+      (unsub))))
+
+(deftest multi-source-derived-cljs-test
+  (testing "multi-source derived: each source's update recomputes; only = changes emit"
+    (let [a       (make-source 1)
+          b       (make-source 2)
+          derived (derive [a b] (fn [x y] (+ x y)))
+          {:keys [calls unsub]} (subscribe derived)]
+      ;; baseline derived = 3
+      (write! a 2)    ;; new sum 4 → emit
+      (write! b 1)    ;; new sum 3 → wait, but prev was 4, so emit
+      ;; rewrite: a=2 b=1 sum=3 (was 4), emits
+      (is (= 2 (count @calls)))
+      (is (= [3 4] (first @calls)))
+      (is (= [4 3] (second @calls)))
+      (unsub))))


### PR DESCRIPTION
## Summary

In both non-Reagent React adapters, the derived-value watch baseline was seeded from the **raw source container** instead of the **derived value**. On the first source update, any derived projection that stayed value-equal but differed in identity from the raw source would spuriously notify subscribers.

## The bug

`implementation/adapters/uix/src/re_frame/adapter/uix.cljs:84` and `implementation/adapters/helix/src/re_frame/adapter/helix.cljs:88`:

```clojure
;; uix.cljs:83-84 (and helix.cljs:87-88, identical shape)
(let [k (gensym "rf-uix-derived-")
      prev-state (atom (deref s))]   ;; <— raw source value
  ...
  (add-watch s k
    (fn [_ _ _ _]
      (let [new-derived (recompute)
            prev-derived @prev-state]   ;; compared against derived
        ...))))
```

The watch callback compares `prev-derived` against the recomputed derived value, but `prev-state` was seeded from the raw source. For projections like `(odd? x)`, `(count xs)`, `(:k m)`, vector projections, or `(boolean ...)`, the raw source value differs in identity from the derived value, so the first source update always tripped the `not=` guard inside `notify` even when the derived value itself was `=`.

## The fix

Seed `prev-state` once from the current derived value at construction time, shared across all source watches:

```clojure
;; uix.cljs / helix.cljs — fixed shape
(let [prev-state (atom (recompute))]   ;; <— derived value at t=0
  (doseq [s source-containers]
    (let [k (gensym "rf-uix-derived-")]
      ...
      (add-watch s k
        (fn [_ _ _ _]
          (let [new-derived (recompute)
                prev-derived @prev-state]
            ...))))))
```

Sharing one baseline across all source watches matches the contract — `notify` re-checks `not=` before fanning out, so a real derived-value change is reported exactly once even when multiple sources fire on the same tick.

## Test cases added (5+ representative projections, per adapter)

Adapter-level CLJS tests under `implementation/adapters/{uix,helix}/test/re_frame/adapter/` that drive `make-derived-value` directly through each adapter map and count notifications received via `subscribe-container`:

- `(odd? x)` — scalar boolean projection (1 → 3 stays `true`, no notify)
- `(count xs)` — collection projection (`[1 2 3]` → `[4 5 6]` stays 3, no notify)
- `(:k m)` — keyword lookup (other keys change, `:k` stays, no notify)
- `(boolean (:logged-in? m))` — coercion projection (extra keys added, no notify)
- `(:items m)` — vector-valued projection (sibling keys change, no notify)
- sequenced odd/even updates — confirms only real `=` changes emit
- multi-source `(+ x y)` — confirms emit-once-per-real-change across two sources

Each "no-op" case also asserts that the **next** real change emits exactly one notification with the correct `[prev nu]` payload.

## Test results

All verification suites pass on the post-fix code:

- `clojure -M:test` in `core/`, `routing/` — green
- `npm run test:cljs` (node-test) — 173 tests, 529 assertions, 0 failures, 0 errors (now includes the 14 new deftests)
- `npm run test:browser` — 173 tests, 539 assertions, 0 failures, 0 errors
- `npm run test:elision` — PASS
- `npm run test:bundle-isolation` — PASS

I also confirmed the regression tests fail on the pre-fix code: temporarily reverted the UIx fix, re-ran `npm run test:cljs`, and observed every new `first-update-no-op-*` assertion fail with the bug present.

## Scope

- Reagent adapter untouched (different internals — not affected).
- Substrate contract in `spec/006` untouched.
- No public API changes.
- Pure internal fix + adapter-level tests.

## Test plan

- [x] CLJS node-test suite passes (`npm run test:cljs`).
- [x] CLJS browser-test suite passes (`npm run test:browser`).
- [x] Bundle elision and isolation checks pass.
- [x] New regression tests fail on the pre-fix code, pass on the fix.
- [x] No changes outside `implementation/adapters/{uix,helix}/`.