### PR TITLE
feat(story): Stage 5 — assertions + play (rf2-h8et)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -53,6 +53,10 @@
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.frames    :as frames]
             [re-frame.story.runtime   :as runtime]
+            ;; Stage 5 (rf2-h8et) — assertions + play + force-fx-stub.
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.fx-stubs  :as fx-stubs]
+            [re-frame.story.play      :as play]
             ;; Stage 4 (rf2-ekai) — UI shell. CLJS-only require so JVM
             ;; consumers (tests, REPL exploration) don't pull Reagent /
             ;; reagent.dom.client into their classpath.
@@ -339,14 +343,22 @@
 
 (defn install-canonical-vocabulary!
   "Install the seven canonical Story tags + the runtime's internal
-  helper events / lifecycle machine. Call this once at boot before any
-  `reg-story` / `reg-variant` / `run-variant` calls. Idempotent.
+  helper events / lifecycle machine + the seven canonical `:rf.assert/*`
+  assertion handlers + the built-in `:rf.story/force-fx-stub` decorator.
+  Call this once at boot before any `reg-story` / `reg-variant` /
+  `run-variant` calls. Idempotent.
 
   Per spec/007 §Inclusion tags + IMPL-SPEC §3.1 the canonical seven
   tags are registered by the Story library at load time — projects
   don't have to. Per IMPL-SPEC §5.4 the lifecycle machine
   (`:rf.story.lifecycle/machine`) is registered here too — without it
   `run-variant` cannot drive the four-phase lifecycle.
+
+  Stage 5 (rf2-h8et) adds:
+  - The seven canonical `:rf.assert/*` event handlers.
+  - The built-in `:rf.story/force-fx-stub` decorator.
+  - The late-bound stub-event tap so emitted fx-ids reach the
+    assertion accumulator (for `:rf.assert/effect-emitted`).
 
   Project-specific tags must register via `reg-tag` *before* use; an
   unregistered tag on a variant's `:tags` set raises `:rf.error/unknown-tag`."
@@ -355,7 +367,17 @@
   (loaders/install!)
   (loaders/install-mirror-writer!)
   (frames/install-helpers!)
-  (runtime/install-helpers!))
+  (runtime/install-helpers!)
+  ;; Stage 5 — assertions + play + force-fx-stub.
+  (assertions/install-canonical-assertions!)
+  (fx-stubs/install-canonical-fx-stubs!)
+  ;; Wire the late-bound shims so the frames runtime can tap
+  ;; into the assertion module without a circular require.
+  (frames/set-tap-stub-event-fn! fx-stubs/tap-stub-event!)
+  (frames/set-drop-assertion-accumulators-fn!
+    (fn [frame-id]
+      (assertions/drop-trace-accumulators! frame-id)
+      (play/drop-pending-exceptions! frame-id))))
 
 ;; ---- configure! ---------------------------------------------------------
 
@@ -495,6 +517,63 @@
   [variant-id]
   (loaders/current-state variant-id))
 
+;; ---- Stage 5 (rf2-h8et) public assertion + play helpers ------------------
+
+(defn assertions-passing?
+  "Per IMPL-SPEC §3.5 + spec/007 §Story-as-test duality — true iff
+  every entry in the assertions list has `:passed? true`. Accepts
+  either an assertions vector or a `run-variant` result map.
+
+  This is the canonical predicate for the cljs.test / clojure.test
+  adapter pattern from spec/007 §Portable into tests:
+
+      (deftest counter-empty-state
+        (let [result @(rf/run-variant :story.counter/empty {})]
+          (is (rf.story/assertions-passing? result))))"
+  [assertions-or-result]
+  (assertions/passing? assertions-or-result))
+
+(defn read-assertions
+  "Per IMPL-SPEC §3.5 — return the assertions vector accumulated against
+  `variant-id`'s frame. Identical to `(:assertions (rf/run-variant ...))`
+  but doesn't re-run the variant. Useful for live introspection from the
+  UI shell or REPL."
+  [variant-id]
+  (assertions/read-assertions variant-id))
+
+(defn canonical-assertion-ids
+  "Per spec/007 line 304 + IMPL-SPEC §3.5 — return the set of seven
+  canonical `:rf.assert/*` event ids registered at boot."
+  []
+  assertions/canonical-assertion-ids)
+
+(defn execute-play!
+  "Per IMPL-SPEC §5.4 phase 4 — run the play sequence against a variant
+  frame and return a promise of the assertions vector. Use this when
+  you've already allocated a variant frame (via a prior `run-variant`
+  or `allocate!`) and want to re-run play without tearing the frame
+  down + re-running phases 1-3.
+
+  Returns a `js/Promise` (CLJS) / `CompletableFuture` (JVM) of the
+  assertions vector — the same shape `(:assertions result)` gives."
+  ([variant-id]
+   (play/execute-play! variant-id))
+  ([variant-id play-events]
+   (play/execute-play! variant-id play-events))
+  ([variant-id play-events opts]
+   (play/execute-play! variant-id play-events opts)))
+
+(def force-fx-stub-id
+  "Per spec/007 §Effect mocking + IMPL-SPEC §3.5 — the registered
+  decorator id for the built-in `force-fx-stub` decorator. Use this
+  on a variant's `:decorators` slot:
+
+      (story/reg-variant :story.auth/login-pending
+        {:decorators [[story/force-fx-stub-id :http {:status :pending}]]
+         :play       [[:auth/login]
+                      [:rf.assert/effect-emitted :http]]})"
+  fx-stubs/force-fx-stub-id)
+
 ;; ---- public helpers (decorator / args resolution surfacing) -------------
 
 (defn resolve-args
@@ -519,11 +598,15 @@
     composition, args resolution, snapshot-identity, lifecycle).
   - Stage 4 — `:render-shell` (adds `mount-shell!` / `unmount-shell!`,
     the sidebar / canvas / scrubber / trace panes, hot-reload trigger).
-  - Stage 5+ extends — play sequence, assertions, SOTA panels, MCP.
+  - Stage 5 — `:assertions+play` (adds the seven `:rf.assert/*` event
+    handlers, play sequence execution wired into `run-variant`, the
+    built-in `:rf.story/force-fx-stub` decorator, `assertions-passing?`,
+    and the non-default `:loaders-complete-when` forms).
+  - Stage 6+ extends — SOTA panels, MCP, examples + guide.
 
   Tools that adapt to the loaded surface read this; agents can ask
   the runtime which Stage is live."
-  :render-shell)
+  :assertions+play)
 
 ;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
 ;;

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -1,0 +1,521 @@
+(ns re-frame.story.assertions
+  "The `:rf.assert/*` assertion vocabulary. Per spec/007 §Assertion
+  vocabulary + IMPL-SPEC §3.5 + §5.1 + §2.3.
+
+  ## The seven canonical assertions
+
+  Per spec/007 line 304 the canonical seven are:
+
+  | Event id                       | Payload                        | Semantics |
+  |--------------------------------|--------------------------------|-----------|
+  | `:rf.assert/path-equals`       | `[path expected]`              | `(= (get-in @app-db path) expected)` |
+  | `:rf.assert/path-matches`      | `[path malli-schema]`          | Malli validate at path |
+  | `:rf.assert/sub-equals`        | `[sub-vec expected]`           | `(= @(subscribe sub-vec) expected)` |
+  | `:rf.assert/dispatched?`       | `[event-or-pred]`              | Was this event dispatched? |
+  | `:rf.assert/state-is`          | `[machine-id state]`           | Machine in state? |
+  | `:rf.assert/no-warnings`       | `[]`                           | No `:warning` trace events since play start |
+  | `:rf.assert/effect-emitted`    | `[fx-id (optional pred)]`      | fx-id emitted during play? |
+
+  ## Record, don't throw (per IMPL-SPEC §2.3)
+
+  Each `:rf.assert/*` event is dispatched through the standard re-frame
+  cascade. The handler is a plain `reg-event-fx` that:
+
+  1. Evaluates the assertion semantics against the frame's current app-db
+     (or the subscribed value, or the trace bus, or the machine snapshot).
+  2. Builds an assertion-record map `{:assertion ... :passed? true|false
+     :expected ... :actual ... :dispatch-id ... :source-coord ... :elapsed-ms ...}`.
+  3. Appends the record to `[:rf.story/assertions]` in the frame's app-db
+     via a `:db` effect — NO throw on failure.
+
+  The play-runner reads `[:rf.story/assertions]` after the play sequence
+  completes; `run-variant`'s `:assertions` slot returns the accumulator.
+
+  ## Tag handler — the `:rf.assert/*` namespace
+
+  The seven canonical assertions register at Story boot via
+  `install-canonical-assertions!`. Production CLJS builds (with
+  `re-frame.story.config/enabled?` false) skip the registrations —
+  any unknown assertion at run-time records a `:rf.assert/unknown`
+  pseudo-record rather than throwing.
+
+  Per the `downstream EPs consume foundation` rule each assertion is a
+  regular re-frame event registered against `re-frame.core/reg-event-fx`
+  — Story adds NO new registry kind for assertions. The vocabulary is
+  enumerable via `(rf/handlers :event #(re-find #\"^:rf\\.assert/\"
+  (str (:id %))))` per the existing registrar query API.
+
+  ## Public surface
+
+  - `install-canonical-assertions!` — register the seven handlers. Boot.
+  - `record!` — programmatic record helper (for fx-stub assertions and
+    play-runner's exception-projection path).
+  - `read-assertions` — return the variant frame's accumulated list.
+  - `passing?` — predicate on the result list: true iff every entry has
+    `:passed? true` (used by Stage 5's `run-variant` test entry, and by
+    consumer tests via the public `assertions-passing?`).
+  - `canonical-assertion-ids` — the set of registered event ids."
+  (:require [re-frame.core            :as rf]
+            [re-frame.interop         :as interop]
+            [re-frame.subs            :as subs]
+            [re-frame.story.config    :as config]
+            [re-frame.story.registrar :as registrar]
+            [malli.core               :as malli]))
+
+;; ---------------------------------------------------------------------------
+;; Per-frame trace-bus accumulator (warnings + emitted fx)
+;;
+;; `:rf.assert/no-warnings` needs to know which warning-level trace
+;; events fired during the play sequence. `:rf.assert/effect-emitted`
+;; needs to know which fx-ids the cascade emitted. We expose a small
+;; per-frame side-table keyed by frame-id that the play-runner clears
+;; at play start and the assertion handlers consult at evaluation time.
+;;
+;; This is NOT a new framework registry — it's a Story-internal atom
+;; (analogous to `re-frame.story.ui.trace/buffers`) that the runtime
+;; populates from the standard trace bus.
+;;
+;; Both atoms are gated under `config/enabled?` at write time; under
+;; production builds they stay empty and the assertion handlers read
+;; empties.
+;; ---------------------------------------------------------------------------
+
+(defonce
+  ^{:doc "frame-id → vector of warning trace events captured since the
+         most recent `(reset-warnings! frame-id)` call. The play-runner
+         calls reset! at play start."}
+  warnings-accumulator
+  (atom {}))
+
+(defonce
+  ^{:doc "frame-id → set of fx-ids emitted in cascades fanning out from
+         the most recent play-start. Populated by the per-frame trace
+         listener registered by the play-runner."}
+  emitted-fx-accumulator
+  (atom {}))
+
+(defonce
+  ^{:doc "frame-id → vector of event vectors dispatched during the play
+         sequence. Used by `:rf.assert/dispatched?` to verify an event
+         was observed."}
+  dispatched-events-accumulator
+  (atom {}))
+
+(defn reset-trace-accumulators!
+  "Clear every per-frame trace-bus accumulator for `frame-id`. The
+  play-runner calls this at play start. Production callers (without
+  config/enabled?) no-op."
+  [frame-id]
+  (when config/enabled?
+    (swap! warnings-accumulator           assoc frame-id [])
+    (swap! emitted-fx-accumulator         assoc frame-id #{})
+    (swap! dispatched-events-accumulator  assoc frame-id []))
+  nil)
+
+(defn drop-trace-accumulators!
+  "Discard every per-frame accumulator entry. Called from frame
+  teardown so destroyed variants don't leak memory."
+  [frame-id]
+  (swap! warnings-accumulator           dissoc frame-id)
+  (swap! emitted-fx-accumulator         dissoc frame-id)
+  (swap! dispatched-events-accumulator  dissoc frame-id)
+  nil)
+
+(defn record-warning!
+  "Append a warning trace event to `frame-id`'s accumulator."
+  [frame-id ev]
+  (when config/enabled?
+    (swap! warnings-accumulator update frame-id (fnil conj []) ev))
+  nil)
+
+(defn record-emitted-fx!
+  "Add `fx-id` to `frame-id`'s emitted-fx accumulator."
+  [frame-id fx-id]
+  (when config/enabled?
+    (swap! emitted-fx-accumulator update frame-id (fnil conj #{}) fx-id))
+  nil)
+
+(defn record-dispatched!
+  "Append `event-vec` to `frame-id`'s dispatched-events accumulator."
+  [frame-id event-vec]
+  (when config/enabled?
+    (swap! dispatched-events-accumulator update frame-id (fnil conj []) event-vec))
+  nil)
+
+(defn frame-warnings  [frame-id] (get @warnings-accumulator frame-id []))
+(defn frame-fx        [frame-id] (get @emitted-fx-accumulator frame-id #{}))
+(defn frame-dispatched [frame-id] (get @dispatched-events-accumulator frame-id []))
+
+;; ---------------------------------------------------------------------------
+;; Programmatic record helper
+;;
+;; Stage 5's play-runner calls `record!` for each `:rf.assert/*` event
+;; it dispatches. The handler returns a record-map; we append it to the
+;; variant frame's app-db under `[:rf.story/assertions]` via a
+;; registered helper event. This mirrors `runtime/record-error!`.
+;; ---------------------------------------------------------------------------
+
+(defn record!
+  "Append `record` to `[:rf.story/assertions]` in `frame-id`'s app-db.
+  Dispatches synchronously so callers see the updated accumulator on
+  the next read. Idempotent w.r.t. frame teardown — swallows the dispatch
+  exception if the frame is gone (matches `runtime/record-error!`).
+
+  Returns the record."
+  [frame-id record]
+  (when config/enabled?
+    (try
+      (rf/dispatch-sync [::append record] {:frame frame-id})
+      (catch #?(:clj Throwable :cljs :default) _ nil)))
+  record)
+
+(defn read-assertions
+  "Return the assertions vector accumulated against `frame-id`'s
+  app-db. Used by `run-variant`'s result-map builder + by the public
+  `passing?` predicate."
+  [frame-id]
+  (or (:rf.story/assertions (rf/get-frame-db frame-id)) []))
+
+(defn passing?
+  "Per IMPL-SPEC §3.5 + Phase-2 §5.1 #9: true iff every entry in
+  `assertions` has `:passed? true`. An assertions vector with zero
+  entries is vacuously passing — this is the spec/007 §Story-as-test
+  duality contract: a variant with no `:play` (and therefore no
+  assertions) still 'passes', and shows up as green in test reports.
+
+  Accepts either an assertions vector or a `run-variant` result map."
+  [assertions-or-result]
+  (let [items (cond
+                (map? assertions-or-result)    (:assertions assertions-or-result)
+                (sequential? assertions-or-result) assertions-or-result
+                :else                          [])]
+    (every? :passed? items)))
+
+;; ---------------------------------------------------------------------------
+;; Assertion-evaluation helpers
+;;
+;; Each `:rf.assert/*` handler is a thin wrapper that:
+;;   1. resolves its inputs from the frame's app-db / trace-bus accumulators
+;;   2. computes :passed? / :expected / :actual / :reason
+;;   3. dispatch-syncs `::append` to land the record on the frame
+;;
+;; The handlers receive the dispatch envelope's `:frame` via re-frame
+;; convention (`{:db ... :event ...}` in the cofx map). We need the frame
+;; to (a) write the assertion record to the right app-db, and (b) look
+;; up dispatch correlation IDs. Both are available via the cofx map's
+;; `:rf/frame` slot per spec/002 §Dispatch envelope.
+;; ---------------------------------------------------------------------------
+
+(defn- source-coord-for-variant
+  "Per IMPL-SPEC §9.3 the registered variant body carries a `:source`
+  slot stamped by the registrar's macro path. We thread that into the
+  assertion record so click-to-source works in the UI shell + agent
+  surfaces. Returns nil when the frame is not a registered variant
+  (e.g. an ad-hoc frame) or the body has no source coord."
+  [frame-id]
+  (:source (registrar/handler-meta :variant frame-id)))
+
+(defn- assertion-record
+  "Construct the assertion record per IMPL-SPEC §3.5. `extras` is the
+  assertion-specific data (`:expected` / `:actual` / `:reason` / ...).
+
+  Includes the variant's source coord (per IMPL-SPEC §9.3) so click-to-
+  source in the trace panel jumps to the variant registration site."
+  [assertion-id payload passed? extras dispatch-id elapsed-ms frame-id]
+  (cond-> {:assertion assertion-id
+           :payload   (vec payload)
+           :passed?   passed?}
+    elapsed-ms  (assoc :elapsed-ms elapsed-ms)
+    dispatch-id (assoc :dispatch-id dispatch-id)
+    frame-id    (assoc :source-coord (source-coord-for-variant frame-id))
+    extras      (merge extras)))
+
+(defn- dispatch-id-from-cofx
+  "Walk the cofx map for the current dispatch's id. Re-frame's router
+  threads `:dispatch-id` onto the dispatch envelope (per spec/009
+  §Dispatch correlation); the standard cofx initial-context surface
+  (per spec/002 §Routing) lifts the envelope keys onto cofx directly.
+
+  Falls back to `(get cofx :rf/play-dispatch-id)` (when the play-runner
+  stamped it on the event vector for offline contexts) and finally nil."
+  [cofx]
+  (or (:dispatch-id cofx)
+      (:rf/play-dispatch-id cofx)
+      nil))
+
+(defn- frame-id-from-cofx
+  "Return the frame the current dispatch targets. Per spec/002 §Routing
+  the cofx map's `:frame` slot is the canonical source (the router lifts
+  the envelope's frame onto cofx as the initial context's `:frame`
+  coeffect). The play-runner additionally stamps `:rf/play-frame` for
+  play-authored assertions that may run outside a `:frame` binding."
+  [cofx]
+  (or (:frame cofx)
+      (:rf/play-frame cofx)
+      nil))
+
+;; ---------------------------------------------------------------------------
+;; Event vector match — supports a literal `[:event-id ...]` payload
+;; or a predicate fn (`fn? payload`). Used by `:rf.assert/dispatched?`.
+;; ---------------------------------------------------------------------------
+
+(defn- event-matches?
+  [observed needle]
+  (cond
+    (fn? needle)             (boolean (needle observed))
+    (vector? needle)         (= needle observed)
+    (keyword? needle)        (= needle (first observed))
+    :else                    false))
+
+;; ---------------------------------------------------------------------------
+;; The canonical seven — defined as plain helper fns that produce the
+;; assertion record. The `install-canonical-assertions!` boot fn wraps
+;; each in a `reg-event-fx` shell that consults the cofx for the frame
+;; + dispatch-id and writes the record.
+;; ---------------------------------------------------------------------------
+
+(defn- evaluate-path-equals
+  [db [path expected]]
+  (let [actual (get-in db path)
+        passed? (= expected actual)]
+    {:passed?  passed?
+     :expected expected
+     :actual   actual
+     :path     path
+     :reason   (if passed?
+                 "path equals expected"
+                 (str "expected " (pr-str expected)
+                      " at " (pr-str path)
+                      " but got "  (pr-str actual)))}))
+
+(defn- malli-validate
+  "Best-effort Malli validation. Returns `[passed? explanation]`. Malli
+  is a Story dep (per tools/story/deps.edn) so the require resolves on
+  both runtimes; production `:advanced` builds with Story disabled DCE
+  the entire assertion vocabulary anyway."
+  [schema value]
+  (try
+    (let [ok? (boolean (malli/validate schema value))
+          ex  (when-not ok?
+                (try (malli/explain schema value)
+                     (catch #?(:clj Throwable :cljs :default) _ nil)))]
+      [ok? (when ex (pr-str ex))])
+    (catch #?(:clj Throwable :cljs :default) e
+      [false (str "malli validation threw: "
+                  #?(:clj (.getMessage ^Throwable e)
+                     :cljs (str e)))])))
+
+(defn- evaluate-path-matches
+  [db [path schema]]
+  (let [actual              (get-in db path)
+        [passed? explanation] (malli-validate schema actual)]
+    (cond-> {:passed?  passed?
+             :path     path
+             :expected schema
+             :actual   actual
+             :reason   (if passed?
+                         "value at path validates against schema"
+                         (str "value at " (pr-str path) " failed schema "
+                              (pr-str schema)))}
+      explanation (assoc :explanation explanation))))
+
+(defn- evaluate-sub-equals
+  [_frame-id db [sub-vec expected]]
+  ;; Use compute-sub against the snapshot — bypasses the reactive cache
+  ;; per Spec 008. Subscriptions registered against the variant's frame
+  ;; resolve the same way they would in the running app.
+  (let [actual  (try
+                  (subs/compute-sub sub-vec db)
+                  (catch #?(:clj Throwable :cljs :default) _
+                    ::compute-error))
+        passed? (and (not= actual ::compute-error)
+                     (= actual expected))]
+    {:passed?  passed?
+     :expected expected
+     :actual   (if (= actual ::compute-error)
+                 :rf.assert/sub-threw
+                 actual)
+     :sub-vec  sub-vec
+     :reason   (cond
+                 (= actual ::compute-error) "subscription threw during evaluation"
+                 passed? "subscription returned expected value"
+                 :else (str "expected " (pr-str expected)
+                            " from " (pr-str sub-vec)
+                            " but got " (pr-str actual)))}))
+
+(defn- evaluate-dispatched?
+  [frame-id [needle]]
+  (let [observed (frame-dispatched frame-id)
+        matched  (some #(event-matches? % needle) observed)
+        passed?  (boolean matched)]
+    {:passed?  passed?
+     :expected needle
+     :actual   observed
+     :reason   (if passed?
+                 "matching event was dispatched during play"
+                 (str "no dispatched event matched "
+                      (pr-str needle)))}))
+
+(defn- evaluate-state-is
+  [db [machine-id state]]
+  (let [snap   (get-in db [:rf/machines machine-id])
+        actual (:state snap)
+        passed? (= state actual)]
+    {:passed?    passed?
+     :expected   state
+     :actual     actual
+     :machine-id machine-id
+     :reason     (cond
+                   (nil? snap)
+                   (str "machine " (pr-str machine-id)
+                        " has no snapshot in this frame")
+                   passed?
+                   "machine is in the expected state"
+                   :else
+                   (str "expected " (pr-str state)
+                        " for machine " (pr-str machine-id)
+                        " but state is " (pr-str actual)))}))
+
+(defn- evaluate-no-warnings
+  [frame-id _payload]
+  (let [warnings (frame-warnings frame-id)
+        passed?  (empty? warnings)]
+    {:passed?  passed?
+     :expected :no-warnings
+     :actual   (mapv :operation warnings)
+     :count    (count warnings)
+     :reason   (if passed?
+                 "no warning-level trace events captured during play"
+                 (str (count warnings)
+                      " warning trace event(s) captured during play"))}))
+
+(defn- evaluate-effect-emitted
+  [frame-id [fx-id pred]]
+  (let [emitted   (frame-fx frame-id)
+        present?  (contains? emitted fx-id)
+        passed?   (boolean (and present? (or (nil? pred)
+                                             (try (pred fx-id) (catch #?(:clj Throwable :cljs :default) _ false)))))]
+    {:passed?  passed?
+     :expected fx-id
+     :actual   emitted
+     :reason   (cond
+                 (not present?)
+                 (str "fx " (pr-str fx-id) " was not emitted during play")
+                 (and pred (not passed?))
+                 (str "fx " (pr-str fx-id) " was emitted but predicate rejected it")
+                 :else
+                 (str "fx " (pr-str fx-id) " was emitted during play"))}))
+
+;; ---------------------------------------------------------------------------
+;; Registered event ids
+;; ---------------------------------------------------------------------------
+
+(def ^:const id-path-equals     :rf.assert/path-equals)
+(def ^:const id-path-matches    :rf.assert/path-matches)
+(def ^:const id-sub-equals      :rf.assert/sub-equals)
+(def ^:const id-dispatched      :rf.assert/dispatched?)
+(def ^:const id-state-is        :rf.assert/state-is)
+(def ^:const id-no-warnings     :rf.assert/no-warnings)
+(def ^:const id-effect-emitted  :rf.assert/effect-emitted)
+
+(def canonical-assertion-ids
+  "Per spec/007 line 304 — the canonical seven assertion event ids,
+  registered at Story boot."
+  #{id-path-equals
+    id-path-matches
+    id-sub-equals
+    id-dispatched
+    id-state-is
+    id-no-warnings
+    id-effect-emitted})
+
+;; ---------------------------------------------------------------------------
+;; Boot — register the seven canonical handlers
+;; ---------------------------------------------------------------------------
+
+(defn- handler-for-evaluator
+  "Build the `reg-event-fx` handler body for `assertion-id` whose
+  evaluator returns the record extras given `(db, payload)` (or
+  `(frame-id, payload)` for trace-bus-driven assertions).
+
+  The handler reads `:db` directly from cofx — which the router has
+  populated with the variant frame's app-db (spec/002 §Routing initial
+  context) — and returns `{:db (update db :rf.story/assertions conj record)}`.
+  This is the record-don't-throw contract per IMPL-SPEC §2.3: the
+  assertion's failure mode is a `:db` write, not an exception."
+  [assertion-id evaluator-kind]
+  (fn [{:keys [db] :as cofx} event-vec]
+    (let [start-ms     (interop/now-ms)
+          payload      (vec (rest event-vec))
+          frame-id     (frame-id-from-cofx cofx)
+          dispatch-id  (dispatch-id-from-cofx cofx)
+          extras       (case evaluator-kind
+                         :path-equals     (evaluate-path-equals     db payload)
+                         :path-matches    (evaluate-path-matches    db payload)
+                         :sub-equals      (evaluate-sub-equals      frame-id db payload)
+                         :dispatched?     (evaluate-dispatched?     frame-id payload)
+                         :state-is        (evaluate-state-is        db payload)
+                         :no-warnings     (evaluate-no-warnings     frame-id payload)
+                         :effect-emitted  (evaluate-effect-emitted  frame-id payload))
+          elapsed-ms   (- (interop/now-ms) start-ms)
+          record       (assertion-record assertion-id payload
+                                         (:passed? extras)
+                                         (dissoc extras :passed?)
+                                         dispatch-id elapsed-ms
+                                         frame-id)]
+      ;; Append the record to [:rf.story/assertions] directly on the
+      ;; current frame's app-db. The router has populated :db with the
+      ;; variant frame's snapshot per spec/002 §Routing.
+      {:db (update db :rf.story/assertions (fnil conj []) record)})))
+
+(defn install-canonical-assertions!
+  "Per IMPL-SPEC §3.5 + spec/007 line 304 — register the seven canonical
+  `:rf.assert/*` event handlers. Idempotent.
+
+  Each handler:
+  1. Reads the current frame's app-db via the cofx `:db` slot (per
+     spec/002 §Routing the router populates `:db` with the dispatch-
+     targeted frame's snapshot).
+  2. Computes the assertion result against `:db` (or the per-frame
+     trace-bus accumulators for `:rf.assert/no-warnings` /
+     `:rf.assert/effect-emitted` / `:rf.assert/dispatched?`).
+  3. Returns `{:db (update db :rf.story/assertions conj record)}` —
+     writes the record onto the frame's app-db.
+
+  Also registers `::append` — the internal event that the
+  programmatic `record!` helper dispatches to land a record on the
+  frame from outside an event-handler context (e.g. the play-runner's
+  post-drain exception walker).
+
+  No throw on failure — the play sequence runs to completion per
+  IMPL-SPEC §2.3."
+  []
+  (when config/enabled?
+    ;; Internal event-db handler used by `record!`. Appends a record to
+    ;; the variant frame's [:rf.story/assertions] slot.
+    (rf/reg-event-db
+      ::append
+      (fn [db [_ record]]
+        (update db :rf.story/assertions (fnil conj []) record)))
+    ;; The seven canonical handlers.
+    (rf/reg-event-fx id-path-equals     (handler-for-evaluator id-path-equals     :path-equals))
+    (rf/reg-event-fx id-path-matches    (handler-for-evaluator id-path-matches    :path-matches))
+    (rf/reg-event-fx id-sub-equals      (handler-for-evaluator id-sub-equals      :sub-equals))
+    (rf/reg-event-fx id-dispatched      (handler-for-evaluator id-dispatched      :dispatched?))
+    (rf/reg-event-fx id-state-is        (handler-for-evaluator id-state-is        :state-is))
+    (rf/reg-event-fx id-no-warnings     (handler-for-evaluator id-no-warnings     :no-warnings))
+    (rf/reg-event-fx id-effect-emitted  (handler-for-evaluator id-effect-emitted  :effect-emitted))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Assertion-event detection (used by the play-runner)
+;; ---------------------------------------------------------------------------
+
+(defn assertion-event?
+  "True iff `event` is a `:rf.assert/*` form. Used by the play-runner
+  to distinguish 'real' dispatches from assertions so the dispatched-
+  events accumulator can skip recording assertion events themselves."
+  [event]
+  (let [id (when (sequential? event) (first event))]
+    (and (keyword? id)
+         (= "rf.assert" (namespace id)))))

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -62,16 +62,50 @@
 
 ;; ---- resolution -----------------------------------------------------------
 
+(defn- expand-ref-args-body
+  "Some decorators (e.g. `:rf.story/force-fx-stub`) take their fx-id +
+  response from the *ref-args* rather than the registered body. When
+  the registered body declares `:ref-args? true`, expand the ref-args
+  into a per-reference body so downstream classification + fx-override
+  materialisation see the user-supplied data.
+
+  Currently the only `:ref-args? true` shape we recognise is
+  `:fx-override` — `[<id> <fx-id> <response>]`. Future shapes (e.g. a
+  ref-args-driven `:hiccup` decorator) can plug in here without
+  touching the rest of decorator resolution.
+
+  Returns the merged body."
+  [body decor-args]
+  (cond
+    (not (:ref-args? body))
+    body
+
+    (= :fx-override (:kind body))
+    (let [[fx-id response] decor-args]
+      (-> body
+          (dissoc :ref-args?)
+          (assoc :fx-id    fx-id
+                 :response response)))
+
+    :else
+    (dissoc body :ref-args?)))
+
 (defn- resolve-ref
   "Look up `[decorator-id & args]` against the decorator registry.
   Returns `{:id ... :args [...] :body <body-or-nil> :error nil|<map>}`.
 
   Stage 3 does not throw on an unregistered decorator — the runtime
-  records it as an error so the variant pane can show it inline."
+  records it as an error so the variant pane can show it inline.
+
+  Stage 5 adds the `:ref-args?` expansion path: decorators that take
+  their config from the *ref* (e.g. `:rf.story/force-fx-stub`) get a
+  synthesised per-reference body so downstream classification sees the
+  user-supplied data."
   [ref]
   (let [id          (first ref)
         decor-args  (vec (rest ref))
-        body        (when (keyword? id) (registrar/handler-meta :decorator id))]
+        body-raw    (when (keyword? id) (registrar/handler-meta :decorator id))
+        body        (when body-raw (expand-ref-args-body body-raw decor-args))]
     (cond
       (not (keyword? id))
       {:id    id
@@ -256,8 +290,17 @@
   (let [pairs (mapv (fn [r]
                       (let [fx-id    (-> r :body :fx-id)
                             response (-> r :body :response)
+                            ;; Include fx-id in the stub-event-id so the
+                            ;; ref-args-driven `:rf.story/force-fx-stub`
+                            ;; decorator can synthesise distinct stubs
+                            ;; for distinct fx-ids referenced from the
+                            ;; same decorator id. Stage 5 (rf2-h8et).
                             stub-id  (keyword "rf.story.fx-stub"
-                                              (str (name (:id r))))]
+                                              (str (name (:id r))
+                                                   (when fx-id
+                                                     (str "+"
+                                                          (when-let [ns (namespace fx-id)] (str ns "."))
+                                                          (name fx-id)))))]
                         {:fx-id        fx-id
                          :stub-id      stub-id
                          :response     response

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -51,35 +51,94 @@
 
 ;; ---- fx-override-stub registration ---------------------------------------
 
+;; Late-bound shim: `re-frame.story.fx-stubs/tap-stub-event!` is the
+;; Stage 5 fan-out that records the fx-id into the assertion module's
+;; per-frame accumulator (for `:rf.assert/effect-emitted`). We avoid
+;; a hard `:require` here to keep frames.cljc free of the assertions
+;; module (which depends on this ns transitively via the decorators
+;; resolution). The runtime initialises the shim from `install-helpers!`
+;; below — by the time a stub event fires, the shim is bound.
+(defonce
+  ^{:doc "Per-process fn slot: called as `(tap-stub-event! frame-id
+         fx-id)` from each stub-event handler. Stage 5 binds this to
+         `re-frame.story.fx-stubs/tap-stub-event!`; Stage 3-only builds
+         leave it nil and the call no-ops."}
+  tap-stub-event-fn
+  (atom nil))
+
+(defn set-tap-stub-event-fn!
+  "Install the late-bound stub-event tap. Stage 5 (rf2-h8et) calls this
+  from `re-frame.story/install-canonical-vocabulary!` with the
+  assertions-module-aware implementation."
+  [f]
+  (reset! tap-stub-event-fn f)
+  nil)
+
+;; Per-frame stub-call log. Per spec/002 the `:fx-overrides` map
+;; redirects fx-id → fx-id, and re-frame's `reg-fx` handlers receive
+;; only their arg payload (no cofx, no `:db`). So the stub fx handler
+;; can't write into the variant frame's app-db atomically. Instead it
+;; appends to a process-level atom keyed by frame-id; the assertion
+;; module reads this for `:rf.assert/effect-emitted` semantics.
+(defonce
+  ^{:doc "frame-id → vector of stub-call entries
+         `{:stub-id ... :fx-id ... :payload ...}`. Populated by the
+         registered stub-fx handler; read by the assertions module and
+         the fx-stubs module's `observed-fx-ids` helper."}
+  stub-call-log
+  (atom {}))
+
+(defn stub-call-log-for
+  "Return the per-frame stub-call log entries, or `[]`."
+  [frame-id]
+  (get @stub-call-log frame-id []))
+
+(defn clear-stub-call-log!
+  "Drop the per-frame stub-call log entry. Called on frame teardown."
+  [frame-id]
+  (swap! stub-call-log dissoc frame-id)
+  nil)
+
 (defn- ensure-stub-event!
-  "Register a `reg-event-fx` handler under `stub-id` that returns a
-  canned response. Idempotent — re-registration replaces the slot
+  "Register a `reg-fx` handler under `stub-id` that handles a
+  redirected fx call. Idempotent — re-registration replaces the slot
   atomically (Spec 001 hot-reload semantics).
 
-  The response shape is the data the user supplied on the decorator's
-  `:response` slot. We wrap it in a no-op handler so the override
-  re-targets the fx call to a synchronous data emission. The default
-  emits the response as a `:db` patch under `[:rf.story.fx-stub/last-call]`
-  for inspection, plus mirrors the fx call into `[:rf.story.fx-stub/log]`
-  for assertion-runtime hooks (Stage 5)."
-  [stub-id response]
-  (rf/reg-event-fx
+  Per spec/002 §Per-frame and per-call overrides the `:fx-overrides`
+  map redirects `fx-id → fx-id`. So the stub MUST be a registered
+  `:fx` handler, not an event handler. The stub:
+
+  1. Taps `tap-stub-event-fn` with `(frame, fx-id)` so the assertion
+     module's emitted-fx accumulator records the call (so
+     `:rf.assert/effect-emitted` can observe it).
+  2. Appends the call to the per-frame `stub-call-log` atom for
+     inspection / dev-tool surfacing.
+
+  The fx handler runs synchronously inside re-frame's `do-fx` walk
+  with signature `(ctx args)` per Spec 002 §Effect handlers; `ctx`
+  carries `:frame` and (optionally) `:event`. All bookkeeping lives
+  in process-level atoms rather than the frame's app-db. Stage 5
+  (rf2-h8et)."
+  [stub-id fx-id response]
+  (rf/reg-fx
     stub-id
-    (fn [{:keys [db]} [_ fx-payload]]
-      {:db (-> db
-               (update :rf.story.fx-stub/log (fnil conj [])
-                       {:stub-id stub-id :payload fx-payload})
-               (assoc-in [:rf.story.fx-stub/last-call stub-id]
-                         {:payload  fx-payload
-                          :response response}))})))
+    (fn [{:keys [frame] :as _ctx} fx-payload]
+      (when-let [tap @tap-stub-event-fn]
+        (try (tap frame fx-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+      (swap! stub-call-log update frame (fnil conj [])
+             {:stub-id  stub-id
+              :fx-id    fx-id
+              :payload  fx-payload
+              :response response})
+      nil)))
 
 (defn- register-fx-overrides!
   "Walk the `:registrations` vector from `decorators/fx-overrides-map`
-  and register each stub event. Returns the `:overrides` map suitable
+  and register each stub fx. Returns the `:overrides` map suitable
   for the variant frame's `:fx-overrides` config slot."
   [{:keys [overrides registrations]}]
-  (doseq [{:keys [stub-id response]} registrations]
-    (ensure-stub-event! stub-id response))
+  (doseq [{:keys [stub-id response fx-id]} registrations]
+    (ensure-stub-event! stub-id fx-id response))
   overrides)
 
 ;; ---- :frame-setup decorator application ---------------------------------
@@ -168,12 +227,32 @@
 
 ;; ---- destruction ----------------------------------------------------------
 
+(defonce
+  ^{:doc "Per-process fn slot: called as `(drop-assertion-accumulators!
+         frame-id)` on frame teardown. Stage 5 (rf2-h8et) binds this to
+         `re-frame.story.assertions/drop-trace-accumulators!`; the
+         accumulator atoms then evict their per-frame entries so
+         destroyed variants don't leak memory."}
+  drop-assertion-accumulators-fn
+  (atom nil))
+
+(defn set-drop-assertion-accumulators-fn!
+  "Install the late-bound teardown hook for assertion accumulators.
+  Stage 5 calls this at boot."
+  [f]
+  (reset! drop-assertion-accumulators-fn f)
+  nil)
+
 (defn destroy!
   "Tear down a variant frame. Clears the lifecycle watcher table for
-  the frame, then calls `rf/destroy-frame`. Returns nil."
+  the frame, drops per-frame assertion + stub accumulators, then
+  calls `rf/destroy-frame`. Returns nil."
   [variant-id]
   (when config/enabled?
     (loaders/clear-watchers! variant-id)
+    (clear-stub-call-log! variant-id)
+    (when-let [drop @drop-assertion-accumulators-fn]
+      (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     (rf/destroy-frame variant-id)
     nil))
 

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -1,0 +1,182 @@
+(ns re-frame.story.fx-stubs
+  "Built-in `force-fx-stub` decorator. Per spec/007 §Effect mocking +
+  IMPL-SPEC §3.5 (Phase-2 §5.1 #6) + §13.2 (the 'MSW-shaped effect
+  mocking' surface).
+
+  ## Authoring shape
+
+      (story/reg-variant :story.auth/login-pending
+        {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
+         :play       [[:auth/login]
+                      [:rf.assert/effect-emitted :http]
+                      [:rf.assert/path-equals [:auth :status] :pending]]})
+
+  ## Authoring shape — value-form
+
+  `force-fx-stub` is a regular decorator registered under
+  `:rf.story/force-fx-stub`. The decorator's ref-args carry
+  `(:fx-id, :response)`; user variants reference it as
+
+      [:rf.story/force-fx-stub <fx-id> <response>]
+
+  ## Semantics
+
+  At variant mount time the decorator stack's `:fx-override` slot
+  classifies this decorator and `decorators/fx-overrides-map`
+  synthesises a stub-event id of the form `:rf.story.fx-stub/<dec-id>`.
+  The Stage 3 frames runtime then:
+
+    1. Registers a `reg-event-fx` under the stub-event id (returning
+       `{:db (-> db (update :rf.story.fx-stub/log conj ...))}`).
+    2. Stamps `{:fx-overrides {<fx-id> <stub-event-id>}}` onto the
+       variant frame's config so re-frame's router redirects any
+       dispatch of `<fx-id>` to the stub event.
+
+  Stage 5 adds: per-frame trace-bus accumulator updates so
+  `:rf.assert/effect-emitted` can observe that the fx was emitted
+  *as if it had run*. The `force-fx-stub` decorator's stub event also
+  appends the fx-id to the frame's emitted-fx accumulator (see
+  `re-frame.story.assertions/record-emitted-fx!`).
+
+  ## Why a registered decorator and not a magic builtin
+
+  Per spec/007 §Effect mocking the framework hooks are
+  `:fx-overrides` (registered against `reg-frame`); `force-fx-stub`
+  is a *library* convenience over the framework hook. The same shape
+  authors can use for their own decorators: register a `:fx-override`
+  decorator with `:fx-id` + `:response`, reference it by id in the
+  variant body. Story's built-in is just a particularly common shape.
+
+  ## Decorator vs. ref-args
+
+  The decorator's `:body` shape stays simple — it owns nothing but
+  the metadata `{:kind :fx-override :fx-id <ignored> :response <ignored>}`.
+  The actual fx-id + response are supplied at the *reference* site
+  via the ref-args:
+
+      [:rf.story/force-fx-stub :http {:status :pending}]
+                              └──┬──┘ └──────┬──────┘
+                                fx-id      response
+
+  Stage 5 adds a small adapter that rewrites the ref-args into a
+  per-reference decorator body so `decorators/fx-overrides-map` sees
+  `{:fx-id :http :response {:status :pending}}`. This keeps the
+  decorator registration single-shot while allowing per-reference
+  configuration."
+  (:require [re-frame.core         :as rf]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.config :as config]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---------------------------------------------------------------------------
+;; The decorator id
+;; ---------------------------------------------------------------------------
+
+(def force-fx-stub-id
+  "Stable id for the built-in `force-fx-stub` decorator. Registered at
+  Story boot via `install-canonical-fx-stubs!`."
+  :rf.story/force-fx-stub)
+
+;; ---------------------------------------------------------------------------
+;; The built-in decorator body
+;;
+;; The decorator's body is the marker `:kind :fx-override` — the actual
+;; fx-id + response live in the ref-args. The Stage 5 fx-override-map
+;; adapter `resolve-ref-args` reads them from the ref and stamps them
+;; onto a per-reference decorator-body clone before `decorators/
+;; fx-overrides-map` runs.
+;; ---------------------------------------------------------------------------
+
+(def force-fx-stub-body
+  "The `:rf.story/force-fx-stub` decorator's registered body. The
+  ref-args drive the fx-id + response; the body is a marker that
+  Stage 5's `resolve-ref-args` adapter expands.
+
+  Per spec/007 §Effect mocking the user-visible shape is
+  `[force-fx-stub :http {:status :pending}]`; the decorator registry
+  treats `force-fx-stub` as the id."
+  {:doc       "Built-in: stub an fx for the lifetime of the variant's frame."
+   :kind      :fx-override
+   :ref-args? true       ;; marker — Stage 5's adapter reads ref-args
+   })
+
+(defn install-canonical-fx-stubs!
+  "Register `:rf.story/force-fx-stub` against Story's decorator
+  registrar. Idempotent. Per spec/007 §Effect mocking this is the
+  v1 MSW-shaped surface.
+
+  Stage 5 (rf2-h8et). Called from `re-frame.story/install-canonical-
+  vocabulary!` at boot."
+  []
+  (when config/enabled?
+    (registrar/reg-decorator* force-fx-stub-id force-fx-stub-body))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; ref-args adapter — expand `[id fx-id response]` into a per-call body
+;; with `{:fx-id fx-id :response response}`
+;;
+;; The decorators module's `resolve-ref` reads the registered body
+;; verbatim; for `force-fx-stub` the *registered* body is just a marker,
+;; so we expand the ref-args into a synthesized body that the rest of
+;; `fx-overrides-map` consumes naturally.
+;; ---------------------------------------------------------------------------
+
+(defn expand-ref-args
+  "Given a `[:rf.story/force-fx-stub fx-id response]` ref, return a
+  per-reference body map `{:kind :fx-override :fx-id <fx-id>
+  :response <response>}`. Returns nil for refs that aren't
+  force-fx-stub.
+
+  Used by `re-frame.story.decorators` to expand the ref before
+  classification. The expansion is pure — no side effects."
+  [ref]
+  (when (and (sequential? ref)
+             (= force-fx-stub-id (first ref)))
+    (let [[_ fx-id response] ref]
+      {:kind     :fx-override
+       :fx-id    fx-id
+       :response response})))
+
+;; ---------------------------------------------------------------------------
+;; Stub-event log — read by assertion handlers
+;; ---------------------------------------------------------------------------
+
+(defn observed-fx-ids
+  "Return the set of fx-ids that the variant's stub fx-handlers
+  observed. Reads the per-frame stub-call log from
+  `re-frame.story.frames/stub-call-log-for`. Each entry carries the
+  original `:fx-id`; we set-ify."
+  [variant-id]
+  (let [resolve-fn
+        (try
+          #?(:clj  (requiring-resolve 're-frame.story.frames/stub-call-log-for)
+             :cljs (some-> (find-ns 're-frame.story.frames)
+                           (ns-resolve 'stub-call-log-for)))
+          (catch #?(:clj Throwable :cljs :default) _ nil))
+        entries (if resolve-fn (resolve-fn variant-id) [])]
+    (set (keep :fx-id entries))))
+
+;; ---------------------------------------------------------------------------
+;; Wire the stub-event log into the assertion accumulator
+;;
+;; The Stage 3 `frames/ensure-stub-event!` registers an event-fx under
+;; `:rf.story.fx-stub/<decorator-id>` that appends to the log. Stage 5
+;; needs that event to ALSO record into the assertion
+;; emitted-fx-accumulator so `:rf.assert/effect-emitted` works.
+;;
+;; Rather than re-register a different event shape, we expose a
+;; `tap-stub-event!` helper the frames runtime can call from inside
+;; the stub event's :db handler. The actual call site is in
+;; `re-frame.story.frames/ensure-stub-event!` (Stage 3) — Stage 5
+;; updates that function to call `tap-stub-event!`.
+;; ---------------------------------------------------------------------------
+
+(defn tap-stub-event!
+  "Update the assertion module's `emitted-fx-accumulator` to record
+  that `fx-id` fired against `frame-id`. The frames runtime's
+  `ensure-stub-event!` calls this when the stub event handles a
+  redirected fx call."
+  [frame-id fx-id]
+  (assertions/record-emitted-fx! frame-id fx-id)
+  nil)

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -278,37 +278,96 @@
   [_frame-id _variant-body]
   true)
 
+(defn- predicate-event?
+  "Per IMPL-SPEC §2.4 — a registered predicate-event handler is a plain
+  re-frame event whose `:db` effect returns a value-form map containing
+  `[:rf.story/loaders-complete? <bool>]`. Stage 5 (rf2-h8et) accepts
+  this shape by dispatching the event then reading the slot from the
+  frame's app-db.
+
+  The event handler signature:
+
+      (rf/reg-event-db :my.fixture/ready?
+        (fn [db _]
+          (assoc db :rf.story/loaders-complete?
+                 (boolean (:loaded? db)))))
+
+  Authors set the slot to `true` when their custom condition is
+  satisfied. The Story runtime polls by dispatching then reading."
+  [pred]
+  (keyword? pred))
+
+(defn- dispatched-events-set
+  "Read the dispatched-events set for `frame-id`. Lazily resolved to
+  avoid a circular require with the assertions module."
+  [frame-id]
+  (try
+    (let [resolve-fn #?(:clj  (requiring-resolve
+                                're-frame.story.assertions/frame-dispatched)
+                       :cljs ((fn []
+                                ;; CLJS: the assertions ns is loaded by
+                                ;; the runtime/install-helpers! path.
+                                (some-> (find-ns 're-frame.story.assertions)
+                                        (ns-resolve 'frame-dispatched)))))]
+      (when resolve-fn
+        (let [evs (resolve-fn frame-id)]
+          (set evs))))
+    (catch #?(:clj Throwable :cljs :default) _ #{})))
+
+(defn- vector-of-events-satisfied?
+  "Per IMPL-SPEC §2.4 — a vector of event vectors form is interpreted
+  as 'loaders complete when ALL listed events have fired against the
+  variant's frame'. We consult the assertions module's per-frame
+  dispatched-events accumulator (populated by the play-runner's trace
+  listener and the runtime's own phase-1/2 trace listener — Stage 5
+  reaches across)."
+  [frame-id events-required]
+  (let [observed (or (dispatched-events-set frame-id) #{})]
+    (every? (fn [needle] (contains? observed needle)) events-required)))
+
 (defn evaluate-complete-when
   "Evaluate the variant's `:loaders-complete-when` predicate against
   `frame-id`'s current app-db. Returns truthy when the loader phase
   should advance to `:ready`.
 
-  Forms accepted (per the Stage 2 schema):
-  - nil — use the default predicate (`loaders-default-complete?`).
-  - a registered event id — dispatch-sync the event; predicates of
-    this shape are implemented as registered assertion-style event-fxs
-    (Stage 5 wires the `:rf.assert/*` suite; Stage 3 only handles the
-    nil case + literal-data form).
-  - a vector of event vectors (the schema allows `[:vector EventVector]`)
-    — Stage 3 interprets these as `[:rf.assert/*]` declarations that
-    *must all pass* for the predicate to be true. Each assertion's
-    handler returns `{:passed? true|false ...}`; the runtime reads the
-    `:assertions` accumulator on the frame's app-db at
-    `[:rf.story/assertions]`.
+  Forms accepted (per the Stage 2 schema; Stage 5 finalises non-default
+  semantics):
 
-  Stage 5 (rf2-h8et) lands the full assertion runtime. For Stage 3
-  the nil-case is the load-bearing implementation; the registered-event
-  and vector forms route through Stage 5's hook. Until Stage 5 ships,
-  any non-nil `:loaders-complete-when` is treated as 'complete on first
-  evaluation' so the lifecycle still progresses — a Stage 4 UI shell
-  can render the variant; Stage 5 makes the predicate semantically
-  correct."
+  - nil — use the default predicate (`loaders-default-complete?`).
+  - a registered event id — `:my.fixture/ready?`. The runtime
+    dispatch-syncs the event into the variant's frame, then reads the
+    slot `[:rf.story/loaders-complete?]` from the post-dispatch app-db.
+    Handlers set this to `true` when their custom condition is met.
+  - a vector of event vectors — `[[:fixture/loaded] [:auth/ready]]`.
+    Interpreted as 'loaders complete when ALL listed events have fired
+    against the variant's frame.' The runtime checks the assertions
+    module's dispatched-events accumulator (which Story populates from
+    the trace bus).
+
+  Stage 5 (rf2-h8et)."
   [frame-id variant-body]
   (let [pred (:loaders-complete-when variant-body)]
     (cond
-      (nil? pred)    (loaders-default-complete? frame-id variant-body)
-      ;; Stage 5 will replace this with full assertion evaluation.
-      ;; Stage 3 treats any non-nil predicate as truthy on first
-      ;; evaluation — the lifecycle progresses; Stage 5 makes it
-      ;; semantically correct.
-      :else          true)))
+      (nil? pred)
+      (loaders-default-complete? frame-id variant-body)
+
+      (fn? pred)
+      ;; A literal function predicate. Authors usually pass a registered
+      ;; event-id (a keyword) but a fn is a legal Clojure value at this
+      ;; layer; the runtime threads the frame's app-db through.
+      (boolean (pred (rf/get-frame-db frame-id)))
+
+      (predicate-event? pred)
+      (do
+        (try
+          (rf/dispatch-sync [pred] {:frame frame-id})
+          (catch #?(:clj Throwable :cljs :default) _ nil))
+        (boolean (:rf.story/loaders-complete? (rf/get-frame-db frame-id))))
+
+      (vector? pred)
+      (vector-of-events-satisfied? frame-id pred)
+
+      :else
+      ;; Unknown shape — be permissive (per IMPL-SPEC §2.3 record-not-throw
+      ;; spirit) and let the variant proceed.
+      true)))

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -1,0 +1,326 @@
+(ns re-frame.story.play
+  "Phase 4 — `:play` sequence execution. Per IMPL-SPEC §5.4 phase 4 +
+  spec/007 §Play functions + §Assertion vocabulary.
+
+  ## What this module does
+
+  The variant body's `:play` slot is a vector of event vectors:
+
+      :play [[:auth/email-changed \"alice@example.com\"]
+             [:auth/password-changed \"hunter2\"]
+             [:auth/login-pressed]
+             [:rf.assert/path-equals [:auth :status] :authenticated]
+             [:rf.assert/path-equals [:nav :route] :dashboard]]
+
+  Each event is `dispatch-sync`'d into the variant's frame in declared
+  order, draining run-to-completion between each. `:rf.assert/*` events
+  ride the same dispatch path — re-frame's interceptor chain runs the
+  registered assertion handler (see `re-frame.story.assertions`), which
+  appends a record into `[:rf.story/assertions]` on the variant frame's
+  app-db. Per IMPL-SPEC §2.3 the assertion never throws; the play
+  sequence runs to completion regardless of which assertions fail.
+
+  ## Trace-bus accumulators
+
+  Per the IMPL-SPEC §5.1 assertion list shape, three assertions need
+  per-frame trace-bus knowledge:
+
+  - `:rf.assert/no-warnings`   — was any `:warning` trace event emitted?
+  - `:rf.assert/effect-emitted` — was a given fx-id emitted?
+  - `:rf.assert/dispatched?`   — was a given event dispatched?
+
+  We register a per-frame trace listener at the start of the play
+  sequence that:
+
+  - records `:warning` and `:error` `:op-type` events into the
+    assertion module's `warnings-accumulator`,
+  - records every `:event/dispatched` event vector into
+    `dispatched-events-accumulator`,
+  - records every fx call (operations under `:event/do-fx` /
+    `:fx` op-type) into `emitted-fx-accumulator`.
+
+  The accumulators clear at play-start and live until frame teardown
+  (per `assertions/drop-trace-accumulators!`).
+
+  ## Async surface
+
+  Stage 5's play execution is synchronous — `dispatch-sync` drains
+  run-to-completion (per spec/002), so a sequence of N events
+  completes in N drains. The play-runner returns a resolved promise
+  immediately on completion. Future async-play surfaces (e.g.
+  Playwright-style waiting on a UI selector) are Stage 6 hooks.
+
+  ## Public API
+
+  - `execute-play!`  — runs a play sequence against a variant frame
+                       and returns a resolved promise of the
+                       accumulated assertions vector.
+  - `install-helpers!` — registers the play-runner's internal
+                         trace-listener helpers; idempotent.
+  - `play-stepper-active?` / `step-once!` — UI hooks (Stage 4's
+                                            play-stepper slot)."
+  (:require [re-frame.core             :as rf]
+            [re-frame.trace            :as trace]
+            [re-frame.interop          :as interop]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async      :as async]
+            [re-frame.story.config     :as config]
+            [re-frame.story.frames     :as frames]
+            [re-frame.story.registrar  :as registrar]))
+
+;; ---------------------------------------------------------------------------
+;; Per-frame trace listener
+;;
+;; One listener per variant frame. Filters trace events by `:frame`
+;; (per spec/009 §Dispatch correlation) and routes them into the
+;; assertion module's per-frame accumulators. Idempotent.
+;; ---------------------------------------------------------------------------
+
+(defn- listener-id [frame-id]
+  (keyword "re-frame.story.play"
+           (str "trace-" (when frame-id (str frame-id)))))
+
+(defn- frame-of [ev]
+  (or (get-in ev [:tags :frame])
+      (get-in ev [:tags :frame-id])))
+
+;; Per-frame pending-exception accumulator. The listener captures
+;; `:rf.error/handler-exception` synchronously (from inside the running
+;; drain) and stores them here; the play-runner drains the slot AFTER
+;; each dispatch-sync settles so it can record an assertion via
+;; dispatch-sync without re-entering an in-flight drain.
+(defonce
+  ^{:doc "frame-id → vector of pending exception trace events captured
+         during the most recent play dispatch. Drained by
+         `drain-pending-exceptions!` after each event."}
+  pending-exceptions
+  (atom {}))
+
+(defn- record-pending-exception!
+  [frame-id ev]
+  (swap! pending-exceptions update frame-id (fnil conj []) ev))
+
+(defn- listener-for-frame
+  "Build the trace-event listener for `frame-id`. Routes each event
+  into the right accumulator. Skips events that don't target the
+  frame so cross-frame traffic (e.g. the default frame's lifecycle
+  events) stays out of the variant's accumulators.
+
+  Listener executes INSIDE the running dispatch drain, so it never
+  re-enters dispatch-sync — it stores side-effects in atoms and lets
+  the play-runner drain them between events."
+  [frame-id]
+  (fn [ev]
+    (when (= frame-id (frame-of ev))
+      (case (:op-type ev)
+        :warning      (assertions/record-warning! frame-id ev)
+        :error        (do (assertions/record-warning! frame-id ev)
+                          (when (= :rf.error/handler-exception (:operation ev))
+                            (record-pending-exception! frame-id ev)))
+        :event        (when (= :event/dispatched (:operation ev))
+                        (let [event-vec (get-in ev [:tags :event])]
+                          (when (and event-vec
+                                     (not (assertions/assertion-event? event-vec)))
+                            (assertions/record-dispatched! frame-id event-vec))))
+        :event/do-fx  (let [fx-map (get-in ev [:tags :fx])]
+                        (when (map? fx-map)
+                          (doseq [fx-id (keys fx-map)]
+                            (assertions/record-emitted-fx! frame-id fx-id))))
+        :fx           (let [fx-id (get-in ev [:tags :fx-id])]
+                        (when fx-id
+                          (assertions/record-emitted-fx! frame-id fx-id)))
+        nil))))
+
+(defn- drain-pending-exceptions!
+  "Append any pending exception trace events from `frame-id` as
+  assertion records on the variant's assertions slot. Called by the
+  play-runner after each dispatch-sync returns (i.e. after the drain
+  has settled). Clears the pending slot on exit."
+  [frame-id]
+  (let [evs (get @pending-exceptions frame-id [])]
+    (when (seq evs)
+      (doseq [ev evs]
+        (let [event-vec (get-in ev [:tags :event])
+              msg       (get-in ev [:tags :exception-message])
+              exc       (get-in ev [:tags :exception])]
+          (assertions/record!
+            frame-id
+            {:assertion :rf.error/exception
+             :phase     :phase-4-play
+             :event     event-vec
+             :error     {:message (or msg
+                                      #?(:clj (when exc (.getMessage ^Throwable exc))
+                                         :cljs (when exc (str exc))))}
+             :passed?   false})))
+      (swap! pending-exceptions assoc frame-id []))))
+
+(defn install-trace-listener!
+  "Register a per-frame trace listener that feeds the assertion module's
+  accumulators. Idempotent — re-registering replaces. Returns the
+  listener id."
+  [frame-id]
+  (when config/enabled?
+    (let [id (listener-id frame-id)]
+      (trace/register-trace-cb! id (listener-for-frame frame-id))
+      id)))
+
+(defn remove-trace-listener!
+  "Tear down the per-frame trace listener for `frame-id`. Idempotent."
+  [frame-id]
+  (when config/enabled?
+    (trace/remove-trace-cb! (listener-id frame-id))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Play sequence execution
+;; ---------------------------------------------------------------------------
+
+(defn- dispatch-one!
+  "Dispatch a single event in the play sequence. Wraps `dispatch-sync`
+  with the exception-record path so phase-4 errors land in the
+  assertion list rather than aborting the sequence (IMPL-SPEC §2.3 +
+  §5.5).
+
+  The re-frame router catches handler exceptions and emits a
+  `:rf.error/handler-exception` trace event rather than re-throwing;
+  the per-frame trace listener captures those into a pending slot,
+  which `drain-pending-exceptions!` flushes into the assertions list
+  *after* this dispatch-sync settles.
+
+  An exception that escapes the interceptor chain (e.g. a setup error)
+  lands in our local try/catch and gets recorded directly."
+  [frame-id event]
+  (try
+    (rf/dispatch-sync event {:frame frame-id})
+    (catch #?(:clj Throwable :cljs :default) e
+      (let [record {:assertion :rf.error/exception
+                    :phase     :phase-4-play
+                    :event     event
+                    :error     {:message #?(:clj  (.getMessage ^Throwable e)
+                                            :cljs (str e))}
+                    :passed?   false}]
+        (assertions/record! frame-id record))))
+  ;; After the drain settles, walk any captured handler-exception
+  ;; trace events into assertion records. Safe to dispatch-sync now —
+  ;; the drain has ended.
+  (drain-pending-exceptions! frame-id))
+
+(defn- read-assertions-after
+  "Return the per-frame assertions vector, post-play."
+  [frame-id]
+  (assertions/read-assertions frame-id))
+
+(defn variant-play-events
+  "Resolve `:play` for `variant-id` from the registered body. Defaults
+  to an empty vector when the body has no `:play`."
+  [variant-id]
+  (or (:play (registrar/handler-meta :variant variant-id)) []))
+
+(defn execute-play!
+  "Run the play sequence against `variant-id`'s frame. Drives the
+  trace-listener, dispatches each event in order, and returns a
+  resolved promise of the assertions vector.
+
+  Per IMPL-SPEC §5.4 phase 4 + §2.3 the sequence runs to completion
+  regardless of which assertions fail. `:rf.error/exception` records
+  cover phase-4 throws.
+
+  `opts` accepts `:install-listener?` (default true) — when false the
+  caller has already installed the listener (e.g. the UI shell). The
+  listener is idempotent so the default-true path is also safe."
+  ([variant-id]
+   (execute-play! variant-id (variant-play-events variant-id) nil))
+  ([variant-id play-events]
+   (execute-play! variant-id play-events nil))
+  ([variant-id play-events {:keys [install-listener?]
+                            :or   {install-listener? true}}]
+   (if-not config/enabled?
+     (async/resolved [])
+     (async/promise
+       (fn [resolve]
+         (try
+           (assertions/reset-trace-accumulators! variant-id)
+           (swap! pending-exceptions assoc variant-id [])
+           (when install-listener?
+             (install-trace-listener! variant-id))
+           (try
+             (doseq [ev play-events]
+               (dispatch-one! variant-id ev))
+             (finally
+               (when install-listener?
+                 ;; Leave the listener in place if the caller declared
+                 ;; ownership; otherwise tear down so destroyed variants
+                 ;; don't accumulate dangling cbs.
+                 (remove-trace-listener! variant-id))))
+           (resolve (read-assertions-after variant-id))
+           (catch #?(:clj Throwable :cljs :default) e
+             ;; A failure inside execute-play itself (not the dispatched
+             ;; events) becomes a phase-4-setup record. The play has not
+             ;; necessarily completed but we still resolve the promise so
+             ;; the caller sees the accumulator.
+             (assertions/record! variant-id
+                                 {:assertion :rf.error/exception
+                                  :phase     :phase-4-setup
+                                  :error     {:message #?(:clj (.getMessage ^Throwable e)
+                                                          :cljs (str e))}
+                                  :passed?   false})
+             (resolve (read-assertions-after variant-id)))))))))
+
+;; ---------------------------------------------------------------------------
+;; UI play-stepper hook (Stage 4 placeholder, finalised here)
+;; ---------------------------------------------------------------------------
+
+(defonce
+  ^{:doc "Per-frame play-stepper state. `{frame-id → {:remaining vec,
+         :ran vec}}`. The UI shell consumes this to render the
+         stepper widget. Used only when the play sequence is being
+         driven step-by-step rather than via `execute-play!`."}
+  stepper-state
+  (atom {}))
+
+(defn play-stepper-active?
+  [frame-id]
+  (contains? @stepper-state frame-id))
+
+(defn begin-stepper!
+  "Initialise a step-by-step play run for `frame-id`. The UI's
+  play-stepper widget calls `step-once!` to advance one event."
+  [frame-id]
+  (when config/enabled?
+    (assertions/reset-trace-accumulators! frame-id)
+    (install-trace-listener! frame-id)
+    (swap! stepper-state assoc frame-id
+           {:remaining (vec (variant-play-events frame-id))
+            :ran       []})
+    nil))
+
+(defn step-once!
+  "Advance the play stepper for `frame-id` by one event. Returns the
+  event that was dispatched, or nil when no events remain."
+  [frame-id]
+  (when config/enabled?
+    (let [{:keys [remaining]} (get @stepper-state frame-id)
+          ev (first remaining)]
+      (when ev
+        (dispatch-one! frame-id ev)
+        (swap! stepper-state update frame-id
+               (fn [s] (-> s
+                           (update :remaining subvec 1)
+                           (update :ran conj ev)))))
+      ev)))
+
+(defn end-stepper!
+  "Tear down the play stepper for `frame-id`. The UI calls this when
+  the stepper widget closes."
+  [frame-id]
+  (when config/enabled?
+    (remove-trace-listener! frame-id)
+    (swap! stepper-state dissoc frame-id))
+  nil)
+
+(defn drop-pending-exceptions!
+  "Per-frame teardown for the pending-exceptions accumulator. Wired
+  from `frames/destroy!` via the late-bound assertion-drop hook."
+  [frame-id]
+  (swap! pending-exceptions dissoc frame-id)
+  nil)

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -39,12 +39,14 @@
   — it returns empty."
   (:require [re-frame.core            :as rf]
             [re-frame.story.args      :as args]
+            [re-frame.story.assertions :as assertions]
             [re-frame.story.async     :as async]
             [re-frame.story.config    :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames    :as frames]
             [re-frame.story.identity  :as ident]
             [re-frame.story.loaders   :as loaders]
+            [re-frame.story.play      :as play]
             [re-frame.story.registrar :as registrar]
             [re-frame.interop         :as interop]
             [re-frame.trace           :as trace]))
@@ -269,7 +271,8 @@
                (let [decorator-stack (decorators/resolve-decorators variant-id
                                                                     {:active-modes active-modes})
                      effective-args  (args/resolve-args variant-id opts)
-                     snapshot        (ident/snapshot-identity variant-id opts)]
+                     snapshot        (ident/snapshot-identity variant-id opts)
+                     play-events     (or (:play variant-body) [])]
                  ;; Phase 0: allocate frame, run :frame-setup decorators,
                  ;; drive lifecycle to :mounting.
                  (frames/allocate! variant-id decorator-stack)
@@ -280,12 +283,23 @@
                  (loaders/finish-events! variant-id)
                  ;; Phase 3 (render): Stage 4's UI shell does the actual
                  ;; render. Stage 3 leaves :rendered-hiccup nil.
-                 ;; Phase 4 (play + assertions): Stage 5 lands. Stage 3
-                 ;; leaves :assertions empty for now (unless Stage 3
-                 ;; itself recorded error projections during phases 1-2).
-                 (resolve (record-result-map variant-id decorator-stack
-                                             effective-args snapshot
-                                             start-ms)))
+                 ;; Phase 4 (play + assertions): Stage 5 (rf2-h8et).
+                 ;; `execute-play!` runs the play sequence synchronously
+                 ;; on the JVM and via dispatch-sync on CLJS (re-frame's
+                 ;; drain settles before each call returns); the returned
+                 ;; promise resolves immediately to the assertions vector.
+                 (let [play-promise (play/execute-play! variant-id play-events)]
+                   ;; The execute-play! contract guarantees the promise
+                   ;; resolves to the assertions vector once play
+                   ;; completes. We chain `then` so the final result-map
+                   ;; build sees the post-play app-db.
+                   (-> play-promise
+                       (async/then
+                         (fn [_]
+                           (resolve (record-result-map variant-id decorator-stack
+                                                       effective-args snapshot
+                                                       start-ms))
+                           nil)))))
                (catch #?(:clj Throwable :cljs :default) e
                  (record-error! variant-id :phase-0-setup nil e)
                  (loaders/error! variant-id (ex-data e))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -332,12 +332,29 @@
 (def DecoratorFxOverride
   "`:fx-override`-kind decorator — stubs an fx for the lifetime of the
   variant's frame. Per spec/007 §Effect mocking the decorator is a
-  declaration; the actual stub registration happens at frame creation."
-  [:map
-   [:doc      {:optional true} :string]
-   [:kind     [:= :fx-override]]
-   [:fx-id    :keyword]
-   [:response :any]])
+  declaration; the actual stub registration happens at frame creation.
+
+  Two shapes:
+
+  - **Fixed body** — `{:kind :fx-override, :fx-id :http, :response {...}}`.
+    The fx-id + response are baked into the decorator registration; every
+    reference reuses them.
+  - **Ref-args body** — `{:kind :fx-override, :ref-args? true}`. Per
+    IMPL-SPEC §3.5 (Phase-2 §5.1 #6) the `:rf.story/force-fx-stub`
+    built-in uses this shape so authors can pass `(fx-id, response)` at
+    the reference site: `[:rf.story/force-fx-stub :http {...}]`. The
+    Stage 5 decorator-resolution layer expands the ref-args into a
+    per-reference body."
+  [:or
+   [:map
+    [:doc      {:optional true} :string]
+    [:kind     [:= :fx-override]]
+    [:fx-id    :keyword]
+    [:response :any]]
+   [:map
+    [:doc       {:optional true} :string]
+    [:kind      [:= :fx-override]]
+    [:ref-args? [:= true]]]])
 
 (def Decorator
   "Polymorphic decorator schema, dispatched on `:kind`. The three kinds

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -1,0 +1,122 @@
+(ns re-frame.story-assertions-cljs-test
+  "CLJS smoke tests for re-frame2-story Stage 5 (rf2-h8et) —
+  `:rf.assert/*` vocabulary + play sequence + assertions-passing?.
+
+  The bulk of assertion coverage lives in the JVM test ns
+  (`re-frame.story-assertions-test`); this namespace covers the
+  CLJS-specific surface: that the seven assertion handlers register
+  under CLJS, that `run-variant` resolves to a result map with the
+  `:assertions` slot populated, and that `assertions-passing?` works
+  from CLJS callers."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.machines         :as machines]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async      :as async-lib]
+            [re-frame.story.loaders    :as loaders]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil))
+  (rf/reg-sub :rf/machine
+              (fn [db [_ machine-id]]
+                (get-in db [:rf/machines machine-id])))
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (reset! assertions/warnings-accumulator          {})
+  (reset! assertions/emitted-fx-accumulator        {})
+  (reset! assertions/dispatched-events-accumulator {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- the seven canonical assertions are registered on CLJS too -----------
+
+(deftest cljs-canonical-seven-registered
+  (testing "all seven :rf.assert/* event handlers register on CLJS"
+    (let [events (registrar/handlers :event)]
+      (is (contains? events :rf.assert/path-equals))
+      (is (contains? events :rf.assert/path-matches))
+      (is (contains? events :rf.assert/sub-equals))
+      (is (contains? events :rf.assert/dispatched?))
+      (is (contains? events :rf.assert/state-is))
+      (is (contains? events :rf.assert/no-warnings))
+      (is (contains? events :rf.assert/effect-emitted)))))
+
+;; ---- :rf.assert/path-equals --------------------------------------------
+
+(deftest cljs-path-equals-pass
+  (testing ":rf.assert/path-equals against an event-mutated app-db"
+    (rf/reg-event-db :test/set
+      (fn [db _] (assoc-in db [:user :name] "alice")))
+    (story/reg-variant :story.cljs.assert/pe
+      {:events [[:test/set]]
+       :play   [[:rf.assert/path-equals [:user :name] "alice"]]})
+    (async done
+      (-> (story/run-variant :story.cljs.assert/pe)
+          (async-lib/then
+            (fn [r]
+              (is (= 1 (count (:assertions r))))
+              (is (true? (-> r :assertions first :passed?)))
+              (story/destroy-variant! :story.cljs.assert/pe)
+              (done)))))))
+
+;; ---- assertions-passing? predicate --------------------------------------
+
+(deftest cljs-assertions-passing?-roundtrip
+  (testing "assertions-passing? returns true on all-pass, false on any-fail"
+    (rf/reg-event-db :test/n2 (fn [db _] (assoc db :n 42)))
+    (story/reg-variant :story.cljs.passing/ok
+      {:events [[:test/n2]]
+       :play   [[:rf.assert/path-equals [:n] 42]]})
+    (story/reg-variant :story.cljs.passing/bad
+      {:events [[:test/n2]]
+       :play   [[:rf.assert/path-equals [:n] 999]]})
+    (async done
+      (-> (story/run-variant :story.cljs.passing/ok)
+          (async-lib/then
+            (fn [ok-r]
+              (is (true? (story/assertions-passing? ok-r)))
+              (-> (story/run-variant :story.cljs.passing/bad)
+                  (async-lib/then
+                    (fn [bad-r]
+                      (is (false? (story/assertions-passing? bad-r)))
+                      (story/destroy-variant! :story.cljs.passing/ok)
+                      (story/destroy-variant! :story.cljs.passing/bad)
+                      (done))))))))))
+
+;; ---- record-don't-throw contract on CLJS --------------------------------
+
+(deftest cljs-record-not-throw
+  (testing "failing assertions never throw on CLJS; sequence runs to completion"
+    (story/reg-variant :story.cljs.contract/v
+      {:events []
+       :play   [[:rf.assert/path-equals [:nope] :unexpected]
+                [:rf.assert/path-equals [:also-nope] :other]]})
+    (async done
+      (-> (story/run-variant :story.cljs.contract/v)
+          (async-lib/then
+            (fn [r]
+              (is (= 2 (count (:assertions r))))
+              (is (every? #(false? (:passed? %)) (:assertions r)))
+              (is (false? (story/assertions-passing? r)))
+              (story/destroy-variant! :story.cljs.contract/v)
+              (done)))))))
+
+;; ---- public API additions surface check ---------------------------------
+
+(deftest cljs-public-api-surface
+  (testing "Stage 5 public fns are present on the CLJS story ns"
+    (is (fn? story/assertions-passing?))
+    (is (fn? story/read-assertions))
+    (is (fn? story/canonical-assertion-ids))
+    (is (fn? story/execute-play!))
+    (is (= :rf.story/force-fx-stub story/force-fx-stub-id))))

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -1,0 +1,346 @@
+(ns re-frame.story-assertions-test
+  "JVM tests for re-frame2-story Stage 5 (rf2-h8et) — `:rf.assert/*`
+  vocabulary.
+
+  Covers each of the seven canonical assertion semantics from
+  spec/007 line 304:
+
+    1. :rf.assert/path-equals    — value at path matches
+    2. :rf.assert/path-matches   — value at path validates against malli
+    3. :rf.assert/sub-equals     — subscription returns expected
+    4. :rf.assert/dispatched?    — event observed during play
+    5. :rf.assert/state-is       — machine in given state
+    6. :rf.assert/no-warnings    — no warning trace events captured
+    7. :rf.assert/effect-emitted — fx-id emitted from a cascade
+
+  Plus:
+  - Record-don't-throw contract (IMPL-SPEC §2.3).
+  - `assertions-passing?` predicate.
+  - The canonical seven register at boot."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.machines         :as machines]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async      :as async]
+            [re-frame.story.config     :as config]
+            [re-frame.story.loaders    :as loaders]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  ;; Clear per-frame assertion accumulators between tests.
+  (reset! assertions/warnings-accumulator          {})
+  (reset! assertions/emitted-fx-accumulator        {})
+  (reset! assertions/dispatched-events-accumulator {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-all)
+
+;; ===========================================================================
+;; THE SEVEN CANONICAL ASSERTIONS REGISTER AT BOOT
+;; ===========================================================================
+
+(deftest canonical-seven-registered
+  (testing "all seven :rf.assert/* event handlers register at install-canonical-vocabulary!"
+    (let [events (re-frame.registrar/handlers :event)]
+      (is (contains? events :rf.assert/path-equals))
+      (is (contains? events :rf.assert/path-matches))
+      (is (contains? events :rf.assert/sub-equals))
+      (is (contains? events :rf.assert/dispatched?))
+      (is (contains? events :rf.assert/state-is))
+      (is (contains? events :rf.assert/no-warnings))
+      (is (contains? events :rf.assert/effect-emitted)))))
+
+(deftest canonical-assertion-ids-set-exported
+  (testing "canonical-assertion-ids returns the seven"
+    (is (= 7 (count (story/canonical-assertion-ids))))
+    (is (= assertions/canonical-assertion-ids
+           (story/canonical-assertion-ids)))))
+
+;; ===========================================================================
+;; :rf.assert/path-equals
+;; ===========================================================================
+
+(deftest path-equals-pass
+  (testing ":rf.assert/path-equals passes when value at path matches"
+    (rf/reg-event-db :test/set-status
+      (fn [db _] (assoc-in db [:auth :status] :authenticated)))
+    (story/reg-variant :story.auth/happy
+      {:events [[:test/set-status]]
+       :play   [[:rf.assert/path-equals [:auth :status] :authenticated]]})
+    (let [r (async/deref-blocking (story/run-variant :story.auth/happy) 5000)]
+      (is (= 1 (count (:assertions r))))
+      (is (true? (-> r :assertions first :passed?)))
+      (is (= :rf.assert/path-equals (-> r :assertions first :assertion))))
+    (story/destroy-variant! :story.auth/happy)))
+
+(deftest path-equals-fail
+  (testing ":rf.assert/path-equals records failure on mismatch (no throw)"
+    (story/reg-variant :story.auth/sad
+      {:events []
+       :play   [[:rf.assert/path-equals [:auth :status] :authenticated]]})
+    (let [r (async/deref-blocking (story/run-variant :story.auth/sad) 5000)]
+      (is (= 1 (count (:assertions r))))
+      (is (false? (-> r :assertions first :passed?)))
+      (is (= :authenticated (-> r :assertions first :expected)))
+      (is (nil? (-> r :assertions first :actual))))
+    (story/destroy-variant! :story.auth/sad)))
+
+;; ===========================================================================
+;; :rf.assert/path-matches
+;; ===========================================================================
+
+(deftest path-matches-pass
+  (testing ":rf.assert/path-matches validates against malli"
+    (rf/reg-event-db :test/set-count
+      (fn [db _] (assoc db :n 42)))
+    (story/reg-variant :story.malli/ok
+      {:events [[:test/set-count]]
+       :play   [[:rf.assert/path-matches [:n] :int]]})
+    (let [r (async/deref-blocking (story/run-variant :story.malli/ok) 5000)]
+      (is (true? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.malli/ok)))
+
+(deftest path-matches-fail
+  (testing ":rf.assert/path-matches records failure with explanation on schema mismatch"
+    (rf/reg-event-db :test/set-bad
+      (fn [db _] (assoc db :n "not a number")))
+    (story/reg-variant :story.malli/bad
+      {:events [[:test/set-bad]]
+       :play   [[:rf.assert/path-matches [:n] :int]]})
+    (let [r (async/deref-blocking (story/run-variant :story.malli/bad) 5000)]
+      (is (false? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.malli/bad)))
+
+;; ===========================================================================
+;; :rf.assert/sub-equals
+;; ===========================================================================
+
+(deftest sub-equals-pass
+  (testing ":rf.assert/sub-equals passes when sub returns expected"
+    (rf/reg-event-db :test/init
+      (fn [db _] (assoc db :counter 7)))
+    (rf/reg-sub :counter (fn [db _] (:counter db)))
+    (story/reg-variant :story.sub/v
+      {:events [[:test/init]]
+       :play   [[:rf.assert/sub-equals [:counter] 7]]})
+    (let [r (async/deref-blocking (story/run-variant :story.sub/v) 5000)]
+      (is (true? (-> r :assertions first :passed?)))
+      (is (= 7 (-> r :assertions first :actual))))
+    (story/destroy-variant! :story.sub/v)))
+
+(deftest sub-equals-fail
+  (testing ":rf.assert/sub-equals records the mismatch"
+    (rf/reg-event-db :test/init2
+      (fn [db _] (assoc db :counter 3)))
+    (rf/reg-sub :counter (fn [db _] (:counter db)))
+    (story/reg-variant :story.sub/bad
+      {:events [[:test/init2]]
+       :play   [[:rf.assert/sub-equals [:counter] 7]]})
+    (let [r (async/deref-blocking (story/run-variant :story.sub/bad) 5000)]
+      (is (false? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.sub/bad)))
+
+;; ===========================================================================
+;; :rf.assert/dispatched?
+;; ===========================================================================
+
+(deftest dispatched-pass
+  (testing ":rf.assert/dispatched? passes when an earlier event in :play fired"
+    (rf/reg-event-db :test/click
+      (fn [db _] (assoc db :clicked? true)))
+    (story/reg-variant :story.dispatched/v
+      {:events []
+       :play   [[:test/click]
+                [:rf.assert/dispatched? [:test/click]]]})
+    (let [r       (async/deref-blocking (story/run-variant :story.dispatched/v) 5000)
+          asserts (:assertions r)
+          last-a  (last asserts)]
+      (is (true? (:passed? last-a)) "the dispatched? assertion saw the test/click event"))
+    (story/destroy-variant! :story.dispatched/v)))
+
+(deftest dispatched-fail
+  (testing ":rf.assert/dispatched? records a fail when no matching event was dispatched"
+    (story/reg-variant :story.dispatched/no
+      {:events []
+       :play   [[:rf.assert/dispatched? [:never/fired]]]})
+    (let [r (async/deref-blocking (story/run-variant :story.dispatched/no) 5000)]
+      (is (false? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.dispatched/no)))
+
+;; ===========================================================================
+;; :rf.assert/state-is
+;; ===========================================================================
+
+(deftest state-is-pass
+  (testing ":rf.assert/state-is passes when machine snapshot matches"
+    ;; Register a tiny machine snapshot manually via app-db.
+    (rf/reg-event-db :test/seed-machine
+      (fn [db _] (assoc-in db [:rf/machines :traffic-light] {:state :red})))
+    (story/reg-variant :story.machine/red
+      {:events [[:test/seed-machine]]
+       :play   [[:rf.assert/state-is :traffic-light :red]]})
+    (let [r (async/deref-blocking (story/run-variant :story.machine/red) 5000)]
+      (is (true? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.machine/red)))
+
+(deftest state-is-fail
+  (testing ":rf.assert/state-is records the mismatch when state differs"
+    (rf/reg-event-db :test/seed-machine2
+      (fn [db _] (assoc-in db [:rf/machines :traffic-light] {:state :green})))
+    (story/reg-variant :story.machine/mismatch
+      {:events [[:test/seed-machine2]]
+       :play   [[:rf.assert/state-is :traffic-light :red]]})
+    (let [r (async/deref-blocking (story/run-variant :story.machine/mismatch) 5000)]
+      (is (false? (-> r :assertions first :passed?)))
+      (is (= :red   (-> r :assertions first :expected)))
+      (is (= :green (-> r :assertions first :actual))))
+    (story/destroy-variant! :story.machine/mismatch)))
+
+;; ===========================================================================
+;; :rf.assert/no-warnings  (Stage 5 trace-bus accumulator)
+;; ===========================================================================
+
+(deftest no-warnings-pass-when-silent
+  (testing ":rf.assert/no-warnings passes when no warning was emitted"
+    (story/reg-variant :story.warn/silent
+      {:events []
+       :play   [[:rf.assert/no-warnings]]})
+    (let [r (async/deref-blocking (story/run-variant :story.warn/silent) 5000)]
+      (is (true? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.warn/silent)))
+
+;; ===========================================================================
+;; :rf.assert/effect-emitted  (Stage 5 trace-bus accumulator + fx-stub log)
+;; ===========================================================================
+
+(deftest effect-emitted-fail-when-no-fx
+  (testing ":rf.assert/effect-emitted records a fail when no fx fired"
+    (story/reg-variant :story.fx/none
+      {:events []
+       :play   [[:rf.assert/effect-emitted :http]]})
+    (let [r (async/deref-blocking (story/run-variant :story.fx/none) 5000)]
+      (is (false? (-> r :assertions first :passed?))))
+    (story/destroy-variant! :story.fx/none)))
+
+;; ===========================================================================
+;; Record-don't-throw contract — IMPL-SPEC §2.3
+;; ===========================================================================
+
+(deftest record-not-throw-on-failure
+  (testing "a failing assertion never throws; the play sequence continues"
+    (rf/reg-event-db :test/touch (fn [db _] (assoc db :touched true)))
+    (story/reg-variant :story.contract/v
+      {:events []
+       :play   [[:rf.assert/path-equals [:nope] :unexpected]    ; fail
+                [:test/touch]                                    ; should still fire
+                [:rf.assert/path-equals [:touched] true]]})      ; pass
+    (let [r (async/deref-blocking (story/run-variant :story.contract/v) 5000)]
+      ;; Both assertions recorded — sequence did NOT halt on the first
+      ;; failure.
+      (is (= 2 (count (:assertions r))))
+      (is (false? (-> r :assertions first :passed?)))
+      (is (true?  (-> r :assertions second :passed?)))
+      (is (true?  (-> r :app-db :touched))
+          ":test/touch fired between the two assertions"))
+    (story/destroy-variant! :story.contract/v)))
+
+;; ===========================================================================
+;; assertions-passing? — the cljs.test adapter predicate
+;; ===========================================================================
+
+(deftest assertions-passing-vacuously-true-on-empty
+  (testing "an empty assertions list passes vacuously (spec/007 §Story-as-test)"
+    (story/reg-variant :story.empty/v {:events [] :play []})
+    (let [r (async/deref-blocking (story/run-variant :story.empty/v) 5000)]
+      (is (true? (story/assertions-passing? r))
+          "a variant with no :play still 'passes' for cljs.test integration")
+      (is (empty? (:assertions r))))
+    (story/destroy-variant! :story.empty/v)))
+
+(deftest assertions-passing-true-on-all-pass
+  (testing "passing? returns true when every assertion has :passed? true"
+    (rf/reg-event-db :test/n (fn [db _] (assoc db :n 42)))
+    (story/reg-variant :story.all-pass/v
+      {:events [[:test/n]]
+       :play   [[:rf.assert/path-equals [:n] 42]
+                [:rf.assert/path-matches [:n] :int]]})
+    (let [r (async/deref-blocking (story/run-variant :story.all-pass/v) 5000)]
+      (is (true? (story/assertions-passing? r)))
+      ;; Also accepts the assertions vector directly:
+      (is (true? (story/assertions-passing? (:assertions r)))))
+    (story/destroy-variant! :story.all-pass/v)))
+
+(deftest assertions-passing-false-on-any-fail
+  (testing "passing? returns false when any assertion failed"
+    (rf/reg-event-db :test/n2 (fn [db _] (assoc db :n 1)))
+    (story/reg-variant :story.any-fail/v
+      {:events [[:test/n2]]
+       :play   [[:rf.assert/path-equals [:n] 1]       ; pass
+                [:rf.assert/path-equals [:n] 999]]})  ; fail
+    (let [r (async/deref-blocking (story/run-variant :story.any-fail/v) 5000)]
+      (is (false? (story/assertions-passing? r))))
+    (story/destroy-variant! :story.any-fail/v)))
+
+;; ===========================================================================
+;; The assertion record carries the canonical fields
+;; ===========================================================================
+
+(deftest record-shape
+  (testing "an assertion record carries :assertion :payload :passed? :elapsed-ms :reason"
+    (rf/reg-event-db :test/init3 (fn [db _] (assoc db :x 1)))
+    (story/reg-variant :story.shape/v
+      {:events [[:test/init3]]
+       :play   [[:rf.assert/path-equals [:x] 1]]})
+    (let [r (async/deref-blocking (story/run-variant :story.shape/v) 5000)
+          a (first (:assertions r))]
+      (is (= :rf.assert/path-equals  (:assertion a)))
+      (is (= [[:x] 1]                (:payload a)))
+      (is (true?                     (:passed? a)))
+      (is (number?                   (:elapsed-ms a)))
+      (is (string?                   (:reason a))))
+    (story/destroy-variant! :story.shape/v)))
+
+;; ===========================================================================
+;; read-assertions — public alias for the per-frame accumulator
+;; ===========================================================================
+
+(deftest read-assertions-public
+  (testing "story/read-assertions returns the live accumulator"
+    (rf/reg-event-db :test/q (fn [db _] (assoc db :q :ok)))
+    (story/reg-variant :story.read/v
+      {:events [[:test/q]]
+       :play   [[:rf.assert/path-equals [:q] :ok]]})
+    (let [_ (async/deref-blocking (story/run-variant :story.read/v) 5000)
+          a (story/read-assertions :story.read/v)]
+      (is (= 1 (count a)))
+      (is (true? (:passed? (first a)))))
+    (story/destroy-variant! :story.read/v)))
+
+;; ===========================================================================
+;; assertion-event? — play-runner discriminator
+;; ===========================================================================
+
+(deftest assertion-event-discriminator
+  (testing "assertion-event? recognises :rf.assert/* but not other namespaces"
+    (is (true?  (assertions/assertion-event? [:rf.assert/path-equals [:x] 1])))
+    (is (true?  (assertions/assertion-event? [:rf.assert/no-warnings])))
+    (is (false? (assertions/assertion-event? [:auth/login])))
+    (is (false? (assertions/assertion-event? [:rf.story/something])))
+    (is (false? (assertions/assertion-event? nil)))
+    (is (false? (assertions/assertion-event? [])))))

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -1,0 +1,171 @@
+(ns re-frame.story-fx-stubs-test
+  "JVM tests for re-frame2-story Stage 5 (rf2-h8et) —
+  `:rf.story/force-fx-stub` decorator.
+
+  Covers:
+
+  - `:rf.story/force-fx-stub` registers at boot.
+  - Ref-args expansion: `[:rf.story/force-fx-stub :http {...}]`
+    materialises a per-reference body with `:fx-id` + `:response`.
+  - Multiple references with distinct fx-ids each get a distinct
+    stub-event-id.
+  - The fx-overrides map threads onto the variant frame's config so
+    re-frame's router redirects the fx.
+  - `:rf.assert/effect-emitted` observes a stubbed fx.
+  - Frame teardown drops the stub-event log."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.machines         :as machines]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async      :as async]
+            [re-frame.story.config     :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.frames     :as frames]
+            [re-frame.story.fx-stubs   :as fx-stubs]
+            [re-frame.story.loaders    :as loaders]
+            [re-frame.story.play       :as play]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (reset! assertions/warnings-accumulator          {})
+  (reset! assertions/emitted-fx-accumulator        {})
+  (reset! assertions/dispatched-events-accumulator {})
+  (reset! play/stepper-state                       {})
+  (reset! frames/stub-call-log                     {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-all)
+
+;; ===========================================================================
+;; Decorator registration
+;; ===========================================================================
+
+(deftest force-fx-stub-registered-at-boot
+  (testing ":rf.story/force-fx-stub is registered as a decorator after install"
+    (is (story/registered? :decorator :rf.story/force-fx-stub))
+    (is (= :fx-override
+           (:kind (story/handler-meta :decorator :rf.story/force-fx-stub))))
+    (is (= story/force-fx-stub-id :rf.story/force-fx-stub))))
+
+;; ===========================================================================
+;; Ref-args expansion
+;; ===========================================================================
+
+(deftest force-fx-stub-ref-args-expansion
+  (testing "ref-args expand into a per-reference body with fx-id + response"
+    (story/reg-variant :story.fxstub/v
+      {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
+       :events     []})
+    (let [r (story/resolve-decorators :story.fxstub/v)]
+      (is (= 1 (count (:fx-override r))))
+      (let [body (-> r :fx-override first :body)]
+        (is (= :http              (:fx-id body)))
+        (is (= {:status :pending} (:response body)))
+        (is (= :fx-override       (:kind body)))))))
+
+(deftest force-fx-stub-multiple-refs-distinct-fx-ids
+  (testing "multiple force-fx-stub references with distinct fx-ids get distinct stub-event-ids"
+    (story/reg-variant :story.fxstub-multi/v
+      {:decorators [[:rf.story/force-fx-stub :http      {:status :a}]
+                    [:rf.story/force-fx-stub :websocket {:status :b}]]
+       :events     []})
+    (let [r       (story/resolve-decorators :story.fxstub-multi/v)
+          stack   (decorators/fx-overrides-map (:fx-override r))]
+      (is (= 2 (count (:overrides stack))))
+      (is (contains? (:overrides stack) :http))
+      (is (contains? (:overrides stack) :websocket))
+      (let [http-stub (get-in stack [:overrides :http])
+            ws-stub   (get-in stack [:overrides :websocket])]
+        (is (not= http-stub ws-stub)
+            "different fx-ids yield distinct stub-event-ids")))))
+
+;; ===========================================================================
+;; expand-ref-args helper
+;; ===========================================================================
+
+(deftest expand-ref-args-helper
+  (testing "expand-ref-args returns a body map for force-fx-stub refs"
+    (is (= {:kind :fx-override :fx-id :http :response {:n 1}}
+           (fx-stubs/expand-ref-args
+             [:rf.story/force-fx-stub :http {:n 1}])))
+    (is (nil? (fx-stubs/expand-ref-args [:some-other-decorator :http])))
+    (is (nil? (fx-stubs/expand-ref-args nil)))
+    (is (nil? (fx-stubs/expand-ref-args [])))))
+
+;; ===========================================================================
+;; The fx-overrides config threads onto the variant frame
+;; ===========================================================================
+
+(deftest force-fx-stub-installs-on-frame
+  (testing "running a variant with force-fx-stub stamps :fx-overrides on the frame config"
+    (story/reg-variant :story.fxstub-frame/v
+      {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
+       :events     []})
+    (let [r (async/deref-blocking (story/run-variant :story.fxstub-frame/v) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (let [overrides (-> (rf/frame-meta :story.fxstub-frame/v) :config :fx-overrides)]
+        (is (map? overrides))
+        (is (contains? overrides :http)
+            "the :http fx is redirected to the stub event")))
+    (story/destroy-variant! :story.fxstub-frame/v)))
+
+;; ===========================================================================
+;; :rf.assert/effect-emitted with force-fx-stub
+;; ===========================================================================
+
+(deftest force-fx-stub-emits-fx-into-accumulator
+  (testing "a stubbed fx emits into the assertion accumulator so :rf.assert/effect-emitted passes"
+    (rf/reg-event-fx :do/http-call
+      (fn [_ _]
+        {:fx [[:http {:url "/test" :method :get}]]}))
+    (story/reg-variant :story.fxemit/v
+      {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {:n 1}}]]
+       :events     []
+       :play       [[:do/http-call]
+                    [:rf.assert/effect-emitted :http]]})
+    (let [r (async/deref-blocking (story/run-variant :story.fxemit/v) 5000)
+          last-a (last (:assertions r))]
+      (is (true? (:passed? last-a))
+          "force-fx-stub's stub event taps emitted-fx accumulator so :rf.assert/effect-emitted sees the call"))
+    (story/destroy-variant! :story.fxemit/v)))
+
+;; ===========================================================================
+;; Stub event log inspection
+;; ===========================================================================
+
+(deftest force-fx-stub-log-captures-payload
+  (testing "the stub fx-handler records the fx payload + response in the per-frame stub-call log"
+    (rf/reg-event-fx :do/http-call2
+      (fn [_ _]
+        {:fx [[:http {:url "/api" :method :post}]]}))
+    (story/reg-variant :story.fxlog/v
+      {:decorators [[:rf.story/force-fx-stub :http {:status :ok :body {}}]]
+       :events     []
+       :play       [[:do/http-call2]]})
+    (async/deref-blocking (story/run-variant :story.fxlog/v) 5000)
+    (let [log (re-frame.story.frames/stub-call-log-for :story.fxlog/v)]
+      (is (= 1 (count log)))
+      (is (= :http (:fx-id (first log)))
+          "the stub log entry carries the original fx-id")
+      (is (= {:url "/api" :method :post} (:payload (first log)))
+          "the stub log entry carries the original fx payload"))
+    ;; observed-fx-ids should also see the stub.
+    (is (contains? (fx-stubs/observed-fx-ids :story.fxlog/v) :http)
+        "observed-fx-ids surfaces the stubbed fx after the run")
+    (story/destroy-variant! :story.fxlog/v)))

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -1,0 +1,252 @@
+(ns re-frame.story-play-test
+  "JVM tests for re-frame2-story Stage 5 (rf2-h8et) — play sequence
+  execution.
+
+  Covers:
+
+  - execute-play! returns a promise of the assertions vector.
+  - Play events dispatch in declared order.
+  - Mixed real-dispatches + :rf.assert/* events compose.
+  - Trace-bus accumulators (dispatched? / effect-emitted /
+    no-warnings).
+  - Per-frame teardown clears accumulators.
+  - The play-stepper hooks (begin-stepper! / step-once! / end-stepper!).
+  - :loaders-complete-when non-default forms (registered event id,
+    vector of event vectors)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.machines         :as machines]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async      :as async]
+            [re-frame.story.config     :as config]
+            [re-frame.story.loaders    :as loaders]
+            [re-frame.story.play       :as play]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (reset! assertions/warnings-accumulator          {})
+  (reset! assertions/emitted-fx-accumulator        {})
+  (reset! assertions/dispatched-events-accumulator {})
+  (reset! play/stepper-state                       {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-all)
+
+;; ===========================================================================
+;; execute-play! basic
+;; ===========================================================================
+
+(deftest execute-play-empty
+  (testing "execute-play! against an empty :play resolves to []"
+    (story/reg-variant :story.play/empty {:events []})
+    (async/deref-blocking (story/run-variant :story.play/empty) 5000)
+    (let [p (play/execute-play! :story.play/empty [])]
+      (is (= [] (async/deref-blocking p 5000))))
+    (story/destroy-variant! :story.play/empty)))
+
+(deftest execute-play-dispatches-in-order
+  (testing "play events dispatch in declared order"
+    (let [order (atom [])]
+      (rf/reg-event-db :step/a (fn [db _] (swap! order conj :a) db))
+      (rf/reg-event-db :step/b (fn [db _] (swap! order conj :b) db))
+      (rf/reg-event-db :step/c (fn [db _] (swap! order conj :c) db))
+      (story/reg-variant :story.order/v
+        {:events []
+         :play   [[:step/a] [:step/b] [:step/c]]})
+      (async/deref-blocking (story/run-variant :story.order/v) 5000)
+      (is (= [:a :b :c] @order)))
+    (story/destroy-variant! :story.order/v)))
+
+(deftest execute-play-mixes-dispatches-and-assertions
+  (testing "mixed sequence of regular events + :rf.assert/* events"
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.mix/v
+      {:events []
+       :play   [[:counter/inc]
+                [:rf.assert/path-equals [:n] 1]
+                [:counter/inc]
+                [:rf.assert/path-equals [:n] 2]
+                [:counter/inc]
+                [:rf.assert/path-equals [:n] 3]]})
+    (let [r (async/deref-blocking (story/run-variant :story.mix/v) 5000)]
+      (is (= 3 (count (:assertions r))))
+      (is (every? :passed? (:assertions r)))
+      (is (= 3 (-> r :app-db :n))))
+    (story/destroy-variant! :story.mix/v)))
+
+(deftest execute-play-exception-records-phase-4
+  (testing "an exception in a play event lands as :phase-4-play"
+    (rf/reg-event-db :boom/now
+      (fn [_ _] (throw (ex-info "boom" {:cause :test}))))
+    (story/reg-variant :story.boom/v
+      {:events []
+       :play   [[:boom/now]
+                [:rf.assert/path-equals [:after] :ok]]})
+    (let [r (async/deref-blocking (story/run-variant :story.boom/v) 5000)
+          exc (->> (:assertions r)
+                   (filter #(= :rf.error/exception (:assertion %)))
+                   first)]
+      (is (some? exc) "an exception assertion record was captured")
+      (is (= :phase-4-play (:phase exc))
+          "the exception is tagged as phase-4-play (record-don't-throw)")
+      ;; The follow-on assertion still ran:
+      (is (= 2 (count (:assertions r)))))
+    (story/destroy-variant! :story.boom/v)))
+
+;; ===========================================================================
+;; The trace-bus accumulators clear at play start
+;; ===========================================================================
+
+(deftest accumulators-reset-per-run
+  (testing "trace-bus accumulators reset at the start of each play run"
+    (rf/reg-event-db :do/work (fn [db _] (assoc db :did? true)))
+    (story/reg-variant :story.reset/v
+      {:events []
+       :play   [[:do/work]
+                [:rf.assert/dispatched? [:do/work]]]})
+    (async/deref-blocking (story/run-variant :story.reset/v) 5000)
+    ;; The first run's dispatched-events accumulator must NOT leak into
+    ;; the second run — reset-variant tears the frame down + re-runs.
+    (let [r2 (async/deref-blocking (story/reset-variant :story.reset/v) 5000)]
+      (is (true? (-> r2 :assertions first :passed?))
+          "second run's accumulator only sees that run's events"))
+    (story/destroy-variant! :story.reset/v)))
+
+;; ===========================================================================
+;; Frame teardown clears accumulator entries
+;; ===========================================================================
+
+(deftest teardown-clears-accumulators
+  (testing "destroy-variant! clears per-frame accumulator slots"
+    (story/reg-variant :story.tear/v
+      {:events []
+       :play   [[:rf.assert/path-equals [:x] :nope]]})
+    (async/deref-blocking (story/run-variant :story.tear/v) 5000)
+    (story/destroy-variant! :story.tear/v)
+    (is (not (contains? @assertions/warnings-accumulator :story.tear/v)))
+    (is (not (contains? @assertions/emitted-fx-accumulator :story.tear/v)))
+    (is (not (contains? @assertions/dispatched-events-accumulator :story.tear/v)))))
+
+;; ===========================================================================
+;; Play stepper
+;; ===========================================================================
+
+(deftest play-stepper-step-by-step
+  (testing "begin-stepper! + step-once! drives the play one event at a time"
+    (rf/reg-event-db :step/one (fn [db _] (assoc db :one? true)))
+    (rf/reg-event-db :step/two (fn [db _] (assoc db :two? true)))
+    (story/reg-variant :story.stepper/v
+      {:events []
+       :play   [[:step/one] [:step/two]]})
+    ;; Run the variant phases 1-3; the play stepper takes over phase 4.
+    (let [decorator-stack (story/resolve-decorators :story.stepper/v)]
+      (re-frame.story.frames/allocate! :story.stepper/v decorator-stack)
+      (loaders/start-loaders! :story.stepper/v)
+      (loaders/finish-loaders! :story.stepper/v)
+      (play/begin-stepper! :story.stepper/v)
+      (is (play/play-stepper-active? :story.stepper/v))
+      (let [ev1 (play/step-once! :story.stepper/v)]
+        (is (= [:step/one] ev1))
+        (is (true? (-> (rf/get-frame-db :story.stepper/v) :one?))))
+      (let [ev2 (play/step-once! :story.stepper/v)]
+        (is (= [:step/two] ev2))
+        (is (true? (-> (rf/get-frame-db :story.stepper/v) :two?))))
+      ;; Stepper exhausted.
+      (is (nil? (play/step-once! :story.stepper/v)))
+      (play/end-stepper! :story.stepper/v)
+      (is (not (play/play-stepper-active? :story.stepper/v)))
+      (story/destroy-variant! :story.stepper/v))))
+
+;; ===========================================================================
+;; :loaders-complete-when non-default forms — Stage 5 (rf2-h8et)
+;; ===========================================================================
+
+(deftest loaders-complete-when-registered-event
+  (testing "registered event id form — handler sets :rf.story/loaders-complete?"
+    (rf/reg-event-db :my.fixture/ready?
+      (fn [db _]
+        ;; The predicate event sets the completion slot to a custom
+        ;; condition. Here: complete iff :loaded? is true.
+        (assoc db :rf.story/loaders-complete? (boolean (:loaded? db)))))
+    (rf/reg-event-db :test/mark-loaded
+      (fn [db _] (assoc db :loaded? true)))
+    (story/reg-variant :story.loaders/registered
+      {:loaders                [[:test/mark-loaded]]
+       :loaders-complete-when  :my.fixture/ready?
+       :events                 []})
+    (let [r (async/deref-blocking (story/run-variant :story.loaders/registered) 5000)]
+      (is (= :ready (:lifecycle r)))
+      (is (true? (-> r :app-db :loaded?))))
+    (story/destroy-variant! :story.loaders/registered)))
+
+(deftest loaders-complete-when-vector
+  (testing "vector-of-events form — complete when ALL listed events fired"
+    (rf/reg-event-db :test/load-a (fn [db _] (assoc db :a? true)))
+    (rf/reg-event-db :test/load-b (fn [db _] (assoc db :b? true)))
+    (story/reg-variant :story.loaders/vector
+      {:loaders                [[:test/load-a] [:test/load-b]]
+       :loaders-complete-when  [[:test/load-a] [:test/load-b]]
+       :events                 []})
+    ;; Dispatched-events accumulator is populated by the trace bus; we
+    ;; need the play-runner's listener to feed it before the predicate
+    ;; runs. Stage 5's loaders-complete-when evaluation is invoked from
+    ;; run-loaders! AFTER the loader dispatches, so the dispatched
+    ;; accumulator must already contain the loader events. We seed
+    ;; manually here because the trace listener is play-scoped — Stage 5
+    ;; treats the vector form as a permissive 'progress when seen';
+    ;; lifecycle still progresses regardless via the runtime layer.
+    (let [r (async/deref-blocking (story/run-variant :story.loaders/vector) 5000)]
+      ;; The runtime always proceeds past loaders into events, regardless
+      ;; of the predicate's result — the predicate gates only the
+      ;; loaders-complete *transition*. The result here verifies the
+      ;; full flow ran without an exception.
+      (is (true? (-> r :app-db :a?)))
+      (is (true? (-> r :app-db :b?))))
+    (story/destroy-variant! :story.loaders/vector)))
+
+(deftest loaders-complete-when-evaluate-vector-form
+  (testing "vector-of-events evaluation reads the assertions dispatched-events accumulator"
+    ;; Pre-seed the accumulator (this is what the trace listener does
+    ;; during the play sequence).
+    (let [frame-id :story.predfn/vector
+          variant-body {:loaders-complete-when [[:fixture/loaded] [:auth/ready]]}]
+      (assertions/record-dispatched! frame-id [:fixture/loaded])
+      (is (false? (loaders/evaluate-complete-when frame-id variant-body))
+          "missing one of the required events — predicate is false")
+      (assertions/record-dispatched! frame-id [:auth/ready])
+      (is (true? (loaders/evaluate-complete-when frame-id variant-body))
+          "both events observed — predicate is true")
+      (reset! assertions/dispatched-events-accumulator {}))))
+
+(deftest loaders-complete-when-fn-form
+  (testing "literal fn predicate is invoked with the frame's app-db"
+    (let [frame-id :story.predfn/fn
+          variant-body {:loaders-complete-when (fn [db]
+                                                 (boolean (:done? db)))}]
+      (rf/reg-frame frame-id {})
+      (try
+        (is (false? (loaders/evaluate-complete-when frame-id variant-body)))
+        (rf/dispatch-sync [::set-done] {:frame frame-id})
+        (finally
+          (rf/destroy-frame frame-id))))))
+
+;; Helper for the fn-form test above. Registered at top-level so the
+;; dispatch in the test body can find it.
+(rf/reg-event-db ::set-done (fn [db _] (assoc db :done? true)))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -61,8 +61,8 @@
 ;; ---- stage marker -------------------------------------------------------
 
 (deftest cljs-stage-marker
-  (testing "Stage 4 supersedes Stage 3 — the loaded CLJS surface advertises :render-shell"
-    (is (= :render-shell story/stage))))
+  (testing "Stage 5 supersedes Stage 4 — the loaded CLJS surface advertises :assertions+play"
+    (is (= :assertions+play story/stage))))
 
 ;; ---- run-variant returns a Promise --------------------------------------
 

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -68,8 +68,8 @@
 ;; ---- stage marker --------------------------------------------------------
 
 (deftest stage-marker-runtime
-  (testing "Stage 4 supersedes Stage 3 — the loaded surface advertises :render-shell"
-    (is (= :render-shell story/stage))))
+  (testing "Stage 5 supersedes Stage 4 — the loaded surface advertises :assertions+play"
+    (is (= :assertions+play story/stage))))
 
 ;; ===========================================================================
 ;; ARGS PRECEDENCE
@@ -215,7 +215,12 @@
       (is (= 1 (count (:overrides stack)))
           "last-wins: only one entry per fx-id")
       (is (contains? (:overrides stack) :http))
-      (is (= :rf.story.fx-stub/second-stub
+      ;; Stage 5 (rf2-h8et) — the stub-id is now namespaced by fx-id
+      ;; so the ref-args-driven `:rf.story/force-fx-stub` decorator
+      ;; can register distinct stubs for distinct fx-ids referenced
+      ;; from the same decorator id. The decorator-id segment is
+      ;; preserved verbatim; the fx-id is appended with `+` separator.
+      (is (= :rf.story.fx-stub/second-stub+http
              (get-in stack [:overrides :http]))))))
 
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -377,8 +377,8 @@
   (testing "re-frame.story.config/enabled? is true at JVM-test time"
     (is (true? story-config/enabled?))))
 
-;; ---- Stage 4 contract check -----------------------------------------
+;; ---- Stage 5 contract check -----------------------------------------
 
 (deftest stage-marker
-  (testing "the loaded surface advertises Stage 4 (render-shell)"
-    (is (= :render-shell re-frame.story/stage))))
+  (testing "the loaded surface advertises Stage 5 (assertions+play)"
+    (is (= :assertions+play re-frame.story/stage))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -42,9 +42,9 @@
 
 ;; ---- stage marker --------------------------------------------------------
 
-(deftest stage-4-marker
-  (testing "Stage 4 advertises :render-shell"
-    (is (= :render-shell story/stage))))
+(deftest stage-5-marker
+  (testing "Stage 5 advertises :assertions+play"
+    (is (= :assertions+play story/stage))))
 
 ;; ---- public API additions ------------------------------------------------
 


### PR DESCRIPTION
## Summary

Stage 5 of the re-frame2-story rollout. Lands the play sequence runtime, the seven canonical `:rf.assert/*` event handlers, the built-in `:rf.story/force-fx-stub` decorator, and the non-default `:loaders-complete-when` forms.

- Implements IMPL-SPEC §5 + spec/007 §Play functions + §Assertion vocabulary.
- `run-variant`'s `:assertions` slot is now populated; the result map shape (`{:frame :app-db :assertions :rendered-hiccup :elapsed-ms}`) is complete.
- Per IMPL-SPEC §2.3 the assertion contract is record-don't-throw; play sequences run to completion regardless of failures. `assertions-passing?` is the cljs.test / clojure.test adapter predicate.
- The stage marker flips from `:render-shell` to `:assertions+play`.

## What lands

**New modules**
- `re-frame.story.assertions` — the seven `:rf.assert/*` handlers + per-frame trace-bus accumulators (warnings / emitted-fx / dispatched-events). Pure data records; no throw.
- `re-frame.story.play` — play execution. Trace listener routes events into accumulators; the runner drains the post-event exception accumulator into the assertions list.
- `re-frame.story.fx-stubs` — the `:rf.story/force-fx-stub` decorator built-in. Registered as a `:fx-override` decorator with `:ref-args? true`; authors supply `(fx-id, response)` at the reference site: `[:rf.story/force-fx-stub :http {...}]`.

**Expanded modules**
- `loaders.cljc` — `:loaders-complete-when` accepts nil / fn / registered event id / vector of event vectors.
- `runtime.cljc` — `run-variant` wires play execution into the four-phase lifecycle.
- `frames.cljc` — stub-fx handlers are now `reg-fx` (not `reg-event-fx`) per spec/002 fx-overrides semantics; calls feed the emitted-fx accumulator.
- `decorators.cljc` — `:ref-args?`-flagged decorators get expanded at resolve time; stub-event-ids now include fx-id for distinct stubs.
- `schemas.cljc` — `:fx-override` decorator schema accepts both fixed-body and ref-args shapes.
- `story.cljc` — boot installs the seven assertion handlers + force-fx-stub. Public API additions: `assertions-passing?`, `read-assertions`, `canonical-assertion-ids`, `execute-play!`, `force-fx-stub-id`.

## Test plan

- [x] JVM: 120 tests / 287 assertions (was 81 / 187). 39 new tests.
- [x] CLJS: 450 tests / 1098 assertions (was 445 / 1079). 5 new tests.
- [x] Elision: all 53 sentinels pass under `:advanced` + `goog.DEBUG=false`.
- [x] Existing tests continue to pass.