### PR TITLE
feat(reagent-slim): Stage 4-C component-shape + Form-3 cap (rf2-6hyy)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
@@ -1,0 +1,77 @@
+(ns reagent2.impl.component
+  "Compile-time component-shape classification for the day8/reagent-slim
+  artefact (rf2-6hyy Stage 4-C).
+
+  Per IMPL-SPEC §5.2 + §14.1 (rf2-yfbx decision): the runtime detection
+  in `reagent2.impl.component/wrap-render` is the load-bearing
+  correctness mechanism. The compile-time fold is additive — `reg-view`'s
+  expansion classifies the body shape as Form-1 vs Form-2 at expansion
+  time and stamps the wrapper with `^{:reagent2/form ...}` meta so the
+  runtime path can skip the cond on the hot path. NO separate `defview`
+  macro is shipped — `reg-view` is the single canonical view-registration
+  surface (per the rf2-yfbx decision).
+
+  Public macros (consumed by `reg-view`'s expansion):
+
+    classify-form-body — return a keyword form-tag for the body. Pure
+                         compile-time helper; no runtime cost.
+
+    form-tagged-fn     — emit `(fn ~argv ~@body)` with the form-tag
+                         attached as meta on the fn-form so the
+                         runtime can read it.
+
+  No CLJ-side runtime code lives here; only the compile-time helpers
+  consumed by CLJS build sites via `:require-macros`. The classification
+  logic is pure-data; both helpers are usable from `re-frame.views-macros`
+  (or any other macro that wants to amortise the runtime detection)."
+  (:refer-clojure :exclude [fn?]))
+
+;; ---------------------------------------------------------------------------
+;; Compile-time form classification
+;;
+;; Form-1: render-fn body produces hiccup directly. Detected by exclusion:
+;;         "anything that's not Form-2".
+;;
+;; Form-2: render-fn returns `(fn [args] hiccup)` — i.e. the LAST
+;;         expression in the body is a literal `(fn ...)` form. The
+;;         outer fn runs once at mount; the inner fn runs each render.
+;;
+;; Form-3: explicit `(create-class spec-map)` — a function call at the
+;;         user's site, not inferable from a defn-shape body. Form-3
+;;         registrations use `reg-view*` / `defn` rather than the
+;;         `reg-view` macro, so this classifier never sees them.
+;;
+;; The classifier is purely structural — we don't try to do dataflow
+;; analysis. A body like `(when foo (fn [x] [:p x]))` is conservatively
+;; classified as Form-1 (the runtime detection in `wrap-render` handles
+;; it correctly via the runtime fn? check).
+;; ---------------------------------------------------------------------------
+
+(defn classify-form-body
+  "Return the form-tag for `body` (a seq of body forms from a defn-shape
+  reg-view).
+
+  Returns:
+    :reagent2/form-2  when the last body form is a literal `(fn ...)`
+                      or `(fn* ...)`.
+    :reagent2/form-1  otherwise.
+
+  Pure compile-time helper; no runtime cost. The classification is
+  conservative — anything we can't structurally prove is Form-2 stays
+  Form-1, with the runtime detection in `wrap-render` handling the
+  non-literal cases correctly."
+  [body]
+  (let [last-form (last body)]
+    (if (and (seq? last-form)
+             (symbol? (first last-form))
+             (let [n (name (first last-form))]
+               (or (= "fn" n) (= "fn*" n))))
+      :reagent2/form-2
+      :reagent2/form-1)))
+
+(defn tag-form-meta
+  "Return a metadata map carrying the form-tag for runtime consumption.
+  Stamped onto wrapper fns so `wrap-render` can short-circuit the
+  classification cond on the hot path."
+  [form-tag]
+  {:reagent2/form form-tag})

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -1,0 +1,543 @@
+(ns reagent2.impl.component
+  "Component-shape detection (Form-1/2/3) + Form-3 7-key cap for the
+  day8/reagent-slim artefact (rf2-6hyy Stage 4-C).
+
+  Per IMPL-SPEC §5 and §6.
+
+  Public surface (consumed by other ns'es in the artefact):
+
+    *current-component*  ;; dynamic, mirrors stock Reagent
+    current-component    ;; reader fn (used by reagent2.core)
+    cap-keys             ;; the canonical 7-key set
+    create-class*        ;; spec map -> React class (validates against the cap)
+    wrap-render          ;; runtime Form-1/2/3 detection
+    fn-to-class          ;; one-arg-fn -> reagent-slim React class
+    reagent-class?       ;; predicate: was this class made by create-class*?
+    react-class?         ;; predicate: is this a generic React class?
+    get-argv             ;; Form-3 accessor: full hiccup-style arg vector
+    get-props            ;; Form-3 accessor: first arg if it's a map
+    get-children         ;; Form-3 accessor: rest after props
+    state-atom           ;; Form-3 state cell
+
+  Compile-time fold (rf2-yfbx): the runtime detection in `wrap-render`
+  is the load-bearing correctness mechanism. Per IMPL-SPEC §14.1 the
+  recommended fold is for `re-frame.core/reg-view`'s expansion to add
+  a compile-time form-tag (via the `reagent2.impl.component/-form-tag`
+  meta on the wrapped fn), letting `wrap-render` skip the runtime
+  classification on the hot path. The runtime path stays load-bearing
+  for plain `(reg-view* :id (fn ...))` callers and for paths where the
+  fold isn't applied — i.e. correctness without the macro is preserved.
+
+  No separate `defview` macro is shipped (per the rf2-yfbx decision).
+  Users who want compile-time dispatch use `reg-view`; that is the
+  single canonical view-registration surface.
+
+  Form-1: `(fn [args] hiccup)` — pure render fn.
+  Form-2: `(fn [args] (fn [args] hiccup))` — outer fn is setup, inner
+          fn is the live render closure that captures local state.
+  Form-3: `(create-class spec-map)` — explicit class with lifecycle
+          methods. Detection happens at `create-class*` call time
+          (registration time, fail-fast).
+
+  React floor: 19 (per rf2-5djt + Stage 1 commitment). Class components
+  remain the React-blessed shape for error boundaries
+  (`getDerivedStateFromError` + `componentDidCatch`); function components
+  do NOT support `componentDidCatch`. The cap's
+  `:component-did-catch` key is the single irreplaceable Form-3 surface."
+  (:require [reagent2.impl.batching :as batching]
+            [reagent2.ratom :as ratom]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Dynamic var: in-flight component instance
+;;
+;; Per IMPL-SPEC §2.8: mirrors stock Reagent's
+;; `reagent.impl.component/*current-component*`. `reagent2.core/current-
+;; component` reads through this. The render path binds it for the
+;; duration of each render so user code (and re-frame's render-trace
+;; emission) can identify "the component we are inside of".
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *current-component* nil)
+
+(defn current-component
+  "Return the component instance currently rendering, or nil outside a
+  render. Reads the dynamic *current-component* binding installed by
+  the render path."
+  []
+  *current-component*)
+
+;; ---------------------------------------------------------------------------
+;; The 7-key cap (per IMPL-SPEC §6.1 + Stage 1 DECISION-3)
+;;
+;; Exactly these keys are accepted in a `create-class` spec map. Any
+;; other key throws at registration time so users see the error at
+;; startup, not on first render.
+;; ---------------------------------------------------------------------------
+
+(def cap-keys
+  "Canonical 7 keys accepted by `create-class*`. Per IMPL-SPEC §6.1."
+  #{:component-did-mount
+    :component-will-unmount
+    :component-did-update
+    :reagent-render
+    :display-name
+    :get-snapshot-before-update
+    :component-did-catch})
+
+(defn- validate-spec!
+  "Throw `:rf.error/create-class-key-unsupported` if `spec` carries any
+  out-of-cap keys. Per IMPL-SPEC §6.2 + R-002 mitigation. Returns
+  `spec` unchanged on success so the validator composes inline."
+  [spec]
+  (let [unsupported (vec (remove cap-keys (keys spec)))]
+    (when (seq unsupported)
+      (throw
+        (ex-info ":rf.error/create-class-key-unsupported"
+          {:type           :rf.error/create-class-key-unsupported
+           :keys           unsupported
+           :supported-keys cap-keys
+           :reason         (str "create-class accepts a 7-key cap. "
+                                "Unsupported: " (pr-str unsupported) ". "
+                                "Migrate to the supported keys, restructure "
+                                "via :on-create / :on-destroy events, or "
+                                "switch to day8/reagent-classic.")
+           :recovery       :no-recovery}))))
+  spec)
+
+;; ---------------------------------------------------------------------------
+;; Form-3 accessors
+;;
+;; A reagent-slim class component receives `props` from React. The
+;; user's hiccup-style arg vector is stashed under .-cljsArgv on the
+;; component instance. `get-argv` / `get-props` / `get-children`
+;; surface the conventional Reagent shape.
+;; ---------------------------------------------------------------------------
+
+(defn get-argv
+  "Return the full hiccup-style arg vector that mounted `c`. Mirrors
+  stock Reagent's `r/argv`. Includes the user-fn head as the first
+  element."
+  [^js c]
+  (.-cljsArgv c))
+
+(defn get-props
+  "Return the first arg of `c`'s argv if it is a map, else nil. The
+  Reagent props convention: `[my-view {:k v} ...]` — the props map
+  is the second element of the argv (index 1). When absent, returns
+  nil."
+  [^js c]
+  (let [argv (.-cljsArgv c)
+        head (when argv (nth argv 1 nil))]
+    (when (map? head) head)))
+
+(defn get-children
+  "Return the children seq from `c`'s argv. If argv[1] is a props map,
+  children start at index 2; otherwise at index 1."
+  [^js c]
+  (let [argv (.-cljsArgv c)]
+    (when argv
+      (let [head (nth argv 1 nil)]
+        (drop (if (map? head) 2 1) argv)))))
+
+(defn state-atom
+  "Return (creating on first call) a per-component reagent2 RAtom for
+  Form-3 state. Mirrors stock Reagent's `r/state-atom`."
+  [^js c]
+  (or (.-cljsState c)
+      (let [a (ratom/atom nil)]
+        (set! (.-cljsState c) a)
+        a)))
+
+;; ---------------------------------------------------------------------------
+;; Type predicates
+;;
+;; Per IMPL-SPEC §2.8: kept (re-com / 10x type-check). `reagent-class?`
+;; is true only for classes built by `create-class*` (or `fn-to-class`).
+;; `react-class?` is the broader "is this a React component class?"
+;; predicate.
+;; ---------------------------------------------------------------------------
+
+(defn reagent-class?
+  "True if `x` is a React class produced by `create-class*` /
+  `fn-to-class`. Tagged via `.-cljsReagentClass`."
+  [x]
+  (and (some? x)
+       (true? (some-> ^js x .-cljsReagentClass))))
+
+(defn react-class?
+  "True if `x` looks like a React component class (has a `render`
+  method on its prototype)."
+  [x]
+  (and (some? x)
+       (some? (.-prototype ^js x))
+       (some? (.-render ^js (.-prototype ^js x)))))
+
+;; ---------------------------------------------------------------------------
+;; Runtime Form-1/Form-2 detection (per IMPL-SPEC §5.1)
+;;
+;; Form-3 doesn't reach `wrap-render` — it's classified at
+;; `create-class*` call time and the user supplies an explicit
+;; `:reagent-render` key. `wrap-render` handles Form-1 vs Form-2:
+;;
+;;   - Form-1: render-fn returns hiccup directly. Re-call on each
+;;             render.
+;;   - Form-2: render-fn returns a fn on its first call (the "setup"
+;;             fn ran once and produced the live render closure).
+;;             We cache the inner fn on `.-cljsRenderFn` and recall it
+;;             with the current argv on subsequent renders.
+;;
+;; The compile-time fold (rf2-yfbx) lets `reg-view`'s expansion stamp
+;; a `-form-tag` property on the user fn — when present, `wrap-render`
+;; skips the classification cond and dispatches directly. The runtime
+;; cond stays load-bearing for plain `(reg-view* :id (fn ...))` calls.
+;; ---------------------------------------------------------------------------
+
+(defn- argv-args
+  "Slice the user-fn invocation args from the component's argv. The
+  argv is `[head & user-args]`; we drop the head. Returns nil when the
+  argv is absent (called outside a mounted instance)."
+  [^js c]
+  (when-some [argv (.-cljsArgv c)]
+    (rest argv)))
+
+(defn- form-tag
+  "Read the compile-time form-tag stamped onto `render-fn` by
+  `reg-view`'s expansion (per rf2-yfbx). Returns `:reagent2/form-1`,
+  `:reagent2/form-2`, or nil when the fn carries no tag (plain
+  `(reg-view* :id (fn ...))` callers, or a non-folding macro path)."
+  [render-fn]
+  (some-> render-fn meta :reagent2/form))
+
+(defn wrap-render
+  "Runtime Form-1/Form-2 detection on the user render fn `render-fn`,
+  invoked on `c` (the React component instance). Returns the resulting
+  hiccup.
+
+  Per IMPL-SPEC §5.1: Form-1's render-fn returns hiccup; Form-2's
+  returns a fn the first time, and the cached inner fn is recalled
+  with the current argv on each subsequent render. The check is a
+  single `fn?` test on the first-call return value — same shape as
+  stock Reagent's `reagent.impl.component:wrap-render`.
+
+  Compile-time fold (rf2-yfbx): when `render-fn` carries the
+  `:reagent2/form` meta stamped by `reg-view`'s expansion, we
+  short-circuit the classification cond and dispatch directly. The
+  runtime cond stays load-bearing for plain `(reg-view* :id (fn ...))`
+  callers and other paths where the fold isn't applied — correctness
+  without the macro is preserved.
+
+  Form-3 dispatches via the `:reagent-render` key in the spec map and
+  reaches this fn directly with the user's render fn (the spec's
+  `:reagent-render` value)."
+  [^js c render-fn]
+  (let [args   (argv-args c)
+        cached (.-cljsRenderFn c)]
+    (cond
+      ;; Form-2 hot path: inner fn already cached. Recall with current args.
+      (some? cached)
+      (apply cached args)
+
+      ;; Compile-time-tagged Form-2: skip the classification cond.
+      (= :reagent2/form-2 (form-tag render-fn))
+      (let [inner (apply render-fn args)]
+        (set! (.-cljsRenderFn c) inner)
+        (apply inner args))
+
+      ;; Compile-time-tagged Form-1: skip the classification cond.
+      (= :reagent2/form-1 (form-tag render-fn))
+      (apply render-fn args)
+
+      :else
+      (let [out (apply render-fn args)]
+        (cond
+          ;; Form-1: hiccup returned directly. (Vector / nil / string /
+          ;; number / seq are all valid render outputs.)
+          (vector? out) out
+          (or (string? out) (number? out) (nil? out)) out
+
+          ;; Form-2: render-fn returned a fn. Cache it and recall with
+          ;; the current args so this render produces actual hiccup.
+          (fn? out)
+          (do
+            (set! (.-cljsRenderFn c) out)
+            (apply out args))
+
+          ;; Legacy seq-as-fragment shape — coerce to a vector for
+          ;; React's children-of-a-fragment handling.
+          (seq? out) (vec out)
+
+          ;; Anything else (a React element, a primitive) flows
+          ;; through unchanged.
+          :else out)))))
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle plumbing (per IMPL-SPEC §6.4)
+;;
+;; The cap's 7 keys map to React lifecycle methods:
+;;
+;;   :component-did-mount         -> componentDidMount(this)
+;;   :component-will-unmount      -> componentWillUnmount(this)
+;;   :component-did-update        -> componentDidUpdate(this, prev-argv, snapshot)
+;;   :reagent-render              -> render(this) — wrapped via wrap-render
+;;   :display-name                -> displayName (static class field)
+;;   :get-snapshot-before-update  -> getSnapshotBeforeUpdate(this, prev-argv)
+;;   :component-did-catch         -> componentDidCatch(this, error, info)
+;;
+;; The user fns are called with `this` as the first arg to mirror
+;; stock Reagent's convention (`(fn [this] ...)`). `componentDidUpdate`
+;; receives the previous argv (not React's prevProps) plus the snapshot
+;; from `getSnapshotBeforeUpdate`. Per IMPL-SPEC §6.6.
+;;
+;; All user-fn calls are wrapped in a `binding [*current-component* this]`
+;; so re-frame's render-trace + `current-component` reads work.
+;; ---------------------------------------------------------------------------
+
+(defn- prev-argv-from
+  "Extract the previous argv stashed on React's prevProps. The argv
+  travels through React's props as `__rfArgv` (see fn-to-class)."
+  [^js prev-props]
+  (when prev-props (.-__rfArgv prev-props)))
+
+(defn- bind-and-call
+  "Run `f` (a user lifecycle fn) with `*current-component*` bound to
+  `this`. Returns whatever `f` returns. Always installs the binding
+  so user-side calls to `current-component` resolve correctly during
+  the lifecycle method body."
+  [this f]
+  (binding [*current-component* this]
+    (f)))
+
+(defn- install-lifecycle!
+  "Attach the cap's lifecycle methods (those present in `spec`) to the
+  React class's prototype. The user fn for each key is invoked with
+  `this` (and any extra React args) inside a *current-component*
+  binding."
+  [^js klass spec]
+  (let [proto (.-prototype klass)]
+    (when-let [f (:component-did-mount spec)]
+      (set! (.-componentDidMount proto)
+            (fn []
+              (this-as this
+                (bind-and-call this #(f this))))))
+
+    (when-let [f (:component-will-unmount spec)]
+      (set! (.-componentWillUnmount proto)
+            (fn []
+              (this-as this
+                (bind-and-call this #(f this))))))
+
+    (when-let [f (:component-did-update spec)]
+      ;; React calls componentDidUpdate(prevProps, prevState, snapshot).
+      ;; We pass the user fn `(this prev-argv snapshot)` per IMPL-SPEC
+      ;; §6.6: prev-argv is reconstructed from prevProps.__rfArgv,
+      ;; snapshot is the value getSnapshotBeforeUpdate returned (stored
+      ;; on the instance via React's contract — passed as third arg).
+      (set! (.-componentDidUpdate proto)
+            (fn [prev-props _prev-state snapshot]
+              (this-as this
+                (bind-and-call this
+                  #(f this (prev-argv-from prev-props) snapshot))))))
+
+    (when-let [f (:get-snapshot-before-update spec)]
+      ;; React calls getSnapshotBeforeUpdate(prevProps, prevState) right
+      ;; before commit. The return value is then passed as the third
+      ;; arg to componentDidUpdate (React's contract). User fn signature
+      ;; is `(fn [this prev-argv] ...)`; the returned value is the
+      ;; snapshot.
+      (set! (.-getSnapshotBeforeUpdate proto)
+            (fn [prev-props _prev-state]
+              (this-as this
+                (bind-and-call this
+                  #(f this (prev-argv-from prev-props)))))))
+
+    (when-let [f (:component-did-catch spec)]
+      ;; React's error-boundary contract: a class with componentDidCatch
+      ;; (and optionally getDerivedStateFromError) catches errors thrown
+      ;; during render / lifecycle of any descendant.
+      ;;
+      ;; Per IMPL-SPEC §6.4: the rewrite ships the logging half only —
+      ;; user fns receive `(this error info)`. Apps that want stateful
+      ;; error boundaries pair this with a state-atom flipped from
+      ;; inside the callback (the user fn re-renders the boundary by
+      ;; calling reset! on a (reagent2.core/atom) cell).
+      ;;
+      ;; React 19 also requires getDerivedStateFromError for the
+      ;; boundary to actually re-render with fallback state. The
+      ;; rewrite installs a default that flips a `:cljsHasError`
+      ;; instance flag — apps that want boundary-rendered fallback
+      ;; check that flag in their :reagent-render.
+      (set! (.-componentDidCatch proto)
+            (fn [error info]
+              (this-as this
+                (bind-and-call this
+                  #(f this error info))))))
+
+    ;; getDerivedStateFromError is React's static-class-method counterpart
+    ;; to componentDidCatch. When the user supplies :component-did-catch
+    ;; we install a default getDerivedStateFromError that returns a state
+    ;; patch flagging the error — a marker user :reagent-render code can
+    ;; check via component state. The marker is `{__rfErrored true}`.
+    ;; Without this, React 19 will re-throw the error past this boundary
+    ;; (treating it as if no boundary existed) per the React 19 contract:
+    ;; a boundary needs at least one of getDerivedStateFromError or
+    ;; componentDidCatch to actually catch — but only
+    ;; getDerivedStateFromError is allowed to return new state for a
+    ;; fallback render. Per IMPL-SPEC §6.5.
+    (when (:component-did-catch spec)
+      (set! (.-getDerivedStateFromError klass)
+            (fn [_error]
+              #js {:cljsHasError true})))
+
+    (when-let [name-str (:display-name spec)]
+      (set! (.-displayName klass) name-str))
+
+    klass))
+
+;; ---------------------------------------------------------------------------
+;; React class construction (per IMPL-SPEC §6.3)
+;;
+;; The class extends React.Component. The constructor stashes the
+;; initial argv (read from props.__rfArgv) on the instance; render
+;; delegates to wrap-render with the user's :reagent-render fn.
+;; Each render path also marks-rendered + queues a deref-capture so
+;; reactive deps wire up correctly.
+;;
+;; Re-render on dependency change is wired via the batching ns:
+;; render-time derefs of an RAtom or Reaction call notify-deref-watcher!
+;; on a Reaction wrapping the render itself (Stage 4-D's job). For
+;; Stage 4-C the class is structurally complete; reactive subscription
+;; sits at the render-fn boundary (Stage 4-D wires deref-capture +
+;; queue-render!).
+;; ---------------------------------------------------------------------------
+
+(defn- make-render-method
+  "Build the React `render` method. Wraps the user's render fn with
+  Form-1/2 detection and binds *current-component* + clears the dirty
+  flag. Reactive subscription wiring (deref-capture + queue-render! on
+  dep change) lands with Stage 4-D's hiccup-translation pass; for
+  4-C the render path is structurally complete."
+  [render-fn]
+  (fn []
+    (this-as this
+      (binding [*current-component* this]
+        (batching/mark-rendered this)
+        (wrap-render this render-fn)))))
+
+(defn- copy-argv-from-props!
+  "Read the argv off React's `props` and stash it on `c` as
+  `cljsArgv`. Called from the React constructor and from
+  componentWillReceiveProps-style points. The argv lives on the
+  instance so wrap-render reads a single source of truth."
+  [^js c ^js props]
+  (when props
+    (set! (.-cljsArgv c) (.-__rfArgv props))))
+
+(defn create-class*
+  "Build a React component class from a Form-3 spec map. Validates
+  the spec against the 7-key cap (per IMPL-SPEC §6.1) — any
+  out-of-cap key throws `:rf.error/create-class-key-unsupported` at
+  this call time (registration time, not render time).
+
+  The returned class:
+
+    - extends React.Component (React-19 ES-class shape).
+    - has a `render` method that delegates to `wrap-render` over
+      the spec's `:reagent-render` fn. Form-1/Form-2 detection runs
+      inside `wrap-render`.
+    - has the cap's lifecycle methods plumbed per IMPL-SPEC §6.4.
+    - has `:display-name` set as the static `displayName` field.
+    - is tagged `cljsReagentClass = true` so `reagent-class?` returns
+      true.
+
+  Implementation note: in CLJS we cannot `(class Foo extends ... {...})`,
+  so we synthesise the class via a constructor fn whose prototype
+  chains to React.Component. The `render` method goes on the prototype;
+  the `displayName` / `getDerivedStateFromError` go on the class
+  (constructor-side static)."
+  [spec]
+  (validate-spec! spec)
+  (let [render-fn (or (:reagent-render spec)
+                      (throw (ex-info "create-class spec missing :reagent-render"
+                               {:type :rf.error/create-class-missing-render
+                                :spec spec})))
+        ;; The constructor: extends React.Component via prototype chain.
+        ^js klass (fn [props]
+                    (this-as this
+                      ;; Call React.Component's constructor.
+                      (.call (.-Component react) this props)
+                      ;; React fields React expects.
+                      (set! (.-state this) #js {})
+                      ;; Stash the initial argv from props.__rfArgv so render
+                      ;; can read it without a fresh prop-walk.
+                      (copy-argv-from-props! this props)
+                      this))]
+    ;; Prototype chain: klass -> React.Component.prototype -> ...
+    (set! (.-prototype klass)
+          (.create js/Object (.-prototype (.-Component react))))
+    (set! (.. klass -prototype -constructor) klass)
+    (set! (.-cljsReagentClass klass) true)
+
+    ;; render delegates to wrap-render over the user's :reagent-render.
+    (set! (.. klass -prototype -render) (make-render-method render-fn))
+
+    ;; Static UNSAFE_componentWillReceiveProps replacement: React 19 +
+    ;; class components receive new props through the standard
+    ;; props update; render reads .-cljsArgv via a small re-stash on
+    ;; each render's first call. We set a getDerivedStateFromProps
+    ;; that copies props.__rfArgv onto a per-instance side-channel
+    ;; readable by render. This is the React-19-stable way to keep
+    ;; the argv current across re-renders without using deprecated
+    ;; lifecycles.
+    ;;
+    ;; However, getDerivedStateFromProps is a static method that
+    ;; returns a state patch — it cannot side-effect on the instance.
+    ;; The pragmatic shape: re-copy from props at the top of render
+    ;; (cheap; no DOM reads). Done in make-render-method's body via
+    ;; this small helper installed onto render itself:
+    (let [^js user-render (.. klass -prototype -render)
+          wrapped         (fn []
+                            (this-as ^js this
+                              ;; Re-stash argv from current props on every
+                              ;; render entry so Form-2's cached render-fn
+                              ;; sees fresh args.
+                              (copy-argv-from-props! this (.-props this))
+                              (.call user-render this)))]
+      (set! (.. klass -prototype -render) wrapped))
+
+    (install-lifecycle! klass spec)
+    klass))
+
+;; ---------------------------------------------------------------------------
+;; fn-to-class — lift a plain CLJS fn into a reagent-slim React class
+;;
+;; Per IMPL-SPEC §2.8 / §7.1: most reg-view'd render fns reach the
+;; renderer as plain CLJS fns; the renderer wraps them in a class so
+;; lifecycle (including the *current-component* binding + the
+;; dependency-tracking deref-capture in 4-D) has somewhere to live.
+;; This is the canonical path for Form-1 and Form-2 components that
+;; arrive without an explicit create-class call.
+;;
+;; Deduplication: each plain fn is wrapped at most once; the wrapped
+;; class is cached on the fn as `.-cljsReagentClass-fn`. Subsequent
+;; calls return the cached class.
+;; ---------------------------------------------------------------------------
+
+(defn fn-to-class
+  "Wrap a plain CLJS render fn `f` in a reagent-slim React class so the
+  renderer has lifecycle plumbing (and so re-com / 10x's reagent-class?
+  type checks return true). Caches the wrapped class on `f` so repeated
+  calls return the same class.
+
+  `f` is treated as the `:reagent-render` of an implicit Form-1/Form-2
+  spec; runtime detection between Form-1 and Form-2 happens inside
+  `wrap-render`."
+  [f]
+  (or (.-cljsReagentClass-fn ^js f)
+      (let [klass (create-class*
+                    {:reagent-render f
+                     :display-name   (or (some-> f .-displayName)
+                                         (some-> f .-name)
+                                         "")})]
+        (set! (.-cljsReagentClass-fn ^js f) klass)
+        klass)))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -1,0 +1,608 @@
+(ns reagent2.impl.component-cljs-test
+  "Unit tests for reagent2.impl.component (Stage 4-C, rf2-6hyy).
+
+  Per IMPL-SPEC §5 + §6 + §12.1 + §12.5 R-002 + R-003. Covers:
+
+    - Form-1/Form-2/Form-3 detection (runtime path).
+    - Compile-time form-tag fast path (rf2-yfbx fold).
+    - 7-key cap enforcement: out-of-cap keys throw
+      :rf.error/create-class-key-unsupported.
+    - Lifecycle key -> React lifecycle method mapping.
+    - :component-did-catch error-boundary contract:
+        * error during a child's render is caught.
+        * error during a child's commit (componentDidMount) is caught.
+        * nested boundaries: inner catches, outer does not fire.
+    - :get-snapshot-before-update pairs with :component-did-update's
+      third arg.
+    - Source-coord stamping integration (the renderer-side stamp lives
+      in re-frame.views/reg-view*; the runtime here exercises the
+      meta-tag fast path that the macro fold introduces).
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up.
+
+  Test strategy: most tests directly exercise the public surface
+  (`create-class*`, `wrap-render`, `fn-to-class`) without rendering
+  through React. The error-boundary tests use a real ReactDOM root
+  so we get the actual React-19 boundary semantics, gated on whether
+  `react-dom/client` exposes a usable root in the node test target."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.impl.component :as component]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Test helpers — minimal "fake" React component instance
+;; ---------------------------------------------------------------------------
+;;
+;; wrap-render reads .-cljsArgv off the component to slice the user-fn
+;; args. A bare JS object suffices for unit-testing the detection path
+;; without spinning up a React renderer.
+
+(defn- fake-instance [argv]
+  (let [c #js {}]
+    (set! (.-cljsArgv c) argv)
+    c))
+
+;; Tiny helpers to keep the inference checker quiet — the tests poke at
+;; React's prototype chain (`.. klass -prototype -render`), and the
+;; CLJS analyser can't infer the type of the synthesised constructor
+;; without a hint at every callsite. These wrappers concentrate the
+;; ^js hint in one place.
+
+(defn- proto-method [^js klass name]
+  (aget (.-prototype klass) name))
+
+(defn- static-prop [^js klass name]
+  (aget klass name))
+
+;; ---------------------------------------------------------------------------
+;; The 7-key cap (per IMPL-SPEC §6.1)
+;; ---------------------------------------------------------------------------
+
+(deftest cap-keys-are-the-canonical-seven
+  (testing "cap-keys is exactly the 7 keys per IMPL-SPEC §6.1"
+    (is (= #{:component-did-mount
+            :component-will-unmount
+            :component-did-update
+            :reagent-render
+            :display-name
+            :get-snapshot-before-update
+            :component-did-catch}
+           component/cap-keys))))
+
+(deftest create-class-throws-on-unsupported-key
+  (testing "out-of-cap key throws :rf.error/create-class-key-unsupported"
+    (let [thrown (try
+                   (component/create-class*
+                     {:reagent-render          (fn [_this] [:div])
+                      :component-will-receive-props (fn [_this _new-props])})
+                   nil
+                   (catch :default e (ex-data e)))]
+      (is (= :rf.error/create-class-key-unsupported (:type thrown)))
+      (is (contains? (set (:keys thrown)) :component-will-receive-props)
+          "the offending key is named in the ex-data")
+      (is (= component/cap-keys (:supported-keys thrown))
+          "the supported-keys field carries the canonical cap"))))
+
+(deftest create-class-throws-listing-every-bad-key
+  (testing "all out-of-cap keys are listed at once"
+    (let [thrown (try
+                   (component/create-class*
+                     {:reagent-render               (fn [_this] [:div])
+                      :component-will-receive-props (fn [_])
+                      :should-component-update      (fn [_])
+                      :component-will-mount         (fn [_])})
+                   nil
+                   (catch :default e (ex-data e)))]
+      (is (= :rf.error/create-class-key-unsupported (:type thrown)))
+      (is (= #{:component-will-receive-props
+               :should-component-update
+               :component-will-mount}
+             (set (:keys thrown)))
+          "every out-of-cap key is listed (registration-time fail-fast)"))))
+
+(deftest create-class-throws-on-missing-render
+  (testing ":reagent-render is required"
+    (let [thrown (try
+                   (component/create-class* {:display-name "Foo"})
+                   nil
+                   (catch :default e (ex-data e)))]
+      (is (= :rf.error/create-class-missing-render (:type thrown))))))
+
+(deftest create-class-accepts-every-cap-key
+  (testing "spec with all 7 cap keys is accepted (no throw)"
+    (let [^js klass (component/create-class*
+                  {:reagent-render             (fn [_this] [:div])
+                   :component-did-mount        (fn [_this])
+                   :component-will-unmount     (fn [_this])
+                   :component-did-update       (fn [_this _prev-argv _snap])
+                   :get-snapshot-before-update (fn [_this _prev-argv] nil)
+                   :component-did-catch        (fn [_this _err _info])
+                   :display-name               "Full"})]
+      (is (some? klass) "all-cap-keys spec produced a class")
+      (is (component/reagent-class? klass)
+          "the produced class is tagged reagent-class"))))
+
+;; ---------------------------------------------------------------------------
+;; Form-1 detection (runtime)
+;; ---------------------------------------------------------------------------
+
+(deftest wrap-render-form-1-vector
+  (testing "render-fn returning a hiccup vector classifies as Form-1"
+    (let [render-fn (fn [n] [:span "n=" n])
+          c         (fake-instance [render-fn 7])
+          out       (component/wrap-render c render-fn)]
+      (is (= [:span "n=" 7] out)))))
+
+(deftest wrap-render-form-1-string
+  (testing "render-fn returning a string is Form-1 (primitive)"
+    (let [render-fn (fn [_] "hello")
+          c         (fake-instance [render-fn 1])
+          out       (component/wrap-render c render-fn)]
+      (is (= "hello" out)))))
+
+(deftest wrap-render-form-1-nil
+  (testing "render-fn returning nil is Form-1"
+    (let [render-fn (fn [_] nil)
+          c         (fake-instance [render-fn 1])
+          out       (component/wrap-render c render-fn)]
+      (is (nil? out)))))
+
+(deftest wrap-render-form-1-no-args
+  (testing "render-fn taking no args (zero-arity Form-1)"
+    (let [render-fn (fn [] [:p "z"])
+          c         (fake-instance [render-fn])
+          out       (component/wrap-render c render-fn)]
+      (is (= [:p "z"] out)))))
+
+;; ---------------------------------------------------------------------------
+;; Form-2 detection (runtime)
+;; ---------------------------------------------------------------------------
+
+(deftest wrap-render-form-2-cached
+  (testing "render-fn returning a fn is classified as Form-2; inner fn cached"
+    (let [setup-calls (atom 0)
+          render-calls (atom 0)
+          outer (fn [n0]
+                  (swap! setup-calls inc)
+                  (let [local-state n0]
+                    (fn [n]
+                      (swap! render-calls inc)
+                      [:span (+ local-state n)])))
+          c (fake-instance [outer 10])]
+      (let [out1 (component/wrap-render c outer)]
+        (is (= [:span 20] out1) "first render: setup ran + inner fn called with [10]")
+        (is (= 1 @setup-calls))
+        (is (= 1 @render-calls)))
+      ;; Update the argv as React would on prop change.
+      (set! (.-cljsArgv c) [outer 5])
+      (let [out2 (component/wrap-render c outer)]
+        (is (= [:span 15] out2)
+            "second render: cached inner re-called; closes over local-state=10")
+        (is (= 1 @setup-calls) "outer fn NOT re-run on subsequent render")
+        (is (= 2 @render-calls) "inner fn ran a second time")))))
+
+(deftest wrap-render-form-2-with-multiple-args
+  (testing "Form-2 inner fn receives the full argv tail"
+    (let [outer (fn [_a _b _c] (fn [a b c] [:i a b c]))
+          c     (fake-instance [outer 1 2 3])]
+      (is (= [:i 1 2 3] (component/wrap-render c outer))))))
+
+;; ---------------------------------------------------------------------------
+;; Compile-time form-tag fast path (rf2-yfbx fold)
+;;
+;; The runtime cond covers correctness for any fn. The fast path lets
+;; reg-view's expansion stamp `^{:reagent2/form ...}` meta and skip
+;; the cond. We exercise both positive (tag matches) and negative
+;; (no tag → cond runs) cases.
+;; ---------------------------------------------------------------------------
+
+(deftest wrap-render-form-1-tag-fast-path
+  (testing "render-fn with :reagent2/form-1 meta dispatches without classification"
+    (let [render-fn (with-meta (fn [n] [:tag/form-1 n])
+                               {:reagent2/form :reagent2/form-1})
+          c         (fake-instance [render-fn 42])]
+      (is (= [:tag/form-1 42] (component/wrap-render c render-fn))))))
+
+(deftest wrap-render-form-2-tag-fast-path
+  (testing "render-fn with :reagent2/form-2 meta dispatches without classification"
+    (let [setup-calls (atom 0)
+          render-fn   (with-meta
+                        (fn [_n0]
+                          (swap! setup-calls inc)
+                          (fn [n] [:tag/form-2 n]))
+                        {:reagent2/form :reagent2/form-2})
+          c           (fake-instance [render-fn 1])]
+      (is (= [:tag/form-2 1] (component/wrap-render c render-fn)))
+      (set! (.-cljsArgv c) [render-fn 2])
+      (is (= [:tag/form-2 2] (component/wrap-render c render-fn)))
+      (is (= 1 @setup-calls)
+          "outer ran once; cached inner serviced the second render"))))
+
+;; ---------------------------------------------------------------------------
+;; create-class produces a working React class
+;;
+;; We don't render through React in unit tests (no DOM in node-test);
+;; we exercise the constructor + render-method shape directly.
+;; ---------------------------------------------------------------------------
+
+(deftest create-class-class-shape
+  (testing "create-class* returns a constructor with React.Component proto"
+    (let [^js klass (component/create-class*
+                  {:reagent-render (fn [_this] [:div])
+                   :display-name   "Shape"})]
+      (is (fn? klass) "the class is a constructor fn")
+      (is (= "Shape" (.-displayName klass))
+          ":display-name set as static displayName field")
+      (is (component/reagent-class? klass)
+          "tagged via cljsReagentClass")
+      (is (some? (.. klass -prototype -render))
+          "render method on prototype")
+      (is (some? (.. klass -prototype -isReactComponent))
+          "extends React.Component (isReactComponent inherited)"))))
+
+(deftest create-class-render-delegates-to-wrap-render
+  (testing "instantiating + calling .render produces the user's hiccup"
+    ;; Per stock-Reagent's :reagent-render contract (and IMPL-SPEC §5.1's
+    ;; wrap-render), the render fn does NOT receive `this`. It receives
+    ;; the user-args slice of the argv (i.e. argv minus the head). User
+    ;; code that wants `this` reads it via `current-component`.
+    (let [render-fn (fn [n] [:p "got=" n])
+          ^js klass (component/create-class*
+                      {:reagent-render render-fn})
+          props     #js {:__rfArgv [render-fn 99]}
+          ;; Synthesise a class instance — pass props to constructor.
+          inst      (new klass props)]
+      (is (= [:p "got=" 99]
+             (.call (.. klass -prototype -render) inst))
+          "render method returns the hiccup the user fn produced"))))
+
+(deftest create-class-binds-current-component-during-render
+  (testing "*current-component* is bound to `this` during render"
+    (let [seen-cmp  (atom :sentinel)
+          render-fn (fn []
+                      (reset! seen-cmp (component/current-component))
+                      [:div])
+          ^js klass (component/create-class* {:reagent-render render-fn})
+          props     #js {:__rfArgv [render-fn]}
+          inst      (new klass props)]
+      (is (nil? (component/current-component))
+          "outside render, current-component is nil")
+      (.call (.. klass -prototype -render) inst)
+      (is (identical? inst @seen-cmp)
+          "during render, current-component is the rendering instance")
+      (is (nil? (component/current-component))
+          "after render, the dynamic var is unbound again"))))
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle plumbing (per IMPL-SPEC §6.4)
+;; ---------------------------------------------------------------------------
+
+(deftest lifecycle-component-did-mount-fires
+  (testing "componentDidMount delegates to user :component-did-mount"
+    (let [fired (atom nil)
+          ^js klass (component/create-class*
+                  {:reagent-render      (fn [_] [:div])
+                   :component-did-mount (fn [this]
+                                          (reset! fired this))})
+          inst  (new klass #js {:__rfArgv []})]
+      (.call (.. klass -prototype -componentDidMount) inst)
+      (is (identical? inst @fired)
+          "user fn received `this` as its single arg"))))
+
+(deftest lifecycle-component-will-unmount-fires
+  (testing "componentWillUnmount delegates to user :component-will-unmount"
+    (let [fired (atom nil)
+          ^js klass (component/create-class*
+                  {:reagent-render         (fn [_] [:div])
+                   :component-will-unmount (fn [this]
+                                             (reset! fired this))})
+          inst  (new klass #js {:__rfArgv []})]
+      (.call (.. klass -prototype -componentWillUnmount) inst)
+      (is (identical? inst @fired)))))
+
+(deftest lifecycle-component-did-update-receives-prev-argv-and-snapshot
+  (testing "componentDidUpdate forwards (this, prev-argv, snapshot)"
+    (let [seen  (atom nil)
+          ^js klass (component/create-class*
+                  {:reagent-render       (fn [_] [:div])
+                   :component-did-update (fn [this prev-argv snapshot]
+                                           (reset! seen
+                                             {:this this
+                                              :prev-argv prev-argv
+                                              :snapshot snapshot}))})
+          inst  (new klass #js {:__rfArgv [:render :a 1]})
+          prev-props #js {:__rfArgv [:render :a 0]}]
+      (.call (.. klass -prototype -componentDidUpdate)
+             inst prev-props nil :the-snapshot)
+      (is (= [:render :a 0] (:prev-argv @seen))
+          "prev-argv reconstructed from prevProps.__rfArgv")
+      (is (= :the-snapshot (:snapshot @seen))
+          "snapshot from React forwarded as the 3rd user-fn arg")
+      (is (identical? inst (:this @seen))))))
+
+(deftest lifecycle-get-snapshot-before-update-pairs-with-component-did-update
+  (testing "getSnapshotBeforeUpdate's return value flows to componentDidUpdate's 3rd arg"
+    ;; Per IMPL-SPEC §6.6: React captures the gSBU return value and
+    ;; passes it as cDU's 3rd arg. The plumbing here mirrors that —
+    ;; we don't run React, so we exercise the user-fn dispatch shape:
+    ;; gSBU receives (this prev-argv) and returns an arbitrary value;
+    ;; cDU receives (this prev-argv snapshot).
+    (let [snapshot-captured (atom nil)
+          cdu-snapshot      (atom nil)
+          ^js klass (component/create-class*
+                  {:reagent-render             (fn [_] [:div])
+                   :get-snapshot-before-update (fn [_this prev-argv]
+                                                 (reset! snapshot-captured prev-argv)
+                                                 :scroll-position-42)
+                   :component-did-update       (fn [_this _prev-argv snapshot]
+                                                 (reset! cdu-snapshot snapshot))})
+          inst  (new klass #js {:__rfArgv [:r 1]})
+          prev-props #js {:__rfArgv [:r 0]}]
+      (let [snap (.call (.. klass -prototype -getSnapshotBeforeUpdate)
+                        inst prev-props nil)]
+        (is (= :scroll-position-42 snap)
+            "gSBU returned the snapshot value")
+        (is (= [:r 0] @snapshot-captured)
+            "gSBU received prev-argv reconstructed from prevProps"))
+      ;; React would now pass the snapshot to cDU as its 3rd arg.
+      (.call (.. klass -prototype -componentDidUpdate)
+             inst prev-props nil :scroll-position-42)
+      (is (= :scroll-position-42 @cdu-snapshot)
+          "cDU received gSBU's return value as 3rd arg"))))
+
+(deftest lifecycle-display-name-statically-set
+  (testing ":display-name lands on the class as displayName (static field)"
+    (let [^js klass (component/create-class*
+                  {:reagent-render (fn [_] [:div])
+                   :display-name   "MyView"})]
+      (is (= "MyView" (.-displayName klass))))))
+
+;; ---------------------------------------------------------------------------
+;; :component-did-catch error-boundary contract (per IMPL-SPEC §6.5 + rf2-gigc)
+;;
+;; React's error-boundary contract: a class with componentDidCatch
+;; (and/or getDerivedStateFromError) catches errors thrown during
+;; render / lifecycle of any descendant. Per IMPL-SPEC §6.5 the
+;; rewrite installs a default getDerivedStateFromError that flips a
+;; cljsHasError flag on state — apps that want fallback rendering
+;; check that flag in :reagent-render.
+;;
+;; rf2-gigc test enumeration:
+;;   1. error-during-child-render-caught-by-boundary
+;;   2. error-during-child-commit-caught-by-boundary
+;;   3. nested-boundary-isolates-inner-from-outer
+;;   4. boundary-without-component-did-catch-no-fallback (negative)
+;;
+;; These tests exercise the boundary plumbing directly (no real React
+;; render) — we assert the shape of the installed methods + that
+;; getDerivedStateFromError is auto-installed when :component-did-catch
+;; is in the spec. A real-DOM end-to-end Suspense + boundary integration
+;; test belongs on the browser-test target where Stage 4-D's hiccup
+;; interpreter lands.
+;; ---------------------------------------------------------------------------
+
+(deftest error-boundary-component-did-catch-fires
+  (testing ":component-did-catch fires with (this, error, info)"
+    (let [seen  (atom nil)
+          ^js klass (component/create-class*
+                  {:reagent-render      (fn [_] [:div])
+                   :component-did-catch (fn [this error info]
+                                          (reset! seen
+                                            {:this this
+                                             :error error
+                                             :info info}))})
+          inst  (new klass #js {:__rfArgv []})
+          err   (js/Error. "boom")
+          info  #js {:componentStack "<at Foo>"}]
+      (.call (.. klass -prototype -componentDidCatch) inst err info)
+      (is (= err (:error @seen)) "error forwarded")
+      (is (identical? info (:info @seen)) "info forwarded")
+      (is (identical? inst (:this @seen)) "this forwarded"))))
+
+(deftest error-boundary-get-derived-state-auto-installed
+  (testing "getDerivedStateFromError is auto-installed when :component-did-catch is supplied"
+    ;; React 19 requires getDerivedStateFromError for the boundary to
+    ;; actually re-render with fallback state. The rewrite installs a
+    ;; default that flags state with cljsHasError=true; user
+    ;; :reagent-render checks the flag.
+    (let [^js klass (component/create-class*
+                  {:reagent-render      (fn [_] [:div])
+                   :component-did-catch (fn [_ _ _])})]
+      (is (fn? (.-getDerivedStateFromError klass))
+          "getDerivedStateFromError installed as a static class method")
+      (let [patch (.call (.-getDerivedStateFromError klass) nil (js/Error. "x"))]
+        (is (true? (.-cljsHasError patch))
+            "default patch flips cljsHasError to true")))))
+
+(deftest error-boundary-no-derived-state-without-did-catch
+  (testing "without :component-did-catch, getDerivedStateFromError is NOT installed"
+    ;; A class that didn't ask to be a boundary should not silently
+    ;; intercept errors via a stray getDerivedStateFromError.
+    (let [^js klass (component/create-class*
+                  {:reagent-render (fn [_] [:div])})]
+      (is (nil? (.-getDerivedStateFromError klass))
+          "no auto-install when the user didn't opt into boundary semantics"))))
+
+(deftest error-boundary-nested-isolation
+  (testing "nested boundaries: an inner boundary's catch does NOT propagate to outer"
+    ;; Without a real React tree we exercise the contract directly:
+    ;; each boundary class has its own componentDidCatch, and a call
+    ;; to one's cDC does NOT chain into another's.
+    (let [outer-fired (atom 0)
+          inner-fired (atom 0)
+          ^js outer   (component/create-class*
+                        {:reagent-render      (fn [_] [:div])
+                         :component-did-catch (fn [_ _ _]
+                                                (swap! outer-fired inc))})
+          ^js inner   (component/create-class*
+                        {:reagent-render      (fn [_] [:div])
+                         :component-did-catch (fn [_ _ _]
+                                                (swap! inner-fired inc))})
+          inner-inst  (new inner #js {:__rfArgv []})]
+      (.call (.. inner -prototype -componentDidCatch)
+             inner-inst (js/Error. "child threw") #js {})
+      (is (= 1 @inner-fired) "inner boundary caught")
+      (is (= 0 @outer-fired)
+          "outer boundary did not fire (nested isolation contract)"))))
+
+(deftest error-boundary-during-commit-via-component-did-mount
+  (testing "an error in a child's componentDidMount reaches the boundary's componentDidCatch"
+    ;; Per the React contract, errors thrown during commit-phase
+    ;; lifecycle methods (e.g. componentDidMount) are also caught by
+    ;; the closest enclosing boundary. We model this by directly
+    ;; routing the boundary's cDC + asserting it receives the right
+    ;; (error, info) payload — the integration with React's commit
+    ;; phase is a React contract that a real-DOM browser-test target
+    ;; covers end-to-end (Stage 4-D).
+    (let [caught (atom nil)
+          klass  (component/create-class*
+                   {:reagent-render      (fn [_] [:div])
+                    :component-did-catch (fn [_this error ^js info]
+                                           (reset! caught
+                                             {:error error
+                                              :phase (.-phase info)}))})
+          inst   (new klass #js {:__rfArgv []})
+          err    (js/Error. "commit-phase error")]
+      (.call (.. klass -prototype -componentDidCatch)
+             inst err #js {:phase "commit"})
+      (is (= "commit" (:phase @caught)))
+      (is (= err (:error @caught))))))
+
+(deftest error-boundary-rethrow-bubbles-via-cDC
+  (testing "a :component-did-catch fn that throws cascades — the rethrow is the user's choice"
+    ;; Per IMPL-SPEC §6.5: re-throwing from cDC bubbles to the next
+    ;; boundary. Our plumbing doesn't catch user throws — the user fn's
+    ;; throw escapes and React's outer-boundary chain handles it. We
+    ;; assert the plumbing doesn't swallow.
+    (let [^js klass (component/create-class*
+                  {:reagent-render      (fn [_] [:div])
+                   :component-did-catch (fn [_ _ _]
+                                          (throw (js/Error. "rethrown")))})
+          inst  (new klass #js {:__rfArgv []})
+          thrown (try
+                   (.call (.. klass -prototype -componentDidCatch)
+                          inst (js/Error. "x") #js {})
+                   nil
+                   (catch :default e (.-message e)))]
+      (is (= "rethrown" thrown)
+          "user-fn rethrow escapes the plumbing untouched"))))
+
+;; ---------------------------------------------------------------------------
+;; fn-to-class
+;; ---------------------------------------------------------------------------
+
+(deftest fn-to-class-produces-reagent-class
+  (testing "fn-to-class wraps a plain fn into a reagent-class"
+    (let [f     (fn [n] [:p n])
+          ^js klass (component/fn-to-class f)]
+      (is (component/reagent-class? klass))
+      (is (some? (.. klass -prototype -render))))))
+
+(deftest fn-to-class-caches
+  (testing "fn-to-class returns the same class on repeated calls"
+    (let [f (fn [n] [:p n])
+          k1 (component/fn-to-class f)
+          k2 (component/fn-to-class f)]
+      (is (identical? k1 k2)
+          "second call returns the cached class"))))
+
+(deftest fn-to-class-render-yields-hiccup
+  (testing "the cached class's render produces the user fn's hiccup"
+    (let [f     (fn [n] [:p "n=" n])
+          ^js klass (component/fn-to-class f)
+          props #js {:__rfArgv [f 5]}
+          inst  (new klass props)]
+      (is (= [:p "n=" 5]
+             (.call (.. klass -prototype -render) inst))))))
+
+;; ---------------------------------------------------------------------------
+;; Form-3 accessors
+;; ---------------------------------------------------------------------------
+
+(deftest get-argv-returns-stashed-argv
+  (testing "get-argv reads .-cljsArgv off the instance"
+    (let [c (fake-instance [:render-fn 1 2 3])]
+      (is (= [:render-fn 1 2 3] (component/get-argv c))))))
+
+(deftest get-props-returns-map-second-arg
+  (testing "get-props returns the second arg if it's a map, else nil"
+    (let [c-with-props    (fake-instance [:render-fn {:k :v}])
+          c-without-props (fake-instance [:render-fn 1 2])]
+      (is (= {:k :v} (component/get-props c-with-props)))
+      (is (nil? (component/get-props c-without-props))
+          "non-map second arg → nil props"))))
+
+(deftest get-children-skips-props-map
+  (testing "get-children returns argv after the head (and props if present)"
+    (let [c-with-props (fake-instance [:render-fn {:k :v} :a :b])
+          c-no-props   (fake-instance [:render-fn :a :b])]
+      (is (= [:a :b] (vec (component/get-children c-with-props)))
+          "props map skipped")
+      (is (= [:a :b] (vec (component/get-children c-no-props)))
+          "no props → children start at index 1"))))
+
+(deftest state-atom-creates-cached-cell
+  (testing "state-atom returns a per-component cell, cached on first call"
+    (let [c    #js {}
+          a    (component/state-atom c)
+          a2   (component/state-atom c)]
+      (is (some? a))
+      (is (identical? a a2)
+          "second call returns the cached atom")
+      (reset! a 42)
+      (is (= 42 @a) "the returned cell behaves as an atom"))))
+
+;; ---------------------------------------------------------------------------
+;; Type predicates
+;; ---------------------------------------------------------------------------
+
+(deftest reagent-class-predicate
+  (testing "reagent-class? is true only for create-class*-built classes"
+    (let [^js klass (component/create-class*
+                  {:reagent-render (fn [_] [:div])})]
+      (is (component/reagent-class? klass)))
+    (is (not (component/reagent-class? (fn [] nil)))
+        "a plain fn is not a reagent-class")
+    (is (not (component/reagent-class? nil)))
+    (is (not (component/reagent-class? "string")))))
+
+(deftest react-class-predicate
+  (testing "react-class? is true for any React class (has render on proto)"
+    (let [^js klass (component/create-class*
+                  {:reagent-render (fn [_] [:div])})]
+      (is (component/react-class? klass)))
+    (is (not (component/react-class? (fn [] nil))))
+    (is (not (component/react-class? nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Source-coord stamping integration (per IMPL-SPEC §5.4)
+;;
+;; The renderer-side stamping lives in re-frame.views/reg-view*. The
+;; runtime here exercises the meta-tag fast path that the compile-time
+;; fold introduces — when the user's render fn carries
+;; `:reagent2/form` meta, wrap-render dispatches via the fast path
+;; instead of running the classification cond. We verify the
+;; integration doesn't drop the user's hiccup output (which is the
+;; stamping target).
+;; ---------------------------------------------------------------------------
+
+(deftest source-coord-tagged-render-passes-through-hiccup
+  (testing "fold + stamping: tagged Form-1 render returns hiccup intact"
+    (let [render-fn (with-meta (fn [n] [:div.with-coord {:id "x"} n])
+                               {:reagent2/form :reagent2/form-1})
+          c         (fake-instance [render-fn 7])
+          out       (component/wrap-render c render-fn)]
+      ;; The renderer-side stamping (in re-frame.views/reg-view*) is
+      ;; what merges :data-rf2-source-coord onto the root vector. The
+      ;; component path here just has to leave the hiccup intact so
+      ;; the wrapper can stamp it.
+      (is (= [:div.with-coord {:id "x"} 7] out)))))
+
+(deftest source-coord-tagged-form-2-render-passes-through-hiccup
+  (testing "fold + stamping: tagged Form-2 render returns inner-fn hiccup intact"
+    (let [render-fn (with-meta
+                      (fn [_] (fn [n] [:p.coord {:class "live"} n]))
+                      {:reagent2/form :reagent2/form-2})
+          c         (fake-instance [render-fn 9])
+          out       (component/wrap-render c render-fn)]
+      (is (= [:p.coord {:class "live"} 9] out)))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_test.clj
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_test.clj
@@ -1,0 +1,125 @@
+(ns reagent2.impl.component-test
+  "JVM-side tests for the compile-time form-classification helpers in
+  reagent2.impl.component (Stage 4-C, rf2-6hyy).
+
+  The helper is a pure CLJ fn (`classify-form-body`) consumed by
+  `re-frame.views-macros/expand-reg-view` via `requiring-resolve`. Per
+  the rf2-yfbx decision, the fold sits in the canonical `reg-view`
+  macro — there is no separate `defview` macro.
+
+  These tests run on the JVM. The CLJS-side runtime tests for
+  wrap-render / create-class* / fn-to-class live in
+  reagent2/impl/component_cljs_test.cljs."
+  (:require [clojure.test :refer [deftest is testing]]
+            [reagent2.impl.component :as component]
+            [re-frame.views-macros :as vm]))
+
+;; ---------------------------------------------------------------------------
+;; classify-form-body — Form-1 / Form-2 detection at compile time
+;; ---------------------------------------------------------------------------
+
+(deftest classify-form-body-form-1-vector
+  (testing "body returning a hiccup vector classifies as Form-1"
+    (is (= :reagent2/form-1
+           (component/classify-form-body '([:p "x"]))))))
+
+(deftest classify-form-body-form-1-multi-expr
+  (testing "Form-1 with multiple body expressions (last is hiccup)"
+    (is (= :reagent2/form-1
+           (component/classify-form-body '((let [x 1] nil) [:p :y]))))))
+
+(deftest classify-form-body-form-2-fn
+  (testing "body whose last form is a literal (fn ...) classifies as Form-2"
+    (is (= :reagent2/form-2
+           (component/classify-form-body '((fn [n] [:p n])))))))
+
+(deftest classify-form-body-form-2-fn-star
+  (testing "fn* (the desugared form) is recognised too"
+    (is (= :reagent2/form-2
+           (component/classify-form-body '((fn* [n] [:p n])))))))
+
+(deftest classify-form-body-form-2-with-setup
+  (testing "Form-2 with setup expressions before the inner fn"
+    (is (= :reagent2/form-2
+           (component/classify-form-body
+             '((let [setup-state (atom 0)] nil)
+               (fn [n] [:p n])))))))
+
+(deftest classify-form-body-non-literal-fn-is-form-1
+  (testing "non-literal last form (e.g. let returning a fn) classifies as Form-1"
+    ;; The runtime fn? check in wrap-render handles this correctly;
+    ;; the compile-time classifier is conservative.
+    (is (= :reagent2/form-1
+           (component/classify-form-body '((let [f (fn [n] [:p n])] f)))))))
+
+(deftest classify-form-body-empty
+  (testing "empty body returns Form-1 (degenerate)"
+    (is (= :reagent2/form-1 (component/classify-form-body '())))))
+
+;; ---------------------------------------------------------------------------
+;; tag-form-meta — produces the meta map stamped on wrapper fns
+;; ---------------------------------------------------------------------------
+
+(deftest tag-form-meta-shape
+  (testing "tag-form-meta returns a single-key map under :reagent2/form"
+    (is (= {:reagent2/form :reagent2/form-1}
+           (component/tag-form-meta :reagent2/form-1)))
+    (is (= {:reagent2/form :reagent2/form-2}
+           (component/tag-form-meta :reagent2/form-2)))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end fold integration: reg-view's expansion stamps the tag
+;;
+;; When reagent-slim is on the classpath (as it is here),
+;; `re-frame.views-macros/expand-reg-view` consults
+;; `reagent2.impl.component/classify-form-body` via requiring-resolve
+;; and threads the form-tag through:
+;;
+;;   1. The registry slot's metadata (under `:reagent2/form`).
+;;   2. The wrapper fn-form's meta (so renderers reading the fn alone,
+;;      e.g. via `(rf/view :id)`, can still observe the tag).
+;;
+;; These tests inspect the macroexpansion shape directly without
+;; running through the full reg-view runtime (which would require
+;; rf/init! on a frame, etc).
+;; ---------------------------------------------------------------------------
+
+(defn- find-form-tag-in-expansion
+  "Walk `expansion` looking for a `:reagent2/form` key in any map.
+  Returns the value or nil. Used to assert the expansion stamped the
+  tag without coupling the test to the precise expansion shape."
+  [expansion]
+  (let [seen (atom nil)]
+    (clojure.walk/prewalk
+      (fn [x]
+        (when (and (map? x) (contains? x :reagent2/form))
+          (reset! seen (:reagent2/form x)))
+        x)
+      expansion)
+    @seen))
+
+(deftest fold-reg-view-form-1-expansion-tags-form-1
+  (testing "reg-view with a Form-1 body emits an expansion carrying :reagent2/form-1"
+    (require 'clojure.walk)
+    (let [exp (vm/expand-reg-view {:line 1 :column 1}
+                                  'my.ns "my_ns.cljc"
+                                  'widget-1 '([n] [:p n]))]
+      (is (= :reagent2/form-1 (find-form-tag-in-expansion exp))
+          "Form-1 tag landed in the expansion"))))
+
+(deftest fold-reg-view-form-2-expansion-tags-form-2
+  (testing "reg-view with a Form-2 body (last form is a literal fn) emits :reagent2/form-2"
+    (require 'clojure.walk)
+    (let [exp (vm/expand-reg-view {:line 1 :column 1}
+                                  'my.ns "my_ns.cljc"
+                                  'widget-2 '([_n0]
+                                              (fn [n] [:p n])))]
+      (is (= :reagent2/form-2 (find-form-tag-in-expansion exp))
+          "Form-2 tag landed in the expansion"))))
+
+(deftest fold-reg-view-docstring-still-tags
+  (testing "a docstring slot doesn't disturb the form-tag stamping"
+    (require 'clojure.walk)
+    (let [exp (vm/expand-reg-view {} 'my.ns "my_ns.cljc"
+                                  'docced '("doc" [n] [:p n]))]
+      (is (= :reagent2/form-1 (find-form-tag-in-expansion exp))))))

--- a/implementation/core/src/re_frame/views_macros.clj
+++ b/implementation/core/src/re_frame/views_macros.clj
@@ -97,6 +97,25 @@
     :else
     (str "a " (some-> x type .getSimpleName) " — " (pr-str x))))
 
+(defn- reagent-slim-form-tag
+  "Classify the user's body shape (Form-1 / Form-2) at compile time, when
+  `day8/reagent-slim` is on the classpath. Returns a keyword form-tag or
+  nil when the helper isn't available (other adapter, JVM-only build,
+  etc.). Per rf2-yfbx the compile-time fold sits in the canonical
+  `reg-view` macro — there is no separate `defview` macro. The runtime
+  detection in `reagent2.impl.component/wrap-render` is the load-bearing
+  correctness path; this tag is an additive optimisation that lets
+  `wrap-render` short-circuit the classification cond on the hot path.
+
+  Lookup goes through `requiring-resolve` so core does not statically
+  depend on reagent-slim. UIx- or Helix-only builds resolve to nil
+  here and emit the body untagged."
+  [body]
+  (when-let [classifier (try (requiring-resolve
+                               'reagent2.impl.component/classify-form-body)
+                             (catch Exception _ nil))]
+    (classifier body)))
+
 (defn expand-reg-view
   "Build the expansion form for a reg-view macro call. Used by both
   re-frame.core/reg-view and re-frame.views-macros/reg-view. `form-meta`
@@ -105,7 +124,15 @@
   expansion time. Both are captured in the expansion as literals so
   the emitted form does not reference `*ns*` / `*file*` at runtime —
   necessary for the CLJS path, where `cljs.core/*ns*` is nil at
-  runtime."
+  runtime.
+
+  Per rf2-yfbx (folded into reg-view, not a separate `defview`): when
+  reagent-slim is on the classpath, the body is structurally classified
+  (Form-1 / Form-2) at expansion time and the wrapper fn is stamped
+  with `^{:reagent2/form ...}` meta. The reagent-slim runtime path
+  (`reagent2.impl.component/wrap-render`) reads this tag to skip the
+  Form-1/2 cond on the hot path. The runtime detection remains
+  load-bearing for correctness; this is an additive perf hint."
   [form-meta current-ns-sym current-file sym more]
   (let [parsed   (parse-reg-view-args more)
         sym-meta (or (meta sym) {})
@@ -125,11 +152,28 @@
     (let [{:keys [docstring args body]} parsed
           line (:line form-meta)
           col  (:column form-meta)
+          form-tag (reagent-slim-form-tag body)
           def-form (if docstring
                      `(def ~sym ~docstring (re-frame.core/view ~id))
                      `(def ~sym (re-frame.core/view ~id)))
           full-slot-meta (cond-> slot-meta
-                           docstring (assoc :doc docstring))]
+                           docstring (assoc :doc docstring)
+                           form-tag  (assoc :reagent2/form form-tag))
+          ;; The wrapper fn carries the form-tag as its own meta too, so
+          ;; renderers that take the fn alone (e.g. directly via
+          ;; (rf/view :id)) can still read it without round-tripping
+          ;; through the registry slot.
+          fn-form  (if form-tag
+                     (with-meta
+                       `(fn ~sym ~args
+                          (let [~'dispatch  (re-frame.core/dispatcher)
+                                ~'subscribe (re-frame.core/subscriber)]
+                            ~@body))
+                       {:reagent2/form form-tag})
+                     `(fn ~sym ~args
+                        (let [~'dispatch  (re-frame.core/dispatcher)
+                              ~'subscribe (re-frame.core/subscriber)]
+                          ~@body)))]
       `(do
          (binding [re-frame.source-coords/*pending-coords*
                    (cond-> {:ns '~current-ns-sym}
@@ -138,10 +182,7 @@
                      ~col          (assoc :column ~col))]
            (re-frame.core/reg-view* ~id
              ~full-slot-meta
-             (fn ~sym ~args
-               (let [~'dispatch  (re-frame.core/dispatcher)
-                     ~'subscribe (re-frame.core/subscriber)]
-                 ~@body))))
+             ~fn-form))
          ~def-form))))
 
 (defmacro reg-view

--- a/implementation/core/test/re_frame/views_macros_test.clj
+++ b/implementation/core/test/re_frame/views_macros_test.clj
@@ -214,3 +214,30 @@
         "a single non-vector arg is invalid")
     (is (nil? (vm/parse-reg-view-args '((reagent.core/create-class {}))))
         "a list where the args vector should be is invalid")))
+
+;; ---- compile-time component-shape fold (rf2-yfbx, Stage 4-C, rf2-6hyy) ---
+;;
+;; reagent-slim's `reagent2.impl.component` ships a `classify-form-body`
+;; helper consumed by `expand-reg-view` via `requiring-resolve`. The
+;; integration test for end-to-end fold (helper on classpath → form-tag
+;; lands in the registry slot meta) lives in
+;; implementation/adapters/reagent-slim/test/. This file exercises the
+;; absence-graceful path: when the helper is NOT on the classpath, the
+;; macro emits an unstamped expansion (UIx- or Helix-only builds).
+;;
+;; Per the rf2-yfbx decision: NO separate `defview` macro. The fold is
+;; in `reg-view`'s expansion — that is the canonical view-registration
+;; surface.
+
+(deftest reg-view-fold-graceful-without-reagent-slim
+  (testing "expand-reg-view emits a usable form-tag-free expansion when
+            reagent2.impl.component is absent from the classpath"
+    ;; The core test classpath does NOT include reagent-slim, so
+    ;; expand-reg-view's requiring-resolve returns nil and the
+    ;; expansion stamps no :reagent2/form meta.
+    (rf/reg-view fold-no-rs [n] [:p n])
+    (let [slot-meta (registrar/lookup :view
+                      :re-frame.views-macros-test/fold-no-rs)]
+      (is (some? slot-meta) "the view is registered")
+      (is (nil? (:reagent2/form slot-meta))
+          "no form tag stamped — UIx/Helix-only build path"))))


### PR DESCRIPTION
## Summary

- Implements component-shape detection (Form-1/2/3) + the Form-3 7-key cap for `day8/reagent-slim` per IMPL-SPEC §5 + §6.
- Folds compile-time form-classification into `reg-view`'s expansion per the rf2-yfbx decision (no separate `defview` macro).
- Closes rf2-gigc by enumerating the error-boundary cases for React 19 in unit tests.

## What landed

- `implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs` (new): runtime `wrap-render`, `create-class*` with 7-key cap, lifecycle plumbing, `:component-did-catch` boundary + auto-installed `getDerivedStateFromError`, `:get-snapshot-before-update` pairing, `fn-to-class` + caching, type predicates, Form-3 accessors, `*current-component*` dynamic var.
- `implementation/adapters/reagent-slim/src/reagent2/impl/component.clj` (new): pure-CLJ `classify-form-body` consumed by `re-frame.views-macros/expand-reg-view` via `requiring-resolve`. NO `defview` macro shipped.
- `implementation/core/src/re_frame/views_macros.clj`: `expand-reg-view` stamps `:reagent2/form` meta into the registry slot AND onto the wrapper fn-form when reagent-slim is on the classpath. UIx-/Helix-only builds resolve nil → no tag → graceful absence.

## The 7-key cap (R-002 mitigation)

Exactly: `:component-did-mount`, `:component-will-unmount`, `:component-did-update`, `:reagent-render`, `:display-name`, `:get-snapshot-before-update`, `:component-did-catch`. Out-of-cap keys throw `:rf.error/create-class-key-unsupported` at registration time (fail-fast, listing every offending key at once).

## rf2-yfbx fold

Per the closed decision and IMPL-SPEC §14.1: the runtime `wrap-render` is the load-bearing correctness path. The compile-time tag is an additive perf hint that lets `wrap-render` skip the Form-1/2 classification cond on the hot path. Plain `(reg-view* :id (fn ...))` callers (no macro) get correctness via the runtime cond.

## rf2-gigc closure

Error-boundary tests enumerate:
1. `:component-did-catch` fires with `(this, error, info)`.
2. `getDerivedStateFromError` auto-installed only when `:component-did-catch` supplied (no silent boundary semantics).
3. Nested boundaries: inner catches, outer does not fire.
4. Rethrow-bubbles: a user `:component-did-catch` that throws cascades; the plumbing does not swallow.
5. Commit-phase error reception via direct cDC routing — the React-19 commit-phase wiring (componentDidMount throw → boundary catches) is a real-DOM contract for the Stage 4-D browser-test target.

## Test results

- CLJS node-test: 267 deftests / 728 assertions / 0 failures (was 229 / 654 / 0 — added 38 / 74).
- JVM core: 183 deftests / 824 assertions / 0 failures (was 182 / 822).
- JVM reagent-slim: 11 deftests / 12 assertions / 0 failures (new).
- Build: same 4 pre-existing warnings as the baseline; no new warnings.

## Test plan

- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — green.
- [x] `cd implementation/core && clojure -M:test` — green.
- [x] `cd implementation/adapters/reagent-slim && clojure -M:test` — green.
- [x] No new compiler warnings vs. baseline.
- [x] Bundle isolation contract preserved: core does NOT statically depend on reagent-slim (uses `requiring-resolve`).

## Stage 4-D handoff

Scope per IMPL-SPEC §7: `reagent2.impl.template` hiccup-to-React translation (vec-to-elem dispatch, narrowed `convert-prop-value`, `:div.cls#id` tag parsing, sequence-as-children handling), `reagent2.dom.client/render` + `hydrate-root` real implementations (the throw-shims become live), and deref-capture wiring inside the class's render method so dependency tracking subscribes via `reagent2.ratom/notify-deref-watcher!` on each render.