### PR TITLE
chore: establish /tools convention for CLJS dev tools (rf2-e6g9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ implementation/                CLJS reference implementation — split into per-
   shadow-cljs.edn              top-level build coordinator: pulls all artefacts onto one classpath
                                for the browser/elision/examples builds
   deps.edn                     top-level build coordinator (clojure-tools): :local/root deps for all
+tools/                         CLJS dev/inspection tools that consume re-frame2's instrumentation
+                               API (Spec 009, Tool-Pair). Sibling of implementation/, not part of
+                               it — bundle-isolated from production builds (rf2-e6g9).
+  story/                       day8/re-frame-2-story — Storybook-flavoured playground (in design)
+  story-mcp/                   day8/re-frame-2-story-mcp — MCP agent surface for story; separate
+                               jar per rf2-m6tu §6.1 (in design)
+  machines-viz/                day8/re-frame-2-machines-viz — XState-style state-chart visualisation
+                               (in design)
+  machines-viz-mcp/            day8/re-frame-2-machines-viz-mcp — MCP surface for machines-viz;
+                               likely separate jar (in design)
+  10x/                         day8/re-frame-2-10x — re-frame-10x v2 (in design; partial answer to
+                               rf2-tijr's repo-placement question)
 skills/                        Claude skills (planned; pair-improver and friends)
 ```
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,115 @@
+# tools/
+
+This directory houses **CLJS dev / inspection tools** that consume re-frame2's
+instrumentation API. Each tool ships as its own Maven artefact, on its own
+release cadence, and is intentionally kept out of the runtime path that
+production consumers depend on.
+
+`tools/` is a sibling of `implementation/`, not part of it. The split is
+deliberate — see the bundle-isolation contract below.
+
+## How `tools/` differs from `implementation/`
+
+| | `implementation/` | `tools/` |
+|---|---|---|
+| Who `:require`s it? | Consumers' production apps | Dev / story / agent surfaces |
+| What contract does it implement? | The Pattern Specification (`spec/`) | Downstream consumer of the spec's instrumentation API (Spec 009, Tool-Pair) |
+| Bundle exposure? | Shipped to end users | Must not reach a production build |
+| Release cadence? | Lockstep through `1.0` (rf2-w05l) | Per-tool, independent |
+| Owns spec surface? | Yes — `implementation/core/` is the canonical reference | No — tools *consume* the surface |
+
+`implementation/core/` is the runtime; everything in `tools/` is a downstream
+observer of that runtime.
+
+## The bundle-isolation contract
+
+Tools must not be reachable from a consumer's production build.
+
+- A tool may `:require` from `implementation/core/` (and from the per-feature
+  artefacts where its job demands it — e.g. a machine visualiser will pull
+  `implementation/machines/`). The dependency flows **tool → implementation**.
+- The reverse is forbidden. Nothing under `implementation/` may `:require`
+  anything under `tools/`. Adding such a dep would haul tooling weight
+  (DOM-heavy UI, monaco, story metadata, MCP server bits) into every
+  consumer's production bundle.
+- The contract is enforced **structurally**: `tools/` is a separate
+  classpath root, not on `implementation/`'s `deps.edn` or
+  `shadow-cljs.edn`. Bundle isolation is "the wrong artefact is absent
+  from the classpath" — same mechanism the substrate adapters use.
+
+Today this convention exists as a directory split plus disciplined
+`deps.edn` hygiene. The physical separation makes the contract obvious
+to humans, agents, and tree-shakers alike.
+
+## Per-tool layout
+
+Each tool gets its own subdirectory, structured like the per-adapter jars
+under `implementation/adapters/`:
+
+```
+tools/
+├── <tool>/
+│   ├── deps.edn              ; declares day8/re-frame-2-<tool>
+│   ├── src/...               ; tool source
+│   └── test/...              ; tool tests
+└── ...
+```
+
+Each `deps.edn` carries a `:local/root` dep on `../../implementation/core`
+(plus whichever per-feature artefacts the tool legitimately consumes).
+Each tool publishes to Clojars under `day8/re-frame-2-<tool>`.
+
+A top-level `tools/deps.edn` and `tools/shadow-cljs.edn` may appear later
+as build coordinators (matching the pattern in `implementation/`) once
+there's more than one tool to coordinate. Not needed yet.
+
+## Future homes
+
+Each entry below is **in design** — none implemented yet. They land here as
+implementation work begins; empty scaffolding is not created up-front.
+
+- **`tools/story/`** — `day8/re-frame-2-story`. Storybook-flavoured component
+  playground with frame-aware controls, machine-state visualisation, and
+  time-travel scrubbing. Spec surface: [`spec/007-Stories.md`](../spec/007-Stories.md).
+
+- **`tools/story-mcp/`** — `day8/re-frame-2-story-mcp`. A separate MCP agent
+  surface for story (per the rf2-m6tu §6.1 separation: human-facing tool and
+  agent-facing surface ship as distinct jars so the MCP server can be loaded
+  without dragging the entire story UI into the classpath).
+
+- **`tools/machines-viz/`** — `day8/re-frame-2-machines-viz`. XState-style
+  state-chart visualisation for machines registered via `reg-machine`.
+  Consumes the trace bus and per-frame machine snapshots.
+
+- **`tools/machines-viz-mcp/`** — `day8/re-frame-2-machines-viz-mcp`. Likely
+  a separate MCP surface for machine viz, mirroring the story / story-mcp
+  split. Confirmed separation pending the first cut.
+
+- **`tools/10x/`** — `day8/re-frame-2-10x`. re-frame-10x v2 — the interactive
+  devtools panel for the runtime. This entry partially answers
+  [`rf2-tijr`](../.beads/) (the repo-placement question): 10x v2 lives here.
+  The vendoring-replaced-by-multi-frame-isolation work tracked by that bead
+  remains open.
+
+## Distinction from `skills/`
+
+`skills/` and `tools/` look superficially similar — both sit at the top level,
+both are downstream of the spec — but they are different artefacts entirely:
+
+| | `skills/` | `tools/` |
+|---|---|---|
+| Artefact kind | Markdown agent definitions (Claude Code skills) | CLJS jars |
+| Consumption model | Loaded by an AI agent at invocation time | `:require`d by a dev build |
+| Build pipeline | npm + Claude Code Plugin packaging | Clojars publish via the multi-artefact release pipeline |
+| Runtime substrate | The agent (Claude Code) | A CLJS runtime + the host's frame(s) |
+
+They are kept separate intentionally — different lifecycles, different
+consumption models, different publication channels.
+
+## See also
+
+- [Spec 009 — Instrumentation](../spec/009-Instrumentation.md) — the API surface tools consume.
+- [Spec Tool-Pair](../spec/Tool-Pair.md) — runtime contract for pair-shaped AI tools (re-frame-pair and equivalents).
+- [Spec 007 — Stories](../spec/007-Stories.md) — the contract `tools/story/` will implement.
+- [`implementation/adapters/README.md`](../implementation/adapters/README.md) — the per-jar layout pattern this directory mirrors.
+- [`skills/README.md`](../skills/README.md) — for the markdown-agent flavour of downstream artefacts.


### PR DESCRIPTION
## Summary

- Adds `tools/` as a top-level sibling of `implementation/`, with `tools/README.md` explaining the convention: CLJS dev/inspection tools that consume re-frame2's instrumentation API ship here as per-tool jars (each with its own Clojars coord), matching the per-adapter pattern in `implementation/adapters/`.
- The directory split makes the bundle-isolation contract physically obvious — tools may `:require` from `implementation/core/` but never vice versa, so tooling weight (DOM-heavy UI, MCP servers, story metadata) cannot reach a consumer's production bundle.
- Lists future homes (all in design, no scaffolding created): `tools/story/`, `tools/story-mcp/`, `tools/machines-viz/`, `tools/machines-viz-mcp/`, `tools/10x/`. The `tools/10x/` placement partially answers `rf2-tijr`'s repo-placement question (note added on that bead).
- Updates the top-level `README.md` Project layout block to reflect the new directory.

## Test plan

- [x] `mkdocs build` ends clean (no new warnings; pre-existing spec-cross-reference INFO lines unchanged).
- [x] No changes under `spec/`, `implementation/`, `examples/`, `docs/`, or `skills/`.
- [x] `tools/README.md` cross-references render correctly against the repo-root layout.