### PR TITLE
docs(guide): refocus ch.11 as the tooling pitch (rf2-1nw6)

### DIFF
--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -205,7 +205,7 @@ Two instances of the same registered view, different frames. Each subtree's `dis
 
 One small detail to recognise when you see it in the inspector: every `reg-view`-rendered DOM element carries a `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` attribute pointing back to the registration that produced it. It's how pair tools and devtools resolve a clicked DOM node back to the source line. The annotation is dev-only — production builds elide it via DCE.
 
-You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Source coordinates](11-devtools-and-pair-tools.md#source-coordinates-clicking-a-button-back-to-its-source-line). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7-rf2-z9n1).
+You don't need to do anything to get it. `reg-view` does it. The full story — format, recovery to file path, exemptions, machine-spec equivalents — is in [chapter 11 §Click-to-source](11-devtools-and-pair-tools.md#click-to-source-the-source-coord-story). The contract is specified in [Spec 006 §source-coord-annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7-rf2-z9n1).
 
 <!-- TODO(rf2-q2x0 — discovered from rf2-u5sq): the flow and routing sub-sections
      below are kept inline as forward-pointers. The "What lives in app-db" sibling

--- a/docs/guide/10-testing.md
+++ b/docs/guide/10-testing.md
@@ -424,5 +424,5 @@ The split is the inverse of what most React-side test suites accumulate over tim
 
 ## Next
 
-- [11 — Devtools and pair tools](11-devtools-and-pair-tools.md) — the trace stream, time-travel, source-coords, and how AI/REPL companions attach.
+- [11 — Tooling](11-devtools-and-pair-tools.md) — the trace bus, epochs, time-travel, source-coords, and the tools that attach to them.
 - [Spec 008 — Testing](../../spec/008-Testing.md) — the full normative surface, JVM/CLJS boundary, and adapter notes.

--- a/docs/guide/11-devtools-and-pair-tools.md
+++ b/docs/guide/11-devtools-and-pair-tools.md
@@ -1,34 +1,221 @@
-# 11 — Devtools and pair tools
+# 11 — Tooling
 
-A re-frame2 app is **inspectable**. Every event the runtime processes, every fx that fires, every render, every error — they all emit structured trace events. Every drain-to-empty-queue settles into an epoch record with a `:db-before`, a `:db-after`, and the cascade's structured `:sub-runs`/`:renders`/`:effects` projections. Every registration carries source coordinates. Every rendered DOM node carries a back-pointer to the registration that produced it. Every frame's last N epochs are kept in a ring buffer, queryable and restorable.
+This is the third of the README's three pillars. The first was spec-first; the second was views-derivative. This one is the payoff.
 
-These surfaces exist so **tools** — not the framework — can build inspection, debugging, and AI-pairing experiences on top.
+Most frameworks bolt tooling on at the end. A devtools panel arrives a year after launch, a profiler a year after that, an AI integration somewhere off to the side; each tool reaches into the runtime through whatever crack it can find, and the cracks aren't the same. re-frame2 inverts the order. The runtime is **a predictable pipeline with a single, deeply integrated trace bus**, and every tool — devtools, story playgrounds, AI pair programmers, conformance harnesses, your own in-app debug panel — attaches to that one surface and gets the whole picture for free.
 
-This chapter is about that contract: what re-frame2 commits to, what tools consume it, and what you do at the keyboard to attach.
+This chapter is the human-facing version of that pitch. What you actually get, what tools already exist or are in design, and how a tool attaches in five lines of code. The contract reference — destroyed-frame behaviour, the full failure-mode tables, the listener-silencing rules — is here too, in a clearly-marked Reference section at the bottom. Read top-down for the story; jump to the bottom when you need the exact shape.
 
-You'll know how to:
+You'll come away knowing:
 
-- Subscribe to the trace stream from a REPL or tool.
-- Walk a frame's epoch history and restore an earlier state.
-- Inject a synthetic `app-db` value (state injection) for repros and experiments.
-- Parse the source-coord DOM attribute back to a code location.
-- Read the static sub-graph topology.
-- Understand what tools see when a frame is destroyed mid-observation.
-- Recognise where the contract ends and where the consuming tool begins.
+- What re-frame2 commits to as a *tooling substrate*, in narrative form.
+- Which tools already exist (`re-frame-pair2`) and which are in design (`re-frame-2-story`, `re-frame-10x` v2, machine visualisers).
+- Why the **trace bus** and **per-cascade epoch records** are the architectural punchline — one observation surface, every tool consumes it.
+- How **source-coord stamping** wires click-to-source from any panel.
+- How to attach your own listener and build a working debug panel in twenty lines.
+- Where to look when you need the contract reference (it's still here, just positioned at the end).
 
-## What "pair tools" are
+## What you get for free
 
-A pair tool is an AI/REPL companion that attaches to a running re-frame2 app. The canonical examples:
+A re-frame2 app, in dev mode, is **inspectable by default**. Without you writing a single instrumentation hook, the runtime produces:
 
-- **[day8/re-frame-pair](https://github.com/day8/re-frame-pair)** — an nREPL middleware + Claude integration that lets an agent inspect, dispatch, hot-swap handlers, time-travel, and stub fxs against a live app.
-- **A future re-frame-10x v2** — a renderer of the same surfaces; trace listener, epoch-history consumer, registry inspector, all wrapped in a UI.
-- **Custom debug panels** built into your app's dev build.
+- **A trace event for every meaningful runtime moment.** Dispatches, handler invocations, fx applications, sub computations, errors, machine transitions, registrations, hot-swaps — they all flow through one channel, the trace bus, as structured maps you can filter, route, or record.
+- **An epoch for every drain-to-empty.** Each time the dispatch queue settles, the runtime emits a fully-shaped record with `:db-before`, `:db-after`, and structured projections of the sub-runs, renders, and effects that the cascade produced. Tools route diagnostics off these directly; you don't fold the raw stream yourself.
+- **A ring buffer of the last N epochs per frame.** Scrub backwards. Restore to any prior `:db-after` with one call. Time-travel is not a feature bolted on by a devtools plugin — it's a runtime primitive.
+- **Source coordinates on every registration.** Every event handler, every sub, every view, every fx knows the `{:ns :file :line :column}` of where it was registered. Every rendered DOM element carries `data-rf2-source-coord` pointing back at the view that produced it. Click anywhere on the screen, walk back to the line of code that put it there.
+- **Static topology you can query.** The sub-graph is buildable from the registry without running the app. So is the registered-machine inventory. So is the fx index. Tools render dependency graphs, state-diagram visualisations, "what depends on this sub?" navigation — all off the same source-of-truth registries the runtime itself uses.
 
-Each consumes the same runtime contract — the trace stream, the registrar query API, the epoch ring buffer, source coordinates. Multiple tools can attach simultaneously; listener ordering isn't contract.
+These surfaces exist for **tools** to consume — not for you to consume by hand, although you can. The framework's job is to keep the data shapes stable and well-named. The tools' job is to present them.
 
-re-frame2's commitment is the **contract**, not the tool. Two tools can disagree on UX, prompt design, or visualisation without disagreeing on the API.
+## The tools
 
-## The trace stream
+Four tools, at different stages of life. They all share one substrate.
+
+### `re-frame-pair2` — the AI pair-programming companion
+
+[**`re-frame-pair2`**](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) is a Claude Code skill that attaches an AI pair programmer to your running re-frame2 app. With it, the agent isn't just reading static source — it can dispatch events, hot-swap a handler, stub a fx, inspect `app-db`, walk epoch history, restore to a prior state, and read structured trace events as they fire. It's the v2 successor to the original [`re-frame-pair`](https://github.com/day8/re-frame-pair) — but where v1 reached into `re-frame-10x` internals to read the epoch buffer, v2 reads `(rf/epoch-history frame-id)` directly. Same vocabulary, no 10x dependency.
+
+You'd use `re-frame-pair2` when you want an AI agent that can do experimentally what a human REPL session would: try a thing, see the trace, decide what's next. The skill's transcripts are kept structured precisely so [`re-frame-pair-improver2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2) — a sibling retrospective skill — can review them and propose improvements to the pair tool itself.
+
+### `re-frame-2-story` — Storybook for frames *(in design)*
+
+A Storybook-flavoured component playground built around re-frame2's frame primitive. Each story is a frame, with controls that dispatch events and surfaces that watch subscriptions. Machine-state visualisation, per-story time-travel, frame-aware fixture data — the same machinery the runtime uses for the live app, scoped to a single component.
+
+[Spec 007 — Stories](../../spec/007-Stories.md) carries the design. You'd use this for catalogue-style visual development: drive a component through every state it can reach, snapshot the rendered tree, document the controls in the same file as the implementation.
+
+### `re-frame-10x` v2 — interactive devtools *(in design)*
+
+The next generation of the in-browser devtools panel. The v1 tool ([`re-frame-10x`](https://github.com/day8/re-frame-10x)) was built against re-frame v1 and ships its own epoch buffer; v2 is being rewritten as a *renderer* of re-frame2's own surfaces — a registered trace listener, a consumer of `epoch-history`, a query consumer of the registrar, a UI on top. Same panels (events, subs, renders, fxs, app-db diff, time-travel), but the substrate underneath is the framework's own, not 10x's bespoke recording machinery.
+
+The architectural punchline is in this rewrite: **a future 10x v2 and `re-frame-pair2` will coexist as parallel listeners on the same trace bus**, neither depending on the other. The runtime's contract is the integration point.
+
+### Machine visualisers *(in design)*
+
+Per-machine visualisation tools — a SCXML-style state-diagram panel, a "what guards/actions fire when?" trace viewer, an interactive transition driver — sit naturally on the source-coord index that `reg-machine` stamps at expansion time. Click a guard on the diagram, jump to its definition. Click a transition arrow, jump to the line that registered it. The framework commits to the index shape; the visualiser ships its own UI affordance over the index. Multiple visualisers can coexist, all consuming the same `(rf/machine-meta machine-id)` query.
+
+Where these go is open. The substrate is in place today.
+
+## The architectural punchline: one observation surface
+
+The thing to internalise: **every tool above consumes the same data**.
+
+Trace stream. Epoch records. Registrar queries. Source-coord indices. Static topology. That's the surface. There is no privileged tool — `re-frame-10x` v2 and `re-frame-pair2` register as peer listeners on the trace bus, each with its own id, each filtering the stream as it likes. Your in-app debug panel attaches the same way, in the same call, with the same shape of data arriving. A future tool nobody's built yet — a story-tool panel, an AI-driven test-generator, a conformance recorder for fixture capture — does too.
+
+This is what *first-class tooling* means in re-frame2: not "we shipped a devtools panel," but "the runtime is built around one observation surface and any tool can attach to it." The framework commits to **stable data shapes and query APIs**; tools own **presentation and orchestration**. Multiple tools coexist on the same contract without coordinating with each other or with the framework.
+
+The integration is *deep*, not bolt-on. The trace events aren't a sidecar log file — they're emitted inline from the pipeline that the runtime is already walking. The epoch records aren't a recording made by a plugin — they're the same records the runtime uses internally to drive `restore-epoch`. There's no second substrate, no shadow runtime, no "make sure devtools is installed first." When the framework knows something happened, the trace bus knows. When the trace bus knows, every attached tool knows.
+
+## Attaching a tool, concretely
+
+Here's a working in-app debug panel that listens to the trace bus, tracks the last ten events, and renders the last five epochs with a restore button on each.
+
+```clojure
+(ns my-app.debug-panel
+  (:require [re-frame.core :as rf]
+            [reagent.core :as r]))
+
+(defonce recent-events (r/atom []))
+
+(rf/register-trace-cb!
+  :my-app/debug-panel
+  (fn [ev]
+    (when (= :event (:op-type ev))
+      (swap! recent-events (fn [evs] (->> (cons ev evs) (take 10) vec))))))
+
+(rf/reg-view debug-panel []
+  (let [events @recent-events
+        epochs (take-last 5 (rf/epoch-history :rf/default))]
+    [:aside.debug-panel
+     [:h3 "Recent events"]
+     [:ul (for [e events] ^{:key (:dispatch-id e)} [:li (str (:operation e))])]
+     [:h3 "Recent epochs"]
+     [:ul (for [ep epochs] ^{:key (:epoch-id ep)}
+            [:li
+             [:button {:on-click #(rf/restore-epoch :rf/default (:epoch-id ep))}
+              (str (:event-id ep))]])]]))
+```
+
+That's the whole shape. The trace listener is a function. The epoch list is a query. The restore is a single call. No framework extension, no plugin contract. The panel composes from the same surfaces `re-frame-pair2` and (a future) `re-frame-10x` v2 consume — the difference is that they're richer renderers of the same data.
+
+A few things to notice:
+
+- The id `:my-app/debug-panel` is the listener's handle; pass it to `remove-trace-cb!` to detach. Tools coexist on the bus by giving themselves a unique namespaced id.
+- The filter `(= :event (:op-type ev))` keeps this listener cheap. Trace events have a load-bearing `:op-type` field that's the universal discriminator — `:event`, `:sub/run`, `:fx`, `:flow`, `:machine`, `:rf.epoch/restored`, and more. New op-types are additive; tools that don't recognise an op-type ignore it without breaking ([Spec 009 §Trace event](../../spec/009-Instrumentation.md)).
+- `(rf/epoch-history :rf/default)` returns the frame's ring buffer, oldest-first. The default depth is 50; configure with `(rf/configure :epoch-history {:depth N})`.
+- `restore-epoch` rewinds the frame's `app-db` to the named epoch's `:db-after`. **Effects already fired** (HTTP sent, navigation pushed) are not reversed — restore is a state operation, not a universe operation. Surface that caveat in your UI.
+
+All of this is **dev-only**. The trace bus is gated on `re-frame.interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production builds elide every emit via Closure DCE. A shipped binary carries no trace bytes and no listener machinery.
+
+## Click-to-source: the source-coord story
+
+The second piece of the tooling pitch is **source-coord stamping**. A tool gestures at a button on screen — a click in `re-frame-10x` v2, a `dom/source-at` call from `re-frame-pair2`, a Playwright locator in an end-to-end test — and asks "where in the code did this come from?" The answer is on the DOM node itself.
+
+```html
+<button data-rf2-source-coord="counter.core:counter:48:5" ...>+</button>
+```
+
+Four colon-separated segments: `<ns>:<sym>:<line>:<col>`. Public, parseable, forward-compatible. Tools split on the colon and recover the four pieces directly. To get the file path too, follow the parsed handler-id back to the registration metadata:
+
+```clojure
+(:rf/source-coord-meta (rf/handler-meta :view :counter.core/counter))
+;; → {:ns "counter.core", :file "counter/core.cljs", :line 48, :column 5}
+```
+
+The same idea generalises to state machines. `reg-machine` is a macro that walks its literal spec form at expansion time and attaches a flat coord index under `:rf.machine/source-coords`, keyed by spec-path tuples:
+
+```clojure
+(:rf.machine/source-coords (rf/machine-meta :auth/login))
+;; {[:guards :form-valid?]                {:ns ... :line ... :column ... :file ...}
+;;  [:actions :commit]                    {...}
+;;  [:states :form :on :submit]           {...}}
+```
+
+A pair-tool or a state-diagram visualiser reads this index for two distinct gestures: **jump to definition** (a click on `:form-valid?` in the diagram reads `[:guards :form-valid?]`) and **jump to call site** (a click on a transition arrow reads `[:states :form :on :submit]`).
+
+The framework commits to the attribute format and the index shape — both are parseable public contracts. The framework does **not** ship `dom-source-at` / `find-by-src` / `fire-click-at-src` helpers; those depend on host-specific DOM access that re-frame2 the framework doesn't assume. Pair tools and devtools panels ship their own helpers over the attribute. The attribute itself is forward-compatible; the helpers can evolve.
+
+Like the trace bus, source-coord stamping is **dev-only**. Production builds elide via DCE; the rendered HTML in a production bundle carries no `data-rf2-source-coord` bytes.
+
+## Scrubbing time
+
+`epoch-history` plus `restore-epoch` is the time-travel surface. Per frame, the runtime keeps a ring buffer of the last N epoch records. Each record carries `:db-before`, `:db-after`, the event that triggered it, and structured projections of the cascade (sub-runs, renders, effects). A tool can:
+
+- **Walk backwards through history.** Render a timeline. Show what each event changed.
+- **Restore to any prior epoch.** One call: `(rf/restore-epoch frame-id epoch-id)`. The runtime rewinds the frame's `app-db` to the recorded `:db-after`, emits a `:rf.epoch/restored` trace event, and the views re-render naturally.
+- **Inject a synthetic state.** Sometimes the state you want never existed: a bug repro arrives as serialised `app-db`, a hot-swapped handler needs an evolved shape, a story-tool wants to render the cart in a specific snapshot. `(rf/reset-frame-db! frame-id new-db)` is the supported write surface — it bypasses dispatch, replaces the container, and records a synthetic epoch so `restore-epoch` can rewind past the injection.
+
+Here's the canonical pair-tool gesture — "rewind to before that event" — in fifteen lines:
+
+```clojure
+(defn epoch-before-event
+  "Return the epoch-id of the most recent epoch in `frame-id`'s history
+   that precedes `target-event-id`, or nil."
+  [frame-id target-event-id]
+  (let [history (rf/epoch-history frame-id)
+        before  (take-while #(not= target-event-id (:event-id %)) history)]
+    (when (seq before)
+      (:epoch-id (last before)))))
+
+(when-let [target (epoch-before-event :app/main :checkout/submit)]
+  (rf/restore-epoch :app/main target))
+```
+
+That same gesture — under different UI — is what `re-frame-pair2`'s "rewind past this event" action does, what `re-frame-10x` v2's timeline scrub will do, what a story-tool's "back to the previous frame state" affordance will do. One surface, many tools.
+
+The time-travel surface ships in `day8/re-frame-2-epoch`. Apps that want time-travel add it alongside core; apps that don't, omit it and the read-shaped surfaces (`epoch-history`, `register-epoch-cb`) degrade silently to empty / no-op. Mutating surfaces (`reset-frame-db!`, `restore-epoch`) raise structurally when the artefact is missing — a silent no-op on a mutation would lie.
+
+## Performance: the prod-friendly channel
+
+The trace bus is dev-only, but there's a second observation channel that's safe to enable in production: **User Timing API entries**, stable-named under the `rf:` prefix.
+
+```
+rf:event:<event-id>
+rf:sub:<sub-id>
+rf:fx:<fx-id>
+rf:render:<view-id>
+```
+
+Any consumer with a `PerformanceObserver` reads them — no re-frame2 API call needed, just the browser primitive:
+
+```javascript
+new PerformanceObserver((list) => {
+  for (const e of list.getEntriesByType('measure')) {
+    if (e.name.startsWith('rf:')) {
+      sendToAPM(e);
+    }
+  }
+}).observe({ type: 'measure', buffered: true });
+```
+
+The channel is gated on `re-frame.performance/enabled?` — a `goog-define` boolean defaulting to `false`. Flip it on in your build when you want APM-style production telemetry; leave it off (the default) and DCE elides every bracket. Timing instrumentation has measurable cost on heavy hot paths, so this is opt-in for prod by design.
+
+```edn
+;; consumer's shadow-cljs.edn
+{:builds {:app {:target           :browser
+                :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
+```
+
+The Performance API surface is CLJS-only — JVM artefacts (SSR, headless tests) emit no perf entries; tools running there use the host's profilers.
+
+## What re-frame2 does not ship
+
+The contract above is sized to the framework's responsibility. Things that are **not** part of re-frame2 itself:
+
+- **The Claude integration in `re-frame-pair2`** — prompts, retrieval, model selection. Lives in the skill.
+- **The nREPL middleware** that bridges agent-to-runtime. Specific to the host stack.
+- **The 10x v2 devtools UI.** It will be a separate artefact, consuming the same trace bus you've already met.
+- **DOM-to-source helpers** (`source-at`, `find-by-src`, `fire-click-at-src`). Tool-side; depends on host-specific DOM access.
+- **Skill-shaped retrospective analysis** of pair sessions — `re-frame-pair-improver2` is a separate Claude skill that reviews sessions and proposes improvements to the pair tool itself.
+
+The split is deliberate: the framework commits to **stable data shapes and query APIs**; tools own **presentation, orchestration, and host integration**. Without that split, the framework would own every consumer's roadmap — and would lock out every consumer it didn't already know about.
+
+---
+
+## Reference
+
+The rest of this chapter is the contract: surface shapes, error tables, behaviour against destroyed frames, the failure-mode enumeration for `restore-epoch` and `reset-frame-db!`. Read top-down if you're implementing a tool. Skip past if you're not — the pitch above is the part you need to internalise.
+
+### Reference: the trace stream
 
 Every event the runtime emits — dispatch boundaries, handler invocations, fx applications, sub computations, errors, machine transitions, registrations, hot-swaps — flows through one channel: the trace stream.
 
@@ -68,7 +255,7 @@ To unsubscribe:
 
 The trace surface is **dev-only** — gated on `re-frame.interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`). Production builds (`:advanced` + `goog.DEBUG=false`) elide every emit via Closure DCE. A shipped binary carries no trace bytes and no listener machinery.
 
-### The retain-N trace ring buffer
+### Reference: the retain-N trace ring buffer
 
 For tools that want to read **recent history** without having been registered earlier, the runtime keeps a configurable ring buffer of the last N trace events:
 
@@ -80,7 +267,7 @@ For tools that want to read **recent history** without having been registered ea
 
 Default depth is per-implementation. The buffer is dev-only and elides under production build flags.
 
-## Per-cascade epoch records
+### Reference: per-cascade epoch records
 
 `register-trace-cb!` is the **raw** stream. For tools that route diagnostics off "what just happened in this drain?", a complementary listener fires once per **drain-settle**, with the cascade's structured projections already computed:
 
@@ -115,24 +302,9 @@ Most pair-shaped tools prefer the assembled stream and reach for the raw stream 
 
 A throw inside an epoch-cb does not propagate to the framework or other listeners — the framework catches and continues. The throwing listener is **not** auto-evicted; eviction is the consumer's call.
 
-## Epoch history and time-travel
+### Reference: epoch history failure modes
 
-Per frame, the runtime keeps a ring buffer of the last N epoch records. The default is 50; configure with `(rf/configure :epoch-history {:depth N})`.
-
-```clojure
-(rf/epoch-history :app/main)
-;; → vector of epoch records, oldest-first
-;;   each carries :epoch-id, :event-id, :db-before, :db-after, :sub-runs, ...
-
-(rf/restore-epoch :app/main some-epoch-id)
-;; rewinds the frame's app-db to the named epoch's :db-after
-;; emits :rf.epoch/restored on success
-;; returns true on success, false on any failure
-```
-
-`restore-epoch` rewinds the frame's `app-db` only — **effects already fired** (HTTP requests sent, navigation pushed, localStorage written) are not reversed. Pair tools surface this caveat in their UI before applying a restore.
-
-Six failure modes are enumerated and named, each emitting a structured error trace event under the reserved `:rf.epoch/*` namespace:
+Six failure modes are enumerated and named for `restore-epoch`, each emitting a structured error trace event under the reserved `:rf.epoch/*` namespace:
 
 | Failure | When |
 |---|---|
@@ -143,23 +315,11 @@ Six failure modes are enumerated and named, each emitting a structured error tra
 | **Version mismatch** | The frame's recorded `:rf/snapshot-version` is incompatible with the currently-loaded machine definition. |
 | **Concurrent-drain rejection** | Called while the frame's drain is still in flight; retry after settle. |
 
-Pair tools display the `:operation` and `:tags` to the user and route from the failure to a remediation. The full table with `:tags` schemas is in [Tool-Pair §Time-travel](../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo).
+`restore-epoch` returns `true` on success, `false` on any failure. Pair tools display the `:operation` and `:tags` to the user and route from the failure to a remediation. The full table with `:tags` schemas is in [Tool-Pair §Time-travel](../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo).
 
-### Walking history and restoring — worked example
-
-A pair tool's "rewind to before that event" affordance:
+Listening for restore outcomes:
 
 ```clojure
-(defn epoch-before-event
-  "Return the epoch-id of the most recent epoch in `frame-id`'s history
-   that precedes `target-event-id`, or nil."
-  [frame-id target-event-id]
-  (let [history (rf/epoch-history frame-id)
-        before  (take-while #(not= target-event-id (:event-id %)) history)]
-    (when (seq before)
-      (:epoch-id (last before)))))
-
-;; Listen for restore success / failure traces.
 (rf/register-trace-cb!
   :my-tool/restore-watcher
   (fn [ev]
@@ -171,40 +331,11 @@ A pair tool's "rewind to before that event" affordance:
       :rf.epoch/restore-version-mismatch    (notify-ui :error ev)
       :rf.epoch/restore-during-drain        (notify-ui :error ev)
       nil)))
-
-;; Trigger.
-(when-let [target (epoch-before-event :app/main :checkout/submit)]
-  (rf/restore-epoch :app/main target))
 ```
 
-The walk-then-restore pattern is the canonical pair-tool gesture; render-tree visualisers, "what did this event do?" probes, and conformance harnesses all build on the same primitives.
+### Reference: `reset-frame-db!` failure modes and synthetic epoch
 
-### Where the time-travel surface lives
-
-Per Strategy B, the time-travel surface ships in the artefact `day8/re-frame-2-epoch`. Apps that want time-travel add it alongside core:
-
-```clojure
-{:deps {day8/re-frame-2        {...}
-        day8/re-frame-2-epoch  {...}}}
-```
-
-When the artefact is on the classpath and `re-frame.epoch` is required at boot, the late-bind hooks publish so the public re-exports in `re-frame.core` (`epoch-history`, `restore-epoch`, `register-epoch-cb`, `reset-frame-db!`) reach into the hook table at call time.
-
-When the artefact is **not** on the classpath, the read-shaped surfaces (`epoch-history`, `register-epoch-cb`) degrade silently — empty vector / no-op. A production build that omits the artefact does not raise. Mutating surfaces (`reset-frame-db!`) raise `:rf.error/epoch-artefact-missing` — the caller's invariant is "this changes state" and a silent no-op would lie.
-
-## Direct state injection: `reset-frame-db!`
-
-Sometimes you need to put a frame in a state the runtime never recorded. A pair-tool agent has just hot-swapped a handler that operates on an evolved `app-db` shape; running a real cascade would re-trigger broken handlers. A story tool wants to render the cart in a specific snapshot without authoring a setup event for every variant. A bug repro arrives as a serialised `app-db` from a user; the agent needs to load it.
-
-`reset-frame-db!` is the supported write surface ([rf2-zq55](#), shipped in PR #170):
-
-```clojure
-(rf/reset-frame-db! :app/main {:cart {:items [{:sku "abc" :qty 2}]}
-                                :checkout/state :ready})
-;; Returns true on success, false on failure.
-```
-
-It bypasses the dispatch loop, replaces the frame's `app-db` container directly, and **records a synthetic epoch** so `restore-epoch` can rewind past the injection. The synthetic epoch carries:
+`reset-frame-db!` (rf2-zq55, shipped in PR #170) bypasses the dispatch loop, replaces the frame's `app-db` container directly, and **records a synthetic epoch** so `restore-epoch` can rewind past the injection. The synthetic epoch carries:
 
 - `:event-id :rf.epoch/db-replaced`
 - `:trigger-event [:rf.epoch/db-replaced]`
@@ -224,7 +355,7 @@ Three failure modes:
 | **Drain in flight** | Called while the frame's drain is in progress; retry after settle. |
 | **Schema mismatch** | `new-db` fails the frame's currently-registered `app-schema` set. With no schemas registered, every `new-db` is accepted. |
 
-`reset-frame-db!` is **not** a substitute for `dispatch`. Use it only when bypass-the-cascade is required (the four use cases above); for anything you want the data loop to see, dispatch a real event.
+`reset-frame-db!` is **not** a substitute for `dispatch`. Use it only when bypass-the-cascade is required (pair-tool agent injection, story-tool snapshot rendering, bug repro loading, hot-swap reshape); for anything you want the data loop to see, dispatch a real event.
 
 ```clojure
 ;; A pair-tool agent has hot-swapped a handler that needs a new app-db shape.
@@ -240,13 +371,7 @@ Three failure modes:
     (rf/restore-epoch :app/main (:epoch-id pre))))
 ```
 
-## Source coordinates: clicking a button back to its source line
-
-A pair tool gestures at a button on screen and asks "where in the code did this come from?" That requires every rendered DOM node to carry a back-pointer to the registration that produced it.
-
-re-frame2's CLJS reference does this two ways, layered:
-
-### 1. The `data-rf2-source-coord` DOM attribute
+### Reference: the `data-rf2-source-coord` attribute format
 
 Every `reg-view`-rendered DOM element receives:
 
@@ -261,47 +386,24 @@ The four colon-separated segments are `<ns>:<sym>:<line>:<col>`:
 - `<line>` — source line at `reg-view` macro-expansion time
 - `<col>` — source column
 
-The format is a **public, parseable contract** ([rf2-q7r0](#), per [Spec-Schemas §`:rf/source-coord-attr`](../../spec/Spec-Schemas.md#rfsource-coord-attr)). Tools split on the colon and recover the four pieces directly.
+The format is a **public, parseable contract** (rf2-q7r0, per [Spec-Schemas §`:rf/source-coord-attr`](../../spec/Spec-Schemas.md#rfsource-coord-attr)). Tools split on the colon and recover the four pieces directly.
 
-To recover the file path too, follow the parsed handler-id back to the registration metadata:
-
-```clojure
-(:rf/source-coord-meta (rf/handler-meta :view :counter.core/counter))
-;; → {:ns "counter.core", :file "counter/core.cljs", :line 48, :column 5}
-```
-
-`:rf/source-coord-meta` (per [Spec-Schemas](../../spec/Spec-Schemas.md)) carries all four keys including `:file`. The DOM attribute is the cheap-on-the-wire form; the registration metadata is the rich form.
+To recover the file path too, follow the parsed handler-id back to the registration metadata via `:rf/source-coord-meta` (per [Spec-Schemas](../../spec/Spec-Schemas.md)), which carries all four keys including `:file`. The DOM attribute is the cheap-on-the-wire form; the registration metadata is the rich form.
 
 The annotation is **dev-only** — gated on the universal `re-frame.interop/debug-enabled?`. Production builds elide via DCE; the rendered HTML in production carries no `data-rf2-source-coord` bytes.
 
 Documented exemption: components whose outermost return is a React Fragment, a `:>` host-component head, or another non-DOM root are exempt. Pair tools fall back to `(rf/handler-meta :view id)` for those nodes.
 
-### 2. State-machine source-coord stamping
+### Reference: machine source-coord index
 
-A complementary surface for state-machines: `reg-machine` is a macro that walks its literal spec form at expansion time and attaches a flat coord index under `:rf.machine/source-coords`, keyed by spec-path tuples:
+The framework commits to **the index shape and the keyword-reference rule** for `:rf.machine/source-coords`:
 
-```clojure
-(:rf.machine/source-coords (rf/machine-meta :auth/login))
-;; {[:guards :form-valid?]                {:ns ... :line ... :column ... :file ...}
-;;  [:actions :commit]                    {...}
-;;  [:states :form :on :submit]           {...}
-;;  [:states :form :on :submit :action]   {...}}
-```
+- **Definition-site stamping for keyword references.** A keyword reference (`{:guard :form-valid?}`) is stamped at its definition site (`[:guards :form-valid?]`), not at the call site — the call site is the keyword itself, which is identity-free.
+- **Reference-site stamping for inline-fn literals.** An inline `(fn [...] ...)` is stamped where it appears.
 
-Pair tools use this index for two distinct gestures:
+Pair tools use this index for two distinct gestures (jump-to-definition, jump-to-call-site); the keyword-reference rule means call-site clicks on a keyword-named slot (`{:guard :form-valid?}`) fall back to the enclosing transition's coord, which IS stamped. Like `data-rf2-source-coord`, the stamping is gated on debug-enabled and elides under production build flags.
 
-- **Jump to definition.** A click on a guard or action name in a state-diagram visualisation reads `[:guards <id>]` / `[:actions <id>]` to find where the fn is implemented.
-- **Jump to call site.** A click on a transition arrow or state node reads the deepest stamped path-tuple matching the node (e.g. `[:states :idle :on :submit]`); for keyword-named slots (`{:guard :form-valid?}`) the slot itself isn't stamped — the tool falls back to the enclosing transition's coord, which IS stamped.
-
-The framework commits to **the index shape and the keyword-reference rule** (definition-site only for keyword refs, reference-site for inline-fn literals). Pair tools ship their own UI affordance over the index. Like `data-rf2-source-coord`, the stamping is gated on debug-enabled and elides under production build flags.
-
-### Where the helpers live
-
-The audit found upstream pair tools ship `dom/source-at`, `dom/find-by-src`, and `dom/fire-click-at-src` helpers. **re-frame2's commitment is the attribute, not the helpers.**
-
-The runtime emits the attribute; the attribute's value format is a committed public contract. Consumers read it via their own host's DOM access (`document.querySelector` in CLJS, `page.locator` in Playwright-driven flows) and parse the four segments locally. The framework does **not** ship `dom-source-at` / `find-by-src` / `fire-click-at-src` helpers — those depend on host-specific DOM access that re-frame2 the framework doesn't assume. A future minor version may introduce framework-side helpers if the ecosystem converges; the attribute contract is forward-compatible.
-
-## The static sub-graph: `sub-topology`
+### Reference: the static sub-graph — `sub-topology`
 
 Subscriptions chain — `:count-doubled` depends on `:count`. The framework knows the dependency graph at registration time (built from `:<-` declarations). For visualisation, dependency analysis, and "what depends on this sub?" navigation, the static graph is exposed:
 
@@ -312,16 +414,9 @@ Subscriptions chain — `:count-doubled` depends on `:count`. The framework know
 ;;    :edges #{[:count-doubled :count] ...}}
 ```
 
-This is **static** — no runtime, no live cache, no Reagent. It reads off the registry. Use it to:
+This is **static** — no runtime, no live cache, no Reagent. It reads off the registry. Use it to render a graph of "everything derived," find the leaves (subs nothing else depends on), find the roots (subs that read `app-db` directly), and spot dead subs (registered but no consumers). The shape lives in [Spec 006 §Subscription topology](../../spec/006-ReactiveSubstrate.md); the function shipped in PR #142 (rf2-8nzo).
 
-- Render a graph of "everything in the app that's derived."
-- Find the leaves (subs nothing else depends on) — the stuff views actually read.
-- Find the roots (subs that read `app-db` directly) — the ground truth.
-- Spot dead subs (registered but no consumers).
-
-The shape lives in [Spec 006 §Subscription topology](../../spec/006-ReactiveSubstrate.md). The function shipped in PR #142 ([rf2-8nzo](#)).
-
-## What happens when a frame is destroyed mid-observation
+### Reference: behaviour against destroyed frames
 
 Multi-frame architectures make frame churn ordinary — story tools mount and unmount frames freely; pair tools probe ephemeral test frames. A pair tool watching a frame's epoch history is guaranteed to encounter destroyed-frame races.
 
@@ -341,97 +436,9 @@ Why "silencing" is a trace and not a return value: the `register-epoch-cb` callb
 
 The full contract is in [Tool-Pair §Surface behaviour against destroyed frames](../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames). Pattern source: rf2-d656.
 
-## What you don't get from re-frame2
-
-The contract above is sized to the framework's responsibility. Things explicitly **not** part of re-frame2:
-
-- **The Claude integration itself** — prompts, retrieval, model selection. Lives in the pair tool.
-- **The nREPL middleware** that bridges agent-to-runtime. Specific to the host.
-- **The conversational interface** ("Tell me about every `:checkout/*` event"). The pair tool's job to prompt-engineer; re-frame2 ships data.
-- **Skill-shaped retrospective analysis** of pair sessions. That's a separate, post-v1 artefact (`re-frame-pair-improver`) — a Claude skill that reviews sessions and proposes improvements to the pair tool itself.
-- **DOM-to-source helpers** (`source-at`, `find-by-src`). Tool-side; depends on host-specific DOM access.
-
-The split is deliberate: the framework commits to **stable data shapes and query APIs**; tools own **presentation and orchestration**. Multiple tools can coexist on the same contract without coordinating with each other or with the framework.
-
-## Performance API consumption — the prod-friendly channel
-
-A separate channel from the dev-only trace stream: the runtime emits **User Timing API** entries that any consumer with a `PerformanceObserver` can read. No re-frame2 API call needed.
-
-Names are stable and namespaced under `rf:`:
-
-```
-rf:event:<event-id>
-rf:sub:<sub-id>
-rf:fx:<fx-id>
-rf:render:<view-id>
-```
-
-```javascript
-// Pull every re-frame entry from the recent run
-performance.getEntriesByType('measure')
-  .filter(e => e.name.startsWith('rf:'))
-  .forEach(e => {
-    const [_rf, bucket, ...idParts] = e.name.split(':');
-    const id = idParts.join(':');
-    sendToAPM(e);
-  });
-
-// Live: PerformanceObserver fires per emitted entry
-new PerformanceObserver((list) => {
-  for (const e of list.getEntriesByType('measure')) {
-    if (e.name.startsWith('rf:')) {
-      sendToAPM(e);
-    }
-  }
-}).observe({ type: 'measure', buffered: true });
-```
-
-The channel is gated on `re-frame.performance/enabled?` — a `goog-define` boolean defaulting to `false`. When the flag is off (default), Closure DCE elides every bracket; `getEntriesByType` returns no `rf:`-prefixed entries because none were emitted. This is **opt-in for prod**; timing instrumentation has measurable cost on heavy hot paths and consumers should choose to pay it.
-
-Flip the flag in your build:
-
-```edn
-;; consumer's shadow-cljs.edn
-{:builds {:app {:target           :browser
-                :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
-```
-
-The Performance API surface is **CLJS-only**. JVM artefacts (SSR, headless tests) emit no perf entries; tools running there use the host's profilers (clj-async-profiler, JFR).
-
-## Putting it together — a minimal "trace + epoch" debug panel
-
-A small in-app panel that prints the last 10 events and the current frame's last 5 epochs:
-
-```clojure
-(ns my-app.debug-panel
-  (:require [re-frame.core :as rf]
-            [reagent.core :as r]))
-
-(defonce recent-events (r/atom []))
-
-(rf/register-trace-cb!
-  :my-app/debug-panel
-  (fn [ev]
-    (when (= :event (:op-type ev))
-      (swap! recent-events (fn [evs] (->> (cons ev evs) (take 10) vec))))))
-
-(rf/reg-view debug-panel []
-  (let [events @recent-events
-        epochs (take-last 5 (rf/epoch-history :rf/default))]
-    [:aside.debug-panel
-     [:h3 "Recent events"]
-     [:ul (for [e events] ^{:key (:dispatch-id e)} [:li (str (:operation e))])]
-     [:h3 "Recent epochs"]
-     [:ul (for [ep epochs] ^{:key (:epoch-id ep)}
-            [:li
-             [:button {:on-click #(rf/restore-epoch :rf/default (:epoch-id ep))}
-              (str (:event-id ep))]])]]))
-```
-
-That's the whole shape. The trace listener is a fn; the epoch list is a query; the restore is a single call. No framework extension, no plugin contract. The panel composes from the same surfaces the upstream pair tool consumes — the tool is just a richer renderer of the same data.
-
 ## Next
 
 - [12 — Routing](12-routing.md) — the URL ↔ state contract.
 - [Tool-Pair](../../spec/Tool-Pair.md) — the full normative contract for pair-shaped tools.
 - [Spec 009 — Instrumentation](../../spec/009-Instrumentation.md) — the trace stream's full shape and the error contract.
+- [`re-frame-pair2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) — the AI pair-programming skill, today.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -35,7 +35,7 @@ Read these when the topic comes up — not as part of the linear sequence. They'
 | 08 | [From re-frame v1](08-from-re-frame-v1.md) | You're migrating an existing re-frame v1 app. Skip if re-frame2 is your starting point. |
 | 09 | [The dynamic-model story](09-the-dynamic-model.md) | You want the long-form essay on *why* less-powerful is more. Skippable for "I just want to write code" readers. |
 | 10 | [Testing](10-testing.md) | You're about to write tests — `re-frame.test-support`, frame fixtures, JVM-vs-CLJS boundary, conformance. |
-| 11 | [Devtools and pair tools](11-devtools-and-pair-tools.md) | You're debugging or reaching for tooling — trace stream, epoch history, time-travel, source-coords, `reset-frame-db!`. |
+| 11 | [Tooling](11-devtools-and-pair-tools.md) | The third-pillar pitch: trace bus, epochs, time-travel, source-coords, and the tools that consume them (`re-frame-pair2`, `re-frame-2-story`, `re-frame-10x` v2). |
 | 12 | [Routing](12-routing.md) | Your app needs URL ↔ state — `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
 
 ### Close-out

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
     - "08 — From re-frame v1": guide/08-from-re-frame-v1.md
     - "09 — The dynamic model": guide/09-the-dynamic-model.md
     - "10 — Testing": guide/10-testing.md
-    - "11 — Devtools and pair tools": guide/11-devtools-and-pair-tools.md
+    - "11 — Tooling": guide/11-devtools-and-pair-tools.md
     - "12 — Routing": guide/12-routing.md
     - "13 — Where to go next": guide/13-where-next.md
 


### PR DESCRIPTION
## Summary

Ch.11 previously read as a contract reference (destroyed-frame surface tables, callback signatures, failure-mode tables) — wrong shape for the guide's third-pillar tooling story that the README promises. Rewrite top-down to lead with the pitch; keep the contract content as clearly-marked Reference sections at the bottom.

- Open with what the reader *gets* from re-frame2's tooling substrate — the trace bus, per-cascade epochs, source-coord stamping, static topology — in narrative voice.
- Walk the four tools by name: `re-frame-pair2` (today), `re-frame-2-story` *(in design)*, `re-frame-10x` v2 *(in design)*, machine visualisers *(in design)*. Each gets a short paragraph framing what it is, what you'd use it for, where it plugs in.
- State the architectural punchline explicitly: every tool consumes the same observation surface as a peer listener; the framework commits to data shapes, tools own presentation.
- Concrete 20-line debug-panel example using `register-trace-cb!` + `epoch-history` + `restore-epoch` — the same primitives the upstream tools consume.
- Contract content (trace stream spec, retain-N buffer, per-cascade records, restore-epoch failure modes, reset-frame-db! synthetic epoch, source-coord attribute format, machine source-coord index, sub-topology, destroyed-frame behaviour) stays in the chapter, repositioned as a clearly-marked `## Reference` block at the bottom. Nothing was deleted.
- Rename chapter title to "Tooling" in mkdocs.yml + guide README.
- Update ch.04 cross-link anchor to match the new section name.

Word count delta: 3317 → 4430 (+1113). Length grew because the pitch is new content — the contract material was retained, not trimmed.

## Test plan

- [x] `mkdocs build` passes with no new warnings (no WARNING/ERROR output; same pre-existing INFO-level spec anchor warnings as on `main`).
- [x] Rebased on `origin/main` after parallel rf2-5gbu (ch.13 close-out) and rf2-9y85 (ch.12 routing reorder) landed. Both edited `docs/guide/README.md` and `mkdocs.yml` non-conflictingly with ch.11.
- [x] Cross-links to ch.11 from ch.04 §source-coord and ch.10's Next block updated to match the new title and new anchor.
- [ ] Render-on-Pages spot-check after merge.

Bead: rf2-1nw6.