### PR TITLE
spec(docs): bundle-cost subsection + listener-ordering reconciliation + head-mismatch reconciliation (rf2-sn1h + rf2-b4wt + rf2-4o1c.4)

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -147,7 +147,7 @@ Pair-shaped tools and 10x v2's flow panel filter `op-type :flow` (per [Tool-Pair
 
 ## Subscription / consumption
 
-re-frame2's trace API uses **synchronous, event-at-a-time delivery** — every registered listener is invoked once per emitted trace event, in registration order, while the runtime is still on the emit call stack. There is no batching, debounce window, or background delivery loop. Listeners SHOULD do minimal work in the callback (queue, append to a buffer, mark a flag) and defer expensive work to a separate timer or animation frame they own.
+re-frame2's trace API uses **synchronous, event-at-a-time delivery** — every registered listener is invoked once per emitted trace event while the runtime is still on the emit call stack. Listener-invocation order is **not contract**; tools must not depend on the order in which sibling listeners receive a given event. There is no batching, debounce window, or background delivery loop. Listeners SHOULD do minimal work in the callback (queue, append to a buffer, mark a flag) and defer expensive work to a separate timer or animation frame they own.
 
 ### The listener API
 
@@ -232,7 +232,8 @@ The two listener APIs are independent: tools may register either, both, or neith
 ### Listener invocation rules
 
 - **Synchronous, event-at-a-time.** Every registered listener is invoked once per emitted trace event, on the runtime's emit call stack. There is no batching, debounce window, or background delivery loop. Listeners SHOULD return quickly; expensive work belongs on a tool-owned timer or rAF.
-- **In-order.** Listeners see events in emission order — i.e. the order the runtime fired them.
+- **Events arrive in emission order.** Each listener sees trace events in the order the runtime fired them. (This is about per-listener *event* order, not order *across* listeners — see the next rule.)
+- **Listener-invocation order is not contract.** When multiple listeners are registered, the order in which sibling listeners receive a given event is unspecified. Tools must not depend on order; each listener receives the same event independently. The same rule applies to `register-epoch-cb` callbacks.
 - **Exception isolation.** An exception thrown by a listener is caught and does *not* propagate to the framework or other listeners. One broken tool can't break the app or block other tools. The caught exception is logged via `re-frame.interop/log-error` (or the host equivalent) and otherwise discarded; the runtime does NOT emit a self-referential trace event for the failed listener (which would risk a re-entrant trace-emit storm). The same handling applies to exceptions thrown by an `register-epoch-cb` callback.
 - **No buffering between listeners and the runtime.** The framework does not retain a delivery buffer; the retain-N ring buffer described next is independent and exists for late-attaching tools.
 
@@ -294,7 +295,7 @@ The framework emits trace events from these call sites:
 - `flows.cljc` — `:rf.flow/registered`, `:rf.flow/computed`, `:rf.flow/skip`, `:rf.flow/cleared`, `:rf.flow/failed` (per [013 §Flow tracing](013-Flows.md#flow-tracing)). All carry `:op-type :flow`.
 - `schemas.cljc` — `:rf.error/schema-validation-failure` (from `validate-app-db!` / `validate-event!` / `validate-cofx!` / `validate-sub-return!`).
 - `spec.cljc` — `:rf.error/schema-validation-failure :where :event :source :boundary` and `:rf.warning/boundary-without-spec` (from the `:spec/validate-at-boundary` interceptor; per [010 §Production builds](010-Schemas.md#production-builds) and rf2-r2uh).
-- `ssr.cljc` — `:warning :rf.warning/multiple-status-set`, `:warning :rf.warning/multiple-redirects`, `:rf.error/sanitised-on-projection`.
+- `ssr.cljc` — `:rf.ssr/hydration-mismatch` (carries `:failing-id` to discriminate body-mismatch from head-mismatch; per [011 §Hydration-mismatch detection](011-SSR.md#hydration-mismatch-detection) and [011 §Mismatch detection — head](011-SSR.md#mismatch-detection--head)), `:warning :rf.warning/multiple-status-set`, `:warning :rf.warning/multiple-redirects`, `:rf.error/sanitised-on-projection`.
 - `epoch.cljc` — `:rf.epoch/snapshotted` per drain-settle, `:rf.epoch/restored` on restore success, `:rf.epoch/db-replaced` on `reset-frame-db!` success (rf2-zq55), plus the six restore-failure categories and the two reset-frame-db! failure categories (`:rf.epoch/reset-frame-db-during-drain`, `:rf.epoch/reset-frame-db-schema-mismatch`), plus `:rf.epoch.cb/silenced-on-frame-destroy` emitted once per `(frame-id, cb-id)` pair on the destroy-cascade boundary (rf2-d656).
 - `views.cljs` — `:view/render` per registered-view render (per [Spec 004 §Render-tree primitives](004-Views.md)).
 - `adapter/context.cljs` — `:rf.error/frame-context-corrupted` (function-component `_currentValue` read observed a non-coercible shape; per rf2-8q66).
@@ -642,14 +643,13 @@ This convention is **stable**: new error categories adopt one of the five existi
 | `:rf.error/override-fallthrough` | An override was specified but no matching id existed | `:overrides-map`, `:looked-up-id` |
 | `:rf.fx/handled` | An fx was successfully dispatched (the runtime reached the fx and either ran the registered handler without exception or completed the reserved-fx-id action). Emitted by `re-frame.fx/handle-one-fx` on the success path so the `:rf/epoch-record` `:effects` projection captures one entry per dispatched fx (per [Spec-Schemas §`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record)) | `:fx-id`, `:fx-args`, `:frame` |
 | `:rf.fx/skipped-on-platform` | An fx was skipped because its `:platforms` excluded the active platform (per [011](011-SSR.md)) | `:fx-id`, `:fx-args`, `:platform`, `:registered-platforms` |
-| `:rf.ssr/hydration-mismatch` | First client render diverges from server-supplied render-tree (per [011](011-SSR.md)) | `:server-hash`, `:client-hash`, `:first-diff-path?` |
+| `:rf.ssr/hydration-mismatch` | First client render diverges from server-supplied render-tree, OR the client-computed head model differs from the server-supplied head. The `:failing-id` discriminator routes the two cases (`:rf/hydrate` for the body, `:rf.ssr/head-mismatch` for the head). Per [011 §Hydration-mismatch detection](011-SSR.md#hydration-mismatch-detection) and [011 §Mismatch detection — head](011-SSR.md#mismatch-detection--head) | `:server-hash`, `:client-hash`, `:failing-id`, `:first-diff-path?` (body), `:head-id` (head) |
 | `:rf.warning/plain-fn-under-non-default-frame-once` | A plain (non-`reg-view`) Reagent fn rendered under a non-default frame; routed to `:rf/default`. Emitted at most once per `(component-id, non-default-frame-id)` pair — see [004 §Plain Reagent fns](004-Views.md) | `:fn-name`, `:rendered-under`, `:routed-to` |
 | `:rf.warning/no-clock-configured` | A timing-sensitive substrate feature (e.g. state-machine `:after` per [005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions)) was exercised on a host whose `re-frame.interop` clock primitives (`now-ms` / `schedule-after!` / `cancel-scheduled!`) weren't wired up. The runtime falls back to the host-native clock if available; this advisory surfaces so tests / agents can spot the missing wiring | `:feature` (e.g. `:rf.machine/after`), `:fallback` (the host-native clock used) |
 | `:rf.error/duplicate-url-binding` | A second frame attempted `:url-bound? true` while another already owns the URL. Per [012 §Multi-frame routing](012-Routing.md#multi-frame-routing) | `:existing-frame`, `:offending-frame` |
 | `:rf.error/system-id-collision` | A spawn whose `:system-id` was already bound in the per-frame `[:rf/system-ids]` reverse index displaced the previous binding. Last-write-wins, matching `reg-event-fx` re-registration semantics. Per [005 §Named addressing via `:system-id`](005-StateMachines.md#named-addressing-via-system-id) and rf2-suue | `:frame`, `:system-id`, `:existing-machine` (the displaced gensym'd id), `:rebound-to` (the new gensym'd id) |
 | `:rf.warning/multiple-status-set` | Two or more `:rf.server/set-status` calls in the same request drain. Last-write-wins; advisory for finding the conflicting handlers. Per [011 §Multiple-status policy](011-SSR.md#multiple-status-policy) | `:writes` (vector of `{:status :handler-id :event}` per write), `:final-status` |
 | `:rf.warning/multiple-redirects` | Two or more `:rf.server/redirect` calls in the same request drain. Last-write-wins. Per [011 §Redirect precedence](011-SSR.md#redirect-precedence) | `:writes` (vector), `:final-redirect` |
-| `:rf.warning/head-mismatch` | Client-computed head model differs from server-supplied head; client re-renders and replaces. Per [011 §Mismatch detection — head](011-SSR.md#mismatch-detection--head) | `:server-hash`, `:client-hash`, `:head-id` |
 | `:rf.warning/interceptors-in-metadata-map` | A `reg-event-*` registration carried `:interceptors` inside its metadata-map; the chain is silently dropped. Per [Conventions §`:interceptors` is positional, not metadata](Conventions.md#interceptors-is-positional-not-metadata-reg-event-) and rf2-bbea | `:reg-fn` (the fn's name as a string), `:id`, `:offending-keys`, `:reason` |
 | `:rf.warning/boundary-without-spec` | The `:spec/validate-at-boundary` interceptor (per [010 §Production builds](010-Schemas.md#production-builds)) was attached to an event handler that carries no `:spec` metadata. The interceptor cannot validate without a schema; the dispatch passes through unchecked. Emitted at most once per `event-id` (suppression cache reset across frame destruction). Per [010 §Production builds](010-Schemas.md#production-builds) and rf2-r2uh | `:event-id`, `:event` (vector), `:reason` |
 | `:rf.error/sanitised-on-projection` | The active error projector threw or returned a non-`:rf/public-error` shape; the runtime fell back to the locked generic-500 public shape. Per [011 §Where sanitisation happens — before render](011-SSR.md#where-sanitisation-happens--before-render) | `:projector-id`, `:original-operation`, `:projection-failure-reason` |
@@ -822,10 +822,10 @@ Each frame has at most one `:on-error` handler. Re-registering the frame replace
 | `:rf.error/effect-map-shape` | `:logged-and-skipped` | The offending top-level key is dropped; `:db` and `:fx` still apply. One trace per offending key. Per [MIGRATION §M-8](MIGRATION.md#m-8-effect-map-keys-consolidated--only-db-and-fx-at-the-top-level). |
 | `:rf.error/override-fallthrough` | `:replaced-with-default` | Use the registered fx as if no override existed. |
 | `:rf.fx/skipped-on-platform` | `:skipped` | Documented; not really an error. |
-| `:rf.ssr/hydration-mismatch` | `:warned-and-replaced` | Re-render client-side; the server's HTML is replaced. |
+| `:rf.ssr/hydration-mismatch` (body, `:failing-id :rf/hydrate`) | `:warned-and-replaced` | Re-render client-side; the server's HTML is replaced. |
+| `:rf.ssr/hydration-mismatch` (head, `:failing-id :rf.ssr/head-mismatch`) | `:warned-and-replaced` | Client renders its head; server's is replaced. |
 | `:rf.warning/multiple-status-set` | `:warned-and-replaced` | Last-write wins; advisory only. |
 | `:rf.warning/multiple-redirects` | `:warned-and-replaced` | Last-write wins; advisory only. |
-| `:rf.warning/head-mismatch` | `:warned-and-replaced` | Client renders its head; server's is replaced. |
 | `:rf.warning/interceptors-in-metadata-map` | `:ignored` | The mis-placed `:interceptors` chain is dropped; registration completes with no positional interceptors. |
 | `:rf.warning/boundary-without-spec` | `:no-recovery` | The boundary interceptor is a no-op for this dispatch (no schema to validate against); the handler runs as if the interceptor were absent. Emitted at most once per `event-id` to flag the misconfiguration. Per [010 §Production builds](010-Schemas.md#production-builds) and rf2-r2uh. |
 | `:rf.error/sanitised-on-projection` | `:replaced-with-default` | Runtime falls back to the locked generic-500 public-error shape. |
@@ -959,7 +959,7 @@ Trace events contain dispatched event vectors, which may include user input (pas
 
 ### Listener ordering
 
-Multiple listeners may register concurrently. Order is registration order (a `swap! assoc` on a single atom). Tools must not depend on order — they each receive the same event independently.
+Multiple listeners may register concurrently. **Listener-invocation order is not contract** — tools must not depend on the order in which sibling listeners receive a given event. Each listener receives the same event independently; nothing about the order in which the runtime walks the listener registry is guaranteed across builds, hosts, or registry implementations. The same rule applies to `register-trace-cb!` (per [§Subscription / consumption](#subscription--consumption) and [§Listener invocation rules](#listener-invocation-rules)) and `register-epoch-cb` (per [`register-epoch-cb` §Invocation rules](#register-epoch-cb--assembled-epoch-listener)).
 
 ### Trace correlation across the cascade
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -348,6 +348,48 @@ Malli is the preferred schema library over `clojure.spec`:
 
 The `:spec` value is opaque to re-frame; only the registered validator function is invoked. A user wishing to use `clojure.spec` or another library registers the appropriate validator. Malli is the documented and supported default.
 
+For the bundle-cost tradeoffs of the Malli default and how to opt out, see [§Bundle cost](#bundle-cost) below.
+
+### Bundle cost
+
+The CLJS reference's Malli mandate adds ~24 KB gzipped to a typical re-frame2 production bundle (per `findings/malli-bundle-cost-audit.md` §3.2 / §4 — bead rf2-qnxf). The cost is real but bounded; the figures below come from a representative-scenario harness compiled `:advanced` with `:closure-defines {goog.DEBUG false}`:
+
+| Scenario | gzipped | Δ vs baseline |
+|---|---:|---:|
+| Baseline counter (no schemas, no Malli) | 91.7 KB | — |
+| `[re-frame.schemas]` required, no Malli | 97.2 KB | +5.6 KB |
+| `[re-frame.schemas] [malli.core]` required, no validation | 120.8 KB | +29.1 KB |
+| Typical app: `reg-app-schema` + `:spec` on every reg-* | 121.5 KB | +29.8 KB |
+| Heavy: validate + explain + decode + transform + generator | 156.1 KB | +64.5 KB |
+
+The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas` namespace adds ~5.6 KB, and `malli.core`'s reachable body adds ~24 KB on top. Validation *calls* are not in this cost — every `validate-*!` body is gated on `re-frame.interop/debug-enabled?` and Closure DCE eliminates the call sites in production (per [§Production builds](#production-builds) and the rf2-11hn strict-elision contract). The cost is `malli.core`'s **library code**, not validation activity.
+
+**Inter-namespace DCE works; intra-namespace DCE does not.** Closure prunes `malli.error`, `malli.transform`, `malli.generator`, etc. from a typical bundle because the user code doesn't require them — only `malli.core` survives. Inside `malli.core`, Closure cannot prove the data-driven dispatch internals dead, so the full namespace stays. The practical rule is: **require what you need at the namespace boundary; nothing more.**
+
+**Safe-in-production list** — namespaces it is OK to require directly from production code paths:
+
+- `malli.core` — the default validator and explainer route through it; the ~24 KB cost is paid once when any code path requires it.
+- `re-frame.schemas` — re-frame2's schemas artefact; ~5.6 KB on top of `malli.core`.
+
+**Restrict to dev / test / 10x tiers** — namespaces that bill per-namespace gzip and should NOT be required from production code:
+
+- `malli.error` — humanise + path-walk; ~6 KB gzipped. Use in dev panels and tests.
+- `malli.transform` — JSON transformer + decoders; ~9 KB gzipped. Only required directly when an app reaches for managed-HTTP's `:auto` decode arm.
+- `malli.generator` — test.check integration; ~15 KB gzipped (carries test.check transitively). Restrict to test code and property-based-test panels.
+- `malli.registry` — composite-registry helpers; ~3 KB gzipped (most lives in `malli.core`).
+- `malli.dev`, `malli.dev.pretty`, `malli.experimental`, `malli.instrument`, `malli.json-schema`, `malli.swagger`, `malli.provider`, `malli.util` — dev-only tooling; never bundle into production code.
+
+**Opt-out path — bypass Malli entirely.** Apps that don't want the Malli bundle install a different validator (or `nil`) via `set-schema-validator!` (per [§Non-Malli validators](#non-malli-validators--the-validator-fn-extension-point) and rf2-froe / PR #237). `set-schema-validator!` with `nil` is the documented hard-no-op: every `validate-*!` site short-circuits to `true`, no validate call ever runs, and the schemas artefact stops carrying a static dependency on Malli. Apps that don't `(:require [malli.core])` themselves pay only the ~5.6 KB schemas-artefact cost.
+
+```clojure
+;; Apps that want zero runtime validation surface (and zero Malli bundle cost)
+(rf/set-schema-validator! nil)
+```
+
+**Boundary-validation path — keep Malli on the production path for untrusted-source events only.** Apps that want Malli's bundle but only run validation at system boundaries attach `:spec/validate-at-boundary` (per [§Production builds](#production-builds) and rf2-r2uh / PR #242) to specific event handlers. The interceptor runs the registered validator against the handler's `:spec` regardless of the global elision flag — boundary handlers validate every payload while 99% of code has zero validation overhead.
+
+**Reframing the "Malli is hard to DCE" intuition.** The intuition is half-right. Closure cannot DCE *inside* `malli.core` (the dynamic-dispatch internals defeat dataflow analysis). But Closure CAN DCE *between* Malli namespaces (typical apps already only carry `malli.core`, not the error / transform / generator subset), and the mandate-cost is bounded by what `malli.core` weighs gzipped: ~24 KB. The heavy-decode scenario (which pulls `malli.error` + `malli.transform` + `malli.generator`) is worst-case; the typical-app cost is half that, and the opt-out path drops it to zero.
+
 ### What schemas don't do
 
 - **They don't enforce non-shape invariants.** Malli describes shapes (this is a string of length ≥ 8; this is a vector of TodoItems). Higher-level invariants (this user's email matches their account; this request's signature is valid) live in handlers, not schemas.

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -296,10 +296,13 @@ Other-language ports may pick a different hash *as long as the canonical-EDN tra
  :tags         {:server-hash "abc123"
                 :client-hash "def456"
                 :frame       :rf/default
-                :first-diff-path [...]}     ;; optional: path into the render tree where divergence first occurs
+                :failing-id  :rf/hydrate           ;; body mismatch (see §Mismatch detection — head for the head case)
+                :first-diff-path [...]}            ;; optional: path into the render tree where divergence first occurs
  :start        (...)
  :end          (...)}
 ```
+
+The `:failing-id` discriminator routes the two hydration-mismatch shapes the runtime emits under one `:operation`: `:rf/hydrate` for body mismatch (the case above) and `:rf.ssr/head-mismatch` for head mismatch (per [§Mismatch detection — head](#mismatch-detection--head)). Consumers branch on `:failing-id` rather than maintaining a parallel category keyword per case.
 
 Recovery is implementation-policy: the CLJS reference defaults to **warn-and-replace** — log the trace event, then re-render client-side, replacing the server's HTML. Strict mode (`:strict-hydration` config) escalates to a hard error for production builds that want to fail fast on misalignment.
 
@@ -469,7 +472,7 @@ The function signature is `(fn [db route] head-model)` — pure, deterministic, 
 3. `(rf/render-head head-id frame-id)` (or equivalently `(compute-head head-id db route)`) returns the head model.
 4. The runtime emits `<head>...</head>` from the model, in canonical order: `<title>` first, then `<meta>` in declaration order, then `<link>`, then `<script>`, then JSON-LD `<script type="application/ld+json">`. `:html-attrs` populate `<html>`; `:body-attrs` populate `<body>`.
 5. Client on hydration recomputes the head model from the now-seeded state (the hydrated payload's `:rf/app-db` plus `:rf/route`).
-6. Mismatch detection: client compares its computed head to the server-supplied head; on mismatch, the client re-renders the head and emits `:rf.warning/head-mismatch`. The server head is replaced (consistency with body-mismatch handling).
+6. Mismatch detection: client compares its computed head to the server-supplied head; on mismatch, the client re-renders the head and emits `:rf.ssr/hydration-mismatch` with `:failing-id :rf.ssr/head-mismatch`. The server head is replaced (consistency with body-mismatch handling).
 
 The hydration payload may carry the server-rendered head model as `:rf/head` (additive, optional, per [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload)) — when present, the client uses it directly for mismatch comparison; when absent, the client recomputes and emits the head as if no server-side head existed (graceful degradation for SPAs that route post-load).
 
@@ -496,7 +499,7 @@ Same shape as body-mismatch (§Hydration-mismatch detection above):
 - The head model is canonically EDN-serialised (sorted keys per map; nil-pruned) and FNV-1a hashed.
 - Server emits `data-rf-head-hash="<hex>"` on the `<html>` element (or in a known `<meta>` tag, host-implementation choice; the canonical site is `<html data-rf-head-hash="...">`).
 - Client computes the same hash on its head model and compares.
-- On mismatch: `:rf.warning/head-mismatch` trace event with `:tags {:server-hash "..." :client-hash "..." :head-id <head-id>}`. Recovery is `:warned-and-replaced` — the client renders its computed head, replacing the server's.
+- On mismatch: `:rf.ssr/hydration-mismatch` trace event with `:tags {:server-hash "..." :client-hash "..." :head-id <head-id> :failing-id :rf.ssr/head-mismatch}`. The `:failing-id` discriminator distinguishes head-mismatch from body-mismatch (which carries `:failing-id :rf/hydrate`) so consumers branch on a single operation key plus the discriminator rather than two parallel operation keys. Recovery is `:warned-and-replaced` — the client renders its computed head, replacing the server's.
 
 #### Default head when no route declares `:head`
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -412,13 +412,12 @@ Pattern-level error categories:
 | `:rf.error/derived-container-replaced` | `replace-container!` called on a derived container (per Spec 006 §make-derived-value) |
 | `:rf.error/adapter-disposed` | An adapter function was called after `dispose-adapter!` ran |
 | `:rf.fx/skipped-on-platform` | Fx was skipped because `:platforms` excluded the active platform |
-| `:rf.ssr/hydration-mismatch` | First client render diverges from server-supplied render-tree |
+| `:rf.ssr/hydration-mismatch` | First client render diverges from server-supplied render-tree, OR client-computed head differs from server-supplied head. `:failing-id` discriminates (`:rf/hydrate` for the body; `:rf.ssr/head-mismatch` for the head) |
 | `:rf.warning/plain-fn-under-non-default-frame-once` | Plain Reagent fn rendered under a non-default frame; emitted once per `(component-id, non-default-frame-id)` pair |
 | `:rf.warning/no-clock-configured` | A timing-sensitive substrate feature was exercised on a host whose interop clock layer is unwired |
 | `:rf.warning/route-shadowed-by-equal-score` | Two registered routes have an equal structural rank |
 | `:rf.warning/multiple-status-set` | Two or more `:rf.server/set-status` calls in the same request drain (last-write-wins) |
 | `:rf.warning/multiple-redirects` | Two or more `:rf.server/redirect` calls in the same request drain (last-write-wins) |
-| `:rf.warning/head-mismatch` | Client-computed head model differs from server-supplied head; client re-renders and replaces |
 | `:rf.error/sanitised-on-projection` | Error projector threw or returned a non-conforming shape; runtime fell back to the locked generic-500 public-error |
 
 ---

--- a/spec/Implementor-Checklist.md
+++ b/spec/Implementor-Checklist.md
@@ -257,7 +257,7 @@ For each capability included in Part 1, the implementor makes the per-capability
 #### T1. Trace-event delivery
 
 - **Why it matters.** Trace events flow into a single per-application stream; subscribers listen. Synchronous, in-order, event-at-a-time delivery per [009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules). Plus a retain-N ring buffer (per [009 §Retain-N trace ring buffer](009-Instrumentation.md#retain-n-trace-ring-buffer-dev-only)) for tools that attach after events have fired.
-- **Options by host.** Hand-rolled per host; the contract is just "deliver each emitted trace map to every registered callback synchronously, in registration order, on the runtime's emit call stack."
+- **Options by host.** Hand-rolled per host; the contract is just "deliver each emitted trace map to every registered callback synchronously, on the runtime's emit call stack." Listener-invocation order is not contract — implementations may use any registry shape (sorted map, hash map, vector) that delivers each event to every registered listener exactly once.
 - **Reference-impl picks.** CLJS uses a single atom (the listener registry) plus a separate ring-buffer atom; each emit walks the registry inline.
 - **Trade-offs.** Hot path: trace allocation must be cheap; listener invocation must short-circuit when no listeners are registered.
 

--- a/spec/Runtime-Architecture.md
+++ b/spec/Runtime-Architecture.md
@@ -23,7 +23,7 @@ The runtime is eight components plus a host-side **interop layer** that the CLJS
 | 5 | **Effect interpreter (`do-fx`)** | Walks the `:fx` vector in source order, dispatching each entry to its registered fx handler. | [002-Frames §`:fx` ordering](002-Frames.md#fx-ordering-and-atomicity-guarantees) |
 | 6 | **Sub-cache** | Per-frame derivation graph + memoised values. Invalidates on `app-db` change; disposes on frame destroy. | [006-ReactiveSubstrate §Subscription cache invalidation](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics) |
 | 7 | **Reactive substrate adapter** | Bridges the core to a reactivity library (Reagent in CLJS reference). Turns container reads into view re-renders. | [006-ReactiveSubstrate](006-ReactiveSubstrate.md) |
-| 8 | **Trace bus** | Per-process event stream; listeners notified synchronously, in registration order, on each emit. Carries every dispatch, fx, machine transition, error, and registry mutation. | [009-Instrumentation](009-Instrumentation.md) |
+| 8 | **Trace bus** | Per-process event stream; listeners notified synchronously on each emit (listener-invocation order is not contract). Carries every dispatch, fx, machine transition, error, and registry mutation. | [009-Instrumentation](009-Instrumentation.md) |
 
 The **interop layer** (`re-frame.interop` in the CLJS reference) is not a runtime component — it is the host-abstraction surface the components call into for `next-tick`, `after-render`, mutable references, host-clock `now-ms`. Other hosts implement it natively; the interface stays small (per [Spec 002 §Interop layer](002-Frames.md#interop-layer--clock-primitives--see-spec-005)).
 
@@ -218,7 +218,7 @@ The Reagent-specific bridging pseudocode — which Reagent primitive realises wh
 **Invariants.**
 - Open shape ([009 §Open shape; new fields are additive](009-Instrumentation.md#open-shape-new-fields-are-additive)).
 - Compile-time elidable in production ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
-- Listener invocation is synchronous, in registration order, on the runtime's emit call stack — every emit returns once every listener has run ([009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules)).
+- Listener invocation is synchronous, on the runtime's emit call stack — every emit returns once every listener has run. Listener-invocation order is **not contract** ([009 §Listener invocation rules](009-Instrumentation.md#listener-invocation-rules)).
 
 ## Lifecycles
 

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -319,7 +319,7 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `ssr-set-status.edn` | `:ssr/set-status` | `:rf.server/set-status 404` populates the response accumulator; HTML body still renders |
 | `ssr-cookie.edn` | `:ssr/cookie` | `:rf.server/set-cookie` adds a structured cookie to `:cookies`; host adapter would serialise to `Set-Cookie:` |
 | `ssr-head-emits.edn` | `:ssr/head-emits` | Active route's `:head` resolves to a registered head fn; rendered HTML's `<head>` contains the expected title/meta/link tags |
-| `ssr-head-hydration.edn` | `:ssr/head-hydration` | Hydration payload carries `:rf/head` + `:rf/head-hash`; client recomputes; matches; no `:rf.warning/head-mismatch` emitted |
+| `ssr-head-hydration.edn` | `:ssr/head-hydration` | Hydration payload carries `:rf/head` + `:rf/head-hash`; client recomputes; matches; no `:rf.ssr/hydration-mismatch` (`:failing-id :rf.ssr/head-mismatch`) emitted |
 | `ssr-error-sanitisation.edn` | `:ssr/error-sanitisation` | Handler throws; trace carries full detail; public response shape is locked generic-500; rendered HTML contains no internal detail |
 | `ssr-error-known-mapping.edn` | `:ssr/error-known-mapping` | Default projector maps `:rf.error/no-such-handler` (routing context) → `{:status 404 :code :not-found ...}` public-error |
 

--- a/spec/conformance/fixtures/ssr-head-hydration.edn
+++ b/spec/conformance/fixtures/ssr-head-hydration.edn
@@ -6,7 +6,7 @@
 {:fixture/id           :ssr/head-hydration
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :ssr/head-contract :ssr/hydration}
- :fixture/doc          "Hydration payload includes the server-supplied head model and head-hash. Client recomputes the head from the same state; computed head matches; no :rf.warning/head-mismatch emitted."
+ :fixture/doc          "Hydration payload includes the server-supplied head model and head-hash. Client recomputes the head from the same state; computed head matches; no :rf.ssr/hydration-mismatch (failing-id :rf.ssr/head-mismatch) emitted."
 
  :fixture/registry
  {:event {:rf/hydrate {:doc "Standard hydration handler."}}
@@ -49,11 +49,13 @@
    :meta  [{:name "description" :content "How re-frame2 ships SSR"}]
    :link  [{:rel "canonical" :href "https://example.com/articles/123"}]}
 
-  ;; Importantly: NO :rf.warning/head-mismatch trace.
+  ;; Importantly: NO :rf.ssr/hydration-mismatch trace with the
+  ;; head discriminator (:failing-id :rf.ssr/head-mismatch).
   ;; :source is a TOP-LEVEL field per Spec 009 §Required top-level fields,
   ;; not a key inside :tags.
   :trace-emissions
   [{:operation :event :source :ssr-hydration :tags {:event-id :rf/hydrate}}]
 
   :trace-not-emitted
-  [{:operation :rf.warning/head-mismatch}]}}
+  [{:operation :rf.ssr/hydration-mismatch
+    :tags      {:failing-id :rf.ssr/head-mismatch}}]}}


### PR DESCRIPTION
## Summary

Three batched spec-doc fixes; runtime untouched.

### rf2-sn1h (P3) — Spec 010 §Bundle cost
- Adds `§Bundle cost` subsection to `spec/010-Schemas.md` citing the rf2-qnxf Malli audit numbers (~24 KB gzipped headline for typical apps).
- Documents that Closure CAN'T DCE inside `malli.core` but DOES DCE between Malli namespaces. Safe-in-production list (`malli.core`, `re-frame.schemas`) vs restrict-to-dev/test/10x list (`malli.error`, `malli.transform`, `malli.generator`, etc.).
- Cites opt-out path: `set-schema-validator!` / `set-schema-validator! nil` (rf2-froe / PR #237).
- Cites boundary path: `:spec/validate-at-boundary` interceptor (rf2-r2uh / PR #242).
- Cross-link from `§Why Malli`.

### rf2-b4wt (P3 BUG) — Spec 009 listener-ordering reconciliation
Three Spec 009 statements disagreed on whether listener-invocation order is contract. Plus the implementation hint `swap! assoc on a single atom` was wrong (Clojure maps don't preserve insertion order). **Resolution: ordering is NOT contract** (truest + simplest framing — apps shouldn't depend on it).

Swept three statements to align:
- `§Subscription / consumption` (line 150): dropped `in registration order`; added explicit not-contract clause.
- `§Listener invocation rules` (line 232): split "in-order" into two bullets — events arrive in emission order; listener-invocation order is not contract — making the distinction explicit.
- `§Resolved decisions §Listener ordering` (line 960): dropped the registration-order claim and the misleading `swap! assoc` parenthetical; added explicit `not contract` plus cross-refs.

Cross-doc sweep: `Runtime-Architecture.md` (two refs) and `Implementor-Checklist.md` (one ref) also asserted `in registration order` for listener invocation; reconciled to `not contract`.

Tool-Pair line 438 cites `[009 §Listener ordering]` — anchor preserved.

### rf2-4o1c.4 (P3 BUG) — Spec 011 head-mismatch trace key
Spec 011 + Spec 009 said `:rf.warning/head-mismatch` was the trace key. Runtime emits `:rf.ssr/hydration-mismatch` with `:failing-id` discriminating (`:rf/hydrate` for body, `:rf.ssr/head-mismatch` for head).

**Resolution (a)**: adopt the runtime canonical shape — spec catches up to runtime since that's what users observe via 10x and similar tooling, and the discriminator pattern is more general than a per-case trace key.

Touched:
- `spec/011-SSR.md`: `§Hydration-mismatch detection` trace example now shows `:failing-id :rf/hydrate`; `§Mismatch detection — head` emits `:rf.ssr/hydration-mismatch` with `:failing-id :rf.ssr/head-mismatch`.
- `spec/009-Instrumentation.md`: `:rf.ssr/hydration-mismatch` row in the category table now covers both cases via `:failing-id`; removed the parallel `:rf.warning/head-mismatch` row; recovery table split into body/head sub-rows; `ssr.cljc` emission list mentions `:rf.ssr/hydration-mismatch` with the discriminator.
- `spec/API.md`: hydration-mismatch row mentions the discriminator; `:rf.warning/head-mismatch` row removed.
- `spec/conformance/README.md` + `spec/conformance/fixtures/ssr-head-hydration.edn`: fixture's `:trace-not-emitted` assertion now references `:rf.ssr/hydration-mismatch` with the head discriminator.

## Test plan

- [x] All 27 SSR e2e tests pass (`clojure -M:test` in `implementation/ssr`).
- [x] All 183 core tests pass (`clojure -M:test` in `implementation/core`).
- [x] No runtime source touched — runtime's `verify-hydration!` already emits the spec-aligned shape.
- [x] Elision sentinels untouched (no schema validation calls added/removed).
- [x] Cross-doc anchor links resolve: `[009 §Listener ordering]`, `[009 §Listener invocation rules]`, `[011 §Hydration-mismatch detection]`, `[011 §Mismatch detection — head]`, `[010 §Bundle cost]` (new).