### PR TITLE
docs(guide): fold app-db shape from ch.04 into ch.03 (rf2-q2x0)

### DIFF
--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -215,9 +215,23 @@ The pattern docs are themselves human-readable — closer in voice to this guide
 
 One consequence of the discipline above worth pausing on: because state lives in one place and updates atomically, **the entire frame's state at any moment is a single value**. That value can be captured, stored, compared, restored. The framework's [Goal 3](../../spec/000-Vision.md#frame-state-revertibility) — *frame state revertibility* — turns this from an implementation detail into a contract: any prior frame value can be restored as a pointer swap, with no out-of-band state left behind. App-level undo is a thin interceptor. Time-travel debugging records values, not events. SSR ships a value. AI experimentation can try a change, observe, revert, retry without registry pollution. Each of these is a consequence of "state is a value"; the architecture commits to that discipline so the consequences are real.
 
+## A note on app-db shape
+
+A frame's `app-db` is "your app's state, in one map." There's no required schema, but a useful convention is one top-level key per *feature* — each feature owning its own slice, accessed through that feature's subs and events:
+
+```clojure
+{:auth     {:user nil :loading? false :error nil}
+ :cart     {:items [] :checkout-state :idle}
+ :articles {:status :loaded :data [...] :loaded-at 1747...}
+ :route    {:id :route/home :params {}}
+ :ui       {:sidebar-open? true :modal nil}}
+```
+
+The same **id-prefix-as-namespace** convention extends to the registry: events for the cart feature live under `:cart/...`, subs under `:cart/items`/`:cart/total`, views under `:cart/summary`. The whole feature is identifiable by its prefix. For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev — [chapter 07](07-server-side.md) shows this when SSR enters the picture.
+
 ## A note on naming
 
-The convention in re-frame2 events:
+The same prefix convention shapes event ids:
 
 - `:feature/verb-noun` — the past tense or imperative for the user's action: `:auth/log-in`, `:cart.item/remove`.
 - `:feature/loaded`, `:feature/load-failed`, `:feature/saved`, `:feature/save-failed` — the result-bearing follow-ups, named after the action they're a result of.

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -207,26 +207,14 @@ One small detail to recognise when you see it in the inspector: every `reg-view`
 
 You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Source coordinates](11-devtools-and-pair-tools.md#source-coordinates-clicking-a-button-back-to-its-source-line). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1).
 
-<!-- TODO(rf2-q2x0 — discovered from rf2-u5sq): app-db shape and the flow/routing
-     forward-pointers below are kept inline because they have no obvious new
-     chapter home today. Future rework could fold "What lives in app-db" into
-     ch.03's state-shape territory and let flows/routing be pure forward-pointers. -->
+<!-- TODO(rf2-q2x0 — discovered from rf2-u5sq): the flow and routing sub-sections
+     below are kept inline as forward-pointers. The "What lives in app-db" sibling
+     was folded into ch.03 by rf2-q2x0; the remaining two are pure pointers to
+     ch.08 (flows) / ch.12 (routing) and stay here because the multi-frame
+     context of this chapter is where readers most naturally ask "is this still
+     all one app-db?" — answer: yes, even computed values, even routing. -->
 
-## What lives in app-db
-
-A frame's `app-db` is "your app's state, in one map." There's no required schema, but a useful convention is one top-level key per *feature* — each feature owning its own slice, accessed through that feature's subs and events:
-
-```clojure
-{:auth     {:user nil :loading? false :error nil}
- :cart     {:items [] :checkout-state :idle}
- :articles {:status :loaded :data [...] :loaded-at 1747...}
- :route    {:id :route/home :params {}}
- :ui       {:sidebar-open? true :modal nil}}
-```
-
-The same **id-prefix-as-namespace** convention extends to the registry: events for the cart feature live under `:cart/...`, subs under `:cart/items`/`:cart/total`, views under `:cart/summary`. The whole feature is identifiable by its prefix. For complex schemas, [Spec 010](../../spec/010-Schemas.md) lets you attach Malli schemas to `app-db` paths so validation happens automatically in dev — [chapter 07](07-server-side.md) shows this when SSR enters the picture.
-
-### Computed values as state — the flow escape hatch
+## Computed values as state — the flow escape hatch
 
 Most derived values are subscriptions — they live in the per-frame sub-cache and are consumed by views. Sometimes, though, the derived value isn't *just* for views: you want it **in `app-db`** so another event handler can read it as plain data, it survives SSR/hydration, it shows up in the inspector, a registered schema can cover it.
 
@@ -242,7 +230,7 @@ That's what **flows** are for. A flow is a registered rule: "when these `app-db`
 
 Flows are deliberately a **niche convenience**, not a sub replacement — a typical re-frame2 app has dozens of subs and one or two flows. Full contract: [Spec 013](../../spec/013-Flows.md).
 
-### Routing as state
+## Routing as state
 
 Routing is just another slice of `app-db`. The current route lives at `:route` (a `{:id :params :query :fragment :transition :nav-token}` map); navigation is an event; the active route is a sub. There's no separate routing runtime — it's data that happens to be reflected in the address bar. The full story (deterministic ranking, navigation tokens, `:can-leave` guards, multi-frame routing) is in [chapter 12](12-routing.md) and [Spec 012](../../spec/012-Routing.md). For this chapter, the load-bearing fact is that routing doesn't break the one-app-db model.
 
@@ -290,7 +278,7 @@ A useful test: if two instances might want to share state under any circumstance
 - Frames are runtime boundaries: each has its own state, queue, sub-cache.
 - Most apps are single-frame; multi-frame is for story tools, SSR, devcards, multi-window.
 - The pattern requires every view to target a specific frame; the CLJS reference uses React context (`frame-provider`) to make that ergonomic.
-- `app-db` is one map. Conventions: namespace by feature, ids reflect feature/area.
+- Computed values (flows) and routing both live in `app-db` — multi-frame doesn't change that.
 
 ## Next
 


### PR DESCRIPTION
## Summary

Folds the `What lives in app-db` section from ch.04 into ch.03 — the chapter most naturally about state shape. This was one of three trimmed-but-homeless sections left inline in ch.04 by the rf2-u5sq restructure; the rf2-q2x0 follow-up bead resolves the one that has an obvious new home.

**Why ch.03**: it already had `A note on naming` covering the feature-prefix convention for event ids. The app-db `feature-as-top-level-key` convention is the matching half of the same idea, so they now sit as a pair (`A note on app-db shape` immediately before `A note on naming`).

## What moved

From ch.04 to ch.03:
- The `app-db` shape example (the `{:auth ... :cart ... :route ... :ui ...}` map)
- The id-prefix-as-namespace convention (events/subs/views all share a feature prefix)
- The Spec 010 / ch.07 forward pointer for Malli schemas on `app-db` paths

## What stayed in ch.04

- `Computed values as state — the flow escape hatch` (ch.08 links to its anchor — kept; promoted H3 to H2; heading text and anchor unchanged)
- `Routing as state` (forward pointer to ch.12 — promoted H3 to H2)
- The inline TODO comment, updated to reflect that 1 of 3 items has been resolved

## Test plan

- [x] `mkdocs build` runs clean — no new anchor warnings introduced
- [x] `#computed-values-as-state-the-flow-escape-hatch` anchor still exists in built site (verified — anchor is stable across H3->H2 promotion; mkdocs slugifies on heading text not level)
- [x] No other guide chapters link to the old `#what-lives-in-app-db` anchor (grep confirms)
- [x] Ch.03 now reads with `app-db shape` + `naming` as a paired beat near the end; ch.04 reads without the digression