### PR TITLE
feat(reagent-slim): Stage 4-D hiccup translation + render (rf2-6hyy)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -1,0 +1,174 @@
+(ns re-frame.adapter.reagent-slim
+  "The day8/reagent-slim adapter — drop-in replacement for the bridge
+  adapter `re-frame.adapter.reagent` (rf2-6hyy Stage 4-D).
+
+  Per IMPL-SPEC §2.1 + §9 + §13.1: this adapter Var emits the same
+  9-key map shape `re-frame.substrate.adapter` consumes; signatures
+  match the bridge's signatures byte-for-byte. Internals swap from
+  `(:require [reagent.core ...] [reagent.ratom ...] [reagent.dom.client ...])`
+  to the rewrite's `reagent2.*` namespaces.
+
+  Why a separate ns rather than overwriting `re-frame.adapter.reagent`:
+  the in-tree shadow-cljs build adds both `adapters/reagent/src` and
+  `adapters/reagent-slim/src` to the classpath at the same time. Two
+  namespaces with the same name would clash. At artefact-publication
+  time (per the deps.edn :main and IMPL-SPEC §13.1) the slim artefact
+  ships its own `re-frame.adapter.reagent` — consumers depend on
+  exactly one of {day8/re-frame-2-reagent, day8/reagent-slim} so the
+  ns is single-source per app. Until the artefact split is
+  consummated, this `-slim` suffix lets both coexist in the monorepo.
+
+  Public surface (signatures unchanged from the bridge):
+
+    adapter           — the substrate spec map (9-key contract)
+    set-hiccup-emitter! — wires SSR's render-to-string into :render-to-string
+
+  Late-bind hooks installed at ns-load time:
+    :reagent/set-hiccup-emitter!  — set to set-hiccup-emitter!
+    :adapter/current-frame        — set to re-frame.views/current-frame
+
+  The current-frame hook is the same one the bridge installs. The
+  Reagent-slim adapter targets the same React-context Provider /
+  `(.-context cmp)` shape the bridge uses (per IMPL-SPEC §9.6),
+  so the views.cljs wiring works unchanged.
+
+  Pre-release status: until the bridge is retired (post-1.0), apps
+  that want the rewrite explicitly opt in by requiring this ns.
+
+  Stage 4-D scope-of-completion (rf2-6hyy):
+    - The substrate-shape Vars (containers, derived values, render,
+      hydrate, dispose) are wired against `reagent2.*`.
+    - `register-context-provider` returns `views/build-frame-provider`,
+      same as the bridge — but the upstream `re-frame.views/current-frame`
+      reads `(reagent.core/current-component)` (stock), NOT
+      `(reagent2.core/current-component)` (slim). For mixed-mode
+      environments the slim's Provider components would not be visible
+      to that reader. This is a known Stage 4-E follow-up: views.cljs
+      needs adapter-agnostic dispatch through a late-bind hook
+      (`:adapter/current-component`) before the slim adapter is fully
+      functional in production. Today it is structurally complete and
+      callable from tests, but mounting through `(rf/init! adapter)`
+      is not yet a drop-in replacement for the bridge.
+    - The `(rf/init! ...)` apps still pin the bridge until 4-E lands;
+      the slim adapter is shipped as the integration target so the
+      adapter-shape can be tested + so 4-E's seam work has a concrete
+      consumer.
+
+  Per rf2-uo7v the SSR surface ships in `day8/re-frame-2-ssr` —
+  this adapter MUST NOT statically `:require [re-frame.ssr]`. Instead
+  it publishes its `set-hiccup-emitter!` callback through the
+  late-bind hook table; if the SSR artefact is on the classpath, its
+  ns-load resolves the hook and wires the emitter."
+  (:require [reagent2.core       :as r]
+            [reagent2.ratom      :as ratom]
+            [reagent2.dom.client :as rdc]
+            [re-frame.late-bind  :as late-bind]
+            [re-frame.views      :as views]))
+
+;; ---- container ------------------------------------------------------------
+
+(defn- make-state-container [initial-value]
+  (r/atom initial-value))
+
+(defn- read-container [container]
+  @container)
+
+(defn- replace-container! [container new-value]
+  (reset! container new-value)
+  nil)
+
+(defn- subscribe-container [container on-change]
+  (let [k (gensym "rf-sub-")]
+    (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
+    (fn unsubscribe [] (remove-watch container k))))
+
+;; ---- derived (reactions) --------------------------------------------------
+
+(defn- make-derived-value [source-containers compute-fn]
+  (ratom/make-reaction
+    (fn [] (apply compute-fn (map deref source-containers)))))
+
+;; ---- render ---------------------------------------------------------------
+
+(defn- render [render-tree mount-point opts]
+  ;; The bridge mounted into a raw DOM container directly; under the
+  ;; rewrite we explicitly create a React-19 root once and reuse it.
+  ;; The unmount thunk closes over the root to call its .unmount.
+  (let [hydrate? (boolean (:hydrate? opts))]
+    (if hydrate?
+      (let [root (rdc/hydrate-root mount-point render-tree)]
+        (fn unmount [] (rdc/unmount root)))
+      (let [root (rdc/create-root mount-point)]
+        (rdc/render root render-tree)
+        (fn unmount [] (rdc/unmount root))))))
+
+(defonce ^:private hiccup-emitter (atom nil))
+
+(defn set-hiccup-emitter!
+  "Install the hiccup → HTML fn used by render-to-string. Idempotent.
+  Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
+  `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
+  resolves it at load time without a static :require."
+  [f]
+  (reset! hiccup-emitter f))
+
+(defn- render-to-string [render-tree opts]
+  (if-let [emit @hiccup-emitter]
+    (emit render-tree opts)
+    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
+                    {:reason      "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
+                     :render-tree render-tree}))))
+
+;; ---- context provider -----------------------------------------------------
+
+(defn- register-context-provider [_frame-keyword]
+  ;; Implementation lives in re-frame.views (CLJS-only). The frame-
+  ;; keyword arg is ignored — `build-frame-provider` is 0-arity
+  ;; (rf2-4y60); the returned component takes the frame keyword at
+  ;; render time. Per IMPL-SPEC §9.4: the views.cljs ns continues to
+  ;; back the frame-provider; the rewrite doesn't replace it.
+  (views/build-frame-provider))
+
+;; ---- disposal -------------------------------------------------------------
+
+(defn- dispose-adapter! []
+  ;; Reactions GC themselves when their owners (componentWillUnmount-
+  ;; disposed render Reactions) go away. Nothing per-adapter to do.
+  nil)
+
+(def adapter
+  "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:
+
+      (require '[re-frame.adapter.reagent-slim :as reagent-slim])
+      (rf/init! reagent-slim/adapter)
+
+  Drop-in shape-compatible with `re-frame.adapter.reagent/adapter` per
+  IMPL-SPEC §2.1 — the only difference is the substrate, not the keys.
+  Per Spec 006 §CLJS reference + rf2-agql: there is no default-adapter
+  registry; adapter wiring is explicit at the call site."
+  {:make-state-container      make-state-container
+   :read-container            read-container
+   :replace-container!        replace-container!
+   :subscribe-container       subscribe-container
+   :make-derived-value        make-derived-value
+   :render                    render
+   :render-to-string          render-to-string
+   :register-context-provider register-context-provider
+   :dispose-adapter!          dispose-adapter!})
+
+;; Per rf2-uo7v + IMPL-SPEC §9.2: publish the hiccup-emitter installer
+;; through the late-bind hook table so re-frame.ssr (in
+;; day8/re-frame-2-ssr) resolves it at its ns-load. Without this, an
+;; app pulling in the SSR seam would have to manually call
+;; `(reagent-slim/set-hiccup-emitter! ssr/render-to-string)` —
+;; the late-bind table makes that wiring automatic when both
+;; artefacts are on the classpath.
+(late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
+
+;; Per rf2-d4sf + IMPL-SPEC §9.6: publish the React-context-aware
+;; current-frame impl through the late-bind hook so subscribe / dispatch
+;; consult the React-context tier of the 3-tier resolution chain. The
+;; rewrite preserves the bridge's class-component context-read shape
+;; (`(.-context cmp)`) per IMPL-SPEC §9.6 — the views.cljs impl works
+;; with reagent-slim's class components without source change.
+(late-bind/set-fn! :adapter/current-frame views/current-frame)

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -1,0 +1,158 @@
+(ns reagent2.core
+  "User-facing compat surface for the day8/reagent-slim artefact
+  (rf2-6hyy Stage 4-D).
+
+  Per IMPL-SPEC §2.2: the audit-binding 14 surfaces. This is the
+  ns most user code imports as `reagent.core`-equivalent — apps
+  migrating from the bridge do `s/reagent\\./reagent2./g` at import
+  sites (per IMPL-SPEC §13.1).
+
+  Symbols **shipped** (per Stage 2 §2.7 audit):
+
+    atom              — RAtom constructor (re-export of reagent2.ratom/atom)
+    create-class      — Form-3 entry point; 7-key cap enforced
+    current-component — in-flight component instance (dynamic-var read)
+    after-render      — schedule fn after next React commit
+    as-element        — hiccup → React element
+    props             — Form-3 accessor (first arg if it's a map)
+    children          — Form-3 accessor (rest after props)
+    argv              — Form-3 accessor (full hiccup-style argv)
+    state             — Form-3 state accessor
+    state-atom        — Form-3 state-atom accessor
+    set-state         — Form-3 state mutator
+    replace-state     — Form-3 state mutator
+    force-update      — force re-render of `this` component
+    reaction          — function form sugar over make-reaction
+
+  Symbols **not shipped** (per Stage 1 §2.4 + DECISION-7 + Stage 2 §2.7
+  audit-confirmed zero usage): `track`, `track!`, `cursor`, `wrap`,
+  `rswap!`, `partial`, `merge-props`, `unsafe-html`, `adapt-react-class`,
+  `reactify-component`, `create-element`, `next-tick`, `flush` (replaced
+  by `reagent2.dom.client/flush-views!`), `dom-node` (Class B throw),
+  `class-names`, `is-client`, `set-default-compiler!`, `create-compiler`,
+  `with-let`, `render` (deprecated stub — Class B throw, see §10).
+
+  Apps that genuinely need a dropped surface stay on
+  day8/reagent-classic (the bridge); the rewrite's commitment is
+  to ship only the surfaces the audited codebases actually exercise."
+  (:refer-clojure :exclude [atom])
+  (:require [reagent2.ratom :as ratom]
+            [reagent2.impl.batching :as batching]
+            [reagent2.impl.component :as component]
+            [reagent2.impl.template :as template]))
+
+;; ---------------------------------------------------------------------------
+;; RAtom + Reaction surfaces
+;; ---------------------------------------------------------------------------
+
+(def atom
+  "Construct a reactive atom (RAtom). See `reagent2.ratom/atom`.
+
+  Like clojure.core/atom — supports IDeref, IReset, ISwap, IWatchable,
+  IMeta — except deref'ing inside a Reaction subscribes the Reaction
+  to changes."
+  ratom/atom)
+
+(defn reaction
+  "Construct a Reaction wrapping fn `f` (function form; the macro form
+  lives in `reagent2.ratom`). Sugar over `reagent2.ratom/make-reaction`.
+
+  Per IMPL-SPEC §14.2: ships the function form because Dash8 uses 25
+  sites of `r/reaction` and the rewrite preserves that surface."
+  [f]
+  (ratom/make-reaction f))
+
+;; ---------------------------------------------------------------------------
+;; Component-shape surface
+;; ---------------------------------------------------------------------------
+
+(defn create-class
+  "Form-3 entry point. Validates `spec` against the 7-key cap (per
+  IMPL-SPEC §6.1); throws `:rf.error/create-class-key-unsupported` on
+  miss. Delegates to `reagent2.impl.component/create-class*`.
+
+  The 7 cap keys: `:component-did-mount`, `:component-will-unmount`,
+  `:component-did-update`, `:reagent-render`, `:display-name`,
+  `:get-snapshot-before-update`, `:component-did-catch`."
+  [spec]
+  (component/create-class* spec))
+
+(defn current-component
+  "Returns the in-flight component instance, or nil outside a render.
+  Reads the dynamic `*current-component*` binding installed by the
+  render path."
+  []
+  (component/current-component))
+
+;; ---------------------------------------------------------------------------
+;; Form-3 accessors
+;; ---------------------------------------------------------------------------
+
+(defn argv
+  "Form-3 accessor: full hiccup-style arg vector that mounted `this`."
+  [this]
+  (component/get-argv this))
+
+(defn props
+  "Form-3 accessor: first arg of `this`'s argv if it is a map, else nil."
+  [this]
+  (component/get-props this))
+
+(defn children
+  "Form-3 accessor: children seq from `this`'s argv (everything after props)."
+  [this]
+  (component/get-children this))
+
+(defn state-atom
+  "Form-3 state cell. Per-component RAtom; created lazily."
+  [this]
+  (component/state-atom this))
+
+(defn state
+  "Form-3 state accessor — derefs the per-component state-atom.
+  Returns nil if no state has been set."
+  [this]
+  @(state-atom this))
+
+(defn set-state
+  "Form-3 state mutator: merges `m` into the per-component state map."
+  [this m]
+  (swap! (state-atom this) merge m))
+
+(defn replace-state
+  "Form-3 state mutator: replaces the per-component state map with `m`."
+  [this m]
+  (reset! (state-atom this) m))
+
+(defn force-update
+  "Force re-render of `this` component. Routes through React's
+  `forceUpdate` directly — bypasses any pending dirty-set dedup."
+  ([^js this]
+   (when-some [fu (.-forceUpdate this)]
+     (.call fu this)))
+  ([^js this _deep?]
+   ;; The `:deep?` arg in stock Reagent triggered a global re-render of
+   ;; the descendant tree. Under React 19 this isn't supported the
+   ;; same way (forceUpdate is per-component); we ignore the flag and
+   ;; force-update just `this`. Per the audit, no production caller
+   ;; actually relied on the deep behaviour.
+   (when-some [fu (.-forceUpdate this)]
+     (.call fu this))))
+
+;; ---------------------------------------------------------------------------
+;; Render-time surfaces
+;; ---------------------------------------------------------------------------
+
+(defn after-render
+  "Schedule `f` to run after the next React commit. Routes through
+  `reagent2.impl.batching/do-after-render`."
+  [f]
+  (batching/do-after-render f))
+
+(defn as-element
+  "Convert hiccup `form` to a React element. Delegates to
+  `reagent2.impl.template/as-element`. Useful when interfacing with
+  React APIs that want a React element directly (e.g. portals,
+  React-side createPortal, etc.)."
+  [form]
+  (template/as-element form))

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/client.cljs
@@ -60,8 +60,14 @@
     Suspense test in dom_client_cljs_test.cljs.
 
   Production cost: zero. `flush-views!` is gated on `js/goog.DEBUG` and
-  DCEs entirely under `:advanced` + `goog.DEBUG=false`."
+  DCEs entirely under `:advanced` + `goog.DEBUG=false`.
+
+  Stage 4-D: `render` and `hydrate-root` are wired to the hiccup
+  interpreter `reagent2.impl.template/as-element`. Both call paths
+  walk the user's hiccup tree once and produce React elements; React
+  then drives its own concurrent rendering through the root."
   (:require [reagent2.impl.batching :as batching]
+            [reagent2.impl.template :as template]
             ["react" :as react]
             ["react-dom/client" :as react-dom-client]))
 
@@ -131,48 +137,68 @@
                          (microtask-tick))))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Mount entries — Stage 4-D / 4-E will wire these to the hiccup
-;; interpreter. Stage 4-B ships the scaffolds so consumers can
-;; `:require` this ns without a load-time error; calls into the
-;; mount fns throw a clear "not yet implemented" until 4-D lands.
+;; Mount entries (Stage 4-D)
+;;
+;; The mount-side surface per IMPL-SPEC §2.4. `render` walks the user's
+;; hiccup `el` once via `reagent2.impl.template/as-element` and hands
+;; the resulting React element tree to React's root. React then drives
+;; its own concurrent rendering — the rewrite's microtask scheduler
+;; covers the Reagent-shape (Form-1/2/3) re-render path; React's
+;; reconciler handles everything downstream (children, hooks, etc.).
+;;
+;; `hydrate-root` is the SSR path: takes a container with pre-rendered
+;; HTML and a hiccup tree; calls `react-dom-client/hydrateRoot` so
+;; React reconciles against the existing DOM. Hydration mismatches
+;; surface as React-19 errors — the rewrite passes them through
+;; honestly per IMPL-SPEC §7.6.
 ;; ---------------------------------------------------------------------------
 
 (defn create-root
   "React 19 root constructor. Wraps `react-dom-client/createRoot`.
 
-  Stage 4-B: thin wrapper; Stage 4-D wires this into the render pipeline."
+  Returns a React 19 root object whose `.render`, `.unmount` methods
+  drive subsequent operations. Pass the root to `render` /
+  `hydrate-root` to push hiccup into it."
   ([container]
    (react-dom-client/createRoot container))
   ([container options]
    (react-dom-client/createRoot container options)))
 
 (defn render
-  "Render hiccup `el` into `root`. Walks `el` via
-  `reagent2.impl.template/as-element` (Stage 4-D).
+  "Render hiccup `el` into React `root`.
 
-  Stage 4-B placeholder — throws until 4-D lands. The signature is
-  pinned now so consumers can compile against it."
-  [_root _el]
-  (throw (ex-info "reagent2.dom.client/render not implemented until Stage 4-D"
-                  {:type :rf.error/not-implemented
-                   :stage :4-D})))
+  Walks `el` via `reagent2.impl.template/as-element` to produce a
+  React element tree, then calls `(.render root react-element)`.
+  React drives its own concurrent rendering downstream; the
+  rewrite's microtask scheduler covers the Reagent-shape
+  (Form-1/2/3) re-render path.
+
+  Returns nil — React 19 root.render returns void."
+  [^js root el]
+  (.render root (template/as-element el))
+  nil)
 
 (defn unmount
-  "Detach `root`. Wraps `(.unmount root)`."
+  "Detach `root`. Wraps `(.unmount root)`. No-op if `root` is nil or
+  has no `.unmount` (pre-existing roots from older React versions)."
   [^js root]
   (when (and (some? root)
              (some? (.-unmount root)))
     (.unmount root)))
 
 (defn hydrate-root
-  "SSR hydration entry. Wraps `react-dom-client/hydrateRoot`.
+  "Hydrate `container` against pre-rendered HTML, producing a React 19
+  root. Walks `el` via `reagent2.impl.template/as-element` to produce
+  the React element tree React reconciles against the existing DOM.
 
-  Stage 4-B placeholder — throws until 4-D lands."
-  ([_container _el]
-   (throw (ex-info "reagent2.dom.client/hydrate-root not implemented until Stage 4-D"
-                   {:type :rf.error/not-implemented
-                    :stage :4-D})))
-  ([_container _el _options]
-   (throw (ex-info "reagent2.dom.client/hydrate-root not implemented until Stage 4-D"
-                   {:type :rf.error/not-implemented
-                    :stage :4-D}))))
+  Returns the React 19 root so callers can hold a reference for
+  later operations (re-renders via `(.render root ...)` or unmounts
+  via `unmount`).
+
+  Hydration-mismatch errors surface as React 19 errors (no
+  Reagent-side suppression; the rewrite passes React's diagnostics
+  through honestly per IMPL-SPEC §7.6)."
+  ([container el]
+   (react-dom-client/hydrateRoot container (template/as-element el)))
+  ([container el options]
+   (react-dom-client/hydrateRoot container (template/as-element el) options)))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -321,11 +321,21 @@
               (this-as this
                 (bind-and-call this #(f this))))))
 
-    (when-let [f (:component-will-unmount spec)]
+    ;; componentWillUnmount: always installed (even when the user
+    ;; spec has no :component-will-unmount) so the per-instance render
+    ;; Reaction can dispose its watch graph. Without this, Reactions
+    ;; the component subscribed to retain references to the (now-
+    ;; unmounted) component and prevent GC. Per IMPL-SPEC §3.4 +
+    ;; Stage 4-D wiring.
+    (let [user-fn (:component-will-unmount spec)]
       (set! (.-componentWillUnmount proto)
             (fn []
-              (this-as this
-                (bind-and-call this #(f this))))))
+              (this-as ^js this
+                (when-some [rea (.-cljsRenderRea this)]
+                  (ratom/dispose! rea)
+                  (set! (.-cljsRenderRea this) nil))
+                (when user-fn
+                  (bind-and-call this #(user-fn this)))))))
 
     (when-let [f (:component-did-update spec)]
       ;; React calls componentDidUpdate(prevProps, prevState, snapshot).
@@ -395,34 +405,59 @@
     klass))
 
 ;; ---------------------------------------------------------------------------
-;; React class construction (per IMPL-SPEC §6.3)
+;; React class construction (per IMPL-SPEC §6.3 + §4.4)
 ;;
 ;; The class extends React.Component. The constructor stashes the
 ;; initial argv (read from props.__rfArgv) on the instance; render
 ;; delegates to wrap-render with the user's :reagent-render fn.
-;; Each render path also marks-rendered + queues a deref-capture so
-;; reactive deps wire up correctly.
 ;;
-;; Re-render on dependency change is wired via the batching ns:
-;; render-time derefs of an RAtom or Reaction call notify-deref-watcher!
-;; on a Reaction wrapping the render itself (Stage 4-D's job). For
-;; Stage 4-C the class is structurally complete; reactive subscription
-;; sits at the render-fn boundary (Stage 4-D wires deref-capture +
-;; queue-render!).
+;; Reactive subscription wiring (Stage 4-D, per IMPL-SPEC §4.4 path 1):
+;; the render method runs the user's render fn inside a Reaction so
+;; that any RAtom / Reaction deref'd during render registers as a
+;; dependency. When a dep changes, the Reaction recomputes (which we
+;; ignore) and the watch fires, enqueueing this React component for
+;; re-render via `batching/queue-render!`.
+;;
+;; Per IMPL-SPEC §4.4 path 1 + Stage 4-A handoff: without this wiring,
+;; views render once and never update on dep change. The Reaction is
+;; per-component and lives on the instance as `cljsRenderRea`.
 ;; ---------------------------------------------------------------------------
 
 (defn- make-render-method
-  "Build the React `render` method. Wraps the user's render fn with
-  Form-1/2 detection and binds *current-component* + clears the dirty
-  flag. Reactive subscription wiring (deref-capture + queue-render! on
-  dep change) lands with Stage 4-D's hiccup-translation pass; for
-  4-C the render path is structurally complete."
+  "Build the React `render` method. Wraps the user's render fn with:
+
+    1. Form-1/2 detection via `wrap-render`.
+    2. *current-component* binding for the duration of the render.
+    3. mark-rendered to clear the dirty flag for the next dep-change cycle.
+    4. Per-component Reaction wrapping the render so deref'd RAtoms /
+       Reactions register as dependencies; on dep change the Reaction
+       schedules re-render via batching/queue-render!. Per IMPL-SPEC
+       §4.4 path 1 + Stage 4-D wiring.
+
+  The Reaction is created lazily on first render and cached on the
+  instance as `.-cljsRenderRea`. It returns the rendered React element;
+  on subsequent dep-driven recomputes it queues a forceUpdate without
+  needing the result (React's own commit produces the DOM)."
   [render-fn]
   (fn []
-    (this-as this
+    (this-as ^js this
       (binding [*current-component* this]
         (batching/mark-rendered this)
-        (wrap-render this render-fn)))))
+        (let [rea (or (.-cljsRenderRea this)
+                      (let [r (ratom/make-reaction
+                                #(wrap-render this render-fn)
+                                :auto-run
+                                ;; Custom auto-run: don't synchronously
+                                ;; recompute on dep change; instead queue
+                                ;; a re-render of this React component.
+                                ;; React drives the next render via its
+                                ;; reconciler; the Reaction recomputes
+                                ;; inside that next render.
+                                (fn [_r]
+                                  (batching/queue-render! this)))]
+                        (set! (.-cljsRenderRea this) r)
+                        r))]
+          @rea)))))
 
 (defn- copy-argv-from-props!
   "Read the argv off React's `props` and stash it on `c` as

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -1,0 +1,593 @@
+(ns reagent2.impl.template
+  "Hiccup → React-element translation for the day8/reagent-slim artefact
+  (rf2-6hyy Stage 4-D).
+
+  Per IMPL-SPEC §7. The pipeline:
+
+      hiccup form
+          │
+          ▼
+      as-element
+          │
+          ├── (string? f)              → text node
+          ├── (number? f)              → text node
+          ├── (vector? f)              → vec-to-elem
+          ├── (seq? f)                 → array of elements (with key warnings)
+          └── (nil? f)                 → React null
+
+  vec-to-elem dispatches on the head:
+
+    | head      | meaning                   |
+    | :>        | React component interop   |
+    | :<>       | React Fragment            |
+    | :r>       | raw React.createElement   |
+    | :f>       | function-component        |
+    | DOM tag   | parse-tag + DOM element   |
+    | user fn   | reagent component         |
+    | class     | reagent class component   |
+
+  Public surface (consumed within the artefact + by the adapter Var):
+
+    as-element        — top-level entry; hiccup → React element
+    vec-to-elem       — vector dispatch (the head-test)
+    parse-tag         — :div.cls#id → {:tag :id :class}
+    convert-prop-value — narrowed per DECISION-2 (§7.2)
+    cached-prop-name  — kebab→camel cache (kept; same as stock)
+    expand-seq        — sequence-as-children + key-warnings
+
+  D2 narrowed `convert-prop-value` (per IMPL-SPEC §7.2): keyword values
+  pass through unchanged for non-HTML-attribute prop names. The audit-
+  driven set `html-attr-names` plus `data-*`/`aria-*` prefix-matched
+  names get the stringification path. Other prop names (e.g. user-
+  defined React-component props, `:value` on a React-context Provider)
+  see the keyword preserved. This deletes the rf2-d4sf coercion seam
+  that the bridge needed to undo over-stringification.
+
+  React 19 strictness (§7.6): refs continue as JS-shape `ref`; no
+  `defaultProps` emission for function components; no
+  `React.Children.only` invocation."
+  (:require [clojure.string :as str]
+            [reagent2.impl.component :as component]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Tag parsing — :div.cls#id shorthand
+;;
+;; Per IMPL-SPEC §7.3: same regex stock Reagent has used for years. We
+;; lift the pattern byte-for-byte and cache parses on first sight.
+;; ---------------------------------------------------------------------------
+
+(def ^:private re-tag
+  "Regex for parsing CSS-style id and class from a Reagent tag keyword.
+   `[#.]?[^#.]+` matched repeatedly captures `tag`, optional `#id`,
+   and any number of `.class` segments."
+  #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
+
+;; Note on field name `className` (rather than `class`): in JS-target
+;; CLJS, `class` is a reserved word and the compiler munges it to
+;; `class$` on the deftype's instance fields, while `(.-class obj)`
+;; reads from the unmangled `.class` slot — so the read silently
+;; returns undefined. We use `className` to match React's prop name
+;; and to dodge the munging entirely.
+(deftype ^:private HiccupTag [tag id className])
+
+(defn parse-tag
+  "Parse a hiccup tag keyword into its `:tag` / `:id` / `:class` parts.
+
+  Returns a `HiccupTag` record. The `class` field carries whitespace-
+  joined classes when the tag has `.foo.bar` shorthand; nil when there
+  are no class shorthand parts. The `id` field is non-nil only when the
+  tag has a `#id` shorthand part. `tag` is the bare element name string.
+
+  Examples:
+
+    (parse-tag :div)         → HiccupTag{tag \"div\" id nil class nil}
+    (parse-tag :div.cls)     → HiccupTag{tag \"div\" id nil class \"cls\"}
+    (parse-tag :div#id)      → HiccupTag{tag \"div\" id \"id\" class nil}
+    (parse-tag :div.a.b#id)  → HiccupTag{tag \"div\" id \"id\" class \"a b\"}"
+  [hiccup-tag]
+  (let [[_ tag id class-shorthand]
+        (re-matches re-tag (name hiccup-tag))
+        class (when class-shorthand
+                (str/replace class-shorthand #"\." " "))]
+    (->HiccupTag tag id class)))
+
+(def ^:private tag-name-cache #js {})
+
+(defn- cached-parse [k]
+  (let [n (name k)]
+    (if (.hasOwnProperty tag-name-cache n)
+      (aget tag-name-cache n)
+      (let [v (parse-tag k)]
+        (aset tag-name-cache n v)
+        v))))
+
+;; ---------------------------------------------------------------------------
+;; Prop-name cache (kebab → camel)
+;;
+;; React expects camelCased prop names (`className`, `htmlFor`,
+;; `tabIndex`, ...). Hiccup convention is kebab-cased keywords. We
+;; cache the conversion so each unique keyword pays the dash-to-camel
+;; cost once.
+;;
+;; `data-*` and `aria-*` are NOT camelCased — React passes them through
+;; as DOM attributes verbatim. The dont-camel-case starter prefix list
+;; per stock Reagent.
+;; ---------------------------------------------------------------------------
+
+(def ^:private dont-camel-case #{"aria" "data"})
+
+(defn- capitalize [s]
+  (if (< (count s) 2)
+    (str/upper-case s)
+    (str (str/upper-case (subs s 0 1)) (subs s 1))))
+
+(defn- dash-to-prop-name [dashed]
+  (if (string? dashed)
+    dashed
+    (let [name-str (name dashed)
+          [start & parts] (str/split name-str #"-")]
+      (if (dont-camel-case start)
+        name-str
+        (apply str start (map capitalize parts))))))
+
+(def ^:private prop-name-cache
+  (doto #js {}
+    (aset "class" "className")
+    (aset "for" "htmlFor")
+    (aset "charset" "charSet")))
+
+(defn cached-prop-name
+  "Look up the React prop-name string for hiccup-keyword `k`.
+  Caches kebab→camel conversion across the build.
+
+  React conventions:
+    :class    → \"className\"
+    :for      → \"htmlFor\"
+    :charset  → \"charSet\"
+    :tab-index → \"tabIndex\"
+    :data-foo → \"data-foo\"  (data-* not camelCased)
+    :aria-label → \"aria-label\" (aria-* not camelCased)"
+  [k]
+  (if (or (keyword? k) (symbol? k))
+    (let [n (name k)]
+      (if-some [cached (when (.hasOwnProperty prop-name-cache n)
+                         (aget prop-name-cache n))]
+        cached
+        (let [v (dash-to-prop-name k)]
+          (aset prop-name-cache n v)
+          v)))
+    k))
+
+;; ---------------------------------------------------------------------------
+;; Narrowed convert-prop-value (per DECISION-2 + IMPL-SPEC §7.2)
+;;
+;; Keyword values stringify only for HTML attribute names. For non-
+;; HTML prop names (e.g. `:value` on a React-context Provider, custom
+;; component props), the keyword passes through unchanged. This deletes
+;; the bridge's coerce-context-value seam (rf2-d4sf) — there's no
+;; over-stringification to undo because we never broadly stringified.
+;; ---------------------------------------------------------------------------
+
+(def html-attr-names
+  "HTML-attribute prop names whose keyword values stringify. Plus
+  the prefix-matched `data-*` / `aria-*` family. Per IMPL-SPEC §7.2."
+  #{:class :id :role})
+
+(defn- ^boolean html-attr-name? [k]
+  (or (contains? html-attr-names k)
+      (let [n (name k)]
+        (or (str/starts-with? n "data-")
+            (str/starts-with? n "aria-")))))
+
+;; Dev-only one-shot warning cache. Keyed on `[k name-of-v]`. The audit
+;; (rf2-cgcv + rf2-kfpf) showed a small number of legitimate non-HTML
+;; keyword props in production code; the warning is informational, not
+;; a deprecation. Per IMPL-SPEC §7.2.
+(defonce ^:private ^{:doc "[k v-name] → true once warned."}
+  warned-keyword-prop (atom #{}))
+
+(defn- warn-once-keyword-prop! [k v]
+  (let [key [(name k) (name v)]]
+    (when-not (contains? @warned-keyword-prop key)
+      (swap! warned-keyword-prop conj key)
+      (when (exists? js/console)
+        (.warn js/console
+               (str "[reagent-slim] keyword value " (pr-str v)
+                    " on non-HTML prop " (pr-str k)
+                    " passes through unchanged. If you intended a string,"
+                    " call (name v) at the call site;"
+                    " otherwise the keyword is preserved (rf2-6hyy §7.2 D2)."))))))
+
+(defn- ^boolean named?* [x]
+  (or (keyword? x) (symbol? x)))
+
+(defn- ^boolean js-val? [x]
+  (not (identical? "object" (goog/typeOf x))))
+
+(declare convert-prop-value)
+
+(defn- kv-conv [o k v]
+  (let [k' (cached-prop-name k)
+        v' (convert-prop-value k v)]
+    (aset o k' v')
+    o))
+
+(defn convert-prop-value
+  "Convert a hiccup prop-map value `v` for prop-name `k` to a React-
+  shaped JS value.
+
+  Per IMPL-SPEC §7.2 (DECISION-2): narrowed keyword stringification.
+  Keywords stringify only for HTML-attribute prop names
+  (`:class`, `:id`, `:role`, `:data-*`, `:aria-*`).
+  Other named values pass through unchanged.
+
+  Other rules:
+
+    - JS values pass through.
+    - Maps recursively convert (style maps + custom-component prop maps).
+    - Coll? values become JS arrays via clj->js (children, vector classes).
+    - Fns pass through (event handlers, ref callbacks).
+    - Everything else passes through unchanged."
+  ([v]
+   ;; 1-arg form: used recursively for map values where there's no
+   ;; outer prop-name context (e.g. nested style objects). Treat
+   ;; named? values as not-an-HTML-attr (they're map values, not
+   ;; outer props). This matches the stringification choices users
+   ;; expect for `:style {:cursor :pointer}` etc. — :cursor is the
+   ;; CSS prop name, not an HTML attr.
+   (cond
+     (js-val? v)  v
+     (named?* v)  (name v)         ; nested map values: stringify (CSS values)
+     (map? v)     (reduce-kv kv-conv #js {} v)
+     (coll? v)    (clj->js v)
+     (ifn? v)     (fn [& args] (apply v args))
+     :else        v))
+  ([k v]
+   (cond
+     (js-val? v)  v
+     (named?* v)  (if (html-attr-name? k)
+                    (name v)
+                    (do
+                      (when ^boolean js/goog.DEBUG
+                        (warn-once-keyword-prop! k v))
+                      v))
+     (map? v)     (reduce-kv kv-conv #js {} v)
+     (coll? v)    (clj->js v)
+     (ifn? v)     (fn [& args] (apply v args))
+     :else        v)))
+
+;; ---------------------------------------------------------------------------
+;; set-id-class — merge :div.foo#bar parts into the prop map
+;;
+;; Per IMPL-SPEC §7.3: user :id wins over parsed shorthand id;
+;; user :class is **prepended with** parsed shorthand class
+;; (matching stock Reagent: `[:div.foo {:class "bar"}]` → "foo bar").
+;; ---------------------------------------------------------------------------
+
+(defn- class-names
+  ([] nil)
+  ([class]
+   (if (coll? class)
+     (let [classes (keep (fn [c]
+                           (when c
+                             (if (named?* c) (name c) c)))
+                         class)]
+       (when (seq classes)
+         (str/join " " classes)))
+     (if (named?* class)
+       (name class)
+       class)))
+  ([a b]
+   (if a
+     (if b (str (class-names a) " " (class-names b)) (class-names a))
+     (class-names b))))
+
+(defn- set-id-class [props ^HiccupTag parsed]
+  (let [id    (.-id parsed)
+        class (.-className parsed)]
+    (cond-> props
+      (and (some? id) (nil? (:id props)))
+      (assoc :id id)
+
+      class
+      (assoc :class (class-names class
+                                 (or (:class props)
+                                     (:className props)))))))
+
+(defn- convert-props
+  "Convert a hiccup prop map `props` to a React-shape JS props object.
+  `parsed` is the HiccupTag with id/class shorthand merged in.
+
+  Returns nil for empty input."
+  [props ^HiccupTag parsed]
+  (let [class       (:class props)
+        normalised  (cond-> props
+                      class (assoc :class (class-names class)))
+        with-shorthand (set-id-class normalised parsed)
+        ^js js-props (when (seq with-shorthand)
+                       (reduce-kv kv-conv #js {} with-shorthand))]
+    js-props))
+
+;; ---------------------------------------------------------------------------
+;; React-key extraction (per stock Reagent)
+;;
+;; A user can attach a key via `^{:key "k"}` meta on the hiccup vector,
+;; OR via `:key` in the props map. We honour the meta first, falling
+;; back to the props map.
+;; ---------------------------------------------------------------------------
+
+(defn- get-react-key [v]
+  (let [k (when (vector? v) (some-> (meta v) :key))]
+    (or k
+        (case (when (vector? v) (nth v 0 nil))
+          (:> :f>) (when (map? (nth v 2 nil)) (:key (nth v 2 nil)))
+          :r>      (some-> (nth v 2 nil) (.-key))
+          (when (map? (nth v 1 nil)) (:key (nth v 1 nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; Source-coord stamping (per IMPL-SPEC §5.4 + §9.4)
+;;
+;; The renderer's source-coord stamping is gated on this dynamic var.
+;; re-frame.views/reg-view*'s wrapper binds it to the formatted attr
+;; value when interop/debug-enabled? is true. The first DOM-tag root
+;; encountered in as-element gets the attr merged in inline; nested
+;; elements see *source-coord* nil (rebound for Form-2 inner-fn calls).
+;;
+;; Production elision: under :advanced + goog.DEBUG=false, the
+;; reg-view* wrapper never binds this var (the wrapper itself sits
+;; inside an interop/debug-enabled? gate). The (when *source-coord*
+;; ...) check at the as-element entry compiles to `(when nil ...)` and
+;; DCEs the entire stamp branch.
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *source-coord* nil)
+
+(defn- merge-source-coord-attr [props]
+  (if-some [coord *source-coord*]
+    (do
+      ;; Consume the binding so nested DOM elements don't get stamped.
+      (set! *source-coord* nil)
+      (assoc props :data-rf2-source-coord coord))
+    props))
+
+;; ---------------------------------------------------------------------------
+;; Hiccup → React element pipeline
+;;
+;; as-element is the entry. It dispatches on the shape of the form:
+;;   - vector  → vec-to-elem
+;;   - seq     → expand-seq (children flattening)
+;;   - nil     → nil (React renders nothing)
+;;   - string/number/JS-value → pass through (text node)
+;;
+;; vec-to-elem reads the head and dispatches:
+;;   - :>  → React-component interop (head supplies the component)
+;;   - :<> → React Fragment
+;;   - :r> → raw React.createElement
+;;   - :f> → function-component dispatch
+;;   - keyword DOM tag → parse-tag + DOM element
+;;   - reagent class → instantiate as React class
+;;   - user fn → wrap via fn-to-class
+;; ---------------------------------------------------------------------------
+
+(declare as-element)
+
+(defn- void-tag? [tag-str]
+  ;; Per HTML5 (and rf2-6phn): void elements that cannot have children.
+  ;; React rejects children passed to these, so we don't emit them.
+  ;; The list is fixed in HTML5 — no maintenance burden.
+  (case tag-str
+    ("area" "base" "br" "col" "embed" "hr" "img" "input" "link"
+     "meta" "param" "source" "track" "wbr") true
+    false))
+
+(defn- make-element
+  "Construct a React element via React.createElement.
+
+  `argv` — the original hiccup vector (for child positions).
+  `component` — the React component (string for DOM, fn/class for components).
+  `js-props` — the converted JS prop object (or nil).
+  `first-child` — index in argv of the first child (1 for a no-prop-map
+                  vector, 2 if the second element is the prop map)."
+  [argv component js-props first-child]
+  (let [n-children (- (count argv) first-child)
+        ;; Void elements: skip child translation; React rejects them.
+        void-elem? (and (string? component) (void-tag? component))]
+    (cond
+      void-elem?
+      (react/createElement component js-props)
+
+      (== n-children 0)
+      (react/createElement component js-props)
+
+      (== n-children 1)
+      (react/createElement component js-props
+                           (as-element (nth argv first-child nil)))
+
+      :else
+      (let [args (reduce-kv (fn [^js a k v]
+                              (when (>= k first-child)
+                                (.push a (as-element v)))
+                              a)
+                            #js [component js-props]
+                            argv)]
+        (.apply (.-createElement react) nil args)))))
+
+(defn expand-seq
+  "Expand a sequence of hiccup forms (e.g. `(map ...)` children) to a
+  JS array of React elements. Per IMPL-SPEC §7.4 — emits a one-shot
+  dev warning per surrounding component when a child vector lacks a
+  `:key` meta or `:key` in its prop map."
+  [s]
+  (let [arr (into-array (map as-element s))]
+    (when ^boolean js/goog.DEBUG
+      (loop [items s]
+        (when-let [el (first items)]
+          (when (and (vector? el)
+                     (not (get-react-key el)))
+            (when (exists? js/console)
+              (.warn js/console
+                     (str "[reagent-slim] each child in a list should have a unique"
+                          " :key prop; saw " (pr-str el)))))
+          (recur (rest items)))))
+    arr))
+
+(defn- ^boolean hiccup-tag? [x]
+  (or (keyword? x) (symbol? x) (string? x)))
+
+(defn- native-element
+  "Emit a DOM element. `parsed` is the parsed HiccupTag; `argv` the
+  full hiccup vector; `first-pos` the index of the first arg position
+  (1 for `:div ...`, 2 for `:> Component ...` etc.).
+
+  Source-coord stamping (§5.4 + §9.4): the first DOM-tag root inside
+  a reg-view'd render gets the *source-coord* dynamic var merged in
+  as `:data-rf2-source-coord`. The merge happens before
+  prop-conversion so the attr name flows through cached-prop-name."
+  [^HiccupTag parsed argv first-pos]
+  (let [component (.-tag parsed)
+        ;; The position of the prop map (if any).
+        head      (nth argv first-pos nil)
+        has-props (or (nil? head) (map? head))
+        props     (cond-> (when has-props head)
+                    *source-coord* merge-source-coord-attr)
+        js-props  (or (convert-props props parsed) #js {})
+        first-child (+ first-pos (if has-props 1 0))]
+    (when-some [key (get-react-key argv)]
+      (set! (.-key js-props) key))
+    (make-element argv component js-props first-child)))
+
+(defn- react-component-element
+  "Emit a React element where `component` is a Reagent / arbitrary
+  React component head (function or class). `argv` is the full hiccup
+  vector; `first-pos` is the position of the props map (or 1 for
+  user-fn calls — the head IS the user fn at index 0).
+
+  For Reagent-style user fns we wrap via `fn-to-class` so the class
+  has reactive subscription (deref-capture) wired in render. The argv
+  travels through React's props as `__rfArgv`."
+  [component argv]
+  (let [klass    (cond
+                   (component/reagent-class? component) component
+                   (component/react-class? component)   component
+                   :else                                 (component/fn-to-class component))
+        js-props #js {:__rfArgv argv}]
+    (when-some [key (get-react-key argv)]
+      (set! (.-key js-props) key))
+    (react/createElement klass js-props)))
+
+(defn- raw-element
+  "Emit `:r>` — raw React.createElement passthrough.
+  `[:r> Component js-props & children]` translates to
+  `React.createElement(Component, js-props, ...children)` with
+  no prop conversion."
+  [argv]
+  (let [component (nth argv 1 nil)
+        js-props  (or (nth argv 2 nil) #js {})]
+    (when-some [key (-> (meta argv) :key)]
+      (set! (.-key js-props) key))
+    (make-element argv component js-props 3)))
+
+(defn- function-element
+  "Emit `:f>` — function-component dispatch.
+  `[:f> some-fn args...]` wraps `some-fn` via `fn-to-class` so that
+  Reagent-shaped reactivity (deref-capture) wires through. We treat
+  this identically to `react-component-element` because all our user
+  fns reach the renderer via fn-to-class."
+  [argv]
+  (let [component (nth argv 1 nil)
+        ;; Reconstruct the argv as if the fn were the head:
+        ;; [head & user-args] becomes [some-fn & user-args].
+        ;; Preserve the original argv's :key meta so React keys flow.
+        synth-argv (with-meta (into [component] (subvec argv 2))
+                              (meta argv))]
+    (react-component-element component synth-argv)))
+
+(defn- fragment-element
+  "Emit `:<>` — React.Fragment.
+  `[:<> & children]` or `[:<> {:key k} & children]`. Props map (if
+  present) is JS-converted; only `:key` is meaningful on Fragments."
+  [argv]
+  (let [head      (nth argv 1 nil)
+        has-props (or (nil? head) (map? head))
+        js-props  (or (when (and has-props (some? head))
+                        (convert-prop-value head))
+                      #js {})
+        first-child (+ 1 (if has-props 1 0))]
+    (when-some [key (get-react-key argv)]
+      (set! (.-key js-props) key))
+    (make-element argv (.-Fragment react) js-props first-child)))
+
+(defn- interop-element
+  "Emit `:>` — arbitrary React component interop.
+  `[:> Component {:prop ...} & children]`. The component is the second
+  element; standard prop conversion applies."
+  [argv]
+  (let [component (nth argv 1 nil)
+        ;; Build a synthetic HiccupTag that names the component by
+        ;; its component slot. We pass nil for id/class — :> doesn't
+        ;; use the shorthand; the tag is a foreign component.
+        synth-tag (->HiccupTag component nil nil)]
+    (native-element synth-tag argv 2)))
+
+(defn vec-to-elem
+  "Dispatch on a hiccup vector's head and emit the React element."
+  [argv]
+  (when (zero? (count argv))
+    (throw (ex-info ":rf.error/template-empty-vector"
+                    {:type :rf.error/template-empty-vector
+                     :reason "Hiccup vector cannot be empty."})))
+  (let [tag (nth argv 0 nil)]
+    (cond
+      ;; Interop heads — checked first so they don't get treated as
+      ;; user fns or DOM tags.
+      (= tag :>)  (interop-element argv)
+      (= tag :<>) (fragment-element argv)
+      (= tag :r>) (raw-element argv)
+      (= tag :f>) (function-element argv)
+
+      ;; DOM-tag head — keyword, symbol, or string.
+      (hiccup-tag? tag)
+      (native-element (cached-parse tag) argv 1)
+
+      ;; Reagent / React class head — instantiate directly.
+      (component/reagent-class? tag)
+      (react-component-element tag argv)
+
+      (component/react-class? tag)
+      (react-component-element tag argv)
+
+      ;; Plain user fn head — wrap via fn-to-class for reactive
+      ;; subscription wiring.
+      (fn? tag)
+      (react-component-element tag argv)
+
+      :else
+      (throw (ex-info ":rf.error/template-bad-tag"
+                      {:type   :rf.error/template-bad-tag
+                       :tag    tag
+                       :argv   argv
+                       :reason "Hiccup head must be a keyword (DOM tag or :>/:<>/:r>/:f>),
+                                a Reagent component class, a React component class, or a fn."})))))
+
+(defn as-element
+  "Top-level hiccup → React element conversion.
+
+  Dispatches per IMPL-SPEC §7.1:
+
+    - string / number / JS value → pass through (text node)
+    - vector → vec-to-elem (handles all the hiccup head cases)
+    - seq → expand-seq (sequence-as-children with key warnings)
+    - keyword / symbol → name (text node)
+    - nil → nil (React renders nothing)
+    - everything else → pass through (let React surface its own error
+      if it's not renderable)"
+  [x]
+  (cond
+    (nil? x)        nil
+    (js-val? x)     x
+    (vector? x)     (vec-to-elem x)
+    (seq? x)        (expand-seq x)
+    (named?* x)     (name x)
+    (satisfies? IPrintWithWriter x) (pr-str x)
+    :else           x))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
@@ -1,0 +1,155 @@
+(ns re-frame.adapter.reagent-slim-cljs-test
+  "Structural tests for re-frame.adapter.reagent-slim (Stage 4-D, rf2-6hyy).
+
+  The substrate-shape contract (per re-frame.substrate.adapter):
+
+    The adapter map carries 9 keys; signatures match the bridge.
+    Apps doing `(rf/init! reagent-slim/adapter)` see the same shape
+    they get from `(rf/init! reagent/adapter)`.
+
+  Test strategy: we don't drive React DOM here (no jsdom in node-
+  test); we exercise the adapter map's keys and the shape of the
+  fns on each slot. The full `(rf/init! ...)` dispatch / subscribe /
+  render path is exercised in the browser-test target (Stage 4-E
+  follow-up).
+
+  IMPORTANT: this test file's ns-require triggers
+  `re-frame.adapter.reagent-slim`'s ns load, which (per the slim
+  adapter's load-time late-bind calls) may rebind the
+  `:adapter/current-frame` and `:reagent/set-hiccup-emitter!`
+  hooks. The bridge's tests don't require this ns and so don't
+  observe the rebind. Stage 4-E will cleanly seam this through
+  per-test-suite adapter selection.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent-slim :as reagent-slim]))
+
+;; ---------------------------------------------------------------------------
+;; Adapter map shape (per IMPL-SPEC §2.1 + Spec 006 §CLJS reference)
+;; ---------------------------------------------------------------------------
+
+(deftest adapter-has-9-canonical-keys
+  (testing "the adapter map carries the 9 substrate-shape keys"
+    (let [k (set (keys reagent-slim/adapter))]
+      (is (= #{:make-state-container
+              :read-container
+              :replace-container!
+              :subscribe-container
+              :make-derived-value
+              :render
+              :render-to-string
+              :register-context-provider
+              :dispose-adapter!}
+             k)
+          "every slot named in re-frame.substrate.adapter is present"))))
+
+(deftest adapter-slot-fns-callable
+  (testing "every adapter-slot value is a fn"
+    (doseq [[k v] reagent-slim/adapter]
+      (is (fn? v) (str "adapter slot " k " is callable")))))
+
+;; ---------------------------------------------------------------------------
+;; State container (round-trip)
+;; ---------------------------------------------------------------------------
+
+(deftest state-container-roundtrip
+  (testing "make-state-container / read / replace cycle"
+    (let [make    (:make-state-container reagent-slim/adapter)
+          read    (:read-container        reagent-slim/adapter)
+          replace (:replace-container!    reagent-slim/adapter)
+          c       (make {:n 0})]
+      (is (= {:n 0} (read c)) "initial value flows through")
+      (replace c {:n 42})
+      (is (= {:n 42} (read c)) "replace updates the container"))))
+
+(deftest state-container-subscribe
+  (testing "subscribe-container fires on change; unsubscribe stops"
+    (let [make      (:make-state-container reagent-slim/adapter)
+          replace   (:replace-container!    reagent-slim/adapter)
+          subscribe (:subscribe-container  reagent-slim/adapter)
+          c         (make {:n 0})
+          seen      (atom [])
+          unsub     (subscribe c (fn [_prev nu] (swap! seen conj nu)))]
+      (replace c {:n 1})
+      (replace c {:n 2})
+      (is (= [{:n 1} {:n 2}] @seen) "two transitions observed")
+      (unsub)
+      (replace c {:n 3})
+      (is (= [{:n 1} {:n 2}] @seen) "no more transitions after unsubscribe"))))
+
+;; ---------------------------------------------------------------------------
+;; Derived value
+;; ---------------------------------------------------------------------------
+
+(deftest derived-value-tracks-source
+  (testing "make-derived-value produces a Reaction that tracks its sources"
+    (let [make-c    (:make-state-container reagent-slim/adapter)
+          replace   (:replace-container!    reagent-slim/adapter)
+          make-d    (:make-derived-value   reagent-slim/adapter)
+          src       (make-c 1)
+          derived   (make-d [src] (fn [v] (* v 100)))]
+      (is (= 100 @derived) "initial derived value")
+      (replace src 5)
+      (is (= 500 @derived) "derived recomputes when source changes"))))
+
+;; ---------------------------------------------------------------------------
+;; render-to-string requires emitter installation
+;; ---------------------------------------------------------------------------
+
+(deftest render-to-string-throws-without-emitter
+  (testing "render-to-string raises when no hiccup-emitter installed"
+    ;; We don't call set-hiccup-emitter! here so the slot is nil.
+    ;; Note: if a previous test ran set-hiccup-emitter!, this assertion
+    ;; would fail. The slim adapter's emitter atom is module-private;
+    ;; we can't reset it from here. We either:
+    ;;   1. Trust test ordering (this test runs first under cljs.test
+    ;;      alpha-sort) — fragile.
+    ;;   2. Just confirm the fn shape exists.
+    ;; Settle for #2:
+    (is (fn? (:render-to-string reagent-slim/adapter)))))
+
+(deftest set-hiccup-emitter-installs-fn
+  (testing "set-hiccup-emitter! lets render-to-string emit"
+    (reagent-slim/set-hiccup-emitter! (fn [tree _opts]
+                                        (str "hiccup:" (pr-str tree))))
+    (let [render-to-string (:render-to-string reagent-slim/adapter)]
+      (is (= "hiccup:[:div]"
+             (render-to-string [:div] {})))
+      ;; Reset for downstream determinism — the atom is module-private,
+      ;; so the cleanest way to get it back to nil is to install a
+      ;; throwing fn. Tests downstream don't actually use this; we
+      ;; leave the fn installed.
+      )))
+
+;; ---------------------------------------------------------------------------
+;; dispose-adapter! is a no-op
+;; ---------------------------------------------------------------------------
+
+(deftest dispose-adapter-runs-cleanly
+  (testing "dispose-adapter! returns nil and doesn't throw"
+    (let [dispose (:dispose-adapter! reagent-slim/adapter)]
+      (is (nil? (dispose))))))
+
+;; ---------------------------------------------------------------------------
+;; render slot accepts a stub root + returns an unmount thunk
+;; ---------------------------------------------------------------------------
+
+(deftest render-slot-fake-root
+  ;; The render slot wraps create-root; we can't easily mock create-root
+  ;; from here. Settle for: the slot is callable. Real render-path tests
+  ;; live in reagent2.dom.client-cljs-test (with stub roots) and
+  ;; browser-test (with jsdom).
+  (testing "render slot is callable"
+    (is (fn? (:render reagent-slim/adapter)))))
+
+;; ---------------------------------------------------------------------------
+;; register-context-provider returns the views ns's frame-provider
+;; ---------------------------------------------------------------------------
+
+(deftest register-context-provider-returns-component
+  (testing "register-context-provider returns a component value"
+    (let [reg (:register-context-provider reagent-slim/adapter)
+          provider (reg :rf/some-frame)]
+      (is (some? provider)
+          "register-context-provider returned a non-nil component"))))

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
@@ -21,6 +21,7 @@
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [reagent2.ratom :as ratom]
             [reagent2.impl.batching :as batching]
+            [reagent2.impl.component :as component]
             [reagent2.dom.client :as dom-client]))
 
 ;; ---------------------------------------------------------------------------
@@ -229,22 +230,175 @@
     (is (fn? dom-client/unmount))
     (is (fn? dom-client/hydrate-root))))
 
-(deftest render-throws-not-implemented
-  (testing "render throws :rf.error/not-implemented until Stage 4-D"
-    (let [thrown (try (dom-client/render :root :el)
-                      false
+(deftest render-callable-stage-4d
+  ;; Stage 4-D landed: render no longer throws — it walks hiccup via
+  ;; reagent2.impl.template/as-element and pushes the result into the
+  ;; root. The full mount-against-real-React path is exercised in
+  ;; render_cljs_test (Stage 4-D); this assertion is the cheap smoke
+  ;; check that the symbol is bound and not the old throw-shim.
+  (testing "render is bound and is not the Stage 4-B throw-shim"
+    (is (fn? dom-client/render))
+    ;; Calling render with non-root/non-hiccup inputs should not
+    ;; raise the old :rf.error/not-implemented; React's own
+    ;; .render method may surface a different error for a bogus
+    ;; root, which is fine.
+    (let [thrown (try (dom-client/render :not-a-root :el)
+                      nil
                       (catch :default e (ex-data e)))]
-      (is (= :rf.error/not-implemented (:type thrown)))
-      (is (= :4-D (:stage thrown))))))
+      (is (not= :rf.error/not-implemented (:type thrown))))))
 
-(deftest hydrate-root-throws-not-implemented
-  (testing "hydrate-root throws :rf.error/not-implemented until Stage 4-D"
-    (let [thrown (try (dom-client/hydrate-root :container :el)
-                      false
-                      (catch :default e (ex-data e)))]
-      (is (= :rf.error/not-implemented (:type thrown)))
-      (is (= :4-D (:stage thrown))))))
+(deftest hydrate-root-callable-stage-4d
+  ;; Stage 4-D landed: hydrate-root no longer throws — it walks hiccup
+  ;; via reagent2.impl.template/as-element and calls
+  ;; react-dom-client/hydrateRoot. The real-DOM hydration path lives
+  ;; in the browser-test target.
+  (testing "hydrate-root is bound and is not the Stage 4-B throw-shim"
+    (is (fn? dom-client/hydrate-root))))
 
 (deftest unmount-handles-nil-gracefully
   (testing "unmount on nil root is a no-op (defensive)"
     (is (nil? (dom-client/unmount nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Stage 4-D: render-path integration (fake-root)
+;;
+;; Real React DOM rendering requires jsdom; node-test runs without one.
+;; We verify the call path uses a stub root (with .render captured) so
+;; we can inspect what gets pushed in. The full real-React pass lives
+;; in the browser-test target.
+;; ---------------------------------------------------------------------------
+
+(deftest render-pushes-react-element-into-root
+  (testing "render walks hiccup via as-element and calls (.render root react-el)"
+    (let [captured (atom nil)
+          fake-root #js {:render (fn [el] (reset! captured el) nil)}]
+      (dom-client/render fake-root [:div "hi"])
+      (let [^js el @captured]
+        (is (some? el) ".render received a React element")
+        (is (= "div" (.-type el)) "the React element wraps the hiccup tag")
+        (is (= "hi" (-> el .-props .-children))
+            "child text travelled through")))))
+
+(deftest render-passes-nil-for-nil-hiccup
+  (testing "render with nil hiccup passes nil to root.render"
+    (let [captured (atom :sentinel)
+          fake-root #js {:render (fn [el] (reset! captured el) nil)}]
+      (dom-client/render fake-root nil)
+      (is (nil? @captured)))))
+
+(deftest render-translates-shorthand-class
+  (testing "render converts :div.foo shorthand on the way in"
+    (let [captured (atom nil)
+          fake-root #js {:render (fn [el] (reset! captured el) nil)}]
+      (dom-client/render fake-root [:div.foo])
+      (is (= "foo" (-> ^js @captured .-props .-className))))))
+
+;; ---------------------------------------------------------------------------
+;; Stage 4-D: deref-capture wiring
+;;
+;; Per IMPL-SPEC §4.4 path 1: a class component's render runs inside a
+;; per-instance Reaction so deref'd RAtoms register as deps. On dep
+;; change the Reaction's auto-run callback queues a forceUpdate via
+;; batching/queue-render!.
+;;
+;; Without this wiring (Stage 4-A handoff note), views render once and
+;; never update. We exercise the wiring via a fake forceUpdate spy.
+;; ---------------------------------------------------------------------------
+
+(deftest render-deref-capture-queues-rerender-on-dep-change
+  (testing "deref-capture wiring: dep change triggers forceUpdate via batching"
+    (async done
+      (let [a            (ratom/atom 0)
+            renders      (atom 0)
+            ;; Render fn that derefs `a` — this should subscribe the
+            ;; component to changes via the per-instance render Reaction.
+            render-fn    (fn []
+                           (swap! renders inc)
+                           [:div @a])
+            ;; Build a class via the same path as fn-to-class.
+            ^js klass    (component/create-class*
+                           {:reagent-render render-fn})
+            ;; Fake forceUpdate so we can observe the queue-render!
+            ;; cascade without running React DOM.
+            forced       (atom 0)
+            inst         (new klass #js {:__rfArgv [render-fn]})]
+        ;; Stub forceUpdate before first render so the queued
+        ;; re-render observes our spy. React would normally provide
+        ;; this; we replicate it for the test.
+        (set! (.-forceUpdate inst) (fn [] (swap! forced inc)))
+        ;; First render: should subscribe to `a`.
+        (.call (.. klass -prototype -render) inst)
+        (is (= 1 @renders) "first render ran")
+        ;; Mutate the dep — should enqueue a re-render via the
+        ;; reaction's auto-run callback.
+        (swap! a inc)
+        (-> (js/Promise.resolve (dom-client/flush-views!))
+            (.then (fn [_]
+                     (is (>= @forced 1)
+                         "forceUpdate fired after dep change (deref-capture wired)")
+                     ;; Cleanup: unmount the test instance to dispose
+                     ;; the reaction's watch graph.
+                     (.call (.. klass -prototype -componentWillUnmount) inst)
+                     (done))))))))
+
+(deftest render-componentwillunmount-disposes-render-reaction
+  (testing "componentWillUnmount disposes the per-instance render Reaction"
+    (let [a            (ratom/atom 0)
+          render-fn    (fn [] [:div @a])
+          ^js klass    (component/create-class*
+                         {:reagent-render render-fn})
+          inst         (new klass #js {:__rfArgv [render-fn]})]
+      (set! (.-forceUpdate inst) (fn [] nil))
+      (.call (.. klass -prototype -render) inst)
+      (is (some? (.-cljsRenderRea inst))
+          "after first render, the render Reaction is cached on the instance")
+      (.call (.. klass -prototype -componentWillUnmount) inst)
+      (is (nil? (.-cljsRenderRea inst))
+          "after componentWillUnmount, the cached Reaction reference is cleared"))))
+
+(deftest render-componentwillunmount-runs-user-callback
+  (testing "componentWillUnmount runs the user :component-will-unmount fn"
+    (let [unmounted     (atom 0)
+          render-fn     (fn [] [:div])
+          will-unmount  (fn [_this] (swap! unmounted inc))
+          ^js klass     (component/create-class*
+                          {:reagent-render render-fn
+                           :component-will-unmount will-unmount})
+          inst          (new klass #js {:__rfArgv [render-fn]})]
+      (set! (.-forceUpdate inst) (fn [] nil))
+      (.call (.. klass -prototype -render) inst)
+      (.call (.. klass -prototype -componentWillUnmount) inst)
+      (is (= 1 @unmounted)
+          "user :component-will-unmount fired in addition to the synthetic disposal"))))
+
+(deftest render-deref-capture-tracks-reaction-changes
+  (testing "deref-capture tracks Reaction (not just RAtom) deps"
+    (async done
+      (let [src          (ratom/atom 0)
+            ;; Build a Reaction that's auto-run so it re-runs on src change.
+            derived      (ratom/make-reaction (fn [] (* @src 100))
+                                              :auto-run true)
+            renders      (atom 0)
+            render-fn    (fn []
+                           (swap! renders inc)
+                           [:div @derived])
+            forced       (atom 0)
+            ^js klass    (component/create-class*
+                           {:reagent-render render-fn})
+            inst         (new klass #js {:__rfArgv [render-fn]})]
+        (set! (.-forceUpdate inst) (fn [] (swap! forced inc)))
+        ;; First render: the per-component render Reaction subscribes
+        ;; to `derived`.
+        (.call (.. klass -prototype -render) inst)
+        (is (= 1 @renders) "first render ran")
+        (is (= 0 @forced) "no forceUpdate yet — no dep change")
+        ;; Mutate src; derived recomputes (auto-run); the per-component
+        ;; render Reaction sees the change and queues forceUpdate.
+        (reset! src 1)
+        (-> (js/Promise.resolve (dom-client/flush-views!))
+            (.then (fn [_]
+                     (is (= 100 @derived) "derived has the post-mutation value")
+                     (is (>= @forced 1)
+                         "forceUpdate fired after Reaction-mediated dep change")
+                     (.call (.. klass -prototype -componentWillUnmount) inst)
+                     (done))))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -1,0 +1,376 @@
+(ns reagent2.impl.template-cljs-test
+  "Unit tests for reagent2.impl.template (Stage 4-D, rf2-6hyy).
+
+  Per IMPL-SPEC §7 + §12.1 + §12.5 R-001. Covers:
+
+    - Tag parsing (:div, :div.cls, :div#id, :div.a.b#id).
+    - Hiccup vector dispatch (:>, :<>, :r>, :f>, DOM tag, user fn).
+    - Narrowed convert-prop-value (D2): HTML-attribute names stringify
+      keyword values; non-HTML names pass through unchanged.
+    - Sequence-as-children flattening + dev-only key warning.
+    - Void-tag handling (children rejected for <br>, <img>, etc.).
+    - cached-prop-name kebab→camel conversion.
+
+  Test strategy: most tests directly inspect the output of
+  template/as-element / parse-tag / convert-prop-value without driving
+  React. The render-path tests walk a hiccup tree through as-element
+  and inspect the resulting React element's `.type`, `.props`, etc.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.impl.template :as template]
+            [reagent2.impl.component :as component]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Tag parsing — :div.cls#id shorthand
+;; ---------------------------------------------------------------------------
+
+(deftest parse-tag-bare
+  (testing "bare tag: :div"
+    (let [parsed (template/parse-tag :div)]
+      (is (= "div" (.-tag parsed)))
+      (is (nil? (.-id parsed)))
+      (is (nil? (.-className parsed))))))
+
+(deftest parse-tag-with-class
+  (testing ":div.foo"
+    (let [parsed (template/parse-tag :div.foo)]
+      (is (= "div" (.-tag parsed)))
+      (is (nil? (.-id parsed)))
+      (is (= "foo" (.-className parsed))))))
+
+(deftest parse-tag-with-id
+  (testing ":div#bar"
+    (let [parsed (template/parse-tag :div#bar)]
+      (is (= "div" (.-tag parsed)))
+      (is (= "bar" (.-id parsed)))
+      (is (nil? (.-className parsed))))))
+
+(deftest parse-tag-with-id-and-class
+  (testing ":div#bar.foo"
+    (let [parsed (template/parse-tag :div#bar.foo)]
+      (is (= "div" (.-tag parsed)))
+      (is (= "bar" (.-id parsed)))
+      (is (= "foo" (.-className parsed))))))
+
+(deftest parse-tag-with-multiple-classes
+  (testing ":div.a.b.c"
+    (let [parsed (template/parse-tag :div.a.b.c)]
+      (is (= "div" (.-tag parsed)))
+      (is (nil? (.-id parsed)))
+      (is (= "a b c" (.-className parsed))
+          "multiple .class shorthand parts join with space"))))
+
+(deftest parse-tag-input
+  (testing ":input — void element parses normally"
+    (let [parsed (template/parse-tag :input)]
+      (is (= "input" (.-tag parsed))))))
+
+;; ---------------------------------------------------------------------------
+;; cached-prop-name — kebab→camel + special cases
+;; ---------------------------------------------------------------------------
+
+(deftest cached-prop-name-class
+  (testing ":class → \"className\""
+    (is (= "className" (template/cached-prop-name :class)))))
+
+(deftest cached-prop-name-for
+  (testing ":for → \"htmlFor\""
+    (is (= "htmlFor" (template/cached-prop-name :for)))))
+
+(deftest cached-prop-name-tab-index
+  (testing ":tab-index → \"tabIndex\" (kebab→camel)"
+    (is (= "tabIndex" (template/cached-prop-name :tab-index)))))
+
+(deftest cached-prop-name-data-attr
+  (testing ":data-foo → \"data-foo\" (data-* not camelCased)"
+    (is (= "data-foo" (template/cached-prop-name :data-foo)))))
+
+(deftest cached-prop-name-aria-attr
+  (testing ":aria-label → \"aria-label\" (aria-* not camelCased)"
+    (is (= "aria-label" (template/cached-prop-name :aria-label)))))
+
+(deftest cached-prop-name-string-passthrough
+  (testing "non-keyword value passes through unchanged"
+    (is (= "alreadyString" (template/cached-prop-name "alreadyString")))))
+
+;; ---------------------------------------------------------------------------
+;; Narrowed convert-prop-value — DECISION-2 (R-001)
+;;
+;; Per IMPL-SPEC §7.2: keyword values stringify only for HTML attribute
+;; names (:class, :id, :role, :data-*, :aria-*). Other names pass
+;; through with a one-shot dev warning.
+;; ---------------------------------------------------------------------------
+
+(deftest convert-prop-value-class-keyword-stringifies
+  (testing ":class with keyword value → string (HTML-attr name)"
+    (is (= "primary"
+           (template/convert-prop-value :class :primary)))))
+
+(deftest convert-prop-value-id-keyword-stringifies
+  (testing ":id with keyword value → string (HTML-attr name)"
+    (is (= "main-header"
+           (template/convert-prop-value :id :main-header)))))
+
+(deftest convert-prop-value-role-keyword-stringifies
+  (testing ":role with keyword value → string (HTML-attr name)"
+    (is (= "button"
+           (template/convert-prop-value :role :button)))))
+
+(deftest convert-prop-value-data-attr-stringifies
+  (testing ":data-foo with keyword value → string (data-* HTML attr)"
+    (is (= "bar"
+           (template/convert-prop-value :data-foo :bar)))))
+
+(deftest convert-prop-value-aria-attr-stringifies
+  (testing ":aria-label with keyword value → string (aria-* HTML attr)"
+    (is (= "close"
+           (template/convert-prop-value :aria-label :close)))))
+
+(deftest convert-prop-value-non-html-keyword-passes-through
+  (testing ":value with keyword value → keyword unchanged (non-HTML name; D2 narrowing)"
+    ;; The bridge would have stringified this; the rewrite preserves
+    ;; the keyword so React-context Provider :value works as intended.
+    (is (= :some-frame
+           (template/convert-prop-value :value :some-frame)))))
+
+(deftest convert-prop-value-custom-prop-name-passes-keyword
+  (testing "custom prop names: :type with keyword passes through"
+    (is (= :primary
+           (template/convert-prop-value :type :primary)))))
+
+(deftest convert-prop-value-string-passthrough
+  (testing "string value passes through unchanged"
+    (is (= "hello"
+           (template/convert-prop-value :class "hello")))))
+
+(deftest convert-prop-value-number-passthrough
+  (testing "number value passes through unchanged"
+    (is (= 42 (template/convert-prop-value :tab-index 42)))))
+
+(deftest convert-prop-value-fn-passthrough
+  (testing "fn value passes through (event handlers)"
+    (let [f (fn [_e])
+          out (template/convert-prop-value :on-click f)]
+      (is (fn? out)))))
+
+(deftest convert-prop-value-1-arg-form-stringifies-named
+  (testing "1-arg form (nested map values) stringifies named values"
+    ;; Used recursively for map values where there's no outer prop-
+    ;; name context (CSS values etc.). Per the impl docstring.
+    (is (= "pointer" (template/convert-prop-value :pointer)))))
+
+;; ---------------------------------------------------------------------------
+;; as-element — primitive cases
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-nil
+  (testing "nil → nil"
+    (is (nil? (template/as-element nil)))))
+
+(deftest as-element-string
+  (testing "string → string"
+    (is (= "hello" (template/as-element "hello")))))
+
+(deftest as-element-number
+  (testing "number → number"
+    (is (= 42 (template/as-element 42)))))
+
+(deftest as-element-keyword
+  (testing "bare keyword → name"
+    (is (= "foo" (template/as-element :foo)))))
+
+(deftest as-element-symbol
+  (testing "bare symbol → name"
+    (is (= "bar" (template/as-element 'bar)))))
+
+;; ---------------------------------------------------------------------------
+;; as-element — DOM tags
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-bare-div
+  (testing "[:div] → React element with tag \"div\""
+    (let [^js el (template/as-element [:div])]
+      (is (= "div" (.-type el))))))
+
+(deftest as-element-div-with-text
+  (testing "[:div \"hi\"] → React element with text child"
+    (let [^js el (template/as-element [:div "hi"])]
+      (is (= "div" (.-type el)))
+      (is (= "hi" (-> el .-props .-children))))))
+
+(deftest as-element-div-with-class
+  (testing "[:div {:class \"foo\"}] → element with className"
+    (let [^js el (template/as-element [:div {:class "foo"}])]
+      (is (= "div" (.-type el)))
+      (is (= "foo" (-> el .-props .-className))))))
+
+(deftest as-element-div-with-id
+  (testing "[:div {:id \"x\"}] → element with id"
+    (let [^js el (template/as-element [:div {:id "x"}])]
+      (is (= "x" (-> el .-props .-id))))))
+
+(deftest as-element-shorthand-class
+  (testing "[:div.foo] → className from shorthand"
+    (let [^js el (template/as-element [:div.foo])]
+      (is (= "foo" (-> el .-props .-className))))))
+
+(deftest as-element-shorthand-id
+  (testing "[:div#bar] → id from shorthand"
+    (let [^js el (template/as-element [:div#bar])]
+      (is (= "bar" (-> el .-props .-id))))))
+
+(deftest as-element-shorthand-class-and-prop-class
+  (testing "[:div.foo {:class \"bar\"}] → \"foo bar\" (shorthand prepends per stock)"
+    (let [^js el (template/as-element [:div.foo {:class "bar"}])]
+      (is (= "foo bar" (-> el .-props .-className))))))
+
+(deftest as-element-shorthand-id-yields-to-prop
+  (testing "[:div#a {:id \"b\"}] → user :id wins over shorthand"
+    (let [^js el (template/as-element [:div#a {:id "b"}])]
+      (is (= "b" (-> el .-props .-id))))))
+
+(deftest as-element-multiple-children
+  (testing "[:div [:span] [:span]] → div with two child elements"
+    (let [^js el (template/as-element [:div [:span "a"] [:span "b"]])]
+      (is (= "div" (.-type el)))
+      (let [children (-> el .-props .-children)]
+        (is (or (array? children) (seqable? children))
+            "multi-child renders as array")))))
+
+(deftest as-element-nested-shorthand
+  (testing "[:div.outer [:span#inner.cls \"hi\"]] — nested shorthand"
+    (let [^js el (template/as-element [:div.outer [:span#inner.cls "hi"]])]
+      (is (= "outer" (-> el .-props .-className)))
+      (let [^js child (-> el .-props .-children)]
+        (is (= "span" (.-type child)))
+        (is (= "cls" (-> child .-props .-className)))
+        (is (= "inner" (-> child .-props .-id)))))))
+
+;; ---------------------------------------------------------------------------
+;; as-element — interop heads (:>, :<>, :r>, :f>)
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-fragment
+  (testing "[:<> [:div] [:span]] → React.Fragment"
+    (let [^js el (template/as-element [:<> [:div "a"] [:span "b"]])]
+      (is (= (.-Fragment react) (.-type el))))))
+
+(deftest as-element-fragment-with-key
+  (testing "[:<> {:key \"k\"} ...] → Fragment with React key"
+    (let [^js el (template/as-element [:<> {:key "k"} [:div "a"]])]
+      (is (= (.-Fragment react) (.-type el)))
+      (is (= "k" (.-key el))))))
+
+(deftest as-element-interop-react-component
+  (testing "[:> Comp {:foo \"bar\"} child] → React.createElement on Comp"
+    (let [Comp (fn FakeComp [_props] nil)
+          ^js el (template/as-element [:> Comp {:foo "bar"} [:span]])]
+      (is (= Comp (.-type el)))
+      (is (= "bar" (-> el .-props .-foo))))))
+
+(deftest as-element-raw
+  (testing "[:r> Comp js-props] → raw createElement, no prop conversion"
+    (let [Comp (fn FakeRaw [_props] nil)
+          js-props #js {:already "shaped"}
+          ^js el (template/as-element [:r> Comp js-props])]
+      (is (= Comp (.-type el)))
+      (is (= "shaped" (-> el .-props .-already))))))
+
+(deftest as-element-function-component
+  (testing "[:f> some-fn arg] → wrapped as React class for reactivity"
+    (let [some-fn (fn [_n] [:div])
+          ^js el (template/as-element [:f> some-fn 42])]
+      ;; f> dispatches through fn-to-class so the head is a class.
+      (is (some? (.-type el)))
+      (is (component/reagent-class? (.-type el))
+          "fn-to-class produced a reagent-slim class for the f>'d fn"))))
+
+(deftest as-element-user-fn
+  (testing "[my-view 1] — user-fn head wraps via fn-to-class"
+    (let [my-view (fn [_n] [:div])
+          ^js el (template/as-element [my-view 1])]
+      (is (component/reagent-class? (.-type el))))))
+
+;; ---------------------------------------------------------------------------
+;; Sequence-as-children + key warnings
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-seq-children
+  (testing "(map ...) children expand to array"
+    (let [seq-children (map (fn [n] ^{:key n} [:span n]) (range 3))
+          ;; We test expand-seq directly because as-element on a vector
+          ;; with a seq inside flattens at the children level.
+          arr (template/expand-seq seq-children)]
+      (is (array? arr) "expand-seq returns a JS array")
+      (is (= 3 (alength arr))))))
+
+;; ---------------------------------------------------------------------------
+;; Void tags — children rejected per HTML5
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-void-tag-no-children
+  (testing "[:br] → React element with no children"
+    (let [^js el (template/as-element [:br])]
+      (is (= "br" (.-type el))))))
+
+(deftest as-element-void-tag-input
+  (testing "[:input {:type \"text\"}] → element with props but no children"
+    (let [^js el (template/as-element [:input {:type "text"}])]
+      (is (= "input" (.-type el)))
+      (is (= "text" (-> el .-props .-type))))))
+
+(deftest as-element-void-tag-img
+  (testing "[:img {:src \"x.png\"}] → img with src"
+    (let [^js el (template/as-element [:img {:src "x.png"}])]
+      (is (= "img" (.-type el)))
+      (is (= "x.png" (-> el .-props .-src))))))
+
+(deftest as-element-void-tag-children-dropped
+  (testing "void tag with child positions: child arg ignored"
+    ;; Per HTML5: br/hr/img/input/etc cannot have children; React would
+    ;; otherwise warn. The renderer drops children for void tags.
+    (let [^js el (template/as-element [:br "should-not-render"])]
+      (is (= "br" (.-type el)))
+      ;; React.createElement(br, props) with no children → undefined
+      ;; or nil children.
+      (is (or (nil? (-> el .-props .-children))
+              (js/Array.isArray (-> el .-props .-children)))))))
+
+;; ---------------------------------------------------------------------------
+;; React keys
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-meta-key
+  (testing "^{:key \"k\"} on hiccup vector flows to React key"
+    (let [^js el (template/as-element ^{:key "k"} [:div "x"])]
+      (is (= "k" (.-key el))))))
+
+(deftest as-element-prop-key
+  (testing "{:key \"k\"} in props → React key"
+    (let [^js el (template/as-element [:div {:key "k"} "x"])]
+      (is (= "k" (.-key el))))))
+
+;; ---------------------------------------------------------------------------
+;; Source-coord stamping (per IMPL-SPEC §5.4 + §9.4)
+;; ---------------------------------------------------------------------------
+
+(deftest as-element-source-coord-stamping
+  (testing "*source-coord* binding is consumed by first DOM-tag root"
+    (binding [template/*source-coord* "myns:my-view:42:7"]
+      (let [^js el (template/as-element [:div [:span "hi"]])]
+        (is (= "myns:my-view:42:7"
+               (aget (.-props el) "data-rf2-source-coord"))
+            "first DOM root gets the attr")
+        ;; Nested element should NOT have the attr (binding consumed).
+        ;; We can't easily inspect the child without driving render, so
+        ;; we settle for: a second as-element call after the first
+        ;; doesn't see the binding (it was consumed).
+        (is (nil? template/*source-coord*)
+            "binding consumed after first DOM root encountered")))))
+
+(deftest as-element-source-coord-no-binding
+  (testing "no *source-coord* binding → no data-rf2-source-coord attr"
+    (let [^js el (template/as-element [:div])]
+      (is (nil? (aget (.-props el) "data-rf2-source-coord"))))))


### PR DESCRIPTION
## Summary

Stage 4-D of the **reagent-slim rewrite**: hiccup interpreter, real `render` / `hydrate-root` mount entries, deref-capture wiring on the class component, the user-facing `reagent2.core` re-export, and a parallel slim adapter Var.

- **`reagent2.impl.template`** — full hiccup → React-element pipeline. `as-element` / `vec-to-elem` dispatch on `:>`, `:<>`, `:r>`, `:f>`, DOM tags, user fns, classes. `parse-tag` with shorthand caching. `convert-prop-value` narrowed per DECISION-2 (HTML attr names stringify keyword values; non-HTML names pass keywords through with a one-shot dev warning). `expand-seq` with key warnings. HTML5 void-tag handling. Source-coord stamping seam via `*source-coord*` dynamic var.
- **`reagent2.dom.client`** — `render` / `hydrate-root` replace the Stage 4-B throw-shims; both walk hiccup via `template/as-element` and call into `react-dom-client`.
- **`reagent2.impl.component`** — `make-render-method` now wraps user render in a per-instance Reaction so deref'd RAtoms/Reactions register as dependencies. On dep change the Reaction's auto-run callback enqueues `queue-render!` (no synchronous recompute — React drives the next render). `componentWillUnmount` always installed so the render Reaction is `dispose!`'d on unmount.
- **`reagent2.core`** — the audit-binding 14 surfaces (`atom`, `create-class`, `current-component`, `after-render`, `as-element`, `props`/`children`/`argv`, `state`/`state-atom`/`set-state`/`replace-state`, `force-update`, `reaction`).
- **`re-frame.adapter.reagent-slim`** — substrate-shape adapter Var mirroring the bridge's `re-frame.adapter.reagent` but using `reagent2.*` internals. Shipped at the `-slim` suffix because both adapter source paths sit on the in-tree shadow-cljs classpath; at artefact-publication time the slim ns gets renamed per IMPL-SPEC §13.1. Stage 4-E follow-up needs an adapter-agnostic `:adapter/current-component` late-bind seam in `re-frame.views` before the slim adapter is functionally drop-in.

339 tests, 862 assertions — all passing. Elision unchanged (4 schema sentinels still ABSENT; rf2-qlx2 preserved).

## Test plan
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — 339 tests, 0 failures
- [x] `npm run test:elision` — PASS, all 4 schema sentinels still ABSENT
- [x] Tag-parsing tests (bare / `.cls` / `#id` / both / multiple classes)
- [x] Interop heads (`:>` / `:<>` / `:r>` / `:f>`)
- [x] Narrowed `convert-prop-value` — HTML-attr names stringify, non-HTML pass through
- [x] Sequence-as-children + dev-only key warnings
- [x] Void tags (`:br`, `:img`, `:input`, etc.) emit no children
- [x] React keys via `^{:key ...}` meta and `:key` prop
- [x] Source-coord stamping consumes the dynamic var
- [x] Deref-capture: RAtom-derefing component re-renders on RAtom change
- [x] Deref-capture: Reaction-derefing component re-renders on Reaction change
- [x] `componentWillUnmount` disposes the per-instance render Reaction
- [x] Slim adapter shape: 9 substrate keys, container round-trip, derived-value tracking