### PR TITLE
feat(story): Stage 2 — core authoring surface (rf2-32dk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Clojure / CLJS
 /.cpcache/
+**/.cpcache/
 /.shadow-cljs/
 /target/
 /out/

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -45,6 +45,16 @@
                 "ssr/test"
                 "epoch/src"
                 "epoch/test"
+                ;; tools/story (re-frame2-story Stage 2, rf2-32dk).
+                ;; Source paths added so the `:node-test` build picks up
+                ;; `tools/story/test/re_frame/story_cljs_test.cljs`. The
+                ;; bundle-isolation contract (tools/README.md) forbids
+                ;; reverse :require — nothing under implementation/ may
+                ;; require anything under tools/. Listing the source
+                ;; path here only makes the files available to shadow's
+                ;; classpath; it does NOT introduce a require dependency.
+                "../tools/story/src"
+                "../tools/story/test"
                 ;; Per rf2-kx74 examples/ is grouped per substrate. Each
                 ;; substrate root is its own shadow-cljs source path so
                 ;; the per-example namespaces (counter.core,

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -26,9 +26,11 @@
 
          ;; Malli drives Story's three-level args / argtypes auto-derivation
          ;; from Spec 010 schemas (see IMPL-SPEC §4 + §5.2). Malli is
-         ;; already a transitive dep via implementation/core; declared
-         ;; explicitly because Story's controls layer reaches into it.
-         metosin/malli           {:mvn/version "0.16.4"}}
+         ;; already a transitive dep via implementation/core; the version
+         ;; pin matches implementation/shadow-cljs.edn's :dependencies
+         ;; entry so the top-level CLJS test build (`npm run test:cljs`)
+         ;; resolves a single Malli on the classpath.
+         metosin/malli           {:mvn/version "0.13.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1,0 +1,394 @@
+(ns re-frame.story
+  "Public API for re-frame2-story. Per IMPL-SPEC §2.8.2 the user-facing
+  namespace lives under `re-frame.story.*`; internal helpers (the
+  registrar side-table, schemas, extends resolution) live under
+  `re-frame.story.<sub-ns>`.
+
+  This namespace re-exports the seven `reg-*` macros and the runtime
+  query helpers that Stage 3+ consume. Stage 2 (rf2-32dk) lands:
+
+  - `reg-story` / `reg-variant` / `reg-workspace` / `reg-mode` /
+    `reg-story-panel` / `reg-decorator` / `reg-tag` macros.
+  - `handlers` / `handler-meta` / `ids` query helpers (mirror of
+    re-frame.registrar's spec/001 public query API).
+  - `variants-of` / `variants-with-tags` lookup convenience.
+  - Programmatic helpers `reg-story*` / `reg-variant*` etc. for tooling
+    that synthesises registrations (the MCP write surface in v1.1
+    consumes these; Stage 7).
+
+  Stage 3 (rf2-von3) adds: `run-variant`, `reset-variant`,
+  `watch-variant`, `variant->edn`, `snapshot-identity`. Stage 2's
+  authoring surface stops at registration; the runtime is the next
+  layer.
+
+  ## Boot
+
+  Call `(re-frame.story/install-canonical-vocabulary!)` once at app
+  startup (typically from your `app.core` ns or your stories ns root)
+  to register the seven canonical tags. Without this, variants tagged
+  `:dev` / `:docs` / etc. will fail registration with `:rf.error/unknown-tag`.
+
+  ## Elision
+
+  All seven `reg-*` macros expand to a `(when re-frame.story.config/enabled?
+  ...)` wrapper. Production CLJS builds set
+  `:closure-defines {re-frame.story.config/enabled? false}` and every
+  registration form elides to `nil`. The public query helpers are plain
+  fns; production code calling them sees an empty side-table.
+
+  ## File contract
+
+  - `re-frame.story.macros` — macro-expansion helpers (`.clj` only).
+  - `re-frame.story.registrar` — the side-table + runtime helpers (`.cljc`).
+  - `re-frame.story.schemas` — Malli schemas (`.cljc`).
+  - `re-frame.story.extends` — `:extends` resolution (`.cljc`).
+  - `re-frame.story.config` — the compile-time `enabled?` flag (`.cljc`)."
+  (:require [re-frame.story.config    :as config]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.schemas   :as schemas]
+            #?(:clj [re-frame.story.macros :as macros]))
+  ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
+  ;; below. Self-refer them via :require-macros so CLJS callers can
+  ;; write `story/reg-story` after `(:require [re-frame.story :as story])`
+  ;; without an explicit :require-macros clause at the call site.
+  ;; Mirror of the `re-frame.core` :require-macros pattern.
+  #?(:cljs (:require-macros
+             [re-frame.story :refer [reg-story reg-variant reg-workspace
+                                     reg-mode reg-story-panel reg-decorator
+                                     reg-tag]])))
+
+;; ---- macros (the seven reg-* forms) --------------------------------------
+;;
+;; Per IMPL-SPEC §6.1 every macro expansion threads through
+;; `(when re-frame.story.config/enabled? ...)` so the closure compiler
+;; elides the registration call under `:advanced` builds. The actual
+;; expansion logic lives in `re-frame.story.macros`; the defmacro forms
+;; here are thin wrappers so consumers writing
+;; `(:require [re-frame.story :as story])` find the macros on the
+;; public ns (mirroring `re-frame.core`'s pattern for `reg-event-db`).
+;;
+;; Each macro captures `&form` meta + `*file*` + `(ns-name *ns*)` from
+;; the caller's compile environment. The helper merges these into
+;; `re-frame.story.registrar/*pending-coords*` around the runtime call.
+
+#?(:clj
+   (defmacro reg-story
+     "Register a story (parent of variants). Per IMPL-SPEC §3.1.
+
+     Body keys (all optional):
+
+     ```
+     {:doc        \"...\"
+      :component  <view-id>
+      :decorators [[:dec-id args...]]
+      :args       {<arg-key> <value>}
+      :argtypes   {<arg-key> {...}}
+      :tags       #{...}
+      :modes      #{...}
+      :substrates #{:reagent :uix :helix :reagent-slim}
+      :platforms  #{:server :client}
+      :variants   {<variant-name> <variant-body>}}   ;; Form-B sugar
+     ```
+
+     Form-B `:variants` desugars to N separate `reg-variant` calls so
+     hot-reload-by-variant works (per spec/007 §Combined `reg-story` form).
+
+     Expansion elides to `nil` under `:advanced` builds with
+     `re-frame.story.config/enabled?` set to `false`."
+     [id metadata]
+     (macros/expand-reg-story (meta &form) *file*
+                              (symbol (str (ns-name *ns*)))
+                              id metadata)))
+
+#?(:clj
+   (defmacro reg-variant
+     "Register a variant (one scenario of a story). Per IMPL-SPEC §3.1.
+
+     Variant body shape — every key is data, no fn-valued slots:
+
+     ```
+     {:doc                   \"...\"
+      :extends               <variant-id>
+      :events                [[:event-id args...]]
+      :play                  [[:event-id args...]]
+      :args                  {<arg-key> <value>}
+      :argtypes              {...}
+      :tags                  #{...}
+      :decorators            [[:dec-id args...]]
+      :loaders               [[:loader-event-id ...]]
+      :loaders-complete-when <event-id-or-vector>
+      :args->events          {<arg-key> <event-id>}
+      :platforms             #{:server :client}
+      :substrates            #{...}
+      :modes                 #{...}}
+     ```
+
+     The body must be 100% EDN-round-trippable. Decorator closures live at
+     the decorator's *registration site* (see `reg-decorator`), not here.
+     Per IMPL-SPEC §2.6 and Phase-2 §5.1 #10.
+
+     `:extends` resolution happens at registration time — see
+     `re-frame.story.extends/resolve-extends`."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-variant*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-workspace
+     "Register a workspace (layout artefact). Per IMPL-SPEC §3.1.
+
+     Five layouts: `:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`.
+     Each requires the matching slot:
+
+     - `:grid` / `:tabs` → `:variants` (vector of variant ids)
+     - `:variants-grid` → none (enumerates from the registry)
+     - `:prose` → `:content` (vector of `{:type :prose|:variant ...}`)
+     - `:custom` → `:render` (registered view id)
+
+     Workspaces are 100% transit-shareable; the `:variants-grid` layout is
+     the v1 devcards-style multi-variant pane (IMPL-SPEC §2.8.4)."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-workspace*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-mode
+     "Register a Mode (saved-tuple of args). Per IMPL-SPEC §2.8.3 + §3.1.
+
+     Body:
+
+     ```
+     {:doc  \"...\"
+      :args {<arg-key> <value>}}
+     ```
+
+     Modes are Chromatic-style saved tuples — when a variant is rendered
+     against mode M, M's `:args` deep-merge into the variant's effective
+     args (precedence: global < mode < story < variant). Each
+     `(variant × mode)` cell has its own snapshot-identity for visual
+     regression keying."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-mode*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-story-panel
+     "Register a story panel — the extension hook into the story tool's
+     chrome. Per spec/007 §Story-tool extension hook.
+
+     Body:
+
+     ```
+     {:doc       \"...\"
+      :title     \"...\"
+      :placement :right | :left | :bottom | :top | :modal
+      :render    <view-id>
+      :for       #{<context-id>}}   ;; optional
+     ```
+
+     Per IMPL-SPEC §2.7 the re-frame-10x epoch panel ships as a registered
+     story panel via this macro."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-story-panel*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-decorator
+     "Register a decorator. Per IMPL-SPEC §3.1 + §13.2 #3.
+
+     Decorators are the **only** Story authoring surface where a closure
+     legally lives — and only on `:hiccup`-kind decorators' `:wrap` slot.
+     Variant bodies reference decorators by id; the closure lives at the
+     decorator's registration site.
+
+     Three kinds:
+
+     - `:hiccup` — `{:kind :hiccup, :wrap (fn [body args] [:div ... body])}`
+     - `:frame-setup` — `{:kind :frame-setup, :init [...], :app-db-patch {...}}`
+     - `:fx-override` — `{:kind :fx-override, :fx-id ..., :response ...}`"
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-decorator*
+                          id metadata)))
+
+#?(:clj
+   (defmacro reg-tag
+     "Register a tag. Per spec/007 §Inclusion tags + IMPL-SPEC §3.1.
+
+     Body:
+
+     ```
+     {:doc \"...\"}
+     ```
+
+     The seven canonical tags (`:dev :docs :test :screenshot :experimental
+     :internal :agent`) register at Story load — projects don't need to
+     register these. Project-specific tags must register before use; a
+     variant whose `:tags` set carries an unregistered tag raises
+     `:rf.error/unknown-tag`.
+
+     `!`-prefix removal-syntax (e.g. `:!dev`) on a variant `:tags` set
+     resolves at registration time against the inherited set — see
+     Phase-2 §5.1 #11."
+     [id metadata]
+     (macros/gen-reg-call (meta &form) *file*
+                          (symbol (str (ns-name *ns*)))
+                          `re-frame.story.registrar/reg-tag*
+                          id metadata)))
+
+;; ---- query API (public) --------------------------------------------------
+
+(defn handlers
+  "Return the `{id → body}` map for `kind`, or `{}`. Stable shape across
+  JVM and CLJS — same as `re-frame.registrar/handlers`. Use this in
+  tooling that enumerates the registered Story artefacts.
+
+  Mirror of the spec/001 §Public registrar query API for Story's
+  side-table. The Story registry is logically a peer of the framework
+  registrar — see IMPL-SPEC §1.1 + bd rf2-7ho2 for the design rationale."
+  [kind]
+  (registrar/handlers kind))
+
+(defn handler-meta
+  "Return the body for `(kind, id)`, or nil."
+  [kind id]
+  (registrar/handler-meta kind id))
+
+(defn ids
+  "Return the id set for `kind`."
+  [kind]
+  (registrar/ids kind))
+
+(defn registered?
+  "True iff `(kind, id)` is registered."
+  [kind id]
+  (registrar/registered? kind id))
+
+(defn all-kinds-with-counts
+  "{kind → count} — dev tooling overlay."
+  []
+  (registrar/all-kinds-with-counts))
+
+;; ---- convenience lookups -------------------------------------------------
+
+(defn variants-of
+  "Return the set of variant ids whose parent is `story-id`."
+  [story-id]
+  (registrar/variants-of story-id))
+
+(defn variants-with-tags
+  "Per IMPL-SPEC §3.2 — return the set of variant ids whose `:tags`
+  intersects `query-tags`. Stage 5 (assertions/play) leans on this; Stage
+  4 (render shell) leans on this to compose the sidebar tree."
+  [query-tags]
+  (registrar/variants-with-tags query-tags))
+
+(defn list-tags
+  "Per IMPL-SPEC §7.4 — return the set of registered tag ids. Tools
+  enumerate this set before assigning tags to a variant."
+  []
+  (ids :tag))
+
+(defn list-modes
+  "Per IMPL-SPEC §7.4 — return the set of registered mode ids."
+  []
+  (ids :mode))
+
+(def canonical-tags
+  "Re-export of the seven canonical tag ids from spec/007 §Inclusion
+  tags. Stable across hosts."
+  schemas/canonical-tags)
+
+;; ---- programmatic registration surface -----------------------------------
+;;
+;; Per IMPL-SPEC §4.9 the `*`-suffix runtime helpers are public for
+;; tooling that synthesises registrations (e.g. the MCP write surface
+;; in v1.1, the test fixture that registers from a fixture file).
+;; Re-exported here so authors with a legit programmatic need can call
+;; them without reaching into the internal ns.
+
+(def reg-story*       registrar/reg-story*)
+(def reg-variant*     registrar/reg-variant*)
+(def reg-workspace*   registrar/reg-workspace*)
+(def reg-mode*        registrar/reg-mode*)
+(def reg-story-panel* registrar/reg-story-panel*)
+(def reg-decorator*   registrar/reg-decorator*)
+(def reg-tag*         registrar/reg-tag*)
+
+;; ---- canonical vocabulary boot ------------------------------------------
+
+(defn install-canonical-vocabulary!
+  "Install the seven canonical Story tags into the registry. Call this
+  once at boot before any `reg-story` / `reg-variant` calls. Idempotent.
+
+  Per spec/007 §Inclusion tags + IMPL-SPEC §3.1 the canonical seven are
+  registered by the Story library at load time — projects don't have to.
+  Project-specific tags must register via `reg-tag` *before* use; an
+  unregistered tag on a variant's `:tags` set raises `:rf.error/unknown-tag`."
+  []
+  (registrar/install-canonical-tags!))
+
+;; ---- registry reset (test fixtures) -------------------------------------
+
+(defn clear-all!
+  "Reset every Story registration. Used by test fixtures. Mirrors
+  `re-frame.registrar/clear-all!`."
+  []
+  (registrar/clear-all!))
+
+(defn clear-kind!
+  "Remove every id under `kind`. Used by test fixtures and hot-reload."
+  [kind]
+  (registrar/clear-kind! kind))
+
+(defn unregister!
+  "Remove a single id under `kind`."
+  [kind id]
+  (registrar/unregister! kind id))
+
+;; ---- Stage 3 stubs (run-variant family) ---------------------------------
+;;
+;; These are deliberately stubbed at Stage 2 — the bead is the authoring
+;; surface only. Stage 3 (rf2-von3) replaces these bodies with the
+;; four-phase lifecycle. The signatures are locked at IMPL-SPEC §3.2 so
+;; downstream code can be written against them today.
+
+(defn variant->edn
+  "Per IMPL-SPEC §3.2 — return the canonical-form serialised body of
+  the registered variant. At Stage 2 this is the side-table body
+  verbatim; the canonicalisation (sorted keys, deterministic vector
+  order) for snapshot-identity is Stage 3's call.
+
+  Returns nil when the variant is unregistered."
+  [variant-id]
+  (handler-meta :variant variant-id))
+
+(defn workspace->edn
+  "Per IMPL-SPEC §3.2 — same for workspaces."
+  [workspace-id]
+  (handler-meta :workspace workspace-id))
+
+;; ---- run-variant / reset-variant / snapshot-identity --------------------
+;;
+;; STAGE 3 (rf2-von3): the four-phase lifecycle owns these. Stage 2
+;; intentionally does NOT implement them. Authors expecting these from
+;; Stage 2 should consult the bead chain.
+;;
+;; A no-op stub here would mask Stage 3's contract; instead the
+;; functions are intentionally absent. Stage 3 lands them at IMPL-SPEC
+;; §3.2's locked signatures.
+
+(def stage
+  "Sentinel that names which Stage's authoring surface is loaded.
+  Stage 2: authoring. Stage 3+: runtime additions. Useful for tools
+  that conditionally adapt to the loaded surface."
+  :authoring)

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -1,0 +1,71 @@
+(ns re-frame.story.config
+  "Compile-time configuration for re-frame2-story.
+
+  The headline export is `enabled?` — the sentinel that gates every
+  Story registration form per IMPL-SPEC §6.1.
+
+  In a CLJS build, `enabled?` is a `goog-define`'d boolean that defaults
+  to `true`. Production builds set
+  `:closure-defines {re-frame.story.config/enabled? false}` (typically
+  alongside `goog.DEBUG false`) and every registration macro expands to
+  `nil`. Closure DCE then removes the entire registration-side ns graph
+  from the production bundle.
+
+  On the JVM side this is just a `def` — JVM consumers of Story (tests,
+  REPL exploration) always see `enabled?` true. Production CLJS builds
+  are the only environment that flips the flag.
+
+  ## Why a separate ns
+
+  The flag lives in its own ns so consumers can override it via
+  `:closure-defines` keyed by a stable, framework-private symbol. The
+  macros ns can't host the define directly because macros live in `.clj`
+  and `goog-define` is `.cljs`-only.
+
+  ## The elision contract this enables
+
+  IMPL-SPEC §6 + Spec 009 §Production builds: PRESENT-in-control,
+  ABSENT-in-release. The macros expand to one form when `enabled?` is
+  true (the registration call); to `nil` when false. Production code
+  that accidentally requires a stories ns sees the namespace load but
+  with no registrations, every Story query returns empty."
+  #?(:cljs (:require-macros [re-frame.story.config])))
+
+;; ---- the compile-time flag -----------------------------------------------
+
+#?(:cljs (goog-define ^boolean enabled?
+           ;; @define {boolean}
+           ;; Defaults to `true` (dev builds). Production sets this to false
+           ;; via :closure-defines.
+           true)
+   :clj  (def ^:const enabled?
+           "JVM-side: Story is always considered enabled. JVM consumers
+           (tests, REPL) operate on the full registration surface. The
+           compile-time elision only meaningfully applies under CLJS
+           `:advanced`."
+           true))
+
+;; ---- macro-side access ---------------------------------------------------
+;;
+;; Macros emit code that checks the flag *at compile time* so the
+;; expansion is the dead-code-friendly form: a single registration call
+;; or a literal `nil`. The check uses `enabled?` as a normal JVM-side
+;; value — at macro-expansion the goog-define hasn't fired yet (it's a
+;; runtime CLJS define), so the macro layer effectively always-on.
+;;
+;; The actual DCE happens because the macro expansion threads through
+;; `(when re-frame.story.config/enabled? ...)`: in CLJS-advanced mode
+;; with `enabled?` defined as `false`, Closure sees the boolean
+;; constant and removes the branch. The macro's job is to lay down that
+;; `(when enabled? ...)` form; the closure compiler does the rest.
+
+#?(:clj
+   (defn elide-form
+     "Wrap `expansion` in `(when re-frame.story.config/enabled? ...)` so
+     the closure compiler can prune the registration call under
+     `:advanced` builds where `enabled?` is defined as `false`.
+
+     Returns the wrapped form."
+     [expansion]
+     `(when re-frame.story.config/enabled?
+        ~expansion)))

--- a/tools/story/src/re_frame/story/extends.cljc
+++ b/tools/story/src/re_frame/story/extends.cljc
@@ -1,0 +1,108 @@
+(ns re-frame.story.extends
+  "`:extends` resolution for `reg-variant`.
+
+  Per spec/007 §Composed variants and IMPL-SPEC §4.6, a variant body
+  may carry `:extends <variant-id>` — the parent's body is merged into
+  the child's (child wins key-by-key), producing a fully data-shaped
+  variant artefact.
+
+  Merge semantics:
+
+  - **Top-level keys**: child wins. `(merge parent child)` semantics —
+    a key present on the child replaces the same key on the parent.
+  - **No vector concat / no map-deep-merge** at this layer. Stage 2's
+    contract is straight `merge`; Stage 3's args-resolution layer is
+    the deep-merge surface (per spec/007 §Args at three levels — there
+    we deep-merge args). This separation keeps the variant-body merge
+    semantically simple.
+  - **`:extends` itself is dropped** from the resolved body — it's a
+    registration-time directive, not a runtime artefact.
+
+  Cycle detection:
+
+  - Walks the parent chain bounded by `*max-extends-depth*` (default 32).
+  - Throws `:rf.error/extends-cycle` if a cycle is detected (we revisit
+    an id already in the chain).
+  - Throws `:rf.error/extends-unknown` if a parent id is not registered
+    when `:extends` is resolved.
+
+  Stage 2 resolves at registration time (per IMPL-SPEC §2.6). Production
+  builds elide the entire registration surface so `:extends` resolution
+  doesn't survive into a production bundle anyway."
+  (:refer-clojure :exclude [resolve]))
+
+(def ^:dynamic *max-extends-depth*
+  "Hard cap on `:extends` chain length. A registration that hits this
+  limit is treated as a cycle. 32 is more than any sane chain — projects
+  hitting this limit either have a cycle or a structural problem.
+
+  Authors who need a longer chain can rebind, but this is a smell."
+  32)
+
+(defn- chain-of
+  "Walk the `:extends` chain from `body` outward. Returns a vector of
+  parent bodies, root-first. The first entry is the deepest parent;
+  the last entry is the immediate parent of the child.
+
+  `lookup` is a fn `(parent-id) → body-or-nil`.
+
+  Throws `:rf.error/extends-cycle` if a cycle is detected (an id
+  appears twice on the chain). Throws `:rf.error/extends-unknown` if a
+  named parent is not yet registered."
+  [body lookup]
+  (loop [acc      []
+         current  body
+         visited  #{}
+         depth    0]
+    (let [parent-id (:extends current)]
+      (cond
+        (nil? parent-id)
+        (vec (reverse acc))
+
+        (contains? visited parent-id)
+        (throw (ex-info (str "re-frame2-story: :extends cycle through "
+                             parent-id)
+                        {:rf.error :rf.error/extends-cycle
+                         :chain    (conj (vec visited) parent-id)
+                         :id       parent-id}))
+
+        (>= depth *max-extends-depth*)
+        (throw (ex-info (str "re-frame2-story: :extends chain exceeds "
+                             *max-extends-depth* " levels at " parent-id)
+                        {:rf.error :rf.error/extends-cycle
+                         :chain    (conj (vec visited) parent-id)
+                         :id       parent-id}))
+
+        :else
+        (if-let [parent (lookup parent-id)]
+          (recur (conj acc parent)
+                 parent
+                 (conj visited parent-id)
+                 (inc depth))
+          (throw (ex-info (str "re-frame2-story: :extends references "
+                               "unregistered variant " parent-id)
+                          {:rf.error :rf.error/extends-unknown
+                           :parent   parent-id})))))))
+
+(defn resolve-extends
+  "Resolve `:extends` on `body` against `lookup` (a fn from parent-id to
+  parent-body). Returns the merged body with `:extends` stripped.
+
+  `lookup` is parameterised so the caller (the registrar) decides where
+  to read parent bodies from. In Stage 2 this is the side-table; the
+  same shape works for any future remote registry.
+
+  Resolution is single-pass: when a parent itself has `:extends`, we
+  recurse — the final body is the result of merging every ancestor in
+  root-first order.
+
+  Per IMPL-SPEC §4.6: 'Resolution at registration time. Cycles raise
+  `:rf.error/extends-cycle`.'"
+  [body lookup]
+  (if-let [_parent-id (:extends body)]
+    (let [chain    (chain-of body lookup)
+          ;; Reduce parent-first: every parent's keys are overridden by
+          ;; the next (more specific) layer, ending with the child.
+          merged   (reduce merge {} (conj (vec chain) body))]
+      (dissoc merged :extends))
+    body))

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -1,0 +1,115 @@
+(ns re-frame.story.macros
+  "Macro-expansion helpers for re-frame2-story.
+
+  This namespace is `:clj`-only — these are the helpers the actual
+  `defmacro` forms in `re-frame.story` call from inside their bodies.
+  The defmacros themselves live in `re-frame.story` so end-users
+  writing `(story/reg-story ...)` find `reg-story` as a Var on the
+  public ns (matching the pattern `re-frame.core` uses for
+  `reg-event-db`).
+
+  Per IMPL-SPEC §6.1 every emitted form threads through
+  `(when re-frame.story.config/enabled? ...)` so the closure compiler
+  elides the registration call under `:advanced` builds with
+  `enabled?` set to `false`. The dev/prod expand split is the
+  PRESENT-in-control / ABSENT-in-release pattern Spec 009 locks for
+  instrumentation.
+
+  ## Source-coord stamping
+
+  Each expansion captures `:line` / `:column` / `:file` / `:ns` from
+  the caller's `&form` and `*file*`, and binds them into
+  `re-frame.story.registrar/*pending-coords*` around the runtime helper
+  call. The helper merges the coords into the registered body under
+  the `:source` key — tools / 10x / IDE jump-to-source consume this via
+  `(story/handler-meta kind id)`.
+
+  ## Form-B `:variants` desugaring
+
+  `expand-reg-story` checks for a literal `:variants` map in the body
+  and, if present, emits N independent `reg-variant*` calls as siblings
+  of the parent `reg-story*` call. Per IMPL-SPEC §4.9 this preserves
+  hot-reload-by-variant: each variant is a separate top-level form so
+  save-and-reload only invalidates the changed slot.")
+
+;; ---- source-coord helper -------------------------------------------------
+
+(defn coords-form
+  "Construct the literal map that the macro expansion will assign to
+  `re-frame.story.registrar/*pending-coords*`. `form-meta` is the value
+  of `(meta &form)` from the calling macro; `file` is `*file*` from the
+  macro's compile environment; `ns-sym` is the consumer's namespace
+  symbol.
+
+  Returns a compile-time Clojure form (a `cond->` expression) that
+  evaluates to the map at runtime. Mirrors
+  `re-frame.core/reg-event-db`'s coord-capture pattern."
+  [form-meta file ns-sym]
+  `(cond-> {:ns '~ns-sym}
+     ~file               (assoc :file ~file)
+     ~(:line form-meta)   (assoc :line ~(:line form-meta))
+     ~(:column form-meta) (assoc :column ~(:column form-meta))))
+
+(defn variant-id-for
+  "Build the variant id from a story id and a variant-name key.
+
+  - story-id `:story.auth.login-form`, variant-name `:empty`
+    → `:story.auth.login-form/empty`
+
+  Per spec/007 §Canonical id grammar."
+  [story-id variant-name]
+  (when-not (keyword? story-id)
+    (throw (ex-info "re-frame2-story: story id must be a keyword"
+                    {:story-id story-id})))
+  (when-not (keyword? variant-name)
+    (throw (ex-info (str "re-frame2-story: variant-name in :variants map "
+                         "must be a keyword (got " (pr-str variant-name) ")")
+                    {:variant-name variant-name})))
+  (let [story-str (subs (str story-id) 1)]    ; strip leading colon
+    (keyword story-str (name variant-name))))
+
+(defn gen-reg-call
+  "Emit a single `(when enabled? (binding [*pending-coords* coords]
+  (registrar/<reg-fn>* id body)))` form. `reg-fn-sym` is a fully-qualified
+  symbol like `re-frame.story.registrar/reg-story*`. `form-meta` is the
+  caller's `(meta &form)`; `file` is the caller's `*file*`; `ns-sym` is
+  the consumer's `(ns-name *ns*)`."
+  [form-meta file ns-sym reg-fn-sym id body]
+  `(when re-frame.story.config/enabled?
+     (binding [re-frame.story.registrar/*pending-coords*
+               ~(coords-form form-meta file ns-sym)]
+       (~reg-fn-sym ~id ~body))))
+
+;; ---- reg-story Form-B desugaring -----------------------------------------
+
+(defn expand-reg-story
+  "Macro-side expansion for `reg-story`. Handles the Form-B `:variants`
+  sugar: if `metadata` is a literal map with `:variants`, emit a `do`
+  block with the parent registration plus N independent `reg-variant*`
+  calls. Otherwise emit a single registration call.
+
+  Returns the syntax-quoted expansion."
+  [form-meta file ns-sym id metadata]
+  (let [coords      (coords-form form-meta file ns-sym)
+        literal-map (when (map? metadata) metadata)
+        variants    (when literal-map (:variants literal-map))
+        ;; The runtime helper expects the parent slice (no :variants);
+        ;; for literal maps strip it at expansion time, for non-literal
+        ;; metadata punt to runtime (helper drops :variants).
+        body-form   (if variants
+                      (dissoc literal-map :variants)
+                      metadata)
+        story-call  `(when re-frame.story.config/enabled?
+                       (binding [re-frame.story.registrar/*pending-coords*
+                                 ~coords]
+                         (re-frame.story.registrar/reg-story* ~id ~body-form)))]
+    (if variants
+      `(do
+         ~story-call
+         ~@(for [[v-name v-body] variants]
+             (let [v-id (variant-id-for id v-name)]
+               `(when re-frame.story.config/enabled?
+                  (binding [re-frame.story.registrar/*pending-coords*
+                            ~coords]
+                    (re-frame.story.registrar/reg-variant* ~v-id ~v-body))))))
+      story-call)))

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -1,0 +1,370 @@
+(ns re-frame.story.registrar
+  "Story's registration side-table.
+
+  Per IMPL-SPEC §1.1 + the no-new-registries discipline (AGENTS.md
+  `downstream-EPs-consume-foundation`), Story does not add new kinds to
+  `re-frame.registrar`'s closed kind-set (which is locked at the
+  spec/001 v1 closed list). Instead, Story owns a **side-table** keyed
+  by Story kind, living inside the `tools/story/` artefact and never
+  reaching a production bundle (via the §6 elision contract).
+
+  ## Stage 2 design tension noted in bd rf2-7ho2
+
+  spec/007 line 447 says 'the framework registrar already supports new
+  kinds via the existing reg- machinery' — but the implementation's
+  registrar (`re-frame.registrar/kinds`) is a **closed** set. The
+  side-table here is the chosen reconciliation: Story-only registrations
+  live in Story's own atom; the framework registrar stays closed. A
+  bridge (`story/handlers`) preserves the spec/007 §Public-query-surfaces
+  contract without crossing the framework boundary.
+
+  ## Kinds Story registers
+
+  - `:story` — parent of variants
+  - `:variant` — concrete scenario; one per frame at runtime (Stage 3)
+  - `:workspace` — layout artefact
+  - `:mode` — saved-tuple of args
+  - `:story-panel` — extension hook into the story-tool's chrome
+  - `:decorator` — closure-bearing wrappers / setup actions
+  - `:tag` — registered inclusion-tag vocabulary
+
+  ## Validation flow
+
+  Each `reg-*!` here:
+
+  1. Validates the body against the matching `re-frame.story.schemas`
+     schema.
+  2. Cross-validates `:tags` against the registered tag vocabulary.
+  3. Resolves `:extends` (variants only) — Stage 2 punts the cycle check
+     to `re-frame.story.extends`.
+  4. Stamps source-coords (per spec/009 / spec/001) — the macro layer
+     captures these from `&form` and threads them via the
+     `*pending-coords*` dynamic var (mirroring `re-frame.source-coords`).
+  5. Writes the resolved body into the side-table.
+
+  Hot-reload semantics mirror `re-frame.registrar`: re-registering the
+  same id replaces the slot atomically; nothing in the runtime is
+  paused; `:on-replacement` hooks (Stage 3 wires this) get notified.
+
+  ## Elision
+
+  The whole namespace lives behind the §6 sentinel: macro expansions
+  call into `reg-*!` only under `goog.DEBUG=true`; under `:advanced`
+  builds the call sites disappear and this entire side-table never gets
+  populated. Production code that accidentally calls a Story query
+  returns empty.
+
+  ## What this namespace does NOT do (deferred to Stage 3)
+
+  - Per-variant frame allocation (`rf/reg-frame` for each variant)
+  - Args resolution precedence
+  - Decorator composition order
+  - Loader four-phase lifecycle
+  - Play execution
+  - Snapshot identity computation"
+  (:require [re-frame.story.schemas :as schemas]
+            #?(:clj [re-frame.story.extends :as extends]
+               :cljs [re-frame.story.extends :as extends])))
+
+;; ---- source-coord plumbing ------------------------------------------------
+;;
+;; Mirrors `re-frame.source-coords/*pending-coords*` — the macros in
+;; `re-frame.story.macros` bind this around the call to `reg-*!` so the
+;; stored slot carries `{:file :line :ns :column}`. Per spec/009 this
+;; metadata is plain data and stays in dev bundles; the macro path is
+;; what is gated by the elision flag.
+
+(def ^:dynamic *pending-coords*
+  "Per-thread source coords captured at the macro-expansion site. nil
+  when a registration is driven programmatically (REPL, hot-reload tool,
+  MCP write surface)."
+  nil)
+
+(defn- merge-coords
+  "Merge `*pending-coords*` into `body`, under the `:source` key. User-
+  supplied `:source` (e.g. an MCP write that wants to preserve the
+  original site) overrides the auto-captured value.
+
+  This mirrors `re-frame.source-coords/merge-coords` but writes to a
+  named `:source` key instead of merging into the top level — the
+  variant body is itself open-shape data, and `:file` / `:line` keys at
+  the top level would conflict with potential user data. `:source` is a
+  reserved Story-owned slot."
+  [body]
+  (let [coords *pending-coords*]
+    (if coords
+      (update body :source #(merge coords %))
+      body)))
+
+;; ---- the side-table -------------------------------------------------------
+
+(defn- fresh-table []
+  {:story       {}
+   :variant     {}
+   :workspace   {}
+   :mode        {}
+   :story-panel {}
+   :decorator   {}
+   :tag         {}})
+
+(defonce
+  ^{:doc "kind → id → body-map. Atomic. Per-process — like the
+         framework registrar, Story's side-table is a single per-process
+         atom keyed by Story kind."}
+  kind->id->body
+  (atom (fresh-table)))
+
+(defn clear-all!
+  "Reset the side-table. Used by test fixtures."
+  []
+  (reset! kind->id->body (fresh-table))
+  nil)
+
+(defn clear-kind!
+  "Remove every id under kind. Used by test fixtures and hot-reload."
+  [kind]
+  (swap! kind->id->body assoc kind {})
+  nil)
+
+(defn unregister!
+  "Remove a single id under kind."
+  [kind id]
+  (swap! kind->id->body update kind dissoc id)
+  nil)
+
+;; ---- query API (mirrors spec/001 public registrar query API) -------------
+
+(defn handlers
+  "Return the `{id → body}` map for `kind`, or `{}`. Mirrors
+  `re-frame.registrar/handlers`."
+  [kind]
+  (get @kind->id->body kind {}))
+
+(defn handler-meta
+  "Return the body for `(kind, id)`, or nil."
+  [kind id]
+  (get-in @kind->id->body [kind id]))
+
+(defn ids
+  "Just the id set for a kind."
+  [kind]
+  (-> (handlers kind) keys set))
+
+(defn registered?
+  "True iff `(kind, id)` is in the side-table."
+  [kind id]
+  (contains? (handlers kind) id))
+
+(defn all-kinds-with-counts
+  "{kind → count} — useful in dev tooling overlays."
+  []
+  (into {}
+        (map (fn [[k m]] [k (count m)]))
+        @kind->id->body))
+
+;; ---- shape validation -----------------------------------------------------
+
+(defn- validate-shape!
+  "Validate `body` against the schema for `kind`. Throws `:rf.error/<kind>-shape`
+  on a miss. Returns the body unchanged on success."
+  [kind id body]
+  (when-let [explain (schemas/validate kind body)]
+    (throw (ex-info (str "re-frame2-story: " (name kind) " body for "
+                         id " does not match " (name kind) " schema")
+                    {:rf.error (keyword "rf.error" (str (name kind) "-shape"))
+                     :kind     kind
+                     :id       id
+                     :explain  explain})))
+  body)
+
+(defn- validate-tag-membership!
+  "Cross-check the variant / story `:tags` set against the registered
+  tag vocabulary. Strips the `!`-prefix removal-syntax marker for the
+  check (per Phase-2 §5.1 #11) — `:!dev` checks that `:dev` is
+  registered.
+
+  Throws `:rf.error/unknown-tag` on a miss."
+  [id tags]
+  (when (seq tags)
+    (let [registered-tag-ids (ids :tag)
+          unknown            (filterv
+                              (fn [tag]
+                                (let [base (if (and (keyword? tag)
+                                                    (let [n (name tag)]
+                                                      (and (pos? (count n))
+                                                           (= \! (first n)))))
+                                             (keyword (namespace tag)
+                                                      (subs (name tag) 1))
+                                             tag)]
+                                  (not (contains? registered-tag-ids base))))
+                              tags)]
+      (when (seq unknown)
+        (throw (ex-info (str "re-frame2-story: unregistered tag(s) on " id
+                             ": " (pr-str unknown))
+                        {:rf.error :rf.error/unknown-tag
+                         :id       id
+                         :unknown  unknown}))))))
+
+;; ---- id-shape policing ----------------------------------------------------
+
+(defn- assert-id!
+  "Throw `:rf.error/<kind>-id-shape` if `id` does not match the canonical
+  grammar for `kind`. Per spec/007 §Canonical id grammar."
+  [kind id]
+  (let [ok? (case kind
+              :story       schemas/story-id?
+              :variant     schemas/variant-id?
+              :workspace   schemas/workspace-id?
+              :mode        schemas/mode-id?
+              ;; story-panel, decorator, tag — any keyword.
+              :story-panel keyword?
+              :decorator   keyword?
+              :tag         keyword?
+              keyword?)]
+    (when-not (ok? id)
+      (throw (ex-info (str "re-frame2-story: " (name kind) " id " (pr-str id)
+                           " does not match the canonical id grammar")
+                      {:rf.error (keyword "rf.error" (str (name kind) "-id-shape"))
+                       :kind     kind
+                       :id       id})))))
+
+;; ---- write API (the runtime helpers the macros expand to) ----------------
+
+(defn reg-story*
+  "Runtime helper for `reg-story` macro. Validates the body, stamps
+  source coords, writes to the side-table. Returns `id`.
+
+  Form-B `:variants` desugaring lives in the *macro* — by the time the
+  helper is called, the body's `:variants` (if any) has been peeled off
+  and the N independent `reg-variant*` calls have been emitted as
+  siblings. So the helper sees only the parent-story slice."
+  [id body]
+  (assert-id! :story id)
+  (let [body (-> body
+                 (dissoc :variants)               ; Form-B sugar is removed by the macro
+                 merge-coords
+                 (->> (validate-shape! :story id)))
+        _    (validate-tag-membership! id (:tags body))]
+    (swap! kind->id->body assoc-in [:story id] body)
+    id))
+
+(defn reg-variant*
+  "Runtime helper for `reg-variant` macro. Per IMPL-SPEC §10 Stage 2:
+
+  1. Validate the body shape.
+  2. Resolve `:extends` (merge parent body, child wins).
+  3. Cross-check tag membership.
+  4. Stamp source coords.
+  5. Write to the side-table."
+  [id body]
+  (assert-id! :variant id)
+  (let [resolved (extends/resolve-extends body
+                                          (fn [pid] (handler-meta :variant pid)))
+        body     (-> resolved
+                     merge-coords
+                     (->> (validate-shape! :variant id)))
+        _        (validate-tag-membership! id (:tags body))]
+    (swap! kind->id->body assoc-in [:variant id] body)
+    id))
+
+(defn reg-workspace*
+  "Runtime helper for `reg-workspace` macro."
+  [id body]
+  (assert-id! :workspace id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :workspace id)))]
+    (swap! kind->id->body assoc-in [:workspace id] body)
+    id))
+
+(defn reg-mode*
+  "Runtime helper for `reg-mode` macro. Per IMPL-SPEC §2.8.3 modes ship
+  in v1."
+  [id body]
+  (assert-id! :mode id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :mode id)))]
+    (swap! kind->id->body assoc-in [:mode id] body)
+    id))
+
+(defn reg-story-panel*
+  "Runtime helper for `reg-story-panel` macro. Per spec/007 §Story-tool
+  extension hook."
+  [id body]
+  (assert-id! :story-panel id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :story-panel id)))]
+    (swap! kind->id->body assoc-in [:story-panel id] body)
+    id))
+
+(defn reg-decorator*
+  "Runtime helper for `reg-decorator` macro. Per IMPL-SPEC §3.1 the
+  decorator's `:wrap` slot is the one fn-valued slot allowed in the
+  Story surface — it lives at the decorator's registration site, NOT in
+  a variant body. The schema enforces this."
+  [id body]
+  (assert-id! :decorator id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :decorator id)))]
+    (swap! kind->id->body assoc-in [:decorator id] body)
+    id))
+
+(defn reg-tag*
+  "Runtime helper for `reg-tag` macro."
+  [id body]
+  (assert-id! :tag id)
+  (let [body (-> body
+                 merge-coords
+                 (->> (validate-shape! :tag id)))]
+    (swap! kind->id->body assoc-in [:tag id] body)
+    id))
+
+;; ---- canonical tag bootstrap ---------------------------------------------
+
+(defn install-canonical-tags!
+  "Register the seven canonical tags from spec/007 §Inclusion tags.
+
+  Called at Story load (via `re-frame.story/install-canonical-vocabulary!`).
+  Safe to call multiple times — re-registration is idempotent at the
+  side-table level (same body replaces same body)."
+  []
+  (doseq [t schemas/canonical-tags]
+    (reg-tag* t {:doc (str "Canonical Story inclusion tag — " (name t)
+                           ". See spec/007 §Inclusion tags.")})))
+
+;; ---- query helpers -------------------------------------------------------
+
+(defn variants-of
+  "Return the variant ids whose story is `story-id`. Cheap O(N) scan
+  over the variant side-table — fine for dev-time use; if perf becomes
+  a concern Stage 3 indexes."
+  [story-id]
+  (let [prefix (str (subs (str story-id) 1) "/")]   ; ":story.foo" → "story.foo/"
+    (->> (ids :variant)
+         (filter (fn [vid] (let [s (str vid)]      ; ":story.foo/empty"
+                             (and (>= (count s) (inc (count prefix)))
+                                  (= (subs s 1 (inc (count prefix))) prefix)))))
+         set)))
+
+(defn variants-with-tag
+  "Return the variant ids whose `:tags` set contains `tag`."
+  [tag]
+  (->> (handlers :variant)
+       (filter (fn [[_ body]] (contains? (:tags body) tag)))
+       (map first)
+       set))
+
+(defn variants-with-tags
+  "Return the variant ids whose `:tags` set intersects `query-tags`. Per
+  IMPL-SPEC §3.2 — the public `variants-with-tags` wraps this."
+  [query-tags]
+  (let [qs (set query-tags)]
+    (->> (handlers :variant)
+         (filter (fn [[_ body]]
+                   (let [tset (:tags body #{})]
+                     (some #(contains? tset %) qs))))
+         (map first)
+         set)))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -1,0 +1,383 @@
+(ns re-frame.story.schemas
+  "Malli schemas for the Story authoring surface.
+
+  These schemas are the structural contract for what `reg-story`,
+  `reg-variant`, `reg-workspace`, `reg-mode`, `reg-story-panel`,
+  `reg-decorator` and `reg-tag` will accept. Per IMPL-SPEC §13.2 #3
+  the `reg-decorator` per-kind body schemas are defined here.
+
+  The schemas enforce:
+
+  - **EDN-first variant bodies** (IMPL-SPEC §2.6, Phase-2 §5.1 #10).
+    Every variant key is data — vectors / maps / keywords / strings /
+    numbers / sets. No fn-valued slots. The closure caveat (a decorator's
+    `:wrap` is a fn) applies at the *decorator registration site*, not the
+    variant body.
+
+  - **Canonical id grammar** (spec/007 §Canonical id grammar). Story ids
+    live under the `:story.<path>` namespace; variant ids extend the story
+    id with `/<name>`; workspace ids live under `:Workspace.<path>/<name>`;
+    mode ids live under `:Mode.<path>/<name>`. Per Conventions.md the
+    `:rf/*` framework prefix stays clear for the framework; Story's
+    prefixes are library-owned.
+
+  - **Tag set membership** is validated at registration time (see
+    `re-frame.story.registrar`) — the schema accepts any keyword set; the
+    registrar cross-checks against `:rf.error/unknown-tag`.
+
+  Schemas are plain Malli forms — see `metosin/malli`. They run on both
+  JVM and CLJS. The `:rf/variant` schema cross-references spec/007
+  §Variant artefact contract.
+
+  ## Where the schemas are used
+
+  - `re-frame.story.registrar/reg-variant*` and siblings validate their
+    incoming body against the matching schema and reject with structured
+    `:rf.error/<artefact>-shape` on a miss.
+  - JVM tests in `tools/story/test/` round-trip example bodies through
+    these schemas.
+
+  ## Elision contract
+
+  The schemas themselves are plain data and survive `:advanced` builds.
+  But all consumers (the registrar entry points) elide their entire
+  validation branch under `goog.DEBUG=false` via the same sentinel
+  pattern Spec 009 locks for instrumentation."
+  (:require [malli.core :as m]))
+
+;; ---- id-shape predicates --------------------------------------------------
+
+(defn story-id?
+  "True iff `id` is a keyword `:story.<dotted-path>` — namespace nil,
+  name starts with `story.` (or is exactly `story`). Per spec/007
+  §Canonical id grammar.
+
+  Note Clojure keyword parsing: `:story.auth.login-form` has nil
+  namespace and name `\"story.auth.login-form\"` — the dots are
+  *inside* the name. Variants have the form `:story.<path>/<variant>`
+  which parses as namespace `\"story.<path>\"` and name `\"<variant>\"`."
+  [id]
+  (and (keyword? id)
+       (nil? (namespace id))
+       (let [nm (name id)]
+         (or (= nm "story")
+             (and (>= (count nm) 6)
+                  (= (subs nm 0 6) "story."))))))
+
+(defn variant-id?
+  "True iff `id` is a keyword whose namespace begins with `story.` and
+  whose name is the variant tail. Per spec/007 the canonical shape is
+  `:story.<path>/<variant>`.
+
+  The framework registrar uses the slash that separates ns and name in
+  Clojure keyword syntax — `:story.auth.login-form/empty` parses as
+  `(namespace) = \"story.auth.login-form\"` and `(name) = \"empty\"`."
+  [id]
+  (and (keyword? id)
+       (let [ns (namespace id)
+             nm (name id)]
+         (and (string? ns)
+              (string? nm)
+              (pos? (count nm))
+              (or (= ns "story")
+                  (and (>= (count ns) 6)
+                       (= (subs ns 0 6) "story.")))))))
+
+(defn workspace-id?
+  "True iff `id` is a keyword `:Workspace.<path>/<name>`."
+  [id]
+  (and (keyword? id)
+       (let [ns (namespace id)
+             nm (name id)]
+         (and (string? ns)
+              (string? nm)
+              (pos? (count nm))
+              (or (= ns "Workspace")
+                  (and (>= (count ns) 10)
+                       (= (subs ns 0 10) "Workspace.")))))))
+
+(defn mode-id?
+  "True iff `id` is a keyword `:Mode.<path>/<name>` (see spec/007 modes)."
+  [id]
+  (and (keyword? id)
+       (let [ns (namespace id)
+             nm (name id)]
+         (and (string? ns)
+              (string? nm)
+              (pos? (count nm))
+              (or (= ns "Mode")
+                  (and (>= (count ns) 5)
+                       (= (subs ns 0 5) "Mode.")))))))
+
+;; ---- canonical tag vocabulary ---------------------------------------------
+
+(def canonical-tags
+  "The seven canonical tags spec/007 §Inclusion tags registers at Story
+  load. Projects MAY register additional tags via `reg-tag`; they MUST
+  register them before use. An unregistered tag on a `:tags` set raises
+  `:rf.error/unknown-tag` at registration."
+  #{:dev :docs :test :screenshot :experimental :internal :agent})
+
+;; ---- shared shapes --------------------------------------------------------
+
+(def EventVector
+  "An event vector: `[<event-id> & args]`. Used in `:events`, `:play`,
+  `:loaders`, decorator `:init`, etc. No fn-valued slots."
+  [:and
+   [:vector :any]
+   [:fn {:error/message "event vector must start with a keyword"}
+    (fn [v]
+      (and (vector? v)
+           (pos? (count v))
+           (keyword? (first v))))]])
+
+(def TagSet
+  "A `:tags` set on a story / variant / workspace. The `!`-prefix
+  removal-syntax keywords (e.g. `:!dev`) are accepted at the schema
+  level; the registrar resolves removals against the inherited set."
+  [:set :keyword])
+
+(def DecoratorRef
+  "A vector `[<decorator-id> & args]` referencing a registered decorator
+  by id. Closures live at the decorator's registration site, not here."
+  [:and
+   [:vector :any]
+   [:fn {:error/message "decorator vector must start with a keyword id"}
+    (fn [v]
+      (and (vector? v)
+           (pos? (count v))
+           (keyword? (first v))))]])
+
+(def DecoratorRefs
+  [:vector DecoratorRef])
+
+(def ArgMap
+  "Free-shape args map. Keys are keywords; values are arbitrary data.
+  The values must be EDN-round-trippable; this is enforced behaviourally
+  by the snapshot-identity computation (Stage 3), not structurally here."
+  [:map-of :keyword :any])
+
+(def ArgtypesMap
+  "Free-shape control descriptors. Auto-derived from the view's Spec 010
+  schema where present; authors override entries."
+  [:map-of :keyword :any])
+
+(def SubstrateSet
+  "Subset of the recognised substrate ids. The framework supplies the
+  closed set; Story validates membership."
+  [:set [:enum :reagent :uix :helix :reagent-slim]])
+
+(def PlatformSet
+  "Subset of `#{:server :client}` per spec/007 `:platforms`."
+  [:set [:enum :server :client]])
+
+(def ModeRefSet
+  "A set of registered mode ids the artefact opts into."
+  [:set :keyword])
+
+;; ---- :rf/story ------------------------------------------------------------
+
+(def Story
+  "Schema for the body of `reg-story`.
+
+  Per IMPL-SPEC §3.1 the body is a metadata map carrying:
+
+  - `:doc` — string, one-sentence what/why.
+  - `:component` — keyword id of a registered `:view`. (The framework's
+    registrar holds the actual view registration.)
+  - `:decorators` — vector of decorator references.
+  - `:args`/`:argtypes` — story-level defaults.
+  - `:tags` — subset of registered tags.
+  - `:modes` — saved-tuple mode ids opt-in.
+  - `:substrates` — default substrate set for variants.
+  - `:platforms` — SSR opt-in.
+  - `:variants` — the Form-B combined-form sugar; the macro desugars
+    into N independent `reg-variant` calls."
+  [:map
+   [:doc        {:optional true} :string]
+   [:component  {:optional true} :keyword]
+   [:decorators {:optional true} DecoratorRefs]
+   [:args       {:optional true} ArgMap]
+   [:argtypes   {:optional true} ArgtypesMap]
+   [:tags       {:optional true} TagSet]
+   [:modes      {:optional true} ModeRefSet]
+   [:substrates {:optional true} SubstrateSet]
+   [:platforms  {:optional true} PlatformSet]
+   ;; The Form-B combined-form sugar. Variant-name keys map to variant
+   ;; bodies — the macro expands these into N independent reg-variant
+   ;; calls. Validated separately when the macro desugars.
+   [:variants   {:optional true} [:map-of :keyword :map]]])
+
+;; ---- :rf/variant ----------------------------------------------------------
+
+(def Variant
+  "Schema for the body of `reg-variant`.
+
+  Per spec/007 §Variant artefact contract this is the load-bearing schema
+  — every key is plain data; no fn-valued slots. The body is 100% EDN-
+  round-trippable.
+
+  Open shape — Story-defined keys are validated; downstream tools may add
+  their own keys without registration ceremony (per Spec-Schemas's
+  open-by-default convention)."
+  [:map
+   [:doc                   {:optional true} :string]
+   [:extends               {:optional true} :keyword]
+   [:events                {:optional true} [:vector EventVector]]
+   [:play                  {:optional true} [:vector EventVector]]
+   [:args                  {:optional true} ArgMap]
+   [:argtypes              {:optional true} ArgtypesMap]
+   [:tags                  {:optional true} TagSet]
+   [:decorators            {:optional true} DecoratorRefs]
+   [:loaders               {:optional true} [:vector EventVector]]
+   [:loaders-complete-when {:optional true}
+    [:or
+     :keyword                                ; registered predicate-event id
+     [:vector EventVector]]]                 ; literal data form
+   [:args->events          {:optional true} [:map-of :keyword :keyword]]
+   [:platforms             {:optional true} PlatformSet]
+   [:substrates            {:optional true} SubstrateSet]
+   [:modes                 {:optional true} ModeRefSet]])
+
+;; ---- :rf/workspace --------------------------------------------------------
+
+(def WorkspaceContentItem
+  "A single content item in a `:prose`-layout workspace. Either a
+  `:prose` block (markdown body) or a `:variant` reference (variant id)."
+  [:or
+   [:map
+    [:type [:= :prose]]
+    [:body :string]]
+   [:map
+    [:type [:= :variant]]
+    [:id :keyword]]])
+
+(def Workspace
+  "Schema for the body of `reg-workspace`. Per IMPL-SPEC §3.1.
+  Five layouts: `:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`."
+  [:and
+   [:map
+    [:doc      {:optional true} :string]
+    [:layout   [:enum :grid :prose :variants-grid :tabs :custom]]
+    [:variants {:optional true} [:vector :keyword]]
+    [:content  {:optional true} [:vector WorkspaceContentItem]]
+    [:render   {:optional true} :keyword]
+    [:modes    {:optional true} ModeRefSet]]
+   ;; Layout-specific requirements. :grid / :variants-grid / :tabs need
+   ;; :variants; :prose needs :content; :custom needs :render.
+   [:fn {:error/message
+         "workspace body's slots must match its :layout (per IMPL-SPEC §3.1)"}
+    (fn [{:keys [layout variants content render]}]
+      (case layout
+        :grid          (vector? variants)
+        :tabs          (vector? variants)
+        :variants-grid true                  ; enumerates from registry
+        :prose         (vector? content)
+        :custom        (keyword? render)
+        false))]])
+
+;; ---- :rf/mode -------------------------------------------------------------
+
+(def Mode
+  "Schema for the body of `reg-mode` — a saved-tuple of global args.
+  Per IMPL-SPEC §2.8.3 modes ship in v1."
+  [:map
+   [:doc  {:optional true} :string]
+   [:args ArgMap]])
+
+;; ---- :rf/story-panel ------------------------------------------------------
+
+(def StoryPanel
+  "Schema for the body of `reg-story-panel`. Per spec/007 §Story-tool
+  extension hook and IMPL-SPEC §3.1."
+  [:map
+   [:doc       {:optional true} :string]
+   [:title     :string]
+   [:placement [:enum :right :left :bottom :top :modal]]
+   [:render    :keyword]
+   [:for       {:optional true} [:set :keyword]]])
+
+;; ---- :rf/decorator (per-kind) ---------------------------------------------
+;; IMPL-SPEC §13.2 #3 flagged that the per-kind shape needed locking;
+;; this is where that gets locked.
+
+(def DecoratorHiccup
+  "`:hiccup`-kind decorator — its `:wrap` slot is a fn that takes the
+  rendered body and the effective args and returns a hiccup vector. This
+  is the **one** legal fn-valued slot in Story's authoring surface and it
+  lives at the decorator's *registration site* — not in a variant body.
+
+  The fn-shape is enforced behaviourally (`(fn? wrap)`) and structurally
+  via the schema below. Both JVM and CLJS recognise `(fn? ...)`."
+  [:map
+   [:doc  {:optional true} :string]
+   [:kind [:= :hiccup]]
+   [:wrap fn?]])
+
+(def DecoratorFrameSetup
+  "`:frame-setup`-kind decorator — declares pre-render setup. Either an
+  ordered list of events to dispatch into the variant's frame
+  (`:init`), or a static app-db patch (`:app-db-patch`), or both."
+  [:and
+   [:map
+    [:doc          {:optional true} :string]
+    [:kind         [:= :frame-setup]]
+    [:init         {:optional true} [:vector EventVector]]
+    [:app-db-patch {:optional true} [:map-of :any :any]]]
+   [:fn {:error/message
+         "frame-setup decorator needs at least one of :init / :app-db-patch"}
+    (fn [{:keys [init app-db-patch]}]
+      (or (some? init) (some? app-db-patch)))]])
+
+(def DecoratorFxOverride
+  "`:fx-override`-kind decorator — stubs an fx for the lifetime of the
+  variant's frame. Per spec/007 §Effect mocking the decorator is a
+  declaration; the actual stub registration happens at frame creation."
+  [:map
+   [:doc      {:optional true} :string]
+   [:kind     [:= :fx-override]]
+   [:fx-id    :keyword]
+   [:response :any]])
+
+(def Decorator
+  "Polymorphic decorator schema, dispatched on `:kind`. The three kinds
+  are the IMPL-SPEC §3.1 lock."
+  [:multi {:dispatch :kind}
+   [:hiccup       DecoratorHiccup]
+   [:frame-setup  DecoratorFrameSetup]
+   [:fx-override  DecoratorFxOverride]])
+
+;; ---- :rf/tag --------------------------------------------------------------
+
+(def Tag
+  "Schema for the body of `reg-tag`. Tag bodies carry a `:doc` only.
+  The vocabulary itself is queryable via `(story/handlers :tag)`."
+  [:map
+   [:doc {:optional true} :string]])
+
+;; ---- validator dispatch table ---------------------------------------------
+
+(def kind->schema
+  "Map from registry kind keyword to its body schema. The registrar
+  entry points (`re-frame.story.registrar/reg-*`) look up the right
+  schema here and call `m/validate` against it."
+  {:story        Story
+   :variant      Variant
+   :workspace    Workspace
+   :mode         Mode
+   :story-panel  StoryPanel
+   :decorator    Decorator
+   :tag          Tag})
+
+(defn validate
+  "Validate `body` against the schema registered for `kind`. Returns
+  `nil` on success; on failure returns the `m/explain` result, suitable
+  for inclusion in an `ex-info` map.
+
+  The boundary the registrar enforces — `:rf.error/<kind>-shape` — uses
+  this. The schemas themselves are plain Malli forms; tools can pull
+  them via the `kind->schema` map for their own reflection."
+  [kind body]
+  (when-let [schema (get kind->schema kind)]
+    (when-not (m/validate schema body)
+      (m/explain schema body))))

--- a/tools/story/test/re_frame/story_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_cljs_test.cljs
@@ -1,0 +1,61 @@
+(ns re-frame.story-cljs-test
+  "CLJS smoke tests for re-frame2-story Stage 2.
+
+  The bulk of registration / schema / extends coverage lives in the
+  JVM test ns (`re-frame.story-test`) — those tests run faster, on
+  more hosts, and exercise the macros from a non-Reagent environment.
+
+  This namespace covers the CLJS-specific surface: the `goog-define`
+  flag at `re-frame.story.config/enabled?`, and a smoke registration
+  round-trip to confirm the macros emit working code in a CLJS
+  compile."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.config :as config]
+            [re-frame.story.schemas :as schemas]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-story-registry [test-fn]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (test-fn))
+
+(use-fixtures :each reset-story-registry)
+
+;; ---- the compile-time flag ----------------------------------------------
+
+(deftest enabled-flag-is-true-in-test-build
+  (testing "Story is enabled in this CLJS test build"
+    (is (true? config/enabled?))))
+
+;; ---- macros emit working code -------------------------------------------
+
+(deftest cljs-smoke-reg-story-and-variant
+  (testing "reg-story + reg-variant macros register against the side-table in CLJS"
+    (story/reg-story :story.cljs.smoke
+      {:doc       "CLJS smoke test."
+       :component :app.cljs/comp
+       :tags      #{:dev}})
+    (story/reg-variant :story.cljs.smoke/default
+      {:doc    "default state"
+       :events [[:init]]
+       :tags   #{:dev}})
+    (is (story/registered? :story   :story.cljs.smoke))
+    (is (story/registered? :variant :story.cljs.smoke/default))))
+
+(deftest cljs-form-b-desugars
+  (testing "Form-B :variants desugars on the CLJS side"
+    (story/reg-story :story.cljs.form-b
+      {:doc       "Form-B test."
+       :component :app.cljs/comp
+       :variants  {:a {:events [[:init-a]]}
+                   :b {:events [[:init-b]]}}})
+    (is (story/registered? :variant :story.cljs.form-b/a))
+    (is (story/registered? :variant :story.cljs.form-b/b))))
+
+;; ---- canonical tag set ---------------------------------------------------
+
+(deftest cljs-canonical-tags-installed
+  (testing "the seven canonical tags load on the CLJS side"
+    (is (= schemas/canonical-tags (story/list-tags)))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -1,0 +1,384 @@
+(ns re-frame.story-test
+  "JVM tests for re-frame2-story Stage 2 (rf2-32dk).
+
+  Covers:
+
+  - Macro expansion → registry write round-trip.
+  - Body shape validation (`:rf.error/<kind>-shape`).
+  - Tag membership (`:rf.error/unknown-tag`).
+  - `:extends` resolution + cycle / unknown-parent detection.
+  - Form-B `:variants` desugaring.
+  - Source-coord stamping.
+  - Query API (`handlers`, `handler-meta`, `variants-with-tags`,
+    `variants-of`).
+  - EDN-round-trip of variant bodies (no fn-valued slots).
+  - Canonical-id-grammar enforcement.
+
+  JVM-runnable because the registration surface is pure data — no
+  Reagent / DOM / shadow-cljs required. Per IMPL-SPEC §1.1 + the
+  `jvm_interop_must_work` user-feedback rule, every artefact that can
+  run on the JVM should."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.config :as story-config]
+            [re-frame.story.extends :as extends]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.schemas :as schemas]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-story-registry [test-fn]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (test-fn))
+
+(use-fixtures :each reset-story-registry)
+
+;; ---- canonical-vocabulary install ---------------------------------------
+
+(deftest canonical-tags-installed
+  (testing "the seven canonical tags are registered after boot"
+    (is (= schemas/canonical-tags (story/list-tags)))
+    (is (every? #(story/registered? :tag %) schemas/canonical-tags))))
+
+;; ---- reg-story basic ----------------------------------------------------
+
+(deftest reg-story-basic
+  (testing "reg-story writes to the side-table under :story kind"
+    (story/reg-story :story.ui.button
+      {:doc       "Primary action button."
+       :component :app.ui/button
+       :args      {:label "Click me"}
+       :tags      #{:dev :docs}})
+    (is (= #{:story.ui.button} (story/ids :story)))
+    (let [body (story/handler-meta :story :story.ui.button)]
+      (is (= "Primary action button." (:doc body)))
+      (is (= :app.ui/button (:component body)))
+      (is (= {:label "Click me"} (:args body)))
+      (is (= #{:dev :docs} (:tags body)))))
+
+  (testing "source-coord is stamped onto the registered body"
+    (story/reg-story :story.ui.icon {:doc "Icon."})
+    (let [body (story/handler-meta :story :story.ui.icon)]
+      (is (map? (:source body)))
+      (is (= 're-frame.story-test (:ns (:source body))))
+      (is (integer? (:line (:source body)))))))
+
+(deftest reg-story-id-shape
+  (testing "reg-story rejects ids outside the :story.<path> grammar"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match the canonical id grammar"
+                          (story/reg-story* :NotAStoryId {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match the canonical id grammar"
+                          (story/reg-story* :foo.bar {})))))
+
+(deftest reg-story-bad-shape
+  (testing "reg-story rejects a body that violates the schema"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match story schema"
+                          (story/reg-story :story.ui.bad
+                            {:tags "not-a-set"})))))
+
+(deftest reg-story-unknown-tag
+  (testing "reg-story raises :rf.error/unknown-tag on an unregistered tag"
+    (try
+      (story/reg-story :story.ui.bad {:tags #{:dev :totally-made-up}})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/unknown-tag (:rf.error (ex-data e))))
+        (is (= [:totally-made-up] (:unknown (ex-data e))))))))
+
+;; ---- reg-variant basic -------------------------------------------------
+
+(deftest reg-variant-basic
+  (testing "reg-variant writes a variant under :variant kind"
+    (story/reg-variant :story.ui.button/default
+      {:doc    "Default state."
+       :events [[:button/init]]
+       :tags   #{:dev :docs}})
+    (let [body (story/handler-meta :variant :story.ui.button/default)]
+      (is (= "Default state." (:doc body)))
+      (is (= [[:button/init]] (:events body)))
+      (is (= #{:dev :docs} (:tags body)))))
+
+  (testing "the variant body is EDN-round-trippable (no fn slots)"
+    (story/reg-variant :story.ui.button/edn-test
+      {:doc    "EDN check."
+       :events [[:button/init]]
+       :play   [[:button/click] [:rf.assert/path-equals [:click] true]]
+       :args   {:label "Hi"}
+       :tags   #{:dev}})
+    (let [body (story/handler-meta :variant :story.ui.button/edn-test)
+          body (dissoc body :source)            ; :source is environment-derived
+          edn  (pr-str body)
+          round-tripped (read-string edn)]
+      (is (= body round-tripped)))))
+
+;; ---- :extends resolution -----------------------------------------------
+
+(deftest extends-resolves-at-registration-time
+  (testing ":extends merges parent into child, child wins"
+    (story/reg-variant :story.auth.login/loading
+      {:events     [[:auth/initialise]
+                    [:auth/email-changed "alice@example.com"]
+                    [:auth/login-pressed]]
+       :decorators [[:force-fx-stub :http {:status :pending}]]
+       :tags       #{:dev}})
+    (story/reg-variant :story.auth.login/loading-with-prefill
+      {:extends :story.auth.login/loading
+       :events  [[:auth/initialise]
+                 [:auth/email-changed "alice@example.com"]
+                 [:auth/password-changed "hunter2"]
+                 [:auth/login-pressed]]
+       :tags    #{:dev :docs}})
+    (let [body (story/handler-meta :variant :story.auth.login/loading-with-prefill)]
+      (is (nil? (:extends body)) ":extends is stripped from the resolved body")
+      (is (= 4 (count (:events body))) "child :events wins")
+      (is (= [[:force-fx-stub :http {:status :pending}]] (:decorators body))
+          ":decorators inherited from parent")
+      (is (= #{:dev :docs} (:tags body)) "child :tags wins"))))
+
+(deftest extends-unknown-parent
+  (testing ":extends to an unregistered variant raises :rf.error/extends-unknown"
+    (try
+      (story/reg-variant :story.auth.login/child
+        {:extends :story.auth.login/no-such-parent
+         :events  []})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/extends-unknown (:rf.error (ex-data e))))))))
+
+(deftest extends-cycle-detection
+  (testing ":extends cycle raises :rf.error/extends-cycle"
+    ;; Set up a cycle: a → b → a. We have to use the raw lookup because
+    ;; reg-variant would reject the second registration on unknown-parent.
+    (let [lookup {:story.a/first  {:extends :story.a/second :events []}
+                  :story.a/second {:extends :story.a/first  :events []}}]
+      (try
+        (extends/resolve-extends (get lookup :story.a/first)
+                                 #(get lookup %))
+        (is false "expected an exception")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/extends-cycle (:rf.error (ex-data e)))))))))
+
+(deftest extends-depth-cap
+  (testing ":extends depth cap fires at *max-extends-depth*"
+    (let [;; A chain of 50 IDs each pointing to the next; n=49 names the
+          ;; deepest, n=0 names the leaf. Resolution from leaf has to
+          ;; walk every parent.
+          chain-len 50
+          chain     (into {}
+                          (for [i (range chain-len)]
+                            (let [this   (keyword "story.chain" (str "n" i))
+                                  parent (when (< (inc i) chain-len)
+                                           (keyword "story.chain" (str "n" (inc i))))]
+                              [this (cond-> {:events []}
+                                      parent (assoc :extends parent))])))]
+      (binding [extends/*max-extends-depth* 32]
+        (try
+          (extends/resolve-extends (get chain :story.chain/n0)
+                                   #(get chain %))
+          (is false "expected an exception")
+          (catch clojure.lang.ExceptionInfo e
+            (is (= :rf.error/extends-cycle (:rf.error (ex-data e))))))))))
+
+;; ---- Form-B desugaring -------------------------------------------------
+
+(deftest form-b-variants-desugar
+  (testing "reg-story with :variants emits N reg-variant calls at expansion"
+    (story/reg-story :story.auth.login-form
+      {:doc       "Login form."
+       :component :app.auth/login-form
+       :args      {:placeholder "you@example.com"}
+       :tags      #{:dev :docs}
+       :variants  {:empty            {:events [[:auth/initialise]]
+                                      :tags   #{:dev :docs}}
+                   :validation-error {:events [[:auth/initialise]
+                                               [:auth/email-changed "x"]
+                                               [:auth/login-pressed]]
+                                      :tags   #{:dev :docs :test}}}})
+    (is (story/registered? :story :story.auth.login-form))
+    (is (story/registered? :variant :story.auth.login-form/empty))
+    (is (story/registered? :variant :story.auth.login-form/validation-error))
+    ;; :variants key is stripped from the parent body
+    (is (nil? (:variants (story/handler-meta :story :story.auth.login-form))))
+    ;; The two variants are independent registrations
+    (is (= 2 (count (story/variants-of :story.auth.login-form))))))
+
+;; ---- workspace ---------------------------------------------------------
+
+(deftest reg-workspace-grid
+  (testing ":grid workspace requires :variants"
+    (story/reg-workspace :Workspace.Auth/all-states
+      {:doc      "Auth states."
+       :layout   :grid
+       :variants [:story.auth.login/empty
+                  :story.auth.login/loading]})
+    (is (story/registered? :workspace :Workspace.Auth/all-states))))
+
+(deftest reg-workspace-prose
+  (testing ":prose workspace requires :content"
+    (story/reg-workspace :Workspace.Auth/docs
+      {:doc     "Auth docs."
+       :layout  :prose
+       :content [{:type :prose   :body "## Auth flow"}
+                 {:type :variant :id   :story.auth.login/empty}]})
+    (is (story/registered? :workspace :Workspace.Auth/docs))))
+
+(deftest reg-workspace-bad-layout
+  (testing "a :grid workspace without :variants fails validation"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match workspace schema"
+                          (story/reg-workspace :Workspace.bad/empty
+                            {:layout :grid})))))
+
+;; ---- mode --------------------------------------------------------------
+
+(deftest reg-mode-saved-tuple
+  (testing "reg-mode stores an args tuple"
+    (story/reg-mode :Mode.app/dark-mobile
+      {:doc  "Dark theme on mobile."
+       :args {:theme :dark :viewport :mobile}})
+    (is (= {:theme :dark :viewport :mobile}
+           (:args (story/handler-meta :mode :Mode.app/dark-mobile))))
+    (is (contains? (story/list-modes) :Mode.app/dark-mobile))))
+
+;; ---- story-panel -------------------------------------------------------
+
+(deftest reg-story-panel-10x-shape
+  (testing "the canonical re-frame-10x embed registration"
+    (story/reg-story-panel :rf.story/epoch-10x
+      {:doc       "re-frame-10x's epoch buffer."
+       :title     "Epochs (10x)"
+       :placement :bottom
+       :render    :re-frame-10x.epoch-panel/view})
+    (let [body (story/handler-meta :story-panel :rf.story/epoch-10x)]
+      (is (= "Epochs (10x)" (:title body)))
+      (is (= :bottom (:placement body)))
+      (is (= :re-frame-10x.epoch-panel/view (:render body))))))
+
+;; ---- decorator (per-kind) ---------------------------------------------
+
+(deftest reg-decorator-hiccup
+  (testing ":hiccup decorator accepts a fn :wrap (only legal fn-slot)"
+    (story/reg-decorator :centered-layout
+      {:doc  "Centre the rendered content."
+       :kind :hiccup
+       :wrap (fn [body _args] [:div.centered body])})
+    (let [body (story/handler-meta :decorator :centered-layout)]
+      (is (= :hiccup (:kind body)))
+      (is (fn? (:wrap body))))))
+
+(deftest reg-decorator-frame-setup
+  (testing ":frame-setup decorator requires :init or :app-db-patch"
+    (story/reg-decorator :mock-auth
+      {:doc  "Inject a mock auth user."
+       :kind :frame-setup
+       :init [[:auth/restore-session {:user "alice"}]]})
+    (is (= :frame-setup (:kind (story/handler-meta :decorator :mock-auth))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match decorator schema"
+                          (story/reg-decorator :mock-empty
+                            {:kind :frame-setup})))))
+
+(deftest reg-decorator-fx-override
+  (testing ":fx-override decorator names the fx-id + canned response"
+    (story/reg-decorator :force-fx-stub
+      {:doc      "Stub :http for the variant's frame."
+       :kind     :fx-override
+       :fx-id    :http
+       :response {:status :pending}})
+    (let [body (story/handler-meta :decorator :force-fx-stub)]
+      (is (= :fx-override (:kind body)))
+      (is (= :http (:fx-id body))))))
+
+(deftest reg-decorator-unknown-kind
+  (testing "decorator with an unknown :kind fails the schema"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match decorator schema"
+                          (story/reg-decorator :bad-kind
+                            {:kind :no-such-kind})))))
+
+;; ---- tag ---------------------------------------------------------------
+
+(deftest reg-tag-project-tag
+  (testing "project tags can be registered and then used on variants"
+    (story/reg-tag :auth/regression-set
+      {:doc "Auth regression-suite variants."})
+    (is (story/registered? :tag :auth/regression-set))
+    ;; Now a variant tagged with it should validate
+    (story/reg-variant :story.auth.login/regression-empty
+      {:events [[:auth/initialise]]
+       :tags   #{:dev :auth/regression-set}})
+    (is (story/registered? :variant :story.auth.login/regression-empty))))
+
+;; ---- !-prefix removal syntax -------------------------------------------
+
+(deftest tags-with-bang-prefix-validate
+  (testing "the !-prefix removal syntax passes tag validation"
+    ;; A variant body's :tags may carry :!dev to remove :dev from the
+    ;; inherited tag set. The registrar accepts these as long as the
+    ;; base (un-prefixed) tag is registered.
+    (story/reg-variant :story.bang/test
+      {:events []
+       :tags   #{:!dev :docs}})
+    (is (story/registered? :variant :story.bang/test))))
+
+(deftest tags-with-bang-prefix-rejects-unknown
+  (testing "the !-prefix variant rejects unknown base tags"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"unregistered tag"
+                          (story/reg-variant :story.bang/bad
+                            {:events []
+                             :tags   #{:!totally-unknown}})))))
+
+;; ---- query API ---------------------------------------------------------
+
+(deftest variants-of-finds-children
+  (testing "variants-of returns only the variants of the requested story"
+    (story/reg-variant :story.foo/a {:events []})
+    (story/reg-variant :story.foo/b {:events []})
+    (story/reg-variant :story.bar/c {:events []})
+    (is (= #{:story.foo/a :story.foo/b} (story/variants-of :story.foo)))
+    (is (= #{:story.bar/c}              (story/variants-of :story.bar)))))
+
+(deftest variants-with-tags-intersection
+  (testing "variants-with-tags returns variants whose :tags intersects the query"
+    (story/reg-variant :story.tag/a {:events [] :tags #{:dev :test}})
+    (story/reg-variant :story.tag/b {:events [] :tags #{:dev :docs}})
+    (story/reg-variant :story.tag/c {:events [] :tags #{:test}})
+    (is (= #{:story.tag/a :story.tag/c} (story/variants-with-tags #{:test})))
+    (is (= #{:story.tag/a :story.tag/b} (story/variants-with-tags #{:docs :dev})))))
+
+(deftest all-kinds-with-counts-reflects-state
+  (testing "all-kinds-with-counts mirrors the side-table"
+    (story/reg-story   :story.x   {:doc "x"})
+    (story/reg-variant :story.x/v {:events []})
+    (let [counts (story/all-kinds-with-counts)]
+      (is (= 1 (:story   counts)))
+      (is (= 1 (:variant counts)))
+      (is (= (count schemas/canonical-tags) (:tag counts))))))
+
+;; ---- variant->edn ----------------------------------------------------
+
+(deftest variant->edn-returns-body
+  (testing "variant->edn returns the registered body verbatim"
+    (story/reg-variant :story.edn/x
+      {:events [[:init]]
+       :tags   #{:dev}})
+    (let [edn (story/variant->edn :story.edn/x)]
+      (is (= [[:init]] (:events edn)))
+      (is (= #{:dev}    (:tags edn))))))
+
+;; ---- elision sentinel ------------------------------------------------
+
+(deftest config-flag-controls-expansion
+  (testing "re-frame.story.config/enabled? is true at JVM-test time"
+    (is (true? story-config/enabled?))))
+
+;; ---- Stage 3 contract check -----------------------------------------
+
+(deftest stage-marker
+  (testing "the loaded surface advertises Stage 2 (authoring)"
+    (is (= :authoring re-frame.story/stage))))


### PR DESCRIPTION
## Summary

Stage 2 of [rf2-u6fb](https://github.com/day8/re-frame2/issues/u6fb) — implements the **core authoring surface** for `day8/re-frame2-story` per [IMPL-SPEC §10 Stage 2](../blob/main/tools/story/IMPL-SPEC.md) and `spec/007-Stories.md`. Builds directly on Stage 1's IMPL-SPEC (PR #274 / bead rf2-2hir).

This PR is the **registration layer only** — `reg-story`, `reg-variant`, etc. + queries. Stage 3 (rf2-von3) lands the runtime (frame allocation, args resolution, four-phase lifecycle); Stage 4 lands the UI shell; subsequent stages follow.

## Public surface delivered

Under `re-frame.story`:

| Macro | Accepts |
|---|---|
| `reg-story` | `id metadata` — parent of variants; Form-B `:variants` map desugars to N independent `reg-variant` calls at expansion time |
| `reg-variant` | `id metadata` — EDN-shaped scenario body (no fn slots); `:extends` resolves at registration; tag membership validated |
| `reg-workspace` | `id metadata` — `:grid` / `:prose` / `:variants-grid` / `:tabs` / `:custom` layouts with layout-specific slot validation |
| `reg-mode` | `id metadata` — Chromatic-style saved-tuple of args (IMPL-SPEC §2.8.3 — v1) |
| `reg-story-panel` | `id metadata` — extension hook (the re-frame-10x embed, design-token panels, etc. consume this) |
| `reg-decorator` | `id metadata` — three kinds: `:hiccup` / `:frame-setup` / `:fx-override` (per-kind Malli schemas, IMPL-SPEC §13.2 #3) |
| `reg-tag` | `id metadata` — tag-vocabulary registration |

Query API (mirrors the spec/001 §Public registrar query API for Story's side-table):

`handlers` · `handler-meta` · `ids` · `registered?` · `variants-of` · `variants-with-tags` · `list-tags` · `list-modes` · `variant->edn` · `workspace->edn` · `all-kinds-with-counts`

Plus programmatic register helpers (`reg-story*` / `reg-variant*` / etc.) for tooling that synthesises registrations (MCP write surface in v1.1).

## Architectural choices made during impl

- **EDN-first variant bodies** (IMPL-SPEC §2.6 / Phase-2 §5.1 #10) — no fn-valued slots. The one legal fn slot is `:hiccup`-decorator `:wrap`, which lives at the decorator's *registration site*. The Malli schema enforces this.
- **Story-owned side-table** at `re-frame.story.registrar` (NOT a new kind in `re-frame.registrar`). `re-frame.registrar`'s kind set is closed to the spec/001 v1 list; Story's registrations route through its own atom. Filed `bd rf2-7ho2` (Suggestion) to track the spec/registrar-conflict resolution for the next maintenance pass.
- **Elision** via `(when re-frame.story.config/enabled? ...)` wrapper on every macro expansion (IMPL-SPEC §6). `:advanced` + `goog.DEBUG=false` consumers set `:closure-defines {re-frame.story.config/enabled? false}` and every registration form elides to `nil`.
- **Source-coord stamping** mirrors `re-frame.source-coords` / `re-frame.core/reg-event-db`'s pattern. Coords write to a reserved `:source` slot on the registered body so they don't shadow user data.
- **Canonical id grammar** policed at registration time (`:rf.error/<kind>-id-shape`).
- **`!`-prefix removal-syntax** (Phase-2 §5.1 #11) accepts `:!dev` when `:dev` is a registered base tag.
- **`:extends` cycle detection** bounded by `*max-extends-depth*` (32); unregistered parent raises `:rf.error/extends-unknown`.

## Files added

| File | LoC |
|---|---|
| `tools/story/src/re_frame/story.cljc` | 394 |
| `tools/story/src/re_frame/story/config.cljc` | 71 |
| `tools/story/src/re_frame/story/extends.cljc` | 108 |
| `tools/story/src/re_frame/story/macros.clj` | 115 |
| `tools/story/src/re_frame/story/registrar.cljc` | 370 |
| `tools/story/src/re_frame/story/schemas.cljc` | 383 |
| `tools/story/test/re_frame/story_test.clj` (JVM) | 384 |
| `tools/story/test/re_frame/story_cljs_test.cljs` | 61 |
| **total** | **1886** |

Plus modifications: `tools/story/deps.edn` (Malli version aligned with the CLJS build), `implementation/shadow-cljs.edn` (`tools/story` source paths added so the top-level `node-test` build picks up the CLJS smoke tests), `.gitignore` (added `**/.cpcache/`).

## What this stage does NOT do

Per IMPL-SPEC stage breakdown — explicitly deferred:

- `run-variant` / four-phase lifecycle / snapshot identity → **Stage 3 (rf2-von3)**
- UI shell (sidebar, canvas, controls, multi-substrate pane) → **Stage 4 (rf2-ekai)**
- `:rf.assert/*` play runtime → **Stage 5 (rf2-h8et)**
- Perf ribbon / a11y / layout-debug / design-tokens / 10x embed adapter → **Stage 6 (rf2-zhwd)**
- MCP jar → **Stage 7 (rf2-tgci)**
- Examples + guide → **Stage 8 (rf2-c9mm)**

`run-variant` / `reset-variant` / `snapshot-identity` are *intentionally absent* from the public ns at Stage 2 so Stage 3 can land them at IMPL-SPEC §3.2's locked signatures without conflicting stub bodies. A `re-frame.story/stage :authoring` sentinel advertises the loaded surface.

## Stage 3 dependencies left clear

The Stage 2 surface threads source-coords through to `:source` on every registered body, marks `:extends`-resolved variants by stripping the `:extends` key from the body, and includes namespaced TODO comments where Stage 3 picks up. The `variant->edn` / `workspace->edn` helpers return the side-table body verbatim — Stage 3's canonicalisation work (sorted keys, deterministic vector order for snapshot-identity) replaces those bodies.

## IMPL-SPEC findings filed

- `rf2-7ho2` (Suggestion): `re-frame.registrar`'s kind set is closed but `spec/007 L447` claims the framework registrar supports new kinds. Story's side-table path is the chosen reconciliation; the bead tracks the spec/implementation alignment for the next maintenance pass.

## Test plan

- [x] `cd tools/story && clojure -M:test` — JVM: 29 tests, 61 assertions, 0 failures, 0 errors
- [x] `cd implementation && npm run test:cljs` — CLJS: 423 tests, 1016 assertions, 0 failures (`re-frame.story-cljs-test` included)
- [x] `cd implementation && npm run test:elision` — pre-existing sentinels still elide cleanly under `:advanced` + `goog.DEBUG=false`
- [x] `cd implementation && npm run test:bundle-isolation` — Story does not leak into the counter example's production bundle
- [x] `mkdocs build` — no new warnings vs baseline
- [x] `cd implementation/core && clojure -M:test` — 183 core tests, 824 assertions, 0 failures (no regression)