### PR TITLE
feat: structured error for frame-context corruption (rf2-8q66)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
@@ -58,11 +58,11 @@
   the resolution-chain contracts under test here — see rf2-c5jz
   for the namespace-stripping issue.
 
-  Scenario-3 pins the *current* behaviour for corrupted
-  `_currentValue` reads (silent fall-through to `:rf/default`). The
-  bead-3 expectation (a structured error event on corruption) is
-  filed as rf2-8q66; once that lands, scenario-3 updates to assert
-  the trace event."
+  Scenario-3 asserts the structured `:rf.error/frame-context-corrupted`
+  trace event fires on a corrupted `_currentValue` read (rf2-8q66
+  closed). Recovery is `:replaced-with-default` — observable
+  behaviour at the call site is unchanged (still resolves to
+  `:rf/default`); the error event is the new diagnostic surface."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.dom.client :as rdc]
             ["react" :as React]
@@ -191,26 +191,31 @@
 ;; observable + diagnostic — emits a structured error event, not a
 ;; silent fallback."
 ;;
-;; The current runtime (re-frame.adapter.context/coerce-context-value)
-;; tolerates only `keyword` and non-empty `string` shapes; anything
-;; else (nil, false, number, object) silently maps to nil and the
-;; lookup chain proceeds to `:rf/default`. There is no
-;; `:rf.error/frame-context-corrupted` (or similar) trace today.
-;;
-;; Per the bead workflow: a scenario that reveals a behavioural gap is
-;; documented as a passing assertion of the *current* observable
-;; behaviour, plus a `bd` bead capturing the gap. The structured-error
-;; expectation is filed as rf2-8q66.
+;; rf2-8q66 closed: when `_currentValue` is a shape
+;; `coerce-context-value` cannot resolve to a frame keyword (nil,
+;; false, number, JS object, empty string), the runtime emits
+;; `:rf.error/frame-context-corrupted` (op-type `:error`, recovery
+;; `:replaced-with-default`) and falls through to `:rf/default`. The
+;; observable resolution still lands on `:rf/default` so apps don't
+;; break — the error event is the new diagnostic surface.
 
-(deftest scenario-3-context-corrupted-current-behaviour
+(defn- collect-traces [k]
+  (let [traces (atom [])]
+    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    traces))
+
+(defn- corruption-traces [traces]
+  (filter #(= :rf.error/frame-context-corrupted (:operation %)) @traces))
+
+(deftest scenario-3-context-corrupted-emits-structured-error
   "Scenario 3 — context-not-present / corrupted error path.
 
-   Pins the *current* behaviour: a non-keyword / non-string
-   `_currentValue` on the shared frame-context falls through to
-   `:rf/default` silently. The bead expectation that this should
-   instead emit a structured error event is filed as rf2-8q66 —
-   fixing it would change observable behaviour and is out of scope
-   for this test ns (rf2-22ds is coverage, not implementation).
+   Asserts the rf2-8q66 contract: a non-coercible `_currentValue` on
+   the shared frame-context emits `:rf.error/frame-context-corrupted`
+   (op-type `:error`, recovery `:replaced-with-default`) and falls
+   through to `:rf/default`. The fall-through is the unchanged
+   pre-rf2-8q66 behaviour; the error event is the new observable
+   surface.
 
    Direct test against the function-component-shape resolver because
    the only ways to corrupt `_currentValue` involve either bypassing
@@ -218,31 +223,69 @@
    does not allow) or directly poking the field — the latter is what
    we do here, since it is the substrate-level seam the resolver
    reads."
-  (let [original (.-_currentValue ^js adapter-context/frame-context)]
+  (let [original (.-_currentValue ^js adapter-context/frame-context)
+        traces   (collect-traces ::scenario-3)]
     (try
-      (testing "nil _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+      (testing "nil _currentValue: error trace fires; resolves to :rf/default"
+        (reset! traces [])
         (set! (.-_currentValue ^js adapter-context/frame-context) nil)
         (is (= :rf/default (adapter-context/function-component-current-frame))
-            "nil falls through to :rf/default (current behaviour)"))
-      (testing "false _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+            "still falls through to :rf/default (recovery preserved)")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one :rf.error/frame-context-corrupted event fired")
+          (is (= :error (:op-type (first errs)))
+              ":op-type is :error per Spec 009 §Error contract")
+          (is (= :replaced-with-default (:recovery (first errs)))
+              ":recovery is :replaced-with-default — fall-through preserved")
+          (is (= :nil (-> errs first :tags :type))
+              ":tags :type names the corrupted shape")
+          (is (contains? (-> errs first :tags) :received)
+              ":tags :received carries the offending value")))
+      (testing "false _currentValue: error trace fires; resolves to :rf/default"
+        (reset! traces [])
         (set! (.-_currentValue ^js adapter-context/frame-context) false)
         (is (= :rf/default (adapter-context/function-component-current-frame))
-            "false falls through to :rf/default (current behaviour)"))
-      (testing "numeric _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+            "still falls through to :rf/default")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one error trace per corrupted read")
+          (is (= :boolean (-> errs first :tags :type))
+              ":tags :type identifies false as a boolean shape")))
+      (testing "numeric _currentValue: error trace fires; resolves to :rf/default"
+        (reset! traces [])
         (set! (.-_currentValue ^js adapter-context/frame-context) 42)
         (is (= :rf/default (adapter-context/function-component-current-frame))
-            "non-keyword non-string falls through to :rf/default (current behaviour)"))
-      (testing "object _currentValue silently falls through to :rf/default (gap: rf2-8q66)"
+            "still falls through to :rf/default")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one error trace per corrupted read")
+          (is (= :number (-> errs first :tags :type))
+              ":tags :type identifies the number shape")
+          (is (= 42 (-> errs first :tags :received))
+              ":tags :received echoes the offending value")))
+      (testing "JS object _currentValue: error trace fires; resolves to :rf/default"
+        (reset! traces [])
         (set! (.-_currentValue ^js adapter-context/frame-context) #js {:not "a frame"})
         (is (= :rf/default (adapter-context/function-component-current-frame))
-            "JS object falls through to :rf/default (current behaviour)"))
-      (testing "empty-string _currentValue falls through to :rf/default"
-        ;; Empty strings are a documented degenerate case — no valid
-        ;; keyword name. coerce-context-value already handles this.
+            "still falls through to :rf/default")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one error trace per corrupted read")
+          (is (= :js-object (-> errs first :tags :type))
+              ":tags :type identifies the JS object shape")))
+      (testing "empty-string _currentValue: error trace fires; resolves to :rf/default"
+        (reset! traces [])
         (set! (.-_currentValue ^js adapter-context/frame-context) "")
         (is (= :rf/default (adapter-context/function-component-current-frame))
-            "empty string is a documented fall-through to :rf/default"))
+            "still falls through to :rf/default")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one error trace per corrupted read")
+          (is (= :empty-string (-> errs first :tags :type))
+              ":tags :type identifies empty-string distinctly from string")))
       (finally
+        (rf/remove-trace-cb! ::scenario-3)
         (set! (.-_currentValue ^js adapter-context/frame-context) original)))))
 
 ;; ---- Scenario 4: cross-frame subscribe resolution -------------------------

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -25,7 +25,8 @@
   Per rf2-3yij Decision 2: factored out of re-frame.views for the UIx
   adapter to read."
   (:require ["react" :as React]
-            [re-frame.frame :as frame]))
+            [re-frame.frame :as frame]
+            [re-frame.trace :as trace]))
 
 (defonce frame-context
   ;; The default value is :rf/default — Spec 002 §`:rf/default` guarantees
@@ -72,6 +73,45 @@
     (keyword? v) v
     (and (string? v) (not= "" v)) (keyword v)))
 
+(defn- value-type-tag
+  "Return a short keyword tag describing v's runtime type, for
+  `:rf.error/frame-context-corrupted` diagnostic payloads. Names
+  shapes the bead enumerates (nil, false, number, empty-string, JS
+  object, …) directly so dashboards can branch without reflecting on
+  pr-str output."
+  [v]
+  (cond
+    (nil? v)              :nil
+    (false? v)            :boolean
+    (true? v)             :boolean
+    (and (string? v)
+         (= "" v))        :empty-string
+    (string? v)           :string
+    (keyword? v)          :keyword
+    (number? v)           :number
+    (symbol? v)           :symbol
+    (map? v)              :map
+    (vector? v)           :vector
+    (sequential? v)       :sequential
+    (coll? v)             :collection
+    (fn? v)               :fn
+    :else                 :js-object))
+
+(defn- emit-frame-context-corrupted!
+  "Emit `:rf.error/frame-context-corrupted` (per Spec 009 §Error
+  categories). The React-context value at the function-component read
+  site (`_currentValue`) was a shape `coerce-context-value` cannot
+  resolve to a frame keyword — typically nil, false, a number, an
+  empty string, or a JS object. Recovery is `:replaced-with-default`:
+  the resolution chain falls through to `:rf/default` (current
+  observable behaviour preserved). Per rf2-8q66."
+  [v]
+  (trace/emit-error! :rf.error/frame-context-corrupted
+                     {:received v
+                      :type     (value-type-tag v)
+                      :recovery :replaced-with-default
+                      :reason   "React-context `_currentValue` is not a frame keyword; check the closest `frame-provider` boundary (or whether the subtree was rendered through an unwrapped portal)."}))
+
 ;; ---- function-component current-frame (UIx / Helix; rf2-d4sf) ------------
 ;;
 ;; UIx and Helix render function components — they have no class-
@@ -105,9 +145,29 @@
   Tolerates Reagent's prop-stringified-keyword shape via
   `coerce-context-value` — relevant when a UIx / Helix subtree is
   embedded in a tree whose `frame-provider` was authored as a Reagent
-  `[:> ...]` interop call."
+  `[:> ...]` interop call.
+
+  Corrupted-`_currentValue` detection (rf2-8q66): the
+  `createContext` default is `:rf/default` (a keyword), so a
+  function-component read should always observe either a keyword or
+  the prop-stringified-keyword shape. Anything else (nil, false, a
+  number, an empty string, a JS object) means the React-context
+  boundary was disturbed — a portal rendering outside its Provider, a
+  library mutating `_currentValue`, or a Provider authored with a
+  non-keyword value. The runtime emits
+  `:rf.error/frame-context-corrupted` and falls through to
+  `:rf/default` (recovery `:replaced-with-default`); apps see the
+  same observable behaviour as before, plus a structured trace event
+  for diagnosis."
   []
   (or frame/*current-frame*
-      (when-some [v (.-_currentValue ^js frame-context)]
-        (coerce-context-value v))
+      (let [v (.-_currentValue ^js frame-context)]
+        (or (coerce-context-value v)
+            ;; Corrupted branch: value is not a frame keyword and not
+            ;; a non-empty string — covers nil, false, numbers, empty
+            ;; strings, and JS objects. Emit the structured error and
+            ;; fall through. Behaviour identical to pre-rf2-8q66 —
+            ;; observable only.
+            (do (emit-frame-context-corrupted! v)
+                nil)))
       :rf/default))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -296,6 +296,7 @@ The framework emits trace events from these call sites:
 - `ssr.cljc` — `:warning :rf.warning/multiple-status-set`, `:warning :rf.warning/multiple-redirects`, `:rf.error/sanitised-on-projection`.
 - `epoch.cljc` — `:rf.epoch/snapshotted` per drain-settle, `:rf.epoch/restored` on restore success, `:rf.epoch/db-replaced` on `reset-frame-db!` success (rf2-zq55), plus the six restore-failure categories and the two reset-frame-db! failure categories (`:rf.epoch/reset-frame-db-during-drain`, `:rf.epoch/reset-frame-db-schema-mismatch`), plus `:rf.epoch.cb/silenced-on-frame-destroy` emitted once per `(frame-id, cb-id)` pair on the destroy-cascade boundary (rf2-d656).
 - `views.cljs` — `:view/render` per registered-view render (per [Spec 004 §Render-tree primitives](004-Views.md)).
+- `adapter/context.cljs` — `:rf.error/frame-context-corrupted` (function-component `_currentValue` read observed a non-coercible shape; per rf2-8q66).
 - `std_interceptors.cljc` — `:rf.error/unwrap-bad-event-shape`.
 - `http_managed.cljc` — `:warning :rf.http/cljs-only-key-ignored-on-jvm`, `:warning :rf.warning/decode-defaulted`, `:info :rf.http/retry-attempt`, `:info :rf.http.interceptor/registered`, `:info :rf.http.interceptor/cleared`, `:error :rf.error/http-interceptor-failed` (request-side interceptor `:before` threw, per [014 §Middleware](014-HTTPRequests.md#middleware), rf2-6y3q), plus the Spec 014 failure categories.
 
@@ -684,6 +685,7 @@ This convention is **stable**: new error categories adopt one of the five existi
 | `:rf.error/no-adapter-specified` | `(rf/init! …)` was called with no args, nil, or a non-map argument (e.g. a keyword). The only legal call shape is `(rf/init! adapter-map)` — require the adapter ns and pass its `adapter` Var, e.g. `(rf/init! reagent/adapter)`. Per [006 §Adapter selection at boot](006-ReactiveSubstrate.md#adapter-selection-at-boot) and rf2-agql. Surfaced as a thrown ex-info, not a trace | `:where` (`'init!`), `:received` (when nil/keyword/non-map), `:expected`, `:recovery` (`:no-recovery`), `:reason` |
 | `:rf.error/render-on-headless-adapter` | `render` was called on the plain-atom (JVM/SSR) adapter, which only supports `render-to-string` (per [006](006-Substrate.md)) | `:reason` |
 | `:rf.error/no-hiccup-emitter-bound` | `render-to-string` was called before the SSR namespace bound the hiccup emitter via `set-hiccup-emitter!` (per [011](011-SSR.md)) | `:reason`, `:render-tree` |
+| `:rf.error/frame-context-corrupted` | A function-component frame-id read (`_currentValue` on the shared React context) observed a value `coerce-context-value` cannot resolve to a frame keyword — nil, false, a number, an empty string, or a JS object. Real-world triggers: a subtree rendered through an unwrapped portal, a Provider authored with a non-keyword `:value`, or a library mutating `_currentValue` externally. Per [006 §Frame-provider via React context](006-ReactiveSubstrate.md) and rf2-8q66 | `:received` (the offending value), `:type` (a short keyword tag — `:nil` / `:boolean` / `:number` / `:string` / `:empty-string` / `:keyword` / `:symbol` / `:map` / `:vector` / `:sequential` / `:collection` / `:fn` / `:js-object`), `:reason` |
 | `:rf.error/flow-cycle` | A flow registration introduced a cycle in the flow-dependency graph (per [013 §Topological ordering](013-Flows.md)). Registration is rejected | `:cycle` (the offending flow ids) |
 | `:rf.error/flow-missing-id` | A `reg-flow` call's flow map omitted `:id` (per [013](013-Flows.md)) | `:flow` (the offending map) |
 | `:rf.error/flow-bad-inputs` | A `reg-flow` call's flow `:inputs` was not a vector of paths (per [013](013-Flows.md)) | `:flow`, `:reason` |
@@ -856,6 +858,7 @@ Each frame has at most one `:on-error` handler. Re-registering the frame replace
 | `:rf.error/adapter-already-installed` | `:no-recovery` | The call throws; the existing adapter remains installed. |
 | `:rf.error/render-on-headless-adapter` | `:no-recovery` | The call throws; user should use `render-to-string` on this adapter. |
 | `:rf.error/no-hiccup-emitter-bound` | `:no-recovery` | The call throws; SSR namespace must be required so `set-hiccup-emitter!` runs. |
+| `:rf.error/frame-context-corrupted` | `:replaced-with-default` | The function-component resolution chain falls through to `:rf/default`. Pre-rf2-8q66 observable behaviour preserved; the error event is the new diagnostic surface. Per [006 §Frame-provider via React context](006-ReactiveSubstrate.md). |
 | `:rf.error/flow-cycle` | `:no-recovery` | Flow registration is rejected. |
 | `:rf.error/flow-missing-id` | `:no-recovery` | Flow registration is rejected. |
 | `:rf.error/flow-bad-inputs` | `:no-recovery` | Flow registration is rejected. |


### PR DESCRIPTION
## Summary

- Function-component frame-id reads now emit `:rf.error/frame-context-corrupted` when `_currentValue` is a shape `coerce-context-value` cannot resolve to a frame keyword (nil, false, a number, an empty string, or a JS object). Recovery is `:replaced-with-default` — observable behaviour at the call site is unchanged (still falls through to `:rf/default`); the error event is the new diagnostic surface.
- Spec 009 updated: per-file index entry for `adapter/context.cljs`, error-category-table row for `:rf.error/frame-context-corrupted` (with `:received` / `:type` / `:reason` payload), and recovery-dispositions row pinning `:replaced-with-default`.
- Scenario 3 of `frame_provider_context_cljs_test` now asserts the structured event fires (it previously pinned the silent-fallback as a regression guard pending this fix; rf2-22ds discovery).

Real-world triggers the new error surfaces:

- A subtree rendered through an unwrapped portal.
- A `frame-provider` authored with a non-keyword `:value`.
- A library mutating the shared context's `_currentValue` externally.

Discovered from rf2-22ds.

## Test plan

- [x] `clojure -M:test` from `implementation/core/`: 182 tests, 822 assertions, 0 failures, 0 errors.
- [x] `npm run test:browser` (shadow-cljs `:browser-test` driven by Playwright/Chromium): 187 tests, 581 assertions, 0 failures, 0 errors. Includes the updated Scenario 3 assertions for nil / false / number / JS-object / empty-string `_currentValue` shapes.
- [x] No change to user-visible behaviour beyond the new error event (resolution still lands on `:rf/default` per the recovery contract).