### PR TITLE
examples: hygiene + best-practice sweep (rf2-79l5)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -18,7 +18,7 @@
    undisturbed; bundle isolation is verified by the per-example
    shadow-cljs builds and the production-elision grep."
   (:require ["react-dom/client" :as react-dom-client]
-            [helix.core         :as helix :refer [$ defnc]]
+            [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
             [re-frame.core      :as rf]
             [re-frame.adapter.helix :as helix-adapter]))

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -12,7 +12,7 @@
    components are plain `defnc`. Per Decision 3 there is no
    auto-injection."
   (:require ["react-dom/client" :as react-dom-client]
-            [helix.core         :as helix :refer [$ defnc]]
+            [helix.core         :refer [$ defnc]]
             [helix.dom          :as d]
             [helix.hooks        :as helix-hooks]
             [re-frame.core :as rf]

--- a/examples/reagent/7Guis/temperature/temperature.cljs
+++ b/examples/reagent/7Guis/temperature/temperature.cljs
@@ -18,7 +18,8 @@
    - Event + sub composition over a single value          (CP-1, CP-2)
    - Pure derivation in subs (Celsius ↔ Fahrenheit)        (CP-2)
    - Schema-bound app-db slice                            (CP-8)"
-  (:require [reagent.dom.client :as rdc]
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Per rf2-p7va, re-frame.schemas ships in
             ;; day8/re-frame-2-schemas. Loading the ns here registers
@@ -56,8 +57,8 @@
     (assoc db :temp {:celsius 0.0 :input-source :celsius :typing "0"})))
 
 (defn parse-num [s]
-  (let [trimmed (clojure.string/trim s)]
-    (when-not (clojure.string/blank? trimmed)
+  (let [trimmed (str/trim s)]
+    (when-not (str/blank? trimmed)
       (let [n (js/parseFloat trimmed)]
         (when-not (js/isNaN n) n)))))
 

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -9,8 +9,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [realworld.schema :as schema]
-            [realworld.http :as rh]
-            [realworld.routing :as routing])
+            [realworld.http :as rh])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (def blank-draft

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -17,8 +17,7 @@
             ;; Requiring re-frame.routing here triggers its load-time
             ;; hook + reg-sub registrations; without it, the rf/reg-route
             ;; calls below throw :rf.error/routing-artefact-missing.
-            [re-frame.routing]
-            [realworld.schema])
+            [re-frame.routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -8,8 +8,7 @@
    - keep logout on the existing auth machine path"
   (:require [re-frame.core :as rf]
             [realworld.schema :as schema]
-            [realworld.http :as rh]
-            [realworld.routing :as routing])
+            [realworld.http :as rh])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 (defn draft-from-user [user]

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -1,6 +1,6 @@
 (ns routing.core
-  "Worked example for [Construction Prompt CP-7](../../Construction-Prompts.md)
-   and [EP 012 Routing](../../012-Routing.md). A small three-page app:
+  "Worked example for [Construction Prompt CP-7](../../../spec/Construction-Prompts.md)
+   and [Spec 012 Routing](../../../spec/012-Routing.md). A small three-page app:
    home, articles list, article detail. Demonstrates URL ↔ frame state,
    navigation as event, route as sub, and route-aware root-view dispatch.
 

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -1,10 +1,10 @@
 (ns ssr.core
-  "Worked example for [Construction Prompt CP-9](../../Construction-Prompts.md)
-   and [EP 011 SSR & Hydration](../../011-SSR.md). A small server+client app:
+  "Worked example for [Construction Prompt CP-9](../../../spec/Construction-Prompts.md)
+   and [Spec 011 SSR & Hydration](../../../spec/011-SSR.md). A small server+client app:
    server renders a 'recent articles' page; client hydrates and remains
    interactive.
 
-   Per [011-SSR.md](../../spec/011-SSR.md): SSR is part of the target
+   Per [011-SSR.md](../../../spec/011-SSR.md): SSR is part of the target
    architecture, not a future concession. View pure-fn requirement,
    id-valued override seam, hydration via :rf/hydrate.
 

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -16,7 +16,7 @@
    Different folder from examples/reagent/counter so the canonical Reagent
    counter is undisturbed; bundle isolation is verified by the
    per-example shadow-cljs builds and the production-elision grep."
-  (:require [uix.core :as uix :refer [$ defui]]
+  (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core    :as rf]
             [re-frame.adapter.uix :as uix-adapter]))


### PR DESCRIPTION
Sweep of `examples/` for re-frame2 idiom adherence, code hygiene,
structural consistency, currency, and best-practice alignment. Mechanical
fixes only — no behavioural changes. All edited examples compile cleanly
under shadow-cljs with 0 warnings.

Companion to rf2-cyom (READMEs, deferred). 18 example apps audited;
9 files edited.

## Mechanical fixes

### Unused `:require` cleanups

- `examples/helix/counter_helix/core.cljs` — drop `:as helix` (only `:refer [$ defnc]` used)
- `examples/helix/login_helix/core.cljs` — drop `:as helix` (`:as helix-hooks` IS used)
- `examples/uix/counter_uix/core.cljs` — drop `:as uix` (only `:refer [$ defui]` used; `uix/login_uix` retains `:as uix` since `uix/use-state` is called)
- `examples/reagent/realworld/article_editor.cljs` — drop `[realworld.routing :as routing]` (alias unused; load-side-effect already guaranteed by `realworld.core`)
- `examples/reagent/realworld/routing.cljs` — drop `[realworld.schema]` (purely side-effect-load that nothing consumes)
- `examples/reagent/realworld/settings.cljs` — drop `[realworld.routing :as routing]` (same as `article_editor.cljs`)

### Missing require fix

- `examples/reagent/7Guis/temperature/temperature.cljs` — `parse-num` (line 58) used `clojure.string/trim` and `clojure.string/blank?` fully-qualified, but the namespace did not require `[clojure.string]`. The example happened to compile via transitive load. Added `[clojure.string :as str]`; switched call sites to `str/trim` / `str/blank?` for consistency with sibling 7GUIs files (`crud`, `cells`, `flight_booker`).

### Broken cross-doc links

`examples/reagent/<example>/` is two levels deep, so `../../foo.md` lands at `examples/foo.md`, not the repo root.

- `examples/reagent/routing/core.cljs` — namespace docstring's two cross-doc links (`Construction-Prompts.md`, `012-Routing.md`) used `../../`; corrected to `../../../spec/`. Rephrased \"EP 012 Routing\" → \"Spec 012 Routing\" for terminology consistency.
- `examples/reagent/ssr/core.cljc` — three cross-doc links (`Construction-Prompts.md`, `011-SSR.md` ×2) corrected the same way; \"EP 011 SSR & Hydration\" → \"Spec 011 SSR & Hydration\".

## Verification

```
cd implementation
npx shadow-cljs compile examples/counter examples/temperature \
                          examples/counter-uix examples/counter-helix \
                          examples/login-helix examples/routing \
                          examples/ssr examples/realworld
```

All 8 builds: `0 warnings`.

## Currency check

Greps confirmed examples carry no stale references after the recent renames:

| Search | Matches in `examples/` |
| --- | --- |
| `reagent-slim-and-fast` | 0 |
| `day8/re-frame-2-reagent` | 0 |
| `re-frame.substrate.` | 0 |
| `implementation/substrates/` | 0 |
| `:timeout-ms` on `:invoke` / `:invoke-all` (Spec 005 PR #223) | 0 |

The single `:timeout-ms` reference at `realworld/http.cljs:91, 110` is on the `:rf.http/managed` request-builder (Spec 014 surface, unrelated to the retired Spec 005 `:invoke` `:timeout-ms`).

## Out of scope (per bead)

- `examples/<dir>/README.md` (rf2-cyom owns those)
- `spec/` and `implementation/`
- New examples or new tests
- `decision-beads.md`
- Example structure rework

## Issues observed but not fixed

Three pedagogical / convention-call items left for follow-up consideration:

1. **`realworld.routing/auth-guard`** is dead code (defined but never registered). Spec 012 doesn't yet ship a route-interceptor registration API; `docs/guide/12-routing.md` mirrors the same shape as a teaching artifact. Leave until the API exists.
2. **`nine_states.core/has-todos?`** guard declared but unreferenced — pedagogical filler with an inline comment that documents the intent.
3. **`[re-frame.views]` documentary requires** in 13 examples are redundant given `re-frame.core`'s transitive pull, but signal intent to the reader. Convention call; not a defect.

Detailed write-up in `findings/examples-hygiene-audit.md` (local-only,
`.git/info/exclude`'d alongside `decision-beads.md`).