### PR TITLE
ci(docs): fix docs workflow — pin transitive upload-artifact (rf2-xmmh)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,8 @@ jobs:
         run: mkdocs build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        # v5 (transitively pins actions/upload-artifact to a SHA, which v3 did not — see rf2-xmmh).
+        uses: actions/upload-pages-artifact@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
         with:
           path: site/
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload Pages artifact
         # v5 (transitively pins actions/upload-artifact to a SHA, which v3 did not — see rf2-xmmh).
-        uses: actions/upload-pages-artifact@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: site/
 


### PR DESCRIPTION
## Summary
- Bump `actions/upload-pages-artifact` from v3 (SHA `56afc609…`) to v5.0.0 (SHA `fc324d35…`) so the transitively-invoked `actions/upload-artifact` is pinned to a full-length commit SHA, satisfying the org policy that has been failing every push to `main` since session start.

## Background
Bead **rf2-xmmh (P2)**. Every recent push to `main` failed the `docs` workflow with:

> The action actions/upload-artifact@v4 is not allowed in day8/re-frame2 because all actions must be pinned to a full-length commit SHA.

Both actions in our workflow were correctly SHA-pinned. The failure came from a **transitive** call: `upload-pages-artifact@v3` internally referenced `actions/upload-artifact@v4` (a tag, not a SHA), which the org's allowlist rejects.

## Path chosen — Path 2 (bump to a newer release)

`actions/upload-pages-artifact@v5.0.0` pins its internal `upload-artifact` reference to a SHA:
```
actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
```

That satisfies the org policy. `deploy-pages@v4.0.5` has no transitive `uses:` references, so it remains unchanged.

Path 3 (manual API upload) and Path 4 (drop the workflow) were not needed.

## Verification

The docs workflow only triggers on `push: [main]` and `workflow_dispatch`, so it does not run on this PR. Verified manually via `gh workflow run docs.yml --ref fix-docs-ci-rf2-xmmh`:

Run: https://github.com/day8/re-frame2/actions/runs/25634461356

- "Set up job" — **SUCCESS** (org-policy gate now passes — the rf2-xmmh failure mode is gone)
- Checkout / Set up Python / Install MkDocs + plugins / Stage spec — all SUCCESS
- "Build site" — FAILURE (pygments `AttributeError: 'NoneType' object has no attribute 'replace'`)

The remaining failure is in `mkdocs build` itself, which is **out of scope** for rf2-xmmh per the explicit "Don't change `mkdocs.yml` or anything about the docs build itself" constraint. It was previously masked by the action-policy block (the workflow never reached `mkdocs build`). Filed as follow-up bead **rf2-4jaz** (`discovered-from` rf2-xmmh).

## Test plan
- [x] `Set up job` step succeeds (no more "actions/upload-artifact@v4 is not allowed")
- [ ] After rf2-4jaz lands, full docs workflow runs green end-to-end