### PR TITLE
fix(conformance): invoke-all fixtures match runtime spawn-args contract; claim :actor/spawn-and-join (rf2-er0t)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -63,6 +63,7 @@
     :routing/nav-token
     :actor/spawn
     :actor/invoke
+    :actor/spawn-and-join                              ;; rf2-6vmw / rf2-er0t
     :actor/system-id                                   ;; rf2-suue / rf2-ecv4
     :actor/timeout                                     ;; rf2-1lop
     ;; Flow capabilities — per Spec 013. The flow-*.edn fixtures

--- a/spec/conformance/fixtures/invoke-all-join-all-completes.edn
+++ b/spec/conformance/fixtures/invoke-all-join-all-completes.edn
@@ -78,9 +78,11 @@
                                  :on-all-complete  [:hydrate/done]
                                  :on-any-failed    [:hydrate/failed]}
                      :invoke-id [:hydrating]}}]
+    ;; Per rf2-er0t: the runtime dissocs :id from each child spec before
+    ;; emitting the :rf.machine/spawn fx; the user-supplied child id rides
+    ;; on :rf/invoke-all-child-id instead.
     [:rf.machine/spawn
      {:machine-id              :load-config
-      :id                      :cfg
       :id-prefix               :load-config
       :rf/spawned-id           :load-config#1
       :rf/parent-id            :rf/transition-pure
@@ -88,7 +90,6 @@
       :rf/invoke-all-child-id  :cfg}]
     [:rf.machine/spawn
      {:machine-id              :load-feature-flags
-      :id                      :flag
       :id-prefix               :load-feature-flags
       :rf/spawned-id           :load-feature-flags#1
       :rf/parent-id            :rf/transition-pure
@@ -96,7 +97,6 @@
       :rf/invoke-all-child-id  :flag}]
     [:rf.machine/spawn
      {:machine-id              :load-user-profile
-      :id                      :user
       :id-prefix               :load-user-profile
       :rf/spawned-id           :load-user-profile#1
       :rf/parent-id            :rf/transition-pure

--- a/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
+++ b/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
@@ -67,28 +67,31 @@
                                  :on-child-error   :failed
                                  :on-some-complete [:phase/three-done]}
                      :invoke-id [:working]}}]
+    ;; Per rf2-er0t: the runtime dissocs :id from each child spec before
+    ;; emitting the :rf.machine/spawn fx; the user-supplied child id rides
+    ;; on :rf/invoke-all-child-id instead.
     [:rf.machine/spawn
-     {:machine-id :worker :id :a :id-prefix :worker
+     {:machine-id :worker :id-prefix :worker
       :rf/spawned-id :worker#1
       :rf/parent-id  :rf/transition-pure
       :rf/invoke-all-id [:working] :rf/invoke-all-child-id :a}]
     [:rf.machine/spawn
-     {:machine-id :worker :id :b :id-prefix :worker
+     {:machine-id :worker :id-prefix :worker
       :rf/spawned-id :worker#2
       :rf/parent-id  :rf/transition-pure
       :rf/invoke-all-id [:working] :rf/invoke-all-child-id :b}]
     [:rf.machine/spawn
-     {:machine-id :worker :id :c :id-prefix :worker
+     {:machine-id :worker :id-prefix :worker
       :rf/spawned-id :worker#3
       :rf/parent-id  :rf/transition-pure
       :rf/invoke-all-id [:working] :rf/invoke-all-child-id :c}]
     [:rf.machine/spawn
-     {:machine-id :worker :id :d :id-prefix :worker
+     {:machine-id :worker :id-prefix :worker
       :rf/spawned-id :worker#4
       :rf/parent-id  :rf/transition-pure
       :rf/invoke-all-id [:working] :rf/invoke-all-child-id :d}]
     [:rf.machine/spawn
-     {:machine-id :worker :id :e :id-prefix :worker
+     {:machine-id :worker :id-prefix :worker
       :rf/spawned-id :worker#5
       :rf/parent-id  :rf/transition-pure
       :rf/invoke-all-id [:working] :rf/invoke-all-child-id :e}]]}


### PR DESCRIPTION
## Summary

The `:rf.machine/spawn` fx-args emitted by the `:invoke-all` entry cascade (`implementation/machines/src/re_frame/machines.cljc` :927) intentionally `dissoc` `:id` from each child spec before emit; the user-supplied child id rides on `:rf/invoke-all-child-id` instead. The conformance fixtures still carried the spurious `:id` key, hidden because the JVM runner's `:claimed-capabilities` did not include `:actor/spawn-and-join`.

## Files touched

- `spec/conformance/fixtures/invoke-all-join-all-completes.edn` — strip the spurious `:id` key from each of the 3 `:rf.machine/spawn` expect-effects.
- `spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn` — strip the spurious `:id` key from each of the 5 `:rf.machine/spawn` expect-effects.
- `implementation/core/test/re_frame/conformance_test.clj` — add `:actor/spawn-and-join` to `claimed-capabilities` so the JVM runner now exercises the three `:invoke-all` fixtures.

`invoke-all-join-any-fails-cancels.edn` only asserts the exit-side `:rf.machine/destroy` fx — no spawn-fx `:id` to strip. It is now picked up by the runner via the new capability claim.

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 183 tests / 824 assertions / 0 failures, 0 errors. The three `:machine/invoke-all-*` fixtures now run and pass.
- [x] `npm run test:cljs` from `implementation/` — 496 tests / 1206 assertions / 0 failures, 0 errors.

Closes rf2-er0t.