### PR TITLE
refactor(examples): realworld/article_editor — parallel machine (mode x lifecycle) (rf2-vxeg)

### DIFF
--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -1,13 +1,29 @@
 (ns realworld.article-editor
   "Article editor for the RealWorld (Conduit) example.
 
-   This sketch shows the current re-frame2 shape for:
-   - a Pattern-Forms slice with draft / touched / submit status
-   - route-driven create-vs-edit branching
-   - unsaved-change blocking via the route's `:can-leave` subscription
-   - ordinary HTTP effects for create / update / delete"
+   This sketch demonstrates:
+   - Pattern-NineStates — one parallel state machine `:ui/article-editor`
+     with two orthogonal regions (`:mode` x `:lifecycle`) replacing the
+     prior mode-flag + lifecycle-status shape (per rf2-vxeg).
+   - Pattern-Forms — the draft / errors / touched / submit-error slice
+     still lives in app-db (`:editor`); the machine carries only the
+     state vocabulary. `:editor/dirty?` is a draft-vs-baseline sub, not
+     a state-machine concern.
+   - The view's input-busy and Delete-button visibility are tag queries
+     (`(rf/has-tag? :ui/article-editor :editor/busy)` and
+     `(rf/has-tag? :ui/article-editor :editor/can-delete)`) rather than
+     boolean discriminator subs.
+   - The view's root is a `case` over `:article-editor/render`, a
+     selector sub that consults a render-priority table against the
+     machine's tag union (per Pattern-NineStates §4)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            ;; Per rf2-xbtj, the Spec 005 state-machine ns lives in the
+            ;; day8/re-frame2-machines artefact. Loading the ns here
+            ;; registers its late-bind hooks so rf/reg-machine (called
+            ;; below at ns-load) and the `:rf/machine` framework subs
+            ;; resolve.
+            [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
@@ -28,14 +44,15 @@
        vec))
 
 (defn editor-slice
-  ([] (editor-slice :create nil blank-draft))
-  ([mode slug baseline]
-   {:mode         mode
-    :slug         slug
+  "The form's app-db slice. Holds Pattern-Forms shape (draft, baseline,
+   errors, touched, submit-error). The machine carries the state
+   vocabulary; this slice carries the data."
+  ([] (editor-slice nil blank-draft))
+  ([slug baseline]
+   {:slug         slug
     :draft        baseline
     :baseline     baseline
     :submitted    nil
-    :status       :idle
     :errors       {}
     :touched      #{}
     :submit-error nil}))
@@ -53,23 +70,115 @@
              :tagList     (parse-tag-list (:tagList draft))}})
 
 ;; ============================================================================
+;; THE MACHINE — :ui/article-editor  (one machine, two regions)
+;; ============================================================================
+;;
+;; The article editor has two orthogonal axes:
+;;
+;;   :mode      — :create (the /editor route, POST to /articles) vs
+;;                :edit (the /editor/:slug route, PUT to /articles/:slug
+;;                and a Delete button). The :edit state also emits the
+;;                :editor/can-delete tag so the view can ask a tag-shaped
+;;                question without inspecting the region directly.
+;;
+;;   :lifecycle — Pattern-Forms lifecycle: :idle | :loading | :submitting
+;;                | :saved | :error. The :loading and :submitting states
+;;                emit the :editor/busy tag so the view can disable
+;;                inputs without a separate `:submitting?` sub.
+;;
+;; Per Spec 005 §Transition broadcast: every event delivered to the
+;; machine is broadcast to every region. Region-distinct event names
+;; below avoid collisions; `:reset` is handled by every region as a
+;; self-target.
+
+(def editor-machine
+  {:type :parallel
+
+   :regions
+   {;; ---- :mode region — create vs edit ----
+    :mode
+    {:initial :create
+     :states
+     {:create
+      ;; The /editor route. POST on submit. No Delete button.
+      {:tags #{:mode/create}
+       :on   {:use-edit   :edit
+              :use-create :create
+              :reset      :create}}
+
+      :edit
+      ;; The /editor/:slug route. PUT on submit. Delete button visible.
+      {:tags #{:mode/edit :editor/can-delete}
+       :on   {:use-create :create
+              :use-edit   :edit
+              :reset      :create}}}}
+
+    ;; ---- :lifecycle region — Pattern-Forms lifecycle ----
+    :lifecycle
+    {:initial :idle
+     :states
+     {:idle
+      {:tags #{:lifecycle/idle}
+       :on   {:fetch-started  :loading
+              :submit-started :submitting
+              :reset          :idle}}
+
+      :loading
+      ;; Edit mode's initial article fetch in flight. Inputs disable
+      ;; via the :editor/busy tag.
+      {:tags #{:lifecycle/loading :editor/busy}
+       :on   {:fetch-succeeded :idle
+              :fetch-failed    :error
+              :reset           :idle}}
+
+      :submitting
+      ;; Save in flight (POST or PUT, decided by :mode) or destructive
+      ;; delete in flight. Inputs disable via the :editor/busy tag.
+      {:tags #{:lifecycle/submitting :editor/busy}
+       :on   {:submit-succeeded :saved
+              :submit-failed    :idle
+              :reset            :idle}}
+
+      :saved
+      ;; Transient post-submit-success state. The :editor/submit-success
+      ;; handler navigates to the article detail page immediately, so
+      ;; this state is short-lived; included for completeness.
+      {:tags #{:lifecycle/saved}
+       :on   {:reset :idle}}
+
+      :error
+      ;; Load-failed state. Submit-failed returns to :idle so the user
+      ;; can retry; load-failed lands here so the view can show the
+      ;; error banner. The submit-error message lives in the editor
+      ;; slice; this state is the page-level render gate.
+      {:tags #{:lifecycle/error}
+       :on   {:fetch-started  :loading
+              :submit-started :submitting
+              :reset          :idle}}}}}})
+
+(rf/reg-machine :ui/article-editor editor-machine)
+
+;; ============================================================================
 ;; EVENTS
 ;; ============================================================================
 
-(rf/reg-event-db :editor/initialise
-  (fn [db _]
-    (assoc db :editor (editor-slice))))
+(rf/reg-event-fx :editor/initialise
+  (fn [{:keys [db]} _]
+    {:db (assoc db :editor (editor-slice))
+     :fx [[:dispatch [:ui/article-editor [:reset]]]]}))
 
 (rf/reg-event-fx :editor/load-article
   {:doc "Load an existing article into the editor in :edit mode.
-         data-fetch retry policy applies (Spec 014)."
+         data-fetch retry policy applies (Spec 014). Broadcasts
+         `:use-edit` so the :mode region tracks the edit-load and
+         `:fetch-started` so the :lifecycle region advances to :loading."
    :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:rf/route :params :slug])]
-      {:db (-> db
-               (assoc :editor (assoc (editor-slice :edit slug blank-draft)
-                                     :status :loading)))
-       :fx [[:rf.http/managed
+      {:db (assoc db :editor (editor-slice slug blank-draft))
+       :fx [[:dispatch [:ui/article-editor [:use-edit]]]
+            [:dispatch [:ui/article-editor [:fetch-started]]]
+            [:rf.http/managed
              (rh/request {:method     :get
                           :path       (str "/articles/" slug)
                           :decode     schema/ArticleResponse
@@ -78,18 +187,17 @@
                           :on-success [:editor/loaded]
                           :on-failure [:editor/load-failed]})]]})))
 
-(rf/reg-event-db :editor/loaded
-  (fn [db [_ {:keys [value]}]]
+(rf/reg-event-fx :editor/loaded
+  (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [article (:article value)
           draft   (draft-from-article article)]
-      (assoc db :editor (editor-slice :edit (:slug article) draft)))))
+      {:db (assoc db :editor (editor-slice (:slug article) draft))
+       :fx [[:dispatch [:ui/article-editor [:fetch-succeeded]]]]})))
 
-(rf/reg-event-db :editor/load-failed
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:editor :status] :error)
-        (assoc-in [:editor :submit-error]
-                  (rh/failure->message failure)))))
+(rf/reg-event-fx :editor/load-failed
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
+     :fx [[:dispatch [:ui/article-editor [:fetch-failed]]]]}))
 
 (rf/reg-event-db :editor/edit-field
   (fn [db [_ field value]]
@@ -104,21 +212,27 @@
 (rf/reg-event-fx :editor/submit
   {:doc "Save the article (POST for create, PUT for edit). NO retry — the
          user's intent is one submission per click; surface errors so the
-         user can decide whether to retry (Spec 014)."
+         user can decide whether to retry (Spec 014).
+
+         Reads the current `:mode` region's state to decide POST vs PUT.
+         Broadcasts `:submit-started` into the lifecycle region; the
+         `:on-success` / `:on-failure` replies broadcast
+         `:submit-succeeded` / `:submit-failed`."
    :rf.http/decode-schemas [schema/ArticleResponse]}
   (fn [{:keys [db]} _]
-    (let [{:keys [mode slug draft]} (:editor db)
+    (let [{:keys [slug draft]} (:editor db)
+          mode   (get-in db [:rf/machines :ui/article-editor :state :mode])
           errors (validate-draft draft)]
       (if (seq errors)
         {:db (-> db
                  (assoc-in [:editor :errors] errors)
                  (assoc-in [:editor :submit-error] "Please fix the highlighted fields."))}
         {:db (-> db
-                 (assoc-in [:editor :status] :submitting)
                  (assoc-in [:editor :submitted] draft)
                  (assoc-in [:editor :errors] {})
                  (assoc-in [:editor :submit-error] nil))
-         :fx [[:rf.http/managed
+         :fx [[:dispatch [:ui/article-editor [:submit-started]]]
+              [:rf.http/managed
                (rh/request {:method     (if (= mode :edit) :put :post)
                             :path       (if (= mode :edit)
                                           (str "/articles/" slug)
@@ -132,23 +246,24 @@
   (fn [{:keys [db]} [_ {:keys [value]}]]
     (let [article (:article value)
           draft   (draft-from-article article)]
-      {:db (assoc db :editor (assoc (editor-slice :edit (:slug article) draft)
-                                    :status :saved))
-       :fx [[:dispatch [:rf.route/navigate :route/article {:slug (:slug article)}]]]})))
+      {:db (assoc db :editor (editor-slice (:slug article) draft))
+       :fx [[:dispatch [:ui/article-editor [:use-edit]]]
+            [:dispatch [:ui/article-editor [:submit-succeeded]]]
+            [:dispatch [:rf.route/navigate :route/article {:slug (:slug article)}]]]})))
 
-(rf/reg-event-db :editor/submit-error
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:editor :status] :idle)
-        (assoc-in [:editor :submit-error]
-                  (rh/failure->message failure)))))
+(rf/reg-event-fx :editor/submit-error
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
+     :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
 
 (rf/reg-event-fx :editor/delete
-  {:doc "Delete the article. No retry — destructive action, one click."}
+  {:doc "Delete the article. No retry — destructive action, one click.
+         Broadcasts `:submit-started` so the lifecycle region advances
+         to :submitting (which carries the :editor/busy tag)."}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:editor :slug])]
-      {:db (assoc-in db [:editor :status] :submitting)
-       :fx [[:rf.http/managed
+      {:fx [[:dispatch [:ui/article-editor [:submit-started]]]
+            [:rf.http/managed
              (rh/request {:method     :delete
                           :path       (str "/articles/" slug)
                           ;; The delete endpoint returns no body; :auto
@@ -160,14 +275,13 @@
 (rf/reg-event-fx :editor/delete-success
   (fn [{:keys [db]} _]
     {:db (assoc db :editor (editor-slice))
-     :fx [[:dispatch [:rf.route/navigate :route/home]]]}))
+     :fx [[:dispatch [:ui/article-editor [:reset]]]
+          [:dispatch [:rf.route/navigate :route/home]]]}))
 
-(rf/reg-event-db :editor/delete-error
-  (fn [db [_ {:keys [failure]}]]
-    (-> db
-        (assoc-in [:editor :status] :idle)
-        (assoc-in [:editor :submit-error]
-                  (rh/failure->message failure)))))
+(rf/reg-event-fx :editor/delete-error
+  (fn [{:keys [db]} [_ {:keys [failure]}]]
+    {:db (assoc-in db [:editor :submit-error] (rh/failure->message failure))
+     :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -178,10 +292,6 @@
 
 (rf/reg-sub :editor/draft :<- [:editor] (fn [editor _] (:draft editor)))
 (rf/reg-sub :editor/errors :<- [:editor] (fn [editor _] (:errors editor)))
-(rf/reg-sub :editor/status :<- [:editor] (fn [editor _] (:status editor)))
-(rf/reg-sub :editor/mode :<- [:editor] (fn [editor _] (:mode editor)))
-(rf/reg-sub :editor/submitting? :<- [:editor/status]
-  (fn [status _] (or (= status :submitting) (= status :loading))))
 (rf/reg-sub :editor/submit-error :<- [:editor]
   (fn [editor _] (:submit-error editor)))
 (rf/reg-sub :editor/dirty?
@@ -194,16 +304,63 @@
   (fn [dirty? _]
     (not dirty?)))
 
+;; ---- render-priority + :article-editor/render selector ----
+;;
+;; The render-priority table is plain data: a vector of {:tag :render}
+;; pairs consulted in order. The `:article-editor/render` sub reads the
+;; machine's tag union and returns the first :render whose :tag is
+;; present. The editor view's `case` over the resolved keyword is the
+;; only branch site.
+;;
+;; Priority rationale: the lifecycle region drives the gate. `:error`
+;; (load-failed) shows the form with the error banner. `:loading`
+;; (edit-mode initial fetch in flight) shows the form with busy inputs.
+;; `:saved` is a transient state immediately followed by navigation;
+;; included so the table is complete. Default is `:editing` — the form
+;; in its normal interactive state.
+
+(def render-priority
+  [{:tag :lifecycle/error      :render :error}
+   {:tag :lifecycle/loading    :render :loading}
+   {:tag :lifecycle/saved      :render :saved}
+   {:tag :lifecycle/submitting :render :editing}
+   {:tag :lifecycle/idle       :render :editing}])
+
+(rf/reg-sub :article-editor/render
+  {:doc "Resolve the editor's render-model keyword by consulting the
+         render-priority table against the `:ui/article-editor` machine's
+         tag union. The root view's `case` is the only branch site."}
+  :<- [:rf/machine :ui/article-editor]
+  (fn sub-editor-render [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+
+;; Legacy sub names kept as thin adapters over the machine so existing
+;; tests and any external callers still resolve. Prefer the tag queries
+;; and the render selector in new code.
+(rf/reg-sub :editor/status
+  :<- [:rf/machine :ui/article-editor]
+  (fn [snap _] (get-in snap [:state :lifecycle])))
+
+(rf/reg-sub :editor/mode
+  :<- [:rf/machine :ui/article-editor]
+  (fn [snap _] (get-in snap [:state :mode])))
+
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================
 
-(reg-view editor-page []
+(reg-view ^{:doc "The shared editor form. Rendered by every render-mode
+                   today; `:editor/busy` disables inputs, `:editor/can-delete`
+                   shows the Delete button."}
+          editor-form []
   (let [draft        @(subscribe [:editor/draft])
         errors       @(subscribe [:editor/errors])
-        submitting?  @(subscribe [:editor/submitting?])
         submit-error @(subscribe [:editor/submit-error])
-        mode         @(subscribe [:editor/mode])]
+        busy?        @(rf/has-tag? :ui/article-editor :editor/busy)
+        can-delete?  @(rf/has-tag? :ui/article-editor :editor/can-delete)]
     [:div.editor-page
      [:div.container.page
       [:div.row
@@ -220,7 +377,7 @@
             {:type        "text"
              :placeholder "Article Title"
              :value       (:title draft)
-             :disabled    submitting?
+             :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :title])
              :on-change   #(dispatch [:editor/edit-field :title (.. % -target -value)])}]
            (when-let [err (:title errors)]
@@ -230,7 +387,7 @@
             {:type        "text"
              :placeholder "What's this article about?"
              :value       (:description draft)
-             :disabled    submitting?
+             :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :description])
              :on-change   #(dispatch [:editor/edit-field :description (.. % -target -value)])}]
            (when-let [err (:description errors)]
@@ -240,7 +397,7 @@
             {:rows        8
              :placeholder "Write your article (in markdown)"
              :value       (:body draft)
-             :disabled    submitting?
+             :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :body])
              :on-change   #(dispatch [:editor/edit-field :body (.. % -target -value)])}]
            (when-let [err (:body errors)]
@@ -250,16 +407,57 @@
             {:type        "text"
              :placeholder "Enter tags"
              :value       (:tagList draft)
-             :disabled    submitting?
+             :disabled    busy?
              :on-change   #(dispatch [:editor/edit-field :tagList (.. % -target -value)])}]]
           [:button.btn.btn-lg.pull-xs-right.btn-primary
-           {:type "submit" :disabled submitting?}
-           (if (= mode :edit) "Update Article" "Publish Article")]
-          (when (= mode :edit)
+           {:type "submit" :disabled busy?}
+           (if can-delete? "Update Article" "Publish Article")]
+          (when can-delete?
             [:button.btn.btn-outline-danger
              {:type "button"
-              :disabled submitting?
+              :disabled busy?
               :on-click #(dispatch [:editor/delete])}
              "Delete Article"])]]]]]]))
 
-    
+;; ---- per-render-state subviews ----
+;;
+;; All render-modes delegate to `editor-form` today; the form's own
+;; tag queries (`:editor/busy`, `:editor/can-delete`) handle the in-form
+;; differences. Splitting them out as separate reg-views keeps the
+;; pattern shape consistent with rf2-qbau / rf2-ljw9 and gives a single
+;; cheap site to introduce render-mode-specific scaffolding (a
+;; full-page spinner, a dedicated load-error layout) without rewriting
+;; the case branch.
+
+(reg-view ^{:doc "Lifecycle :idle / :submitting — the form in its normal
+                   interactive (or busy) state."}
+          editor-editing []
+  [editor-form])
+
+(reg-view ^{:doc "Lifecycle :loading — edit-mode initial fetch in
+                   flight. Today renders the form with disabled inputs
+                   (via the :editor/busy tag); the form-only render is
+                   pixel-equivalent to the prior behaviour."}
+          editor-loading []
+  [editor-form])
+
+(reg-view ^{:doc "Lifecycle :error — load failed. Renders the form
+                   with the submit-error banner; pixel-equivalent to
+                   the prior behaviour."}
+          editor-error []
+  [editor-form])
+
+(reg-view ^{:doc "Lifecycle :saved — transient post-submit-success
+                   state. The :editor/submit-success handler navigates
+                   immediately, so this view is rarely visible."}
+          editor-saved []
+  [editor-form])
+
+(reg-view editor-page []
+  (let [render-mode @(subscribe [:article-editor/render])]
+    (case render-mode
+      :error   [editor-error]
+      :loading [editor-loading]
+      :saved   [editor-saved]
+      :editing [editor-editing]
+      [editor-editing])))

--- a/examples/reagent/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/reagent/realworld/test/realworld/article_editor_test.cljs
@@ -1,7 +1,10 @@
 (ns realworld.article-editor-test
   "Headless tests for realworld.article-editor — create flow and
    navigation guard. Retrofitted under rf2-o8t6 to use Spec 014's
-   `:rf.http/managed` substrate via the framework-shipped canned-stub fxs."
+   `:rf.http/managed` substrate via the framework-shipped canned-stub fxs.
+   Refactored under rf2-vxeg to query the `:ui/article-editor` parallel
+   machine (regions `:mode` x `:lifecycle`) instead of the prior
+   mode-flag + lifecycle-status shape."
   (:require [re-frame.core :as rf]
             [realworld.article-editor]
             [realworld.test-helpers :as th])
@@ -23,11 +26,17 @@
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
                                  :fx-overrides {:rf.http/managed :rf.http/managed.canned-editor-save}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
+    ;; The :mode region starts at :create; the :lifecycle region starts
+    ;; at :idle.
+    (assert (= :create (rf/compute-sub [:editor/mode] (rf/get-frame-db f))))
+    (assert (= :idle   (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
     (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :body "Body"] {:frame f})
     (rf/dispatch-sync [:editor/submit] {:frame f})
+    ;; A successful submit advances :mode → :edit and :lifecycle → :saved.
     (assert (= :saved (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
+    (assert (= :edit  (rf/compute-sub [:editor/mode] (rf/get-frame-db f))))
     (assert (false? (rf/compute-sub [:editor/dirty?] (rf/get-frame-db f))))))
 
 (defn editor-can-leave-test []


### PR DESCRIPTION
## Summary

- Mirrors rf2-qbau (home page) and rf2-ljw9 (profile). Replaces the editor's mode-flag + lifecycle-status shape with one parallel machine `:ui/article-editor` plus a render-priority table.
- Two orthogonal regions: `:mode` (`:create` | `:edit`) and `:lifecycle` (`:idle` | `:loading` | `:submitting` | `:saved` | `:error`). The `:edit` state tags `:editor/can-delete`; the `:loading` and `:submitting` states tag `:editor/busy`. The view's input-busy and Delete-button visibility become tag queries (`rf/has-tag?`) instead of boolean discriminator subs.
- Root view is now a `case` over `:article-editor/render`, a selector sub over the snapshot's tag union with a 5-entry render-priority vector. Events broadcast region-distinct transitions; POST-vs-PUT in `:editor/submit` reads the `:mode` region's state from the snapshot.
- The Pattern-Forms `:editor` slice (draft/baseline/errors/touched/submit-error) still lives in app-db. `:editor/dirty?` remains a draft-vs-baseline sub; `:editor/can-leave?` remains its negation. `:editor/status` and `:editor/mode` are kept as thin adapters over the machine.

LoC: `article_editor.cljs` 265 → 463 (+198); same clarity-vs-LoC outcome as rf2-qbau and rf2-ljw9.

## Test plan

- [x] `npm run test:cljs` — 496 tests / 1206 assertions, 0 failures, 0 errors
- [x] `npm run test:elision` — clean
- [x] `python -m mkdocs build --strict` — 0 new warnings (187 pre-existing, all unrelated)
- [x] Headless test updated to query the parallel machine surface (`:mode` advances to `:edit` after submit-success; `:lifecycle` advances to `:saved`)