### PR TITLE
feat(story-mcp): Stage 7 — separate-jar MCP agent surface (rf2-tgci)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -1,0 +1,130 @@
+# tools/story-mcp/
+
+`day8/re-frame2-story-mcp` — the **MCP (Model Context Protocol) agent
+surface** for re-frame2-story. Lands as Stage 7 of the Story epic
+(`rf2-tgci`); design contract is [`tools/story/IMPL-SPEC.md` §7](../story/IMPL-SPEC.md).
+
+## What it is
+
+A JVM-side stdio JSON-RPC server that exposes Story's read (and gated
+write) surface as MCP tools. AI agents (Claude Code, Cursor, Copilot)
+launch the server as a subprocess, perform the `initialize` handshake,
+then call tools like `list-stories`, `run-variant`, `snapshot-identity`,
+`get-story-instructions` to navigate / drive / introspect the Story
+library.
+
+## What it isn't
+
+- **Not** an IDE plugin. Agent hosts (Claude Code etc.) bring the MCP
+  client side; this artefact is the server.
+- **Not** part of Story's authoring runtime. It reads from
+  `re-frame.story`'s public query API and dispatches to its public
+  runtime fns; nothing here registers new framework primitives.
+- **Not** reachable from production CLJS bundles. Per
+  [`tools/README.md`](../README.md) the dependency arrow flows
+  tool → implementation; this jar is on a separate classpath root.
+
+## Quick start
+
+```bash
+# Run the server (stdio transport). The agent host typically invokes
+# this for you; you rarely run it by hand.
+cd tools/story-mcp
+clojure -M -m re-frame.story-mcp.server
+
+# Open the write surface (defaults to off — IMPL-SPEC §7.3):
+clojure -M -m re-frame.story-mcp.server --allow-writes
+# or
+RF_STORY_MCP_ALLOW_WRITES=true clojure -M -m re-frame.story-mcp.server
+# or
+clojure -J-Drf.story-mcp.allow-writes=true -M -m re-frame.story-mcp.server
+```
+
+Tests:
+
+```bash
+cd tools/story-mcp
+clojure -M:test
+```
+
+## Tool registry
+
+The tool set splits into four categories per IMPL-SPEC §7.2 + §7.3.
+
+### Dev — for agents helping build new stories
+
+| Tool                         | Semantics                                                                                       |
+|------------------------------|-------------------------------------------------------------------------------------------------|
+| `get-story-instructions`     | Return Story's authoring conventions (the seven `reg-*` macros, hard rules, lifecycle).         |
+| `preview-variant`            | Given `:variant-id`, run the canvas pipeline and return state + assertions + a sharable URL.    |
+| `list-substrates`            | The substrates registered via `register-substrate!` (Reagent canonical; UIx / Helix opt-in).    |
+
+### Docs — for agents reading the story library
+
+| Tool                | Semantics                                                                |
+|---------------------|--------------------------------------------------------------------------|
+| `list-stories`      | All registered stories (optional `:tags` filter).                        |
+| `get-story`         | One story's full body + its variant ids.                                 |
+| `get-variant`       | One variant's resolved EDN body.                                         |
+| `list-tags`         | Canonical tags + project-custom tags.                                    |
+| `list-modes`        | Registered modes (Chromatic-style saved arg tuples).                     |
+| `list-assertions`   | The seven canonical `:rf.assert/*` vocab + arity docs.                   |
+| `variant->edn`      | Round-trippable EDN of a variant (text-only result for byte stability).  |
+
+### Testing — for agents running stories headlessly
+
+| Tool                | Semantics                                                                              |
+|---------------------|----------------------------------------------------------------------------------------|
+| `run-variant`       | Execute the four-phase lifecycle; return result map (`:frame :app-db :assertions ...`). |
+| `snapshot-identity` | Content-hash of (variant × args × decorators × loaders × substrate × modes).           |
+| `run-a11y`          | Read axe-core violations for a variant (CLJS panel writes; this tool reads).           |
+| `read-failures`     | Recent assertion failures accumulated against the variant frame.                       |
+
+### Write — v1.1, dev-only, gated
+
+| Tool                  | Semantics                                                                              |
+|-----------------------|----------------------------------------------------------------------------------------|
+| `register-variant`    | Programmatically register a variant. **Gated** behind `--allow-writes` (default off).  |
+| `unregister-variant`  | Symmetric to `register-variant`. Same gate.                                            |
+
+The write gate exists because an agent that can register variants on
+demand activates the self-healing loop (write story → run → read
+failures → fix). That power must be opt-in, not default; CI runs
+should always leave it closed.
+
+## Protocol
+
+- Transport: **stdio**, newline-delimited JSON-RPC 2.0 per [MCP
+  2025-06-18 §Transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
+- Capabilities advertised: `tools` (with `listChanged: false`).
+- Methods handled: `initialize`, `tools/list`, `tools/call`, `ping`,
+  `shutdown`, `notifications/initialized` (silent accept).
+- Unknown methods → `-32601 method-not-found`.
+- Malformed JSON → `-32700 parse-error` with `id: null` (the loop
+  survives and continues reading).
+
+## File layout
+
+```
+tools/story-mcp/
+├── deps.edn                                      ; coord day8/re-frame2-story-mcp
+├── README.md                                     ; this file
+└── src/re_frame/story_mcp/
+    ├── config.cljc                               ; protocol-version + allow-writes? gate
+    ├── protocol.cljc                             ; JSON-RPC envelope + frame I/O
+    ├── tools.cljc                                ; 16 tool implementations + registry
+    └── server.cljc                               ; dispatcher + -main + run-loop
+└── test/re_frame/story_mcp/
+    ├── protocol_test.clj                         ; wire-format coverage
+    └── tools_test.clj                            ; per-tool semantics + dispatcher + run-loop
+```
+
+## See also
+
+- [`tools/story/IMPL-SPEC.md`](../story/IMPL-SPEC.md) §7 — the contract.
+- [`tools/README.md`](../README.md) — per-tool jar convention + bundle isolation.
+- [`spec/007-Stories.md`](../../spec/007-Stories.md) — the spec the
+  Story runtime implements (this jar is one of its consumers).
+- [`spec/Tool-Pair.md`](../../spec/Tool-Pair.md) — the runtime contract
+  for pair-shaped AI tools (Story-MCP follows it implicitly via the
+  Story public surface).

--- a/tools/story-mcp/deps.edn
+++ b/tools/story-mcp/deps.edn
@@ -1,0 +1,67 @@
+;; day8/re-frame2-story-mcp — MCP (Model Context Protocol) agent surface
+;; for re-frame2-story (rf2-tgci; Stage 7 of rf2-u6fb).
+;;
+;; Per tools/story/IMPL-SPEC.md §7 the agent surface ships as a separate
+;; artefact from `day8/re-frame2-story` so the MCP server can be loaded
+;; without dragging the entire Story UI / authoring macro substrate into
+;; the classpath, and so consumers of Story-the-tool need not pull in
+;; stdio / JSON-RPC dependencies they don't use.
+;;
+;; ## Bundle isolation
+;;
+;; Per `tools/README.md` the dependency arrow flows tool → implementation
+;; (and never the reverse). This artefact depends on `tools/story/`
+;; (`:local/root "../story"`) which in turn depends on `implementation/`.
+;; Nothing under `implementation/` may `:require` anything from this
+;; artefact; nothing in production CLJS bundles may either.
+;;
+;; ## JVM-only
+;;
+;; Story-MCP is JVM-side: its job is to terminate the agent host's stdio
+;; channel and bridge `tools/story/`'s public surface over JSON-RPC. The
+;; sources are `.cljc` only so the underlying registrar reads work
+;; identically when the server is hosted in-process (an nREPL-attached
+;; CLJS build calling `re-frame.story-mcp/-main` would be reasonable;
+;; per IMPL-SPEC §7.1 the canonical deploy is a CLJ subprocess launched
+;; by the agent's IDE host).
+;;
+;; ## Release
+;;
+;; Independent cadence from `day8/re-frame2-story` (per tools/README.md —
+;; per-tool jars release independently). The release workflow swaps
+;; `:local/root` → `:mvn/version` before invoking clein, identical to
+;; the adapter jars.
+{:paths ["src"]
+ :deps  {;; Story is the agent surface's read substrate. Every MCP
+         ;; tool routes through `re-frame.story`'s public query API
+         ;; (`handlers`, `handler-meta`, `run-variant`, `variant->edn`,
+         ;; `snapshot-identity`, …) — see IMPL-SPEC §7.4.
+         day8/re-frame2-story {:local/root "../story"}
+
+         ;; JSON wire format. Cheshire is the project's existing JSON
+         ;; library (implementation/http uses it via requiring-resolve);
+         ;; we declare it as a direct runtime dep here because every
+         ;; JSON-RPC frame round-trips through it.
+         cheshire/cheshire    {:mvn/version "5.12.0"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+
+  ;; Clojars deploy. Mirrors tools/story/deps.edn — the release workflow
+  ;; rewrites :local/root → :mvn/version before invoking clein.
+  :clein {:extra-deps {io.github.noahtheduke/clein
+                       {:git/url "https://github.com/day8/clein.git"
+                        :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
+          :main-opts  ["-m" "noahtheduke.clein"]}
+
+  :clein/build
+  {:lib      day8/re-frame2-story-mcp
+   :main     re-frame.story-mcp.server
+   :url      "https://github.com/day8/re-frame2"
+   :version  "../../VERSION"
+   :license  {:name "MIT"
+              :url  "https://opensource.org/licenses/MIT"}
+   :src-dirs ["src"]}}}

--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -1,0 +1,111 @@
+(ns re-frame.story-mcp.config
+  "Compile + runtime configuration for the Story-MCP server.
+
+  Per IMPL-SPEC §7.3 the write surface (`register-variant`,
+  `unregister-variant`) is gated behind `allow-writes?`. The default is
+  `false`: writes are dev-only and must be enabled explicitly. CI runs
+  should always boot with the gate closed; an agent host that wants the
+  self-healing loop (write story → run → read failures → fix) opts in.
+
+  ## Surface
+
+  - `allow-writes?` — atom holding the boolean flag. Read by the
+    write-surface tools (`re-frame.story-mcp.tools/register-variant` and
+    friends); a `false` value causes the tool to return an MCP error
+    result (`isError: true`) rather than a protocol-level error per the
+    spec/2025-06-18 tools §Error Handling guidance.
+  - `set-allow-writes!` — write helper. Called from `-main` (`--allow-writes`
+    CLI flag), from the JVM property `-Drf.story-mcp.allow-writes=true`,
+    or programmatically (tests).
+  - `protocol-version` — the MCP protocol version this server advertises.
+
+  ## Why a separate ns
+
+  Symmetry with `re-frame.story.config` — keep the boolean knobs together
+  so an agent host or test fixture can adjust them without reaching into
+  the server / tools namespaces. Per IMPL-SPEC §13.2 #6 the
+  protocol-version target is a documented decision the implementation
+  bead (rf2-tgci) lands."
+  (:require [clojure.string :as str]))
+
+;; ---- MCP protocol version --------------------------------------------------
+
+(def ^:const protocol-version
+  "The MCP protocol version this server advertises in the `initialize`
+  handshake. Pinned to `2025-06-18` — the latest spec at Stage 7 land.
+
+  The spec's version-negotiation rule: if the client requests a version
+  we don't recognise, we still respond with the one we support; the
+  client decides whether to disconnect. Per
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+  §Version Negotiation."
+  "2025-06-18")
+
+(def ^:const server-name
+  "Server `name` advertised in the `initialize` response's `serverInfo`."
+  "re-frame2-story-mcp")
+
+;; ---- write-surface gate ---------------------------------------------------
+
+(defonce
+  ^{:doc "Atom holding the write-surface gate. Defaults to `false`. Per
+         IMPL-SPEC §7.3 the write surface (`register-variant` /
+         `unregister-variant`) is gated; CI runs leave this `false` and
+         dev hosts opt in.
+
+         The flag is a runtime atom (not a `def`) so tests can flip it
+         per-fixture without reloading the namespace. The CLI flag
+         `--allow-writes` and the JVM property `-Drf.story-mcp.allow-writes`
+         seed it at server boot."}
+  allow-writes?
+  (atom false))
+
+(defn set-allow-writes!
+  "Set the write-surface gate. Idempotent. Returns the new value."
+  [v]
+  (let [coerced (boolean v)]
+    (reset! allow-writes? coerced)
+    coerced))
+
+(defn writes-allowed?
+  "True iff the write surface is currently enabled."
+  []
+  (boolean @allow-writes?))
+
+;; ---- boot config from env / sysprop ---------------------------------------
+
+(defn read-boot-config
+  "Read boot-time configuration from JVM sysprops + env vars.
+
+  Recognised sources (later wins):
+
+  - JVM sysprop `rf.story-mcp.allow-writes` — `\"true\"` / `\"1\"` enables.
+  - Env var `RF_STORY_MCP_ALLOW_WRITES` — same.
+
+  Returns a map `{:allow-writes? boolean}`. The caller (`-main`) merges
+  in CLI overrides before calling `apply-config!`."
+  []
+  (let [sysprop (some-> (System/getProperty "rf.story-mcp.allow-writes")
+                        str/trim
+                        str/lower-case)
+        envv    (some-> (System/getenv "RF_STORY_MCP_ALLOW_WRITES")
+                        str/trim
+                        str/lower-case)
+        truthy? #(contains? #{"true" "1" "yes" "y" "on"} %)]
+    {:allow-writes? (boolean (or (truthy? sysprop)
+                                 (truthy? envv)))}))
+
+(defn apply-config!
+  "Apply a boot-config map to the runtime atoms. Returns the applied map."
+  [{:keys [allow-writes?] :as cfg}]
+  (when (some? allow-writes?)
+    (set-allow-writes! allow-writes?))
+  cfg)
+
+;; ---- stage marker --------------------------------------------------------
+
+(def stage
+  "Sentinel naming which Stage's surface is loaded. Matches the marker
+  pattern from `re-frame.story/stage` — Story Stage 7 lands the MCP
+  agent surface in a separate jar."
+  :mcp)

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -1,0 +1,183 @@
+(ns re-frame.story-mcp.protocol
+  "MCP / JSON-RPC 2.0 wire-format helpers.
+
+  Per https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+  the stdio transport is newline-delimited JSON-RPC: one message per
+  line on stdin/stdout, UTF-8, no embedded newlines, no extra noise on
+  stdout (only valid MCP messages). stderr is free-form logging.
+
+  This namespace owns the wire framing — read a line, parse JSON,
+  validate the JSON-RPC envelope shape, hand off to a handler, serialise
+  the response, write a line. The handler logic itself (`tools/list`,
+  `tools/call`, etc.) lives in `re-frame.story-mcp.server`; the tool
+  implementations live in `re-frame.story-mcp.tools`.
+
+  ## JSON-RPC error codes
+
+  Per JSON-RPC 2.0 §5.1 and MCP's reuse of them:
+
+  | Code     | Name              | When                                    |
+  |----------|-------------------|-----------------------------------------|
+  | -32700   | parse-error       | Malformed JSON on the wire.             |
+  | -32600   | invalid-request   | Not a valid JSON-RPC request envelope.  |
+  | -32601   | method-not-found  | Unknown method (incl. unknown tool).    |
+  | -32602   | invalid-params    | Method recognised, params shape wrong.  |
+  | -32603   | internal-error    | Server-side fault.                      |
+
+  Tool-execution errors (a known tool returning a failure) use the
+  `tools/call` result shape with `isError: true` per the MCP spec §Error
+  Handling guidance — they are NOT protocol-level errors."
+  (:require [cheshire.core :as json]
+            [clojure.string :as str]))
+
+;; ---- error codes ----------------------------------------------------------
+
+(def ^:const code-parse-error      -32700)
+(def ^:const code-invalid-request  -32600)
+(def ^:const code-method-not-found -32601)
+(def ^:const code-invalid-params   -32602)
+(def ^:const code-internal-error   -32603)
+
+;; ---- envelope construction -----------------------------------------------
+
+(defn response
+  "Build a JSON-RPC success response envelope. `id` is the request id
+  (echoed from the request); `result` is the method-specific payload."
+  [id result]
+  {:jsonrpc "2.0"
+   :id      id
+   :result  result})
+
+(defn error-response
+  "Build a JSON-RPC error response envelope.
+
+  `id` may be `nil` (for top-of-protocol failures where the id couldn't
+  be parsed); per JSON-RPC 2.0 §5 the `id` slot is always present in an
+  error response — `null` is the correct value when unknown."
+  ([id code message]
+   (error-response id code message nil))
+  ([id code message data]
+   {:jsonrpc "2.0"
+    :id      id
+    :error   (cond-> {:code code :message message}
+               (some? data) (assoc :data data))}))
+
+(defn notification?
+  "Per JSON-RPC 2.0 §4.1, a notification is a request without an `id`.
+  Notifications get no response. Assumes keys have been keywordised
+  (parse-json does this)."
+  [message]
+  (and (map? message)
+       (not (contains? message :id))))
+
+(defn request?
+  "True iff `message` has the JSON-RPC request shape (`jsonrpc:\"2.0\"`,
+  `method` present, `id` present). The `id` MAY be a number, string, or
+  null per the spec — we accept any non-vector / non-map scalar."
+  [message]
+  (and (map? message)
+       (= "2.0" (:jsonrpc message))
+       (contains? message :method)
+       (contains? message :id)))
+
+(defn valid-envelope?
+  "True iff `message` is a syntactically-valid JSON-RPC 2.0 request OR
+  notification — both shapes are accepted here; the dispatcher decides
+  which to act on. Notifications omit `id`; requests carry it."
+  [message]
+  (and (map? message)
+       (= "2.0" (:jsonrpc message))
+       (string? (:method message))
+       (not (str/blank? (:method message)))))
+
+;; ---- JSON I/O ------------------------------------------------------------
+
+(defn parse-json
+  "Parse a JSON string into a Clojure map. Returns the parsed value, or
+  throws `ex-info` with `:rf.error/parse-error` on a malformed payload.
+
+  Keys are converted to keywords for ergonomic dispatch — this matches
+  what the rest of the namespace expects (`(:method m)`, `(:jsonrpc m)`,
+  `(:id m)`). String keys inside `params` are NOT converted: tool
+  argument maps are typically keyword-keyed at the tools layer, but
+  user-supplied JSON-keys may be arbitrary strings; the tool dispatcher
+  re-keywordises the top level when it parses arguments."
+  [^String s]
+  (try
+    (json/parse-string s true)
+    (catch Throwable e
+      (throw (ex-info "re-frame2-story-mcp: JSON parse failure"
+                      {:rf.error :rf.error/parse-error
+                       :raw      (when s (subs s 0 (min 200 (count s))))}
+                      e)))))
+
+(defn write-json
+  "Serialise `message` to JSON. Returns the string (no trailing newline —
+  the line-writer at `server.cljc` adds it). Throws on a non-encodable
+  value; the catch path at the dispatcher turns the throw into an
+  internal-error response."
+  [message]
+  (json/generate-string message))
+
+;; ---- frame I/O (stdio line-delimited) ------------------------------------
+
+(defn read-frame
+  "Read one newline-delimited JSON frame from `^java.io.BufferedReader reader`.
+  Returns the parsed map, or `::eof` when the reader has closed, or
+  throws `:rf.error/parse-error` on malformed JSON.
+
+  Empty / whitespace lines are silently consumed (some agent hosts emit
+  trailing newlines)."
+  [^java.io.BufferedReader reader]
+  (loop []
+    (let [line (.readLine reader)]
+      (cond
+        (nil? line)                   ::eof
+        (str/blank? line)             (recur)
+        :else                         (parse-json line)))))
+
+(defn write-frame!
+  "Write one newline-delimited JSON frame to `^java.io.Writer writer`,
+  flushing immediately. Per the MCP stdio transport spec, every message
+  must terminate with a newline and contain no embedded newlines —
+  Cheshire's default `generate-string` doesn't emit newlines.
+
+  Throws if the encoder fails (the caller is expected to translate that
+  into an internal-error response before retrying the write)."
+  [^java.io.Writer writer message]
+  (.write writer ^String (write-json message))
+  (.write writer "\n")
+  (.flush writer)
+  nil)
+
+;; ---- error helpers -------------------------------------------------------
+
+(defn parse-error
+  "Build a parse-error response. `id` is `nil` because by definition we
+  couldn't parse the request to extract one."
+  []
+  (error-response nil code-parse-error "Parse error"))
+
+(defn method-not-found
+  "Build a method-not-found error for `method`. Used by the dispatcher
+  when `(:method message)` doesn't match a registered handler — and by
+  `tools/call` when the named tool isn't in the registry."
+  [id method]
+  (error-response id code-method-not-found
+                  (str "Method not found: " method)))
+
+(defn invalid-params
+  "Build an invalid-params error. `details` is human-readable."
+  [id details]
+  (error-response id code-invalid-params
+                  (str "Invalid params: " details)))
+
+(defn internal-error
+  "Build an internal-error response. `details` is human-readable. The
+  `:data` slot carries a structured error map per JSON-RPC 2.0 §5.1
+  (the spec allows servers to attach arbitrary `data` to error
+  responses; agent clients may surface it for debugging)."
+  ([id details]
+   (internal-error id details nil))
+  ([id details data]
+   (error-response id code-internal-error details data)))

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -1,0 +1,264 @@
+(ns re-frame.story-mcp.server
+  "MCP server entry-point. Runs the JSON-RPC dispatch loop over stdin /
+  stdout per the MCP stdio transport spec (newline-delimited JSON,
+  UTF-8, no embedded newlines, stderr free-form for logging).
+
+  ## Lifecycle (per spec/2025-06-18/basic/lifecycle)
+
+  1. Server starts; reads from stdin in a loop.
+  2. First message must be `initialize` — we respond with our protocol
+     version + capabilities + serverInfo.
+  3. Client sends `notifications/initialized` (no response).
+  4. Client sends `tools/list`, `tools/call`, etc.; we dispatch.
+  5. Shutdown: client closes stdin → readLine returns nil → we exit.
+
+  ## Dispatch table
+
+  Implemented methods:
+
+  - `initialize`           — handshake
+  - `notifications/initialized` — accepted; no response (notification)
+  - `tools/list`           — return the tool registry descriptors
+  - `tools/call`           — invoke a named tool
+  - `ping`                 — protocol-level liveness probe; empty result
+  - `shutdown`             — graceful exit hint (not in 2025-06-18 spec
+                             but several agent hosts emit it; we accept
+                             and respond before letting the stdin EOF
+                             close us)
+
+  Unknown methods → `-32601 method-not-found`.
+
+  ## Why a separate dispatch ns
+
+  Keeps the wire framing (`protocol.cljc`) isolated from the method
+  semantics here, and the method semantics isolated from the tool
+  implementations (`tools.cljc`). The split lets tests cover the wire
+  layer without booting the full Story registrar (see
+  `protocol_test.clj`)."
+  (:gen-class)
+  (:require [clojure.string :as str]
+            [re-frame.story :as story]
+            [re-frame.story-mcp.config :as config]
+            [re-frame.story-mcp.protocol :as proto]
+            [re-frame.story-mcp.tools :as tools]))
+
+;; ---- logging --------------------------------------------------------------
+;;
+;; Per MCP stdio transport: stderr is free-form for logging. We use a
+;; tiny `log!` fn instead of taking on a logging dep — keeps the
+;; classpath lean. The format is deliberately simple so an agent host
+;; that captures stderr sees one log line per call.
+
+(defn log!
+  "Write a log line to stderr. Stays out of stdout — per MCP stdio rules,
+  stdout is reserved for valid MCP messages only."
+  [& parts]
+  (binding [*out* *err*]
+    (println (str "[re-frame2-story-mcp] " (str/join " " (map str parts))))
+    (flush)))
+
+;; ---- handshake ------------------------------------------------------------
+
+(defn- handle-initialize
+  "Build the `initialize` response. Echoes the client's `protocolVersion`
+  when we support it (only `2025-06-18` at Stage 7 land); otherwise we
+  reply with our supported version and let the client decide whether to
+  disconnect per the spec's version-negotiation rule."
+  [id _params]
+  (let [version config/protocol-version]
+    (proto/response id
+                    {:protocolVersion version
+                     :capabilities    {:tools {:listChanged false}}
+                     :serverInfo      {:name    config/server-name
+                                       :version (try
+                                                  ;; Read VERSION from the
+                                                  ;; project root. Best-effort:
+                                                  ;; if the file isn't on the
+                                                  ;; classpath (uberjar deploy),
+                                                  ;; fall back to "dev".
+                                                  (or (some-> (clojure.java.io/resource "VERSION")
+                                                              slurp
+                                                              str/trim)
+                                                      "dev")
+                                                  (catch Throwable _ "dev"))}
+                     :instructions    (str "Story MCP agent surface. Call `tools/list` for the registry, "
+                                           "then `tools/call` with the named tool + arguments. "
+                                           "See `get-story-instructions` for Story's authoring conventions.")})))
+
+;; ---- tools/list -----------------------------------------------------------
+
+(defn- handle-tools-list
+  "Return the tool registry descriptors. We don't paginate — the
+  registry is small enough (sixteen tools at Stage 7) that a single
+  response is fine."
+  [id _params]
+  (proto/response id {:tools (tools/tool-descriptors)}))
+
+;; ---- tools/call -----------------------------------------------------------
+
+(defn- handle-tools-call
+  "Invoke a tool. `params` shape: `{:name <string> :arguments <map>}`."
+  [id params]
+  (let [tool-name (:name params)
+        arguments (:arguments params)]
+    (cond
+      (not (string? tool-name))
+      (proto/invalid-params id "tools/call requires `name` (string)")
+
+      :else
+      (if-let [result (tools/invoke-tool tool-name arguments)]
+        (proto/response id result)
+        (proto/method-not-found id (str "tools/call name=" tool-name))))))
+
+;; ---- ping / shutdown ------------------------------------------------------
+
+(defn- handle-ping
+  "Empty success result. Per MCP §Utilities/ping."
+  [id _params]
+  (proto/response id {}))
+
+(defn- handle-shutdown
+  "Some agent hosts send `shutdown` before closing stdin. The
+  2025-06-18 spec relies on stream close instead, but we accept and
+  respond so well-behaved clients don't see a timeout."
+  [id _params]
+  (proto/response id {}))
+
+;; ---- dispatcher -----------------------------------------------------------
+
+(defn dispatch
+  "Dispatch a parsed JSON-RPC message to the appropriate handler.
+  Returns a response envelope, or nil if the input is a notification
+  (notifications get no response per JSON-RPC 2.0 §4.1).
+
+  Public for tests."
+  [message]
+  (cond
+    (not (proto/valid-envelope? message))
+    (proto/error-response (:id message) proto/code-invalid-request
+                          "Invalid JSON-RPC envelope")
+
+    ;; Notifications — no response. Per the spec a notification is a
+    ;; request without an `id`. We accept `notifications/initialized`
+    ;; explicitly (it's the canonical handshake completion); other
+    ;; notifications are silently dropped.
+    (not (contains? message :id))
+    nil
+
+    :else
+    (let [{:keys [id method params]} message]
+      (case method
+        "initialize"                     (handle-initialize id params)
+        "notifications/initialized"      nil  ; defensive: this is a notification, shouldn't hit here
+        "tools/list"                     (handle-tools-list id params)
+        "tools/call"                     (handle-tools-call id params)
+        "ping"                           (handle-ping id params)
+        "shutdown"                       (handle-shutdown id params)
+        (proto/method-not-found id method)))))
+
+(defn- handle-frame!
+  "Process one parsed frame: dispatch, write the response (if any) to
+  the writer. Catches handler-side throws and converts them to
+  internal-error responses so the loop survives.
+
+  Public for tests."
+  [^java.io.Writer writer message]
+  (try
+    (when-let [resp (dispatch message)]
+      (proto/write-frame! writer resp))
+    (catch Throwable e
+      (log! "handler threw:" (ex-message e))
+      (try
+        (proto/write-frame! writer
+                            (proto/internal-error (:id message)
+                                                  (str "Server fault: " (ex-message e))
+                                                  {:exception (.getName (class e))}))
+        (catch Throwable e2
+          (log! "write also threw:" (ex-message e2)))))))
+
+;; ---- main loop ------------------------------------------------------------
+
+(defn run-loop!
+  "Drive the read → dispatch → write loop against `reader` / `writer`.
+  Returns when the reader hits EOF (stdin closed). Exposed for tests
+  that wire an in-memory pipe instead of stdin/stdout.
+
+  Each iteration:
+    1. Read one newline-delimited frame.
+    2. Parse JSON. Parse failures yield a `-32700` error response with
+       `id: null` (we have no parsed id to echo).
+    3. Dispatch. Method-level errors are responses; tool-level errors
+       are wrapped in the `tools/call` result with `isError: true`."
+  [^java.io.BufferedReader reader ^java.io.Writer writer]
+  (loop []
+    (let [frame (try
+                  (proto/read-frame reader)
+                  (catch Throwable e
+                    (log! "parse error:" (ex-message e))
+                    (try
+                      (proto/write-frame! writer (proto/parse-error))
+                      (catch Throwable e2
+                        (log! "write of parse-error response failed:" (ex-message e2))))
+                    ::recover))]
+      (cond
+        ;; `proto/read-frame` returns ::proto/eof (the ::eof sentinel
+        ;; auto-namespaced to its source ns) when stdin closes. The
+        ;; loop exits.
+        (= :re-frame.story-mcp.protocol/eof frame) :eof
+        ;; Recovery from a parse-error: we already wrote the error
+        ;; response; loop to the next frame.
+        (= ::recover frame)                        (recur)
+        :else
+        (do
+          (handle-frame! writer frame)
+          (recur))))))
+
+;; ---- -main ----------------------------------------------------------------
+
+(defn- parse-args
+  "Parse CLI args. Minimal — no third-party CLI lib required at Stage
+  7. Supported flags:
+
+  - `--allow-writes` (boolean) — open the write surface.
+
+  Returns a config map."
+  [argv]
+  (loop [args argv
+         cfg  {}]
+    (if-let [a (first args)]
+      (case a
+        "--allow-writes"     (recur (rest args) (assoc cfg :allow-writes? true))
+        "--allow-writes=true" (recur (rest args) (assoc cfg :allow-writes? true))
+        "--allow-writes=false" (recur (rest args) (assoc cfg :allow-writes? false))
+        ;; Unknown flag — log and ignore. The MCP spec doesn't define
+        ;; CLI conventions, so being permissive here is correct.
+        (do (log! "unknown CLI flag:" a)
+            (recur (rest args) cfg)))
+      cfg)))
+
+(defn boot!
+  "Apply boot configuration + install Story's canonical vocabulary.
+  Idempotent; exposed for tests that want to set up the server without
+  taking over stdin/stdout."
+  ([] (boot! {}))
+  ([cli-cfg]
+   (let [cfg (merge (config/read-boot-config) cli-cfg)]
+     (config/apply-config! cfg)
+     (story/install-canonical-vocabulary!)
+     (log! "booted; allow-writes?=" (config/writes-allowed?)
+           " protocol=" config/protocol-version
+           " server=" config/server-name)
+     cfg)))
+
+(defn -main
+  "Entry point. Boots, then runs the stdio JSON-RPC loop until stdin
+  closes. Per IMPL-SPEC §7.1 the agent host (Claude Code / Cursor /
+  Copilot) launches this as a subprocess and terminates it by closing
+  stdin (or SIGTERM after a timeout)."
+  [& argv]
+  (let [cli-cfg (parse-args argv)]
+    (boot! cli-cfg)
+    (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))
+          writer (java.io.OutputStreamWriter. System/out "UTF-8")]
+      (run-loop! reader writer)
+      (log! "stdin closed; exiting"))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
@@ -1,0 +1,739 @@
+(ns re-frame.story-mcp.tools
+  "MCP tool implementations. Each tool reads from / writes to
+  `re-frame.story`'s public surface; nothing here registers new
+  framework primitives or touches Story's internals.
+
+  Per IMPL-SPEC §7.2 the tool surface splits into three categories
+  matching Storybook MCP's Dev / Docs / Testing shape, plus a gated
+  v1.1 write surface from §7.3.
+
+  ## Tool registry
+
+  Each tool is a map:
+
+      {:name        \"<dash-separated-name>\"
+       :description \"<one-line semantics>\"
+       :category    :dev | :docs | :testing | :write
+       :inputSchema { ... JSON schema ... }
+       :handler     (fn [args] result-map-or-error)}
+
+  The handler returns either:
+
+  - A success map `{:content [{:type \"text\" :text \"...\"}] :structuredContent {...}}`
+    — wrapped by `tools/call` into a JSON-RPC result.
+  - An error map `{:content [{:type \"text\" :text \"error msg\"}] :isError true}`
+    — for tool-execution errors (the tool ran but failed).
+
+  Protocol-level errors (unknown tool name, malformed `arguments`) live
+  on the dispatcher in `re-frame.story-mcp.server`.
+
+  ## Why not call into Story's internals directly?
+
+  Story's `re-frame.story` ns is the contract. Per IMPL-SPEC §7.4
+  Story's core jar exposes `handlers`, `handler-meta`, `run-variant`,
+  `variant->edn`, `snapshot-identity`, `list-tags`, `list-modes`, the
+  Stage 5 assertion helpers, and `variant-share-url`. Nothing here
+  reaches past that public surface."
+  (:require [clojure.edn :as edn]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [re-frame.story :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.async :as async]
+            [re-frame.story-mcp.config :as config]))
+
+;; ---------------------------------------------------------------------------
+;; Result-builder helpers
+;; ---------------------------------------------------------------------------
+
+(defn- pr-edn
+  "Serialise a value to a stable, EDN-round-trippable string. Used to
+  embed Story data inside an MCP text content item. Uses `pr-str` —
+  keywords stay keywords, sets stay sets, no JSON lossiness."
+  [v]
+  (binding [*print-readably* true]
+    (pr-str v)))
+
+(defn- text-result
+  "Build a success result with a single text content item. `structured`
+  (optional) lands on the `structuredContent` slot per the spec/2025-06-18
+  tools §Structured content guidance — agent clients that prefer JSON
+  data over text can read it directly without re-parsing."
+  ([text]
+   {:content [{:type "text" :text text}]})
+  ([text structured]
+   (cond-> {:content [{:type "text" :text text}]}
+     (some? structured) (assoc :structuredContent structured))))
+
+(defn- error-result
+  "Build a tool-execution error result. Per MCP §Error Handling these
+  use `isError: true` rather than a protocol-level JSON-RPC error so
+  the agent client can surface the failure to the LLM without aborting
+  the conversation."
+  ([msg]
+   (error-result msg nil))
+  ([msg structured]
+   (cond-> {:content [{:type "text" :text msg}]
+            :isError true}
+     (some? structured) (assoc :structuredContent structured))))
+
+;; ---------------------------------------------------------------------------
+;; Args helpers
+;; ---------------------------------------------------------------------------
+
+(defn- read-keyword
+  "Read a keyword from agent-supplied arguments. MCP arguments arrive as
+  JSON, so keyword-typed Story ids come in as strings. We strip a
+  leading `\":\"` if present (some agents may serialise EDN-ish), and
+  use `read-string` only for namespaced keywords; otherwise plain
+  `keyword`.
+
+  Returns nil if the input is nil or empty."
+  [v]
+  (cond
+    (keyword? v) v
+    (nil? v)     nil
+    (string? v)  (let [s (if (and (> (count v) 0) (= \: (.charAt ^String v 0)))
+                           (subs v 1)
+                           v)]
+                   (cond
+                     (str/blank? s)           nil
+                     (str/includes? s "/")    (let [[ns nm] (str/split s #"/" 2)]
+                                                (keyword ns nm))
+                     :else                    (keyword s)))
+    :else        nil))
+
+(defn- required-arg
+  "Read a required argument. Returns `[value nil]` on success, or
+  `[nil error-result]` on miss."
+  [args k]
+  (let [v (get args k)]
+    (if (or (nil? v) (and (string? v) (str/blank? v)))
+      [nil (error-result (str "Missing required argument: " (name k)))]
+      [v nil])))
+
+;; ---------------------------------------------------------------------------
+;; Dev tools (instructions + preview)
+;; ---------------------------------------------------------------------------
+
+(def ^:private story-instructions-text
+  "The agent-onboarding text returned by `get-story-instructions`. Kept
+  inline as a single string to keep this jar self-contained — no
+  external resource read needed at boot."
+  (str
+    "re-frame2-story authoring conventions (agent quick reference).\n"
+    "Full spec: spec/007-Stories.md + tools/story/IMPL-SPEC.md.\n"
+    "\n"
+    "Registration: seven `reg-*` macros under re-frame.story/. Each\n"
+    "expansion threads `(when re-frame.story.config/enabled? ...)` so\n"
+    "production CLJS builds elide via Closure DCE.\n"
+    "\n"
+    "  (reg-story   :story.<path>              { :doc :component :decorators :args :argtypes\n"
+    "                                            :tags :modes :substrates :platforms :variants })\n"
+    "  (reg-variant :story.<path>/<variant>    { :doc :extends :events :play :args :argtypes\n"
+    "                                            :tags :decorators :loaders :loaders-complete-when\n"
+    "                                            :args->events :platforms :substrates :modes })\n"
+    "  (reg-workspace :Workspace.<path>/<name> { :doc :layout :variants :content :render :modes })\n"
+    "  (reg-mode     :mode/<name>              { :doc :args })\n"
+    "  (reg-story-panel :<panel-id>            { :doc :title :placement :render :for })\n"
+    "  (reg-decorator :<dec-id>                { :kind :wrap | :init :app-db-patch | :fx-id :response })\n"
+    "  (reg-tag      :<tag-id>                 { :doc })\n"
+    "\n"
+    "Hard rules:\n"
+    "  - Variant bodies are 100% EDN-round-trippable. NO closures, NO\n"
+    "    fns. The single legal closure-bearing slot is a `:hiccup`-kind\n"
+    "    decorator's `:wrap`, at the decorator's registration site.\n"
+    "  - Variants reference decorators by id: `:decorators [[:dec-id args]]`.\n"
+    "  - Inclusion tags must be registered before a variant references\n"
+    "    them. Seven canonical tags ship pre-registered:\n"
+    "      :dev :docs :test :screenshot :experimental :internal :agent.\n"
+    "    `:!tag` syntax removes an inherited tag (`:extends` chain).\n"
+    "  - Assertions are events under the `:rf.assert/*` namespace. Seven\n"
+    "    canonical assertions: path-equals, path-matches, sub-equals,\n"
+    "    dispatched?, state-is, no-warnings, effect-emitted.\n"
+    "\n"
+    "Lifecycle (`run-variant`): four phases — loaders → events → render\n"
+    "→ play. `:rf.assert/*` events in `:play` accumulate records on the\n"
+    "frame; they do NOT throw on failure. `assertions-passing?` is the\n"
+    "vacuous-pass predicate (empty assertions vector is green).\n"
+    "\n"
+    "Snapshots: `snapshot-identity` hashes the canonical (variant ×\n"
+    "args × decorators × loaders × substrate × modes) tuple. Stable\n"
+    "across hosts; use for visual-regression keying.\n"))
+
+(defn- tool-get-story-instructions
+  "Dev: return the Story authoring conventions in agent-friendly form."
+  [_args]
+  (text-result story-instructions-text))
+
+(defn- tool-preview-variant
+  "Dev: given a variant id, return the canvas state + share URL.
+
+  Per IMPL-SPEC §7.2 'returns rendered hiccup for a variant + the
+  assertions list'. We invoke `run-variant`, deref the promise (JVM
+  side has `async/deref-blocking`), and serialise the result map.
+
+  Also includes the variant share URL (per IMPL-SPEC §2.8.5 + Stage 6
+  `story/variant-share-url`) so the agent can hand the cell to a
+  human collaborator."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk        (read-keyword vid)
+            body      (story/variant->edn vk)]
+        (if (nil? body)
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (let [opts       (cond-> {}
+                             (some? (:substrate args))    (assoc :substrate (read-keyword (:substrate args)))
+                             (some? (:active-modes args)) (assoc :active-modes
+                                                                 (mapv read-keyword (:active-modes args)))
+                             (some? (:cell-overrides args)) (assoc :cell-overrides
+                                                                   (:cell-overrides args)))
+                base-url   (or (:base-url args) "")
+                share-url  (story/variant-share-url vk base-url opts)
+                result     (try
+                             (async/deref-blocking (story/run-variant vk opts)
+                                                   ;; Default 5s — preview is a snapshot,
+                                                   ;; not a long-running load.
+                                                   5000)
+                             (catch Throwable e
+                               {:lifecycle :error
+                                :assertions [{:assertion :rf.error/run-failed
+                                              :passed? false
+                                              :reason (ex-message e)}]}))
+                payload    {:variant-id   vk
+                            :share-url    share-url
+                            :lifecycle    (:lifecycle result)
+                            :elapsed-ms   (:elapsed-ms result)
+                            :app-db       (:app-db result)
+                            :assertions   (:assertions result)
+                            :rendered-hiccup (:rendered-hiccup result)
+                            :snapshot     (:snapshot result)
+                            :effective-args (:effective-args result)}]
+            (text-result (pr-edn payload) payload)))))))
+
+(defn- tool-list-substrates
+  "Dev: what substrates can be used. Reads the registered substrate set
+  via the Story-public surface.
+
+  Per IMPL-SPEC §2.2: substrates are registered via
+  `register-substrate!` on CLJS (the actual render-fn is CLJS-only).
+  On the JVM (where the MCP server lives by default) the registered
+  set is the CLJS-side one ONLY when the server is co-hosted with the
+  CLJS runtime (a shared-process deploy via nREPL). The JVM-standalone
+  deploy reads an empty set — that's a correct answer for that deploy
+  (no CLJS substrates are runnable from a JVM-only host)."
+  [_args]
+  (let [subs (try
+               ;; `story/registered-substrates` is CLJS-only (`#?(:cljs ...)`).
+               ;; On JVM there's no `def`, so we use `resolve` to detect that
+               ;; cleanly and return an empty set rather than blowing up.
+               (let [f (resolve 'story/registered-substrates)]
+                 (if f (sort (vec (f))) []))
+               (catch Throwable _ []))
+        payload {:substrates (vec subs)}]
+    (text-result (pr-edn payload) payload)))
+
+;; ---------------------------------------------------------------------------
+;; Docs tools (introspection)
+;; ---------------------------------------------------------------------------
+
+(defn- tool-list-stories
+  "Docs: all registered stories (with optional tag filters).
+
+  `args`:
+    :tags — vector of tag ids (strings or `:keyword` forms); narrows
+            the result to stories whose `:tags` set intersects this."
+  [args]
+  (let [stories (story/handlers :story)
+        tags    (when-let [ts (:tags args)]
+                  (set (map read-keyword ts)))
+        filtered (if (seq tags)
+                   (into {}
+                         (filter (fn [[_id body]]
+                                   (some tags (:tags body #{}))))
+                         stories)
+                   stories)
+        payload  {:stories (vec (for [[sid body] filtered]
+                                  {:id   sid
+                                   :doc  (:doc body)
+                                   :tags (vec (:tags body))
+                                   :variants (sort (story/variants-of sid))}))}]
+    (text-result (pr-edn payload) payload)))
+
+(defn- tool-get-story
+  "Docs: one story's full body."
+  [args]
+  (let [[sid err] (required-arg args :story-id)]
+    (if err err
+      (let [sk   (read-keyword sid)
+            body (story/handler-meta :story sk)]
+        (if (nil? body)
+          (error-result (str "Story not found: " (pr-str sk)))
+          (let [payload {:id sk :body body :variants (sort (story/variants-of sk))}]
+            (text-result (pr-edn payload) payload)))))))
+
+(defn- tool-get-variant
+  "Docs: one variant's full body (`handler-meta :variant id`)."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk   (read-keyword vid)
+            body (story/variant->edn vk)]
+        (if (nil? body)
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (let [payload {:id vk :body body}]
+            (text-result (pr-edn payload) payload)))))))
+
+(defn- tool-list-tags
+  "Docs: canonical tags + custom tags."
+  [_args]
+  (let [registered (story/list-tags)
+        canonical  story/canonical-tags
+        custom     (set/difference (set registered) (set canonical))
+        payload    {:canonical (vec (sort-by str canonical))
+                    :custom    (vec (sort-by str custom))
+                    :all       (vec (sort-by str registered))}]
+    (text-result (pr-edn payload) payload)))
+
+(defn- tool-list-modes
+  "Docs: registered modes (from `reg-mode`). Returns each mode's id +
+  body so agents can see the `:args` saved tuple."
+  [_args]
+  (let [modes   (story/handlers :mode)
+        payload {:modes (vec (for [[mid body] modes]
+                               {:id mid :doc (:doc body) :args (:args body)}))}]
+    (text-result (pr-edn payload) payload)))
+
+(def ^:private canonical-assertion-docs
+  "Per spec/007 line 304 + IMPL-SPEC §3.5 the canonical seven
+  assertions' arities."
+  [{:id :rf.assert/path-equals
+    :payload "[path expected]"
+    :semantics "(= (get-in @app-db path) expected)"}
+   {:id :rf.assert/path-matches
+    :payload "[path malli-schema]"
+    :semantics "Malli validate at path"}
+   {:id :rf.assert/sub-equals
+    :payload "[sub-vec expected]"
+    :semantics "(= @(subscribe sub-vec) expected)"}
+   {:id :rf.assert/dispatched?
+    :payload "[event-or-pred]"
+    :semantics "Was this event dispatched during play?"}
+   {:id :rf.assert/state-is
+    :payload "[machine-id state]"
+    :semantics "Machine in state?"}
+   {:id :rf.assert/no-warnings
+    :payload "[]"
+    :semantics "No :warning trace events since play start"}
+   {:id :rf.assert/effect-emitted
+    :payload "[fx-id (optional pred)]"
+    :semantics "fx-id emitted during play?"}])
+
+(defn- tool-list-assertions
+  "Docs: the `:rf.assert/*` canonical vocabulary + arity docs."
+  [_args]
+  (let [registered (story/canonical-assertion-ids)
+        payload    {:canonical canonical-assertion-docs
+                    :registered (vec (sort-by str registered))}]
+    (text-result (pr-edn payload) payload)))
+
+(defn- tool-variant->edn
+  "Docs: round-trippable EDN of a registered variant. Identical payload
+  to `get-variant` but framed as EDN-only — the `structuredContent`
+  slot is omitted so agents that want strict EDN parse the text."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk   (read-keyword vid)
+            body (story/variant->edn vk)]
+        (if (nil? body)
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (text-result (pr-edn body)))))))
+
+;; ---------------------------------------------------------------------------
+;; Testing tools (execution)
+;; ---------------------------------------------------------------------------
+
+(defn- tool-run-variant
+  "Testing: execute a variant, return the run-variant result map.
+
+  Per IMPL-SPEC §3.2 + §3.5 the result shape is
+  `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms ...}`.
+
+  Args:
+    :variant-id     required
+    :substrate      optional — keyword or string
+    :active-modes   optional — coll of mode ids
+    :cell-overrides optional — map of arg overrides
+    :timeout-ms     optional — JVM blocking timeout; default 10000"
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk   (read-keyword vid)]
+        (if (nil? (story/variant->edn vk))
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (let [opts     (cond-> {}
+                           (some? (:substrate args))     (assoc :substrate (read-keyword (:substrate args)))
+                           (some? (:active-modes args))  (assoc :active-modes
+                                                                (mapv read-keyword (:active-modes args)))
+                           (some? (:cell-overrides args)) (assoc :cell-overrides
+                                                                 (:cell-overrides args)))
+                timeout  (or (:timeout-ms args) 10000)
+                result   (try
+                           (async/deref-blocking (story/run-variant vk opts) timeout)
+                           (catch Throwable e
+                             {:lifecycle :error
+                              :variant-id vk
+                              :assertions [{:assertion :rf.error/run-failed
+                                            :passed? false
+                                            :reason (ex-message e)}]}))
+                payload  {:frame           (:frame result vk)
+                          :app-db          (:app-db result)
+                          :assertions      (:assertions result)
+                          :rendered-hiccup (:rendered-hiccup result)
+                          :elapsed-ms      (:elapsed-ms result)
+                          :snapshot        (:snapshot result)
+                          :lifecycle       (:lifecycle result)
+                          :passing?        (story/assertions-passing? result)}]
+            (text-result (pr-edn payload) payload)))))))
+
+(defn- tool-snapshot-identity
+  "Testing: content-hash of the canonicalised variant (for external
+  visual-regression). Returns
+  `{:variant-id :active-modes :substrate :content-hash}`."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk   (read-keyword vid)]
+        (if (nil? (story/variant->edn vk))
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (let [opts    (cond-> {}
+                          (some? (:substrate args))    (assoc :substrate (read-keyword (:substrate args)))
+                          (some? (:active-modes args)) (assoc :active-modes
+                                                              (mapv read-keyword (:active-modes args))))
+                payload (story/snapshot-identity vk opts)]
+            (text-result (pr-edn payload) payload)))))))
+
+(defn- tool-run-a11y
+  "Testing: run axe-core against a variant, return violations.
+
+  Per IMPL-SPEC §7.2 the implementation delegates to a11y panel data
+  (`a11y/violations-by-frame` per Stage 6's hot-zone-hooks report).
+  The actual axe-core run is CLJS-only (it loads an in-browser
+  `<script>`); from the JVM-side MCP server we can only READ the
+  violations atom that the CLJS canvas has accumulated.
+
+  The canonical agent workflow is:
+    1. Open the Story shell in the browser; navigate to the variant.
+    2. Click the a11y panel's 'Run' button (or the panel auto-runs on
+       canvas mount per Stage 6).
+    3. Call this MCP tool to read the violations the panel stored.
+
+  When the server is JVM-standalone (no co-hosted CLJS runtime) this
+  returns an empty result with a hint."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk    (read-keyword vid)
+            atomv (try
+                    (let [v (resolve 're-frame.story.ui.a11y/violations-by-frame)]
+                      (when v (deref @v)))
+                    (catch Throwable _ nil))
+            violations (when atomv (get atomv vk))
+            payload {:variant-id vk
+                     :violations (vec (or violations []))
+                     :note       (when (nil? atomv)
+                                   "a11y is CLJS-only; this JVM-standalone deploy can't run axe-core. Run the panel in-browser; the violations atom is read by this tool.")}]
+        (text-result (pr-edn payload) payload)))))
+
+(defn- tool-read-failures
+  "Testing: accumulated assertion failures across recent `run-variant`
+  calls. Reads the variant frame's `:rf.story/assertions` accumulator
+  via `re-frame.story/read-assertions`.
+
+  Useful for an agent that ran a variant a moment ago and wants to
+  inspect failures without re-running."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk         (read-keyword vid)
+            all        (assertions/read-assertions vk)
+            failures   (filterv (complement :passed?) all)
+            payload    {:variant-id vk
+                        :total      (count all)
+                        :failures   (vec failures)
+                        :passing?   (story/assertions-passing? all)}]
+        (text-result (pr-edn payload) payload)))))
+
+;; ---------------------------------------------------------------------------
+;; Write surface (v1.1, dev-only — gated)
+;; ---------------------------------------------------------------------------
+
+(defn- assert-writes-allowed
+  "Returns nil when writes are allowed; an error-result otherwise. The
+  caller short-circuits on the non-nil branch."
+  []
+  (when-not (config/writes-allowed?)
+    (error-result
+      (str "Write surface disabled. Set `:rf.story-mcp/allow-writes?` "
+           "(or `--allow-writes` CLI flag, or "
+           "`-Drf.story-mcp.allow-writes=true` JVM property) to enable. "
+           "Per IMPL-SPEC §7.3 the write surface is dev-only; CI runs "
+           "should leave it off.")
+      {:gated true :tool "register-variant"})))
+
+(defn- tool-register-variant
+  "Write: programmatically register a variant. Gated behind
+  `allow-writes?` per IMPL-SPEC §7.3.
+
+  Args:
+    :variant-id  required — `:story.<path>/<variant>` keyword id.
+    :body        required — the variant body (a map; will be read as
+                 EDN via `clojure.edn/read-string` if a string is sent
+                 over the wire)."
+  [args]
+  (or (assert-writes-allowed)
+      (let [[vid e1] (required-arg args :variant-id)
+            [body e2] (required-arg args :body)]
+        (cond
+          e1 e1
+          e2 e2
+          :else
+          (let [vk      (read-keyword vid)
+                body-v  (cond
+                          (map? body)    body
+                          (string? body) (try
+                                           (edn/read-string body)
+                                           (catch Throwable _
+                                             ::edn-error))
+                          :else          nil)]
+            (cond
+              (= body-v ::edn-error)
+              (error-result (str "Could not parse :body as EDN. Send a map or a valid EDN string."))
+
+              (not (map? body-v))
+              (error-result (str ":body must be a map; got " (some-> body-v class .getName)))
+
+              :else
+              (try
+                (let [id (story/reg-variant* vk body-v)]
+                  (let [payload {:variant-id id :registered? true}]
+                    (text-result (pr-edn payload) payload)))
+                (catch Throwable e
+                  (error-result (str "Registration failed: " (ex-message e))
+                                (merge {:variant-id vk}
+                                       (select-keys (ex-data e) [:rf.error :explain])))))))))))
+
+(defn- tool-unregister-variant
+  "Write: programmatically unregister a variant. Gated behind
+  `allow-writes?`."
+  [args]
+  (or (assert-writes-allowed)
+      (let [[vid err] (required-arg args :variant-id)]
+        (if err err
+          (let [vk    (read-keyword vid)
+                had?  (some? (story/variant->edn vk))]
+            (story/unregister! :variant vk)
+            (let [payload {:variant-id vk :unregistered? had?}]
+              (text-result (pr-edn payload) payload)))))))
+
+;; ---------------------------------------------------------------------------
+;; Tool registry
+;; ---------------------------------------------------------------------------
+
+(def ^:private kw-or-string
+  "Recurring JSON-schema fragment — accept either string-form keywords
+  (`\":story.foo/bar\"`) or the bare-name form (`\"story.foo/bar\"`)."
+  {:type "string"
+   :description "A Clojure keyword id, as a string. Either `:story.foo/bar` or `story.foo/bar` is accepted."})
+
+(def tool-registry
+  "The full tool registry. Order matters for `tools/list` output —
+  agents tend to scan top-to-bottom — so we list categories in the
+  documented IMPL-SPEC §7.2 order: dev, docs, testing, then write."
+  [;; ---- Dev -------------------------------------------------------------
+   {:name        "get-story-instructions"
+    :category    :dev
+    :description "Return Story's authoring conventions in agent-friendly form (the seven reg-* macros, hard rules, lifecycle, snapshots)."
+    :inputSchema {:type "object" :properties {} :additionalProperties false}
+    :handler     tool-get-story-instructions}
+
+   {:name        "preview-variant"
+    :category    :dev
+    :description "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string
+                               :substrate kw-or-string
+                               :active-modes {:type "array" :items kw-or-string}
+                               :cell-overrides {:type "object"}
+                               :base-url {:type "string"
+                                          :description "Optional base URL for the share link (no default)."}}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-preview-variant}
+
+   {:name        "list-substrates"
+    :category    :dev
+    :description "What substrates can be used. Returns the set registered via `register-substrate!` (Reagent is canonical; UIx / Helix opt-in per host)."
+    :inputSchema {:type "object" :properties {} :additionalProperties false}
+    :handler     tool-list-substrates}
+
+   ;; ---- Docs ------------------------------------------------------------
+   {:name        "list-stories"
+    :category    :docs
+    :description "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids."
+    :inputSchema {:type "object"
+                  :properties {:tags {:type "array" :items kw-or-string
+                                      :description "Optional tag filter; story `:tags` set must intersect."}}
+                  :additionalProperties false}
+    :handler     tool-list-stories}
+
+   {:name        "get-story"
+    :category    :docs
+    :description "Return one story's full body (`:doc`, `:component`, `:decorators`, `:args`, ... + its variant ids)."
+    :inputSchema {:type "object"
+                  :properties {:story-id kw-or-string}
+                  :required ["story-id"]
+                  :additionalProperties false}
+    :handler     tool-get-story}
+
+   {:name        "get-variant"
+    :category    :docs
+    :description "Return one variant's full body (the resolved EDN, with `:extends` already applied at registration time)."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-get-variant}
+
+   {:name        "list-tags"
+    :category    :docs
+    :description "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project."
+    :inputSchema {:type "object" :properties {} :additionalProperties false}
+    :handler     tool-list-tags}
+
+   {:name        "list-modes"
+    :category    :docs
+    :description "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`."
+    :inputSchema {:type "object" :properties {} :additionalProperties false}
+    :handler     tool-list-modes}
+
+   {:name        "list-assertions"
+    :category    :docs
+    :description "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids."
+    :inputSchema {:type "object" :properties {} :additionalProperties false}
+    :handler     tool-list-assertions}
+
+   {:name        "variant->edn"
+    :category    :docs
+    :description "Round-trippable EDN of a registered variant. Text result only (no structuredContent); use this when you want byte-stable EDN."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-variant->edn}
+
+   ;; ---- Testing ---------------------------------------------------------
+   {:name        "run-variant"
+    :category    :testing
+    :description "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`)."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string
+                               :substrate kw-or-string
+                               :active-modes {:type "array" :items kw-or-string}
+                               :cell-overrides {:type "object"}
+                               :timeout-ms {:type "integer" :minimum 1
+                                            :description "JVM blocking timeout. Default 10000."}}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-run-variant}
+
+   {:name        "snapshot-identity"
+    :category    :testing
+    :description "Content-hash of (variant × resolved args × decorators × loaders × substrate × modes). Stable across hosts; key for visual-regression."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string
+                               :substrate kw-or-string
+                               :active-modes {:type "array" :items kw-or-string}}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-snapshot-identity}
+
+   {:name        "run-a11y"
+    :category    :testing
+    :description "Read axe-core violations for a variant from `re-frame.story.ui.a11y/violations-by-frame`. The actual axe-core run is CLJS-only; this tool returns whatever the in-browser panel has accumulated."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-run-a11y}
+
+   {:name        "read-failures"
+    :category    :testing
+    :description "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-read-failures}
+
+   ;; ---- Write (v1.1, gated) --------------------------------------------
+   {:name        "register-variant"
+    :category    :write
+    :description "Register a variant programmatically. GATED behind `:rf.story-mcp/allow-writes?` (default false). Enables the self-healing loop: write story → run → read failures → fix."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string
+                               :body {:oneOf [{:type "object"}
+                                              {:type "string"
+                                               :description "EDN-encoded variant body, parsed via clojure.edn/read-string."}]}}
+                  :required ["variant-id" "body"]
+                  :additionalProperties false}
+    :handler     tool-register-variant}
+
+   {:name        "unregister-variant"
+    :category    :write
+    :description "Unregister a variant. GATED behind `:rf.story-mcp/allow-writes?` (default false). Symmetric to `register-variant`."
+    :inputSchema {:type "object"
+                  :properties {:variant-id kw-or-string}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-unregister-variant}])
+
+(defn tool-descriptors
+  "Build the `tools/list` response payload: each tool's name +
+  description + inputSchema, in registry order. The MCP spec also
+  allows a `title` field; we omit it (the names are already
+  human-readable dash-separated forms)."
+  []
+  (mapv (fn [{:keys [name description inputSchema]}]
+          {:name        name
+           :description description
+           :inputSchema inputSchema})
+        tool-registry))
+
+(defn tool-by-name
+  "Look up a tool's registry entry by string name. Returns nil if no
+  such tool — the caller (server dispatcher) turns that into a
+  protocol-level method-not-found error."
+  [tool-name]
+  (some (fn [t] (when (= tool-name (:name t)) t)) tool-registry))
+
+(defn invoke-tool
+  "Invoke `tool-name` with `arguments` (a map of keyword-keyed args).
+  Returns the tool's result map, or nil if no such tool. The caller
+  serialises the result into a `tools/call` JSON-RPC response.
+
+  Catches any throw from the handler and returns it as a tool-execution
+  error (`isError: true`) per MCP §Error Handling — handlers SHOULD
+  return error-results themselves, but this is the belt-and-braces
+  catch."
+  [tool-name arguments]
+  (when-let [t (tool-by-name tool-name)]
+    (try
+      ((:handler t) (or arguments {}))
+      (catch Throwable e
+        (error-result (str "Tool handler threw: " (ex-message e))
+                      {:tool      tool-name
+                       :exception (.getName (class e))
+                       :data      (ex-data e)})))))

--- a/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
@@ -1,0 +1,161 @@
+(ns re-frame.story-mcp.protocol-test
+  "Wire-format tests for the MCP JSON-RPC protocol layer.
+
+  Covers:
+   - JSON parse / encode round-trip
+   - Envelope validation
+   - Frame I/O over an in-memory reader/writer
+   - Error-response shapes (parse-error, method-not-found, invalid-params,
+     internal-error)
+   - Notification vs request discrimination
+
+  Per IMPL-SPEC §7 Stage 7 the wire layer is testable without booting
+  Story's registrar — the dispatcher and tool implementations are
+  separate (tools_test.clj covers those)."
+  (:require [cheshire.core :as json]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.story-mcp.protocol :as proto]))
+
+;; ---- envelope construction -----------------------------------------------
+
+(deftest response-envelope-shape
+  (testing "success response carries jsonrpc/id/result"
+    (let [r (proto/response 7 {:hello "world"})]
+      (is (= "2.0" (:jsonrpc r)))
+      (is (= 7 (:id r)))
+      (is (= {:hello "world"} (:result r)))
+      (is (not (contains? r :error))))))
+
+(deftest error-envelope-shape
+  (testing "error response carries jsonrpc/id/error"
+    (let [e (proto/error-response 42 proto/code-method-not-found "no such tool")]
+      (is (= "2.0" (:jsonrpc e)))
+      (is (= 42 (:id e)))
+      (is (= proto/code-method-not-found (-> e :error :code)))
+      (is (= "no such tool" (-> e :error :message)))
+      (is (not (contains? (:error e) :data)))))
+  (testing "error response carries optional :data"
+    (let [e (proto/error-response 1 proto/code-invalid-params "bad arg"
+                                   {:offending "key"})]
+      (is (= {:offending "key"} (-> e :error :data)))))
+  (testing "id may be nil (parse-error before id is known)"
+    (let [e (proto/parse-error)]
+      (is (nil? (:id e)))
+      (is (= proto/code-parse-error (-> e :error :code))))))
+
+;; ---- envelope validation -------------------------------------------------
+
+(deftest envelope-validity
+  (testing "request shape"
+    (is (proto/request? {:jsonrpc "2.0" :method "tools/list" :id 1})))
+  (testing "missing id → notification"
+    (is (not (proto/request? {:jsonrpc "2.0" :method "x"})))
+    (is (proto/notification? {:jsonrpc "2.0" :method "x"}))
+    (is (proto/valid-envelope? {:jsonrpc "2.0" :method "x"})))
+  (testing "missing jsonrpc version → invalid"
+    (is (not (proto/valid-envelope? {:method "x" :id 1}))))
+  (testing "wrong jsonrpc version → invalid"
+    (is (not (proto/valid-envelope? {:jsonrpc "1.0" :method "x" :id 1}))))
+  (testing "missing method → invalid"
+    (is (not (proto/valid-envelope? {:jsonrpc "2.0" :id 1}))))
+  (testing "blank method → invalid"
+    (is (not (proto/valid-envelope? {:jsonrpc "2.0" :method "" :id 1})))))
+
+;; ---- JSON parse / encode --------------------------------------------------
+
+(deftest json-parse-keywordises-keys
+  (testing "parsed map has keyword keys"
+    (let [m (proto/parse-json "{\"method\":\"tools/list\",\"id\":1}")]
+      (is (= "tools/list" (:method m)))
+      (is (= 1 (:id m))))))
+
+(deftest json-parse-throws-on-malformed
+  (testing "malformed JSON throws ex-info with rf.error/parse-error"
+    (try
+      (proto/parse-json "{not json")
+      (is false "should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/parse-error (:rf.error (ex-data e))))))))
+
+(deftest json-encode-roundtrip
+  (testing "encode then decode yields the same map (keywordised)"
+    (let [m {:jsonrpc "2.0" :id 1 :result {:foo "bar"}}
+          s (proto/write-json m)
+          back (json/parse-string s true)]
+      (is (= m back)))))
+
+;; ---- frame I/O -----------------------------------------------------------
+
+(defn- reader-of
+  "Build a BufferedReader over a string literal — used to drive
+  `read-frame` in tests without touching stdin."
+  [^String s]
+  (java.io.BufferedReader. (java.io.StringReader. s)))
+
+(deftest read-frame-parses-one-line
+  (testing "single-line frame"
+    (let [r (reader-of "{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":3}\n")
+          f (proto/read-frame r)]
+      (is (= {:jsonrpc "2.0" :method "ping" :id 3} f)))))
+
+(deftest read-frame-skips-blank-lines
+  (testing "blank lines between frames are silently consumed"
+    (let [r (reader-of "\n\n{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":1}\n")
+          f (proto/read-frame r)]
+      (is (= {:jsonrpc "2.0" :method "ping" :id 1} f)))))
+
+(deftest read-frame-eof-sentinel
+  (testing "EOF returns the protocol-namespaced ::eof keyword"
+    (let [r (reader-of "")]
+      (is (= :re-frame.story-mcp.protocol/eof (proto/read-frame r))))))
+
+(deftest read-frame-propagates-parse-error
+  (testing "malformed JSON throws (caller writes parse-error response)"
+    (let [r (reader-of "{garbage\n")]
+      (try
+        (proto/read-frame r)
+        (is false "should have thrown")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/parse-error (:rf.error (ex-data e)))))))))
+
+(deftest write-frame-roundtrips
+  (testing "write-frame appends a newline; round-trip via reader"
+    (let [sw (java.io.StringWriter.)
+          _  (proto/write-frame! sw {:jsonrpc "2.0" :id 1 :result {:ok true}})
+          out (.toString sw)]
+      (is (.endsWith out "\n"))
+      (is (not (.contains (subs out 0 (dec (count out))) "\n"))
+          "no embedded newlines per MCP stdio transport rules")
+      (let [r (reader-of out)]
+        (is (= {:jsonrpc "2.0" :id 1 :result {:ok true}}
+               (proto/read-frame r)))))))
+
+(deftest write-frame-multiple-frames-on-one-stream
+  (testing "two frames produce two readable lines"
+    (let [sw (java.io.StringWriter.)]
+      (proto/write-frame! sw {:jsonrpc "2.0" :id 1 :result {}})
+      (proto/write-frame! sw {:jsonrpc "2.0" :id 2 :result {:n 7}})
+      (let [r (reader-of (.toString sw))]
+        (is (= {:jsonrpc "2.0" :id 1 :result {}}     (proto/read-frame r)))
+        (is (= {:jsonrpc "2.0" :id 2 :result {:n 7}} (proto/read-frame r)))
+        (is (= :re-frame.story-mcp.protocol/eof      (proto/read-frame r)))))))
+
+;; ---- error-helpers --------------------------------------------------------
+
+(deftest method-not-found-includes-method-name
+  (testing "method-not-found message names the offending method"
+    (let [e (proto/method-not-found 9 "tools/quux")]
+      (is (= proto/code-method-not-found (-> e :error :code)))
+      (is (re-find #"tools/quux" (-> e :error :message))))))
+
+(deftest invalid-params-renders-details
+  (testing "invalid-params attaches detail string to message"
+    (let [e (proto/invalid-params 5 "missing :variant-id")]
+      (is (= proto/code-invalid-params (-> e :error :code)))
+      (is (re-find #"missing :variant-id" (-> e :error :message))))))
+
+(deftest internal-error-attaches-data
+  (testing "internal-error optional :data lands on the error envelope"
+    (let [e (proto/internal-error 3 "boom" {:trace "abc"})]
+      (is (= proto/code-internal-error (-> e :error :code)))
+      (is (= {:trace "abc"} (-> e :error :data))))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1,0 +1,431 @@
+(ns re-frame.story-mcp.tools-test
+  "Per-tool semantics + the server dispatcher's `initialize` / `tools/list`
+  / `tools/call` plumbing.
+
+  Tests boot Story's canonical vocabulary in a per-test fixture so the
+  registrar carries the seven canonical tags + the lifecycle machine,
+  then register a small fixture story + variant so each tool has
+  something to read."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story-mcp.config :as config]
+            [re-frame.story-mcp.protocol :as proto]
+            [re-frame.story-mcp.server :as server]
+            [re-frame.story-mcp.tools :as tools]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-story-and-config
+  "Each test gets a fresh Story registry + write-gate set to false (the
+  documented default per IMPL-SPEC §7.3). Tests that need writes flip
+  the gate explicitly."
+  [t]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (config/set-allow-writes! false)
+  ;; Fixture story + variant.
+  (story/reg-story :story.button
+    {:doc       "A clickable button."
+     :component :app.ui/button
+     :tags      #{:dev :docs}
+     :args      {:label "Click me"}})
+  (story/reg-variant :story.button/primary
+    {:doc  "Primary button."
+     :args {:label "Save"}
+     :tags #{:dev}})
+  (story/reg-variant :story.button/secondary
+    {:doc  "Secondary button."
+     :args {:label "Cancel"}
+     :tags #{:docs}})
+  (story/reg-mode :Mode.theme/dark
+    {:doc  "Dark theme."
+     :args {:theme :dark}})
+  (t))
+
+(use-fixtures :each reset-story-and-config)
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- invoke
+  "Invoke a tool by name. Returns the result map (success or error)."
+  [tool-name args]
+  (tools/invoke-tool tool-name args))
+
+(defn- success? [result]
+  (and (map? result)
+       (vector? (:content result))
+       (not (true? (:isError result)))))
+
+(defn- error? [result]
+  (and (map? result)
+       (true? (:isError result))))
+
+;; ---------------------------------------------------------------------------
+;; Registry shape
+;; ---------------------------------------------------------------------------
+
+(deftest registry-shape
+  (testing "tool-registry is a vector of complete entries"
+    (doseq [t tools/tool-registry]
+      (is (string? (:name t)) (str "tool name: " (:name t)))
+      (is (string? (:description t)))
+      (is (map? (:inputSchema t)))
+      (is (#{:dev :docs :testing :write} (:category t)))
+      (is (fn? (:handler t)))))
+  (testing "tool-descriptors strips category + handler (MCP wire shape)"
+    (let [ds (tools/tool-descriptors)]
+      (is (every? #(every? % [:name :description :inputSchema]) ds))
+      (is (every? #(not (contains? % :handler)) ds))
+      (is (every? #(not (contains? % :category)) ds)))))
+
+(deftest registry-covers-impl-spec-7-2
+  (testing "every tool from IMPL-SPEC §7.2 + §7.3 is present"
+    (let [names (set (map :name tools/tool-registry))]
+      ;; Dev
+      (is (contains? names "get-story-instructions"))
+      (is (contains? names "preview-variant"))
+      (is (contains? names "list-substrates"))
+      ;; Docs
+      (is (contains? names "list-stories"))
+      (is (contains? names "get-story"))
+      (is (contains? names "get-variant"))
+      (is (contains? names "list-tags"))
+      (is (contains? names "list-modes"))
+      (is (contains? names "list-assertions"))
+      (is (contains? names "variant->edn"))
+      ;; Testing
+      (is (contains? names "run-variant"))
+      (is (contains? names "snapshot-identity"))
+      (is (contains? names "run-a11y"))
+      (is (contains? names "read-failures"))
+      ;; Write
+      (is (contains? names "register-variant"))
+      (is (contains? names "unregister-variant")))))
+
+;; ---------------------------------------------------------------------------
+;; Dev tools
+;; ---------------------------------------------------------------------------
+
+(deftest get-story-instructions-returns-text
+  (let [r (invoke "get-story-instructions" {})]
+    (is (success? r))
+    (let [text (-> r :content first :text)]
+      (is (string? text))
+      (is (re-find #"reg-story" text))
+      (is (re-find #":rf.assert" text))
+      (is (re-find #"snapshot-identity" text)))))
+
+(deftest preview-variant-happy
+  (let [r (invoke "preview-variant" {:variant-id "story.button/primary"
+                                     :base-url "http://localhost:8000/"})
+        s (:structuredContent r)]
+    (is (success? r))
+    (is (= :story.button/primary (:variant-id s)))
+    (is (string? (:share-url s)))
+    (is (re-find #"story\.button(/|%2F)primary" (:share-url s)))
+    (is (some? (:lifecycle s)))))
+
+(deftest preview-variant-not-found
+  (let [r (invoke "preview-variant" {:variant-id "story.nope/missing"})]
+    (is (error? r))
+    (is (re-find #"not found" (-> r :content first :text)))))
+
+(deftest preview-variant-missing-arg
+  (let [r (invoke "preview-variant" {})]
+    (is (error? r))
+    (is (re-find #"variant-id" (-> r :content first :text)))))
+
+(deftest list-substrates-returns-vector
+  (let [r (invoke "list-substrates" {})]
+    (is (success? r))
+    (is (vector? (-> r :structuredContent :substrates)))))
+
+;; ---------------------------------------------------------------------------
+;; Docs tools
+;; ---------------------------------------------------------------------------
+
+(deftest list-stories-no-filter
+  (let [r (invoke "list-stories" {})
+        ss (-> r :structuredContent :stories)]
+    (is (success? r))
+    (is (= 1 (count ss)))
+    (is (= :story.button (-> ss first :id)))
+    (is (= 2 (count (-> ss first :variants))))))
+
+(deftest list-stories-tag-filter
+  (testing "filtering by :docs returns the button story"
+    (let [r (invoke "list-stories" {:tags ["docs"]})]
+      (is (success? r))
+      (is (= [:story.button]
+             (mapv :id (-> r :structuredContent :stories))))))
+  (testing "filtering by :test (no matches) returns empty"
+    (let [r (invoke "list-stories" {:tags ["test"]})]
+      (is (success? r))
+      (is (empty? (-> r :structuredContent :stories))))))
+
+(deftest get-story-happy
+  (let [r (invoke "get-story" {:story-id "story.button"})]
+    (is (success? r))
+    (is (= :story.button (-> r :structuredContent :id)))
+    (is (= "A clickable button." (-> r :structuredContent :body :doc)))))
+
+(deftest get-story-not-found
+  (let [r (invoke "get-story" {:story-id "story.nope"})]
+    (is (error? r))))
+
+(deftest get-variant-happy
+  (let [r (invoke "get-variant" {:variant-id "story.button/primary"})]
+    (is (success? r))
+    (is (= :story.button/primary (-> r :structuredContent :id)))
+    (is (= "Primary button." (-> r :structuredContent :body :doc)))))
+
+(deftest list-tags-includes-canonical
+  (let [r (invoke "list-tags" {})
+        s (:structuredContent r)]
+    (is (success? r))
+    (is (every? (set (:canonical s))
+                [:dev :docs :test :screenshot :experimental :internal :agent]))))
+
+(deftest list-modes-returns-fixture-mode
+  (let [r (invoke "list-modes" {})
+        ms (-> r :structuredContent :modes)]
+    (is (success? r))
+    (is (= 1 (count ms)))
+    (is (= :Mode.theme/dark (-> ms first :id)))
+    (is (= {:theme :dark} (-> ms first :args)))))
+
+(deftest list-assertions-returns-canonical-seven
+  (let [r (invoke "list-assertions" {})
+        s (:structuredContent r)]
+    (is (success? r))
+    (is (= 7 (count (:canonical s))))
+    (is (some #(= :rf.assert/path-equals (:id %)) (:canonical s)))
+    (is (some #(= :rf.assert/no-warnings (:id %)) (:canonical s)))))
+
+(deftest variant-edn-roundtrips
+  (testing "variant->edn returns readable EDN text"
+    (let [r (invoke "variant->edn" {:variant-id "story.button/primary"})]
+      (is (success? r))
+      (let [text (-> r :content first :text)
+            back (clojure.edn/read-string text)]
+        (is (map? back))
+        (is (= "Primary button." (:doc back)))))))
+
+;; ---------------------------------------------------------------------------
+;; Testing tools
+;; ---------------------------------------------------------------------------
+
+(deftest run-variant-happy
+  (let [r (invoke "run-variant" {:variant-id "story.button/primary"})
+        s (:structuredContent r)]
+    (is (success? r))
+    (is (= :story.button/primary (:frame s)))
+    (is (true? (:passing? s)) "no assertions ⇒ vacuously passing")
+    (is (vector? (:assertions s)))))
+
+(deftest run-variant-unknown
+  (let [r (invoke "run-variant" {:variant-id "story.nope/missing"})]
+    (is (error? r))
+    (is (re-find #"not found" (-> r :content first :text)))))
+
+(deftest snapshot-identity-stable
+  (testing "the same args produce the same content-hash"
+    (let [r1 (invoke "snapshot-identity" {:variant-id "story.button/primary"})
+          r2 (invoke "snapshot-identity" {:variant-id "story.button/primary"})]
+      (is (success? r1))
+      (is (success? r2))
+      (is (= (-> r1 :structuredContent :content-hash)
+             (-> r2 :structuredContent :content-hash))))))
+
+(deftest snapshot-identity-unknown
+  (let [r (invoke "snapshot-identity" {:variant-id "story.nope/missing"})]
+    (is (error? r))))
+
+(deftest run-a11y-jvm-returns-note
+  (testing "JVM-standalone deploy returns empty violations with the documented hint"
+    (let [r (invoke "run-a11y" {:variant-id "story.button/primary"})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (vector? (:violations s)))
+      (is (string? (:note s)))
+      (is (re-find #"CLJS-only" (:note s))))))
+
+(deftest read-failures-empty-after-no-run
+  (testing "no run yet ⇒ zero accumulated assertions"
+    (let [r (invoke "read-failures" {:variant-id "story.button/primary"})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 0 (:total s)))
+      (is (empty? (:failures s)))
+      (is (true? (:passing? s))))))
+
+;; ---------------------------------------------------------------------------
+;; Write surface (gating)
+;; ---------------------------------------------------------------------------
+
+(deftest register-variant-gated-by-default
+  (testing "default config rejects register-variant"
+    (is (false? (config/writes-allowed?)))
+    (let [r (invoke "register-variant" {:variant-id "story.button/danger"
+                                        :body {:doc "Danger button."
+                                               :args {:label "Delete"}}})]
+      (is (error? r))
+      (is (re-find #"Write surface disabled" (-> r :content first :text)))
+      (is (true? (-> r :structuredContent :gated))))))
+
+(deftest register-variant-happy-when-allowed
+  (testing "with allow-writes? true, registration goes through"
+    (config/set-allow-writes! true)
+    (let [r (invoke "register-variant" {:variant-id "story.button/danger"
+                                        :body {:doc "Danger button."
+                                               :args {:label "Delete"}}})]
+      (is (success? r))
+      (is (= :story.button/danger (-> r :structuredContent :variant-id)))
+      (is (true? (-> r :structuredContent :registered?)))
+      ;; Variant is now reachable via the read surface.
+      (is (some? (story/variant->edn :story.button/danger))))))
+
+(deftest register-variant-edn-string-body
+  (testing "body may arrive as an EDN-encoded string"
+    (config/set-allow-writes! true)
+    (let [r (invoke "register-variant"
+                    {:variant-id "story.button/wire"
+                     :body "{:doc \"Wire body.\" :args {:label \"OK\"}}"})]
+      (is (success? r))
+      (is (= "Wire body." (:doc (story/variant->edn :story.button/wire)))))))
+
+(deftest register-variant-rejects-bad-shape
+  (testing "registration with an invalid body returns a tool-execution error"
+    (config/set-allow-writes! true)
+    (let [r (invoke "register-variant"
+                    {:variant-id "story.button/bad"
+                     :body {:tags #{:nonexistent-tag}}})]
+      (is (error? r))
+      (is (re-find #"(?i)Registration failed" (-> r :content first :text))))))
+
+(deftest unregister-variant-gated-by-default
+  (let [r (invoke "unregister-variant" {:variant-id "story.button/primary"})]
+    (is (error? r))
+    (is (re-find #"Write surface disabled" (-> r :content first :text)))))
+
+(deftest unregister-variant-happy-when-allowed
+  (config/set-allow-writes! true)
+  (let [r (invoke "unregister-variant" {:variant-id "story.button/primary"})]
+    (is (success? r))
+    (is (true? (-> r :structuredContent :unregistered?)))
+    (is (nil? (story/variant->edn :story.button/primary)))))
+
+;; ---------------------------------------------------------------------------
+;; Server dispatcher (initialize, tools/list, tools/call, error paths)
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-initialize-handshake
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 1 :method "initialize"
+                :params {:protocolVersion "2025-06-18"
+                         :capabilities {}
+                         :clientInfo {:name "test-client" :version "0.0.0"}}})]
+    (is (= 1 (:id resp)))
+    (is (= config/protocol-version (-> resp :result :protocolVersion)))
+    (is (= config/server-name (-> resp :result :serverInfo :name)))
+    (is (map? (-> resp :result :capabilities)))))
+
+(deftest dispatch-tools-list-returns-registry
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 2 :method "tools/list"})
+        ts (-> resp :result :tools)]
+    (is (= 2 (:id resp)))
+    (is (vector? ts))
+    (is (= (count tools/tool-registry) (count ts)))
+    (is (some #(= "list-stories" (:name %)) ts))))
+
+(deftest dispatch-tools-call-happy
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 3 :method "tools/call"
+                :params {:name "get-story"
+                         :arguments {:story-id "story.button"}}})]
+    (is (= 3 (:id resp)))
+    (is (some? (:result resp)))
+    (is (not (true? (-> resp :result :isError))))))
+
+(deftest dispatch-tools-call-unknown-tool
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 4 :method "tools/call"
+                :params {:name "unknown-tool" :arguments {}}})]
+    (is (= proto/code-method-not-found (-> resp :error :code))
+        "an unknown tool yields a protocol-level method-not-found")))
+
+(deftest dispatch-malformed-envelope
+  (testing "missing jsonrpc version yields invalid-request"
+    (let [resp (server/dispatch {:method "tools/list" :id 5})]
+      (is (= proto/code-invalid-request (-> resp :error :code))))))
+
+(deftest dispatch-unknown-method
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 6 :method "nope/whatever"})]
+    (is (= proto/code-method-not-found (-> resp :error :code)))
+    (is (re-find #"nope/whatever" (-> resp :error :message)))))
+
+(deftest dispatch-notification-no-response
+  (testing "a JSON-RPC notification yields nil (no response)"
+    (is (nil? (server/dispatch
+                {:jsonrpc "2.0" :method "notifications/initialized"})))))
+
+(deftest dispatch-ping-empty-result
+  (let [resp (server/dispatch
+               {:jsonrpc "2.0" :id 7 :method "ping"})]
+    (is (= {} (:result resp)))))
+
+;; ---------------------------------------------------------------------------
+;; Run-loop end-to-end (in-memory)
+;; ---------------------------------------------------------------------------
+
+(deftest run-loop-handles-multi-frame-session
+  (testing "handshake + tools/list + tools/call over a pipe of frames"
+    (let [in-text (str "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\"}}\n"
+                       "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n"
+                       "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n"
+                       "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"list-tags\",\"arguments\":{}}}\n")
+          reader (java.io.BufferedReader. (java.io.StringReader. in-text))
+          sw     (java.io.StringWriter.)]
+      (server/run-loop! reader sw)
+      ;; Split written output into frames, parse each.
+      (let [out-lines (filter seq (clojure.string/split-lines (.toString sw)))
+            frames    (mapv #(cheshire.core/parse-string % true) out-lines)]
+        ;; Three responses (initialize, tools/list, tools/call) — the
+        ;; `notifications/initialized` notification yielded no response.
+        (is (= 3 (count frames)))
+        (is (= 1 (:id (nth frames 0))))
+        (is (= 2 (:id (nth frames 1))))
+        (is (= 3 (:id (nth frames 2))))
+        (is (= config/protocol-version
+               (-> (nth frames 0) :result :protocolVersion)))
+        (is (vector? (-> (nth frames 1) :result :tools)))
+        (is (-> (nth frames 2) :result :content vector?))))))
+
+(deftest run-loop-survives-parse-error
+  (testing "a malformed frame produces a parse-error response; loop continues"
+    (let [in-text (str "{this is garbage\n"
+                       "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"ping\"}\n")
+          reader (java.io.BufferedReader. (java.io.StringReader. in-text))
+          sw     (java.io.StringWriter.)]
+      (server/run-loop! reader sw)
+      (let [out-lines (filter seq (clojure.string/split-lines (.toString sw)))
+            frames    (mapv #(cheshire.core/parse-string % true) out-lines)]
+        (is (= 2 (count frames)))
+        (is (= proto/code-parse-error (-> (nth frames 0) :error :code)))
+        (is (= 9 (:id (nth frames 1))))))))
+
+;; ---------------------------------------------------------------------------
+;; Boot config
+;; ---------------------------------------------------------------------------
+
+(deftest boot-config-defaults-locked-down
+  (testing "boot config defaults allow-writes? to false"
+    (let [cfg (#'server/parse-args [])]
+      (is (nil? (:allow-writes? cfg))))))
+
+(deftest boot-config-allow-writes-flag
+  (testing "--allow-writes flips the gate"
+    (let [cfg (#'server/parse-args ["--allow-writes"])]
+      (is (true? (:allow-writes? cfg))))))

--- a/tools/story/IMPL-SPEC.md
+++ b/tools/story/IMPL-SPEC.md
@@ -1073,59 +1073,100 @@ process; the story runtime runs in the app.
 
 ### 7.2 Tool surface (Storybook MCP-borrowed shape)
 
-Per Phase 2 §6.9 the toolset splits into three:
+Per Phase 2 §6.9 the toolset splits into three. Stage 7 (rf2-tgci) lands
+the registry below in `re-frame.story-mcp.tools/tool-registry`. Each
+tool's wire shape carries an MCP-compliant `inputSchema` (JSON Schema);
+the tool descriptors are returned verbatim from `tools/list`.
 
 **Dev tools** (instructions + preview):
 - `get-story-instructions` — agent-onboarding text: how stories are
   authored, the EDN-first constraint, the canonical variant body keys.
-- `preview-variant {:variant-id ...}` — returns rendered hiccup for a
-  variant + the assertions list.
+- `preview-variant {:variant-id ... :substrate? ... :active-modes? ... :cell-overrides? ... :base-url? ...}`
+  — returns `{:lifecycle :share-url :app-db :assertions :rendered-hiccup :snapshot :elapsed-ms :effective-args}`.
+- `list-substrates` — returns the set registered via
+  `re-frame.story/register-substrate!` (Reagent canonical; UIx / Helix
+  opt-in per host). JVM-standalone hosts return `[]`.
 
 **Docs tools** (introspection):
-- `list-stories` — `(rf/handlers :story)` enumeration.
-- `get-story {:story-id ...}` — full story metadata.
-- `get-variant {:variant-id ...}` — full variant body (as EDN).
-- `list-tags` — `(rf/handlers :tag)`.
+- `list-stories {:tags? [...]}` — `(rf/handlers :story)` enumeration,
+  optionally filtered by tag-set intersection.
+- `get-story {:story-id ...}` — full story metadata + child variant ids.
+- `get-variant {:variant-id ...}` — full variant body (as EDN, plus the
+  structuredContent JSON projection).
+- `list-tags` — canonical + project-custom tags split.
 - `list-modes` — `(rf/handlers :mode)`.
-- `list-assertions` — the registered `:rf.assert/*` vocabulary.
-- `variant->edn {:variant-id ...}` — canonical EDN form.
+- `list-assertions` — the canonical seven `:rf.assert/*` events with
+  arity + semantics docs.
+- `variant->edn {:variant-id ...}` — canonical EDN form, text-only
+  result for byte-stable round-tripping.
 
 **Testing tools** (execution):
-- `run-variant {:variant-id ... :render? ...}` — full lifecycle invocation.
-- `snapshot-identity {:variant-id ... :mode ... :substrate ...}` — content
-  hash.
-- `run-a11y {:variant-id ...}` — axe-core results (delegates to a11y
-  panel data; Stage 6).
-- `read-failures {:variant-id ...}` — diagnostic for the last `run-variant`
-  call.
+- `run-variant {:variant-id ... :substrate? ... :active-modes? ... :cell-overrides? ... :timeout-ms?}`
+  — full lifecycle invocation; returns
+  `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :lifecycle :passing?}`.
+- `snapshot-identity {:variant-id ... :substrate? ... :active-modes?}`
+  — content hash.
+- `run-a11y {:variant-id ...}` — axe-core results (delegates to
+  `re-frame.story.ui.a11y/violations-by-frame`, the panel data from
+  Stage 6). JVM-standalone hosts return an empty list + a documented
+  hint that axe-core requires the in-browser panel.
+- `read-failures {:variant-id ...}` — diagnostic for the variant's
+  accumulated `:rf.story/assertions` accumulator (no re-run).
 
 ### 7.3 Write surface (v1.1, dev-only, gated)
 
-- `register-variant {:variant-id ... :body ...}` — emits a `reg-variant`
-  call into a connected REPL.
-- `unregister-variant {:variant-id ...}` — symmetric.
+- `register-variant {:variant-id ... :body ...}` — invokes
+  `re-frame.story/reg-variant*` (the public programmatic helper).
+  `:body` may be a map (preferred) or an EDN-encoded string.
+- `unregister-variant {:variant-id ...}` — invokes
+  `re-frame.story/unregister! :variant <id>`.
 
-Gated behind `:rf.story.mcp/write-enabled?` config flag (default `false`).
-The agent's "self-healing loop" — write story → run → read failures → fix
-— activates with the write surface; without it the loop is read-only.
+Gated behind `re-frame.story-mcp.config/allow-writes?` (atom; default
+`false`). Three input paths flip the gate at boot:
+
+- CLI flag: `--allow-writes`
+- JVM sysprop: `-Drf.story-mcp.allow-writes=true`
+- Env var: `RF_STORY_MCP_ALLOW_WRITES=true`
+
+When the gate is closed, a write-surface tool returns a tool-execution
+error (`isError: true` with the documented hint) rather than a
+protocol-level error — agents see the failure mode without aborting
+the conversation. CI runs leave the gate closed.
+
+The agent's "self-healing loop" — write story → run → read failures →
+fix — activates with the write surface; without it the loop is
+read-only.
 
 ### 7.4 What Story's core jar exposes (no MCP coupling)
 
 ```clojure
 ;; Public read primitives, in re-frame.story
-(handlers-of-kind kind)                          ; thin wrapper over (rf/handlers kind)
-(story-tree)                                     ; structured by `.`-split dotted path
-(get-variant variant-id)                         ; canonical EDN body
-(get-story story-id)
-(list-tags) (list-modes) (list-assertions)
+(handlers kind)                                  ; spec/001-mirror; per Story kind
+(handler-meta kind id)
+(ids kind) (registered? kind id)
+(variants-of story-id) (variants-with-tags qtags)
+(variant->edn variant-id) (workspace->edn workspace-id)
+(list-tags) (list-modes) canonical-tags
 (run-variant variant-id opts)                    ; per §3.2
+(reset-variant variant-id opts) (watch-variant variant-id callback)
 (snapshot-identity variant-id opts)
-(variant->edn variant-id)
+(read-assertions variant-id) (assertions-passing? result)
+(canonical-assertion-ids)
+(variant-share-url variant-id base-url opts)     ; per §2.8.5
+(registered-substrates)                          ; CLJS-only
+
+;; Public write primitives — used by MCP's gated write surface (Stage 7)
+;; AND by hot-reload tooling / fixture loaders that synthesise registrations.
+(reg-story*       id body)   (reg-variant*     id body)
+(reg-workspace*   id body)   (reg-mode*        id body)
+(reg-story-panel* id body)   (reg-decorator*   id body)
+(reg-tag*         id body)
+(unregister! kind id) (clear-kind! kind) (clear-all!)
 ```
 
 Stage 7's `tools/story-mcp/` is a thin adapter: takes JSON-RPC requests,
-calls these CLJS functions, serialises responses back over stdio. Zero
-agent-specific logic lives in `tools/story/`.
+calls these CLJS / CLJC functions, serialises responses back over stdio.
+Zero agent-specific logic lives in `tools/story/`.
 
 ---
 
@@ -1426,20 +1467,50 @@ list for failure-projection).
 
 **Scope.** The separate-jar agent surface per §7. Stdio + JSON-RPC
 transport; toolset definitions per the Storybook MCP shape (Dev / Docs /
-Testing); read-only at v1 (`register-variant` / `unregister-variant` gated
-v1.1).
+Testing); the write surface (`register-variant` / `unregister-variant`)
+landed but gated behind a config flag — disabled by default, opt-in for
+dev hosts that want the self-healing loop.
 
-**Deliverables.**
-- `tools/story-mcp/deps.edn`: declares `day8/re-frame2-story-mcp`; depends
-  on `:local/root "../story"` for the underlying primitives.
-- `tools/story-mcp/src/re_frame/story/mcp.clj`: the MCP server (JVM-side
-  CLJ; consumes Tool-Pair primitives to drive the live CLJS app).
-- `tools/story-mcp/IMPL-SPEC.md`: its own implementation contract.
+**Deliverables (landed rf2-tgci).**
+- `tools/story-mcp/deps.edn`: declares `day8/re-frame2-story-mcp`;
+  `:local/root "../story"` for the Story read substrate; Cheshire for
+  JSON.
+- `tools/story-mcp/src/re_frame/story_mcp/config.cljc`: the
+  `allow-writes?` gate + the pinned MCP protocol version (`2025-06-18`,
+  per §13.2 #6) + the `stage :mcp` marker.
+- `tools/story-mcp/src/re_frame/story_mcp/protocol.cljc`: JSON-RPC 2.0
+  envelope + frame I/O (newline-delimited JSON over stdio, per the MCP
+  stdio transport spec).
+- `tools/story-mcp/src/re_frame/story_mcp/tools.cljc`: the sixteen tool
+  implementations + the `tool-registry` data structure consumed by
+  `tools/list` and `tools/call`.
+- `tools/story-mcp/src/re_frame/story_mcp/server.cljc`: the `initialize`
+  / `tools/list` / `tools/call` / `ping` / `shutdown` dispatcher + the
+  `run-loop!` over stdin/stdout + `-main` entry point.
+- `tools/story-mcp/README.md`: quick start + the tool registry summary.
+- `tools/story-mcp/test/re_frame/story_mcp/{protocol,tools}_test.clj`:
+  wire-format + per-tool semantics + dispatcher + run-loop coverage.
+
+The Story core jar deliberately carries NO stdio / JSON-RPC dependency
+— this is the §7 separation: Story-the-tool and Story-MCP-the-agent-
+surface ship as distinct artefacts.
 
 **Dependencies.** Stages 2–3 (registry + run-variant must be queryable).
-Tool-Pair surface (`spec/Tool-Pair.md`) for the JVM-to-CLJS bridge.
+Tool-Pair surface (`spec/Tool-Pair.md`) for the JVM-to-CLJS bridge when
+the server is co-hosted with a CLJS runtime (the canonical
+JVM-standalone deploy reads only the JVM-side registrar slice; CLJS-
+only state like substrates / a11y violations is empty + the tool
+returns a documented hint).
 
-**Files touched.** All of `tools/story-mcp/*` (new artefact dir).
+**Stage marker.** Story's own `re-frame.story/stage` stays at
+`:sota-features` (the surface it last extended). The MCP jar carries
+its own `re-frame.story-mcp.config/stage = :mcp` — the two artefacts
+have independent stage progression and ship at independent cadence per
+`tools/README.md`.
+
+**Files touched.** All of `tools/story-mcp/*` (new artefact dir);
+`tools/story/IMPL-SPEC.md` §7 updated with the landed tool registry +
+gating rules.
 
 ### Stage 8 — Examples + guide integration
 


### PR DESCRIPTION
## Summary

Stand up `tools/story-mcp/` as `day8/re-frame2-story-mcp`: a JVM-side
stdio JSON-RPC server exposing Story's read (and gated write) surface
to MCP-speaking AI agents. Per IMPL-SPEC §7 the agent surface ships
separately from the Story core jar so the MCP server can be loaded
without dragging Story's UI / authoring macros into the classpath, and
so Story consumers don't pull in stdio / JSON-RPC dependencies they
don't use.

Stage 7 of the Story epic (rf2-u6fb). Closes rf2-tgci.

## Tool registry (16 tools, four categories per IMPL-SPEC §7.2 + §7.3)

**Dev** — for agents building new stories
- `get-story-instructions` — Story's authoring conventions (the seven `reg-*`, EDN-first rule, lifecycle, snapshots)
- `preview-variant` — canvas state + assertions + a sharable URL
- `list-substrates` — registered substrates (Reagent canonical; UIx / Helix opt-in)

**Docs** — for agents reading the library
- `list-stories` (optional `:tags` filter)
- `get-story`, `get-variant`
- `list-tags`, `list-modes`, `list-assertions`
- `variant->edn` (text-only, byte-stable EDN)

**Testing** — for agents running stories headlessly
- `run-variant` — four-phase lifecycle execution; returns `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?}`
- `snapshot-identity` — content hash for visual-regression keying
- `run-a11y` — reads `re-frame.story.ui.a11y/violations-by-frame` (CLJS-only writes; JVM standalone returns empty + documented hint)
- `read-failures` — accumulated assertion failures since last `run-variant`

**Write** (v1.1, dev-only, gated)
- `register-variant`, `unregister-variant`
- Gated behind `re-frame.story-mcp.config/allow-writes?` (default `false`); opt-in via `--allow-writes` CLI flag, `-Drf.story-mcp.allow-writes=true` sysprop, or `RF_STORY_MCP_ALLOW_WRITES=true` env

## Wire layer

MCP 2025-06-18 over stdio (newline-delimited JSON-RPC 2.0, UTF-8, stderr for free-form logging). Handles `initialize`, `tools/list`, `tools/call`, `ping`, `shutdown`, `notifications/initialized`. Unknown methods → `-32601 method-not-found`; malformed JSON → `-32700 parse-error` with the loop surviving.

## File layout

```
tools/story-mcp/
├── deps.edn                                      ; day8/re-frame2-story-mcp; :local/root → ../story; Cheshire
├── README.md                                     ; quick start + tool registry summary
├── src/re_frame/story_mcp/
│   ├── config.cljc                               ; allow-writes? gate + protocol version + stage marker
│   ├── protocol.cljc                             ; JSON-RPC envelope + frame I/O
│   ├── tools.cljc                                ; 16 tool impls + tool-registry
│   └── server.cljc                               ; dispatcher + run-loop + -main
└── test/re_frame/story_mcp/
    ├── protocol_test.clj                         ; wire-format coverage
    └── tools_test.clj                            ; per-tool + dispatcher + run-loop
```

LoC: 264 + 183 + 111 + 739 = 1297 src; 161 + 431 = 592 test; 130 + 67 = 197 supporting. 2086 total.

## Test plan

- [x] `cd tools/story-mcp && clojure -M:test` — 55 tests / 247 assertions / 0 failures
- [x] `cd tools/story && clojure -M:test` — 145 tests / 353 assertions (regression, unchanged)
- [x] `cd implementation && npm run test:elision` — PASS (story-mcp is JVM-only; elision sentinel unchanged)
- [x] `python -m mkdocs build` — 180 warnings (all pre-existing on origin/main; my edits added zero new warnings)

## Stage 8 dependencies left clear

Stage 8 (rf2-c9mm, examples + guide) can demonstrate the MCP surface using:
- `list-stories`, `get-story`, `get-variant` for navigation
- `run-variant`, `snapshot-identity` for testing
- `get-story-instructions` for agent onboarding
- Optionally `register-variant` with `--allow-writes` for the self-healing-loop demo

Story's `re-frame.story/stage` stays at `:sota-features`; the MCP jar carries its own `re-frame.story-mcp.config/stage = :mcp` — independent stage progression at independent release cadence per `tools/README.md`.

## IMPL-SPEC §7 changes

- §7.2 updated with the landed sixteen-tool registry + per-tool arg shapes
- §7.3 documents the three boot paths for the write gate (CLI flag, sysprop, env var) and the tool-execution-error response shape when the gate is closed
- §7.4 corrected to enumerate the actual public surface Story's core jar exposes (handler queries, run-variant family, the seven `reg-*` programmatic helpers, `variant-share-url`, `registered-substrates`)
- §10 Stage 7 entry updated to reflect the landed deliverables + stage-marker decision

## Suggestion beads

None — IMPL-SPEC §7 was tight enough that the implementation landed without spec gaps.