### PR TITLE
feat(views): adapter/current-component late-bind hook (rf2-wbnl)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -172,3 +172,17 @@
 ;; (`(.-context cmp)`) per IMPL-SPEC §9.6 — the views.cljs impl works
 ;; with reagent-slim's class components without source change.
 (late-bind/set-fn! :adapter/current-frame views/current-frame)
+
+;; Per rf2-wbnl: publish reagent2's `current-component` through the
+;; late-bind hook so `re-frame.views` reads the in-flight component
+;; from the slim adapter's reactive substrate, not from stock
+;; Reagent's. Before rf2-wbnl, views.cljs statically `:require`d
+;; `reagent.core` and called its `current-component` directly — under
+;; the slim adapter that read returned nil for slim-rendered
+;; components, which silently dropped the React-context tier of the
+;; resolution chain (`subscribe`/`dispatch` under a non-default
+;; `frame-provider` routed to `:rf/default`). The classic bridge
+;; installs the same hook against stock Reagent; consumers that
+;; require exactly one of the two adapter ns's see the matching
+;; reader installed.
+(late-bind/set-fn! :adapter/current-component r/current-component)

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/current_component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/current_component_cljs_test.cljs
@@ -1,0 +1,62 @@
+(ns re-frame.adapter.current-component-cljs-test
+  "Per rf2-wbnl — coverage for the `:adapter/current-component` late-bind
+  hook installed by `re-frame.adapter.reagent-slim`.
+
+  Background: before rf2-wbnl, `re-frame.views` statically `:require`d
+  `reagent.core` and called `(reagent.core/current-component)` directly.
+  Under the slim adapter (which ships `reagent2.core`) that read returned
+  nil for slim-rendered components and silently dropped the React-context
+  tier of the frame resolution chain — meaning `(rf/init! reagent-slim/adapter)`
+  was structurally callable but not yet a drop-in functional swap for the
+  bridge.
+
+  Scope of this file (slim adapter):
+    - Requiring `re-frame.adapter.reagent-slim` registers
+      `reagent2.core/current-component` against the hook.
+    - With no slim component in flight, the hook returns nil — matching
+      the no-component shape views.cljs relies on.
+
+  Note re cross-test order (bridge vs slim): both adapter ns's register
+  the same hook key at ns-load. Whichever is loaded last wins. Under the
+  in-tree shadow-cljs node-test build that loads both adapter trees, this
+  test asserts the slim adapter's hook value at the moment its own ns
+  loaded — by re-establishing the slim binding inside the test we make
+  the assertion order-independent.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.core :as r]
+            [re-frame.late-bind :as late-bind]
+            ;; ns-load registers the :adapter/current-component hook.
+            [re-frame.adapter.reagent-slim]))
+
+(defn- with-slim-hook
+  "Install the slim adapter's hook for the duration of `f`, restoring the
+  pre-existing value afterwards. Lets this test assert the slim binding
+  even when the bridge's ns-load registered a different reader after the
+  slim ns loaded."
+  [f]
+  (let [original (late-bind/get-fn :adapter/current-component)]
+    (try
+      (late-bind/set-fn! :adapter/current-component r/current-component)
+      (f)
+      (finally
+        (late-bind/set-fn! :adapter/current-component original)))))
+
+(deftest slim-adapter-installs-hook
+  (testing "requiring re-frame.adapter.reagent-slim registers a current-component hook"
+    (with-slim-hook
+      (fn []
+        (is (some? (late-bind/get-fn :adapter/current-component))
+            "the hook is installed")
+        (is (identical? r/current-component
+                        (late-bind/get-fn :adapter/current-component))
+            "the hook points at reagent2.core/current-component (the slim build)")))))
+
+(deftest slim-hook-returns-nil-outside-render
+  (testing "calling the installed slim hook outside a render returns nil"
+    (with-slim-hook
+      (fn []
+        (let [hook (late-bind/get-fn :adapter/current-component)]
+          (is (nil? (hook))
+              "no in-flight slim component → nil"))))))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -145,3 +145,14 @@
 ;; reads `_currentValue` directly (function components have no
 ;; class-context slot).
 (late-bind/set-fn! :adapter/current-frame views/current-frame)
+
+;; Per rf2-wbnl: publish stock Reagent's `current-component` through
+;; the late-bind hook so `re-frame.views` can read the in-flight
+;; component without statically `:require`ing `reagent.core`. This is
+;; what lets the slim adapter (which ships its own `reagent2.core`
+;; build) install a different `current-component` reader. The classic
+;; bridge wires the hook to stock Reagent's reader; the slim adapter
+;; wires it to `reagent2.core/current-component`. Without this hook,
+;; views.cljs would always call stock Reagent's reader and miss
+;; slim-adapter components in mixed-mode environments.
+(late-bind/set-fn! :adapter/current-component r/current-component)

--- a/implementation/adapters/reagent/test/re_frame/adapter_current_component_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_current_component_cljs_test.cljs
@@ -1,0 +1,66 @@
+(ns re-frame.adapter-current-component-cljs-test
+  "Per rf2-wbnl — coverage for the `:adapter/current-component` late-bind
+  hook installed by `re-frame.adapter.reagent`.
+
+  Background: before rf2-wbnl, `re-frame.views` statically `:require`d
+  `reagent.core` and called `(reagent.core/current-component)` directly.
+  That hard-coupled views.cljs to stock Reagent — under the slim adapter
+  (which ships `reagent2.core`) the read returned nil for slim-rendered
+  components and silently dropped the React-context tier of the frame
+  resolution chain. The fix introduces an
+  `:adapter/current-component` late-bind hook the active adapter
+  publishes at ns-load time; views.cljs reads through the hook.
+
+  Scope of this file (classic bridge):
+    - Requiring `re-frame.adapter.reagent` registers
+      `reagent.core/current-component` against the hook.
+    - With no Reagent component in flight, the hook returns nil — the
+      shape views.cljs's `current-frame` relies on for the no-component
+      fall-through.
+
+  Note re cross-test order (bridge vs slim): both adapter ns's register
+  the same hook key at ns-load. Whichever is loaded last wins. Under the
+  in-tree shadow-cljs node-test build that loads both adapter trees,
+  this test asserts the bridge's binding by re-establishing it inside
+  each test — making the assertion order-independent.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent.core :as r]
+            [re-frame.late-bind :as late-bind]
+            ;; ns-load registers the :adapter/current-component hook.
+            [re-frame.adapter.reagent]))
+
+(defn- with-bridge-hook
+  "Install the classic bridge's hook for the duration of `f`, restoring
+  the pre-existing value afterwards. Lets this test assert the bridge
+  binding even when the slim ns-load registered a different reader after
+  the bridge ns loaded."
+  [f]
+  (let [original (late-bind/get-fn :adapter/current-component)]
+    (try
+      (late-bind/set-fn! :adapter/current-component r/current-component)
+      (f)
+      (finally
+        (late-bind/set-fn! :adapter/current-component original)))))
+
+(deftest classic-bridge-installs-hook
+  (testing "requiring re-frame.adapter.reagent registers :adapter/current-component"
+    (with-bridge-hook
+      (fn []
+        (is (some? (late-bind/get-fn :adapter/current-component))
+            "the hook is installed")
+        (is (identical? r/current-component
+                        (late-bind/get-fn :adapter/current-component))
+            "the hook points at stock reagent.core/current-component")))))
+
+(deftest hook-returns-nil-outside-render
+  (testing "calling the installed hook outside a Reagent render returns nil"
+    ;; `r/current-component` returns nil when no component is in flight.
+    ;; views.cljs's `current-frame` relies on this no-component shape to
+    ;; skip the React-context tier and fall through to :rf/default.
+    (with-bridge-hook
+      (fn []
+        (let [hook (late-bind/get-fn :adapter/current-component)]
+          (is (nil? (hook))
+              "no in-flight component → nil"))))))

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -101,6 +101,9 @@
     :adapter/current-frame    re-frame.views/current-frame                                       ;; rf2-d4sf — Reagent path; class-component (.-context cmp)
                               re-frame.adapter.context/function-component-current-frame          ;;          — UIx / Helix path; function-component _currentValue read
                                                                                                   ;; Published by the active adapter ns at load time so subscribe / dispatch consult the React-context tier of the resolution chain. Signature: (fn []) -> frame-id keyword.
+    :adapter/current-component reagent.core/current-component                                    ;; rf2-wbnl — classic-bridge path; stock Reagent's in-flight component
+                               reagent2.core/current-component                                   ;;          — slim adapter path; reagent2.core's in-flight component
+                                                                                                  ;; Published by the active adapter ns at load time so re-frame.views can resolve the current Reagent component without hard-binding to one Reagent build. The slim adapter ships its own reactive substrate; without this hook views.cljs would call stock Reagent's current-component and miss slim-rendered components. Signature: (fn []) -> Reagent component or nil. nil when no adapter is installed; views.cljs treats nil cleanly (skips React-context tier, falls through to :rf/default).
     :epoch/settle!            re-frame.epoch/settle!
     :epoch/discard-buffer!    re-frame.epoch/discard-buffer!
     :epoch/in-flight-buffer   re-frame.epoch/in-flight-buffer

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -13,9 +13,18 @@
   late-binding by id (e.g. across module boundaries, runtime-computed
   ids, or hot-reload semantics), call `(re-frame.core/view :id)`
   to obtain the wrapped fn and use `[(rf/view :id) args]` as the
-  hiccup head."
-  (:require [reagent.core   :as r]
-            [re-frame.frame :as frame]
+  hiccup head.
+
+  Per rf2-wbnl this ns no longer statically `:require`s `reagent.core`.
+  The in-flight Reagent component is read through the late-bind hook
+  `:adapter/current-component`, which the active adapter ns publishes
+  at load time. The classic bridge points the hook at
+  `reagent.core/current-component`; the slim adapter points it at
+  `reagent2.core/current-component`. With no adapter installed the
+  hook returns nil and the React-context tier of the resolution chain
+  is skipped — equivalent to a non-Reagent render context, which is
+  what JVM / headless tests already rely on."
+  (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
@@ -82,6 +91,25 @@
   (let [frame-kw (or (:frame props) :rf/default)]
     (into [(build-frame-provider) frame-kw] children)))
 
+;; ---- in-flight Reagent component (rf2-wbnl) ------------------------------
+;;
+;; The active adapter (classic bridge or slim) publishes its Reagent build's
+;; `current-component` fn through the `:adapter/current-component` late-bind
+;; hook at ns-load time. This ns must NOT statically `:require [reagent.core]`
+;; — doing so hard-couples views.cljs to stock Reagent and silently shadows
+;; the slim adapter's components in mixed-mode environments. Per the bead's
+;; resolution-chain note: dynamic var → adapter.current-component
+;; (late-bind) → nil. When no adapter has installed the hook the call returns
+;; nil and the React-context tier is skipped.
+
+(defn- current-component
+  "Resolve the in-flight Reagent component via the active adapter's hook.
+  Returns nil when no adapter has registered the hook (JVM / headless
+  builds; no-adapter tests). Per rf2-wbnl."
+  []
+  (when-let [hook (late-bind/get-fn :adapter/current-component)]
+    (hook)))
+
 ;; ---- frame resolution at render time -------------------------------------
 
 (def ^:dynamic *current-frame* nil)
@@ -111,7 +139,7 @@
   regardless of how the Provider was authored."
   []
   (or frame/*current-frame*
-      (when-let [cmp (r/current-component)]
+      (when-let [cmp (current-component)]
         (adapter-context/coerce-context-value (.-context cmp)))
       :rf/default))
 
@@ -162,7 +190,7 @@
   mints a fresh token per call — that mirrors the per-mount-fresh
   semantics for tests that simulate one mount per call."
   []
-  (if-let [cmp (r/current-component)]
+  (if-let [cmp (current-component)]
     (or (.-rfInstanceToken ^js cmp)
         (let [tok (mint-instance-token!)]
           (set! (.-rfInstanceToken ^js cmp) tok)
@@ -458,7 +486,7 @@
   routed to.
 
   Conditions for the warning to fire (all must hold):
-    1. We are mid-render — `(r/current-component)` returns a component.
+    1. We are mid-render — `(current-component)` returns a component.
     2. The component is NOT a reg-view-wrapped one — its `contextType`
        is not the shared `frame-context`. (reg-view-wrapped components
        carry the `:contextType` so they read the surrounding Provider's
@@ -481,7 +509,7 @@
   via late-bind and not called)."
   [resolved-frame-id _query-v]
   (when interop/debug-enabled?
-    (let [cmp (r/current-component)]
+    (let [cmp (current-component)]
       ;; Condition 1: must be mid-render.
       (when (some? cmp)
         ;; Condition 2: component must NOT be reg-view-wrapped. The

--- a/implementation/core/test/re_frame/views_current_component_cljs_test.cljs
+++ b/implementation/core/test/re_frame/views_current_component_cljs_test.cljs
@@ -1,0 +1,71 @@
+(ns re-frame.views-current-component-cljs-test
+  "Per rf2-wbnl — coverage for the no-adapter / no-component fall-through
+  semantics of `re-frame.views/current-frame`.
+
+  Pre-rf2-wbnl, views.cljs statically `:require`d `reagent.core` and
+  called `(reagent.core/current-component)` directly. Post-rf2-wbnl
+  views.cljs reads the in-flight component through the
+  `:adapter/current-component` late-bind hook, which the active adapter
+  installs at ns-load time.
+
+  Resolution chain (per Spec 002 §Reading the frame from React context):
+    1. `frame/*current-frame*` (dynamic var; set by `with-frame`)
+    2. closest enclosing frame-provider via React context
+    3. `:rf/default`
+
+  This file exercises the no-adapter path: with the hook unset (or
+  installed but with no in-flight component), tier 2 returns nil and
+  resolution falls through to tier 3 (`:rf/default`). This is exactly
+  the headless / pre-init shape the runtime relies on.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.views :as views]))
+
+(defn- with-hook-as-nil
+  "Run `f` with the named late-bind hook set to nil. Restores the
+  original value after `f` returns or throws — keeps cross-test
+  isolation intact (the in-tree shadow-cljs build loads both adapter
+  trees, so the hook value at test time is non-nil; flipping it lets
+  us assert the absent-hook contract)."
+  [hook-key f]
+  (let [original (late-bind/get-fn hook-key)]
+    (try
+      (late-bind/set-fn! hook-key nil)
+      (f)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
+(deftest current-frame-with-no-adapter-hook
+  (testing "current-frame falls through to :rf/default when the hook is unset"
+    (with-hook-as-nil :adapter/current-component
+      (fn []
+        (is (nil? (late-bind/get-fn :adapter/current-component))
+            "precondition: the hook is unset")
+        ;; No dynamic var is bound, no adapter hook is installed → tier 3
+        ;; (:rf/default) is the only remaining tier.
+        (is (= :rf/default (views/current-frame))
+            "with no dynamic-var binding and no adapter hook, current-frame returns :rf/default")))))
+
+(deftest current-frame-honours-dynamic-var-without-hook
+  (testing "with the hook unset, the dynamic-var tier still wins"
+    (with-hook-as-nil :adapter/current-component
+      (fn []
+        (binding [frame/*current-frame* :test/dynamic-frame]
+          (is (= :test/dynamic-frame (views/current-frame))
+              "tier 1 (dynamic var) is consulted before the (absent) hook"))))))
+
+(deftest current-frame-tolerates-hook-returning-nil
+  (testing "an installed hook that returns nil is equivalent to no hook"
+    ;; A real adapter's `current-component` returns nil outside a render.
+    ;; views.cljs must treat nil-from-hook the same as no-hook: skip the
+    ;; React-context tier, fall through to :rf/default.
+    (let [original (late-bind/get-fn :adapter/current-component)]
+      (try
+        (late-bind/set-fn! :adapter/current-component (constantly nil))
+        (is (= :rf/default (views/current-frame))
+            "hook returning nil → fall through to :rf/default")
+        (finally
+          (late-bind/set-fn! :adapter/current-component original))))))


### PR DESCRIPTION
## Summary

- Adds `:adapter/current-component` late-bind hook so `re-frame.views` reads the in-flight Reagent component through the active adapter, not by hard-coupling to stock Reagent's `reagent.core/current-component`.
- The classic bridge points the hook at `reagent.core/current-component`; the slim adapter (`re-frame.adapter.reagent-slim`) points it at `reagent2.core/current-component`. With this hook in place, `(rf/init! reagent-slim/adapter)` becomes a drop-in functional swap for `(rf/init! reagent/adapter)`.
- views.cljs drops its static `:require [reagent.core]` and routes the three call sites that previously used `r/current-component` (`current-frame`, `reagent-component-token`, `maybe-warn-plain-fn-under-non-default-frame!`) through a single private `current-component` helper that performs the hook lookup. Resolution-chain semantics of `current-frame` are unchanged: dynamic var → React-context tier (now hook-resolved) → `:rf/default`. With no adapter installed, the hook returns nil and the React-context tier is cleanly skipped — matching the headless / pre-init fall-through the runtime already relies on.

Bead: rf2-wbnl (P2). Closes the Stage 4-D follow-up flagged in `re-frame.adapter.reagent-slim`'s ns docstring.

## Test plan

- [x] Classic bridge: `(require '[re-frame.adapter.reagent])` installs `reagent.core/current-component` against `:adapter/current-component`; hook returns nil outside a render.
- [x] Slim adapter: `(require '[re-frame.adapter.reagent-slim])` installs `reagent2.core/current-component` against `:adapter/current-component`; hook returns nil outside a render.
- [x] No-adapter / nil-hook: `re-frame.views/current-frame` falls through to `:rf/default` when the hook is unset.
- [x] Dynamic-var tier still wins when the hook is absent.
- [x] Hook returning nil is treated identically to no-hook (the live shape outside a render).
- [x] All 346 CLJS tests pass (`npm run test:cljs`).
- [x] All 183 JVM core tests pass (`clojure -M:test`).
- [x] All 187 browser tests pass (`npm run test:browser`) — covers the seven runtime scenarios in `frame_provider_context_cljs_test`, including nested-provider inheritance, default-frame fallback, cross-frame subscribe / dispatch resolution, and React-19 strict-mode composition.
- [x] 4 elision schema sentinels still ABSENT under `:advanced` + `goog.DEBUG=false` (`npm run test:elision`).