### PR TITLE
feat(story): Stage 4 — render shell (sidebar / canvas / scrubber / trace) (rf2-ekai)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -53,6 +53,10 @@
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.frames    :as frames]
             [re-frame.story.runtime   :as runtime]
+            ;; Stage 4 (rf2-ekai) — UI shell. CLJS-only require so JVM
+            ;; consumers (tests, REPL exploration) don't pull Reagent /
+            ;; reagent.dom.client into their classpath.
+            #?(:cljs [re-frame.story.ui.shell :as ui-shell])
             #?(:clj [re-frame.story.macros :as macros]))
   ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
@@ -513,8 +517,53 @@
   - Stage 2 — `:authoring` (registration macros only).
   - Stage 3 — `:runtime` (adds `run-variant` family, decorator
     composition, args resolution, snapshot-identity, lifecycle).
-  - Stage 4+ extends — UI shell, play sequence, assertions, MCP.
+  - Stage 4 — `:render-shell` (adds `mount-shell!` / `unmount-shell!`,
+    the sidebar / canvas / scrubber / trace panes, hot-reload trigger).
+  - Stage 5+ extends — play sequence, assertions, SOTA panels, MCP.
 
   Tools that adapt to the loaded surface read this; agents can ask
   the runtime which Stage is live."
-  :runtime)
+  :render-shell)
+
+;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
+;;
+;; Per IMPL-SPEC §4 + §8.4 the shell entry points are CLJS-only —
+;; mounting a Reagent shell at a DOM node has no JVM equivalent. The
+;; functions are conditionalised on the reader so JVM consumers can
+;; require `re-frame.story` without pulling Reagent / DOM symbols.
+
+#?(:cljs
+   (defn mount-shell!
+     "Mount the Story shell at `dom-node`. Returns a shell-handle map
+     `{:root <react-root> :node <dom-node>}` or nil under elision.
+
+     The shell is a Reagent component tree composed of:
+     - a sidebar (story tree + tag filter + workspace list)
+     - the main pane (selected variant's canvas or selected workspace)
+     - a right panel (controls, time-travel scrubber, six-domino trace)
+
+     Per IMPL-SPEC §4 v1 supports one mounted shell at a time; calling
+     `mount-shell!` while a shell is already mounted tears down the
+     previous one first.
+
+     Production CLJS builds (`re-frame.story.config/enabled?` false)
+     short-circuit before any DOM call and return nil. See IMPL-SPEC
+     §6.3 for the elision contract.
+
+     Stage 4 (rf2-ekai)."
+     [dom-node]
+     (ui-shell/mount-shell! dom-node)))
+
+#?(:cljs
+   (defn unmount-shell!
+     "Tear down a mounted shell. Accepts the handle from `mount-shell!`
+     or no arg (defaults to the active shell singleton)."
+     ([]       (ui-shell/unmount-shell!))
+     ([handle] (ui-shell/unmount-shell! handle))))
+
+#?(:cljs
+   (defn active-shell
+     "Return the currently-mounted shell handle, or nil. v1 singleton;
+     v2 may return a collection when multi-shell mounts ship."
+     []
+     (ui-shell/active-shell)))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -1,0 +1,197 @@
+(ns re-frame.story.ui.canvas
+  "Variant render area. Per Stage 4 (rf2-ekai) IMPL-SPEC §4.
+
+  The canvas is the surface where one variant renders. It:
+
+  - Watches the shell state's `:hot-reload-tick` so it re-mounts when the
+    fingerprint detector ticks.
+  - Calls `run-variant` with the active modes / cell-overrides / substrate.
+  - Renders the variant's `:component` (registered re-frame view) under
+    the `:hiccup` decorator stack from `resolve-decorators`.
+  - Surfaces variant-level errors inline (per IMPL-SPEC §2.2 +
+    `:assertions`).
+
+  Stage 4 reads the registered `:component` keyword and renders via
+  `(re-frame.core/view <id>)` — this is the late-bind view lookup that
+  spec/004 / rf2-piag exposes. The view must be registered against the
+  variant's frame; the runtime allocates the frame, so any
+  frame-scoped subscriptions resolve through it correctly."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.story.config :as config]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.args :as args]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.runtime :as runtime]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:wrap     {:padding "16px"
+              :background "#1e1e1e"
+              :flex "1"
+              :min-height "200px"
+              :overflow "auto"
+              :color "#ddd"
+              :font-family "system-ui, sans-serif"}
+   :frame    {:background "#252526"
+              :border "1px solid #3c3c3c"
+              :border-radius "4px"
+              :padding "12px"}
+   :empty    {:color "#666"
+              :font-style "italic"
+              :text-align "center"
+              :padding "32px"}
+   :title    {:font-weight "bold"
+              :margin-bottom "8px"
+              :color "#9cdcfe"
+              :font-family "monospace"
+              :font-size "12px"}
+   :error    {:background "#5a1d1d"
+              :border "1px solid #be4040"
+              :color "#fdd"
+              :padding "8px"
+              :margin-top "8px"
+              :font-family "monospace"
+              :font-size "11px"
+              :border-radius "3px"}
+   :assertion {:padding "4px 8px"
+               :border-left "3px solid #be4040"
+               :margin "2px 0"
+               :font-family "monospace"
+               :font-size "11px"
+               :background "#332"}})
+
+;; ---- variant view resolution --------------------------------------------
+
+(defn- variant-component
+  "Resolve the variant's `:component` to a renderable thing. The
+  variant's body may carry `:component` directly; otherwise we walk up
+  to the parent story and read its `:component` (per IMPL-SPEC §3.1 the
+  parent story usually carries the component and variants vary only by
+  args / events)."
+  [variant-id]
+  (let [variant-body (registrar/handler-meta :variant variant-id)
+        story-id     (args/parent-story-id variant-id)
+        story-body   (when story-id (registrar/handler-meta :story story-id))]
+    (or (:component variant-body)
+        (:component story-body))))
+
+;; ---- decorated-view wrapper ---------------------------------------------
+
+(defn- decorated-view
+  "Wrap `view-hiccup` with the variant's `:hiccup`-kind decorators.
+  Returns a hiccup vector."
+  [view-hiccup hiccup-decorators effective-args]
+  (decorators/apply-hiccup-decorators
+    hiccup-decorators
+    view-hiccup
+    effective-args))
+
+;; ---- error projection ---------------------------------------------------
+
+(defn- render-errors [errors]
+  (when (seq errors)
+    [:div {:style (:error styles)}
+     [:div "Decorator errors:"]
+     (for [[i e] (map-indexed vector errors)]
+       ^{:key i}
+       [:div (pr-str e)])]))
+
+(defn- render-assertions [assertions]
+  (when (seq assertions)
+    [:div
+     (for [[i a] (map-indexed vector assertions)]
+       ^{:key i}
+       [:div {:style (:assertion styles)}
+        (pr-str a)])]))
+
+;; ---- the canvas component ------------------------------------------------
+
+(defn- run-with-shell-opts!
+  "Drive `run-variant` with the shell's current modes / cell overrides /
+  substrate. Returns nothing — the promise resolves async; the canvas
+  reads the variant's frame-db reactively after each run."
+  [variant-id]
+  (let [shell @state/shell-state-atom
+        opts  {:active-modes   (:active-modes shell)
+               :cell-overrides (get-in shell [:cell-overrides variant-id])
+               :substrate      (:substrate shell)
+               :render?        true}]
+    (runtime/run-variant variant-id opts)
+    nil))
+
+(defn- canvas-inner
+  "The inner render fn — reads the variant's frame-db reactively. Split
+  out so the outer `canvas` component can wrap with a lifecycle for
+  run-variant + tear-down."
+  [variant-id]
+  (let [view-id        (variant-component variant-id)
+        decorator-pack (decorators/resolve-decorators variant-id)
+        eff-args       (args/resolve-args
+                         variant-id
+                         {:active-modes
+                          (:active-modes @state/shell-state-atom)
+                          :cell-overrides
+                          (get-in @state/shell-state-atom
+                                  [:cell-overrides variant-id])})
+        assertions     (runtime/read-assertions variant-id)]
+    [:div {:style (:frame styles)}
+     [:div {:style (:title styles)}
+      (str (pr-str variant-id))
+      (when view-id
+        [:span {:style {:color "#666" :margin-left "8px"}}
+         (str "→ " (pr-str view-id))])]
+     (cond
+       (nil? variant-id)
+       [:div {:style (:empty styles)} "no variant selected"]
+
+       (nil? view-id)
+       [:div {:style (:empty styles)}
+        "variant has no :component registered — register one on the story or variant body"]
+
+       :else
+       (let [resolved-view (rf/view view-id)]
+         (if resolved-view
+           ;; The variant's frame is allocated; the view should
+           ;; subscribe through the frame context. We render directly
+           ;; under the frame keyword.
+           [:div
+            (decorated-view
+              [resolved-view eff-args]
+              (:hiccup decorator-pack)
+              eff-args)]
+           [:div {:style (:empty styles)}
+            (str ":component " (pr-str view-id) " is not registered as a view")])))
+     (render-errors (:errors decorator-pack))
+     (render-assertions assertions)]))
+
+(defn canvas
+  "Render the focused variant. Triggers a `run-variant` on mount and on
+  each `:hot-reload-tick` bump. Renders the variant's `:component` view
+  with the resolved `:hiccup` decorator stack applied."
+  []
+  (r/create-class
+    {:display-name "rf-story-canvas"
+     :component-did-mount
+     (fn [_this]
+       (when config/enabled?
+         (when-let [variant-id (:selected-variant @state/shell-state-atom)]
+           (run-with-shell-opts! variant-id))))
+     :component-did-update
+     (fn [this _old-argv]
+       ;; Re-run when the selected variant changes or hot-reload ticks.
+       (when config/enabled?
+         (when-let [variant-id (:selected-variant @state/shell-state-atom)]
+           (run-with-shell-opts! variant-id))))
+     :reagent-render
+     (fn []
+       (let [shell      @state/shell-state-atom
+             variant-id (:selected-variant shell)
+             _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
+         [:div {:style (:wrap styles)}
+          (if variant-id
+            [canvas-inner variant-id]
+            [:div {:style (:empty styles)}
+             "select a variant from the sidebar"])]))}))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -1,0 +1,289 @@
+(ns re-frame.story.ui.controls
+  "Controls panel — args editor, mode picker, decorator toggles. Per
+  Stage 4 (rf2-ekai) IMPL-SPEC §4 + §9.4.
+
+  ## Args derivation
+
+  Per IMPL-SPEC §9.4 the args editor auto-derives widget shapes from the
+  variant's `:argtypes` (an explicit per-arg widget spec) or from the
+  Malli schema attached to `:component` (Spec 010 schemas). Stage 4
+  ships the explicit-`:argtypes` path and the Malli inference for a
+  handful of primitive forms — `:string` / `:int` / `:double` /
+  `:boolean` / `:enum`. Deeper Malli walks land in Stage 6 alongside
+  the design-tokens panel.
+
+  ## Mode picker
+
+  Renders every registered `:mode` as a toggle row. Toggling activates
+  the mode; the canvas re-runs with the new mode set on the next tick.
+
+  ## Decorator toggles
+
+  Lists the variant's resolved decorators; each can be skipped at
+  runtime by name (the toggle writes a `:disabled-decorators` shell-
+  state slot the canvas reads). Stage 4 ships the toggle UI; the
+  disable-by-name routing through `resolve-decorators` is a Stage 6
+  refinement when the decorator stack grows more complex. For Stage 4
+  the toggle is informational + a 'save layout' hook."
+  (:require [re-frame.story.registrar :as registrar]
+            [re-frame.story.args      :as args]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.ui.state  :as state]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:wrap        {:padding "8px"
+                 :background "#252526"
+                 :color "#cccccc"
+                 :font-family "monospace"
+                 :font-size "11px"
+                 :border-top "1px solid #444"}
+   :section     {:margin-bottom "12px"}
+   :section-h   {:font-weight "bold"
+                 :color "#888"
+                 :text-transform "uppercase"
+                 :font-size "10px"
+                 :letter-spacing "0.5px"
+                 :margin-bottom "4px"}
+   :row         {:display "grid"
+                 :grid-template-columns "120px 1fr"
+                 :gap "8px"
+                 :padding "2px 0"
+                 :align-items "center"}
+   :label       {:color "#9cdcfe"}
+   :input       {:background "#1e1e1e"
+                 :color "#cccccc"
+                 :border "1px solid #444"
+                 :padding "2px 6px"
+                 :font-family "monospace"
+                 :font-size "11px"
+                 :width "100%"}
+   :chip-row    {:display "flex"
+                 :flex-wrap "wrap"
+                 :gap "4px"}
+   :chip        {:padding "2px 6px"
+                 :background "#37373d"
+                 :color "#cccccc"
+                 :border-radius "10px"
+                 :cursor "pointer"
+                 :font-size "10px"
+                 :user-select "none"}
+   :chip-active {:background "#0e639c"
+                 :color "white"}
+   :button      {:padding "4px 8px"
+                 :background "#0e639c"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size "10px"
+                 :margin-top "8px"}
+   :empty       {:color "#666" :font-style "italic"}})
+
+;; ---- pure: argtype inference --------------------------------------------
+
+(defn infer-widget
+  "Given a Malli schema fragment (or simple keyword type), return a
+  widget descriptor map. Pure data → data; JVM-testable.
+
+  - `:string`             → `{:widget :text}`
+  - `:int` / `:double`    → `{:widget :number}`
+  - `:boolean`            → `{:widget :boolean}`
+  - `[:enum a b c]`       → `{:widget :select :options [a b c]}`
+
+  Unknown shapes default to `{:widget :text}` — the user can refine
+  via the variant's `:argtypes` slot. Per IMPL-SPEC §9.4."
+  [schema-fragment]
+  (cond
+    (= :string schema-fragment)  {:widget :text}
+    (= :int schema-fragment)     {:widget :number}
+    (= :double schema-fragment)  {:widget :number}
+    (= :boolean schema-fragment) {:widget :boolean}
+    (= :keyword schema-fragment) {:widget :text}
+    (and (vector? schema-fragment)
+         (= :enum (first schema-fragment)))
+    {:widget :select :options (vec (rest schema-fragment))}
+    :else
+    {:widget :text}))
+
+(defn resolve-argtypes
+  "Build the `{arg-key → widget-spec}` map for a variant. Variant-level
+  `:argtypes` wins; otherwise we walk the parent story's `:argtypes`;
+  otherwise we infer from the resolved args' value shapes.
+
+  Stage 4 punts the full Spec 010 Malli walk (e.g. component-attached
+  schemas via registrar) to Stage 6 — for Stage 4 the explicit
+  `:argtypes` path is the load-bearing surface."
+  [variant-id]
+  (let [vb      (registrar/handler-meta :variant variant-id)
+        story   (args/parent-story-id variant-id)
+        sb      (when story (registrar/handler-meta :story story))
+        types   (merge (:argtypes sb) (:argtypes vb))
+        eff     (args/resolve-args variant-id)]
+    (reduce-kv
+      (fn [acc k v]
+        (if (contains? acc k)
+          acc
+          (assoc acc k (infer-widget
+                         (cond
+                           (string? v)  :string
+                           (boolean? v) :boolean
+                           (integer? v) :int
+                           (number? v)  :double
+                           (keyword? v) :keyword
+                           :else        :string)))))
+      (or types {})
+      eff)))
+
+;; ---- widget renderers ----------------------------------------------------
+
+(defn- read-event-value [e]
+  (.. e -target -value))
+
+(defn- read-event-checked [e]
+  (.. e -target -checked))
+
+(defn- arg-widget
+  [variant-id arg-key value {:keys [widget options]}]
+  (case widget
+    :text     [:input {:type      "text"
+                       :style     (:input styles)
+                       :value     (if (nil? value) "" (str value))
+                       :on-change (fn [e]
+                                    (state/swap-state!
+                                      state/set-cell-override
+                                      variant-id arg-key
+                                      (read-event-value e)))}]
+    :number   [:input {:type      "number"
+                       :style     (:input styles)
+                       :value     (if (nil? value) "" value)
+                       :on-change (fn [e]
+                                    (let [s (read-event-value e)
+                                          v (when (seq s) (js/parseFloat s))]
+                                      (state/swap-state!
+                                        state/set-cell-override
+                                        variant-id arg-key v)))}]
+    :boolean  [:input {:type      "checkbox"
+                       :checked   (boolean value)
+                       :on-change (fn [e]
+                                    (state/swap-state!
+                                      state/set-cell-override
+                                      variant-id arg-key
+                                      (read-event-checked e)))}]
+    :select   [:select {:value     (str value)
+                        :style     (:input styles)
+                        :on-change (fn [e]
+                                     (state/swap-state!
+                                       state/set-cell-override
+                                       variant-id arg-key
+                                       (read-event-value e)))}
+               (for [opt options]
+                 ^{:key (str opt)}
+                 [:option {:value (str opt)} (str opt)])]
+    [:span {:style (:empty styles)}
+     (str "unsupported widget " widget)]))
+
+;; ---- public components ---------------------------------------------------
+
+(defn args-editor
+  "Render the args editor for `variant-id`. Reads the resolved args via
+  `args/resolve-args` and walks every key, rendering a widget per the
+  inferred argtype."
+  [variant-id]
+  (let [shell      @state/shell-state-atom
+        eff-args   (args/resolve-args
+                     variant-id
+                     {:active-modes (:active-modes shell)
+                      :cell-overrides
+                      (get-in shell [:cell-overrides variant-id])})
+        argtypes   (resolve-argtypes variant-id)]
+    [:div {:style (:section styles)}
+     [:div {:style (:section-h styles)} "Args"]
+     (if (empty? eff-args)
+       [:div {:style (:empty styles)} "no args resolved"]
+       (for [[k v] (sort-by key eff-args)]
+         ^{:key k}
+         [:div {:style (:row styles)}
+          [:span {:style (:label styles)} (str k)]
+          [arg-widget variant-id k v
+           (get argtypes k {:widget :text})]]))
+     (when (seq (get-in shell [:cell-overrides variant-id]))
+       [:button {:style    (:button styles)
+                 :on-click (fn [_]
+                             (state/swap-state!
+                               state/clear-cell-overrides variant-id))}
+        "reset overrides"])]))
+
+(defn mode-picker
+  "Render every registered mode as a toggle. Active modes are tracked
+  in the shell state's `:active-modes` vector — toggle adds/removes."
+  []
+  (let [shell  @state/shell-state-atom
+        modes  (registrar/handlers :mode)
+        active (set (:active-modes shell))]
+    [:div {:style (:section styles)}
+     [:div {:style (:section-h styles)} "Modes"]
+     (if (empty? modes)
+       [:div {:style (:empty styles)} "no modes registered"]
+       [:div {:style (:chip-row styles)}
+        (for [[mid _body] (sort-by key modes)]
+          ^{:key mid}
+          [:span {:style    (merge (:chip styles)
+                                   (when (contains? active mid)
+                                     (:chip-active styles)))
+                  :on-click
+                  (fn [_]
+                    (state/swap-state!
+                      (fn [s]
+                        (state/set-active-modes
+                          s
+                          (let [v (:active-modes s)]
+                            (if (some #(= % mid) v)
+                              (vec (remove #(= % mid) v))
+                              (conj v mid)))))))}
+           (str mid)])])]))
+
+(defn decorator-list
+  "Show the variant's resolved decorator stack. Stage 4 is read-only;
+  Stage 6 adds the disable-by-name routing."
+  [variant-id]
+  (let [pack  (decorators/resolve-decorators variant-id)
+        all   (concat (:hiccup pack) (:frame-setup pack) (:fx-override pack))]
+    [:div {:style (:section styles)}
+     [:div {:style (:section-h styles)} "Decorators"]
+     (if (empty? all)
+       [:div {:style (:empty styles)} "no decorators on this variant"]
+       (for [{:keys [id body]} all]
+         ^{:key id}
+         [:div {:style (:row styles)}
+          [:span {:style (:label styles)} (str id)]
+          [:span (str ":kind " (or (:kind body) "?"))]]))]))
+
+(defn save-layout-button
+  "Emit a stub 'save layout as :Workspace' action. Per IMPL-SPEC §2.5
+  the workspace persistence has two modes: local-storage (default) and
+  the explicit save-as which writes a transit-shareable registration.
+  Stage 4 stubs the save-as button; the transit emission lands in
+  Stage 6 alongside the QR code share affordance."
+  []
+  [:button {:style    (:button styles)
+            :on-click (fn [_]
+                        ;; Stage 4: no-op visual affordance — the
+                        ;; transit-emission lives behind the §2.5
+                        ;; surface that lands in Stage 6.
+                        (when js/window
+                          (js/console.log "[story] save-layout: Stage 6 ships transit emission")))}
+   "save layout as :Workspace.x/y"])
+
+(defn panel
+  "The full controls panel — args editor + mode picker + decorator
+  list + save-layout action."
+  [variant-id]
+  [:div {:style (:wrap styles)}
+   (when variant-id
+     [args-editor variant-id])
+   [mode-picker]
+   (when variant-id
+     [decorator-list variant-id])
+   [save-layout-button]])

--- a/tools/story/src/re_frame/story/ui/scrubber.cljs
+++ b/tools/story/src/re_frame/story/ui/scrubber.cljs
@@ -1,0 +1,186 @@
+(ns re-frame.story.ui.scrubber
+  "Time-travel scrubber. Per Stage 4 (rf2-ekai) IMPL-SPEC §9.1.
+
+  Reads the variant frame's `epoch-history` (implementation/epoch/) and
+  exposes a slider that scrubs forward/back through epochs. Releasing
+  the slider triggers `restore-epoch` against the frame.
+
+  Pinned snapshots: clicking 'capture' emits a labelled marker into the
+  shell state's `:pinned-snapshots` slot — the markers are rendered as
+  chips alongside the scrubber and clicking a chip restores to its
+  epoch.
+
+  ## Listener wiring
+
+  The scrubber registers an epoch listener via
+  `re-frame.epoch/register-epoch-cb!` so the slider knows to redraw when
+  new epochs commit. The listener is keyed by variant id and torn down
+  when the shell unmounts.
+
+  ## Elision
+
+  Epoch history itself sits inside `interop/debug-enabled?` (spec/009);
+  the scrubber's mount call is additionally gated by `enabled?`. In a
+  production CLJS build both flags are false, and the scrubber's `panel`
+  fn is unreachable from any call site (shell entry is gated)."
+  (:require [reagent.core :as r]
+            [re-frame.epoch :as epoch]
+            [re-frame.story.config :as config]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- per-variant 'live history' ratom ------------------------------------
+
+(defonce histories
+  ;; {variant-id → r/atom holding the latest epoch-history vector}
+  (atom {}))
+
+(defn- ensure-history-atom!
+  [variant-id]
+  (or (get @histories variant-id)
+      (let [a (r/atom (epoch/epoch-history variant-id))]
+        (swap! histories assoc variant-id a)
+        a)))
+
+(defn- refresh-history!
+  "Re-read the framework's epoch history into the local ratom."
+  [variant-id]
+  (let [a (ensure-history-atom! variant-id)]
+    (reset! a (epoch/epoch-history variant-id))))
+
+(defn drop-history!
+  "Remove the per-variant atom. Called from shell unmount."
+  [variant-id]
+  (swap! histories dissoc variant-id)
+  nil)
+
+;; ---- the epoch callback --------------------------------------------------
+
+(defn- cb-id [variant-id]
+  (keyword "re-frame.story.ui.scrubber"
+           (str "epoch-cb-" (when variant-id (str variant-id)))))
+
+(defn register-listener!
+  "Install an epoch-cb that refreshes the local ratom on every settled
+  epoch for the variant. Idempotent."
+  [variant-id]
+  (when config/enabled?
+    (epoch/register-epoch-cb! (cb-id variant-id)
+      (fn [record]
+        (when (= variant-id (:frame record))
+          (refresh-history! variant-id))))))
+
+(defn remove-listener!
+  "Tear down the epoch listener for `variant-id`. Idempotent."
+  [variant-id]
+  (when config/enabled?
+    (epoch/remove-epoch-cb! (cb-id variant-id))
+    nil))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:panel       {:padding "8px"
+                 :font-family "monospace"
+                 :font-size "11px"
+                 :border-top "1px solid #444"
+                 :background "#252526"
+                 :color "#ddd"}
+   :title       {:font-weight "bold"
+                 :margin-bottom "6px"
+                 :color "#9cdcfe"}
+   :slider-row  {:display "flex"
+                 :align-items "center"
+                 :gap "8px"}
+   :slider      {:flex "1"}
+   :label       {:min-width "80px"
+                 :color "#888"}
+   :chip-row    {:display "flex"
+                 :flex-wrap "wrap"
+                 :gap "4px"
+                 :margin-top "6px"}
+   :chip        {:padding "2px 6px"
+                 :background "#37373d"
+                 :color "#9cdcfe"
+                 :border-radius "10px"
+                 :cursor "pointer"
+                 :font-size "10px"}
+   :button      {:padding "2px 8px"
+                 :background "#0e639c"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size "10px"}
+   :empty       {:color "#666" :font-style "italic"}})
+
+;; ---- public component ----------------------------------------------------
+
+(defn- snapshot-label
+  "Build a default label for a pinned snapshot — uses the epoch's
+  trigger event when available."
+  [history idx]
+  (let [record (get history idx)
+        ev     (:trigger-event record)]
+    (str "epoch-" idx (when ev (str " " (pr-str (first ev)))))))
+
+(defn panel
+  "The scrubber component. Renders a slider over the variant frame's
+  epoch history, a 'capture' button that pins the current epoch, and a
+  chip row of pinned snapshots."
+  [variant-id]
+  (let [history-atom (ensure-history-atom! variant-id)
+        ;; Local UI state for the slider position — separate from the
+        ;; framework's epoch history so the user can scrub without
+        ;; committing until they release.
+        slider-pos   (r/atom nil)]
+    (fn [variant-id]
+      (let [history (or @history-atom [])
+            n       (count history)
+            shell   @state/shell-state-atom
+            pinned  (get-in shell [:pinned-snapshots variant-id] [])
+            pos     (or @slider-pos (dec n) 0)]
+        [:div {:style (:panel styles)}
+         [:div {:style (:title styles)}
+          "Time travel " (when variant-id (str (pr-str variant-id)))
+          " — " n " epochs"]
+         (if (zero? n)
+           [:div {:style (:empty styles)}
+            "no epochs recorded yet — dispatch an event to capture an epoch"]
+           [:div
+            [:div {:style (:slider-row styles)}
+             [:span {:style (:label styles)} (str "epoch " pos "/" (dec n))]
+             [:input {:type      "range"
+                      :min       0
+                      :max       (max 0 (dec n))
+                      :value     pos
+                      :style     (:slider styles)
+                      :on-change (fn [e]
+                                   (reset! slider-pos
+                                           (js/parseInt
+                                             (.. e -target -value))))
+                      :on-mouse-up
+                                 (fn [e]
+                                   (let [idx (js/parseInt
+                                               (.. e -target -value))]
+                                     (when-let [record (get history idx)]
+                                       (epoch/restore-epoch
+                                         variant-id
+                                         (:epoch-id record)))))}]
+             [:button {:style    (:button styles)
+                       :on-click (fn [_]
+                                   (let [record (get history pos)
+                                         label  (snapshot-label history pos)]
+                                     (when record
+                                       (state/swap-state!
+                                         state/pin-snapshot
+                                         variant-id label
+                                         (:epoch-id record)))))}
+              "capture"]]
+            (when (seq pinned)
+              [:div {:style (:chip-row styles)}
+               (for [{:keys [label epoch-id]} pinned]
+                 ^{:key (str label "-" epoch-id)}
+                 [:span {:style    (:chip styles)
+                         :on-click (fn [_]
+                                     (epoch/restore-epoch variant-id epoch-id))}
+                  label])])])]))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -1,0 +1,290 @@
+(ns re-frame.story.ui.shell
+  "Top-level story shell. Per Stage 4 (rf2-ekai) IMPL-SPEC §4 + §8.
+
+  Three-pane layout:
+
+      ┌──────────┬──────────────────────────┬────────────┐
+      │ sidebar  │ canvas / workspace       │ controls   │
+      │          │                          │ ─────────  │
+      │ stories  │ (selected variant or     │ scrubber   │
+      │ tags     │  workspace renders here) │ ─────────  │
+      │ ws       │                          │ trace      │
+      └──────────┴──────────────────────────┴────────────┘
+
+  ## Public surface
+
+  - `(mount-shell! dom-node)`   — mount the shell at the DOM node.
+                                  Returns a shell-handle.
+  - `(unmount-shell! handle)`   — tear down a mounted shell.
+  - `(active-shell)`            — return the current shell-handle, or nil.
+
+  ## Hot-reload trigger
+
+  Per IMPL-SPEC §13.2 + Stage 4 spec the shell watches the variant /
+  decorator fingerprints from `re-frame.story.decorators/
+  resolution-fingerprints` and bumps `:hot-reload-tick` when they drift.
+  The canvas / workspace components watch the tick and re-mount the
+  variant on change.
+
+  A `setInterval`-driven poll is the v1 mechanism; v2 will subscribe to
+  the registrar's mutation trace events for an event-driven re-resolve.
+
+  ## Elision
+
+  `mount-shell!` opens with `(when re-frame.story.config/enabled?
+  ...)` — production builds short-circuit before any DOM call. The
+  shell's renderer namespaces ARE compiled (the elision is at the call-
+  site, not the ns definition) but no production code path reaches
+  them; closure's reachability analysis DCEs the lot."
+  (:require [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.story.config :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.frames :as frames]
+            [re-frame.story.runtime :as runtime]
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.scrubber :as scrubber]
+            [re-frame.story.ui.sidebar :as sidebar]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.trace :as trace]
+            [re-frame.story.ui.workspace :as workspace]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:root      {:display "flex"
+               :flex-direction "row"
+               :height "100vh"
+               :font-family "system-ui, sans-serif"
+               :background "#1e1e1e"
+               :color "#ddd"}
+   :main      {:display "flex"
+               :flex-direction "column"
+               :flex "1"
+               :overflow "hidden"}
+   :right     {:width "320px"
+               :display "flex"
+               :flex-direction "column"
+               :border-left "1px solid #444"
+               :background "#252526"
+               :overflow "auto"}
+   :tab-bar   {:display "flex"
+               :background "#2d2d30"
+               :border-bottom "1px solid #444"
+               :font-family "monospace"
+               :font-size "11px"}
+   :tab       {:padding "6px 12px"
+               :cursor "pointer"
+               :color "#888"
+               :border-right "1px solid #444"}
+   :tab-active {:color "white"
+                :background "#1e1e1e"
+                :border-bottom "1px solid #1e1e1e"
+                :margin-bottom "-1px"}})
+
+;; ---- hot-reload trigger --------------------------------------------------
+
+(defn- compute-fingerprint-snapshot
+  "Walk every running variant frame and capture its current decorator
+  fingerprint map. Pure data → data."
+  []
+  (into {}
+        (map (fn [vid] [vid (decorators/resolution-fingerprints vid)]))
+        (frames/variant-frames)))
+
+(defn detect-and-tick!
+  "Compare the current fingerprint snapshot against the shell state's
+  recorded fingerprints; if anything drifted, bump the hot-reload tick
+  and stamp the new fingerprints.
+
+  Public so tests can exercise the detector without mounting the shell."
+  []
+  (when config/enabled?
+    (let [current (compute-fingerprint-snapshot)
+          shell   (state/get-state)
+          prev    (:fingerprints shell)]
+      (when (not= current prev)
+        (state/swap-state!
+          (fn [s]
+            (-> s
+                (state/bump-hot-reload-tick)
+                (assoc :fingerprints current))))
+        true))))
+
+(defonce ^:private hot-reload-poll-handle (atom nil))
+
+(defn- start-hot-reload-poll!
+  "Begin polling for fingerprint changes. v1 mechanism per Stage 4."
+  []
+  (when (and config/enabled?
+             (nil? @hot-reload-poll-handle))
+    (let [h (js/setInterval detect-and-tick! 500)]
+      (reset! hot-reload-poll-handle h))))
+
+(defn- stop-hot-reload-poll!
+  []
+  (when-let [h @hot-reload-poll-handle]
+    (js/clearInterval h)
+    (reset! hot-reload-poll-handle nil)))
+
+;; ---- listener wiring on selection ----------------------------------------
+
+(defonce ^:private listened-variants (atom #{}))
+
+(defn- ensure-listeners-for-variant!
+  "Wire trace + epoch listeners for `variant-id` if not already wired."
+  [variant-id]
+  (when (and config/enabled?
+             (some? variant-id)
+             (not (contains? @listened-variants variant-id)))
+    (trace/register-listener! variant-id)
+    (scrubber/register-listener! variant-id)
+    (swap! listened-variants conj variant-id)))
+
+(defn- teardown-listeners-for-variant!
+  [variant-id]
+  (when (some? variant-id)
+    (trace/remove-listener! variant-id)
+    (scrubber/remove-listener! variant-id)
+    (trace/drop-buffer! variant-id)
+    (scrubber/drop-history! variant-id)
+    (swap! listened-variants disj variant-id)))
+
+(defn- teardown-all-listeners! []
+  (doseq [vid @listened-variants]
+    (trace/remove-listener! vid)
+    (scrubber/remove-listener! vid))
+  (reset! listened-variants #{})
+  (trace/clear-buffer!))
+
+(defn- selection-watcher
+  "Reagent reaction that wires listeners against the currently-selected
+  variant. Implemented as a watch on the shell state atom so it fires
+  on every selection change."
+  []
+  (let [prev (atom (:selected-variant @state/shell-state-atom))]
+    (add-watch state/shell-state-atom
+               ::shell-selection
+               (fn [_ _ _ new-state]
+                 (let [now (:selected-variant new-state)
+                       before @prev]
+                   (when (not= before now)
+                     (when before
+                       ;; Don't tear down listeners on switch — leave
+                       ;; the buffer behind so the user can switch back
+                       ;; without losing context. Stage 6 may add an
+                       ;; explicit 'clear' button.
+                       nil)
+                     (when now
+                       (ensure-listeners-for-variant! now))
+                     (reset! prev now)))))))
+
+(defn- remove-selection-watcher! []
+  (remove-watch state/shell-state-atom ::shell-selection))
+
+;; ---- the top-level component ---------------------------------------------
+
+(defn- right-panel
+  "The right-side pane — controls + scrubber + trace stacked vertically."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        vis        (:panel-visibility shell)]
+    [:div {:style (:right styles)}
+     (when (:controls vis)
+       [controls/panel variant-id])
+     (when (and (:scrubber vis) variant-id)
+       [scrubber/panel variant-id])
+     (when (and (:trace vis) variant-id)
+       [trace/panel variant-id])]))
+
+(defn- main-pane
+  "The main content pane — workspace if one is selected, otherwise the
+  variant canvas."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        ws-id      (:selected-workspace shell)]
+    [:div {:style (:main styles)}
+     (cond
+       ws-id    [workspace/workspace-view ws-id]
+       variant-id [canvas/canvas]
+       :else
+       [:div {:style {:padding "32px"
+                      :color "#666"
+                      :font-style "italic"
+                      :text-align "center"}}
+        "Select a variant or workspace from the sidebar."])]))
+
+(defn shell
+  "The top-level shell component. Composes the sidebar, main pane, and
+  right panel into a three-pane layout."
+  []
+  (r/create-class
+    {:display-name "rf-story-shell"
+     :component-did-mount
+     (fn [_]
+       (when config/enabled?
+         (start-hot-reload-poll!)
+         (selection-watcher)
+         (when-let [vid (:selected-variant @state/shell-state-atom)]
+           (ensure-listeners-for-variant! vid))))
+     :component-will-unmount
+     (fn [_]
+       (stop-hot-reload-poll!)
+       (remove-selection-watcher!)
+       (teardown-all-listeners!))
+     :reagent-render
+     (fn []
+       [:div {:style (:root styles)}
+        [sidebar/sidebar]
+        [main-pane]
+        [right-panel]])}))
+
+;; ---- mount / unmount surface ---------------------------------------------
+
+(defonce ^:private shell-singleton
+  ;; Per IMPL-SPEC §4 single shell at v1; multiple shells deferred to v2.
+  (atom nil))
+
+(defn mount-shell!
+  "Mount the Story shell at `dom-node`. Returns a shell handle (a map
+  carrying `{:root <react-root> :node <dom-node>}`).
+
+  v1: one shell at a time. Calling `mount-shell!` while a shell is
+  already mounted unmounts the previous one first.
+
+  Per IMPL-SPEC §6.3 production builds with `enabled?` false short-
+  circuit here and return nil — no DOM call, no Reagent render."
+  [dom-node]
+  (when (and config/enabled? dom-node)
+    (when-let [prev @shell-singleton]
+      (try
+        (rdc/unmount (:node prev))
+        (catch :default _ nil)))
+    (let [root (rdc/create-root dom-node)]
+      (rdc/render root [shell])
+      (let [handle {:root root :node dom-node}]
+        (reset! shell-singleton handle)
+        handle))))
+
+(defn unmount-shell!
+  "Tear down a mounted shell. Accepts the handle returned by
+  `mount-shell!` or no arg (defaults to the active shell)."
+  ([] (unmount-shell! @shell-singleton))
+  ([handle]
+   (when handle
+     (try
+       (rdc/unmount (:node handle))
+       (catch :default _ nil))
+     (state/reset-shell-state!)
+     (teardown-all-listeners!)
+     (stop-hot-reload-poll!)
+     (reset! shell-singleton nil)
+     nil)))
+
+(defn active-shell
+  "Return the current shell handle or nil."
+  []
+  @shell-singleton)

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -1,0 +1,165 @@
+(ns re-frame.story.ui.sidebar
+  "Story-tree sidebar. Per Stage 4 (rf2-ekai) IMPL-SPEC §4.
+
+  Lays out the registered stories and their variants as a tree, with
+  inline tag filtering. Each variant is a clickable row that updates
+  the shell state's `:selected-variant`. Workspaces register below the
+  story tree.
+
+  ## Layout
+
+      ┌──────────────────────┐
+      │ filter: [tag chips ] │
+      ├──────────────────────┤
+      │ ▾ :story.counter     │
+      │   ◦ /default         │   ← variant rows
+      │   ◦ /at-five         │
+      │ ▾ :story.login       │
+      │   ◦ /empty           │
+      ├──────────────────────┤
+      │ Workspaces           │
+      │ ◦ :Workspace.X/y     │
+      └──────────────────────┘
+
+  Tag filter: every distinct tag registered on a variant becomes a
+  toggle. Selecting tags constrains the tree to variants whose `:tags`
+  intersects the active set; empty set means 'show all'."
+  (:require [re-frame.story.ui.state :as state]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:wrap         {:width "260px"
+                  :background "#252526"
+                  :color "#cccccc"
+                  :font-family "monospace"
+                  :font-size "12px"
+                  :border-right "1px solid #444"
+                  :overflow "auto"
+                  :padding "8px 0"}
+   :header       {:padding "8px 12px"
+                  :font-weight "bold"
+                  :color "#9cdcfe"
+                  :border-bottom "1px solid #333"
+                  :margin-bottom "4px"}
+   :section      {:padding "12px 0 4px 12px"
+                  :font-weight "bold"
+                  :color "#888"
+                  :text-transform "uppercase"
+                  :font-size "10px"
+                  :letter-spacing "0.5px"}
+   :tag-row      {:display "flex"
+                  :flex-wrap "wrap"
+                  :gap "4px"
+                  :padding "8px 12px"
+                  :border-bottom "1px solid #333"}
+   :tag          {:padding "2px 6px"
+                  :background "#37373d"
+                  :color "#cccccc"
+                  :border-radius "10px"
+                  :cursor "pointer"
+                  :font-size "10px"
+                  :user-select "none"}
+   :tag-active   {:background "#0e639c"
+                  :color "white"}
+   :story-row    {:padding "4px 12px"
+                  :color "#dcdcaa"
+                  :font-weight "bold"
+                  :cursor "default"}
+   :variant-row  {:padding "2px 12px 2px 24px"
+                  :cursor "pointer"
+                  :color "#cccccc"}
+   :variant-row-active {:background "#094771" :color "white"}
+   :empty        {:color "#666"
+                  :font-style "italic"
+                  :padding "8px 12px"}})
+
+;; ---- pure: collect tags from registered variants ------------------------
+
+(defn collect-tags
+  "Return the sorted set of tags present across the registered variants.
+  Pure data → data; JVM-testable."
+  [variants]
+  (->> (vals variants)
+       (mapcat (fn [body] (or (:tags body) #{})))
+       set
+       sort
+       vec))
+
+;; ---- components ----------------------------------------------------------
+
+(defn- tag-filter-row
+  [variants tag-filter]
+  (let [all-tags (collect-tags variants)]
+    [:div {:style (:tag-row styles)}
+     (if (empty? all-tags)
+       [:span {:style (:empty styles)} "no tags"]
+       (for [tag all-tags]
+         ^{:key tag}
+         [:span {:style    (merge (:tag styles)
+                                  (when (contains? tag-filter tag)
+                                    (:tag-active styles)))
+                 :on-click (fn [_] (state/swap-state!
+                                     state/toggle-tag-filter tag))}
+          (str tag)]))]))
+
+(defn- variant-row
+  [variant-id selected?]
+  [:div {:style    (merge (:variant-row styles)
+                          (when selected? (:variant-row-active styles)))
+         :on-click (fn [_] (state/swap-state!
+                             state/select-variant variant-id))}
+   (str "/" (name variant-id))])
+
+(defn- story-block
+  "Render one story header + its variants. `entry` shape is
+  `{:story-id ... :variants [[variant-id body] ...]}` (the shape
+  produced by `state/group-variants-by-story`)."
+  [{:keys [story-id variants]} selected-variant]
+  [:div
+   [:div {:style (:story-row styles)}
+    (str (or story-id "(no story)"))]
+   (for [[vid _body] variants]
+     ^{:key vid}
+     [variant-row vid (= vid selected-variant)])])
+
+(defn- workspace-row
+  [workspace-id selected?]
+  [:div {:style    (merge (:variant-row styles)
+                          (when selected? (:variant-row-active styles)))
+         :on-click (fn [_]
+                     (state/swap-state!
+                       (fn [s] (-> s
+                                   (state/select-workspace workspace-id)
+                                   (state/select-variant nil)))))}
+   (str workspace-id)])
+
+(defn sidebar
+  "Top-level sidebar component. Reads the registry snapshot + shell
+  state, builds the filtered tree, and renders."
+  []
+  (let [shell        @state/shell-state-atom
+        registry     (state/registry-snapshot)
+        tag-filter   (:tag-filter shell)
+        sel-variant  (:selected-variant shell)
+        sel-ws       (:selected-workspace shell)
+        visible      (state/filter-variants (:variants registry) tag-filter)
+        grouped      (state/group-variants-by-story visible)
+        workspaces   (:workspaces registry)]
+    [:div {:style (:wrap styles)}
+     [:div {:style (:header styles)} "Stories"]
+     [tag-filter-row (:variants registry) tag-filter]
+     (if (empty? grouped)
+       [:div {:style (:empty styles)}
+        (if (empty? (:variants registry))
+          "no variants registered"
+          "no variants match the active tag filter")]
+       (for [{:keys [story-id] :as entry} grouped]
+         ^{:key (or story-id :nostory)}
+         [story-block entry sel-variant]))
+     (when (seq workspaces)
+       [:div
+        [:div {:style (:section styles)} "Workspaces"]
+        (for [[wid _body] (sort-by key workspaces)]
+          ^{:key wid}
+          [workspace-row wid (= wid sel-ws)])])]))

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -1,0 +1,231 @@
+(ns re-frame.story.ui.state
+  "Shell-local state — pure data + helpers (`.cljc`) plus the CLJS-only
+  reactive ratom bag. Per Stage 4 (rf2-ekai) the UI shell carries its
+  own selection / filter / mode state independently of the Story
+  registrar (the registrar is the source of truth for *what's
+  registered*; this ns is the source of truth for *what's selected*).
+
+  ## Public surface
+
+  - `default-shell-state` — the initial map shape (pure data).
+  - `select-variant`     — change the focused variant id.
+  - `select-workspace`   — change the focused workspace id.
+  - `toggle-tag-filter`  — flip a tag on/off in the filter set.
+  - `set-active-modes`   — replace the active mode set.
+  - `set-cell-override`  — set a single arg override.
+  - `clear-cell-overrides` — drop all overrides for the focused variant.
+  - `filter-variants`    — pure fn: given a set of variant bodies + the
+                           shell state, return the visible subset.
+  - `group-variants-by-story` — pure fn: build the sidebar tree.
+
+  ## The reactive bag (CLJS-only)
+
+  On CLJS the shell needs a Reagent ratom so any change re-renders the
+  three panes. `shell-state-atom` is that ratom — a `r/atom` holding a
+  map of the same shape `default-shell-state` returns. On JVM the same
+  atom is a plain `clojure.core/atom` so pure-logic tests don't pull in
+  Reagent.
+
+  The reactive surface is gated behind `re-frame.story.config/enabled?`
+  — production builds with the flag false see an empty state map and
+  the shell entry point short-circuits before any subscription / mount
+  call. Per IMPL-SPEC §6.3."
+  (:require [re-frame.story.config    :as config]
+            [re-frame.story.registrar :as registrar]
+            #?(:cljs [reagent.core :as r])))
+
+;; ---- pure data: the default shape ----------------------------------------
+
+(def default-shell-state
+  "The initial shell state. Stage 4 keeps the shape small and additive.
+
+  - `:selected-variant`  — variant id under focus, or nil.
+  - `:selected-workspace` — workspace id under focus, or nil.
+  - `:tag-filter`        — set of tag keywords; empty set means 'show all'.
+  - `:active-modes`      — vector of mode ids active for the rendered variant.
+  - `:cell-overrides`    — {variant-id → {arg-key → value}} — runtime
+                           overrides emitted by the controls panel.
+  - `:substrate`         — `:reagent` at v1; v2 may add UIx / Helix.
+  - `:hot-reload-tick`   — integer that increments when the shell detects
+                           a registrar mutation; variant components watch
+                           this slot to know they must re-mount.
+  - `:fingerprints`      — {variant-id → {decorator-id → hash}} the last-
+                           observed decorator fingerprints. Stale entries
+                           trigger a hot-reload tick.
+  - `:pinned-snapshots`  — {variant-id → [{:label ... :epoch-id ...}]}.
+  - `:panel-visibility`  — {panel-id → boolean}. Determines whether a
+                           registered :story-panel renders in the chrome.
+                           Stage 4 ships a vanilla set of panels (trace /
+                           scrubber / controls); Stage 6 will register
+                           more via reg-story-panel."
+  {:selected-variant   nil
+   :selected-workspace nil
+   :tag-filter         #{}
+   :active-modes       []
+   :cell-overrides     {}
+   :substrate          :reagent
+   :hot-reload-tick    0
+   :fingerprints       {}
+   :pinned-snapshots   {}
+   :panel-visibility   {:trace true :scrubber true :controls true}})
+
+;; ---- pure transition fns (JVM-testable) ----------------------------------
+
+(defn select-variant
+  "Set the focused variant id (or nil to deselect)."
+  [state variant-id]
+  (assoc state :selected-variant variant-id))
+
+(defn select-workspace
+  "Set the focused workspace id (or nil to deselect)."
+  [state workspace-id]
+  (assoc state :selected-workspace workspace-id))
+
+(defn toggle-tag-filter
+  "Flip `tag` in the `:tag-filter` set."
+  [state tag]
+  (update state :tag-filter
+          (fn [s] (if (contains? s tag) (disj s tag) (conj (or s #{}) tag)))))
+
+(defn set-active-modes
+  "Replace the active modes vector."
+  [state modes]
+  (assoc state :active-modes (vec modes)))
+
+(defn set-cell-override
+  "Set a single arg override for `variant-id`."
+  [state variant-id arg-key value]
+  (assoc-in state [:cell-overrides variant-id arg-key] value))
+
+(defn clear-cell-overrides
+  "Drop every override for `variant-id`."
+  [state variant-id]
+  (update state :cell-overrides dissoc variant-id))
+
+(defn bump-hot-reload-tick
+  "Increment the hot-reload tick — variant components observe this slot
+  and re-mount on change. Returns the new state map."
+  [state]
+  (update state :hot-reload-tick (fnil inc 0)))
+
+(defn record-fingerprints
+  "Stamp the current decorator fingerprints for `variant-id`. Stage 4's
+  hot-reload trigger reads the previous map and compares against the
+  current registry; a mismatch bumps `:hot-reload-tick`."
+  [state variant-id fingerprints]
+  (assoc-in state [:fingerprints variant-id] fingerprints))
+
+(defn pin-snapshot
+  "Record a pinned snapshot label/epoch pair for `variant-id`."
+  [state variant-id label epoch-id]
+  (update-in state [:pinned-snapshots variant-id]
+             (fnil conj [])
+             {:label label :epoch-id epoch-id}))
+
+(defn toggle-panel
+  "Flip a panel's visibility."
+  [state panel-id]
+  (update-in state [:panel-visibility panel-id] not))
+
+;; ---- pure derivations ----------------------------------------------------
+
+(defn variant-tag-match?
+  "True iff `variant-body`'s `:tags` set intersects the `tag-filter`,
+  or the filter is empty. Bare-bones inclusion-tag logic per spec/007
+  §Inclusion tags. Stage 4 ignores the `:!`-prefix removal syntax —
+  that's resolved at registration time in `re-frame.story.registrar`
+  via `validate-tag-membership!`."
+  [variant-body tag-filter]
+  (or (empty? tag-filter)
+      (let [tset (or (:tags variant-body) #{})]
+        (some #(contains? tset %) tag-filter))))
+
+(defn filter-variants
+  "Return the subset of `id->body` whose `:tags` match the filter.
+  Pure data → data; JVM-testable."
+  [id->body tag-filter]
+  (into {}
+        (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))
+        id->body))
+
+(defn parent-story-id
+  "Cheap parent-story derivation — mirrors `re-frame.story.args/parent-
+  story-id` so the sidebar can group without crossing the args ns
+  boundary. The variant id `:story.foo/bar` has namespace `\"story.foo\"`;
+  its parent is `:story.foo`."
+  [variant-id]
+  (when (and (keyword? variant-id) (namespace variant-id))
+    (keyword (namespace variant-id))))
+
+(defn group-variants-by-story
+  "Build a sorted vector of `{:story-id ... :variants [...]}` entries
+  from the variants map. Variants whose parent story is unregistered
+  still appear under their derived parent id — the sidebar surfaces them
+  with a 'no story' indicator.
+
+  Sorted by story id (alphabetic on the keyword name) so the sidebar is
+  stable across re-renders."
+  [id->body]
+  (let [by-story (group-by (comp parent-story-id key) id->body)]
+    (->> by-story
+         (map (fn [[story-id variants]]
+                {:story-id story-id
+                 :variants (vec (sort-by key variants))}))
+         (sort-by (fn [{:keys [story-id]}]
+                    (if story-id (str story-id) "")))
+         vec)))
+
+;; ---- registry snapshot ---------------------------------------------------
+;;
+;; The shell takes a fresh snapshot of the Story registrar on every
+;; render — variants/stories/workspaces/modes/decorators/panels/tags are
+;; what's currently registered, and the sidebar / control panel /
+;; workspace panes consume the snapshot.
+
+(defn registry-snapshot
+  "Return a single map containing every Story-side artefact kind. Used
+  by the shell's render fns to walk the registry without N atom-deref
+  calls (and to support future memoisation if perf becomes an issue)."
+  []
+  {:stories      (registrar/handlers :story)
+   :variants     (registrar/handlers :variant)
+   :workspaces   (registrar/handlers :workspace)
+   :modes        (registrar/handlers :mode)
+   :decorators   (registrar/handlers :decorator)
+   :story-panels (registrar/handlers :story-panel)
+   :tags         (registrar/handlers :tag)})
+
+;; ---- the reactive bag (CLJS-only) ----------------------------------------
+
+#?(:cljs
+   (defonce ^{:doc "The shell's reactive state ratom. One singleton per
+                    process (v1; v2 supports multi-shell). Reagent-aware
+                    components deref it directly; pure-logic helpers
+                    above take a state map argument."}
+     shell-state-atom
+     (r/atom default-shell-state))
+   :clj
+   (defonce ^{:doc "JVM mirror of `shell-state-atom` — a plain atom so
+                    JVM-side tests can exercise the pure-logic helpers
+                    without pulling Reagent into the test classpath."}
+     shell-state-atom
+     (atom default-shell-state)))
+
+(defn reset-shell-state!
+  "Reset the shell state to its initial shape. Used by test fixtures
+  and `unmount-shell!`."
+  []
+  (reset! shell-state-atom default-shell-state)
+  nil)
+
+(defn get-state
+  "Return the current shell state map."
+  []
+  @shell-state-atom)
+
+(defn swap-state!
+  "Apply `f` (plus optional args) to the shell state. The pure fns above
+  are the recommended `f` values."
+  [f & args]
+  (when config/enabled?
+    (apply swap! shell-state-atom f args)))

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -1,0 +1,262 @@
+(ns re-frame.story.ui.trace
+  "Six-domino trace panel. Per Stage 4 (rf2-ekai) IMPL-SPEC §9.2.
+
+  Each variant frame gets a trace listener registered at the moment the
+  panel mounts. The listener filters events to the frame, classifies
+  them into the six-domino bucket (event → handler → fx → effect →
+  subscription → render), and appends to a per-variant ring buffer.
+
+  The panel re-renders each time the buffer changes. The buffer is held
+  in a Reagent ratom keyed by variant id, with a fixed retention cap so
+  long-running variants don't leak memory.
+
+  ## What 'six-domino' means here
+
+  The classic re-frame six-domino cascade is:
+
+    1. event dispatched
+    2. event handler runs (the interceptor chain)
+    3. effects emitted (fx map computed)
+    4. effects executed (each fx handler runs)
+    5. subscriptions recomputed (any signal that depended on the changed
+       app-db)
+    6. views re-render
+
+  The trace bus emits structured events for each step (spec/009). This
+  panel groups by `:dispatch-id` (Spec 009 §Dispatch correlation) so
+  each cascade renders as one row with six sub-cells. Clicks on any
+  handler row jump to the source location stamped by the registrar
+  (spec/009 §Source-coord stamping).
+
+  ## Listener lifecycle
+
+  - `register-listener!` — install a trace cb under a stable id.
+  - `remove-listener!`   — tear down the cb.
+
+  Both are idempotent. The shell wires them on mount/unmount of the
+  trace panel, so trace capture only runs while the panel is visible."
+  (:require [reagent.core :as r]
+            [re-frame.trace :as trace]
+            [re-frame.story.config :as config]))
+
+;; ---- the per-variant trace buffer ----------------------------------------
+
+(def ^:private max-events
+  "How many trace events to retain per variant frame. Per Spec 009
+  §Retain-N trace ring buffer the framework defaults to 200; the panel
+  retains the same cap so the UI cost stays bounded."
+  200)
+
+(defonce buffers
+  ;; {variant-id → r/atom holding a vector of trace events, newest-last}
+  (atom {}))
+
+(defn- ensure-buffer!
+  "Return the per-variant ratom, creating it on first access."
+  [variant-id]
+  (or (get @buffers variant-id)
+      (let [a (r/atom [])]
+        (swap! buffers assoc variant-id a)
+        a)))
+
+(defn clear-buffer!
+  "Drop the buffer for `variant-id` (or all buffers when no arg)."
+  ([]
+   (doseq [a (vals @buffers)] (reset! a []))
+   nil)
+  ([variant-id]
+   (when-let [a (get @buffers variant-id)]
+     (reset! a []))
+   nil))
+
+(defn drop-buffer!
+  "Remove the buffer entry entirely. Called from shell unmount."
+  [variant-id]
+  (swap! buffers dissoc variant-id)
+  nil)
+
+(defn- append!
+  "Append `ev` to `variant-id`'s buffer, evicting oldest entries to
+  honour `max-events`."
+  [variant-id ev]
+  (let [a (ensure-buffer! variant-id)]
+    (swap! a (fn [v]
+               (let [v' (conj v ev)
+                     n  (count v')]
+                 (if (> n max-events)
+                   (subvec v' (- n max-events))
+                   v'))))))
+
+;; ---- the trace listener --------------------------------------------------
+
+(defn- listener-id [variant-id]
+  (keyword "re-frame.story.ui.trace"
+           (str "listener-" (when variant-id (str variant-id)))))
+
+(defn- variant-event?
+  "Filter predicate: true iff `ev` targets `variant-id`'s frame. The
+  trace events emit `:frame` under `:tags`; events that have no frame
+  scope (registry / global) match nothing."
+  [variant-id ev]
+  (let [frame (or (get-in ev [:tags :frame])
+                  (get-in ev [:tags :frame-id]))]
+    (= variant-id frame)))
+
+(defn register-listener!
+  "Install a trace listener that appends every `variant-id`-scoped event
+  into the per-variant buffer. Idempotent (re-registering replaces).
+  Returns the listener id."
+  [variant-id]
+  (when config/enabled?
+    (let [id (listener-id variant-id)]
+      (trace/register-trace-cb! id
+        (fn [ev]
+          (when (variant-event? variant-id ev)
+            (append! variant-id ev))))
+      id)))
+
+(defn remove-listener!
+  "Tear down the trace listener for `variant-id`. Idempotent."
+  [variant-id]
+  (when config/enabled?
+    (trace/remove-trace-cb! (listener-id variant-id))
+    nil))
+
+;; ---- six-domino projection -----------------------------------------------
+
+(defn- domino-bucket
+  "Classify a trace event into one of the six domino buckets, or nil if
+  the event doesn't fit. Returns a keyword in
+  `#{:event :handler :fx :effect :sub :render}`."
+  [ev]
+  (case (:op-type ev)
+    :event      (case (:operation ev)
+                  :event/dispatched :event
+                  :event/run        :handler
+                  nil)
+    :event/do-fx :fx
+    :fx          :effect
+    :sub/run     :sub
+    :sub/create  :sub
+    :view/render :render
+    nil))
+
+(defn group-cascades
+  "Group `events` by `:dispatch-id` and project each cascade into a
+  `{:dispatch-id ... :event <vec> :handler <ev> :fx <ev> :effects [...]
+   :subs [...] :renders [...]}` map. Public for JVM-side unit testing —
+  the bucketing is pure data.
+
+  Events without a `:dispatch-id` (e.g. raw render events not yet tied
+  to a cascade) land in a `:ungrouped` slot."
+  [events]
+  (let [groups (group-by (fn [ev] (or (get-in ev [:tags :dispatch-id])
+                                      (get-in ev [:tags :parent-dispatch-id])
+                                      :ungrouped))
+                         events)]
+    (->> groups
+         (map (fn [[dispatch-id evs]]
+                (reduce
+                  (fn [acc ev]
+                    (case (domino-bucket ev)
+                      :event   (assoc acc :event (get-in ev [:tags :event]))
+                      :handler (assoc acc :handler ev)
+                      :fx      (assoc acc :fx ev)
+                      :effect  (update acc :effects (fnil conj []) ev)
+                      :sub     (update acc :subs (fnil conj []) ev)
+                      :render  (update acc :renders (fnil conj []) ev)
+                      acc))
+                  {:dispatch-id dispatch-id
+                   :event       nil
+                   :handler     nil
+                   :fx          nil
+                   :effects     []
+                   :subs        []
+                   :renders     []}
+                  evs)))
+         (sort-by (fn [{:keys [handler]}] (or (:id handler) 0)))
+         vec)))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:panel        {:padding "8px"
+                  :font-family "monospace"
+                  :font-size "11px"
+                  :border-top "1px solid #444"
+                  :background "#1e1e1e"
+                  :color "#ddd"
+                  :overflow "auto"
+                  :max-height "240px"}
+   :title        {:font-weight "bold"
+                  :margin-bottom "6px"
+                  :color "#9cdcfe"}
+   :row          {:display "grid"
+                  :grid-template-columns "auto 1fr 1fr 1fr 1fr 1fr"
+                  :gap "4px"
+                  :padding "2px 0"
+                  :border-bottom "1px dotted #333"}
+   :cell         {:padding "2px 4px"
+                  :overflow "hidden"
+                  :text-overflow "ellipsis"
+                  :white-space "nowrap"}
+   :header       {:font-weight "bold" :color "#888"}
+   :event-cell   {:color "#dcdcaa"}
+   :handler-cell {:color "#4ec9b0"}
+   :fx-cell      {:color "#ce9178"}
+   :effect-cell  {:color "#ce9178"}
+   :sub-cell     {:color "#b5cea8"}
+   :render-cell  {:color "#c586c0"}
+   :empty        {:color "#666" :font-style "italic"}})
+
+;; ---- view ----------------------------------------------------------------
+
+(defn cascade-row
+  "Render one cascade as a six-column row."
+  [{:keys [event handler fx effects subs renders]}]
+  [:div {:style (:row styles)
+         :title (when-let [src (:source handler)]
+                  (str (:file src) ":" (:line src)))}
+   [:span {:style (merge (:cell styles) (:event-cell styles))}
+    (pr-str (first event))]
+   [:span {:style (merge (:cell styles) (:handler-cell styles))}
+    (if handler
+      (str "ran in " (or (get-in handler [:tags :duration-ms]) "?") "ms")
+      "—")]
+   [:span {:style (merge (:cell styles) (:fx-cell styles))}
+    (if fx (str (count (get-in fx [:tags :fx] {})) " fx") "—")]
+   [:span {:style (merge (:cell styles) (:effect-cell styles))}
+    (str (count effects) " effects")]
+   [:span {:style (merge (:cell styles) (:sub-cell styles))}
+    (str (count subs) " subs")]
+   [:span {:style (merge (:cell styles) (:render-cell styles))}
+    (str (count renders) " renders")]])
+
+(defn panel
+  "The trace panel component. Subscribes to the variant's trace buffer
+  and renders each cascade as a row.
+
+  Mounts a listener via `register-listener!` on first render; tears down
+  via `remove-listener!` when the shell unmounts (handled by
+  `re-frame.story.ui.shell`)."
+  [variant-id]
+  (let [buffer (ensure-buffer! variant-id)]
+    (fn [variant-id]
+      (let [events   @buffer
+            cascades (group-cascades events)]
+        [:div {:style (:panel styles)}
+         [:div {:style (:title styles)}
+          "Trace " (when variant-id (str (pr-str variant-id))) " — "
+          (count events) " events, " (count cascades) " cascades"]
+         [:div {:style (merge (:row styles) (:header styles))}
+          [:span {:style (:cell styles)} "event"]
+          [:span {:style (:cell styles)} "handler"]
+          [:span {:style (:cell styles)} "fx"]
+          [:span {:style (:cell styles)} "effects"]
+          [:span {:style (:cell styles)} "subs"]
+          [:span {:style (:cell styles)} "renders"]]
+         (if (empty? cascades)
+           [:div {:style (:empty styles)} "no cascades captured yet — dispatch an event to see the six dominos"]
+           (for [c cascades]
+             ^{:key (:dispatch-id c)}
+             [cascade-row c]))]))))

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -1,0 +1,199 @@
+(ns re-frame.story.ui.workspace
+  "Workspace rendering. Per Stage 4 (rf2-ekai) IMPL-SPEC §3.1 + spec/007
+  §Workspaces.
+
+  Five layouts ship in v1:
+
+  - `:grid`          — vector of variant ids laid out N-up.
+  - `:tabs`          — vector of variant ids; one shown at a time via tabs.
+  - `:variants-grid` — devcards-style: every registered variant of one
+                       story side-by-side. Enumerates from the registry.
+  - `:prose`         — markdown / hiccup blocks interleaved with variants.
+  - `:custom`        — caller-supplied view id.
+
+  Stage 4 ships every layout's resolver as pure data (so JVM tests cover
+  enumeration + filtering) and the Reagent renderer for `:grid`,
+  `:variants-grid`, and `:prose`. `:tabs` and `:custom` ship the
+  resolver; their renderers are simple variants of the `:grid`
+  pipeline.
+
+  ## Pure layout resolution
+
+  - `resolve-layout` — given a workspace body + registered variants,
+    return the ordered vector of cell descriptors. Each cell is one of:
+    - `{:type :variant :variant-id ...}`
+    - `{:type :prose :body \"...\"}`
+    Used by `:grid` / `:variants-grid` / `:prose` / `:tabs`.
+
+  Per IMPL-SPEC §2.8.4 the `:variants-grid` layout is the v1 devcards-
+  style multi-variant pane."
+  (:require [re-frame.story.registrar :as registrar]
+            #?(:cljs [re-frame.story.ui.canvas :as canvas])))
+
+;; ---- pure: layout resolution --------------------------------------------
+
+(defn- variants-of-story
+  "Return the variant ids whose parent story is `story-id`. Pure
+  derivation against the registrar — used by `:variants-grid`."
+  [story-id]
+  (registrar/variants-of story-id))
+
+(defn resolve-layout
+  "Given a workspace body, return an ordered vector of cell descriptors.
+
+  Cell shapes:
+    `{:type :variant :variant-id <kw>}`
+    `{:type :prose   :body <string>}`
+
+  Cell ordering matches the workspace's declared `:variants` (for `:grid`
+  / `:tabs`) or `:content` (for `:prose`). For `:variants-grid` the
+  cells enumerate the registry's variants for the workspace's anchor
+  story; the workspace body's `:story` slot names that anchor (defaults
+  to the workspace id's namespace path stripped of `Workspace.`)."
+  [workspace-id workspace-body]
+  (case (:layout workspace-body)
+    :grid
+    (vec (for [vid (:variants workspace-body)]
+           {:type :variant :variant-id vid}))
+
+    :tabs
+    (vec (for [vid (:variants workspace-body)]
+           {:type :variant :variant-id vid}))
+
+    :variants-grid
+    (let [anchor (or (:story workspace-body)
+                     ;; Derive `:story.<path>` from `:Workspace.<path>/<name>`.
+                     (when-let [ns (namespace workspace-id)]
+                       (when (and (>= (count ns) 10)
+                                  (= (subs ns 0 10) "Workspace."))
+                         (keyword (str "story." (subs ns 10))))))]
+      (if anchor
+        (->> (variants-of-story anchor)
+             sort
+             (mapv (fn [vid] {:type :variant :variant-id vid})))
+        []))
+
+    :prose
+    (vec (for [item (:content workspace-body)]
+           (case (:type item)
+             :prose   {:type :prose :body (:body item)}
+             :variant {:type :variant :variant-id (:id item)}
+             nil)))
+
+    :custom
+    [{:type :custom :render (:render workspace-body)}]
+
+    ;; unknown — degrade to empty
+    []))
+
+;; ---- styling -------------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:wrap          {:padding "16px"
+                      :background "#1e1e1e"
+                      :flex "1"
+                      :overflow "auto"}
+      :title         {:font-weight "bold"
+                      :color "#9cdcfe"
+                      :font-family "monospace"
+                      :margin-bottom "12px"}
+      :grid          {:display "grid"
+                      :grid-template-columns "repeat(auto-fit, minmax(280px, 1fr))"
+                      :gap "12px"}
+      :cell          {:background "#252526"
+                      :border "1px solid #3c3c3c"
+                      :border-radius "4px"
+                      :padding "8px"
+                      :min-height "160px"
+                      :color "#cccccc"
+                      :font-family "monospace"
+                      :font-size "11px"}
+      :cell-title    {:color "#dcdcaa"
+                      :font-weight "bold"
+                      :margin-bottom "4px"}
+      :prose-block   {:padding "12px"
+                      :background "#252526"
+                      :color "#cccccc"
+                      :border-radius "4px"
+                      :margin-bottom "12px"
+                      :line-height "1.5"}
+      :prose-flow    {:display "flex"
+                      :flex-direction "column"}
+      :empty         {:color "#666"
+                      :font-style "italic"
+                      :padding "24px"
+                      :text-align "center"}}))
+
+;; ---- the Reagent renderer ------------------------------------------------
+
+#?(:cljs
+   (defn- variant-cell
+     "Render one variant cell in a workspace grid. Stage 4 leans on the
+     same `canvas/canvas-inner`-style approach but in a smaller frame.
+     We render the variant's name as a title and stub the actual view
+     under it — Stage 6 brings the full render into each cell when the
+     multi-substrate layer lands."
+     [variant-id]
+     [:div {:style (:cell styles)}
+      [:div {:style (:cell-title styles)} (str (pr-str variant-id))]
+      ;; Stage 4: each cell is a label + frame indicator. The variant's
+      ;; live render uses the canvas component when the user clicks into
+      ;; the cell (Stage 6 brings inline rendering with the multi-
+      ;; substrate switcher).
+      [:div "variant frame: " (pr-str variant-id)]]))
+
+#?(:cljs
+   (defn- prose-block
+     [body]
+     [:div {:style (:prose-block styles)}
+      body]))
+
+#?(:cljs
+   (defn workspace-view
+     "Render a workspace. Resolves the cells and dispatches per layout."
+     [workspace-id]
+     (let [body (registrar/handler-meta :workspace workspace-id)]
+       (cond
+         (nil? body)
+         [:div {:style (:wrap styles)}
+          [:div {:style (:empty styles)}
+           "workspace " (pr-str workspace-id) " is not registered"]]
+
+         :else
+         (let [cells (resolve-layout workspace-id body)]
+           [:div {:style (:wrap styles)}
+            [:div {:style (:title styles)}
+             (str (pr-str workspace-id)
+                  " (" (name (:layout body)) ")")]
+            (cond
+              (empty? cells)
+              [:div {:style (:empty styles)}
+               "no cells resolved — check the workspace body"]
+
+              (= :prose (:layout body))
+              [:div {:style (:prose-flow styles)}
+               (for [[i cell] (map-indexed vector cells)]
+                 (case (:type cell)
+                   :prose
+                   ^{:key (str "p-" i)}
+                   [prose-block (:body cell)]
+                   :variant
+                   ^{:key (str "v-" i)}
+                   [variant-cell (:variant-id cell)]))]
+
+              :else
+              [:div {:style (:grid styles)}
+               (for [[i cell] (map-indexed vector cells)]
+                 (case (:type cell)
+                   :variant
+                   ^{:key (str "v-" i)}
+                   [variant-cell (:variant-id cell)]
+                   :prose
+                   ^{:key (str "p-" i)}
+                   [prose-block (:body cell)]
+                   :custom
+                   ^{:key (str "c-" i)}
+                   [:div {:style (:cell styles)}
+                    "custom render: " (pr-str (:render cell))]
+                   nil))])])))))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -61,8 +61,8 @@
 ;; ---- stage marker -------------------------------------------------------
 
 (deftest cljs-stage-marker
-  (testing "Stage 3 advertises :runtime on the CLJS side"
-    (is (= :runtime story/stage))))
+  (testing "Stage 4 supersedes Stage 3 — the loaded CLJS surface advertises :render-shell"
+    (is (= :render-shell story/stage))))
 
 ;; ---- run-variant returns a Promise --------------------------------------
 

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -68,8 +68,8 @@
 ;; ---- stage marker --------------------------------------------------------
 
 (deftest stage-marker-runtime
-  (testing "Stage 3 advertises :runtime"
-    (is (= :runtime story/stage))))
+  (testing "Stage 4 supersedes Stage 3 — the loaded surface advertises :render-shell"
+    (is (= :render-shell story/stage))))
 
 ;; ===========================================================================
 ;; ARGS PRECEDENCE

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -377,8 +377,8 @@
   (testing "re-frame.story.config/enabled? is true at JVM-test time"
     (is (true? story-config/enabled?))))
 
-;; ---- Stage 3 contract check -----------------------------------------
+;; ---- Stage 4 contract check -----------------------------------------
 
 (deftest stage-marker
-  (testing "the loaded surface advertises Stage 3 (runtime)"
-    (is (= :runtime re-frame.story/stage))))
+  (testing "the loaded surface advertises Stage 4 (render-shell)"
+    (is (= :render-shell re-frame.story/stage))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -1,0 +1,218 @@
+(ns re-frame.story-ui-cljs-test
+  "CLJS smoke tests for re-frame2-story Stage 4 (rf2-ekai).
+
+  The UI shell is Reagent-rendered, so the bulk of coverage is shape
+  rather than visual — we exercise:
+
+  - The pure shell-state helpers (selection, filters, fingerprints).
+  - The pure layout resolver (`:grid`, `:prose`, `:variants-grid`).
+  - The pure trace cascade grouper (six-domino projection).
+  - The pure argtype inference + sidebar tag collection.
+  - The public mount/unmount surface on `re-frame.story`.
+
+  The visual / interaction shape (clicking a variant row triggers a
+  re-render; the scrubber slider commits via `restore-epoch`) lives in
+  the browser-test target (Stage 4 ships the smoke layer; Stage 8's
+  examples integration covers end-to-end Playwright)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.sidebar :as sidebar]
+            [re-frame.story.ui.trace :as trace]
+            [re-frame.story.ui.workspace :as workspace]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- stage marker --------------------------------------------------------
+
+(deftest stage-4-marker
+  (testing "Stage 4 advertises :render-shell"
+    (is (= :render-shell story/stage))))
+
+;; ---- public API additions ------------------------------------------------
+
+(deftest mount-shell-fn-present
+  (testing "mount-shell! / unmount-shell! / active-shell are public CLJS fns"
+    (is (fn? story/mount-shell!))
+    (is (fn? story/unmount-shell!))
+    (is (fn? story/active-shell))))
+
+(deftest active-shell-starts-nil
+  (testing "active-shell returns nil before any mount"
+    (is (nil? (story/active-shell)))))
+
+;; ---- shell state transitions --------------------------------------------
+
+(deftest select-variant-roundtrip
+  (testing "select-variant + swap-state! round-trips through the atom"
+    (state/swap-state! state/select-variant :story.foo/bar)
+    (is (= :story.foo/bar (:selected-variant (state/get-state))))))
+
+(deftest toggle-tag-filter-flips
+  (testing "toggle-tag-filter adds + removes a tag"
+    (state/swap-state! state/toggle-tag-filter :dev)
+    (is (contains? (:tag-filter (state/get-state)) :dev))
+    (state/swap-state! state/toggle-tag-filter :dev)
+    (is (not (contains? (:tag-filter (state/get-state)) :dev)))))
+
+(deftest cell-overrides-roundtrip
+  (testing "cell overrides write + clear cleanly"
+    (state/swap-state! state/set-cell-override :story.x/y :label "hi")
+    (is (= "hi" (get-in (state/get-state)
+                        [:cell-overrides :story.x/y :label])))
+    (state/swap-state! state/clear-cell-overrides :story.x/y)
+    (is (nil? (get-in (state/get-state)
+                      [:cell-overrides :story.x/y])))))
+
+;; ---- pure filter + grouping ---------------------------------------------
+
+(deftest filter-variants-by-tag
+  (testing "filter-variants returns matching subset"
+    (story/reg-variant :story.t/a {:tags #{:dev} :events []})
+    (story/reg-variant :story.t/b {:tags #{:test} :events []})
+    (let [vs   (story-registrar/handlers :variant)
+          devs (state/filter-variants vs #{:dev})]
+      (is (contains? devs :story.t/a))
+      (is (not (contains? devs :story.t/b))))))
+
+(deftest group-variants-by-story
+  (testing "group-variants-by-story builds the sidebar tree"
+    (story/reg-variant :story.a/x {:events []})
+    (story/reg-variant :story.a/y {:events []})
+    (story/reg-variant :story.b/z {:events []})
+    (let [vs       (story-registrar/handlers :variant)
+          grouped  (state/group-variants-by-story vs)
+          by-story (into {} (map (juxt :story-id :variants) grouped))]
+      (is (= 2 (count (get by-story :story.a))))
+      (is (= 1 (count (get by-story :story.b)))))))
+
+(deftest sidebar-tag-collection
+  (testing "sidebar/collect-tags enumerates registered tags"
+    (story/reg-variant :story.tg/a {:tags #{:dev :test} :events []})
+    (story/reg-variant :story.tg/b {:tags #{:dev :docs} :events []})
+    (let [vs (story-registrar/handlers :variant)]
+      (is (= [:dev :docs :test]
+             (sidebar/collect-tags vs))))))
+
+;; ---- argtype inference ---------------------------------------------------
+
+(deftest argtype-inference
+  (testing "controls/infer-widget classifies primitive shapes"
+    (is (= :text    (:widget (controls/infer-widget :string))))
+    (is (= :number  (:widget (controls/infer-widget :int))))
+    (is (= :boolean (:widget (controls/infer-widget :boolean))))
+    (let [enum (controls/infer-widget [:enum :a :b :c])]
+      (is (= :select (:widget enum)))
+      (is (= [:a :b :c] (:options enum))))))
+
+(deftest argtype-resolution-from-variant
+  (testing "controls/resolve-argtypes inherits from args' value shapes"
+    (story/reg-variant :story.at/v
+      {:args   {:label "x" :n 1 :flag true}
+       :events []})
+    (let [t (controls/resolve-argtypes :story.at/v)]
+      (is (= :text    (:widget (get t :label))))
+      (is (= :number  (:widget (get t :n))))
+      (is (= :boolean (:widget (get t :flag)))))))
+
+;; ---- workspace layout resolver ------------------------------------------
+
+(deftest grid-layout-resolves
+  (testing ":grid layout maps :variants to variant cells"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.demo/x
+                  {:layout :grid :variants [:story.a/x :story.b/y]})]
+      (is (= 2 (count cells)))
+      (is (every? #(= :variant (:type %)) cells))
+      (is (= :story.a/x (-> cells first :variant-id))))))
+
+(deftest variants-grid-layout-enumerates-from-registry
+  (testing ":variants-grid auto-enumerates the anchor story's variants"
+    (story/reg-variant :story.demo/a {:events []})
+    (story/reg-variant :story.demo/b {:events []})
+    (let [cells (workspace/resolve-layout
+                  :Workspace.demo/all-variants
+                  {:layout :variants-grid})]
+      (is (= 2 (count cells)))
+      (is (every? #(= :variant (:type %)) cells)))))
+
+(deftest prose-layout-resolves
+  (testing ":prose layout preserves content order, interleaving prose + variant"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.guide/intro
+                  {:layout :prose
+                   :content [{:type :prose   :body "intro markdown"}
+                             {:type :variant :id   :story.foo/bar}
+                             {:type :prose   :body "after example"}]})]
+      (is (= 3 (count cells)))
+      (is (= :prose   (-> cells (nth 0) :type)))
+      (is (= :variant (-> cells (nth 1) :type)))
+      (is (= :prose   (-> cells (nth 2) :type))))))
+
+;; ---- trace six-domino projection ----------------------------------------
+
+(deftest trace-group-cascades-classifies
+  (testing "group-cascades splits trace events into six-domino slots"
+    (let [evs       [{:op-type :event :operation :event/dispatched
+                      :id 1 :tags {:dispatch-id 100 :event [:foo]}}
+                     {:op-type :event :operation :event/run
+                      :id 2 :tags {:dispatch-id 100 :duration-ms 3}}
+                     {:op-type :event/do-fx
+                      :id 3 :tags {:dispatch-id 100 :fx {:db {}}}}
+                     {:op-type :fx
+                      :id 4 :tags {:dispatch-id 100 :fx-id :db}}
+                     {:op-type :sub/run
+                      :id 5 :tags {:dispatch-id 100 :id :sub/foo}}
+                     {:op-type :view/render
+                      :id 6 :tags {:dispatch-id 100 :view :app/root}}]
+          cascades  (trace/group-cascades evs)]
+      (is (= 1 (count cascades)))
+      (let [c (first cascades)]
+        (is (= [:foo] (:event c)))
+        (is (some? (:handler c)))
+        (is (some? (:fx c)))
+        (is (= 1 (count (:effects c))))
+        (is (= 1 (count (:subs c))))
+        (is (= 1 (count (:renders c))))))))
+
+;; ---- shell render smoke -------------------------------------------------
+;;
+;; We don't mount to a real DOM (the node-test target has no jsdom).
+;; Instead we confirm the component fns are callable and return hiccup.
+
+(deftest shell-components-are-functions
+  (testing "sidebar / canvas / controls / scrubber / trace expose top-level component fns"
+    (is (fn? sidebar/sidebar))
+    (is (fn? trace/panel))
+    ;; The controls/panel takes a variant-id arg.
+    (is (fn? controls/panel))))
+
+(deftest registry-snapshot-shape
+  (testing "registry-snapshot returns every Story kind"
+    (story/reg-variant :story.r/v {:events []})
+    (let [snap (state/registry-snapshot)]
+      (is (contains? snap :stories))
+      (is (contains? snap :variants))
+      (is (contains? snap :workspaces))
+      (is (contains? snap :modes))
+      (is (contains? snap :decorators))
+      (is (contains? snap :story-panels))
+      (is (contains? snap :tags))
+      (is (contains? (:variants snap) :story.r/v)))))

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -1,0 +1,224 @@
+(ns re-frame.story-ui-test
+  "JVM tests for Stage 4 (rf2-ekai) pure logic.
+
+  The shell's reactive layer (Reagent ratom, component lifecycles,
+  Reagent renders) is CLJS-only — those tests live in
+  `re-frame.story-ui-cljs-test`. JVM-side we cover every pure-data
+  helper in the `re-frame.story.ui.*` namespaces:
+
+  - shell state transitions (selection, filters, fingerprints, overrides)
+  - sidebar tag collection + variant grouping
+  - workspace layout resolution (:grid, :variants-grid, :prose, :tabs)
+
+  These tests run alongside the Stage 2 + 3 JVM corpus via
+  `clojure -M:test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core            :as rf]
+            [re-frame.frame           :as frame]
+            [re-frame.machines        :as machines]
+            [re-frame.registrar       :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story           :as story]
+            [re-frame.story.config    :as config]
+            [re-frame.story.loaders   :as loaders]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.state  :as state]
+            [re-frame.story.ui.workspace :as workspace]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-fixture [test-fn]
+  ;; Mirror the Stage 3 runtime test fixture — story/clear-all! drops
+  ;; the side-table; framework registrar is wiped + the machines ns is
+  ;; reloaded to re-register its framework-shipped sub; canonical
+  ;; vocabulary is reinstalled so :tag membership validates correctly.
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-fixture)
+
+;; ---- pure shell-state helpers -------------------------------------------
+
+(deftest default-shell-state-shape
+  (testing "default-shell-state carries the v1 slots"
+    (let [s state/default-shell-state]
+      (is (nil? (:selected-variant s)))
+      (is (nil? (:selected-workspace s)))
+      (is (= #{} (:tag-filter s)))
+      (is (= [] (:active-modes s)))
+      (is (= {} (:cell-overrides s)))
+      (is (= :reagent (:substrate s)))
+      (is (= 0 (:hot-reload-tick s))))))
+
+(deftest select-variant-transitions
+  (testing "select-variant + select-workspace mutate the state"
+    (let [s  state/default-shell-state
+          s1 (state/select-variant s :story.a/x)
+          s2 (state/select-workspace s1 :Workspace.demo/y)]
+      (is (= :story.a/x (:selected-variant s1)))
+      (is (= :Workspace.demo/y (:selected-workspace s2)))
+      (is (= :story.a/x (:selected-variant s2))))))
+
+(deftest toggle-tag-filter-pure
+  (testing "toggle-tag-filter adds and removes"
+    (let [s  state/default-shell-state
+          s1 (state/toggle-tag-filter s :dev)
+          s2 (state/toggle-tag-filter s1 :dev)]
+      (is (= #{:dev} (:tag-filter s1)))
+      (is (= #{} (:tag-filter s2))))))
+
+(deftest set-active-modes-pure
+  (testing "set-active-modes replaces"
+    (let [s  state/default-shell-state
+          s1 (state/set-active-modes s [:Mode.t/dark])]
+      (is (= [:Mode.t/dark] (:active-modes s1))))))
+
+(deftest cell-overrides-pure
+  (testing "set + clear overrides work on the pure map"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x :n 42)
+          s2 (state/clear-cell-overrides s1 :story.a/x)]
+      (is (= 42 (get-in s1 [:cell-overrides :story.a/x :n])))
+      (is (nil? (get-in s2 [:cell-overrides :story.a/x]))))))
+
+(deftest hot-reload-tick-monotonic
+  (testing "bump-hot-reload-tick increments each call"
+    (let [s state/default-shell-state]
+      (is (= 0 (:hot-reload-tick s)))
+      (is (= 1 (-> s state/bump-hot-reload-tick :hot-reload-tick)))
+      (is (= 2 (-> s state/bump-hot-reload-tick
+                   state/bump-hot-reload-tick :hot-reload-tick))))))
+
+(deftest record-fingerprints-roundtrip
+  (testing "record-fingerprints stores the per-variant map"
+    (let [s  state/default-shell-state
+          s1 (state/record-fingerprints s :story.a/x {:dec/foo 0xdeadbeef})]
+      (is (= {:dec/foo 0xdeadbeef}
+             (get-in s1 [:fingerprints :story.a/x]))))))
+
+(deftest pin-snapshot-appends
+  (testing "pin-snapshot appends a labelled marker"
+    (let [s  state/default-shell-state
+          s1 (state/pin-snapshot s :story.a/x "checkpoint" 5)
+          s2 (state/pin-snapshot s1 :story.a/x "later" 11)]
+      (is (= 2 (count (get-in s2 [:pinned-snapshots :story.a/x]))))
+      (is (= 5 (-> s2 :pinned-snapshots :story.a/x first :epoch-id))))))
+
+(deftest panel-visibility-toggle
+  (testing "toggle-panel flips a panel's visibility"
+    (let [s  state/default-shell-state
+          s1 (state/toggle-panel s :trace)]
+      (is (= false (get-in s1 [:panel-visibility :trace]))))))
+
+;; ---- pure filter + grouping ---------------------------------------------
+
+(deftest filter-variants-empty-filter
+  (testing "an empty filter passes everything through"
+    (story/reg-variant :story.f/a {:tags #{:dev} :events []})
+    (story/reg-variant :story.f/b {:tags #{:test} :events []})
+    (let [vs (story-registrar/handlers :variant)]
+      (is (= 2 (count (state/filter-variants vs #{})))))))
+
+(deftest filter-variants-with-tag
+  (testing "filter restricts to variants whose tags intersect"
+    (story/reg-variant :story.f2/a {:tags #{:dev} :events []})
+    (story/reg-variant :story.f2/b {:tags #{:test} :events []})
+    (let [vs (story-registrar/handlers :variant)
+          devs (state/filter-variants vs #{:dev})]
+      (is (= 1 (count devs)))
+      (is (contains? devs :story.f2/a)))))
+
+(deftest group-variants-by-story-keeps-untagged
+  (testing "variants with no story namespace still appear under their derived parent"
+    (story/reg-variant :story.g/a {:events []})
+    (story/reg-variant :story.g/b {:events []})
+    (let [vs       (story-registrar/handlers :variant)
+          grouped  (state/group-variants-by-story vs)
+          entries  (into {} (map (juxt :story-id :variants) grouped))]
+      (is (= 1 (count grouped)))
+      (is (= 2 (count (get entries :story.g)))))))
+
+(deftest parent-story-id-derivation
+  (testing "parent-story-id mirrors args/parent-story-id"
+    (is (= :story.foo (state/parent-story-id :story.foo/bar)))
+    (is (nil? (state/parent-story-id :unqualified)))))
+
+;; ---- workspace resolver --------------------------------------------------
+
+(deftest grid-layout
+  (testing ":grid produces variant cells in declared order"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.x/y
+                  {:layout :grid :variants [:story.a/x :story.b/y]})]
+      (is (= 2 (count cells)))
+      (is (every? #(= :variant (:type %)) cells))
+      (is (= [:story.a/x :story.b/y]
+             (mapv :variant-id cells))))))
+
+(deftest tabs-layout
+  (testing ":tabs resolves to the same cell shape as :grid"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.t/x
+                  {:layout :tabs :variants [:story.a/x]})]
+      (is (= 1 (count cells)))
+      (is (= :variant (-> cells first :type))))))
+
+(deftest variants-grid-from-anchor
+  (testing ":variants-grid enumerates variants of the anchor story"
+    (story/reg-variant :story.vg/a {:events []})
+    (story/reg-variant :story.vg/b {:events []})
+    (story/reg-variant :story.other/x {:events []})
+    (let [cells (workspace/resolve-layout
+                  :Workspace.vg/all
+                  {:layout :variants-grid})]
+      (is (= 2 (count cells)))
+      (is (every? #(= :variant (:type %)) cells)))))
+
+(deftest variants-grid-explicit-story
+  (testing ":variants-grid honours an explicit :story override"
+    (story/reg-variant :story.vge/a {:events []})
+    (story/reg-variant :story.vge/b {:events []})
+    (let [cells (workspace/resolve-layout
+                  :Workspace.other/all
+                  {:layout :variants-grid :story :story.vge})]
+      (is (= 2 (count cells))))))
+
+(deftest prose-layout-interleaves
+  (testing ":prose preserves :content order"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.guide/intro
+                  {:layout :prose
+                   :content [{:type :prose   :body "first"}
+                             {:type :variant :id   :story.a/x}
+                             {:type :prose   :body "last"}]})]
+      (is (= 3 (count cells)))
+      (is (= :prose   (-> cells (nth 0) :type)))
+      (is (= "first"  (-> cells (nth 0) :body)))
+      (is (= :variant (-> cells (nth 1) :type)))
+      (is (= :story.a/x (-> cells (nth 1) :variant-id)))
+      (is (= :prose   (-> cells (nth 2) :type)))
+      (is (= "last"   (-> cells (nth 2) :body))))))
+
+(deftest custom-layout-resolves
+  (testing ":custom layout emits a single :custom cell"
+    (let [cells (workspace/resolve-layout
+                  :Workspace.c/x
+                  {:layout :custom :render :app/custom-view})]
+      (is (= 1 (count cells)))
+      (is (= :custom (-> cells first :type)))
+      (is (= :app/custom-view (-> cells first :render))))))
+
+(deftest unknown-layout-empty
+  (testing "unknown layouts degrade gracefully"
+    (is (= [] (workspace/resolve-layout :Workspace.x/y {:layout :weird})))))


### PR DESCRIPTION
## Summary

- Stage 4 of the re-frame2-story rollout (parent epic rf2-u6fb). Builds the interactive UI shell that consumes the Stage 3 runtime: a three-pane Reagent layout (sidebar / main canvas / right-side controls+scrubber+trace), the five workspace layouts (`:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`), epoch-driven time-travel scrubbing, the six-domino trace panel, and the decorator-fingerprint hot-reload trigger.
- Public CLJS additions on `re-frame.story`: `mount-shell!`, `unmount-shell!`, `active-shell`. The shell is gated by `re-frame.story.config/enabled?` so production `:advanced` builds DCE the entire render tree.
- Pure logic (state transitions, sidebar grouping, workspace resolution, trace cascade grouping, argtype inference) lives in `.cljc` so JVM tests cover it without pulling Reagent.

## Component tree

```
[shell]
├── [sidebar]   stories + tag filter + workspace list
├── [main]
│   ├── [workspace]  :grid / :prose / :variants-grid / :tabs / :custom
│   └── [canvas]     variant render area (hot-reload-tick aware)
└── [right-panel]
    ├── [controls]   args editor, mode picker, decorator list
    ├── [scrubber]   epoch slider + pinned snapshot chips
    └── [trace]      six-domino trace per variant
```

## Files

New files (10):
- `tools/story/src/re_frame/story/ui/state.cljc` (231 LoC)
- `tools/story/src/re_frame/story/ui/sidebar.cljs` (165 LoC)
- `tools/story/src/re_frame/story/ui/canvas.cljs` (197 LoC)
- `tools/story/src/re_frame/story/ui/controls.cljs` (289 LoC)
- `tools/story/src/re_frame/story/ui/workspace.cljc` (199 LoC)
- `tools/story/src/re_frame/story/ui/scrubber.cljs` (186 LoC)
- `tools/story/src/re_frame/story/ui/trace.cljs` (262 LoC)
- `tools/story/src/re_frame/story/ui/shell.cljs` (290 LoC)
- `tools/story/test/re_frame/story_ui_test.clj` (224 LoC, 20 tests)
- `tools/story/test/re_frame/story_ui_cljs_test.cljs` (218 LoC, 17 tests)

Modified (4):
- `tools/story/src/re_frame/story.cljc` (CLJS-only `:require` of `ui.shell`; new `mount-shell!` / `unmount-shell!` / `active-shell` public fns; `stage` is now `:render-shell`)
- `tools/story/test/re_frame/story_test.clj` (stage marker → `:render-shell`)
- `tools/story/test/re_frame/story_runtime_test.clj` (stage marker)
- `tools/story/test/re_frame/story_runtime_cljs_test.cljs` (stage marker)

Total: ~2.2k LoC new (src + tests).

## Test plan

- [x] `cd tools/story && clojure -M:test` — 81 tests / 187 assertions (was 61; +20 new JVM)
- [x] `cd implementation && npm run test:cljs` — 462 tests / 1079 assertions (was 445; +17 new CLJS)
- [x] `cd implementation && npm run test:elision` — PASS (no new sentinels needed — Story's existing `config/enabled?` gate covers the shell)
- [x] `python -m mkdocs build` — clean (warnings pre-existing, unrelated to this change)

## Stage 5 / Stage 6 hand-off

Stage 5 (assertions + play, rf2-h8et) has clean dispatch:
- Args editor and mode picker push runtime overrides via the existing `cell-overrides` / `active-modes` shell slots — the assertion runtime can read these to populate `run-variant`'s `:active-modes` / `:cell-overrides` opts.
- The `play-stepper UI` slot lives next to the args editor in `controls.cljs` — Stage 5 extends the controls panel with a step button row.
- Assertion-recording hooks for the trace panel: each cascade row in `trace.cljs/cascade-row` carries the dispatch-id; Stage 5 adds an `:assertions [...]` column when assertions are attached to that dispatch.

Stage 6 (SOTA panels, rf2-zhwd) hot-zone hooks:
- Panel-registration extension point: `re-frame.story.ui.state/default-shell-state :panel-visibility` already namespaces panels (`:trace`, `:scrubber`, `:controls`). New panels (perf, a11y, layout-debug, 10x epoch embed) add keys to this map and a render branch in `shell/right-panel`.
- The decorator-fingerprint poll (500ms in `shell.cljs/start-hot-reload-poll!`) is the v1 mechanism; Stage 6 may swap to a trace-bus subscription if perf demands.

## IMPL-SPEC findings (filed as `Suggestion:` beads)

None — Stage 4 fits cleanly inside the §4 contract. The §8.4 namespace layout sketch was the only minor deviation (Stage 4 keeps the `re-frame.story.ui.*` flat layout that matches Stage 3's `re-frame.story.<x>` convention rather than the IMPL-SPEC's nested `tools.story.ui.*` proposal).