### PR TITLE
fix(ssr): reconcile head-hydration payload keys (rf2-4o1c.5)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -639,23 +639,21 @@
                  (pr-str (mapv :operation @traces))))))))
 
 ;; ===========================================================================
-;; ssr-head-hash-mismatch — head-model hash differs across server/client
+;; ssr-head-hash-mismatch — head-vs-body discriminator on the unified hash
 ;; ===========================================================================
 ;;
-;; Per Spec 011 §Mismatch detection — head: the head-model is hashed
-;; separately from the body so head/body mismatches can be reported with
-;; the right operation tag. The runtime today routes both through
-;; verify-hydration!; we surface a head-mismatch by tagging the
-;; :failing-id with :rf.ssr/head-mismatch — once rf2-8pif distinguishes
-;; head and body natively this can become :operation :head.
+;; Per Spec 011 §Mismatch detection — head: head-mismatch and body-mismatch
+;; share the unified :rf/render-hash channel in v1; the discriminator is
+;; :failing-id. A dedicated head-hash payload key + wire attribute is
+;; reserved for the post-v1 reg-head extension. The runtime routes both
+;; through verify-hydration! and surfaces head-vs-body via :failing-id.
 
 (deftest ssr-head-hash-mismatch
-  (testing "verify-hydration! detects a head-hash mismatch and tags the trace as :head"
+  (testing "verify-hydration! surfaces a head-mismatch via :failing-id on the unified render-hash channel"
     (let [verify-fn @(resolve 're-frame.ssr/verify-hydration!)
-          ;; Hydration payload carries the SERVER's head-hash.
-          ;; (We park it under :rf/render-hash because the runtime's
-          ;; current verify-hydration! reads server-hash from there;
-          ;; the head/body distinction lives in :failing-id below.)
+          ;; Hydration payload carries the SERVER's render-hash. v1's
+          ;; unified channel covers head + body; the head-vs-body
+          ;; distinction lives entirely in :failing-id below.
           payload   {:rf/version     1
                      :rf/app-db      {:rf/route {:id :route/article :params {:id "123"}}}
                      :rf/render-hash "head-hash-server-A"}

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -63,7 +63,6 @@ The `:rf/hydration-payload` is **bounded** — it carries the minimum data the c
 | `:rf/frame-id` | The frame to hydrate into. |
 | `:rf/app-db` | The serialised app-db slice — server's authoritative state. **Replace** policy on hydrate. |
 | `:rf/schema-digest` (optional) | Hash of the server's registered `app-schema` set; mismatches emit `:rf.ssr/schema-digest-mismatch`. |
-| `:rf/head` (optional) | Server-rendered head model for head-mismatch comparison. |
 | `:rf/route` (carried inside `:rf/app-db` under the `:rf/route` slice) | Active route, populated by `:rf.route/handle-url-change` server-side. |
 | `:rf/machines` (carried inside `:rf/app-db`) | State-machine snapshots; survive the round-trip per [011 §`:after` is no-op under SSR](#after-is-no-op-under-ssr). |
 | `:rf/sub-warmups` (optional, future-additive) | Pre-computed sub values; absent in v1 (see [§Hydration of non-state runtime artefacts](#hydration-of-non-state-runtime-artefacts)). |
@@ -474,7 +473,7 @@ The function signature is `(fn [db route] head-model)` — pure, deterministic, 
 5. Client on hydration recomputes the head model from the now-seeded state (the hydrated payload's `:rf/app-db` plus `:rf/route`).
 6. Mismatch detection: client compares its computed head to the server-supplied head; on mismatch, the client re-renders the head and emits `:rf.ssr/hydration-mismatch` with `:failing-id :rf.ssr/head-mismatch`. The server head is replaced (consistency with body-mismatch handling).
 
-The hydration payload may carry the server-rendered head model as `:rf/head` (additive, optional, per [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload)) — when present, the client uses it directly for mismatch comparison; when absent, the client recomputes and emits the head as if no server-side head existed (graceful degradation for SPAs that route post-load).
+Head-mismatch detection in v1 piggy-backs on the unified `:rf/render-hash` channel: the server-rendered HTML carries a single structural hash that covers both head and body; the runtime emits one `:rf.ssr/hydration-mismatch` trace on disagreement and discriminates head-vs-body via the `:failing-id` tag (per [§Hydration-mismatch detection](#hydration-mismatch-detection)). A dedicated `:rf/head` model on the wire (and its companion `:rf/head-hash`) is reserved for a post-v1 `reg-head` payload extension — when `reg-head` lands as a non-deferred surface those keys will be defined under `:rf/hydration-payload-postv1` in [Spec-Schemas](Spec-Schemas.md#rfhydration-payload). The v1 client recomputes the head from the hydrated `:rf/app-db` (plus `:rf/route`); SPAs that route post-load see the same graceful path because no separate head channel is required.
 
 #### `render-head`
 
@@ -496,10 +495,9 @@ Lock: **one registered `:head` per route**. No composition (parent + child route
 
 Same shape as body-mismatch (§Hydration-mismatch detection above):
 
-- The head model is canonically EDN-serialised (sorted keys per map; nil-pruned) and FNV-1a hashed.
-- Server emits `data-rf-head-hash="<hex>"` on the `<html>` element (or in a known `<meta>` tag, host-implementation choice; the canonical site is `<html data-rf-head-hash="...">`).
-- Client computes the same hash on its head model and compares.
-- On mismatch: `:rf.ssr/hydration-mismatch` trace event with `:tags {:server-hash "..." :client-hash "..." :head-id <head-id> :failing-id :rf.ssr/head-mismatch}`. The `:failing-id` discriminator distinguishes head-mismatch from body-mismatch (which carries `:failing-id :rf/hydrate`) so consumers branch on a single operation key plus the discriminator rather than two parallel operation keys. Recovery is `:warned-and-replaced` — the client renders its computed head, replacing the server's.
+- The render-tree's structural hash (per [§Hydration-mismatch detection](#hydration-mismatch-detection)) covers head as well as body in v1 — head and body share the unified `:rf/render-hash` channel. A dedicated `data-rf-head-hash` attribute is reserved for the post-v1 `reg-head` extension; v1 implementations emit only `data-rf-render-hash` on the root element.
+- Client computes the same hash on the recomputed render-tree (head + body) and compares against the server-supplied hash.
+- On mismatch where the divergence is localised to head: `:rf.ssr/hydration-mismatch` trace event with `:tags {:server-hash "..." :client-hash "..." :failing-id :rf.ssr/head-mismatch}`. The `:failing-id` discriminator distinguishes head-mismatch from body-mismatch (which carries `:failing-id :rf/hydrate`) so consumers branch on a single operation key plus the discriminator rather than two parallel operation keys. Recovery is `:warned-and-replaced` — the client renders its computed head, replacing the server's. Implementations that have not yet shipped `reg-head` continue to discriminate by `:failing-id` based on the diff path; the discriminator is the public contract.
 
 #### Default head when no route declares `:head`
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1417,9 +1417,7 @@ Per [011 §The `:rf/hydrate` event](011-SSR.md#the-rfhydrate-event). The **canon
                                         [:id     :keyword]
                                         [:params {:optional true} :map]
                                         [:query  {:optional true} :map]]]
-   [:rf/render-hash   {:optional true} :string]                            ;; hash of the server-rendered render-tree, for mismatch detection
-   [:rf/head          {:optional true} [:ref :rf/head-model]]              ;; server-rendered head model (per [011 §Head/meta contract](011-SSR.md#headmeta-contract)) — client uses it for head-mismatch detection
-   [:rf/head-hash     {:optional true} :string]                            ;; hash of the server-rendered head model, for head-mismatch detection
+   [:rf/render-hash   {:optional true} :string]                            ;; structural hash of the server-rendered render-tree, for mismatch detection. Covers both body and head — the runtime emits a single `:rf.ssr/hydration-mismatch` and discriminates head-vs-body via the `:failing-id` tag (per [011 §Hydration-mismatch detection](011-SSR.md#hydration-mismatch-detection)). The head-hash surface (a separate `:rf/head-hash` key) is reserved for the post-v1 `reg-head` payload extension and not part of the v1 wire.
    [:rf/schema-digest {:optional true} :string]                            ;; hash of the server's registered app-schema set (per [010-Schemas.md](010-Schemas.md))
    ])
 ```

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -319,7 +319,7 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `ssr-set-status.edn` | `:ssr/set-status` | `:rf.server/set-status 404` populates the response accumulator; HTML body still renders |
 | `ssr-cookie.edn` | `:ssr/cookie` | `:rf.server/set-cookie` adds a structured cookie to `:cookies`; host adapter would serialise to `Set-Cookie:` |
 | `ssr-head-emits.edn` | `:ssr/head-emits` | Active route's `:head` resolves to a registered head fn; rendered HTML's `<head>` contains the expected title/meta/link tags |
-| `ssr-head-hydration.edn` | `:ssr/head-hydration` | Hydration payload carries `:rf/head` + `:rf/head-hash`; client recomputes; matches; no `:rf.ssr/hydration-mismatch` (`:failing-id :rf.ssr/head-mismatch`) emitted |
+| `ssr-head-hydration.edn` | `:ssr/head-hydration` | Hydration payload carries the unified `:rf/render-hash` (covering head + body in v1); client recomputes; matches; no `:rf.ssr/hydration-mismatch` (`:failing-id :rf.ssr/head-mismatch`) emitted. A dedicated `:rf/head` / `:rf/head-hash` payload channel is reserved for the post-v1 `reg-head` extension. |
 | `ssr-error-sanitisation.edn` | `:ssr/error-sanitisation` | Handler throws; trace carries full detail; public response shape is locked generic-500; rendered HTML contains no internal detail |
 | `ssr-error-known-mapping.edn` | `:ssr/error-known-mapping` | Default projector maps `:rf.error/no-such-handler` (routing context) → `{:status 404 :code :not-found ...}` public-error |
 

--- a/spec/conformance/fixtures/ssr-head-emits.edn
+++ b/spec/conformance/fixtures/ssr-head-emits.edn
@@ -50,9 +50,12 @@
    "<meta property=\"og:image\" content=\"https://example.com/og.png\">"
    "<link rel=\"canonical\" href=\"https://example.com/articles/123\">"]
 
-  ;; The head emission also writes a head-hash attribute on <html> for
-  ;; client-side mismatch detection.
-  :ssr/html-attr-present "data-rf-head-hash"
+  ;; The render-tree's structural hash (covering head + body) rides
+  ;; on the root element as `data-rf-render-hash` for client-side
+  ;; mismatch detection. A dedicated head-hash attribute is reserved
+  ;; for the post-v1 `reg-head` extension; v1 emits only the unified
+  ;; render-hash. Per [011 §Mismatch detection — head].
+  :ssr/html-attr-present "data-rf-render-hash"
 
   :trace-emissions
   [{:operation :event :tags {:event-id :rf/server-init}}

--- a/spec/conformance/fixtures/ssr-head-hydration.edn
+++ b/spec/conformance/fixtures/ssr-head-hydration.edn
@@ -1,12 +1,15 @@
 ;; Conformance fixture: ssr/head-hydration
-;; The hydration payload carries :rf/head and :rf/head-hash. After
-;; hydration the client recomputes the head and verifies it matches
-;; the server-rendered head. Per [011 §Mismatch detection — head].
+;; The hydration payload carries the server's render-hash (which in v1
+;; covers both head and body — head-mismatch detection rides on the
+;; unified :rf/render-hash channel and the runtime discriminates head
+;; vs body via :failing-id). The client recomputes the same hash; no
+;; :rf.ssr/hydration-mismatch (failing-id :rf.ssr/head-mismatch)
+;; emitted. Per [011 §Mismatch detection — head].
 
 {:fixture/id           :ssr/head-hydration
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :ssr/head-contract :ssr/hydration}
- :fixture/doc          "Hydration payload includes the server-supplied head model and head-hash. Client recomputes the head from the same state; computed head matches; no :rf.ssr/hydration-mismatch (failing-id :rf.ssr/head-mismatch) emitted."
+ :fixture/doc          "Hydration payload carries the unified :rf/render-hash; the client recomputes the same hash; no :rf.ssr/hydration-mismatch (failing-id :rf.ssr/head-mismatch) emitted. A separate :rf/head / :rf/head-hash payload channel is reserved for the post-v1 reg-head extension."
 
  :fixture/registry
  {:event {:rf/hydrate {:doc "Standard hydration handler."}}
@@ -29,15 +32,14 @@
                 :rf/app-db     {:articles {"123" {:title "re-frame2 SSR"
                                                   :summary "How re-frame2 ships SSR"}}
                                 :route    {:id :route/article :params {:id "123"}}}
-                :rf/head       {:title "Article: re-frame2 SSR — Example"
-                                :meta  [{:name "description" :content "How re-frame2 ships SSR"}]
-                                :link  [{:rel "canonical" :href "https://example.com/articles/123"}]}
-                :rf/head-hash  "head-hash-server-A"}]]
+                :rf/render-hash "render-hash-server-A"}]]
 
  :fixture/render-after-hydrate
- ;; Harness simulates the client recomputing the head; the simulated client
- ;; head-hash matches the server-supplied hash. No mismatch trace.
- {:simulated-client-head-hash "head-hash-server-A"}
+ ;; Harness simulates the client recomputing the render-tree (head + body)
+ ;; to the same hash. No mismatch trace. Per Spec 011 §Mismatch detection —
+ ;; head: head-mismatch and body-mismatch share the :rf/render-hash channel
+ ;; in v1; the discriminator is :failing-id.
+ {:simulated-client-render-hash "render-hash-server-A"}
 
  :fixture/expect
  {:final-app-db {:articles {"123" {:title "re-frame2 SSR"


### PR DESCRIPTION
## Summary

Spec 011 + Spec-Schemas advertised optional `:rf/head` + `:rf/head-hash` payload keys for head-mismatch detection, but the `:rf/hydrate` runtime reads only `:rf/render-hash`. The `reg-head` / `render-head` / `active-head` trio those payload keys depend on is itself deferred (per `MIGRATION.md`), and the SSR conformance harness has no DSL op for them — so the v1 contract was carrying paper-only keys with no implementation path.

## Path chosen: (b) tighten the spec to match the runtime

Path (a) — implementing `:rf/head` / `:rf/head-hash` reading — would commit v1 to a head/body split whose producer side (`reg-head`, `render-head`, head emission to wire) is also unimplemented. Path (b) is the clean pre-release move:

- Drop `:rf/head` + `:rf/head-hash` from the v1 `:rf/hydration-payload` schema (`spec/Spec-Schemas.md`).
- Drop them from Spec 011's payload-scope table and head-hydration section.
- Update `spec/011-SSR.md` §Mismatch detection — head to document that head-mismatch detection rides on the unified `:rf/render-hash` channel; head-vs-body discrimination lives in `:failing-id` (already canonical post rf2-4o1c.4).
- Reserve the dedicated head-payload keys for `:rf/hydration-payload-postv1` so they can land when `reg-head` ships as a non-deferred surface.
- Rewrite the `ssr-head-hydration.edn` fixture so `:rf/render-hash` is the canonical (and only) head-detection mechanism — no more workaround framing.
- Update `ssr-head-emits.edn` to assert `data-rf-render-hash` (the actual v1 wire attribute) rather than the unimplemented `data-rf-head-hash`.
- Rewrite the `ssr-end-to-end-test.clj` comment that called out the parking under `:rf/render-hash` as a workaround — the unified channel IS the v1 contract.
- Update `spec/conformance/README.md` to reflect the v1 contract in the fixture table entry.

## Why path (b)

- `reg-head` / `render-head` / `active-head` are explicitly deferred per `spec/MIGRATION.md` line 1040 — the head contract is paper-only in v1.
- Zero implementation: no `reg-head`, no `render-head`, no head emission to wire, no `data-rf-head-hash` attribute anywhere in `implementation/`.
- The conformance DSL interpreter has no `:return-head` op — the head fixtures' `:fixture/handlers` for the `:head` registry were inert.
- The end-to-end test deliberately parked the head hash under `:rf/render-hash`; the workaround comment betrayed that the unified channel was already canonical.
- The `:failing-id :rf.ssr/head-mismatch` discriminator (canonical post rf2-4o1c.4) already supports head-vs-body distinction on the unified channel.

## Test plan

- [x] `cd implementation/ssr && clojure -M:test` — 27 tests, 102 assertions, 0 failures
- [x] `cd implementation && npm run test:elision` — all elision sentinels present-in-control / absent-in-release as expected
- [x] `cd implementation/core && clojure -M:test -n re-frame.conformance-test` — full conformance corpus passes including `:ssr/head-hydration` and `:ssr/head-emits`

Closes rf2-4o1c.5.