### PR TITLE
feat(reagent-slim): Stage 4-A reactivity primitives (rf2-6hyy)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -68,6 +68,7 @@ declare -A ARTEFACT_PATHS=(
   [core]="core"
   [schemas]="schemas"
   [reagent]="adapters/reagent"
+  [reagent-slim]="adapters/reagent-slim"
   [uix]="adapters/uix"
   [helix]="adapters/helix"
   [machines]="machines"
@@ -78,15 +79,15 @@ declare -A ARTEFACT_PATHS=(
   [epoch]="epoch"
 )
 
-ARTEFACTS=(core schemas reagent uix helix machines routing flows http ssr epoch)
+ARTEFACTS=(core schemas reagent reagent-slim uix helix machines routing flows http ssr epoch)
 
 # core is the lockstep root: it does not depend on any other re-frame-2
 # artefact, so the :local/root core-reference check below skips it.
-NON_CORE=(schemas reagent uix helix machines routing flows http ssr epoch)
+NON_CORE=(schemas reagent reagent-slim uix helix machines routing flows http ssr epoch)
 
 # Adapters (substrate adapters) are one directory deeper than per-feature
 # artefacts.
-ADAPTERS=(reagent uix helix)
+ADAPTERS=(reagent reagent-slim uix helix)
 
 is_adapter() {
   local needle="$1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,48 @@ jobs:
       - name: Run JVM tests (reagent artefact, classpath probe)
         run: clojure -M:test || echo "no JVM-runnable tests in reagent artefact (expected)"
 
+  jvm-reagent-slim:
+    name: JVM reagent-slim-adapter (clojure -M:test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/adapters/reagent-slim
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-reagent-slim-${{ hashFiles('implementation/adapters/reagent-slim/deps.edn', 'implementation/core/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-reagent-slim-
+            ${{ runner.os }}-clj-
+
+      # The reagent-slim artefact (rf2-5djt Stage 4, rf2-6hyy) is the
+      # React-19 Reagent rewrite. Its :test alias carries CLJS unit
+      # tests only — the adapter ns is :cljs-only. The job exists so
+      # the artefact's deps + classpath wiring stay green. Skip-on-empty
+      # is acceptable; the cognitect test-runner returns 0 when there
+      # are no test namespaces matching its pattern. The CLJS unit
+      # tests run via shadow-cljs's :node-test build (see cljs job).
+      - name: Run JVM tests (reagent-slim artefact, classpath probe)
+        run: clojure -M:test || echo "no JVM-runnable tests in reagent-slim artefact (expected)"
+
   jvm-uix:
     name: JVM uix-adapter (clojure -M:test)
     runs-on: ubuntu-latest

--- a/implementation/adapters/reagent-slim/deps.edn
+++ b/implementation/adapters/reagent-slim/deps.edn
@@ -1,0 +1,41 @@
+;; day8/reagent-slim — re-frame2's Reagent rewrite (rf2-5djt; Stage 4 rf2-6hyy).
+;;
+;; Stage 4-A scope: the reactive primitives (reagent2.ratom). Subsequent
+;; sub-stages add the render scheduler (4-B), component-shape detection
+;; (4-C), hiccup translation (4-D), pure-CLJS render-to-static-markup
+;; (4-E), throw-on-call shims (4-F), examples + MIGRATION (4-G).
+;;
+;; Per the IMPL-SPEC §1: this artefact is the "slim" rewrite of stock
+;; Reagent for React 19. It replaces (does not depend on) stock Reagent.
+;; The bridge `day8/re-frame-2-reagent` continues to ship in parallel so
+;; consumers that need the dropped surfaces (`track`, `cursor`, `wrap`,
+;; `with-let`, etc.) keep a path to the React-19-stable React API.
+;;
+;; The :clein/build :version pulls from the repo-root VERSION via the
+;; adapter-tier path "../../../VERSION" (the lockstep-version contract;
+;; see .github/scripts/verify-version-lockstep.sh — adapters are one
+;; directory deeper than per-feature artefacts). The day8/re-frame-2
+;; coordinate uses :local/root "../../core" — the release workflow
+;; rewrites this to :mvn/version "${VERSION}" at deploy time.
+{:paths ["src"]
+ :deps  {day8/re-frame-2 {:local/root "../../core"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+
+  :clein {:extra-deps {io.github.noahtheduke/clein
+                       {:git/url "https://github.com/day8/clein.git"
+                        :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
+          :main-opts  ["-m" "noahtheduke.clein"]}
+
+  :clein/build
+  {:lib      day8/reagent-slim
+   :main     re-frame.adapter.reagent
+   :url      "https://github.com/day8/re-frame2"
+   :version  "../../../VERSION"
+   :license  {:name "MIT"
+              :url  "https://opensource.org/licenses/MIT"}
+   :src-dirs ["src"]}}}

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
@@ -1,0 +1,36 @@
+(ns reagent2.ratom
+  "CLJS-side macros for reagent2.ratom.
+
+  Per IMPL-SPEC §2.3:
+
+    - `reaction` ships as a 5-line indirection over `make-reaction`.
+      Required for rf8 wizard/reports_util.cljs:158, 166 (rf2-kfpf §3).
+      Dash8 also uses the function form `reagent.core/reaction` (25
+      sites); that surface lives in `reagent2.core` (Stage 4-D).
+
+    - `run!` is NOT shipped — audit-confirmed zero usage across re-com /
+      10x / Dash8 / rf8 (per §2.3 \"Symbols not shipped\" list).
+
+  No CLJ-side runtime code lives here; only the macros consumed by CLJS
+  build sites via `:require-macros`."
+  (:refer-clojure :exclude [run!]))
+
+(defmacro reaction
+  "Sugar for (make-reaction (fn [] body)). The body executes inside a
+  reactive context — derefs of RAtoms / Reactions inside `body` register
+  as dependencies, and the Reaction recomputes when any of them change.
+
+  Example:
+
+    (def first-name (r/atom \"Alice\"))
+    (def last-name  (r/atom \"Tan\"))
+    (def full-name  (reaction (str @first-name \" \" @last-name)))
+    @full-name  ;=> \"Alice Tan\"
+    (reset! first-name \"Bob\")
+    @full-name  ;=> \"Bob Tan\"
+
+  Per IMPL-SPEC §2.3: 5-line indirection. The function form
+  `reagent2.core/reaction` (Stage 4-D) is equivalent but takes a
+  thunk argument explicitly."
+  [& body]
+  `(reagent2.ratom/make-reaction (fn [] ~@body)))

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -1,0 +1,482 @@
+(ns reagent2.ratom
+  "Reactive primitives for the day8/reagent-slim artefact.
+
+  Bounded surface per IMPL-SPEC §2.3 (rf2-6hyy Stage 4-A):
+
+    Types:      RAtom, Reaction
+    Protocols:  IReactiveAtom, IDisposable
+    Functions:  atom, make-reaction, dispose!, add-on-dispose!,
+                reactive?, flush!
+    Macros:     reaction, run!  (in reagent2/ratom.clj)
+
+  Symbols deliberately NOT shipped (audit-confirmed zero usage across
+  re-com / 10x / Dash8 / rf8 — see IMPL-SPEC §2.3 + §2.3a):
+
+    - track, track!, cursor, wrap, make-wrapper
+    - Track, RCursor, Wrapper types
+    - IRunnable protocol
+    - run-in-reaction, with-let-values (impl-internal in stock; not
+      part of the rewrite's surface)
+
+  Apps that genuinely need a dropped surface stay on day8/reagent-classic
+  (the bridge); the rewrite's commitment is to ship only the surfaces
+  the audited codebases actually exercise.
+
+  Design notes (per IMPL-SPEC §3 + Stage 2 §4 efficiency analysis):
+
+    - RAtom and Reaction shapes match stock Reagent byte-for-byte. The
+      reactive kernel is one of stock Reagent's well-designed pieces —
+      the wins live elsewhere (bundle pruning, microtask scheduler,
+      narrowed convert-prop-value).
+
+    - IReactiveAtom is the canonical `ratom?` test. Both RAtom and
+      Reaction reify it. `re-frame.interop/ratom?` does
+      `(satisfies? IReactiveAtom x)` — protocol-based, not class-based.
+
+    - IDisposable is the cross-substrate cache-wiring contract. UIx
+      and Helix adapters reify this same protocol on their derived-value
+      objects so `re-frame.interop/add-on-dispose!` dispatches uniformly
+      via protocol — no `instance?` branch in core. The shape of
+      `dispose!` and `add-on-dispose!` MUST NOT change.
+
+  Stage-4-A scope: pure reactive primitives, no DOM/component coupling.
+  Stage 4-B will add the microtask render scheduler and wire
+  `(set! batch/ratom-flush flush!)` so the render layer can drain the
+  reactive queue on each commit boundary."
+  (:refer-clojure :exclude [atom run!])
+  (:require-macros [reagent2.ratom])
+  (:require [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; Reactive context
+;; ---------------------------------------------------------------------------
+
+(declare flush!)
+
+(declare ^:dynamic *ratom-context*)
+
+(defonce ^boolean debug false)
+(defonce ^:private generation 0)
+(defonce ^:private -running (clojure.core/atom 0))
+
+(defn ^boolean reactive?
+  "True if invoked inside a reactive context — i.e. inside the body of a
+  Reaction or another deref-capturing scope. Reads the dynamic
+  *ratom-context*. Used by render code that wants to detect whether a
+  deref will subscribe (reactive) vs just snapshot (non-reactive)."
+  []
+  (some? *ratom-context*))
+
+(defn running
+  "Diagnostic: count of currently-running reactions when `debug` is true.
+  Returns 0 unless `debug` was set before any Reactions were created."
+  []
+  (+ @-running))
+
+;; ---------------------------------------------------------------------------
+;; Internal helpers
+;; ---------------------------------------------------------------------------
+
+(defn- ^number arr-len [x]
+  (if (nil? x) 0 (alength x)))
+
+(defn- ^boolean arr-eq [x y]
+  (let [len (arr-len x)]
+    (and (== len (arr-len y))
+         (loop [i 0]
+           (or (== i len)
+               (if (identical? (aget x i) (aget y i))
+                 (recur (inc i))
+                 false))))))
+
+(defn- in-context
+  "Run f with *ratom-context* bound to obj. Any deref inside f registers
+  the deref'd ratom on obj (via notify-deref-watcher!), which is how a
+  Reaction discovers its dependencies."
+  [obj f]
+  (binding [*ratom-context* obj]
+    (f)))
+
+(defn- deref-capture
+  "Run f as the body of Reaction r, capturing the set of ratoms it derefs.
+  After f returns, diff the captured set against r's existing watching
+  set; subscribe r to newly-watched ratoms and unsubscribe from
+  no-longer-watched ratoms. Clears the dirty? flag on r."
+  [f ^clj r]
+  (set! (.-captured r) nil)
+  (when ^boolean js/goog.DEBUG
+    (set! (.-ratomGeneration r) (set! generation (inc generation))))
+  (let [res (in-context r f)
+        c   (.-captured r)]
+    (set! (.-dirty? r) false)
+    ;; Optimise common case where derefs occur in same order
+    (when-not (arr-eq c (.-watching r))
+      (._update-watching r c))
+    res))
+
+(defn- notify-deref-watcher!
+  "Add `derefed` to the captured array on the in-flight reactive context.
+  No-op outside a reactive context."
+  [derefed]
+  (when-some [^clj r *ratom-context*]
+    (let [c (.-captured r)]
+      (if (nil? c)
+        (set! (.-captured r) (array derefed))
+        (.push c derefed)))))
+
+(defn- check-watches [old new]
+  (when debug
+    (swap! -running + (- (count new) (count old))))
+  new)
+
+(defn- add-w [^clj this key f]
+  (let [w (.-watches this)]
+    (set! (.-watches this) (check-watches w (assoc w key f)))
+    (set! (.-watchesArr this) nil)))
+
+(defn- remove-w [^clj this key]
+  (let [w (.-watches this)]
+    (set! (.-watches this) (check-watches w (dissoc w key)))
+    (set! (.-watchesArr this) nil)))
+
+(defn- notify-w [^clj this old new]
+  (let [w   (.-watchesArr this)
+        a   (if (nil? w)
+              (->> (.-watches this)
+                   (reduce-kv #(doto %1 (.push %2) (.push %3)) #js [])
+                   (set! (.-watchesArr this)))
+              w)
+        len (alength a)]
+    (loop [i 0]
+      (when (< i len)
+        (let [k (aget a i)
+              f (aget a (inc i))]
+          (f k this old new))
+        (recur (+ 2 i))))))
+
+(defn- pr-atom [a writer opts s v]
+  (-write writer (str "#object[reagent2.ratom." s " "))
+  (pr-writer (binding [*ratom-context* nil] v) writer opts)
+  (-write writer "]"))
+
+;; ---------------------------------------------------------------------------
+;; Reaction-flush queue
+;;
+;; Reactions whose dependencies have changed get pushed into rea-queue.
+;; flush! drains the queue, recomputing each Reaction. The render
+;; scheduler (Stage 4-B, reagent2.impl.batching) hooks into this via
+;; the assignable `batch/ratom-flush` slot so the render-commit
+;; boundary drains pending reactive work.
+;;
+;; Stage 4-A ships rea-queue + flush! standalone; the render-side
+;; integration lands with 4-B.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private rea-queue nil)
+
+(defonce ^{:doc "Hook the render scheduler installs to schedule a microtask
+                drain of rea-queue. Defaults to nil (synchronous flush
+                only); Stage 4-B's reagent2.impl.batching sets this so a
+                Reaction whose dependency changed schedules a drain
+                automatically."}
+  rea-schedule (clojure.core/atom nil))
+
+(defn- rea-enqueue [r]
+  (when (nil? rea-queue)
+    (set! rea-queue #js [])
+    (when-let [s @rea-schedule]
+      (s)))
+  (.push rea-queue r))
+
+;; ---------------------------------------------------------------------------
+;; IReactiveAtom — marker protocol
+;; ---------------------------------------------------------------------------
+
+(defprotocol IReactiveAtom
+  "Marker protocol for reactive atoms — RAtom and Reaction reify this.
+  `re-frame.interop/ratom?` tests `(satisfies? IReactiveAtom x)` so any
+  reify that wants to be ratom-shaped to re-frame2 must implement this
+  protocol.")
+
+;; ---------------------------------------------------------------------------
+;; RAtom — reactive atom
+;; ---------------------------------------------------------------------------
+
+(deftype RAtom [^:mutable state meta validator
+                ^:mutable watches ^:mutable watchesArr]
+  IAtom
+  IReactiveAtom
+
+  IEquiv
+  (-equiv [o other] (identical? o other))
+
+  IDeref
+  (-deref [this]
+    (notify-deref-watcher! this)
+    state)
+
+  IReset
+  (-reset! [a new-value]
+    (when-not (nil? validator)
+      (assert (validator new-value) "Validator rejected reference state"))
+    (let [old-value state]
+      (set! state new-value)
+      (when-not (nil? watches)
+        (notify-w a old-value new-value))
+      new-value))
+
+  ISwap
+  (-swap! [a f]          (-reset! a (f state)))
+  (-swap! [a f x]        (-reset! a (f state x)))
+  (-swap! [a f x y]      (-reset! a (f state x y)))
+  (-swap! [a f x y more] (-reset! a (apply f state x y more)))
+
+  IWithMeta
+  (-with-meta [_ new-meta] (RAtom. state new-meta validator watches watchesArr))
+
+  IMeta
+  (-meta [_] meta)
+
+  IPrintWithWriter
+  (-pr-writer [a w opts] (pr-atom a w opts "RAtom" {:val (-deref a)}))
+
+  IWatchable
+  (-notify-watches [this old new] (notify-w this old new))
+  (-add-watch [this key f]        (add-w this key f))
+  (-remove-watch [this key]       (remove-w this key))
+
+  IHash
+  (-hash [this] (goog/getUid this)))
+
+(defn atom
+  "Construct a reactive atom (RAtom).
+
+  Like clojure.core/atom — supports IDeref, IReset, ISwap, IWatchable,
+  IMeta — except deref'ing inside a Reaction subscribes the Reaction
+  to changes. This is the deref-time subscription mechanism that wires
+  user state into the reactive graph.
+
+  Two-arity overload accepts :meta and :validator like clojure.core/atom.
+  (Stock Reagent's :equal? is NOT shipped — audit-confirmed zero usage.)"
+  ([x] (->RAtom x nil nil nil nil))
+  ([x & {:keys [meta validator]}]
+   (->RAtom x meta validator nil nil)))
+
+;; ---------------------------------------------------------------------------
+;; IDisposable — cross-substrate cache-wiring contract
+;; ---------------------------------------------------------------------------
+
+(defprotocol IDisposable
+  "Cross-substrate disposal protocol. The cache-wiring contract per
+  IMPL-SPEC §3.4 + Spec 006 §subscription-cache: re-frame's per-slot
+  evict logic calls `re-frame.interop/add-on-dispose!` which dispatches
+  via this protocol. UIx and Helix derived-value reifies implement the
+  same shape, so a single protocol-dispatch handles every substrate
+  with no instance? branch in core.
+
+  Signatures MUST NOT change."
+  (dispose! [this]
+    "Tear down. Removes watches, runs on-dispose hooks, marks the
+     reaction dirty so future derefs recompute (or throw).")
+  (add-on-dispose! [this f]
+    "Register a 1-arg callback to fire when this Reaction is disposed.
+     Multiple callbacks accumulate; they run in registration order."))
+
+(defn- handle-reaction-change [^clj this _sender old new]
+  (._handle-change this _sender old new))
+
+;; ---------------------------------------------------------------------------
+;; Reaction — derived value with equality memoisation
+;;
+;; Layout per IMPL-SPEC §3.2: the same nine-field shape stock Reagent
+;; uses. Stage 2 §4 ("Keep as-is") concluded the kernel is correct.
+;; ---------------------------------------------------------------------------
+
+(deftype Reaction [^:mutable f ^:mutable state ^:mutable ^boolean dirty?
+                   ^:mutable watching ^:mutable watches ^:mutable watchesArr
+                   ^:mutable auto-run ^:mutable on-set ^:mutable on-dispose
+                   ^:mutable on-dispose-arr ^:mutable caught]
+  IAtom
+  IReactiveAtom
+
+  IWatchable
+  (-notify-watches [this old new] (notify-w this old new))
+  (-add-watch [this key f]        (add-w this key f))
+  (-remove-watch [this key]
+    (let [was-empty (empty? watches)]
+      (remove-w this key)
+      (when (and (not was-empty)
+                 (empty? watches)
+                 (nil? auto-run))
+        (dispose! this))))
+
+  IReset
+  (-reset! [a newval]
+    (assert (fn? on-set) "Reaction is read-only; on-set is not allowed")
+    (let [oldval state]
+      (set! state newval)
+      (on-set oldval newval)
+      (notify-w a oldval newval)
+      newval))
+
+  ISwap
+  (-swap! [a f]          (-reset! a (f (._peek-at a))))
+  (-swap! [a f x]        (-reset! a (f (._peek-at a) x)))
+  (-swap! [a f x y]      (-reset! a (f (._peek-at a) x y)))
+  (-swap! [a f x y more] (-reset! a (apply f (._peek-at a) x y more)))
+
+  Object
+  (_peek-at [this]
+    (binding [*ratom-context* nil]
+      (-deref this)))
+
+  (_handle-change [this _sender oldval newval]
+    (when-not (or (identical? oldval newval) dirty?)
+      (if (nil? auto-run)
+        (do
+          (set! dirty? true)
+          (rea-enqueue this))
+        (if (true? auto-run)
+          (._run this false)
+          (auto-run this)))))
+
+  (_update-watching [this derefed]
+    (let [new (set derefed)
+          old (set watching)]
+      (set! watching derefed)
+      (doseq [w (set/difference new old)]
+        (-add-watch w this handle-reaction-change))
+      (doseq [w (set/difference old new)]
+        (-remove-watch w this))))
+
+  (_queued-run [this]
+    (when (and dirty? (some? watching))
+      (._run this true)))
+
+  (_try-capture [this f]
+    (try
+      (set! caught nil)
+      (deref-capture f this)
+      (catch :default e
+        (set! state e)
+        (set! caught e)
+        (set! dirty? false))))
+
+  (_run [this check]
+    (let [oldstate state
+          res      (if check
+                     (._try-capture this f)
+                     (deref-capture f this))]
+      (set! state res)
+      ;; Equality memoisation per IMPL-SPEC §3.2: use = (not identical?)
+      ;; because Reaction bodies produce new data structures every run.
+      ;; Skip notify-watches when the recomputed value is = the old one.
+      (when-not (or (nil? watches)
+                    (= oldstate res))
+        (notify-w this oldstate res))
+      res))
+
+  (_set-opts [this {:keys [auto-run on-set on-dispose]}]
+    (when (some? auto-run)
+      (set! (.-auto-run this) auto-run))
+    (when (some? on-set)
+      (set! (.-on-set this) on-set))
+    (when (some? on-dispose)
+      (set! (.-on-dispose this) on-dispose)))
+
+  IDeref
+  (-deref [this]
+    (when-some [e caught]
+      (throw e))
+    (let [non-reactive (nil? *ratom-context*)]
+      (when non-reactive
+        (flush!))
+      (if (and non-reactive (nil? auto-run))
+        ;; Outside any reactive context AND no auto-run subscribers:
+        ;; pure on-demand recompute. No watcher-graph wiring; just run f
+        ;; and notify any explicit watches if the result changed.
+        (when dirty?
+          (let [oldstate state]
+            (set! state (f))
+            (when-not (or (nil? watches) (= oldstate state))
+              (notify-w this oldstate state))))
+        ;; Inside a reactive context (or auto-run set): subscribe the
+        ;; outer context to this Reaction; recompute if dirty.
+        (do
+          (notify-deref-watcher! this)
+          (when dirty?
+            (._run this false)))))
+    state)
+
+  IDisposable
+  (dispose! [this]
+    (let [s  state
+          wg watching]
+      (set! watching nil)
+      (set! state nil)
+      (set! auto-run nil)
+      (set! dirty? true)
+      (doseq [w (set wg)]
+        (-remove-watch w this))
+      (when (some? on-dispose)
+        (on-dispose s))
+      (when-some [a on-dispose-arr]
+        (dotimes [i (alength a)]
+          ((aget a i) this)))))
+
+  (add-on-dispose! [this f]
+    (if-some [a on-dispose-arr]
+      (.push a f)
+      (set! (.-on-dispose-arr this) (array f))))
+
+  IEquiv
+  (-equiv [o other] (identical? o other))
+
+  IPrintWithWriter
+  (-pr-writer [a w opts] (pr-atom a w opts "Reaction" {:val (-deref a)}))
+
+  IHash
+  (-hash [this] (goog/getUid this)))
+
+(defn flush!
+  "Drain rea-queue: recompute every queued Reaction whose dependencies
+  changed, in enqueue order. Notifies watchers per the equality-memo
+  contract. Loops until the queue is empty (a recompute may itself
+  enqueue downstream Reactions).
+
+  Stage 4-A: callable directly. Stage 4-B's reagent2.impl.batching will
+  install this as `batch/ratom-flush` so the render-commit boundary
+  drains automatically."
+  []
+  (loop []
+    (let [q rea-queue]
+      (when-not (nil? q)
+        (set! rea-queue nil)
+        (dotimes [i (alength q)]
+          (let [^Reaction r (aget q i)]
+            (._queued-run r)))
+        (recur)))))
+
+(defn make-reaction
+  "Construct a Reaction wrapping body fn `f`.
+
+  Optional kwargs:
+
+    :auto-run    nil (default), true (synchronous on-change), or a 1-arg
+                 fn called with the reaction on each change. With nil,
+                 the reaction enqueues itself for the next flush! when
+                 a dependency changes.
+    :on-set      fn called on -reset!/-swap! with [old new] before
+                 watches fire. Only meaningful if you intend to call
+                 reset! on the Reaction.
+    :on-dispose  fn called with the last computed value when dispose!
+                 runs.
+
+  IMPL-SPEC §3.2: the kernel preserves stock Reagent's shape because
+  the Stage 2 efficiency analysis confirmed it's correct as-is."
+  [f & {:keys [auto-run on-set on-dispose]}]
+  (let [r (->Reaction f nil true nil nil nil nil nil nil nil nil)]
+    (._set-opts r {:auto-run    auto-run
+                   :on-set      on-set
+                   :on-dispose  on-dispose})
+    r))

--- a/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
@@ -1,0 +1,362 @@
+(ns reagent2.ratom-cljs-test
+  "Unit tests for reagent2.ratom (Stage 4-A, rf2-6hyy).
+
+  Covers:
+
+    - RAtom: atom-shape protocols (IDeref, IReset, ISwap, IWatchable,
+      IMeta, IWithMeta), validator, watch fire-once-per-change,
+      identity-equality.
+
+    - Reaction: deref-time dependency capture, equality memoisation,
+      dirty-flag transitions, on-dispose hooks, dispose! teardown,
+      auto-run modes.
+
+    - Protocol satisfaction: IReactiveAtom (the canonical ratom? test
+      `re-frame.interop/ratom?` uses), IDisposable (cross-substrate
+      cache-wiring contract per IMPL-SPEC §3.4).
+
+    - reactive? predicate gating on *ratom-context*.
+
+    - flush! drains the rea-queue including downstream cascades.
+
+    - reaction macro: 5-line indirection over make-reaction.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.ratom :as ratom :refer-macros [reaction]]))
+
+;; ---------------------------------------------------------------------------
+;; RAtom — atom-shape protocols
+;; ---------------------------------------------------------------------------
+
+(deftest ratom-construction
+  (testing "atom returns an RAtom"
+    (let [a (ratom/atom 1)]
+      (is (instance? ratom/RAtom a))
+      (is (= 1 @a))))
+
+  (testing "atom accepts :meta and :validator kwargs"
+    (let [a (ratom/atom 0 :meta {:tag :counter})]
+      (is (= {:tag :counter} (meta a))))
+
+    (let [a (ratom/atom 0 :validator number?)]
+      (reset! a 5)
+      (is (= 5 @a))
+      (is (thrown? js/Error (reset! a "bad")))))
+
+  (testing "RAtom satisfies IReactiveAtom (the ratom? protocol)"
+    (is (satisfies? ratom/IReactiveAtom (ratom/atom 0)))))
+
+(deftest ratom-reset-swap
+  (let [a (ratom/atom 0)]
+    (testing "reset!"
+      (is (= 7 (reset! a 7)))
+      (is (= 7 @a)))
+
+    (testing "swap! 1-arity"
+      (is (= 8 (swap! a inc)))
+      (is (= 8 @a)))
+
+    (testing "swap! n-arity"
+      (is (= 18 (swap! a + 10)))
+      (is (= 28 (swap! a + 5 5)))
+      (is (= 38 (swap! a + 1 2 3 4))))))
+
+(deftest ratom-watches
+  (testing "add-watch fires on change with [k prev nu] arity"
+    (let [a     (ratom/atom 0)
+          fired (atom [])]
+      (add-watch a :w (fn [k _r prev nu] (swap! fired conj [k prev nu])))
+      (reset! a 1)
+      (reset! a 2)
+      ;; Each watch fires once per change with the actual previous value.
+      (is (= [[:w 0 1] [:w 1 2]] @fired))))
+
+  (testing "remove-watch stops notifications"
+    (let [a     (ratom/atom 0)
+          fired (atom 0)]
+      (add-watch a :w (fn [_ _ _ _] (swap! fired inc)))
+      (reset! a 1)
+      (remove-watch a :w)
+      (reset! a 2)
+      (is (= 1 @fired)))))
+
+(deftest ratom-meta
+  (testing "with-meta produces a fresh RAtom with the new meta"
+    (let [a (ratom/atom 0 :meta {:k :v})
+          b (with-meta a {:k :z})]
+      (is (= {:k :v} (meta a)))
+      (is (= {:k :z} (meta b)))
+      (is (= 0 @b)))))
+
+(deftest ratom-identity-equality
+  (testing "RAtoms are reference-equal only"
+    (let [a (ratom/atom 1)
+          b (ratom/atom 1)]
+      (is (= a a))
+      (is (not= a b))
+      (is (not (identical? a b))))))
+
+;; ---------------------------------------------------------------------------
+;; Reaction — derived value
+;; ---------------------------------------------------------------------------
+
+(deftest reaction-basic
+  (testing "Reaction recomputes on dependency change (deref-fast-path)"
+    ;; Without auto-run, deref outside a reactive context goes through
+    ;; the fast path (per IMPL-SPEC §3.2): just call f, no subscribing.
+    ;; The reaction stays dirty? after every reset! and recomputes on
+    ;; the next deref. This is stock-Reagent semantics.
+    (let [a (ratom/atom 1)
+          r (ratom/make-reaction (fn [] (* @a 10)))]
+      (is (= 10 @r))
+      (reset! a 2)
+      ;; r is now dirty (from rea-enqueue) — next deref recomputes.
+      (is (= 20 @r))))
+
+  (testing "Reaction satisfies IReactiveAtom"
+    (let [r (ratom/make-reaction (fn [] 0))]
+      (is (satisfies? ratom/IReactiveAtom r))))
+
+  (testing "Reaction satisfies IDisposable"
+    (let [r (ratom/make-reaction (fn [] 0))]
+      (is (satisfies? ratom/IDisposable r)))))
+
+(deftest reaction-equality-memo
+  (testing "watchers do not fire when recomputed value is = old value"
+    ;; :auto-run true → r subscribes eagerly + recomputes synchronously
+    ;; on dep change. This is the path that exercises the equality
+    ;; memoisation in _run (per IMPL-SPEC §3.2 — kept from stock).
+    (let [a           (ratom/atom {:k 1})
+          watch-calls (atom 0)
+          r           (ratom/make-reaction
+                        (fn [] (:k @a))
+                        :auto-run true)]
+      ;; Force initial compute so r subscribes to a.
+      (is (= 1 @r))
+      (add-watch r :w (fn [_ _ _ _] (swap! watch-calls inc)))
+      ;; Same :k but different map identity — should NOT fire watch
+      ;; (= memoisation kicks in: oldstate=1, res=1).
+      (reset! a {:k 1})
+      (is (= 0 @watch-calls))
+      ;; Different :k — should fire.
+      (reset! a {:k 2})
+      (is (= 1 @watch-calls))
+      (is (= 2 @r)))))
+
+(deftest reaction-multiple-deps
+  (testing "Reaction tracks multiple dependencies"
+    (let [a (ratom/atom 2)
+          b (ratom/atom 3)
+          r (ratom/make-reaction (fn [] (+ @a @b)))]
+      (is (= 5 @r))
+      (reset! a 10)
+      (is (= 13 @r))
+      (reset! b 100)
+      (is (= 110 @r)))))
+
+(deftest reaction-dependency-pruning
+  (testing "Reaction unsubscribes from no-longer-watched ratoms"
+    (let [flag (ratom/atom true)
+          a    (ratom/atom 1)
+          b    (ratom/atom 100)
+          r    (ratom/make-reaction (fn [] (if @flag @a @b)))]
+      (is (= 1 @r))
+      ;; Switch the branch.
+      (reset! flag false)
+      (is (= 100 @r))
+      ;; Now `a` is no longer a dependency. Mutating it must not
+      ;; recompute (no watchers wired to a anymore in r's path).
+      (reset! a 999)
+      (is (= 100 @r)))))
+
+(deftest reaction-dispose-clears-watches
+  (testing "dispose! removes watches from upstream RAtoms"
+    ;; Use :auto-run to ensure r subscribes to a (the fast-path deref
+    ;; doesn't wire upstream watches per IMPL-SPEC §3.2).
+    (let [a              (ratom/atom 0)
+          r              (ratom/make-reaction (fn [] @a) :auto-run true)
+          _              @r ;; trigger _run, which wires upstream watch
+          watches-before (.-watches a)]
+      (is (some? watches-before))
+      (ratom/dispose! r)
+      (let [watches-after (.-watches a)]
+        ;; Either nil or empty after dispose.
+        (is (or (nil? watches-after)
+                (empty? watches-after)))))))
+
+(deftest reaction-add-on-dispose
+  (testing "add-on-dispose! callbacks fire in registration order"
+    (let [r       (ratom/make-reaction (fn [] 1))
+          fired   (atom [])]
+      (ratom/add-on-dispose! r (fn [_] (swap! fired conj :a)))
+      (ratom/add-on-dispose! r (fn [_] (swap! fired conj :b)))
+      (ratom/add-on-dispose! r (fn [_] (swap! fired conj :c)))
+      (ratom/dispose! r)
+      (is (= [:a :b :c] @fired))))
+
+  (testing "on-dispose kwarg fires before add-on-dispose! callbacks"
+    (let [fired   (atom [])
+          r       (ratom/make-reaction
+                    (fn [] 1)
+                    :on-dispose (fn [_] (swap! fired conj :on-dispose-kwarg)))]
+      (ratom/add-on-dispose! r (fn [_] (swap! fired conj :added)))
+      (ratom/dispose! r)
+      (is (= [:on-dispose-kwarg :added] @fired)))))
+
+(deftest reaction-auto-run-true
+  (testing ":auto-run true triggers synchronous recompute on dep change"
+    (let [a       (ratom/atom 1)
+          calls   (atom 0)
+          r       (ratom/make-reaction
+                    (fn [] (swap! calls inc) @a)
+                    :auto-run true)]
+      ;; Force initial run so the reaction subscribes.
+      @r
+      (is (= 1 @calls))
+      (reset! a 2)
+      ;; auto-run true → synchronous recompute on change
+      (is (= 2 @calls))
+      (is (= 2 @r)))))
+
+(deftest reaction-auto-run-fn
+  (testing ":auto-run fn-form receives the reaction on change"
+    (let [a       (ratom/atom 1)
+          received (atom nil)
+          r       (ratom/make-reaction
+                    (fn [] @a)
+                    :auto-run (fn [r] (reset! received r)))]
+      @r
+      (reset! a 2)
+      (is (some? @received))
+      (is (instance? ratom/Reaction @received)))))
+
+;; ---------------------------------------------------------------------------
+;; reactive? + reactive context
+;; ---------------------------------------------------------------------------
+
+(deftest reactive-predicate
+  (testing "reactive? false outside any reactive context"
+    (is (false? (ratom/reactive?))))
+
+  (testing "reactive? true inside a Reaction body that goes through _run"
+    ;; The deref-fast-path (non-reactive deref of a no-auto-run Reaction)
+    ;; does NOT bind *ratom-context* — it just calls f. That's stock
+    ;; Reagent's design (per IMPL-SPEC §3.2). Use :auto-run true so the
+    ;; first deref goes through `_run` → `deref-capture` → `in-context`,
+    ;; which does bind *ratom-context*.
+    (let [seen (atom nil)
+          r    (ratom/make-reaction
+                 (fn [] (reset! seen (ratom/reactive?)))
+                 :auto-run true)]
+      @r
+      (is (true? @seen)))))
+
+;; ---------------------------------------------------------------------------
+;; flush! — rea-queue drain
+;; ---------------------------------------------------------------------------
+
+(deftest flush-drains-queue
+  (testing "flush! recomputes queued Reactions"
+    ;; A Reaction enqueues itself only if it had wired upstream watches
+    ;; (i.e. went through _run / deref-capture). The fast-path deref
+    ;; does NOT wire watches (IMPL-SPEC §3.2). Use :auto-run nil but
+    ;; deref under another reactive context to wire watches, OR use
+    ;; an explicit upstream Reaction. We choose the latter: r1 has
+    ;; auto-run, so it's subscribed; mutating a triggers r1's queue
+    ;; entry.
+    (let [a     (ratom/atom 1)
+          fired (atom [])
+          r     (ratom/make-reaction (fn [] @a) :auto-run true)]
+      ;; Force initial subscription via _run.
+      @r
+      (add-watch r :w (fn [_ _ _ nu] (swap! fired conj nu)))
+      ;; auto-run true → synchronous recompute on dep change.
+      ;; The watch fires inside the auto-run's _run path.
+      (reset! a 2)
+      (is (= [2] @fired))))
+
+  (testing "flush! drains downstream cascades"
+    ;; r1 has no auto-run; r2 derefs r1, so r2's deref-capture
+    ;; subscribes r2 to r1. r1 in turn must subscribe to a — give r1
+    ;; auto-run so it does. Then mutating a fires r1 (synchronous), r1
+    ;; fires r2 via its watcher (enqueued); flush! drains r2.
+    (let [a       (ratom/atom 1)
+          r1      (ratom/make-reaction (fn [] (* @a 10)) :auto-run true)
+          r2-vals (atom [])
+          r2      (ratom/make-reaction
+                    (fn [] (+ @r1 1))
+                    :auto-run true)]
+      ;; Force initial run-paths to wire subscriptions.
+      @r1 @r2
+      (add-watch r2 :w (fn [_ _ _ nu] (swap! r2-vals conj nu)))
+      (reset! a 2)
+      ;; auto-run on both is synchronous: a=2 → r1=20 → r2=21.
+      (is (= [21] @r2-vals)))))
+
+(deftest deref-outside-context-recomputes
+  (testing "deref'ing a Reaction outside a reactive context recomputes"
+    ;; The fast-path (non-reactive deref of a no-auto-run Reaction)
+    ;; doesn't subscribe; it just calls f. So every deref re-runs f
+    ;; and reports the current value of upstream RAtoms — matches
+    ;; stock Reagent's read-through-on-fast-path semantics.
+    (let [a (ratom/atom 1)
+          r (ratom/make-reaction (fn [] (* @a 10)))]
+      (is (= 10 @r))
+      (reset! a 5)
+      (is (= 50 @r)))))
+
+(deftest queued-reaction-drains-on-flush
+  (testing "rea-queue path: enqueue on dep change, flush! drains"
+    ;; A no-auto-run Reaction subscribes to its deps via deref-capture
+    ;; only when its body runs in a reactive context. We exercise this
+    ;; by deref'ing r INSIDE another (auto-run) Reaction's body — the
+    ;; outer reactive context is what triggers the subscription.
+    (let [a       (ratom/atom 1)
+          r-vals  (atom [])
+          r       (ratom/make-reaction (fn [] (* @a 10)))
+          ;; Outer with auto-run derefs r — wires r → a watching, AND
+          ;; r → outer via r's own watch.
+          outer   (ratom/make-reaction
+                    (fn [] @r)
+                    :auto-run true)]
+      ;; Force initial run paths.
+      @outer
+      ;; Now mutate a. Stock Reagent semantics: r enqueues itself; the
+      ;; auto-run on outer fires when r changes. Drain via flush!.
+      (add-watch outer :w (fn [_ _ _ nu] (swap! r-vals conj nu)))
+      (reset! a 3)
+      (ratom/flush!)
+      ;; outer should have observed r=30.
+      (is (= [30] @r-vals)))))
+
+;; ---------------------------------------------------------------------------
+;; reaction macro — 5-line indirection
+;; ---------------------------------------------------------------------------
+
+(deftest reaction-macro
+  (testing "(reaction body) is equivalent to (make-reaction (fn [] body))"
+    (let [a (ratom/atom 3)
+          r (reaction (* @a @a))]
+      (is (= 9 @r))
+      (reset! a 4)
+      (is (= 16 @r))
+      (is (instance? ratom/Reaction r)))))
+
+;; ---------------------------------------------------------------------------
+;; Cross-substrate cache-wiring contract (IMPL-SPEC §3.4)
+;;
+;; Per the spec: the cross-substrate cache calls add-on-dispose! on a
+;; substrate-side derived value. The protocol dispatch must work
+;; uniformly. This test sanity-checks that the protocol-based dispatch
+;; resolves on a Reaction without needing an instance? branch.
+;; ---------------------------------------------------------------------------
+
+(deftest cross-substrate-disposable-protocol
+  (testing "add-on-dispose! is callable via protocol dispatch alone"
+    (let [r     (ratom/make-reaction (fn [] 0))
+          fired (atom false)]
+      ;; Call through the protocol, NOT via direct method on the type:
+      (ratom/add-on-dispose! r (fn [_] (reset! fired true)))
+      (ratom/dispose! r)
+      (is (true? @fired)))))

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -2,11 +2,12 @@
 ;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit).
 ;;
 ;; The published artefacts are
-;;   - core/     (day8/re-frame-2)
-;;   - reagent/  (day8/re-frame-2-reagent)
-;;   - uix/      (day8/re-frame-2-uix,      rf2-3yij)
-;;   - helix/    (day8/re-frame-2-helix,    rf2-2qit)
-;;   - schemas/  (day8/re-frame-2-schemas,  rf2-p7va)
+;;   - core/          (day8/re-frame-2)
+;;   - reagent/       (day8/re-frame-2-reagent)
+;;   - reagent-slim/  (day8/reagent-slim,        rf2-5djt Stage 4)
+;;   - uix/           (day8/re-frame-2-uix,      rf2-3yij)
+;;   - helix/         (day8/re-frame-2-helix,    rf2-2qit)
+;;   - schemas/       (day8/re-frame-2-schemas,  rf2-p7va)
 ;;   - machines/ (day8/re-frame-2-machines, rf2-xbtj)
 ;;   - routing/  (day8/re-frame-2-routing,  rf2-k682)
 ;;   - flows/    (day8/re-frame-2-flows,    rf2-tfw3)
@@ -33,6 +34,7 @@
 {:paths []
  :deps  {day8/re-frame-2          {:local/root "core"}
          day8/re-frame-2-reagent  {:local/root "adapters/reagent"}
+         day8/reagent-slim        {:local/root "adapters/reagent-slim"}
          day8/re-frame-2-uix      {:local/root "adapters/uix"}
          day8/re-frame-2-helix    {:local/root "adapters/helix"}
          day8/re-frame-2-schemas  {:local/root "schemas"}
@@ -50,6 +52,7 @@
   :test
   {:extra-paths ["core/test"
                  "adapters/reagent/test"
+                 "adapters/reagent-slim/test"
                  "adapters/uix/test"
                  "adapters/helix/test"
                  "schemas/test"

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -25,6 +25,8 @@
                 "core/test"
                 "adapters/reagent/src"
                 "adapters/reagent/test"
+                "adapters/reagent-slim/src"
+                "adapters/reagent-slim/test"
                 "adapters/uix/src"
                 "adapters/uix/test"
                 "adapters/helix/src"


### PR DESCRIPTION
## Summary

First sub-stage of Stage 4 (rf2-6hyy) — the reactive primitives layer of the reagent-slim rewrite. Lands `reagent2.ratom` per IMPL-SPEC §2.3 + §3, plus the artefact scaffolding (deps.edn, top-level deps.edn / shadow-cljs.edn, lockstep verifier, CI job).

- New artefact: `day8/reagent-slim` at `implementation/adapters/reagent-slim/`
- Surface: `RAtom`, `Reaction`, `IReactiveAtom`, `IDisposable`, `atom`, `make-reaction`, `dispose!`, `add-on-dispose!`, `reactive?`, `flush!`, `(reaction ...)` macro
- Kernel matches stock Reagent's shape byte-for-byte (Stage 2 §4 \"Keep as-is\")
- Dropped surfaces (track/cursor/wrap/Track/RCursor/Wrapper/IRunnable/run!) — audit-confirmed zero usage

## Test plan

- [x] `clojure -M:test` from `implementation/adapters/reagent-slim/` — JVM classpath probe green (no JVM tests; the adapter is :cljs-only)
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — 198 tests / 601 assertions / 0 failures (was 197/600 before this PR; 25 new deftests in `reagent2.ratom-cljs-test`)
- [x] `bash .github/scripts/verify-version-lockstep.sh` — passes; reagent-slim recognised as adapter tier with `:version \"../../../VERSION\"` and `:local/root \"../../core\"`
- [ ] CI green on the new `jvm-reagent-slim` job

## What's next

Subsequent sub-stages (each its own PR after the prior merges):

- 4-B: render scheduler + microtask `flush-views!`
- 4-C: component-shape detection (compile-time fold into reg-view) + Form-3 7-key cap
- 4-D: hiccup translation (`reagent2.dom.client`) + adapter Var integration
- 4-E: pure-CLJS `render-to-static-markup` (`reagent2.dom.server`)
- 4-F: Class B throw-on-call shims + delete `coerce-context-value`
- 4-G: examples + MIGRATION entry

Cross-references: parent epic rf2-5djt; Stage 1 (rf2-ui6g) closed surface; Stage 2 (rf2-142b) sized wins; Stage 3 (rf2-60le) IMPL-SPEC drives this implementation.