### PR TITLE
refactor(examples): realworld/profile — parallel machine (tab × data) (rf2-ljw9)

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -24,7 +24,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 ## Other patterns this example exercises
 
 - **Auth state machine** — login, register, session-restore, logout as one machine (Spec 005); each transition issues a managed-HTTP request and routes the reply through machine actions.
-- **Pattern-NineStates** — the home page (`articles.cljs`) uses a parallel-region state machine (`:realworld/articles-home`) with three orthogonal axes (`:feed` × `:filter` × `:data`); a render-priority table + a selector sub (`:articles.home/render`) collapse the tag union to a single render keyword so the root view is a `case`, not a priority `cond`. The canonical worked example is in `examples/reagent/nine_states/`; this is the production-shaped variant. See [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md).
+- **Pattern-NineStates** — the home page (`articles.cljs`) uses a parallel-region state machine (`:realworld/articles-home`) with three orthogonal axes (`:feed` × `:filter` × `:data`); a render-priority table + a selector sub (`:articles.home/render`) collapse the tag union to a single render keyword so the root view is a `case`, not a priority `cond`. The profile pages (`profile.cljs`) apply the same shape at smaller scale: a `:ui/profile` parallel machine with two regions (`:tab` × `:data`), its own render-priority table, and a `:profile/render` selector sub — the cross-axis "which slice's articles to render" math lives in the machine instead of a sub that branches on the route id. The canonical worked example is in `examples/reagent/nine_states/`; this is the production-shaped variant. See [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md).
 - **Pattern-RemoteData** — your feed, article detail, comments, profile banner, authored articles, favorited articles, and tags all use the same lifecycle slice (Pattern-RemoteData). The home page's `:articles` slice keeps its slice shape for the optimistic-update paths (`favorites.cljs/find-article` scans across `[:articles :feed :profile.articles :profile.favorites]`) while the home-page render decision is driven by the parallel machine's tags.
 - **Pattern-Forms** — login, register, comment post, article editor, and settings reuse the same draft/submission shape.
 - **Routing** — route table, path params, query params, auth gating, route-driven loads, and navigation blocking for the editor.
@@ -45,7 +45,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 | `favorites.cljs` | implemented | Favorite toggle and followed-authors feed; optimistic updates with managed-HTTP rollback. |
 | `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete. **`:article/load` uses default reply addressing.** |
 | `article_editor.cljs` | implemented | New/edit/delete article plus unsaved-change guard. |
-| `profile.cljs` | implemented | Profile banner, authored/favorited tabs, follow/unfollow. |
+| `profile.cljs` | implemented | Profile banner, authored/favorited tabs, follow/unfollow. Uses Pattern-NineStates — a `:ui/profile` parallel machine with two regions (`:tab` × `:data`) + a render-priority table; the root view is a `case` over `:profile/render`. |
 | `settings.cljs` | implemented | User settings form and logout affordance. |
 | `tags.cljs` | implemented | Home-page query helpers (`?tag=` and `?feed=your`). |
 | `ssr.cljc` | implemented | RealWorld-specific hydration payload helper; pairs with `../ssr/core.cljc`. |

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -1,14 +1,36 @@
 (ns realworld.profile
   "Profile pages for the RealWorld (Conduit) example.
 
-   One route family, three remote-data slices:
-   - `:profile` for the public profile banner
-   - `:profile.articles` for authored articles
-   - `:profile.favorites` for favorited articles
+   This sketch demonstrates:
+   - Pattern-NineStates — one parallel state machine `:ui/profile` with
+     two orthogonal regions (`:tab` × `:data`) replacing the prior
+     cross-axis sub + priority `cond` shape (per rf2-ljw9).
+   - Pattern-RemoteData lifecycle folded into the `:data` region; the
+     region's state-keyword IS the banner's status. The article-list
+     items still live in app-db slices (`:profile.articles`,
+     `:profile.favorites`) so the optimistic-update paths in
+     favorites.cljs continue to find articles across slices.
+   - Tab switching expressed as `:tab` region transitions broadcast
+     from the route's `:on-match` (just like the home page's
+     `:home/load` broadcasts the feed-region transition).
+   - The profile view's root is a `case` over `:profile/render`, a
+     selector sub that consults a render-priority table against the
+     machine's tag union (per Pattern-NineStates §4).
+
+   Three remote-data slices behind the view:
+   - `:profile`             — public banner (username, bio, image, following)
+   - `:profile.articles`    — authored articles
+   - `:profile.favorites`   — favorited articles
 
    Follow/unfollow is optimistic and shared across the banner plus any
    article cards rendered from the profile routes."
   (:require [re-frame.core :as rf]
+            ;; Per rf2-xbtj, the Spec 005 state-machine ns lives in the
+            ;; day8/re-frame2-machines artefact. Loading the ns here
+            ;; registers its late-bind hooks so rf/reg-machine (called
+            ;; below at ns-load) and the `:rf/machine` framework subs
+            ;; resolve.
+            [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh]
             [realworld.routing :as routing]
@@ -24,15 +46,112 @@
   (get-in db [:rf/route :params :username]))
 
 ;; ============================================================================
+;; THE MACHINE — :ui/profile  (one machine, two regions)
+;; ============================================================================
+;;
+;; The profile page has two orthogonal axes:
+;;
+;;   :tab    — which list of articles is rendered (authored vs favorited).
+;;             Driven by `:show-articles` / `:show-favorites` broadcasts
+;;             from the route's `:on-match` (see `routing.cljs`'s
+;;             `:route/profile` and `:route/profile.favorites`). The
+;;             state-keyword tells the view which app-db slice's items
+;;             to render.
+;;
+;;   :data   — Pattern-NineStates' data lifecycle for the banner fetch.
+;;             The slice's `:status` field is still set for parity with
+;;             other slices, but the region's state-keyword IS the
+;;             page's render gate. The article-list slices keep their
+;;             slice shape and load independently.
+;;
+;; Per Spec 005 §Transition broadcast: every event delivered to the
+;; machine is broadcast to every region. Region-distinct event names
+;; below avoid collisions; `:reset` is handled by every region as a
+;; self-target.
+
+(def profile-machine
+  {:type :parallel
+
+   ;; The banner's latest error map. The profile/article items
+   ;; themselves still live in app-db slices.
+   :data {:error nil}
+
+   :actions
+   {:set-error
+    (fn action-set-error [data [_ {:keys [failure]}]]
+      {:data (assoc data :error failure)})
+
+    :clear-error
+    (fn action-clear-error [data _event]
+      {:data (assoc data :error nil)})}
+
+   :regions
+   {;; ---- :data region — Pattern-NineStates lifecycle for the banner ----
+    :data
+    {:initial :nothing
+     :states
+     {:nothing
+      {:tags #{:data/nothing}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}
+
+      :loading
+      ;; First fetch in flight; banner not yet rendered.
+      {:tags #{:data/loading :data/transient}
+       :on   {:fetch-succeeded {:target :loaded :action :clear-error}
+              :fetch-failed    {:target :error  :action :set-error}
+              :reset           :nothing}}
+
+      :refreshing
+      ;; Reload while prior banner remains visible. Tagged :data/loaded
+      ;; so the render-priority resolves to the `:loaded` view; the
+      ;; :data/refreshing tag could drive an inline indicator.
+      {:tags #{:data/loaded :data/refreshing :data/transient}
+       :on   {:fetch-succeeded {:target :loaded :action :clear-error}
+              :fetch-failed    {:target :error  :action :set-error}
+              :reset           :nothing}}
+
+      :loaded
+      {:tags #{:data/loaded}
+       :on   {:fetch-started :refreshing
+              :reset         :nothing}}
+
+      :error
+      {:tags #{:data/error}
+       :on   {:fetch-started :loading
+              :reset         :nothing}}}}
+
+    ;; ---- :tab region — which article list the view renders ----
+    :tab
+    {:initial :articles
+     :states
+     {:articles
+      ;; `/profile/:username` — reads the :profile.articles slice.
+      {:tags #{:tab/articles}
+       :on   {:show-favorites :favorites
+              :show-articles  :articles
+              :reset          :articles}}
+
+      :favorites
+      ;; `/profile/:username/favorites` — reads :profile.favorites.
+      {:tags #{:tab/favorites}
+       :on   {:show-articles  :articles
+              :show-favorites :favorites
+              :reset          :articles}}}}}})
+
+(rf/reg-machine :ui/profile profile-machine)
+
+;; ============================================================================
 ;; INITIALISATION
 ;; ============================================================================
 
-(rf/reg-event-db :profile/initialise
-  (fn [db _]
-    (-> db
-        (assoc :profile (request-slice))
-        (assoc :profile.articles (assoc (request-slice) :data []))
-        (assoc :profile.favorites (assoc (request-slice) :data [])))))
+(rf/reg-event-fx :profile/initialise
+  (fn [{:keys [db]} _]
+    {:db (-> db
+             (assoc :profile (request-slice))
+             (assoc :profile.articles (assoc (request-slice) :data []))
+             (assoc :profile.favorites (assoc (request-slice) :data [])))
+     :fx [[:dispatch [:ui/profile [:reset]]]]}))
 
 ;; ============================================================================
 ;; LOADS
@@ -40,7 +159,11 @@
 
 (rf/reg-event-fx :profile/load
   {:doc "Load the public profile (username, bio, image, following).
-         Public endpoint; data-fetch retry."
+         Public endpoint; data-fetch retry.
+
+         Broadcasts `:fetch-started` into the `:ui/profile` machine so
+         the `:data` region advances to `:loading` (or `:refreshing`
+         from `:loaded`)."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
@@ -49,7 +172,8 @@
                          (if (get-in db [:profile :data]) :fetching :loading))
                (assoc-in [:profile :error] nil)
                (update-in [:profile :attempt] (fnil inc 0)))
-       :fx [[:rf.http/managed
+       :fx [[:dispatch [:ui/profile [:fetch-started]]]
+            [:rf.http/managed
              (rh/request {:method     :get
                           :path       (str "/profiles/" username)
                           :auth?      false
@@ -59,22 +183,27 @@
                           :on-success [:profile/loaded]
                           :on-failure [:profile/load-failed]})]]})))
 
-(rf/reg-event-db :profile/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:profile :status] :loaded)
-        (assoc-in [:profile :data] (:profile value))
-        (assoc-in [:profile :error] nil)
-        (assoc-in [:profile :loaded-at] (current-time-ms)))))
+(rf/reg-event-fx :profile/loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:profile :status] :loaded)
+             (assoc-in [:profile :data] (:profile value))
+             (assoc-in [:profile :error] nil)
+             (assoc-in [:profile :loaded-at] (current-time-ms)))
+     :fx [[:dispatch [:ui/profile [:fetch-succeeded]]]]}))
 
-(rf/reg-event-db :profile/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:profile :status] :error)
-        (assoc-in [:profile :error] (rh/failure->message failure)))))
+(rf/reg-event-fx :profile/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    (let [message (rh/failure->message failure)]
+      {:db (-> db
+               (assoc-in [:profile :status] :error)
+               (assoc-in [:profile :error] message))
+       :fx [[:dispatch [:ui/profile [:fetch-failed {:failure message}]]]]})))
 
 (rf/reg-event-fx :profile.articles/load
-  {:doc "Load the profile's authored articles. Public; data-fetch retry."
+  {:doc "Load the profile's authored articles. Public; data-fetch retry.
+         Also broadcasts `:show-articles` so the `:ui/profile` :tab
+         region tracks the active tab."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
@@ -82,7 +211,8 @@
                (assoc-in [:profile.articles :status] :loading)
                (assoc-in [:profile.articles :error] nil)
                (update-in [:profile.articles :attempt] (fnil inc 0)))
-       :fx [[:rf.http/managed
+       :fx [[:dispatch [:ui/profile [:show-articles]]]
+            [:rf.http/managed
              (rh/request {:method     :get
                           :path       (str "/articles?author=" username)
                           :auth?      false
@@ -106,7 +236,9 @@
         (assoc-in [:profile.articles :error] (rh/failure->message failure)))))
 
 (rf/reg-event-fx :profile.favorites/load
-  {:doc "Load the profile's favorited articles. Public; data-fetch retry."
+  {:doc "Load the profile's favorited articles. Public; data-fetch retry.
+         Also broadcasts `:show-favorites` so the `:ui/profile` :tab
+         region tracks the active tab."
    :rf.http/decode-schemas [schema/ArticlesResponse]}
   (fn [{:keys [db]} _]
     (let [username (username-from-db db)]
@@ -114,7 +246,8 @@
                (assoc-in [:profile.favorites :status] :loading)
                (assoc-in [:profile.favorites :error] nil)
                (update-in [:profile.favorites :attempt] (fnil inc 0)))
-       :fx [[:rf.http/managed
+       :fx [[:dispatch [:ui/profile [:show-favorites]]]
+            [:rf.http/managed
              (rh/request {:method     :get
                           :path       (str "/articles?favorited=" username)
                           :auth?      false
@@ -183,11 +316,9 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :profile (fn [db _] (:profile db)))
-(rf/reg-sub :profile/data :<- [:profile] (fn [slice _] (:data slice)))
-(rf/reg-sub :profile/error :<- [:profile] (fn [slice _] (:error slice)))
-(rf/reg-sub :profile/loading? :<- [:profile]
-  (fn [slice _] (#{:loading :fetching} (:status slice))))
+(rf/reg-sub :profile         (fn [db _] (:profile db)))
+(rf/reg-sub :profile/data    :<- [:profile] (fn [s _] (:data s)))
+(rf/reg-sub :profile/error   :<- [:profile] (fn [s _] (:error s)))
 
 (rf/reg-sub :profile.articles/data
   (fn [db _] (get-in db [:profile.articles :data])))
@@ -195,84 +326,122 @@
 (rf/reg-sub :profile.favorites/data
   (fn [db _] (get-in db [:profile.favorites :data])))
 
-(rf/reg-sub :profile/current-tab
-  (fn [db _]
-    (if (= :route/profile.favorites (get-in db [:rf/route :id]))
-      :favorites
-      :articles)))
-
-(rf/reg-sub :profile/current-articles
-  (fn [db _]
-    (if (= :route/profile.favorites (get-in db [:rf/route :id]))
-      (get-in db [:profile.favorites :data])
-      (get-in db [:profile.articles :data]))))
-
 (rf/reg-sub :profile/own-profile?
   (fn [db _]
     (= (get-in db [:auth :user :username])
        (get-in db [:profile :data :username]))))
 
+;; ---- render-priority + :profile/render selector ----
+;;
+;; Plain data: a vector of {:tag :render} pairs consulted in order.
+;; The `:profile/render` sub reads the machine's tag union and returns
+;; the first :render whose :tag is present. The view's `case` over
+;; the resolved keyword is the only branch site.
+;;
+;; Priority rationale: the data region's lifecycle wins outright —
+;; `:loading` (first-load spinner) above `:error` above `:loaded`.
+;; `:refreshing` resolves to `:loaded` (the prior banner stays visible).
+
+(def render-priority
+  [{:tag :data/loading :render :loading}
+   {:tag :data/error   :render :error}
+   {:tag :data/loaded  :render :loaded}
+   {:tag :data/nothing :render :nothing}])
+
+(rf/reg-sub :profile/render
+  {:doc "Resolve the profile page's render-model keyword by consulting
+         the render-priority table against the `:ui/profile` machine's
+         tag union. The root view's `case` is the only branch site."}
+  :<- [:rf/machine :ui/profile]
+  (fn sub-profile-render [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+
+(rf/reg-sub :profile/current-articles
+  {:doc "The article list currently rendered by the profile view: the
+         `:tab` region's active state-keyword picks which app-db slice
+         to read from."}
+  :<- [:rf/machine :ui/profile]
+  :<- [:profile.articles/data]
+  :<- [:profile.favorites/data]
+  (fn sub-current-articles [[snap authored favorited] _]
+    (case (get-in snap [:state :tab])
+      :favorites (or favorited [])
+      (or authored []))))
+
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================
 
+(reg-view ^{:doc "Data region :loading — first banner fetch in flight."}
+          profile-loading []
+  [:div.article-preview "Loading profile…"])
+
+(reg-view ^{:doc "Data region :error — banner fetch failed."}
+          profile-error []
+  (let [err @(subscribe [:profile/error])]
+    [:div.article-preview.error
+     (str "Couldn't load profile: " (pr-str err))]))
+
+(reg-view ^{:doc "Data region :nothing — pre-fetch placeholder."}
+          profile-nothing []
+  [:div.article-preview "No profile loaded."])
+
+(reg-view ^{:doc "Data region :loaded — banner, tabs, and the active
+                  tab's article list."}
+          profile-loaded []
+  (let [profile     @(subscribe [:profile/data])
+        own?        @(subscribe [:profile/own-profile?])
+        on-favs?    @(rf/has-tag? :ui/profile :tab/favorites)
+        articles*   @(subscribe [:profile/current-articles])]
+    [:<>
+     [:div.user-info
+      [:div.container
+       [:div.row
+        [:div.col-xs-12.col-md-10.offset-md-1
+         [:img.user-img {:src (:image profile)}]
+         [:h4 (:username profile)]
+         [:p (:bio profile)]
+         (if own?
+           [routing/route-link {:to :route/settings
+                                :class "btn btn-sm btn-outline-secondary action-btn"}
+            [:i.ion-gear-a] " Edit Profile Settings"]
+           [:button.btn.btn-sm.btn-outline-secondary.action-btn
+            {:type "button"
+             :on-click #(dispatch [(if (:following profile)
+                                     :profile/unfollow
+                                     :profile/follow)])}
+            (if (:following profile) "Unfollow " "Follow ")
+            (:username profile)])]]]]
+     [:div.container
+      [:div.row
+       [:div.col-xs-12.col-md-10.offset-md-1
+        [:div.articles-toggle
+         [:ul.nav.nav-pills.outline-active
+          [:li.nav-item
+           [routing/route-link {:to     :route/profile
+                                :params {:username (:username profile)}
+                                :class  (str "nav-link" (when-not on-favs? " active"))}
+            "My Articles"]]
+          [:li.nav-item
+           [routing/route-link {:to     :route/profile.favorites
+                                :params {:username (:username profile)}
+                                :class  (str "nav-link" (when on-favs? " active"))}
+            "Favorited Articles"]]]]
+        (if (seq articles*)
+          (for [article articles*]
+            ^{:key (:slug article)}
+            [articles/article-preview {:article article}])
+          [:div.article-preview "No articles here yet."])]]]]))
+
 (reg-view profile-page []
-  (let [profile       @(subscribe [:profile/data])
-        profile-error @(subscribe [:profile/error])
-        loading?      @(subscribe [:profile/loading?])
-        own?          @(subscribe [:profile/own-profile?])
-        tab           @(subscribe [:profile/current-tab])
-        articles*     @(subscribe [:profile/current-articles])]
+  (let [render-mode @(subscribe [:profile/render])]
     [:div.profile-page
-     (cond
-       loading?
-       [:div.article-preview "Loading profile…"]
-
-       profile-error
-       [:div.article-preview.error
-        (str "Couldn't load profile: " (pr-str profile-error))]
-
-       profile
-       [:<>
-        [:div.user-info
-         [:div.container
-          [:div.row
-           [:div.col-xs-12.col-md-10.offset-md-1
-            [:img.user-img {:src (:image profile)}]
-            [:h4 (:username profile)]
-            [:p (:bio profile)]
-            (if own?
-              [routing/route-link {:to :route/settings
-                                   :class "btn btn-sm btn-outline-secondary action-btn"}
-               [:i.ion-gear-a] " Edit Profile Settings"]
-              [:button.btn.btn-sm.btn-outline-secondary.action-btn
-               {:type "button"
-                :on-click #(dispatch [(if (:following profile)
-                                        :profile/unfollow
-                                        :profile/follow)])}
-               (if (:following profile) "Unfollow " "Follow ")
-               (:username profile)])]]]]
-        [:div.container
-         [:div.row
-          [:div.col-xs-12.col-md-10.offset-md-1
-           [:div.articles-toggle
-            [:ul.nav.nav-pills.outline-active
-             [:li.nav-item
-              [routing/route-link {:to     :route/profile
-                                   :params {:username (:username profile)}
-                                   :class  (str "nav-link" (when (= tab :articles) " active"))}
-               "My Articles"]]
-             [:li.nav-item
-              [routing/route-link {:to     :route/profile.favorites
-                                   :params {:username (:username profile)}
-                                   :class  (str "nav-link" (when (= tab :favorites) " active"))}
-               "Favorited Articles"]]]]
-           (if (seq articles*)
-             (for [article articles*]
-               ^{:key (:slug article)}
-               [articles/article-preview {:article article}])
-             [:div.article-preview "No articles here yet."])]]]]
-
-       :else
-       [:div.article-preview "No profile loaded."])]))
-
+     (case render-mode
+       :loading [profile-loading]
+       :error   [profile-error]
+       :loaded  [profile-loaded]
+       :nothing [profile-nothing]
+       [profile-nothing])]))


### PR DESCRIPTION
## Summary

Mirrors **rf2-qbau** (PR #295) on the home page. Profile-page (`examples/reagent/realworld/profile.cljs`) has two orthogonal axes — tab (`:articles` vs `:favorites`) and Pattern-RemoteData lifecycle for the banner fetch. Replaces the cross-axis sub + priority-cond view shape with one parallel machine.

- **`:ui/profile` parallel machine, two regions:**
  - `:tab` — `:articles` | `:favorites` (driven by the route's `:on-match` broadcasting `:show-articles` / `:show-favorites`)
  - `:data` — `:nothing → :loading | :refreshing → :loaded | :error` (Pattern-NineStates lifecycle for the banner fetch)
- **Render-priority table** (plain data) + **`:profile/render`** selector sub that consults the table against the snapshot's tag union.
- **Root view collapses to one `case`** over `:profile/render`. The cross-axis `:profile/current-articles` math (previously read `[:rf/route :id]` to pick the slice) becomes a selector sub that reads `(:state :tab)` from the snapshot.
- **Tab clicks** dispatch route navigations (unchanged); the routes' `:on-match` events broadcast the matching `:tab` region transition.
- **Data fetches** broadcast `:fetch-started` / `:fetch-succeeded` / `:fetch-failed` into the machine.

What stays:
- Article-slice data still lives in app-db slices (`:profile.articles`, `:profile.favorites`) — same call as rf2-qbau. Keeps `favorites.cljs/find-article`'s optimistic-update paths working.
- Banner-slice (`:profile`) still carries `:status`/`:data`/`:error` for parity with other slices; the region's state-keyword is the page's render gate.

## Regions and tag vocabularies

| Region  | States                                              | Tags                                                                 |
| ------- | --------------------------------------------------- | -------------------------------------------------------------------- |
| `:tab`  | `:articles`, `:favorites`                           | `:tab/articles`, `:tab/favorites`                                    |
| `:data` | `:nothing`, `:loading`, `:refreshing`, `:loaded`, `:error` | `:data/nothing`, `:data/loading`, `:data/refreshing`, `:data/transient`, `:data/loaded`, `:data/error` |

## Render-priority table

```clojure
(def render-priority
  [{:tag :data/loading :render :loading}
   {:tag :data/error   :render :error}
   {:tag :data/loaded  :render :loaded}
   {:tag :data/nothing :render :nothing}])
```

## Test plan

- [x] `npm run test:cljs` — 496 tests / 1206 assertions / 0 failures
- [x] `npm run test:elision` — PASS
- [x] `mkdocs build --strict` — no new warnings (pre-existing 186 warnings unchanged)

## LoC delta

`profile.cljs`: **278 → 447 (+169)**. As with rf2-qbau, the machine declaration is verbose and per-render-state subviews add chrome, but the root view's branching collapses into a `case`, the priority lives in data, and the model is visible in the machine declaration.

## Verdict

Mirrors the rf2-qbau outcome shape exactly. Machine declaration is verbose; LoC went up; but:
- The two axes are visible in the regions map at a glance.
- The "which slice's articles are we rendering?" question is answered by reading `(:state :tab)` from the snapshot — one place, not a sub that branches on the route id.
- The root view is a `case` over a single keyword, not a four-clause priority `cond`.
- Tag-shaped queries (`(rf/has-tag? :ui/profile :tab/favorites)` for the nav-link active class) replace the `:profile/current-tab` boolean sub.

Audit reference: `findings/examples-tags-parallel-audit.md` §2.11 (verdict D).