### PR TITLE
docs(guide): reorder routing chapter — basics first (rf2-9y85)

### DIFF
--- a/docs/guide/12-routing.md
+++ b/docs/guide/12-routing.md
@@ -8,6 +8,8 @@ There is no separate routing runtime. There are no route-aware components. There
 
 This chapter walks through the routing surface: registering routes, navigating, reading the route in views, the navigation token that suppresses stale loads, the `:can-leave` protocol for unsaved-changes prompts, and how multi-frame apps handle routes that don't push to the URL.
 
+The chapter has two halves. The **basics** (everything up to the "Reference and advanced topics" divider) get you to a working URL ↔ state ↔ view loop: registering routes, navigating, reading the route, loading data, the not-found route. Read that part top-to-bottom. The **reference half** that follows is per-topic: `:on-error`, `:can-leave`, nav-tokens, query-string knobs, multi-frame routing, the pure helpers, the RealWorld worked example, tooling hooks. Read those sections when the topic comes up, not as the next-link in the linear sequence.
+
 You'll know how to:
 
 - Register a route with path params, query params, defaults, and retain keys.
@@ -216,28 +218,6 @@ Semantics:
 
 The `:on-match` list is the **enumerable, machine-readable** answer to "what loads when this route is active?"
 
-## Per-route error handling: `:on-error`
-
-If any event in `:on-match` errors, the runtime:
-
-1. Sets `:rf.route/transition` to `:error`.
-2. Populates `:rf.route/error` with the structured error map.
-3. If the route declares an `:on-error` event, dispatches it. The error map is available via `(:error (:rf/route db))`.
-
-```clojure
-(rf/reg-route :route/cart
-  {:path     "/cart"
-   :on-match [[:cart/load-items]]
-   :on-error [:route/cart-load-failed]})
-
-(rf/reg-event-fx :route/cart-load-failed
-  (fn [{:keys [db]} _]
-    (let [error (get-in db [:rf/route :error])]
-      {:db (assoc-in db [:cart :load-error] (:rf.error/message error))})))
-```
-
-`:on-error` is **route-scoped** error handling, layered over [Spec 009](../../spec/009-Instrumentation.md)'s structured error contract — it doesn't replace it. The structured error trace event still fires; `:on-error` is the route's response to it.
-
 ## The `:rf.route/not-found` route
 
 Apps **must** register a `:rf.route/not-found` route. The id is special-cased in one direction: when a URL fails to match any registered route, the runtime sets `:rf/route` to `{:id :rf.route/not-found :params {:url <url>} ...}` and proceeds with that route's `:on-match` events.
@@ -262,6 +242,34 @@ It's an ordinary `reg-route` — `:on-match`, `:on-error`, `:scroll`, `:tags` al
 If no `:rf.route/not-found` is registered, the runtime emits a `:rf.warning/no-not-found-route` trace and falls back to a built-in placeholder view (a minimal `<h1>Not Found</h1>` page) so the request still produces a response. Test fixtures and the conformance corpus assume the user-registered shape.
 
 URL-validation failures (a route's path matches but its `:params` schema rejects the captured values) also route here, with `:reason :validation` in the `:params` slice.
+
+---
+
+## Reference and advanced topics
+
+The sections that follow are per-topic reference material. They're independent of one another — reach for them when the topic comes up. `:on-error` is the route's response to a load failure. `:can-leave` blocks navigation when you have unsaved work. Nav-tokens are the framework's stale-result suppression mechanism (mostly transparent — you'll meet them when you write an async `:on-match` continuation). Query strings, multi-frame routing, the pure `match-url` / `route-url` helpers, and the RealWorld worked example round out the surface. Tooling and AI-amenability close the chapter.
+
+## Per-route error handling: `:on-error`
+
+If any event in `:on-match` errors, the runtime:
+
+1. Sets `:rf.route/transition` to `:error`.
+2. Populates `:rf.route/error` with the structured error map.
+3. If the route declares an `:on-error` event, dispatches it. The error map is available via `(:error (:rf/route db))`.
+
+```clojure
+(rf/reg-route :route/cart
+  {:path     "/cart"
+   :on-match [[:cart/load-items]]
+   :on-error [:route/cart-load-failed]})
+
+(rf/reg-event-fx :route/cart-load-failed
+  (fn [{:keys [db]} _]
+    (let [error (get-in db [:rf/route :error])]
+      {:db (assoc-in db [:cart :load-error] (:rf.error/message error))})))
+```
+
+`:on-error` is **route-scoped** error handling, layered over [Spec 009](../../spec/009-Instrumentation.md)'s structured error contract — it doesn't replace it. The structured error trace event still fires; `:on-error` is the route's response to it.
 
 ## Navigation tokens — stale-result suppression
 


### PR DESCRIPTION
## Summary

Ch.12 (Routing) was a 547-line deep-dive that interleaved the essential basics (URL ↔ state ↔ view loop) with reference material (\`:on-error\`, nav-tokens, \`:can-leave\`, query knobs, multi-frame routing, pure helpers, RealWorld worked example). Readers wanting basics had to scroll past advanced material; readers looking up reference material had to scroll past intro prose.

Per the bead's decision criteria, I picked **option B** (reposition in place) over option A (split into two files). Rationale:

- The chapter's worked example (the RealWorld scaffold) threads basics AND reference together — it uses \`:can-leave\`, \`:tags\`, the auth-guard interceptor. Splitting basics into one file and reference into another would either:
  1. Force the worked example into the reference file (making the basics file abstract and missing its capstone), or
  2. Force forward-pointers from the basics file to the reference for content the worked example uses inline.
- The existing classification in \`guide/README.md\` already positions ch.12 as an optional deep-dive (not core path). Renumbering to promote it would create cross-link churn for marginal benefit.

## Changes

- Move \`:rf.route/not-found\` ahead of \`:on-error\` so the basics half runs: intro → artefact → registering → slice → navigation event → URL changes → reading → linking → \`:on-match\` → not-found.
- Insert an explicit \`## Reference and advanced topics\` divider with a short index paragraph naming the per-topic sections that follow (\`:on-error\`, nav-tokens, \`:can-leave\`, query strings, multi-frame, pure helpers, worked example, tooling).
- Update the chapter intro to flag the two-half structure so readers know what to skim and what to read top-to-bottom.

No renumbering, no nav changes, no cross-link churn — \`grep\` confirms no anchor-specific links into ch.12 anywhere in \`docs/\` or \`spec/\`; the three filename references (in \`README.md\`, \`04-views-and-frames.md\`, \`11-devtools-and-pair-tools.md\`) all just point at the file.

## Line counts

| | Before | After |
|---|---|---|
| docs/guide/12-routing.md | 547 | 555 |

The +8-line bump is the divider, the new index paragraph after it, and the two-half pointer in the intro. Net content unchanged.

## mkdocs build

Builds clean in 2.36s. The remaining INFO-level anchor mismatches are all pre-existing in \`spec/*.md\` and unrelated to this PR's routing-chapter changes.

## Test plan

- [x] \`mkdocs build\` clean
- [x] Existing cross-links into \`12-routing.md\` still resolve (no anchor-specific links exist)
- [x] Reference-section table of contents (the index paragraph) names every advanced topic that follows
- [ ] Reviewer eyeballs the new structure: basics half (intro through \`:rf.route/not-found\`) reads top-to-bottom; reference half (after the divider) reads as per-topic lookup