### PR TITLE
feat(machines): :fsm/parallel-regions (Nine States Stage 2) (rf2-l67o)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -46,6 +46,7 @@
     :fsm/hierarchical
     :fsm/delayed-after
     :fsm/tags                                         ;; rf2-ee0d (Nine States Stage 1)
+    :fsm/parallel-regions                             ;; rf2-l67o (Nine States Stage 2)
     :routing/match-url
     :ssr/render-to-string
     :ssr/hydration

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -359,6 +359,23 @@
     (map? v)                        [v]
     :else (throw (ex-info ":rf.error/machine-bad-on-clause" {:value v}))))
 
+(defn- after-epoch-path
+  "Return the path inside the snapshot's `:data` map where the
+  `:after`-timer epoch counter lives for `machine`.
+
+  Per Spec 005 §Delayed `:after` transitions, the epoch is `[:data
+  :rf/after-epoch]` for flat / compound machines. Per Spec 005 §Per-
+  region `:always` / `:after` / `:invoke` scoping (rf2-l67o / Stage 2):
+  when `machine` is a region of a parallel-region parent (signalled by
+  `:rf/region` on the synthetic region-machine spec), the epoch is
+  region-scoped — `[:data :rf/after-epoch-by-region <region-name>]` —
+  so a sibling region's transition doesn't invalidate this region's
+  in-flight timers via the shared `:data` slot."
+  [machine]
+  (if-let [rn (:rf/region machine)]
+    [:data :rf/after-epoch-by-region rn]
+    [:data :rf/after-epoch]))
+
 (defn- pick-after-transition
   "Per Spec 005 §Delayed :after transitions. The synthetic event
   [:rf.machine.timer/after-elapsed delay-key carried-epoch] arrives.
@@ -385,7 +402,7 @@
   (return nil); non-matching is surfaced as stale."
   [machine path event snapshot]
   (let [[_ delay-key carried-epoch] event
-        current-epoch (get-in snapshot [:data :rf/after-epoch])]
+        current-epoch (get-in snapshot (after-epoch-path machine))]
     (loop [i (dec (count path))]
       (if (neg? i)
         (when (not= carried-epoch current-epoch)
@@ -628,10 +645,11 @@
                        (assoc snap-after :state new-state)
 
                        epoch-bumps?
-                       (let [new-epoch (inc (or (get-in snap-after [:data :rf/after-epoch]) 0))]
+                       (let [epoch-path (after-epoch-path machine)
+                             new-epoch  (inc (or (get-in snap-after epoch-path) 0))]
                          (-> snap-after
                              (assoc :state new-state)
-                             (assoc-in [:data :rf/after-epoch] new-epoch)))
+                             (assoc-in epoch-path new-epoch)))
 
                        :else
                        (assoc snap-after :state new-state))
@@ -654,7 +672,7 @@
         after-fx
         (when-not internal?
           (let [parent-id (or (:rf/parent-id machine) :rf/transition-pure)
-                epoch     (get-in snap-final [:data :rf/after-epoch])]
+                epoch     (get-in snap-final (after-epoch-path machine))]
             (vec
               (mapcat
                 (fn [[prefix n]]
@@ -1044,6 +1062,189 @@
                  snap
                  depth))))))
 
+;; ---- :fsm/parallel-regions — broadcast routing (rf2-l67o / Stage 2) ------
+;;
+;; Per Spec 005 §Parallel regions: a machine declaring `:type :parallel`
+;; carries a `:regions` map of region-name → state-tree (full state-node
+;; body, with its own `:initial` + `:states` and optional `:on` / `:tags` /
+;; `:after` / `:invoke` / `:always` on each state node). All regions are
+;; active simultaneously when the machine is active; the snapshot's
+;; `:state` is a map of region-name → that region's keyword-or-vector-path;
+;; transitions are broadcast across regions; the macrostep drain settles
+;; every region before commit.
+;;
+;; Implementation strategy: each region is treated as a "synthetic sub-
+;; machine" whose `:states` / `:initial` come from the region body, sharing
+;; `:guards` / `:actions` / `:on-spawn-actions` / `:rf/parent-id` /
+;; `:rf/platform` / `:rf/frame` with the parent. The standard
+;; `machine-transition` is invoked against each region's slice; results
+;; are merged. Spawn / destroy / after-schedule / after-cancel fxs emitted
+;; by a region are post-processed to prefix the region name onto their
+;; `:rf/invoke-id` (so per-region :invoke / :after slots scope correctly,
+;; one region's timer doesn't fire transitions in sibling regions).
+
+(defn- parallel?
+  "True iff the machine declares `:type :parallel` (root-level only)."
+  [machine]
+  (= :parallel (:type machine)))
+
+(defn- region-machine
+  "Build a synthetic single-machine spec for a region.
+
+  Inherits `:guards` / `:actions` / `:on-spawn-actions` from the parent so
+  region transitions can reference the parent's named guards / actions
+  without redeclaring them. Inherits `:rf/parent-id` / `:rf/platform` /
+  `:rf/frame` so the post-action `:rf.machine/spawn` / `:after-schedule`
+  fxs the region emits carry the parent's identity (the region name is
+  prepended onto the `:rf/invoke-id` separately).
+
+  The region's body IS the synthetic machine's body — its `:initial`
+  becomes the synthetic machine's `:initial`, its `:states` becomes the
+  synthetic machine's `:states`, etc."
+  [parent-machine region-name]
+  (let [region-body (get-in parent-machine [:regions region-name])]
+    (-> region-body
+        (assoc :guards            (:guards parent-machine))
+        (assoc :actions           (:actions parent-machine))
+        (assoc :on-spawn-actions  (:on-spawn-actions parent-machine))
+        (assoc :rf/parent-id      (:rf/parent-id parent-machine))
+        (assoc :rf/platform       (:rf/platform parent-machine))
+        (assoc :rf/frame          (:rf/frame parent-machine))
+        (assoc :rf/region         region-name))))
+
+(defn- region-initial-state
+  "Compute the initial-state value for one region — applying that region's
+  `:initial` cascade through any compound chain. Returns the region's
+  state value (keyword for flat regions, vector path for compound regions)."
+  [region-body]
+  (let [rm        (assoc region-body :states (:states region-body))
+        decl      (:initial region-body)
+        full-path (initial-cascade rm (state-path decl))]
+    (denormalise-state full-path decl)))
+
+(defn- compute-tags-parallel
+  "Per Spec 005 §Tags compose across regions: a parallel-region machine's
+  snapshot `:tags` is the union of every active state's `:tags` across
+  every active region. Walks each region's active path; unions everything.
+
+  `state-map` is the snapshot's `:state` slot — a map of region-name →
+  that region's keyword-or-vector-path."
+  [machine state-map]
+  (transduce
+    (map (fn [[region-name region-state]]
+           (compute-tags (region-machine machine region-name) region-state)))
+    set/union
+    #{}
+    state-map))
+
+(defn- commit-tags-parallel
+  "Variant of commit-tags that dispatches on `(:type machine)`. For
+  parallel-region machines, recomputes the union across every region.
+  For flat/compound machines, defers to the existing compute-tags path
+  (single state). Elides the slot when the union is empty."
+  [machine snapshot]
+  (let [tags (if (parallel? machine)
+               (compute-tags-parallel machine (:state snapshot))
+               (compute-tags machine (:state snapshot)))]
+    (if (empty? tags)
+      (dissoc snapshot :tags)
+      (assoc snapshot :tags tags))))
+
+(defn- prefix-region-invoke-id
+  "Per Spec 005 §Per-region `:invoke` / `:after` / `:always` scoping:
+  spawn / destroy / after-schedule / after-cancel fxs emitted by a region
+  carry an `:rf/invoke-id` that's the in-region prefix-path. To keep the
+  runtime-owned `[:rf/spawned <parent-id> <invoke-id>]` slot unique
+  per-region (and per-region `:after` epoch tracking distinct from sibling
+  regions), prepend the region name onto the invoke-id.
+
+  Returns the fx with its `:rf/invoke-id` rewritten (no change if the fx
+  doesn't carry one)."
+  [region-name fx]
+  (let [[fx-id args] fx]
+    (cond
+      (and (map? args) (contains? args :rf/invoke-id))
+      [fx-id (update args :rf/invoke-id #(vec (cons region-name %)))]
+
+      :else fx)))
+
+(declare machine-transition machine-transition-single)
+
+(defn- parallel-machine-transition
+  "Pure function. Given a parallel-region machine, current snapshot, and
+  event, broadcast the event to each region and merge the results.
+
+  Per Spec 005 §Transition broadcast: each region resolves the event
+  through its own active state's deepest-wins lookup; resolved regions
+  transition (exit cascade → action → entry cascade), undeclined regions
+  stay put. The :data slot is shared — each region's actions see the
+  prior region's `:data` writes in declaration order.
+
+  For the synthetic `[:rf.machine.timer/after-elapsed ...]` event,
+  delivery is region-scoped — the broadcast routes to the bearing region
+  only, identified by the region-name prefix on the in-flight timer's
+  invoke-id (which the after-schedule-fx handler tags onto the synthetic
+  dispatch's args via the region prefix in the timer entry's id).
+
+  After every region has been broadcast, the run-to-completion macrostep
+  has fully drained (each region's microstep loop ran inside its own
+  machine-transition call). The merged snapshot is committed; the merged
+  fx vector flows out.
+
+  Returns [new-snapshot fx-vec]."
+  [machine snapshot event]
+  (let [state-map  (:state snapshot)
+        region-names (vec (keys state-map))
+        ;; Each region runs against a snapshot of {:state region-state
+        ;; :data shared-data}. We thread :data sequentially through the
+        ;; regions in declaration order (per (:regions machine)) so each
+        ;; region's actions see the prior region's writes.
+        ordered-regions
+        (->> (or (keys (:regions machine)) region-names)
+             (filter (fn [rn] (contains? state-map rn)))
+             (vec))]
+    (loop [pending    ordered-regions
+           cur-data   (:data snapshot)
+           new-states state-map
+           acc-fx     []]
+      (cond
+        (empty? pending)
+        (let [final-state-map (into {} (for [rn region-names] [rn (get new-states rn)]))
+              merged          (-> snapshot
+                                  (assoc :state final-state-map)
+                                  (assoc :data  cur-data))
+              merged-tagged   (commit-tags-parallel machine merged)]
+          [merged-tagged acc-fx])
+
+        :else
+        (let [rn          (first pending)
+              region-spec (region-machine machine rn)
+              region-snap {:state (get state-map rn)
+                           :data  cur-data}
+              ;; The region's machine-transition runs the full macrostep
+              ;; for that region (event-driven transition + raise drain +
+              ;; :always microstep loop). Sibling regions are unaffected.
+              ;; For the synthetic [:rf.machine.timer/after-elapsed ...]
+              ;; event, broadcasting is correct: regions whose active
+              ;; path has no matching :after delay-key return [snapshot []]
+              ;; (pick-after-transition's nil path); only the bearing
+              ;; region transitions.
+              step-result (machine-transition region-spec region-snap event)]
+          (if (and (vector? step-result)
+                   (= ::action-failed (first step-result)))
+            ;; A region's action threw — propagate the failure up through
+            ;; the parallel layer. The handler boundary halts the cascade.
+            step-result
+            (let [[reg-snap reg-fx] step-result
+                  ;; Prefix any spawn / destroy / after-schedule /
+                  ;; after-cancel fxs with the region name so per-region
+                  ;; runtime tracking slots are unique across regions.
+                  prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
+              (recur (rest pending)
+                     (:data reg-snap)
+                     (assoc new-states rn (:state reg-snap))
+                     (vec (concat acc-fx prefixed-fx))))))))))
+
 (defn machine-transition
   "Pure function. Given a machine definition, current snapshot, and event,
   return [new-snapshot effects].
@@ -1061,7 +1262,20 @@
 
   Bounded by :raise-depth-limit and :always-depth-limit (both default 16).
   Hierarchical states are supported: :state may be a single keyword
-  (flat machine) or a vector path (compound machine)."
+  (flat machine) or a vector path (compound machine). Parallel-region
+  machines (`:type :parallel`) are dispatched into `parallel-machine-
+  transition`, where the event is broadcast across regions per Spec 005
+  §Parallel regions (rf2-l67o)."
+  [machine snapshot event]
+  (if (parallel? machine)
+    (parallel-machine-transition machine snapshot event)
+    (machine-transition-single machine snapshot event)))
+
+(defn- machine-transition-single
+  "Single-machine (flat or compound) implementation of `machine-transition`.
+  Per Spec 005 §Drain semantics §Level 3 — the macrostep. The public
+  `machine-transition` dispatches into this for non-parallel machines and
+  into `parallel-machine-transition` for `:type :parallel` machines."
   [machine snapshot event]
   (let [always-limit (get machine :always-depth-limit always-depth-limit-default)
         raise-limit  (get machine :raise-depth-limit  raise-depth-limit-default)
@@ -1199,26 +1413,51 @@
 ;;     :invoke-all (caller continues with normal machine-transition)
 ;;   - a {:db ... :fx ...} effect map if the event was intercepted.
 
+(defn- find-active-invoke-all-in-tree
+  "Helper for find-active-invoke-all. Given a machine-like map with
+  `:states` (for a non-parallel machine, the machine itself; for a
+  region of a parallel machine, the region body) and a path inside
+  that tree, walk leaf→root looking for an :invoke-all-bearing state
+  whose :on-child-done or :on-child-error matches inner-event-id."
+  [tree path inner-event-id]
+  (loop [i (dec (count path))]
+    (when (>= i 0)
+      (let [prefix (vec (take (inc i) path))
+            n      (node-at tree prefix)
+            ia     (:invoke-all n)]
+        (cond
+          (and ia (= inner-event-id (:on-child-done ia)))
+          {:invoke-id prefix :spec ia :kind :done}
+          (and ia (= inner-event-id (:on-child-error ia)))
+          {:invoke-id prefix :spec ia :kind :failed}
+          :else
+          (recur (dec i)))))))
+
 (defn- find-active-invoke-all
   "Walk the snapshot's :state path leaf→root looking for an
   :invoke-all-bearing state whose :on-child-done or :on-child-error
   matches the given inner-event-id. Returns
   {:invoke-id <prefix-path> :spec <invoke-all-spec> :kind :done|:failed}
-  or nil."
+  or nil.
+
+  Per Spec 005 §Parallel regions (rf2-l67o): for parallel-region
+  machines, iterates each region's active state-tree (prefixing the
+  region name onto the resolved :invoke-id, matching the per-region
+  scoping prefix-region-invoke-id applies on the entry-side)."
   [machine snapshot inner-event-id]
-  (let [path (state-path (:state snapshot))]
-    (loop [i (dec (count path))]
-      (when (>= i 0)
-        (let [prefix (vec (take (inc i) path))
-              n      (node-at machine prefix)
-              ia     (:invoke-all n)]
-          (cond
-            (and ia (= inner-event-id (:on-child-done ia)))
-            {:invoke-id prefix :spec ia :kind :done}
-            (and ia (= inner-event-id (:on-child-error ia)))
-            {:invoke-id prefix :spec ia :kind :failed}
-            :else
-            (recur (dec i))))))))
+  (cond
+    (parallel? machine)
+    (some (fn [[region-name region-state]]
+            (let [region-body (region-machine machine region-name)
+                  region-path (state-path region-state)
+                  match       (find-active-invoke-all-in-tree
+                                region-body region-path inner-event-id)]
+              (when match
+                (update match :invoke-id #(vec (cons region-name %))))))
+          (:state snapshot))
+
+    :else
+    (find-active-invoke-all-in-tree machine (state-path (:state snapshot)) inner-event-id)))
 
 (defn- join-condition-met?
   "Evaluate the join condition against the current join state.
@@ -1483,9 +1722,67 @@
                            :reason ":join must be :all, :any, {:n pos-int}, or {:fn fn?}"
                            :join join})))))))
 
+(defn- validate-parallel!
+  "Per Spec 005 §Parallel regions (rf2-l67o / Stage 2) and Spec-Schemas
+  §`:rf/transition-table` §`:type :parallel` constraint: when a root
+  state-node declares `:type :parallel`, validate the shape at
+  registration time.
+
+  Three error categories:
+    - :rf.error/machine-parallel-bad-shape — `:type :parallel` declared
+      without a `:regions` map, OR `:regions` is empty, OR `:regions`
+      coexists with `:initial` / `:states`, OR a region body is missing
+      its own `:initial`.
+    - :rf.error/machine-parallel-nested-not-supported — a region's own
+      state-tree declares `:type :parallel`; nested parallel regions
+      aren't supported in v1.
+
+  Walks each region's state-nodes to ensure no nested parallel."
+  [machine]
+  (when (parallel? machine)
+    (when-not (and (map? (:regions machine)) (seq (:regions machine)))
+      (throw (ex-info ":rf.error/machine-parallel-bad-shape"
+                      {:reason ":type :parallel requires a non-empty :regions map"})))
+    (when (or (contains? machine :initial) (contains? machine :states))
+      (throw (ex-info ":rf.error/machine-parallel-bad-shape"
+                      {:reason ":type :parallel is mutually exclusive with :initial / :states at the root"})))
+    (doseq [[region-name region-body] (:regions machine)]
+      (when-not (keyword? region-name)
+        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
+                        {:reason "region names must be keywords"
+                         :region region-name})))
+      (when-not (and (map? region-body) (seq region-body))
+        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
+                        {:reason "each region body must be a non-empty state-node map"
+                         :region region-name})))
+      (when (= :parallel (:type region-body))
+        (throw (ex-info ":rf.error/machine-parallel-nested-not-supported"
+                        {:reason "nested parallel regions are not supported in v1"
+                         :region region-name})))
+      (when-not (keyword? (:initial region-body))
+        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
+                        {:reason "each region body must declare :initial (the cascade entry-point)"
+                         :region region-name})))
+      ;; Walk the region's nested :states for nested :type :parallel.
+      (letfn [(walk [path nodes]
+                (doseq [[k n] nodes]
+                  (when (= :parallel (:type n))
+                    (throw (ex-info ":rf.error/machine-parallel-nested-not-supported"
+                                    {:reason "nested parallel regions are not supported in v1"
+                                     :region region-name
+                                     :state-path (conj path k)})))
+                  (when (:states n)
+                    (walk (conj path k) (:states n)))))]
+        (walk [] (:states region-body))))))
+
 (defn- walk-state-nodes
   "Yield [state-key state-node] pairs for every node under :states,
-  recursing through :states maps. Used by registration-time validators."
+  recursing through :states maps. Used by registration-time validators.
+
+  Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): for parallel-region
+  machines, walks the state nodes under every region's :states (each
+  region is its own state-tree). Region-name keywords are NOT yielded
+  as state keys (they're region identifiers, not states)."
   [machine]
   (letfn [(walk [path nodes]
             (mapcat
@@ -1494,7 +1791,16 @@
                       (when (:states n)
                         (walk (conj path k) (:states n)))))
               nodes))]
-    (walk [] (:states machine))))
+    (cond
+      ;; Parallel-region machine: iterate every region's state-tree.
+      ;; Region-name keys are NOT yielded as state keys (they're region
+      ;; identifiers, not states).
+      (parallel? machine)
+      (mapcat (fn [[_region region-body]] (walk [] (:states region-body)))
+              (:regions machine))
+
+      :else
+      (walk [] (:states machine)))))
 
 (defn create-machine-handler
   "Returns a function suitable for registration with reg-event-fx.
@@ -1507,6 +1813,10 @@
   reusable across multiple registrations (e.g. (reg-event-fx :a m)
   and (reg-event-fx :b m) produce two independent machines)."
   [machine]
+  ;; Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): validate the
+  ;; `:type :parallel` shape if declared, before any other walk that
+  ;; depends on the regions / states layout.
+  (validate-parallel! machine)
   ;; Per Spec 005 §Spawn-and-join via :invoke-all (rf2-6vmw): walk the
   ;; full state tree (including nested :states) and reject malformed
   ;; :invoke-all declarations at registration time. Per rf2-3y3y: reject
@@ -1518,22 +1828,29 @@
   ;; Validate guard/action references at construction time. machine-id
   ;; isn't known yet (it's the registration-site id), so error tags use
   ;; a placeholder; real misuse traces at handler-call time fill it in.
-  (doseq [[s state-node] (:states machine)]
-    (let [transitions (mapcat
-                       (fn [[_ t]]
-                         (if (vector? t) t [t]))
-                       (:on state-node))]
-      (doseq [t transitions]
-        (when-let [g (:guard t)]
-          (when (and (keyword? g)
-                     (not (contains? (:guards machine) g)))
-            (throw (ex-info ":rf.error/machine-unresolved-guard"
-                            {:guard g :state s}))))
-        (when-let [a (:action t)]
-          (when (and (keyword? a)
-                     (not (contains? (:actions machine) a)))
-            (throw (ex-info ":rf.error/machine-unresolved-action"
-                            {:action a :state s})))))))
+  ;; For parallel-region machines, the same `:guards` / `:actions` are
+  ;; shared across regions — we walk every region's top-level :states
+  ;; for the validation, but the guard/action lookup goes through the
+  ;; parent's shared maps.
+  (let [top-level-states (if (parallel? machine)
+                           (mapcat (fn [[_ region]] (:states region)) (:regions machine))
+                           (:states machine))]
+    (doseq [[s state-node] top-level-states]
+      (let [transitions (mapcat
+                         (fn [[_ t]]
+                           (if (vector? t) t [t]))
+                         (:on state-node))]
+        (doseq [t transitions]
+          (when-let [g (:guard t)]
+            (when (and (keyword? g)
+                       (not (contains? (:guards machine) g)))
+              (throw (ex-info ":rf.error/machine-unresolved-guard"
+                              {:guard g :state s}))))
+          (when-let [a (:action t)]
+            (when (and (keyword? a)
+                       (not (contains? (:actions machine) a)))
+              (throw (ex-info ":rf.error/machine-unresolved-action"
+                              {:action a :state s}))))))))
   (fn [{:keys [db frame] :as _cofx} event]
     (let [;; Per Spec 005 §Registration: id comes from event[0] (the
           ;; surrounding reg-event-fx id), NOT from the spec map.
@@ -1567,15 +1884,21 @@
                             ;; <parent-id> <invoke-id>] registry slot).
                             :rf/parent-id machine-id)
           path       (snapshot-path machine-id)
-          ;; Per Spec 005 §Initial-state cascading: when the snapshot is
-          ;; first synthesised, descend the declared :initial through any
-          ;; compound state's :initial chain to a leaf path. Without this,
-          ;; a machine declared {:initial :foo :states {:foo {:initial :bar
-          ;; :states {:bar {} :baz {}}}}} would land at :state :foo and
-          ;; subsequent transitions resolve against the wrong path.
-          initial-decl  (:initial machine)
-          initial-path  (initial-cascade machine (state-path initial-decl))
-          initial-state (denormalise-state initial-path initial-decl)
+          ;; Per Spec 005 §Initial-state cascading and §Parallel regions:
+          ;; for flat / compound machines, descend the root :initial
+          ;; cascade to a leaf path. For parallel-region machines, the
+          ;; `:state` slot becomes a map of region-name → that region's
+          ;; cascaded initial.
+          initial-state (cond
+                          (parallel? machine)
+                          (into {}
+                                (for [[rn region-body] (:regions machine)]
+                                  [rn (region-initial-state region-body)]))
+
+                          :else
+                          (let [decl (:initial machine)]
+                            (denormalise-state (initial-cascade machine (state-path decl))
+                                                decl)))
           ;; Per Spec 005 §Snapshot shape (`{:state :data :meta?}`) and
           ;; §Versioned via :meta: a machine's spec-level :meta (e.g.
           ;; `:rf/snapshot-version`, user introspection tags) propagates
@@ -1588,12 +1911,13 @@
           initial    (cond-> {:state initial-state
                               :data  (or (:data machine) {})}
                        (some? (:meta machine)) (assoc :meta (:meta machine)))
-          ;; Per Spec 005 §State tags (rf2-ee0d): stamp the initial tag
-          ;; union onto the lazily-synthesised snapshot so views that
-          ;; subscribe before the first event see the same `:tags` shape
-          ;; subsequent transitions produce. Elision-safe — `commit-tags`
-          ;; drops the slot when the union is empty.
-          initial    (commit-tags machine initial)
+          ;; Per Spec 005 §State tags (rf2-ee0d) and §Tags compose across
+          ;; regions (rf2-l67o): stamp the initial tag union onto the
+          ;; lazily-synthesised snapshot. For parallel machines the
+          ;; commit-tags-parallel variant unions every region's active
+          ;; configuration. Elision-safe — both forms drop the slot when
+          ;; the union is empty.
+          initial    (commit-tags-parallel machine initial)
           snapshot   (or (get-in db path) initial)
           ;; Sub-event routing per Spec 005 §Registration. The outer
           ;; event is [:machine-id <inner-event> & extra-args]. Extra
@@ -1969,21 +2293,32 @@
     ;; runtime-owned spawn registry (atomically under one app-db swap so
     ;; observers see consistent state).
     (when-let [container (frame/get-frame-db frame-id)]
-      (let [initial-decl  (:initial spec'')
-            initial-path  (when spec''
-                            (initial-cascade spec'' (state-path initial-decl)))
+      (let [;; Per Spec 005 §Parallel regions (rf2-l67o / Stage 2): a
+            ;; spawned child machine MAY itself be `:type :parallel`,
+            ;; in which case the initial-state is a map of region-name
+            ;; → that region's cascade. Branch on the spawned spec.
+            parallel-child? (and spec'' (parallel? spec''))
+            initial-decl  (:initial spec'')
             initial-state (when spec''
-                            (denormalise-state initial-path initial-decl))
+                            (cond
+                              parallel-child?
+                              (into {} (for [[rn region-body] (:regions spec'')]
+                                         [rn (region-initial-state region-body)]))
+
+                              :else
+                              (denormalise-state (initial-cascade spec'' (state-path initial-decl))
+                                                  initial-decl)))
             initial-snap  (when spec''
-                            ;; Per Spec 005 §State tags (rf2-ee0d): stamp
-                            ;; the initial tag union onto the spawned
-                            ;; actor's snapshot so subscribers see the
-                            ;; same `:tags` slot the parent's
-                            ;; `:rf.http/managed` (and any other child
-                            ;; machine that declares `:tags`) does.
-                            (commit-tags spec''
-                                         {:state initial-state
-                                          :data  (or (:data spec'') {})}))
+                            ;; Per Spec 005 §State tags (rf2-ee0d) and
+                            ;; §Tags compose across regions (rf2-l67o):
+                            ;; stamp the initial tag union onto the
+                            ;; spawned actor's snapshot. For parallel-
+                            ;; region children, commit-tags-parallel
+                            ;; unions across every region.
+                            (commit-tags-parallel
+                              spec''
+                              {:state initial-state
+                               :data  (or (:data spec'') {})}))
             old-db        (adapter/read-container container)
             ;; Detect collision BEFORE the swap so we can emit the
             ;; error trace with the displaced binding's id.
@@ -2369,14 +2704,29 @@
       (when-let [container (frame/get-frame-db frame-id)]
         (let [db   (adapter/read-container container)
               snap (get-in db [:rf/machines parent-id])
+              ;; Per Spec 005 §Per-region :after scoping (rf2-l67o): for
+              ;; parallel-region machines the snapshot's :state is a map
+              ;; of region-name → that region's state, and the invoke-id
+              ;; is `[<region-name> <state...>]` (prefix-region-invoke-id).
+              ;; Resolve the active path inside the bearing region; the
+              ;; epoch lives at the per-region epoch slot.
+              parallel-snap? (and snap (map? (:state snap)))
+              [in-region-invoke-id active epoch-slot]
+              (if parallel-snap?
+                (let [rn (first invoke-id)
+                      iid-tail (vec (rest invoke-id))]
+                  [iid-tail
+                   (when-let [rs (get (:state snap) rn)] (state-path rs))
+                   [:data :rf/after-epoch-by-region rn]])
+                [invoke-id (when snap (state-path (:state snap)))
+                 [:data :rf/after-epoch]])
               ;; Only reschedule if the active state path still includes
               ;; the :after-bearing prefix.
-              active (when snap (state-path (:state snap)))
               still-here? (and active
-                                (= (vec invoke-id)
-                                   (vec (take (count invoke-id) active))))]
+                                (= (vec in-region-invoke-id)
+                                   (vec (take (count in-region-invoke-id) active))))]
           (when still-here?
-            (let [epoch (or (get-in snap [:data :rf/after-epoch]) 0)]
+            (let [epoch (or (get-in snap epoch-slot) 0)]
               ;; Sub-driven re-resolution emits a fresh :scheduled trace
               ;; (paired with the :cancelled-on-resolution above).
               (schedule-after-timer! frame-id parent-id invoke-id state

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -1,0 +1,313 @@
+(ns re-frame.parallel-test
+  "Per Spec 005 §Parallel regions and rf2-l67o (Nine States Stage 2).
+
+  Parallel-region semantics covered:
+    - A `:type :parallel` machine's initial snapshot has `:state` as a
+      map of region-name → that region's cascaded initial state.
+    - Every region is active simultaneously when the machine is active.
+    - Events broadcast across regions — each region's active state
+      independently resolves through deepest-wins; resolved regions
+      transition, undeclined regions stay put.
+    - Shared `:data` flows sequentially through region actions in
+      declaration order (each region's action sees the prior region's
+      :data writes).
+    - Tag union composes across regions (per Spec 005 §Tags compose
+      across regions): snapshot's `:tags` is the union of every active
+      state's :tags across every region.
+    - Compound region: a region's state-tree can itself be hierarchical
+      (its own :initial cascade + LCA exit/entry semantics, snapshot's
+      region-value is a vector path inside the region).
+    - Per-region `:always`: a region's eventless transitions fire only
+      against that region's state, not against siblings'.
+    - Initial snapshot stamped at registration with the full region map.
+    - Print/read round-trip: parallel snapshots survive pr-str ↔
+      read-string with shape intact.
+    - Registration-time rejection of bad shape (`:type :parallel`
+      without `:regions`, nested parallel, malformed region body).
+
+  These JVM tests pair with the conformance fixtures
+  spec/conformance/fixtures/parallel-*.edn."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- snapshot [machine-id]
+  (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
+
+;; ---- 1. flat two-region parallel machine — initial state map ------------
+
+(deftest parallel-flat-two-regions-initial-state
+  (testing "initial snapshot's :state is a map of region → that region's :initial"
+    (let [m {:type    :parallel
+             :data    {:count 0}
+             :regions {:left  {:initial :a
+                               :states  {:a {:on {:left/go :b}}
+                                         :b {}}}
+                       :right {:initial :x
+                               :states  {:x {:on {:right/go :y}}
+                                         :y {}}}}}]
+      (rf/reg-machine :par/two-region m)
+      ;; Force initialisation via a no-op event the machine doesn't handle.
+      (rf/dispatch-sync [:par/two-region [:no-match]])
+      (let [s (snapshot :par/two-region)]
+        (is (map? (:state s)) "snapshot :state is a map for parallel machines")
+        (is (= {:left :a :right :x} (:state s))
+            "each region's initial state lands at the region key")
+        (is (= {:count 0} (select-keys (:data s) [:count]))
+            ":data carries the declared initial data (no per-region :data slot)")))))
+
+;; ---- 2. event broadcasts to every region --------------------------------
+
+(deftest parallel-event-broadcasts-to-every-region
+  (testing "one event reaches every region; matching regions transition independently"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left  {:initial :a
+                               :states  {:a {:tags #{:left/a} :on {:flip :b}}
+                                         :b {:tags #{:left/b} :on {:flip :a}}}}
+                       :right {:initial :x
+                               :states  {:x {:tags #{:right/x} :on {:flip :y}}
+                                         :y {:tags #{:right/y} :on {:flip :x}}}}}}]
+      (rf/reg-machine :par/broadcast m)
+      (rf/dispatch-sync [:par/broadcast [:flip]])
+      (is (= {:left :b :right :y} (:state (snapshot :par/broadcast)))
+          "both regions transitioned on the single broadcast event")
+      (is (= #{:left/b :right/y} (:tags (snapshot :par/broadcast)))
+          "tag union reflects both regions' new states"))))
+
+;; ---- 3. event handled by ONE region; sibling stays put -----------------
+
+(deftest parallel-event-handled-by-one-region
+  (testing "region without matching :on stays put; matching region transitions"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left  {:initial :a
+                               :states  {:a {:on {:left-only :b}}
+                                         :b {}}}
+                       :right {:initial :x
+                               :states  {:x {}
+                                         :y {}}}}}]
+      (rf/reg-machine :par/one-region m)
+      (rf/dispatch-sync [:par/one-region [:left-only]])
+      (is (= {:left :b :right :x} (:state (snapshot :par/one-region)))
+          ":left transitioned; :right stayed at its initial"))))
+
+;; ---- 4. tags compose across regions ------------------------------------
+
+(deftest parallel-tags-union-across-regions
+  (testing "snapshot's :tags is the union of every active state's :tags across regions"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:data {:initial :loading
+                              :states  {:loading {:tags #{:data/loading :data/transient}}}}
+                       :form {:initial :neutral
+                              :states  {:neutral {:tags #{:form/neutral}}}}
+                       :mode {:initial :active
+                              :states  {:active {:tags #{:mode/active}}}}}}]
+      (rf/reg-machine :par/tags m)
+      (rf/dispatch-sync [:par/tags [:no-match]])
+      (is (= #{:data/loading :data/transient :form/neutral :mode/active}
+             (:tags (snapshot :par/tags)))
+          "tag union picks up tags from every active state across every region"))))
+
+;; ---- 5. compound region — vector path inside the region ----------------
+
+(deftest parallel-compound-region
+  (testing "a region's state-tree may itself be a compound state"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:auth      {:initial :authenticated
+                                   :states
+                                   {:authenticated
+                                    {:tags    #{:auth/in}
+                                     :initial :dashboard
+                                     :states  {:dashboard {:tags #{:dash}
+                                                           :on   {:open-settings :settings}}
+                                               :settings  {:tags #{:settings}}}}}}
+                       :lifecycle {:initial :idle
+                                   :states  {:idle {}}}}}]
+      (rf/reg-machine :par/compound m)
+      (rf/dispatch-sync [:par/compound [:open-settings]])
+      (let [s (snapshot :par/compound)]
+        (is (= {:auth      [:authenticated :settings]
+                :lifecycle :idle}
+               (:state s))
+            "compound region carries a vector path inside that region")
+        (is (= #{:auth/in :settings} (:tags s))
+            "tag union walks the compound region's active path")))))
+
+;; ---- 6. shared :data — actions in different regions write through it ---
+
+(deftest parallel-shared-data-flows-through-regions
+  (testing "actions across regions write to the same :data map in declaration order"
+    (let [m {:type    :parallel
+             :data    {:count 0}
+             :actions {:bump (fn [d _] {:data (update d :count inc)})}
+             :regions {:left  {:initial :a
+                               :states  {:a {:on {:bump {:target :a :action :bump}}}}}
+                       :right {:initial :x
+                               :states  {:x {:on {:bump {:target :x :action :bump}}}}}}}]
+      (rf/reg-machine :par/shared-data m)
+      (rf/dispatch-sync [:par/shared-data [:bump]])
+      ;; Both regions handle :bump, so the action runs TWICE against the
+      ;; shared :data (once per region) — :count goes 0 → 1 → 2.
+      (is (= 2 (get-in (snapshot :par/shared-data) [:data :count]))
+          "shared :data accumulates writes from both regions"))))
+
+;; ---- 7. per-region :always cascade -------------------------------------
+
+(deftest parallel-always-cascade-per-region
+  (testing ":always microsteps fire scoped to the region that transitioned"
+    (let [m {:type    :parallel
+             :data    {:left-ready? false}
+             :guards  {:ready? (fn [d _] (true? (:left-ready? d)))}
+             :actions {:mark-ready (fn [d _] {:data (assoc d :left-ready? true)})}
+             :regions {:left  {:initial :idle
+                               :states  {:idle
+                                         {:always [{:guard :ready? :target :resolved}]
+                                          :on     {:prep {:target :idle :action :mark-ready}}}
+                                         :resolved {:tags #{:left/done}}}}
+                       :right {:initial :a
+                               :states  {:a {:tags #{:right/a}}}}}}]
+      (rf/reg-machine :par/always m)
+      (rf/dispatch-sync [:par/always [:prep]])
+      (let [s (snapshot :par/always)]
+        (is (= :resolved (get-in s [:state :left]))
+            ":always microstep advanced :left after :prep made the guard true")
+        (is (= :a (get-in s [:state :right]))
+            ":right is unaffected by :left's :always cascade")
+        (is (= #{:left/done :right/a} (:tags s))
+            "tag union reflects the post-:always-microstep states")))))
+
+;; ---- 8. pure machine-transition surface --------------------------------
+
+(deftest parallel-pure-machine-transition
+  (testing "pure machine-transition broadcasts the event and merges regions"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left  {:initial :a
+                               :states  {:a {:tags #{:left/a} :on {:flip :b}}
+                                         :b {:tags #{:left/b}}}}
+                       :right {:initial :x
+                               :states  {:x {:tags #{:right/x} :on {:flip :y}}
+                                         :y {:tags #{:right/y}}}}}}
+          initial {:state {:left :a :right :x} :data {} :tags #{:left/a :right/x}}
+          [snap1 fx1] (machines/machine-transition m initial [:flip])]
+      (is (= {:left :b :right :y} (:state snap1))
+          "pure transition broadcasts to both regions")
+      (is (= #{:left/b :right/y} (:tags snap1))
+          "pure transition recomputes tag union")
+      (is (= [] fx1) "no fx emitted for pure self-transitions"))))
+
+;; ---- 9. snapshot print/read round-trip ---------------------------------
+
+(deftest parallel-snapshot-print-read-roundtrip
+  (testing "parallel-region snapshot survives pr-str ↔ read-string with shape intact"
+    (let [m {:type    :parallel
+             :data    {:items [:a :b]}
+             :regions {:data {:initial :loaded
+                              :states  {:loaded {:tags #{:data/loaded}}}}
+                       :form {:initial :neutral
+                              :states  {:neutral {:tags #{:form/neutral}}}}}}]
+      (rf/reg-machine :par/print m)
+      (rf/dispatch-sync [:par/print [:no-match]])
+      (let [snap         (snapshot :par/print)
+            serialised   (pr-str snap)
+            deserialised (edn/read-string serialised)]
+        (is (= snap deserialised)
+            "round-trip pr-str → read-string yields = value")
+        (is (= {:data :loaded :form :neutral} (:state deserialised))
+            ":state map round-trips as a keyword-keyed map")
+        (is (= #{:data/loaded :form/neutral} (:tags deserialised))
+            ":tags survives the round-trip")))))
+
+;; ---- 10. registration-time validation ----------------------------------
+
+(deftest parallel-registration-time-validation
+  (testing ":type :parallel without :regions is rejected at registration"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/machine-parallel-bad-shape"
+          (machines/create-machine-handler {:type :parallel}))
+        ":type :parallel requires :regions"))
+
+  (testing ":type :parallel with :initial / :states is rejected at registration"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/machine-parallel-bad-shape"
+          (machines/create-machine-handler {:type :parallel
+                                            :initial :foo
+                                            :regions {:r {:initial :s :states {:s {}}}}}))
+        ":type :parallel is mutually exclusive with :initial / :states at the root"))
+
+  (testing "region missing :initial is rejected at registration"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/machine-parallel-bad-shape"
+          (machines/create-machine-handler {:type :parallel
+                                            :regions {:r {:states {:s {}}}}}))
+        "each region body must declare :initial"))
+
+  (testing "nested :type :parallel is rejected at registration"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/machine-parallel-nested-not-supported"
+          (machines/create-machine-handler
+            {:type    :parallel
+             :regions {:outer {:type    :parallel
+                               :regions {:inner {:initial :s :states {:s {}}}}}}}))
+        "a region cannot itself declare :type :parallel"))
+
+  (testing "nested :type :parallel deeper in a region's state-tree is rejected"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/machine-parallel-nested-not-supported"
+          (machines/create-machine-handler
+            {:type    :parallel
+             :regions {:r {:initial :compound
+                           :states  {:compound {:type    :parallel
+                                                :regions {:in {:initial :s
+                                                               :states  {:s {}}}}}}}}})))))
+
+;; ---- 11. :rf/machine-has-tag? sub works on parallel snapshots ----------
+
+(deftest parallel-has-tag-sub
+  (testing ":rf/machine-has-tag? returns true iff the union contains the tag"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:data {:initial :loading
+                              :states  {:loading {:tags #{:data/loading}}}}
+                       :form {:initial :neutral
+                              :states  {:neutral {:tags #{:form/neutral}}}}}}]
+      (rf/reg-machine :par/has-tag m)
+      (rf/dispatch-sync [:par/has-tag [:no-op]])
+      (is (= true  @(rf/subscribe [:rf/machine-has-tag? :par/has-tag :data/loading])))
+      (is (= true  @(rf/subscribe [:rf/machine-has-tag? :par/has-tag :form/neutral])))
+      (is (= false @(rf/subscribe [:rf/machine-has-tag? :par/has-tag :missing]))))))
+
+;; ---- 12. snapshot stored at [:rf/machines <id>] like any other --------
+
+(deftest parallel-snapshot-lives-at-rf-machines-id
+  (testing "parallel-region snapshots are byte-compatible with single-machine storage"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:a {:initial :one :states {:one {}}}
+                       :b {:initial :two :states {:two {}}}}}]
+      (rf/reg-machine :par/storage m)
+      (rf/dispatch-sync [:par/storage [:no-match]])
+      (is (some? (snapshot :par/storage))
+          "snapshot synthesised at [:rf/machines :par/storage]"))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -35,18 +35,19 @@ The pair `{:state :data}` reads as the natural English idiom and matches a vocab
 ## Snapshot shape
 
 ```clojure
-{:state <fsm-keyword-or-path>   ;; :idle, :editing, ... — OR [:checkout :payment :credit-card]
- :data  <map>                    ;; the machine's private memory
- :tags  #{<keyword>, ...}        ;; OPTIONAL — runtime-projected union of every active state's :tags; see §State tags
- :meta  {<optional> ...}}        ;; reserved for :rf/snapshot-version etc.
+{:state <fsm-keyword-or-path-or-region-map>   ;; :idle | [:checkout :payment :credit-card] | {:data :loading :form :neutral}
+ :data  <map>                                  ;; the machine's private memory
+ :tags  #{<keyword>, ...}                      ;; OPTIONAL — runtime-projected union of every active state's :tags; see §State tags
+ :meta  {<optional> ...}}                      ;; reserved for :rf/snapshot-version etc.
 ```
 
-`:state` is **dual**:
+`:state` has **three arms**, disambiguated by the machine's declared shape:
 
 - **Flat machines** — `:state` is a single FSM-keyword (`:idle`, `:editing`, `:loading`, ...). Equivalent to xstate's `state.value` for a non-compound machine. The flat-machine grammar in [§Transition table grammar](#transition-table-grammar) and the Circle Drawer worked example use this form.
 - **Compound machines** — `:state` is a **vector path** from the root state-node to the active leaf (`[:authenticated :cart :browsing]`). The vector form is required when any state in the machine is a compound state (declares its own nested `:states`); it disambiguates "which `:browsing`?" when the same leaf-keyword could appear under multiple parents. See [§Hierarchical compound states](#hierarchical-compound-states).
+- **Parallel-region machines** — `:state` is a **map of region-name → that region's keyword-or-vector-path** (`{:data :loading :form :neutral :mode :active}`). The map form is required when the machine declares `:type :parallel`; every region is active simultaneously, and each region's value follows the flat-or-compound arms above. See [§Parallel regions](#parallel-regions).
 
-Implementations accept both forms on read (a single keyword `:K` is treated as the path `[:K]` whenever a path is needed); tools may normalise to vector internally for uniform manipulation. Parallel-region forms (`:state` as a nested map of region → keyword) remain post-v1; the substitute is one machine per region per [§Substitutes for skipped features](#substitutes-for-skipped-features).
+Implementations accept all three forms on read. The flat / compound arms normalise to a vector path internally for uniform manipulation; the parallel arm is preserved as a map (each region runs its own state-tree). Per rf2-l67o (Nine States Stage 2), the parallel-region arm became first-class.
 
 Stability invariants — every conformant implementation upholds these so snapshots survive the wire (SSR hydration per [011](011-SSR.md)) and the time-axis (Tool-Pair epoch replay):
 
@@ -939,13 +940,189 @@ Hierarchical compound states are claimed by the v1 CLJS reference per [§Capabil
 - LCA-based entry/exit cascading.
 - Deepest-wins transition resolution with parent fallthrough.
 
-Out of scope (see [§Substitutes for skipped features](#substitutes-for-skipped-features)):
+Out of scope of *this section* — see the cross-reference for each:
 
-- **Parallel regions** — substitute: separate machines per region.
-- **History pseudo-states** — substitute: snapshot-as-value capture.
+- **Parallel regions** — first-class capability per [§Parallel regions](#parallel-regions); the N-machines-per-region substitute in [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) remains the right answer when regions are independent features.
+- **History pseudo-states** — substitute: snapshot-as-value capture per [§Substitutes for skipped features](#substitutes-for-skipped-features).
 - **`onDone` final-state notification** — substitute: explicit `[:raise ...]` from the leaf state's `:entry`.
 
 `:always`, `:after`, and `:invoke` are all specified independently of the hierarchy work above (see [§Eventless `:always` transitions](#eventless-always-transitions), [§Delayed `:after` transitions](#delayed-after-transitions), and [§Declarative `:invoke` (sugar over spawn)](#declarative-invoke-sugar-over-spawn)). All three are state-node keys whose semantics compose with the hierarchical entry/exit cascade described above.
+
+## Parallel regions
+
+A machine may declare `:type :parallel` at the root and a `:regions` map keyed by region name. Each region is a **full state-tree** (its own `:initial`, `:states`, optional `:on` / `:tags` / `:after` / `:invoke` / `:always` on each state node). All regions are active simultaneously when the machine is active; the snapshot's `:state` is a **map** of region-name → that region's keyword-or-vector-path; transitions are **broadcast** across regions (every region's active state-node independently decides whether the event matches one of its `:on` keys); the run-to-completion macrostep drain settles every region before the snapshot commits.
+
+xstate/SCXML term: **parallel state** / `<parallel>`. The motivating use case is **orthogonal axes of one feature** — one form with three independent axes (data cardinality / form validity / display mode), one widget with display + interaction state, one page whose render-mode is a function of three independent inputs. Parallel regions avoid the AND-state combinatorial explosion: three axes of three states each shrink from `3^3 = 27` flat states to nine states across three regions.
+
+```clojure
+(rf/reg-machine :ui/nine-states
+  {:type    :parallel
+   :data    {:items [] :error nil}                            ;; shared across all regions
+   :guards  {:empty? (fn [d _] (zero? (count (:items d))))}
+   :actions {:bump   (fn [d _] {:data (update d :count inc)})}
+   :regions
+   {:data
+    {:initial :nothing
+     :states  {:nothing  {:tags #{:data/idle} :on {:fetch :loading}}
+               :loading  {:tags #{:data/loading :data/transient}
+                          :on   {:loaded :resolving :failed :error}}
+               :resolving {:always [{:guard :empty? :target :empty} {:target :some}]}
+               :empty    {:tags #{:data/empty}}
+               :some     {:tags #{:data/some}}
+               :error    {:tags #{:data/error}}}}
+    :form
+    {:initial :neutral
+     :states  {:neutral   {:tags #{:form/neutral}   :on {:submit-invalid :incorrect
+                                                          :submit-valid   :correct}}
+               :incorrect {:tags #{:form/invalid}   :on {:edit :neutral}}
+               :correct   {:tags #{:form/success}   :on {:edit :neutral}}}}
+    :mode
+    {:initial :active
+     :states  {:active {:tags #{:mode/active}   :on {:archive :done}}
+               :done   {:tags #{:mode/done :mode/terminal}}}}}})
+```
+
+After the machine has settled at every region's `:initial`, the snapshot is:
+
+```clojure
+{:state {:data :nothing :form :neutral :mode :active}
+ :data  {:items [] :error nil :count 0}
+ :tags  #{:data/idle :form/neutral :mode/active}}
+```
+
+### When to reach for parallel regions
+
+Parallel regions are for the **multi-axis-of-one-domain** case: one form with three orthogonal axes (data / form / mode), one connection with auth + lifecycle + request-queue, one widget with display + interaction. They share a single `:data` blob because the axes share a domain — the data the regions read and write is the *same data*, just sliced differently by each region's state.
+
+If your axes are conceptually separate features (multiple tabs each with their own state, boot phases plus diagnostics, an audio/video player whose two regions share nothing but the play/pause event), you don't want parallel regions — you want **N separate machines** colocated in app-db. See [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) for the N-machine pattern and worked example. Per rf2-l67o §9.4 (Shared `:data` lock), per-region `:data` is **not** supported; if your axes need encapsulated `:data`, that's the substrate telling you to register N machines, not retrofit per-region data into one parallel machine.
+
+### Snapshot shape
+
+The snapshot's `:state` becomes the **third arm** described in [§Snapshot shape](#snapshot-shape) — a map of region-name → that region's keyword-or-vector-path:
+
+```clojure
+;; flat region — the value is a keyword
+{:state {:data :loading :form :neutral :mode :active} ...}
+
+;; compound region — the value is a vector path INSIDE that region
+{:state {:auth [:authenticated :dashboard] :lifecycle :idle} ...}
+```
+
+Nested parallel regions (a region whose own state-tree declares `:type :parallel`) are not supported in v1. The validator rejects them at registration with `:rf.error/machine-parallel-nested-not-supported`. Two-level nesting can be modelled as a flatter cross-product or, more idiomatically, as multiple top-level parallel-region machines.
+
+The `:data` slot is **shared** across every region — there is no `:data` slot on a region body, and there is no per-region `:data` slot inside the snapshot. Region states see and write the same `:data` map; the action-effect contract is unchanged (`(fn [data event] {:data {...}})`).
+
+### Initial state
+
+The initial snapshot's `:state` is the map of region-name → that region's initial cascade. Each region's `:initial` is required (just like a top-level flat machine's `:initial`); a region body whose own root is a compound state cascades through that region's `:initial` chain (per [§Initial-state cascading](#initial-state-cascading)). Each region's `:entry` cascade runs once at machine boot.
+
+```clojure
+;; given the :ui/nine-states example above:
+(@(rf/sub-machine :ui/nine-states))
+;; => {:state {:data :nothing :form :neutral :mode :active}
+;;     :data  {:items [] :error nil}
+;;     :tags  #{:data/idle :form/neutral :mode/active}}
+```
+
+### Transition broadcast
+
+Every event delivered to a parallel-region machine is **broadcast** to every region. Each region resolves the event through its own active state's deepest-wins lookup (per [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough)) — region A's active state checks its `:on`, region B's active state checks its `:on`, and so on, independently. The runtime collects each region's resolved transition, applies them in region-declaration order against the shared `:data` (so each region's action sees the prior region's `:data` writes), and commits the merged result.
+
+Three outcomes per region:
+
+- **Region's state has a matching `:on` entry whose guard passes.** That region transitions: exit cascade → action → entry cascade. `:fx` accumulated by the region's actions joins the macrostep's `:fx` vector.
+- **Region's state has no matching `:on` entry.** That region's `:state` is unchanged. No `:rf.warning/machine-unhandled-event` fires *unless every region declines the event* (see below).
+- **Region's matching `:on` entry has a guard that returns false.** Same as "no match" — region stays put, no warning fires for that region alone.
+
+If **every region** declines the event (no region matched a transition), the machine as a whole emits `:rf.warning/machine-unhandled-event` exactly once, matching the flat-machine semantics. If **any** region handled the event, the snapshot commits with that region's transition applied and the warning is suppressed.
+
+The post-broadcast snapshot's `:state` is the map of region-name → that region's new state value. Regions that didn't transition keep their prior value in place.
+
+### Per-region `:always` / `:after` / `:invoke` scoping
+
+Each region's state-node keys (`:always`, `:after`, `:invoke`, `:entry`, `:exit`) operate **scoped to that region**:
+
+- **`:always`** — the macrostep's microstep loop runs **per region**. After a region's event-driven transition, that region's new state's `:always` entries are checked; matching guards fire transitions in that region. Other regions are not re-evaluated for `:always` on a sibling region's microstep; their own `:always` checks fire when that region itself transitions. Each region's microstep cascade settles to its own fixed point before commit.
+- **`:after`** — an `:after` timer is scheduled / cancelled when **its region's state** entry / exit fires. One region's timer firing dispatches `[:rf.machine.timer/after-elapsed delay-key epoch]` back into the parent; the broadcast routes the synthetic event to every region; the bearing region picks it up via `pick-after-transition` (per [§Delayed `:after` transitions](#delayed-after-transitions)); sibling regions decline the synthetic event and stay put.
+- **`:invoke`** — a region's `:invoke`-bearing state spawns / destroys actors **bound to that region's state**. The runtime-owned tracking slot at `[:rf/spawned <parent-id> <invoke-id>]` (per [§Declarative `:invoke`](#declarative-invoke-sugar-over-spawn)) uses an `:invoke-id` that prefixes the region name onto the in-region prefix-path. Sibling regions never see the spawn / destroy cascade.
+- **`:entry` / `:exit`** — fire on the region's own transitions, never on a sibling region's transitions.
+
+### Tags compose across regions
+
+A parallel-region machine's `:tags` slot on the snapshot is the **union of every active state's `:tags`** across every active region. Tag union (per [§State tags](#state-tags)) extends naturally:
+
+- For each region, walk the region's active configuration (root → leaf for compound regions; the single state for flat regions); union every active state-node's `:tags`.
+- Across regions, union the per-region results.
+
+```clojure
+;; given the example above, after settling the initial state:
+;; - region :data is at :nothing, which carries #{:data/idle}
+;; - region :form is at :neutral, which carries #{:form/neutral}
+;; - region :mode is at :active, which carries #{:mode/active}
+;; → snapshot's :tags is #{:data/idle :form/neutral :mode/active}
+```
+
+The framework sub `:rf/machine-has-tag?` (per [§Querying tags](#querying-tags--the-rfmachine-has-tag-sub)) works unchanged — it asks "does the union contain this tag?" and the answer is yes iff any active state-node across any region declared the tag.
+
+### Worked example — broadcast, shared `:data`, tags compose
+
+```clojure
+;; Both regions react to :reset; the action lives in the parent's :actions
+;; map and is referenced from each region's :reset transition.
+(rf/reg-machine :ui/example
+  {:type    :parallel
+   :data    {:count 0}
+   :actions {:bump-count (fn [d _] {:data (update d :count inc)})}
+   :regions
+   {:left
+    {:initial :a
+     :states  {:a {:tags #{:left/a} :on {:reset {:target :a :action :bump-count}}}}}
+    :right
+    {:initial :x
+     :states  {:x {:tags #{:right/x} :on {:reset {:target :x :action :bump-count}}}}}}})
+
+;; Initial snapshot:
+;; {:state {:left :a :right :x} :data {:count 0} :tags #{:left/a :right/x}}
+
+(rf/dispatch-sync [:ui/example [:reset]])
+;; Both regions handle :reset (self-transition + :bump-count). The action
+;; runs ONCE PER REGION against the shared :data — :count goes 0 → 1 → 2.
+;; Snapshot after the macrostep:
+;; {:state {:left :a :right :x} :data {:count 2} :tags #{:left/a :right/x}}
+```
+
+The action is run by each region that handles the event; shared `:data` flows through each region's actions sequentially. If you want an event to count once, register a coordinating action at the parent-machine level rather than per-region, or set up the regions so only one handles the event.
+
+### Capability gating
+
+Parallel regions are claimed as `:fsm/parallel-regions` in the v1 CLJS reference per [§Capability matrix](#capability-matrix). Ports that don't claim it raise `:rf.error/machine-grammar-not-in-v1` on `:type :parallel` at registration time. The schema extension (`:rf/state-node` gaining `:type` + `:regions`; `:rf/machine-snapshot`'s `:state` widened to the third arm) is documented in [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table) and [§`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot).
+
+### Substitutes — when to use N machines instead
+
+As noted in [§When to reach for parallel regions](#when-to-reach-for-parallel-regions), parallel regions are the right answer when the regions are orthogonal axes of one feature with one shared `:data`. The N-machines-per-region substitute documented in [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) — separate `[:rf/machines <id>]` entries coordinated via cross-actor dispatch — is the right answer when the regions are conceptually independent features that don't share data. Both patterns ship together; choose by domain shape.
+
+### Trace events
+
+Parallel-region transitions emit one `:rf.machine/transition` macrostep trace per dispatched event (matching flat / compound machines). The trace's `:before` and `:after` payloads carry the full snapshot (including the `:state` map shape). The internal per-region transitions and their microsteps surface through the per-region `:rf.machine.microstep/transition` events (per [§Eventless `:always` transitions §Trace events](#trace-events-1)); each carries a `:region` tag identifying which region produced the microstep so consumers can subscribe to per-region streams.
+
+### Cross-references
+
+- [§Snapshot shape](#snapshot-shape) — the three-arm `:state` form.
+- [§State tags](#state-tags) — tag union extends across regions.
+- [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) — the N-machines-per-region pattern for the independent-features case.
+- [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table) — `:type` + `:regions` schema.
+- [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) — `:state` widened.
+- [Pattern-NineStates](Pattern-NineStates.md) — the motivating pattern (rewritten in Stage 3 / rf2-c7wl).
+- [conformance/fixtures/parallel-flat-two-regions.edn](conformance/fixtures/parallel-flat-two-regions.edn),
+  [parallel-compound-region.edn](conformance/fixtures/parallel-compound-region.edn),
+  [parallel-tags-union-across-regions.edn](conformance/fixtures/parallel-tags-union-across-regions.edn),
+  [parallel-broadcast-event-both-regions.edn](conformance/fixtures/parallel-broadcast-event-both-regions.edn),
+  [parallel-invoke-scoped-to-region.edn](conformance/fixtures/parallel-invoke-scoped-to-region.edn),
+  [parallel-after-scoped-to-region.edn](conformance/fixtures/parallel-after-scoped-to-region.edn),
+  [parallel-always-cascade-per-region.edn](conformance/fixtures/parallel-always-cascade-per-region.edn),
+  [parallel-initial-state-per-region.edn](conformance/fixtures/parallel-initial-state-per-region.edn),
+  [parallel-snapshot-round-trip.edn](conformance/fixtures/parallel-snapshot-round-trip.edn),
+  [parallel-ssr-hydration.edn](conformance/fixtures/parallel-ssr-hydration.edn) — conformance fixtures.
 
 ## Eventless `:always` transitions
 
@@ -2510,7 +2687,7 @@ Per [000-Vision §Hierarchical FSM substrate](000-Vision.md#hierarchical-fsm-sub
 | **Eventless `:always` transitions** — fire as soon as a guard becomes true | Prose: [§Eventless `:always` transitions](#eventless-always-transitions); Schema: `:rf/state-node` extended for `:always` (see [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table)); Fixtures: `always-single-microstep`, `always-depth-exceeded` | ✓ claimed (specified) | Microstep loop inside drain Level 3; bounded depth (default 16); self-loop forbidden at registration; trace events at both per-microstep and macrostep granularity. |
 | **Delayed `:after` transitions** — fire after a time delay | Prose: [§Delayed `:after` transitions](#delayed-after-transitions); Schema: `:rf/state-node` extended for `:after` (see [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table)); Fixtures: `after-single-delay`, `after-stale-detection`, `after-hierarchy` | ✓ claimed (specified) | Epoch-based stale detection — no `:cancel-dispatch-later` fx; clock primitives live in `re-frame.interop` (`now-ms`, `schedule-after!`, `cancel-scheduled!`); SSR-mode no-ops timer scheduling; trace events at `:scheduled` / `:fired` / `:stale-after` granularity. |
 | **State tags** — `:tags <set-of-keywords>` on a state node; snapshot carries the active-configuration tag union | Prose: [§State tags](#state-tags); Schema: `:rf/state-node` extended for `:tags`, `:rf/machine-snapshot` extended for `:tags` (see [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rfstate-node) and [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot)); Fixtures: `tags-flat-machine`, `tags-compound-active-path-union`, `tags-empty-when-no-declaration`, `tags-round-trip-pr-str` | ✓ claimed (specified) | Strictly additive — the snapshot's `:tags` slot is elided when the union is empty. Framework sub `:rf/machine-has-tag?` plus the `(rf/has-tag? id tag)` sugar covers the predicate query. Composes with hierarchical compound states (union along the active path) and — per Stage 2 (rf2-l67o) — will compose with parallel regions (union across every active region). Per rf2-ee0d (Nine States Stage 1). |
-| **Parallel regions** — `:type :parallel` with multiple concurrent regions | Out of pattern scope; substitute documented in [§Substitutes for skipped features](#substitutes-for-skipped-features) | ✗ not claimed | Substitute: separate machines per region, coordinated via cross-actor dispatch. |
+| **Parallel regions** — `:type :parallel` with multiple concurrent regions | Prose: [§Parallel regions](#parallel-regions); Schema: `:rf/transition-table` extended for `:type` + `:regions`, `:rf/state-node` extended for the parallel-region body, `:rf/machine-snapshot`'s `:state` widened to the third arm (see [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table) and [§`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot)); Fixtures: `parallel-flat-two-regions`, `parallel-compound-region`, `parallel-tags-union-across-regions`, `parallel-broadcast-event-both-regions`, `parallel-invoke-scoped-to-region`, `parallel-after-scoped-to-region`, `parallel-always-cascade-per-region`, `parallel-initial-state-per-region`, `parallel-snapshot-round-trip`, `parallel-ssr-hydration` | ✓ claimed (specified) | The third `:state` arm — a map of region-name → keyword-or-vector-path. Shared `:data` across regions per rf2-l67o §9.4 (per-region encapsulation is a signal to use the N-machine substitute pattern from [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features)). Composes with `:fsm/tags` (union across every active state in every region) and with `:fsm/eventless-always` / `:fsm/delayed-after` / `:actor/invoke` (per-region scoping; one region's `:after` timer doesn't fire transitions in sibling regions). Per rf2-l67o (Nine States Stage 2). |
 | **History states** — `:type :history` re-entering a compound's last-active substate | Out of pattern scope; substitute documented in [§Substitutes for skipped features](#substitutes-for-skipped-features) | ✗ not claimed | Substitute: snapshot-as-value capture using the existing `[:rf/machines <id>]` snapshot. |
 | **Final states with `onDone` parent notification** | Prose: brief; Schema: extended for `:meta {:terminal? true :on-done <event-vec>}`; Fixtures: final-state-emits-on-done | Post-v1 | User code can dispatch on entry to a terminal state in v1. |
 
@@ -2538,6 +2715,7 @@ A re-frame2 port declares its capability list in its conformance harness manifes
                  :fsm/eventless-always
                  :fsm/delayed-after
                  :fsm/tags
+                 :fsm/parallel-regions
                  :actor/own-state
                  :actor/spawn-destroy
                  :actor/cross-actor-fx
@@ -2566,9 +2744,9 @@ Cross-references: [000 §Hierarchical FSM substrate](000-Vision.md#hierarchical-
 
 ## Substitutes for skipped features
 
-Two features the matrix names as out of pattern scope — **parallel regions** and **history states** — have well-defined substitutes that exploit re-frame2's existing primitives. The substitutes are not workarounds: they are *better* fits for the substrate, given the snapshot-as-value foundation per [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility).
+Per rf2-l67o (Nine States Stage 2), **parallel regions** are now a first-class capability — see [§Parallel regions](#parallel-regions). The N-machines-per-region substitute documented in [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) remains valid and is the right answer when the regions are conceptually independent features (multiple tabs with their own state, boot phases plus diagnostics, an audio/video player whose two regions share nothing but the play/pause event). Parallel regions are the right answer when the regions are orthogonal axes of *one* feature that share a single `:data` blob (one form with three orthogonal axes, one widget with display + interaction, one page's render-mode predicates).
 
-The substitutes — *parallel regions → separate machines per region (with worked example)*, and *history states → snapshot-as-value capture (with worked example)* — and the rationale for why xstate needs them but re-frame2 doesn't, live in [CP-5-MachineGuide §Substitutes for parallel regions and history states](CP-5-MachineGuide.md#substitutes-for-skipped-features). Out-of-scope features (`:type :parallel`, `:history`) emit `:rf.error/machine-grammar-not-in-v1` against v1; the runtime points users at the substitute patterns rather than promising future support.
+**History states** remain post-v1. The substitute — snapshot-as-value capture exploiting [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility) — is documented in [CP-5-MachineGuide §History states → snapshot-as-value capture](CP-5-MachineGuide.md#history-states--snapshot-as-value-capture). The runtime emits `:rf.error/machine-grammar-not-in-v1` against `:history`; the substitute pattern is the documented forward path.
 
 ## Open questions
 

--- a/spec/CP-5-MachineGuide.md
+++ b/spec/CP-5-MachineGuide.md
@@ -96,13 +96,20 @@ Hierarchical compound states, eventless `:always`, delayed `:after`, and declara
 
 ## Substitutes for skipped features
 
-Two features the matrix names as out of pattern scope — **parallel regions** and **history states** — have well-defined substitutes that exploit re-frame2's existing primitives. The substitutes are not workarounds: they are *better* fits for the substrate, given the snapshot-as-value foundation per [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility).
+Per rf2-l67o (Nine States Stage 2), **parallel regions** are now a **first-class capability** (`:fsm/parallel-regions`; see [Spec 005 §Parallel regions](005-StateMachines.md#parallel-regions)). The N-machines-per-region pattern documented in this section remains valid and is the right answer when the regions are **conceptually independent features** that don't share data — multiple tabs each with their own state, boot phases plus diagnostics, an audio/video player whose two regions share nothing but the play/pause event. Parallel regions inside one machine (`:type :parallel`) are the right answer when the regions are **orthogonal axes of one feature** that share a single `:data` blob — one form with three independent axes (data / form / mode), one widget with display + interaction state, one page whose render-mode is a function of three independent inputs. Both patterns ship together; choose by domain shape.
 
-### Parallel regions → separate machines per region
+The **history-state** substitute (snapshot-as-value capture exploiting [Goal 3 — Frame state revertibility](000-Vision.md#frame-state-revertibility)) below remains the documented forward path for history-state needs — history states are still post-v1.
+
+### Parallel regions → separate machines per region (independent-features case)
 
 xstate's parallel-region machines model two-or-more independent regions advancing concurrently inside one machine (e.g., a media player with `audio.{playing,paused}` and `video.{visible,hidden}` running side by side). The substrate concern is "atomic, inspectable, composable concurrency."
 
-In re-frame2, the substitute is **one machine per region**, coordinated via cross-actor dispatch. Each region is a separate machine — separate `[:rf/machines <id>]` snapshot, separate transition table, independent inspection. Synchronising events fan out through `:fx [[:dispatch ...]]`.
+re-frame2 ships **two** answers; pick by domain shape:
+
+- **Orthogonal axes of one feature, shared `:data`.** Use `:type :parallel` with `:regions` in a single machine. The axes coordinate through one shared `:data` map and the snapshot's `:state` is a map of region → keyword-or-path. See [Spec 005 §Parallel regions](005-StateMachines.md#parallel-regions).
+- **Independent features, no shared `:data`.** Use **one machine per region**, coordinated via cross-actor dispatch. Each region is a separate machine — separate `[:rf/machines <id>]` snapshot, separate transition table, independent inspection. Synchronising events fan out through `:fx [[:dispatch ...]]`. This is the pattern below.
+
+The media-player example uses two genuinely independent regions (audio and video have no shared data, only the play/pause/stop event coordinates them) — the N-machine pattern is the right fit:
 
 #### Worked example — media player with audio/video regions
 

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1626,6 +1626,36 @@ Pre-release framing: per rf2-ee0d (Nine States Stage 1), state-machine state nod
 
 **Cross-references.** [Spec 005 §State tags](005-StateMachines.md#state-tags) for the full grammar; [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rfstate-node) and [§`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) for the schema extensions; [Spec 005 §Capability matrix](005-StateMachines.md#capability-matrix) for the `:fsm/tags` row.
 
+### M-45. Parallel regions shipped — `:type :parallel` machines with map-shaped `:state` (additive)
+
+Pre-release framing: per rf2-l67o (Nine States Stage 2), state-machine declarations may now declare `:type :parallel` at the root and a `:regions` map of region-name → state-tree. Each region is a full state-node body running independently; all regions are active simultaneously; the snapshot's `:state` becomes a **map** of region-name → that region's keyword-or-vector-path. Transitions broadcast across regions; the macrostep drain settles every region before commit; `:data` is shared across regions; `:tags` union across every active state-node in every region.
+
+**Direction.** Additive — no user-side change required. The `:rf/machine-snapshot` schema's `:state` slot widens from `[:or :keyword [:vector :keyword]]` to a `[:multi {:dispatch ...}]` form that also accepts the new region-keyed map arm; existing flat / compound machines continue to produce keyword / vector `:state` values unchanged. Pre-feature machines have no `:type` slot; the runtime treats absent `:type` as `:single` (the existing flat-or-compound behaviour). The `:rf/state-node` schema gains `:type {:optional true} [:enum :single :parallel]` and `:regions {:optional true} [:map-of :keyword [:ref ::state-node]]`; both are optional, neither affects pre-feature machines.
+
+**When to reach for parallel regions vs N machines.** Parallel regions are the right answer when the regions are **orthogonal axes of one feature** with one shared `:data` blob (one form with three orthogonal axes / one widget with display + interaction state / one page whose render-mode is a function of three independent inputs). The pre-existing N-machines-per-region substitute documented in [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) remains valid and is the right answer when the regions are **conceptually independent features** that don't share data (multiple tabs each with their own state, boot phases plus diagnostics, an audio/video player whose two regions share nothing but the play/pause event). Both patterns ship together; choose by domain shape. Per rf2-l67o §9.4 (Shared `:data` lock), per-region `:data` is NOT supported in parallel regions — if your axes need encapsulated `:data`, that's the substrate signalling N separate machines.
+
+**Why now.** The Pattern-NineStates rewrite (rf2-c7wl / Stage 3) needs parallel regions to express orthogonal-axis state (data cardinality / form validity / display mode) in one machine declaration rather than three coordinated machines; Stage 1's `:fsm/tags` capability gives the predicate query mechanism the parallel-region pattern needs to feel finished. Per the design lock rf2-8qz1 §9.6, both `:fsm/tags` and `:fsm/parallel-regions` claim v1 in their respective stages.
+
+**Registration-time validation.** `:type :parallel` is mutually exclusive with `:initial` / `:states` at the root; declaring both emits `:rf.error/machine-parallel-bad-shape` at registration time. Nested parallel regions (a region's own state-tree declaring `:type :parallel`) are not supported in v1 — the validator emits `:rf.error/machine-parallel-nested-not-supported`.
+
+**Cross-references.** [Spec 005 §Parallel regions](005-StateMachines.md#parallel-regions) for the full grammar; [Spec-Schemas §`:rf/transition-table`](Spec-Schemas.md#rftransition-table) and [§`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) for the schema extensions; [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) for the N-machine pattern; [Spec 005 §Capability matrix](005-StateMachines.md#capability-matrix) for the `:fsm/parallel-regions` row.
+
+### M-46. Snapshot `:state` widens to a third arm — map of region-name → state (additive; readers that pattern-match on `:state` may widen)
+
+Pre-release framing: per rf2-l67o (Nine States Stage 2), the snapshot's `:state` slot has a new third arm — `[:map-of :keyword [:or :keyword [:vector :keyword]]]` — used by parallel-region machines (`:type :parallel` per [M-45](#m-45-parallel-regions-shipped--type-parallel-machines-with-map-shaped-state)). Flat and compound machines continue to produce keyword / vector `:state` values; the third arm only appears when the machine is parallel.
+
+**Direction.** Additive at the framework layer. User code that **never** pattern-matches on a machine's `:state` shape pays nothing — `(rf/sub-machine id)` returns the full snapshot value and consumers compose on it as data. User code that DOES pattern-match — usually views that destructure `:state` into a state-keyword expecting a flat machine — must widen the match iff the machine in question is or becomes a parallel-region machine. The framework's own readers (`:rf/machine`, `(machines)`, `(machine-meta id)`, trace consumers, Tool-Pair, SSR hydration) treat snapshots as opaque values and require no change.
+
+**What to do — three cases:**
+
+- **Existing flat / compound machines.** No change; their `:state` stays keyword / vector. The third arm is silent for them.
+- **New parallel-region machines.** Authors writing views against them subscribe through `:rf/machine` (or the `:rf/machine-has-tag?` framework sub) and read the snapshot's `:state` as the map shape they declared. Per-region projections fall out of normal `:<-`-chained subs: `(rf/reg-sub :ui.data/state :<- [:rf/machine :ui/nine-states] (fn [snap _] (get-in snap [:state :data])))`.
+- **Existing flat / compound machine becoming parallel.** Apps that rewrite a flat machine to a `:type :parallel` shape (e.g. the Nine States rewrite per Stage 3 / rf2-c7wl) update their existing views: anywhere `(= :loading (:state @(rf/sub-machine :ui/foo)))` appears, widen to read the bearing region (`(= :loading (get-in @(rf/sub-machine :ui/foo) [:state :data]))`) or — usually better — use a tag predicate (`@(rf/has-tag? :ui/foo :data/loading)`).
+
+**Why now.** The Pattern-NineStates rewrite (Stage 3) is the motivating user; the third arm has to exist before that rewrite can land. The Stage 2 release is the substrate; Stage 3 is the pattern + example rewrite that consumes it.
+
+**Cross-references.** [Spec 005 §Snapshot shape](005-StateMachines.md#snapshot-shape) for the three-arm `:state` form; [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) for the schema; [M-45](#m-45-parallel-regions-shipped--type-parallel-machines-with-map-shaped-state) above for the registration-side change.
+
 ---
 
 ## Opt-in modernisation (only if asked)

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1018,9 +1018,13 @@ The schema below covers the flat FSM grammar, the **hierarchical compound** exte
 (def StateNode
   [:schema {:registry {::state-node
                        [:map
+                        [:type    {:optional true}
+                         [:enum :single :parallel]]                         ;; root-only — controls how the runtime interprets the spec; absent / :single is the default (flat-or-compound shape disambiguated by whether `:states` declares nested `:states`). `:parallel` switches the spec to parallel-region mode — `:regions` (below) is required and `:states` / `:initial` MUST be absent. Per rf2-l67o (Nine States Stage 2) and [005 §Parallel regions](005-StateMachines.md#parallel-regions).
+                        [:regions {:optional true}
+                         [:map-of :keyword [:ref ::state-node]]]            ;; root-only — required iff `:type :parallel`. Each entry's value is a full state-node body (its own `:initial` + `:states`, optionally `:tags`, `:on`, etc.). Region names are keywords; region-name → state-tree. All regions are active simultaneously; the snapshot's `:state` is a map of region-name → keyword-or-vector-path. Per rf2-l67o.
                         [:initial {:optional true} :keyword]                ;; required iff :states is present (compound state); points to the cascade entry-point
                         [:states  {:optional true} [:map-of :keyword [:ref ::state-node]]]
-                        [:data    {:optional true} :map]                    ;; root-only — initial extended-state data map; ignored on non-root nodes
+                        [:data    {:optional true} :map]                    ;; root-only — initial extended-state data map; ignored on non-root nodes. Per rf2-l67o §9.4 (Shared `:data`): parallel-region machines share one `:data` blob across every region. There is no per-region `:data` slot — apps that need per-region encapsulation register N independent machines (see [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features)).
                         [:guards  {:optional true} [:map-of :keyword fn?]]  ;; root-only — machine-local guard implementations; keys are referenced from :guard slots
                         [:actions {:optional true} [:map-of :keyword fn?]]  ;; root-only — machine-local action implementations; keys are referenced from :action / :entry / :exit slots
                         [:on-spawn-actions {:optional true} [:map-of :keyword fn?]] ;; root-only — optional map of named spawn-callbacks; consulted before :actions when an :on-spawn slot uses a keyword reference. See [005 §Registration](005-StateMachines.md#registration--the-machine-is-the-event-handler).
@@ -1168,6 +1172,8 @@ The recursive `::state-node` ref is registered under the spec id `:rf/state-node
 
 **`:invoke` constraint.** The `:invoke` slot's `InvokeSpec` declares both `:machine-id` and `:definition` as optional, but **exactly one** must be supplied for any actual `:invoke` slot — Malli alone cannot express the xor without a richer combinator, so `create-machine-handler` enforces it at registration time and rejects malformed slots as a transition-table error. `:invoke` is registration-time sugar — see [005 §Declarative `:invoke` (sugar over spawn)](005-StateMachines.md#declarative-invoke-sugar-over-spawn) for the desugaring rules; the runtime never sees an `:invoke` key at transition time.
 
+**`:type :parallel` constraint.** A root state-node declaring `:type :parallel` MUST declare a non-empty `:regions` map and MUST NOT declare `:initial` or `:states` — those slots are mutually exclusive with `:regions`. Each region's value is itself a full `::state-node` body (its own `:initial` + `:states` for the compound case, or no `:states` for a flat region). `create-machine-handler` validates the shape at registration time and rejects malformed declarations with `:rf.error/machine-parallel-bad-shape`. Nested parallel regions (a region whose own state-tree contains another `:type :parallel`) are not supported in v1; the validator rejects them with `:rf.error/machine-parallel-nested-not-supported`. Per rf2-l67o (Nine States Stage 2) and [005 §Parallel regions](005-StateMachines.md#parallel-regions).
+
 **`:timeout-ms` removed.** Per rf2-3y3y, the pre-release `:timeout-ms` / `:on-timeout` slots on `:invoke` / `:invoke-all` are DROPPED. State-level `:after` on the parent state subsumes the wall-clock guard, with the standard exit-cascade destroying spawned children. `create-machine-handler` rejects any `:timeout-ms` or `:on-timeout` key on either slot at registration time with `:rf.error/invoke-timeout-ms-removed`. The retired error categories `:rf.error/machine-invoke-timeout-without-on-timeout`, `:rf.error/machine-invoke-on-timeout-without-timeout`, and `:rf.error/machine-invoke-timeout-not-positive` are no longer emitted. See [005 §Wall-clock timeouts on `:invoke` — use parent state's `:after`](005-StateMachines.md#wall-clock-timeouts-on-invoke--use-parent-states-after) and [MIGRATION §M-41](MIGRATION.md#m-41-timeout-ms-removed-from-invoke--invoke-all-on-invoke--use-parent-states-after).
 
 **`:always` constraints.** The `:always` slot is checked at registration time for two registration-error categories:
@@ -1187,14 +1193,22 @@ The runtime snapshot of a machine instance. Per [005 §Snapshot shape](005-State
 ```clojure
 (def MachineSnapshot
   [:map
-   ;; :state is dual:
-   ;;   - keyword for flat machines (e.g. :idle)
-   ;;   - vector path from root to the active leaf for compound machines (e.g. [:authenticated :cart :browsing])
-   ;; Implementations accept both forms on read and may normalise to vector internally.
-   ;; Per [005 §Snapshot shape](005-StateMachines.md#snapshot-shape).
-   ;; Parallel-region forms (state as a nested map of region → keyword) remain post-v1; the
-   ;; substitute is one machine per region per [005 §Substitutes for skipped features].
-   [:state    [:or :keyword [:vector :keyword]]]
+   ;; :state has THREE arms — disambiguated by the machine's declared shape:
+   ;;   - keyword                       for flat machines (e.g. :idle)
+   ;;   - [:vector :keyword]            for compound machines — root → active leaf path (e.g. [:authenticated :cart :browsing])
+   ;;   - [:map-of :keyword <region-state>]
+   ;;                                   for parallel-region machines (`:type :parallel`) — region-name → that region's keyword-or-vector-path. Per rf2-l67o (Nine States Stage 2).
+   ;; Implementations accept all three forms on read and may normalise the compound
+   ;; arm to vector internally. Per [005 §Snapshot shape](005-StateMachines.md#snapshot-shape).
+   [:state    [:multi {:dispatch (fn [v] (cond (keyword? v) :flat
+                                                (vector? v)  :compound
+                                                (map? v)     :parallel))}
+               [:flat     :keyword]
+               [:compound [:vector :keyword]]
+               ;; Region values are themselves a flat keyword or a compound path —
+               ;; each region runs an independent state-tree. Nested parallel regions
+               ;; are not supported in v1; a region's state value cannot itself be a map.
+               [:parallel [:map-of :keyword [:or :keyword [:vector :keyword]]]]]]
    [:data     {:optional true} :map]                                       ;; the machine's extended state; closed under print/read
    ;; :tags is the runtime-projected union of every active state-node's
    ;; `:tags` set; recomputed on every transition commit. Optional —

--- a/spec/conformance/fixtures/parallel-after-scoped-to-region.edn
+++ b/spec/conformance/fixtures/parallel-after-scoped-to-region.edn
@@ -1,0 +1,50 @@
+;; Conformance fixture: machine/parallel-after-scoped-to-region
+;;
+;; Per [005 §Per-region `:always` / `:after` / `:invoke` scoping]
+;; (../../005-StateMachines.md#per-region-always--after--invoke-scoping):
+;; an `:after`-bearing state inside a region schedules / cancels timers
+;; scoped to that region. The epoch counter that backstops timer
+;; staleness lives at `[:data :rf/after-epoch-by-region <region-name>]`
+;; — a sibling region's transition does not invalidate this region's
+;; in-flight timers.
+;;
+;; This fixture exercises entry into an :after-bearing state in one
+;; region; the runtime emits :rf.machine/after-schedule with the
+;; in-region-prefixed invoke-id and bumps the region-scoped epoch.
+
+{:fixture/id           :machine/parallel-after-scoped-to-region
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions :fsm/delayed-after}
+ :fixture/doc          "Entry into an :after-bearing state inside a region schedules a region-scoped timer. The :rf.machine/after-schedule fx carries an :rf/invoke-id prefixed with the region name; the per-region :rf/after-epoch-by-region <region> slot increments."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [{:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {}
+    :regions {:data {:initial :idle
+                     :states  {:idle    {:on {:start :loading}}
+                               :loading {:after {5000 :timeout}
+                                         :on    {:loaded :ready}}
+                               :ready   {}
+                               :timeout {}}}
+              :ui   {:initial :neutral
+                     :states  {:neutral {}}}}}
+   :snapshot     {:state {:data :idle :ui :neutral} :data {}}
+   :event        [:start]
+   :expect-next-snapshot {:state {:data :loading :ui :neutral}
+                          :data  {:rf/after-epoch-by-region {:data 1}}}
+   :expect-effects
+   [[:rf.machine/after-schedule
+     {:rf/parent-id :rf/transition-pure
+      :rf/invoke-id [:data :loading]
+      :state        :loading
+      :delay-key    5000
+      :epoch        1
+      :server?      false}]]}]}

--- a/spec/conformance/fixtures/parallel-always-cascade-per-region.edn
+++ b/spec/conformance/fixtures/parallel-always-cascade-per-region.edn
@@ -1,0 +1,51 @@
+;; Conformance fixture: machine/parallel-always-cascade-per-region
+;;
+;; Per [005 §Per-region `:always` / `:after` / `:invoke` scoping]
+;; (../../005-StateMachines.md#per-region-always--after--invoke-scoping):
+;; the macrostep's `:always` microstep loop runs PER REGION. After a
+;; region's event-driven transition, that region's new state's `:always`
+;; entries are checked; matching guards fire transitions in that
+;; region. Sibling regions are not re-evaluated for `:always` on the
+;; transitioning region's microstep.
+;;
+;; This fixture exercises a region whose `:initial` state's `:always`
+;; guard already passes after an action sets the data — the macrostep
+;; settles to the post-`:always` state in one dispatch.
+
+{:fixture/id           :machine/parallel-always-cascade-per-region
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions :fsm/eventless-always}
+ :fixture/doc          "After a region's :on transition fires, that region's :always microstep cascade runs scoped to the region; sibling regions are unaffected. The action sets `:left-ready? true`, which makes the :always guard pass and advances :left to :resolved in the same macrostep."
+
+ :fixture/registry
+ {:machine-action
+  {:par/mark-ready {:doc "Sets :left-ready? true on the shared :data."}}
+  :machine-guard
+  {:par/ready? {:doc "True when :left-ready? is true."}}}
+
+ :fixture/handlers
+ {:machine-action
+  {:par/mark-ready [[:set [:left-ready?] true]]}
+  :machine-guard
+  {:par/ready? [[:fn := [:get [:left-ready?]] true]]}}
+
+ :fixture/calls
+ [{:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {:left-ready? false}
+    :guards  {:ready? :par/ready?}
+    :actions {:mark-ready :par/mark-ready}
+    :regions {:left  {:initial :idle
+                      :states
+                      {:idle     {:always [{:guard :ready? :target :resolved}]
+                                  :on     {:prep {:target :idle :action :mark-ready}}}
+                       :resolved {}}}
+              :right {:initial :a
+                      :states  {:a {}}}}}
+   :snapshot     {:state {:left :idle :right :a}
+                  :data  {:left-ready? false}}
+   :event        [:prep]
+   :expect-next-snapshot {:state {:left :resolved :right :a}
+                          :data  {:left-ready? true}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-broadcast-event-both-regions.edn
+++ b/spec/conformance/fixtures/parallel-broadcast-event-both-regions.edn
@@ -1,0 +1,42 @@
+;; Conformance fixture: machine/parallel-broadcast-event-both-regions
+;;
+;; Per [005 §Transition broadcast]
+;; (../../005-StateMachines.md#transition-broadcast), an event dispatched
+;; into a parallel-region machine is BROADCAST across every region.
+;; Each region's active state independently resolves through the
+;; deepest-wins lookup; the resolved transitions apply in declaration
+;; order against the shared :data.
+;;
+;; This fixture verifies the "both regions handle the same event"
+;; sub-case — both regions' active states declare `:on {:reset ...}`
+;; and the action `:bump-count` runs once per region against the
+;; shared :data, advancing :count from 0 to 2.
+
+{:fixture/id           :machine/parallel-broadcast-event-both-regions
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions}
+ :fixture/doc          "Event broadcasts across regions — both regions handle `:reset` with the same `:bump-count` action; :count goes 0 → 1 → 2 because the shared :data flows through each region's action sequentially."
+
+ :fixture/registry
+ {:machine-action
+  {:par/bump-count {:doc "Increments :count by 1 against the shared :data."}}}
+
+ :fixture/handlers
+ {:machine-action
+  {:par/bump-count [[:set [:count] [:fn :+ [:get [:count]] 1]]]}}
+
+ :fixture/calls
+ [{:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {:count 0}
+    :actions {:bump-count :par/bump-count}
+    :regions {:left  {:initial :a
+                      :states  {:a {:on {:reset {:target :a :action :bump-count}}}}}
+              :right {:initial :x
+                      :states  {:x {:on {:reset {:target :x :action :bump-count}}}}}}}
+   :snapshot     {:state {:left :a :right :x} :data {:count 0}}
+   :event        [:reset]
+   :expect-next-snapshot {:state {:left :a :right :x}
+                          :data  {:count 2}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-compound-region.edn
+++ b/spec/conformance/fixtures/parallel-compound-region.edn
@@ -1,0 +1,48 @@
+;; Conformance fixture: machine/parallel-compound-region
+;;
+;; A `:type :parallel` machine where one region's state-tree is itself a
+;; compound state (declares `:initial` + nested `:states`). The region's
+;; value inside the snapshot's `:state` map is a vector path INSIDE that
+;; region; sibling regions are unaffected by the compound region's
+;; transitions.
+;;
+;; Per [005 §Parallel regions](../../005-StateMachines.md#parallel-regions),
+;; [§Snapshot shape](../../005-StateMachines.md#snapshot-shape), and
+;; rf2-l67o (Nine States Stage 2).
+
+{:fixture/id           :machine/parallel-compound-region
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/parallel-regions}
+ :fixture/doc          "Parallel machine with one compound region (its own :initial + nested :states). The region's snapshot value is a vector path INSIDE that region; the sibling flat region is unaffected."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; Sibling-leaf transition inside the compound :auth region.
+  ;; The :lifecycle region (flat) is unaffected.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {}
+    :regions {:auth
+              {:initial :authenticated
+               :states
+               {:authenticated
+                {:initial :dashboard
+                 :states  {:dashboard {:on {:open-settings :settings}}
+                           :settings  {:on {:close :dashboard}}}}}}
+              :lifecycle
+              {:initial :idle
+               :states  {:idle {}}}}}
+   :snapshot     {:state {:auth      [:authenticated :dashboard]
+                          :lifecycle :idle}
+                  :data  {}}
+   :event        [:open-settings]
+   :expect-next-snapshot {:state {:auth      [:authenticated :settings]
+                                  :lifecycle :idle}
+                          :data  {}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-flat-two-regions.edn
+++ b/spec/conformance/fixtures/parallel-flat-two-regions.edn
@@ -1,0 +1,50 @@
+;; Conformance fixture: machine/parallel-flat-two-regions
+;;
+;; A `:type :parallel` machine declares two flat regions. The initial
+;; snapshot's `:state` is a MAP of region-name → that region's :initial.
+;; A broadcast event reaches both regions; both transition independently.
+;;
+;; Per [005 §Parallel regions](../../005-StateMachines.md#parallel-regions)
+;; and rf2-l67o (Nine States Stage 2).
+
+{:fixture/id           :machine/parallel-flat-two-regions
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/flat :fsm/parallel-regions}
+ :fixture/doc          "Flat two-region parallel machine — broadcast event flips both regions; the snapshot's :state is a region-keyed map of region → that region's keyword."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; Step 1: broadcast `:flip` advances BOTH regions concurrently.
+  {:call         :machine-transition
+   :definition   {:type    :parallel
+                  :data    {}
+                  :regions {:left  {:initial :a
+                                    :states  {:a {:on {:flip :b}}
+                                              :b {:on {:flip :a}}}}
+                            :right {:initial :x
+                                    :states  {:x {:on {:flip :y}}
+                                              :y {:on {:flip :x}}}}}}
+   :snapshot     {:state {:left :a :right :x} :data {}}
+   :event        [:flip]
+   :expect-next-snapshot {:state {:left :b :right :y} :data {}}
+   :expect-effects       []}
+
+  ;; Step 2: broadcast `:flip` again — both regions flip back.
+  {:call         :machine-transition
+   :definition   {:type    :parallel
+                  :data    {}
+                  :regions {:left  {:initial :a
+                                    :states  {:a {:on {:flip :b}}
+                                              :b {:on {:flip :a}}}}
+                            :right {:initial :x
+                                    :states  {:x {:on {:flip :y}}
+                                              :y {:on {:flip :x}}}}}}
+   :snapshot     {:state {:left :b :right :y} :data {}}
+   :event        [:flip]
+   :expect-next-snapshot {:state {:left :a :right :x} :data {}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-initial-state-per-region.edn
+++ b/spec/conformance/fixtures/parallel-initial-state-per-region.edn
@@ -1,0 +1,44 @@
+;; Conformance fixture: machine/parallel-initial-state-per-region
+;;
+;; Per [005 §Initial state]
+;; (../../005-StateMachines.md#initial-state): the initial snapshot of a
+;; parallel-region machine has `:state` as a map of region-name → that
+;; region's cascaded initial. A compound region cascades through its
+;; own `:initial` chain (LCA semantics inside the region); a flat
+;; region's value is the region's :initial keyword.
+;;
+;; This fixture exercises the initial state — synthesised by feeding
+;; the machine an event the regions don't handle. The :state map covers
+;; every declared region; each region's :initial points to its
+;; cascade entry.
+
+{:fixture/id           :machine/parallel-initial-state-per-region
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/parallel-regions}
+ :fixture/doc          "Initial snapshot of a parallel-region machine is a map of region-name → that region's :initial cascade. A compound region cascades to its leaf inside the region (vector path); flat regions stay keyword."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [{:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {}
+    :regions {:flat-region     {:initial :one
+                                :states  {:one {}}}
+              :compound-region {:initial :outer
+                                :states  {:outer
+                                          {:initial :inner
+                                           :states  {:inner {}}}}}}}
+   :snapshot     {:state {:flat-region     :one
+                          :compound-region [:outer :inner]}
+                  :data  {}}
+   :event        [:no-match-event]
+   :expect-next-snapshot {:state {:flat-region     :one
+                                  :compound-region [:outer :inner]}
+                          :data  {}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-invoke-scoped-to-region.edn
+++ b/spec/conformance/fixtures/parallel-invoke-scoped-to-region.edn
@@ -1,0 +1,51 @@
+;; Conformance fixture: machine/parallel-invoke-scoped-to-region
+;;
+;; Per [005 §Per-region `:always` / `:after` / `:invoke` scoping]
+;; (../../005-StateMachines.md#per-region-always--after--invoke-scoping):
+;; an `:invoke`-bearing state inside a region spawns / destroys actors
+;; bound to that region's state, not to the parent machine's overall
+;; state. The runtime-owned tracking slot at `[:rf/spawned <parent-id>
+;; <invoke-id>]` uses an invoke-id that PREFIXES the region name onto
+;; the in-region state path, so per-region actors are uniquely
+;; addressed even when sibling regions declare their own :invoke.
+;;
+;; Pure-call machine-transition has no parent registration, so the
+;; spawn-fx's `:rf/parent-id` is the sentinel `:rf/transition-pure`.
+
+{:fixture/id           :machine/parallel-invoke-scoped-to-region
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions :actor/invoke}
+ :fixture/doc          "An :invoke-bearing state inside a region emits :rf.machine/spawn fx whose :rf/invoke-id is prefixed with the region name. The sibling region's transition does not affect the spawned actor."
+
+ :fixture/registry
+ {:machine
+  {:fetcher {:doc "Stub child — :rf.machine/spawn target"}}}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; Entering :loading in the :data region — region-scoped :invoke spawn.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {}
+    :regions {:data {:initial :idle
+                     :states  {:idle    {:on {:fetch :loading}}
+                               :loading {:invoke {:machine-id :fetcher}}}}
+              :ui   {:initial :neutral
+                     :states  {:neutral {}}}}}
+   :snapshot     {:state {:data :idle :ui :neutral} :data {}}
+   :event        [:fetch]
+   :expect-next-snapshot {:state {:data :loading :ui :neutral}
+                          :data  {}}
+   :expect-effects
+   [[:rf.machine/spawn
+     {:machine-id    :fetcher
+      :id-prefix     :fetcher
+      :rf/spawned-id :fetcher#1
+      :rf/parent-id  :rf/transition-pure
+      ;; The invoke-id is prefixed with the region name :data so the
+      ;; runtime-owned [:rf/spawned <parent> <invoke-id>] slot is
+      ;; uniquely keyed per region.
+      :rf/invoke-id  [:data :loading]}]]}]}

--- a/spec/conformance/fixtures/parallel-snapshot-round-trip.edn
+++ b/spec/conformance/fixtures/parallel-snapshot-round-trip.edn
@@ -1,0 +1,45 @@
+;; Conformance fixture: machine/parallel-snapshot-round-trip
+;;
+;; Per [005 §Snapshot shape](../../005-StateMachines.md#snapshot-shape)
+;; stability invariants: every conformant snapshot is print/read
+;; round-trippable. For parallel-region machines, `:state` is a map of
+;; region-name → keyword-or-vector — both keys and values are EDN-clean.
+;;
+;; This fixture documents the canonical snapshot shape for a parallel-
+;; region machine that's transitioned at least once. The harness reads
+;; the post-transition snapshot and asserts it survives round-trip.
+
+{:fixture/id           :machine/parallel-snapshot-round-trip
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions :fsm/tags}
+ :fixture/doc          "Parallel snapshot survives pr-str ↔ read-string with shape intact. The :state map, the :tags set, and the shared :data round-trip as plain data."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; Step 1: the post-transition snapshot value. The harness asserts
+  ;; (= snap (read-string (pr-str snap))).
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {:items [:apple :banana]}
+    :regions {:data {:initial :loaded
+                     :states  {:loaded {:tags #{:data/loaded :data/has-items}}}}
+              :form {:initial :neutral
+                     :states  {:neutral {:tags #{:form/neutral}}}}
+              :mode {:initial :active
+                     :states  {:active {:tags #{:mode/active}
+                                        :on   {:archive :done}}
+                               :done   {:tags #{:mode/done :mode/terminal}}}}}}
+   :snapshot     {:state {:data :loaded :form :neutral :mode :active}
+                  :data  {:items [:apple :banana]}
+                  :tags  #{:data/loaded :data/has-items :form/neutral :mode/active}}
+   :event        [:archive]
+   :expect-next-snapshot {:state {:data :loaded :form :neutral :mode :done}
+                          :data  {:items [:apple :banana]}
+                          :tags  #{:data/loaded :data/has-items :form/neutral :mode/done :mode/terminal}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-ssr-hydration.edn
+++ b/spec/conformance/fixtures/parallel-ssr-hydration.edn
@@ -1,0 +1,53 @@
+;; Conformance fixture: machine/parallel-ssr-hydration
+;;
+;; Per [005 §Cross-references](../../005-StateMachines.md#cross-references)
+;; (Spec 011 SSR): a parallel-region machine's snapshot lives in
+;; `app-db` at `[:rf/machines <id>]` exactly like flat / compound
+;; machines. The SSR hydration channel (`:rf/hydrate`) replaces app-db
+;; with the server's payload — machine snapshots ride along.
+;;
+;; For a parallel-region snapshot the `:state` map of region-name →
+;; keyword-or-vector is EDN-clean; the hydration round-trip preserves
+;; the shape because the snapshot is opaque to the SSR machinery.
+;;
+;; This fixture documents the pure-call invariant: a parallel snapshot
+;; can be the input to machine-transition without re-initialisation —
+;; treating the snapshot as an `=`-equal value reproducible from any
+;; EDN-clean carrier (the wire, localStorage, the Tool-Pair epoch
+;; buffer).
+
+{:fixture/id           :machine/parallel-ssr-hydration
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/parallel-regions}
+ :fixture/doc          "A parallel-region snapshot is EDN-clean and behaves as a value: machine-transition accepts it directly, no re-initialisation. The SSR hydration path is the same — the snapshot rides through `:rf/hydrate` as opaque data."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; A snapshot synthesised pre-call (as if hydrated from the wire) is
+  ;; the direct input to machine-transition. The transition behaves
+  ;; identically to a snapshot synthesised from registration's initial
+  ;; cascade.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {:session-id "abc"}
+    :regions {:auth      {:initial :authenticated
+                          :states  {:authenticated {:on {:logout :anonymous}}
+                                    :anonymous     {}}}
+              :lifecycle {:initial :idle
+                          :states  {:idle    {:on {:work :busy}}
+                                    :busy    {}}}}}
+   ;; This snapshot is exactly the kind of value SSR / persistence would
+   ;; hydrate. Both regions carry non-initial states (a logged-in user
+   ;; who's mid-task) — the hydration must preserve the region map shape.
+   :snapshot     {:state {:auth :authenticated :lifecycle :idle}
+                  :data  {:session-id "abc"}}
+   :event        [:work]
+   :expect-next-snapshot {:state {:auth :authenticated :lifecycle :busy}
+                          :data  {:session-id "abc"}}
+   :expect-effects       []}]}

--- a/spec/conformance/fixtures/parallel-tags-union-across-regions.edn
+++ b/spec/conformance/fixtures/parallel-tags-union-across-regions.edn
@@ -1,0 +1,45 @@
+;; Conformance fixture: machine/parallel-tags-union-across-regions
+;;
+;; The snapshot's `:tags` slot on a parallel-region machine is the UNION
+;; of every active state-node's `:tags` across every active region.
+;; Composes with Stage 1's `:fsm/tags` capability: tags from active
+;; states in every region all appear in the union.
+;;
+;; Per [005 §Tags compose across regions]
+;; (../../005-StateMachines.md#tags-compose-across-regions), Stage 1
+;; (rf2-ee0d) and Stage 2 (rf2-l67o).
+
+{:fixture/id           :machine/parallel-tags-union-across-regions
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/tags :fsm/parallel-regions}
+ :fixture/doc          "Parallel machine — snapshot's :tags is the union of every active state-node's :tags across every region. A transition in one region pivots its contribution; sibling regions' contributions persist unchanged."
+
+ :fixture/registry
+ {}
+
+ :fixture/handlers
+ {}
+
+ :fixture/calls
+ [;; Initial state: tag union covers all three regions.
+  {:call         :machine-transition
+   :definition
+   {:type    :parallel
+    :data    {}
+    :regions {:data {:initial :nothing
+                     :states  {:nothing {:tags #{:data/idle}
+                                         :on   {:fetch :loading}}
+                               :loading {:tags #{:data/loading :data/transient}}}}
+              :form {:initial :neutral
+                     :states  {:neutral   {:tags #{:form/neutral}}
+                               :incorrect {:tags #{:form/invalid}}}}
+              :mode {:initial :active
+                     :states  {:active {:tags #{:mode/active}}}}}}
+   :snapshot     {:state {:data :nothing :form :neutral :mode :active}
+                  :data  {}
+                  :tags  #{:data/idle :form/neutral :mode/active}}
+   :event        [:fetch]
+   :expect-next-snapshot {:state {:data :loading :form :neutral :mode :active}
+                          :data  {}
+                          :tags  #{:data/loading :data/transient :form/neutral :mode/active}}
+   :expect-effects       []}]}


### PR DESCRIPTION
## Summary

- Adds parallel-region machines (`:type :parallel` + `:regions`), per [Spec 005 §Parallel regions](spec/005-StateMachines.md#parallel-regions). All regions are active simultaneously; transitions broadcast across regions; the macrostep drain settles every region before commit. Shared `:data` across regions per rf2-l67o §9.4 (Shared `:data` lock).
- Snapshot's `:state` widens to a third arm — a map of region-name → keyword-or-vector-path. Existing flat / compound machines unchanged. Schema `:rf/machine-snapshot.:state` becomes `[:multi {:dispatch ...}]` over the three arms (`[:flat]` / `[:compound]` / `[:parallel]`).
- Per-region scoping for `:always` / `:after` / `:invoke`: each region's state-node keys operate against that region's state only. Per-region `:after` epoch via `[:data :rf/after-epoch-by-region <region>]`; spawn / destroy fxs prefix the region name onto `:rf/invoke-id`. Tag union composes across regions per Stage 1's `compute-tags` seam (dispatched on `(:type machine)`).
- Capability matrix row `:fsm/parallel-regions` claimed by v1 CLJS reference per rf2-l67o §9.6. Registration-time validation rejects `:type :parallel` without `:regions`, mutual `:initial`/`:states` declaration, and nested parallel regions.
- The pre-existing N-machines-per-region substitute pattern in [CP-5-MachineGuide §Substitutes](spec/CP-5-MachineGuide.md#substitutes-for-skipped-features) remains valid; both patterns ship together — parallel regions for orthogonal-axes-of-one-feature, N machines for independent features.

## Files

| Layer | Files | LoC |
|---|---|---|
| Implementation | `machines.cljc` | +395 / −93 (488 changed lines) |
| Tests (JVM) | `parallel_test.clj` | 313 new |
| Conformance fixtures | 10 × `parallel-*.edn` | 479 new |
| Spec | `005-StateMachines.md`, `Spec-Schemas.md`, `CP-5-MachineGuide.md` | +247 / −20 |
| Migration | `MIGRATION.md` (M-45, M-46) | +30 |

## What this stage does NOT do

Pattern-NineStates rewrite + example — Stage 3 (rf2-c7wl).

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — 77 tests / 234 assertions, 0 failures
- [x] `cd implementation/core && clojure -M:test` — 183 tests / 824 assertions (incl. 10 new parallel conformance fixtures), 0 failures
- [x] `cd implementation && npm run test:cljs` — 483 tests / 1168 assertions, 0 failures
- [x] `cd implementation && npm run test:elision` — PASS
- [x] `python -m mkdocs build --strict` — 180 warnings (unchanged from baseline)