### PR TITLE
fix(spec): rewrite Pattern-WebSocket worked example for consistency (rf2-axbq)

### DIFF
--- a/docs/guide/05-state-machines.md
+++ b/docs/guide/05-state-machines.md
@@ -320,16 +320,16 @@ Three recurring shapes from [chapter 03](03-events-state-cycle.md) are state mac
 WebSocket, Server-Sent Events, WebRTC peers — anything with retry, backoff, heartbeat, subscriptions, and server-pushed events — is state-machine-shaped:
 
 ```text
-:disconnected ─open─►   :connecting
-:connecting   ─opened─► :authenticating
-:authenticating ─ok─►   :connected ◄─┐
-:connected    ─close─►  :reconnecting ─after backoff─► :connecting
-:reconnecting ─max retries─► :failed
+:disconnected      ─ws/connect─►   :active / :connecting
+:active /:connecting ─opened─►     :active / :authenticating
+:active /:authenticating ─ok─►     :active / :connected
+:active / *        ─closed─►       :reconnecting ─after backoff─► :active / :connecting
+:reconnecting      ─max retries─►  :failed
 ```
 
-`:connected` typically has sub-states (`:idle / :sending / :receiving`); `:reconnecting` carries the exponential-backoff counter in `:data`; subscribed topics live in `:data :subscriptions` and re-issue automatically on entry to `:connected` (so subscriptions survive reconnects). Messages flowing *over* the open connection are ordinary Pattern-AsyncEffect interactions — request-reply with a correlation id; the connection machine is the long-lived host.
+`:connecting`, `:authenticating`, and `:connected` sit under one compound parent `:active`. The parent owns the `:invoke` of the child socket actor — its lifetime spans every leaf that dispatches through it, so the actor stays alive across the success-path transitions and is destroyed only when control leaves `:active` (to `:reconnecting`, `:failed`, or `:disconnected`). `:reconnecting` carries the exponential-backoff counter in `:data` and uses a fn-form `:after` delay; subscribed topics live in `:data :subscriptions` and re-issue automatically on entry to `:connected` (so subscriptions survive reconnects). Messages flowing *over* the open connection are ordinary Pattern-AsyncEffect interactions — request-reply with a correlation id, tracked in `:data :in-flight`; the connection machine is the long-lived host that performs the correlation step.
 
-The connection machine composes the locked substrate end-to-end: hierarchical states for `:connected`, `:after` for backoff, `:always` for max-retries guards and queue flushing on entry, `:invoke` to spawn a child socket actor that owns the actual `WebSocket` object. No new mechanism — just one machine exercising every primitive at once. Full walkthrough: [`spec/Pattern-WebSocket.md`](../../spec/Pattern-WebSocket.md).
+The connection machine composes the locked substrate end-to-end: a hierarchical parent for the actor's lifetime, `:after` for backoff, `:always` for max-retries guards and queue flushing on entry, `:invoke` to spawn the child socket actor that owns the actual `WebSocket` object, and the connection-epoch idiom (the socket actor's gensym'd id IS the epoch) to suppress messages from a torn-down socket. No new mechanism — just one machine exercising every primitive at once. Full walkthrough: [`spec/Pattern-WebSocket.md`](../../spec/Pattern-WebSocket.md).
 
 ### Pattern-Boot — initialisation as a machine
 

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -27,59 +27,59 @@ This pattern applies equally to **Server-Sent Events (EventSource)** and **WebRT
 
 ## The connection state machine
 
-The canonical states form a hierarchical machine. Top-level states cover the lifecycle; `:connected` is a compound state with sub-states because once the connection is up there are still distinct internal modes (idle / sending / receiving). Other top-level states do not need internal hierarchy.
+The canonical states form a hierarchical machine. `:connecting`, `:authenticating`, and `:connected` sit under a single compound parent `:active` because they share one critical invariant: **the live socket actor must outlive all three**. Anchoring the `:invoke` on the parent — not on `:connecting` — keeps the actor alive across the success-path transitions (`:connecting` → `:authenticating` → `:connected`) without re-spawning a fresh socket each time the leaf changes.
 
 | State | Meaning |
 |---|---|
 | `:disconnected` | No socket; not yet attempted, or destroyed cleanly. |
-| `:connecting` | Socket opening. |
-| `:authenticating` | Socket open; auth handshake in flight. |
-| `:connected` | Socket open and authenticated; sub-states `:idle / :sending / :receiving`. |
-| `:reconnecting` | Connection lost; waiting on `:after` backoff before re-attempt. |
-| `:failed` | Max retries exceeded; manual recovery only. (Terminal until external `[:reconnect]` dispatched.) |
+| `:active` | Compound parent; owns the `:websocket/socket` `:invoke`. Leaves: `:connecting`, `:authenticating`, `:connected`. |
+| `:reconnecting` | Connection lost; waiting on `:after` backoff before re-attempt. Socket actor has been destroyed. |
+| `:failed` | Max retries exceeded; manual recovery only. Terminal until external `[:ws/connect ...]` dispatched. |
 
 ### Standard transitions
 
 ```text
-:disconnected     --:open-->        :connecting
-:connecting       --:opened-->      :authenticating
-:connecting       --:error-->       :reconnecting
-:authenticating   --:auth-ok-->     :connected
-:authenticating   --:auth-failed--> :failed
-:connected        --:close-->       :reconnecting
-:connected        --:fatal-->       :failed
-:reconnecting     --:after backoff-->  :connecting
-:reconnecting     --:always max-retries-->  :failed
-:failed           --[:reconnect]-->  :connecting
+:disconnected           --:ws/connect-->         :active / :connecting
+:active / :connecting   --:ws/opened-->          :active / :authenticating
+:active / :authenticating --:ws/auth-ok-->       :active / :connected
+:active / :authenticating --:ws/auth-failed-->   :failed
+:active / *             --:ws/closed-->          :reconnecting
+:active / *             --:ws/fatal-->           :failed
+:reconnecting           --:after backoff-->      :active / :connecting
+:reconnecting           --:always max-retries--> :failed
+:failed                 --:ws/connect-->         :active / :connecting
 ```
+
+Per [005 §Transition resolution — deepest-wins with parent fallthrough](005-StateMachines.md#transition-resolution--deepest-wins-with-parent-fallthrough), `:ws/closed` and `:ws/fatal` are declared on `:active` once and inherited by every leaf — every `:connecting`-error, `:authenticating`-error, and `:connected`-error path routes through the same parent-level transition.
 
 The connection machine composes the locked substrate:
 
-- **Hierarchical states** ([005 §Hierarchical compound states](005-StateMachines.md)) — `:connected` has internal sub-states.
-- **`:after`** ([005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions)) — exponential backoff timer in `:reconnecting`. The `:after` epoch ensures stale timers from prior reconnect attempts are silently ignored on transitions away.
-- **`:always`** ([005 §Eventless `:always` transitions](005-StateMachines.md)) — max-retries guard fires immediately on entry to `:reconnecting` if `:retries` exceeds the limit, transitioning straight to `:failed`. Also used to flush queued messages on entry to `:connected`.
-- **Machine-scoped `:guards` / `:actions`** ([005 §Registration — the machine IS the event handler](005-StateMachines.md)) — for `:max-retries-exceeded?`, `:has-queued-messages?`, `:bump-retry-count`, `:flush-queue`, etc.
-- **`:invoke`** ([005 §Declarative `:invoke`](005-StateMachines.md#declarative-invoke-sugar-over-spawn)) — `:connecting` invokes a `:websocket/socket` actor that owns the actual `WebSocket` object; `:exit` destroys it. The actor's lifetime is bound to the parent state.
-- **[Pattern-StaleDetection](Pattern-StaleDetection.md)** — replies from a previous connection epoch (e.g., a `:received` event from a socket that has since been replaced) are suppressed via the same epoch idiom that `:after` already uses. Each connection epoch advances on `:reconnecting` entry.
+- **Hierarchical states** ([005 §Hierarchical compound states](005-StateMachines.md#hierarchical-compound-states)) — `:active` is the parent of three connection-leaves; the parent owns the socket actor.
+- **`:after`** ([005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions)) — exponential backoff timer in `:reconnecting`, expressed as a **fn-form delay** `(fn [snap] ms)` that reads the current `:retries` and `:base-ms` from `:data`. The `:after`-epoch invariant ([005 §Epoch-based stale detection](005-StateMachines.md#epoch-based-stale-detection)) guarantees stale timers from prior `:reconnecting` visits are silently dropped on transitions away.
+- **`:always`** ([005 §Eventless `:always` transitions](005-StateMachines.md#eventless-always-transitions)) — max-retries guard fires immediately on entry to `:reconnecting` if `:retries` exceeds the limit, transitioning straight to `:failed`. Also used to flush queued messages on entry to `:connected`.
+- **Machine-scoped `:guards` / `:actions`** ([005 §Registration — the machine IS the event handler](005-StateMachines.md#registration--the-machine-is-the-event-handler)) — for `:max-retries-exceeded?`, `:has-queued-messages?`, `:bump-retry-count`, `:flush-queue`, `:current-socket?`, etc.
+- **`:invoke`** ([005 §Declarative `:invoke`](005-StateMachines.md#declarative-invoke-sugar-over-spawn)) — `:active` invokes a `:websocket/socket` actor that owns the actual `WebSocket` object; the actor's lifetime is bound to the `:active` parent. Any transition that exits `:active` (to `:reconnecting`, to `:failed`, or to `:disconnected`) destroys the actor; re-entering `:active` after `:after` backoff spawns a fresh socket.
+- **[Pattern-StaleDetection](Pattern-StaleDetection.md)** — the **connection epoch** is the socket-actor's own gensym'd id. Every event the socket actor dispatches into the parent carries its `:socket-id`; the parent's actions check that the carried id matches the live `(:socket-id data)` before committing. Replies from a previous connection epoch — `:ws/received` from a socket that has since been replaced — fail the check and are dropped via a `:rf.ws/stale-socket` trace. The same idiom that `:after` already uses internally, applied to socket-actor identity.
 
 ## Worked example — connection machine
 
 ```clojure
 (rf/reg-event-fx :ws/connection
-  {:doc "WebSocket connection lifecycle: disconnected → connecting → authenticating
-         → connected → reconnecting (with backoff) → failed."}
+  {:doc "WebSocket connection lifecycle: disconnected → active{:connecting →
+         :authenticating → :connected} → reconnecting (with backoff) → failed."}
   (rf/create-machine-handler
     {:initial :disconnected
-     :data    {:url           nil                  ;; supplied by :connect; see :connect action below
-               :auth-token    nil                  ;; supplied by :connect (or refreshed at runtime)
-               :retries       0
-               :max-retries   8
-               :backoff-ms    1000
-               :max-backoff   30000
-               :socket-id     nil
-               :subscriptions #{}                  ;; topics to (re-)subscribe on connect
-               :queue         []                   ;; messages buffered while disconnected
-               :in-flight     {}}                  ;; correlation-id → reply-event
+     :data    {:url            nil               ;; supplied by :ws/connect; refreshed by :ws/refresh-token
+               :auth-token     nil               ;; supplied by :ws/connect (or refreshed at runtime)
+               :retries        0
+               :max-retries    8
+               :base-ms        1000              ;; initial backoff
+               :max-backoff-ms 30000
+               :socket-id      nil               ;; address of the currently-live socket actor
+               :subscriptions  #{}               ;; topics to (re-)subscribe on :connected entry
+               :queue          []                ;; messages buffered while disconnected
+               :in-flight      {}                ;; {request-id → {:reply-event ... :timeout-ms ...}}
+               :error          nil}
 
      :guards
      {:max-retries-exceeded?
@@ -88,123 +88,222 @@ The connection machine composes the locked substrate:
 
       :has-queued-messages?
       (fn [data _]
-        (seq (:queue data)))}
+        (seq (:queue data)))
+
+      :current-socket?
+      ;; True iff the incoming socket-stamped event came from the actor
+      ;; this machine currently owns. Connection-epoch staleness check
+      ;; (Pattern-StaleDetection): replies from a prior socket-id are
+      ;; suppressed without disturbing the live snapshot.
+      (fn [data [_ {:keys [source-socket-id]}]]
+        (= source-socket-id (:socket-id data)))}
 
      :actions
      {:record-connection-opts
-      ;; Caller supplies :url and :auth-token at connect time:
-      ;;   (rf/dispatch [:ws/connection [:ws/connect {:url        "wss://api.example.com/ws"
-      ;;                                              :auth-token (some-token)}]])
-      ;; The opts land in :data; subsequent reconnect attempts reuse them.
+      ;; Caller passes URL + token on :ws/connect; opts land in :data and
+      ;; every subsequent reconnect re-reads them via :invoke's :data fn.
       (fn [data [_ {:keys [url auth-token]}]]
         {:data (assoc data :url url :auth-token auth-token)})
 
-      :bump-retry
-      (fn [data _]
-        {:data (-> data
-                   (update :retries inc)
-                   (update :backoff-ms #(min (* 2 %) (:max-backoff data))))})
-
-      :reset-retry
-      (fn [data _]
-        {:data (assoc data :retries 0 :backoff-ms 1000)})
-
-      :record-token
-      ;; Used when the running app refreshes the auth token without a full reconnect.
+      :refresh-token
+      ;; The auth machine calls this after an out-of-band refresh; the
+      ;; next :active entry's :invoke :data fn picks up the fresh token.
       (fn [data [_ token]]
         {:data (assoc data :auth-token token)})
 
+      :bump-retry (fn [data _] {:data (update data :retries inc)})
+
+      :clear-socket-id
+      (fn [data _] {:data (assoc data :socket-id nil)})
+
       :send-auth
-      ;; The socket actor accepts a [:send msg] event; route into it.
+      ;; Route an :auth message into the live socket actor.
       (fn [data _]
         {:fx [[:dispatch [(:socket-id data) [:send {:type  :auth
                                                     :token (:auth-token data)}]]]]})
 
-      :resubscribe
-      ;; On (re)connect, re-issue subscriptions tracked in :data.
+      :on-connected
+      ;; Compound entry action for :connected — :reset-retry + :resubscribe
+      ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
+      ;; registered id, never a vector.)
       (fn [data _]
-        {:fx (mapv (fn [topic]
-                     [:dispatch [(:socket-id data)
-                                 [:send {:type :subscribe :topic topic}]]])
-                   (:subscriptions data))})
+        {:data (assoc data :retries 0)
+         :fx   (mapv (fn [topic]
+                       [:dispatch [(:socket-id data)
+                                   [:send {:type :subscribe :topic topic}]]])
+                     (:subscriptions data))})
 
       :flush-queue
-      ;; Send any messages buffered while disconnected; clear the queue.
+      ;; Send everything buffered while disconnected; clear the queue.
       (fn [data _]
         {:data (assoc data :queue [])
          :fx   (mapv (fn [msg] [:dispatch [(:socket-id data) [:send msg]]])
                      (:queue data))})
 
       :enqueue-message
-      ;; Buffer a send while disconnected.
+      ;; Buffer a send while the connection is not yet :connected.
       (fn [data [_ msg]]
         {:data (update data :queue conj msg)})
 
+      :register-request
+      ;; Caller: [:ws/request {:request-id ..., :body ..., :reply ...}].
+      ;; Record the in-flight entry, forward to the socket, schedule a timeout.
+      (fn [data [_ {:keys [request-id body reply timeout-ms]
+                    :or   {timeout-ms 30000}}]]
+        {:data (assoc-in data [:in-flight request-id]
+                         {:reply-event reply :timeout-ms timeout-ms})
+         :fx   [[:dispatch [(:socket-id data)
+                            [:send (assoc body :request-id request-id)]]]
+                [:dispatch-later
+                 {:ms       timeout-ms
+                  :dispatch [:ws/connection
+                             [:ws/request-timeout
+                              {:request-id       request-id
+                               :source-socket-id (:socket-id data)}]]}]]})
+
+      :clear-request
+      (fn [data [_ {:keys [request-id]}]]
+        {:data (update data :in-flight dissoc request-id)})
+
+      :record-and-reset
+      ;; Compound action — record fresh opts AND reset the retry counter.
+      ;; Used on manual :ws/connect from :reconnecting / :failed (the
+      ;; running app has refreshed the token; reconnect immediately).
+      (fn [data [_ {:keys [url auth-token]}]]
+        {:data (-> data
+                   (assoc :url url :auth-token auth-token)
+                   (assoc :retries 0))})
+
       :record-error
-      (fn [data [_ err]]
-        {:data (assoc data :error err)})}
+      (fn [data [_ err]] {:data (assoc data :error err)})}
 
      :states
      {:disconnected
-      {:on {:ws/connect {:target :connecting
+      {:on {:ws/connect {:target [:active]
                          :action :record-connection-opts}
             :ws/send    {:action :enqueue-message}}}
 
-      :connecting
-      {:invoke {:machine-id :websocket/socket
-                ;; Spawn-spec :data fn (mechanism 2 in Pattern-AsyncEffect's
-                ;; "Parameter passing across the boundary"): the child socket
-                ;; actor reads the URL and auth-token from the parent's :data.
+      :active
+      {;; The socket actor is invoked at the parent level — its lifetime
+       ;; spans :connecting, :authenticating, and :connected. Any transition
+       ;; that exits :active (to :reconnecting, :failed, or :disconnected)
+       ;; destroys it; re-entering :active spawns a fresh one.
+       :invoke {:machine-id :websocket/socket
+                ;; Mechanism 2 from Pattern-AsyncEffect §Parameter passing
+                ;; across the boundary — the child reads URL + auth-token
+                ;; from the parent's :data at spawn time. Every re-entry to
+                ;; :active picks up whatever the parent's :data currently
+                ;; holds, so a :refresh-token between reconnects flows in
+                ;; without any extra wiring.
                 :data       (fn [snap _] {:url        (-> snap :data :url)
                                           :auth-token (-> snap :data :auth-token)})
-                :on-spawn   (fn [d id] (assoc d :socket-id id))}
-       :on     {:ws/opened  {:target :authenticating}
-                :ws/error   {:target :reconnecting
+                ;; Record the spawned actor id so subsequent dispatches
+                ;; and :current-socket? checks have a value to compare.
+                :on-spawn   (fn [data id] (assoc data :socket-id id))}
+
+       ;; Exit cascade — on any transition that leaves :active, clear the
+       ;; stale socket-id from :data. The runtime destroys the actor
+       ;; automatically (per :invoke's desugared exit, [005 §Desugaring rules]);
+       ;; this just keeps the parent's :data tidy so :current-socket?'s
+       ;; comparison against `nil` correctly rejects late events.
+       :exit  :clear-socket-id
+
+       ;; Parent-level transitions inherited by every leaf
+       ;; (per [005 §Transition resolution]). Any transport-level error
+       ;; or close during :connecting / :authenticating / :connected
+       ;; routes through one of these.
+       :on    {:ws/closed   {:target :reconnecting
                              :action :bump-retry}
-                :ws/send    {:action :enqueue-message}}}
+               :ws/error    {:target :reconnecting
+                             :action :bump-retry}
+               :ws/fatal    {:target :failed
+                             :action :record-error}
+               :ws/send     {:action :enqueue-message}
+               :ws/refresh-token {:action :refresh-token}
+               ;; A request issued before the connection is :connected is
+               ;; queued like any other send (the request-id is preserved
+               ;; in the queued body); the active leaf overrides for the
+               ;; :connected case below.
+               :ws/request  {:action :enqueue-message}}
 
-      :authenticating
-      {:entry :send-auth
-       :on    {:ws/auth-ok     {:target :connected}
-               :ws/auth-failed {:target :failed
-                                :action :record-error}
-               :ws/error       {:target :reconnecting
-                                :action :bump-retry}
-               :ws/send        {:action :enqueue-message}}}
+       :initial :connecting
 
-      :connected
-      {:entry  [:reset-retry :resubscribe]
-       :always [{:guard :has-queued-messages? :action :flush-queue}]
-       :on     {:ws/closed   {:target :reconnecting
-                              :action :bump-retry}
-                :ws/fatal    {:target :failed
-                              :action :record-error}
-                :ws/received {:action (fn [_ [_ msg]]
-                                        ;; Translate the server-pushed event into a
-                                        ;; named dispatched event; the running-app
-                                        ;; handlers commit it.
-                                        {:fx [[:dispatch [:ws/handle-message msg]]]})}
-                :ws/send     {:action (fn [data [_ msg]]
-                                        {:fx [[:dispatch [(:socket-id data)
-                                                          [:send msg]]]]})}}
-       :initial :idle
-       :states  {:idle      {}
-                 :sending   {}
-                 :receiving {}}}
+       :states
+       {:connecting
+        {:on {:ws/opened {:target :authenticating}}}
+
+        :authenticating
+        {:entry :send-auth
+         :on    {:ws/auth-ok     {:target :connected}
+                 :ws/auth-failed {:target [:failed]
+                                  :action :record-error}}}
+
+        :connected
+        {:entry  :on-connected
+         :always [{:guard :has-queued-messages? :action :flush-queue}]
+         :on     {;; Pushed server event with no correlation id — forward.
+                  ;; The :current-socket? guard suppresses messages dispatched
+                  ;; in-flight from a prior socket whose destroy hadn't
+                  ;; flushed by the time the dispatch landed.
+                  :ws/received {:guard  :current-socket?
+                                :action (fn [data [_ {:keys [body] :as ev}]]
+                                          (if-let [rid (:request-id body)]
+                                            ;; Correlated reply — look up
+                                            ;; the in-flight entry and
+                                            ;; dispatch the registered
+                                            ;; reply event; clear the slot.
+                                            (let [{:keys [reply-event]}
+                                                  (get-in data [:in-flight rid])]
+                                              {:data (update data :in-flight dissoc rid)
+                                               :fx   (when reply-event
+                                                       [[:dispatch (conj reply-event body)]])})
+                                            ;; Server push — translate to a
+                                            ;; named running-app event.
+                                            {:fx [[:dispatch [:ws/handle-message body]]]}))}
+
+                  ;; Override the parent's :ws/send: while :connected the
+                  ;; message goes straight to the wire instead of queueing.
+                  :ws/send    {:action (fn [data [_ msg]]
+                                         {:fx [[:dispatch [(:socket-id data)
+                                                           [:send msg]]]]})}
+
+                  ;; Override the parent's :ws/request: while :connected
+                  ;; the request is registered + sent immediately.
+                  :ws/request {:action :register-request}
+
+                  :ws/request-timeout
+                  {:guard  :current-socket?
+                   :action :clear-request}}}}}
 
       :reconnecting
       {:always [{:guard :max-retries-exceeded? :target :failed}]
-       :after  {1000 {:target :connecting}}     ;; the backoff-ms is read from :data
-                                                 ;; via a per-snapshot computation in
-                                                 ;; richer specs; shown literal here.
-       :on     {:ws/connect {:target :connecting :action :reset-retry}
-                :ws/send    {:action :enqueue-message}}}
+       ;; Exponential backoff, computed at state entry from the current
+       ;; retry count. Per [005 §Value shape] the fn-form delay is called
+       ;; once at entry against the entering snapshot; the :after epoch
+       ;; carries through the synthetic timer event so a transition out
+       ;; of :reconnecting (e.g., a manual :ws/connect) makes the in-flight
+       ;; backoff timer stale. Add a jitter term in production.
+       :after  {(fn [snap]
+                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
+                    (min (* base-ms (Math/pow 2 retries))
+                         max-backoff-ms)))
+                {:target [:active]}}
+       :on     {;; Manual reconnect (e.g., after the auth machine refreshes
+                ;; the token) — short-circuit the backoff, record fresh opts,
+                ;; zero the retry counter, re-enter :active.
+                :ws/connect {:target [:active]
+                             :action :record-and-reset}
+                :ws/send    {:action :enqueue-message}
+                :ws/request {:action :enqueue-message}
+                :ws/refresh-token {:action :refresh-token}}}
 
       :failed
-      {:on {:ws/connect {:target :connecting :action :reset-retry}}}}}))
+      {:on {:ws/connect       {:target [:active]
+                               :action :record-and-reset}
+            :ws/refresh-token {:action :refresh-token}}}}}))
 ```
 
-The `:websocket/socket` invoked actor is itself a small machine (or fx-backed event handler) that owns the JS `WebSocket` instance and translates `:open`, `:message`, `:error`, `:close` events into dispatches back to the parent connection machine. Its lifetime is bound to the parent's `:connecting` state — leaving `:connecting` (whether to `:authenticating` on success or `:reconnecting` on error) destroys it; entering it again creates a fresh socket. (Per [005 §Composition with explicit `:entry` / `:exit`](005-StateMachines.md#composition-with-explicit-entry--exit) the parent can read the actor's last reported state on exit.)
+The `:websocket/socket` invoked actor is itself a small machine (or fx-backed event handler) that owns the JS `WebSocket` instance and translates `:open`, `:message`, `:error`, `:close` events into dispatches back to the parent connection machine. Every outgoing dispatch carries `:source-socket-id` (the actor's `:rf/self-id`, per [005 §Runtime stamps on the spawned actor's `:data`](005-StateMachines.md#runtime-stamps-on-the-spawned-actors-data-rf2-ijm7)) so the parent's `:current-socket?` guard can suppress messages from a prior socket if one happens to dispatch in flight as the cascade tears it down. The actor's lifetime is bound to `:active` — leaving `:active` (whether to `:reconnecting` on error or `:failed` fatally) destroys it; re-entering `:active` creates a fresh socket.
 
 ### Parameters
 
@@ -215,7 +314,7 @@ The connection's `:url` and `:auth-token` arrive on the `:ws/connect` event:
                                            :auth-token (some-token)}]])
 ```
 
-The `:record-connection-opts` action persists them into `:data`; the `:connecting` state's spawn-spec `:data` fn reads them out and threads them into the child `:websocket/socket` actor. A reconnect (after `:closed` or `:error`) reuses whatever is in `:data` — no need to re-pass the URL on every reconnect attempt.
+`:record-connection-opts` persists them into `:data`; the `:active` state's `:invoke` `:data` fn reads them out at spawn time and threads them into the child `:websocket/socket` actor. **Every reconnect re-reads `:data` at the new `:active` entry**, so a refreshed token (via `[:ws/connection [:ws/refresh-token new-token]]`) automatically flows into the next socket without re-dispatching `:ws/connect`. A full re-target (different URL) is a fresh `:ws/connect` that records the new opts and forces an `:active` re-entry.
 
 For the canonical menu of mechanisms — event payload (used here for caller-supplied URL/token), spawn-spec `:data` fn (used between this machine and the child socket actor), and boot-time host config (when the URL is fixed by build-time config and threaded in by the boot machine) — see [Pattern-AsyncEffect §Parameter passing across the boundary](Pattern-AsyncEffect.md#parameter-passing-across-the-boundary).
 
@@ -223,7 +322,7 @@ For the canonical menu of mechanisms — event payload (used here for caller-sup
 
 The connection machine tracks subscribed topics in `:data :subscriptions` (a set). On entry to `:connected`, the `:resubscribe` action re-issues subscribe messages for every topic — guaranteeing subscriptions survive reconnects.
 
-To subscribe / unsubscribe at runtime, dispatch a sub/unsub event into the connection machine that updates `:subscriptions` and sends the message:
+To subscribe / unsubscribe at runtime, the running app dispatches sub/unsub events the connection machine handles by updating `:subscriptions` and forwarding the wire-message:
 
 ```clojure
 ;; Subscribe to a topic — pure :data update + send.
@@ -233,43 +332,28 @@ To subscribe / unsubscribe at runtime, dispatch a sub/unsub event into the conne
             :fx   [[:dispatch [(:socket-id data) [:send {:type :subscribe :topic topic}]]]]})}
 ```
 
-The exact subscribe-message wire format is application-specific; the pattern is "track in `:data`, re-issue on `:connected` entry."
+(Wire the slot into `:connected`'s `:on` map alongside `:ws/received` and `:ws/send`.) The exact subscribe-message wire format is application-specific; the pattern is "track in `:data`, re-issue on `:connected` entry."
 
 ### Message correlation for request-reply
 
-Some WebSocket protocols are request-reply with a correlation id. The pattern: track in-flight requests in `:data :in-flight` keyed by id; on `:ws/received`, look up the id and dispatch the registered reply event:
+Request-reply protocols carry a correlation id on every request and matching reply. The pattern, fully implemented in the worked example above:
 
-```clojure
-:ws/request
-{:action (fn [data [_ {:keys [reply] :as msg}]]
-           (let [id (random-uuid)]
-             {:data (assoc-in data [:in-flight id] reply)
-              :fx   [[:dispatch [(:socket-id data) [:send (assoc msg :id id)]]]]}))}
-```
+1. **Caller dispatches `[:ws/connection [:ws/request {:request-id ..., :body ..., :reply [::handler ...], :timeout-ms 10000}]]`.**
+2. **`:register-request` action** records the in-flight entry — `(:in-flight data)` gains `{request-id {:reply-event ... :timeout-ms ...}}` — forwards the body (with `:request-id` stamped) to the socket actor, and schedules a `:dispatch-later` for the timeout.
+3. **`:ws/received` arrives with `{:body {:request-id ... :result ...}}`.** The `:connected` state's handler checks the connection-epoch guard (`:current-socket?`) and then branches: a body carrying `:request-id` looks up the in-flight entry and dispatches the registered reply event; a body without `:request-id` is a server push and routes to `:ws/handle-message`. Either branch clears the in-flight slot when correlated.
+4. **`:ws/request-timeout` fires** if no reply arrives within the timeout window. The `:clear-request` action removes the in-flight entry; the caller's reply event never fires. (Apps that want to surface "request timed out" to the caller can do so by dispatching a per-feature error event from `:clear-request` instead.)
 
-When `:ws/received` fires, look up `(:in-flight data) (:id msg)`, dispatch the reply event, and remove it from `:in-flight`. Each request-reply *over* the open socket is a Pattern-AsyncEffect interaction; the connection machine is the long-lived host.
+The correlation id can be any `=`-comparable value — a `(random-uuid)` is the canonical default, but per-feature `[:feature/load slug]` vectors compose with [Spec 014 §`:request-id` (internal)](014-HTTPRequests.md#request-id-internal)'s precedent. Each request-reply *over* the open socket is a Pattern-AsyncEffect interaction; the connection machine is the long-lived host that performs the correlation step Pattern-AsyncEffect leaves to the caller.
 
 ### Heartbeat / keepalive
 
-Use `:after` on `:connected` to schedule a periodic ping; on receiving a pong, the timer resets via state re-entry (or via a dedicated sub-state with its own `:after`):
-
-```clojure
-:connected
-{:after {30000 {:target :connected :action :send-ping}}     ;; self-loop external; re-arms timer
- ...}
-```
-
-If the pong does not arrive within a window, the parent transitions to `:reconnecting`. A child machine for the heartbeat (invoked from `:connected`) is cleaner for non-trivial cases.
+Use `:after` on `:connected` to schedule a periodic ping: `:after {30000 {:target :connected :action :send-ping}}` self-loops externally, re-arming the timer. If the pong does not arrive within a window, transition to `:reconnecting`. A child heartbeat machine invoked from `:connected` is cleaner for non-trivial cases.
 
 ### Server-pushed events
 
-Server pushes (`:ws/received` events that are not request-replies) are translated into named dispatched events the running-app handlers consume. The connection machine's role is mechanical — receive, translate, dispatch. The semantic interpretation lives in the per-feature event handlers.
+Server pushes (`:ws/received` events with no `:request-id`) are translated into named dispatched events the running-app handlers consume. The connection machine's role is mechanical — receive, validate the socket-id, translate, dispatch. The semantic interpretation lives in the per-feature event handlers:
 
 ```clojure
-:ws/received
-{:action (fn [_ [_ msg]]
-           {:fx [[:dispatch [:ws/handle-message msg]]]})}
-
 (rf/reg-event-fx :ws/handle-message
   (fn [_ [_ {:keys [type] :as msg}]]
     (case type
@@ -280,7 +364,7 @@ Server pushes (`:ws/received` events that are not request-replies) are translate
 
 ### Re-authentication on reconnect
 
-Token expiry across reconnects: the `:authenticating` state always runs after `:connecting`, so re-auth is the default. If the token has expired, the auth handshake fails, the machine transitions to `:failed`, and the running app dispatches `[:auth/refresh-token]` followed by `[:ws/connection [:ws/connect]]` once the new token is available.
+Token expiry across reconnects has two recovery paths, both supported by the worked machine. **Proactive**: the auth machine refreshes the token and dispatches `[:ws/connection [:ws/refresh-token new-token]]`; the `:refresh-token` action updates `:data :auth-token`; the next `:active` entry's `:invoke` `:data` fn picks up the fresh value. **Reactive**: a reconnect into `:authenticating` fails with `:ws/auth-failed` and the machine transitions to `:failed`; the auth machine observes via `sub-machine` (per [005 §Subscribing to machines via `sub-machine`](005-StateMachines.md#subscribing-to-machines-via-sub-machine)), runs its refresh, and dispatches `[:ws/connection [:ws/connect {:url ... :auth-token new-token}]]` to re-target. Either way, refreshed credentials land in `:data` and the next `:active` entry threads them through `:invoke` `:data`.
 
 ## SSR
 
@@ -295,20 +379,23 @@ This mirrors the rule for any client-only fx: the `:platforms` metadata gates ex
 - **Per-message machine-spawn-and-destroy.** The connection machine is long-lived. Spawning a new machine per outgoing message is structural overkill — use a single connection machine with `:in-flight` correlation tracking instead.
 - **Treating WebSocket as Pattern-AsyncEffect.** A connection that retries, reconnects, and survives across message boundaries is state-machine-shaped. Use this pattern.
 - **Storing the `WebSocket` object in `app-db`.** The JS `WebSocket` is not a value; it cannot serialise; it cannot survive Tool-Pair epoch replay. The `:websocket/socket` actor owns it via a host-side reference; only its id appears in `:data`.
+- **Anchoring the `:invoke` on `:connecting` instead of the `:active` parent.** A socket actor scoped to `:connecting` is destroyed the moment the leaf transitions to `:authenticating` — every dispatch from `:authenticating` and `:connected` then addresses a dead actor. The actor's lifetime must outlive every leaf that dispatches through it; the hierarchical parent is the natural anchor.
+- **Forgetting to re-thread connection opts on reconnect.** Recording `:url` and `:auth-token` only in `:disconnected`'s `:ws/connect` handler — and never refreshing them on the `:reconnecting` → `:active` path — means a token expiry mid-session can never recover. Either store opts in `:data` (where the `:invoke` `:data` fn re-reads them on every `:active` entry — the worked example's approach) or provide an explicit `:ws/refresh-token` slot at the parent level.
+- **Skipping the connection-epoch check on `:ws/received`.** Without `:current-socket?` (or equivalent), a slow `:message` event from a torn-down socket can land in `:connected` after a reconnect and be processed against the new connection's `:in-flight` map — at best a wrong-reply dispatch; at worst an in-flight slot cleared by a stale correlation id. The check is one line; skipping it is the websocket equivalent of [012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression)'s nav-token bug.
 - **Hardcoding the wire format in the pattern.** EDN, JSON, MessagePack, Protobuf — the connection machine doesn't care. The `:websocket/socket` actor serialises on send and deserialises on receive; the machine sees plain Clojure values.
 
 ## Composition with related patterns
 
-- **[Pattern-AsyncEffect](Pattern-AsyncEffect.md)** — distinct but adjacent. Individual request-reply messages over the open socket fit Pattern-AsyncEffect (the open connection acts as the fx); the connection lifecycle itself does not.
-- **[Pattern-StaleDetection](Pattern-StaleDetection.md)** — composes for stale replies. When the socket has been replaced, replies from the prior socket epoch are suppressed via the standard epoch idiom — the same mechanism `:after` already uses internally.
-- **[Pattern-Boot](Pattern-Boot.md)** — "establish real-time connection" is often a late boot phase; the boot machine's `:routing` or a dedicated `:connecting-realtime` state `:invoke`s the connection machine.
+- **[Pattern-AsyncEffect](Pattern-AsyncEffect.md)** — distinct but adjacent. Individual request-reply messages over the open socket fit Pattern-AsyncEffect (the open connection acts as the fx); the connection lifecycle itself does not. The request-reply correlation step the connection machine performs is what Pattern-AsyncEffect leaves to the caller — Pattern-WebSocket's `:in-flight` map is the worked example of that step.
+- **[Pattern-StaleDetection](Pattern-StaleDetection.md)** — composes twice. First for the `:after` backoff timer (the runtime's built-in epoch handles it). Second for the connection-epoch: the live socket-id IS the epoch; `:current-socket?` is the guard; `:rf.ws/stale-socket` is the trace.
+- **[Pattern-Boot](Pattern-Boot.md)** — "establish real-time connection" is often a late boot phase; the boot machine's `:routing` or a dedicated `:connecting-realtime` state dispatches `[:ws/connection [:ws/connect ...]]` to kick the connection machine into `:active`.
 - **`:after` / `:always` / `:invoke` / hierarchical states** ([005](005-StateMachines.md)) — the locked machine substrate. This pattern is the canonical worked example exercising all four together.
-- **No Suspense** ([Principles.md](Principles.md)) — connection state is explicit (`:connecting`, `:authenticating`, etc.), not implicit "loading"; views render against the snapshot's `:state`.
+- **No Suspense** ([Principles.md](Principles.md)) — connection state is explicit (`:disconnected`, `:active / :connecting`, `:active / :connected`, `:reconnecting`, `:failed`), not implicit "loading"; views render against the snapshot's `:state`.
 
 ## Cross-references
 
 - [005-StateMachines.md](005-StateMachines.md) — the substrate; this pattern is a worked example exercising hierarchical states, `:after`, `:always`, and `:invoke` together.
 - [Pattern-AsyncEffect.md](Pattern-AsyncEffect.md) — sibling pattern for one-shot async work.
-- [Pattern-StaleDetection.md](Pattern-StaleDetection.md) — epoch idiom; this pattern reuses it for connection-epoch staleness.
+- [Pattern-StaleDetection.md](Pattern-StaleDetection.md) — epoch idiom; this pattern reuses it twice (backoff timer + connection epoch).
 - [Pattern-Boot.md](Pattern-Boot.md) — boot may include connection establishment as a phase.
 - [011-SSR §`:after` is no-op under SSR](011-SSR.md#after-is-no-op-under-ssr) — the server-side rule for the connection machine's timers.


### PR DESCRIPTION
## Summary

Rewrites `spec/Pattern-WebSocket.md`'s worked example to fix five concrete internal inconsistencies flagged in [rf2-axbq](../tree/main/.beads). The previous example had a contradiction between the declared actor lifetime and the happy-path transitions; a reconnect path that couldn't refresh credentials; backoff + stale-suppression claimed in prose but absent from the worked machine; request/reply correlation promised but never implemented; and decorative `:connected` sub-states that didn't transition between themselves.

The result is a single internally-consistent machine — a hierarchical `:active` parent owns the `:invoke`'d socket actor, the actor's lifetime spans `:connecting` → `:authenticating` → `:connected`, reconnects re-read `:data` opts via the spawn-spec `:data` fn, backoff uses the fn-form `:after` delay parameterised on `:retries`, request/reply correlation is fully worked through `:in-flight` with per-request timeouts, and the connection-epoch idiom (socket-id as epoch, `:current-socket?` as guard) handles messages from torn-down sockets.

## Five inconsistencies, each with a one-line fix

1. **Actor lifetime contradicted happy path** — fixed by hierarchical `:active` parent state that owns the `:invoke`.
2. **Reconnect didn't refresh opts** — fixed by `:invoke`'s `:data` fn re-reading `:url`/`:auth-token` from parent's `:data` on every `:active` entry, plus a parent-level `:ws/refresh-token` slot.
3. **Backoff + stale-suppression promised but not shown** — fixed by fn-form `:after` delay `(fn [snap] (min (* base-ms (Math/pow 2 retries)) max-backoff-ms))` and the connection-epoch idiom (socket-id as epoch, `:current-socket?` guard, `:rf.ws/stale-socket` trace).
4. **Request/reply correlation missing** — fixed by `:register-request` action that records `:in-flight` entry, schedules `:dispatch-later` for timeout; `:ws/received` on `:connected` branches on `:request-id` and dispatches the registered reply.
5. **Decorative `:connected` sub-states** — removed.

## Other changes

- `:entry [...]` / `:action [...]` vector forms (flagged by Spec 005 §State nodes and §Actions as invalid — they require a single fn or single keyword ref) replaced with named compound actions. The same violation in Pattern-Boot is tracked by rf2-8pls (Suggestion bead filed during this rewrite).
- `:ws/error` lifted to `:active`'s `:on` so transport errors during any leaf route uniformly through the parent's exit cascade.
- Anti-patterns gained two entries: "anchoring `:invoke` on `:connecting`" and "forgetting to re-thread connection opts on reconnect".
- `docs/guide/05-state-machines.md`'s Pattern-WebSocket subsection updated for the new hierarchical-parent shape (was describing sub-states of `:connected` that no longer exist).

## Test plan

- [x] `mkdocs build --strict` exits 0
- [x] LoC delta on `spec/Pattern-WebSocket.md`: 314 → 401 (+27%, under the +30% cap)
- [x] No new framework features required — example uses only existing machine surface (hierarchical states, `:invoke` with `:data` fn, fn-form `:after` delay, `:always`, machine-scoped guards/actions)
- [x] Guide chapter 05's Pattern-WebSocket subsection aligned with the rewrite
- [x] `:on-connected` and `:record-and-reset` compound actions comply with Spec 005's "single fn or single keyword ref" rule for `:entry` / `:action` slots