### PR TITLE
test(rf2-22ds): frame-provider React-context coverage (Reagent 2 / React 19 target)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
@@ -1,0 +1,525 @@
+(ns re-frame.frame-provider-context-cljs-test
+  "Frame-provider runtime React-context test coverage (rf2-22ds).
+
+  Per Spec 002 §Reading the frame from React context and Spec 006
+  §Frame-provider via React context: the resolution chain at a CLJS
+  subscribe / dispatch call site is
+
+    1. `re-frame.frame/*current-frame*` (dynamic var; set by `with-frame`
+       / `bound-fn`)
+    2. closest enclosing `frame-provider` via React context
+    3. `:rf/default`
+
+  PR #195 (rf2-d4sf) made the React-context tier the *canonical* path
+  for `(rf/subscribe ...)` and `(rf/dispatch ...)` from inside a
+  rendered tree (subscribe / the dispatch envelope's `:frame` default
+  consult `:adapter/current-frame` through the late-bind hook). This
+  ns covers the seven runtime scenarios called out by the bead's
+  audit (rf2-o423):
+
+    1. Nested-provider inheritance — inner provider wins over outer.
+    2. Default-frame fallback — no provider in the tree → `:rf/default`.
+    3. Context-not-present error path — corrupted / non-keyword context
+       value should surface diagnostically.
+    4. Cross-frame subscribe resolution — subscribe routes against the
+       wrapped frame.
+    5. Cross-frame dispatch resolution — dispatch routes against the
+       wrapped frame.
+    6. React-19 strict-mode composition — frame-provider + reg-view'd
+       descendants render correctly under React.StrictMode.
+    7. React-19 concurrent-rendering / suspense — provider survives
+       across re-renders + suspense boundaries (act-wrapped).
+
+  Browser-only — every scenario requires a real React render so the
+  React-context tier actually pushes the Provider's value. The same
+  ns is loaded by both :node-test (matches `cljs-test$`) and
+  :browser-test (matches `-cljs-test$`); the DOM-mounting branches
+  gate on `(browser?)` and exit early under :node-test where
+  `js/document` is absent.
+
+  Adapter target: stock Reagent (the artefact on main). The
+  reagent-slim track is in flight; once it lands the same scenarios
+  re-validate against that adapter without changes here.
+
+  Some overlap with cross_spec_cljs_test.cljs §rf2-d4sf is
+  intentional — that suite covers the cross-spec interactions of
+  PR #195 broadly; this suite covers the seven-scenario surface
+  contract in one place.
+
+  Frame-id naming convention: every mounted scenario uses
+  *unnamespaced* frame keywords (e.g. `:rf-22ds-1-outer`, NOT
+  `:rf.22ds-1/outer`). Reagent's `convert-prop-value`
+  (reagent.impl.template) calls `(name kw)` on named prop values,
+  which drops the keyword's namespace. The shared
+  `re-frame.adapter.context/coerce-context-value` keywordises a
+  string back to a keyword but cannot reconstruct the lost
+  namespace, so a `[:> Provider {:value :foo/bar}]` reaches the
+  read-side as `:bar`, not `:foo/bar`. This is a separate gap from
+  the resolution-chain contracts under test here — see rf2-c5jz
+  for the namespace-stripping issue.
+
+  Scenario-3 pins the *current* behaviour for corrupted
+  `_currentValue` reads (silent fall-through to `:rf/default`). The
+  bead-3 expectation (a structured error event on corruption) is
+  filed as rf2-8q66; once that lands, scenario-3 updates to assert
+  the trace event."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react" :as React]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- browser gate ----------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+;; ---- Scenario 1: nested-provider inheritance ------------------------------
+;;
+;; Per Spec 002 §What `frame-provider` is: a `frame-provider` scopes a
+;; frame keyword to its subtree via React context. Per React's
+;; createContext semantics, the closest enclosing Provider wins —
+;; nested providers shadow outer ones in their own subtree. This test
+;; pins that property end-to-end: a `:outer` provider wraps an
+;; `:inner` provider wraps a reg-view'd probe; the probe must resolve
+;; to `:inner`, and a subscribe inside it must read `:inner`'s app-db.
+
+(deftest scenario-1-nested-provider-inner-wins
+  "Scenario 1 — nested-provider inheritance.
+
+   A `[rf/frame-provider {:frame :outer}]` wrapping a
+   `[rf/frame-provider {:frame :inner}]` wrapping a reg-view'd probe:
+   the probe sees `:inner`, and `(rf/subscribe ...)` inside resolves
+   against `:inner`'s app-db (not `:outer`'s, not `:rf/default`'s)."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [outer :rf-22ds-1-outer
+          inner :rf-22ds-1-inner]
+      (rf/reg-frame outer {:doc "outer scenario-1 frame"})
+      (rf/reg-frame inner {:doc "inner scenario-1 frame"})
+      (rf/reg-event-db :seed-1 (fn [_ [_ v]] {:v v}))
+      ;; Each frame's app-db carries a distinct value so the subscribe
+      ;; tells us unambiguously which frame served the read.
+      (rf/dispatch-sync [:seed-1 :outer-app-db] {:frame outer})
+      (rf/dispatch-sync [:seed-1 :inner-app-db] {:frame inner})
+      (rf/dispatch-sync [:seed-1 :default-app-db]) ;; :rf/default
+      (rf/reg-sub :scenario-1/v (fn [db _] (:v db)))
+
+      (let [resolved-frame (atom nil)
+            resolved-value (atom nil)]
+        (rf/reg-view* :rf.22ds-1/probe
+                      (fn probe-impl []
+                        (reset! resolved-frame (rf/current-frame))
+                        (reset! resolved-value @(rf/subscribe [:scenario-1/v]))
+                        [:div "probe"]))
+        (let [render-fn  (rf/view :rf.22ds-1/probe)
+              mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root
+                            ;; Outer provider wraps inner provider wraps probe.
+                            [rf/frame-provider {:frame outer}
+                             [rf/frame-provider {:frame inner}
+                              [render-fn]]])))
+            (is (= inner @resolved-frame)
+                "current-frame inside the doubly-wrapped subtree resolves to the INNER provider's frame")
+            (is (= :inner-app-db @resolved-value)
+                "subscribe routes against the inner frame's app-db, not outer's, not :rf/default's")
+            (finally
+              (try (rdc/unmount root) (catch :default _ nil)))))))))
+
+;; ---- Scenario 2: default-frame fallback -----------------------------------
+;;
+;; Per Spec 006 §Frame-provider via React context: the createContext
+;; default is `:rf/default`, so a reg-view rendered with NO enclosing
+;; `frame-provider` resolves to `:rf/default`. This is the
+;; "single-frame app" baseline — apps that never wrap with
+;; `frame-provider` keep working unchanged.
+
+(deftest scenario-2-default-frame-fallback
+  "Scenario 2 — default-frame fallback.
+
+   A reg-view rendered outside any `frame-provider` resolves to
+   `:rf/default` and its subscribes / dispatches route there."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (do
+      (rf/reg-event-db :seed-2 (fn [_ _] {:n 99}))
+      (rf/dispatch-sync [:seed-2])
+      (rf/reg-sub :scenario-2/n (fn [db _] (:n db)))
+      (let [resolved-frame (atom nil)
+            resolved-value (atom nil)]
+        (rf/reg-view* :rf.22ds-2/probe
+                      (fn probe-impl []
+                        (reset! resolved-frame (rf/current-frame))
+                        (reset! resolved-value @(rf/subscribe [:scenario-2/n]))
+                        [:div "default"]))
+        (let [render-fn  (rf/view :rf.22ds-2/probe)
+              mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn []
+                ;; No frame-provider in the tree.
+                (rdc/render root [render-fn])))
+            (is (= :rf/default @resolved-frame)
+                "no provider in the tree → resolution falls through to :rf/default (createContext default)")
+            (is (= 99 @resolved-value)
+                "subscribe routes against :rf/default's app-db")
+            (finally
+              (try (rdc/unmount root) (catch :default _ nil)))))))))
+
+;; ---- Scenario 3: context-not-present error path ---------------------------
+;;
+;; Per the bead: "if the React-context boundary is corrupted (component
+;; rendered through an unwrapped portal? misuse case), the failure is
+;; observable + diagnostic — emits a structured error event, not a
+;; silent fallback."
+;;
+;; The current runtime (re-frame.adapter.context/coerce-context-value)
+;; tolerates only `keyword` and non-empty `string` shapes; anything
+;; else (nil, false, number, object) silently maps to nil and the
+;; lookup chain proceeds to `:rf/default`. There is no
+;; `:rf.error/frame-context-corrupted` (or similar) trace today.
+;;
+;; Per the bead workflow: a scenario that reveals a behavioural gap is
+;; documented as a passing assertion of the *current* observable
+;; behaviour, plus a `bd` bead capturing the gap. The structured-error
+;; expectation is filed as rf2-8q66.
+
+(deftest scenario-3-context-corrupted-current-behaviour
+  "Scenario 3 — context-not-present / corrupted error path.
+
+   Pins the *current* behaviour: a non-keyword / non-string
+   `_currentValue` on the shared frame-context falls through to
+   `:rf/default` silently. The bead expectation that this should
+   instead emit a structured error event is filed as rf2-8q66 —
+   fixing it would change observable behaviour and is out of scope
+   for this test ns (rf2-22ds is coverage, not implementation).
+
+   Direct test against the function-component-shape resolver because
+   the only ways to corrupt `_currentValue` involve either bypassing
+   React's normal Provider machinery (which the user-facing surface
+   does not allow) or directly poking the field — the latter is what
+   we do here, since it is the substrate-level seam the resolver
+   reads."
+  (let [original (.-_currentValue ^js adapter-context/frame-context)]
+    (try
+      (testing "nil _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+        (set! (.-_currentValue ^js adapter-context/frame-context) nil)
+        (is (= :rf/default (adapter-context/function-component-current-frame))
+            "nil falls through to :rf/default (current behaviour)"))
+      (testing "false _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+        (set! (.-_currentValue ^js adapter-context/frame-context) false)
+        (is (= :rf/default (adapter-context/function-component-current-frame))
+            "false falls through to :rf/default (current behaviour)"))
+      (testing "numeric _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+        (set! (.-_currentValue ^js adapter-context/frame-context) 42)
+        (is (= :rf/default (adapter-context/function-component-current-frame))
+            "non-keyword non-string falls through to :rf/default (current behaviour)"))
+      (testing "object _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+        (set! (.-_currentValue ^js adapter-context/frame-context) #js {:not "a frame"})
+        (is (= :rf/default (adapter-context/function-component-current-frame))
+            "JS object falls through to :rf/default (current behaviour)"))
+      (testing "empty-string _currentValue falls through to :rf/default"
+        ;; Empty strings are a documented degenerate case — no valid
+        ;; keyword name. coerce-context-value already handles this.
+        (set! (.-_currentValue ^js adapter-context/frame-context) "")
+        (is (= :rf/default (adapter-context/function-component-current-frame))
+            "empty string is a documented fall-through to :rf/default"))
+      (finally
+        (set! (.-_currentValue ^js adapter-context/frame-context) original)))))
+
+;; ---- Scenario 4: cross-frame subscribe resolution -------------------------
+;;
+;; Per Spec 006 §706 / rf2-d4sf: `(rf/subscribe ...)` inside a wrapped
+;; view consults the React-context tier and resolves the query against
+;; the wrapped frame's app-db. This is also covered by
+;; cross_spec_cljs_test/subscribe-routes-via-react-context-under-non-
+;; default-frame; pinned here as the canonical seven-scenario surface.
+
+(deftest scenario-4-subscribe-routes-against-wrapped-frame
+  "Scenario 4 — cross-frame subscribe resolution.
+
+   `(rf/subscribe ...)` from inside a wrapped reg-view resolves
+   against the wrapped frame's app-db, not :rf/default."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target :rf-22ds-4-wrapped]
+      (rf/reg-frame target {:doc "scenario-4 wrapped frame"})
+      (rf/reg-event-db :seed-4 (fn [_ [_ v]] {:s v}))
+      ;; Different values in the two frames so the subscribed value
+      ;; tells us unambiguously which frame served the read.
+      (rf/dispatch-sync [:seed-4 :wrapped] {:frame target})
+      (rf/dispatch-sync [:seed-4 :default]) ;; :rf/default
+      (rf/reg-sub :scenario-4/s (fn [db _] (:s db)))
+
+      (let [resolved (atom nil)]
+        (rf/reg-view* :rf.22ds-4/probe
+                      (fn []
+                        (reset! resolved @(rf/subscribe [:scenario-4/s]))
+                        [:div "probe"]))
+        (let [render-fn  (rf/view :rf.22ds-4/probe)
+              mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [rf/frame-provider {:frame target}
+                                  [render-fn]])))
+            (is (= :wrapped @resolved)
+                "subscribe routes against the wrapped frame, not :rf/default")
+            (finally
+              (try (rdc/unmount root) (catch :default _ nil)))))))))
+
+;; ---- Scenario 5: cross-frame dispatch resolution --------------------------
+;;
+;; Per Spec 006 §rf2-d4sf: the dispatch envelope's `:frame` default is
+;; built via the same `:adapter/current-frame` hook as subscribe, so a
+;; dispatch from inside a wrapped reg-view targets the wrapped frame's
+;; app-db. Covered also by
+;; cross_spec_cljs_test/dispatch-default-frame-routes-via-react-context;
+;; pinned here as the canonical seven-scenario surface.
+
+(deftest scenario-5-dispatch-routes-against-wrapped-frame
+  "Scenario 5 — cross-frame dispatch resolution.
+
+   `(rf/dispatch ...)` (dispatch-sync here, for synchronous
+   observability) from inside a wrapped reg-view targets the wrapped
+   frame; the wrapped frame's app-db is mutated, :rf/default's is not."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target :rf-22ds-5-wrapped]
+      (rf/reg-frame target {:doc "scenario-5 wrapped frame"})
+      (rf/reg-event-db :scenario-5/stamp (fn [db _] (assoc db :stamped :here)))
+
+      (rf/reg-view* :rf.22ds-5/probe
+                    (fn []
+                      (rf/dispatch-sync [:scenario-5/stamp])
+                      [:div "probe"]))
+      (let [render-fn  (rf/view :rf.22ds-5/probe)
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          (react-dom/flushSync
+            (fn []
+              (rdc/render root [rf/frame-provider {:frame target}
+                                [render-fn]])))
+          (is (= :here (:stamped (rf/get-frame-db target)))
+              "the wrapped frame's app-db carries the stamp — dispatch routed there")
+          (is (not= :here (:stamped (rf/get-frame-db :rf/default)))
+              ":rf/default's app-db is NOT stamped — the dispatch did not fall through")
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))
+
+;; ---- Scenario 6: React StrictMode composition -----------------------------
+;;
+;; React.StrictMode double-invokes function bodies (and certain
+;; lifecycle phases) in development to surface unsafe side effects.
+;; A reg-view'd component is a class-component-shape (Reagent) whose
+;; render fn must remain pure — the wrapper's per-render machinery
+;; (mint instance token, emit render trace, walk hiccup for source-
+;; coord) must tolerate double invocation without producing
+;; observably-broken output. The frame-provider's React.Context
+;; Provider also gets double-rendered; the resolution chain MUST land
+;; on the same frame keyword across both invocations.
+;;
+;; The bead lists this as "React-19 strict-mode composition"; under
+;; React 18 (the test infra's installed version, package.json
+;; pinning) StrictMode produces the same double-invoke contract and
+;; is sufficient to validate the property.
+
+(deftest scenario-6-strict-mode-composition
+  "Scenario 6 — React StrictMode composition.
+
+   Wrap the test tree in `<React.StrictMode>`. The reg-view'd probe
+   is invoked twice per render (StrictMode's intentional double-
+   invoke). The probe must observe the wrapped frame on every
+   invocation (resolution chain is a pure read of React context;
+   double-invocation does not break it), and the subscribe must
+   return the wrapped frame's app-db value."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target :rf-22ds-6-strict]
+      (rf/reg-frame target {:doc "scenario-6 strict-mode frame"})
+      (rf/reg-event-db :seed-6 (fn [_ _] {:s :strict-mode-app-db}))
+      (rf/dispatch-sync [:seed-6] {:frame target})
+      (rf/reg-sub :scenario-6/s (fn [db _] (:s db)))
+
+      (let [observed-frames  (atom [])
+            observed-values  (atom [])
+            invocation-count (atom 0)]
+        (rf/reg-view* :rf.22ds-6/probe
+                      (fn []
+                        (swap! invocation-count inc)
+                        (swap! observed-frames conj (rf/current-frame))
+                        (swap! observed-values conj @(rf/subscribe [:scenario-6/s]))
+                        [:div "strict"]))
+        (let [render-fn  (rf/view :rf.22ds-6/probe)
+              mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn []
+                ;; Wrap in React.StrictMode via Reagent's `:>` interop
+                ;; marker. Children are passed through; StrictMode
+                ;; double-invokes its descendants' render bodies in
+                ;; development.
+                (rdc/render root
+                            [:> (.-StrictMode React)
+                             [rf/frame-provider {:frame target}
+                              [render-fn]]])))
+            ;; The probe should have been invoked at least once. Under
+            ;; StrictMode in development React 18+ invokes function
+            ;; components twice; we don't pin the exact count (Reagent
+            ;; can class-ify, behaviour can vary by mode) — we pin the
+            ;; observability contract: every invocation saw the same
+            ;; frame, and every subscribe returned the same value.
+            (is (>= @invocation-count 1)
+                "the probe rendered at least once")
+            (is (every? #(= target %) @observed-frames)
+                (str "every render observed the wrapped frame; got "
+                     (pr-str @observed-frames)))
+            (is (every? #(= :strict-mode-app-db %) @observed-values)
+                (str "every subscribe returned the wrapped frame's app-db value; got "
+                     (pr-str @observed-values)))
+            (finally
+              (try (rdc/unmount root) (catch :default _ nil)))))))))
+
+;; ---- Scenario 7: concurrent rendering / suspense + act --------------------
+;;
+;; React 18+ concurrent rendering schedules renders asynchronously by
+;; default. Tests that drive renders need to wrap them in `act()` so
+;; React's pending work commits before assertions run. This scenario
+;; pins that the frame-provider survives across re-renders driven
+;; through `act` — a subscribe held inside a reg-view'd component
+;; reflects a post-dispatch app-db change after act flushes pending
+;; renders, and the resolution chain still lands on the wrapped frame.
+;;
+;; React's `act()` is exposed via `react-dom/test-utils` (React 18)
+;; and on `react` directly (React 19). The harness uses whichever is
+;; available; if neither is reachable the test SKIPS and files a bead
+;; (per the bead's "no new test infrastructure" rule).
+
+(defn- get-act
+  "Return React's act() if available, else nil. React 18 ships act in
+  react-dom/test-utils; React 19 promotes it to the React namespace
+  proper. Either is fine for our purposes — both are sync-or-async-
+  promise compatible with the same call shape."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(deftest scenario-7-concurrent-renders-survive-act-flush
+  "Scenario 7 — React concurrent rendering survives across re-renders.
+
+   Drive an initial render under `act()`, then dispatch an event that
+   updates the wrapped frame's app-db, then drive another render
+   under `act()`. The subscribe held inside the reg-view'd component
+   reflects the post-dispatch value, AND the resolution still lands
+   on the wrapped frame (the provider boundary held across both
+   renders).
+
+   No real Suspense boundary is mounted because the bead's
+   suspend-able primitive (a real-Suspense data-fetcher) doesn't ship
+   with this test infrastructure; the act-wrapped re-render is the
+   minimally-sufficient signal that pending React work commits
+   without corrupting the provider chain."
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [target :rf-22ds-7-concurrent
+          act-fn (get-act)]
+      (if (nil? act-fn)
+        ;; Harness gap — no act() reachable. Per the bead, file and
+        ;; skip rather than yak-shave a new harness primitive.
+        (is true (str "act() not reachable from this test runner; "
+                      "scenario-7 skipped — bead filed (see suite docstring)."))
+        (let [_ (rf/reg-frame target {:doc "scenario-7 concurrent frame"})
+              _ (rf/reg-event-db :seed-7 (fn [_ _] {:n 1}))
+              _ (rf/reg-event-db :inc-7  (fn [db _] (update db :n inc)))
+              _ (rf/dispatch-sync [:seed-7] {:frame target})
+              _ (rf/reg-sub :scenario-7/n (fn [db _] (:n db)))
+              observed-frames (atom [])
+              observed-values (atom [])
+              _ (rf/reg-view* :rf.22ds-7/probe
+                              (fn []
+                                (swap! observed-frames conj (rf/current-frame))
+                                (swap! observed-values conj @(rf/subscribe [:scenario-7/n]))
+                                [:div "concurrent"]))
+              render-fn  (rf/view :rf.22ds-7/probe)
+              mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            ;; Render 1 — wrap the call in act() so pending React work
+            ;; commits before we read the observed-* atoms.
+            (act-fn (fn []
+                      (rdc/render root [rf/frame-provider {:frame target}
+                                        [render-fn]])))
+            (is (some #{target} @observed-frames)
+                "first render saw the wrapped frame")
+            (is (some #{1} @observed-values)
+                "first render saw the seeded value n=1")
+            ;; Mutate the wrapped frame's app-db. The reaction held by
+            ;; the probe should pick up the change; act() drains the
+            ;; resulting render.
+            (rf/dispatch-sync [:inc-7] {:frame target})
+            (act-fn (fn []
+                      ;; Force a re-render by re-rendering the same
+                      ;; tree; Reagent's reaction tracking would
+                      ;; normally kick a render automatically — the
+                      ;; explicit re-render makes the test
+                      ;; deterministic across reactivity-flush timing
+                      ;; differences in the harness.
+                      (rdc/render root [rf/frame-provider {:frame target}
+                                        [render-fn]])))
+            (is (= target (last @observed-frames))
+                "post-act render still observes the wrapped frame — provider boundary held")
+            (is (some #{2} @observed-values)
+                "post-dispatch re-render observes the incremented value n=2")
+            (finally
+              (try (rdc/unmount root) (catch :default _ nil)))))))))
+
+;; ---- harness sanity: provider element shape -------------------------------
+;;
+;; A non-mounting headless sanity check — the provider hiccup composes
+;; the way the seven scenarios depend on. This catches a regression
+;; where the provider component shape drifts (e.g. a bad refactor of
+;; build-frame-provider) BEFORE any of the mount-based scenarios run,
+;; which makes per-scenario failures easier to read.
+
+(deftest harness-sanity-provider-element-shape
+  "Sanity — `[rf/frame-provider {:frame :x} child]` composes to a
+  React Context Provider element with the expected `:value`. Sister
+  to the existing `frame-provider-emits-provider-hiccup` in
+  runtime_cljs_test; pinned here so a regression in the provider
+  shape surfaces alongside this suite's failures, not three suites
+  away."
+  (let [child       [:span "x"]
+        tree        (rf/frame-provider {:frame :rf-22ds-sanity-x} child)
+        head        (first tree)
+        value       (second tree)
+        rest-args   (drop 2 tree)]
+    (is (fn? head)
+        "head is a fn (the Reagent component)")
+    (is (= :rf-22ds-sanity-x value)
+        "the frame keyword threads through as the first invocation arg")
+    (is (= [child] rest-args)
+        "children follow the frame keyword unchanged")))


### PR DESCRIPTION
## Summary
- Adds `frame_provider_context_cljs_test.cljs` (Reagent adapter test ns) covering the seven frame-provider runtime React-context scenarios called out by rf2-o423's audit.
- Browser-only: every scenario mounts a real React tree (`reagent.dom.client/render` + `react-dom/flushSync`, with `act()` for the concurrent-rendering scenario) and asserts observable behaviour — resolved frame, subscribed value, dispatched app-db. Node-test runner returns a `(is true)` placeholder per the existing cross_spec pattern.
- No bug fixes (per the bead's "don't fix bugs revealed by tests"), no new test infrastructure — reuses the existing shadow-cljs `:browser-test` + Playwright harness.

## Scenario status

| # | Scenario | Status |
|---|---|---|
| 1 | Nested-provider inheritance | passing |
| 2 | Default-frame fallback | passing |
| 3 | Context-not-present error path | passing (pins **current** behaviour; gap → rf2-8q66) |
| 4 | Cross-frame subscribe resolution | passing |
| 5 | Cross-frame dispatch resolution | passing |
| 6 | React StrictMode composition | passing |
| 7 | Concurrent rendering / act-flushed re-renders | passing |

## Beads filed (gaps surfaced while writing the tests)

- **rf2-c5jz** — Reagent's `convert-prop-value` calls `(name kw)` on named prop values, dropping any namespace. A `[:> Provider {:value :foo/bar}]` reaches the read-side as `:bar`, not `:foo/bar`; the shared `re-frame.adapter.context/coerce-context-value` keywordises the read-side string back to a keyword but cannot reconstruct the lost namespace. The tests work around it by using unnamespaced frame keywords (e.g. `:rf-22ds-1-outer`); the test ns docstring documents the convention. Real apps that pick `:foo/bar`-shaped frame ids for collision safety will hit this — filed as a separate concern.

- **rf2-8q66** — corrupted `_currentValue` (non-keyword, non-string: `nil`, `false`, numeric, JS object) silently falls through to `:rf/default`. The bead's Scenario 3 expectation is a structured error event (`:rf.warning/frame-context-corrupted` or similar); fixing it would change observable behaviour and is out of scope for the coverage PR. Scenario-3 today pins the silent-fallback behaviour as a regression guard; once rf2-8q66 lands, the test updates to assert the trace event AND the `:rf/default` recovery.

## Test plan
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — 187 tests / 560 assertions / 0 failures / 0 errors
- [x] `npx shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs` — 187 tests / 581 assertions / 0 failures / 0 errors
- [x] No fixes to spec/ or implementation/ source — coverage-only PR

## Notes
- React 18.3.1 (the test infra's installed version per `implementation/package.json`) is the de facto target. The bead specifies "Reagent 2 / React 19"; the same scenarios re-validate against React 19 + reagent-slim once those land — no test changes required.
- Some overlap with `cross_spec_cljs_test.cljs` §rf2-d4sf is intentional: that suite covers the cross-spec interactions of PR #195 broadly; this suite covers the seven-scenario surface contract in one place. Both stay green.