### PR TITLE
fix(spec): Pattern-Boot — consolidate vector-form :entry actions per Spec 005 (rf2-8pls)

### DIFF
--- a/spec/Pattern-Boot.md
+++ b/spec/Pattern-Boot.md
@@ -112,7 +112,15 @@ Each phase uses `:invoke` to spawn the async work; transitions on success or fai
       :resolve-initial-route
       ;; Reads :route from URL and seeds the :route slice (per Spec 012).
       (fn [_ _]
-        {:fx [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})}
+        {:fx [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})
+
+      :enter-routing
+      ;; Compound entry action for :routing — :set-phase + :resolve-initial-route
+      ;; in one fn. (Per [005 §State nodes] :entry takes one fn or one
+      ;; registered id, never a vector.)
+      (fn [data _]
+        {:data (assoc data :phase :routing :phase-attempt 0)
+         :fx   [[:dispatch [:rf.route/handle-url-change (.. js/window -location -href)]]]})}
 
      :states
      {;; :configuring runs an explicit Pattern-AsyncEffect instance: the boot
@@ -169,7 +177,7 @@ Each phase uses `:invoke` to spawn the async work; transitions on success or fai
        :on    {:hydrate/done {:target :routing}}}
 
       :routing
-      {:entry [:set-phase :resolve-initial-route]
+      {:entry :enter-routing
        ;; If the running app needs the WebSocket URL from config, the :ready
        ;; transition threads it into the connection machine's :connect event
        ;; (per Pattern-AsyncEffect mechanism 1):


### PR DESCRIPTION
## Summary

- Spec 005 §State nodes and §Actions require ``:entry`` / ``:exit`` / ``:action`` to be a single fn or single keyword reference, never a vector. ``spec/Pattern-Boot.md`` line 172 violated this with ``:entry [:set-phase :resolve-initial-route]``.
- Fixed by introducing a named ``:enter-routing`` compound action and pointing the ``:routing`` state's ``:entry`` at the single keyword — the same fix shape rf2-axbq used in Pattern-WebSocket (PR #282).
- Full audit of ``spec/Pattern-Boot.md`` confirmed line 172 was the only violation. Other ``:entry`` slots are already single keyword refs; ``:action`` keys inside multi-candidate transition vectors (e.g. ``:failed [{... :action :bump-attempt} {... :action :record-error}]``) are the legal Spec 005 §Transitions form — each candidate's ``:action`` is singular.

## Audit findings

| Line | Slot | Before | After |
|---|---|---|---|
| 172 (now 180) | ``:entry`` on ``:routing`` | ``:entry [:set-phase :resolve-initial-route]`` | ``:entry :enter-routing`` |

One new compound action added to the machine's ``:actions`` map (``:enter-routing``) that inlines what ``:set-phase`` and ``:resolve-initial-route`` would have done for the ``:routing`` state: sets ``:data :phase :routing``, zeroes ``:phase-attempt``, dispatches ``:rf.route/handle-url-change``.

## Test plan

- [x] Audit every ``:entry`` / ``:exit`` / ``:action`` slot in ``spec/Pattern-Boot.md`` for vector forms
- [x] Apply fix to the single violation on line 172
- [x] mkdocs build ``--strict`` — same warning count (183) before and after the change; zero new warnings; baseline failure is the pre-existing guide → spec link issue unrelated to this fix
- [x] Confirm no other Pattern-Boot violations remain

Closes rf2-8pls.