### PR TITLE
docs(guide): restructure README + ch.02 + ch.04 for reader intent (rf2-cu7a + rf2-125o + rf2-u5sq)

### DIFF
--- a/docs/guide/02-your-first-app.md
+++ b/docs/guide/02-your-first-app.md
@@ -4,38 +4,7 @@ The smallest interesting program is a counter: a number, two buttons, the number
 
 The full source is in [`examples/reagent/counter/core.cljs`](../../examples/reagent/counter/core.cljs). This chapter walks through it section by section, explaining what each piece is doing and *why it's shaped the way it is*. By the end you'll have seen every load-bearing primitive in re-frame2 at least once.
 
-## Choose your substrate
-
-Before the code, one decision: **which view substrate is rendering this?** re-frame2's runtime — the registry, the dispatch loop, events, fx, subs, machines — is substrate-agnostic. The primitives you use in `app-db`, in event handlers, and in subs are identical regardless. What differs is how the view layer is wired into React.
-
-Three substrate adapters are available today:
-
-- **Reagent** — the canonical CLJS reference. Hiccup-shaped views, deref-tracking subscriptions (`@(subscribe ...)`), the substrate the rest of this guide uses. Pick this if you have no other constraint.
-- **UIx** — a CLJS adapter targeting React function components and hooks idiomatically. Useful if you're integrating with a JS-side codebase that expects React fn-components, or if you want UIx's compile-time JSX-style ergonomics.
-- **Helix** — same shape as UIx in spirit; pick it if your team already uses Helix.
-
-Each ships as its own Maven artefact alongside core (per Strategy B — see [rf2-5vjj](../../spec/MIGRATION.md)):
-
-```clojure
-;; deps.edn — Reagent (the canonical "first app" stack)
-{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
-        day8/re-frame-2-reagent  {:mvn/version "2.0.0"}
-        reagent                   {:mvn/version "2.0.0"}}}
-
-;; deps.edn — UIx
-{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
-        day8/re-frame-2-uix      {:mvn/version "2.0.0"}
-        com.pitch/uix.core       {:mvn/version "..."}}}
-
-;; deps.edn — Helix
-{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
-        day8/re-frame-2-helix    {:mvn/version "2.0.0"}
-        lilactown/helix          {:mvn/version "..."}}}
-```
-
-Per the [feature-opt-in story](../../spec/MIGRATION.md), core ships with **none** of the substrate adapters baked in — you add the artefact for the substrate you've picked. The same pattern applies to optional capabilities (state machines, routing, HTTP, schemas, SSR, time-travel) — each ships as its own artefact, and an app that doesn't use a feature doesn't bundle its code.
-
-This chapter uses Reagent throughout. The `dispatch`, `subscribe`, and `reg-view` primitives are identical across substrates; the difference shows up in the mount call (`reagent.dom.client/render` vs `uix.dom/render-root` vs Helix's mount fn) and in how the view body composes — Reagent uses hiccup, UIx and Helix use their own component DSLs. The pattern survives.
+This chapter uses **Reagent** — the canonical CLJS view substrate, the one the rest of the guide uses. (re-frame2 also has UIx and Helix adapters; the [Same pattern on other adapters](#same-pattern-on-other-adapters) section at the end covers how this same code looks under those substrates, plus the Maven artefact details. You can skip that section on a first read.)
 
 ## What we're building
 
@@ -244,20 +213,7 @@ Each adapter namespace exports an `adapter` Var (the nine-fn spec map Spec 006 d
 
 Calling `(rf/init!)` with no args (or with a keyword like `:reagent`, or with `nil`) raises `:rf.error/no-adapter-specified` — the only legal call shape is `(rf/init! adapter-map)`. The error message points back at the adapter-ns + adapter-Var pattern so the recovery path is obvious.
 
-The same shape applies to UIx, Helix, and SSR — each ships an `adapter` Var:
-
-```clojure
-(require '[re-frame.adapter.uix :as uix])
-(rf/init! uix/adapter)
-
-(require '[re-frame.adapter.helix :as helix])
-(rf/init! helix/adapter)
-
-(require '[re-frame.ssr :as ssr])   ;; JVM-side server bootstrap
-(rf/init! ssr/adapter)
-```
-
-For a mixed-substrate app — say a build that imports both Reagent and UIx — pick the active adapter by passing the right Var. There is no multi-adapter ambiguity to resolve at boot: only one adapter is ever installed, and the call site names it.
+(The same call shape applies to the other adapters — UIx, Helix, SSR. The [Same pattern on other adapters](#same-pattern-on-other-adapters) section at the end of this chapter shows what that looks like.)
 
 ## What just happened
 
@@ -319,6 +275,54 @@ If you wanted the counter to also remember a history of past values, you'd:
 That's it. The shape doesn't change. There's no new primitive to learn. Every change happens in the place you'd expect: a new event handler, a new sub, a new view fragment.
 
 This is the real claim of re-frame2: **the cost of new features is bounded by the size of the feature, not by the size of the app**. In a poorly-shaped app, adding a feature requires reading a substantial fraction of the existing code to know where to wire it in. In a re-frame2 app, you read the events, the subs, and the view that touches the area you're changing, and that's enough.
+
+## Same pattern on other adapters
+
+Now that you've seen the counter end-to-end on Reagent, here's the wider picture: re-frame2's runtime — the registry, the dispatch loop, events, fx, subs, machines — is **substrate-agnostic**. The primitives you've used in `app-db`, in event handlers, and in subs are identical regardless of which substrate is rendering. What differs is how the view layer is wired into React.
+
+Three substrate adapters are available today:
+
+- **Reagent** — the canonical CLJS reference. Hiccup-shaped views, deref-tracking subscriptions (`@(subscribe ...)`), the substrate this chapter and the rest of the guide uses. Pick this if you have no other constraint.
+- **UIx** — a CLJS adapter targeting React function components and hooks idiomatically. Useful if you're integrating with a JS-side codebase that expects React fn-components, or if you want UIx's compile-time JSX-style ergonomics.
+- **Helix** — same shape as UIx in spirit; pick it if your team already uses Helix.
+
+Each ships as its own Maven artefact alongside core (per Strategy B — see [rf2-5vjj](../../spec/MIGRATION.md)):
+
+```clojure
+;; deps.edn — Reagent (the canonical "first app" stack)
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-reagent  {:mvn/version "2.0.0"}
+        reagent                   {:mvn/version "2.0.0"}}}
+
+;; deps.edn — UIx
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-uix      {:mvn/version "2.0.0"}
+        com.pitch/uix.core       {:mvn/version "..."}}}
+
+;; deps.edn — Helix
+{:deps {day8/re-frame-2          {:mvn/version "2.0.0"}
+        day8/re-frame-2-helix    {:mvn/version "2.0.0"}
+        lilactown/helix          {:mvn/version "..."}}}
+```
+
+Per the [feature-opt-in story](../../spec/MIGRATION.md), core ships with **none** of the substrate adapters baked in — you add the artefact for the substrate you've picked. The same pattern applies to optional capabilities (state machines, routing, HTTP, schemas, SSR, time-travel) — each ships as its own artefact, and an app that doesn't use a feature doesn't bundle its code.
+
+The `dispatch`, `subscribe`, and `reg-view` primitives are identical across substrates; the difference shows up in the mount call (`reagent.dom.client/render` vs `uix.dom/render-root` vs Helix's mount fn) and in how the view body composes — Reagent uses hiccup, UIx and Helix use their own component DSLs. The pattern survives.
+
+The `init!` call follows the same shape on every adapter — pick the right `adapter` Var and pass it:
+
+```clojure
+(require '[re-frame.adapter.uix :as uix])
+(rf/init! uix/adapter)
+
+(require '[re-frame.adapter.helix :as helix])
+(rf/init! helix/adapter)
+
+(require '[re-frame.ssr :as ssr])   ;; JVM-side server bootstrap
+(rf/init! ssr/adapter)
+```
+
+For a mixed-substrate app — say a build that imports both Reagent and UIx — pick the active adapter by passing the right Var. There is no multi-adapter ambiguity to resolve at boot: only one adapter is ever installed, and the call site names it.
 
 ## Next
 

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -88,9 +88,7 @@ The macro errors at compile time if you hand it a Form-3 (`reagent.core/create-c
 
 The architecture above assumes a view inside a `frame-provider` subtree picks up the surrounding frame. The CLJS reference uses **React context** to carry this — when you wrap a subtree with `[rf/frame-provider {:frame :left} ...]`, every registered view rendered underneath receives the frame id through context, and the auto-injected `dispatch`/`subscribe` resolves against it.
 
-In practice, the propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` will dispatch to `:left`. **Caveat:** as of today the CLJS implementation has a partial gap here — the resolution chain spec/002 §3 documents (dynamic-var → React context → `:rf/default`) is not fully wired in the current CLJS reference. Subscribe consults the dynamic-var tier and falls back to `:rf/default`; the React-context tier is documented but not yet connected in the read path. The split-counter example below works in the canonical case (one frame-per-mount, set up via `frame-provider` plus dispatch-sync seed events) because the dynamic-var tier carries the frame for each render, but more elaborate cases — sibling views under different frame-providers within a single render pass that BOTH need to read state — should be tested against your specific shape.
-
-The behaviour is tracked at [rf2-d4sf](#); the contract in this guide describes what works today, not what spec/002 §3 promises long-term. When the gap closes, the resolution is automatic — your code does not change. The chapter's example (and the runnable [`examples/reagent/counter/core.cljs`](../../examples/reagent/counter/core.cljs)) exercises only the part that works today.
+The propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` dispatches to `:left`. The full resolution chain (dynamic-var → React context → `:rf/default`) is specified in [Spec 002 §3](../../spec/002-Frames.md); a partial implementation gap in the current CLJS reference is tracked at [rf2-d4sf](#). The split-counter example below exercises the part that works today; when the gap closes the resolution is automatic and your code does not change.
 
 ### The Var-reference idiom
 
@@ -205,30 +203,18 @@ Two instances of the same registered view, different frames. Each subtree's `dis
 
 ## Source coordinates on rendered DOM
 
-A small but load-bearing detail: every `reg-view`-rendered DOM element receives a `data-rf2-source-coord` attribute pointing back to the registration that produced it.
+One small detail to recognise when you see it in the inspector: every `reg-view`-rendered DOM element carries a `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` attribute pointing back to the registration that produced it. It's how pair tools and devtools resolve a clicked DOM node back to the source line. The annotation is dev-only — production builds elide it via DCE.
 
-```html
-<button data-rf2-source-coord="counter.core:counter:48:5" ...>+</button>
-```
+You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Source coordinates](11-devtools-and-pair-tools.md#source-coordinates-clicking-a-button-back-to-its-source-line). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1).
 
-The four colon-separated segments are `<ns>:<sym>:<line>:<col>` — the registration's namespace, the registered symbol, and the source line/column captured at macro-expansion time. (To recover the file path too, look it up via `(rf/handler-meta :view <id>)`; the registration metadata carries `:rf/source-coord-meta` with `:ns`/`:line`/`:column`/`:file`.)
-
-The annotation is **mandatory** in the CLJS reference per [Spec 006](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) — every adapter whose host has a DOM-attribute concept injects it. It exists so pair-tools and devtools can take a clicked DOM node and resolve it back to the source line that produced the view; [chapter 11](11-devtools-and-pair-tools.md) walks through what tools do with it.
-
-Two production-elision details matter:
-
-- The annotation is **dev-only** — gated on the universal `re-frame.interop/debug-enabled?` flag (the CLJS mirror of `goog.DEBUG`). `:advanced` builds with `goog.DEBUG=false` strip the attribute via Closure DCE; the rendered HTML in production carries no `data-rf2-source-coord` bytes.
-- Components whose outermost return is a React Fragment, a `:>`-prefixed host component, or another non-DOM root are exempt — the runtime can't attach an attribute to a fragment. Pair-tools fall back to the registration's metadata for those nodes.
-
-You don't need to do anything to get the annotation. `reg-view` does it. The mention here is so you recognise the attribute when you see it in the inspector.
+<!-- TODO(rf2-q2x0 — discovered from rf2-u5sq): app-db shape and the flow/routing
+     forward-pointers below are kept inline because they have no obvious new
+     chapter home today. Future rework could fold "What lives in app-db" into
+     ch.03's state-shape territory and let flows/routing be pure forward-pointers. -->
 
 ## What lives in app-db
 
-The single most common question new re-frame users ask: *what shape should I put my app-db in?*
-
-The honest answer is: whatever shape suits your app. There's no required schema. `app-db` is "your app's state, in one map." How you organise that map is your business.
-
-That said, conventions help:
+A frame's `app-db` is "your app's state, in one map." There's no required schema, but a useful convention is one top-level key per *feature* — each feature owning its own slice, accessed through that feature's subs and events:
 
 ```clojure
 {:auth     {:user nil :loading? false :error nil}
@@ -238,21 +224,11 @@ That said, conventions help:
  :ui       {:sidebar-open? true :modal nil}}
 ```
 
-A top-level key per *feature*. Each feature owns its own slice. No feature reaches into another feature's slice directly — instead, it goes through the other feature's subs (to read) and dispatches the other feature's events (to write).
-
-This **id-prefix-as-namespace** convention extends to the registry: events for the cart feature live under `:cart/...` and `:cart.item/...`; subs that read the cart's slice live under `:cart/items`, `:cart/total`; views live under `:cart/summary`. The whole feature is identifiable by its prefix. Adding or removing a feature is a `git mv` away from being a single coherent unit.
-
-For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev. We'll see this in [chapter 07](07-server-side.md) when SSR enters the picture.
+The same **id-prefix-as-namespace** convention extends to the registry: events for the cart feature live under `:cart/...`, subs under `:cart/items`/`:cart/total`, views under `:cart/summary`. The whole feature is identifiable by its prefix. For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev — [chapter 07](07-server-side.md) shows this when SSR enters the picture.
 
 ### Computed values as state — the flow escape hatch
 
-Most derived values you reach for in re-frame2 are subscriptions: the rectangle's area derived from `:width` and `:height`, the cart's total derived from its items, the form's submittable-state derived from validity flags. Subs live in the per-frame sub-cache and are consumed by views.
-
-Sometimes, though, the derived value isn't *just* for views. You want it **in `app-db`**, where:
-- another event handler can read it as plain data,
-- it survives SSR/hydration round-trips,
-- it shows up in the `app-db` inspector,
-- a registered schema can cover it.
+Most derived values are subscriptions — they live in the per-frame sub-cache and are consumed by views. Sometimes, though, the derived value isn't *just* for views: you want it **in `app-db`** so another event handler can read it as plain data, it survives SSR/hydration, it shows up in the inspector, a registered schema can cover it.
 
 That's what **flows** are for. A flow is a registered rule: "when these `app-db` paths change, run this pure function and write the result to that `app-db` path." Same compute-on-input-change semantics as subs; different storage location.
 
@@ -264,13 +240,11 @@ That's what **flows** are for. A flow is a registered rule: "when these `app-db`
    :path   [:area]})
 ```
 
-Flows are deliberately a **niche convenience**, not a sub replacement. Most derived values are still subs — flows pay an `app-db` write per recomputation, and they're only worth that cost when the derived value is genuinely part of the application's state. A typical re-frame2 app has dozens of subs and one or two flows. Full contract: [Spec 013](../../spec/013-Flows.md).
+Flows are deliberately a **niche convenience**, not a sub replacement — a typical re-frame2 app has dozens of subs and one or two flows. Full contract: [Spec 013](../../spec/013-Flows.md).
 
 ### Routing as state
 
-A specific case of "feature-as-slice" worth flagging: **routing**. The current route lives in `app-db` at `:route` — a small map of `{:id :params :query :fragment :transition :nav-token}`. Navigation is an event (`:rf.route/navigate`); URL changes are events (`:rf.route/handle-url-change`); the active route is a sub. There's no separate routing runtime, no route-aware components, no "route context" — it's just data that happens to be reflected in the address bar.
-
-The substrate gives you a few things you'd otherwise hand-roll: a deterministic ranking algorithm (so `/users/me` and `/users/:id` always agree on which one wins), per-navigation tokens that ride through async work and let stale results suppress themselves cleanly, fragments as a first-class part of the route slice, and `:can-leave` guards that pause navigation through `:rf/pending-navigation` so the user can confirm or cancel an "unsaved changes?" prompt. The full contract is in [Spec 012](../../spec/012-Routing.md). For this chapter, the load-bearing fact is just: routing is one more slice of `app-db`, not a parallel system.
+Routing is just another slice of `app-db`. The current route lives at `:route` (a `{:id :params :query :fragment :transition :nav-token}` map); navigation is an event; the active route is a sub. There's no separate routing runtime — it's data that happens to be reflected in the address bar. The full story (deterministic ranking, navigation tokens, `:can-leave` guards, multi-frame routing) is in [chapter 12](12-routing.md) and [Spec 012](../../spec/012-Routing.md). For this chapter, the load-bearing fact is that routing doesn't break the one-app-db model.
 
 ## A small example: split counter
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -8,6 +8,12 @@ If you're an AI agent or implementor, you want the [specification](../../spec/) 
 
 ## Chapters
 
+The guide is in two parts. The **core path** (chapters 01-07) builds the mental model in sequence — read these in order, end to end, and you have re-frame2. The **optional deep dives** (chapters 08-12) are *à la carte*: read them when the topic comes up, not as the next-link in the linear sequence.
+
+### Core path
+
+Read these in order. Each chapter assumes the previous one.
+
 | # | Chapter | What it covers |
 |---|---|---|
 | 01 | [Why re-frame2](01-why-re-frame2.md) | The argument. What problem this solves. Why it works. |
@@ -17,15 +23,24 @@ If you're an AI agent or implementor, you want the [specification](../../spec/) 
 | 05 | [State machines](05-state-machines.md) | When the answer to a flow is a finite state machine. |
 | 06 | [Doing HTTP requests](06-doing-http-requests.md) | `:rf.http/managed` — the canonical request fx, end-to-end. |
 | 07 | [The server side](07-server-side.md) | SSR and hydration without losing your mind. |
-| 08 | [From re-frame v1](08-from-re-frame-v1.md) | What's the same, what's different, what to do. |
-| 09 | [The dynamic-model story](09-the-dynamic-model.md) | The deeper essay on *why* less-powerful is more. |
-| 10 | [Testing](10-testing.md) | `re-frame.test-support`, frame fixtures, JVM-vs-CLJS boundary, conformance. |
-| 11 | [Devtools and pair tools](11-devtools-and-pair-tools.md) | Trace stream, epoch history, time-travel, source-coords, `reset-frame-db!`. |
-| 12 | [Routing](12-routing.md) | URL ↔ state contract, `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
-
-After the chapters: read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login, routing, ssr, managed-http-counter, state-machine-walkthrough), then benchmarks (todomvc, 7GUIs, nine-states), then the RealWorld scaffold. Fifteen examples total, each with a Playwright smoke spec; the catalogue maps each one to the Specs it exercises.
 
 If you're impatient, read [01](01-why-re-frame2.md) and skip to [02](02-your-first-app.md). If you're skeptical, [01](01-why-re-frame2.md) is where the argument lives.
+
+### Optional deep dives
+
+Read these when the topic comes up — not as part of the linear sequence. They're independent of one another.
+
+| # | Chapter | When to read it |
+|---|---|---|
+| 08 | [From re-frame v1](08-from-re-frame-v1.md) | You're migrating an existing re-frame v1 app. Skip if re-frame2 is your starting point. |
+| 09 | [The dynamic-model story](09-the-dynamic-model.md) | You want the long-form essay on *why* less-powerful is more. Skippable for "I just want to write code" readers. |
+| 10 | [Testing](10-testing.md) | You're about to write tests — `re-frame.test-support`, frame fixtures, JVM-vs-CLJS boundary, conformance. |
+| 11 | [Devtools and pair tools](11-devtools-and-pair-tools.md) | You're debugging or reaching for tooling — trace stream, epoch history, time-travel, source-coords, `reset-frame-db!`. |
+| 12 | [Routing](12-routing.md) | Your app needs URL ↔ state — `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
+
+### Worked examples
+
+Once you've finished the core path, read the [worked examples](../../examples/README.md) — pedagogical sketches first (counter, login, routing, ssr, managed-http-counter, state-machine-walkthrough), then benchmarks (todomvc, 7GUIs, nine-states), then the RealWorld scaffold. Fifteen examples total, each with a Playwright smoke spec; the catalogue maps each one to the Specs it exercises.
 
 ## After the chapters — the system-understanding bridge
 


### PR DESCRIPTION
Batched guide-rework PR covering three P3 Codex beads. Each rework is a structural reordering / minimisation; no substantive content rewrites. Chapter filenames are unchanged so existing cross-references (`mkdocs.yml`, `docs/index.md`, `implementation/adapters/README.md`, ch.08's link to ch.04 §Computed-values-as-state) stay intact.

## Per-bead changes

### rf2-cu7a — README structure

`docs/guide/README.md` now splits the flat chapter table into:

- **Core path** (01-07) — read these in order; each chapter assumes the previous one. Builds the mental model.
- **Optional deep dives** (08-12) — read when the topic comes up, with a "when to read it" column instead of "what it covers". Independent of one another.

The chapter filenames and numbering are untouched. The "If you're impatient" hint and the worked-examples section are preserved (the latter renamed `### Worked examples` to avoid clashing with the existing `## After the chapters — the system-understanding bridge` section that follows).

### rf2-125o — ch.02 reordering

`docs/guide/02-your-first-app.md` previously front-loaded ~30 lines of adapter / Maven artefact detail before the reader saw the counter. Restructured to:

- Open with a single sentence: "This chapter uses Reagent — the rest is at the end."
- The runnable counter + section-by-section walkthrough now starts immediately.
- All UIx/Helix/SSR detail (substrate menu, deps.edn snippets, multi-adapter `init!` examples) moved into a new "Same pattern on other adapters" section at the end of the chapter.
- The `init!` discussion in the body keeps the Reagent example and forward-points to the appendix for the cross-substrate listing.

No content lost — every paragraph that previously existed is still in the file, just reordered.

### rf2-u5sq — ch.04 scope

`docs/guide/04-views-and-frames.md` carried five topics adjacent to the views+frames through-line. Treatment:

| Topic | Original lines | Treatment |
|---|---|---|
| Frame propagation caveat | 87-93 (3 paragraphs) | Inline minimisation — trimmed to a single paragraph pointing at Spec 002 §3 and rf2-d4sf |
| Source coordinates on rendered DOM | 206-223 | Spin out — ch.11 §Source coordinates already covers this fully; ch.04 reduced to a recognition-only note with a forward-link |
| "What lives in app-db" | 225-245 | Inline minimisation — tightened in place |
| Computed values as state (flows) | 247-267 | Inline minimisation — heading preserved verbatim because ch.08 links to its anchor |
| Routing as state | 269-273 | Inline minimisation — reduced to a forward-pointer at ch.12 |

A TODO comment in the file flags the last three as candidates for future rework (folding "What lives in app-db" into ch.03 would be the natural next step). Follow-up bead **rf2-q2x0** filed (discovered-from rf2-u5sq, P4) captures that work.

## Deferred / follow-up

- **rf2-q2x0** (new, P4, discovered-from rf2-u5sq) — Guide ch.04 follow-up: consider folding app-db shape into ch.03. Filed because the three trimmed sections in ch.04 have no obvious new chapter home today; future rework can revisit once ch.03's state-shape territory is reshaped.

## Cross-doc links verified intact

- `mkdocs.yml` nav entries all reference unchanged paths.
- `docs/index.md` link to `guide/README.md` still resolves.
- `implementation/adapters/README.md:57` link to ch.02 still resolves.
- `docs/guide/08-from-re-frame-v1.md:191` link to `04-views-and-frames.md#computed-values-as-state--the-flow-escape-hatch` still resolves (heading preserved verbatim).
- New within-chapter anchor `#same-pattern-on-other-adapters` in ch.02 resolves.
- New cross-chapter forward-link in ch.04 to ch.11 §Source coordinates resolves.

## Test plan

- [ ] mkdocs build (CI on PR — docs.yml workflow) passes.
- [ ] Visual scan of the rendered guide-overview page on the PR preview confirms the two-section layout reads cleanly.