### PR TITLE
feat(story): Stage 3 — runtime (frames, args, decorators, loaders) (rf2-von3)

### DIFF
--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -24,6 +24,17 @@
          ;; dep stays.
          reagent/reagent         {:mvn/version "1.2.0"}
 
+         ;; Stage 3 (rf2-von3) — the loader four-phase lifecycle is
+         ;; implemented as a state machine via `re-frame.machines` per
+         ;; IMPL-SPEC §5.4 and the standing 'no new registries' rule
+         ;; (AGENTS.md `downstream-EPs-consume-foundation`). Story's
+         ;; runtime registers `:rf.story.lifecycle/machine` at boot;
+         ;; per-variant snapshots live at `[:rf/machines
+         ;; :rf.story.lifecycle/machine]` inside each variant frame's
+         ;; app-db. Without machines on the classpath the lifecycle
+         ;; cannot run, so the dep is mandatory at Stage 3+.
+         day8/re-frame2-machines {:local/root "../../implementation/machines"}
+
          ;; Malli drives Story's three-level args / argtypes auto-derivation
          ;; from Spec 010 schemas (see IMPL-SPEC §4 + §5.2). Malli is
          ;; already a transitive dep via implementation/core; the version

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -46,6 +46,13 @@
   (:require [re-frame.story.config    :as config]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.schemas   :as schemas]
+            ;; Stage 3 (rf2-von3) — runtime modules.
+            [re-frame.story.args      :as args]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.identity  :as identity]
+            [re-frame.story.loaders   :as loaders]
+            [re-frame.story.frames    :as frames]
+            [re-frame.story.runtime   :as runtime]
             #?(:clj [re-frame.story.macros :as macros]))
   ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
@@ -327,15 +334,40 @@
 ;; ---- canonical vocabulary boot ------------------------------------------
 
 (defn install-canonical-vocabulary!
-  "Install the seven canonical Story tags into the registry. Call this
-  once at boot before any `reg-story` / `reg-variant` calls. Idempotent.
+  "Install the seven canonical Story tags + the runtime's internal
+  helper events / lifecycle machine. Call this once at boot before any
+  `reg-story` / `reg-variant` / `run-variant` calls. Idempotent.
 
-  Per spec/007 §Inclusion tags + IMPL-SPEC §3.1 the canonical seven are
-  registered by the Story library at load time — projects don't have to.
+  Per spec/007 §Inclusion tags + IMPL-SPEC §3.1 the canonical seven
+  tags are registered by the Story library at load time — projects
+  don't have to. Per IMPL-SPEC §5.4 the lifecycle machine
+  (`:rf.story.lifecycle/machine`) is registered here too — without it
+  `run-variant` cannot drive the four-phase lifecycle.
+
   Project-specific tags must register via `reg-tag` *before* use; an
   unregistered tag on a variant's `:tags` set raises `:rf.error/unknown-tag`."
   []
-  (registrar/install-canonical-tags!))
+  (registrar/install-canonical-tags!)
+  (loaders/install!)
+  (loaders/install-mirror-writer!)
+  (frames/install-helpers!)
+  (runtime/install-helpers!))
+
+;; ---- configure! ---------------------------------------------------------
+
+(defn configure!
+  "Configure Story's global defaults. Per IMPL-SPEC §5.2 the global
+  args map is the first layer of the args-precedence chain (theme,
+  locale, ...). The host application calls this once at boot.
+
+  `{:global-args {...}}` — replace the global args map.
+
+  Other keys are accepted for forward compatibility but ignored at
+  Stage 3."
+  [{:keys [global-args] :as _opts}]
+  (when (some? global-args)
+    (config/set-global-args! global-args))
+  nil)
 
 ;; ---- registry reset (test fixtures) -------------------------------------
 
@@ -379,16 +411,110 @@
 
 ;; ---- run-variant / reset-variant / snapshot-identity --------------------
 ;;
-;; STAGE 3 (rf2-von3): the four-phase lifecycle owns these. Stage 2
-;; intentionally does NOT implement them. Authors expecting these from
-;; Stage 2 should consult the bead chain.
-;;
-;; A no-op stub here would mask Stage 3's contract; instead the
-;; functions are intentionally absent. Stage 3 lands them at IMPL-SPEC
-;; §3.2's locked signatures.
+;; STAGE 3 (rf2-von3): the four-phase lifecycle. These call into
+;; `re-frame.story.runtime`. Each returns a promise (CLJS) or
+;; CompletableFuture (JVM); see `re-frame.story.async` for the shape.
+
+(defn run-variant
+  "Per IMPL-SPEC §3.2. Allocate a frame for `variant-id`, run the four-
+  phase lifecycle (loaders → events → render → play), and return a
+  promise/future of the result map.
+
+  `opts`:
+    :active-modes    coll of registered mode ids; deep-merged into args
+    :cell-overrides  runtime arg overrides (controls panel)
+    :substrate       active substrate (`:reagent`, `:uix`, ...)
+    :render?         when truthy, Stage 4's UI shell renders into
+                     `:rendered-hiccup`. Stage 3 leaves the slot nil.
+    :assertions      Stage 5's hook. Stage 3 accepts the slot but
+                     leaves the runtime semantics to Stage 5.
+
+  Result map:
+
+      {:frame           <variant-id>
+       :app-db          {...}
+       :assertions      [...]
+       :rendered-hiccup nil           ; Stage 4
+       :elapsed-ms      <ms>
+       :snapshot        {:variant-id ... :content-hash \"...\"}
+       :decorators      {:hiccup [...] :frame-setup [...] :fx-override [...]
+                         :errors [...]}
+       :effective-args  {...}
+       :lifecycle       :ready | :error}"
+  ([variant-id]       (runtime/run-variant variant-id nil))
+  ([variant-id opts]  (runtime/run-variant variant-id opts)))
+
+(defn reset-variant
+  "Tear down + re-run `variant-id`. Per IMPL-SPEC §3.2."
+  ([variant-id]       (runtime/reset-variant variant-id nil))
+  ([variant-id opts]  (runtime/reset-variant variant-id opts)))
+
+(defn watch-variant
+  "Subscribe to lifecycle transitions for `variant-id`'s frame. Per
+  IMPL-SPEC §3.2. `callback` receives
+  `{:frame-id <id> :from <state> :to <state> :event <inner-event>}`
+  on every transition. Returns a 0-arity unsubscribe fn."
+  [variant-id callback]
+  (runtime/watch-variant variant-id callback))
+
+(defn snapshot-identity
+  "Per IMPL-SPEC §3.2 + §5.6. Content-hash over the canonicalised
+  `(variant × resolved-args × decorators × loaders × substrate × modes)`
+  tuple. Stable across hosts.
+
+  Returns `{:variant-id ... :active-modes [...] :substrate ...
+  :content-hash \"<8-char hex>\"}`."
+  ([variant-id]       (runtime/snapshot-identity variant-id))
+  ([variant-id opts]  (runtime/snapshot-identity variant-id opts)))
+
+(defn destroy-variant!
+  "Tear down a variant frame allocated via `run-variant`. Per IMPL-
+  SPEC §5.1 — the caller (UI shell / test fixture) owns teardown."
+  [variant-id]
+  (frames/destroy! variant-id))
+
+(defn variant-frames
+  "Return every registered variant frame id. Stage 4's UI shell uses
+  this to lay out the active variant pane."
+  []
+  (frames/variant-frames))
+
+(defn variant-frame?
+  "True iff `frame-id` is a variant frame."
+  [frame-id]
+  (frames/variant-frame? frame-id))
+
+(defn lifecycle-state
+  "Return the lifecycle's current discrete state for the variant's
+  frame (`:pre-mount`, `:mounting`, `:loading`, `:ready`, `:error`).
+  Returns `:pre-mount` if the variant hasn't been run yet."
+  [variant-id]
+  (loaders/current-state variant-id))
+
+;; ---- public helpers (decorator / args resolution surfacing) -------------
+
+(defn resolve-args
+  "Per IMPL-SPEC §5.2 — materialise the effective args map for a
+  variant render given the active modes + cell overrides. See
+  `re-frame.story.args/resolve-args`."
+  ([variant-id]       (args/resolve-args variant-id))
+  ([variant-id opts]  (args/resolve-args variant-id opts)))
+
+(defn resolve-decorators
+  "Per IMPL-SPEC §5.3 — return the variant's resolved decorator stack
+  classified by kind (`{:hiccup [...] :frame-setup [...] :fx-override [...]
+  :errors [...]}`). See `re-frame.story.decorators/resolve-decorators`."
+  ([variant-id]       (decorators/resolve-decorators variant-id))
+  ([variant-id opts]  (decorators/resolve-decorators variant-id opts)))
 
 (def stage
-  "Sentinel that names which Stage's authoring surface is loaded.
-  Stage 2: authoring. Stage 3+: runtime additions. Useful for tools
-  that conditionally adapt to the loaded surface."
-  :authoring)
+  "Sentinel that names which Stage's surface is loaded.
+
+  - Stage 2 — `:authoring` (registration macros only).
+  - Stage 3 — `:runtime` (adds `run-variant` family, decorator
+    composition, args resolution, snapshot-identity, lifecycle).
+  - Stage 4+ extends — UI shell, play sequence, assertions, MCP.
+
+  Tools that adapt to the loaded surface read this; agents can ask
+  the runtime which Stage is live."
+  :runtime)

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -1,0 +1,137 @@
+(ns re-frame.story.args
+  "Args-precedence resolution. Per IMPL-SPEC §5.2 + spec/007 §Args at
+  three levels.
+
+  When the rendering layer asks 'what args is this variant rendered
+  with?', the runtime composes five sources in this strict order (later
+  wins):
+
+  1. **Global args** — `re-frame.story.config/global-args` (host's
+     boot-time defaults: theme, locale).
+  2. **Story args** — `:args` on the parent story.
+  3. **Mode args** — the *active* modes' `:args` (deep-merge, not
+     replace). When the caller passes a set of modes, each mode's
+     `:args` deep-merges in declared order.
+  4. **Variant args** — `:args` on the variant.
+  5. **Cell-local overrides** — runtime overrides from controls
+     (`:story/set-arg`), passed in via the `cell-overrides` arg.
+
+  Deep-merge semantics: maps recurse; non-map values (vectors, sets,
+  scalars) replace. Per IMPL-SPEC §5.2 and Storybook's documented
+  convention.
+
+  ## Elision
+
+  This namespace is pure — every fn is data → data. Production builds
+  retain the fns (per IMPL-SPEC §6.3 — `run-variant`'s body survives
+  with no registrations to act on, returning empty). Story callers
+  invoke `resolve-args` only inside the `(when enabled? ...)`-gated
+  runtime entry points; the call site disappears in production along
+  with the rest of the runtime."
+  (:require [re-frame.story.config    :as config]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- deep-merge -----------------------------------------------------------
+
+(defn deep-merge
+  "Recursive merge: when both `a` and `b` are maps, merge them entry-by-
+  entry with deep-merge on overlapping keys. Otherwise `b` replaces `a`.
+
+  Per IMPL-SPEC §5.2: 'Deep-merge (per Storybook's convention) for
+  nested maps; override-by-replacement for vectors.'
+
+  - `(deep-merge nil x)` → `x`.
+  - `(deep-merge {} {})` → `{}`.
+  - Vectors and sets are NOT merged element-wise — they replace."
+  [a b]
+  (cond
+    (and (map? a) (map? b))
+    (reduce-kv
+      (fn [m k v]
+        (assoc m k (deep-merge (get m k) v)))
+      a
+      b)
+
+    (nil? b) a
+
+    :else b))
+
+(defn deep-merge-all
+  "Deep-merge a sequence of maps in order. Later wins."
+  [maps]
+  (reduce deep-merge {} (remove nil? maps)))
+
+;; ---- parent-story lookup --------------------------------------------------
+
+(defn parent-story-id
+  "Derive the parent story id from a variant id. Per spec/007
+  §Canonical id grammar, a variant id `:story.foo.bar/empty` has
+  namespace `\"story.foo.bar\"` and name `\"empty\"`; the parent story
+  id is the keyword named `:story.foo.bar`.
+
+  Returns nil if `variant-id` does not match the variant-id grammar."
+  [variant-id]
+  (when (and (keyword? variant-id)
+             (some? (namespace variant-id)))
+    (keyword (namespace variant-id))))
+
+;; ---- mode-set materialisation --------------------------------------------
+
+(defn- mode-args
+  "Return the `:args` map registered against `mode-id`, or `{}` if the
+  mode is unregistered. Stage 3 does not throw on an unregistered mode;
+  callers (Stage 4 UI shell, Stage 5 play-runner) ignore missing modes.
+  Tools surface the mismatch as a validation warning."
+  [mode-id]
+  (or (:args (registrar/handler-meta :mode mode-id)) {}))
+
+(defn- active-modes-args
+  "Compose every active mode's `:args` map by deep-merging in declared
+  order. `active-modes` is a sequential collection — order is
+  preserved so two modes touching the same arg-key resolve last-wins."
+  [active-modes]
+  (deep-merge-all (map mode-args active-modes)))
+
+;; ---- public surface -------------------------------------------------------
+
+(defn resolve-args
+  "Materialise the effective args map for a variant render.
+
+  Per IMPL-SPEC §5.2 the precedence chain is:
+
+      global-args
+        < story-args
+        < mode-args (in declared order, deep-merge)
+        < variant-args
+        < cell-overrides
+
+  Arguments:
+  - `variant-id` — the variant's keyword id.
+  - `opts` (optional) — `{:active-modes [...] :cell-overrides {...}}`.
+    `:active-modes` is a sequential coll of mode ids (preserve order
+    so deep-merge is deterministic). `:cell-overrides` is a map of
+    runtime overrides from the controls panel.
+
+  Returns the deep-merged args map. If the variant or its parent
+  story is unregistered, the corresponding layer contributes `{}`. The
+  fn never throws on a missing artefact — the caller may decide whether
+  that's an error (Stage 4 surfaces it inline; Stage 5 records it as
+  a `:rf.error/unknown-variant` assertion)."
+  ([variant-id]
+   (resolve-args variant-id nil))
+  ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
+   (let [variant-body (registrar/handler-meta :variant variant-id)
+         story-id     (parent-story-id variant-id)
+         story-body   (when story-id (registrar/handler-meta :story story-id))
+         global       (config/get-global-args)
+         story-args   (:args story-body)
+         mode-args    (active-modes-args (or active-modes []))
+         variant-args (:args variant-body)
+         overrides    (or cell-overrides {})]
+     (deep-merge-all [global story-args mode-args variant-args overrides]))))
+
+(defn get-effective-args
+  "Alias for `resolve-args` matching the IMPL-SPEC §5.2 public-name
+  call-out (`get-effective-args`). Same arguments, same return."
+  ([variant-id] (resolve-args variant-id nil))
+  ([variant-id opts] (resolve-args variant-id opts)))

--- a/tools/story/src/re_frame/story/async.cljc
+++ b/tools/story/src/re_frame/story/async.cljc
@@ -1,0 +1,159 @@
+(ns re-frame.story.async
+  "Promise / CompletableFuture abstraction for Story's runtime.
+
+  Per IMPL-SPEC §3.2 + §13.2, `run-variant` returns a promise-like
+  object that the host can await:
+
+  - On CLJS the return value is a native `js/Promise`.
+  - On JVM the return value is a `java.util.concurrent.CompletableFuture`.
+
+  Stage 3 (rf2-von3) is the call: this namespace abstracts the two so
+  the rest of the runtime can write portable code.
+
+  ## API
+
+  - `(promise f)` — run `f` (a 1-arg fn that receives a resolver fn) and
+    return a promise / future. The resolver, when called with a value,
+    completes the promise. If `f` throws, the promise rejects.
+    Shadows `clojure.core/promise` — Story's `promise` is the
+    canonical constructor in this namespace.
+  - `(resolved v)` — return an already-resolved promise carrying `v`.
+  - `(rejected e)` — return an already-rejected promise carrying `e`.
+  - `(then p f)` — chain `f` (a 1-arg fn) over the promise's resolved
+    value, returning a new promise.
+  - `(catch* p f)` — chain `f` (a 1-arg fn taking the thrown value) over
+    the promise's rejection path, returning a new promise.
+  - `(deref-blocking p timeout-ms)` — JVM-only: block the caller until
+    the future resolves (or the timeout elapses). For tests / REPL.
+    CLJS callers don't block — they use `then` / `await` instead.
+  - `(promise? x)` — true iff `x` is a promise / future of our flavour.
+
+  ## Why not core.async
+
+  Per the user-feedback rule `no_core_async`, re-frame2 does not depend
+  on core.async. Story's async surface uses native Promise (CLJS) and
+  CompletableFuture (JVM) directly — the two surfaces the host runtime
+  already exposes. No additional dependency."
+  (:refer-clojure :exclude [promise]))
+
+;; ---- construction ---------------------------------------------------------
+
+(defn promise
+  "Run `f` (a 1-arg fn that receives a resolver fn) and return a
+  promise / future. The resolver, when called with a value, completes
+  the promise. If `f` throws synchronously, the promise rejects with
+  the throwable.
+
+  Two-resolver shape `(fn [resolve reject] ...)` is also supported when
+  `f` declares two args."
+  [f]
+  #?(:cljs
+     (js/Promise.
+       (fn [resolve reject]
+         (try
+           (let [arity (or (some-> f .-length) 1)]
+             (if (= arity 2)
+               (f resolve reject)
+               (f resolve)))
+           (catch :default e
+             (reject e)))))
+     :clj
+     (let [cf (java.util.concurrent.CompletableFuture.)]
+       (try
+         (let [arity (try
+                       ;; Reflection on the fn class. Returns 1 if we can't
+                       ;; tell — most call sites use the 1-arg form.
+                       (let [methods (.getDeclaredMethods (class f))]
+                         (some (fn [^java.lang.reflect.Method m]
+                                 (when (and (= "invoke" (.getName m))
+                                            (= 2 (.getParameterCount m)))
+                                   2))
+                               methods))
+                       (catch Throwable _ nil))
+               resolve-fn (fn [v] (.complete cf v))
+               reject-fn  (fn [e] (.completeExceptionally cf
+                                                          (if (instance? Throwable e)
+                                                            e
+                                                            (ex-info "re-frame.story.async rejection"
+                                                                     {:rejection e}))))]
+           (if (= 2 arity)
+             (f resolve-fn reject-fn)
+             (f resolve-fn)))
+         (catch Throwable e
+           (.completeExceptionally cf e)))
+       cf)))
+
+(defn resolved
+  "Return an already-resolved promise / future carrying `v`."
+  [v]
+  #?(:cljs (js/Promise.resolve v)
+     :clj  (java.util.concurrent.CompletableFuture/completedFuture v)))
+
+(defn rejected
+  "Return an already-rejected promise / future carrying `e`."
+  [e]
+  #?(:cljs (js/Promise.reject e)
+     :clj  (let [cf (java.util.concurrent.CompletableFuture.)]
+             (.completeExceptionally cf (if (instance? Throwable e)
+                                          e
+                                          (ex-info "re-frame.story.async rejection"
+                                                   {:rejection e})))
+             cf)))
+
+;; ---- composition ----------------------------------------------------------
+
+(defn then
+  "Chain `f` over the promise's resolved value. Returns a new promise.
+  `f` may return a plain value (wrapped into a resolved promise) or
+  another promise (chained)."
+  [p f]
+  #?(:cljs (.then ^js/Promise p f)
+     :clj  (.thenCompose ^java.util.concurrent.CompletableFuture p
+                         (reify java.util.function.Function
+                           (apply [_ v]
+                             (let [r (f v)]
+                               (if (instance? java.util.concurrent.CompletionStage r)
+                                 r
+                                 (java.util.concurrent.CompletableFuture/completedFuture r))))))))
+
+(defn catch*
+  "Chain `f` over the promise's rejection path. `f` receives the
+  rejection value (a Throwable on JVM, any value on CLJS). Returns a
+  new promise that resolves to `f`'s return value (or re-rejects if `f`
+  itself throws)."
+  [p f]
+  #?(:cljs (.catch ^js/Promise p f)
+     :clj  (.exceptionally ^java.util.concurrent.CompletableFuture p
+                           (reify java.util.function.Function
+                             (apply [_ t]
+                               ;; CompletableFuture wraps user throwables in
+                               ;; CompletionException. Unwrap so `f` sees the
+                               ;; underlying cause — matches JS Promise.catch
+                               ;; semantics (which delivers the rejection
+                               ;; value as-is).
+                               (let [unwrapped (if (instance? java.util.concurrent.CompletionException t)
+                                                 (or (.getCause ^Throwable t) t)
+                                                 t)]
+                                 (f unwrapped)))))))
+
+(defn promise?
+  "True iff `x` is a promise / future of our flavour."
+  [x]
+  #?(:cljs (and (some? x) (fn? (.-then ^js x)))
+     :clj  (instance? java.util.concurrent.CompletionStage x)))
+
+;; ---- JVM-only blocking deref ---------------------------------------------
+
+#?(:clj
+   (defn deref-blocking
+     "JVM-only: block the caller until `p` resolves (or `timeout-ms`
+     elapses). Returns the resolved value, or throws if the promise
+     rejected. Use for tests / REPL.
+
+     CLJS callers don't block — chain with `then` / use `await` on the
+     promise instead."
+     ([p] (.get ^java.util.concurrent.CompletableFuture p))
+     ([p timeout-ms]
+      (.get ^java.util.concurrent.CompletableFuture p
+            timeout-ms
+            java.util.concurrent.TimeUnit/MILLISECONDS))))

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -69,3 +69,31 @@
      [expansion]
      `(when re-frame.story.config/enabled?
         ~expansion)))
+
+;; ---- *global-args* (Stage 3, rf2-von3) ----------------------------------
+;;
+;; Per IMPL-SPEC §5.2 the args-precedence chain starts with `global-args`:
+;; defaults the story-tool's host application sets at boot (theme, locale).
+;; Stage 3's args-resolution layer reads this atom; `configure!` writes it.
+;;
+;; The atom is a plain Clojure data store — surviving `:advanced` builds
+;; is harmless because it's empty by default. The mutation surface
+;; (`configure!`) lives behind the `enabled?` gate at its call site.
+
+(defonce
+  ^{:doc "Atom holding the global args map. Per IMPL-SPEC §5.2 — Layer
+         1 of the args-precedence chain. Defaults to `{}`; the host
+         calls `re-frame.story/configure!` at boot to seed."}
+  global-args
+  (atom {}))
+
+(defn set-global-args!
+  "Replace the global args map. Story's `configure!` calls this."
+  [m]
+  (reset! global-args (or m {}))
+  nil)
+
+(defn get-global-args
+  "Return the current global args map."
+  []
+  @global-args)

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -1,0 +1,273 @@
+(ns re-frame.story.decorators
+  "Decorator composition. Per IMPL-SPEC §5.3 + spec/007 §Decorators.
+
+  Decorators come in three kinds (each registered via `reg-decorator`):
+
+  - `:hiccup` — `{:wrap (fn [body args] [:div ... body])}`. Wraps the
+    rendered tree.
+  - `:frame-setup` — `{:init [event-vec ...] :app-db-patch {...}}`.
+    Runs at frame creation, before phase-1 loaders.
+  - `:fx-override` — `{:fx-id ... :response ...}`. Stubs an fx for the
+    lifetime of the variant's frame.
+
+  ## Composition order
+
+  Per IMPL-SPEC §5.3 the runtime walks `(concat story-decorators
+  variant-decorators)` in declared order and groups by `:kind`:
+
+  - `:hiccup` decorators — outermost wraps innermost. The first
+    decorator's `:wrap` is the outermost element in the rendered tree;
+    the last decorator's `:wrap` is the innermost wrapper of the bare
+    rendered view.
+  - `:frame-setup` decorators — declared order, run sequentially.
+  - `:fx-override` decorators — declared order; collisions on the same
+    `:fx-id` resolve last-wins (the inner-most decorator wins).
+
+  ## Resolution
+
+  Variant `:decorators` is a vector of `[decorator-id & args]` vectors.
+  Inline decorator forms (where the first element is itself a map)
+  are NOT supported — Stage 2's schema forbids them. Story-level
+  decorators live on the parent story's `:decorators` slot.
+
+  Unknown decorator-ids surface as an entry in the returned `:errors`
+  vector; the runtime then projects those into the variant's
+  `:assertions` (per IMPL-SPEC §5.5)."
+  (:require [re-frame.story.args      :as args]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- collection -----------------------------------------------------------
+
+(defn- variant-decorator-refs
+  "Return the variant body's `:decorators` vector, or `[]`."
+  [variant-id]
+  (or (:decorators (registrar/handler-meta :variant variant-id)) []))
+
+(defn- story-decorator-refs
+  "Return the parent story's `:decorators` vector, or `[]`."
+  [variant-id]
+  (let [story-id (args/parent-story-id variant-id)
+        body     (when story-id (registrar/handler-meta :story story-id))]
+    (or (:decorators body) [])))
+
+(defn- collect-decorator-refs
+  "Build the ordered `[decorator-ref ...]` list for the variant.
+
+  Story decorators come first (outermost when applied as hiccup
+  wrappers), variant decorators second. Active modes contribute no
+  decorators at v1 — per IMPL-SPEC §3.1 modes carry `:args` only."
+  [variant-id]
+  (vec (concat (story-decorator-refs variant-id)
+               (variant-decorator-refs variant-id))))
+
+;; ---- resolution -----------------------------------------------------------
+
+(defn- resolve-ref
+  "Look up `[decorator-id & args]` against the decorator registry.
+  Returns `{:id ... :args [...] :body <body-or-nil> :error nil|<map>}`.
+
+  Stage 3 does not throw on an unregistered decorator — the runtime
+  records it as an error so the variant pane can show it inline."
+  [ref]
+  (let [id          (first ref)
+        decor-args  (vec (rest ref))
+        body        (when (keyword? id) (registrar/handler-meta :decorator id))]
+    (cond
+      (not (keyword? id))
+      {:id    id
+       :args  decor-args
+       :body  nil
+       :error {:rf.error :rf.error/decorator-bad-ref
+               :ref      ref
+               :reason   "decorator reference must start with a keyword id"}}
+
+      (nil? body)
+      {:id    id
+       :args  decor-args
+       :body  nil
+       :error {:rf.error :rf.error/decorator-unknown
+               :id       id
+               :reason   (str "no decorator registered under " id)}}
+
+      :else
+      {:id    id
+       :args  decor-args
+       :body  body
+       :error nil})))
+
+;; ---- cycle / re-registration detection -----------------------------------
+;;
+;; Per IMPL-SPEC §13.2 hot-reload, the runtime must be able to ask the
+;; registrar 'has decorator X been re-registered since I cached it?' and
+;; refresh if so. Stage 3 provides the freshness check; Stage 4 (UI
+;; shell) wires the trigger.
+
+(defn decorator-fingerprint
+  "Per-decorator fingerprint suitable for hot-reload comparison. Two
+  fingerprints are equal iff the decorator's registered body is equal
+  (excluding `:source`-coord noise that varies across recompiles).
+
+  Used by the UI shell to detect when a decorator changed and the
+  cached resolution must be invalidated. Stage 4 calls this; Stage 3
+  surfaces it."
+  [decorator-id]
+  (let [body (registrar/handler-meta :decorator decorator-id)
+        body (dissoc body :source)]
+    (hash body)))
+
+(defn resolution-fingerprints
+  "Return `{decorator-id → fingerprint}` for every decorator the variant
+  will use. Stage 4 caches the resolved decorator stack alongside this
+  map and re-resolves if any fingerprint diverges from the registry's
+  current value."
+  [variant-id]
+  (let [refs (collect-decorator-refs variant-id)]
+    (into {}
+          (keep (fn [ref]
+                  (let [id (first ref)]
+                    (when (keyword? id)
+                      [id (decorator-fingerprint id)]))))
+          refs)))
+
+;; ---- public surface -------------------------------------------------------
+
+(defn resolve-decorators
+  "Per IMPL-SPEC §5.3 — collect, classify, and order the decorator stack
+  for the variant. Returns:
+
+      {:hiccup       [<resolved-decorator> ...]
+       :frame-setup  [<resolved-decorator> ...]
+       :fx-override  [<resolved-decorator> ...]
+       :errors       [<error-map> ...]
+       :fingerprints {<decorator-id> <hash>}}
+
+  Each `<resolved-decorator>` carries `{:id ... :args [...] :body
+  <registered-body>}`. Unknown decorators land in `:errors` instead of
+  their kind-vector — the runtime projects them as `:rf.error/decorator-*`
+  assertions per IMPL-SPEC §5.5.
+
+  Composition order (per IMPL-SPEC §5.3):
+  - `:hiccup` — outermost wraps innermost. Story decorators come first
+    (outermost); variant decorators last (innermost).
+  - `:frame-setup` — declared order (story first, variant second).
+  - `:fx-override` — declared order; last-wins on a key collision.
+
+  `opts` accepts `:active-modes` for forward compatibility — v1 modes
+  carry no decorators, but the slot exists for v2 (per IMPL-SPEC
+  §13.2)."
+  ([variant-id]
+   (resolve-decorators variant-id nil))
+  ([variant-id _opts]
+   (let [refs       (collect-decorator-refs variant-id)
+         resolved   (mapv resolve-ref refs)
+         {:keys [hiccup frame-setup fx-override errors]}
+         (reduce
+           (fn [acc r]
+             (cond
+               (:error r)
+               (update acc :errors conj (:error r))
+
+               (= :hiccup (:kind (:body r)))
+               (update acc :hiccup conj r)
+
+               (= :frame-setup (:kind (:body r)))
+               (update acc :frame-setup conj r)
+
+               (= :fx-override (:kind (:body r)))
+               (update acc :fx-override conj r)
+
+               :else
+               (update acc :errors conj
+                       {:rf.error :rf.error/decorator-unknown-kind
+                        :id       (:id r)
+                        :kind     (:kind (:body r))
+                        :reason   (str "decorator " (:id r)
+                                       " has unrecognised :kind "
+                                       (pr-str (:kind (:body r))))})))
+           {:hiccup [] :frame-setup [] :fx-override [] :errors []}
+           resolved)]
+     {:hiccup        hiccup
+      :frame-setup   frame-setup
+      :fx-override   fx-override
+      :errors        errors
+      :fingerprints  (into {}
+                           (keep (fn [r] (when (nil? (:error r))
+                                           [(:id r)
+                                            (decorator-fingerprint (:id r))])))
+                           resolved)})))
+
+;; ---- hiccup application --------------------------------------------------
+
+(defn apply-hiccup-decorators
+  "Apply the `:hiccup`-kind decorators to a rendered tree. The first
+  entry in `hiccup-decorators` is the outermost wrap; the last entry
+  is the innermost wrap (adjacent to `body`).
+
+  Per IMPL-SPEC §5.3 — 'outermost wraps innermost' means we walk the
+  vector in *reverse*, calling each `:wrap` on the accumulating tree:
+  the last decorator wraps `body`, then the second-to-last wraps the
+  result, and so on. The final result is the outermost decorator's
+  wrap of every inner wrap.
+
+  `effective-args` is the resolved args map (per `args/resolve-args`);
+  every `:wrap` fn receives `[body effective-args]`. Decorator-level
+  ref-args (the `[& args]` tail of a `[:dec-id & args]` ref) are NOT
+  passed in the variant-body model — per spec/007 §Three kinds of
+  decorator, decorator ref-args are static configuration of the
+  decorator, not call-time args."
+  [hiccup-decorators body effective-args]
+  (reduce
+    (fn [acc r]
+      (let [wrap-fn (-> r :body :wrap)
+            ;; Decorator ref-args (`[:dec-id arg1 arg2]`) get merged into
+            ;; the effective args as a `:decorator/args` slot so the
+            ;; wrap fn can pick them out without losing access to the
+            ;; user's args. Two-arg wrap-fns receive `(body args-map)`
+            ;; per spec/007's example; the ref-args are accessible via
+            ;; `(:decorator/args args-map)`.
+            wrap-args (assoc effective-args :decorator/args (:args r))]
+        (wrap-fn acc wrap-args)))
+    body
+    (reverse hiccup-decorators)))
+
+;; ---- fx-override materialisation -----------------------------------------
+
+(defn fx-overrides-map
+  "Materialise the `:fx-overrides` map a `:fx-override`-decorator stack
+  contributes to the variant frame's `:config`. The runtime threads
+  this directly into `(rf/reg-frame variant-id {... :fx-overrides ...})`
+  (per spec/002 §reg-frame).
+
+  Each `:fx-override` decorator carries `{:fx-id <id> :response <data>}`.
+  We synthesise a per-decorator replacement event-fx id of the form
+  `:rf.story.fx-stub/<decorator-id>` and the runtime registers the
+  replacement event-fx as `(reg-event-fx that-id (fn [_ _] ...))`
+  before the variant frame's `reg-frame` call. Last-wins on `:fx-id`
+  collision (the inner-most decorator wins).
+
+  Returns `{:overrides {<fx-id> <stub-event-id>}
+            :registrations [{:event-id <stub-event-id>
+                             :response <data>} ...]}`.
+
+  The Stage 3 runtime walks `:registrations` and calls `reg-event-fx`
+  for each before `reg-frame`-ing the variant; then threads the
+  `:overrides` map onto the frame's config."
+  [fx-override-decorators]
+  (let [pairs (mapv (fn [r]
+                      (let [fx-id    (-> r :body :fx-id)
+                            response (-> r :body :response)
+                            stub-id  (keyword "rf.story.fx-stub"
+                                              (str (name (:id r))))]
+                        {:fx-id        fx-id
+                         :stub-id      stub-id
+                         :response     response
+                         :decorator-id (:id r)}))
+                    fx-override-decorators)
+        ;; Last-wins on fx-id: dedupe pairs preserving the LAST entry
+        ;; per fx-id.
+        by-fx (reduce (fn [acc p] (assoc acc (:fx-id p) p)) {} pairs)
+        finals (vals by-fx)]
+    {:overrides     (into {}
+                          (map (fn [p] [(:fx-id p) (:stub-id p)]))
+                          finals)
+     :registrations (vec finals)}))

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -1,0 +1,211 @@
+(ns re-frame.story.frames
+  "Per-variant frame allocation. Per IMPL-SPEC §5.1 + spec/007
+  §Relationship-with-frames.
+
+  Each rendered variant is its own re-frame frame (spec/002), allocated
+  fresh on `run-variant` and torn down by the caller via
+  `destroy-variant!`. Story does NOT introduce a new frame substrate —
+  it consumes `re-frame.core/reg-frame` / `destroy-frame` / `reset-frame!`.
+
+  ## Frame config
+
+  When the runtime allocates a variant frame, it constructs a
+  `reg-frame` config of the shape:
+
+      {:doc          \"Variant frame for <variant-id>.\"
+       :preset       :story
+       :rf/story?    true
+       :rf/variant   <variant-id>
+       :fx-overrides {<fx-id> <stub-event-id>}}
+
+  - `:preset :story` (spec/002 §Frame presets) sets `:drain-depth 16`
+    + redirects `:rf.http/managed` to its canned stub, which is the
+    sensible default for a sandboxed playground frame.
+  - `:rf/story?` and `:rf/variant` are Story-stamped metadata so tools
+    (10x, the snapshot service, the MCP query layer) can identify a
+    variant frame from its `frame-meta`.
+  - `:fx-overrides` carries the `:fx-override`-decorator stack's
+    `{fx-id → stub-event-id}` map. The runtime registers each stub
+    event before `reg-frame`-ing so the override is live before
+    `:on-create` runs.
+
+  ## Lifecycle
+
+  - `allocate!` — create the frame (and register fx-override stubs);
+    install the lifecycle machine's `:pre-mount` snapshot.
+  - `destroy!` — tear down the frame; clear watchers.
+  - `reset!*` — destroy + re-allocate; the caller then re-runs the
+    lifecycle.
+
+  ## Hot-reload
+
+  Stage 4's UI shell observes the registrar's `:rf.registry/handler-*`
+  trace events and re-runs `reset!*` for any variant whose registered
+  body changed. Stage 3 surfaces the entry point; the trigger lives in
+  Stage 4."
+  (:require [re-frame.core            :as rf]
+            [re-frame.story.config    :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.loaders   :as loaders]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- fx-override-stub registration ---------------------------------------
+
+(defn- ensure-stub-event!
+  "Register a `reg-event-fx` handler under `stub-id` that returns a
+  canned response. Idempotent — re-registration replaces the slot
+  atomically (Spec 001 hot-reload semantics).
+
+  The response shape is the data the user supplied on the decorator's
+  `:response` slot. We wrap it in a no-op handler so the override
+  re-targets the fx call to a synchronous data emission. The default
+  emits the response as a `:db` patch under `[:rf.story.fx-stub/last-call]`
+  for inspection, plus mirrors the fx call into `[:rf.story.fx-stub/log]`
+  for assertion-runtime hooks (Stage 5)."
+  [stub-id response]
+  (rf/reg-event-fx
+    stub-id
+    (fn [{:keys [db]} [_ fx-payload]]
+      {:db (-> db
+               (update :rf.story.fx-stub/log (fnil conj [])
+                       {:stub-id stub-id :payload fx-payload})
+               (assoc-in [:rf.story.fx-stub/last-call stub-id]
+                         {:payload  fx-payload
+                          :response response}))})))
+
+(defn- register-fx-overrides!
+  "Walk the `:registrations` vector from `decorators/fx-overrides-map`
+  and register each stub event. Returns the `:overrides` map suitable
+  for the variant frame's `:fx-overrides` config slot."
+  [{:keys [overrides registrations]}]
+  (doseq [{:keys [stub-id response]} registrations]
+    (ensure-stub-event! stub-id response))
+  overrides)
+
+;; ---- :frame-setup decorator application ---------------------------------
+
+(defn- apply-frame-setup!
+  "Walk the resolved `:frame-setup` decorators and execute their
+  `:init` events + `:app-db-patch` against the freshly-allocated frame.
+  Per IMPL-SPEC §5.3 these fire before `:loaders` — so before phase 1
+  in the lifecycle.
+
+  Each decorator's `:init` events are dispatched synchronously; the
+  `:app-db-patch` (a `path → value` map) is merged into the frame's
+  app-db via a registered helper event."
+  [frame-id frame-setup-decorators]
+  (doseq [r frame-setup-decorators]
+    (let [body          (:body r)
+          init-events   (:init body)
+          patch         (:app-db-patch body)]
+      (when patch
+        (rf/dispatch-sync [::apply-app-db-patch patch] {:frame frame-id}))
+      (doseq [ev init-events]
+        (rf/dispatch-sync ev {:frame frame-id})))))
+
+(defn install-helpers!
+  "Register Story-internal helper events: `::apply-app-db-patch` for
+  `:frame-setup` decorators' `:app-db-patch` slot. Idempotent."
+  []
+  (when config/enabled?
+    (rf/reg-event-db
+      ::apply-app-db-patch
+      (fn [db [_ patch]]
+        (reduce-kv
+          (fn [d path v]
+            (assoc-in d (if (vector? path) path [path]) v))
+          db
+          patch)))))
+
+;; ---- allocation -----------------------------------------------------------
+
+(defn- variant-frame-config
+  "Construct the `reg-frame` config map for a variant.
+
+  Per spec/002 §reg-frame the framework recognises:
+    :preset :story
+    :fx-overrides {...}
+    plus arbitrary user-stamped keys.
+
+  Per IMPL-SPEC §5.1 we stamp `:rf/story?` and `:rf/variant` so tools
+  can recognise variant frames from their `frame-meta`."
+  [variant-id fx-overrides]
+  (cond-> {:doc        (str "Variant frame for " variant-id ".")
+           :preset     :story
+           :rf/story?  true
+           :rf/variant variant-id}
+    (seq fx-overrides) (assoc :fx-overrides fx-overrides)))
+
+(defn allocate!
+  "Create the variant's frame, register fx-override stubs, run
+  `:frame-setup` decorators' init events, and drive the lifecycle
+  machine to `:mounting`. Returns the variant-id (which doubles as the
+  frame-id).
+
+  `decorator-stack` is the result of `decorators/resolve-decorators`;
+  the runtime computes it upstream.
+
+  If a frame is already registered under `variant-id` (hot-reload
+  case), the runtime should `destroy!` first then call `allocate!`.
+  Calling `allocate!` against an existing frame goes through
+  `reg-frame`'s surgical-update path — config is replaced but the
+  app-db / sub-cache are preserved. That's the wrong shape for a
+  story-runtime which expects a fresh app-db; the caller (`runtime/
+  reset-variant`) destroys first."
+  [variant-id decorator-stack]
+  (when config/enabled?
+    (install-helpers!)
+    (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
+          fx-overrides   (register-fx-overrides! fx-stack)
+          config-map     (variant-frame-config variant-id fx-overrides)]
+      ;; Allocate the frame.
+      (rf/reg-frame variant-id config-map)
+      ;; Drive lifecycle to :mounting.
+      (loaders/mount! variant-id)
+      ;; Apply :frame-setup decorators (their :init events + :app-db-patch).
+      (apply-frame-setup! variant-id (:frame-setup decorator-stack))
+      variant-id)))
+
+;; ---- destruction ----------------------------------------------------------
+
+(defn destroy!
+  "Tear down a variant frame. Clears the lifecycle watcher table for
+  the frame, then calls `rf/destroy-frame`. Returns nil."
+  [variant-id]
+  (when config/enabled?
+    (loaders/clear-watchers! variant-id)
+    (rf/destroy-frame variant-id)
+    nil))
+
+;; ---- destroy + re-allocate -----------------------------------------------
+
+(defn reset!*
+  "Destroy the variant frame and re-allocate it. Used by
+  `runtime/reset-variant`. The caller is responsible for re-running
+  the four-phase lifecycle (loaders → events → render → play) after."
+  [variant-id decorator-stack]
+  (destroy! variant-id)
+  (allocate! variant-id decorator-stack))
+
+;; ---- frame-meta introspection --------------------------------------------
+
+(defn variant-frame?
+  "True iff `frame-id` is a variant frame (was allocated via
+  `allocate!`). Reads the frame's `:config :rf/story?` slot."
+  [frame-id]
+  (true? (get-in (rf/frame-meta frame-id) [:config :rf/story?])))
+
+(defn variant-frames
+  "Return every registered variant frame id. Stage 4's UI shell uses
+  this to lay out the active variant pane."
+  []
+  (->> (rf/frame-ids)
+       (filter variant-frame?)
+       set))
+
+;; ---- variant-body lookup convenience -------------------------------------
+
+(defn variant-body
+  "Return the registered variant body, or nil if unregistered."
+  [variant-id]
+  (registrar/handler-meta :variant variant-id))

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -1,0 +1,211 @@
+(ns re-frame.story.identity
+  "Snapshot-identity content-hashing. Per IMPL-SPEC §5.6 + spec/007
+  §Variant snapshot identity.
+
+  Every variant has a stable **snapshot identity** — a content hash
+  over the canonicalised `(variant × resolved-args × decorators ×
+  loaders × substrate × modes)` tuple. Visual-regression services
+  key against `[variant-id content-hash]` — when the body changes,
+  the hash changes; when it doesn't, the hash is stable across hosts
+  and runs.
+
+  ## What's in the hash
+
+  Per IMPL-SPEC §5.6 the hash includes:
+
+  - Variant id
+  - `:events`, `:play`, `:loaders` (in declared order; canonicalised)
+  - Effective `:args` (post-merge with story + active modes)
+  - Decorator id sequence + their ref-args
+  - Tag set
+  - Parent story `:component` id
+  - Parent story `:decorators`
+  - Active substrate (when computing per-substrate identity)
+  - Active modes (when computing per-mode identity)
+
+  ## Hash function
+
+  IMPL-SPEC §5.6 specifies `sha-256` of a transit-serialised canonical
+  form. Stage 3 implements a **portable** hash function: a stable
+  string serialisation (deterministic key order; sets/vectors written
+  with stable order) hashed with `hash` (JVM `clojure.lang.Util/hasheq`,
+  CLJS `cljs.core/hash`).
+
+  Trade-off vs sha-256: `hash` is 32-bit and faster, but only ~4-billion
+  states. For visual-regression keying that's enough provided the
+  caller dedupes by `[variant-id content-hash]` (the variant id is
+  unique; the hash is per-variant per-cell). The sha-256 path is left
+  as a Stage 6+ extension when an external service needs cryptographic
+  collision-resistance.
+
+  The canonical-form keyword `:rf/snapshot-canonical-v1` is included as
+  the first slot of the hashed structure, so future canonical-form
+  revisions can introduce `:rf/snapshot-canonical-v2` without breaking
+  v1 baselines."
+  (:require [re-frame.story.args      :as args]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- canonicalisation ----------------------------------------------------
+
+(defprotocol Canonicalise
+  "Render a value into a canonical form: stable key order in maps,
+  stable element order in sets, terminal types (strings, keywords,
+  numbers, booleans, nil) unchanged. Returns a value that round-trips
+  through `pr-str` deterministically across hosts."
+  (-canon [x]))
+
+(extend-protocol Canonicalise
+  nil
+  (-canon [_] nil)
+
+  #?(:clj  java.lang.Boolean :cljs boolean)
+  (-canon [x] x)
+
+  #?(:clj  java.lang.Number  :cljs number)
+  (-canon [x] x)
+
+  #?(:clj  java.lang.String  :cljs string)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.Keyword :cljs Keyword)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.Symbol  :cljs Symbol)
+  (-canon [x] x)
+
+  #?(:clj  clojure.lang.IPersistentMap  :cljs IMap)
+  (-canon [x]
+    ;; Map canon: sort by the canonicalised key (via pr-str of the
+    ;; canon-key). The serialisation is symmetric — both JVM and CLJS
+    ;; sort the same way because `pr-str` over canonical scalars is
+    ;; identical across hosts.
+    (let [entries (->> x
+                       (map (fn [[k v]] [(-canon k) (-canon v)]))
+                       (sort-by (fn [[k _]] (pr-str k))))]
+      (into [] (mapcat identity) entries)))
+
+  #?(:clj  clojure.lang.IPersistentVector :cljs PersistentVector)
+  (-canon [x] (mapv -canon x))
+
+  #?(:clj  clojure.lang.IPersistentList :cljs List)
+  (-canon [x] (mapv -canon x))
+
+  #?(:clj  clojure.lang.IPersistentSet  :cljs PersistentHashSet)
+  (-canon [x]
+    ;; Stable set order: sort canonicalised elements by their pr-str.
+    (vec (sort-by pr-str (map -canon x))))
+
+  #?(:clj  Object             :cljs default)
+  (-canon [x]
+    ;; Fallback for ISeq / LazySeq / etc — realise into a vector with
+    ;; canonical recursion. `pr-str` over the result is deterministic.
+    (cond
+      (sequential? x) (mapv -canon x)
+      (set? x)        (vec (sort-by pr-str (map -canon x)))
+      (map? x)        (let [entries (->> x
+                                         (map (fn [[k v]] [(-canon k) (-canon v)]))
+                                         (sort-by (fn [[k _]] (pr-str k))))]
+                        (into [] (mapcat identity) entries))
+      :else           x)))
+
+(defn canonical-form
+  "Return a canonical-form representation of `x`. Maps are vectors of
+  `[k v k v ...]` sorted by key; sets are vectors sorted by element;
+  vectors recurse; scalars unchanged. The resulting tree round-trips
+  through `pr-str` deterministically across hosts."
+  [x]
+  (-canon x))
+
+;; ---- per-host hash --------------------------------------------------------
+
+(defn content-hash
+  "Stable string hash of `x` (post-canonicalisation). Returns a
+  lowercase hex string of fixed width (8 chars — 32-bit `hash`).
+
+  Per IMPL-SPEC §5.6 the canonical form is keyed by
+  `:rf/snapshot-canonical-v1` so future canonical-form revisions can
+  bump the version without breaking baselines."
+  [x]
+  (let [canon (canonical-form [:rf/snapshot-canonical-v1 x])
+        s     (pr-str canon)
+        h     (bit-and 0xffffffff (hash s))
+        hex   #?(:clj  (format "%08x" h)
+                 :cljs (let [s (.toString h 16)
+                             pad (- 8 (.-length s))]
+                         (if (pos? pad)
+                           (str (apply str (repeat pad "0")) s)
+                           s)))]
+    hex))
+
+;; ---- snapshot tuple -------------------------------------------------------
+
+(defn- variant-body-slice
+  "Return the slice of the variant body that contributes to the snapshot
+  identity. Excludes runtime-environmental keys (`:source` coords) and
+  Stage 4+ slots that don't yet exist (kept for forward compatibility)."
+  [variant-id]
+  (let [body (registrar/handler-meta :variant variant-id)]
+    (when body
+      (select-keys body
+                   [:events :play :loaders :loaders-complete-when
+                    :tags :args->events :platforms :substrates]))))
+
+(defn- story-body-slice
+  "Story-level slice that the variant inherits for identity purposes.
+  Per IMPL-SPEC §5.6 the parent story's `:component` id and
+  `:decorators` are part of the variant's identity."
+  [variant-id]
+  (let [story-id (args/parent-story-id variant-id)
+        body     (when story-id (registrar/handler-meta :story story-id))]
+    (when body
+      (select-keys body [:component :decorators :tags]))))
+
+(defn snapshot-tuple
+  "Build the canonical tuple that feeds `content-hash` for a variant.
+  Returns a map.
+
+  Arguments:
+  - `variant-id` — keyword variant id.
+  - `opts` (optional) — `{:active-modes [...] :cell-overrides {...}
+                          :substrate <keyword>}`.
+
+  The tuple captures everything the visual-regression service treats
+  as identity-determining. A change to ANY of these fields produces a
+  fresh hash; otherwise the hash is stable across runs."
+  ([variant-id] (snapshot-tuple variant-id nil))
+  ([variant-id {:keys [active-modes cell-overrides substrate] :as _opts}]
+   (let [variant      (variant-body-slice variant-id)
+         story        (story-body-slice variant-id)
+         effective    (args/resolve-args variant-id
+                                         {:active-modes   active-modes
+                                          :cell-overrides cell-overrides})]
+     {:rf/snapshot-canonical :rf/snapshot-canonical-v1
+      :variant-id            variant-id
+      :variant               variant
+      :story                 story
+      :effective-args        effective
+      :active-modes          (vec (or active-modes []))
+      :substrate             substrate})))
+
+(defn snapshot-identity
+  "Public entry point per IMPL-SPEC §3.2 — return the snapshot-identity
+  record for `(variant × active-modes × cell-overrides × substrate)`.
+
+  Returns:
+
+      {:variant-id   <variant-id>
+       :active-modes [<mode-id> ...]
+       :substrate    <substrate-id>
+       :content-hash \"<8-char hex>\"}
+
+  Stable across hosts (JVM and CLJS produce the same hex hash for the
+  same canonical inputs). Visual-regression services key against
+  `[variant-id content-hash]`."
+  ([variant-id] (snapshot-identity variant-id nil))
+  ([variant-id {:keys [active-modes substrate] :as opts}]
+   (let [tuple (snapshot-tuple variant-id opts)
+         hex   (content-hash tuple)]
+     {:variant-id    variant-id
+      :active-modes  (vec (or active-modes []))
+      :substrate     substrate
+      :content-hash  hex})))

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -1,0 +1,314 @@
+(ns re-frame.story.loaders
+  "Four-phase loader lifecycle. Per IMPL-SPEC §5.4 + spec/007 §Loaders.
+
+  The lifecycle moves through five discrete states:
+
+      :pre-mount  →  :mounting  →  :loading  →  :ready
+                                        │
+                                        └────►  :error
+
+  Phases (mapped to states):
+
+  1. **`:pre-mount`** — runs before the variant frame is created.
+     Examples: prefetch HTTP, set initial fixtures (the runtime stages
+     events before the frame exists).
+  2. **`:mounting`** — frame allocated; `:frame-setup` decorators run
+     their `:init` events and `:app-db-patch` is applied.
+  3. **`:loading`** — `:loaders` events dispatch in declared order. The
+     `:loaders-complete-when` predicate evaluates after each loader's
+     drain settles. Default: 'complete when no further loader-tagged
+     events are in flight'. The variant overrides this for long-lived
+     fx (e.g. `:websocket`) per IMPL-SPEC §2.4.
+  4. **`:ready`** — `:events` have run; render allowed.
+  5. **`:error`** — terminal error projection per IMPL-SPEC §5.5.
+
+  ## Substrate
+
+  Per the user-feedback rule + IMPL-SPEC §5.4, the lifecycle is
+  expressed as a `re-frame.machines` machine — NOT ad-hoc state
+  tracking. The machine is registered at Story-boot under the id
+  `:rf.story.lifecycle/machine`. Each variant frame holds its own
+  snapshot at `[:rf/machines :rf.story.lifecycle/machine]` and mirrors
+  the discrete state at `[:rf.story/lifecycle]` for direct read access.
+
+  The transitions are driven by the runtime dispatching synthetic
+  events into the variant frame:
+
+  - `[:rf.story.lifecycle/machine [:rf.story.lifecycle/mount]]`
+  - `[:rf.story.lifecycle/machine [:rf.story.lifecycle/loaders-started]]`
+  - `[:rf.story.lifecycle/machine [:rf.story.lifecycle/loaders-complete]]`
+  - `[:rf.story.lifecycle/machine [:rf.story.lifecycle/events-complete]]`
+  - `[:rf.story.lifecycle/machine [:rf.story.lifecycle/errored err]]`
+
+  ## Watchers
+
+  Per IMPL-SPEC §3.2 `watch-variant` subscribes to lifecycle
+  transitions. Stage 3 implements the watcher table here; the trace
+  bus fires `:rf.story.lifecycle/transition` on every state change.
+
+  ## Elision
+
+  The machine registration sits behind the
+  `re-frame.story.config/enabled?` gate (per IMPL-SPEC §6). Production
+  CLJS builds with the flag false never register the machine; the
+  Story runtime entry points read `(rf/handler-meta :event
+  :rf.story.lifecycle/machine)` and find nothing, returning early."
+  (:require [re-frame.story.config    :as config]
+            #?(:clj  [re-frame.machines :as machines]
+               :cljs [re-frame.machines :as machines])
+            [re-frame.core            :as rf]))
+
+;; ---- canonical ids --------------------------------------------------------
+
+(def lifecycle-machine-id
+  "Stable id for Story's lifecycle machine. One registration; per-
+  variant snapshots live at `[:rf/machines :rf.story.lifecycle/machine]`
+  inside each variant frame's app-db."
+  :rf.story.lifecycle/machine)
+
+(def state-mirror-path
+  "Side-mirror path. After every transition the lifecycle's `:action`
+  copies the new discrete state to `[:rf.story/lifecycle]` so callers
+  can read it without the `:rf/machines` indirection."
+  [:rf.story/lifecycle])
+
+;; ---- transition vocabulary -----------------------------------------------
+
+(def event-mount             :rf.story.lifecycle/mount)
+(def event-loaders-started   :rf.story.lifecycle/loaders-started)
+(def event-loaders-complete  :rf.story.lifecycle/loaders-complete)
+(def event-events-complete   :rf.story.lifecycle/events-complete)
+(def event-errored           :rf.story.lifecycle/errored)
+
+;; ---- machine spec ---------------------------------------------------------
+
+(def lifecycle-machine
+  "The lifecycle machine. Per Spec 005's machine grammar.
+
+  States:
+    :pre-mount  (initial)
+    :mounting
+    :loading
+    :ready
+    :error
+
+  Transitions:
+    :pre-mount  --mount-->            :mounting
+    :pre-mount  --errored-->          :error
+    :mounting   --loaders-started-->  :loading
+    :mounting   --errored-->          :error
+    :loading    --loaders-complete--> :ready
+    :loading    --errored-->          :error
+    :ready      --errored-->          :error
+    :error      (terminal)
+
+  Every transition's `:action` mirrors the new discrete state to
+  `[:rf.story/lifecycle]` via the standard machine actions surface.
+  Actions in re-frame.machines are 2-arity fns `(fn [data event] data')`
+  receiving the snapshot's `:data` and the inbound event; they return
+  the new `:data`. The lifecycle machine carries no `:data` of its own;
+  the actions update a `:rf.story/last-event` debug slot that surfaces
+  through the snapshot's `:data`.
+
+  The discrete-state mirror to `[:rf.story/lifecycle]` is performed by
+  the runtime AFTER every dispatch (see `dispatch-lifecycle-event!`)
+  rather than via an action — actions in re-frame.machines mutate the
+  machine's `:data`, not the surrounding app-db. The runtime owns the
+  surrounding-app-db write."
+  {:doc      "re-frame2-story lifecycle machine."
+   :initial  :pre-mount
+   :data     {}
+   :states
+   {:pre-mount
+    {:on {:rf.story.lifecycle/mount            :mounting
+          :rf.story.lifecycle/errored          :error}}
+
+    :mounting
+    {:on {:rf.story.lifecycle/loaders-started  :loading
+          :rf.story.lifecycle/errored          :error}}
+
+    :loading
+    {:on {:rf.story.lifecycle/loaders-complete :ready
+          :rf.story.lifecycle/errored          :error}}
+
+    :ready
+    {:on {:rf.story.lifecycle/errored          :error}}
+
+    :error
+    {}}})
+
+;; ---- registration ---------------------------------------------------------
+
+(defn install!
+  "Register the lifecycle machine. Idempotent — calling twice replaces
+  the registration in place per Spec 001 hot-reload semantics. The
+  Story runtime calls this from `re-frame.story/install-canonical-vocabulary!`
+  at boot.
+
+  The registration sits behind the `enabled?` gate so production
+  builds (with the flag false) skip it — the side-table and machine
+  registry stay empty, and `run-variant` short-circuits."
+  []
+  (when config/enabled?
+    (machines/reg-machine* lifecycle-machine-id lifecycle-machine)))
+
+;; ---- per-frame snapshot reads --------------------------------------------
+
+(defn snapshot
+  "Read the lifecycle machine's snapshot from a frame's app-db. Returns
+  `{:state <state-kw> :data {...}}` or nil if the machine hasn't fired
+  yet on this frame.
+
+  `rf/get-frame-db` returns the value-form app-db map (per Spec 002
+  §Public registrar query API); we then `get-in` to the machine's
+  snapshot slot."
+  [frame-id]
+  (let [db (rf/get-frame-db frame-id)]
+    (when db
+      (get-in db [:rf/machines lifecycle-machine-id]))))
+
+(defn current-state
+  "Return the lifecycle's current discrete state (`:pre-mount`,
+  `:mounting`, `:loading`, `:ready`, `:error`) for the variant frame.
+  Returns `:pre-mount` if the machine has not yet been driven."
+  [frame-id]
+  (or (:state (snapshot frame-id))
+      :pre-mount))
+
+;; ---- watcher table -------------------------------------------------------
+
+(defonce
+  ^{:doc "Per-frame watcher registry. `frame-id → vec-of-callbacks`.
+         Each callback is invoked with `{:frame-id ... :from <state>
+         :to <state> :event <event>}` on every transition. Per IMPL-
+         SPEC §3.2 `watch-variant` populates this; Stage 5 (play +
+         assertions) reads it for assertion-runtime hooks."}
+  watchers
+  (atom {}))
+
+(defn add-watcher!
+  "Register a callback fired on every lifecycle transition for
+  `frame-id`. Returns a 0-arity unsubscribe fn. The callback signature:
+
+      (fn [{:keys [frame-id from to event]}] ...)"
+  [frame-id callback]
+  (swap! watchers update frame-id (fnil conj []) callback)
+  (fn unsubscribe []
+    (swap! watchers update frame-id
+           (fn [cbs] (vec (remove #(= % callback) cbs))))
+    nil))
+
+(defn clear-watchers!
+  "Remove every watcher for `frame-id` (or all watchers when no arg).
+  Used by test fixtures + frame teardown."
+  ([] (reset! watchers {}) nil)
+  ([frame-id] (swap! watchers dissoc frame-id) nil))
+
+(defn- fire-watchers!
+  [frame-id from to event]
+  (when-let [cbs (get @watchers frame-id)]
+    (doseq [cb cbs]
+      (try
+        (cb {:frame-id frame-id :from from :to to :event event})
+        (catch #?(:clj Throwable :cljs :default) _ nil)))))
+
+;; ---- transition driver ---------------------------------------------------
+
+(defn dispatch-lifecycle-event!
+  "Drive the lifecycle machine via a synthetic event dispatched into
+  `frame-id`. Mirrors the new discrete state to `[:rf.story/lifecycle]`
+  via a follow-up dispatch-sync, and fires every registered watcher.
+
+  Returns the new discrete state.
+
+  Stage 3's runtime calls this after each phase transition:
+
+    (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/mount])
+    (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/loaders-started])
+    (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/loaders-complete])
+    (dispatch-lifecycle-event! frame-id [:rf.story.lifecycle/errored err])"
+  [frame-id inner-event]
+  (when config/enabled?
+    (let [from (current-state frame-id)
+          ;; Machine handler convention per Spec 005: outer event is
+          ;; [<machine-id> <inner-event>]. The machine reads inner from
+          ;; event[1] for its :on lookup.
+          envelope [lifecycle-machine-id inner-event]]
+      (rf/dispatch-sync envelope {:frame frame-id})
+      (let [to (current-state frame-id)]
+        ;; Mirror to the friendly path.
+        (rf/dispatch-sync [::set-lifecycle-state-mirror to] {:frame frame-id})
+        (fire-watchers! frame-id from to inner-event)
+        to))))
+
+;; The mirror-state writer is a normal event-db handler. It writes the
+;; current discrete state to `[:rf.story/lifecycle]` so callers can
+;; read the state without going through the machine snapshot path.
+(defn install-mirror-writer!
+  "Register the `::set-lifecycle-state-mirror` event-db handler.
+  Idempotent."
+  []
+  (when config/enabled?
+    (rf/reg-event-db
+      ::set-lifecycle-state-mirror
+      (fn [db [_ state]]
+        (assoc db :rf.story/lifecycle state)))))
+
+;; ---- public driver helpers -----------------------------------------------
+
+(defn mount!         [frame-id] (dispatch-lifecycle-event! frame-id [event-mount]))
+(defn start-loaders! [frame-id] (dispatch-lifecycle-event! frame-id [event-loaders-started]))
+(defn finish-loaders! [frame-id] (dispatch-lifecycle-event! frame-id [event-loaders-complete]))
+(defn finish-events! [frame-id] (dispatch-lifecycle-event! frame-id [event-events-complete]))
+(defn error!         [frame-id err]
+  (dispatch-lifecycle-event! frame-id [event-errored err]))
+
+;; ---- loaders-complete-when evaluation -----------------------------------
+
+(defn loaders-default-complete?
+  "Default predicate for `:loaders-complete-when`. Per IMPL-SPEC §2.4 +
+  §5.4: 'loaders are complete when no further loader-tagged events are
+  in flight'. For the simple synchronous case (the 99% path),
+  re-frame's run-to-completion drain settles before `dispatch-sync`
+  returns; the loaders queue is empty when the predicate is called.
+
+  Returns true unconditionally — Stage 3 relies on `dispatch-sync`
+  having drained the queue. Variants that fire long-lived fx
+  (websocket / interval) override the predicate per IMPL-SPEC §2.4."
+  [_frame-id _variant-body]
+  true)
+
+(defn evaluate-complete-when
+  "Evaluate the variant's `:loaders-complete-when` predicate against
+  `frame-id`'s current app-db. Returns truthy when the loader phase
+  should advance to `:ready`.
+
+  Forms accepted (per the Stage 2 schema):
+  - nil — use the default predicate (`loaders-default-complete?`).
+  - a registered event id — dispatch-sync the event; predicates of
+    this shape are implemented as registered assertion-style event-fxs
+    (Stage 5 wires the `:rf.assert/*` suite; Stage 3 only handles the
+    nil case + literal-data form).
+  - a vector of event vectors (the schema allows `[:vector EventVector]`)
+    — Stage 3 interprets these as `[:rf.assert/*]` declarations that
+    *must all pass* for the predicate to be true. Each assertion's
+    handler returns `{:passed? true|false ...}`; the runtime reads the
+    `:assertions` accumulator on the frame's app-db at
+    `[:rf.story/assertions]`.
+
+  Stage 5 (rf2-h8et) lands the full assertion runtime. For Stage 3
+  the nil-case is the load-bearing implementation; the registered-event
+  and vector forms route through Stage 5's hook. Until Stage 5 ships,
+  any non-nil `:loaders-complete-when` is treated as 'complete on first
+  evaluation' so the lifecycle still progresses — a Stage 4 UI shell
+  can render the variant; Stage 5 makes the predicate semantically
+  correct."
+  [frame-id variant-body]
+  (let [pred (:loaders-complete-when variant-body)]
+    (cond
+      (nil? pred)    (loaders-default-complete? frame-id variant-body)
+      ;; Stage 5 will replace this with full assertion evaluation.
+      ;; Stage 3 treats any non-nil predicate as truthy on first
+      ;; evaluation — the lifecycle progresses; Stage 5 makes it
+      ;; semantically correct.
+      :else          true)))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1,0 +1,331 @@
+(ns re-frame.story.runtime
+  "Story runtime orchestration. Per IMPL-SPEC §3.2 + §5.
+
+  Stage 3 (rf2-von3) lands the runtime that consumes Stage 2's
+  registered artefacts and resolves them into a runnable variant:
+
+  - `run-variant`     — allocate frame; run four-phase lifecycle;
+                        return a promise/future of the result map.
+  - `reset-variant`   — tear down and re-run.
+  - `watch-variant`   — subscribe to lifecycle transitions.
+  - `snapshot-identity` — re-export of `re-frame.story.identity/snapshot-identity`.
+
+  ## The result map
+
+  Per IMPL-SPEC §3.2 the resolved value of `run-variant` is:
+
+      {:frame           <variant-id>
+       :app-db          {...}
+       :assertions      [{:assertion ... :passed? true ...} ...]
+       :rendered-hiccup [...]               ; when :render? true
+       :elapsed-ms      <number>
+       :snapshot        {:variant-id ... :content-hash ...}
+       :decorators      {:hiccup [...] :frame-setup [...]
+                          :fx-override [...] :errors [...]}
+       :effective-args  {...}
+       :lifecycle       :ready | :error}
+
+  Stage 5 (rf2-h8et) lands the play-sequence runtime that populates
+  `:assertions` with full assertion semantics. Stage 3 leaves the slot
+  present and empty.
+
+  ## Elision
+
+  Every entry point checks `re-frame.story.config/enabled?`. When
+  false (production CLJS builds), the fns return an empty result map
+  immediately — the inner body, the registrar lookups, and the frame
+  allocation all elide. Per IMPL-SPEC §6.3 this is a *feature*:
+  production code that accidentally calls `run-variant` does not throw
+  — it returns empty."
+  (:require [re-frame.core            :as rf]
+            [re-frame.story.args      :as args]
+            [re-frame.story.async     :as async]
+            [re-frame.story.config    :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.frames    :as frames]
+            [re-frame.story.identity  :as ident]
+            [re-frame.story.loaders   :as loaders]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.interop         :as interop]
+            [re-frame.trace           :as trace]))
+
+;; ---- empty / disabled result ---------------------------------------------
+
+(defn- empty-result
+  "Per IMPL-SPEC §6.3: production callers see an empty result map
+  rather than an exception. The shape matches a successful run with
+  no registrations to act on."
+  [variant-id]
+  {:frame           variant-id
+   :app-db          {}
+   :assertions      []
+   :rendered-hiccup nil
+   :elapsed-ms      0
+   :snapshot        nil
+   :decorators      {:hiccup [] :frame-setup [] :fx-override [] :errors []}
+   :effective-args  {}
+   :lifecycle       :ready})
+
+;; Forward declarations so phase fns (defined before record-error!) can
+;; project exceptions per IMPL-SPEC §5.5 without reordering the file.
+(declare record-error!)
+
+;; ---- phase exception capture --------------------------------------------
+;;
+;; re-frame's interceptor chain catches handler exceptions internally and
+;; emits a `:rf.error/handler-exception` trace event rather than re-
+;; throwing. Stage 3's phase runners need to convert those trace events
+;; into assertion records (per IMPL-SPEC §5.5).
+;;
+;; The capture pattern: register a trace listener around each phase
+;; that collects matching errors into an atom. After the phase, walk
+;; the atom and record each into the variant frame's `:rf.story/
+;; assertions` accumulator.
+
+(defonce ^:private capture-counter (atom 0))
+
+(defn- capture-phase-errors
+  "Run `body-fn` (a 0-arg thunk) with a registered trace listener that
+  collects `:rf.error/handler-exception` events targeting `variant-id`'s
+  frame. After the body returns, walks the captured errors and records
+  each as a phase-tagged assertion via `record-error!`. Returns `body-fn`'s
+  return value."
+  [variant-id phase body-fn]
+  (let [collected (atom [])
+        cb-id     (keyword "re-frame.story.runtime"
+                           (str "capture-" (swap! capture-counter inc)))
+        listener  (fn [ev]
+                    (when (and (= :rf.error/handler-exception (:operation ev))
+                               (= variant-id (get-in ev [:tags :frame])))
+                      (swap! collected conj ev)))]
+    (trace/register-trace-cb! cb-id listener)
+    (try
+      (let [result (body-fn)]
+        (doseq [ev @collected]
+          (record-error! variant-id phase
+                         (get-in ev [:tags :event])
+                         (get-in ev [:tags :exception])))
+        result)
+      (finally
+        (trace/remove-trace-cb! cb-id)))))
+
+;; ---- phase-2 events execution --------------------------------------------
+
+(defn- run-events!
+  "Phase 2: dispatch every event in `:events` (story-level concat
+  variant-level) into the variant's frame, draining between each. Per
+  IMPL-SPEC §5.4 phase 2."
+  [variant-id]
+  (let [variant-body (frames/variant-body variant-id)
+        story-id     (args/parent-story-id variant-id)
+        story-body   (when story-id (registrar/handler-meta :story story-id))
+        story-events (or (:events story-body) [])
+        var-events   (or (:events variant-body) [])
+        all-events   (concat story-events var-events)]
+    (capture-phase-errors
+      variant-id :phase-2-events
+      (fn []
+        (doseq [ev all-events]
+          (try
+            (rf/dispatch-sync ev {:frame variant-id})
+            (catch #?(:clj Throwable :cljs :default) e
+              ;; Synchronous throws (rare — re-frame's interceptor chain
+              ;; usually catches and re-emits via trace) record here.
+              (record-error! variant-id :phase-2-events ev e))))))))
+
+;; ---- phase-1 loaders execution -------------------------------------------
+
+(defn- run-loaders!
+  "Phase 1: dispatch every event in `:loaders` into the variant's
+  frame, evaluating `:loaders-complete-when` after each. Per IMPL-SPEC
+  §5.4 phase 1.
+
+  In Stage 3 the simple synchronous path is the load-bearing one:
+  `dispatch-sync` drains run-to-completion before returning, so the
+  default predicate's 'no further events in flight' check passes
+  trivially. Variants with long-lived fx (websocket / interval) supply
+  `:loaders-complete-when` to override; Stage 3 routes those through
+  the predicate evaluator (Stage 5 adds the full assertion runtime)."
+  [variant-id]
+  (let [variant-body (frames/variant-body variant-id)
+        loader-events (or (:loaders variant-body) [])]
+    (loaders/start-loaders! variant-id)
+    (capture-phase-errors
+      variant-id :phase-1-loaders
+      (fn []
+        (doseq [ev loader-events]
+          (try
+            (rf/dispatch-sync ev {:frame variant-id})
+            (catch #?(:clj Throwable :cljs :default) e
+              (record-error! variant-id :phase-1-loaders ev e))))))
+    ;; Evaluate :loaders-complete-when. In Stage 3 the predicate
+    ;; resolves synchronously; Stage 6+ might add an async-retry shape.
+    (let [complete? (loaders/evaluate-complete-when variant-id variant-body)]
+      (when complete?
+        (loaders/finish-loaders! variant-id)))))
+
+;; ---- error recording -----------------------------------------------------
+
+(defn- error-record
+  "Build an error projection map per IMPL-SPEC §5.5."
+  [phase event err]
+  {:assertion :rf.error/exception
+   :phase     phase
+   :event     event
+   :error     {:message #?(:clj  (.getMessage ^Throwable err)
+                           :cljs (str err))
+               :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
+                                            :cljs ExceptionInfo) err)
+                          (ex-data err))}
+   :passed?   false})
+
+(defn record-error!
+  "Append an error record to the variant frame's `[:rf.story/assertions]`
+  accumulator. Per IMPL-SPEC §5.5 errors continue the play sequence
+  rather than aborting — the full picture is captured."
+  [variant-id phase event err]
+  (let [record (error-record phase event err)]
+    (try
+      (rf/dispatch-sync [::append-assertion record] {:frame variant-id})
+      (catch #?(:clj Throwable :cljs :default) _
+        ;; The frame may already be torn down; swallow.
+        nil))
+    record))
+
+;; ---- helper event registrations ------------------------------------------
+
+(defn install-helpers!
+  "Register the runtime's internal helper events. Idempotent."
+  []
+  (when config/enabled?
+    (rf/reg-event-db
+      ::append-assertion
+      (fn [db [_ record]]
+        (update db :rf.story/assertions (fnil conj []) record)))))
+
+;; ---- assertions read -----------------------------------------------------
+
+(defn read-assertions
+  "Return the assertions vector for `variant-id`'s frame, or `[]`."
+  [variant-id]
+  (or (:rf.story/assertions (rf/get-frame-db variant-id)) []))
+
+;; ---- run-variant ---------------------------------------------------------
+
+(defn- record-result-map
+  "Build the result map returned by `run-variant`. Pure data; gathers
+  whatever the runtime accumulated against the variant's frame."
+  [variant-id decorator-stack effective-args snapshot start-ms]
+  (let [app-db (rf/get-frame-db variant-id)]
+    {:frame           variant-id
+     :app-db          (or app-db {})
+     :assertions      (or (:rf.story/assertions app-db) [])
+     :rendered-hiccup nil       ;; Stage 4 fills this in
+     :elapsed-ms      (- (interop/now-ms) start-ms)
+     :snapshot        snapshot
+     :decorators      decorator-stack
+     :effective-args  effective-args
+     :lifecycle       (loaders/current-state variant-id)}))
+
+(defn run-variant
+  "Per IMPL-SPEC §3.2. Allocate a frame for `variant-id`, run the four-
+  phase lifecycle, and return a promise/future of the result map.
+
+  `opts`:
+    :active-modes    coll of registered mode ids; deep-merged into args
+    :cell-overrides  runtime arg overrides (controls panel)
+    :substrate       active substrate (`:reagent`, `:uix`, ...)
+    :render?         when truthy, Stage 4's UI shell renders into
+                     `:rendered-hiccup`. Stage 3 leaves the slot nil.
+    :assertions      Stage 5's hook. Stage 3 accepts the slot but
+                     leaves the runtime semantics to Stage 5.
+
+  Returns a Promise (CLJS) / CompletableFuture (JVM). Per IMPL-SPEC
+  §13.2 this is Stage 3's locked async-return shape.
+
+  Production callers (CLJS `:advanced` with `enabled?` false) get an
+  immediately-resolved promise of the empty result map — per IMPL-SPEC
+  §6.3 the runtime doesn't throw when nothing is registered."
+  ([variant-id] (run-variant variant-id nil))
+  ([variant-id opts]
+   (if-not config/enabled?
+     (async/resolved (empty-result variant-id))
+     (let [start-ms        (interop/now-ms)
+           {:keys [active-modes cell-overrides substrate]} opts
+           variant-body    (frames/variant-body variant-id)]
+       (cond
+         (nil? variant-body)
+         (async/resolved (assoc (empty-result variant-id)
+                                :lifecycle :error
+                                :assertions [{:assertion :rf.error/unknown-variant
+                                              :variant-id variant-id
+                                              :passed? false}]))
+
+         :else
+         (async/promise
+           (fn [resolve]
+             (try
+               (install-helpers!)
+               (let [decorator-stack (decorators/resolve-decorators variant-id
+                                                                    {:active-modes active-modes})
+                     effective-args  (args/resolve-args variant-id opts)
+                     snapshot        (ident/snapshot-identity variant-id opts)]
+                 ;; Phase 0: allocate frame, run :frame-setup decorators,
+                 ;; drive lifecycle to :mounting.
+                 (frames/allocate! variant-id decorator-stack)
+                 ;; Phase 1: loaders.
+                 (run-loaders! variant-id)
+                 ;; Phase 2: events.
+                 (run-events! variant-id)
+                 (loaders/finish-events! variant-id)
+                 ;; Phase 3 (render): Stage 4's UI shell does the actual
+                 ;; render. Stage 3 leaves :rendered-hiccup nil.
+                 ;; Phase 4 (play + assertions): Stage 5 lands. Stage 3
+                 ;; leaves :assertions empty for now (unless Stage 3
+                 ;; itself recorded error projections during phases 1-2).
+                 (resolve (record-result-map variant-id decorator-stack
+                                             effective-args snapshot
+                                             start-ms)))
+               (catch #?(:clj Throwable :cljs :default) e
+                 (record-error! variant-id :phase-0-setup nil e)
+                 (loaders/error! variant-id (ex-data e))
+                 (resolve (record-result-map variant-id nil nil nil start-ms)))))))))))
+
+;; ---- reset-variant -------------------------------------------------------
+
+(defn reset-variant
+  "Tear down the variant frame and re-run `run-variant` with `opts`.
+  Per IMPL-SPEC §3.2. Used by Stage 4's UI shell on hot-reload + user-
+  triggered 'reset' button.
+
+  Returns a promise/future of the new result map."
+  ([variant-id] (reset-variant variant-id nil))
+  ([variant-id opts]
+   (when config/enabled?
+     (frames/destroy! variant-id))
+   (run-variant variant-id opts)))
+
+;; ---- watch-variant -------------------------------------------------------
+
+(defn watch-variant
+  "Per IMPL-SPEC §3.2 — subscribe to lifecycle transitions for
+  `variant-id`'s frame. `callback` is invoked on every state change
+  with `{:frame-id ... :from <state> :to <state> :event <event>}`.
+
+  Returns a 0-arity unsubscribe fn.
+
+  Stage 4's UI shell + Stage 5's assertions runtime consume this. The
+  watcher table is per-frame so destroyed frames clean up automatically
+  via `frames/destroy!`."
+  [variant-id callback]
+  (when config/enabled?
+    (loaders/add-watcher! variant-id callback)))
+
+;; ---- snapshot-identity re-export ----------------------------------------
+
+(defn snapshot-identity
+  "Per IMPL-SPEC §3.2. Compute the content-hash for
+  `(variant × active-modes × cell-overrides × substrate)`. See
+  `re-frame.story.identity/snapshot-identity` for the canonical form."
+  ([variant-id] (ident/snapshot-identity variant-id))
+  ([variant-id opts] (ident/snapshot-identity variant-id opts)))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -1,0 +1,128 @@
+(ns re-frame.story-runtime-cljs-test
+  "CLJS smoke tests for re-frame2-story Stage 3 (rf2-von3).
+
+  The bulk of runtime coverage lives in the JVM test ns
+  (`re-frame.story-runtime-test`) — args precedence, decorator
+  composition, snapshot-identity, lifecycle state-machine — all of
+  which run faster on the JVM with no Reagent / DOM dependencies.
+
+  This namespace covers the CLJS-specific surface: that the runtime
+  compiles under CLJS, that `run-variant` returns a `js/Promise`,
+  and that `snapshot-identity` produces stable hex hashes on both
+  hosts (the matching JVM test asserts identical hashes; the CLJS
+  smoke just confirms the function runs)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.machines :as machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.async :as async-lib]
+            [re-frame.story.loaders :as loaders]))
+
+;; ---- fixtures ------------------------------------------------------------
+;;
+;; CLJS doesn't allow runtime `require`, so the JVM fixture's
+;; `(require 're-frame.machines :reload)` step (which re-installs the
+;; machines artefact's reg-subs / event handlers after a registrar
+;; clear-all!) needs a different shape on CLJS. The CLJS approach
+;; manually re-runs the side-effecting parts of the machines ns.
+;; Since CLJS test isolation between deftests is less stringent than
+;; the JVM corpus (no per-test require :reload), we tolerate a
+;; non-empty registrar carrying over between tests.
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  ;; Seat the plain-atom adapter. `rf/init!` is idempotent at the
+  ;; install-adapter! layer (the test build may have seated it
+  ;; already via another suite's boot).
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil))
+  ;; Re-register the machines artefact's framework-shipped sub
+  ;; (`:rf/machine`) after the registrar clear. The JVM equivalent
+  ;; uses `(require 're-frame.machines :reload)` which is unavailable
+  ;; in CLJS — we manually re-invoke the side-effecting part.
+  (rf/reg-sub :rf/machine
+              (fn [db [_ machine-id]]
+                (get-in db [:rf/machines machine-id])))
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+;; Per cljs.test: async tests require fixtures to be supplied in
+;; map form — function-form fixtures can't suspend around the async
+;; body. Wrap the reset fn as a map.
+(use-fixtures :each {:before reset-all!})
+
+;; ---- stage marker -------------------------------------------------------
+
+(deftest cljs-stage-marker
+  (testing "Stage 3 advertises :runtime on the CLJS side"
+    (is (= :runtime story/stage))))
+
+;; ---- run-variant returns a Promise --------------------------------------
+
+(deftest cljs-run-variant-returns-promise
+  (testing "run-variant returns a js/Promise"
+    (rf/reg-event-db :test/inc
+      (fn [db _] (update db :counter (fnil inc 0))))
+    (story/reg-variant :story.cljs.run/v
+      {:events [[:test/inc] [:test/inc]]})
+    (let [p (story/run-variant :story.cljs.run/v)]
+      (is (async-lib/promise? p))
+      (async done
+        (-> p
+            (async-lib/then
+              (fn [r]
+                (is (= :story.cljs.run/v (:frame r)))
+                (is (= :ready            (:lifecycle r)))
+                (is (= 2                 (:counter (:app-db r))))
+                (story/destroy-variant! :story.cljs.run/v)
+                (done))))))))
+
+;; ---- snapshot-identity --------------------------------------------------
+
+(deftest cljs-snapshot-identity-shape
+  (testing "snapshot-identity produces an 8-char hex hash"
+    (story/reg-story :story.cljs.id
+      {:component :app/v :args {:a 1}})
+    (story/reg-variant :story.cljs.id/v
+      {:events [[:init]] :tags #{:dev}})
+    (let [s (story/snapshot-identity :story.cljs.id/v
+                                     {:substrate :reagent})]
+      (is (= :story.cljs.id/v (:variant-id s)))
+      (is (string?            (:content-hash s)))
+      (is (= 8 (count (:content-hash s)))))))
+
+;; ---- args precedence ----------------------------------------------------
+
+(deftest cljs-resolve-args-precedence
+  (testing "args precedence chain works on CLJS"
+    (story/configure! {:global-args {:theme :light}})
+    (story/reg-story :story.cljs.args
+      {:args {:label "story"}})
+    (story/reg-variant :story.cljs.args/v
+      {:args {:label "variant"} :events []})
+    (let [r (story/resolve-args :story.cljs.args/v
+                                {:cell-overrides {:icon :star}})]
+      (is (= :light    (:theme r)))
+      (is (= "variant" (:label r)))
+      (is (= :star     (:icon r))))))
+
+;; ---- decorator composition ----------------------------------------------
+
+(deftest cljs-decorator-resolution
+  (testing "decorator resolution works on CLJS"
+    (story/reg-decorator :centered
+      {:kind :hiccup
+       :wrap (fn [body _] [:div.centered body])})
+    (story/reg-variant :story.cljs.dec/v
+      {:decorators [[:centered]]
+       :events     []})
+    (let [r (story/resolve-decorators :story.cljs.dec/v)]
+      (is (= 1 (count (:hiccup r))))
+      (is (= :centered (-> r :hiccup first :id))))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1,0 +1,491 @@
+(ns re-frame.story-runtime-test
+  "JVM tests for re-frame2-story Stage 3 (rf2-von3) — runtime.
+
+  Covers:
+
+  - Args precedence: global < story < mode < variant < cell-overrides
+    with deep-merge on nested maps and replace on vectors.
+  - Decorator composition: classification by `:kind`, ordering (story
+    decorators before variant decorators), hiccup wrap composition,
+    fx-override registration.
+  - Snapshot-identity: stability across re-runs; sensitivity to
+    every input axis per IMPL-SPEC §5.6.
+  - Lifecycle state machine: `:pre-mount → :mounting → :loading →
+    :ready` via runtime fns + watcher firing.
+  - `run-variant` end-to-end: registered variant → frame allocated →
+    events drained → result map populated.
+  - Frame teardown via `destroy-variant!`.
+  - Error projection per IMPL-SPEC §5.5.
+
+  All tests run on the JVM via `clojure -M:test`. Per the
+  `jvm_interop_must_work` user-feedback rule the runtime must be JVM-
+  portable — `run-variant` returns a CompletableFuture on JVM (vs JS
+  Promise on CLJS); the tests `deref` it for the result map."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core            :as rf]
+            [re-frame.frame           :as frame]
+            [re-frame.machines        :as machines]
+            [re-frame.registrar       :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story           :as story]
+            [re-frame.story.args      :as args]
+            [re-frame.story.async     :as async]
+            [re-frame.story.config    :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.frames    :as frames]
+            [re-frame.story.identity  :as ident]
+            [re-frame.story.loaders   :as loaders]
+            [re-frame.story.runtime   :as runtime]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [test-fn]
+  ;; Tear down Story's side-table.
+  (story/clear-all!)
+  ;; Tear down the framework registrar so test isolation holds.
+  (registrar/clear-all!)
+  ;; Tear down every non-default frame.
+  (reset! frame/frames {})
+  ;; Install the plain-atom adapter (matches the machines test fixture
+  ;; pattern). `rf/init!` is idempotent once seated; we tolerate the
+  ;; double-install error if the adapter is already in place.
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  ;; Re-require machines so its `reg-sub :rf/machine` survives the
+  ;; registrar/clear-all! call. Mirrors the machines test fixtures.
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  ;; Re-install the canonical vocabulary (tags + lifecycle machine).
+  (story/install-canonical-vocabulary!)
+  ;; Make sure :rf/default is always present.
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-all)
+
+;; ---- stage marker --------------------------------------------------------
+
+(deftest stage-marker-runtime
+  (testing "Stage 3 advertises :runtime"
+    (is (= :runtime story/stage))))
+
+;; ===========================================================================
+;; ARGS PRECEDENCE
+;; ===========================================================================
+
+(deftest deep-merge-merges-nested-maps
+  (testing "deep-merge recurses into maps"
+    (is (= {:a {:b 1 :c 2}}
+           (args/deep-merge {:a {:b 1}} {:a {:c 2}}))))
+
+  (testing "non-map values replace"
+    (is (= {:a [3]}
+           (args/deep-merge {:a [1 2]} {:a [3]}))))
+
+  (testing "nil right-hand is a no-op"
+    (is (= {:a 1} (args/deep-merge {:a 1} nil))))
+
+  (testing "scalar replaces nested map"
+    (is (= {:a 5} (args/deep-merge {:a {:b 1}} {:a 5})))))
+
+(deftest resolve-args-precedence-chain
+  (testing "global < story < mode < variant < cell-overrides"
+    (story/configure! {:global-args {:theme :light :verbose? false}})
+    (story/reg-story :story.ui.button
+      {:doc       "btn"
+       :component :app.ui/button
+       :args      {:label "Story label" :verbose? true}})
+    (story/reg-mode :Mode.app/dark
+      {:args {:theme :dark}})
+    (story/reg-variant :story.ui.button/default
+      {:args   {:label "Variant label" :icon :star}
+       :events []})
+    (let [resolved (story/resolve-args :story.ui.button/default
+                                       {:active-modes  [:Mode.app/dark]
+                                        :cell-overrides {:label "Cell label"}})]
+      (is (= :dark         (:theme resolved))    "mode wins over global")
+      (is (= true          (:verbose? resolved)) "story wins over global")
+      (is (= "Cell label"  (:label resolved))    "cell-overrides win over variant")
+      (is (= :star         (:icon resolved))     "variant arg passes through"))))
+
+(deftest resolve-args-deep-merge-on-nested
+  (testing "nested maps deep-merge across layers"
+    (story/configure! {:global-args {:layout {:max-width 1024 :padding 8}}})
+    (story/reg-story :story.layout.box
+      {:args {:layout {:padding 16}}})
+    (story/reg-variant :story.layout.box/deep
+      {:args   {:layout {:margin 4}}
+       :events []})
+    (let [r (story/resolve-args :story.layout.box/deep)]
+      (is (= 1024 (get-in r [:layout :max-width])))
+      (is (= 16   (get-in r [:layout :padding]))   "story wins")
+      (is (= 4    (get-in r [:layout :margin]))))))
+
+(deftest resolve-args-unregistered-variant
+  (testing "unregistered variant resolves to {} without throwing"
+    (is (= {} (story/resolve-args :story.missing/x)))))
+
+;; ===========================================================================
+;; DECORATOR COMPOSITION
+;; ===========================================================================
+
+(deftest decorators-classified-by-kind
+  (testing "hiccup / frame-setup / fx-override decorators land in their slots"
+    (story/reg-decorator :centered
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.centered body])})
+    (story/reg-decorator :mock-auth
+      {:kind :frame-setup
+       :init [[:auth/restore-session {:user "alice"}]]})
+    (story/reg-decorator :stub-http
+      {:kind :fx-override
+       :fx-id :http
+       :response {:status :pending}})
+    (story/reg-variant :story.composed/v
+      {:decorators [[:centered] [:mock-auth] [:stub-http]]
+       :events     []})
+    (let [r (story/resolve-decorators :story.composed/v)]
+      (is (= 1 (count (:hiccup r))))
+      (is (= :centered (-> r :hiccup first :id)))
+      (is (= 1 (count (:frame-setup r))))
+      (is (= :mock-auth (-> r :frame-setup first :id)))
+      (is (= 1 (count (:fx-override r))))
+      (is (= :stub-http (-> r :fx-override first :id)))
+      (is (empty? (:errors r))))))
+
+(deftest decorators-story-then-variant-order
+  (testing "story decorators come before variant decorators in declared order"
+    (story/reg-decorator :outer
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.outer body])})
+    (story/reg-decorator :inner
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.inner body])})
+    (story/reg-story :story.compose
+      {:decorators [[:outer]]})
+    (story/reg-variant :story.compose/v
+      {:decorators [[:inner]]
+       :events     []})
+    (let [r       (story/resolve-decorators :story.compose/v)
+          ids     (mapv :id (:hiccup r))]
+      (is (= [:outer :inner] ids)
+          "story decorators precede variant decorators in declared order"))))
+
+(deftest decorators-apply-hiccup-outermost-first
+  (testing "apply-hiccup-decorators wraps innermost first, outermost last"
+    (story/reg-decorator :outer
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.outer body])})
+    (story/reg-decorator :inner
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.inner body])})
+    (story/reg-story :story.wrap
+      {:decorators [[:outer]]})
+    (story/reg-variant :story.wrap/v
+      {:decorators [[:inner]]
+       :events     []})
+    (let [r       (story/resolve-decorators :story.wrap/v)
+          wrapped (decorators/apply-hiccup-decorators (:hiccup r) [:span "x"] {})]
+      ;; Outermost is :outer; inside it is :inner; inside that is the span.
+      (is (= [:div.outer [:div.inner [:span "x"]]] wrapped)))))
+
+(deftest decorators-unknown-id-becomes-error
+  (testing "an unregistered decorator id surfaces in :errors"
+    (story/reg-variant :story.bad/v
+      {:decorators [[:totally-unregistered]]
+       :events     []})
+    (let [r (story/resolve-decorators :story.bad/v)]
+      (is (= 1 (count (:errors r))))
+      (is (= :rf.error/decorator-unknown
+             (-> r :errors first :rf.error))))))
+
+(deftest fx-overrides-map-last-wins
+  (testing "two fx-override decorators with the same :fx-id resolve last-wins"
+    (story/reg-decorator :first-stub
+      {:kind :fx-override :fx-id :http :response {:n 1}})
+    (story/reg-decorator :second-stub
+      {:kind :fx-override :fx-id :http :response {:n 2}})
+    (story/reg-variant :story.fx/v
+      {:decorators [[:first-stub] [:second-stub]]
+       :events     []})
+    (let [r       (story/resolve-decorators :story.fx/v)
+          stack   (decorators/fx-overrides-map (:fx-override r))]
+      (is (= 1 (count (:overrides stack)))
+          "last-wins: only one entry per fx-id")
+      (is (contains? (:overrides stack) :http))
+      (is (= :rf.story.fx-stub/second-stub
+             (get-in stack [:overrides :http]))))))
+
+;; ===========================================================================
+;; SNAPSHOT IDENTITY
+;; ===========================================================================
+
+(deftest snapshot-identity-stable-across-runs
+  (testing "two calls with the same inputs produce the same hash"
+    (story/reg-story :story.id
+      {:component :app/v :args {:a 1}})
+    (story/reg-variant :story.id/v
+      {:events [[:init]] :args {:b 2} :tags #{:dev}})
+    (let [a (story/snapshot-identity :story.id/v {:substrate :reagent})
+          b (story/snapshot-identity :story.id/v {:substrate :reagent})]
+      (is (= (:content-hash a) (:content-hash b)))
+      (is (= 8 (count (:content-hash a)))
+          "8-char hex"))))
+
+(deftest snapshot-identity-changes-with-args
+  (testing "changing a variant's :args changes the hash"
+    (story/reg-story :story.id-args
+      {:component :app/v})
+    (story/reg-variant :story.id-args/v {:args {:x 1} :events []})
+    (let [h1 (-> (story/snapshot-identity :story.id-args/v) :content-hash)]
+      (story/reg-variant :story.id-args/v {:args {:x 2} :events []})
+      (let [h2 (-> (story/snapshot-identity :story.id-args/v) :content-hash)]
+        (is (not= h1 h2))))))
+
+(deftest snapshot-identity-changes-with-mode
+  (testing "different active-modes produce different hashes"
+    (story/reg-story :story.id-mode
+      {:component :app/v :args {:theme :light}})
+    (story/reg-mode :Mode.app/dark  {:args {:theme :dark}})
+    (story/reg-mode :Mode.app/light {:args {:theme :light}})
+    (story/reg-variant :story.id-mode/v {:events []})
+    (let [hd (-> (story/snapshot-identity :story.id-mode/v
+                                          {:active-modes [:Mode.app/dark]})
+                 :content-hash)
+          hl (-> (story/snapshot-identity :story.id-mode/v
+                                          {:active-modes [:Mode.app/light]})
+                 :content-hash)]
+      (is (not= hd hl)))))
+
+(deftest snapshot-identity-changes-with-substrate
+  (testing "different substrate produces different hash"
+    (story/reg-story :story.id-sub
+      {:component :app/v})
+    (story/reg-variant :story.id-sub/v {:events []})
+    (let [hr (-> (story/snapshot-identity :story.id-sub/v {:substrate :reagent})
+                 :content-hash)
+          hu (-> (story/snapshot-identity :story.id-sub/v {:substrate :uix})
+                 :content-hash)]
+      (is (not= hr hu)))))
+
+(deftest snapshot-identity-canonical-key-stable
+  (testing "the canonical-form key :rf/snapshot-canonical-v1 is included"
+    (let [canon (ident/canonical-form [:rf/snapshot-canonical-v1 :x])]
+      (is (some? canon)))
+    (is (= (ident/content-hash {:a 1 :b 2})
+           (ident/content-hash {:b 2 :a 1}))
+        "map key order doesn't affect the hash")))
+
+;; ===========================================================================
+;; LIFECYCLE STATE MACHINE
+;; ===========================================================================
+
+(deftest lifecycle-machine-registered
+  (testing "the lifecycle machine is registered after install-canonical-vocabulary!"
+    (is (some (set [loaders/lifecycle-machine-id]) (machines/machines)))))
+
+(deftest lifecycle-transitions-pre-mount-to-ready
+  (testing "the lifecycle progresses through every documented state"
+    (story/reg-variant :story.life/v {:events [] :loaders []})
+    (let [r       (story/resolve-decorators :story.life/v)]
+      (frames/allocate! :story.life/v r)
+      (is (= :mounting (loaders/current-state :story.life/v)))
+      (loaders/start-loaders! :story.life/v)
+      (is (= :loading (loaders/current-state :story.life/v)))
+      (loaders/finish-loaders! :story.life/v)
+      (is (= :ready (loaders/current-state :story.life/v)))
+      (frames/destroy! :story.life/v))))
+
+(deftest lifecycle-mirror-to-friendly-path
+  (testing "the discrete state is mirrored to [:rf.story/lifecycle]"
+    (story/reg-variant :story.mirror/v {:events []})
+    (let [r (story/resolve-decorators :story.mirror/v)]
+      (frames/allocate! :story.mirror/v r)
+      (loaders/start-loaders! :story.mirror/v)
+      (let [db (rf/get-frame-db :story.mirror/v)]
+        (is (= :loading (:rf.story/lifecycle db))))
+      (frames/destroy! :story.mirror/v))))
+
+(deftest lifecycle-watcher-fires-on-transitions
+  (testing "watch-variant callbacks see every transition"
+    (story/reg-variant :story.watch/v {:events []})
+    (let [transitions (atom [])
+          unsubscribe (story/watch-variant
+                        :story.watch/v
+                        (fn [t] (swap! transitions conj t)))
+          r           (story/resolve-decorators :story.watch/v)]
+      (frames/allocate! :story.watch/v r)
+      (loaders/start-loaders! :story.watch/v)
+      (loaders/finish-loaders! :story.watch/v)
+      (is (= [:pre-mount :mounting :loading]
+             (mapv :from @transitions)))
+      (is (= [:mounting :loading :ready]
+             (mapv :to @transitions)))
+      (unsubscribe)
+      (frames/destroy! :story.watch/v))))
+
+;; ===========================================================================
+;; RUN-VARIANT END-TO-END
+;; ===========================================================================
+
+(deftest run-variant-basic
+  (testing "run-variant returns a future of the result map"
+    (rf/reg-event-db :test/inc
+      (fn [db _] (update db :counter (fnil inc 0))))
+    (story/reg-variant :story.run/v
+      {:events [[:test/inc] [:test/inc]]})
+    (let [fut (story/run-variant :story.run/v)
+          r   (async/deref-blocking fut 5000)]
+      (is (= :story.run/v        (:frame r)))
+      (is (= :ready              (:lifecycle r)))
+      (is (= 2                   (:counter (:app-db r))))
+      (is (number?               (:elapsed-ms r)))
+      (is (= :story.run/v        (-> r :snapshot :variant-id)))
+      (is (string?               (-> r :snapshot :content-hash))))
+    (story/destroy-variant! :story.run/v)))
+
+(deftest run-variant-with-loaders-and-events
+  (testing "run-variant drains loaders before events"
+    (rf/reg-event-db :test/load
+      (fn [db _] (assoc db :loaded? true)))
+    (rf/reg-event-db :test/use
+      (fn [db _]
+        (assoc db :used-loaded? (boolean (:loaded? db)))))
+    (story/reg-variant :story.flow/v
+      {:loaders [[:test/load]]
+       :events  [[:test/use]]})
+    (let [r (async/deref-blocking (story/run-variant :story.flow/v) 5000)]
+      (is (true? (-> r :app-db :loaded?)))
+      (is (true? (-> r :app-db :used-loaded?))
+          "events ran AFTER loaders"))
+    (story/destroy-variant! :story.flow/v)))
+
+(deftest run-variant-frame-setup-decorator
+  (testing ":frame-setup decorators fire :init events before loaders"
+    (rf/reg-event-db :test/mock-init
+      (fn [db _] (assoc db :mock {:user "alice"})))
+    (rf/reg-event-db :test/observe
+      (fn [db _] (assoc db :observed-mock (:mock db))))
+    (story/reg-decorator :mock-frame
+      {:kind :frame-setup
+       :init [[:test/mock-init]]})
+    (story/reg-variant :story.fs/v
+      {:decorators [[:mock-frame]]
+       :events     [[:test/observe]]})
+    (let [r (async/deref-blocking (story/run-variant :story.fs/v) 5000)]
+      (is (= {:user "alice"} (-> r :app-db :observed-mock))
+          ":init events ran before :events; observe saw the mock"))
+    (story/destroy-variant! :story.fs/v)))
+
+(deftest run-variant-unknown-variant
+  (testing "run-variant of an unregistered variant produces an error result"
+    (let [r (async/deref-blocking (story/run-variant :story.nope/x) 5000)]
+      (is (= :error (:lifecycle r)))
+      (is (= :rf.error/unknown-variant
+             (-> r :assertions first :assertion))))))
+
+(deftest reset-variant-tears-down-then-runs-fresh
+  (testing "reset-variant produces a fresh app-db"
+    (rf/reg-event-db :test/inc
+      (fn [db _] (update db :counter (fnil inc 0))))
+    (story/reg-variant :story.reset/v
+      {:events [[:test/inc]]})
+    (let [r1 (async/deref-blocking (story/run-variant :story.reset/v) 5000)
+          r2 (async/deref-blocking (story/reset-variant :story.reset/v) 5000)]
+      (is (= 1 (:counter (:app-db r1))))
+      (is (= 1 (:counter (:app-db r2)))
+          "reset gives a fresh frame; counter starts again at 0 then increments to 1"))
+    (story/destroy-variant! :story.reset/v)))
+
+;; ===========================================================================
+;; FRAME-META INTROSPECTION
+;; ===========================================================================
+
+(deftest variant-frames-marked
+  (testing "variant frames carry :rf/story? + :rf/variant on their config"
+    (story/reg-variant :story.fm/v {:events []})
+    (let [r (story/resolve-decorators :story.fm/v)]
+      (frames/allocate! :story.fm/v r)
+      (let [m (rf/frame-meta :story.fm/v)]
+        (is (true?              (get-in m [:config :rf/story?])))
+        (is (= :story.fm/v      (get-in m [:config :rf/variant])))
+        (is (= :story           (get-in m [:config :preset]))))
+      (is (contains? (story/variant-frames) :story.fm/v))
+      (is (true? (story/variant-frame? :story.fm/v)))
+      (frames/destroy! :story.fm/v))))
+
+;; ===========================================================================
+;; ERROR PROJECTION
+;; ===========================================================================
+
+(deftest event-throwing-projects-as-assertion
+  (testing "a thrown exception during :events lands in :assertions"
+    (rf/reg-event-db :test/boom
+      (fn [_ _] (throw (ex-info "bang" {:why :test}))))
+    (story/reg-variant :story.err/v
+      {:events [[:test/boom]]})
+    (let [r (async/deref-blocking (story/run-variant :story.err/v) 5000)]
+      ;; Phase-2 errors don't roll back the lifecycle; :ready is the
+      ;; terminal state per IMPL-SPEC §5.5 — we record and continue.
+      (is (some #(= :rf.error/exception (:assertion %)) (:assertions r))
+          "an exception assertion was recorded")
+      (is (some #(= :phase-2-events (:phase %)) (:assertions r))))
+    (story/destroy-variant! :story.err/v)))
+
+;; ===========================================================================
+;; CONFIGURE!
+;; ===========================================================================
+
+(deftest configure-sets-global-args
+  (testing "configure! writes the global-args layer"
+    (story/configure! {:global-args {:theme :dark}})
+    (is (= {:theme :dark} (config/get-global-args)))
+    (story/reg-variant :story.cfg/v {:events []})
+    (let [r (story/resolve-args :story.cfg/v)]
+      (is (= :dark (:theme r))))))
+
+;; ===========================================================================
+;; ASYNC ABSTRACTION
+;; ===========================================================================
+
+(deftest async-resolved-and-then
+  (testing "async/resolved produces a complete future"
+    (is (= 42 (async/deref-blocking (async/resolved 42) 1000)))))
+
+(deftest async-then-chains
+  (testing "async/then chains over a resolved promise"
+    (is (= 43
+           (async/deref-blocking
+             (async/then (async/resolved 42) inc)
+             1000)))))
+
+(deftest async-rejected-catch
+  (testing "async/catch* recovers a rejection"
+    (let [recovered (async/catch* (async/rejected (ex-info "no" {}))
+                                  (fn [_] :recovered))]
+      (is (= :recovered (async/deref-blocking recovered 1000))))))
+
+(deftest async-promise-resolver
+  (testing "async/promise's resolver completes the future"
+    (let [p (async/promise (fn [resolve] (resolve :ok)))]
+      (is (= :ok (async/deref-blocking p 1000))))))
+
+;; ===========================================================================
+;; PUBLIC API STABILITY
+;; ===========================================================================
+
+(deftest public-api-surface
+  (testing "every Stage 3 IMPL-SPEC §3.2 fn is present on the public ns"
+    (is (fn? @#'story/run-variant))
+    (is (fn? @#'story/reset-variant))
+    (is (fn? @#'story/watch-variant))
+    (is (fn? @#'story/snapshot-identity))
+    (is (fn? @#'story/destroy-variant!))
+    (is (fn? @#'story/configure!))
+    (is (fn? @#'story/resolve-args))
+    (is (fn? @#'story/resolve-decorators))
+    (is (fn? @#'story/lifecycle-state))
+    (is (fn? @#'story/variant-frames))
+    (is (fn? @#'story/variant-frame?))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -380,5 +380,5 @@
 ;; ---- Stage 3 contract check -----------------------------------------
 
 (deftest stage-marker
-  (testing "the loaded surface advertises Stage 2 (authoring)"
-    (is (= :authoring re-frame.story/stage))))
+  (testing "the loaded surface advertises Stage 3 (runtime)"
+    (is (= :runtime re-frame.story/stage))))


### PR DESCRIPTION
## Summary

Stage 3 of the re-frame2-story epic (rf2-u6fb). Implements the runtime that consumes Stage 2's registered artefacts and resolves them into a runnable variant — frame allocation, args resolution, decorator composition, four-phase loader lifecycle, and the public `run-variant` / `reset-variant` / `watch-variant` / `snapshot-identity` surface.

## Public API additions

On `re-frame.story`:

| Fn | Purpose |
|---|---|
| `run-variant` | allocate frame; run four-phase lifecycle; return promise/future of result map |
| `reset-variant` | tear down + re-run |
| `watch-variant` | subscribe to lifecycle transitions |
| `destroy-variant!` | tear down a running variant |
| `snapshot-identity` | content-hash over `(variant × args × decorators × loaders × substrate × modes)` |
| `resolve-args` / `resolve-decorators` | materialise effective args / decorator stack |
| `lifecycle-state` / `variant-frames` / `variant-frame?` | introspection helpers |
| `configure!` | seed `global-args` for the args-precedence chain |

`stage` advertises `:runtime` (was `:authoring` after Stage 2).

## Async return shape

Per IMPL-SPEC §3.2 + §13.2 — `run-variant` returns a **JS Promise** on CLJS, **CompletableFuture** on JVM. The abstraction lives in `re-frame.story.async` (no core.async, per the standing `no_core_async` directive).

## Lifecycle state machine

Uses `re-frame.machines` per the standing rule. Five states:

```
:pre-mount → :mounting → :loading → :ready
                              │
                              └────► :error
```

Per-variant snapshots live at `[:rf/machines :rf.story.lifecycle/machine]`; the discrete state is mirrored to `[:rf.story/lifecycle]` for direct read access.

`re-frame.story.machines` is now a Story dep (`tools/story/deps.edn`).

## Files added

- `tools/story/src/re_frame/story/args.cljc` (137 LoC)
- `tools/story/src/re_frame/story/async.cljc` (159)
- `tools/story/src/re_frame/story/decorators.cljc` (273)
- `tools/story/src/re_frame/story/frames.cljc` (211)
- `tools/story/src/re_frame/story/identity.cljc` (211)
- `tools/story/src/re_frame/story/loaders.cljc` (314)
- `tools/story/src/re_frame/story/runtime.cljc` (331)
- `tools/story/test/re_frame/story_runtime_test.clj` (491; 31 tests)
- `tools/story/test/re_frame/story_runtime_cljs_test.cljs` (128; 5 tests)

## Test plan

- [x] `cd tools/story && clojure -M:test` — 61 tests / 139 assertions / 0F / 0E
- [x] `cd implementation && npm run test:cljs` — 428 tests / 1029 assertions / 0F / 0E
- [x] `cd implementation && npm run test:elision` — PASS (production sentinels absent; control bundle confirms methodology has signal)
- [x] `python -m mkdocs build` — clean (pre-existing warnings only — identical to origin/main)

## Stage 3 does NOT do

- UI shell — Stage 4 (rf2-ekai)
- Play sequence + full assertion runtime — Stage 5 (rf2-h8et). Stage 3 leaves the `:loaders-complete-when` non-default forms (registered-event id, vector-of-event-vectors) routed through a Stage 5 hook — Stage 3 treats any non-nil predicate as 'complete on first evaluation' so the lifecycle still progresses
- Perf / a11y / design-tokens / 10x embed — Stage 6 (rf2-zhwd)
- MCP — Stage 7 (rf2-tgci)

## Stage 4 hooks left clear

- `variant-frames` / `variant-frame?` — UI shell's pane enumeration surface
- `watch-variant` — UI shell subscribes for lifecycle-transition rerender triggers
- `decorators/decorator-fingerprint` / `decorators/resolution-fingerprints` — hot-reload cache invalidation (Stage 4 wires the trigger; Stage 3 surfaces the diff)
- `run-variant` accepts `:render?` / `:assertions` slots — Stage 4 fills `:rendered-hiccup`; Stage 5 fills `:assertions`