### PR TITLE
test(schemas): CLJS production-mode coverage for :spec/validate-at-boundary (rf2-84e9)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -570,6 +570,60 @@ jobs:
       - name: Compile :browser-test, serve, and run Playwright runner
         run: npm run test:browser
 
+  cljs-browser-schemas-boundary-prod:
+    name: CLJS (shadow-cljs :browser-test-schemas-boundary-prod, :advanced + goog.DEBUG=false, rf2-84e9)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-boundary-prod-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-boundary-prod-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      # Production-mode CLJS smoke for `:spec/validate-at-boundary`
+      # (Spec 010 §Production builds, rf2-r2uh / rf2-84e9). Compiles
+      # `re-frame.schemas-boundary-prod-test` under `:advanced` +
+      # `goog.DEBUG=false` so Closure constant-folds the dev gate.
+      # Locks the cross-substrate dev/prod-gate contract that the JVM
+      # smoke can only assert via `with-redefs spec/dev-mode?` (which
+      # cannot prove the genuine `:advanced` constant-fold).
+      - name: Compile :browser-test-schemas-boundary-prod, serve, and run Playwright runner
+        run: npm run test:browser-schemas-boundary-prod
+
   cljs-elision:
     name: CLJS production elision (Spec 009, bead rf2-11hn)
     runs-on: ubuntu-latest

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
+    "test:browser-schemas-boundary-prod": "shadow-cljs release browser-test-schemas-boundary-prod && node scripts/serve-and-run-schemas-boundary-prod-tests.cjs",
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:bundle-isolation": "shadow-cljs release examples/counter && node scripts/check-bundle-isolation.cjs",

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
@@ -1,0 +1,32 @@
+(ns re-frame.schemas-boundary-prod-runner
+  "Custom browser-test runner for the production-mode schemas boundary
+  smoke (Spec 010 §Production builds, rf2-r2uh / rf2-84e9).
+
+  The default shadow-cljs `:browser-test` runner-ns `shadow.test.browser`
+  uses `cljs-test-display.core/init!`, which does `(set! root-node-id …)`
+  on a `(goog-define root-node-id …)`. Under `:advanced` Closure rejects
+  the re-assignment of a `@define` — the build fails with
+  `@define cljs_test_display.core.root_node_id has already been set`.
+
+  This runner bypasses cljs-test-display and runs `cljs.test/run-tests`
+  directly. The default cljs.test reporter writes the
+  `Ran N tests containing M assertions.` summary to the browser console
+  (via `*print-fn*` → `console.log`), which is exactly what the
+  Playwright runner (scripts/run-browser-tests.cjs) watches for. No DOM
+  reporter is needed because the orchestrator polls the console stream."
+  (:require [cljs.test :as test]
+            [shadow.test :as st]
+            [shadow.test.env :as env]
+            ;; Pull the prod-mode boundary smoke into the test
+            ;; environment so shadow.test/run-all-tests discovers it.
+            [re-frame.schemas-boundary-prod-test]))
+
+(defn ^:export init []
+  (-> (env/get-test-data)
+      (env/reset-test-data!))
+  ;; shadow.test/run-all-tests delegates to cljs.test/run-tests with the
+  ;; default reporter — which prints the summary to *print-fn*, mapped
+  ;; under shadow-cljs's :browser-test target to console.log. The
+  ;; Playwright orchestrator scans the captured console stream for the
+  ;; "Ran N tests" line.
+  (st/run-all-tests))

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -1,0 +1,158 @@
+(ns re-frame.schemas-boundary-prod-test
+  "Production-mode CLJS smoke for `:spec/validate-at-boundary` (rf2-r2uh,
+  rf2-84e9).
+
+  The JVM smoke (`re-frame.schemas-test`) exercises the dev/prod gate by
+  rebinding `re-frame.spec/dev-mode?` via `with-redefs`. That proves the
+  *interceptor logic* under both branches, but it cannot prove the
+  *real-world elision contract* — that under `:advanced` +
+  `goog.DEBUG=false`, the Closure compiler constant-folds the dev gate
+  to `false` so the production validation branch is the only code path
+  that survives.
+
+  The companion node-test smoke (`re-frame.schemas-cljs-test`) compiles
+  with `goog.DEBUG=true` (cljs default) and asserts the boundary
+  interceptor is a no-op in dev: step-1 validation in the router has
+  already run.
+
+  This namespace is the dual — it compiles under the dedicated
+  `:browser-test-schemas-boundary-prod` shadow-cljs build with
+  `:closure-defines {goog.DEBUG false}` + `release` (`:advanced`), so:
+
+    1. `re-frame.spec/dev-mode?` constant-folds to `false`, and the
+       boundary's production validation branch runs.
+    2. `re-frame.trace/emit-error!` ALSO elides under the same gate
+       (its body sits inside `(when interop/debug-enabled? ...)`) — the
+       boundary's failure-trace emission is silent in production.
+    3. The handler-skip recovery (`:rf/skip-handler?` set on the
+       context) is the load-bearing observable surface.
+
+  We deliberately use the ns suffix `-prod-test` (not `-cljs-test`) so
+  the default `:browser-test` and `:node-test` builds (whose regexes
+  match `-cljs-test$` / `cljs-test$`) do NOT pick this file up. The
+  prod-mode assertions would fail under `goog.DEBUG=true` because the
+  boundary is a no-op in dev (per Spec 010 L145)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ;; Pull malli into the bundle. The boundary interceptor
+            ;; routes through the registered validator via the
+            ;; :schemas/validate-with-registered-fn late-bind hook;
+            ;; without malli on the classpath the default validator is
+            ;; nil and the boundary no-ops. The conformance fixtures
+            ;; for app-db slice validation rely on user code requiring
+            ;; malli at app boot; this test does the same.
+            [malli.core]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; Mirror schemas_cljs_test.cljs's fixture: snapshot/restore the
+;; registrar (rf2-am9d) and clear :app-schema between tests.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter     reagent-adapter/adapter
+     :clear-kinds [:app-schema]}))
+
+;; ---- boundary interceptor under `:advanced` + `goog.DEBUG=false` ---------
+
+(deftest boundary-skips-handler-on-invalid-event-in-prod
+  (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:advanced`
+            + `goog.DEBUG=false` the boundary interceptor takes its
+            production validation branch. A malformed event against the
+            handler's `:spec` causes `:rf/skip-handler?` to be set on
+            the context, and the handler is NOT invoked.
+
+            Under the same gate, the router's step-1 `validate-event!`
+            body has DCE'd — only the boundary interceptor is enforcing
+            the schema at this dispatch."
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :api/strict
+        {:spec [:cat [:= :api/strict] :int]}
+        [rf/validate-at-boundary]
+        (fn [_ _] (swap! calls inc) {}))
+      ;; Malformed payload: handler MUST be skipped.
+      (rf/dispatch-sync [:api/strict "not-an-int"])
+      (is (= 0 @calls)
+          "handler was skipped — boundary interceptor set :rf/skip-handler? on the context"))))
+
+(deftest boundary-passes-valid-event-through-in-prod
+  (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:advanced`
+            + `goog.DEBUG=false` a valid event against the handler's
+            `:spec` flows through the boundary interceptor unchanged.
+            The handler runs exactly once."
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :api/strict
+        {:spec [:cat [:= :api/strict] :int]}
+        [rf/validate-at-boundary]
+        (fn [_ _] (swap! calls inc) {}))
+      (rf/dispatch-sync [:api/strict 42])
+      (is (= 1 @calls)
+          "handler ran exactly once — valid payload, boundary passed through"))))
+
+(deftest boundary-failure-trace-elides-in-prod
+  (testing "Per Spec 009 §Production builds + Spec 010 §Production
+            builds: under `:advanced` + `goog.DEBUG=false`,
+            `trace/emit-error!` also elides (its body sits inside
+            `(when interop/debug-enabled? ...)`). The boundary's failure
+            emission therefore does NOT fire a trace in production —
+            the handler-skip is silent.
+
+            This pins the dual-elision contract: trace gate AND boundary
+            gate both fold under the same closure-define. A registered
+            trace callback would never see a boundary emission because
+            the entire emit body has DCE'd."
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :api/strict
+        {:spec [:cat [:= :api/strict] :int]}
+        [rf/validate-at-boundary]
+        (fn [_ _] (swap! calls inc) {}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::prod-no-trace (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:api/strict "not-an-int"])
+        (rf/remove-trace-cb! ::prod-no-trace)
+        (is (= 0 @calls)
+            "handler skipped (boundary did its job)")
+        ;; Under `:advanced` + `goog.DEBUG=false` the trace surface is
+        ;; entirely elided — register-trace-cb! / emit-* bodies all
+        ;; live inside `(when interop/debug-enabled? ...)`. No traces
+        ;; reach the callback by design.
+        (is (empty? @traces)
+            "no traces observed — Spec 009 §Production builds elision contract holds")))))
+
+(deftest boundary-direct-before-invocation-in-prod
+  (testing "Per Spec 010 §Per-step recovery step 1: directly invoking the
+            boundary interceptor's `:before` slot is a deterministic
+            surface for asserting the recovery contract. Under
+            `:advanced` + `goog.DEBUG=false` (production), the
+            `:before` slot's prod branch validates the event and sets
+            `:rf/skip-handler?` on the context when the schema fails."
+    (rf/reg-event-fx :api/strict
+      {:spec [:cat [:= :api/strict] :int]}
+      [rf/validate-at-boundary]
+      (fn [_ _] {}))
+    (let [before    (:before rf/validate-at-boundary)
+          valid-ctx (before {:coeffects {:event [:api/strict 42]}})
+          bad-ctx   (before {:coeffects {:event [:api/strict "not-an-int"]}})]
+      (is (not (:rf/skip-handler? valid-ctx))
+          "valid event: :rf/skip-handler? unset — handler will run")
+      (is (true? (:rf/skip-handler? bad-ctx))
+          "MALFORMED event in prod: :rf/skip-handler? set true — handler is skipped"))))
+
+(deftest boundary-noop-when-validator-is-nil-in-prod
+  (testing "Per Spec 010 §Non-Malli validators (rf2-froe): even under
+            `:advanced` + `goog.DEBUG=false`, setting the validator to
+            `nil` disables every validation surface — including the
+            boundary interceptor. The handler runs on a wildly malformed
+            payload because validation has been opted out."
+    (rf/set-schema-validator! nil)
+    (try
+      (let [calls (atom 0)]
+        (rf/reg-event-fx :api/disabled
+          {:spec [:cat [:= :api/disabled] :int]}
+          [rf/validate-at-boundary]
+          (fn [_ _] (swap! calls inc) {}))
+        (rf/dispatch-sync [:api/disabled "wildly-malformed"])
+        (is (= 1 @calls)
+            "handler ran — nil validator means no boundary check, even in production"))
+      (finally
+        (schemas/reset-schema-validator!)))))

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -194,3 +194,75 @@
             "no validation trace fires when the validator is nil"))
       (finally
         (schemas/reset-schema-validator!)))))
+
+;; ---- rf2-r2uh — :spec/validate-at-boundary dev-mode no-op (rf2-84e9) ------
+;;
+;; The :node-test build compiles with `goog.DEBUG=true` (cljs default,
+;; no closure-define override) — the runtime-equivalent of a dev build.
+;; Per Spec 010 §Production builds (L145), in dev the boundary
+;; interceptor is a no-op: the router's step-1 validate-event! call has
+;; already run, and running validation a second time would just duplicate
+;; the trace.
+;;
+;; A complementary `:browser-test` build (`:browser-test-schemas-boundary-prod`)
+;; compiles `schemas_boundary_prod_test.cljs` under `:advanced` +
+;; `goog.DEBUG=false`, where Closure constant-folds the dev gate to false
+;; and the boundary takes its production validation branch. The pair of
+;; CLJS smokes pins the cross-substrate dev/prod-gate contract that the
+;; JVM tests cover via `with-redefs spec/dev-mode?` (which cannot prove
+;; the genuine `:advanced` constant-fold).
+
+(deftest boundary-interceptor-noop-in-dev-cljs
+  (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:node-test`
+            (goog.DEBUG=true) the boundary interceptor's :before slot is
+            a no-op even on a malformed event — it does NOT set
+            :rf/skip-handler? and does NOT emit a boundary-tagged trace.
+            Step-1 validation in the router is what enforces the schema
+            in dev; the boundary interceptor's prod-mode body never runs."
+    (rf/reg-event-fx :api/strict
+      {:spec [:cat [:= :api/strict] :int]}
+      [rf/validate-at-boundary]
+      (fn [_ _] {}))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::boundary-dev (fn [ev] (swap! traces conj ev)))
+      ;; Direct :before invocation isolates the boundary's behaviour
+      ;; from the surrounding router/step-1 path so we observe the
+      ;; boundary's own dev-mode contract.
+      (let [before    (:before rf/validate-at-boundary)
+            valid-ctx (before {:coeffects {:event [:api/strict 42]}})
+            bad-ctx   (before {:coeffects {:event [:api/strict "not-an-int"]}})]
+        (rf/remove-trace-cb! ::boundary-dev)
+        (is (not (:rf/skip-handler? valid-ctx))
+            "valid event: boundary did not set :rf/skip-handler? (no-op)")
+        (is (not (:rf/skip-handler? bad-ctx))
+            "MALFORMED event in dev: boundary STILL did not set :rf/skip-handler? — the dev-mode no-op contract")
+        (let [boundary-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
+                                                (= :boundary (-> % :tags :source)))
+                                          @traces)]
+          (is (empty? boundary-violations)
+              "no boundary-tagged trace fired — boundary was a no-op in dev"))))))
+
+(deftest boundary-interceptor-dev-dispatch-skips-via-step-1
+  (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:node-test`
+            (goog.DEBUG=true) a full dispatch of a malformed payload
+            still skips the handler — but via the router's step-1
+            validate-event! path, NOT via the boundary. The boundary's
+            contract is silent in dev. We observe the handler-skip
+            (router did its job) and the absence of a :source :boundary
+            trace tag (boundary itself stayed quiet)."
+    (let [calls (atom 0)]
+      (rf/reg-event-fx :api/strict
+        {:spec [:cat [:= :api/strict] :int]}
+        [rf/validate-at-boundary]
+        (fn [_ _] (swap! calls inc) {}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::dev-dispatch (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:api/strict "not-an-int"])
+        (rf/remove-trace-cb! ::dev-dispatch)
+        (is (= 0 @calls)
+            "handler was skipped — router's step-1 validation fired in dev")
+        (let [boundary-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))
+                                                (= :boundary (-> % :tags :source)))
+                                          @traces)]
+          (is (empty? boundary-violations)
+              "no :source :boundary trace fired — only the dev-mode step-1 trace ran"))))))

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -30,7 +30,16 @@ const net = require('net');
 const path = require('path');
 
 const DEFAULT_PORT = 8021;
-const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test');
+// $BROWSER_TEST_ROOT lets a caller point the orchestrator at a different
+// shadow-cljs :browser-test output directory — used by the prod-mode
+// schemas boundary build (Spec 010 §Production builds, rf2-r2uh /
+// rf2-84e9), whose `:advanced + goog.DEBUG=false` bundle lands in
+// `out/browser-test-schemas-boundary-prod/` rather than the default
+// `out/browser-test/`.
+const ROOT_OVERRIDE = process.env.BROWSER_TEST_ROOT;
+const ROOT = ROOT_OVERRIDE
+  ? path.resolve(ROOT_OVERRIDE)
+  : path.resolve(__dirname, '..', 'out', 'browser-test');
 const INDEX = path.join(ROOT, 'index.html');
 const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
 const READY_TIMEOUT_MS = 30000;

--- a/implementation/scripts/serve-and-run-schemas-boundary-prod-tests.cjs
+++ b/implementation/scripts/serve-and-run-schemas-boundary-prod-tests.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/*
+ * Thin wrapper around scripts/serve-and-run-browser-tests.cjs for the
+ * production-mode schemas boundary smoke (Spec 010 §Production builds,
+ * rf2-r2uh / rf2-84e9).
+ *
+ * The shadow-cljs build `:browser-test-schemas-boundary-prod` compiles
+ * `re-frame.schemas-boundary-prod-test` under `:advanced` with
+ * `goog.DEBUG=false`. The output lands in
+ * `out/browser-test-schemas-boundary-prod/` rather than the default
+ * `out/browser-test/`.
+ *
+ * This wrapper sets the `BROWSER_TEST_ROOT` and `BROWSER_TEST_PORT`
+ * env vars so the shared orchestrator (serve-and-run-browser-tests.cjs)
+ * serves the prod-mode bundle on a separate port. A Windows/POSIX-
+ * agnostic wrapper avoids the `cross-env` dev-dependency the inline
+ * `KEY=value command` shell idiom would otherwise require.
+ */
+
+'use strict';
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test-schemas-boundary-prod');
+const RUNNER = path.resolve(__dirname, 'serve-and-run-browser-tests.cjs');
+
+const result = spawnSync(process.execPath, [RUNNER], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    BROWSER_TEST_ROOT: ROOT,
+    BROWSER_TEST_PORT: '8022',
+  },
+});
+
+process.exit(result.status == null ? 1 : result.status);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -100,6 +100,41 @@
    :devtools  {:http-port 8021
                :http-root "out/browser-test"}}
 
+  ;; Production-mode boundary smoke (Spec 010 §Production builds, rf2-r2uh /
+  ;; rf2-84e9).
+  ;;
+  ;; Compiles `re-frame.schemas-boundary-prod-test` under :advanced with
+  ;; `goog.DEBUG=false`. Under this combination, the Closure compiler
+  ;; constant-folds `re-frame.interop/debug-enabled?` to `false`,
+  ;; so `re-frame.spec/dev-mode?` folds with it and the boundary
+  ;; interceptor takes its production validation branch. The JVM smoke
+  ;; cannot prove the genuine `:advanced` constant-fold (it rebinds
+  ;; `spec/dev-mode?` via `with-redefs`); this browser-test build does.
+  ;;
+  ;; The ns-regexp `-boundary-prod-test$` matches only files named
+  ;; `*_boundary_prod_test.cljs` — distinct from the default
+  ;; `:browser-test` build's `-cljs-test$` and `:node-test` build's
+  ;; `cljs-test$`, so this test file is run ONLY under this prod-mode
+  ;; build. Running it under DEBUG=true would fail (the dev-mode boundary
+  ;; is a no-op by design); the companion node-test ns
+  ;; `re-frame.schemas-cljs-test` carries the dev-mode assertions.
+  ;;
+  ;; The :runner-ns is a custom runner (re-frame.schemas-boundary-prod-runner)
+  ;; instead of the default `shadow.test.browser`. The default runner uses
+  ;; `cljs-test-display.core/init!` which does `(set! root-node-id …)` on
+  ;; a `(goog-define root-node-id …)` — and Closure rejects re-assigning a
+  ;; @define under :advanced. The custom runner runs cljs.test directly
+  ;; and prints its summary to the browser console where the Playwright
+  ;; orchestrator already watches for the "Ran N tests" line.
+  :browser-test-schemas-boundary-prod
+  {:target    :browser-test
+   :ns-regexp "-boundary-prod-test$"
+   :test-dir  "out/browser-test-schemas-boundary-prod"
+   :runner-ns re-frame.schemas-boundary-prod-runner
+   :compiler-options {:closure-defines {goog.DEBUG false}}
+   :devtools  {:http-port 8022
+               :http-root "out/browser-test-schemas-boundary-prod"}}
+
   ;; Production-elision probe (Spec 009 §Production builds, bead rf2-11hn).
   ;;
   ;; Compiles re-frame.elision-probe under :advanced with goog.DEBUG=false.


### PR DESCRIPTION
## Summary

The `:spec/validate-at-boundary` interceptor's dev/prod gate (`re-frame.spec/dev-mode?`) was exercised entirely on the JVM via `with-redefs`. That proves the interceptor logic but cannot prove the real-world elision contract — under `:advanced` + `goog.DEBUG=false`, Closure constant-folds the dev gate and only the production validation branch survives. JVM `with-redefs` cannot reach that.

This PR adds a CLJS smoke pair:

- **`re-frame.schemas-cljs-test`** (existing `:node-test`, `goog.DEBUG=true`): two new tests assert the dev-mode no-op contract — direct `:before` invocation observes the boundary stays silent in dev; a full `dispatch-sync` observes that the handler-skip in dev comes from the router's step-1 path, not the boundary.
- **`re-frame.schemas-boundary-prod-test`** (new `:browser-test-schemas-boundary-prod` build, `:advanced` + `goog.DEBUG=false`): five tests assert the production validation branch — handler skipped on malformed payload, valid payload flows through, failure-trace elision via the dual trace-surface gate, and the nil-validator opt-out.

## Build wiring

- New shadow-cljs build `:browser-test-schemas-boundary-prod` uses ns-regexp `-boundary-prod-test$` (distinct from the default `:browser-test` / `:node-test` regexes) so the prod-mode file is loaded ONLY by this build. Running it under `goog.DEBUG=true` would fail (boundary is a no-op in dev by design).
- Custom `:runner-ns` `re-frame.schemas-boundary-prod-runner` replaces the default `shadow.test.browser` — `cljs-test-display.core/init!` does `(set! root-node-id …)` on a goog-define, and Closure rejects re-assigning a `@define` under `:advanced`. The custom runner runs `cljs.test/run-tests` directly and prints to the browser console where the existing Playwright orchestrator already watches.
- Existing `serve-and-run-browser-tests.cjs` gains a `$BROWSER_TEST_ROOT` env-var override so the same orchestrator serves both bundles.
- New npm script `test:browser-schemas-boundary-prod` runs the build + serves + runs Playwright on the new bundle.
- New CI job `cljs-browser-schemas-boundary-prod` mirrors `cljs-browser` and runs the prod-mode smoke under headless Chromium.

## DEBUG branches covered

| Branch | Build | Asserts |
|---|---|---|
| `goog.DEBUG=true` (dev) | `:node-test` + default `:browser-test` | Boundary is a no-op; router step-1 enforces |
| `goog.DEBUG=false` (prod) | new `:browser-test-schemas-boundary-prod` (`:advanced`) | Boundary validates inline; handler skipped on invalid; trace surface elides |

## Test plan

- [x] JVM `clojure -M:test` (core): 183 tests / 824 assertions / 0 failures / 0 errors
- [x] JVM `clojure -M:test` (schemas): 46 tests / 162 assertions / 0 failures / 0 errors
- [x] CLJS `npm run test:cljs` (`:node-test`): 498 tests / 1211 assertions / 0 failures / 0 errors
- [x] CLJS `npm run test:browser` (`:browser-test`): 498 tests / 1232 assertions / 0 failures / 0 errors
- [x] CLJS `npm run test:browser-schemas-boundary-prod` (NEW, `:advanced` + `goog.DEBUG=false`): 5 tests / 7 assertions / 0 failures / 0 errors
- [x] CLJS `npm run test:elision`: all sentinels behave per Spec 009 contract

bd: rf2-84e9