### PR TITLE
spec(Spec-Schemas): widen :fixture/calls schema + reconcile :effects-routed (rf2-d67g)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1828,16 +1828,61 @@ The host-agnostic conformance fixture format. Per [conformance/README.md](confor
    [:fixture/frame-config {:optional true} :map]
    [:fixture/dispatches   {:optional true} [:vector [:vector :any]]]
 
+   ;; `:fixture/calls` carries direct invocations of pure primitives (Mode B).
+   ;; Each entry dispatches on `:call`; per-op record shapes match the
+   ;; fixture-runner's case dispatch (`implementation/core/test/re_frame/conformance_test.clj` `run-call`).
+   ;; The six operators cover state-machine transitions, URL ↔ route helpers, and SSR rendering.
    [:fixture/calls
     {:optional true}
     [:vector
-     [:map
-      [:call                  [:= :machine-transition]]
-      [:definition            :any]
-      [:snapshot              :any]
-      [:event                 [:vector :any]]
-      [:expect-next-snapshot  :any]
-      [:expect-effects        [:vector :any]]]]]
+     [:multi {:dispatch :call}
+      ;; Pure machine-transition. Returns [next-snapshot effects].
+      [:machine-transition
+       [:map
+        [:call                 [:= :machine-transition]]
+        [:definition           :any]                                          ;; transition table per [005-StateMachines.md](005-StateMachines.md)
+        [:snapshot             :any]                                          ;; {:state :data} input snapshot
+        [:event                [:vector :any]]                                ;; event vector to apply
+        [:expect-next-snapshot :any]                                          ;; expected snapshot after transition
+        [:expect-effects       [:vector :any]]]]                              ;; expected fx vector returned by the action
+
+      ;; URL → route-match. `:expect` is the match map or `nil` for unmatched.
+      [:match-url
+       [:map
+        [:call    [:= :match-url]]
+        [:url     :string]
+        [:expect  :any]]]                                                     ;; {:route-id :params :query :validation-failed?} or nil
+
+      ;; route-id + params [+ query] → URL string.
+      [:route-url
+       [:map
+        [:call      [:= :route-url]]
+        [:route-id  :keyword]
+        [:params    :map]
+        [:query     {:optional true} :map]                                    ;; 3-arity form when present
+        [:expect    :string]]]                                                ;; the rebuilt URL
+
+      ;; Round-trip property: route-url ∘ match-url is identity for the URL.
+      [:round-trip
+       [:map
+        [:call  [:= :round-trip]]
+        [:url   :string]]]
+
+      ;; Asserts winner's :rf.route/rank tuple compares greater than loser's
+      ;; via lex compare. Per [012 §Route ranking algorithm](012-Routing.md#route-ranking-algorithm).
+      [:assert-rank-greater
+       [:map
+        [:call    [:= :assert-rank-greater]]
+        [:winner  :keyword]                                                   ;; route-id expected to outrank
+        [:loser   :keyword]]]                                                 ;; route-id expected to be outranked
+
+      ;; SSR pure render. `:input` is hiccup or a registered-view event vector.
+      [:render-to-string
+       [:map
+        [:call    [:= :render-to-string]]
+        [:input   :any]                                                       ;; hiccup or [:view-id args ...]
+        [:opts    {:optional true} :map]                                      ;; {:doctype? bool} etc.
+        [:expect  :string]]]]]]                                               ;; expected HTML output
 
    [:fixture/expect
     {:optional true}
@@ -1846,8 +1891,7 @@ The host-agnostic conformance fixture format. Per [conformance/README.md](confor
      [:sub-values          {:optional true} [:map-of [:vector :any] :any]]
      [:sub-graph-topology  {:optional true} :map]
      [:trace-emissions     {:optional true} [:vector :map]]
-     [:effects-routed      {:optional true} [:vector :any]]
-     [:expected-fx-emitted {:optional true} [:vector :any]]]]])
+     [:effects-routed      {:optional true} [:vector :any]]]]])               ;; routed-fx pairs in declaration order, per [conformance/README.md](conformance/README.md) §Fixture lifecycle
 ```
 
 `:rf/fixture-handler-body` is a synonym for `:rf/handler-body-dsl` (defined above) — the fixture format reuses the canonical DSL grammar rather than redefining it. Reserved built-ins are enumerated in [conformance/README.md §Handler-body DSL builtins](conformance/README.md#handler-body-dsl-builtins).


### PR DESCRIPTION
## Summary

- **Fix 1 — widen `:fixture/calls`.** The published schema typed entries as a single record with literal `:call = :machine-transition`. Six operators are actually in the live corpus and dispatched on by the fixture-runner (`implementation/core/test/re_frame/conformance_test.clj` `run-call`): `:machine-transition`, `:match-url`, `:route-url`, `:round-trip`, `:assert-rank-greater`, `:render-to-string`. Widen to a Malli `:multi` dispatched on `:call`, with one per-op record schema carrying the keys that operator actually requires. Implementors who lint fixture files against the schema can now accept every routing / SSR / routing-rank fixture.

- **Fix 2 — drop `:expected-fx-emitted`.** Audit found `:expected-fx-emitted` only in the schema itself: the corpus uses `:effects-routed` exclusively (24 fixtures, 0 occurrences of `:expected-fx-emitted`); the runner reads only `:effects-routed`; the conformance README documents only `:effects-routed`. Removed.

### Design choice for Fix 1: option (b) — multispec dispatched on `:call`

The per-op key shapes are substantively different (six distinct payloads, not minor key variations on a shared body), so the multispec form gives implementors actionable per-op feedback when linting — e.g. "missing `:winner`" on a malformed `:assert-rank-greater` rather than a vague "extra/missing keys" against a flat enum. Each branch documents the operator's contract in line with the fixture-runner's dispatch.

### Files touched

- `spec/Spec-Schemas.md` (only)

## Test plan

- [x] Audit: 6 `:call` operators present in `spec/conformance/fixtures/*.edn` (75 occurrences across 25 files); confirmed against runner's `case` arms at `conformance_test.clj:619-714`.
- [x] Audit: `:expected-fx-emitted` not used anywhere except the schema; `:effects-routed` is the canonical name (corpus + runner + conformance README all agree).
- [x] Cross-doc consistency: `spec/conformance/README.md` already documents the six `:call` ops and uses `:effects-routed` only — no changes needed there.
- [x] `clojure -M:test -n re-frame.conformance-test` from `implementation/core/` — 0 failures, 0 errors.