### PR TITLE
spec: document hybrid retry-ownership — managed-HTTP transport, machines semantic (rf2-wylu)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1847,6 +1847,12 @@ A common partial-success idiom is to declare `:after` for the phase-level timeou
 
 Cross-references: [§Spawning](#spawning--dynamic-actors) for the imperative-spawn surface; [§Declarative `:invoke` (sugar over spawn)](#declarative-invoke-sugar-over-spawn) for the per-child sugar that `:invoke-all` extends; [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rftransition-table) for the schema; [Pattern-Boot](Pattern-Boot.md) for boot-flow worked examples leveraging `:invoke-all` for hydrate-as-spawn-and-join.
 
+## Cross-spec interactions
+
+### Retry-ownership boundary with `:rf.http/managed`
+
+State machines own **semantic retry**; `:rf.http/managed` owns **transport-level retry**. Per [Spec 014 §Boundary — transport vs semantic retry](014-HTTPRequests.md#boundary--transport-vs-semantic-retry), the test for which owner applies is whether the retry decision is a function of attempt count + failure category alone (transport — owned by `:retry`) or depends on response body / app state / another request's outcome (semantic — owned by the machine). A state spec's `:invoke` of `:rf.http/managed` configures transport retry on the request itself; the machine's transition on the resulting `:succeeded` / `:failed` reply expresses the semantic retry — re-target to a refresh state, delay via `:after` before re-issuing, route to a different state on a different failure category. The two layers compose without overlap. See [Pattern-Boot §Worked example — auth-machine and the retry-ownership boundary](Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary) for the canonical illustration.
+
 ## Reply patterns
 
 xstate's `sendTo` + `sender` lets a child reply to a specific request. In re-frame, no new API: include the reply event in the request:

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -224,6 +224,10 @@ The default `:accept` returns `{:ok decoded}` for 2xx responses, `{:failure {:ki
 
 ## Retry and backoff
 
+`:rf.http/managed`'s `:retry` slot owns **transport-level retry only** — retries whose decision is a pure function of the failure category and the attempt count. Network errors, 5xx, per-attempt timeouts, CORS rejection: each is a `:rf.http/*` category the runtime classifies before decode, and the policy is "given attempt N and a category from `:on`, wait `backoff(N)` ms, then re-issue the same request." The failure category, the attempt count, and the configured backoff are the only inputs; the response body, the application state, and the outcome of any other request never enter the picture.
+
+This is deliberate. Retry decisions that depend on more than category + attempt are **semantic retry** — the response body says "rate-limited, try again with the new token", or the application is in a state that gates whether to re-issue, or another in-flight request's outcome decides whether this one should retry. Semantic retry is owned by **state machines** (Spec 005), not by `:rf.http/managed`. See [§Boundary — transport vs semantic retry](#boundary--transport-vs-semantic-retry) below.
+
 ```clojure
 :retry {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
         :max-attempts 4
@@ -244,6 +248,25 @@ The default `:accept` returns `{:ok decoded}` for 2xx responses, `{:failure {:ki
 | `:backoff.:jitter` | bool | Add random ±25% jitter to each delay. |
 
 Each retry advances the carried epoch (per Pattern-StaleDetection); a stale request (e.g. one whose target route changed mid-retry) is suppressed without dispatching the reply.
+
+### Boundary — transport vs semantic retry
+
+The retry-ownership rule, stated as a single test: **does the retry decision depend on anything other than the failure category and the attempt count?** If no, `:rf.http/managed` `:retry` is the right home. If yes, lift the retry into a state machine.
+
+| Decision shape | Owner | How |
+|---|---|---|
+| "After a 503, wait `backoff(N)` and try again — up to N times." | `:rf.http/managed` `:retry` | Function of attempt count + category. Transport. |
+| "After a network timeout, retry with exponential backoff." | `:rf.http/managed` `:retry` | Function of attempt count + category. Transport. |
+| "After a 401, refresh the token, **then** retry the original request." | State machine | Response-conditional; another request must succeed first. Semantic. |
+| "If the response body says `{:error \"rate-limited\" :retry-after 5}`, wait the body's hinted delay." | State machine | Body-conditional. Semantic. |
+| "Retry the failed write only if the user is still on the page that issued it." | State machine | App-state-conditional. Semantic. |
+| "Retry every load-asset call that failed during boot, but not if the user navigated away." | State machine | App-state-conditional, joined across multiple requests. Semantic. |
+
+**Why the split.** Transport retry is mechanical — every category's retry policy is the same shape, and the runtime can express it as a config map at the call site. Semantic retry is a **state transition with side-effecting prerequisites** — refreshing a token, checking app state, joining outcomes across requests. Encoding that into `:retry` would either bloat the slot's vocabulary (predicates over response body, dispatched-effect callbacks per attempt, nested conditions) or hide the control flow inside an opaque blob that doesn't show up in traces. Spec 005's machines already give the substrate for "transition on outcome with guards and entry actions"; semantic retry is just a state-machine transition, and the trace stream sees every decision.
+
+**The escape hatch.** When you reach for "retry-on body matches X", "retry-after refresh", or "retry-when app-state says go" — stop, lift the call site into a state machine state, give that state an `:invoke` of `:rf.http/managed` (per [Pattern-AsyncEffect](Pattern-AsyncEffect.md)), and write the semantic retry as a transition on the failure reply. The machine handles the conditional logic; `:rf.http/managed` keeps doing transport retry inside each attempt the machine launches. Both halves compose — a state machine that drives `:rf.http/managed` requests can still configure transport-level `:retry` on each of those requests; the machine's semantic retry sits *outside* the per-request retry loop.
+
+See [Pattern-Boot §Worked example — auth-machine and the retry-ownership boundary](Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary) for a concrete demonstration of both halves working together (the auth flow that motivated the boundary in the first place — 5xx-retry-with-backoff at the transport layer, 401-vs-refresh at the semantic layer).
 
 ### Retry × `:on-failure` semantics
 
@@ -620,7 +643,10 @@ Adjacent surfaces that are first-class re-frame2 commitments but live in their o
 - [Pattern-RemoteData](Pattern-RemoteData.md) — the 5-key request-lifecycle slice; `:rf.http/managed` writes through this slice.
 - [Pattern-StaleDetection](Pattern-StaleDetection.md) — epoch carry; managed requests inherit it.
 - [Spec 002 §Routing](002-Frames.md#routing-the-dispatch-envelope) — frame-aware fx contract; reply dispatches inherit `:frame`.
+- [Spec 005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions) — the substrate semantic retry rides on; the machine fires a transition on the failure reply, optionally delays via `:after`, and re-issues the request from the next state's `:invoke`.
+- [Spec 005 §Spawn-and-join via `:invoke-all`](005-StateMachines.md#spawn-and-join-via-invoke-all) — multi-request semantic retry (refresh-then-retry, fan-out-with-conditional-retry) lives here.
 - [Spec 009 §Trace event envelope](009-Instrumentation.md) — trace envelope shape; `:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`, and the `:rf.http/*` failure-category traces follow it.
 - [Spec 010 §Schemas](010-Schemas.md) — Malli decode integration; `:decode <schema>` runs through `010`'s decode pipeline.
+- [Pattern-Boot §Worked example — auth-machine and the retry-ownership boundary](Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary) — the canonical end-to-end illustration of [§Boundary — transport vs semantic retry](#boundary--transport-vs-semantic-retry).
 - [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the `:rf.http/*` namespace is reserved for this Spec.
 - [`re-frame-fetch-fx`](https://github.com/superstructor/re-frame-fetch-fx) — the inspiration; Spec 014 adds retry, accept-step, default-reply-addressing, schema-driven decode, JVM coverage, and stale-suppression on top.

--- a/spec/Pattern-AsyncEffect.md
+++ b/spec/Pattern-AsyncEffect.md
@@ -206,5 +206,6 @@ Pattern-RemoteData is the specific case of Pattern-AsyncEffect for HTTP requests
 - [Pattern-RemoteData.md](Pattern-RemoteData.md) — specific case (HTTP + lifecycle slice).
 - [Pattern-StaleDetection.md](Pattern-StaleDetection.md) — composition for stale-suppression.
 - [Pattern-WebSocket.md](Pattern-WebSocket.md) — sibling pattern for long-lived connections.
-- [Pattern-Boot.md](Pattern-Boot.md) — chained async sequence at startup.
+- [Pattern-Boot.md](Pattern-Boot.md) — chained async sequence at startup; carries the worked example for the retry-ownership boundary.
+- [014-HTTPRequests §Boundary — transport vs semantic retry](014-HTTPRequests.md#boundary--transport-vs-semantic-retry) — when the async fx is `:rf.http/managed`, retry partitions: transport-level retry inside the fx (function of attempt count + category), semantic retry at the state-machine layer that drives the fx (response-conditional, app-state-conditional). Both layers compose without overlap.
 - [examples/reagent/login/core.cljs](../examples/reagent/login/core.cljs) — `:http` fx registration and reply-driven state machine.

--- a/spec/Pattern-Boot.md
+++ b/spec/Pattern-Boot.md
@@ -186,6 +186,103 @@ Each phase uses `:invoke` to spawn the async work; transitions on success or fai
 
 The frame's `:on-create` dispatches `[:app/boot [:rf/start]]` (or the equivalent per the host); the machine self-initialises (per [005 §Restore semantics]) and runs.
 
+### Worked example — auth-machine and the retry-ownership boundary
+
+The auth phase of boot is the canonical demonstration of the **hybrid retry-ownership rule** from [Spec 014 §Boundary — transport vs semantic retry](014-HTTPRequests.md#boundary--transport-vs-semantic-retry):
+
+- **Transport retry** — function of attempt count + failure category — is owned by `:rf.http/managed` `:retry`. Network errors, 5xx, per-attempt timeouts; "wait `backoff(N)` and try again." Local to the request.
+- **Semantic retry** — response-conditional, app-state-conditional, joined-across-requests — is owned by the state machine. 401-then-refresh-then-retry; "if the body says rate-limited, transition to `:cooldown` and re-issue from there"; "if another in-flight request fails first, abandon this one." Cross-request control flow.
+
+Both halves coexist on the same call site: the machine drives `:rf.http/managed` requests, and each managed request configures its own transport-level `:retry`. The two layers compose without overlap — the machine's transition fires only after the transport-level retry loop has either succeeded or fully exhausted its attempts.
+
+The pattern, distilled to a worked sketch:
+
+```clojure
+;; ---------- Transport retry — :rf.http/managed handles 5xx + network ----------
+;; This is the call site the machine's :invoke spawns. The :retry slot owns
+;; "after a 503, wait backoff(N) and try again." That decision is mechanical:
+;; failure category + attempt count. No state, no other request, no body
+;; matching — pure transport retry.
+
+(rf/reg-event-fx ::fetch-me
+  (fn [_ [_ {:keys [token]}]]
+    {:fx [[:rf.http/managed
+           {:request {:method  :get
+                      :url     "/api/me"
+                      :headers {"Authorization" (str "Bearer " token)}}
+            :decode  MeResponse
+            :retry   {:on           #{:rf.http/transport
+                                      :rf.http/http-5xx
+                                      :rf.http/timeout}
+                      :max-attempts 3
+                      :backoff      {:base-ms 250 :factor 2 :max-ms 5000 :jitter true}}
+            :on-success [:auth/me-loaded]
+            :on-failure [:auth/transport-failed]}]]}))
+
+;; ---------- Semantic retry — state machine handles 401-vs-200-vs-fatal ------
+;; The auth machine routes by outcome:
+;;   - :succeeded → done.
+;;   - :failed with kind :rf.http/http-status status 401 → :refreshing.
+;;     The refresh path itself is a managed request; on success it loops back
+;;     to :loading-me — a *semantic* retry of the original /api/me call.
+;;   - :failed otherwise (5xx after retries exhausted, network error,
+;;     decode-failure) → :login. Transport already retried; now the machine
+;;     gives up.
+;; The :refreshing → :loading-me transition is the semantic retry: it
+;; depends on another request succeeding *first*, which is exactly the case
+;; that doesn't fit inside :rf.http/managed's :retry slot.
+
+(rf/reg-event-fx :auth/flow
+  (rf/create-machine-handler
+    {:initial :loading-me
+     :data    {:token nil :user nil :error nil}
+
+     :guards
+     {:got-401? (fn [_ [_ {:keys [failure]}]]
+                  (and (= :rf.http/http-4xx (:kind failure))
+                       (= 401 (:status failure))))
+      :token-stale? (fn [{:keys [data]} _]
+                      (some? (:token data)))}                  ;; refresh viable
+
+     :actions
+     {:record-token (fn [d [_ {:keys [token]}]] {:data (assoc d :token token)})
+      :record-user  (fn [d [_ {:keys [value]}]] {:data (assoc d :user value)})
+      :record-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+
+     :states
+     {:loading-me
+      {:invoke {:src ::fetch-me
+                :data (fn [{:keys [data]} _] {:token (:token data)})}
+       :on    {:succeeded {:target :authenticated :action :record-user}
+               :failed    [{:guard  :got-401?
+                            :target :refreshing
+                            :action :record-error}
+                           {:target :login                         ;; non-401 → fatal
+                            :action :record-error}]}}
+
+      :refreshing
+      {:invoke {:src ::refresh-token}
+       :on    {:succeeded {:target :loading-me                    ;; semantic retry
+                           :action :record-token}
+               :failed    {:target :login                         ;; refresh failed → fatal
+                           :action :record-error}}}
+
+      :authenticated {:meta {:terminal? true}}
+      :login         {:meta {:terminal? true}}}}))
+```
+
+The boundary is teachable in three sentences:
+
+1. **`:rf.http/managed` `:retry` retries the same request when nothing else has to change.** Same URL, same headers, same body, same auth — only the wait time and the attempt counter differ. Transport-level.
+2. **The state machine retries when something has to change first** — refreshing a token, waiting for another request, conditioning on the response body, conditioning on app state. Semantic-level.
+3. **They compose.** The machine's `:invoke` spawns a managed request that itself retries 5xx; once that loop terminates (success or exhaustion), the machine sees a single `:succeeded` / `:failed` event and transitions accordingly. No call site has to choose one layer or the other — every non-trivial request configures both.
+
+#### Refresh-vs-init distinction
+
+The auth flow above runs **after init** — the machine reaches `:loading-me` because the user already has a (possibly stale) token from an earlier session, and `:refreshing` is the answer to "the token expired mid-session." Init is different: there's no token to refresh, so a 401 routes straight to `:login` rather than `:refreshing`. Apps that distinguish the two carry an `:init?` flag in `:data` and gate the `:got-401?` transition on `(and got-401? (not init?))`; init's 401 falls through to `:login`. The transport-level retry of 5xx applies identically in both modes — it doesn't care whether the request is the init fetch or a mid-session refetch.
+
+Cross-references: this section is the worked example referenced from [Spec 014 §Boundary — transport vs semantic retry](014-HTTPRequests.md#boundary--transport-vs-semantic-retry); the broader research that surfaced the boundary lives in [findings/boot-as-statemachine-dash8-rf8.md](../findings/boot-as-statemachine-dash8-rf8.md) (the Dash8 / rf8 boot-flow study that motivated rf2-wylu).
+
 ### Boot UI — reading progress from the snapshot
 
 A view subscribes to the machine snapshot via `sub-machine` (per [005 §Reading the snapshot](005-StateMachines.md)) and renders the visible-progress slice carried in `:data`:
@@ -297,4 +394,6 @@ Routes that depend on auth (a "must-be-logged-in" route) work because `:authenti
 - [005-StateMachines.md](005-StateMachines.md) — the substrate; the boot machine uses standard hierarchical / `:invoke` / `:after` mechanics.
 - [011-SSR.md](011-SSR.md) — server-side `:rf/server-init` and the hydration handoff.
 - [012-Routing.md](012-Routing.md) — the `:routing` boot state delegates to the routing surface.
+- [014-HTTPRequests §Boundary — transport vs semantic retry](014-HTTPRequests.md#boundary--transport-vs-semantic-retry) — the retry-ownership rule the auth-machine worked example illustrates.
+- [findings/boot-as-statemachine-dash8-rf8.md](../findings/boot-as-statemachine-dash8-rf8.md) — the Dash8 / rf8 study that surfaced the hybrid retry-ownership boundary (rf2-wylu).
 - [examples/reagent/login/core.cljs](../examples/reagent/login/core.cljs) — single-purpose flow machine; same shape, narrower scope.


### PR DESCRIPTION
## Summary

- Documents the hybrid retry-ownership rule from Mike's call in rf2-zg4g (2026-05-10): `:rf.http/managed` owns **transport-level** retry (function of attempt count + failure category); state machines own **semantic** retry (response-conditional, app-state-conditional, joined across requests).
- Pure spec/doc work. No implementation changes. Pre-release framing — no migration burden.
- Resolves rf2-wylu (this bead) and rf2-zg4g (the originating decision bead).

## What landed

- **`spec/014-HTTPRequests.md` §Retry** — lead paragraph clarifies transport-only ownership; new `§Boundary — transport vs semantic retry` subsection states the test ("does the decision depend on anything other than category + attempt count?"), gives a six-row decision table (which retry shape goes where, with examples), and points at the Pattern-Boot worked example.
- **`spec/Pattern-Boot.md`** — new `§Worked example — auth-machine and the retry-ownership boundary` showing the two halves composing on the same call site:
  - Transport: `:rf.http/managed` `:retry` handles 5xx + network with attempt-count + backoff.
  - Semantic: state machine handles 401-vs-200-vs-fatal — `:refreshing → :loading-me` is the semantic retry (depends on another request succeeding first).
  - Refresh-vs-init distinction called out (init's 401 routes to `:login`; mid-session 401 routes to `:refreshing`).
- **`spec/Pattern-AsyncEffect.md`** — cross-reference added.
- **`spec/005-StateMachines.md`** — new `§Cross-spec interactions / Retry-ownership boundary with :rf.http/managed` subsection (one paragraph, cross-links 014 and Pattern-Boot).

## Why now

Both halves of the boundary now exist in the substrate. The blockers are cleared:

- **Transport retry**: PR #183 (rf2-6y3q) shipped per-frame `:rf.http/managed` request interceptors.
- **Semantic retry**: PR #223 (rf2-3y3y `:after`) shipped state-level timed transitions; PR #185 (rf2-6vmw) shipped `:invoke-all` spawn-and-join.

The boundary was an open question (`§8.1` of `findings/boot-as-statemachine-dash8-rf8.md`); this PR locks the rule in canonical patterns so authors and AI scaffolders pick the right layer up-front.

## Test plan

- [x] No implementation changed — pure spec/doc work.
- [x] All anchor links verified to resolve to real headings (`#boundary--transport-vs-semantic-retry` in 014, `#worked-example--auth-machine-and-the-retry-ownership-boundary` in Pattern-Boot).
- [x] Tests not exercised — no test file references the modified specs.
- [ ] mkdocs build (CI runs on PR; will surface any broken anchors).

## Files

- `spec/005-StateMachines.md` (+6 lines)
- `spec/014-HTTPRequests.md` (+26 lines)
- `spec/Pattern-AsyncEffect.md` (+2 lines, -1)
- `spec/Pattern-Boot.md` (+99 lines)

Resolves: rf2-wylu, rf2-zg4g