### PR TITLE
refactor(examples): extract inline tests into separate test files (rf2-xa3e)

### DIFF
--- a/examples/reagent/nine_states/README.md
+++ b/examples/reagent/nine_states/README.md
@@ -111,11 +111,14 @@ shadow-cljs watch examples/nine-states
 
 (Run `npm run test:examples` at least once first so `out/examples/nine-states/index.html` is staged; subsequent watch builds reuse it.)
 
-The headless tests run from a CLJS REPL:
+The headless tests live in [`test/nine_states/core_test.cljs`](test/nine_states/core_test.cljs) and run as part of the framework's CLJS test suite. To run them ad-hoc from a CLJS REPL:
 
 ```clojure
-(nine-states.core/run-all-tests)
-;; => :ok
+(require '[nine-states.core])          ;; loads the example registrations
+(require '[nine-states.core-test :as t])
+(t/test-state-1-nothing)
+(t/test-state-2-loading)
+;; ...one per state.
 ```
 
 ## Cross-references

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -54,16 +54,17 @@
    - **Inspectability bias** — non-trivial guards / actions are named
      entries in the machine's `:guards` / `:actions` maps; only trivial
      transitions use inline fns.
-   - **Headless tests** at the bottom — every state has a fixture that
-     drives `app-db` into that state and asserts against tags +
-     `:ui/render`. Browserless via `compute-sub` / `dispatch-sync`.
+   - **Headless tests** — every state has a fixture that drives `app-db`
+     into that state and asserts against tags + `:ui/render`. Browserless
+     via `compute-sub` / `dispatch-sync`. The fixtures live in a sibling
+     `test/nine_states/core_test.cljs` (ns `nine-states.core-test`) so
+     this source file stays test-free.
 
    Layout follows the single-file style of `examples/reagent/login/core.cljs`
    and `examples/reagent/7Guis/circle_drawer/circle_drawer.cljs`. In a real
    codebase this would split per CP-6 conventions across schema / events /
    subs / views / machines / tests files."
-  (:require [cljs.test :refer-macros [is]]
-            [reagent.dom.client :as rdc]
+  (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
@@ -86,7 +87,7 @@
             [re-frame.http-managed]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================
 ;; CONSTANTS
@@ -657,123 +658,14 @@
    [new-todo-form]])
 
 ;; ============================================================================
-;; HEADLESS TESTS
-;; ============================================================================
-;;
-;; One fixture per state. Each: drive `app-db` to the state via dispatch-sync,
-;; then assert against the machine's tag union and the resolved
-;; :ui/render keyword. Browserless via `compute-sub` (no DOM required).
-
-(defn- has-tag?
-  "Read the machine's tag union against a frame's app-db."
-  [frame tag]
-  (contains? (get-in (rf/get-frame-db frame)
-                     [:rf/machines :ui/nine-states :tags])
-             tag))
-
-(defn- render-model [frame]
-  (rf/compute-sub [:ui/render] (rf/get-frame-db frame)))
-
-(def ^:private demo-overrides
-  "Per-test :fx-overrides map that routes `:rf.http/managed` to the in-process
-   demo stub so tests run without a backend."
-  {:rf.http/managed :nine-states.http/managed-demo})
-
-(defn- new-frame []
-  (rf/make-frame
-    {:on-create    [:nine-states.app/initialise]
-     :fx-overrides demo-overrides}))
-
-(defn test-state-1-nothing []
-  (with-frame [f (new-frame)]
-    (is       (has-tag?    f :data/nothing))
-    (is (not  (has-tag?    f :data/loading)))
-    (is (=    :nothing     (render-model f)))))
-
-(defn test-state-2-loading []
-  ;; The demo stub resolves synchronously, so we observe :loading by
-  ;; dispatching :fetch-started directly (without a follow-up reply).
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:ui/nine-states [:fetch-started]] {:frame f})
-    (is       (has-tag?    f :data/loading))
-    (is       (has-tag?    f :data/transient))
-    (is (=    :loading     (render-model f)))))
-
-(defn test-state-3-empty []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
-    (is       (has-tag?    f :data/empty))
-    (is (not  (has-tag?    f :data/one)))
-    (is (=    :empty       (render-model f)))))
-
-(defn test-state-4-one []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 1}] {:frame f})
-    (is       (has-tag?    f :data/one))
-    (is (=    :one         (render-model f)))))
-
-(defn test-state-5-some []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
-    (is       (has-tag?    f :data/some))
-    (is (=    :some        (render-model f)))))
-
-(defn test-state-6-too-many []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame f})
-    (is       (has-tag?    f :data/too-many))
-    (is (=    :too-many    (render-model f)))))
-
-(defn test-state-7-incorrect []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
-    (rf/dispatch-sync [:new-todo/submit] {:frame f})
-    (is       (has-tag?    f :form/invalid))
-    (is (=    :incorrect   (render-model f)))))
-
-(defn test-state-8-correct []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
-    (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
-    (rf/dispatch-sync [:new-todo/submit] {:frame f})
-    ;; Tags reflect the overlap honestly: :form/success AND :data/one
-    ;; are both true simultaneously. The render-priority table
-    ;; resolves it: :correct wins.
-    (is       (has-tag?    f :form/success))
-    (is       (has-tag?    f :data/one))
-    (is (=    :correct     (render-model f)))))
-
-(defn test-state-9-done []
-  (with-frame [f (new-frame)]
-    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
-    (rf/dispatch-sync [:ui/nine-states [:archive {:now 1}]] {:frame f})
-    (let [snap (get-in (rf/get-frame-db f) [:rf/machines :ui/nine-states])]
-      (is (= :done (get-in snap [:state :mode])))
-      (is (= 1    (get-in snap [:data :archived-at]))))
-    (is       (has-tag?    f :mode/done))
-    (is       (has-tag?    f :mode/read-only))
-    (is (=    :done        (render-model f)))))
-
-(defn run-all-tests []
-  (test-state-1-nothing)
-  (test-state-2-loading)
-  (test-state-3-empty)
-  (test-state-4-one)
-  (test-state-5-some)
-  (test-state-6-too-many)
-  (test-state-7-incorrect)
-  (test-state-8-correct)
-  (test-state-9-done)
-  :ok)
-
-;; ============================================================================
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 ;;
 ;; The DOM mount is gated on (exists? js/document) so the namespace can
 ;; load in non-DOM CLJS hosts (shadow-cljs :node-test, headless test
-;; harnesses, JVM). The pure run-all-tests fn above runs in any CLJS
-;; host without touching React.
+;; harnesses, JVM). The headless fixtures live in
+;; `test/nine_states/core_test.cljs` and run in any CLJS host without
+;; touching React.
 
 (defonce react-root
   (when (exists? js/document)

--- a/examples/reagent/nine_states/test/nine_states/core_test.cljs
+++ b/examples/reagent/nine_states/test/nine_states/core_test.cljs
@@ -1,0 +1,106 @@
+(ns nine-states.core-test
+  "Headless tests for nine-states.core.
+
+   One fixture per state. Each: drive `app-db` to the state via
+   `dispatch-sync`, then assert against the machine's tag union and the
+   resolved `:ui/render` keyword. Browserless via `compute-sub` (no DOM
+   required).
+
+   Wired into the framework's CLJS test run by
+   `re-frame.nine-states-cljs-test` under
+   `implementation/adapters/reagent/test/re_frame/`, which wraps each
+   fixture in a `testing` block under a single `deftest`."
+  (:require [cljs.test :refer-macros [is]]
+            [re-frame.core :as rf]
+            [nine-states.core])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn- has-tag?
+  "Read the machine's tag union against a frame's app-db."
+  [frame tag]
+  (contains? (get-in (rf/get-frame-db frame)
+                     [:rf/machines :ui/nine-states :tags])
+             tag))
+
+(defn- render-model [frame]
+  (rf/compute-sub [:ui/render] (rf/get-frame-db frame)))
+
+(def ^:private demo-overrides
+  "Per-test :fx-overrides map that routes `:rf.http/managed` to the in-process
+   demo stub so tests run without a backend."
+  {:rf.http/managed :nine-states.http/managed-demo})
+
+(defn- new-frame []
+  (rf/make-frame
+    {:on-create    [:nine-states.app/initialise]
+     :fx-overrides demo-overrides}))
+
+(defn test-state-1-nothing []
+  (with-frame [f (new-frame)]
+    (is       (has-tag?    f :data/nothing))
+    (is (not  (has-tag?    f :data/loading)))
+    (is (=    :nothing     (render-model f)))))
+
+(defn test-state-2-loading []
+  ;; The demo stub resolves synchronously, so we observe :loading by
+  ;; dispatching :fetch-started directly (without a follow-up reply).
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:ui/nine-states [:fetch-started]] {:frame f})
+    (is       (has-tag?    f :data/loading))
+    (is       (has-tag?    f :data/transient))
+    (is (=    :loading     (render-model f)))))
+
+(defn test-state-3-empty []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
+    (is       (has-tag?    f :data/empty))
+    (is (not  (has-tag?    f :data/one)))
+    (is (=    :empty       (render-model f)))))
+
+(defn test-state-4-one []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 1}] {:frame f})
+    (is       (has-tag?    f :data/one))
+    (is (=    :one         (render-model f)))))
+
+(defn test-state-5-some []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
+    (is       (has-tag?    f :data/some))
+    (is (=    :some        (render-model f)))))
+
+(defn test-state-6-too-many []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 25}] {:frame f})
+    (is       (has-tag?    f :data/too-many))
+    (is (=    :too-many    (render-model f)))))
+
+(defn test-state-7-incorrect []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:new-todo/edit-field :title "ab"] {:frame f})
+    (rf/dispatch-sync [:new-todo/submit] {:frame f})
+    (is       (has-tag?    f :form/invalid))
+    (is (=    :incorrect   (render-model f)))))
+
+(defn test-state-8-correct []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 0}] {:frame f})
+    (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
+    (rf/dispatch-sync [:new-todo/submit] {:frame f})
+    ;; Tags reflect the overlap honestly: :form/success AND :data/one
+    ;; are both true simultaneously. The render-priority table
+    ;; resolves it: :correct wins.
+    (is       (has-tag?    f :form/success))
+    (is       (has-tag?    f :data/one))
+    (is (=    :correct     (render-model f)))))
+
+(defn test-state-9-done []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:nine-states.demo/load {:n 4}] {:frame f})
+    (rf/dispatch-sync [:ui/nine-states [:archive {:now 1}]] {:frame f})
+    (let [snap (get-in (rf/get-frame-db f) [:rf/machines :ui/nine-states])]
+      (is (= :done (get-in snap [:state :mode])))
+      (is (= 1    (get-in snap [:data :archived-at]))))
+    (is       (has-tag?    f :mode/done))
+    (is       (has-tag?    f :mode/read-only))
+    (is (=    :done        (render-model f)))))

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -1,30 +1,51 @@
 (ns re-frame.nine-states-cljs-test
-  "Integration test: load examples/reagent/nine_states/core and run its 9
-  headless test fixtures. Each fixture drives app-db into one of the
-  canonical UI states and asserts the matching state-sub fires.
+  "Integration test: drives the nine-states example's headless test
+   fixtures. Each fixture spins a fresh frame via `make-frame`, drives
+   `app-db` into one of the canonical UI states, and asserts the
+   matching tag union + `:ui/render` keyword.
 
-  The example registers its handlers / subs / views / machines at
-  namespace-load time. CLJS has no runtime (require :reload), so this
-  test relies on those registrations staying live for the test run.
-  Each test-state-N fixture inside the example uses make-frame to spin
-  up a fresh frame, so per-test isolation comes from frame creation,
-  not registry resets.
+   The fixtures live under examples/reagent/nine_states/test/nine_states/ — extracted
+   from the example's `core.cljs` so the production source stays
+   test-free (mirrors the realworld layout).
 
-  Per rf2-am9d the fixture uses snapshot/restore via
-  re-frame.test-support so the contract is uniform across CLJS
-  fixtures — the snapshot captures the example's ns-load
-  registrations, and the restore on the way out leaves them intact for
-  any subsequent test ns."
-  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+   The example registers its handlers / subs / views / machines at
+   namespace-load time. CLJS has no runtime (require :reload), so this
+   test relies on those registrations staying live for the test run.
+   Each test-state-N fixture uses make-frame to spin up a fresh frame,
+   so per-test isolation comes from frame creation, not registry resets.
+
+   Per rf2-am9d the fixture uses snapshot/restore via
+   re-frame.test-support so the contract is uniform across CLJS
+   fixtures — the snapshot captures the example's ns-load
+   registrations, and the restore on the way out leaves them intact for
+   any subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
-            [nine-states.core :as ns-core]))
+            [nine-states.core]
+            [nine-states.core-test :as ns-t]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
 (deftest nine-states-runs-end-to-end
-  (is (= :ok (ns-core/run-all-tests))
-      "nine-states.core/run-all-tests should walk all 9 UI states and return :ok"))
+  (testing "state 1 — nothing (never fetched)"
+    (ns-t/test-state-1-nothing))
+  (testing "state 2 — loading (fetch in flight)"
+    (ns-t/test-state-2-loading))
+  (testing "state 3 — empty (fetched, zero results)"
+    (ns-t/test-state-3-empty))
+  (testing "state 4 — one (single-item layout)"
+    (ns-t/test-state-4-one))
+  (testing "state 5 — some (small, manageable list)"
+    (ns-t/test-state-5-some))
+  (testing "state 6 — too-many (overwhelming list)"
+    (ns-t/test-state-6-too-many))
+  (testing "state 7 — incorrect (form validation error)"
+    (ns-t/test-state-7-incorrect))
+  (testing "state 8 — correct (form submit happy path)"
+    (ns-t/test-state-8-correct))
+  (testing "state 9 — done (terminal, read-only)"
+    (ns-t/test-state-9-done)))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -65,6 +65,7 @@
                 ;; examples/reagent/.
                 "../examples/reagent"
                 "../examples/reagent/7Guis"
+                "../examples/reagent/nine_states/test"
                 "../examples/reagent/realworld/test"
                 "../examples/uix"
                 "../examples/helix"]


### PR DESCRIPTION
## Summary

`examples/reagent/nine_states/core.cljs` carried ~109 lines of inline test fixtures + `run-all-tests` + `cljs.test/is` asserts. The bead asks us to move them out so readers reaching for the example don't have to scroll past test code, and the test code itself gets a proper home alongside the source it covers — mirroring the existing realworld layout.

After auditing every `.cljs` / `.cljc` / `.clj` source under `examples/` for `deftest` / `(is ...)` / `(testing ...)` / `t/is` invocations, **`nine_states/core.cljs` was the only remaining offender**. Every other example either had no inline tests or already lived in a properly-named `*_test.cljs` file (i.e. `counter_with_stories/stories_cljs_test.cljs`, all the `realworld/test/*` files).

## What moved

| Item | Before | After |
| --- | --- | --- |
| `nine_states/core.cljs` LoC | 793 | 684 (-109) |
| Inline test fixtures (`test-state-1-nothing` … `test-state-9-done`) | in `core.cljs` | `examples/reagent/nine_states/test/nine_states/core_test.cljs` |
| Test helpers (`has-tag?`, `render-model`, `new-frame`, `demo-overrides`) | in `core.cljs` (only used by tests) | moved with the fixtures |
| `run-all-tests` aggregator | in `core.cljs` | removed — replaced by per-state `testing` blocks in the framework aggregator |
| `[cljs.test :refer-macros [is]]` require | in `core.cljs` | dropped |
| `with-frame` in `:require-macros` | in `core.cljs` | dropped (only used by tests) |
| Aggregator `re-frame.nine-states-cljs-test` | invoked `nine-states.core/run-all-tests` once | wraps each fixture in its own `testing` block under one `deftest` |
| Shadow `:source-paths` | — | `../examples/reagent/nine_states/test` added |

## Files touched

- `examples/reagent/nine_states/core.cljs` (-109 lines; tests removed, doc-string + mount comment updated)
- `examples/reagent/nine_states/test/nine_states/core_test.cljs` (new — ns `nine-states.core-test`, 25 `is` assertions across 9 fixtures)
- `examples/reagent/nine_states/README.md` (REPL-iteration snippet now points at the new ns)
- `implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs` (per-state `testing` wrappers replace the single-shot `run-all-tests` call; ns docstring updated to mention the relocation)
- `implementation/shadow-cljs.edn` (add the new test source path)

## Test counts

- **Before**: `npm run test:cljs` → 496 tests, **1206** assertions, 0 failures
- **After**: `npm run test:cljs` → 496 tests, **1205** assertions, 0 failures

The lost assertion is the outer `(is (= :ok (ns-core/run-all-tests)))` wrapper that's now redundant — the 25 inner per-state assertions still run, now under richer per-state `testing` contexts.

## Test plan

- [x] `npm run test:cljs` — 496 tests / 1205 assertions / 0 failures / 0 errors
- [x] `npm run test:elision` — PASS
- [x] `shadow-cljs compile examples/nine-states` — 0 warnings
- [x] Audit grep on `examples/**/*.{cljs,cljc,clj}` for `deftest` / `(is\s+\(` / `(testing` — only matches are inside `*_test.cljs` files (which is correct)