### PR TITLE
refactor(examples): realworld/articles home-page — parallel machine + render-priority (rf2-qbau)

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -24,7 +24,8 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 ## Other patterns this example exercises
 
 - **Auth state machine** — login, register, session-restore, logout as one machine (Spec 005); each transition issues a managed-HTTP request and routes the reply through machine actions.
-- **Pattern-RemoteData** — global feed, your feed, article detail, comments, profile banner, authored articles, favorited articles, and tags all use the same lifecycle slice (Pattern-RemoteData).
+- **Pattern-NineStates** — the home page (`articles.cljs`) uses a parallel-region state machine (`:realworld/articles-home`) with three orthogonal axes (`:feed` × `:filter` × `:data`); a render-priority table + a selector sub (`:articles.home/render`) collapse the tag union to a single render keyword so the root view is a `case`, not a priority `cond`. The canonical worked example is in `examples/reagent/nine_states/`; this is the production-shaped variant. See [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md).
+- **Pattern-RemoteData** — your feed, article detail, comments, profile banner, authored articles, favorited articles, and tags all use the same lifecycle slice (Pattern-RemoteData). The home page's `:articles` slice keeps its slice shape for the optimistic-update paths (`favorites.cljs/find-article` scans across `[:articles :feed :profile.articles :profile.favorites]`) while the home-page render decision is driven by the parallel machine's tags.
 - **Pattern-Forms** — login, register, comment post, article editor, and settings reuse the same draft/submission shape.
 - **Routing** — route table, path params, query params, auth gating, route-driven loads, and navigation blocking for the editor.
 - **Optimistic updates** — favorite toggle, comment delete, and follow/unfollow all show rollback-friendly event shapes against the managed-HTTP failure path.
@@ -40,7 +41,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 | `http.cljs` | implemented | `request` builder + `data-fetch-retry` policy + `failure->message` projector for `:rf.http/managed`. |
 | `routing.cljs` | implemented | Route table, auth guard, route-link helper, browser wiring. |
 | `auth.cljs` | implemented | Auth machine plus login/register forms (managed-HTTP). |
-| `articles.cljs` | implemented | Home page, global feed, popular tags, tag filter UI; managed-HTTP with retry + abort. |
+| `articles.cljs` | implemented | Home page, global feed, popular tags, tag filter UI; managed-HTTP with retry + abort. Home page uses Pattern-NineStates — a `:realworld/articles-home` parallel machine with three regions (`:feed` × `:filter` × `:data`) + a render-priority table; the root view is a `case` over `:articles.home/render`. |
 | `favorites.cljs` | implemented | Favorite toggle and followed-authors feed; optimistic updates with managed-HTTP rollback. |
 | `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete. **`:article/load` uses default reply addressing.** |
 | `article_editor.cljs` | implemented | New/edit/delete article plus unsaved-change guard. |
@@ -52,6 +53,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 ## Architecture references
 
 - [`spec/014-HTTPRequests.md`](../../../spec/014-HTTPRequests.md) — **`:rf.http/managed`** (this is the canonical demo).
+- [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md)
 - [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md)
 - [`spec/Pattern-Forms.md`](../../../spec/Pattern-Forms.md)
 - [`spec/012-Routing.md`](../../../spec/012-Routing.md)

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -2,11 +2,27 @@
   "Home-page article feeds for the RealWorld (Conduit) example.
 
    This sketch demonstrates:
-   - Pattern-RemoteData for the global article list and popular tags
-   - route-query driven loading (`?tag=` and `?feed=your`)
-   - home-page tabs expressed as ordinary navigation events
-   - view reuse across the home page and profile pages"
+   - Pattern-NineStates — one parallel state machine with three orthogonal
+     regions (`:feed` × `:filter` × `:data`) replacing the prior multi-axis
+     state-in-separate-slices shape (per rf2-qbau).
+   - Pattern-RemoteData lifecycle folded into the `:data` region; the
+     region's state-keyword IS the status. The actual article items still
+     live in app-db slices (`:articles`, `:feed`) so optimistic-update
+     paths in favorites.cljs continue to find articles across slices.
+   - route-query driven loading (`?tag=` and `?feed=your`) — every
+     navigation broadcasts the corresponding feed-region transition.
+   - home-page tabs expressed as feed-region state transitions.
+   - The home view's root is a `case` over `:articles.home/render`, a
+     selector sub that consults a render-priority table against the
+     machine's tag union (per Pattern-NineStates §4).
+   - view reuse across the home page and profile pages."
   (:require [re-frame.core :as rf]
+            ;; Per rf2-xbtj, the Spec 005 state-machine ns lives in the
+            ;; day8/re-frame2-machines artefact. Loading the ns here
+            ;; registers its late-bind hooks so rf/reg-machine (called
+            ;; below at ns-load) and the `:rf/machine` framework subs
+            ;; resolve.
+            [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh]
             [realworld.routing :as routing])
@@ -18,13 +34,169 @@
   {:status :idle :data data :error nil :loaded-at nil :attempt 0})
 
 ;; ============================================================================
+;; THE MACHINE — :realworld/articles-home  (one machine, three regions)
+;; ============================================================================
+;;
+;; The home page has three orthogonal axes:
+;;
+;;   :feed   — which feed is rendered (global / your-feed / tag-filtered
+;;             global). The state-keyword tells the view which app-db
+;;             slice's items to read from (`:articles` for :global and
+;;             :tag-feed; `:feed` for :user-feed). Driven by the
+;;             `:home/show-*` events which navigate the route's `?feed=`
+;;             and `?tag=` query params.
+;;
+;;   :filter — whether a tag filter is active. Always `:tagged` whenever
+;;             :feed is :tag-feed; tracked as a separate region so views
+;;             that render the filter chip can ask a tag-shaped question
+;;             without inspecting the feed region.
+;;
+;;   :data   — Pattern-NineStates' data lifecycle for whichever feed is
+;;             active. The slice's `:status` field is gone — the region's
+;;             state-keyword IS the lifecycle phase. The :resolving
+;;             eventless microstep picks `:empty` or `:some` from the
+;;             count stamped into the machine's shared `:data`.
+;;
+;; Per Spec 005 §Transition broadcast: every event delivered to the
+;; machine is broadcast to every region. Region-distinct event names
+;; below avoid collisions; the `:reset` event is handled by every
+;; region as a self-target.
+
+(def home-machine
+  {:type :parallel
+
+   ;; The machine carries the active feed's item-count (drives the
+   ;; cardinality bucket) plus the latest error map. The items
+   ;; themselves still live in app-db slices (`:articles`, `:feed`) so
+   ;; the optimistic-update paths in favorites.cljs continue to find
+   ;; them across slices.
+   :data {:count 0 :error nil}
+
+   :guards
+   {:empty?
+    (fn guard-empty? [data _event]
+      (zero? (:count data 0)))}
+
+   :actions
+   {:set-count
+    ;; :fetch-succeeded carries the resolved count under :items.
+    (fn action-set-count [data [_ {:keys [items]}]]
+      {:data (-> data
+                 (assoc :count (count items))
+                 (assoc :error nil))})
+
+    :set-error
+    (fn action-set-error [data [_ {:keys [failure]}]]
+      {:data (assoc data :error failure)})
+
+    :clear-count
+    (fn action-clear-count [data _event]
+      {:data (assoc data :count 0 :error nil)})}
+
+   :regions
+   {;; ---- :data region — Pattern-NineStates lifecycle ----
+    :data
+    {:initial :nothing
+     :states
+     {:nothing
+      {:tags #{:data/nothing}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :loading
+      ;; First fetch in flight; no prior items.
+      {:tags #{:data/loading :data/transient}
+       :on   {:fetch-succeeded {:target :resolving :action :set-count}
+              :fetch-failed    {:target :error     :action :set-error}
+              :reset           :nothing}}
+
+      :refreshing
+      ;; Reload while prior items remain visible. Tagged :data/some so
+      ;; the render-priority resolves to the `:some` view; the
+      ;; :data/refreshing tag drives the inline refresh indicator.
+      {:tags #{:data/some :data/refreshing :data/transient}
+       :on   {:fetch-succeeded {:target :resolving :action :set-count}
+              :fetch-failed    {:target :error     :action :set-error}
+              :reset           :nothing}}
+
+      :resolving
+      ;; Eventless microstep: after :set-count writes the new count,
+      ;; pick the cardinality bucket. First match wins.
+      {:always [{:guard :empty? :target :empty}
+                {:target :some}]}
+
+      :empty
+      {:tags #{:data/empty}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :some
+      {:tags #{:data/some}
+       :on   {:fetch-started :refreshing
+              :reset         :nothing}}
+
+      :error
+      {:tags #{:data/error}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}}}
+
+    ;; ---- :feed region — which feed the view renders ----
+    :feed
+    {:initial :global
+     :states
+     {:global
+      ;; The default landing. Reads from the :articles slice.
+      {:tags #{:feed/global}
+       :on   {:show-user-feed {:target :user-feed :action :clear-count}
+              :show-tag-feed  {:target :tag-feed  :action :clear-count}
+              :show-global    :global
+              :reset          :global}}
+
+      :user-feed
+      ;; `?feed=your`. Reads from the :feed slice. Authenticated only.
+      {:tags #{:feed/user-feed}
+       :on   {:show-global   {:target :global   :action :clear-count}
+              :show-tag-feed {:target :tag-feed :action :clear-count}
+              :show-user-feed :user-feed
+              :reset         :global}}
+
+      :tag-feed
+      ;; `?tag=X`. Still reads from the :articles slice; the tag
+      ;; modifies the request URL upstream.
+      {:tags #{:feed/tag-feed}
+       :on   {:show-global    {:target :global    :action :clear-count}
+              :show-user-feed {:target :user-feed :action :clear-count}
+              :show-tag-feed  :tag-feed
+              :reset          :global}}}}
+
+    ;; ---- :filter region — chip / sidebar state ----
+    :filter
+    {:initial :none
+     :states
+     {:none
+      {:tags #{:filter/none}
+       :on   {:apply-filter :tagged
+              :clear-filter :none
+              :reset        :none}}
+
+      :tagged
+      {:tags #{:filter/tagged}
+       :on   {:apply-filter :tagged
+              :clear-filter :none
+              :reset        :none}}}}}})
+
+(rf/reg-machine :realworld/articles-home home-machine)
+
+;; ============================================================================
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-db :articles/initialise
-  {:doc "Seed the global-articles slice to the standard idle shape."}
-  (fn [db _]
-    (assoc db :articles (request-slice []))))
+(rf/reg-event-fx :articles/initialise
+  {:doc "Seed the global-articles slice to the standard idle shape and
+         reset the home machine to its initial configuration."}
+  (fn [{:keys [db]} _]
+    {:db (assoc db :articles (request-slice []))
+     :fx [[:dispatch [:realworld/articles-home [:reset]]]]}))
 
 (rf/reg-event-db :tags/initialise
   (fn [db _]
@@ -40,7 +212,11 @@
          a Malli-decoded response and the standard data-fetch retry policy.
          The request is tagged with `:request-id :articles/load` so a
          re-issue (e.g., user changes tag mid-load) supersedes the prior
-         in-flight request and an `:articles/cancel` fx aborts cleanly."
+         in-flight request and an `:articles/cancel` fx aborts cleanly.
+
+         Also broadcasts `:fetch-started` into the home machine so the
+         `:data` region advances to `:loading` (or `:refreshing` from
+         `:some`)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     (let [tag       (get-in db [:rf/route :query :tag])
@@ -52,7 +228,8 @@
                (assoc-in [:articles :status] (if has-data? :fetching :loading))
                (assoc-in [:articles :error] nil)
                (update-in [:articles :attempt] (fnil inc 0)))
-       :fx [[:rf.http/managed
+       :fx [[:dispatch [:realworld/articles-home [:fetch-started]]]
+            [:rf.http/managed
              (rh/request {:method     :get
                           :path       path
                           :auth?      false
@@ -62,25 +239,34 @@
                           :on-success [:articles/loaded]
                           :on-failure [:articles/load-failed]})]]})))
 
-(rf/reg-event-db :articles/loaded
+(rf/reg-event-fx :articles/loaded
   {:doc "Successful fetch. Replace the list and clear any prior error.
          Receives `{:kind :success :value <ArticlesResponse>}` from
-         Spec 014's reply-addressing."}
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:articles :status] :loaded)
-        (assoc-in [:articles :data] (vec (:articles value)))
-        (assoc-in [:articles :error] nil)
-        (assoc-in [:articles :loaded-at] (current-time-ms)))))
+         Spec 014's reply-addressing. Folds the new count into the home
+         machine via `:fetch-succeeded`; the `:data` region's
+         `:resolving` `:always`-cascade picks `:empty` or `:some`."}
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    (let [items (vec (:articles value))]
+      {:db (-> db
+               (assoc-in [:articles :status] :loaded)
+               (assoc-in [:articles :data] items)
+               (assoc-in [:articles :error] nil)
+               (assoc-in [:articles :loaded-at] (current-time-ms)))
+       :fx [[:dispatch [:realworld/articles-home
+                        [:fetch-succeeded {:items items}]]]]})))
 
-(rf/reg-event-db :articles/load-failed
+(rf/reg-event-fx :articles/load-failed
   {:doc "Failed fetch. Keep prior data when present and surface a
          human-readable error message (projected from the Spec 014
-         failure map)."}
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:articles :status] :error)
-        (assoc-in [:articles :error] (rh/failure->message failure)))))
+         failure map). Folds the failure into the home machine via
+         `:fetch-failed`; the `:data` region advances to `:error`."}
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    (let [message (rh/failure->message failure)]
+      {:db (-> db
+               (assoc-in [:articles :status] :error)
+               (assoc-in [:articles :error] message))
+       :fx [[:dispatch [:realworld/articles-home
+                        [:fetch-failed {:failure message}]]]]})))
 
 (rf/reg-event-fx :articles/cancel
   {:doc "Abort an in-flight :articles/load. Useful when the user navigates
@@ -88,9 +274,10 @@
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :articles/load]]}))
 
-(rf/reg-event-db :articles/reset
-  (fn [db _]
-    (assoc db :articles (request-slice []))))
+(rf/reg-event-fx :articles/reset
+  (fn [{:keys [db]} _]
+    {:db (assoc db :articles (request-slice []))
+     :fx [[:dispatch [:realworld/articles-home [:reset]]]]}))
 
 ;; ============================================================================
 ;; TAGS
@@ -134,17 +321,57 @@
 ;; ============================================================================
 
 (rf/reg-sub :articles            (fn [db _] (:articles db)))
-(rf/reg-sub :articles/status     :<- [:articles] (fn [s _] (:status s)))
 (rf/reg-sub :articles/data       :<- [:articles] (fn [s _] (:data s)))
 (rf/reg-sub :articles/error      :<- [:articles] (fn [s _] (:error s)))
-(rf/reg-sub :articles/loading?   :<- [:articles/status] #(= % :loading))
-(rf/reg-sub :articles/fetching?  :<- [:articles/status]
-  #(or (= % :loading) (= % :fetching)))
 
 (rf/reg-sub :tags                (fn [db _] (:tags db)))
 (rf/reg-sub :tags/data           :<- [:tags] (fn [s _] (:data s)))
 (rf/reg-sub :tags/loading?       :<- [:tags]
   (fn [s _] (#{:loading :fetching} (:status s))))
+
+;; ---- render-priority + :articles.home/render selector ----
+;;
+;; The render-priority table is plain data: a vector of {:tag :render}
+;; pairs consulted in order. The `:articles.home/render` sub reads the
+;; machine's tag union and returns the first :render whose :tag is
+;; present. The home view's `case` over the resolved keyword is the
+;; only branch site; everything else reads tags directly.
+;;
+;; Priority rationale: the data region's lifecycle wins outright —
+;; `:loading` (first-load spinner) above `:error` above the cardinality
+;; buckets. `:refreshing` resolves to `:some` (the prior list stays
+;; visible, with an inline refresh indicator the `:some` view renders
+;; via the `:data/refreshing` tag).
+
+(def render-priority
+  [{:tag :data/loading :render :loading}
+   {:tag :data/error   :render :error}
+   {:tag :data/empty   :render :empty}
+   {:tag :data/some    :render :some}
+   {:tag :data/nothing :render :empty}])
+
+(rf/reg-sub :articles.home/render
+  {:doc "Resolve the home page's render-model keyword by consulting the
+         render-priority table against the machine's tag union. The
+         root view's `case` is the only branch site."}
+  :<- [:rf/machine :realworld/articles-home]
+  (fn sub-articles-home-render [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+
+(rf/reg-sub :articles.home/active-articles
+  {:doc "The article list currently rendered by the home view: the
+         `:feed` region's active state-keyword picks which app-db slice
+         to read from."}
+  :<- [:rf/machine :realworld/articles-home]
+  :<- [:articles/data]
+  :<- [:feed/data]
+  (fn sub-active-articles [[snap global-items feed-items] _]
+    (case (get-in snap [:state :feed])
+      :user-feed (or feed-items [])
+      (or global-items []))))
 
 ;; ============================================================================
 ;; VIEWS
@@ -177,23 +404,44 @@
          ^{:key tag}
          [:li.tag-default.tag-pill.tag-outline tag])]]]))
 
+;; ---- per-render-state subviews ----
+
+(reg-view ^{:doc "Data region :loading — first fetch in flight, no prior items."}
+          articles-loading []
+  [:div.article-preview "Loading articles…"])
+
+(reg-view ^{:doc "Data region :error — fetch failed."}
+          articles-error []
+  (let [err @(subscribe [:articles/error])
+        feed-err @(subscribe [:feed/error])]
+    [:div.article-preview.error
+     (str "Couldn't load articles: " (pr-str (or err feed-err)))]))
+
+(reg-view ^{:doc "Data region :empty / :nothing — no articles to show."}
+          articles-empty []
+  [:div.article-preview "No articles are here… yet."])
+
+(reg-view ^{:doc "Data region :some — articles to show. Inline refresh
+                  indicator overlays when the :data/refreshing tag is
+                  set (a same-feed reload in flight)."}
+          articles-some []
+  (let [articles    @(subscribe [:articles.home/active-articles])
+        refreshing? @(rf/has-tag? :realworld/articles-home :data/refreshing)]
+    [:<>
+     (when refreshing? [:div.refresh-indicator "Refreshing…"])
+     (for [article articles]
+       ^{:key (:slug article)}
+       [article-preview {:article article}])]))
+
 (reg-view ^{:doc "Global feed / your feed / tag-filtered home page."}
           home-page []
-  (let [authed?         @(subscribe [:auth/authenticated?])
-        feed-kind       @(subscribe [:home/feed-kind])
-        selected-tag    @(subscribe [:home/selected-tag])
-        global-loading?  @(subscribe [:articles/loading?])
-        global-fetching? @(subscribe [:articles/fetching?])
-        global-error    @(subscribe [:articles/error])
-        global-articles @(subscribe [:articles/data])
-        feed-loading?   @(subscribe [:feed/loading?])
-        feed-error      @(subscribe [:feed/error])
-        your-feed       @(subscribe [:feed/data])
-        tags            @(subscribe [:tags/data])
-        [loading? fetching? err articles]
-        (if (= feed-kind :your)
-          [feed-loading? false feed-error your-feed]
-          [global-loading? global-fetching? global-error global-articles])]
+  (let [authed?      @(subscribe [:auth/authenticated?])
+        selected-tag @(subscribe [:home/selected-tag])
+        on-user-feed? @(rf/has-tag? :realworld/articles-home :feed/user-feed)
+        on-global?    @(rf/has-tag? :realworld/articles-home :feed/global)
+        tag-filtered? @(rf/has-tag? :realworld/articles-home :filter/tagged)
+        tags          @(subscribe [:tags/data])
+        render-mode   @(subscribe [:articles.home/render])]
     [:div.home-page
      [:div.banner
       [:div.container
@@ -208,41 +456,30 @@
             [:li.nav-item
              [:a.nav-link
               {:href "#"
-               :class (when (= feed-kind :your) "active")
+               :class (when on-user-feed? "active")
                :on-click #(do (.preventDefault %)
                               (dispatch [:home/show-your-feed]))}
               "Your Feed"]])
           [:li.nav-item
            [:a.nav-link
             {:href "#"
-             :class (when (= feed-kind :global) "active")
+             :class (when on-global? "active")
              :on-click #(do (.preventDefault %)
                             (dispatch [:home/show-global-feed]))}
             "Global Feed"]]
-          (when selected-tag
+          (when tag-filtered?
             [:li.nav-item
              [:a.nav-link.active
               {:href "#"
                :on-click #(do (.preventDefault %)
                               (dispatch [:tags/clear-filter]))}
               [:i.ion-pound] " " selected-tag]])]]
-        (cond
-          loading?
-          [:div.article-preview "Loading articles…"]
-
-          err
-          [:div.article-preview.error
-           (str "Couldn't load articles: " (pr-str err))]
-
-          (empty? articles)
-          [:div.article-preview "No articles are here… yet."]
-
-          :else
-          [:<>
-           (when fetching? [:div.refresh-indicator "Refreshing…"])
-           (for [article articles]
-             ^{:key (:slug article)}
-             [article-preview {:article article}])])]
+        (case render-mode
+          :loading [articles-loading]
+          :error   [articles-error]
+          :empty   [articles-empty]
+          :some    [articles-some]
+          [articles-empty])]
        [:div.col-md-3
         [:div.sidebar
          [:p "Popular Tags"]
@@ -254,4 +491,3 @@
               :on-click #(do (.preventDefault %)
                              (dispatch [:tags/apply-filter tag]))}
              tag])]]]]]]))
-

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -57,7 +57,11 @@
 (rf/reg-event-fx :feed/load
   {:doc "Fetch the authenticated user's feed. Tagged with
          `:request-id :feed/load` so :feed/cancel can abort an in-flight
-         load when the user navigates away (Spec 014 §Aborts)."
+         load when the user navigates away (Spec 014 §Aborts).
+
+         Also broadcasts `:fetch-started` into the home machine so the
+         `:data` region advances to `:loading` (or `:refreshing` from
+         `:some`)."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     {:db (-> db
@@ -65,7 +69,8 @@
                        (if (seq (get-in db [:feed :data])) :fetching :loading))
              (assoc-in [:feed :error] nil)
              (update-in [:feed :attempt] (fnil inc 0)))
-     :fx [[:rf.http/managed
+     :fx [[:dispatch [:realworld/articles-home [:fetch-started]]]
+          [:rf.http/managed
            (rh/request {:method     :get
                         :path       "/articles/feed"
                         :decode     schema/ArticlesResponse
@@ -80,18 +85,29 @@
   (fn [_ _]
     {:fx [[:rf.http/managed-abort :feed/load]]}))
 
-(rf/reg-event-db :feed/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:feed :status] :loaded)
-        (assoc-in [:feed :data] (vec (:articles value)))
-        (assoc-in [:feed :loaded-at] (current-time-ms)))))
+(rf/reg-event-fx :feed/loaded
+  {:doc "Successful user-feed fetch. Folds the new count into the home
+         machine via `:fetch-succeeded`; the `:data` region's
+         `:resolving` `:always`-cascade picks `:empty` or `:some`."}
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    (let [items (vec (:articles value))]
+      {:db (-> db
+               (assoc-in [:feed :status] :loaded)
+               (assoc-in [:feed :data] items)
+               (assoc-in [:feed :loaded-at] (current-time-ms)))
+       :fx [[:dispatch [:realworld/articles-home
+                        [:fetch-succeeded {:items items}]]]]})))
 
-(rf/reg-event-db :feed/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:feed :status] :error)
-        (assoc-in [:feed :error] (rh/failure->message failure)))))
+(rf/reg-event-fx :feed/load-failed
+  {:doc "Failed user-feed fetch. Folds the failure into the home machine
+         via `:fetch-failed`; the `:data` region advances to `:error`."}
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    (let [message (rh/failure->message failure)]
+      {:db (-> db
+               (assoc-in [:feed :status] :error)
+               (assoc-in [:feed :error] message))
+       :fx [[:dispatch [:realworld/articles-home
+                        [:fetch-failed {:failure message}]]]]})))
 
 ;; ============================================================================
 ;; FAVORITES

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -5,18 +5,41 @@
    owns the route-query driven part of the home page:
    - `?tag=<name>` filters the global articles list
    - `?feed=your` switches the home page to the authenticated feed
-   - navigation is always expressed as `:rf.route/navigate` events"
+   - navigation is always expressed as `:rf.route/navigate` events
+
+   `:home/load` is dispatched by the `:route/home` `:on-match`; it
+   broadcasts the per-axis transitions into the home machine
+   (`:realworld/articles-home`) before kicking the per-feed fetch."
   (:require [re-frame.core :as rf]))
 
 (defn home-query [db]
   (get-in db [:rf/route :query] {}))
 
 (rf/reg-event-fx :home/load
+  {:doc "Route :on-match handler for `:route/home`. Reads the route's
+         query params and:
+           - broadcasts the `:feed` region into `:user-feed` / `:tag-feed`
+             / `:global` per `?feed=` and `?tag=`,
+           - broadcasts the `:filter` region into `:tagged` / `:none`
+             per `?tag=`,
+           - kicks the per-feed fetch (`:articles/load` or `:feed/load`).
+         Each fetch handler in turn broadcasts `:fetch-started` into the
+         home machine's `:data` region (per articles.cljs and
+         favorites.cljs)."}
   (fn [{:keys [db]} _]
-    (let [{:keys [feed]} (home-query db)]
-      {:fx (cond-> [[:dispatch [:tags/load]]]
-             (= "your" feed) (conj [:dispatch [:feed/load]])
-             (not= "your" feed) (conj [:dispatch [:articles/load]]))})))
+    (let [{:keys [feed tag] :as _query} (home-query db)
+          your-feed? (= "your" feed)
+          tag-feed?  (and (not your-feed?) (some? tag))
+          feed-event (cond
+                       your-feed? [:show-user-feed]
+                       tag-feed?  [:show-tag-feed]
+                       :else      [:show-global])
+          filter-event (if tag [:apply-filter] [:clear-filter])]
+      {:fx (cond-> [[:dispatch [:realworld/articles-home feed-event]]
+                    [:dispatch [:realworld/articles-home filter-event]]
+                    [:dispatch [:tags/load]]]
+             your-feed?       (conj [:dispatch [:feed/load]])
+             (not your-feed?) (conj [:dispatch [:articles/load]]))})))
 
 (rf/reg-event-fx :home/show-global-feed
   (fn [_ _]
@@ -45,4 +68,3 @@
 (rf/reg-sub :home/feed-kind
   :<- [:home/query]
   (fn [query _] (if (= "your" (:feed query)) :your :global)))
-


### PR DESCRIPTION
## Summary

- Refactor the realworld home page to use Pattern-NineStates: one parallel state machine (`:realworld/articles-home`) with three orthogonal regions (`:feed` × `:filter` × `:data`) plus a render-priority table and a selector sub (`:articles.home/render`).
- The home view's root becomes a `case` over the resolved render keyword, replacing the prior priority `cond` over four boolean discriminator subs and the cross-axis four-vector tuple destructure (audit-flagged at `articles.cljs:189-196` + `:229-245`).
- Articles still live in app-db slices (`:articles`, `:feed`) so favorites.cljs's optimistic-update paths still find articles across slices — only `:count` + `:error` live in the machine's `:data`.

## Machine shape

```
:feed   — :global / :user-feed / :tag-feed   (tags :feed/*)
:filter — :none / :tagged                    (tags :filter/*)
:data   — :nothing / :loading / :refreshing / :resolving /
          :empty / :some / :error            (tags :data/*)
```

The `:data` region carries the Pattern-NineStates lifecycle: a `:resolving` eventless microstep picks `:empty` or `:some` from the count stamped by the `:set-count` action. The `:refreshing` state preserves the prior \"Refreshing…\" UX on same-feed reloads.

## Render priority

```
:data/loading → :loading
:data/error   → :error
:data/empty   → :empty
:data/some    → :some
:data/nothing → :empty
```

## What changed for the home view

- 11 subscriptions + 4-vector tuple destructure → 7 subs (5 tag-shaped) + 1 render-keyword sub.
- 4-branch priority `cond` → 4-branch `case` over render keyword.
- 4 inline render blocks → 4 per-state reg-views.

## Files touched

- `examples/reagent/realworld/articles.cljs` (+236 LoC; the machine declaration is verbose by design)
- `examples/reagent/realworld/favorites.cljs` (+16 LoC; `:feed/load` + reply handlers broadcast machine transitions)
- `examples/reagent/realworld/tags.cljs` (+22 LoC; `:home/load` drives the feed + filter regions from route query)
- `examples/reagent/realworld/README.md` (Pattern-NineStates paragraph + articles.cljs row updated)

Per rf2-pt5m's audit (`findings/examples-tags-parallel-audit.md` §2.11.2 + §4), this is the canonical multi-axis-state-in-separate-slices shape in the entire examples corpus.

## Test plan

- [x] `npm run test:cljs` — 496 tests, 1206 assertions, 0 failures, 0 errors.
- [x] `npm run test:elision` — PASS.
- [x] `npm run test:examples` — all 21 examples PASS including `realworld (Conduit) — Spec 014 demo`.
- [x] `shadow-cljs compile examples/realworld` — clean (0 warnings).