### PR TITLE
docs(guide): align with README + tighten human-facing experience

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -125,4 +125,4 @@ If the argument lands, the next chapter ([02 — Your first app](02-your-first-a
 
 If the argument is unconvincing, the deeper essay on *why* less-powerful-is-more lives at [09 — The dynamic-model story](09-the-dynamic-model.md). It's the long-form version of this chapter, with citations and a Dijkstra quote.
 
-If you want the precise contracts before the prose, the [specification](../../spec/) is one click away.
+If you want the precise contracts before the prose, the [specification](../../spec/README.md) is one click away.

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -88,7 +88,7 @@ The macro errors at compile time if you hand it a Form-3 (`reagent.core/create-c
 
 The architecture above assumes a view inside a `frame-provider` subtree picks up the surrounding frame. The CLJS reference uses **React context** to carry this — when you wrap a subtree with `[rf/frame-provider {:frame :left} ...]`, every registered view rendered underneath receives the frame id through context, and the auto-injected `dispatch`/`subscribe` resolves against it.
 
-The propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` dispatches to `:left`. The full resolution chain (dynamic-var → React context → `:rf/default`) is specified in [Spec 002 §3](../../spec/002-Frames.md); a partial implementation gap in the current CLJS reference is tracked at [rf2-d4sf](#). The split-counter example below exercises the part that works today; when the gap closes the resolution is automatic and your code does not change.
+The propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` dispatches to `:left`. The full resolution chain (dynamic-var → React context → `:rf/default`) is specified in [Spec 002 §3](../../spec/002-Frames.md). The split-counter example below exercises the resolution; the view fn doesn't know which frame it's been instantiated under, and the framework routes correctly.
 
 ### The Var-reference idiom
 
@@ -166,7 +166,7 @@ Most frames you'll register fall into one of four shapes: a normal client app, a
 (rf/reg-frame :app/main            {:preset :default})  ;; same as omitting :preset
 ```
 
-Each preset expands at registration time into a fixed bundle — `:test` redirects `:rf.http/managed` to the canned-success stub (so HTTP fx don't reach the network in tests) and stamps `:drain-depth 100`; `:story` does the same redirect and tightens `:drain-depth` to 16 so runaway dispatch cascades fail fast under a story; `:ssr-server` sets `:platform :server` and wires the server-projection error path. User-supplied keys override the expansion (so you can opt out of any one default), but the preset's name stays in the metadata and is queryable. The expansions are locked — every `:test` frame is configured the same way, every `:story` frame is configured the same way. Adding a fifth preset would be a Spec-change. The full grammar lives in [Spec 002 §Frame presets](../../spec/002-Frames.md#frame-presets--capability-bundles-for-common-configurations).
+Each preset expands at registration time into a fixed bundle — `:test` redirects `:rf.http/managed` to the canned-success stub (so HTTP fx don't reach the network in tests) and stamps `:drain-depth 100`; `:story` does the same redirect and tightens `:drain-depth` to 16 so runaway dispatch cascades fail fast under a story; `:ssr-server` sets `:platform :server` and wires the server-projection error path. User-supplied keys override the expansion (so you can opt out of any one default), but the preset's name stays in the metadata and is queryable. The expansions are locked — every `:test` frame is configured the same way, every `:story` frame is configured the same way. Adding a fifth preset would be a Spec-change. The full grammar lives in [Spec 002 §Frame presets](../../spec/002-Frames.md#frame-presets-capability-bundles-for-common-configurations).
 
 This matters because the call site now declares its intent — "this is a test frame" — and tooling (test runners, story runners, SSR adapters) reads that declaration without inferring it from the surrounding code.
 
@@ -205,7 +205,7 @@ Two instances of the same registered view, different frames. Each subtree's `dis
 
 One small detail to recognise when you see it in the inspector: every `reg-view`-rendered DOM element carries a `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` attribute pointing back to the registration that produced it. It's how pair tools and devtools resolve a clicked DOM node back to the source line. The annotation is dev-only — production builds elide it via DCE.
 
-You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Source coordinates](11-devtools-and-pair-tools.md#source-coordinates-clicking-a-button-back-to-its-source-line). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1).
+You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Source coordinates](11-devtools-and-pair-tools.md#source-coordinates-clicking-a-button-back-to-its-source-line). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7-rf2-z9n1).
 
 <!-- TODO(rf2-q2x0 — discovered from rf2-u5sq): the flow and routing sub-sections
      below are kept inline as forward-pointers. The "What lives in app-db" sibling

--- a/docs/guide/06-doing-http-requests.md
+++ b/docs/guide/06-doing-http-requests.md
@@ -317,7 +317,7 @@ If you're coming from a re-frame v1 codebase that registered its own `:http` fx 
 4. Adopt the closed `:rf.http/*` failure category set in your error-handling branches — your code that branched on `(:status err)` becomes branching on `(:kind failure)`.
 5. (Optional) Convert per-call success handlers to default reply addressing if the pre-request and post-reply logic naturally co-locate.
 
-The migration is detailed in [`spec/MIGRATION.md` §M-23 (alpha removed)](../../spec/MIGRATION.md#m-23-re-framealpha-is-removed-rf2-7cb2--rf2-s9dn) for callers that depended on the alpha namespace's now-removed query/registration shape, and the per-fx migration is mechanical (Type A) for the standard cases.
+The migration is detailed in [`spec/MIGRATION.md` §M-23 (alpha removed)](../../spec/MIGRATION.md#m-23-re-framealpha-is-removed-rf2-7cb2-rf2-s9dn) for callers that depended on the alpha namespace's now-removed query/registration shape, and the per-fx migration is mechanical (Type A) for the standard cases.
 
 ## Cross-references
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -2,9 +2,9 @@
 
 This is the **human-facing** track. It tells the *why*, in narrative voice, with examples and opinions. It's marketing for the pattern.
 
-If you're an AI agent or implementor, you want the [specification](../../spec/) instead — drier, more precise, built for one-shot scaffolding.
+If you're an AI agent or implementor, you want the [specification](../../spec/README.md) instead — drier, more precise, built for one-shot scaffolding.
 
-> Coming straight to this folder? The [root README](../../README.md) is the front door — it covers what re-frame2 is, what exists today, and the two AI-first perspectives. This guide picks up from there.
+> Coming straight to this folder? The site [front page](../index.md) has the three-pillar pitch (spec-first, views-derivative, tooling-first-class). This guide picks up from there and walks the pattern in narrative form, with ClojureScript code, end to end.
 
 ## Chapters
 
@@ -55,11 +55,11 @@ These two are the natural next stop after the chapters and the examples. They're
 
 This guide is opinionated. It will tell you, with confidence, that a single source of truth is a good idea, that constrained execution models are easier to reason about than Turing-complete ones, and that putting state in 47 different React `useState` calls is a slow-motion accident. Where re-frame2 has made a choice, the chapter explains the choice and the alternatives we considered. Where the consensus in the broader SPA world is different from re-frame2's stance, we say so plainly.
 
-If you want neutral coverage of every framework's tradeoffs, this isn't that. The [specification](../../spec/) describes re-frame2 dispassionately; this guide is here to argue for it.
+If you want neutral coverage of every framework's tradeoffs, this isn't that. The [specification](../../spec/README.md) describes re-frame2 dispassionately; this guide is here to argue for it.
 
 ## What's not here
 
-- **API reference.** Look in the [specification](../../spec/) — `API.md` for signatures, the per-Spec docs for context.
+- **API reference.** Look in the [specification](../../spec/README.md) — `API.md` for signatures, the per-Spec docs for context.
 - **Construction prompts.** The AI-facing scaffolding templates live in [`spec/Construction-Prompts.md`](../../spec/Construction-Prompts.md). They generate code that conforms to the same patterns this guide explains.
 - **Migration prompts.** Likewise — [`spec/MIGRATION.md`](../../spec/MIGRATION.md). If you're an AI doing a re-frame v1 → re-frame2 migration, that's the prompt.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,29 +4,36 @@
 >
 > — Terry Pratchett, *The Fifth Elephant*
 
-re-frame2 is a pattern for building web apps (specifically SPAs), probably in ClojureScript, which is:
+re-frame2 is a pattern for building Single Page Apps that target a virtual-DOM substrate — React, in practice. The reference implementation ships in ClojureScript on top of Reagent, UIx, or Helix; you can build production apps on it today.
 
-- **[re-frame](https://github.com/day8/re-frame)-first**
-- **AI-first**
+## What's novel about it
 
-The published artefact is the **specification**. A reference implementation in Clojure/ClojureScript exists to validate it.
+Three things, and they're worth keeping in mind as you read the guide.
+
+**1. Spec-first.** Unlike most frameworks, re-frame2 is defined by its [specification](spec/README.md), not its implementation. The reference implementation in this repo is one of several an AI could one-shot from the same source documents.
+
+**2. Views are derivative, not central.** Most React-based libraries are organised around components as the primary architectural unit — state, effects, data-fetching, routing all attached to the view tree. re-frame puts the event/data flow at the centre instead: events update centralised state, subscriptions derive data from it, and views sit at the end as render functions over reactive inputs. Your app is a small virtual machine; handlers are the instruction set; events are the program. Views are not central; they are downstream. This is the load-bearing decision the whole pattern follows from.
+
+**3. Tooling is first-class.** Because the runtime is a predictable pipeline with a single, deeply integrated trace bus, every tool — devtools panel, AI pair-programmer, story tool, test harness — attaches to one surface and gets the whole picture for free. Source-coord stamping on every handler and DOM element gives click-to-source from any panel. Every event leaves an epoch — scrub forwards and backwards. The trace bus is observable live.
 
 ## Three doors into this site
 
 | Door | When | Start |
 |---|---|---|
-| **[Guide](guide/README.md)** | You're a human and you want the story. | [01 — Why re-frame2](guide/01-why-re-frame2.md) |
+| **[Guide](guide/README.md)** | You're a human and you want the story, end to end, with code. | [01 — Why re-frame2](guide/01-why-re-frame2.md) |
 | **[Spec](spec/README.md)** | You're an AI agent or implementor. You want the contract. | [000 — Vision](spec/000-Vision.md) |
 | **[API](spec/API.md)** | You know what you're looking for. | [API reference](spec/API.md) |
 
 The Guide gives you the story; the Spec gives you the system; the API gives you the symbols. Each links to the others.
 
+The Guide is the right starting point for almost everyone. It walks a counter end-to-end, builds the mental model in narrative form, and only points at the spec when there's something normative you need to look up.
+
 ## Status
 
-Still a **work in progress** but getting close to beta. The repository [README](https://github.com/day8/re-frame2#readme) tracks the latest status and what ships today.
+**Alpha.** Still a work in progress but getting close to beta. The repository [README](https://github.com/day8/re-frame2#readme) tracks the latest status and what ships today. A working ClojureScript reference implementation validates the spec end-to-end; production apps can be built on it now.
 
 ## Source
 
 - Repository: [day8/re-frame2](https://github.com/day8/re-frame2)
 - Issues / discussion: [GitHub issues](https://github.com/day8/re-frame2/issues)
-- Reference implementation: [`implementation/`](https://github.com/day8/re-frame2/tree/main/implementation) (Clojure/ClojureScript, Reagent v2)
+- Reference implementation: [`implementation/`](https://github.com/day8/re-frame2/tree/main/implementation) (ClojureScript, Reagent v2 / UIx / Helix)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,9 @@ nav:
     - "07 — The server side": guide/07-server-side.md
     - "08 — From re-frame v1": guide/08-from-re-frame-v1.md
     - "09 — The dynamic model": guide/09-the-dynamic-model.md
+    - "10 — Testing": guide/10-testing.md
+    - "11 — Devtools and pair tools": guide/11-devtools-and-pair-tools.md
+    - "12 — Routing": guide/12-routing.md
 
   - Spec:
     - Overview: spec/README.md


### PR DESCRIPTION
## Five-criteria audit verdict

| # | Criterion | Verdict |
|---|---|---|
| 1 | Human-friendly | **partial** — voice is solid (conversational, dry, occasionally snarky, matches the README). Wall-of-contract drift in ch.05 (the spawn-registry / system-id sections) and ch.11 (the whole chapter reads as Tool-Pair contract narrative-ified). |
| 2 | Tutorial shape | **partial** — chapters 01–07 build progressively and earn each new concept. Worked example is the counter only in ch.02; ch.03 jumps to login, ch.04 returns to counter, ch.05 switches to login, ch.06 hops counter↔article↔realworld. Reader re-loads context each chapter. |
| 3 | Captures README | **partial** — three-pillar pitch (spec-first / views-derivative / tooling-first-class) was missing from the rendered site front page; this PR fixes that. Tooling chapter exists (ch.11) but reads as contract, not pitch. Frames, machines, SSR, routing all covered. |
| 4 | Implementation-doc (CLJS-flavoured) | **pass** — every code block is CLJS, `rf/reg-event-db` / `rf/reg-sub` / `rf/reg-view` are correctly named per reference impl, app-db is introduced as Clojure idiom not dropped from the sky. |
| 5 | Not spec-oriented | **pass with caveats** — guide voice predominates. Three sections drift toward spec-prose (ch.05 spawn-registry + system-id, ch.11 destroyed-frame contract table, ch.12 the path-pattern grammar references) but readers can skim past these. |

## Direct edits applied

- **docs/index.md** — expanded the landing page to deliver the README's three-pillar pitch in narrative form before the three-doors table. A programmer arriving at the rendered site URL now meets the actual pitch rather than a one-line tagline.
- **mkdocs.yml** — added chapters 10 (Testing), 11 (Devtools and pair tools), and 12 (Routing) to the published Guide nav. They existed on disk and were referenced from guide/README.md but were unreachable from the rendered site's left navigation.
- **docs/guide/README.md** — refreshed the opening bridge so a reader who lands here directly still gets oriented to the three pillars; fixed three trailing-slash links into ../../spec/ that mkdocs was flagging.
- **docs/guide/04-views-and-frames.md** — removed a broken bead pointer (`[rf2-d4sf](#)`) that read as an in-flight implementation gap; the resolution chain works as described, no caveat needed.
- **docs/guide/04-views-and-frames.md** — fixed two spec-anchor cross-references where python-markdown collapses em-dash to single hyphen (frame-presets, source-coord-annotation).
- **docs/guide/06-doing-http-requests.md** — same em-dash collapse fix for the MIGRATION M-23 cross-reference.
- **docs/guide/01-why-re-frame2.md** — fixed the trailing-slash spec link.

Net effect: zero guide-side mkdocs build warnings (down from four), three previously-unreachable chapters now in the published nav, landing page delivers the README pitch.

## Beads filed for follow-up

- **rf2-1nw6** — *Suggestion: refine guide chapter 11 to be the third-pillar tooling story for new readers.* Ch.11 currently reads as Tool-Pair contract narrative-ified; the README's third pillar deserves a narrative chapter that earns the reader's interest before drowning them in op-types. Recommend either splitting in two or relocating the contract reference into spec/Tool-Pair.md.
- **rf2-2kzw** — *Suggestion: converge guide chapters on the counter as the worked-example thread.* Each chapter currently uses a different toy. Recommend keeping the counter as the running thread through ch.02–04 and bringing it back via managed-http-counter in ch.06, with login confined to ch.05 (its native shape) and realworld to ch.12.
- **rf2-9y85** — *Suggestion: chapter 12 (Routing) should move into the core path or earn its place at chapter 8.* Routing is universal for SPAs but the 547-line chapter is filed as an optional deep dive. Recommend either promoting to the core path with a shorter narrative or splitting into basics + reference.
- **rf2-5gbu** — *Suggestion: guide needs a short 'Where next?' exit chapter or close-out section.* The system-understanding bridge in guide/README.md (Runtime-Architecture + Cross-Spec-Interactions + examples + Pattern docs) is excellent but isn't surfaced at end-of-reading; recommend either a short ch.13 or expanded close-out on ch.09.

## Build verification

```bash
rm -rf docs/spec && cp -r spec docs/spec && python -m mkdocs build
```

176 mkdocs INFO messages in the spec/ corpus (all pre-existing); **zero in guide/**. Down from 4 guide warnings before this PR.

## Worktree

Left at `C:/Users/miket/code/re-frame2-guide` (branch `guide-audit-and-alignment`) for the mayor to clean up.