### PR TITLE
ci(docs): fix mkdocs build — pymdownx.highlight crash (rf2-4jaz)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.44
 pymdown-extensions==10.11.2
+# Pin pygments below 2.20 (rf2-4jaz). Pygments 2.20.0 added an html.escape()
+# call around the HtmlFormatter `filename` option, which crashes when
+# pymdown-extensions 10.11.2 passes filename=None for fenced code blocks
+# without an explicit title. 2.19.x handled None silently.
+pygments==2.19.2


### PR DESCRIPTION
## Summary

- Pin `pygments==2.19.2` in `requirements.txt` so `mkdocs build` no longer crashes with `AttributeError: 'NoneType' object has no attribute 'replace'`.
- Resolves rf2-4jaz, the docs build failure that surfaced once rf2-xmmh (#232) unblocked the org-policy gate and the workflow finally reached the build step.

## Root cause

Pygments 2.20.0 (released 2026-03-29) added an `html.escape(...)` call around the `HtmlFormatter` `filename` option:

```py
# pygments/formatters/html.py @ 2.20.0
self.filename = html.escape(self._decodeifneeded(options.get('filename', '')))
```

`pymdown-extensions` 10.11.2 always passes `filename=title` to the formatter, where `title` defaults to `None` for fenced code blocks without an explicit title. `html.escape(None)` then raises, killing the build at the first non-titled fence (`guide/05-state-machines.md` in our run).

Pygments 2.19.2 calls `_decodeifneeded` only — which tolerates `None` — so pinning is the cheapest fix. The real fix belongs upstream in pymdown-extensions; we can drop the pin once they cut a release that defends `title=None`.

## Path chosen

Path 1 from the bead's three options (pin pygments). Did not need to touch markdown source or bump pymdownx.

## Test plan

- [x] Reproduce locally: `python -m venv .venv && .venv/Scripts/pip install -r requirements.txt && rm -rf docs/spec && cp -r spec docs/spec && mkdocs build` — completes with `INFO - Documentation built in 2.47 seconds`, exit 0.
- [x] `site/guide/05-state-machines/index.html` (the page the failing CI run named in the traceback) is now produced.
- [ ] Docs CI workflow on this PR completes the `Build site` step green.