### PR TITLE
docs(spec): reconcile Cross-Spec status vocab + refresh index post-014 (rf2-em4g + rf2-62os)

### DIFF
--- a/spec/AI-Audit.md
+++ b/spec/AI-Audit.md
@@ -1,16 +1,18 @@
 # AI-First Audit
 
 > **Type:** Audit
-> Applies the nine AI-first properties as a checklist against the re-frame2 corpus — the numbered Specs (000–013) plus the companion documents that participate in the AI-implementable goal (Spec-Schemas, Construction-Prompts, conformance/README). Surfaces gaps for the next round of design work.
+> Applies the nine AI-first properties as a checklist against the re-frame2 corpus — the numbered Specs (000–014) plus the companion documents that participate in the AI-implementable goal (Spec-Schemas, Construction-Prompts, conformance/README). Surfaces gaps for the next round of design work.
 
 ## Scope
 
 This audit grades every artefact in `spec/` that contributes to the **pattern's contract** or to its **AI-implementability**. Specifically:
 
-- **Numbered Specs** (000, 002, 004, 005, 008, 009, 010, 011, 012) — the per-area normative specifications. Specs 001 (Registration), 006 (ReactiveSubstrate), and 007 (Stories) are graded indirectly through the cross-cutting goal sections below; they do not yet have stand-alone Per-Spec scoring tables.
+- **Numbered Specs** (000, 002, 004, 005, 008, 009, 010, 011, 012) — the per-area normative specifications with stand-alone Per-Spec scoring tables below. Specs 001 (Registration), 006 (ReactiveSubstrate), 007 (Stories), 013 (Flows), and 014 (HTTP Requests) are graded indirectly through the cross-cutting goal sections below; they do not yet have stand-alone Per-Spec scoring tables.
 - **Spec-Schemas** — the spec's own runtime-shape catalogue.
 - **Construction-Prompts** — the AI-scaffolding catalogue.
 - **conformance/README** — the fixture format and capability-tagging convention.
+
+**Coverage policy.** Per-Spec scoring is intentionally selective: a Spec earns a stand-alone table once its surface has stabilised enough to grade against all nine properties without thrash. New Specs land in the cross-cutting sections first and graduate to a Per-Spec table when the next audit pass adds them. The audit therefore lags the live numbered set by design; absence from the Per-Spec list does not mean the Spec is out of scope, only that it is being graded indirectly until the next pass.
 
 Other companion documents (Principles, Conventions, Patterns, MIGRATION, Tool-Pair, Implementor-Checklist, README) are out of scope: they are rationale, conventions, or migration artefacts, not contracts an implementation conforms to.
 

--- a/spec/Cross-Spec-Interactions.md
+++ b/spec/Cross-Spec-Interactions.md
@@ -15,7 +15,7 @@ Each interaction is one numbered subsection with five fields:
 - **Scenario** — one sentence describing the situation that surfaces the interaction.
 - **Behaviour** — the decided outcome.
 - **Reason** — why the behaviour was chosen, often a constraint pulled forward from a goal.
-- **Status** — `Pinned` (a working fixture in [conformance/fixtures](conformance/fixtures/) verifies the behaviour) or `Provisional` (the rule is documented but not yet pinned by a fixture; the named fixture file does not exist).
+- **Status** — `Pinned`, `Provisional`, or `Locked` (see legend immediately below).
 
 Interactions are grouped by the Specs that meet, in roughly the order an implementor encounters them. The grouping is for navigation only; each interaction stands on its own.
 
@@ -25,8 +25,9 @@ Interactions are grouped by the Specs that meet, in roughly the order an impleme
 |---|---|
 | **`Pinned`** | A working fixture in the conformance corpus enforces this rule. An implementation that fails the fixture fails conformance. |
 | **`Provisional`** | The rule is documented as a decided behaviour, but no fixture exists yet. Implementations should follow it; deviation is not yet detectable through the corpus. Provisional → Pinned as fixtures land. |
+| **`Locked`** | The entry documents a normatively-settled, family-level architectural rule already owned by the cited Spec; there is no run-time scenario for a fixture to capture. The interaction exists here only to surface the rule from the perspective of where Specs meet. Locked entries do not transition to `Pinned`. |
 
-**Current state of the corpus (2026-05-09).** First wave of cross-Spec fixtures landed under bead rf2-bhhu — interactions 5, 6, 7, and 19 are now `Pinned`. The second wave (rf2-msd4) closed the conformance runner's `reg-machine` / `:throw` op gap and pinned interactions 11, 12, and 17. The remaining 13 stay `Provisional`; their fixture filenames remain *targets for future authoring* until the corresponding runner / runtime gaps close (rendering capability per [rf2-j9yf](#); adapter-lifecycle hooks; tool-pair time-travel; hot-reload-mid-cascade hooks; etc.). Pinning these is tracked under follow-up beads filed by rf2-bhhu. When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
+**Current state of the corpus (2026-05-09).** First wave of cross-Spec fixtures landed under bead rf2-bhhu — interactions 5, 6, 7, and 19 are now `Pinned`. The second wave (rf2-msd4) closed the conformance runner's `reg-machine` / `:throw` op gap and pinned interactions 11, 12, and 17. One entry (interaction 21) is `Locked` — a documentation-only family-level rule, owned by Spec 004, not fixture-trackable. The remaining 13 stay `Provisional`; their fixture filenames remain *targets for future authoring* until the corresponding runner / runtime gaps close (rendering capability per [rf2-j9yf](#); adapter-lifecycle hooks; tool-pair time-travel; hot-reload-mid-cascade hooks; etc.). Pinning these is tracked under follow-up beads filed by rf2-bhhu. When a fixture lands, the entry's status flips to **`Pinned`** and the filename becomes a live link.
 
 ## Frames × Machines
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -9,7 +9,7 @@ The **load-bearing decisions** live in [000-Vision.md](000-Vision.md). Each per-
 
 The directory has two orthogonal axes:
 
-1. **Bucket axis (normative vs. companion).** Numbered Specs (000–013) plus [API.md](API.md) and [MIGRATION.md](MIGRATION.md) define the contract. Everything else explains, scaffolds, validates, or demonstrates that contract.
+1. **Bucket axis (normative vs. companion).** Numbered Specs (000–014) plus [API.md](API.md) and [MIGRATION.md](MIGRATION.md) define the contract. Everything else explains, scaffolds, validates, or demonstrates that contract.
 2. **Layer axis (foundation / capability / companion).** Three explicit layers structure the corpus:
 
 | Layer | What it contains | Role |
@@ -20,7 +20,7 @@ The directory has two orthogonal axes:
 
 Within the Companion layer, each doc carries a **Type** (the companion-document genre axis): Reference, Migration, Convention, Construction Prompts, Audit, Schemas, or Pattern. Every doc declares its Type via the `> **Type:**` header. The Foundation and Capability layers do not carry a Type header — their layer is determined by numbering. The Type vocabulary is closed for v1; new Types require a companion-doc convention update.
 
-**About Spec 003.** The numbering 000–013 has one gap: there is no `003-*.md`. Slot 003 is **reserved** for a future Spec on cross-frame composition (frame supervisors, parent/child frame relationships, frame-graph topology) — design work that depends on Specs 002 and 005 being settled. The slot is held open so existing Spec numbers do not need to renumber when 003 lands.
+**About Spec 003.** The numbering 000–014 has one gap: there is no `003-*.md`. Slot 003 is **reserved** for a future Spec on cross-frame composition (frame supervisors, parent/child frame relationships, frame-graph topology) — design work that depends on Specs 002 and 005 being settled. The slot is held open so existing Spec numbers do not need to renumber when 003 lands.
 
 ## Documents
 


### PR DESCRIPTION
## Summary

Two related Codex-filed doc-only beads, batched.

### rf2-em4g — Cross-Spec Interactions status vocabulary

`spec/Cross-Spec-Interactions.md` defined a two-state status model (`Pinned` / `Provisional`) but interaction 21 (the registration-family asymmetry note) used a third marker (`Locked`) without an entry in the legend. Reconciled by **adding `Locked` to the canonical status legend** with semantics that match actual usage:

> The entry documents a normatively-settled, family-level architectural rule already owned by the cited Spec; there is no run-time scenario for a fixture to capture. The interaction exists here only to surface the rule from the perspective of where Specs meet. Locked entries do not transition to `Pinned`.

Renaming was rejected: interaction 21 is genuinely not fixture-trackable (it documents *why* `reg-view` is the only `reg-*` macro), so it does not fit either of the existing markers. The corpus-state paragraph already implicitly excluded the `Locked` entry from the "remaining 13 stay Provisional" count (7 Pinned + 1 Locked + 13 Provisional = 21 total) — that count is preserved and the `Locked` entry now gets an explicit mention.

The interaction entries themselves are unchanged.

### rf2-62os — Spec index refresh after Spec 014

The corpus-navigation docs still described the numbered spec set as ending at 013. Spec 014 (HTTP Requests) has landed and is referenced in the README's capability-layer table. The mismatch is now repaired:

- `spec/README.md` — bucket-axis line and About-Spec-003 paragraph now describe the numbered set as 000-014.
- `spec/AI-Audit.md` — header scope line now references 000-014; Scope section explicitly lists 013 (Flows) and 014 (HTTP Requests) alongside 001/006/007 as graded indirectly through the cross-cutting goal sections rather than via a stand-alone Per-Spec table.
- `spec/AI-Audit.md` — added a **Coverage policy** paragraph stating plainly that Per-Spec scoring is intentionally selective and that the audit lags the live numbered set by design — taking the bead's "state that policy plainly rather than implying whole-corpus coverage" path rather than fabricating a stand-alone scoring pass for 014.

The Spec content itself is unchanged.

## Per-bead change summary

| Bead | Files | Change |
|---|---|---|
| rf2-em4g | `spec/Cross-Spec-Interactions.md` | `Locked` added to status legend; status field lead-in updated; corpus-state paragraph mentions the one `Locked` entry. |
| rf2-62os | `spec/README.md` | `000-013` → `000-014` in bucket-axis line and About-Spec-003 paragraph. |
| rf2-62os | `spec/AI-Audit.md` | Header `000-013` → `000-014`; Scope adds 013/014 to indirectly-graded list; Coverage policy paragraph added. |

## Test plan

- [x] All "000-013" references in `spec/` rewritten or removed (verified via grep).
- [x] `Cross-Spec-Interactions.md`'s sole `Locked` entry (interaction 21) is now covered by the legend; the 7+1+13=21 status arithmetic is consistent with the corpus-state paragraph.
- [x] Doc-only change; no implementation or test code touched.

Pre-release framing throughout.