### PR TITLE
chore(template): restructure into spec/ folder per rf2-bfax convention (rf2-2qy6)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -3,6 +3,9 @@
 > `day8/clj-template.re-frame2` — scaffolding tool for new re-frame2 apps
 > (rf2-lrtc). The v2 equivalent of v1's
 > [`day8/re-frame-template`](https://github.com/day8/re-frame-template).
+>
+> **Spec:** [`spec/`](./spec/) — the tool's normative contract per the
+> per-tool [spec/ folder convention (rf2-bfax)](../README.md#per-tool-spec-folder-convention-rf2-bfax).
 
 This tool generates a fresh re-frame2 application skeleton. It is the
 front door for new users: one command and you have a working CLJS app
@@ -13,7 +16,8 @@ wired against the alpha-channel `day8/re-frame2-*` coords, ready to
 
 Once published to Clojars (per the standard release workflow), invoke
 the template via clj-new. The substrate selector rides on `:edn-args`
-because clj-new's `create` strips unknown top-level args:
+because clj-new's `create` strips unknown top-level args
+([why](./spec/DESIGN-RATIONALE.md#2--edn-args-over-a-top-level-substrate-key)):
 
 ```bash
 # Reagent — the canonical substrate (default)
@@ -30,26 +34,11 @@ clojure -X:project/new :template re-frame2 :name acme/my-app \
 
 That assumes the standard `:project/new` alias is wired in
 `~/.clojure/deps.edn` per
-[clj-new's README](https://github.com/seancorfield/clj-new):
+[clj-new's README](https://github.com/seancorfield/clj-new). If you
+don't have that alias, see [API §Inline invocation](./spec/API.md#inline-invocation).
 
-```clojure
-{:aliases
- {:project/new {:extra-deps {com.github.seancorfield/clj-new
-                             {:mvn/version "1.3.415"}}
-                :exec-fn    clj-new/create
-                :exec-args  {:template "app"}}}}
-```
-
-If you don't have that alias, the equivalent inline form is:
-
-```bash
-clojure -Sdeps '{:deps {com.github.seancorfield/clj-new
-                        {:mvn/version "1.3.415"}}}' \
-        -X clj-new/create :template re-frame2 :name acme/my-app
-```
-
-Until the alpha publish lands on Clojars, use the `:local/root` route to
-exercise the template from a checkout of this repo:
+Until the alpha publish lands on Clojars, use the `:local/root` route
+to exercise the template from a checkout of this repo:
 
 ```bash
 clojure -Sdeps '{:deps {day8/clj-template.re-frame2
@@ -57,154 +46,48 @@ clojure -Sdeps '{:deps {day8/clj-template.re-frame2
         -X clj-new/create :template re-frame2 :name acme/my-app
 ```
 
-## What you get
-
-For substrate `:reagent` (default):
-
-```
-my-app/
-├── deps.edn                  re-frame2 + Reagent adapter + shadow-cljs
-├── shadow-cljs.edn           :app (watch/release) + :test builds
-├── package.json              react + react-dom + shadow-cljs
-├── README.md                 "run shadow-cljs watch app; open localhost:8280"
-├── .gitignore
-├── resources/public/
-│   └── index.html            host page; loads /js/main.js
-└── src/my_app/
-    ├── core.cljs             entry point — mounts the view
-    ├── events.cljs           :counter/initialise, :counter/increment
-    ├── subs.cljs             :counter/value
-    └── views.cljs            the counter view
-```
-
-The UIx and Helix variants follow the same shape; only `core.cljs`,
-`views.cljs`, `deps.edn`, and the substrate adapter coord change.
-
-The generated counter mirrors the canonical counter examples in this
-repo at `examples/<substrate>/counter*/core.cljs` — the user who runs
-the template sees the same shape they read about in
-[the guide](../../docs/guide/).
-
-## Implementation choice
-
-This template is a **`clj-new` template**.
-
-`clj-new` is the modern successor to lein-template; consumed via
-`clojure -X:project/new`. It is mature, declarative (resource templates
-with Mustache substitution), and widely understood by the Clojure
-community. The v1 `re-frame-template` was lein-template; clj-new is its
-direct lineage.
-
-Two alternatives were considered:
-
-- **`deps-new`** (option B) — newer, similar shape but with a different
-  config style. Equally viable. clj-new wins on familiarity: more
-  prior art, the v1 template's audience knows the workflow.
-- **Small CLI / `bb` script with interactive prompts** (option C) —
-  more flexible for branching choices ("include Story? include 10x?")
-  but heavier-weight for the user (extra runtime, extra prompts) and
-  outside Clojure norms. Reserved for the day branching choices
-  materially exceed clj-new's substitution capability — see also
-  the "future toggles" comment in `src/clj/new/re_frame2.clj`.
-
-## How it works
-
-clj-new resolves a template by name. For `:template re-frame2` it
-searches Clojars/Maven Central for `<group>/clj-template.re-frame2` —
-we publish as `day8/clj-template.re-frame2`. Once resolved, clj-new
-classloads the template, calls its entry function, and writes the
-generated tree to the user's current directory.
-
-### Layout
-
-```
-tools/template/
-├── deps.edn                              ; this artefact's deps
-├── README.md                             ; this file
-└── src/clj/new/
-    ├── re_frame2.clj                     ; the entry function
-    └── re_frame2/                        ; resource tree (Mustache templates)
-        ├── shared/                       ; substrate-agnostic files
-        │   ├── README.md
-        │   ├── gitignore
-        │   ├── events.cljs
-        │   ├── subs.cljs
-        │   └── index.html
-        ├── reagent/                      ; Reagent-specific
-        │   ├── deps.edn
-        │   ├── shadow-cljs.edn
-        │   ├── package.json
-        │   ├── core.cljs
-        │   └── views.cljs
-        ├── uix/                          ; UIx-specific
-        │   └── (same shape)
-        └── helix/                        ; Helix-specific
-            └── (same shape)
-```
-
-clj-new's `renderer "re-frame2"` discovers files by classpath path
-`clj/new/re_frame2/<file>` (hyphens get sanitised to underscores; nested
-paths are preserved). The entry fn assembles the file list, choosing
-the substrate-specific subdirectory based on the `:substrate` arg.
-
-### Substitution variables
-
-clj-new's `project-data` gives us the standard set:
-
-| Variable | Meaning | Example |
-|---|---|---|
-| `{{name}}` | Project name (un-grouped) | `my-app` |
-| `{{namespace}}` | Project's main ns | `acme.my-app` |
-| `{{nested-dirs}}` | The ns as a directory path | `acme/my_app` |
-| `{{group}}` | The group portion of the coord | `acme` |
-| `{{year}}`, `{{date}}` | Calendar values | `2026`, `2026-05-11` |
-
-Plus template-specific:
-
-| Variable | Meaning | Example |
-|---|---|---|
-| `{{substrate}}` | The chosen substrate name | `reagent`, `uix`, `helix` |
-| `{{rf2-version}}` | re-frame2 coord version | `0.0.1.alpha` |
-| `{{shadow-version}}` | shadow-cljs pin | `2.28.20` |
-| `{{react-version}}` | react & react-dom pin | `18.3.1` |
-
-## Bundle isolation / elision contract
-
-Per [`tools/README.md`](../README.md), tools must not be reachable from
-a consumer's production build. This template satisfies the contract
-trivially: **the template jar is never on a consumer's runtime
-classpath**. It is a build-time scaffold; consumers invoke it via
-`clojure -X:project/new` and what lands in their project is the
-generated source tree, not this jar. The dependency flow is
-unidirectional: user → clj-new → this template → generated files; the
-generated app has no compile-time or runtime knowledge of the template.
-
-## Testing
-
-A JVM test under `test/clj/new/re_frame2/core_test.clj` exercises the
-template end-to-end for each of the three substrates:
-
-1. Generate a tmp app via the template's main fn.
-2. Walk the produced file tree and assert the expected shape.
-3. Run `clojure -P` against the generated `deps.edn` to confirm a
-   successful deps-parse.
-
-Run it from this directory:
+Then:
 
 ```bash
+cd my-app
+npm install
+clojure -M:shadow watch app   # or: npx shadow-cljs watch app
+# open http://localhost:8280
+```
+
+You should see the counter — the same shape walked through in
+[Guide chapter 02 — Your first app](../../docs/guide/02-your-first-app.md).
+
+## Testing the template
+
+The JVM test exercises the template end-to-end for each substrate:
+
+```bash
+cd tools/template
 clojure -M:test
 ```
 
-The `clojure -P` step requires a clojure CLI on PATH; if it isn't
-available the test logs and skips that assertion (deps-parse is a
-nice-to-have signal — the file-tree shape is the harder contract).
+See [Principles §P7](./spec/Principles.md#p7--tested-end-to-end-per-substrate).
+
+## Spec
+
+The normative contract lives under [`spec/`](./spec/):
+
+| File | What's in it |
+|---|---|
+| [`spec/000-Vision.md`](./spec/000-Vision.md) | What the tool is for; lineage from v1; goals; non-goals. |
+| [`spec/001-Substrate-Variants.md`](./spec/001-Substrate-Variants.md) | Reagent / UIx / Helix variants; the `:edn-args` invocation form; substrate coercion. |
+| [`spec/002-Generated-Shape.md`](./spec/002-Generated-Shape.md) | The file tree emitted; the resource tree; substitution variables. |
+| [`spec/Principles.md`](./spec/Principles.md) | The design principles (build-time only, counter as canonical example, substrate-agnostic shell, `:edn-args` selection). |
+| [`spec/API.md`](./spec/API.md) | The consolidated public invocation surface. |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | WHY each major decision (clj-new vs deps-new vs CLI, `:edn-args` plumbing, three substrates in v1, counter as example, no-Story-yet, pin lockstep). |
 
 ## Cross-references
 
 - [`tools/README.md`](../README.md) — the tools/ convention and the
-  bundle-isolation contract.
-- [`spec/Construction-Prompts.md`](../../spec/Construction-Prompts.md) —
-  AI-driven scaffolding prompts; the template is for human-driven
+  bundle-isolation contract this template satisfies trivially.
+- [`spec/Construction-Prompts.md`](../../spec/Construction-Prompts.md)
+  — AI-driven scaffolding prompts; the template is for human-driven
   scaffolding, the prompts cover the agent-driven path.
 - [`examples/reagent/counter/`](../../examples/reagent/counter/) — the
   canonical counter the Reagent variant mirrors.

--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -1,0 +1,98 @@
+# Template — Vision
+
+> Bead [rf2-lrtc](../../../). Tool [`tools/template/`](../). Artefact
+> `day8/clj-template.re-frame2`.
+>
+> The v2 equivalent of v1's
+> [`day8/re-frame-template`](https://github.com/day8/re-frame-template).
+
+## What this tool is
+
+`re-frame2-template` is the **front-door scaffolding tool** for new
+re-frame2 apps. One command and a developer has a working CLJS app
+wired against the alpha-channel `day8/re-frame2-*` coords, ready to
+`shadow-cljs watch app`.
+
+It is a [clj-new](https://github.com/seancorfield/clj-new) template
+— a build-time generator, invoked via:
+
+```bash
+clojure -X:project/new :template re-frame2 :name acme/my-app
+```
+
+What lands in the user's directory is a complete CLJS project: a
+substrate-adapter wired against re-frame2, a host HTML page, a
+shadow-cljs build, and a worked counter mirroring
+[`examples/<substrate>/counter*/`](../../../examples/).
+
+## Lineage
+
+v1's `day8/re-frame-template` was a lein-template — the same posture,
+the same audience, the same "one command, working app" promise. The
+v2 tool inherits that lineage. The technology underneath shifts:
+
+- **lein-template → clj-new.** clj-new is the modern successor; same
+  declarative resource-templates-with-Mustache shape, consumed via
+  the `clojure` CLI rather than `lein new`.
+- **re-frame → re-frame2.** The generated app's deps target the alpha
+  re-frame2 coords. The shape of the generated counter mirrors v2's
+  reference examples, not v1's.
+- **One substrate → three substrates.** v1 was Reagent only. v2's
+  template ships Reagent (canonical default), UIx, and Helix
+  variants. The substrate selector rides on `:edn-args` (see
+  [001-Substrate-Variants.md](001-Substrate-Variants.md)).
+
+A v1 user who knew `lein new re-frame my-app` reads the v2 invocation
+and recognises the shape. That continuity is deliberate.
+
+## Goals
+
+- **One command, working app.** The generated tree builds with
+  `shadow-cljs watch app` immediately — no follow-up edits required.
+- **Substrate-agnostic shell, substrate-specific views.** Events,
+  subs, and the host HTML are shared across variants; only the entry
+  point (`core.cljs`), the view (`views.cljs`), and the substrate
+  adapter coord differ.
+- **Counter as canonical example.** The generated counter is the
+  same shape the developer reads about in [Guide chapter 02
+  — Your first app](../../../docs/guide/02-your-first-app.md)
+  (rf2-2kzw throughline). What the template emits is what the guide
+  walks through.
+- **Lockstep with the reference implementation's pins.** The
+  shadow-cljs / react pins the template emits track
+  `implementation/package.json` — the smoke-tested combination is
+  what users get.
+
+## Non-goals
+
+- **Branching feature toggles** (include-Story? include-10x?
+  include-routing?). The first cut keeps the template flat — one
+  substrate flag, no other choices. Branching is reserved for the
+  day choices materially exceed clj-new's substitution capability
+  ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §clj-new vs CLI).
+- **Bundling Story.** [`tools/story/`](../../story/) is the future
+  Storybook-class playground for re-frame2; the template
+  intentionally doesn't pre-wire it. Story-stabilisation lands
+  first; a `counter_with_stories`-style variant follows
+  ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §No-Story-yet).
+- **Multi-frame scaffolds.** Frames (Spec 002) are a runtime
+  concern. The template emits a single-frame app; the user reads
+  Guide chapter 04 to add more.
+- **Server-side hosting.** No backend; the template is a pure CLJS
+  SPA. SSR scaffolding (Spec 011) lands as a separate template
+  variant if/when SSR matures.
+
+## Cross-references
+
+- [`tools/README.md`](../../README.md) — the tools/ convention and
+  the per-tool spec/ folder convention (rf2-bfax).
+- [001-Substrate-Variants.md](001-Substrate-Variants.md) — the three
+  shipped variants.
+- [002-Generated-Shape.md](002-Generated-Shape.md) — the file tree
+  the template emits.
+- [API.md](API.md) — the consolidated public invocation surface.
+- [DESIGN-RATIONALE.md](DESIGN-RATIONALE.md) — WHY each major call
+  was made.
+- [Guide chapter 02 — Your first app](../../../docs/guide/02-your-first-app.md)
+  — the worked-example throughline the template's generated counter
+  aligns with (rf2-2kzw).

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -1,0 +1,133 @@
+# Template — Substrate Variants
+
+> Capability doc. The template ships three substrate variants; this
+> file documents each, the invocation form, and the rationale for the
+> `:edn-args` plumbing.
+
+## The three variants
+
+| Substrate | Beads | Default? | View library | Generated `core.cljs` shape |
+|---|---|---|---|---|
+| `:reagent` | (canonical) | yes | Reagent | Reagent component + `r/render` |
+| `:uix` | rf2-3yij | no | UIx | UIx defui + `uix/render-root` |
+| `:helix` | rf2-2qit | no | Helix | Helix defnc + `createRoot` |
+
+Reagent is the canonical default — the substrate every re-frame and
+re-frame2 example targets first. UIx and Helix are equally supported;
+the choice is the developer's, surfaced via the `:edn-args` selector
+described below.
+
+## Invocation form
+
+The substrate selector rides on `:edn-args` because clj-new's
+`create` strips unknown top-level args (this is a harness constraint
+discovered during implementation — see
+[DESIGN-RATIONALE](DESIGN-RATIONALE.md) §edn-args-not-top-level):
+
+```bash
+# Reagent — the canonical substrate (default)
+clojure -X:project/new :template re-frame2 :name acme/my-app
+
+# UIx
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix]'
+
+# Helix
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :helix]'
+```
+
+`:edn-args` is a flat alternating-key-value vector: clj-new passes
+its contents through to the template's entry fn as `& args`. The
+template wraps the args in `apply hash-map` and reads `:substrate`.
+
+## Substrate coercion
+
+The template accepts the substrate arg as a keyword, a string (with
+or without leading `:`), or a symbol — clj-new harnesses around the
+wider Clojure tooling ecosystem hand keywords through inconsistently,
+and tolerating all three keeps the command line forgiving:
+
+```clojure
+(coerce-substrate :uix)        ;; => :uix
+(coerce-substrate "uix")       ;; => :uix
+(coerce-substrate ":uix")      ;; => :uix
+(coerce-substrate 'uix)        ;; => :uix
+(coerce-substrate :unknown)    ;; => throws — clear message
+(coerce-substrate nil)         ;; => :reagent (default)
+```
+
+Anything not in `#{:reagent :uix :helix}` throws an `ex-info` with
+the offending value and the set of valid substrates in `ex-data`.
+
+## What each variant emits
+
+All three variants emit the same top-level project shape — see
+[002-Generated-Shape.md](002-Generated-Shape.md). The substrate
+choice swaps:
+
+- `core.cljs` — the entry point. Reagent uses `reagent.dom/render`;
+  UIx uses `uix.dom/render-root`; Helix uses `react-dom/client`'s
+  `createRoot`.
+- `views.cljs` — the counter view. Reagent uses plain hiccup;
+  UIx uses `$` with `defui`; Helix uses `defnc` and `d/...`
+  elements.
+- `deps.edn` — the substrate-adapter coord changes:
+  `day8/re-frame2-reagent`, `day8/re-frame2-uix`, or
+  `day8/re-frame2-helix`. The runtime coord `day8/re-frame2` is
+  identical across variants.
+- `shadow-cljs.edn` and `package.json` — react / react-dom pins
+  are identical; the substrate's own npm dep (where applicable)
+  is added.
+
+The substrate-agnostic shell — `events.cljs`, `subs.cljs`,
+`README.md`, `.gitignore`, `resources/public/index.html` — lives
+under the `shared/` resource sub-tree and is emitted identically
+across all three variants.
+
+## The counter throughline
+
+Every variant emits a working counter. The counter is the same
+shape the developer reads about in:
+
+- [Guide chapter 02 — Your first app](../../../docs/guide/02-your-first-app.md)
+  — the friendly walkthrough.
+- [`examples/reagent/counter/`](../../../examples/reagent/counter/) —
+  the canonical Reagent counter.
+- [`examples/uix/counter_uix/`](../../../examples/uix/counter_uix/) —
+  the UIx counter.
+- [`examples/helix/counter_helix/`](../../../examples/helix/counter_helix/) —
+  the Helix counter.
+
+What the template emits is what the guide walks through (rf2-2kzw
+throughline). A developer who runs `clojure -X:project/new
+:template re-frame2 ...` and then reads Guide chapter 02 sees the
+same code in both places.
+
+## Future variants
+
+Reserved space — not implemented:
+
+- **Re-frame2 + Story scaffolding.** Adds `tools/story/`'s
+  registrations and a worked `counter_with_stories`. Lands once
+  Story stabilises post-1.0 (see
+  [DESIGN-RATIONALE](DESIGN-RATIONALE.md) §No-Story-yet).
+- **SSR.** Once Spec 011 has a Reagent-side reference implementation
+  the template can ship an SSR variant of the counter.
+- **reagent-slim.** Once the substrate-portable reagent-slim adapter
+  exists (rf2-3sk6) the template can ship it as a fourth substrate
+  choice.
+- **TypeScript port.** Per Spec 000 — re-frame2 is a pattern, not a
+  CLJS library. A `create-re-frame2-app` style npm template is
+  reserved for a future iteration.
+
+Adding a variant requires:
+
+1. A new entry in the `valid-substrates` set in
+   `src/clj/new/re_frame2.clj`.
+2. A new resource sub-tree at
+   `src/clj/new/re_frame2/<substrate>/` (matching the existing
+   reagent/uix/helix shape).
+3. A test entry in `test/clj/new/re_frame2/core_test.clj`.
+
+The substrate-agnostic `shared/` tree is reused as-is.

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -1,0 +1,182 @@
+# Template — Generated Shape
+
+> Capability doc. The file layout the template emits, the resource
+> tree it reads from, and the substitution variables threaded
+> through.
+
+## What lands in the user's directory
+
+For substrate `:reagent` (the default):
+
+```
+my-app/
+├── deps.edn                  re-frame2 + Reagent adapter + shadow-cljs
+├── shadow-cljs.edn           :app (watch/release) + :test builds
+├── package.json              react + react-dom + shadow-cljs
+├── README.md                 "run shadow-cljs watch app; open localhost:8280"
+├── .gitignore
+├── resources/public/
+│   └── index.html            host page; loads /js/main.js
+└── src/my_app/
+    ├── core.cljs             entry point — mounts the view
+    ├── events.cljs           :counter/initialise, :counter/increment
+    ├── subs.cljs             :counter/value
+    └── views.cljs            the counter view
+```
+
+The UIx and Helix variants follow the same shape; only `core.cljs`,
+`views.cljs`, `deps.edn`, and the substrate-adapter coord change.
+See [001-Substrate-Variants.md](001-Substrate-Variants.md) §What
+each variant emits.
+
+## The counter
+
+Every variant emits a working counter:
+
+- An init event `:counter/initialise` seeds `app-db` with `{:counter
+  0}`.
+- An action event `:counter/increment` adds `1` to `[:counter]`.
+- A sub `:counter/value` reads the current count.
+- A view subscribes to `:counter/value` and renders the value plus
+  an increment button that dispatches `:counter/increment`.
+
+This is the same shape the developer reads about in [Guide chapter
+02 — Your first app](../../../docs/guide/02-your-first-app.md) and
+in the [`examples/<substrate>/counter*/`](../../../examples/)
+trees. The template's generated counter and the guide's worked
+example align (rf2-2kzw throughline).
+
+## Resource tree (template-side)
+
+The template's own resource tree mirrors the generated tree's
+substrate-axis split:
+
+```
+tools/template/
+├── deps.edn                              ; this artefact's deps
+├── README.md                             ; install + invoke
+├── spec/                                 ; this folder
+└── src/clj/new/
+    ├── re_frame2.clj                     ; the entry function
+    └── re_frame2/                        ; resource tree (Mustache templates)
+        ├── shared/                       ; substrate-agnostic files
+        │   ├── README.md
+        │   ├── gitignore
+        │   ├── events.cljs
+        │   ├── subs.cljs
+        │   └── index.html
+        ├── reagent/                      ; Reagent-specific
+        │   ├── deps.edn
+        │   ├── shadow-cljs.edn
+        │   ├── package.json
+        │   ├── core.cljs
+        │   └── views.cljs
+        ├── uix/                          ; UIx-specific
+        │   └── (same shape)
+        └── helix/                        ; Helix-specific
+            └── (same shape)
+```
+
+`shared/` files are emitted into every generated app unchanged.
+`<substrate>/` files are emitted only when that substrate is
+selected. Adding a substrate is "drop a new sub-tree at
+`re_frame2/<substrate>/`" plus a one-line change to the
+`valid-substrates` set.
+
+## How clj-new finds the resources
+
+clj-new's `renderer` and `raw-resourcer` build their lookup path as
+`clj/new/<sanitized-template-name>/<file>`. The template's entry fn
+keys its renderer off the top-level template name `re-frame2` and
+passes the relative resource path (e.g. `shared/README.md` or
+`reagent/core.cljs`) as the file:
+
+```clojure
+(let [render     (renderer "re-frame2")
+      raw        (raw-resourcer "re-frame2")
+      sub-render (fn [path] (render path data))
+      sub-raw    (fn [path] (raw path))]
+  (->files data
+           ["deps.edn"
+            (sub-render (str substrate-name "/deps.edn"))]
+           ["src/{{nested-dirs}}/core.cljs"
+            (sub-render (str substrate-name "/core.cljs"))]
+           ["src/{{nested-dirs}}/events.cljs"
+            (sub-render "shared/events.cljs")]
+           ;; ...
+           ))
+```
+
+The `renderer` reads each resource through clj-new's Mustache
+renderer, applying the `data` map's substitutions. `raw-resourcer`
+copies bytes through without substitution — used today only for
+`.gitignore` (clj-new's `->files` strips leading dots from generated
+filenames so the source is committed as `gitignore`, sans-dot, and
+gets renamed at emit time).
+
+Internal slashes in the path are preserved on the classpath lookup;
+hyphens in the top-level template name get sanitised to
+underscores (`re-frame2` → `re_frame2/`). That's why the resource
+tree lives at `src/clj/new/re_frame2/...`.
+
+## Substitution variables
+
+Two layers thread through every Mustache-rendered file: clj-new's
+standard set and the template's own additions.
+
+### From clj-new's `project-data`
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `{{name}}` | Project name (un-grouped) | `my-app` |
+| `{{namespace}}` | Project's main ns | `acme.my-app` |
+| `{{nested-dirs}}` | The ns as a directory path | `acme/my_app` |
+| `{{group}}` | The group portion of the coord | `acme` |
+| `{{artifact}}` | The artefact portion | `my-app` |
+| `{{year}}`, `{{date}}` | Calendar values | `2026`, `2026-05-11` |
+
+### Template-specific
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `{{substrate}}` | The chosen substrate name | `reagent`, `uix`, `helix` |
+| `{{reagent?}}` | Conditional section flag | `true` / `false` |
+| `{{uix?}}` | Conditional section flag | `true` / `false` |
+| `{{helix?}}` | Conditional section flag | `true` / `false` |
+| `{{rf2-version}}` | re-frame2 coord version | `0.0.1.alpha` |
+| `{{shadow-version}}` | shadow-cljs pin | `2.28.20` |
+| `{{react-version}}` | react & react-dom pin | `18.3.1` |
+
+The `?`-suffixed flags exist because Mustache sections key on a
+truthy value; `{{#reagent?}}...{{/reagent?}}` lets a shared file
+gate small substrate-specific snippets without splitting the
+template into more sub-trees. Today most substrate-specific
+divergence lives at the file level (see [the resource
+tree](#resource-tree-template-side)); the section flags are
+reserved for future shared-file substrate gating.
+
+## Pin lockstep
+
+`{{rf2-version}}`, `{{shadow-version}}`, and `{{react-version}}` are
+defined inline in `src/clj/new/re_frame2.clj`. They are bumped in
+lockstep with `implementation/package.json` and the runtime
+coords' release cadence:
+
+- `:rf2-version` tracks the re-frame2 alpha-channel release at the
+  time of template publish.
+- `:shadow-version` and `:react-version` match
+  `implementation/package.json` so the combination the template
+  emits is the combination CI has smoke-tested.
+
+Bumping these is part of the per-release checklist when the
+template's own version cuts.
+
+## Cross-references
+
+- [001-Substrate-Variants.md](001-Substrate-Variants.md) — the
+  per-variant detail (what `core.cljs` / `views.cljs` look like).
+- [API.md](API.md) — the full invocation surface.
+- [DESIGN-RATIONALE.md](DESIGN-RATIONALE.md) §clj-new-vs-deps-new
+  — why this Mustache-resource shape was chosen.
+- [Guide chapter 02 — Your first app](../../../docs/guide/02-your-first-app.md)
+  — the counter walkthrough the generated app aligns with.

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -1,0 +1,157 @@
+# Template — API
+
+> The consolidated public surface. Every invocation form, every
+> argument, every supported flag.
+
+## Invocation
+
+The template is invoked via clj-new's `create`:
+
+```bash
+clojure -X:project/new :template re-frame2 :name <coord> \
+        [:edn-args '[:substrate <kw>]']
+```
+
+Where:
+
+- `<coord>` is a group-qualified Clojure name — e.g. `acme/my-app`.
+  `name` is required.
+- `<kw>` is one of `:reagent` `:uix` `:helix`. Optional. Defaults
+  to `:reagent`.
+
+The `:project/new` alias is the standard clj-new alias. If it isn't
+wired in `~/.clojure/deps.edn`, see [§Inline invocation](#inline-invocation)
+below.
+
+## Examples
+
+```bash
+# Reagent — canonical substrate (default)
+clojure -X:project/new :template re-frame2 :name acme/my-app
+
+# UIx
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix]'
+
+# Helix
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :helix]'
+```
+
+## Args reference
+
+### Top-level (clj-new harness)
+
+| Arg | Required | Meaning |
+|---|---|---|
+| `:template` | yes | The template name. Must be `re-frame2` to invoke this template. |
+| `:name` | yes | Group-qualified project coord. |
+| `:edn-args` | no | Pass-through bag for template-specific args. See below. |
+| `:to-dir` | no | Override the directory clj-new creates the project in. Defaults to a sibling of CWD named after `:name`'s artefact. |
+
+### Template-specific (inside `:edn-args`)
+
+| Arg | Required | Meaning | Default |
+|---|---|---|---|
+| `:substrate` | no | One of `:reagent` `:uix` `:helix`. | `:reagent` |
+
+`:substrate` accepts a keyword, a string (with or without leading
+`:`), or a symbol. The template coerces to a keyword internally.
+Anything not in the valid set throws.
+
+Future toggles (`:include-story?`, `:include-10x?`,
+`:include-routing?`) would slot in as additional `:edn-args`
+entries. None ship in v1.
+
+## Why `:edn-args`
+
+clj-new's `create` strips unknown top-level args before
+classloading the template's entry fn — only its own well-known
+keys (`:template`, `:name`, `:to-dir`, etc.) pass through directly.
+`:edn-args` is the documented pass-through bag: its contents are
+handed to the template's entry fn as `& args`, a flat
+alternating-key-value sequence the template wraps in
+`apply hash-map`.
+
+This is documented in clj-new's README but surfaced in this
+template as an implementation finding — see
+[DESIGN-RATIONALE](DESIGN-RATIONALE.md) §edn-args-not-top-level.
+
+## Standard `:project/new` alias
+
+The invocation form assumes the standard clj-new alias is wired in
+`~/.clojure/deps.edn` per
+[clj-new's README](https://github.com/seancorfield/clj-new):
+
+```clojure
+{:aliases
+ {:project/new {:extra-deps {com.github.seancorfield/clj-new
+                             {:mvn/version "1.3.415"}}
+                :exec-fn    clj-new/create
+                :exec-args  {:template "app"}}}}
+```
+
+The `:exec-args {:template "app"}` default is harmless — `:template
+re-frame2` on the invocation line overrides it.
+
+## Inline invocation
+
+If the `:project/new` alias isn't available, the equivalent inline
+form is:
+
+```bash
+clojure -Sdeps '{:deps {com.github.seancorfield/clj-new
+                        {:mvn/version "1.3.415"}}}' \
+        -X clj-new/create :template re-frame2 :name acme/my-app
+```
+
+The same `:edn-args '[:substrate :uix]'` style applies.
+
+## Local-development invocation
+
+Until the alpha publish lands on Clojars, use the `:local/root`
+route to exercise the template from a checkout of this repo:
+
+```bash
+clojure -Sdeps '{:deps {day8/clj-template.re-frame2
+                        {:local/root "tools/template"}}}' \
+        -X clj-new/create :template re-frame2 :name acme/my-app
+```
+
+This is the path the template's own JVM tests
+(`test/clj/new/re_frame2/core_test.clj`) take internally — they
+invoke the entry fn directly without the clj-new harness.
+
+## Outputs
+
+What lands in the user's directory: see
+[002-Generated-Shape.md §What lands in the user's directory](002-Generated-Shape.md#what-lands-in-the-users-directory).
+
+What console output to expect:
+
+```
+Generating a re-frame2 project called my-app — reagent substrate.
+```
+
+Or `— uix substrate.` / `— helix substrate.` per the selector.
+
+## Errors
+
+| Condition | Behaviour |
+|---|---|
+| `:substrate` not one of `#{:reagent :uix :helix}` | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
+| `:name` missing | clj-new's harness rejects before template is invoked. |
+| `:name` not group-qualified | clj-new's harness rejects (`acme/my-app`, not `my-app`). |
+| Target directory already exists | clj-new's harness aborts to avoid clobbering. |
+
+## Cross-references
+
+- [000-Vision.md](000-Vision.md) — what the tool is for.
+- [001-Substrate-Variants.md](001-Substrate-Variants.md) — what
+  each substrate variant looks like.
+- [002-Generated-Shape.md](002-Generated-Shape.md) — what file
+  tree gets emitted.
+- [Principles.md §P4](Principles.md#p4--substrate-selection-via-edn-args)
+  — the `:edn-args` selector design.
+- [DESIGN-RATIONALE.md](DESIGN-RATIONALE.md) — WHY this surface
+  shape.

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,303 @@
+# Template — Design Rationale
+
+> WHY each major decision was made. The audit trail behind the
+> [000-Vision](000-Vision.md) / [001-Substrate-Variants](001-Substrate-Variants.md)
+> / [002-Generated-Shape](002-Generated-Shape.md) / [Principles](Principles.md)
+> / [API](API.md) shape. Beads referenced as rf2-xxxx.
+
+## §1 — clj-new over deps-new
+
+**Decision.** This template is a [clj-new](https://github.com/seancorfield/clj-new)
+template, not a [deps-new](https://github.com/seancorfield/deps-new)
+template.
+
+**Alternatives considered.**
+
+| Option | What it is | Outcome |
+|---|---|---|
+| A — clj-new | The modern successor to lein-template; resource templates with Mustache substitution; consumed via `clojure -X:project/new`. | **Selected.** |
+| B — deps-new | Newer than clj-new; similar shape but with a different config style and a slightly more programmatic surface. | Rejected. |
+| C — Small CLI / `bb` script with interactive prompts | A bb-based wizard ("include Story? include 10x? Reagent or UIx or Helix?"). | Rejected for v1. |
+
+**Why clj-new.**
+
+- **Lineage.** v1's `day8/re-frame-template` was lein-template;
+  clj-new is its direct successor — same declarative Mustache shape,
+  same audience, same "one command, working app" promise. A v1
+  user knows the workflow.
+- **Maturity.** clj-new is mature; the Mustache substitution model
+  is widely understood by the Clojure community; resource
+  templates are easy to inspect and edit.
+- **Tooling-team portability.** The Clojure tooling team
+  (sean-corfield) maintains clj-new. The artefact is a known
+  quantity for downstream consumers.
+
+**Why not deps-new.** Equally viable on a technical axis. clj-new
+wins on familiarity: more prior art, the v1 template's audience
+knows the workflow. There is no second-class capability gap that
+would favour deps-new here.
+
+**Why not a bb-based wizard (option C).** More flexible for
+branching choices ("include Story? include 10x?") but:
+
+- Heavier-weight for the user (extra runtime, extra prompts).
+- Outside Clojure norms — the community expectation for "scaffold
+  a new project" is clj-new / lein new, not a bespoke script.
+- v1's branching surface is **one flag** (substrate). clj-new's
+  substitution capability is more than adequate.
+
+Option C is reserved for the day branching choices materially
+exceed clj-new's substitution capability — see the "future
+toggles" comment in `src/clj/new/re_frame2.clj` and
+[001-Substrate-Variants.md §Future variants](001-Substrate-Variants.md#future-variants).
+
+## §2 — `:edn-args` over a top-level `:substrate` key
+
+**Decision.** The substrate selector rides on `:edn-args`:
+
+```bash
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix]'
+```
+
+Not the more obvious:
+
+```bash
+# Doesn't work — clj-new strips unknown top-level args
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :substrate :uix
+```
+
+**Why.**
+
+This was an **implementation finding**. The first cut of the
+template wired `:substrate` as a top-level arg. When tested
+end-to-end via `clojure -X:project/new`, the substrate arg never
+reached the template's entry fn — clj-new's `create` was stripping
+it.
+
+Reading clj-new's harness confirmed: `create` strips unknown
+top-level args before classloading the template. The documented
+pass-through bag is `:edn-args`, which clj-new hands through to
+the template's entry fn as `& args`. The template wraps the args
+in `apply hash-map` and reads `:substrate` from there.
+
+**The capture in spec form.** This is documented in clj-new's
+README but is non-obvious from the template-author side until you
+hit it. Filing it in DESIGN-RATIONALE (rather than just fixing the
+code) makes the constraint visible to the next person who reads
+the spec — and signals that any future `:substrate`-adjacent flag
+must go through the same `:edn-args` plumbing.
+
+**Forgiving coercion.** Once the selector reaches the template,
+the value is coerced from keyword / string / symbol uniformly
+(see [001-Substrate-Variants.md §Substrate coercion](001-Substrate-Variants.md#substrate-coercion)).
+The clj-new ecosystem hands keywords through inconsistently across
+shells; the template tolerates the variants.
+
+## §3 — Three substrates in v1 (Reagent / UIx / Helix)
+
+**Decision.** Ship Reagent, UIx, and Helix variants together in
+the first cut.
+
+**Alternatives considered.**
+
+| Option | What it is | Outcome |
+|---|---|---|
+| A — Reagent only, defer UIx / Helix | Match v1's surface (Reagent only). | Rejected. |
+| B — Reagent + UIx | Two substrates; defer Helix. | Rejected. |
+| C — Reagent + UIx + Helix | Three substrates from day one. | **Selected.** |
+
+**Why all three.**
+
+- **Substrate-portability is a re-frame2 design assertion.** Spec
+  006 (Reactive Substrate) and the per-adapter jars
+  (`implementation/adapters/{reagent,uix,helix}`) commit re-frame2
+  to substrate-agnostic business logic and substrate-specific
+  render edges. The template, as the front door, should demonstrate
+  this from day one. Shipping Reagent only would imply Reagent is
+  privileged.
+- **Cost is marginal.** The shared shell (`events.cljs`,
+  `subs.cljs`, host HTML) is identical across substrates. Only
+  `core.cljs`, `views.cljs`, `deps.edn`, and the npm pins
+  differ. The per-substrate resource sub-tree is ~5 files.
+- **CI exercises all three.** The JVM test
+  (`test/clj/new/re_frame2/core_test.clj`) runs every substrate
+  end-to-end, so adding a substrate has a low maintenance tax.
+
+Reagent remains the default — it's the canonical substrate every
+re-frame example targets first. UIx and Helix are equal citizens,
+not afterthoughts.
+
+## §4 — Counter as the canonical example
+
+**Decision.** Every variant emits a counter. Not a TodoMVC, not a
+hello-world, not a routing-demo.
+
+**Why.**
+
+- **rf2-2kzw throughline.** [Guide chapter 02 — Your first
+  app](../../../docs/guide/02-your-first-app.md) walks through a
+  counter. The reference `examples/<substrate>/counter*/` apps
+  are counters. The template emits a counter. A developer who
+  runs the template and then opens the guide sees the same code
+  in both places.
+- **Smallest meaningful surface.** A counter exercises the full
+  cycle: init event, action event, sub, view that dispatches.
+  Nothing smaller covers the cycle; nothing larger is justified
+  for a scaffolding tool.
+- **No domain.** A counter doesn't tie the template to a problem
+  domain (todo lists, login forms, dashboards). The user replaces
+  it with their actual feature on first edit.
+
+A TodoMVC or login-form variant would be a richer example, but
+they are richer examples of re-frame2, not richer scaffolds. The
+template is for getting started; the per-substrate `examples/`
+trees are for studying complete patterns.
+
+## §5 — No-Story-yet
+
+**Decision.** The template does **not** pre-wire
+[`tools/story/`](../../story/) or emit a `counter_with_stories`
+scaffold. Reserved for a future iteration.
+
+**Why.**
+
+- **Story is in active development.** Stage 8 (rf2-c9mm) just
+  landed. Stage 9 (Storybook ↔ Story migration tooling) is
+  in flight. The surface is moving.
+- **Coupling cost.** A template that pre-wires Story would have
+  to track every change to the seven `reg-*` macros, the variant
+  id grammar, and the snapshot-identity contract. Today that
+  rate of change is too high.
+- **Opt-in is fine.** A user who wants Story today adds it to
+  their `deps.edn` manually:
+
+  ```clojure
+  day8/re-frame2-story {:mvn/version "..."}
+  ```
+
+  And points at `examples/reagent/counter_with_stories/` for the
+  shape.
+
+The follow-up: once Story stabilises post-1.0, add an
+`:include-story?` flag in `:edn-args` (along the lines of
+[001-Substrate-Variants.md §Future variants](001-Substrate-Variants.md#future-variants))
+that wires Story registrations and emits a story-augmented
+counter view.
+
+## §6 — Pin source-of-truth in one place
+
+**Decision.** `:rf2-version`, `:shadow-version`, `:react-version`
+are defined as inline literals in `src/clj/new/re_frame2.clj`'s
+entry fn — not in an EDN data file, not in a Clojars-fetched
+manifest, not derived from anything.
+
+**Why.**
+
+- **Releasability.** Bumping the template is a one-file edit. CI
+  cuts a new template jar; the new defaults flow to consumers on
+  next invocation.
+- **Visibility.** A reader of the entry fn sees the pins inline,
+  alongside the substrate decode and the file emit list. No
+  indirection through "go check this EDN data file."
+- **Lockstep with `implementation/package.json`.** The pins match
+  what the reference implementation's CI smoke-tests. Bumping
+  shadow-cljs in `implementation/package.json` triggers a
+  matching bump here — part of the per-release checklist.
+
+The alternative — deriving pins at template-build-time from
+`implementation/package.json` — was considered and rejected. It
+would tie the template's build to the implementation tree's
+state at template-publish time, with no win in correctness over
+"manually bump in lockstep."
+
+## §7 — Resource tree shape (shared/ + per-substrate/)
+
+**Decision.** The template's resource tree splits into:
+
+```
+src/clj/new/re_frame2/
+├── shared/          ; identical across substrates
+└── <substrate>/     ; substrate-specific
+```
+
+Not a flat layout with substrate-prefixed filenames, not a
+per-variant top-level tree (no shared tree at all).
+
+**Why.**
+
+- **Substrate-agnostic shell is the right cut.** Events, subs,
+  host HTML, README, .gitignore are substrate-portable by design.
+  Splitting them out into `shared/` makes that visible. A reader
+  of `tools/template/src/clj/new/re_frame2/` sees the architecture
+  immediately.
+- **Adding a substrate is "drop a sub-tree."** Future substrates
+  (reagent-slim, SSR variants) plug in by adding a sibling of
+  `reagent/`, `uix/`, `helix/`. Nothing in `shared/` needs to
+  change.
+- **clj-new's renderer doesn't care.** clj-new's `renderer` keys
+  off the top-level template name and treats internal slashes as
+  classpath subpaths. The shape is purely organisational.
+
+## §8 — JVM test (no clj-new harness in the test path)
+
+**Decision.** The JVM test
+(`test/clj/new/re_frame2/core_test.clj`) invokes the template's
+entry fn directly, bypassing clj-new's `create` harness. It does
+three things per substrate: generate to a tmp dir, walk the
+file tree, run `clojure -P` against the generated `deps.edn`.
+
+**Why.**
+
+- **Fast.** No classloading clj-new, no Maven resolution of
+  template coords, no harness setup. The test runs in seconds.
+- **Hermetic.** Doesn't depend on the test machine having a
+  particular `:project/new` alias configured.
+- **The clj-new harness layer is tested by clj-new itself.** What
+  the template is responsible for is the entry fn's behaviour:
+  emit the right files, with the right substitutions, throw on
+  bad input. The test exercises that surface.
+
+The `clojure -P` deps-parse is a "best-effort" check — it confirms
+the generated `deps.edn` is well-formed and that re-frame2 coords
+resolve. It requires a `clojure` CLI on PATH; if absent, the test
+logs and skips. Deps-parse is a nice-to-have signal; the harder
+contract is the file-tree shape.
+
+## §9 — Forgiving substrate coercion
+
+**Decision.** `coerce-substrate` accepts keyword, string (with or
+without leading `:`), symbol; throws on anything else.
+
+**Why.**
+
+- **The Clojure CLI ecosystem hands keywords through
+  inconsistently across shells.** On some shells / OSes,
+  `:substrate :uix` reaches the entry fn as the keyword `:uix`;
+  on others, as the string `":uix"`; in some setups, with the
+  leading colon stripped; occasionally as a symbol.
+- **Coercion is cheap.** A six-line `cond` covers all four cases.
+  No reason to make the user fight quoting.
+- **Strict on the value set.** Any input that maps to a keyword
+  outside `#{:reagent :uix :helix}` throws with a clear message
+  naming the valid set. The user sees the typo and fixes it.
+
+The inverse — strict on input shape, forgiving on value set
+(silent fallback to default) — would be worse: a typo silently
+delivers the Reagent variant instead of the requested UIx, and
+the user finds out at `shadow-cljs watch app` time.
+
+## Cross-references
+
+- [000-Vision.md](000-Vision.md) — non-goals (Story bundling, SSR,
+  TypeScript port).
+- [001-Substrate-Variants.md](001-Substrate-Variants.md) — the
+  current shipped variants + future variants surface.
+- [002-Generated-Shape.md](002-Generated-Shape.md) — resource tree
+  + substitution variables.
+- [Principles.md](Principles.md) — the design principles these
+  decisions implement.
+- [API.md](API.md) — the consolidated public surface.
+- [`tools/README.md`](../../README.md) — the per-tool spec/ folder
+  convention (rf2-bfax).

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -1,0 +1,144 @@
+# Template — Principles
+
+> The design principles `tools/template/` commits against. Short
+> companion doc; the WHY for the major decisions lives in
+> [DESIGN-RATIONALE.md](DESIGN-RATIONALE.md).
+
+## P1 — Build-time only
+
+The template is **never on a consumer's runtime classpath**. It is a
+build-time scaffold; consumers invoke it via
+`clojure -X:project/new` and what lands in their project is the
+generated source tree, not this jar.
+
+This is the strongest version of the bundle-isolation contract
+[`tools/README.md`](../../README.md) lays out. Every other tool in
+`tools/` has to argue why it satisfies the contract (separate
+classpath root, deps.edn hygiene, DCE-friendly macros). The
+template satisfies it trivially: it never appears anywhere except
+the user's `clojure -X:project/new` invocation, and only then on
+the CLJ-side build tool's classpath, never the generated app's.
+
+The dependency flow is unidirectional:
+
+```
+user → clj-new → this template → generated files
+```
+
+The generated app has **no compile-time or runtime knowledge of
+the template**. The generated `deps.edn` does not depend on
+`day8/clj-template.re-frame2`; the generated source does not
+`:require` from it. Once the template emits its files, the
+template's role is over.
+
+## P2 — Counter as the canonical example
+
+Every variant emits a working counter. The counter:
+
+- Is the same shape developers read about in [Guide chapter 02
+  — Your first app](../../../docs/guide/02-your-first-app.md).
+- Matches the per-substrate `examples/<substrate>/counter*/`
+  reference apps.
+- Uses the smallest amount of re-frame2 surface that demonstrates
+  the full cycle: an init event, an action event, a sub, a view
+  that dispatches.
+
+This is rf2-2kzw's "counter throughline" principle applied to the
+scaffolding tool. A developer who runs
+`clojure -X:project/new :template re-frame2 :name acme/my-app` and
+then opens the guide sees the same code in both places. No
+mismatch, no "wait, what's this different shape doing here?"
+moment.
+
+Branching out from counter (a TodoMVC variant, a routing variant,
+a forms variant) is a future template-mode question. v1 of the
+template keeps the example minimal.
+
+## P3 — Substrate-agnostic shell, substrate-specific surface
+
+Events (`events.cljs`), subs (`subs.cljs`), and the host shell
+(`README.md`, `.gitignore`, `resources/public/index.html`) are
+**identical across all three substrates**. They live under
+`shared/` in the resource tree.
+
+The substrate-specific files are:
+
+- `core.cljs` — substrate-specific render.
+- `views.cljs` — substrate-specific component syntax.
+- `deps.edn` — substrate-specific adapter coord.
+- `shadow-cljs.edn` and `package.json` — substrate-specific npm
+  pins.
+
+This split is enforced at the resource-tree level (see
+[002-Generated-Shape.md §Resource tree](002-Generated-Shape.md#resource-tree-template-side)).
+Adding a new substrate means dropping a new sub-tree; the shared
+shell does not need to be touched.
+
+The split also surfaces a re-frame2 design assertion: business
+logic (events + subs + state shape) is substrate-portable. Only
+the render edge differs. The template's resource layout demonstrates
+this.
+
+## P4 — Substrate selection via `:edn-args`
+
+The substrate selector rides on `:edn-args`, not on a top-level
+`:substrate` key:
+
+```bash
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix]'
+```
+
+This is a clj-new harness constraint surfaced during implementation
+— clj-new's `create` strips unknown top-level args before
+classloading the template's entry fn. `:edn-args` is the documented
+pass-through bag, and it is what the template reads from.
+
+See [DESIGN-RATIONALE](DESIGN-RATIONALE.md) §edn-args-not-top-level
+for the audit trail.
+
+## P5 — Pins in lockstep with the reference implementation
+
+`:rf2-version`, `:shadow-version`, and `:react-version` are defined
+in one place — the entry ns — and bumped in lockstep with
+`implementation/package.json` and the re-frame2 alpha release
+cadence.
+
+The point: what the template emits should match what the reference
+implementation's own CI is exercising. A developer who runs the
+template and then files an issue should be running the same combo
+the maintainers smoke-test. Drift here is a bug.
+
+## P6 — Forgiving on input shape, strict on substrate set
+
+The template accepts the substrate arg as a keyword, a string
+(with or without leading `:`), or a symbol — clj-new harnesses
+across the wider tooling ecosystem hand keywords through
+inconsistently, and the template tolerates the variants.
+
+But the substrate **value** is strict: anything not in
+`#{:reagent :uix :helix}` throws with a clear message naming the
+valid set. No silent fallback to default, no "did you mean...?"
+fuzz. The user sees the typo and fixes it.
+
+## P7 — Tested end-to-end, per substrate
+
+The template's JVM test (`test/clj/new/re_frame2/core_test.clj`)
+exercises each substrate end-to-end:
+
+1. Generate a tmp app via the template's main fn.
+2. Walk the produced file tree and assert the expected shape.
+3. Run `clojure -P` against the generated `deps.edn` to confirm a
+   successful deps-parse.
+
+The test runs on CI. A change that breaks file-tree shape for any
+substrate fails the build. The `clojure -P` check is best-effort
+— it requires a `clojure` CLI on PATH, logs and skips if not
+available.
+
+## Cross-references
+
+- [`tools/README.md`](../../README.md) — the bundle-isolation
+  contract this template satisfies trivially.
+- [000-Vision.md](000-Vision.md) — non-goals.
+- [DESIGN-RATIONALE.md](DESIGN-RATIONALE.md) — WHY decisions.


### PR DESCRIPTION
## Summary

- Decompose `tools/template/README.md` into a per-tool `spec/` folder, matching the rf2-bfax convention documented in `tools/README.md`.
- README keeps quick-start material (install + invoke); `spec/` owns the normative contract, audit trail, and design rationale.
- Pure docs reorganisation — template behaviour (resources, substitutions, tests) is untouched.

## What moved where

| Was in README | Now lives in |
|---|---|
| Quick-start invocation + `:local/root` route | README (kept) |
| "What you get" generated tree | `spec/002-Generated-Shape.md` |
| Three-substrate variants + `:edn-args` invocation | `spec/001-Substrate-Variants.md` |
| Resource tree + substitution variables | `spec/002-Generated-Shape.md` |
| Implementation-choice rationale (clj-new vs deps-new vs CLI) | `spec/DESIGN-RATIONALE.md` |
| Bundle isolation / elision contract | `spec/Principles.md` (P1) |
| Testing pointer | README (link) + `spec/Principles.md` (P7) |
| Cross-references | README (kept) |

## New spec files

| File | Lines | Words |
|---|---|---|
| `spec/000-Vision.md` | 98 | 525 |
| `spec/001-Substrate-Variants.md` | 133 | 661 |
| `spec/002-Generated-Shape.md` | 182 | 860 |
| `spec/Principles.md` | 144 | 779 |
| `spec/API.md` | 157 | 645 |
| `spec/DESIGN-RATIONALE.md` | 303 | 1753 |

README slimmed from 214 → 97 lines (981 → 428 words).

## DESIGN-RATIONALE captures

The audit trail the README was eliding:

1. **clj-new over deps-new** — lineage + tooling-team portability.
2. **`:edn-args` over top-level `:substrate`** — clj-new harness constraint surfaced during implementation (clj-new's `create` strips unknown top-level args).
3. **Three substrates in v1** (Reagent / UIx / Helix) — substrate-portability is a re-frame2 design assertion; the front door should demonstrate it from day one.
4. **Counter as the canonical example** — rf2-2kzw throughline alignment with Guide chapter 02.
5. **No-Story-yet** — Story is in active development; pre-wiring would couple template release cadence to the moving target. Reserved as `:include-story?` post-Story-stabilisation.
6. **Pin source-of-truth in one place** — `rf2-version` / `shadow-version` / `react-version` inline in the entry ns, bumped in lockstep with `implementation/package.json`.
7. **Resource tree shape** (`shared/` + per-substrate) — adding a substrate is "drop a sub-tree."
8. **JVM test bypassing clj-new harness** — fast, hermetic, exercises the entry fn's surface.
9. **Forgiving substrate coercion** — keyword / string / symbol all accepted; strict on the value set.

## Convention alignment

The shape mirrors the project-level `spec/`: numbered capability docs + `Principles` + `API` + `DESIGN-RATIONALE`. No `findings/` subfolder — the template had no major audit research (cf. Story's two-phase research lineage which justifies its `findings/`).

Following the `tools/story/IMPL-SPEC.md` precedent, the per-tool `spec/` folder is **GitHub-rendered only** — not added to mkdocs nav. The `docs.yml` CI workflow stages only the project-level `spec/` tree.

## Test plan

- [x] `mkdocs build --strict` passes (exit 0; pre-existing INFO-level dead anchors in unchanged spec docs unrelated to this PR).
- [x] All cross-references inside the new spec files resolve (relative paths walk back to `tools/`, repo root, `spec/`, `docs/guide/`, and `examples/` correctly).
- [x] README quick-start still works as a standalone entry point — every detail a new user needs to run the template is either in the README or one click away in `spec/API.md`.
- [x] No source code touched; template behaviour unchanged.

Bead: rf2-2qy6.