### PR TITLE
docs(guide): converge worked example on counter (ch.02-06) (rf2-2kzw)

### DIFF
--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -12,17 +12,17 @@ That sounds bureaucratic. The payoff is enormous. Let's see why.
 
 ## The problem with side-effects in handlers
 
-Imagine the obvious thing: an event handler that fetches user data on login.
+The counter from chapter 02 only changed `app-db`. The moment the counter wants to reach outside itself — fetch the next increment from a server, persist its value to localStorage, beep — the temptation is to do the obvious thing right there in the handler:
 
 ```clojure
 ;; ❌ Don't do this
-(rf/reg-event-db :user/login
-  (fn [db [_ creds]]
-    (.then (js/fetch "/api/login" #js {:method "POST" :body creds})
+(rf/reg-event-db :counter/inc-from-server
+  (fn [db _event]
+    (.then (js/fetch "/api/inc.json")
            (fn [resp]
              ;; ... what now?
              ))
-    (assoc db :auth/loading? true)))
+    (assoc db :counter/loading? true)))
 ```
 
 There are at least three problems with this.
@@ -37,19 +37,17 @@ The solution: **don't let the handler do the side-effect. Have it describe the s
 
 ## Effects as data
 
-Here's the same login event in re-frame2 idiom:
+Here's the same counter-fetch event in re-frame2 idiom:
 
 ```clojure
-(rf/reg-event-fx :user/login
-  (fn [{:keys [db]} [_ creds]]
-    {:db (assoc db :auth/loading? true)
+(rf/reg-event-fx :counter/inc-from-server
+  (fn [{:keys [db]} _event]
+    {:db (assoc db :counter/loading? true)
      :fx [[:rf.http/managed
-           {:request    {:method :post
-                         :url    "/api/login"
-                         :body   creds
-                         :request-content-type :json}
-            :on-success [:user/login-success]
-            :on-failure [:user/login-error]}]]}))
+           {:request    {:method :get
+                         :url    "/api/inc.json"}
+            :on-success [:counter/inc-loaded]
+            :on-failure [:counter/inc-error]}]]}))
 ```
 
 Three things changed:
@@ -61,24 +59,24 @@ Three things changed:
 Then there are two follow-up handlers, each pure:
 
 ```clojure
-(rf/reg-event-db :user/login-success
+(rf/reg-event-db :counter/inc-loaded
   (fn [db [_ {:keys [value]}]]
     (-> db
-        (assoc :auth/loading? false)
-        (assoc :auth/user (:user value)))))
+        (assoc :counter/loading? false)
+        (update :count + (:delta value)))))
 
-(rf/reg-event-db :user/login-error
+(rf/reg-event-db :counter/inc-error
   (fn [db [_ {:keys [failure]}]]
     (-> db
-        (assoc :auth/loading? false)
-        (assoc :auth/error failure))))
+        (assoc :counter/loading? false)
+        (assoc :counter/error failure))))
 ```
 
-The runtime is what actually *does* the HTTP request. It looks at the effect map, sees `[:rf.http/managed {...}]`, looks up the registered fx, and hands it the args. When the request resolves, the fx dispatches `[:user/login-success {:kind :success :value v}]` or `[:user/login-error {:kind :failure :failure m}]`. Those events go through the queue exactly like any other event. The cycle runs.
+The runtime is what actually *does* the HTTP request. It looks at the effect map, sees `[:rf.http/managed {...}]`, looks up the registered fx, and hands it the args. When the request resolves, the fx dispatches `[:counter/inc-loaded {:kind :success :value v}]` or `[:counter/inc-error {:kind :failure :failure m}]`. Those events go through the queue exactly like any other event. The cycle runs.
 
 `:rf.http/managed` is the canonical HTTP fx — managed decoding, retry-with-backoff, abort, schema-driven decode, frame-aware reply addressing — and it's covered in detail in [chapter 06 — Doing HTTP requests](06-doing-http-requests.md). This chapter uses it to make the effects-as-data shape concrete; the full surface lives there.
 
-This shape makes the dynamic story tractable again. You can trace the login flow by reading three handlers, in order, top to bottom. There are no callbacks. There are no `.then` chains. There's data going in, data going out, data going in again.
+This shape makes the dynamic story tractable again. You can trace the counter-fetch flow by reading three handlers, in order, top to bottom. There are no callbacks. There are no `.then` chains. There's data going in, data going out, data going in again.
 
 ## The standard effect map
 
@@ -92,11 +90,11 @@ The shape an `reg-event-fx` handler returns is intentionally narrow: two top-lev
 That's all. Top-level `:dispatch`, `:dispatch-later`, `:dispatch-n` from re-frame v1 are gone — they fold into `:fx` as `[:dispatch ...]` / `[:dispatch-later {...}]` rows. The single shape across every effect is the load-bearing piece: tooling, tests, and the runtime each see one consistent grammar instead of two parallel ones. (This consolidation is migration rule M-8 in [`spec/MIGRATION.md`](../../spec/MIGRATION.md).)
 
 ```clojure
-{:db (assoc db :saved? true)
+{:db (assoc db :counter/saved? true)
  :fx [[:rf.http/managed
-       {:request {:method :post :url "/api/save" :body (:draft db)
+       {:request {:method :post :url "/api/counter" :body {:count (:count db)}
                   :request-content-type :json}}]
-      [:localstorage/set  {:key "last-saved" :value (now)}]
+      [:localstorage/set  {:key "counter" :value (:count db)}]
       [:rf.nav/push-url   "/saved"]
       [:dispatch          [:notification/show "Saved!"]]]}
 ```
@@ -129,7 +127,7 @@ For HTTP, the framework already ships `:rf.http/managed` — managed decoding, r
 
 ## Why effects-as-data is worth the verbosity
 
-It is more verbose. The login flow in idiomatic React is one async function with `await`. In re-frame2 it's three handlers + a registered fx. Six places where you'd have one.
+It is more verbose. The fetch-an-increment flow in idiomatic React is one async function with `await`. In re-frame2 it's three handlers + a registered fx. Six places where you'd have one.
 
 The benefits:
 
@@ -139,11 +137,11 @@ The benefits:
 
 ```clojure
 (rf/with-managed-request-stubs
-  {[:post "/api/login"] {:reply {:ok {:user {:email "test@example.com"}}}}}
+  {[:get "/api/inc.json"] {:reply {:ok {:delta 1}}}}
   (rf/with-frame [f (rf/make-frame
-                     {:on-create [:user/login {:email "a@b.c" :password "..."}]})]
-    (is (= "test@example.com"
-           (-> (rf/get-frame-db f) :auth/user :email)))))
+                     {:on-create [:counter/initialise]})]
+    (rf/dispatch-sync [:counter/inc-from-server] {:frame f})
+    (is (= 6 (:count (rf/get-frame-db f))))))
 ```
 
 The framework ships `with-managed-request-stubs` (and the lower-level `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs) precisely so tests can synthesise managed-HTTP replies without a network. It's a registry redirect, not a mock — the same dispatch shape the real fx produces lands in the test handler.

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -12,9 +12,9 @@ In the simplest case (one app, one page) these collapse together: there's *the* 
 A **view** is a function. It takes some inputs (props, mostly) and returns a description of what should be on the screen. In re-frame2, that description is **hiccup**: nested Clojure vectors that look like the DOM tree they describe.
 
 ```clojure
-[:div.greeting
- [:h1 "Hello"]
- [:p "Welcome back, " [:strong "Mike"] "."]]
+[:div.counter
+ [:h1 "Apples"]
+ [:p "Count: " [:strong "5"]]]
 ```
 
 Hiccup is *just data*. You can `pprint` it. You can build it programmatically. You can ship it across the wire. You can write a hiccup → HTML emitter that runs on the JVM (which is exactly what server-side rendering uses).
@@ -23,31 +23,31 @@ The fact that hiccup is data, rather than JSX-flavoured pseudo-HTML or a templat
 
 ### Plain views vs registered views
 
-The simplest view is a plain Clojure function:
+The chapter-02 counter view was the simplest case — no arguments, all state read through a sub. A small step up is a view that takes an argument. Suppose we want the counter to display a label alongside its number:
 
 ```clojure
-(defn greeting [name]
-  [:div.greeting
-   [:h1 "Hello"]
-   [:p "Welcome back, " [:strong name] "."]])
+(defn labelled-counter [label]
+  [:div.counter
+   [:h1 label]
+   [:span @(rf/subscribe [:count])]])
 ```
 
-You can use it anywhere by referencing the var: `[greeting "Mike"]` inside another piece of hiccup. Reagent (the underlying view substrate in the CLJS reference) calls the function and substitutes its return value into the tree.
+You can use it anywhere by referencing the var: `[labelled-counter "Apples"]` inside another piece of hiccup. Reagent (the underlying view substrate in the CLJS reference) calls the function and substitutes its return value into the tree.
 
 For most apps, this works fine. There's no ceremony, no registration, nothing to register or look up.
 
 But there's a sharper version: **registered views**.
 
 ```clojure
-(rf/reg-view greeting [name]
-  [:div.greeting
-   [:h1 "Hello"]
-   [:p "Welcome back, " [:strong name] "."]])
+(rf/reg-view labelled-counter [label]
+  [:div.counter
+   [:h1 label]
+   [:span @(subscribe [:count])]])
 ```
 
 Two things change:
 
-1. The view is registered under an auto-derived keyword, `(keyword *ns* "greeting")`. It's now in the registry alongside events, subs, fx. Tooling can list it. AIs can introspect it. You can query its `:doc`/`:spec` metadata.
+1. The view is registered under an auto-derived keyword, `(keyword *ns* "labelled-counter")`. It's now in the registry alongside events, subs, fx. Tooling can list it. AIs can introspect it. You can query its `:doc`/`:spec` metadata.
 
 2. **Inside the view's body, `dispatch` and `subscribe` are bound to the surrounding frame.** This is the load-bearing reason to register views. Without it, plain Reagent functions read state from a hard-coded default frame; you can't put two instances of the same view next to each other showing different state.
 
@@ -76,10 +76,10 @@ Form-1 views — render fns whose body is a literal hiccup expression — get th
   [:div @(subscribe [:count])])
 
 ;; Form-2 — captures args; useful for setup-once-then-render
-(rf/reg-view greeting [name]
-  (let [greeted-at (js/Date.now)]
-    (fn render [name]
-      [:div "Hello, " name " (at " greeted-at ")"])))
+(rf/reg-view labelled-counter [label]
+  (let [mounted-at (js/Date.now)]
+    (fn render [label]
+      [:div label ": " @(subscribe [:count]) " (mounted " mounted-at ")"])))
 ```
 
 The macro errors at compile time if you hand it a Form-3 (`reagent.core/create-class`) or a non-literal-fn body — the message points you at the underlying fn `reg-view*` for those rare cases. The compile-time check is the load-bearing piece: it stops the auto-inject from silently doing the wrong thing when the body shape isn't what the macro can rewrite.
@@ -95,17 +95,17 @@ The propagation is part of `reg-view`'s contract: a registered view inside `fram
 `reg-view` is defn-shape: it auto-defs the symbol you supply. Reference that var like any other Reagent component:
 
 ```clojure
-(rf/reg-view greeting [name] ...)
+(rf/reg-view labelled-counter [label] ...)
 
 ;; ... elsewhere
 [:div
- [greeting "Mike"]
- [greeting "Sandra"]]
+ [labelled-counter "Apples"]
+ [labelled-counter "Oranges"]]
 ```
 
 This reads exactly like Reagent. There's nothing to learn. It just happens to work for the multi-frame case because of the registration that's also happening.
 
-An alternative form exists — `(rf/view :my-ns/greeting)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `view` is the escape hatch for those specific cases.
+An alternative form exists — `(rf/view :my-ns/labelled-counter)` for runtime-id'd dispatch and late-binding (cross-module reference, hot-reload-sensitive call sites) — but the Var idiom is what you'll see most. `view` is the escape hatch for those specific cases.
 
 ## Frames
 
@@ -160,10 +160,10 @@ Both end with the same shape: a frame is in the global frame registry under its 
 Most frames you'll register fall into one of four shapes: a normal client app, a per-test fixture, a story variant, a per-request SSR frame. Writing the metadata for each by hand each time would be repetitive *and* would make the intent of the call site invisible. So re-frame2 ships a closed set of four canonical **presets**:
 
 ```clojure
-(rf/reg-frame :test/auth-flow      {:preset :test})
-(rf/reg-frame :story.cart/loading  {:preset :story})
-(rf/reg-frame :ssr.req/abc123      {:preset :ssr-server})
-(rf/reg-frame :app/main            {:preset :default})  ;; same as omitting :preset
+(rf/reg-frame :test/counter-flow      {:preset :test})
+(rf/reg-frame :story.counter/loading  {:preset :story})
+(rf/reg-frame :ssr.req/abc123         {:preset :ssr-server})
+(rf/reg-frame :app/main               {:preset :default})  ;; same as omitting :preset
 ```
 
 Each preset expands at registration time into a fixed bundle — `:test` redirects `:rf.http/managed` to the canned-success stub (so HTTP fx don't reach the network in tests) and stamps `:drain-depth 100`; `:story` does the same redirect and tightens `:drain-depth` to 16 so runaway dispatch cascades fail fast under a story; `:ssr-server` sets `:platform :server` and wires the server-projection error path. User-supplied keys override the expansion (so you can opt out of any one default), but the preset's name stays in the metadata and is queryable. The expansions are locked — every `:test` frame is configured the same way, every `:story` frame is configured the same way. Adding a fifth preset would be a Spec-change. The full grammar lives in [Spec 002 §Frame presets](../../spec/002-Frames.md#frame-presets-capability-bundles-for-common-configurations).

--- a/docs/guide/06-doing-http-requests.md
+++ b/docs/guide/06-doing-http-requests.md
@@ -2,9 +2,7 @@
 
 Most SPAs spend their lives talking to a server. A handler dispatches; a fetch goes out; some milliseconds later a reply lands; the handler integrates the reply; the view re-renders. Repeat a few thousand times per session.
 
-[Chapter 03](03-events-state-cycle.md) introduced the *shape* of that interaction: side-effects are data, the runtime interprets, the handler stays pure. This chapter narrows in on **the canonical mechanism re-frame2 ships for HTTP** — the `:rf.http/managed` fx — and walks through the contract end-to-end.
-
-The full normative contract lives in [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md). This chapter is the human-track companion: what the fx is, what it does, why it's shaped the way it is, and how the runnable examples exercise it.
+[Chapter 03](03-events-state-cycle.md) gave the counter a network reach: `:counter/inc-from-server` issued a managed request, the reply landed back, the count moved. That sketch is the spine of this chapter. We'll keep the counter as the worked example and unpack every contract row `:rf.http/managed` carries — request shape, decode pipeline, retry, abort, frame-aware reply — by extending the counter one feature at a time. The full normative contract lives in [`spec/014-HTTPRequests.md`](../../spec/014-HTTPRequests.md); this chapter is the human-track companion.
 
 ## What `:rf.http/managed` is
 
@@ -12,18 +10,18 @@ A registered fx whose args map describes an HTTP request *as data*, and whose ru
 
 You don't write the fetch. You don't write the `.then` chain. You don't reach for `js/fetch` or `java.net.http.HttpClient` directly. You return a map, the runtime does the rest.
 
-A first taste, in the simplest possible form:
+A first taste, in the simplest possible form — a button that asks the server for an increment and applies the reply to the counter:
 
 ```clojure
-(rf/reg-event-fx :ping
+(rf/reg-event-fx :counter/+1
   (fn [{:keys [db]} [_ msg]]
     (if-let [reply (:rf/reply msg)]
       ;; Reply branch — same handler, different role.
-      {:db (assoc db :pinged-at (:elapsed-at reply))}
+      {:db (update db :count + (-> reply :value :delta))}
 
       ;; Initial branch — issue the managed request.
       {:fx [[:rf.http/managed
-             {:request {:url "/ping"}}]]})))
+             {:request {:url "/api/inc.json"}}]]})))
 ```
 
 Two lines of fx, no decode, no accept, no retry. Default `:method` is `:get`. Default decode is `:auto` (sniff the response Content-Type). Default reply addressing dispatches *back to this same event id* with `:rf/reply` merged into the original message — so one handler covers both roles, distinguishable by `(:rf/reply msg)`.
@@ -51,20 +49,20 @@ The args map for `:rf.http/managed` is small. The required keys are `:request` (
 
 ```clojure
 {:request    {:method  :post
-              :url     "/api/articles"
-              :params  {:tag "clojure"}
-              :body    {:title "..."}
+              :url     "/api/counter"
+              :params  {:scope "session"}
+              :body    {:delta 1}
               :request-content-type :json
               :headers {"X-Trace" "abc"}}
- :decode     ArticleResponse           ;; Malli schema, kw, fn, or :auto
+ :decode     CounterResponse           ;; Malli schema, kw, fn, or :auto
  :accept     (fn [decoded] {:ok decoded})  ;; default = success-on-2xx
  :retry      {:on #{:rf.http/transport :rf.http/http-5xx}
               :max-attempts 4
               :backoff      {:base-ms 250 :factor 2 :max-ms 5000 :jitter true}}
  :timeout-ms 30000
- :on-success [:articles/loaded]        ;; default = back to originator
- :on-failure [:articles/load-error]    ;; default = back to originator
- :request-id :articles/load            ;; for abort + supersede
+ :on-success [:counter/loaded]         ;; default = back to originator
+ :on-failure [:counter/load-error]     ;; default = back to originator
+ :request-id :counter/load             ;; for abort + supersede
  :abort-signal external-controller-signal}
 ```
 
@@ -91,28 +89,28 @@ When you don't specify `:on-success` / `:on-failure`, the fx captures the origin
 So your handler ends up looking like:
 
 ```clojure
-(rf/reg-event-fx :article/load
-  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+(rf/reg-event-fx :counter/load
+  (fn [{:keys [db]} [_ {:as msg}]]
     (if-let [reply (:rf/reply msg)]
       ;; Reply path
       (case (:kind reply)
         :success
         {:db (-> db
-                 (assoc-in [:article :status] :loaded)
-                 (assoc-in [:article :data]   (:value reply)))}
+                 (assoc :counter/status :loaded)
+                 (assoc :count (-> reply :value :count)))}
 
         :failure
         {:db (-> db
-                 (assoc-in [:article :status] :error)
-                 (assoc-in [:article :error]  (:failure reply)))})
+                 (assoc :counter/status :error)
+                 (assoc :counter/error  (:failure reply)))})
 
       ;; Initial path
       {:db (-> db
-               (assoc-in [:article :status] :loading)
-               (assoc-in [:article :error]  nil))
+               (assoc :counter/status :loading)
+               (assoc :counter/error  nil))
        :fx [[:rf.http/managed
-             {:request {:url (str "/articles/" slug)}
-              :decode  ArticleResponse}]]})))
+             {:request {:url "/api/counter"}
+              :decode  CounterResponse}]]})))
 ```
 
 One handler, two roles, distinguishable by the `:rf/reply` sentinel. The reply payload's outer shape is `{:kind :success :value v}` or `{:kind :failure :failure m}`; the inner `:kind` (under `:failure`) names the `:rf.http/*` category.
@@ -144,7 +142,7 @@ The `:decode` key controls how the response body is parsed.
 
 The `:decode` key takes:
 
-- **A Malli schema** (the canonical form): `:decode ArticleResponse`. The fx parses the body by content-type, runs Malli's `decode`, hands the validated value to `:accept`. A 2xx body that fails to decode classifies as `:rf.http/decode-failure`.
+- **A Malli schema** (the canonical form): `:decode CounterResponse`. The fx parses the body by content-type, runs Malli's `decode`, hands the validated value to `:accept`. A 2xx body that fails to decode classifies as `:rf.http/decode-failure`.
 - **A keyword**: `:decode :json` (force JSON), `:text`, `:blob`, `:array-buffer`, `:form-data`. No Malli step.
 - **A function** `(fn [body-text headers] decoded)` — full control. Throwing on a 2xx classifies as `:rf.http/decode-failure`.
 - **`:auto`** (the default): sniff the response Content-Type. `application/json*` → JSON. `text/*` → text. Otherwise blob. Whenever `:auto` resolves and the user did NOT explicitly supply `:decode`, the runtime emits a single `:rf.warning/decode-defaulted` trace per request — informational, not an error, just visible in tooling so you can choose to be explicit.
@@ -154,18 +152,18 @@ The `:decode` key takes:
 Pair tools and AI generators want to know which schemas a handler expects from the wire — without invoking the handler. Declare them at registration time via the `:rf.http/decode-schemas` metadata key:
 
 ```clojure
-(rf/reg-event-fx :article/load
-  {:doc                    "Load an article."
-   :rf.http/decode-schemas [ArticleResponse]}     ;; declared up-front for tooling
-  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+(rf/reg-event-fx :counter/load
+  {:doc                    "Load the persisted counter."
+   :rf.http/decode-schemas [CounterResponse]}     ;; declared up-front for tooling
+  (fn [{:keys [db]} [_ {:as msg}]]
     (if-let [reply (:rf/reply msg)]
       ...
       {:fx [[:rf.http/managed
-             {:request {:url (str "/articles/" slug)}
-              :decode  ArticleResponse}]]})))     ;; same schema at the call site
+             {:request {:url "/api/counter"}
+              :decode  CounterResponse}]]})))     ;; same schema at the call site
 ```
 
-Then `(rf/handler-meta :event :article/load)` returns metadata carrying `:rf.http/decode-schemas [ArticleResponse]`, which tools introspect. **Optional, never enforced** — the runtime does not cross-check that the call-site `:decode` matches the declared schemas. The metadata is reflective sugar; runtime enforcement would want a `defmanaged-event-fx` macro that DRYs the declaration, which is out of v1 scope.
+Then `(rf/handler-meta :event :counter/load)` returns metadata carrying `:rf.http/decode-schemas [CounterResponse]`, which tools introspect. **Optional, never enforced** — the runtime does not cross-check that the call-site `:decode` matches the declared schemas. The metadata is reflective sugar; runtime enforcement would want a `defmanaged-event-fx` macro that DRYs the declaration, which is out of v1 scope.
 
 ## Retry and backoff
 
@@ -190,12 +188,13 @@ A common shape in real apps: declare a shared retry policy for read-only data fe
    :max-attempts 3
    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
 
-;; Apply to reads:
-[:rf.http/managed {:request {:url "/articles"} :decode ArticleListResponse :retry data-fetch-retry}]
+;; Apply to reads — e.g. loading the persisted counter:
+[:rf.http/managed {:request {:url "/api/counter"} :decode CounterResponse :retry data-fetch-retry}]
 
-;; Don't apply to writes:
-[:rf.http/managed {:request {:method :post :url "/articles" :body draft :request-content-type :json}
-                   :decode  ArticleResponse}]
+;; Don't apply to writes — e.g. saving the counter:
+[:rf.http/managed {:request {:method :post :url "/api/counter"
+                             :body {:count (:count db)} :request-content-type :json}
+                   :decode  CounterResponse}]
 ```
 
 The realworld example does exactly this — see `examples/reagent/realworld/http.cljs`.
@@ -205,15 +204,15 @@ The realworld example does exactly this — see `examples/reagent/realworld/http
 A stable id on the request lets a subsequent `:rf.http/managed-abort` fx cancel the in-flight request. The id can be anything `=`-comparable: a keyword, a string, a vector, a uuid.
 
 ```clojure
-(rf/reg-event-fx :search/query
-  (fn [{:keys [db]} [_ {:keys [q] :as msg}]]
+(rf/reg-event-fx :counter/start-long
+  (fn [{:keys [db]} [_ {:as msg}]]
     (if-let [reply (:rf/reply msg)]
-      ;; ...handle results...
-      {:fx [[:rf.http/managed-abort :search]                 ;; cancel previous
+      ;; ...handle the late reply (or its :rf.http/aborted form)...
+      {:fx [[:rf.http/managed-abort :counter/long]           ;; cancel previous
             [:rf.http/managed
-             {:request    {:url "/search" :params {:q q}}
-              :request-id :search
-              :decode     SearchResponse}]]})))
+             {:request    {:url "/api/long"}
+              :request-id :counter/long
+              :decode     CounterResponse}]]})))
 ```
 
 When two in-flight requests share an id, issuing a new one with the same id supersedes the old one — the previous request aborts with `:reason :request-id-superseded`. A manual `:rf.http/managed-abort` aborts whichever request currently holds the id with `:reason :user`. Aborted requests dispatch `:on-failure` (or the default reply path) with `:kind :rf.http/aborted`.
@@ -246,11 +245,11 @@ Tests want managed-HTTP requests to resolve against canned data, not the network
 
 ```clojure
 ;; Success stub — synthesises a success reply.
-(rf/dispatch-sync [:article/load {:slug "hello"}]
+(rf/dispatch-sync [:counter/load]
                   {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
 
 ;; Failure stub — synthesises a failure reply.
-(rf/dispatch-sync [:article/load {:slug "missing"}]
+(rf/dispatch-sync [:counter/load]
                   {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
 ```
 
@@ -262,12 +261,12 @@ For test suites that exercise many requests:
 
 ```clojure
 (rf/with-managed-request-stubs
-  {[:get  "/articles/hello"]   {:reply {:ok hello-article}}
-   [:get  "/articles/missing"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
-   [:post "/articles"]         {:reply {:ok new-article}}}
-  (rf/dispatch-sync [:article/load {:slug "hello"}])
-  (rf/dispatch-sync [:article/load {:slug "missing"}])
-  (rf/dispatch-sync [:article/create {:title "..."}]))
+  {[:get  "/api/counter"]       {:reply {:ok {:count 5}}}
+   [:get  "/api/does-not-exist"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
+   [:post "/api/counter"]        {:reply {:ok {:count 6}}}}
+  (rf/dispatch-sync [:counter/load])
+  (rf/dispatch-sync [:counter/load-bad])
+  (rf/dispatch-sync [:counter/save]))
 ```
 
 The helper inspects each `:rf.http/managed` invocation's `:request :method` + `:request :url` and routes through the configured reply. Wrap a test, run dispatches, assert against the resulting `app-db`. No browser, no network.
@@ -276,7 +275,7 @@ The canned-stub fxs gate on `interop/debug-enabled?` — they elide in productio
 
 ## Worked example — `examples/reagent/managed_http_counter/`
 
-The runnable demo of every contract above lives in [`examples/reagent/managed_http_counter/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter). It's a counter where each button issues a managed HTTP request and the reply lands back in app-db.
+The runnable demo of every contract above lives in [`examples/reagent/managed_http_counter/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter). It's the same counter from chapter 02, extended with HTTP — each button issues a managed request and the reply lands back in app-db. The counter's spine carries through unchanged; HTTP layers on top.
 
 Five buttons, each exercising a different slice of the contract:
 


### PR DESCRIPTION
## Summary

The early-chapters worked example was switching toys every chapter — counter in 02, login in 03, back to counter in 04, login in 05, counter/article/realworld in 06. Every chapter the reader had to re-load context. Tutorial shape suffered.

This PR converges ch.02-04 + ch.06 onto the counter, confining login to ch.05 where state machines is the chapter's topic.

## Per-chapter changes

- **ch.02** — unchanged (already pure counter).
- **ch.03** — rewrite the worked example as `:counter/inc-from-server` / `:counter/inc-loaded` / `:counter/inc-error`. Same effects-as-data lesson, same test-stub pattern, same prose; the toy is the counter, persisting to localStorage and fetching deltas from a server. Replaces the `:user/login` flow. (+21 words)
- **ch.04** — replace the `greeting` view with a `labelled-counter` view that takes a label arg. Same Form-1/Form-2 demonstration, same Var-reference idiom. Frame-presets variety preserved (test/story/ssr/default) but renamed to counter-themed where natural. (+24 words)
- **ch.05** — unchanged. Login flow stays here, where it's the natural FSM example.
- **ch.06** — rewrite the central `:article/load` worked example as `:counter/load`. The `managed_http_counter` runnable demo was already the natural anchor; the chapter intro now points at it from the first line. The realworld breadth demo stays at the end (it remains the legitimate breadth survey). (+31 words)

## Hot zones

- No agents currently in flight against ch.02-06; clean dispatch.
- Realworld description block in ch.06 deliberately preserved as-is (it describes the actual realworld example's contents).

## Test plan

- [x] mkdocs build — clean, no new warnings vs main
- [x] cross-link audit — all inter-chapter links and Spec links intact
- [x] word-count deltas — minimal (+21/+24/+31 across three chapters)
- [x] each chapter re-read end-to-end after editing