### PR TITLE
feat(schemas): implement set-schema-validator! seam (rf2-froe)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -589,6 +589,40 @@
    (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
      (f opts-or-frame-id))))
 
+(defn set-schema-validator!
+  "Register the validator fn that every dev-time schema-validation site
+  routes through. Per Spec 010 §Non-Malli validators (rf2-froe) the
+  seam is the substitute-Malli extension point — apps that want to
+  drop the ~24 KB gzipped Malli surface (rf2-qnxf bundle audit) swap
+  in their own validator at boot.
+
+  Argument shapes:
+
+    (rf/set-schema-validator! validate-fn)
+      validate-fn :: (fn [schema value] truthy?)
+                   | nil   ;; disables validation entirely
+
+    (rf/set-schema-validator! {:validate validate-fn :explain explain-fn})
+      Atomic swap of both fns at once.
+
+  Default behaviour ships Malli's validate / explain pair; calling
+  this fn replaces them. Returns nil when the schemas artefact is
+  not on the classpath (apps that don't want schemas don't need to
+  pull `day8/re-frame-2-schemas`)."
+  [validate-fn-or-map]
+  (when-let [f (late-bind/get-fn :schemas/set-schema-validator!)]
+    (f validate-fn-or-map)))
+
+(defn set-schema-explainer!
+  "Register the explainer fn — `(fn [schema value] explanation)` — used
+  to enrich schema-validation-failure traces' `:explain` key. Per
+  Spec 010 §Non-Malli validators (rf2-froe). See
+  `set-schema-validator!` for the validator companion. Returns nil
+  when the schemas artefact is not on the classpath."
+  [explain-fn]
+  (when-let [f (late-bind/get-fn :schemas/set-schema-explainer!)]
+    (f explain-fn)))
+
 #?(:clj
    (defmacro reg-machine
      "Register a machine as an event handler. Per Spec 001 the metadata

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -64,6 +64,10 @@
     :schemas/snapshot-by-frame    re-frame.schemas/snapshot-schemas-by-frame
     :schemas/restore-by-frame!    re-frame.schemas/restore-schemas-by-frame!
     :schemas/clear-by-frame!      re-frame.schemas/clear-schemas-by-frame!
+    :schemas/set-schema-validator!         re-frame.schemas/set-schema-validator! ;; rf2-froe — pluggable validator
+    :schemas/set-schema-explainer!         re-frame.schemas/set-schema-explainer! ;; rf2-froe — companion explainer
+    :schemas/validate-with-registered-fn   re-frame.schemas/validate-with-registered-fn ;; rf2-r2uh boundary seam
+    :schemas/explain-with-registered-fn    re-frame.schemas/explain-with-registered-fn  ;; rf2-r2uh boundary seam
     :machines/reg-machine             re-frame.machines/reg-machine* ;; rf2-8bp3 — plain-fn surface
     :machines/create-machine-handler  re-frame.machines/create-machine-handler
     :machines/machine-transition      re-frame.machines/machine-transition

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -15,8 +15,14 @@
   the active frame (`(frame/current-frame)`); `(reg-app-schema path
   schema {:frame frame-id})` registers explicitly.
 
-  This first-pass implementation uses Malli when available; if the user
-  hasn't pulled Malli into their project, schemas are silently ignored."
+  Per Spec 010 §Non-Malli validators (rf2-froe) the validator and
+  explainer fns are pluggable via `set-schema-validator!` /
+  `set-schema-explainer!`. The default validator delegates to Malli
+  (`(resolve 'malli.core/validate)`); apps that want to opt out — to
+  drop the ~24 KB gzipped Malli surface measured in
+  findings/malli-bundle-cost-audit.md — register a different fn (or
+  `nil` for a hard no-op). The `:spec` value remains opaque to the
+  framework; only the registered validator interprets it."
   (:require #?(:cljs [goog.crypt :as gcrypt])
             #?(:cljs [goog.crypt.Sha256])
             [re-frame.registrar :as registrar]
@@ -28,35 +34,169 @@
   #?(:clj (:import [java.security MessageDigest]
                    [java.nio.charset StandardCharsets])))
 
-(defn- malli-validate*
+;; ---- pluggable validator / explainer (rf2-froe) ---------------------------
+;;
+;; Per Spec 010 §Non-Malli validators — the validator-fn extension point.
+;; The framework never inspects the value stored in `:spec` directly;
+;; every validation site routes through the registered validator fn.
+;; This is the seam Malli plugs into by default; apps that want to drop
+;; the ~24 KB gzipped Malli surface (rf2-qnxf) call
+;; `(rf/set-schema-validator! some-other-fn)` (or `nil` for no-op) at
+;; boot before any reg-app-schema / :spec metadata lands.
+;;
+;; Two fns are registered separately so the validate hot path stays
+;; cheap (validate returns truthy/falsey; explain is only invoked on
+;; the failure branch to populate the trace's `:explain` key):
+;;
+;;   :validate (fn [schema value] truthy?)
+;;             — same shape as Malli's `validate`. nil disables; the
+;;             call site treats nil as "pass everything".
+;;
+;;   :explain  (fn [schema value] explanation)
+;;             — same shape as Malli's `explain`. nil = no explanation
+;;             attached to the failure trace.
+;;
+;; A combined `(set-schema-validator! {:validate ... :explain ...})`
+;; arity exists for callers who want to install both atomically.
+
+(defn- default-malli-validate
+  "The default validator — delegates to malli.core/validate. Returns
+  truthy on conform, falsey on fail. When Malli is not on the
+  classpath the resolve returns nil and we treat the value as
+  passing (we cannot disprove the shape). Apps that want
+  Malli-absent behaviour to be a hard fail register a stricter
+  validator via `set-schema-validator!`."
   [schema value]
-  ;; Defensive: if Malli isn't loaded, treat as 'pass'. Real builds will
-  ;; have Malli on the path. Uses requiring-resolve on JVM (lazy load);
-  ;; on CLJS we require malli.core directly via :require so the var is
-  ;; reachable through resolve.
   #?(:clj
      (try
-       (let [validate (requiring-resolve 'malli.core/validate)]
-         (validate schema value))
+       (if-let [v (requiring-resolve 'malli.core/validate)]
+         (v schema value)
+         true)
        (catch Throwable _ true))
      :cljs
      (try
-       (let [validate (resolve 'malli.core/validate)]
-         (if validate (validate schema value) true))
+       (if-let [v (resolve 'malli.core/validate)]
+         (v schema value)
+         true)
        (catch :default _ true))))
 
-(defn- malli-explain*
+(defn- default-malli-explain
+  "The default explainer — delegates to malli.core/explain. Returns
+  the Malli explanation map on fail or nil on conform / when Malli
+  is not on the classpath."
   [schema value]
   #?(:clj
      (try
-       (let [explain (requiring-resolve 'malli.core/explain)]
-         (explain schema value))
+       (when-let [e (requiring-resolve 'malli.core/explain)]
+         (e schema value))
        (catch Throwable _ nil))
      :cljs
      (try
-       (let [explain (resolve 'malli.core/explain)]
-         (when explain (explain schema value)))
+       (when-let [e (resolve 'malli.core/explain)]
+         (e schema value))
        (catch :default _ nil))))
+
+(defonce
+  ^{:doc "The currently-registered validator fn — `(fn [schema value]
+          truthy?)`. Default delegates to Malli; apps swap via
+          `set-schema-validator!`. Setting the atom to `nil` disables
+          validation everywhere (every `validate-*!` call returns
+          true without inspecting the schema)."}
+  validator-fn
+  (atom default-malli-validate))
+
+(defonce
+  ^{:doc "The currently-registered explainer fn — `(fn [schema value]
+          explanation)`. Populates the failure trace's `:explain`
+          key. Default delegates to Malli's `explain`; nil means no
+          explanation is attached."}
+  explainer-fn
+  (atom default-malli-explain))
+
+(defn set-schema-validator!
+  "Register the validator fn that every dev-time validation site routes
+  through. Per Spec 010 §Non-Malli validators (rf2-froe) the seam is
+  the substitute-Malli extension point — apps that want to drop Malli
+  (the ~24 KB gzipped surface measured in the rf2-qnxf bundle audit)
+  swap in their own validator at boot, before the first `reg-app-schema`
+  or `:spec`-bearing `reg-*` lands.
+
+  Argument shapes:
+
+    (set-schema-validator! validate-fn)
+      validate-fn :: (fn [schema value] truthy?)
+                   | nil   ;; disables validation entirely
+      Same signature as `malli.core/validate` — truthy on conform,
+      falsey on fail. The explainer is left untouched (apps that want
+      to also swap explanations call `set-schema-explainer!`).
+
+    (set-schema-validator! {:validate validate-fn :explain explain-fn})
+      Atomic swap of both fns at once. Either key may be `nil` to
+      disable the corresponding hot path. Keys not supplied leave the
+      existing registration in place.
+
+  Per Spec 010 §Non-Malli validators the validator-fn must be pure
+  (same `(schema, value)` returns the same result) and must be
+  production-elidable alongside `re-frame.interop/debug-enabled?` —
+  every call site is already gated on `debug-enabled?`, so the
+  validator's body is unreachable in `:advanced` + `goog.DEBUG=false`
+  builds.
+
+  Last-write-wins on re-registration. Returns the validator that was
+  installed (may be nil)."
+  [validate-fn-or-map]
+  (cond
+    (map? validate-fn-or-map)
+    (let [{:keys [validate explain]
+           :or   {validate ::unset
+                  explain  ::unset}} validate-fn-or-map]
+      (when-not (= ::unset validate) (reset! validator-fn validate))
+      (when-not (= ::unset explain)  (reset! explainer-fn  explain))
+      @validator-fn)
+
+    :else
+    (do (reset! validator-fn validate-fn-or-map)
+        @validator-fn)))
+
+(defn set-schema-explainer!
+  "Register the explainer fn — `(fn [schema value] explanation)` — that
+  every failure-trace site calls to enrich the trace's `:explain` key.
+  See `set-schema-validator!`. Setting `nil` disables explanations
+  (the failure trace simply omits the `:explain` data).
+
+  Last-write-wins. Returns the explainer that was installed (may be
+  nil)."
+  [explain-fn]
+  (reset! explainer-fn explain-fn)
+  @explainer-fn)
+
+(defn reset-schema-validator!
+  "Reset the validator and explainer atoms back to the default Malli-
+  delegating fns. Test-support helper — restores the framework default
+  after a test that called `set-schema-validator!` / `set-schema-
+  explainer!`."
+  []
+  (reset! validator-fn default-malli-validate)
+  (reset! explainer-fn default-malli-explain))
+
+(defn- run-validator
+  "Hot-path entry — invoke the registered validator fn against a
+  `(schema, value)` pair. Returns true (pass) when no validator is
+  registered (nil) so the call sites treat 'no validator' as 'no
+  validation' rather than 'every value fails'."
+  [schema value]
+  (if-let [f @validator-fn]
+    (f schema value)
+    true))
+
+(defn- run-explainer
+  "Hot-path entry — invoke the registered explainer fn against a
+  `(schema, value)` pair. Returns nil when no explainer is registered
+  (nil); call sites then omit the `:explain` key from the failure
+  trace."
+  [schema value]
+  (when-let [f @explainer-fn]
+    (f schema value)))
 
 ;; ---- per-frame storage ----------------------------------------------------
 ;;
@@ -340,10 +480,15 @@
 (defn validate-app-db!
   "After a handler commits :db, walk every registered app-schema for the
   named frame and validate the post-state. Failures trace as
-  :rf.error/schema-validation-failure with a Malli explanation.
+  :rf.error/schema-validation-failure with the registered explainer's
+  output attached.
 
   Per Spec 010 §Per-frame schemas only the named frame's schemas are
   walked — schemas registered against sibling frames are ignored.
+
+  Validation routes through the registered validator/explainer fns
+  (rf2-froe). When `set-schema-validator!` has been called with `nil`
+  this fn is a hard no-op for every schema in the frame.
 
   Arities:
     (validate-app-db! db)                       ;; current frame
@@ -355,17 +500,17 @@
   ([db] (validate-app-db! db nil (frame/current-frame)))
   ([db event-id] (validate-app-db! db event-id (frame/current-frame)))
   ([db event-id frame-id]
-   (when interop/debug-enabled?
+   (when (and interop/debug-enabled? @validator-fn)
      (doseq [[path m] (frame-schema-entries frame-id)]
        (let [val-at (get-in db path)
              schema (:schema m)]
-         (when-not (malli-validate* schema val-at)
+         (when-not (run-validator schema val-at)
            (trace/emit-error! :rf.error/schema-validation-failure
                               (cond-> {:where    :app-db
                                        :path     path
                                        :value    val-at
                                        :frame    frame-id
-                                       :explain  (malli-explain* schema val-at)
+                                       :explain  (run-explainer schema val-at)
                                        :reason   (str "App-db at path " path
                                                       " failed schema " schema
                                                       ": expected "
@@ -390,13 +535,16 @@
 
   Per Spec 009 §Production builds the entire body lives inside a
   `(when interop/debug-enabled? ...)` gate so :advanced+goog.DEBUG=false
-  DCE-elides every reason string, every keyword, and every malli call."
+  DCE-elides every reason string, every keyword, and every validator
+  call. Per Spec 010 §Non-Malli validators (rf2-froe) the validator
+  is pluggable; when none is registered this fn returns true (pass)
+  without inspecting the schema."
   [event-id event handler-meta]
-  (if interop/debug-enabled?
+  (if (and interop/debug-enabled? @validator-fn)
     (if-let [schema (:spec handler-meta)]
-      (if (malli-validate* schema event)
+      (if (run-validator schema event)
         true
-        (do
+        (let [explanation (run-explainer schema event)]
           (trace/emit-error! :rf.error/schema-validation-failure
                              {:where       :event
                               :event-id    event-id
@@ -404,8 +552,8 @@
                               :spec-id     event-id
                               :received    event
                               :event       event
-                              :malli-error (malli-explain* schema event)
-                              :explain     (malli-explain* schema event)
+                              :malli-error explanation
+                              :explain     explanation
                               :reason      (str "Event " event-id
                                                 " payload failed schema "
                                                 schema ", got "
@@ -425,13 +573,15 @@
   default (nil) per the :replaced-with-default recovery.
 
   Per Spec 009 §Production builds the entire body lives inside a
-  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly."
+  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly.
+  Per Spec 010 §Non-Malli validators (rf2-froe) the validator is
+  pluggable; when none is registered this fn returns true."
   [sub-id query-v value sub-meta]
-  (if interop/debug-enabled?
+  (if (and interop/debug-enabled? @validator-fn)
     (if-let [schema (:spec sub-meta)]
-      (if (malli-validate* schema value)
+      (if (run-validator schema value)
         true
-        (do
+        (let [explanation (run-explainer schema value)]
           (trace/emit-error! :rf.error/schema-validation-failure
                              {:where       :sub-return
                               :sub-id      sub-id
@@ -440,8 +590,8 @@
                               :query-v     query-v
                               :received    value
                               :value       value
-                              :malli-error (malli-explain* schema value)
-                              :explain     (malli-explain* schema value)
+                              :malli-error explanation
+                              :explain     explanation
                               :reason      (str "Subscription " sub-id
                                                 " return value failed schema "
                                                 schema ", got "
@@ -461,13 +611,15 @@
   responsible for skipping the handler (recovery: :no-recovery).
 
   Per Spec 009 §Production builds the entire body lives inside a
-  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly."
+  `(when interop/debug-enabled? ...)` gate so DCE elides it cleanly.
+  Per Spec 010 §Non-Malli validators (rf2-froe) the validator is
+  pluggable; when none is registered this fn returns true."
   [cofx-id event-id value cofx-meta]
-  (if interop/debug-enabled?
+  (if (and interop/debug-enabled? @validator-fn)
     (if-let [schema (:spec cofx-meta)]
-      (if (malli-validate* schema value)
+      (if (run-validator schema value)
         true
-        (do
+        (let [explanation (run-explainer schema value)]
           (trace/emit-error! :rf.error/schema-validation-failure
                              {:where       :cofx
                               :cofx-id     cofx-id
@@ -476,8 +628,8 @@
                               :spec-id     cofx-id
                               :received    value
                               :value       value
-                              :malli-error (malli-explain* schema value)
-                              :explain     (malli-explain* schema value)
+                              :malli-error explanation
+                              :explain     explanation
                               :reason      (str "Coeffect " cofx-id
                                                 " injected value failed schema "
                                                 schema ", got "
@@ -486,6 +638,44 @@
           false))
       true)
     true))
+
+;; ---- public boundary-validation entry point (rf2-r2uh integration) -------
+;;
+;; The boundary-validation interceptor (rf2-r2uh, NOT YET IMPLEMENTED)
+;; runs `:spec` validation on a handler at production-build time —
+;; outside the `interop/debug-enabled?` gate that guards the hot-path
+;; validate-*! fns above. Per Spec 010 §Production builds the boundary
+;; interceptor MUST route through the same registered validator the
+;; dev-mode hot path uses (so a substituted validator covers both
+;; surfaces). This namespace publishes `validate-with-registered-fn`
+;; as the call the interceptor reaches for; rf2-r2uh wires the
+;; interceptor through it.
+;;
+;; Contract: returns true on conform; false on fail; true (pass) when
+;; no validator is registered. Does NOT emit a trace — the boundary
+;; interceptor is responsible for emitting :rf.error/schema-validation-
+;; failure :where :event with the appropriate envelope. Pure check
+;; surface.
+
+(defn validate-with-registered-fn
+  "Apply the registered validator to `(schema, value)`. Public seam for
+  the boundary-validation interceptor (rf2-r2uh). Returns true on
+  conform; false on fail; true when no validator is registered (the
+  call-site treats no-validator as no-validation, mirroring the hot
+  path).
+
+  Does NOT consult `interop/debug-enabled?` — the boundary interceptor
+  runs in production by design."
+  [schema value]
+  (run-validator schema value))
+
+(defn explain-with-registered-fn
+  "Apply the registered explainer to `(schema, value)`. Companion to
+  `validate-with-registered-fn` for the boundary-validation
+  interceptor (rf2-r2uh). Returns the explanation map / data on fail;
+  nil when the schema conforms or no explainer is registered."
+  [schema value]
+  (run-explainer schema value))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -511,11 +701,17 @@
 (late-bind/set-fn! :schemas/validate-cofx!       validate-cofx!)
 (late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
 
+;; Boundary-validation seam (rf2-r2uh integration).
+(late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
+(late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
+
 ;; Public-API re-export hooks (consumed by re-frame.core).
-(late-bind/set-fn! :schemas/reg-app-schema       reg-app-schema)
-(late-bind/set-fn! :schemas/app-schema-at        app-schema-at)
-(late-bind/set-fn! :schemas/app-schemas          app-schemas)
-(late-bind/set-fn! :schemas/app-schemas-digest   app-schemas-digest)
+(late-bind/set-fn! :schemas/reg-app-schema        reg-app-schema)
+(late-bind/set-fn! :schemas/app-schema-at         app-schema-at)
+(late-bind/set-fn! :schemas/app-schemas           app-schemas)
+(late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
+(late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
+(late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; reset-runtime-fixture). The fixture wants to capture and restore

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -25,6 +25,7 @@
             ;; the same.
             [malli.core]
             [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -144,3 +145,52 @@
       (is (= "sha256:e3b0c44298fc1c14"
              (rf/app-schemas-digest :test/empty-cljs))
           "empty-set digest is byte-identical with the JVM path"))))
+
+;; ---- rf2-froe — set-schema-validator! seam under CLJS ---------------------
+
+(deftest custom-validator-runs-under-reagent
+  (testing "Per Spec 010 §Non-Malli validators (rf2-froe): a custom
+            validator installed via rf/set-schema-validator! is invoked
+            on the Reagent reactive substrate just as it is on the JVM.
+            Locks the cross-substrate seam contract."
+    (let [calls (atom 0)
+          custom (fn [_s v] (swap! calls inc) (= v 42))]
+      (rf/set-schema-validator! custom)
+      (try
+        (rf/reg-app-schema [:n] :int)
+        (rf/reg-event-db :n/init  (fn [_ _] {:n 42}))
+        (rf/reg-event-db :n/break (fn [db _] (assoc db :n 99)))
+        (let [traces (atom [])]
+          (rf/register-trace-cb! ::cv (fn [ev] (swap! traces conj ev)))
+          (rf/dispatch-sync [:n/init])
+          (rf/dispatch-sync [:n/break])
+          (rf/remove-trace-cb! ::cv)
+          (is (pos? @calls)
+              "the custom validator was invoked through the live dispatch path")
+          (let [violations (filter #(= :rf.error/schema-validation-failure
+                                       (:operation %))
+                                   @traces)]
+            (is (= 1 (count violations))
+                "the custom validator's falsey result fired the failure trace once
+                 — for the :n/break commit; :n/init's value of 42 passed.")))
+        (finally
+          (schemas/reset-schema-validator!))))))
+
+(deftest nil-validator-disables-reagent-validation
+  (testing "Per Spec 010 §Non-Malli validators (rf2-froe): nil validator
+            disables every validation site under Reagent — including
+            the live :db commit that would otherwise fire."
+    (rf/set-schema-validator! nil)
+    (try
+      (rf/reg-app-schema [:n] :int)
+      (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::nv (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:n/break])
+        (rf/remove-trace-cb! ::nv)
+        (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                (:operation %))
+                            @traces))
+            "no validation trace fires when the validator is nil"))
+      (finally
+        (schemas/reset-schema-validator!)))))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -25,7 +25,8 @@
   file covers the elision toggle (which fixtures cannot flip from EDN)
   and the projector-mapping shape (which is a separate surface from the
   trace emission)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -40,6 +41,10 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  ;; Per rf2-froe — `set-schema-validator!` swaps the framework
+  ;; validator/explainer atoms; restore the Malli defaults so a test
+  ;; that mutates them does not poison sibling tests.
+  (schemas/reset-schema-validator!)
   (rf/init! plain-atom/adapter)
   (test-fn))
 
@@ -538,3 +543,182 @@
     (is (= (rf/app-schemas-digest :test/o1)
            (rf/app-schemas-digest :test/o2))
         "same schema set, different registration order → same digest")))
+
+;; ---- rf2-froe — set-schema-validator! seam -------------------------------
+;;
+;; Per Spec 010 §Non-Malli validators (rf2-froe) the validator and
+;; explainer fns are pluggable via `(rf/set-schema-validator! ...)` /
+;; `(rf/set-schema-explainer! ...)`. Default delegates to Malli; apps
+;; that want to drop the ~24 KB gzipped Malli surface (rf2-qnxf bundle
+;; audit) substitute another fn (or `nil` for no-op).
+
+(deftest default-validator-delegates-to-malli
+  (testing "Per Spec 010 §Non-Malli validators — out of the box the
+            validator delegates to Malli; apps that don't call
+            set-schema-validator! get the same behaviour they had
+            before the seam landed."
+    (rf/reg-app-schema [:n] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::default-malli (fn [ev] (swap! traces conj ev)))
+      ;; Malformed value triggers the default Malli validate to return
+      ;; falsey -> trace fires.
+      (schemas/validate-app-db! {:n "not-an-int"} :test/handler)
+      (rf/remove-trace-cb! ::default-malli)
+      (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "default Malli validator catches the type mismatch")))))
+
+(deftest custom-validator-is-invoked-instead-of-malli
+  (testing "Per Spec 010 §Non-Malli validators — set-schema-validator! swaps
+            in any (fn [schema value] truthy?); the framework calls it on
+            every validation site instead of the default."
+    (let [calls (atom [])
+          ;; Mock validator: fail on any value containing the substring
+          ;; \"bad\"; pass everything else. Records every (schema, value)
+          ;; pair it sees so the test can assert the call.
+          custom (fn [schema value]
+                   (swap! calls conj [schema value])
+                   (not (and (string? value) (str/includes? value "bad"))))]
+      (rf/set-schema-validator! custom)
+      (rf/reg-app-schema [:label] :string)
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::custom (fn [ev] (swap! traces conj ev)))
+        (schemas/validate-app-db! {:label "hello"} :h/ok)        ;; passes
+        (schemas/validate-app-db! {:label "totally-bad"} :h/no)  ;; fails
+        (rf/remove-trace-cb! ::custom)
+        (is (= 2 (count @calls))
+            "custom validator was invoked for both validation calls")
+        (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations))
+              "exactly one trace fired — for the value the custom validator rejected")
+          (is (= "totally-bad" (-> violations first :tags :value))))))))
+
+(deftest nil-validator-disables-validation-everywhere
+  (testing "Per Spec 010 §Non-Malli validators — passing nil to
+            set-schema-validator! disables validation entirely; every
+            validate-* fn returns true without inspecting the schema."
+    (rf/set-schema-validator! nil)
+    (rf/reg-app-schema [:n] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::nilv (fn [ev] (swap! traces conj ev)))
+      ;; Malformed value would normally fire a trace; with nil
+      ;; validator the call site short-circuits.
+      (schemas/validate-app-db! {:n "definitely-not-an-int"} :test/h)
+      (rf/remove-trace-cb! ::nilv)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                          @traces))
+          "nil validator: no validation, no trace, no surprise"))))
+
+(deftest nil-validator-also-disables-event-validation
+  (testing "Per Spec 010 §Non-Malli validators — nil validator covers every
+            validation site, not just app-db. The event-validation site
+            short-circuits too."
+    (rf/set-schema-validator! nil)
+    (let [calls (atom 0)]
+      (rf/reg-event-db :user/strict
+        {:spec [:cat [:= :user/strict] :int]}
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::nile (fn [ev] (swap! traces conj ev)))
+        ;; A wildly malformed payload — but with no validator the
+        ;; check is skipped and the handler runs anyway.
+        (rf/dispatch-sync [:user/strict "not-an-int"])
+        (rf/remove-trace-cb! ::nile)
+        (is (= 1 @calls)
+            "handler ran — nil validator means no pre-handler check")
+        (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                            @traces))
+            "no validation trace fires when validator is nil")))))
+
+(deftest set-schema-validator-map-arity-installs-both-fns
+  (testing "Per Spec 010 §Non-Malli validators — the map arity of
+            set-schema-validator! installs validate and explain
+            atomically. Apps that want a custom explainer alongside
+            their custom validator use this form."
+    (let [validate-calls (atom 0)
+          explain-calls  (atom 0)
+          v-fn (fn [_s v] (swap! validate-calls inc) (= v :good))
+          e-fn (fn [s v]  (swap! explain-calls inc) {:my-explanation [s v]})]
+      (rf/set-schema-validator! {:validate v-fn :explain e-fn})
+      (rf/reg-app-schema [:k] :keyword)
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::map (fn [ev] (swap! traces conj ev)))
+        (schemas/validate-app-db! {:k :good}   :h/pass)
+        (schemas/validate-app-db! {:k :nope}   :h/fail)
+        (rf/remove-trace-cb! ::map)
+        (is (= 2 @validate-calls) "custom validate fn ran for both calls")
+        (is (= 1 @explain-calls)  "custom explain fn ran only on the failure path")
+        (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations)))
+          (is (= {:my-explanation [:keyword :nope]}
+                 (-> violations first :tags :explain))
+              "the trace's :explain key carries the custom explainer's output"))))))
+
+(deftest set-schema-explainer-only-leaves-validator-untouched
+  (testing "set-schema-explainer! swaps just the explainer; the validator
+            (default Malli) keeps catching real failures."
+    (let [explained (atom nil)
+          custom-e  (fn [_s v] (reset! explained v) {:custom-said v})]
+      ;; Validator stays at its default (Malli); only the explainer is
+      ;; substituted.
+      (rf/set-schema-explainer! custom-e)
+      (rf/reg-app-schema [:n] [:int])
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::eonly (fn [ev] (swap! traces conj ev)))
+        (schemas/validate-app-db! {:n "broken"} :h/oops)
+        (rf/remove-trace-cb! ::eonly)
+        (is (= "broken" @explained) "custom explainer ran with the bad value")
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (= {:custom-said "broken"} (-> v :tags :explain))))))))
+
+(deftest reset-schema-validator-restores-defaults
+  (testing "reset-schema-validator! brings the framework default back —
+            test-support helper for cleaning up after a custom
+            registration. After reset, the default Malli behaviour
+            resumes."
+    ;; Install a sabotage validator: passes everything (so a known-bad
+    ;; value would slip past).
+    (rf/set-schema-validator! (fn [_ _] true))
+    (rf/reg-app-schema [:n] [:int])
+    ;; First confirm the sabotage is in effect.
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sab (fn [ev] (swap! traces conj ev)))
+      (schemas/validate-app-db! {:n "bad"} :h/sabotage)
+      (rf/remove-trace-cb! ::sab)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                          @traces))
+          "sabotage validator passes everything — no trace"))
+    ;; Reset back to default Malli, retry the bad value, expect a trace.
+    (schemas/reset-schema-validator!)
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::rst (fn [ev] (swap! traces conj ev)))
+      (schemas/validate-app-db! {:n "bad"} :h/back-to-default)
+      (rf/remove-trace-cb! ::rst)
+      (is (= 1 (count (filter #(= :rf.error/schema-validation-failure (:operation %))
+                              @traces)))
+          "default Malli validator is back in place — bad value catches"))))
+
+(deftest validate-with-registered-fn-bypasses-debug-gate
+  (testing "Per rf2-r2uh integration — validate-with-registered-fn is the
+            public seam the boundary-validation interceptor will call. It
+            does NOT consult interop/debug-enabled? (the boundary
+            interceptor runs in production by design); it routes through
+            the registered validator the same way the dev hot path does."
+    (rf/set-schema-validator! (fn [_ v] (= v :good)))
+    (with-redefs [interop/debug-enabled? false]
+      (is (true?  (schemas/validate-with-registered-fn :keyword :good))
+          "valid value passes — debug gate ignored")
+      (is (false? (schemas/validate-with-registered-fn :keyword :bad))
+          "invalid value fails — debug gate ignored"))))
+
+(deftest validator-set-via-public-api-is-visible-on-schemas-ns
+  (testing "The public re-export rf/set-schema-validator! flows through to
+            the schemas namespace's validator-fn atom."
+    (let [my-fn (fn [_ _] :sentinel)]
+      (rf/set-schema-validator! my-fn)
+      (is (= my-fn @schemas/validator-fn)
+          "the atom carries the fn the user registered"))))

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -254,21 +254,40 @@ After the procedure above (using the CLJS reference's `pr-str` serialisation for
 
 ## Non-Malli validators — the validator-fn extension point
 
-The runtime never inspects the value stored in `:spec`. Validation always goes through a single registered **validator fn** of shape:
+The runtime never inspects the value stored in `:spec`. Validation always goes through a registered **validator fn**. The CLJS reference splits the surface into two fns — a fast pass/fail check on the hot path and an explainer used only on the failure branch — so the dev-mode validation site stays cheap:
 
 ```clojure
-(fn validator [schema value] result)
-;; result :: nil          — the value conforms (no error)
-;;       | {:explanation <data> :path? [...] :rule? <id>}    ;; structured failure
+;; The validator: pass/fail check on the hot path.
+(fn validate [schema value] truthy?)
+;;   truthy   — the value conforms
+;;   falsey   — the value fails the schema
+
+;; The explainer: invoked only when validate returns falsey, to
+;; populate the failure trace's :explain key.
+(fn explain  [schema value] explanation-or-nil)
 ```
 
-The validator fn is registered at the substrate level — typically once per app at boot, not per `:spec`:
+Both fns are registered at boot, before the first `reg-app-schema` or `:spec`-bearing `reg-*` lands:
 
 ```clojure
+;; (1) Just the validator — the explainer is left untouched.
 (rf/set-schema-validator! my-validator-fn)
+
+;; (2) Atomic swap of both fns at once.
+(rf/set-schema-validator! {:validate my-validator-fn
+                            :explain  my-explainer-fn})
+
+;; (3) Just the explainer — validator stays at its current value.
+(rf/set-schema-explainer! my-explainer-fn)
+
+;; (4) Hard no-op: passing nil disables validation everywhere.
+;;     Every validate-*! site short-circuits without inspecting the
+;;     schema. Apps that want zero validation surface (and zero Malli
+;;     bundle cost) install nil at boot.
+(rf/set-schema-validator! nil)
 ```
 
-The CLJS reference's default validator delegates to Malli (`(m/explain schema value)` adapted to the result shape above). Substituting a different validator (a `clojure.spec` adapter, a JSON-Schema validator, a host's structural-typecheck wrapper) is a **single registration call** — the rest of the spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
+The CLJS reference's default validator/explainer pair delegates to Malli (`malli.core/validate` + `malli.core/explain`). Substituting a different validator (a `clojure.spec` adapter, a JSON-Schema validator, a host's structural-typecheck wrapper) is a **single registration call** — the rest of the spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
 
 Locked rules:
 
@@ -276,8 +295,42 @@ Locked rules:
 - **The validator fn is pure** — same `(schema, value)` returns the same result. Implementations may memoise but tests must not depend on memoisation.
 - **The validator fn must be production-elidable** alongside `re-frame.interop/debug-enabled?` — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
 - **Schema digests** ([§Schema digest](#schema-digest)) are computed from the schema **values** as serialised by the registered validator's `serialise` companion fn (see [§Schema digest](#schema-digest)) — not from the validator. Two ports using different validators against the same Malli-EDN schemas produce the same digest; two ports using *different* schema languages produce different digests by construction.
+- **`nil` validator means no validation, not "every value fails"**. Setting validator to nil is the documented opt-out — every `validate-*!` site short-circuits to `true` (pass). The schemas mandate stays unchanged at the framework level (apps still attach `:spec` and `reg-app-schema`); only the runtime check is disabled.
 
 What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (Malli for app schemas, JSON-Schema for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
+
+### Worked example — installing a no-op validator at boot
+
+The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cost-audit.md` §3.7 / §4): an app that doesn't need runtime schema validation can install a no-op at boot and avoid pulling Malli into its production bundle.
+
+```clojure
+(ns my-app.core
+  (:require [re-frame.core :as rf]
+            [re-frame.schemas]   ;; load the schemas artefact (rf2-p7va)
+            ;; NOTE: we do NOT (:require [malli.core]) here — the
+            ;; default validator's (resolve 'malli.core/validate) returns
+            ;; nil and the no-op below replaces it entirely.
+            ))
+
+;; Install the no-op BEFORE the first reg-app-schema / :spec metadata.
+;; Any (fn [schema value] truthy?) that returns true unconditionally
+;; passes every value; nil disables the call site even faster.
+(rf/set-schema-validator! nil)
+
+;; Schemas attach as usual — they're inert data the framework still
+;; surfaces via app-schemas / app-schemas-digest, but no validate
+;; call ever runs against them.
+(rf/reg-app-schema [:user] [:map [:id :uuid]])
+(rf/reg-event-fx :auth/login
+  {:spec [:cat [:= :auth/login] [:map [:email :string]]]}
+  ...)
+```
+
+### Boundary-validation seam
+
+The validator/explainer pair also fronts the boundary-validation interceptor (`:spec/validate-at-boundary`, see [§Production builds](#production-builds)). The interceptor's call into the registered fns happens outside the `interop/debug-enabled?` gate — so a substituted validator covers both the dev-mode hot path and the prod-mode boundary surface.
+
+The schemas namespace exposes two fns the interceptor calls — `validate-with-registered-fn` and `explain-with-registered-fn` — both routing through the same atoms `set-schema-validator!` mutates. Apps that swap in their own validator therefore reach every validation surface with one call, not three.
 
 ## Notes
 
@@ -322,3 +375,5 @@ Apps evolve; `app-db` shapes evolve; schemas evolve. Whether re-frame2 ships a v
 ### Non-Malli library support
 
 Substitution is via a single `set-schema-validator!` registration; the `:spec` value is opaque to re-frame; the registered validator interprets it. Malli is the default and supported library; substitution is one call. See [§Non-Malli validators — the validator-fn extension point](#non-malli-validators--the-validator-fn-extension-point).
+
+The seam is implemented (rf2-froe): `(rf/set-schema-validator! validate-fn)`, `(rf/set-schema-validator! {:validate ... :explain ...})`, and `(rf/set-schema-explainer! explain-fn)` are all live in `re-frame.core` (re-exporting from `re-frame.schemas`). Default behaviour ships Malli's `validate` / `explain`; passing `nil` to `set-schema-validator!` is the documented hard-no-op for apps that want zero runtime validation surface. The schemas mandate at the framework level (every `reg-*` may attach `:spec`; `reg-app-schema` registers path schemas) is independent of which validator is registered.


### PR DESCRIPTION
## Summary

Implements Spec 010 §Non-Malli validators — the documented `set-schema-validator!` extension point that has not been implemented until now (rf2-froe).

The runtime never inspects the value stored in `:spec`; every validation site routes through a registered validator fn. Default ships Malli's `validate` / `explain` pair (no behaviour change for existing apps); apps that want to drop the ~24 KB gzipped Malli bundle cost (per the rf2-qnxf [findings/malli-bundle-cost-audit.md](https://github.com/day8/re-frame2/blob/main/findings/malli-bundle-cost-audit.md)) install a different validator at boot — or `nil` for a hard no-op.

- `(rf/set-schema-validator! validate-fn)` swaps the validator (`(fn [schema value] truthy?)` — Malli's `validate` shape).
- `(rf/set-schema-validator! {:validate ... :explain ...})` swaps both atomically.
- `(rf/set-schema-explainer! explain-fn)` swaps the explainer alone.
- `(rf/set-schema-validator! nil)` disables every validation site.
- Boundary-validation seam (`validate-with-registered-fn` / `explain-with-registered-fn`) published for rf2-r2uh to wire the `:spec/validate-at-boundary` interceptor through.

## Files touched

- `implementation/schemas/src/re_frame/schemas.cljc` — atoms, public fns, refactored 4 `validate-*!` call sites through the seam, boundary-validation entry points.
- `implementation/core/src/re_frame/core.cljc` — `set-schema-validator!` / `set-schema-explainer!` re-exports via late-bind.
- `implementation/core/src/re_frame/late_bind.cljc` — new hook keys documented.
- `spec/010-Schemas.md` — §Non-Malli validators rewritten with concrete API + worked example + boundary-seam note; §Resolved decisions updated.
- `implementation/schemas/test/re_frame/schemas_test.clj` — fixture resets the validator atom; 9 new tests for the seam.
- `implementation/schemas/test/re_frame/schemas_cljs_test.cljs` — 2 new CLJS smokes under Reagent.

## Test plan

- [x] JVM schemas tests pass: `cd implementation/schemas && clojure -M:test` → 38 tests / 136 assertions / 0 failures.
- [x] JVM core tests pass: 182 tests / 822 assertions / 0 failures.
- [x] CLJS node-test pass: 231 tests / 657 assertions / 0 failures.
- [x] Existing schemas tests (29) continue to pass — the default validator preserves current behaviour.

## Notes for rf2-r2uh

The boundary-validation interceptor seam is published as two public fns in `re-frame.schemas`:

- `validate-with-registered-fn [schema value]` — pass/fail check; routes through `@validator-fn`; bypasses `interop/debug-enabled?` (the boundary interceptor runs in production by design).
- `explain-with-registered-fn [schema value]` — companion explainer, returns the explanation map / nil.

Both are also published through the late-bind hook table as `:schemas/validate-with-registered-fn` and `:schemas/explain-with-registered-fn` so rf2-r2uh's interceptor can reach them without a static `:require` (per rf2-p7va).

The interceptor's contract per Spec 010 §Production builds (failures emit `:rf.error/schema-validation-failure :where :event` with the same recovery as dev-mode step-1 failures) is the interceptor's responsibility — these helpers are pure check fns, no trace emission.