### PR TITLE
fix(spec-005): reconcile :invoke :data fn-form (rf2-h131)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -697,7 +697,20 @@
                                            :rf/invoke-all true}]]
                     :else nil))
                 exited-pairs)))
-          [snap-after-spawns spawn-fx]
+          ;; Per Spec 005 §Declarative :invoke (rf2-h131) and §Errors:
+          ;; if `:data` is a fn and it throws during materialisation,
+          ;; route through the same `::action-failed` sentinel that
+          ;; `collect-actions` uses for action throws, so the cascade
+          ;; halts cleanly at machine-transition with
+          ;; `:rf.error/machine-action-exception`.
+          materialise-data (fn [d snap]
+                             (if (fn? d)
+                               (try
+                                 [:ok (d snap event)]
+                                 (catch #?(:clj Throwable :cljs :default) e
+                                   [:fail e]))
+                               [:ok d]))
+          spawn-result
           (if internal?
             [snap-final []]
             (reduce
@@ -713,46 +726,74 @@
                         frame-id    (or (:rf/frame machine) :rf/transition-pure)
                         spawned-id  (or (:invoke-id inv)
                                         (next-spawn-id frame-id machine-id))
-                        ;; Carry the resolved id forward so spawn-fx registers
-                        ;; the live handler under the SAME id the :on-spawn
-                        ;; callback observed (rf2-suue lifecycle wiring) AND
-                        ;; the runtime can write [:rf/spawned parent-id
-                        ;; invoke-id] -> spawned-id (rf2-t07u).
-                        spawn-args  (-> inv
-                                        (assoc :id-prefix    machine-id)
-                                        (assoc :rf/spawned-id spawned-id)
-                                        (assoc :rf/parent-id  parent-id)
-                                        (assoc :rf/invoke-id  invoke-id))
-                        on-spawn-fn (let [aref (:on-spawn inv)]
-                                      (when aref
-                                        (or (chase-ref (:on-spawn-actions machine) aref)
-                                            (chase-ref (:actions machine) aref))))
-                        ;; Per Spec 005 §Declarative :invoke (sugar over spawn):
-                        ;; the :on-spawn callback signature is (fn [data id] new-data).
-                        ;; Per rf2-een2 / rf2-smba: the callback operates on :data
-                        ;; (not the snapshot wrapper), uniform with regular actions
-                        ;; whose canonical contract is (fn [data event] effects).
-                        ;; The runtime patches the returned data back into the snapshot.
-                        ;; Per rf2-t07u (Option A revised): :on-spawn is now purely
-                        ;; advisory user-side bookkeeping — the runtime no longer
-                        ;; depends on the user writing the id under any specific
-                        ;; :data slot. Runtime tracks the spawn-id itself in
-                        ;; [:rf/spawned parent-id invoke-id].
-                        s'          (if on-spawn-fn
-                                      (let [data     (:data s)
-                                            new-data (on-spawn-fn data spawned-id)]
-                                        (if new-data
-                                          (assoc s :data new-data)
-                                          s))
-                                      s)]
-                    ;; Per rf2-3y3y: :timeout-ms / :on-timeout slots on
-                    ;; :invoke are dropped; wall-clock guards on
-                    ;; :invoke-bearing states are expressed via the parent
-                    ;; state's :after slot. Registration-time validation
-                    ;; rejects any :timeout-ms / :on-timeout key with
-                    ;; :rf.error/invoke-timeout-ms-removed.
-                    [s' (vec (concat acc-fx
-                                     [[:rf.machine/spawn spawn-args]]))])
+                        ;; Per Spec 005 §Declarative :invoke (sugar over spawn)
+                        ;; and §Spec-spec keys (rf2-h131): `:data` admits a
+                        ;; function form `(fn [snap ev] data)` so the initial
+                        ;; data can depend on the snapshot at the moment of
+                        ;; entry. The snapshot is the post-action value (the
+                        ;; transition's `:action` has already run, so any
+                        ;; `:data` writes the action made are visible). The
+                        ;; reduction's accumulator `s` is exactly that — the
+                        ;; post-action snapshot, evolved through any prior
+                        ;; sibling-entry `:on-spawn` callbacks. If `:data` is
+                        ;; a fn, materialise it here BEFORE building
+                        ;; `spawn-args`; the spawn-fx handler must see a
+                        ;; literal map (it stamps `:rf/self-id` etc. into
+                        ;; `:data`, which would throw on a fn). Per spec
+                        ;; §Errors: if the fn throws, halt the cascade.
+                        [mat-status mat-data]
+                        (if (contains? inv :data)
+                          (materialise-data (:data inv) s)
+                          [:ok nil])]
+                    (if (= :fail mat-status)
+                      (reduced
+                        [::action-failed
+                         {:action-ref :rf.invoke/data-fn
+                          :exception  mat-data
+                          :invoke-id  invoke-id}])
+                      (let [inv'        (if (contains? inv :data)
+                                          (assoc inv :data mat-data)
+                                          inv)
+                            ;; Carry the resolved id forward so spawn-fx registers
+                            ;; the live handler under the SAME id the :on-spawn
+                            ;; callback observed (rf2-suue lifecycle wiring) AND
+                            ;; the runtime can write [:rf/spawned parent-id
+                            ;; invoke-id] -> spawned-id (rf2-t07u).
+                            spawn-args  (-> inv'
+                                            (assoc :id-prefix    machine-id)
+                                            (assoc :rf/spawned-id spawned-id)
+                                            (assoc :rf/parent-id  parent-id)
+                                            (assoc :rf/invoke-id  invoke-id))
+                            on-spawn-fn (let [aref (:on-spawn inv)]
+                                          (when aref
+                                            (or (chase-ref (:on-spawn-actions machine) aref)
+                                                (chase-ref (:actions machine) aref))))
+                            ;; Per Spec 005 §Declarative :invoke (sugar over spawn):
+                            ;; the :on-spawn callback signature is (fn [data id] new-data).
+                            ;; Per rf2-een2 / rf2-smba: the callback operates on :data
+                            ;; (not the snapshot wrapper), uniform with regular actions
+                            ;; whose canonical contract is (fn [data event] effects).
+                            ;; The runtime patches the returned data back into the snapshot.
+                            ;; Per rf2-t07u (Option A revised): :on-spawn is now purely
+                            ;; advisory user-side bookkeeping — the runtime no longer
+                            ;; depends on the user writing the id under any specific
+                            ;; :data slot. Runtime tracks the spawn-id itself in
+                            ;; [:rf/spawned parent-id invoke-id].
+                            s'          (if on-spawn-fn
+                                          (let [data     (:data s)
+                                                new-data (on-spawn-fn data spawned-id)]
+                                            (if new-data
+                                              (assoc s :data new-data)
+                                              s))
+                                          s)]
+                        ;; Per rf2-3y3y: :timeout-ms / :on-timeout slots on
+                        ;; :invoke are dropped; wall-clock guards on
+                        ;; :invoke-bearing states are expressed via the parent
+                        ;; state's :after slot. Registration-time validation
+                        ;; rejects any :timeout-ms / :on-timeout key with
+                        ;; :rf.error/invoke-timeout-ms-removed.
+                        [s' (vec (concat acc-fx
+                                         [[:rf.machine/spawn spawn-args]]))])))
 
                   (:invoke-all n)
                   ;; Per Spec 005 §Spawn-and-join via :invoke-all (rf2-6vmw).
@@ -785,53 +826,91 @@
                                       :rf/invoke-id invoke-id
                                       :join-state   join-state}]
                         ;; Build per-child spawn-args.
-                        child-spawn-fxs
-                        (mapv
-                          (fn [child]
-                            (let [machine-id (:machine-id child)
-                                  spawned-id (:rf/spawned-id child)
-                                  spawn-args (-> child
-                                                 (dissoc :id)
-                                                 (assoc :id-prefix    machine-id)
-                                                 (assoc :rf/spawned-id spawned-id)
-                                                 (assoc :rf/parent-id  parent-id)
-                                                 ;; The :invoke-all-id ties the spawn back
-                                                 ;; to the parent's join state without
-                                                 ;; re-using the :invoke-id slot meaning.
-                                                 (assoc :rf/invoke-all-id invoke-id)
-                                                 (assoc :rf/invoke-all-child-id (:id child)))]
-                              [:rf.machine/spawn spawn-args]))
-                          children')
-                        ;; Run :on-spawn callbacks per child (advisory).
-                        s' (reduce
-                             (fn [snap child]
-                               (let [aref (:on-spawn child)
-                                     f    (when aref
-                                            (or (chase-ref (:on-spawn-actions machine) aref)
-                                                (chase-ref (:actions machine) aref)))]
-                                 (if f
-                                   (let [data     (:data snap)
-                                         new-data (f data (:rf/spawned-id child))]
-                                     (if new-data (assoc snap :data new-data) snap))
-                                   snap)))
-                             s
-                             children')]
-                    ;; Per rf2-3y3y: :timeout-ms / :on-timeout slots on
-                    ;; :invoke-all are dropped; wall-clock guards on the
-                    ;; whole-join are expressed via the :invoke-all-bearing
-                    ;; state's :after slot.
-                    [s' (vec (concat acc-fx [init-fx] child-spawn-fxs))])
+                        ;; Per Spec 005 §Spec-spec keys (rf2-h131): each child
+                        ;; invoke-spec admits the same `:data` keys as a single
+                        ;; `:invoke`, including the fn-form `(fn [snap ev] data)`.
+                        ;; Materialise here, before passing to the spawn-fx (which
+                        ;; expects a literal map per the post-action snapshot
+                        ;; contract documented at §Declarative `:invoke`).
+                        ;; Materialisation may throw; collect a [:fail e :child-id k]
+                        ;; sentinel so the reducer outer can short-circuit.
+                        child-spawn-build
+                        (reduce
+                          (fn [acc child]
+                            (let [[mat-status mat-data] (if (contains? child :data)
+                                                          (materialise-data (:data child) s)
+                                                          [:ok nil])]
+                              (if (= :fail mat-status)
+                                (reduced [:fail mat-data (:id child)])
+                                (let [machine-id (:machine-id child)
+                                      spawned-id (:rf/spawned-id child)
+                                      child'     (if (contains? child :data)
+                                                   (assoc child :data mat-data)
+                                                   child)
+                                      spawn-args (-> child'
+                                                     (dissoc :id)
+                                                     (assoc :id-prefix    machine-id)
+                                                     (assoc :rf/spawned-id spawned-id)
+                                                     (assoc :rf/parent-id  parent-id)
+                                                     ;; The :invoke-all-id ties the spawn back
+                                                     ;; to the parent's join state without
+                                                     ;; re-using the :invoke-id slot meaning.
+                                                     (assoc :rf/invoke-all-id invoke-id)
+                                                     (assoc :rf/invoke-all-child-id (:id child)))]
+                                  (conj acc [:rf.machine/spawn spawn-args])))))
+                          []
+                          children')]
+                    (if (and (vector? child-spawn-build)
+                             (= :fail (first child-spawn-build)))
+                      (reduced
+                        [::action-failed
+                         {:action-ref :rf.invoke-all/data-fn
+                          :exception  (second child-spawn-build)
+                          :invoke-id  invoke-id
+                          :child-id   (nth child-spawn-build 2)}])
+                      (let [child-spawn-fxs child-spawn-build
+                            ;; Run :on-spawn callbacks per child (advisory).
+                            s' (reduce
+                                 (fn [snap child]
+                                   (let [aref (:on-spawn child)
+                                         f    (when aref
+                                                (or (chase-ref (:on-spawn-actions machine) aref)
+                                                    (chase-ref (:actions machine) aref)))]
+                                     (if f
+                                       (let [data     (:data snap)
+                                             new-data (f data (:rf/spawned-id child))]
+                                         (if new-data (assoc snap :data new-data) snap))
+                                       snap)))
+                                 s
+                                 children')]
+                        ;; Per rf2-3y3y: :timeout-ms / :on-timeout slots on
+                        ;; :invoke-all are dropped; wall-clock guards on the
+                        ;; whole-join are expressed via the :invoke-all-bearing
+                        ;; state's :after slot.
+                        [s' (vec (concat acc-fx [init-fx] child-spawn-fxs))])))
 
                   :else
                   [s acc-fx]))
               [snap-final []]
-              entered-pairs))
-          all-fx (vec (concat fx
-                              (or after-cancel-fx [])
-                              (or destroy-fx [])
-                              spawn-fx
-                              (or after-fx [])))]
-      [snap-after-spawns all-fx])))))
+              entered-pairs))]
+      ;; Per rf2-h131: if any :invoke / :invoke-all `:data` fn-form threw
+      ;; during materialisation, the reduce short-circuited with
+      ;; `[::action-failed info]`. Propagate the same sentinel
+      ;; machine-transition expects from collect-actions so the cascade
+      ;; halts cleanly with `:rf.error/machine-action-exception`.
+      (if (and (vector? spawn-result)
+               (= ::action-failed (first spawn-result)))
+        [::action-failed (assoc (second spawn-result)
+                                :decl-path  decl-path
+                                :transition transition
+                                :state-path src-path)]
+        (let [[snap-after-spawns spawn-fx] spawn-result
+              all-fx (vec (concat fx
+                                  (or after-cancel-fx [])
+                                  (or destroy-fx [])
+                                  spawn-fx
+                                  (or after-fx [])))]
+          [snap-after-spawns all-fx])))))))
 
 (defn- pick-always-transition
   "Per Spec 005 §Eventless :always transitions: walk path leaf→root

--- a/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
@@ -1,0 +1,209 @@
+(ns re-frame.invoke-data-fn-form-test
+  "Per rf2-h131 and Spec 005 §Declarative `:invoke` (sugar over spawn)
+  §Spec-spec keys: `:data` admits a function form `(fn [snap ev] data)`
+  so the spawned child's initial data can be derived from the parent's
+  post-action snapshot + the triggering event.
+
+  The four invariants under test:
+
+   1. **Literal-map `:data` (regression).** A literal map is passed
+      through verbatim — the back-compat path that pre-rf2-h131
+      already worked.
+
+   2. **fn-form `:data` is materialised.** When `:data` is a fn, the
+      runtime invokes `(data snap event)` and passes the resulting
+      map (NOT the fn itself) to the spawned child.
+
+   3. **fn-form sees the post-action snapshot.** A transition's
+      `:action` writes to `:data`; the fn-form sees those writes.
+      Per Spec 005 line 1511.
+
+   4. **fn-form throw routes to :rf.error/machine-action-exception.**
+      Per Spec 005 §Errors line 1597 — same category as any
+      user-supplied fn that throws during a machine action.
+
+  Also covers `:invoke-all` symmetrically — each child's `:data` admits
+  the same fn-form per Spec 005 §Spec-spec keys (line 1818)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- snapshot
+  [machine-id]
+  (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
+
+(defn- frame-db []
+  (rf/get-frame-db :rf/default))
+
+;; ---- (1) literal-map :data — back-compat regression -----------------------
+
+(deftest literal-map-data-passes-through
+  (testing "literal-map `:data` arrives at the spawned child verbatim"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:invoke {:machine-id :worker/proc
+                                      :data       {:url "/api/foo" :method :get}}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/literal parent)
+      (rf/dispatch-sync [:sup/literal [:start]])
+      (let [child-data (:data (snapshot :worker/proc#1))]
+        (is (= "/api/foo" (:url child-data))
+            "the literal map's :url survived the spawn")
+        (is (= :get (:method child-data))
+            "the literal map's :method survived the spawn")))))
+
+;; ---- (2) fn-form :data — materialised at spawn ----------------------------
+
+(deftest fn-form-data-is-materialised
+  (testing "fn-form `:data` is invoked; the spawned child receives the resulting map, NOT the fn"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :data    {:endpoint "/api/login"}
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:invoke {:machine-id :worker/proc
+                                      :data       (fn [snap _]
+                                                    {:url    (-> snap :data :endpoint)
+                                                     :method :post})}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/fn-form parent)
+      (rf/dispatch-sync [:sup/fn-form [:start]])
+      (let [child-data (:data (snapshot :worker/proc#1))]
+        (is (map? child-data)
+            "the spawned child's :data is a literal map, not the fn")
+        (is (= "/api/login" (:url child-data))
+            "the fn-form derived :url from the parent's :data.:endpoint")
+        (is (= :post (:method child-data))
+            "the fn-form-derived :method survived the spawn")
+        ;; Runtime stamps :rf/self-id etc. into :data per rf2-ijm7 — the
+        ;; materialised map is the BASE the runtime then augments.
+        (is (= :worker/proc#1 (:rf/self-id child-data))
+            "the runtime stamped :rf/self-id over the materialised map")))))
+
+;; ---- (3) fn-form sees post-action snapshot --------------------------------
+
+(deftest fn-form-data-sees-post-action-snapshot
+  (testing "fn-form `:data` sees `:data` writes the transition's `:action` made (post-action snapshot per Spec 005:1511)"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :data    {:base-url "http://api.example.com"}
+                  :actions {:assemble-endpoint
+                            (fn [data _]
+                              ;; The action writes :endpoint into :data;
+                              ;; the :invoke :data fn must see it.
+                              {:data (assoc data :endpoint
+                                            (str (:base-url data) "/v1/me"))})}
+                  :states
+                  {:idle    {:on {:start {:target :working
+                                          :action :assemble-endpoint}}}
+                   :working {:invoke {:machine-id :worker/proc
+                                      :data       (fn [snap _]
+                                                    {:url (-> snap :data :endpoint)})}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/post-action parent)
+      (rf/dispatch-sync [:sup/post-action [:start]])
+      (is (= "http://api.example.com/v1/me"
+             (:url (:data (snapshot :worker/proc#1))))
+          "fn-form saw :data after :assemble-endpoint ran"))))
+
+;; ---- (3b) fn-form sees the triggering event -------------------------------
+
+(deftest fn-form-data-sees-triggering-event
+  (testing "fn-form `:data` receives the inbound event vector as its second arg"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:fetch :working}}
+                   :working {:invoke {:machine-id :worker/proc
+                                      :data       (fn [_ ev]
+                                                    {:from-event ev})}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/event-form parent)
+      (rf/dispatch-sync [:sup/event-form [:fetch :req-1]])
+      (is (= [:fetch :req-1]
+             (:from-event (:data (snapshot :worker/proc#1))))
+          "fn-form's second arg was the triggering event"))))
+
+;; ---- (4) fn-form throw routes to :rf.error/machine-action-exception ------
+
+(deftest fn-form-data-throw-routes-to-machine-action-exception
+  (testing "fn-form `:data` throw halts the cascade and emits :rf.error/machine-action-exception (Spec 005:1597)"
+    (let [traces (atom [])
+          child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:invoke {:machine-id :worker/proc
+                                      :data       (fn [_ _]
+                                                    (throw (ex-info "boom" {:why :test})))}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/throwing parent)
+      (try
+        (trace/register-trace-cb! ::h131-error
+                                  (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:sup/throwing [:start]])
+        ;; The cascade halted: no actor was spawned. Per Spec 005 §Errors,
+        ;; the snapshot does NOT commit — the parent's lazy initial snapshot
+        ;; is preserved (or stays absent if it was never materialised).
+        (is (nil? (snapshot :worker/proc#1))
+            "no spawned actor — the cascade halted before spawn-fx ran")
+        (let [parent-snap (snapshot :sup/throwing)]
+          (is (or (nil? parent-snap)
+                  (= :idle (:state parent-snap)))
+              "parent did not commit the transition (snapshot is either absent or still :idle)"))
+        ;; The error trace fired with the canonical category. Per Spec 009,
+        ;; error traces carry :op-type :error and the category as :operation.
+        (is (some #(and (= :error (:op-type %))
+                        (= :rf.error/machine-action-exception (:operation %)))
+                  @traces)
+            "an :rf.error/machine-action-exception trace was emitted")
+        (finally (trace/remove-trace-cb! ::h131-error))))))
+
+;; ---- (5) :invoke-all child :data fn-form is materialised ------------------
+
+(deftest invoke-all-child-data-fn-form-is-materialised
+  (testing "each :invoke-all child's `:data` admits the same fn-form per Spec 005:1818"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :data    {:base "/api"}
+                  :states
+                  {:idle      {:on {:fan-out :hydrating}}
+                   :hydrating {:invoke-all
+                               {:children
+                                [{:id         :one
+                                  :machine-id :hydra/leaf
+                                  :data       (fn [snap _]
+                                                {:url (str (-> snap :data :base) "/one")})}
+                                 {:id         :two
+                                  :machine-id :hydra/leaf
+                                  :data       (fn [snap _]
+                                                {:url (str (-> snap :data :base) "/two")})}]
+                                :on-child-done   :child/done
+                                :on-child-error  :child/error
+                                :on-all-complete [:done]}}}}]
+      (rf/reg-machine :hydra/leaf child)
+      (rf/reg-machine :sup/all parent)
+      (rf/dispatch-sync [:sup/all [:fan-out]])
+      ;; Two children spawned, each with materialised :data.
+      (is (= "/api/one"
+             (:url (:data (snapshot :hydra/leaf#1))))
+          "first child's fn-form derived :url from parent's :data")
+      (is (= "/api/two"
+             (:url (:data (snapshot :hydra/leaf#2))))
+          "second child's fn-form derived :url from parent's :data"))))

--- a/implementation/machines/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_cljs_test.cljs
@@ -538,6 +538,53 @@
                 @traces)
           "expected :rf.machine/destroyed trace targeting :http/post#1"))))
 
+;; ---- (4a') :invoke :data fn-form materialised at spawn (rf2-h131) ---------
+;; Per Spec 005 §Spec-spec keys (line 1503/1511): `:data` admits a function
+;; form `(fn [snap ev] data)` so the spawned child's initial data can be
+;; derived from the parent's post-action snapshot + the triggering event.
+;; The runtime materialises the fn before passing the value to the
+;; spawn-fx (which expects a literal map).
+
+(deftest machine-invoke-data-fn-form-cljs
+  (testing "fn-form `:data` is materialised — spawned child receives the result map, NOT the fn"
+    (let [child   {:initial :running :data {} :states {:running {}}}
+          parent  {:initial :idle
+                   :data    {:endpoint "/api/login"}
+                   :states
+                   {:idle    {:on {:start :working}}
+                    :working {:invoke {:machine-id :h131/worker
+                                       :data       (fn [snap _]
+                                                     {:url    (-> snap :data :endpoint)
+                                                      :method :post})}}}}]
+      (rf/reg-machine :h131/worker child)
+      (rf/reg-machine :h131/sup parent)
+      (rf/dispatch-sync [:h131/sup [:start]])
+      (let [child-data (:data (snapshot :h131/worker#1))]
+        (is (map? child-data)
+            "spawned child's :data is a literal map, not the fn")
+        (is (= "/api/login" (:url child-data))
+            "fn-form derived :url from the parent's :data.:endpoint")
+        (is (= :post (:method child-data))
+            "fn-form-derived :method survived the spawn"))))
+  (testing "fn-form `:data` sees the post-action snapshot (Spec 005:1511)"
+    (let [child   {:initial :running :data {} :states {:running {}}}
+          parent  {:initial :idle
+                   :data    {:base "https://api.example.com"}
+                   :actions {:assemble (fn [data _]
+                                         {:data (assoc data :endpoint
+                                                       (str (:base data) "/v1/me"))})}
+                   :states
+                   {:idle    {:on {:go {:target :working :action :assemble}}}
+                    :working {:invoke {:machine-id :h131b/worker
+                                       :data       (fn [snap _]
+                                                     {:url (-> snap :data :endpoint)})}}}}]
+      (rf/reg-machine :h131b/worker child)
+      (rf/reg-machine :h131b/sup parent)
+      (rf/dispatch-sync [:h131b/sup [:go]])
+      (is (= "https://api.example.com/v1/me"
+             (:url (:data (snapshot :h131b/worker#1))))
+          "fn-form saw the :data writes the transition's :action made"))))
+
 ;; ---- (4b) state-level :after on :invoke-bearing state (rf2-3y3y) ----------
 ;; Per Spec 005 §Wall-clock timeouts on :invoke — use parent state's :after.
 ;; The pre-rf2-3y3y :timeout-ms slot on :invoke / :invoke-all is dropped;


### PR DESCRIPTION
## Summary

Spec 005 §Spec-spec keys documents `:invoke :data` admitting a function form `(fn [snap ev] data)` so the spawned child's initial data can be derived from the parent's post-action snapshot + the triggering event. The runtime gap: `apply-transition-once` copied `:data` through verbatim, so a fn-form resulted in the runtime attempting `(assoc fn :rf/self-id ...)` inside `spawn-fx` — throws on JVM, silent fail on CLJS.

This PR implements path A (per the bead) — materialise the fn at spawn, against the loop-evolving accumulator snapshot (matching the spec's "moment of entry" semantics — each entered state's `:invoke` sees the snapshot as it was when this state's entry fires, including any prior sibling-entry `:on-spawn` writes) and the triggering event. Per Spec 005 §Errors line 1597, fn-form throws route through the canonical `::action-failed` short-circuit `collect-actions` already uses — no new error category, no new trace tag.

Symmetric fix for `:invoke-all` child `:data` per Spec 005:1818.

## Audit evidence (path picking)

- **Spec advertises the feature.** Spec 005 lines 1503 (table), 1511 (key extension), 1524 (desugaring rule "with `:data` materialised — call the fn if `:data` is a fn"), 1532-1542 (worked example), 1597 (the error category), 1622-1624 (login flow worked example), 1818 (`:invoke-all` admits the same).
- **Implementation gap is real.** `apply-transition-once` :invoke reduction at lines 706-755 (pre-fix) copied `inv` into `spawn-args` without invoking `:data`.
- **No fixtures use fn-form.** All fixtures (`invoke-spawn-on-entry-destroy-on-exit.edn` and friends) use literal maps. CI green ≠ feature works.
- **No callers use fn-form today.** Including the freshly-merged rf2-ijm7 HTTP wrapper tests — which use literal maps because they don't need parent-snapshot-derived data, not as a workaround.
- **Spec-tightening would lose a real feature.** The fn-form is the headline example for parent-snapshot-derived child data (e.g., HTTP children with parent-derived URL parameters / auth tokens). Implementing is ~30 lines of the runtime change; documenting-it-away would be more invasive than fixing it.

## Files touched

- `implementation/machines/src/re_frame/machines.cljc` — :invoke + :invoke-all materialisation + ::action-failed short-circuit propagation
- `implementation/machines/test/re_frame/invoke_data_fn_form_test.clj` (new) — JVM tests
- `implementation/machines/test/re_frame/machines_cljs_test.cljs` — CLJS tests

## Test plan

- [x] New JVM tests: `invoke_data_fn_form_test.clj` — 6 tests / 13 assertions covering literal-map regression, fn-form materialisation, post-action visibility, event arg, throw routing, `:invoke-all` child fn-form
- [x] New CLJS tests: `machine-invoke-data-fn-form-cljs` — 2 testing blocks / 4 assertions
- [x] `cd implementation/machines && clojure -M:test` — 55 tests / 175 assertions / 0 failures
- [x] `cd implementation/core && clojure -M:test` — 183 tests / 824 assertions / 0 failures (includes conformance suite)
- [x] `cd implementation/http && clojure -M:test` — 35 tests / 107 assertions / 0 failures
- [x] `cd implementation/{epoch,flows,routing,schemas,ssr} && clojure -M:test` — all green
- [x] `npm run test:elision` — PASS (no schema sentinels in prod, all expected sentinels present in control)
- [x] `npm run test:cljs` — 419 tests / 1010 assertions / 0 failures

## rf2-ijm7 follow-up

The bead asked whether rf2-ijm7's JVM test workaround can be reverted. Audit shows those tests use literal-map `:data` because the use case is literal request data — not a workaround. No revert needed.