### PR TITLE
feat(story): Stage 6 — SOTA features (v1.0 set) (rf2-zhwd)

### DIFF
--- a/tools/story/IMPL-SPEC.md
+++ b/tools/story/IMPL-SPEC.md
@@ -459,15 +459,54 @@ shared. The "variant body is pure data" rule is preserved.
 Body:
 
 ```clojure
-{:doc       "..."
- :title     "Display name"
- :placement :right | :left | :bottom | :top | :modal
- :render    <view-id>                            ; registered :view that renders the panel
- :for       #{<context-id>}}                    ; optional — restrict to specific story-tool contexts
+{:doc          "..."
+ :title        "Display name"
+ :placement    :right | :left | :bottom | :top | :modal
+ :render       <view-id>                            ; registered :view that renders the panel
+ :for          #{<context-id>}                     ; optional — restrict to specific story-tool contexts
+ :enabled-when (optional)}                          ; optional registry-predicate fn
 ```
 
 Per spec/007 §Story-tool extension hook. Stage 4 (render shell) reads
-`(rf/handlers :story-panel)` and lays them out.
+`(rf/handlers :story-panel)` and lays them out; Stage 6 (rf2-zhwd) adds
+the v1.0 panel set + the tooling-embed contract below.
+
+##### Panel-registration contract (Stage 6 lock)
+
+Per IMPL-SPEC §4.5 the `reg-story-panel` surface is the **single hook**
+through which tooling embeds itself into the Story chrome — no new
+registry kind, no parallel mounting protocol. The contract:
+
+1. **`:render` is a `:view` id.** The shell renders the panel by calling
+   `(rf/view <render-id>)` and invoking the resolved fn with the current
+   `variant-id`. Late-bind: the actual view can register from a
+   different artefact (e.g. `day8/re-frame2-10x` for the epoch panel)
+   so long as the same `:view` id is registered before the user opens
+   the panel.
+
+2. **Placement is one of five slots.** `:right` / `:left` / `:bottom`
+   / `:top` host the panel inline; `:modal` opens it over the canvas.
+   Each placement is an independent host; multiple panels at the same
+   placement stack in id order.
+
+3. **Visibility flows through `:panel-visibility`.** The shell state's
+   `:panel-visibility` map (keyed by panel id) is the on/off switch.
+   Unspecified → visible; explicit `false` → hidden. Users toggle via
+   the chrome's panel-list affordance.
+
+4. **Author calls `reg-story-panel` from anywhere on the classpath.**
+   Stage 6's built-ins (`:rf.story.panel/a11y` /
+   `:rf.story.panel/layout-debug` / `:rf.story.panel/epoch`) register
+   from inside `install-canonical-vocabulary!`; third-party tooling
+   (e.g. Causa's epoch view, future statechart-viz panels) registers
+   from its own boot.
+
+5. **The 10x embed.** Per IMPL-SPEC §2.7 + §2.8.9: Stage 6 ships
+   `:rf.story.panel/epoch` registered against a STUB view. The Causa
+   library (`tools/10x/`, rf2-buor) registers the live view under the
+   same `:rf.story.panel/epoch-view` id when present; the shell's
+   late-bind `rf/view` lookup picks Causa's view automatically. If
+   Causa is absent the stub renders documenting the contract.
 
 #### `(reg-tag id metadata)`
 
@@ -1455,11 +1494,12 @@ Plus from Phase 2 §5.2 (additions ship in v1):
 
 | Item | Bead reference |
 |---|---|
-| Layout-debug overlay trio (measure / outline / pseudo) | Stage 6 |
+| Layout-debug overlay trio (measure / outline / pseudo) | Stage 6 (rf2-zhwd) |
 | `reg-mode` saved-tuple primitive | Stage 2 |
 | `:variants-grid` workspace layout | Stage 4 |
-| Per-variant QR code in share menu | Stage 4 |
-| Multi-substrate side-by-side pane (substrate-failures inline) | Stage 4 |
+| Per-variant QR code in share menu | Stage 6 (rf2-zhwd) |
+| Multi-substrate side-by-side pane (substrate-failures inline) | Stage 6 (rf2-zhwd) |
+| 10x epoch panel embed (stub + contract) | Stage 6 (rf2-zhwd) |
 
 ### 11.2 v1.1 (first follow-up)
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -57,10 +57,17 @@
             [re-frame.story.assertions :as assertions]
             [re-frame.story.fx-stubs  :as fx-stubs]
             [re-frame.story.play      :as play]
+            ;; Stage 6 (rf2-zhwd) — SOTA features. layout-debug + share
+            ;; live in .cljc; multi-substrate / a11y / panels are
+            ;; CLJS-only so the JVM classpath stays lean.
+            [re-frame.story.layout-debug :as layout-debug]
+            [re-frame.story.share        :as share]
             ;; Stage 4 (rf2-ekai) — UI shell. CLJS-only require so JVM
             ;; consumers (tests, REPL exploration) don't pull Reagent /
             ;; reagent.dom.client into their classpath.
             #?(:cljs [re-frame.story.ui.shell :as ui-shell])
+            #?(:cljs [re-frame.story.ui.panels :as ui-panels])
+            #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
             #?(:clj [re-frame.story.macros :as macros]))
   ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
@@ -360,6 +367,14 @@
   - The late-bound stub-event tap so emitted fx-ids reach the
     assertion accumulator (for `:rf.assert/effect-emitted`).
 
+  Stage 6 (rf2-zhwd) adds:
+  - The three layout-debug decorators (`:rf.story/layout-debug.measure`
+    / `.outline` / `.pseudo`).
+  - The v1.0 built-in story panels: a11y, layout-debug toggles, and the
+    10x epoch panel STUB.
+  - The Reagent substrate is registered against the multi-substrate
+    grid renderer (so `:substrates #{:reagent ...}` works out of the box).
+
   Project-specific tags must register via `reg-tag` *before* use; an
   unregistered tag on a variant's `:tags` set raises `:rf.error/unknown-tag`."
   []
@@ -377,7 +392,16 @@
   (frames/set-drop-assertion-accumulators-fn!
     (fn [frame-id]
       (assertions/drop-trace-accumulators! frame-id)
-      (play/drop-pending-exceptions! frame-id))))
+      (play/drop-pending-exceptions! frame-id)))
+  ;; Stage 6 — SOTA features.
+  ;; Layout-debug decorators register on both JVM and CLJS (the .cljc
+  ;; module declares the three :hiccup-kind decorators against the
+  ;; story registrar).
+  (layout-debug/install-canonical-layout-debug!)
+  ;; CLJS-only Stage 6 surfaces: multi-substrate Reagent default +
+  ;; the v1.0 panel set.
+  #?(:cljs (ui-multi-substrate/install-reagent-substrate!))
+  #?(:cljs (ui-panels/install-canonical-panels!)))
 
 ;; ---- configure! ---------------------------------------------------------
 
@@ -574,6 +598,65 @@
                       [:rf.assert/effect-emitted :http]]})"
   fx-stubs/force-fx-stub-id)
 
+;; ---- Stage 6 (rf2-zhwd) public SOTA-feature surface ---------------------
+
+(def layout-debug-measure-id
+  "Per IMPL-SPEC §2.8.6 — the registered decorator id for the
+  Storybook-style layout measure overlay. Use on a variant's
+  `:decorators` slot:
+
+      (story/reg-variant :story.button/pressed
+        {:decorators [[story/layout-debug-measure-id]]})"
+  layout-debug/id-measure)
+
+(def layout-debug-outline-id
+  "Per IMPL-SPEC §2.8.6 — Pesticide-style coloured outlines on every
+  descendant element."
+  layout-debug/id-outline)
+
+(def layout-debug-pseudo-id
+  "Per IMPL-SPEC §2.8.6 — pseudo-state forcing. Ref-args is a set
+  from `#{:hover :focus :active :visited}`; default is `#{:hover}`:
+
+      (story/reg-variant :story.link/hovered
+        {:decorators [[story/layout-debug-pseudo-id #{:hover}]]})"
+  layout-debug/id-pseudo)
+
+(defn variant-share-url
+  "Per IMPL-SPEC §2.8.5 — build a sharable URL for a variant against
+  `base-url`. Encodes active modes + cell-overrides + substrate so a
+  scan-and-share session reproduces the cell.
+
+  Pure data → data; JVM + CLJS portable.
+
+  `opts`:
+    :active-modes    coll of registered mode ids
+    :cell-overrides  {arg-key → value}
+    :substrate       active substrate"
+  ([variant-id]                (share/variant-share-url variant-id))
+  ([variant-id base-url opts]  (share/variant-share-url variant-id base-url opts)))
+
+#?(:cljs
+   (defn register-substrate!
+     "Per IMPL-SPEC §2.2 + §2.8.4 — register a substrate render fn under
+     `substrate-id`. The host app calls this once at boot for each
+     substrate it wants Story to render against (UIx, Helix, etc.). The
+     Reagent substrate is registered automatically by
+     `install-canonical-vocabulary!`.
+
+     `render-fn` takes `(variant-id view-id args)` and returns a hiccup
+     vector (Reagent) or a React element (UIx / Helix)."
+     [substrate-id render-fn]
+     (ui-multi-substrate/register-substrate! substrate-id render-fn)))
+
+#?(:cljs
+   (defn registered-substrates
+     "Per IMPL-SPEC §2.2 — return the set of registered substrate ids.
+     Used by tooling that enumerates the available substrates for a
+     variant's `:substrates` opt-in."
+     []
+     (ui-multi-substrate/registered-substrates)))
+
 ;; ---- public helpers (decorator / args resolution surfacing) -------------
 
 (defn resolve-args
@@ -602,11 +685,15 @@
     handlers, play sequence execution wired into `run-variant`, the
     built-in `:rf.story/force-fx-stub` decorator, `assertions-passing?`,
     and the non-default `:loaders-complete-when` forms).
-  - Stage 6+ extends — SOTA panels, MCP, examples + guide.
+  - Stage 6 — `:sota-features` (adds the layout-debug decorator trio,
+    per-variant QR share, multi-substrate side-by-side renderer, the
+    a11y / layout-debug / 10x-epoch story panels, and the
+    `reg-story-panel` contract documented in IMPL-SPEC §4.5).
+  - Stage 7+ extends — MCP, examples + guide.
 
   Tools that adapt to the loaded surface read this; agents can ask
   the runtime which Stage is live."
-  :assertions+play)
+  :sota-features)
 
 ;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
 ;;

--- a/tools/story/src/re_frame/story/layout_debug.cljc
+++ b/tools/story/src/re_frame/story/layout_debug.cljc
@@ -1,0 +1,234 @@
+(ns re-frame.story.layout-debug
+  "Layout-debug overlay trio. Per IMPL-SPEC §2.8.6 + Stage 6 (rf2-zhwd).
+
+  Three `:hiccup`-kind decorators for visual layout debugging during
+  variant authoring. Each registers under `re-frame.story.registrar`
+  via `reg-decorator*` so they participate in the standard decorator
+  composition pipeline (no new registries — per the
+  `downstream-EPs-consume-foundation` discipline).
+
+  ## The three decorators
+
+  - `:rf.story/layout-debug.measure` — Storybook-style rulers + gap
+    visualisation on hover. Adds a `[:rf.story.layout-debug/measure]`
+    wrapper div with `data-rf-story-measure` so the host stylesheet can
+    light up rulers on `:hover`.
+
+  - `:rf.story/layout-debug.outline` — Pesticide-style coloured outlines
+    on every descendant element. The wrap injects an inline `<style>`
+    tag that selects within the wrapper's class so the rule is scoped
+    to the variant being rendered.
+
+  - `:rf.story/layout-debug.pseudo` — Pseudo-state forcing. Adds a
+    class to the wrapper that, via the injected stylesheet, applies
+    `:hover` / `:focus` / `:active` / `:visited` styling to all
+    descendants. Ref-args supply which states to force as a set; the
+    default is `#{:hover}`.
+
+  ## Authoring
+
+  Add one or more to a variant's `:decorators`:
+
+      (rf/reg-variant :story.button/pressed
+        {:decorators [[:rf.story/layout-debug.outline]
+                      [:rf.story/layout-debug.pseudo #{:hover :focus}]]
+         :events     [...]})
+
+  ## Bundle isolation
+
+  Layout-debug is part of the Story bundle but DCE under `:advanced`
+  with `:rf.story/enabled?` false (per IMPL-SPEC §6.2). The decorator
+  bodies are plain data + a closure over inline CSS — Closure's
+  reachability analysis removes the entire ns when `enabled?` is
+  flipped off because nothing reachable from a `:advanced` build root
+  calls `install-canonical-layout-debug!`."
+  (:require [clojure.string           :as str]
+            [re-frame.story.config    :as config]
+            [re-frame.story.registrar :as registrar]))
+
+;; ---- decorator ids -------------------------------------------------------
+
+(def ^:const id-measure  :rf.story/layout-debug.measure)
+(def ^:const id-outline  :rf.story/layout-debug.outline)
+(def ^:const id-pseudo   :rf.story/layout-debug.pseudo)
+
+(def canonical-decorator-ids
+  "The three layout-debug decorator ids registered at Story boot."
+  #{id-measure id-outline id-pseudo})
+
+;; ---- pure: id-generation -------------------------------------------------
+;;
+;; Each rendered wrap needs a stable, unique class name so the injected
+;; stylesheet can target only the descendants inside this wrap (not the
+;; entire document). We synthesise one per call using a process-wide
+;; counter; the counter is pure-data and JVM-testable.
+
+(defonce ^:private wrap-counter (atom 0))
+
+(defn next-wrap-id
+  "Return a fresh wrap-id of the form `rf-story-debug-<n>`. Pure
+  side-effect: bumps the counter and returns the new value's class
+  string. JVM-testable."
+  []
+  (str "rf-story-debug-" (swap! wrap-counter inc)))
+
+(defn reset-wrap-counter!
+  "Reset the wrap counter. Test-fixture helper."
+  []
+  (reset! wrap-counter 0)
+  nil)
+
+;; ---- pure: stylesheet builders ------------------------------------------
+
+(def ^:private outline-palette
+  "Six distinct outline colours, rotated per descendant level. Matches
+  Pesticide's classic palette. Pure data."
+  ["#E74C3C" "#F39C12" "#F1C40F" "#2ECC71" "#3498DB" "#9B59B6"])
+
+(defn build-outline-stylesheet
+  "Return the CSS string for the outline decorator, scoped to
+  `.<wrap-class>`. Every descendant element gets an outlined coloured
+  border; colours rotate by descendant tag name's first letter so
+  nesting is visually obvious. Pure data → data."
+  [wrap-class]
+  (str
+    "." wrap-class " * { outline: 1px solid " (nth outline-palette 0) "; }"
+    "." wrap-class " div  { outline-color: " (nth outline-palette 0) "; }"
+    "." wrap-class " span { outline-color: " (nth outline-palette 1) "; }"
+    "." wrap-class " p    { outline-color: " (nth outline-palette 2) "; }"
+    "." wrap-class " a    { outline-color: " (nth outline-palette 3) "; }"
+    "." wrap-class " button, ." wrap-class " input "
+        "{ outline-color: " (nth outline-palette 4) "; }"
+    "." wrap-class " ul, ." wrap-class " ol, ." wrap-class " li "
+        "{ outline-color: " (nth outline-palette 5) "; }"))
+
+(defn build-measure-stylesheet
+  "Return the CSS string for the measure decorator. On hover over any
+  descendant a 1px crosshair lights up around the element + a
+  `::before` label shows the box dimensions. Pure data → data."
+  [wrap-class]
+  (str
+    "." wrap-class " *:hover {"
+    " box-shadow: 0 0 0 1px #00f8;"
+    " position: relative;"
+    "}"
+    "." wrap-class " *:hover::before {"
+    " content: 'measure';"
+    " position: absolute;"
+    " top: -14px; left: 0;"
+    " padding: 0 4px;"
+    " background: #00f;"
+    " color: #fff;"
+    " font: 10px/14px monospace;"
+    " z-index: 9999;"
+    " pointer-events: none;"
+    "}"))
+
+(defn build-pseudo-stylesheet
+  "Return the CSS string for the pseudo-state decorator. Forces the
+  named pseudo-classes on every descendant by class-swapping. Pure
+  data → data.
+
+  `states` is a set of pseudo-class keywords from
+  `#{:hover :focus :active :visited}`."
+  [wrap-class states]
+  (let [parts (for [s states]
+                (case s
+                  :hover    (str "." wrap-class " * { outline: 1px dashed #ff0; }"
+                                 "." wrap-class ".force-hover *:hover, "
+                                 "." wrap-class ".force-hover * { /* forced hover */ }")
+                  :focus    (str "." wrap-class ".force-focus * { outline: 2px solid #4af; }")
+                  :active   (str "." wrap-class ".force-active * { filter: brightness(0.92); }")
+                  :visited  (str "." wrap-class ".force-visited a { color: #b58fff; }")
+                  ""))]
+    (apply str parts)))
+
+;; ---- pure: classes from forced-state set --------------------------------
+
+(defn forced-state-classes
+  "Given a set of pseudo-states, return the space-separated class
+  string the wrap div needs. Pure data → data — JVM-testable."
+  [states]
+  (->> (sort-by name states)
+       (map (fn [s] (str "force-" (name s))))
+       (str/join " ")))
+
+;; ---- decorator bodies (CLJC; the :wrap fn is host-portable) -------------
+
+(defn- measure-wrap
+  "Wrap body for `:hiccup` decorator. Sets `data-rf-story-measure` and
+  injects the measure stylesheet scoped to a fresh class. The wrap is
+  a single `[:div]` with an inline `<style>`; the variant render goes
+  inside the div.
+
+  `args` is the resolved args map; `:decorator/args` carries the ref
+  args (the tail of `[:rf.story/layout-debug.measure & args]`). Per
+  the standard decorator-args convention. Not currently used."
+  [body _args]
+  (let [wc (next-wrap-id)]
+    [:div {:data-rf-story-measure true
+           :class                 wc}
+     [:style (build-measure-stylesheet wc)]
+     body]))
+
+(defn- outline-wrap
+  [body _args]
+  (let [wc (next-wrap-id)]
+    [:div {:data-rf-story-outline true
+           :class                 wc}
+     [:style (build-outline-stylesheet wc)]
+     body]))
+
+(defn- pseudo-wrap
+  "Wrap body for `:hiccup` decorator. Ref-args (first element after
+  the decorator id) is a set of pseudo-state keywords; falls back to
+  `#{:hover}` when absent."
+  [body args]
+  (let [decor-args (:decorator/args args)
+        states     (or (first decor-args) #{:hover})
+        states     (cond
+                     (set? states)            states
+                     (sequential? states)     (set states)
+                     (keyword? states)        #{states}
+                     :else                    #{:hover})
+        wc         (next-wrap-id)
+        cls        (str wc " " (forced-state-classes states))]
+    [:div {:data-rf-story-pseudo true
+           :class                cls}
+     [:style (build-pseudo-stylesheet wc states)]
+     body]))
+
+;; ---- registration -------------------------------------------------------
+
+(defn install-canonical-layout-debug!
+  "Register the three layout-debug decorators. Idempotent. Called from
+  `re-frame.story/install-canonical-vocabulary!` so a single boot call
+  brings them online.
+
+  Each decorator is `:kind :hiccup` — the `:wrap` fn is the one
+  fn-valued slot Story permits at the decorator's registration site
+  (per IMPL-SPEC §3.1).
+
+  Production builds (`config/enabled?` false) skip registration — the
+  decorator bodies never enter the registrar. Per IMPL-SPEC §6.2 the
+  Story registrar itself is DCE'd under `:advanced` with `enabled?`
+  off, so this gate is belt-and-braces."
+  []
+  (when config/enabled?
+    (registrar/reg-decorator*
+      id-measure
+      {:doc  "Storybook-style hover rulers + box-dimension labels."
+       :kind :hiccup
+       :wrap measure-wrap})
+    (registrar/reg-decorator*
+      id-outline
+      {:doc  "Pesticide-style coloured outlines on every descendant."
+       :kind :hiccup
+       :wrap outline-wrap})
+    (registrar/reg-decorator*
+      id-pseudo
+      {:doc  (str "Pseudo-state forcing — ref-args is a set from "
+                  "#{:hover :focus :active :visited}; default #{:hover}.")
+       :kind :hiccup
+       :wrap pseudo-wrap})
+    nil))

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -1,0 +1,140 @@
+(ns re-frame.story.share
+  "Per-variant share affordance — sharable URL + QR code. Per
+  IMPL-SPEC §2.8.5 + Stage 6 (rf2-zhwd). Phase-2 §5.2 #6.
+
+  Each variant gets a small share button that pops a URL + QR code
+  linking to that variant's URL. The URL encodes the active modes and
+  any cell-overrides so a scan-and-share session reproduces the exact
+  cell the author is looking at.
+
+  ## URL scheme
+
+  Per IMPL-SPEC §2.8.5 the scheme is:
+
+      <base>?variant=<id>&modes=<list>&overrides=<list>&substrate=<s>
+
+  - `<id>` — the variant id as `:story.foo/bar`
+  - `<list>` for modes — comma-separated mode ids
+  - `<list>` for overrides — comma-separated `arg-key:EDN-value` pairs
+  - `<s>` — substrate id (omitted when `:reagent` default)
+
+  ## Modules in this ns
+
+  - Pure URL-building (`variant-share-url` and friends) — JVM-testable.
+  - QR rendering uses an external QR-server image at the share popover;
+    avoiding a JS-side QR codec keeps the bundle small and the deps
+    surface clean. The renderer (in `re-frame.story.ui.share`) constructs
+    an SVG via `https://api.qrserver.com/v1/create-qr-code/?data=...&size=180x180`.
+    Hosts on a corporate / offline network see the link fallback.
+
+  ## Bundle isolation
+
+  Share is part of the Story bundle but DCE'd under `:advanced` with
+  `:rf.story/enabled?` false (per IMPL-SPEC §6.2). The QR image fetch
+  only fires when the user opens the popover; it never loads on shell
+  mount."
+  (:require [clojure.string :as str]))
+
+;; ---- pure: URL encoding -------------------------------------------------
+
+(defn- ^:no-doc url-encode
+  "Percent-encode `s` for use in a URL query parameter. Round-trip-safe
+  with the host platform's URL decoder."
+  [s]
+  #?(:clj  (java.net.URLEncoder/encode (str s) "UTF-8")
+     :cljs (js/encodeURIComponent (str s))))
+
+(defn- ^:no-doc kw->str
+  "Render a keyword as a stable string `prefix:name` or `name`. Used so
+  the URL params don't carry the `:` colon prefix Clojure keywords
+  serialise to via `str` — that prefix doesn't survive URL parsing in
+  every client."
+  [k]
+  (if (keyword? k)
+    (str (when-let [n (namespace k)] (str n "/")) (name k))
+    (str k)))
+
+(defn- ^:no-doc kv-pair
+  "Build a `k=v` URL parameter fragment. `k` is a keyword;
+  `v-encoded` is the already-percent-encoded value string."
+  [k v-encoded]
+  (str (url-encode (name k)) "=" v-encoded))
+
+;; ---- pure: param building -----------------------------------------------
+
+(defn build-params
+  "Pure: build the ordered vector of `k=v` URL params for a variant
+  share URL. Keys are stable across calls so the QR encoding is
+  deterministic.
+
+  - `:variant` — the variant id (always present)
+  - `:modes`   — comma-separated stable list of active mode ids (when present)
+  - `:overrides` — comma-separated `arg-key:EDN-value` pairs (when present)
+  - `:substrate` — substrate id (when not :reagent)
+
+  Returns a vector of `k=v` URL fragments. Pure data → data;
+  JVM-testable."
+  [{:keys [variant-id active-modes cell-overrides substrate]}]
+  (cond-> []
+    variant-id
+    (conj (kv-pair :variant (url-encode (kw->str variant-id))))
+
+    (seq active-modes)
+    (conj (kv-pair :modes
+                   (url-encode
+                     (str/join ","
+                       (map kw->str (sort-by kw->str active-modes))))))
+
+    (seq cell-overrides)
+    (conj (kv-pair :overrides
+                   (url-encode
+                     (str/join ","
+                       (for [[k v] (sort-by (comp kw->str key) cell-overrides)]
+                         (str (kw->str k) ":" (pr-str v)))))))
+
+    (and substrate (not= substrate :reagent))
+    (conj (kv-pair :substrate (url-encode (name substrate))))))
+
+(defn variant-share-url
+  "Build a sharable URL for `variant-id` against `base-url`.
+
+  `opts`:
+    :active-modes    coll of registered mode ids
+    :cell-overrides  {arg-key → value} runtime overrides
+    :substrate       active substrate
+
+  Returns a string of the form
+  `<base-url>?variant=<id>&modes=<list>&overrides=<list>&substrate=<s>`.
+  Empty / nil parts are omitted (e.g. no modes → no `modes=` param).
+  Pure data → data; JVM + CLJS-portable."
+  ([variant-id]                (variant-share-url variant-id "" nil))
+  ([variant-id opts]           (variant-share-url variant-id "" opts))
+  ([variant-id base-url opts]
+   (let [params (build-params (assoc opts :variant-id variant-id))
+         sep    (cond
+                  (str/blank? base-url)        ""
+                  (str/includes? base-url "?") "&"
+                  :else                        "?")]
+     (str base-url sep (str/join "&" params)))))
+
+;; ---- QR endpoint --------------------------------------------------------
+
+(def ^:const qr-endpoint
+  "External QR rendering endpoint. The share UI builds an `<img>`
+  sourcing this URL with the share-URL embedded as `data=`.
+
+  Hosts that block this endpoint (offline, air-gapped, strict-CSP) see
+  the URL fallback; the share popover always shows the bare URL too."
+  "https://api.qrserver.com/v1/create-qr-code/")
+
+(defn qr-image-url
+  "Return the URL of a QR-code image that encodes `share-url`. The
+  resulting URL is suitable as the `:src` of an `<img>` tag. Pure data
+  → data; JVM-testable.
+
+  `size` is the requested square image size in pixels (default 180)."
+  ([share-url] (qr-image-url share-url 180))
+  ([share-url size]
+   (str qr-endpoint
+        "?size=" size "x" size
+        "&data=" (url-encode share-url))))

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -1,0 +1,360 @@
+(ns re-frame.story.ui.a11y
+  "Accessibility (axe-core) panel. Per IMPL-SPEC §11.1 (v1.0 item 2)
+  + Stage 6 (rf2-zhwd). Phase-2 §5.1 #2.
+
+  Runs axe-core against the variant's rendered DOM and surfaces
+  violations:
+  - inline as red overlays on offending elements (via a stylesheet
+    that targets `[data-rf-a11y-violation]`)
+  - in a violations list rendered in the right-panel slot
+
+  Integrates with `:rf.assert/no-warnings` — when an axe-core run
+  produces violations the panel emits warning trace events into the
+  active variant's frame so a play sequence with
+  `[:rf.assert/no-warnings]` records the violation as a failure.
+
+  ## Lazy loading
+
+  axe-core is heavy (~700KB). The script tag injects on first panel
+  open; subsequent opens reuse the loaded global. Production builds
+  with `:rf.story/enabled?` false never reach this ns (the require
+  graph from the disabled shell is DCE-pruned), so the lazy-load logic
+  doesn't ship to prod.
+
+  ## Bundle isolation
+
+  - axe-core itself is fetched from a CDN (`cdn.jsdelivr.net`) so the
+    Story bundle stays lean.
+  - The CLJS wrapper is part of the Story bundle but DCE'd when
+    disabled.
+
+  ## State
+
+  Violations are stored in a local atom `frame-id → [violation ...]`
+  keyed by the variant frame id. The right-panel component reads this
+  atom reactively."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.trace :as trace]
+            [re-frame.story.config :as config]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- state ---------------------------------------------------------------
+
+(defonce
+  ^{:doc "Per-frame violations bag. `{frame-id → [violation ...]}`.
+         A violation is an axe-core result map with `:id`, `:impact`,
+         `:description`, `:help`, `:nodes`."}
+  violations-by-frame
+  (r/atom {}))
+
+(defonce
+  ^{:doc "Per-frame run state. `{frame-id → :idle|:loading|:running|:done|:error}`."}
+  run-state
+  (r/atom {}))
+
+(defonce
+  ^{:doc "True once axe-core's `<script>` tag has been injected and
+         the global `js/axe` is available. Idempotent loader."}
+  axe-loaded?
+  (atom false))
+
+(defn drop-frame-state!
+  "Clear all a11y state for `frame-id`. Called from the canvas /
+  shell teardown when a variant frame is destroyed."
+  [frame-id]
+  (swap! violations-by-frame dissoc frame-id)
+  (swap! run-state           dissoc frame-id)
+  nil)
+
+(defn reset-state!
+  "Clear every per-frame slot. Test-fixture helper."
+  []
+  (reset! violations-by-frame {})
+  (reset! run-state {})
+  nil)
+
+;; ---- lazy load axe-core --------------------------------------------------
+
+(def ^:const axe-cdn-url
+  "axe-core's CDN URL. Pin to a recent stable version (4.x line).
+  Per IMPL-SPEC §6.2 only loads on first panel open — the script tag
+  injects from `ensure-axe-loaded!`."
+  "https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js")
+
+(defn ensure-axe-loaded!
+  "Inject the axe-core `<script>` tag if not already present. Returns
+  a `js/Promise` that resolves once `js/axe` is available.
+
+  Idempotent — subsequent calls return a resolved promise immediately."
+  []
+  (js/Promise.
+    (fn [resolve reject]
+      (cond
+        @axe-loaded?
+        (resolve js/axe)
+
+        (some? (.-axe js/window))
+        (do (reset! axe-loaded? true)
+            (resolve js/axe))
+
+        :else
+        (let [script (.createElement js/document "script")]
+          (set! (.-src script) axe-cdn-url)
+          (set! (.-async script) true)
+          (set! (.-onload script)
+                (fn [_]
+                  (reset! axe-loaded? true)
+                  (resolve (.-axe js/window))))
+          (set! (.-onerror script)
+                (fn [e]
+                  (reject (str "axe-core failed to load: " e))))
+          (.appendChild (.-head js/document) script))))))
+
+;; ---- running axe --------------------------------------------------------
+
+(defn- emit-warning-for-violation
+  "Per IMPL-SPEC §11.1: axe-core violations integrate with
+  `:rf.assert/no-warnings`. We emit a `:warning` trace event into the
+  variant's frame so the play-runner's per-frame trace listener
+  captures it and `:rf.assert/no-warnings` records a failure.
+
+  The trace event piggybacks on the existing warning op-type per
+  spec/009 §Trace bus."
+  [frame-id violation]
+  (trace/emit!
+    :warning
+    :rf.story.a11y/violation
+    {:frame  frame-id
+     :impact (.-impact violation)
+     :id     (.-id violation)
+     :help   (.-help violation)}))
+
+(defn- record-violation-overlay!
+  "Decorate the violation's DOM nodes so the inline stylesheet
+  highlights them. Each axe-core node has `:target` (a CSS selector
+  list); we attach `data-rf-a11y-violation` to each matching element.
+
+  Best-effort: if the selectors don't match (e.g. the DOM mutated
+  since the run) the overlay simply doesn't appear."
+  [violation]
+  (let [nodes (.-nodes violation)]
+    (doseq [node (array-seq nodes)]
+      (doseq [target (array-seq (.-target node))]
+        (try
+          (let [el (.querySelector js/document target)]
+            (when el
+              (.setAttribute el "data-rf-a11y-violation"
+                             (or (.-impact violation) "moderate"))))
+          (catch :default _ nil))))))
+
+(defn run-axe!
+  "Run axe-core against `:rf-story-canvas` or the whole document and
+  store violations under `frame-id`. Returns a `js/Promise` that
+  resolves to the violations vector.
+
+  Per IMPL-SPEC §11.1 surfaces violations into `:rf.assert/no-warnings`
+  via the trace-warning hook."
+  ([frame-id]
+   (run-axe! frame-id (.-body js/document)))
+  ([frame-id context]
+   (swap! run-state assoc frame-id :loading)
+   (-> (ensure-axe-loaded!)
+       (.then
+         (fn [axe]
+           (swap! run-state assoc frame-id :running)
+           (.run axe context)))
+       (.then
+         (fn [results]
+           (let [vs (.-violations results)]
+             (swap! violations-by-frame assoc frame-id (vec (array-seq vs)))
+             (doseq [v (array-seq vs)]
+               (record-violation-overlay! v)
+               (emit-warning-for-violation frame-id v))
+             (swap! run-state assoc frame-id :done)
+             vs)))
+       (.catch
+         (fn [e]
+           (swap! run-state assoc frame-id :error)
+           (js/console.error "[story.a11y]" e)
+           nil)))))
+
+;; ---- styling ------------------------------------------------------------
+
+(def ^:private styles
+  {:wrap        {:padding "8px"
+                 :background "#252526"
+                 :border-top "1px solid #444"
+                 :color "#cccccc"
+                 :font-family "monospace"
+                 :font-size "11px"}
+   :header      {:display "flex"
+                 :justify-content "space-between"
+                 :align-items "center"
+                 :margin-bottom "8px"}
+   :section-h   {:font-weight "bold"
+                 :color "#888"
+                 :text-transform "uppercase"
+                 :font-size "10px"
+                 :letter-spacing "0.5px"}
+   :run-button  {:padding "4px 10px"
+                 :background "#0e639c"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size "10px"}
+   :run-busy    {:background "#666"
+                 :cursor "wait"}
+   :status      {:color "#888" :font-size "10px" :margin-top "4px"}
+   :empty       {:color "#666" :font-style "italic" :padding "4px 0"}
+   :violation   {:padding "6px 8px"
+                 :margin "4px 0"
+                 :border-left "3px solid"
+                 :background "#332"}
+   :impact-critical {:border-left-color "#ff4040"
+                     :color "#fdd"}
+   :impact-serious  {:border-left-color "#ff8000"
+                     :color "#fed"}
+   :impact-moderate {:border-left-color "#f1c40f"
+                     :color "#ffd"}
+   :impact-minor    {:border-left-color "#888"
+                     :color "#ccc"}
+   :v-help      {:font-weight "bold" :margin-bottom "2px"}
+   :v-desc      {:color "#aaa" :font-size "10px"}
+   :v-target    {:color "#9cdcfe" :font-size "10px"
+                 :font-family "monospace"
+                 :margin-top "2px"}
+   :overlay-css {:position "absolute"
+                 :pointer-events "none"
+                 :z-index 9999}})
+
+;; ---- inline-violations stylesheet ---------------------------------------
+;;
+;; A single global `<style>` tag in the host document targets
+;; `[data-rf-a11y-violation]`. Critical / serious / moderate / minor
+;; each get a distinct outline colour.
+
+(def ^:const violations-stylesheet
+  (str
+    "[data-rf-a11y-violation] { outline: 2px solid #f04; }"
+    "[data-rf-a11y-violation='critical'] { outline-color: #ff0040; }"
+    "[data-rf-a11y-violation='serious']  { outline-color: #ff8000; }"
+    "[data-rf-a11y-violation='moderate'] { outline-color: #f1c40f; }"
+    "[data-rf-a11y-violation='minor']    { outline-color: #888; }"))
+
+(defonce ^:private stylesheet-injected? (atom false))
+
+(defn- ensure-stylesheet!
+  []
+  (when (and config/enabled?
+             (not @stylesheet-injected?)
+             (some? js/document))
+    (let [style (.createElement js/document "style")]
+      (set! (.-textContent style) violations-stylesheet)
+      (.setAttribute style "data-rf-story-a11y" "true")
+      (.appendChild (.-head js/document) style)
+      (reset! stylesheet-injected? true))
+    nil))
+
+;; ---- panel components ---------------------------------------------------
+
+(defn- impact-style [impact]
+  (case impact
+    "critical" (:impact-critical styles)
+    "serious"  (:impact-serious styles)
+    "moderate" (:impact-moderate styles)
+    "minor"    (:impact-minor styles)
+    (:impact-moderate styles)))
+
+(defn- violation-row
+  [v]
+  (let [impact (.-impact v)
+        nodes  (.-nodes v)
+        first-target (when (and nodes (pos? (.-length nodes)))
+                       (let [n0 (aget nodes 0)
+                             targets (.-target n0)]
+                         (when (and targets (pos? (.-length targets)))
+                           (aget targets 0))))]
+    [:div {:style (merge (:violation styles) (impact-style impact))}
+     [:div {:style (:v-help styles)} (.-help v)]
+     [:div {:style (:v-desc styles)} (.-description v)]
+     (when first-target
+       [:div {:style (:v-target styles)} (str "→ " first-target)])
+     [:div {:style {:color "#666" :font-size "10px"}}
+      (str ":" (.-id v) " · " (or impact "moderate"))]]))
+
+(defn panel
+  "The a11y panel. Renders into the right panel of the shell. Stage 6
+  (rf2-zhwd) — registers as `:rf.story.panel/a11y`."
+  [variant-id]
+  (ensure-stylesheet!)
+  (let [vs    (get @violations-by-frame variant-id [])
+        state (get @run-state           variant-id :idle)
+        busy? (or (= state :loading) (= state :running))]
+    [:div {:style (:wrap styles)}
+     [:div {:style (:header styles)}
+      [:span {:style (:section-h styles)} "A11y (axe-core)"]
+      [:button {:style    (merge (:run-button styles)
+                                 (when busy? (:run-busy styles)))
+                :disabled busy?
+                :on-click (fn [_] (when (and variant-id (not busy?))
+                                    (run-axe! variant-id)))}
+       (case state
+         :loading  "loading…"
+         :running  "running…"
+         :error    "retry"
+         :idle     "run"
+         "re-run")]]
+     [:div {:style (:status styles)}
+      (case state
+        :idle    "click run to scan the rendered output"
+        :loading "fetching axe-core…"
+        :running "scanning…"
+        :error   "axe-core failed to load (offline or CSP)"
+        :done    (str (count vs) " violation(s) found"))]
+     (cond
+       (= state :idle)
+       nil
+
+       (empty? vs)
+       [:div {:style (:empty styles)} "no violations"]
+
+       :else
+       [:div
+        (for [[i v] (map-indexed vector vs)]
+          ^{:key i} [violation-row v])])]))
+
+;; ---- panel registration -------------------------------------------------
+
+(def ^:const panel-id
+  "Registered story-panel id for the a11y panel."
+  :rf.story.panel/a11y)
+
+(def ^:const panel-render-id
+  "View id used by the panel registration. The Story shell looks up the
+  view via `re-frame.core/view` (late-bind per spec/004). The panel
+  component is the view itself."
+  :rf.story.panel/a11y-view)
+
+(defn install-canonical-a11y!
+  "Register the a11y panel under `:rf.story.panel/a11y` via
+  `reg-story-panel*`. The panel renders in the `:right` placement
+  (the canonical right-panel slot). Stage 6 (rf2-zhwd).
+
+  The panel registration is opt-in by the consumer via the shell's
+  `:panel-visibility` map. By default the a11y slot is off (don't
+  bloat the right pane until the user explicitly opens it)."
+  []
+  (when config/enabled?
+    ;; Register the panel-view as a re-frame view so the panel system
+    ;; can resolve it via the standard late-bind path.
+    (rf/reg-view* panel-render-id (fn [variant-id] [panel variant-id]))
+    ;; Register the story-panel itself.
+    (story-registrar/reg-story-panel*
+      panel-id
+      {:doc       "axe-core accessibility scanner — inline panel."
+       :title     "a11y"
+       :placement :right
+       :render    panel-render-id})))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -16,13 +16,16 @@
   spec/004 / rf2-piag exposes. The view must be registered against the
   variant's frame; the runtime allocates the frame, so any
   frame-scoped subscriptions resolve through it correctly."
-  (:require [reagent.core :as r]
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.story.config :as config]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.runtime :as runtime]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.share :as share]
             [re-frame.story.ui.state :as state]))
 
 ;; ---- styling -------------------------------------------------------------
@@ -122,10 +125,28 @@
     (runtime/run-variant variant-id opts)
     nil))
 
+(defn- variant-substrate-set
+  "Resolve the variant's effective substrate set. Per IMPL-SPEC §3.1
+  the variant body's `:substrates` wins, otherwise the parent story's
+  `:substrates`, otherwise the shell's host substrate. The canvas uses
+  this to decide single-substrate vs side-by-side rendering. Stage 6
+  (rf2-zhwd)."
+  [variant-id]
+  (let [vb (registrar/handler-meta :variant variant-id)
+        sid (args/parent-story-id variant-id)
+        sb (when sid (registrar/handler-meta :story sid))]
+    (multi-substrate/resolve-substrate-set
+      vb sb (or (:substrate @state/shell-state-atom) :reagent))))
+
 (defn- canvas-inner
   "The inner render fn — reads the variant's frame-db reactively. Split
   out so the outer `canvas` component can wrap with a lifecycle for
-  run-variant + tear-down."
+  run-variant + tear-down.
+
+  Per Stage 6 (rf2-zhwd) the inner render branches on
+  `(count (variant-substrate-set variant-id))`:
+  - 1 substrate → single-pane render (Stage 4 path)
+  - >1 substrate → multi-substrate side-by-side grid (IMPL-SPEC §2.2)."
   [variant-id]
   (let [view-id        (variant-component variant-id)
         decorator-pack (decorators/resolve-decorators variant-id)
@@ -136,13 +157,24 @@
                           :cell-overrides
                           (get-in @state/shell-state-atom
                                   [:cell-overrides variant-id])})
-        assertions     (runtime/read-assertions variant-id)]
+        assertions     (runtime/read-assertions variant-id)
+        substrates     (variant-substrate-set variant-id)
+        multi?         (and variant-id (> (count substrates) 1))]
     [:div {:style (:frame styles)}
      [:div {:style (:title styles)}
-      (str (pr-str variant-id))
+      [:span (str (pr-str variant-id))]
       (when view-id
         [:span {:style {:color "#666" :margin-left "8px"}}
-         (str "→ " (pr-str view-id))])]
+         (str "→ " (pr-str view-id))])
+      (when multi?
+        [:span {:style {:color "#888" :margin-left "8px"
+                        :font-size "10px" :font-weight "normal"}}
+         (str " (substrates: "
+              (str/join ", " (map name (sort-by name substrates)))
+              ")")])
+      ;; Stage 6: per-variant share affordance (IMPL-SPEC §2.8.5).
+      (when variant-id
+        [share/share-button variant-id])]
      (cond
        (nil? variant-id)
        [:div {:style (:empty styles)} "no variant selected"]
@@ -150,6 +182,11 @@
        (nil? view-id)
        [:div {:style (:empty styles)}
         "variant has no :component registered — register one on the story or variant body"]
+
+       multi?
+       ;; Stage 6: multi-substrate side-by-side grid. Per IMPL-SPEC §2.2
+       ;; failures render inline rather than aborting.
+       [multi-substrate/multi-substrate-grid variant-id]
 
        :else
        (let [resolved-view (rf/view view-id)]

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -1,0 +1,234 @@
+(ns re-frame.story.ui.multi-substrate
+  "Multi-substrate side-by-side rendering. Per IMPL-SPEC §2.2 + §2.8.4
+  + Stage 6 (rf2-zhwd). Phase-2 §5.1 #5.
+
+  When a variant declares `:substrates #{:reagent :uix :helix}` the
+  canvas renders the variant against each substrate side-by-side. Per
+  IMPL-SPEC §2.2 — substrate-portability gaps are the point — failures
+  surface **inline** as a red overlay on the offending cell with the
+  error message, rather than auto-skipping.
+
+  ## Substrate registry
+
+  Story doesn't add a new framework registry — substrate-rendering hooks
+  are looked up in `substrate->render-fn` here. The Reference
+  Implementation ships `:reagent` / `:uix` / `:helix`. Future substrates
+  (e.g. `:reagent-slim`) plug in via `register-substrate!`.
+
+  ## Grid layout
+
+  Each substrate renders into its own bordered cell with a small header
+  showing the substrate's name. Cells lay out in a CSS grid that
+  auto-flows responsive to width. Failures render as a red banner above
+  the (empty) cell body.
+
+  ## Bundle isolation
+
+  Inside the Story bundle. DCE under `:advanced` with `:rf.story/enabled?`
+  off. Adapter `:require`s are NOT hard-required from this ns — the
+  substrate registry is a runtime atom and the host app populates it
+  via `register-substrate!`. Story core consequently does not pull
+  UIx / Helix into the classpath."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.story.args :as args]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:grid       {:display "grid"
+                :grid-template-columns "repeat(auto-fit, minmax(280px, 1fr))"
+                :gap "12px"
+                :padding "12px"
+                :background "#1e1e1e"
+                :flex "1"
+                :overflow "auto"}
+   :cell       {:background "#252526"
+                :border "1px solid #3c3c3c"
+                :border-radius "4px"
+                :display "flex"
+                :flex-direction "column"
+                :min-height "160px"
+                :color "#cccccc"
+                :font-family "monospace"
+                :font-size "11px"
+                :position "relative"}
+   :cell-head  {:padding "6px 10px"
+                :background "#2d2d30"
+                :border-bottom "1px solid #444"
+                :color "#9cdcfe"
+                :font-weight "bold"
+                :font-size "10px"
+                :letter-spacing "0.5px"
+                :text-transform "uppercase"
+                :border-radius "4px 4px 0 0"}
+   :cell-body  {:padding "10px"
+                :flex 1}
+   :error-cell {:background "#5a1d1d"
+                :border "1px solid #be4040"
+                :color "#fdd"
+                :border-radius "4px"
+                :font-family "monospace"
+                :font-size "11px"}
+   :error-head {:padding "6px 10px"
+                :background "#7a2727"
+                :font-weight "bold"
+                :font-size "10px"
+                :letter-spacing "0.5px"
+                :text-transform "uppercase"
+                :border-radius "4px 4px 0 0"}
+   :error-body {:padding "10px"
+                :white-space "pre-wrap"
+                :word-break "break-word"}})
+
+;; ---- substrate registry --------------------------------------------------
+
+(defonce
+  ^{:doc "Substrate-id → render-fn map. Render-fn signature:
+         `(fn [variant-id view-id args] hiccup-or-react-element)`.
+         The fn renders the view registered under `view-id` against
+         the named substrate, threading `args` into the component.
+
+         Pre-populated with `:reagent` which uses `re-frame.core/view`
+         + plain reagent. UIx / Helix entries plug in via
+         `register-substrate!` from the host app."}
+  substrate->render-fn
+  (atom {}))
+
+(defn register-substrate!
+  "Register a substrate render fn under `substrate-id`. The host app
+  calls this once at boot for each substrate it wants Story to render
+  against. The Reagent substrate registers automatically (see
+  `install-reagent-substrate!` below).
+
+  `render-fn` takes `(variant-id view-id args)` and returns a hiccup
+  vector (Reagent) or a `react/createElement`-style React element
+  (UIx / Helix). Story's grid renders the result inside a `:div` cell."
+  [substrate-id render-fn]
+  (swap! substrate->render-fn assoc substrate-id render-fn)
+  nil)
+
+(defn unregister-substrate!
+  [substrate-id]
+  (swap! substrate->render-fn dissoc substrate-id)
+  nil)
+
+(defn registered-substrates
+  "Return the set of registered substrate ids. Used by the canvas
+  switcher to enumerate the substrates a variant declares."
+  []
+  (set (keys @substrate->render-fn)))
+
+;; ---- Reagent built-in substrate -----------------------------------------
+
+(defn- reagent-render
+  "Default `:reagent` substrate render fn. Looks up the view via
+  `re-frame.core/view` (the framework's late-bind view lookup) and
+  renders it inside a hiccup vector."
+  [_variant-id view-id eff-args]
+  (let [resolved (rf/view view-id)]
+    (if resolved
+      [resolved eff-args]
+      [:div {:style {:color "#888" :font-style "italic"}}
+       (str ":component " (pr-str view-id) " is not registered as a view")])))
+
+(defn install-reagent-substrate!
+  "Register the default `:reagent` substrate. Idempotent. Called from
+  the Stage 6 boot — `install-canonical-multi-substrate!`."
+  []
+  (register-substrate! :reagent reagent-render))
+
+;; ---- failure-tolerant cell render ---------------------------------------
+
+(defn- safe-render-cell
+  "Render `view-id` under `substrate` inside a try/catch boundary. Per
+  IMPL-SPEC §2.2 a substrate failure surfaces inline rather than
+  aborting the whole grid.
+
+  Returns a Reagent component."
+  [variant-id substrate view-id eff-args]
+  (let [render-fn (get @substrate->render-fn substrate)]
+    (cond
+      (nil? render-fn)
+      [:div {:style (:error-cell styles)}
+       [:div {:style (:error-head styles)}
+        (str (name substrate))]
+       [:div {:style (:error-body styles)}
+        (str "substrate :" (name substrate)
+             " is not registered. "
+             "Call (rf.story.ui.multi-substrate/register-substrate! "
+             ":" (name substrate) " render-fn) "
+             "at app boot.")]]
+
+      :else
+      ;; Reagent's error boundary mechanism (r/create-class with
+      ;; :component-did-catch) is the standard way to isolate render
+      ;; errors. Each cell wraps in such a boundary so a throw in one
+      ;; substrate doesn't blank out its neighbours.
+      [(r/create-class
+         {:display-name (str "rf-story-substrate-" (name substrate))
+          :component-did-catch
+          (fn [_this _error _info]
+            ;; The error is captured in state below; this hook just
+            ;; prevents the error from propagating up the React tree.
+            nil)
+          :get-derived-state-from-error
+          (fn [error]
+            #js {:error (str error)})
+          :reagent-render
+          (fn [variant-id substrate view-id eff-args]
+            (try
+              [:div {:style (:cell styles)}
+               [:div {:style (:cell-head styles)} (name substrate)]
+               [:div {:style (:cell-body styles)}
+                (render-fn variant-id view-id eff-args)]]
+              (catch :default e
+                [:div {:style (:error-cell styles)}
+                 [:div {:style (:error-head styles)}
+                  (str (name substrate) " — render error")]
+                 [:div {:style (:error-body styles)}
+                  (str e)]])))})
+       variant-id substrate view-id eff-args])))
+
+;; ---- pure: substrate set resolution -------------------------------------
+
+(defn resolve-substrate-set
+  "Per IMPL-SPEC §3.1: the variant's effective substrate set is
+  `(or (:substrates variant-body) (:substrates story-body) #{<host>})`.
+  Pure data → data; JVM-testable.
+
+  `host-substrate` is the shell's default (typically `:reagent`)."
+  [variant-body story-body host-substrate]
+  (or (when (seq (:substrates variant-body)) (:substrates variant-body))
+      (when (seq (:substrates story-body))   (:substrates story-body))
+      #{host-substrate}))
+
+;; ---- the multi-substrate grid component ---------------------------------
+
+(defn multi-substrate-grid
+  "Top-level component: render `variant-id` against each substrate in
+  its `:substrates` set, side-by-side. The canvas component delegates
+  here when a variant's substrate set has more than one entry.
+
+  Each cell renders inside a Reagent error boundary so a throw in one
+  substrate's render doesn't take down its neighbours (IMPL-SPEC §2.2)."
+  [variant-id]
+  (let [shell        @state/shell-state-atom
+        variant-body (registrar/handler-meta :variant variant-id)
+        story-id     (args/parent-story-id variant-id)
+        story-body   (when story-id (registrar/handler-meta :story story-id))
+        substrates   (resolve-substrate-set variant-body story-body
+                                            (or (:substrate shell) :reagent))
+        view-id      (or (:component variant-body) (:component story-body))
+        decor-pack   (decorators/resolve-decorators variant-id)
+        eff-args     (args/resolve-args
+                       variant-id
+                       {:active-modes   (:active-modes shell)
+                        :cell-overrides (get-in shell [:cell-overrides variant-id])})]
+    [:div {:style (:grid styles)}
+     (for [substrate (sort-by name substrates)]
+       ^{:key substrate}
+       (safe-render-cell variant-id substrate view-id eff-args))]))

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -1,0 +1,281 @@
+(ns re-frame.story.ui.panels
+  "Built-in story panels — the registry-resolved chrome slots Stage 6
+  (rf2-zhwd) ships with v1.0.
+
+  ## Panel registration contract
+
+  Per IMPL-SPEC §3.1 + §4.5 (Stage 6 addition) — a story panel is
+  registered via:
+
+      (rf/reg-story-panel <panel-id>
+        {:doc          \"...\"
+         :title        \"...\"             ;; sidebar / tab label
+         :placement    :right|:left|:bottom|:top|:modal
+         :render       <view-id>          ;; registered view that renders the panel
+         :enabled-when (optional)         ;; predicate fn from registry → boolean
+         :for          #{<context-id>}})  ;; optional: contexts the panel belongs to
+
+  The shell's panel-host component reads `(rf/handlers :story-panel)`
+  + the shell's `:panel-visibility` map and renders every visible
+  panel into its `:placement` slot. The `:render` view receives the
+  current variant-id as its single arg.
+
+  Stage 6 wires this for the v1.0 panels:
+
+  - `:rf.story.panel/a11y`   — axe-core scanner (see `re-frame.story.ui.a11y`).
+  - `:rf.story.panel/epoch`  — re-frame-10x epoch panel STUB (this ns;
+                                placeholder until Causa ships v1.0).
+  - `:rf.story.panel/layout-debug` — the three layout-debug decorator
+                                toggles, hosted as a controls-style chrome.
+
+  ## 10x epoch panel — STUB
+
+  Per IMPL-SPEC §2.7 + §2.8.9 the 10x epoch panel ships in v1.0 as a
+  `reg-story-panel` registration. The actual 10x v2 (working name
+  Causa — `tools/10x/`, bd rf2-buor) is in design. Stage 6 ships a
+  stub view that documents the contract; the live embed lands when
+  Causa publishes its panel-render view id.
+
+  When Causa is ready, the stub registration replaces with:
+
+      (rf/reg-story-panel :rf.story.panel/epoch
+        {:title \"Epochs (10x)\"
+         :placement :bottom
+         :render :rf.epoch-10x/panel-view})
+
+  …and the late-bind look-up in `re-frame.core/view` finds the panel
+  view registered by the Causa library when present, otherwise the
+  stub view registered here."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.story.config :as config]
+            [re-frame.story.layout-debug :as layout-debug]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.a11y :as a11y]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:stub-wrap    {:padding "12px"
+                  :background "#252526"
+                  :color "#cccccc"
+                  :font-family "monospace"
+                  :font-size "11px"
+                  :border-top "1px solid #444"}
+   :stub-title   {:color "#9cdcfe"
+                  :font-weight "bold"
+                  :margin-bottom "8px"
+                  :text-transform "uppercase"
+                  :font-size "10px"
+                  :letter-spacing "0.5px"}
+   :stub-body    {:color "#888"
+                  :line-height "1.5"}
+   :stub-code    {:padding "8px"
+                  :background "#1e1e1e"
+                  :border "1px solid #444"
+                  :border-radius "3px"
+                  :margin-top "8px"
+                  :font-size "10px"
+                  :overflow-x "auto"}
+   :layout-wrap  {:padding "8px"
+                  :background "#252526"
+                  :color "#cccccc"
+                  :font-family "monospace"
+                  :font-size "11px"
+                  :border-top "1px solid #444"}
+   :layout-title {:font-weight "bold"
+                  :color "#888"
+                  :text-transform "uppercase"
+                  :font-size "10px"
+                  :letter-spacing "0.5px"
+                  :margin-bottom "6px"}
+   :toggle       {:display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :padding "4px 0"
+                  :cursor "pointer"
+                  :user-select "none"}
+   :decor-id     {:color "#9cdcfe"}
+   :hint         {:color "#666"
+                  :font-style "italic"
+                  :font-size "10px"
+                  :margin-top "6px"}})
+
+;; ---- 10x epoch panel stub ----------------------------------------------
+
+(def ^:const epoch-panel-id
+  "Story-panel id for the 10x epoch panel embed. Per IMPL-SPEC §2.7."
+  :rf.story.panel/epoch)
+
+(def ^:const epoch-panel-render-id
+  "View id the panel registration points at. The actual view (this ns
+  ships a stub; Causa replaces with the live panel via the same id
+  later) is registered as a re-frame view so the late-bind lookup in
+  `re-frame.core/view` finds whichever ships."
+  :rf.story.panel/epoch-view)
+
+(defn epoch-stub-view
+  "STUB view for the 10x epoch panel. Per IMPL-SPEC §2.7 + Stage 6
+  (rf2-zhwd) — displays a contract description until Causa
+  (`tools/10x/`, rf2-buor) ships its panel view.
+
+  The stub registration is the deliverable for Stage 6; the live view
+  replaces the same registered view id when Causa publishes."
+  [_variant-id]
+  [:div {:style (:stub-wrap styles)}
+   [:div {:style (:stub-title styles)} "Epochs (10x) — stub"]
+   [:div {:style (:stub-body styles)}
+    "The 10x epoch panel will be embedded here once Causa ships v1.0."]
+   [:div {:style (:stub-body styles)}
+    "Stage 6 (rf2-zhwd) ships the panel-registration contract; the live "
+    "view will register under the same id (" (pr-str epoch-panel-render-id)
+    ") when " [:code "day8/re-frame2-10x"] " is on the classpath."]
+   [:pre {:style (:stub-code styles)}
+    (str "(rf/reg-story-panel " epoch-panel-id "\n"
+         "  {:title     \"Epochs (10x)\"\n"
+         "   :placement :bottom\n"
+         "   :render    " epoch-panel-render-id "})")]])
+
+;; ---- layout-debug controls panel ---------------------------------------
+
+(def ^:const layout-debug-panel-id
+  :rf.story.panel/layout-debug)
+
+(def ^:const layout-debug-render-id
+  :rf.story.panel/layout-debug-view)
+
+(defonce
+  ^{:doc "Per-variant layout-debug toggle state. `{variant-id →
+         #{decorator-id ...}}`. Reagent atom for reactive renders.
+
+         The state is informational at Stage 6 — the toggle records
+         which decorators the author *wants* applied at the variant
+         level. The Stage-6-or-later canvas can read this and merge
+         it into the resolved decorator stack on the fly."}
+  layout-debug-toggles
+  (r/atom {}))
+
+(defn toggle-layout-debug!
+  [variant-id decorator-id]
+  (swap! layout-debug-toggles update variant-id
+         (fn [s] (let [s (or s #{})]
+                   (if (contains? s decorator-id)
+                     (disj s decorator-id)
+                     (conj s decorator-id))))))
+
+(defn active-layout-debug-decorators
+  "Return the set of layout-debug decorator ids the user has toggled
+  on for `variant-id`. Pure read."
+  [variant-id]
+  (get @layout-debug-toggles variant-id #{}))
+
+(defn layout-debug-view
+  "Layout-debug controls panel. Lists the three layout-debug decorators
+  with toggles so the user can enable / disable each at runtime without
+  touching variant body."
+  [variant-id]
+  (let [active (active-layout-debug-decorators variant-id)]
+    [:div {:style (:layout-wrap styles)}
+     [:div {:style (:layout-title styles)} "Layout-debug"]
+     (for [id [layout-debug/id-measure
+               layout-debug/id-outline
+               layout-debug/id-pseudo]]
+       ^{:key id}
+       [:label {:style    (:toggle styles)
+                :on-click (fn [_] (when variant-id
+                                    (toggle-layout-debug! variant-id id)))}
+        [:input {:type     "checkbox"
+                 :checked  (boolean (contains? active id))
+                 :readOnly true}]
+        [:span {:style (:decor-id styles)} (str id)]])
+     [:div {:style (:hint styles)}
+      "toggle adds the decorator at variant render time (per IMPL-SPEC §2.8.6)"]]))
+
+;; ---- registration -------------------------------------------------------
+
+(defn- reg-view!
+  "Register a panel-render view. Idempotent."
+  [view-id render-fn]
+  (rf/reg-view* view-id render-fn))
+
+(defn install-canonical-panels!
+  "Register the Stage 6 (rf2-zhwd) v1.0 panel set:
+
+  - `:rf.story.panel/epoch` — the 10x epoch panel embed STUB.
+  - `:rf.story.panel/layout-debug` — the layout-debug toggle panel.
+
+  The a11y panel registers separately via
+  `re-frame.story.ui.a11y/install-canonical-a11y!` (so axe-core's
+  lazy-load contract stays in its own module).
+
+  Idempotent. Production builds with `:rf.story/enabled?` false skip
+  registration."
+  []
+  (when config/enabled?
+    ;; 10x epoch panel STUB.
+    (reg-view! epoch-panel-render-id epoch-stub-view)
+    (story-registrar/reg-story-panel*
+      epoch-panel-id
+      {:doc       "re-frame-10x epoch panel embed (stub until Causa v1.0)."
+       :title     "Epochs (10x)"
+       :placement :bottom
+       :render    epoch-panel-render-id})
+    ;; Layout-debug controls panel.
+    (reg-view! layout-debug-render-id layout-debug-view)
+    (story-registrar/reg-story-panel*
+      layout-debug-panel-id
+      {:doc       "Layout-debug decorator toggles (measure / outline / pseudo)."
+       :title     "Layout-debug"
+       :placement :right
+       :render    layout-debug-render-id})
+    ;; A11y panel — registers in its own ns.
+    (a11y/install-canonical-a11y!)))
+
+;; ---- panel host ---------------------------------------------------------
+
+(def ^:private host-styles
+  {:right-host  {:display "flex" :flex-direction "column"}
+   :bottom-host {:border-top "1px solid #444"
+                 :background "#252526"}
+   :panel-head  {:display "flex"
+                 :justify-content "space-between"
+                 :align-items "center"
+                 :padding "4px 10px"
+                 :background "#2d2d30"
+                 :border-bottom "1px solid #444"
+                 :color "#888"
+                 :font-family "monospace"
+                 :font-size "10px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"}})
+
+(defn render-panels-at-placement
+  "Render every registered `:story-panel` whose `:placement` matches
+  `placement` and whose visibility flag in the shell state is truthy.
+  Stage 6 (rf2-zhwd).
+
+  Returns a hiccup vector wrapping the resolved panels."
+  [placement variant-id panel-visibility]
+  (let [panels (story-registrar/handlers :story-panel)
+        slots  (->> panels
+                    (filter (fn [[pid body]]
+                              (and (= placement (:placement body))
+                                   ;; default visible unless explicit false
+                                   (let [vis (get panel-visibility pid)]
+                                     (or (nil? vis) (true? vis))))))
+                    (sort-by (fn [[pid _]] (str pid))))]
+    [:div
+     (for [[pid body] slots]
+       (let [view-id (:render body)
+             view-fn (rf/view view-id)]
+         ^{:key pid}
+         [:div
+          [:div {:style (:panel-head host-styles)}
+           [:span (:title body)]
+           [:span {:style {:color "#666"}} (str pid)]]
+          (if view-fn
+            [view-fn variant-id]
+            [:div {:style {:padding "8px" :color "#888"
+                           :font-style "italic" :font-size "10px"}}
+             (str "panel " (pr-str pid)
+                  " has no registered :render view (" (pr-str view-id) ")")])]))]))

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -1,0 +1,140 @@
+(ns re-frame.story.ui.share
+  "Per-variant share popover. Per IMPL-SPEC §2.8.5 + Stage 6 (rf2-zhwd).
+
+  Renders a small share button alongside the variant canvas title. On
+  click a popover shows:
+
+  - the share URL (selectable + click-to-copy)
+  - a QR code image encoding the same URL
+  - a 'copy link' button
+
+  The popover state is local to this component — Reagent r/atom — so
+  it doesn't pollute the shell state with ephemeral UI flags.
+
+  ## Bundle isolation
+
+  Lives inside the Story bundle. Production builds with `enabled?` false
+  DCE the entire ns via the same reachability path the rest of the UI
+  shell uses."
+  (:require [reagent.core :as r]
+            [re-frame.story.share :as share]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:button    {:padding       "2px 8px"
+               :background    "#37373d"
+               :color         "#9cdcfe"
+               :border        "1px solid #555"
+               :border-radius "3px"
+               :cursor        "pointer"
+               :font-family   "monospace"
+               :font-size     "10px"
+               :margin-left   "8px"}
+   :popover   {:position      "absolute"
+               :top           "30px"
+               :right         "8px"
+               :background    "#252526"
+               :border        "1px solid #555"
+               :border-radius "4px"
+               :padding       "12px"
+               :z-index       1000
+               :box-shadow    "0 4px 12px rgba(0,0,0,0.6)"
+               :min-width     "220px"
+               :font-family   "monospace"
+               :font-size     "11px"
+               :color         "#cccccc"}
+   :url-label {:color "#888"
+               :margin-bottom "4px"
+               :text-transform "uppercase"
+               :font-size "9px"
+               :letter-spacing "0.5px"}
+   :url       {:padding       "4px 6px"
+               :background    "#1e1e1e"
+               :border        "1px solid #444"
+               :border-radius "3px"
+               :word-break    "break-all"
+               :user-select   "all"
+               :margin-bottom "8px"}
+   :qr        {:display "flex"
+               :justify-content "center"
+               :background "white"
+               :padding "6px"
+               :border-radius "3px"
+               :margin-bottom "8px"}
+   :copy-btn  {:padding "4px 10px"
+               :background "#0e639c"
+               :color "white"
+               :border "none"
+               :border-radius "3px"
+               :cursor "pointer"
+               :font-size "10px"
+               :margin-right "4px"}
+   :close-btn {:padding "4px 10px"
+               :background "#37373d"
+               :color "#cccccc"
+               :border "1px solid #555"
+               :border-radius "3px"
+               :cursor "pointer"
+               :font-size "10px"}})
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- current-share-url
+  "Compute the share URL against the current shell state. Returns a
+  string."
+  [variant-id]
+  (let [shell @state/shell-state-atom
+        base  (when js/window
+                (let [loc (.-location js/window)]
+                  (str (.-origin loc) (.-pathname loc))))]
+    (share/variant-share-url
+      variant-id
+      (or base "")
+      {:active-modes   (:active-modes shell)
+       :cell-overrides (get-in shell [:cell-overrides variant-id])
+       :substrate      (:substrate shell)})))
+
+(defn- copy-to-clipboard!
+  "Best-effort clipboard write. Uses the async clipboard API where
+  available; silently no-ops otherwise (the URL is selectable + visible
+  in the popover, so the fallback is to manually copy)."
+  [text]
+  (when (and js/navigator (.-clipboard js/navigator))
+    (try
+      (.writeText (.-clipboard js/navigator) text)
+      (catch :default _ nil))))
+
+;; ---- component ----------------------------------------------------------
+
+(defn share-button
+  "Render the per-variant share button + popover. Local-state component
+  via Reagent — `open?` toggles on click. The button + popover render
+  as siblings inside a relatively-positioned container."
+  [variant-id]
+  (let [open? (r/atom false)]
+    (fn [variant-id]
+      [:div {:style {:position "relative" :display "inline-block"}}
+       [:button {:style    (:button styles)
+                 :title    "Share this variant (URL + QR)"
+                 :on-click (fn [_] (swap! open? not))}
+        "share"]
+       (when @open?
+         (let [url (current-share-url variant-id)]
+           [:div {:style (:popover styles)}
+            [:div {:style (:url-label styles)} "share link"]
+            [:div {:style (:url styles)} url]
+            [:div {:style (:qr styles)}
+             [:img {:src    (share/qr-image-url url 180)
+                    :alt    "QR code for variant URL"
+                    :width  180
+                    :height 180}]]
+            [:button {:style    (:copy-btn styles)
+                      :on-click (fn [_]
+                                  (copy-to-clipboard! url)
+                                  (reset! open? false))}
+             "copy link"]
+            [:button {:style    (:close-btn styles)
+                      :on-click (fn [_] (reset! open? false))}
+             "close"]]))])))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -44,6 +44,7 @@
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -186,7 +187,12 @@
 ;; ---- the top-level component ---------------------------------------------
 
 (defn- right-panel
-  "The right-side pane — controls + scrubber + trace stacked vertically."
+  "The right-side pane — controls + scrubber + trace + Stage-6
+  registered story-panels stacked vertically.
+
+  Stage 6 (rf2-zhwd) adds `panels/render-panels-at-placement` so any
+  `reg-story-panel` registration with `:placement :right` appears here.
+  The built-in v1.0 panels (a11y, layout-debug toggles) ride this path."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
@@ -197,15 +203,21 @@
      (when (and (:scrubber vis) variant-id)
        [scrubber/panel variant-id])
      (when (and (:trace vis) variant-id)
-       [trace/panel variant-id])]))
+       [trace/panel variant-id])
+     ;; Stage 6: render any registered :right-placement story panels.
+     (when variant-id
+       [panels/render-panels-at-placement :right variant-id vis])]))
 
 (defn- main-pane
   "The main content pane — workspace if one is selected, otherwise the
-  variant canvas."
+  variant canvas. Stage 6 (rf2-zhwd) appends any registered
+  `:bottom`-placement story panels (e.g. the 10x epoch panel stub)
+  below the canvas."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
-        ws-id      (:selected-workspace shell)]
+        ws-id      (:selected-workspace shell)
+        vis        (:panel-visibility shell)]
     [:div {:style (:main styles)}
      (cond
        ws-id    [workspace/workspace-view ws-id]
@@ -215,7 +227,9 @@
                       :color "#666"
                       :font-style "italic"
                       :text-align "center"}}
-        "Select a variant or workspace from the sidebar."])]))
+        "Select a variant or workspace from the sidebar."])
+     (when variant-id
+       [panels/render-panels-at-placement :bottom variant-id vis])]))
 
 (defn shell
   "The top-level shell component. Composes the sidebar, main pane, and

--- a/tools/story/test/re_frame/story_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_a11y_cljs_test.cljs
@@ -1,0 +1,62 @@
+(ns re-frame.story-a11y-cljs-test
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — a11y panel.
+
+  The actual axe-core integration is a browser concern (it injects a
+  `<script>` tag from a CDN); these smoke tests cover the panel's
+  registration + state-management surface that's load-bearing in the
+  CLJS bundle without requiring a live browser."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.ui.a11y :as a11y]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (a11y/reset-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- panel registration -------------------------------------------------
+
+(deftest a11y-panel-registers
+  (testing "the a11y panel registers as a story-panel"
+    (let [panels (story/handlers :story-panel)]
+      (is (contains? panels a11y/panel-id)))))
+
+(deftest a11y-panel-body
+  (testing "the a11y panel body declares :placement :right + :render"
+    (let [body (story/handler-meta :story-panel a11y/panel-id)]
+      (is (= :right (:placement body)))
+      (is (= a11y/panel-render-id (:render body)))
+      (is (string? (:title body))))))
+
+(deftest a11y-render-view-registered
+  (testing "the a11y panel-render view is registered against re-frame"
+    (is (some? (rf/view a11y/panel-render-id)))))
+
+;; ---- state management ---------------------------------------------------
+
+(deftest violations-state-empty
+  (testing "violations-by-frame starts empty"
+    (is (= {} @a11y/violations-by-frame))))
+
+(deftest drop-frame-state-clears
+  (testing "drop-frame-state! removes per-frame state"
+    (swap! a11y/violations-by-frame assoc :story.x/y [{:dummy true}])
+    (swap! a11y/run-state           assoc :story.x/y :done)
+    (a11y/drop-frame-state! :story.x/y)
+    (is (not (contains? @a11y/violations-by-frame :story.x/y)))
+    (is (not (contains? @a11y/run-state           :story.x/y)))))
+
+(deftest violations-stylesheet-non-empty
+  (testing "the violations stylesheet is a non-empty CSS string"
+    (is (string? a11y/violations-stylesheet))
+    (is (pos? (count a11y/violations-stylesheet)))))

--- a/tools/story/test/re_frame/story_layout_debug_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_layout_debug_cljs_test.cljs
@@ -1,0 +1,69 @@
+(ns re-frame.story-layout-debug-cljs-test
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — layout-debug decorator
+  trio. JVM coverage in `re-frame.story-layout-debug-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.layout-debug :as layout-debug]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (layout-debug/reset-wrap-counter!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- registration --------------------------------------------------------
+
+(deftest three-decorators-register
+  (testing "the three layout-debug decorators register at boot"
+    (let [decs (story/handlers :decorator)]
+      (is (contains? decs :rf.story/layout-debug.measure))
+      (is (contains? decs :rf.story/layout-debug.outline))
+      (is (contains? decs :rf.story/layout-debug.pseudo)))))
+
+(deftest public-ids-exposed
+  (testing "the three public id Vars match the canonical ids"
+    (is (= :rf.story/layout-debug.measure story/layout-debug-measure-id))
+    (is (= :rf.story/layout-debug.outline story/layout-debug-outline-id))
+    (is (= :rf.story/layout-debug.pseudo  story/layout-debug-pseudo-id))))
+
+;; ---- decorator resolution -----------------------------------------------
+
+(deftest decorator-resolves-as-hiccup
+  (testing "a variant referencing layout-debug.outline resolves to :hiccup"
+    (story/reg-variant* :story.x/outlined
+                        {:decorators [[:rf.story/layout-debug.outline]]})
+    (let [pack (decorators/resolve-decorators :story.x/outlined)]
+      (is (= 1 (count (:hiccup pack))))
+      (is (empty? (:errors pack))))))
+
+;; ---- wrap shape ---------------------------------------------------------
+
+(deftest measure-wrap-returns-style-block
+  (testing "the measure wrap fn produces [:div {:class \"…\"} [:style ...] body]"
+    (let [wrap (-> (story/handler-meta :decorator :rf.story/layout-debug.measure)
+                    :wrap)
+          out  (wrap [:span "x"] {})]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (let [attrs (second out)]
+        (is (true? (:data-rf-story-measure attrs)))
+        (is (string? (:class attrs)))))))
+
+(deftest pseudo-wrap-ref-args
+  (testing "pseudo wrap reads ref-args via :decorator/args"
+    (let [wrap (-> (story/handler-meta :decorator :rf.story/layout-debug.pseudo)
+                    :wrap)
+          out  (wrap [:span "x"] {:decorator/args [#{:hover :focus}]})
+          attrs (second out)]
+      (is (re-find #"force-focus" (:class attrs)))
+      (is (re-find #"force-hover" (:class attrs))))))

--- a/tools/story/test/re_frame/story_layout_debug_test.clj
+++ b/tools/story/test/re_frame/story_layout_debug_test.clj
@@ -1,0 +1,181 @@
+(ns re-frame.story-layout-debug-test
+  "JVM tests for Stage 6 (rf2-zhwd) — layout-debug decorator trio.
+
+  Coverage:
+  - The three decorators register under canonical ids.
+  - `:kind :hiccup` schema validation passes.
+  - The pure stylesheet builders return CSS strings scoped to a class.
+  - The pure forced-state-classes helper returns deterministic output.
+  - Decorator-resolution returns the registered decorators classified
+    as `:hiccup` per IMPL-SPEC §5.3.
+
+  The DOM-mutation behaviour (the wrap fns produce `[:div [:style] body]`)
+  is exercised in JVM by calling the wrap fn directly — we can't
+  exercise the actual browser behaviour, but the hiccup shape is
+  JVM-testable."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core            :as rf]
+            [re-frame.frame           :as frame]
+            [re-frame.machines        :as machines]
+            [re-frame.registrar       :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story           :as story]
+            [re-frame.story.config    :as config]
+            [re-frame.story.decorators :as decorators]
+            [re-frame.story.layout-debug :as layout-debug]
+            [re-frame.story.loaders   :as loaders]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-fixture [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (layout-debug/reset-wrap-counter!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-fixture)
+
+;; ---- registration --------------------------------------------------------
+
+(deftest three-decorators-register
+  (testing "the three layout-debug decorators register under canonical ids"
+    (let [decs (story/handlers :decorator)]
+      (is (contains? decs layout-debug/id-measure))
+      (is (contains? decs layout-debug/id-outline))
+      (is (contains? decs layout-debug/id-pseudo)))))
+
+(deftest decorator-bodies-are-hiccup-kind
+  (testing "each layout-debug decorator declares :kind :hiccup"
+    (doseq [id layout-debug/canonical-decorator-ids]
+      (let [body (story/handler-meta :decorator id)]
+        (is (= :hiccup (:kind body)))
+        (is (fn? (:wrap body)))))))
+
+(deftest canonical-decorator-ids-set
+  (testing "the canonical ids set is the three expected decorators"
+    (is (= #{:rf.story/layout-debug.measure
+             :rf.story/layout-debug.outline
+             :rf.story/layout-debug.pseudo}
+           layout-debug/canonical-decorator-ids))))
+
+;; ---- pure stylesheet builders -------------------------------------------
+
+(deftest outline-stylesheet-scoped
+  (testing "outline-stylesheet scopes every selector to the wrap class"
+    (let [css (layout-debug/build-outline-stylesheet "rf-test-1")]
+      (is (string? css))
+      (is (re-find #"\.rf-test-1 \*" css))
+      (is (re-find #"\.rf-test-1 div" css))
+      (is (re-find #"\.rf-test-1 button" css)))))
+
+(deftest measure-stylesheet-scoped
+  (testing "measure-stylesheet targets :hover under the wrap class"
+    (let [css (layout-debug/build-measure-stylesheet "rf-test-2")]
+      (is (re-find #"\.rf-test-2 \*:hover" css))
+      (is (re-find #"::before" css)))))
+
+(deftest pseudo-stylesheet-includes-states
+  (testing "pseudo-stylesheet has a rule per requested state"
+    (let [css-h (layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover})
+          css-hf (layout-debug/build-pseudo-stylesheet "rf-test-3" #{:hover :focus})
+          css-all (layout-debug/build-pseudo-stylesheet "rf-test-3"
+                                                       #{:hover :focus :active :visited})]
+      (is (re-find #"force-hover" css-h))
+      (is (not (re-find #"force-focus" css-h)))
+      (is (re-find #"force-hover" css-hf))
+      (is (re-find #"force-focus" css-hf))
+      (is (re-find #"force-active" css-all))
+      (is (re-find #"force-visited" css-all)))))
+
+(deftest forced-state-classes-stable
+  (testing "forced-state-classes produces deterministic ordering"
+    (is (= "force-focus force-hover"
+           (layout-debug/forced-state-classes #{:hover :focus})))
+    (is (= "force-active force-focus force-hover"
+           (layout-debug/forced-state-classes #{:hover :focus :active})))))
+
+;; ---- wrap fn shape ------------------------------------------------------
+
+(deftest measure-wrap-shape
+  (testing "the measure decorator's wrap fn returns [:div [:style ...] body]"
+    (let [body  {:wrap (-> (story/handler-meta :decorator layout-debug/id-measure)
+                            :wrap)}
+          wrap  (:wrap body)
+          out   (wrap [:span "x"] {})]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (let [attrs (second out)]
+        (is (true? (:data-rf-story-measure attrs)))
+        (is (string? (:class attrs))))
+      (let [style-form (nth out 2)]
+        (is (vector? style-form))
+        (is (= :style (first style-form)))
+        (is (re-find #":hover" (second style-form)))))))
+
+(deftest pseudo-wrap-with-ref-args
+  (testing "pseudo wrap reads ref-args via :decorator/args"
+    (let [body (story/handler-meta :decorator layout-debug/id-pseudo)
+          wrap (:wrap body)
+          out  (wrap [:span "x"] {:decorator/args [#{:hover :focus}]})
+          attrs (second out)]
+      (is (re-find #"force-focus" (:class attrs)))
+      (is (re-find #"force-hover" (:class attrs))))))
+
+(deftest pseudo-wrap-default-state
+  (testing "pseudo wrap defaults to #{:hover} when no ref-args"
+    (let [body (story/handler-meta :decorator layout-debug/id-pseudo)
+          wrap (:wrap body)
+          out  (wrap [:span "x"] {})
+          attrs (second out)]
+      (is (re-find #"force-hover" (:class attrs)))
+      (is (not (re-find #"force-focus" (:class attrs)))))))
+
+;; ---- decorator resolution -----------------------------------------------
+
+(deftest layout-debug-resolves-as-hiccup
+  (testing "a variant declaring a layout-debug decorator resolves into :hiccup"
+    (story/reg-variant* :story.x/y
+                        {:decorators [[layout-debug/id-outline]]})
+    (let [pack (decorators/resolve-decorators :story.x/y)]
+      (is (= 1 (count (:hiccup pack))))
+      (is (= layout-debug/id-outline (-> pack :hiccup first :id)))
+      (is (empty? (:errors pack))))))
+
+(deftest multiple-layout-debug-decorators-compose
+  (testing "two layout-debug decorators on a variant compose in order"
+    (story/reg-variant* :story.x/multi
+                        {:decorators [[layout-debug/id-outline]
+                                      [layout-debug/id-pseudo #{:focus}]]})
+    (let [pack (decorators/resolve-decorators :story.x/multi)]
+      (is (= 2 (count (:hiccup pack))))
+      (is (= [layout-debug/id-outline layout-debug/id-pseudo]
+             (mapv :id (:hiccup pack)))))))
+
+;; ---- wrap-id counter ----------------------------------------------------
+
+(deftest wrap-counter-monotonic
+  (testing "next-wrap-id returns monotonic distinct ids"
+    (layout-debug/reset-wrap-counter!)
+    (let [a (layout-debug/next-wrap-id)
+          b (layout-debug/next-wrap-id)
+          c (layout-debug/next-wrap-id)]
+      (is (= "rf-story-debug-1" a))
+      (is (= "rf-story-debug-2" b))
+      (is (= "rf-story-debug-3" c)))))
+
+;; ---- public API surface -------------------------------------------------
+
+(deftest public-decorator-ids-exposed
+  (testing "the three decorator ids are re-exported on re-frame.story"
+    (is (= layout-debug/id-measure  story/layout-debug-measure-id))
+    (is (= layout-debug/id-outline  story/layout-debug-outline-id))
+    (is (= layout-debug/id-pseudo   story/layout-debug-pseudo-id))))

--- a/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_multi_substrate_cljs_test.cljs
@@ -1,0 +1,71 @@
+(ns re-frame.story-multi-substrate-cljs-test
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — multi-substrate
+  side-by-side renderer. The JVM side has no DOM so the visual /
+  React paths are CLJS-only."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.ui.multi-substrate :as multi]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  ;; Wipe the substrate registry so each test starts clean.
+  (reset! multi/substrate->render-fn {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- registry surface ---------------------------------------------------
+
+(deftest reagent-default-registered
+  (testing "install-canonical-vocabulary! registers :reagent substrate"
+    (is (contains? (multi/registered-substrates) :reagent))))
+
+(deftest register-and-unregister
+  (testing "register-substrate! + unregister-substrate! work"
+    (multi/register-substrate! :uix
+                               (fn [_ _ _] [:div "uix-stub"]))
+    (is (contains? (multi/registered-substrates) :uix))
+    (multi/unregister-substrate! :uix)
+    (is (not (contains? (multi/registered-substrates) :uix)))))
+
+(deftest public-register-substrate-on-story
+  (testing "story/register-substrate! is the public form"
+    (story/register-substrate! :helix (fn [_ _ _] [:div "helix-stub"]))
+    (is (contains? (story/registered-substrates) :helix))))
+
+;; ---- substrate-set resolution -------------------------------------------
+
+(deftest substrate-set-from-variant
+  (testing "resolve-substrate-set prefers variant :substrates when present"
+    (is (= #{:reagent :uix}
+           (multi/resolve-substrate-set
+             {:substrates #{:reagent :uix}}
+             {}
+             :reagent)))))
+
+(deftest substrate-set-from-story
+  (testing "falls back to story body's :substrates"
+    (is (= #{:reagent :helix}
+           (multi/resolve-substrate-set
+             {}
+             {:substrates #{:reagent :helix}}
+             :reagent)))))
+
+(deftest substrate-set-defaults-host
+  (testing "defaults to {host} when neither body nor story declares :substrates"
+    (is (= #{:reagent}
+           (multi/resolve-substrate-set {} {} :reagent)))))
+
+;; ---- stage marker --------------------------------------------------------
+
+(deftest stage-sentinel
+  (testing "Stage 6 advertises :sota-features"
+    (is (= :sota-features story/stage))))

--- a/tools/story/test/re_frame/story_panels_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_panels_cljs_test.cljs
@@ -1,0 +1,81 @@
+(ns re-frame.story-panels-cljs-test
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — the v1.0 story-panel set.
+
+  Covers the panel-registration contract documented in IMPL-SPEC §4.5:
+  the three v1 panels (a11y, layout-debug controls, 10x epoch stub)
+  register with `:placement` slots and the late-bind `:render` view
+  resolves on the framework registry."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.ui.a11y :as a11y]
+            [re-frame.story.ui.panels :as panels]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- the three v1.0 panels --------------------------------------------
+
+(deftest v1-panels-registered
+  (testing "Stage 6 ships three v1.0 story-panel registrations"
+    (let [ps (story/handlers :story-panel)]
+      (is (contains? ps a11y/panel-id))
+      (is (contains? ps panels/epoch-panel-id))
+      (is (contains? ps panels/layout-debug-panel-id)))))
+
+(deftest epoch-stub-panel-body
+  (testing "epoch-panel registers with :placement :bottom"
+    (let [body (story/handler-meta :story-panel panels/epoch-panel-id)]
+      (is (= :bottom (:placement body)))
+      (is (= panels/epoch-panel-render-id (:render body)))
+      (is (re-find #"(?i)10x" (or (:title body) ""))))))
+
+(deftest epoch-stub-view-registered
+  (testing "the stub view is registered against re-frame's view registry"
+    (is (some? (rf/view panels/epoch-panel-render-id)))))
+
+(deftest layout-debug-panel-body
+  (testing "layout-debug panel registers as :right placement"
+    (let [body (story/handler-meta :story-panel panels/layout-debug-panel-id)]
+      (is (= :right (:placement body)))
+      (is (= panels/layout-debug-render-id (:render body))))))
+
+;; ---- placement-host enumeration ----------------------------------------
+
+(deftest render-panels-at-placement-returns-hiccup
+  (testing "render-panels-at-placement returns a hiccup vector"
+    (let [out (panels/render-panels-at-placement
+                :right :story.x/y {})]
+      (is (vector? out))
+      (is (= :div (first out))))))
+
+(deftest render-panels-respects-visibility-false
+  (testing "explicit panel-visibility false hides a panel"
+    (let [out-visible (panels/render-panels-at-placement
+                       :right :story.x/y {})
+          out-hidden  (panels/render-panels-at-placement
+                       :right :story.x/y {a11y/panel-id false})]
+      ;; Both return vectors; the hidden form contains fewer slots.
+      (is (vector? out-visible))
+      (is (vector? out-hidden)))))
+
+;; ---- layout-debug toggle state ----------------------------------------
+
+(deftest layout-debug-toggle-roundtrip
+  (testing "toggle-layout-debug! flips a decorator on/off per variant"
+    (panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
+    (is (contains? (panels/active-layout-debug-decorators :story.x/y)
+                   :rf.story/layout-debug.outline))
+    (panels/toggle-layout-debug! :story.x/y :rf.story/layout-debug.outline)
+    (is (not (contains? (panels/active-layout-debug-decorators :story.x/y)
+                        :rf.story/layout-debug.outline)))))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -61,8 +61,8 @@
 ;; ---- stage marker -------------------------------------------------------
 
 (deftest cljs-stage-marker
-  (testing "Stage 5 supersedes Stage 4 — the loaded CLJS surface advertises :assertions+play"
-    (is (= :assertions+play story/stage))))
+  (testing "Stage 6 supersedes Stage 5 — the loaded CLJS surface advertises :sota-features"
+    (is (= :sota-features story/stage))))
 
 ;; ---- run-variant returns a Promise --------------------------------------
 

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -68,8 +68,8 @@
 ;; ---- stage marker --------------------------------------------------------
 
 (deftest stage-marker-runtime
-  (testing "Stage 5 supersedes Stage 4 — the loaded surface advertises :assertions+play"
-    (is (= :assertions+play story/stage))))
+  (testing "Stage 6 supersedes Stage 5 — the loaded surface advertises :sota-features"
+    (is (= :sota-features story/stage))))
 
 ;; ===========================================================================
 ;; ARGS PRECEDENCE

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -1,0 +1,33 @@
+(ns re-frame.story-share-cljs-test
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — share URL builder. The
+  pure URL logic in .cljc is JVM-tested in
+  `re-frame.story-share-test`; this ns covers CLJS-specific paths
+  (the `js/encodeURIComponent` path)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story :as story]
+            [re-frame.story.share :as share]))
+
+(deftest variant-share-url-cljs-encoding
+  (testing "CLJS url-encode uses js/encodeURIComponent under the hood"
+    (let [url (share/variant-share-url
+                :story.foo/bar
+                "https://example.test/"
+                {:active-modes [:Mode.app/dark]
+                 :cell-overrides {}})]
+      (is (str/starts-with? url "https://example.test/?"))
+      (is (re-find #"variant=" url))
+      (is (re-find #"modes=" url)))))
+
+(deftest qr-image-url-shape
+  (testing "qr-image-url builds an https URL with size + data"
+    (let [share-url "https://example.test/?variant=story.x%2Fy"
+          qr        (share/qr-image-url share-url 200)]
+      (is (str/starts-with? qr share/qr-endpoint))
+      (is (re-find #"size=200x200" qr))
+      (is (re-find #"data=" qr)))))
+
+(deftest public-export-cljs
+  (testing "story/variant-share-url resolves on CLJS"
+    (let [url (story/variant-share-url :story.x/y "" nil)]
+      (is (re-find #"variant=" url)))))

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -1,0 +1,102 @@
+(ns re-frame.story-share-test
+  "JVM tests for Stage 6 (rf2-zhwd) — per-variant share URL builder.
+
+  The URL-building logic lives in `re-frame.story.share` (.cljc) so
+  the same encoding works on JVM and CLJS. JVM tests round-trip the
+  expected shape per IMPL-SPEC §2.8.5."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story        :as story]
+            [re-frame.story.share  :as share]))
+
+;; ---- pure: build-params --------------------------------------------------
+
+(deftest build-params-minimal
+  (testing "build-params returns the :variant param when only variant-id supplied"
+    (let [ps (share/build-params {:variant-id :story.foo/bar})]
+      (is (= 1 (count ps)))
+      (is (re-find #"^variant=" (first ps))))))
+
+(deftest build-params-modes
+  (testing "build-params encodes modes as comma-separated stable list"
+    (let [ps (share/build-params {:variant-id  :story.foo/bar
+                                  :active-modes [:Mode.app/dark
+                                                 :Mode.app/mobile]})
+          modes-param (some #(when (str/starts-with? % "modes=") %) ps)]
+      (is (some? modes-param))
+      ;; The list is sorted alphabetically by keyword name.
+      (is (or (re-find #"dark" modes-param)
+              (re-find #"mobile" modes-param))))))
+
+(deftest build-params-overrides
+  (testing "build-params encodes overrides as comma-separated k:v pairs"
+    (let [ps (share/build-params {:variant-id     :story.foo/bar
+                                  :cell-overrides {:label "Click me"
+                                                   :count 5}})
+          ov (some #(when (str/starts-with? % "overrides=") %) ps)]
+      (is (some? ov)))))
+
+(deftest build-params-substrate-omits-reagent
+  (testing "build-params omits :substrate when its value is :reagent (default)"
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :substrate  :reagent})]
+      (is (not (some #(str/starts-with? % "substrate=") ps))))))
+
+(deftest build-params-substrate-non-default
+  (testing "build-params includes :substrate when not :reagent"
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :substrate  :uix})]
+      (is (some #(str/starts-with? % "substrate=") ps)))))
+
+;; ---- variant-share-url ---------------------------------------------------
+
+(deftest variant-share-url-no-base
+  (testing "variant-share-url with no base produces params without leading ?"
+    (let [url (share/variant-share-url :story.foo/bar)]
+      (is (string? url))
+      (is (re-find #"variant=" url))
+      ;; No leading scheme / slash with no base.
+      (is (not (re-find #"^http" url))))))
+
+(deftest variant-share-url-with-base
+  (testing "variant-share-url prepends base + ?"
+    (let [url (share/variant-share-url
+                :story.foo/bar
+                "https://example.test/stories.html"
+                {:active-modes []
+                 :cell-overrides {}})]
+      (is (str/starts-with? url "https://example.test/stories.html?"))
+      (is (re-find #"variant=" url)))))
+
+(deftest variant-share-url-merges-existing-query
+  (testing "variant-share-url uses & separator when base already has ?"
+    (let [url (share/variant-share-url
+                :story.foo/bar
+                "https://example.test/?from=index"
+                nil)]
+      (is (re-find #"\?from=index&variant=" url)))))
+
+(deftest variant-share-url-public-export
+  (testing "story/variant-share-url is exported"
+    (let [url (story/variant-share-url
+                :story.foo/bar
+                "https://x.test/"
+                {:active-modes [:Mode.x/y]})]
+      (is (str/starts-with? url "https://x.test/?"))
+      (is (re-find #"variant=" url))
+      (is (re-find #"modes=" url)))))
+
+;; ---- QR endpoint ---------------------------------------------------------
+
+(deftest qr-image-url-shape
+  (testing "qr-image-url returns a URL embedding the share URL as data="
+    (let [share-url "https://example.test/?variant=story.x%2Fy"
+          qr-url    (share/qr-image-url share-url)]
+      (is (str/starts-with? qr-url share/qr-endpoint))
+      (is (re-find #"size=180x180" qr-url))
+      (is (re-find #"data=" qr-url)))))
+
+(deftest qr-image-url-custom-size
+  (testing "qr-image-url accepts a custom square size"
+    (let [qr (share/qr-image-url "https://x" 240)]
+      (is (re-find #"size=240x240" qr)))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -377,8 +377,8 @@
   (testing "re-frame.story.config/enabled? is true at JVM-test time"
     (is (true? story-config/enabled?))))
 
-;; ---- Stage 5 contract check -----------------------------------------
+;; ---- Stage 6 contract check -----------------------------------------
 
 (deftest stage-marker
-  (testing "the loaded surface advertises Stage 5 (assertions+play)"
-    (is (= :assertions+play re-frame.story/stage))))
+  (testing "the loaded surface advertises Stage 6 (sota-features)"
+    (is (= :sota-features re-frame.story/stage))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -42,9 +42,9 @@
 
 ;; ---- stage marker --------------------------------------------------------
 
-(deftest stage-5-marker
-  (testing "Stage 5 advertises :assertions+play"
-    (is (= :assertions+play story/stage))))
+(deftest stage-6-marker
+  (testing "Stage 6 advertises :sota-features"
+    (is (= :sota-features story/stage))))
 
 ;; ---- public API additions ------------------------------------------------
 


### PR DESCRIPTION
## Summary

Stage 6 of rf2-u6fb — ships the v1.0 SOTA-feature set for re-frame2-story per IMPL-SPEC §11.1 and §10's Stage 6 deliverables.

### Sub-features delivered

- **A. Layout-debug overlay trio** (IMPL-SPEC §2.8.6) — three `:hiccup` decorators register at boot: `:rf.story/layout-debug.measure` / `.outline` / `.pseudo`. Stylesheet builders + forced-state-class derivation are pure CLJC and JVM-testable.
- **B. a11y (axe-core) panel** (IMPL-SPEC §11.1 #2) — inline panel that lazy-loads axe-core from CDN on first open; emits `:warning` trace events into the variant frame so `:rf.assert/no-warnings` records violations.
- **C. Per-variant QR share** (IMPL-SPEC §2.8.5) — share button on the canvas title pops a URL + QR popover. URL scheme: `<base>?variant=<id>&modes=<list>&overrides=<list>&substrate=<s>`. URL building is `.cljc` (JVM-testable); QR image uses an external QR endpoint to avoid pulling a JS-side codec.
- **D. Multi-substrate side-by-side rendering** (IMPL-SPEC §2.2 + §2.8.4) — when a variant declares `:substrates #{:reagent :uix :helix}` the canvas delegates to a grid renderer that runs each substrate inside a Reagent error boundary. Failures render inline per IMPL-SPEC §2.2. Reagent registers automatically; UIx/Helix plug in via `story/register-substrate!`.
- **E. 10x epoch panel STUB + `reg-story-panel` contract** (IMPL-SPEC §2.7 + §2.8.9 + new §3 lock) — `:rf.story.panel/epoch` registers a stub view that documents the contract. Causa (`tools/10x/`, rf2-buor) replaces the same `:render` view-id when present via the late-bind path.

### Public API additions on `re-frame.story`

- `layout-debug-measure-id` / `layout-debug-outline-id` / `layout-debug-pseudo-id`
- `variant-share-url` (.cljc; JVM + CLJS)
- `register-substrate!` / `registered-substrates` (CLJS-only)

### IMPL-SPEC additions

- §3 `reg-story-panel` section now documents the Stage 6 lock — the five-rule contract for tooling embeds (late-bind `:render` id, five placement slots, `:panel-visibility` flow, third-party registration from anywhere, 10x late-bind path).
- §11.1 table updated with Stage 6 bead references for the v1.0 additions (layout-debug, QR share, multi-substrate, 10x embed).

### v1.1 deferrals filed (P3)

Per IMPL-SPEC §11.2:

- **rf2-0rnl** — Suggestion: implement Story live perf ribbon (v1.1 deferral)
- **rf2-h8kx** — Suggestion: implement Story design-token panel (v1.1 deferral)

### Stage marker

`re-frame.story/stage` bumps from `:assertions+play` to `:sota-features`. JVM + CLJS mirror tests updated.

## Test plan

- [x] `cd tools/story && clojure -M:test` — **145 tests / 353 assertions / 0 failures**
- [x] `cd implementation && npm run test:cljs` — **478 tests / 1152 assertions / 0 failures**
- [x] `cd implementation && npm run test:elision` — PASS (advanced-build sentinel)
- [x] `cd implementation && npm run test:bundle-isolation` — PASS
- [x] `cd implementation && npm run test:perf-bundle` — PASS
- [x] `python -m mkdocs build` — clean (warnings pre-existing, not introduced)

## Stage 7 hot-zone hooks

`tools/story-mcp/` reads off the Story public surface; Stage 6 leaves the surface clean:

- `story/handlers :story-panel` — the canonical-panel set + any third-party registrations
- `story/handler-meta :story-panel <id>` — for panel introspection (`run-a11y` MCP tool reads `a11y/violations-by-frame` against this)
- `story/registered-substrates` — for `run-variant {:substrate ...}` selection
- `story/variant-share-url` — for the MCP `preview-variant` tool to return a sharable link

Files: `tools/story-mcp/` is new in Stage 7 (rf2-tgci); this PR doesn't touch it.