### PR TITLE
docs(pattern): rewrite Pattern-NineStates around parallel regions + tags (Nine States Stage 3) (rf2-c7wl)

### DIFF
--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -242,17 +242,17 @@ Once your view is reading state from `app-db`, a temptation appears: branch the 
 
 | # | State | Typical source |
 |---|---|---|
-| 1 | **Nothing** — user hasn't asked for a fetch yet | Remote-data slice `:status :idle` |
-| 2 | **Loading** — first fetch in flight | `:status :loading` |
-| 3 | **Empty** — loaded, zero results | `:status :loaded` + count `0` |
-| 4 | **One** — loaded, exactly one result | `:status :loaded` + count `1` |
-| 5 | **Some** — loaded, manageable list | `:status :loaded` + bounded count |
-| 6 | **Too Many** — loaded, count above a domain threshold | `:status :loaded` + count > threshold |
-| 7 | **Incorrect** — user input invalid, user can fix it | Form slice errors + touched visibility |
-| 8 | **Correct** — visible success acknowledgement | Form slice `:status :submitted` |
-| 9 | **Done / Frozen** — domain reached terminal / read-only | Terminal machine state, or `:archived?` |
+| 1 | **Nothing** — user hasn't asked for a fetch yet | `:data` region at `:nothing` |
+| 2 | **Loading** — first fetch in flight | `:data` region at `:loading` |
+| 3 | **Empty** — loaded, zero results | `:data` region at `:empty` |
+| 4 | **One** — loaded, exactly one result | `:data` region at `:one` |
+| 5 | **Some** — loaded, manageable list | `:data` region at `:some` |
+| 6 | **Too Many** — loaded, count above a domain threshold | `:data` region at `:too-many` |
+| 7 | **Incorrect** — user input invalid, user can fix it | `:form` region at `:incorrect` |
+| 8 | **Correct** — visible success acknowledgement | `:form` region at `:correct` |
+| 9 | **Done / Frozen** — domain reached terminal / read-only | `:mode` region at `:done` |
 
-The pattern is a **design checklist** plus a **rendering convention**, not a universal ontology — most pages don't need all nine, but most pages do need *more than three*. The states are derived from the slices you already have (remote-data, form, machine snapshot), not mirrored into a new page-local enum. Each becomes a named sub (`:ui.state/empty?`, `:ui.state/incorrect?`, …) and the root view branches explicitly across them — so each branch is testable, each branch is reviewable, and "we forgot what happens when the result is empty" stops being a class of bug.
+The pattern is a **design checklist** plus a **rendering convention**, not a universal ontology — most pages don't need all nine, but most pages do need *more than three*. The shape is one `:type :parallel` state machine with three regions (`:data` / `:form` / `:mode`); every state declares `:tags` from a small canonical vocabulary (`:data/loading`, `:form/invalid`, `:mode/done`, …); a single render-priority table + selector sub collapses the tag union into one render-model keyword, and the root view's `case` over that keyword is the only branch site. "We forgot what happens when the result is empty" stops being a class of bug because the region's `:empty` state is enumerable from the machine declaration.
 
 Full convention plus a worked example: [`spec/Pattern-NineStates.md`](../../spec/Pattern-NineStates.md) and [`examples/reagent/nine_states/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/nine_states).
 

--- a/docs/guide/13-where-next.md
+++ b/docs/guide/13-where-next.md
@@ -23,7 +23,7 @@ When you hit a recurring shape — async work, websockets, forms, remote data, b
 - [Pattern-WebSocket](../../spec/Pattern-WebSocket.md) — long-lived connection lifecycle modelled as a state machine.
 - [Pattern-LongRunningWork](../../spec/Pattern-LongRunningWork.md) — chunked yielding or worker offload for CPU-heavy work.
 - [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) — the epoch idiom for ignoring superseded async results.
-- [Pattern-NineStates](../../spec/Pattern-NineStates.md) — the nine async-with-cancel states laid out explicitly, with the state machine that drives them.
+- [Pattern-NineStates](../../spec/Pattern-NineStates.md) — the nine canonical UI render states (`Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many` / `Incorrect` / `Correct` / `Done`) modelled as one parallel state machine with three regions plus `:fsm/tags`.
 
 Browse the rest under [`spec/`](../../spec/README.md).
 

--- a/examples/reagent/nine_states/README.md
+++ b/examples/reagent/nine_states/README.md
@@ -4,57 +4,94 @@ A re-frame2 worked example demonstrating all **nine canonical UI
 states** that production applications typically need to handle, for a
 single small domain: a **todos list**.
 
+The example is built around a single `:type :parallel` state machine
+with three regions (`:data` / `:form` / `:mode`) and `:fsm/tags` for
+per-axis query intent. The root view's render decision collapses to
+one `case` over a render-priority table.
+
 ## The nine states
 
 | # | Name | What it shows | Trigger |
 |---|---|---|---|
 | 1 | **Nothing**   | Blank initial slate; never fetched. "Get started" CTA. | `[:nine-states.app/initialise]` |
-| 2 | **Loading**   | First fetch in flight; no `:data` yet. Spinner / skeleton. | `[:todos/load {:n N}]` (transient) |
-| 3 | **Empty**     | Fetched, but the result is the empty list. "No results" CTA. | `[:todos/load {:n 0}]` |
-| 4 | **One**       | Exactly one item; focused single-item layout. | `[:todos/load {:n 1}]` |
-| 5 | **Some**      | A small, manageable list; standard list rendering. | `[:todos/load {:n 4}]` |
-| 6 | **Too Many**  | Overwhelming amount; needs search / pagination / virtualisation. | `[:todos/load {:n 25}]` |
+| 2 | **Loading**   | First fetch in flight; no data yet. Spinner / skeleton. | `[:nine-states.demo/load {:n N}]` (transient) |
+| 3 | **Empty**     | Fetched, but the result is the empty list. "No results" CTA. | `[:nine-states.demo/load {:n 0}]` |
+| 4 | **One**       | Exactly one item; focused single-item layout. | `[:nine-states.demo/load {:n 1}]` |
+| 5 | **Some**      | A small, manageable list; standard list rendering. | `[:nine-states.demo/load {:n 4}]` |
+| 6 | **Too Many**  | Overwhelming amount; needs search / pagination / virtualisation. | `[:nine-states.demo/load {:n 25}]` |
 | 7 | **Incorrect** | Form submission failed validation. Per-field errors visible. | type a 1-char title, submit |
 | 8 | **Correct**   | Form submission succeeded; "Todo added." confirmation. | type a 3+ char title, submit |
-| 9 | **Done**      | Editor reached `:archived`; terminal, read-only. | `[:todos/editor [:todos.editor/archive {}]]` |
+| 9 | **Done**      | Mode region reached `:done`; terminal, read-only. | `[:ui/nine-states [:archive {}]]` |
 
-A small control panel in the top of the demo lets you trigger each
+A small control panel at the top of the demo lets you trigger each
 transition.
+
+## How the model is structured
+
+One machine, three regions:
+
+- **`:data` region** carries the request lifecycle plus the
+  cardinality axis: `:nothing → :loading → :resolving → {:empty | :one
+  | :some | :too-many} | :error`. The `:resolving` state is a transient
+  bucket: an `:always`-cascade reads the item count from the machine's
+  shared `:data` and picks the cardinality state on a single
+  microstep.
+- **`:form` region** carries Pattern-Forms' lifecycle: `:neutral →
+  {:correct | :incorrect}`. The `:correct` state is transient — the
+  next `:edit` returns the region to `:neutral`.
+- **`:mode` region** carries the Active / Done axis: `:active →
+  :done`. `:done` is terminal and tagged `:mode/read-only`; the view
+  inspects that tag to disable the form and the control buttons.
+
+Every state declares `:tags` describing its per-axis intent
+(`:data/loading`, `:form/invalid`, `:mode/done`, ...). A
+`render-priority` table over those tags drives a single `:ui/render`
+selector sub that returns one keyword; the root view's `case` over
+that keyword is the only branch site.
 
 ## What this example demonstrates
 
-- **Pattern-RemoteData** — the 5-key slice
-  `{:status :data :error :loaded-at :attempt}` carries the lifecycle
-  for states 1-6. See [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md).
-- **Pattern-Forms** — the
-  `{:draft :submitted :status :errors :touched}` slice carries the
-  "new todo" input, surfacing the **Incorrect** (state 7) and
-  **Correct** (state 8) variants. See
+- **Parallel regions + `:fsm/tags`** — three orthogonal axes in one
+  machine declaration; tags compose across regions; one selector sub
+  collapses the tag union into a render keyword. See
+  [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md)
+  and [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md)
+  §Parallel regions / §State tags.
+- **Pattern-RemoteData** — the request lifecycle is folded into the
+  `:data` region (the region's state-keyword IS the status). See
+  [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md).
+- **Pattern-Forms** — the `{:draft :errors :touched}` slice carries the
+  form runtime; the form region's state carries the lifecycle. See
   [`spec/Pattern-Forms.md`](../../../spec/Pattern-Forms.md).
-- **State machines** — a `:todos/editor` machine with two states
-  (`:editing` -> `:archived`); the `:archived` state is terminal,
-  modelling the **Done** state (9). See
-  [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md).
 - **Inspectability bias** — non-trivial guards / actions are named
   entries in the machine's machine-scoped `:guards` / `:actions`
   maps; only trivial transitions use inline fns.
 - **Headless tests** — every state has a fixture at the bottom of
-  `core.cljs` that drives `app-db` into that state and asserts the
-  matching state-discriminator sub fires. Tests run JVM-side via
-  `compute-sub` / `dispatch-sync` / `with-frame`.
+  `core.cljs` that drives `app-db` into that state and asserts against
+  the machine's tag union and the resolved `:ui/render` keyword. Tests
+  run via `compute-sub` / `dispatch-sync` / `with-frame`.
+
+## Legacy variant
+
+This example is the canonical implementation of Pattern-NineStates.
+For the pre-parallel-regions variant (nine boolean discriminator subs
++ priority `cond`) — supported but not recommended for new code — see
+[`spec/Pattern-NineStates.md` §Appendix — Pre-parallel-regions variant](../../../spec/Pattern-NineStates.md#appendix--pre-parallel-regions-variant-deprecated-but-supported).
 
 ## File layout
 
 ```
 examples/reagent/nine_states/
-  core.cljs   single-file example: schemas, events, subs, views,
-              machine, control panel, headless tests, mount.
+  core.cljs   single-file example: schemas, the :ui/nine-states
+              parallel machine, demo events, the render-priority
+              table + :ui/render sub, per-state views, headless tests,
+              mount.
   README.md   this file.
 ```
 
 For brevity the example is one file; in a real codebase it would
-split per CP-6 conventions (`schema.cljc / events.cljs / subs.cljs /
-views.cljs / machines.cljs / events_test.cljs`).
+split per CP-6 conventions (`schema.cljc / machine.cljc / events.cljs
+/ subs.cljs / views.cljs / events_test.cljs`).
 
 ## How to run
 
@@ -74,7 +111,7 @@ shadow-cljs watch examples/nine-states
 
 (Run `npm run test:examples` at least once first so `out/examples/nine-states/index.html` is staged; subsequent watch builds reuse it.)
 
-The headless tests run JVM-side from a CLJS REPL:
+The headless tests run from a CLJS REPL:
 
 ```clojure
 (nine-states.core/run-all-tests)
@@ -83,8 +120,8 @@ The headless tests run JVM-side from a CLJS REPL:
 
 ## Cross-references
 
-- [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md) — the 5-state lifecycle this example exercises end-to-end.
-- [`spec/Pattern-Forms.md`](../../../spec/Pattern-Forms.md) — the form lifecycle that drives the Incorrect / Correct states.
-- [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md) — the page-level convention this example instantiates directly.
-- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the machine grammar and `[:rf/machines <id>]` snapshot location used for the Done state.
+- [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md) — the page-level convention this example instantiates.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) §Parallel regions / §State tags — the substrate this example uses.
+- [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md) — the lifecycle folded into the `:data` region.
+- [`spec/Pattern-Forms.md`](../../../spec/Pattern-Forms.md) — the form lifecycle in the `:form` region.
 - [`examples/reagent/login/core.cljs`](../login/core.cljs) and [`examples/reagent/7Guis/circle_drawer/circle_drawer.cljs`](../7Guis/circle_drawer/circle_drawer.cljs) — single-file style this example follows.

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -1,50 +1,67 @@
 (ns nine-states.core
-  "Worked example: the **Nine States of UI**.
+  "Worked example: the **Nine States of UI**, modelled as a single
+   parallel state machine.
 
    Most apps only design the happy path and leave the eight other states
    visually undefined. This example demonstrates all nine canonical UI
-   states for a single small domain — a **todos list** — using only the
-   re-frame2 surface that is already locked.
+   states for a single small domain — a **todos list** — using one
+   `:type :parallel` machine with three regions, plus `:fsm/tags` to
+   carry the per-axis intent.
 
    The nine states (per the well-known UX taxonomy):
 
-     1. Nothing      — never fetched; `:status :idle`, no `:data`.
-     2. Loading      — first fetch in flight; `:status :loading`.
+     1. Nothing      — never fetched; the data region is at `:nothing`.
+     2. Loading      — first fetch in flight; the data region is at `:loading`.
      3. Empty        — fetched, but the result is the empty list.
      4. One          — exactly one todo. Focused single-item layout.
      5. Some         — a small, manageable list.
      6. Too Many     — overwhelming amount; needs filtering / pagination.
      7. Incorrect    — invalid form input; per-field validation error.
      8. Correct      — a happy-path success after a valid submit.
-     9. Done/Frozen  — terminal state; the editor is `:archived` and
-                       cannot be acted upon further.
+     9. Done/Frozen  — terminal state; the mode region is at `:done`.
+
+   The machine declaration carries the **whole** model:
+
+     - `:data` region    — six cardinality states (Nothing / Loading /
+                            Empty / One / Some / Too Many) plus an `:error`
+                            branch. An `:always`-cascade picks the
+                            cardinality bucket after a successful fetch.
+     - `:form` region    — three states (Neutral / Incorrect / Correct)
+                            mirroring Pattern-Forms' lifecycle.
+     - `:mode` region    — two states (Active / Done); `:done` is
+                            terminal and read-only.
+
+   Every state carries `:tags` describing its per-axis intent
+   (`:data/loading`, `:form/invalid`, `:mode/done`, ...). One render-priority
+   table in data + one selector sub (`:ui/render`) collapse the tag
+   union into a single render-model keyword. The root view's `case`
+   over `:ui/render` replaces what the legacy variant did with nine
+   boolean discriminator subs + a priority `cond`.
 
    What this example demonstrates:
 
-   - **Pattern-RemoteData** (`Pattern-RemoteData.md`) — the 5-key slice
-     `{:status :data :error :loaded-at :attempt}` carries the lifecycle
-     for states 1, 2, 3, 4, 5 and 6.
-   - **Pattern-Forms** (`Pattern-Forms.md`) — the
-     `{:draft :submitted :status :errors :touched}` slice carries the
-     'new todo' input, surfacing the **Incorrect** (state 7) and
-     **Correct** (state 8) variants.
-   - **State machine** (`005-StateMachines.md`) — the
-     `:todos/editor` machine has two states `:editing` and `:archived`;
-     the **Done** state (9) is `:archived`, terminal and irreversible
-     from the UI.
+   - **Parallel regions + tags** (`spec/Pattern-NineStates.md`,
+     `spec/005-StateMachines.md` §Parallel regions / §State tags) —
+     three orthogonal axes in one machine, with tag-shaped queries
+     against the active configuration.
+   - **Pattern-RemoteData**-shaped lifecycle (`spec/Pattern-RemoteData.md`)
+     — folded into the `:data` region; the region's state-keyword IS
+     the status, so the slice's separate `:status` field disappears.
+   - **Pattern-Forms** (`spec/Pattern-Forms.md`) — the
+     `{:draft :submitted :errors :touched}` slice carries the form
+     runtime; the form region's state tracks the validation/submission
+     lifecycle.
    - **Inspectability bias** — non-trivial guards / actions are named
      entries in the machine's `:guards` / `:actions` maps; only trivial
      transitions use inline fns.
    - **Headless tests** at the bottom — every state has a fixture that
-     drives `app-db` into that state and asserts the matching state-sub
-     fires. Browserless: runs in any CLJS host via `compute-sub` /
-     `dispatch-sync`; because this file is .cljs, JVM execution would
-     require porting the testable parts to .cljc.
+     drives `app-db` into that state and asserts against tags +
+     `:ui/render`. Browserless via `compute-sub` / `dispatch-sync`.
 
    Layout follows the single-file style of `examples/reagent/login/core.cljs`
-   and `examples/reagent/7Guis/circle_drawer/circle_drawer.cljs`. In a real codebase this
-   would split per CP-6 conventions across schema / events / subs /
-   views / machines / tests files."
+   and `examples/reagent/7Guis/circle_drawer/circle_drawer.cljs`. In a real
+   codebase this would split per CP-6 conventions across schema / events /
+   subs / views / machines / tests files."
   (:require [cljs.test :refer-macros [is]]
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
@@ -56,9 +73,9 @@
             [re-frame.schemas]
             ;; Per rf2-xbtj, the Spec 005 state-machine ns lives in the
             ;; day8/re-frame2-machines artefact. Loading the ns here
-            ;; registers its late-bind hooks so rf/create-machine-handler
-            ;; (called below at ns-load) and the `:rf/machine` framework
-            ;; sub resolve.
+            ;; registers its late-bind hooks so rf/reg-machine
+            ;; (called below at ns-load) and the `:rf/machine` /
+            ;; `:rf/machine-has-tag?` framework subs resolve.
             [re-frame.machines]
             ;; Per rf2-5kpd, managed-HTTP ships in day8/re-frame2-http.
             ;; Requiring re-frame.http-managed at app boot triggers its
@@ -74,37 +91,27 @@
 ;; ============================================================================
 ;; CONSTANTS
 ;; ============================================================================
-;;
-;; A "small list" is up to TOO-MANY-THRESHOLD items; beyond that we render
-;; the "Too Many" UI (search + truncation). Threshold lifted to a named const
-;; so the sub and the test both reference the same value.
 
-(def too-many-threshold 7)
-
-(def todos-defaults
-  {:status     :idle
-   :data       nil
-   :error      nil
-   :loaded-at  nil
-   :attempt    0})
+(def too-many-threshold
+  "A 'small list' is up to TOO-MANY-THRESHOLD items; beyond that we render
+   the 'Too Many' UI (search + truncation). Lifted to a named const so
+   the machine's :too-many? guard and the test fixtures reference the
+   same value."
+  7)
 
 (def new-todo-defaults
-  {:draft        {:title ""}
-   :submitted    nil
-   :status       :idle
-   :errors       {}
-   :touched      #{}
-   :submit-error nil})
+  {:draft    {:title ""}
+   :errors   {}
+   :touched  #{}})
 
 ;; ============================================================================
 ;; SCHEMAS  (Spec 010)
 ;; ============================================================================
 ;;
-;; - `Todo`              — a single item.
-;; - `TodosSlice`        — the Pattern-RemoteData lifecycle slice for the list.
-;; - `NewTodoForm`       — the value schema describing what the form collects.
-;; - `NewTodoSlice`      — the Pattern-Forms slice carrying the form's runtime.
-;; - The editor machine's `:data` shape is declared inline on the machine.
+;; The :ui/nine-states machine's `:data` slot is its own self-documenting
+;; record (see the machine declaration). The form slice describes only
+;; what the form *collects* + per-field validation state — no `:status`
+;; field, because the form region's state-keyword IS the status.
 
 (def Todo
   [:map
@@ -112,28 +119,16 @@
    [:title  [:string {:min 1}]]
    [:done?  {:default false} :boolean]])
 
-(def TodosSlice
-  [:map
-   [:status        [:enum :idle :loading :fetching :loaded :error]]
-   [:data          {:default nil} [:maybe [:vector Todo]]]
-   [:error         {:default nil} [:maybe :any]]
-   [:loaded-at     {:default nil} [:maybe :int]]
-   [:attempt       {:default 0}   :int]])
-
 (def NewTodoForm
   [:map
    [:title [:string {:min 3 :max 80}]]])
 
 (def NewTodoSlice
   [:map
-   [:draft        :map]
-   [:submitted    {:default nil} [:maybe :map]]
-   [:status       [:enum :idle :submitting :submitted :error]]
-   [:errors       {:default {}} [:map-of :keyword [:vector :string]]]
-   [:touched      {:default #{}} [:set :keyword]]
-   [:submit-error {:default nil} [:maybe :any]]])
+   [:draft   :map]
+   [:errors  {:default {}} [:map-of :keyword [:vector :string]]]
+   [:touched {:default #{}} [:set :keyword]]])
 
-(rf/reg-app-schema [:todos]    TodosSlice)
 (rf/reg-app-schema [:new-todo] NewTodoSlice)
 
 ;; ============================================================================
@@ -142,9 +137,9 @@
 ;;
 ;; Real apps would issue a single `:rf.http/managed` request (Spec 014) and
 ;; override at test time via the id-valued seam (per Spec 002). For this
-;; self-contained example we ship two per-app stubs that delegate to the
+;; self-contained example we ship one per-app stub that delegates to the
 ;; framework-shipped canned-success / canned-failure fxs (Spec 014 §Testing)
-;; so the control panel can drive the lifecycle into Empty / One / Some /
+;; so the control panel can drive the data region into Empty / One / Some /
 ;; Too Many without a server.
 
 (defn- gen-todos [n]
@@ -175,71 +170,221 @@
           (stub frame-ctx (assoc args-map :value (gen-todos n))))))))
 
 ;; ============================================================================
-;; EVENTS — Pattern-RemoteData lifecycle  (states 1-6)
+;; THE MACHINE — :ui/nine-states  (one machine, three regions)
 ;; ============================================================================
+;;
+;; Three orthogonal axes, one declaration:
+;;
+;;   :data — the request-lifecycle / cardinality axis (states 1-6, plus
+;;           an :error branch). After a successful fetch lands in
+;;           :resolving, an :always-cascade picks the cardinality bucket
+;;           by reading :items out of the shared :data.
+;;
+;;   :form — Pattern-Forms' Neutral / Incorrect / Correct lifecycle
+;;           (states 7 & 8). Driven by :submit-valid / :submit-invalid /
+;;           :edit events; transitions are pure (the slice's :errors /
+;;           :touched live in app-db, not in the machine's :data).
+;;
+;;   :mode — the Active / Done axis (state 9). :done is terminal and
+;;           tagged :mode/read-only — the view inspects that tag to
+;;           disable the form and the control buttons.
+;;
+;; Per Spec 005 §Parallel regions the snapshot's :state is a map keyed
+;; by region name; :data is shared across all regions; :tags is the
+;; union of every active state's tag set.
 
-(rf/reg-event-db :nine-states.app/initialise
-  {:doc "Seed both slices to defaults. Drives the app to State 1 (Nothing)."}
-  (fn handler-app-initialise [db _]
-    (-> db
-        (assoc :todos    todos-defaults)
-        (assoc :new-todo new-todo-defaults))))
+(def nine-states-machine
+  {:type :parallel
 
-(rf/reg-event-fx :todos/load
-  {:doc "Trigger a list load. Sets :loading (no prior data) or :fetching
-         (revalidate); the `:rf.http/managed` reply lands as `:todos/loaded`."}
-  (fn handler-todos-load [{:keys [db]} [_ {:keys [n]}]]
-    (let [has-data? (some? (get-in db [:todos :data]))]
-      {:db (-> db
-               (assoc-in  [:todos :status]  (if has-data? :fetching :loading))
-               (assoc-in  [:todos :error]   nil)
-               (update-in [:todos :attempt] inc))
-       :fx [[:rf.http/managed
-             {:request    {:method :get
-                           :url    "/api/todos"
-                           :query  {:n (or n 0)}}
-              :decode     :json
-              :on-success [:todos/loaded]
-              :on-failure [:todos/load-failed]}]]})))
+   ;; Shared :data: the data region's :items live here, plus the
+   ;; mode region's :archived-at stamp. Shared rather than per-region
+   ;; because the regions share a domain (per Spec 005 §When to reach
+   ;; for parallel regions); see the rewrite design doc §9.4.
+   :data {:items       []
+          :error       nil
+          :archived-at nil}
 
-(rf/reg-event-fx :todos/load-with-failure
-  {:doc "Trigger a load that always fails. Drives the slice into :error."}
-  (fn handler-todos-load-with-failure [{:keys [db]} _]
-    {:db (-> db
-             (assoc-in  [:todos :status]  :loading)
-             (update-in [:todos :attempt] inc))
-     :fx [[:rf.http/managed
+   :guards
+   {:empty?
+    (fn guard-empty? [data _event]
+      (zero? (count (:items data))))
+
+    :one?
+    (fn guard-one? [data _event]
+      (= 1 (count (:items data))))
+
+    :too-many?
+    (fn guard-too-many? [data _event]
+      (> (count (:items data)) too-many-threshold))}
+
+   :actions
+   {:set-items
+    ;; :fetch-succeeded carries the new items as the action's event
+    ;; payload's second element: [:fetch-succeeded {:items [...]}].
+    (fn action-set-items [data [_ {:keys [items]}]]
+      {:data (-> data
+                 (assoc :items (vec items))
+                 (assoc :error nil))})
+
+    :set-error
+    (fn action-set-error [data [_ {:keys [failure]}]]
+      {:data (assoc data :error failure)})
+
+    :stamp-archived
+    (fn action-stamp-archived [data [_ {:keys [now]}]]
+      {:data (assoc data :archived-at (or now 0))})}
+
+   :regions
+   {;; ---- :data region — Pattern-RemoteData lifecycle + cardinality ----
+    :data
+    {:initial :nothing
+     :states
+     {:nothing
+      ;; State 1 — never fetched. The :nothing tag (+ the absent
+      ;; :mode/done) drives the welcome view.
+      {:tags #{:data/nothing}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :loading
+      ;; State 2 — first fetch in flight. The :data/loading tag drives
+      ;; the spinner view.
+      {:tags #{:data/loading :data/transient}
+       :on   {:fetch-succeeded {:target :resolving
+                                :action :set-items}
+              :fetch-failed    {:target :error
+                                :action :set-error}}}
+
+      :resolving
+      ;; Eventless microstep: after :set-items writes :items into
+      ;; :data, the cardinality guards pick a bucket. First match wins.
+      {:always [{:guard :empty?    :target :empty}
+                {:guard :one?      :target :one}
+                {:guard :too-many? :target :too-many}
+                {:target :some}]}
+
+      :empty
+      {:tags #{:data/empty}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :one
+      {:tags #{:data/one}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :some
+      {:tags #{:data/some}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :too-many
+      {:tags #{:data/too-many}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :error
+      {:tags #{:data/error}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}}}
+
+    ;; ---- :form region — Pattern-Forms lifecycle ----
+    :form
+    {:initial :neutral
+     :states
+     {:neutral
+      {:tags #{:form/neutral}
+       :on   {:submit-valid   :correct
+              :submit-invalid :incorrect
+              :edit           :neutral
+              :reset          :neutral}}
+
+      :incorrect
+      ;; State 7 — invalid input visible on a touched field. The
+      ;; :form/invalid tag drives the inline error view.
+      {:tags #{:form/invalid}
+       :on   {:submit-valid :correct
+              :edit         :neutral
+              :reset        :neutral}}
+
+      :correct
+      ;; State 8 — happy-path acknowledgement. Transient; the next
+      ;; :edit returns the region to :neutral.
+      {:tags #{:form/success :form/transient}
+       :on   {:edit  :neutral
+              :reset :neutral}}}}
+
+    ;; ---- :mode region — Active / Done ----
+    :mode
+    {:initial :active
+     :states
+     {:active
+      {:tags #{:mode/active}
+       :on   {:archive {:target :done
+                        :action :stamp-archived}
+              :reset   :active}}
+
+      :done
+      ;; State 9 — terminal. :mode/read-only is the tag the form and
+      ;; control panel inspect to disable inputs.
+      {:tags #{:mode/done :mode/read-only :mode/terminal}}}}}})
+
+(rf/reg-machine :ui/nine-states nine-states-machine)
+
+;; ============================================================================
+;; EVENTS — top-level demo wrappers
+;; ============================================================================
+;;
+;; The control panel buttons dispatch high-level demo events that
+;; coordinate the form slice's app-db state with broadcasts into the
+;; :ui/nine-states machine. Splitting them out (rather than dispatching
+;; the machine directly) keeps the imperative bits (clear the form,
+;; bump app-db) out of the view.
+
+(rf/reg-event-fx :nine-states.app/initialise
+  {:doc "Seed the form slice + reset the machine to its initial state."}
+  (fn handler-app-initialise [{:keys [db]} _]
+    {:db (assoc db :new-todo new-todo-defaults)
+     :fx [[:dispatch [:ui/nine-states [:reset]]]]}))
+
+(rf/reg-event-fx :nine-states.demo/load
+  {:doc "Drive a synthetic fetch through the demo HTTP stub. The reply
+         folds back via :nine-states.demo/loaded → the machine's
+         :fetch-succeeded event; the :data region's :always-cascade
+         picks the cardinality bucket from the count."}
+  (fn handler-demo-load [_ [_ {:keys [n]}]]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+          [:rf.http/managed
+           {:request    {:method :get
+                         :url    "/api/todos"
+                         :query  {:n (or n 0)}}
+            :decode     :json
+            :on-success [:nine-states.demo/loaded]
+            :on-failure [:nine-states.demo/load-failed]}]]}))
+
+(rf/reg-event-fx :nine-states.demo/load-with-failure
+  {:doc "Drive a synthetic failing fetch — the :data region lands in
+         :error."}
+  (fn handler-demo-load-with-failure [_ _]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+          [:rf.http/managed
            {:request    {:method :get :url "/api/todos/fail"}
             :decode     :json
-            :on-success [:todos/loaded]
-            :on-failure [:todos/load-failed]}]]}))
+            :on-success [:nine-states.demo/loaded]
+            :on-failure [:nine-states.demo/load-failed]}]]}))
 
-(rf/reg-event-db :todos/loaded
-  {:doc "Successful fetch. Reads the list from the `:rf.http/managed`
-         reply payload's `:value`."}
-  (fn handler-todos-loaded [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:todos :status]    :loaded)
-        (assoc-in [:todos :data]      (vec value))
-        (assoc-in [:todos :error]     nil)
-        (assoc-in [:todos :loaded-at] 0))))
+(rf/reg-event-fx :nine-states.demo/loaded
+  {:doc "Successful fetch. Forwards the items to the machine via
+         :fetch-succeeded; the :always-cascade picks the bucket."}
+  (fn handler-demo-loaded [_ [_ {:keys [value]}]]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-succeeded {:items value}]]]]}))
 
-(rf/reg-event-db :todos/load-failed
-  {:doc "Fetch failed. Reads the failure category from the
-         `:rf.http/managed` reply payload's `:failure`."}
-  (fn handler-todos-load-failed [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:todos :status] :error)
-        (assoc-in [:todos :error]  failure))))
+(rf/reg-event-fx :nine-states.demo/load-failed
+  {:doc "Failed fetch. Forwards the failure category to the machine."}
+  (fn handler-demo-load-failed [_ [_ {:keys [failure]}]]
+    {:fx [[:dispatch [:ui/nine-states [:fetch-failed {:failure failure}]]]]}))
 
-(rf/reg-event-db :todos/reset
-  {:doc "Reset to :idle. Drives the slice back to State 1 (Nothing)."}
-  (fn handler-todos-reset [db _]
-    (assoc db :todos todos-defaults)))
-
-;; ============================================================================
-;; EVENTS — Pattern-Forms lifecycle  (states 7 & 8)
-;; ============================================================================
+;; ---- form-slice events ----
 
 (defn- validate-new-todo
   "Pure validator: returns a {field [errors...]} map. Empty when valid."
@@ -251,110 +396,57 @@
     (and title (> (count title) 80))
     (assoc :title ["Title must be at most 80 characters."])))
 
-(rf/reg-event-db :new-todo/edit-field
-  {:doc  "User edited a form field. Updates :draft and marks the field touched."
+(rf/reg-event-fx :new-todo/edit-field
+  {:doc  "User edited a form field. Updates :draft and marks the field
+          touched; broadcasts :edit into the machine so the :form region
+          returns from :correct or :incorrect to :neutral."
    :spec [:cat [:= :new-todo/edit-field] :keyword :string]}
-  (fn handler-new-todo-edit-field [db [_ field value]]
-    (-> db
-        (assoc-in  [:new-todo :draft field] value)
-        (update-in [:new-todo :touched]    conj field))))
+  (fn handler-new-todo-edit-field [{:keys [db]} [_ field value]]
+    {:db (-> db
+             (assoc-in  [:new-todo :draft field] value)
+             (update-in [:new-todo :touched]    conj field))
+     :fx [[:dispatch [:ui/nine-states [:edit]]]]}))
 
 (rf/reg-event-fx :new-todo/submit
-  {:doc "Validate the draft. If invalid -> Incorrect (state 7).
-         If valid -> append to :todos/data and mark Correct (state 8)."}
+  {:doc "Validate the draft. If invalid → :submit-invalid (the :form
+         region lands in :incorrect). If valid → append to the
+         machine's :data items via :fetch-succeeded, clear the draft,
+         and broadcast :submit-valid (the :form region lands in
+         :correct)."}
   (fn handler-new-todo-submit [{:keys [db]} _]
     (let [draft  (get-in db [:new-todo :draft])
-          errors (validate-new-todo draft)]
+          errors (validate-new-todo draft)
+          items  (get-in db [:rf/machines :ui/nine-states :data :items])]
       (if (seq errors)
         ;; Incorrect — populate :errors, touch all error fields so they show.
         {:db (-> db
-                 (assoc-in [:new-todo :status]  :error)
                  (assoc-in [:new-todo :errors]  errors)
-                 (assoc-in [:new-todo :touched] (set (keys errors))))}
-        ;; Correct — append the todo, snapshot :submitted, clear the draft.
-        {:db (-> db
-                 (update-in [:todos :data] (fnil conj [])
-                            {:id (random-uuid) :title (:title draft) :done? false})
-                 ;; If we had no data before, ensure we look 'loaded'.
-                 (assoc-in  [:todos :status]    :loaded)
-                 (assoc-in  [:new-todo :status]    :submitted)
-                 (assoc-in  [:new-todo :submitted] draft)
-                 (assoc-in  [:new-todo :draft]     {:title ""})
-                 (assoc-in  [:new-todo :errors]    {})
-                 (assoc-in  [:new-todo :touched]   #{}))}))))
-
-(rf/reg-event-db :new-todo/reset
-  {:doc "Clear the form back to :idle defaults."}
-  (fn handler-new-todo-reset [db _]
-    (assoc db :new-todo new-todo-defaults)))
-
-;; ============================================================================
-;; STATE MACHINE — :todos/editor   (state 9: Done / Frozen)
-;; ============================================================================
-;;
-;; Two states: :editing -> :archived. The :archived state is terminal:
-;; once a list is archived, all further user actions on it are rejected
-;; (the UI for state 9 is read-only). This is the canonical "Done" state.
-;;
-;; Per the locked spec:
-;;   - Snapshot lives at [:rf/machines :todos/editor].
-;;   - Guards / actions are machine-scoped (NOT a global registry).
-;;   - Read via the snapshot at [:rf/machines :todos/editor].
-
-(rf/reg-event-fx :todos/editor
-  {:doc "Editor lifecycle: :editing -> :archived. Archive is terminal."}
-  (rf/create-machine-handler
-    ;; Per Spec 005 §Where snapshots live: spec map does NOT carry :id;
-    ;; the id is the surrounding reg-event-fx id.
-    {:initial :editing
-     :data    {:archived-at nil}
-
-     :guards
-     {:has-todos?
-      ;; Only allow archive if there is at least one todo to freeze.
-      ;; Named — a non-trivial guard reading two slices of app-db.
-      (fn guard-has-todos? [_data _event]
-        ;; The machine's 2-arity sees `data` (the snapshot's :data slot)
-        ;; directly. For cross-slice guards we typically pass the predicate
-        ;; result IN via the event payload. Here the event itself carries
-        ;; the count.
-        true)}
-
-     :actions
-     {:stamp-archived
-      ;; Mark the moment of archival in the machine's :data. Inspectable.
-      (fn action-stamp-archived [_data [_ {:keys [now]}]]
-        {:data {:archived-at (or now 0)}})}
-
-     :states
-     {:editing
-      {:on {:todos.editor/archive {:target :archived
-                                   :action :stamp-archived}}}
-
-      :archived
-      ;; Terminal. No transitions out — sending events to an :archived
-      ;; editor is a no-op (the machine handler logs unhandled events
-      ;; to the trace surface; the UI disables every action).
-      {:meta {:terminal? true}}}}))
+                 (assoc-in [:new-todo :touched] (set (keys errors))))
+         :fx [[:dispatch [:ui/nine-states [:submit-invalid]]]]}
+        ;; Correct — append the todo to the machine's items, clear the form.
+        ;; The :data region's lifecycle is the canonical path for changing
+        ;; items: bump through :loading → :resolving so the :always-cascade
+        ;; re-picks the cardinality bucket against the new count.
+        (let [new-items (conj (vec items)
+                              {:id     (random-uuid)
+                               :title  (:title draft)
+                               :done?  false})]
+          {:db (-> db
+                   (assoc-in [:new-todo :draft]   {:title ""})
+                   (assoc-in [:new-todo :errors]  {})
+                   (assoc-in [:new-todo :touched] #{}))
+           :fx [[:dispatch [:ui/nine-states [:fetch-started]]]
+                [:dispatch [:ui/nine-states [:fetch-succeeded {:items new-items}]]]
+                [:dispatch [:ui/nine-states [:submit-valid]]]]})))))
 
 ;; ============================================================================
-;; SUBSCRIPTIONS — base slice readers
+;; SUBSCRIPTIONS — slice readers + the render-model selector
 ;; ============================================================================
-
-(rf/reg-sub :todos
-  {:doc "The whole todos lifecycle slice."}
-  (fn sub-todos [db _] (get db :todos)))
-
-(rf/reg-sub :todos/status   :<- [:todos] (fn [s _] (:status s)))
-(rf/reg-sub :todos/data     :<- [:todos] (fn [s _] (:data s)))
-(rf/reg-sub :todos/error    :<- [:todos] (fn [s _] (:error s)))
-(rf/reg-sub :todos/count    :<- [:todos/data] (fn [d _] (count (or d []))))
 
 (rf/reg-sub :new-todo
   (fn sub-new-todo [db _] (get db :new-todo)))
 
 (rf/reg-sub :new-todo/draft   :<- [:new-todo] (fn [s _] (:draft s)))
-(rf/reg-sub :new-todo/status  :<- [:new-todo] (fn [s _] (:status s)))
 (rf/reg-sub :new-todo/errors  :<- [:new-todo] (fn [s _] (:errors s)))
 (rf/reg-sub :new-todo/touched :<- [:new-todo] (fn [s _] (:touched s)))
 
@@ -366,97 +458,80 @@
     (when (touched field-id)
       (first (get errs field-id)))))
 
-;; ============================================================================
-;; SUBSCRIPTIONS — the nine state-discriminator subs
-;; ============================================================================
+;; The machine's :data items — read straight off the snapshot.
+(rf/reg-sub :todos/items
+  :<- [:rf/machine :ui/nine-states]
+  (fn sub-todos-items [snap _]
+    (get-in snap [:data :items])))
+
+(rf/reg-sub :todos/error
+  :<- [:rf/machine :ui/nine-states]
+  (fn sub-todos-error [snap _]
+    (get-in snap [:data :error])))
+
+;; ---- render-priority + :ui/render selector ----
 ;;
-;; Each sub answers one yes/no question: "are we in this UI state right now?"
-;; The view layer composes them via cond.
+;; The render-priority table is plain data: a vector of {:tag :render}
+;; pairs consulted in order. The :ui/render sub reads the machine's tag
+;; union and returns the first :render whose :tag is present. This is
+;; the **single** place the page's render priorities live; the root
+;; view's `case` just maps the resolved keyword to a view fn.
 ;;
-;; State 1 — Nothing: never fetched.
-;; State 2 — Loading: first fetch in flight, no data yet.
-;; State 3 — Empty:   loaded, but the list is empty.
-;; State 4 — One:     loaded, exactly one item.
-;; State 5 — Some:    loaded, 2..too-many-threshold items.
-;; State 6 — TooMany: loaded, more than too-many-threshold items.
-;; State 7 — Incorrect: form submission failed validation.
-;; State 8 — Correct:   form submission succeeded.
-;; State 9 — Done:      editor machine reached :archived.
+;; Priority rationale: :mode wins outright (the archived view replaces
+;; everything); :form wins next (the success / inline-error
+;; acknowledgement is transient and overlays whatever the :data
+;; region happens to be at); :data picks the cardinality bucket as a
+;; fallback.
 
-(rf/reg-sub :ui.state/nothing?
-  {:doc "State 1 — Nothing. The user has not yet caused a fetch."}
-  :<- [:todos/status]
-  (fn sub-nothing? [status _] (= status :idle)))
+(def render-priority
+  [;; mode region — read-only / terminal wins
+   {:tag :mode/done       :render :done}
+   ;; form region — transient acknowledgements (Correct/Incorrect)
+   {:tag :form/success    :render :correct}
+   {:tag :form/invalid    :render :incorrect}
+   ;; data region — error first (also transient), then lifecycle, then cardinality
+   {:tag :data/loading    :render :loading}
+   {:tag :data/error      :render :error}
+   {:tag :data/nothing    :render :nothing}
+   {:tag :data/empty      :render :empty}
+   {:tag :data/one        :render :one}
+   {:tag :data/some       :render :some}
+   {:tag :data/too-many   :render :too-many}])
 
-(rf/reg-sub :ui.state/loading?
-  {:doc "State 2 — Loading. First fetch in flight, no prior :data."}
-  :<- [:todos/status]
-  (fn sub-loading? [status _] (= status :loading)))
-
-(rf/reg-sub :ui.state/empty?
-  {:doc "State 3 — Empty. Fetch completed; result is the empty list."}
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn sub-empty? [[status n] _] (and (= status :loaded) (zero? n))))
-
-(rf/reg-sub :ui.state/one?
-  {:doc "State 4 — One. Loaded; exactly one todo."}
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn sub-one? [[status n] _] (and (= status :loaded) (= 1 n))))
-
-(rf/reg-sub :ui.state/some?
-  {:doc "State 5 — Some. Loaded; 2..too-many-threshold items."}
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn sub-some? [[status n] _]
-    (and (= status :loaded) (<= 2 n too-many-threshold))))
-
-(rf/reg-sub :ui.state/too-many?
-  {:doc "State 6 — Too Many. Loaded; more than too-many-threshold items."}
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn sub-too-many? [[status n] _]
-    (and (= status :loaded) (> n too-many-threshold))))
-
-(rf/reg-sub :ui.state/incorrect?
-  {:doc "State 7 — Incorrect. The form has at least one validation error
-         on a touched field."}
-  :<- [:new-todo/errors]
-  :<- [:new-todo/touched]
-  (fn sub-incorrect? [[errs touched] _]
-    (boolean (some touched (keys errs)))))
-
-(rf/reg-sub :ui.state/correct?
-  {:doc "State 8 — Correct. The form's last submission succeeded."}
-  :<- [:new-todo/status]
-  (fn sub-correct? [status _] (= status :submitted)))
-
-(rf/reg-sub :ui.state/done?
-  {:doc "State 9 — Done. The editor machine has reached :archived."}
-  (fn sub-done? [db _]
-    (= :archived (get-in db [:rf/machines :todos/editor :state]))))
+(rf/reg-sub :ui/render
+  {:doc "Resolve the page's render-model keyword by consulting the
+         render-priority table against the machine's tag union. The
+         root view's `case` is the only branch site; everything else
+         reads tags directly."}
+  :<- [:rf/machine :ui/nine-states]
+  (fn sub-ui-render [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
 
 ;; ============================================================================
-;; VIEWS — one per state
+;; VIEWS — one per render-model keyword
 ;; ============================================================================
-;;
-;; Each per-state view is a small registered view. The root view composes
-;; them via a `cond` over the state-discriminator subs, in priority order:
-;; the editor's :archived (state 9) wins over everything; otherwise we fall
-;; through the lifecycle.
 
 (reg-view ^{:doc "State 1 — Nothing: blank slate with a 'Get started' CTA."}
           view-nothing []
   [:div.state.state-nothing
    [:h2 "Welcome"]
    [:p "You haven't loaded any todos yet."]
-   [:button {:on-click #(dispatch [:todos/load {:n 0}])} "Get started"]])
+   [:button {:on-click #(dispatch [:nine-states.demo/load {:n 0}])} "Get started"]])
 
-(reg-view ^{:doc "State 2 — Loading: spinner / skeleton. NEVER blank the page on revalidation."}
+(reg-view ^{:doc "State 2 — Loading: spinner / skeleton."}
           view-loading []
   [:div.state.state-loading
    [:p "Loading todos…"]])
+
+(reg-view ^{:doc "Error branch — transport / server failure (Pattern-RemoteData :error)."}
+          view-error []
+  (let [err @(subscribe [:todos/error])]
+    [:div.state.state-error
+     [:p.error (str "Couldn't load: " (:message err))]
+     [:button {:on-click #(dispatch [:nine-states.demo/load {:n 4}])} "Retry"]]))
 
 (reg-view ^{:doc "State 3 — Empty: 'No todos yet' + CTA to add one."}
           view-empty []
@@ -466,21 +541,21 @@
 
 (reg-view ^{:doc "State 4 — One: focused single-item layout."}
           view-one []
-  (let [todo (first @(subscribe [:todos/data]))]
+  (let [todo (first @(subscribe [:todos/items]))]
     [:div.state.state-one
      [:h2 "Your todo"]
      [:p.title (:title todo)]]))
 
 (reg-view ^{:doc "State 5 — Some: standard list."}
           view-some []
-  (let [todos @(subscribe [:todos/data])]
+  (let [todos @(subscribe [:todos/items])]
     [:div.state.state-some
      [:h2 (str (count todos) " todos")]
      [:ul (for [t todos] ^{:key (:id t)} [:li (:title t)])]]))
 
 (reg-view ^{:doc "State 6 — Too Many: search + truncation."}
           view-too-many []
-  (let [todos    @(subscribe [:todos/data])
+  (let [todos    @(subscribe [:todos/items])
         shown    (take too-many-threshold todos)
         overflow (- (count todos) too-many-threshold)]
     [:div.state.state-too-many
@@ -504,7 +579,7 @@
 
 (reg-view ^{:doc "State 9 — Done/Frozen: archived list. Read-only."}
           view-done []
-  (let [todos @(subscribe [:todos/data])]
+  (let [todos @(subscribe [:todos/items])]
     [:div.state.state-done
      [:h2 "Archived"]
      [:p "This list has been archived. It is read-only."]
@@ -513,12 +588,18 @@
 ;; ============================================================================
 ;; VIEWS — control panel + form + root
 ;; ============================================================================
+;;
+;; The form and control panel use `(rf/has-tag? :ui/nine-states
+;; :mode/read-only)` to disable themselves when the :mode region is
+;; :done. The legacy variant queried `:ui.state/done?` for the same
+;; thing; tags are cleaner because the view doesn't need to know
+;; *which* state of which region carries the read-only intent.
 
-(reg-view ^{:doc "Form for adding a todo. Drives the Forms slice (states 7 & 8)."}
+(reg-view ^{:doc "Form for adding a todo. Drives the form region (states 7 & 8)."}
           new-todo-form []
-  (let [draft     @(subscribe [:new-todo/draft])
-        field-err @(subscribe [:new-todo/field-error :title])
-        done?     @(subscribe [:ui.state/done?])]
+  (let [draft       @(subscribe [:new-todo/draft])
+        field-err   @(subscribe [:new-todo/field-error :title])
+        read-only?  @(rf/has-tag? :ui/nine-states :mode/read-only)]
     [:form.new-todo
      {:on-submit (fn [e]
                    (.preventDefault e)
@@ -526,176 +607,152 @@
      [:input {:type        "text"
               :placeholder "What needs doing?"
               :value       (:title draft)
-              :disabled    done?
+              :disabled    read-only?
               :on-change   #(dispatch [:new-todo/edit-field :title
                                        (.. % -target -value)])}]
-     [:button {:type "submit" :disabled done?} "Add"]
+     [:button {:type "submit" :disabled read-only?} "Add"]
      (when field-err [:p.error field-err])]))
 
-(reg-view ^{:doc "Buttons to drive the app into each of the nine states."}
+(reg-view ^{:doc "Buttons to drive the demo into each of the nine states."}
           control-panel []
-  (let [done? @(subscribe [:ui.state/done?])]
+  (let [read-only? @(rf/has-tag? :ui/nine-states :mode/read-only)]
     [:div.control-panel
      [:h3 "Drive the demo"]
      [:button {:on-click #(dispatch [:nine-states.app/initialise])
-               :disabled done?} "1. Nothing"]
-     [:button {:on-click #(dispatch [:todos/load-with-failure])
-               :disabled done?} "Trigger error"]
-     [:button {:on-click #(dispatch [:todos/load {:n 0}])
-               :disabled done?} "3. Empty"]
-     [:button {:on-click #(dispatch [:todos/load {:n 1}])
-               :disabled done?} "4. One"]
-     [:button {:on-click #(dispatch [:todos/load {:n 4}])
-               :disabled done?} "5. Some"]
-     [:button {:on-click #(dispatch [:todos/load {:n 25}])
-               :disabled done?} "6. Too Many"]
-     [:button {:on-click #(dispatch [:todos/editor [:todos.editor/archive {}]])
-               :disabled done?} "9. Archive (Done)"]]))
+               :disabled read-only?} "1. Nothing"]
+     [:button {:on-click #(dispatch [:nine-states.demo/load-with-failure])
+               :disabled read-only?} "Trigger error"]
+     [:button {:on-click #(dispatch [:nine-states.demo/load {:n 0}])
+               :disabled read-only?} "3. Empty"]
+     [:button {:on-click #(dispatch [:nine-states.demo/load {:n 1}])
+               :disabled read-only?} "4. One"]
+     [:button {:on-click #(dispatch [:nine-states.demo/load {:n 4}])
+               :disabled read-only?} "5. Some"]
+     [:button {:on-click #(dispatch [:nine-states.demo/load {:n 25}])
+               :disabled read-only?} "6. Too Many"]
+     [:button {:on-click #(dispatch [:ui/nine-states [:archive {}]])
+               :disabled read-only?} "9. Archive (Done)"]]))
 
-(reg-view ^{:doc "Root view: pick exactly one of the nine state views, plus form
-                  and control panel."}
+(reg-view ^{:doc "Root view: one `case` over :ui/render picks exactly one
+                  per-state view; the form and control panel render
+                  alongside."}
           root-view []
-  (let [done?      @(subscribe [:ui.state/done?])
-        correct?   @(subscribe [:ui.state/correct?])
-        incorrect? @(subscribe [:ui.state/incorrect?])
-        nothing?   @(subscribe [:ui.state/nothing?])
-        loading?   @(subscribe [:ui.state/loading?])
-        empty?     @(subscribe [:ui.state/empty?])
-        one?       @(subscribe [:ui.state/one?])
-        some?*     @(subscribe [:ui.state/some?])
-        too-many?  @(subscribe [:ui.state/too-many?])
-        error      @(subscribe [:todos/error])]
-    [:div.app
-     [:h1 "Nine States of UI — todos"]
-     [control-panel]
-     [:hr]
-     (cond
-       done?      [view-done]
-       incorrect? [view-incorrect]
-       correct?   [view-correct]
-       nothing?   [view-nothing]
-       loading?   [view-loading]
-       error      [:div.state.state-error
-                   [:p.error (str "Couldn't load: " (:message error))]
-                   [:button {:on-click #(dispatch [:todos/load {:n 4}])}
-                    "Retry"]]
-       empty?     [view-empty]
-       one?       [view-one]
-       some?*     [view-some]
-       too-many?  [view-too-many]
-       :else      [:p "(unrecognised state)"])
-     [:hr]
-     [new-todo-form]]))
+  [:div.app
+   [:h1 "Nine States of UI — todos"]
+   [control-panel]
+   [:hr]
+   (case @(subscribe [:ui/render])
+     :done      [view-done]
+     :correct   [view-correct]
+     :incorrect [view-incorrect]
+     :nothing   [view-nothing]
+     :loading   [view-loading]
+     :error     [view-error]
+     :empty     [view-empty]
+     :one       [view-one]
+     :some      [view-some]
+     :too-many  [view-too-many]
+     [:p "(unrecognised state)"])
+   [:hr]
+   [new-todo-form]])
 
 ;; ============================================================================
 ;; HEADLESS TESTS
 ;; ============================================================================
 ;;
 ;; One fixture per state. Each: drive `app-db` to the state via dispatch-sync,
-;; then assert the matching state-discriminator sub fires and that no
-;; mutually-exclusive sibling fires. Browserless via `compute-sub` (no DOM
-;; required); this file is .cljs, so JVM execution would require porting the
-;; testable parts to .cljc.
+;; then assert against the machine's tag union and the resolved
+;; :ui/render keyword. Browserless via `compute-sub` (no DOM required).
 
-(defn- in-state?
-  "Read a state-discriminator sub against the frame's app-db."
-  [frame state-sub]
-  (rf/compute-sub [state-sub] (rf/get-frame-db frame)))
+(defn- has-tag?
+  "Read the machine's tag union against a frame's app-db."
+  [frame tag]
+  (contains? (get-in (rf/get-frame-db frame)
+                     [:rf/machines :ui/nine-states :tags])
+             tag))
+
+(defn- render-model [frame]
+  (rf/compute-sub [:ui/render] (rf/get-frame-db frame)))
 
 (def ^:private demo-overrides
   "Per-test :fx-overrides map that routes `:rf.http/managed` to the in-process
    demo stub so tests run without a backend."
   {:rf.http/managed :nine-states.http/managed-demo})
 
+(defn- new-frame []
+  (rf/make-frame
+    {:on-create    [:nine-states.app/initialise]
+     :fx-overrides demo-overrides}))
+
 (defn test-state-1-nothing []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (is (in-state? f :ui.state/nothing?))
-    (is (not (in-state? f :ui.state/loading?)))
-    (is (not (in-state? f :ui.state/empty?)))))
+  (with-frame [f (new-frame)]
+    (is       (has-tag?    f :data/nothing))
+    (is (not  (has-tag?    f :data/loading)))
+    (is (=    :nothing     (render-model f)))))
 
 (defn test-state-2-loading []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    ;; Set status directly to :loading (the actual stub resolves synchronously,
-    ;; so we assert against an explicit pre-loaded shape).
-    (rf/dispatch-sync [:todos/loaded {:kind :success :value []}] {:frame f}) ;; loaded with no data
-    (rf/dispatch-sync [:todos/reset]      {:frame f})
-    (rf/dispatch-sync [:todos/load-with-failure] {:frame f})
-    ;; The failure stub fires :on-failure synchronously, so :status ends in :error;
-    ;; the `loading?` predicate is false at the *end* of the drain — which is
-    ;; the correct semantic. We instead assert that the lifecycle visited
-    ;; :loading by checking :attempt was bumped.
-    (is (pos? (:attempt (rf/compute-sub [:todos] (rf/get-frame-db f)))))))
+  ;; The demo stub resolves synchronously, so we observe :loading by
+  ;; dispatching :fetch-started directly (without a follow-up reply).
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:ui/nine-states [:fetch-started]] {:frame f})
+    (is       (has-tag?    f :data/loading))
+    (is       (has-tag?    f :data/transient))
+    (is (=    :loading     (render-model f)))))
 
 (defn test-state-3-empty []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 0}] {:frame f})
-    (is       (in-state? f :ui.state/empty?))
-    (is (not (in-state? f :ui.state/one?)))
-    (is (not (in-state? f :ui.state/some?)))
-    (is (not (in-state? f :ui.state/too-many?)))))
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
+    (is       (has-tag?    f :data/empty))
+    (is (not  (has-tag?    f :data/one)))
+    (is (=    :empty       (render-model f)))))
 
 (defn test-state-4-one []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 1}] {:frame f})
-    (is       (in-state? f :ui.state/one?))
-    (is (not (in-state? f :ui.state/empty?)))
-    (is (not (in-state? f :ui.state/some?)))))
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 1}] {:frame f})
+    (is       (has-tag?    f :data/one))
+    (is (=    :one         (render-model f)))))
 
 (defn test-state-5-some []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
-    (is       (in-state? f :ui.state/some?))
-    (is (not (in-state? f :ui.state/one?)))
-    (is (not (in-state? f :ui.state/too-many?)))))
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
+    (is       (has-tag?    f :data/some))
+    (is (=    :some        (render-model f)))))
 
 (defn test-state-6-too-many []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 25}] {:frame f})
-    (is       (in-state? f :ui.state/too-many?))
-    (is (not (in-state? f :ui.state/some?)))))
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame f})
+    (is       (has-tag?    f :data/too-many))
+    (is (=    :too-many    (render-model f)))))
 
 (defn test-state-7-incorrect []
-  (with-frame [f (rf/make-frame {:on-create [:nine-states.app/initialise]})]
-    ;; Type a too-short title, then submit — should land in :error / :incorrect?
+  (with-frame [f (new-frame)]
     (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
-    (rf/dispatch-sync [:new-todo/submit]                {:frame f})
-    (is       (in-state? f :ui.state/incorrect?))
-    (is (not (in-state? f :ui.state/correct?)))))
+    (rf/dispatch-sync [:new-todo/submit] {:frame f})
+    (is       (has-tag?    f :form/invalid))
+    (is (=    :incorrect   (render-model f)))))
 
 (defn test-state-8-correct []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 0}]                  {:frame f})
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
     (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
-    (rf/dispatch-sync [:new-todo/submit]                    {:frame f})
-    (is       (in-state? f :ui.state/correct?))
-    (is (not (in-state? f :ui.state/incorrect?)))
-    (is       (in-state? f :ui.state/one?))))    ;; correctness side-effect
+    (rf/dispatch-sync [:new-todo/submit] {:frame f})
+    ;; Tags reflect the overlap honestly: :form/success AND :data/one
+    ;; are both true simultaneously. The render-priority table
+    ;; resolves it: :correct wins.
+    (is       (has-tag?    f :form/success))
+    (is       (has-tag?    f :data/one))
+    (is (=    :correct     (render-model f)))))
 
 (defn test-state-9-done []
-  (with-frame [f (rf/make-frame
-                   {:on-create    [:nine-states.app/initialise]
-                    :fx-overrides demo-overrides})]
-    (rf/dispatch-sync [:todos/load {:n 4}] {:frame f})
-    (rf/dispatch-sync [:todos/editor [:todos.editor/archive {:now 1}]] {:frame f})
-    ;; Snapshot lives at [:rf/machines :todos/editor].
-    (let [snap (get-in (rf/get-frame-db f) [:rf/machines :todos/editor])]
-      (is (= :archived (:state snap)))
-      (is (= 1         (:archived-at (:data snap)))))
-    (is (in-state? f :ui.state/done?))))
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
+    (rf/dispatch-sync [:ui/nine-states [:archive {:now 1}]] {:frame f})
+    (let [snap (get-in (rf/get-frame-db f) [:rf/machines :ui/nine-states])]
+      (is (= :done (get-in snap [:state :mode])))
+      (is (= 1    (get-in snap [:data :archived-at]))))
+    (is       (has-tag?    f :mode/done))
+    (is       (has-tag?    f :mode/read-only))
+    (is (=    :done        (render-model f)))))
 
 (defn run-all-tests []
   (test-state-1-nothing)
@@ -715,12 +772,9 @@
 ;;
 ;; The DOM mount is gated on (exists? js/document) so the namespace can
 ;; load in non-DOM CLJS hosts (shadow-cljs :node-test, headless test
-;; harnesses, JVM). The pure run-all-tests fn at line 670 runs in any
-;; CLJS host without touching React.
+;; harnesses, JVM). The pure run-all-tests fn above runs in any CLJS
+;; host without touching React.
 
-;; The React root is named `react-root` (not `root`) so it does NOT
-;; collide with anything else in this ns; reg-view defs `root-view`,
-;; which is what we render.
 (defonce react-root
   (when (exists? js/document)
     (rdc/create-root (js/document.getElementById "app"))))

--- a/spec/Pattern-Forms.md
+++ b/spec/Pattern-Forms.md
@@ -279,8 +279,8 @@ Forms typically don't need SSR-rendered hydration; the form is interactive clien
 - [Pattern-RemoteData.md](Pattern-RemoteData.md) — the submit lifecycle reuses the request-lifecycle slice when the server is involved
 - [005-StateMachines.md](005-StateMachines.md) — multi-step wizards use machines on top of the form slice
 - [examples/reagent/login/core.cljs](../examples/reagent/login/core.cljs) — login form built on this convention plus a state machine
-- [Pattern-NineStates.md](Pattern-NineStates.md) — the page-level convention that turns form validation and success into explicit `Incorrect` / `Correct` UI states.
-- [examples/reagent/nine_states/](../examples/reagent/nine_states/) — worked example whose Incorrect state exercises this form lifecycle (validation errors, touched-field display, recovery to Correct).
+- [Pattern-NineStates.md](Pattern-NineStates.md) — the page-level convention that folds form validation and success into the `:form` region of a parallel state machine, surfacing `Incorrect` / `Correct` as tag-tagged states alongside the data and mode axes.
+- [examples/reagent/nine_states/](../examples/reagent/nine_states/) — worked example whose `:form` region exercises this lifecycle (validation errors, touched-field display, recovery from `:incorrect` to `:neutral` via `:edit`).
 - [examples/reagent/realworld/auth.cljs](../examples/reagent/realworld/auth.cljs) — RealWorld's login and register forms exercise the full convention; [article_editor.cljs](../examples/reagent/realworld/article_editor.cljs) and [comments.cljs](../examples/reagent/realworld/comments.cljs) extend it across more shapes.
 
 ## Conformance checklist

--- a/spec/Pattern-NineStates.md
+++ b/spec/Pattern-NineStates.md
@@ -1,7 +1,7 @@
 # Pattern — Nine States of UI
 
 > **Type:** Pattern
-> A page-level convention for making common UI states explicit: blank, loading, cardinality variants, validation failure, success, and terminal/frozen. Built from existing re-frame2 primitives; convention, not Spec.
+> A page-level convention for making common UI states explicit: blank, loading, cardinality variants, validation failure, success, and terminal/frozen. Built from a single parallel state machine plus `:fsm/tags`; convention, not Spec.
 
 > **Code samples are in ClojureScript** (the CLJS reference). The pattern itself is host-agnostic.
 
@@ -14,11 +14,13 @@ This is a **named pattern**, not a Spec. It does not introduce a runtime feature
 - easy to test headlessly
 - hard to forget during implementation
 
-The pattern is assembled from three existing pieces:
+The pattern is assembled from primitives already in re-frame2:
 
-- [Pattern-RemoteData](Pattern-RemoteData.md) for `Nothing`, `Loading`, `Empty`, `One`, `Some`, `Too Many`
-- [Pattern-Forms](Pattern-Forms.md) for `Incorrect` and often `Correct`
-- [005-StateMachines.md](005-StateMachines.md) or an explicit domain flag for `Done` / `Frozen`
+- [005-StateMachines.md §Parallel regions](005-StateMachines.md#parallel-regions) — three orthogonal axes (data lifecycle / form validity / mode) modelled as three regions of one machine.
+- [005-StateMachines.md §State tags](005-StateMachines.md#state-tags) — per-axis intent (`:data/loading`, `:form/invalid`, `:mode/done`) attached to states so view-level queries can ask tag-shaped questions across the active configuration.
+- [Pattern-RemoteData](Pattern-RemoteData.md) — the lifecycle vocabulary folded into the `:data` region (`:nothing → :loading → :resolving → {:empty | :one | :some | :too-many} | :error`).
+- [Pattern-Forms](Pattern-Forms.md) — the validation / submission lifecycle folded into the `:form` region (`:neutral → {:correct | :incorrect}`).
+- A small selector sub over a **render-priority** table that collapses the tag union into a single render-model keyword.
 
 The pattern is useful because most apps are only designed for the happy path. The empty result, single-item case, too-many-results case, validation failure, and terminal/frozen state all end up visually undefined unless they are treated as first-class.
 
@@ -28,17 +30,17 @@ For a list-or-workflow page, the canonical checklist is:
 
 | # | Name | Meaning | Typical source |
 |---|---|---|---|
-| 1 | **Nothing** | The user has not yet caused a fetch or the page has been reset. | Remote-data slice `:status :idle` |
-| 2 | **Loading** | First fetch in flight; no prior data yet. | Remote-data slice `:status :loading` |
-| 3 | **Empty** | Loaded successfully, but the result is empty. | `:status :loaded` + item count `0` |
-| 4 | **One** | Loaded successfully, exactly one result. | `:status :loaded` + item count `1` |
-| 5 | **Some** | Loaded successfully, a manageable list. | `:status :loaded` + item count in a bounded range |
-| 6 | **Too Many** | Loaded successfully, but the result volume changes the UI shape. | `:status :loaded` + item count above a threshold |
-| 7 | **Incorrect** | User input is invalid; the user can fix it. | Form slice `:errors` / touched-field visibility |
-| 8 | **Correct** | A successful submission or transient success acknowledgement. | Form slice `:status :submitted` or feature-local success flag |
-| 9 | **Done / Frozen** | The domain reached a terminal or read-only state. | Terminal machine state or explicit domain flag |
+| 1 | **Nothing** | The user has not yet caused a fetch or the page has been reset. | `:data` region at `:nothing` |
+| 2 | **Loading** | First fetch in flight; no prior data yet. | `:data` region at `:loading` |
+| 3 | **Empty** | Loaded successfully, but the result is empty. | `:data` region at `:empty` |
+| 4 | **One** | Loaded successfully, exactly one result. | `:data` region at `:one` |
+| 5 | **Some** | Loaded successfully, a manageable list. | `:data` region at `:some` |
+| 6 | **Too Many** | Loaded successfully, but the result volume changes the UI shape. | `:data` region at `:too-many` |
+| 7 | **Incorrect** | User input is invalid; the user can fix it. | `:form` region at `:incorrect` |
+| 8 | **Correct** | A successful submission or transient success acknowledgement. | `:form` region at `:correct` |
+| 9 | **Done / Frozen** | The domain reached a terminal or read-only state. | `:mode` region at `:done` |
 
-These are **page-level render states**, not one shared enum in the runtime.
+These are **page-level render states**, not one shared enum in the runtime. The three axes are independent; the snapshot's `:tags` carries them all simultaneously, and the render-priority table decides which one wins for any given commit.
 
 ## What this pattern is not
 
@@ -52,107 +54,197 @@ It is not:
 In particular:
 
 - `Incorrect` means **user-fixable invalid input**, not network failure.
-- Transport failures still belong to the feature's ordinary `:error` branch.
+- Transport failures still belong to the `:data` region's `:error` branch.
 - `Done` means **terminal / frozen / archived / irreversible**, not merely "loaded" or "completed once."
 
 Treat the nine states as a **design checklist** and a **rendering convention**, not as a universal ontology.
 
+## The shape
+
+One machine. Three regions. Tags on states. One selector sub. One `case` in the root view.
+
+```clojure
+(rf/reg-machine :ui/nine-states
+  {:type :parallel
+   :data {:items [] :error nil}                 ;; shared across regions
+
+   :guards
+   {:empty?    (fn [d _] (zero? (count (:items d))))
+    :one?      (fn [d _] (= 1 (count (:items d))))
+    :too-many? (fn [d _] (> (count (:items d)) too-many-threshold))}
+
+   :actions
+   {:set-items (fn [d [_ {:keys [items]}]] {:data (assoc d :items (vec items) :error nil)})
+    :set-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+
+   :regions
+   {:data
+    {:initial :nothing
+     :states
+     {:nothing   {:tags #{:data/nothing}
+                  :on   {:fetch-started :loading}}
+      :loading   {:tags #{:data/loading :data/transient}
+                  :on   {:fetch-succeeded {:target :resolving :action :set-items}
+                         :fetch-failed    {:target :error     :action :set-error}}}
+      :resolving {:always [{:guard :empty?    :target :empty}
+                           {:guard :one?      :target :one}
+                           {:guard :too-many? :target :too-many}
+                           {:target :some}]}
+      :empty     {:tags #{:data/empty}    :on {:fetch-started :loading}}
+      :one       {:tags #{:data/one}      :on {:fetch-started :loading}}
+      :some      {:tags #{:data/some}     :on {:fetch-started :loading}}
+      :too-many  {:tags #{:data/too-many} :on {:fetch-started :loading}}
+      :error     {:tags #{:data/error}    :on {:fetch-started :loading}}}}
+
+    :form
+    {:initial :neutral
+     :states
+     {:neutral   {:tags #{:form/neutral}
+                  :on   {:submit-valid   :correct
+                         :submit-invalid :incorrect
+                         :edit           :neutral}}
+      :incorrect {:tags #{:form/invalid}
+                  :on   {:submit-valid :correct
+                         :edit         :neutral}}
+      :correct   {:tags #{:form/success :form/transient}
+                  :on   {:edit :neutral}}}}
+
+    :mode
+    {:initial :active
+     :states
+     {:active {:tags #{:mode/active}
+               :on   {:archive :done}}
+      :done   {:tags #{:mode/done :mode/read-only :mode/terminal}}}}}})
+```
+
+The render-priority table is plain data:
+
+```clojure
+(def render-priority
+  [;; mode region — terminal wins outright
+   {:tag :mode/done       :render :done}
+   ;; form region — transient acknowledgements
+   {:tag :form/success    :render :correct}
+   {:tag :form/invalid    :render :incorrect}
+   ;; data region — lifecycle then cardinality
+   {:tag :data/loading    :render :loading}
+   {:tag :data/error      :render :error}
+   {:tag :data/nothing    :render :nothing}
+   {:tag :data/empty      :render :empty}
+   {:tag :data/one        :render :one}
+   {:tag :data/some       :render :some}
+   {:tag :data/too-many   :render :too-many}])
+
+(rf/reg-sub :ui/render
+  :<- [:rf/machine :ui/nine-states]
+  (fn [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+```
+
+The root view:
+
+```clojure
+(reg-view root-view []
+  (case @(subscribe [:ui/render])
+    :done      [view-done]
+    :correct   [view-correct]
+    :incorrect [view-incorrect]
+    :nothing   [view-nothing]
+    :loading   [view-loading]
+    :error     [view-error]
+    :empty     [view-empty]
+    :one       [view-one]
+    :some      [view-some]
+    :too-many  [view-too-many]
+    [view-fallback]))
+```
+
+Views that need a single tag-shaped predicate (typically "is the page read-only?") subscribe directly with `(rf/has-tag? :ui/nine-states :mode/read-only)` — the framework sub `:rf/machine-has-tag?` shipped with [§State tags](005-StateMachines.md#state-tags). The `case` over `:ui/render` is for choosing the **whole** view; individual disabled-attribute toggles read tags directly.
+
 ## Canonical rules
 
-### 1. Derive the states from existing slices
+Four rules. Read them as a checklist.
 
-Do **not** invent a new page-local enum like `:ui-state :loading | :empty | :one | :some ...` when the state is already derivable from:
+### 1. Identify the orthogonal axes
 
-- a remote-data slice
-- a form slice
-- a machine snapshot
-- a simple domain flag
+Most pages of this shape have three axes:
 
-The point of the pattern is to reuse the explicit state you already have, not to mirror it into another slot.
+- **Data axis** — the request-lifecycle plus cardinality story (states 1-6 plus an error branch).
+- **Form axis** — the validation / submission lifecycle (states 7-8); only present on pages that take user input.
+- **Mode axis** — the active / read-only / terminal axis (state 9); only present on pages that can become frozen.
 
-### 2. Give each state a named discriminator
+Some pages have fewer axes (a static settings panel: just data). Some have more (a per-row permissions axis on a CRUD panel). The pattern scales by adding a region per axis; it does not require all three.
 
-Expose one named sub per state:
+Do **not** flatten the axes into a single page-local enum like `:ui-state :nothing | :loading | :empty | :one | ... | :done`. The cross-product is `~7 × 3 × 2 = 42` named states, half of which never appear in practice; the pattern is designed to **avoid** that explosion.
 
-```clojure
-(rf/reg-sub :ui.state/nothing? ...)
-(rf/reg-sub :ui.state/loading? ...)
-(rf/reg-sub :ui.state/empty? ...)
-(rf/reg-sub :ui.state/one? ...)
-(rf/reg-sub :ui.state/some? ...)
-(rf/reg-sub :ui.state/too-many? ...)
-(rf/reg-sub :ui.state/incorrect? ...)
-(rf/reg-sub :ui.state/correct? ...)
-(rf/reg-sub :ui.state/done? ...)
-```
+### 2. Declare one parallel machine with one region per axis
 
-This gives:
+A `:type :parallel` machine (per [§Parallel regions](005-StateMachines.md#parallel-regions)) takes a `:regions` map keyed by region name. Each region is a full state-tree (its own `:initial`, `:states`, optional `:always` / `:after` / `:invoke`). All regions are active simultaneously when the machine is active; the snapshot's `:state` is a **map** of region-name → that region's state value; transitions are **broadcast** across regions; the run-to-completion drain settles every region before commit.
 
-- inspectability
-- easy headless tests
-- explicit documentation of intended UI states
+Regions share a single `:data` blob — they coordinate axes of one feature, so they read and write the same underlying data, just sliced differently. If your axes are conceptually separate features (multiple tabs each with their own state, an audio/video player whose two regions share nothing but the play/pause event, encapsulated `:data`), you don't want parallel regions — you want **N separate machines** colocated in app-db. See [005-StateMachines.md §When to reach for parallel regions](005-StateMachines.md#when-to-reach-for-parallel-regions) and [CP-5-MachineGuide §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) for the redirect.
 
-The sub ids are illustrative. Feature code may namespace them differently.
+### 3. Tag each state with its axis-level intent
 
-### 3. Render by explicit branch, not hidden heuristics
+Per [§State tags](005-StateMachines.md#state-tags), every state may declare `:tags <set-of-keywords>`. The runtime maintains a `:tags` slot on the snapshot — the union of every active state's tag set across every active region — and the framework sub `:rf/machine-has-tag?` answers the predicate question.
 
-The page's root view should branch explicitly:
+Use a small canonical tag vocabulary, namespaced per axis:
 
-```clojure
-(rf/reg-view root-view []
-  (cond
-    @(subscribe [:ui.state/done?])      [view-done]
-    @(subscribe [:ui.state/incorrect?]) [view-incorrect]
-    @(subscribe [:ui.state/correct?])   [view-correct]
-    @(subscribe [:ui.state/nothing?])   [view-nothing]
-    @(subscribe [:ui.state/loading?])   [view-loading]
-    @(subscribe [:ui.state/empty?])     [view-empty]
-    @(subscribe [:ui.state/one?])       [view-one]
-    @(subscribe [:ui.state/some?])      [view-some]
-    @(subscribe [:ui.state/too-many?])  [view-too-many]
-    :else                               [view-fallback]))
-```
+- `:data/nothing` / `:data/loading` / `:data/empty` / `:data/one` / `:data/some` / `:data/too-many` / `:data/error` / `:data/transient`
+- `:form/neutral` / `:form/invalid` / `:form/success` / `:form/transient`
+- `:mode/active` / `:mode/done` / `:mode/read-only` / `:mode/terminal`
 
-The exact ordering depends on the feature, but the branch structure should be visible in one place.
+Tag names are illustrative. Feature code may namespace them differently — the only framework-reserved prefixes are `:rf/*` and `:rf.*/*` (per [Conventions.md §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)).
 
-### 4. Make the `Some` / `Too Many` threshold explicit
+The point of tags isn't to encode every state. The point is to carry the **query-shaped intent** so views and tests can ask "is the page in any loading-ish state?" without enumerating every nested path that counts as loading-ish. New states added later under existing tags pick up the query for free.
 
-`Too Many` is domain-specific. It is not a fixed framework constant.
+### 4. Compute the render selection in one selector sub, with priority in data
 
-Use a named threshold:
+The page's render decision is **one selector sub** that consults a render-priority **vector** against the machine's tag union and returns a single keyword. The root view's `case` over that keyword is the only branch site.
+
+This puts the priority in **data** (the `render-priority` vector — printable, testable, comparable) rather than in **control flow** (a priority `cond` in the root view). A test can pretty-print the priority table; a tool can read it; a code review can compare two pages' priorities side by side.
+
+The selector sub re-runs only when the tag union changes; Reagent's equality dedup gates downstream renders against the resolved keyword. The root view re-renders only when `:ui/render` actually changes — not every time the form region advances if the priority winner is still `:done`.
+
+## Why this shape
+
+Compared to the pre-parallel-regions variant (see the appendix), the parallel-machine shape gives:
+
+- **The three axes are visible in the machine declaration.** Anyone reading `:regions {:data ... :form ... :mode ...}` sees the model immediately.
+- **No mutual-exclusion lie.** Multiple axes can be true simultaneously; the priority is explicit in *data* (the render-priority vector) rather than buried in *control flow* (a priority `cond`'s clause order). The legacy variant's "correct? AND one?" overlap (post-submit on an empty list, `:form/success` and `:data/one` are both true) is a first-class property of the model now, not a workaround.
+- **Tags carry the query intent.** "Is the page in any loading state?" → `(rf/has-tag? :ui/nine-states :data/loading)`. The view doesn't need a separate `:ui.state/loading?` sub.
+- **Adding an axis is one region, not a row × column expansion.** A permissions axis becomes a fourth region with two states (`:editable` / `:read-only`); the render priority gains one entry; the view's `case` gains one branch.
+
+## How the states are usually derived
+
+### From the `:data` region
+
+States 1-6 plus the error branch come from the request lifecycle plus a small `:always`-cascade in `:resolving`:
+
+- `:fetch-started` advances the region from any cardinality bucket (or `:nothing` / `:error`) to `:loading`.
+- `:fetch-succeeded` lands the items in shared `:data` via the `:set-items` action and advances to `:resolving`.
+- `:resolving`'s `:always` cascade picks the cardinality bucket from the count, first-match-wins.
+- `:fetch-failed` lands the failure in shared `:data` via `:set-error` and advances to `:error`.
+
+The cardinality threshold is named, not buried in a sub:
 
 ```clojure
 (def too-many-threshold 7)
 ```
 
-and make the discriminator sub read from that named constant. Do not bury the threshold in a view body.
+### From the `:form` region
 
-### 5. Treat `Incorrect` as validation-visible, not merely invalid-under-the-hood
+States 7-8 come from the form lifecycle. The region's events (`:submit-valid` / `:submit-invalid` / `:edit`) are broadcast from the corresponding `:new-todo/*` events that own the slice's `{:draft :errors :touched}` shape (per [Pattern-Forms](Pattern-Forms.md)). The region's state-keyword IS the form's status; the slice's `:errors` and `:touched` carry the per-field detail the view uses to render the inline error.
 
-The page is in `Incorrect` when the user can **see** and act on the invalid state. In practice that means:
+`Incorrect` is the page state when the user can **see** and act on the invalid state — touched fields, attempted submission, visible form-level errors. The form region's `:incorrect` state is entered only after `:submit-invalid` is broadcast; an in-progress edit that hasn't been submitted does not put the page in `Incorrect`. This composes directly with [Pattern-Forms](Pattern-Forms.md)' visibility rules.
 
-- field is touched, or
-- submit has been attempted, or
-- form-level errors are visible
+`Correct` is the page state when the UI renders a visible success acknowledgement — "Todo added." / a green confirmation banner / a brief success toast. If success is immediately followed by navigation and there is no visible acknowledgement, the `:form` region can skip the `:correct` state entirely; the form region becomes a two-state `:neutral ↔ :incorrect` machine and the render-priority table simply never produces `:correct`.
 
-This pattern therefore composes directly with [Pattern-Forms](Pattern-Forms.md)' visibility rules.
+### From the `:mode` region
 
-### 6. Treat `Correct` as a real UI state only when the success is visible
-
-Sometimes success is immediately followed by navigation and there is no visible `Correct` state. In that case, do not force one.
-
-Use `Correct` when the UI actually renders a success acknowledgement:
-
-- "Todo added."
-- green confirmation banner
-- brief success toast
-- field reset plus success checkmark
-
-If success is not visually distinct, omit this state from the page's explicit branch set.
-
-### 7. `Done` comes from terminal domain semantics
-
-Use `Done` / `Frozen` when the user has reached a state where the UI must become read-only or terminal:
+State 9 comes from a terminal transition in the `:mode` region. Use it when the user has reached a state where the UI must become read-only:
 
 - archived
 - submitted and immutable
@@ -160,85 +252,7 @@ Use `Done` / `Frozen` when the user has reached a state where the UI must become
 - expired edit window
 - closed incident
 
-This typically comes from:
-
-- a terminal machine state, or
-- an explicit domain flag like `:archived? true`
-
-Do not use `Done` as a synonym for "request succeeded."
-
-## How the states are usually derived
-
-### From a remote-data slice
-
-The first six states usually come from the request-lifecycle slice plus result count:
-
-```clojure
-(rf/reg-sub :ui.state/nothing?
-  :<- [:todos/status]
-  (fn [status _] (= status :idle)))
-
-(rf/reg-sub :ui.state/loading?
-  :<- [:todos/status]
-  (fn [status _] (= status :loading)))
-
-(rf/reg-sub :ui.state/empty?
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn [[status n] _] (and (= status :loaded) (zero? n))))
-
-(rf/reg-sub :ui.state/one?
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn [[status n] _] (and (= status :loaded) (= 1 n))))
-
-(rf/reg-sub :ui.state/some?
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn [[status n] _] (and (= status :loaded) (<= 2 n too-many-threshold))))
-
-(rf/reg-sub :ui.state/too-many?
-  :<- [:todos/status]
-  :<- [:todos/count]
-  (fn [[status n] _] (and (= status :loaded) (> n too-many-threshold))))
-```
-
-This is why `Pattern-RemoteData` distinguishes `:idle`, `:loading`, and `:loaded`: the page can render `Nothing`, `Loading`, and the cardinality states separately.
-
-### From a form slice
-
-`Incorrect` and often `Correct` come from the form lifecycle:
-
-```clojure
-(rf/reg-sub :ui.state/incorrect?
-  :<- [:new-todo/errors]
-  :<- [:new-todo/touched]
-  (fn [[errs touched] _]
-    (boolean (some touched (keys errs)))))
-
-(rf/reg-sub :ui.state/correct?
-  :<- [:new-todo/status]
-  (fn [status _]
-    (= status :submitted)))
-```
-
-### From a machine or domain flag
-
-`Done` / `Frozen` often comes from a machine snapshot:
-
-```clojure
-(rf/reg-sub :ui.state/done?
-  (fn [db _]
-    (= :archived (get-in db [:rf/machines :todos/editor :state]))))
-```
-
-or from an explicit domain slot:
-
-```clojure
-(rf/reg-sub :ui.state/done?
-  (fn [db _]
-    (true? (get-in db [:invoice :paid?]))))
-```
+The `:done` state carries the `:mode/read-only` tag; the view inspects that tag (`(rf/has-tag? :ui/nine-states :mode/read-only)`) to disable inputs, control buttons, and other affordances. Do not use `:mode/done` as a synonym for "request succeeded" — that's the `:form/success` tag in the form region.
 
 ## Worked example
 
@@ -247,11 +261,7 @@ The canonical worked example is:
 - [examples/reagent/nine_states/core.cljs](../examples/reagent/nine_states/core.cljs)
 - [examples/reagent/nine_states/README.md](../examples/reagent/nine_states/README.md)
 
-It demonstrates:
-
-- `Nothing`, `Loading`, `Empty`, `One`, `Some`, `Too Many` from a todos remote-data slice
-- `Incorrect` / `Correct` from a new-todo form
-- `Done` from a two-state editor machine (`:editing -> :archived`)
+It demonstrates the full machine declaration, the render-priority table, the `:ui/render` selector sub, per-state views, and a headless test per state asserting against tags + the resolved render-model keyword.
 
 ## When to use this pattern
 
@@ -272,31 +282,84 @@ It is especially useful for:
 
 ## When not to force it
 
-Do not force all nine states onto:
+Do not force this pattern onto:
 
-- tiny static panels
-- pages with no load lifecycle
+- tiny static panels with no load lifecycle
 - pages where `One` vs `Some` vs `Too Many` has no visual consequence
 - forms that navigate away immediately on success
+- pages whose axes are conceptually separate features (encapsulated `:data`, no shared domain)
 
-The point is not numerology. The point is to make the **important** UI states explicit and testable.
+The point is not numerology. The point is to make the **important** UI states explicit and testable. If a page only has the data axis, declare a one-region machine (or no machine at all — Pattern-RemoteData with a flat sub graph is sufficient). If the axes don't share data, register N separate machines per the CP-5-MachineGuide substitute pattern.
 
 ## Cross-references
 
-- [Pattern-RemoteData.md](Pattern-RemoteData.md) — request lifecycle behind states 1-6
-- [Pattern-Forms.md](Pattern-Forms.md) — validation and submission lifecycle behind states 7-8
-- [005-StateMachines.md](005-StateMachines.md) — terminal/frozen state behind state 9
-- [004-Views.md](004-Views.md#loading-state-is-explicit-not-implicit) — explicit-state view philosophy this pattern exemplifies
-- [examples/reagent/nine_states/README.md](../examples/reagent/nine_states/README.md) — worked example
+- [005-StateMachines.md §Parallel regions](005-StateMachines.md#parallel-regions) — the substrate.
+- [005-StateMachines.md §State tags](005-StateMachines.md#state-tags) — the substrate.
+- [Pattern-RemoteData.md](Pattern-RemoteData.md) — the lifecycle folded into the `:data` region.
+- [Pattern-Forms.md](Pattern-Forms.md) — the lifecycle folded into the `:form` region.
+- [CP-5-MachineGuide.md §Substitutes](CP-5-MachineGuide.md#substitutes-for-skipped-features) — the N-machines-per-region pattern, the right answer when axes are independent features.
+- [004-Views.md §Loading state is explicit](004-Views.md#loading-state-is-explicit-not-implicit) — the explicit-state view philosophy this pattern exemplifies.
+- [examples/reagent/nine_states/README.md](../examples/reagent/nine_states/README.md) — worked example.
 
 ## Conformance checklist
 
 A page applies this pattern well when:
 
-- Its important UI states are named explicitly rather than implied.
-- Remote-data cardinality states (`Nothing`, `Loading`, `Empty`, `One`, `Some`, `Too Many`) are derived from the data lifecycle rather than hand-waved into one generic loaded branch.
-- Validation failure is rendered explicitly as `Incorrect`, not hidden behind an undifferentiated error message.
-- Success is rendered explicitly as `Correct` when the page actually has a visible success acknowledgement.
-- Terminal/read-only behaviour is rendered explicitly as `Done` / `Frozen` when the domain needs it.
-- The root view branches explicitly across the applicable states.
-- The discriminator subs are easy to drive in headless tests.
+- The page's render axes are visible as regions of one parallel machine (or as N machines when the axes are independent features).
+- States declare `:tags` from a small per-axis canonical vocabulary; new states added later pick up tag-based queries for free.
+- The render decision lives in one selector sub over a render-priority **vector**, not in a priority `cond` in the view.
+- The root view branches via `case` over the resolved render-model keyword.
+- Tag-shaped predicates are read via `(rf/has-tag? machine-id tag)` (the framework sub `:rf/machine-has-tag?`) rather than via per-state boolean discriminator subs.
+- The headless test fixture per state drives `app-db` to the state and asserts against the tag union and the resolved `:ui/render` keyword.
+
+---
+
+## Appendix — Pre-parallel-regions variant (deprecated but supported)
+
+Before re-frame2 shipped `:fsm/tags` and `:fsm/parallel-regions`, the pattern was implemented with **nine boolean discriminator subs** and a root-level priority `cond`. That variant still works — neither capability removed an existing primitive — but new code should use the parallel-machine variant above. The legacy variant is documented here so existing pages have a reference.
+
+### Shape
+
+```clojure
+;; nine boolean subs, one per state
+(rf/reg-sub :ui.state/nothing?
+  :<- [:todos/status]
+  (fn [status _] (= status :idle)))
+
+(rf/reg-sub :ui.state/loading?
+  :<- [:todos/status]
+  (fn [status _] (= status :loading)))
+
+(rf/reg-sub :ui.state/empty?
+  :<- [:todos/status]
+  :<- [:todos/count]
+  (fn [[status n] _] (and (= status :loaded) (zero? n))))
+
+;; ... seven more ...
+
+;; root view branches via priority cond
+(reg-view root-view []
+  (cond
+    @(subscribe [:ui.state/done?])      [view-done]
+    @(subscribe [:ui.state/incorrect?]) [view-incorrect]
+    @(subscribe [:ui.state/correct?])   [view-correct]
+    @(subscribe [:ui.state/nothing?])   [view-nothing]
+    @(subscribe [:ui.state/loading?])   [view-loading]
+    @(subscribe [:ui.state/empty?])     [view-empty]
+    @(subscribe [:ui.state/one?])       [view-one]
+    @(subscribe [:ui.state/some?])      [view-some]
+    @(subscribe [:ui.state/too-many?])  [view-too-many]
+    :else                               [view-fallback]))
+```
+
+### Why deprecated
+
+The nine boolean subs aren't mutually exclusive (a post-submit on a single-item list is `:ui.state/correct?` AND `:ui.state/one?` simultaneously); the cond's priority order is the only thing stopping double-rendering. That's a priority hack, not a state model.
+
+The three orthogonal axes (data cardinality / form validity / mode) are flattened into a single sub-vocabulary; the view layer recomposes them via priority order, and a tooling consumer that asks "what data state is this page in?" cannot get an answer without re-deriving it from the seven flat boolean subs.
+
+Adding an axis grows the sub population multiplicatively — a permissions axis adds row × column expansion to the priority cond, plus new subs to discriminate every combination the view renders.
+
+### Why still supported
+
+The legacy variant uses no capability beyond Layer-3 `:<-` subs, which ship in every conforming re-frame2 host. Pages that already follow the variant don't have to migrate; they keep working unchanged. The framework's only commitment is that `:rf/machine`, `:rf/machine-has-tag?`, and the regular sub graph all remain first-class so a page can adopt the parallel-machine variant incrementally (e.g. introduce the machine alongside the existing subs, then drop subs one at a time as views switch to tag queries).

--- a/spec/Pattern-RemoteData.md
+++ b/spec/Pattern-RemoteData.md
@@ -265,8 +265,8 @@ Per [011-SSR.md](011-SSR.md):
 - [011-SSR.md](011-SSR.md) — SSR-side fetch handling and `:platforms` metadata
 - [009-Instrumentation.md §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/fx-handler-exception` for failed fetches
 - [examples/reagent/login/core.cljs](../examples/reagent/login/core.cljs) — the login feature uses a simplified version of this lifecycle
-- [Pattern-NineStates.md](Pattern-NineStates.md) — the page-level convention that composes this lifecycle into `Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many`.
-- [examples/reagent/nine_states/](../examples/reagent/nine_states/) — worked example exercising all five status states + data-shape variations (Empty / One / Some / Too Many).
+- [Pattern-NineStates.md](Pattern-NineStates.md) — the page-level convention that folds this lifecycle into the `:data` region of a parallel `:fsm/tags`-enabled state machine, composing the request lifecycle with form-validity and mode axes into the canonical `Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many` rendering.
+- [examples/reagent/nine_states/](../examples/reagent/nine_states/) — worked example whose `:data` region exercises all the lifecycle states + cardinality variations (Empty / One / Some / Too Many) inside the parallel-machine shape.
 - [examples/reagent/realworld/articles.cljs](../examples/reagent/realworld/articles.cljs) — the RealWorld (Conduit) article-list page is the canonical full-shape exercise: standard 5-key slice, four lifecycle events, convenience subs, route `:on-match` integration, headless tests covering load + revalidate + failure.
 
 ## Conformance checklist


### PR DESCRIPTION
## Summary

Stage 3 of the Nine States arc. Stages 1 ([#283 / rf2-ee0d](https://github.com/day8/re-frame2/pull/283) — `:fsm/tags`) and 2 ([#284 / rf2-l67o](https://github.com/day8/re-frame2/pull/284) — `:fsm/parallel-regions`) shipped the substrate; this PR rewrites the pattern doc + worked example + cross-refs to use it. **No new substrate work.**

### Pattern-NineStates.md

Rewritten around one parallel machine with three regions plus state tags. The canonical rules collapse from **seven** to **four**:

1. Identify the orthogonal axes (data cardinality / form validity / mode are the canonical three).
2. Declare one parallel machine with one region per axis.
3. Tag each state with its axis-level intent from a small canonical vocabulary (`:data/loading`, `:form/invalid`, `:mode/done`, ...).
4. Compute the render selection in one selector sub, with the priority explicit in *data* (a `render-priority` vector) — not buried in the view's `cond`.

The pre-parallel-regions variant (nine boolean discriminator subs + priority `cond`) moves to an **Appendix — Pre-parallel-regions variant (deprecated but supported)** so existing apps have a reference.

### examples/reagent/nine_states/core.cljs

Rewritten around the parallel machine. Drops the nine boolean discriminator subs; the `:data` region carries the request lifecycle + cardinality story (with an `:always`-cascade picking the cardinality bucket from the count); the `:form` region carries the Pattern-Forms lifecycle; the `:mode` region carries the active/done axis. One `:ui/render` selector sub consults the render-priority table against the snapshot's `:tags`; the root view is one `case`.

Headless tests assert against `:rf/machine-has-tag?` (tag presence) and the resolved `:ui/render` keyword instead of nine sibling boolean discriminator subs. The State 8 fixture explicitly checks that `:form/success` AND `:data/one` are both true post-submit — overlap is now a first-class property of the model, not a workaround.

### Cross-references

- `spec/Pattern-RemoteData.md` and `spec/Pattern-Forms.md` — Nine States cross-refs reworded to describe the lifecycle as folded into the `:data` / `:form` regions.
- `docs/guide/04-views-and-frames.md` — the introductory Pattern-NineStates section updated to describe the parallel-machine shape.
- `docs/guide/13-where-next.md` — the catalogue line updated to mention the parallel machine + tags rather than "async-with-cancel".

### LoC delta

- `spec/Pattern-NineStates.md`: 303 → 365 lines (+62).
- `examples/reagent/nine_states/core.cljs`: 740 → 793 lines (+53). The design doc's estimate was ~540; reality is bigger because the machine declaration runs ~120 lines and the form/demo events that thread broadcasts into the machine add another ~80. The conceptual gain (machine is the model; one selector sub; one `case`) still lands.
- `examples/reagent/nine_states/README.md`: 91 → 127 lines (+36).

### Test results

- `cd implementation/machines && clojure -M:test` — 77 tests / 234 assertions / 0 failures / 0 errors.
- `cd implementation/core && clojure -M:test` — 183 tests / 824 assertions / 0 failures / 0 errors.
- `cd implementation && npm run test:cljs` — 483 tests / 1169 assertions / 0 failures / 0 errors (includes `re-frame.nine-states-cljs-test` which drives the example's `run-all-tests` end-to-end through all nine fixtures).
- `cd implementation && npm run test:elision` — PASS.
- `python -m mkdocs build --strict` — 180 warnings (all pre-existing in `guide/12` / `guide/13`; count unchanged from `origin/main`).

## Test plan

- [ ] Read the rewritten `spec/Pattern-NineStates.md` — does the four-rule structure hang together, and does the appendix preserve enough of the legacy variant for an existing app to find its way?
- [ ] Read the rewritten example — is the machine declaration the right size + shape, and do the demo events make sense as the canonical way to broadcast into it?
- [ ] Verify the Playwright smoke spec still passes (`npm run test:examples`).
- [ ] Confirm the example's LoC delta is acceptable (or push back if it should be smaller).