### PR TITLE
docs(guide): teach the canonical patterns (rf2-2c6r)

### DIFF
--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -206,6 +206,7 @@ Each of these has been distilled into a **Pattern** doc — convention, not Spec
 - [Pattern-WebSocket](../../spec/Pattern-WebSocket.md) — long-lived connection as a state machine.
 - [Pattern-LongRunningWork](../../spec/Pattern-LongRunningWork.md) — chunked yielding or worker offload for CPU-heavy work.
 - [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) — the epoch idiom for ignoring superseded async results.
+- [Pattern-NineStates](../../spec/Pattern-NineStates.md) — making the nine common UI states (`Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many` / `Incorrect` / `Correct` / `Done`) explicit in data so each branch is testable.
 
 The pattern docs are themselves human-readable — closer in voice to this guide than to the Specs. When the shape of a feature you're building matches one of them, read the pattern doc and copy the shape; don't invent a new one.
 

--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -234,6 +234,28 @@ Flows are deliberately a **niche convenience**, not a sub replacement — a typi
 
 Routing is just another slice of `app-db`. The current route lives at `:route` (a `{:id :params :query :fragment :transition :nav-token}` map); navigation is an event; the active route is a sub. There's no separate routing runtime — it's data that happens to be reflected in the address bar. The full story (deterministic ranking, navigation tokens, `:can-leave` guards, multi-frame routing) is in [chapter 12](12-routing.md) and [Spec 012](../../spec/012-Routing.md). For this chapter, the load-bearing fact is that routing doesn't break the one-app-db model.
 
+## Making the common UI states explicit — Pattern-NineStates
+
+Once your view is reading state from `app-db`, a temptation appears: branch the render on a few obvious cases (`loading`, `loaded`, `error`) and call it done. The trouble is that most pages have more than three meaningful states, and the missing ones — the empty result, the single-item case, the too-many-results case, the validation-failure case, the terminal "this is archived now" case — end up visually undefined unless you treat them as first-class.
+
+**Pattern-NineStates** names the canonical checklist for a page-level render contract:
+
+| # | State | Typical source |
+|---|---|---|
+| 1 | **Nothing** — user hasn't asked for a fetch yet | Remote-data slice `:status :idle` |
+| 2 | **Loading** — first fetch in flight | `:status :loading` |
+| 3 | **Empty** — loaded, zero results | `:status :loaded` + count `0` |
+| 4 | **One** — loaded, exactly one result | `:status :loaded` + count `1` |
+| 5 | **Some** — loaded, manageable list | `:status :loaded` + bounded count |
+| 6 | **Too Many** — loaded, count above a domain threshold | `:status :loaded` + count > threshold |
+| 7 | **Incorrect** — user input invalid, user can fix it | Form slice errors + touched visibility |
+| 8 | **Correct** — visible success acknowledgement | Form slice `:status :submitted` |
+| 9 | **Done / Frozen** — domain reached terminal / read-only | Terminal machine state, or `:archived?` |
+
+The pattern is a **design checklist** plus a **rendering convention**, not a universal ontology — most pages don't need all nine, but most pages do need *more than three*. The states are derived from the slices you already have (remote-data, form, machine snapshot), not mirrored into a new page-local enum. Each becomes a named sub (`:ui.state/empty?`, `:ui.state/incorrect?`, …) and the root view branches explicitly across them — so each branch is testable, each branch is reviewable, and "we forgot what happens when the result is empty" stops being a class of bug.
+
+Full convention plus a worked example: [`spec/Pattern-NineStates.md`](../../spec/Pattern-NineStates.md) and [`examples/reagent/nine_states/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/nine_states).
+
 ## A small example: split counter
 
 Two counters, side by side, isolated:

--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -313,12 +313,64 @@ Each of these is opt-in — implementations declare which capabilities they supp
 
 ## Patterns that bottom out in machines
 
-Two of the recurring shapes from [chapter 03](03-events-state-cycle.md) end up being state machines underneath:
+Two recurring shapes from [chapter 03](03-events-state-cycle.md) are state machines underneath. Both are pattern docs (convention), not Specs (contract). The shape is worth knowing in outline even if you don't write one today — the moment you reach for `setTimeout`-driven reconnect logic or an `:app/init` event that does six things, you'll recognise it.
 
-- [Pattern-WebSocket](../../spec/Pattern-WebSocket.md) — a long-lived connection has phases (`:disconnected`, `:connecting`, `:connected`, `:reconnecting`, `:failed`), retry-with-backoff via `:after`, queued sends while disconnected, server-pushed events. The whole connection lifecycle is naturally a machine; messages flowing over an open connection are ordinary async-effect interactions.
-- [Pattern-Boot](../../spec/Pattern-Boot.md) — multi-step initialisation with sequential dependencies, visible progress, fail-fatal points, and recoverable retry. For trivial boots a chained event sequence works; for non-trivial boots the canonical answer is a boot machine.
+### Pattern-WebSocket — a connection as a machine
 
-Both are pattern docs (convention), not Specs (contract). When the shape of a feature you're building is one of these, read the pattern doc and copy the shape.
+WebSocket, Server-Sent Events, WebRTC peers — anything with retry, backoff, heartbeat, subscriptions, and server-pushed events — is state-machine-shaped:
+
+```text
+:disconnected ─open─►   :connecting
+:connecting   ─opened─► :authenticating
+:authenticating ─ok─►   :connected ◄─┐
+:connected    ─close─►  :reconnecting ─after backoff─► :connecting
+:reconnecting ─max retries─► :failed
+```
+
+`:connected` typically has sub-states (`:idle / :sending / :receiving`); `:reconnecting` carries the exponential-backoff counter in `:data`; subscribed topics live in `:data :subscriptions` and re-issue automatically on entry to `:connected` (so subscriptions survive reconnects). Messages flowing *over* the open connection are ordinary Pattern-AsyncEffect interactions — request-reply with a correlation id; the connection machine is the long-lived host.
+
+The connection machine composes the locked substrate end-to-end: hierarchical states for `:connected`, `:after` for backoff, `:always` for max-retries guards and queue flushing on entry, `:invoke` to spawn a child socket actor that owns the actual `WebSocket` object. No new mechanism — just one machine exercising every primitive at once. Full walkthrough: [`spec/Pattern-WebSocket.md`](../../spec/Pattern-WebSocket.md).
+
+### Pattern-Boot — initialisation as a machine
+
+For trivial boots — one or two steps, no error states, no progress UI — a chain of dispatched events is fine:
+
+```clojure
+(rf/reg-event-fx :app/init
+  (fn [_ _]
+    {:fx [[:dispatch [:config/load]]]}))
+
+(rf/reg-event-fx :config/load
+  (fn [_ _]
+    {:fx [[:rf.http/managed
+           {:request    {:url "/config"}
+            :on-success [:config/loaded]
+            :on-failure [:app/init-failed]}]]}))
+
+(rf/reg-event-fx :config/loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (assoc db :config (:body value))
+     :fx [[:dispatch [:app/ready]]]}))
+```
+
+The frame's `:on-create` fires `:app/init`, the chain runs to completion, the UI renders.
+
+Once the boot graph has more than a few steps — auth restoration, profile load, hydration from `localStorage`, route resolution, real-time connect — chained events scatter logic across N unrelated handlers. The canonical answer is a **boot state machine** with named phases:
+
+| State | Meaning |
+|---|---|
+| `:configuring` | Reading static config. |
+| `:authenticating` | Restoring session token; refreshing if needed. |
+| `:loading-profile` | Fetching user profile / feature flags. |
+| `:hydrating` | Applying client-side persistent state. |
+| `:routing` | Resolving the initial route. |
+| `:ready` | Boot complete. (Terminal.) |
+| `:auth-failed` / `:fatal-error` | Per-phase error states. |
+| `:retrying-auth` | Recovery state with `:after` backoff. |
+
+Each phase `:invoke`s the async work; transitions on success / failure; entry actions update the visible-progress slice in `:data`. The boot UI subscribes to the snapshot and renders "Loading config…" / "Signing in…" / "Almost ready…" by state. The whole sequence is one inspectable, testable, traceable machine.
+
+The boot machine is also the canonical seam between **host-supplied static config** (a `/config` endpoint, build-time env vars) and the **running app's dynamic state** — `:configuring` lands the config into `:data`; subsequent states read from `:data :config` and thread values into the next phase's spawn-spec rather than reaching into globals. Full walkthrough including the auth-machine's transport-vs-semantic retry boundary: [`spec/Pattern-Boot.md`](../../spec/Pattern-Boot.md).
 
 ## When to reach for a machine, and when not to
 

--- a/docs/guide/06-doing-http-requests.md
+++ b/docs/guide/06-doing-http-requests.md
@@ -273,6 +273,36 @@ The helper inspects each `:rf.http/managed` invocation's `:request :method` + `:
 
 The canned-stub fxs gate on `interop/debug-enabled?` — they elide in production builds, so tests pay no production cost.
 
+## The standard request-lifecycle slice
+
+`:rf.http/managed` gives you the *mechanics* of a request — fire it, decode the reply, retry, abort. It doesn't give you the *shape* of the slice you write that reply into. Across every feature that loads remote data, the same five-key shape recurs:
+
+```clojure
+{:status     :idle | :loading | :fetching | :loaded | :error
+ :data       <result-or-nil>
+ :error      <error-or-nil>
+ :loaded-at  <timestamp-or-nil>
+ :attempt    <int>}                 ;; bumps on every fetch; 0 means "never fetched"
+```
+
+This is **Pattern-RemoteData** — convention, not Spec. Every team that builds a non-trivial app converges on something like it; the pattern doc just names a canonical shape so codebases (and AI scaffolds) don't each invent a slightly different one.
+
+The load-bearing piece is the **`:loading` vs `:fetching` split**:
+
+| Status | Meaning | Typical UI | Has `:data`? |
+|---|---|---|---|
+| `:idle` | Never fetched. | Empty state / call-to-action. | No. |
+| `:loading` | First fetch in flight. No `:data` yet. | Spinner / skeleton. | No. |
+| `:fetching` | Re-fetch in flight while we already have `:data` (revalidation, polling, retry-with-data). | Subtle progress indicator at most; **never blank the page**. | Yes (the previous `:data`). |
+| `:loaded` | Fetch completed. `:data` is fresh. | Render `:data`. | Yes. |
+| `:error` | The most recent fetch failed. Prior `:data` may still be present. | Error UI; offer retry; still render stale `:data` if appropriate. | Maybe. |
+
+The split exists because the UI for an empty page mid-load is a spinner, but the UI for a page that already has data and is refreshing isn't — without the split, every revalidation flashes a spinner over loaded content.
+
+Four standard events shape the slice, namespaced per feature (`:articles/load`, `:articles/loaded`, `:articles/load-failed`, optionally `:articles/reset`). The `:load` handler picks `:loading` vs `:fetching` based on whether `:data` is currently `nil`; `:loaded` sets `:data` and `:loaded-at`; `:load-failed` records the error but keeps any prior `:data` so the view can still render staleness rather than blank. Convenience subs like `:loading?` (truly empty + in-flight) and `:fetching?` (any in-flight) drive views without per-feature gymnastics.
+
+For the full slice schema, the four-event walkthrough, optimistic-update rollback, and the `:loaded-at` / `:stale-after-ms` freshness story, see [`spec/Pattern-RemoteData.md`](../../spec/Pattern-RemoteData.md). The RealWorld example exercises the full shape across `articles`, `feed`, `profile`, and `comments` slices.
+
 ## Worked example — `examples/reagent/managed_http_counter/`
 
 The runnable demo of every contract above lives in [`examples/reagent/managed_http_counter/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter). It's the same counter from chapter 02, extended with HTTP — each button issues a managed request and the reply lands back in app-db. The counter's spine carries through unchanged; HTTP layers on top.


### PR DESCRIPTION
## Summary

Sixth-criterion follow-up to the guide audit. The other five criteria were addressed by PRs #263-267; this one covers the Pattern-*.md worked-example conventions.

Audited each `spec/Pattern-*.md` against the guide. Three patterns (AsyncEffect, StaleDetection, plus the WebSocket+Boot machine outlines) were already in reasonable shape; four needed direct edits; two warrant follow-up beads for fuller coverage.

### Direct edits

- **ch.03** — Pattern-NineStates added to the recurring-shapes enumeration; it was missing from the otherwise-complete list.
- **ch.04** — new Pattern-NineStates section teaching the nine-state checklist (Nothing / Loading / Empty / One / Some / Too Many / Incorrect / Correct / Done) as a page-level render contract derived from existing slices.
- **ch.05** — replaced the one-paragraph "patterns that bottom out in machines" callout with proper subsections for Pattern-WebSocket (states + transitions + composition with the locked substrate) and Pattern-Boot (chained-events vs boot-machine form, six standard phases, host-config-seam role).
- **ch.06** — new Pattern-RemoteData section teaching the standard five-key request-lifecycle slice and the load-bearing `:loading` vs `:fetching` split, which the chapter previously left to the spec cross-reference.

### Follow-up beads filed

- **rf2-9o0j** — Suggestion: teach Pattern-Forms in the guide (form-slice + seven-event lifecycle + touched-OR-submit-attempted visibility rule). Warrants either a section in ch.05 or its own mid-guide chapter; too large for this PR.
- **rf2-n20h** — Suggestion: teach Pattern-LongRunningWork in the guide (chunked state-machine + `:after 0` yielding + worker-offload preference). Worked example exercises `:after`/`:always`/hierarchical guards — naturally fits as a section in ch.05.

### Coverage audit verdicts

| Pattern | Verdict | Action |
|---|---|---|
| Pattern-AsyncEffect | Covered well | None (ch.03 is the AsyncEffect chapter) |
| Pattern-RemoteData | Covered shallowly | Added 5-key slice + loading/fetching split to ch.06 |
| Pattern-Forms | Uncovered | Filed rf2-9o0j |
| Pattern-Boot | Covered shallowly | Strengthened ch.05 subsection |
| Pattern-WebSocket | Covered shallowly | Strengthened ch.05 subsection |
| Pattern-LongRunningWork | Uncovered | Filed rf2-n20h |
| Pattern-StaleDetection | Covered well | None (ch.12 + ch.03 enumeration) |
| Pattern-NineStates | Uncovered | Added section to ch.04, enumerated in ch.03 |

## Test plan

- [x] mkdocs build runs clean (no new warnings introduced)
- [x] Cross-references all resolve (`spec/Pattern-*.md` links)
- [x] Voice matches the guide (conversational, dry, CLJS examples; counter-as-worked-example where applicable)
- [x] Pattern docs themselves untouched (normative)