### PR TITLE
fix(machines): registration-time validator now walks nested states for guard/action references (rf2-oz9t)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1828,29 +1828,41 @@
   ;; Validate guard/action references at construction time. machine-id
   ;; isn't known yet (it's the registration-site id), so error tags use
   ;; a placeholder; real misuse traces at handler-call time fill it in.
-  ;; For parallel-region machines, the same `:guards` / `:actions` are
-  ;; shared across regions — we walk every region's top-level :states
-  ;; for the validation, but the guard/action lookup goes through the
-  ;; parent's shared maps.
-  (let [top-level-states (if (parallel? machine)
-                           (mapcat (fn [[_ region]] (:states region)) (:regions machine))
-                           (:states machine))]
-    (doseq [[s state-node] top-level-states]
-      (let [transitions (mapcat
-                         (fn [[_ t]]
-                           (if (vector? t) t [t]))
-                         (:on state-node))]
-        (doseq [t transitions]
-          (when-let [g (:guard t)]
-            (when (and (keyword? g)
-                       (not (contains? (:guards machine) g)))
-              (throw (ex-info ":rf.error/machine-unresolved-guard"
-                              {:guard g :state s}))))
-          (when-let [a (:action t)]
-            (when (and (keyword? a)
-                       (not (contains? (:actions machine) a)))
-              (throw (ex-info ":rf.error/machine-unresolved-action"
-                              {:action a :state s}))))))))
+  ;;
+  ;; Per rf2-oz9t: drive the validation off `walk-state-nodes` so every
+  ;; state in the tree is checked, not just top-level :states. Cover
+  ;; every transition-bearing slot the runtime resolves keyword refs
+  ;; through: `:on` transition tables, `:always` transitions, and the
+  ;; single-action `:entry` / `:exit` slots. For parallel-region
+  ;; machines, `walk-state-nodes` already iterates every region's
+  ;; state-tree; the shared `:guards` / `:actions` maps live at the
+  ;; parent (machine) level.
+  (let [guards-map  (:guards machine)
+        actions-map (:actions machine)
+        check-guard! (fn [g s]
+                       (when (and (keyword? g)
+                                  (not (contains? guards-map g)))
+                         (throw (ex-info ":rf.error/machine-unresolved-guard"
+                                         {:guard g :state s}))))
+        check-action! (fn [a s]
+                        (when (and (keyword? a)
+                                   (not (contains? actions-map a)))
+                          (throw (ex-info ":rf.error/machine-unresolved-action"
+                                          {:action a :state s}))))]
+    (doseq [[s state-node] (walk-state-nodes machine)]
+      ;; :on transitions: { event-key → transition | [transition ...] }.
+      (doseq [[_ t] (:on state-node)
+              t     (if (vector? t) t [t])]
+        (check-guard!  (:guard t)  s)
+        (check-action! (:action t) s))
+      ;; :always transitions: a vector of transition maps. Each may
+      ;; carry :guard and/or :action just like :on entries.
+      (doseq [t (:always state-node)]
+        (check-guard!  (:guard t)  s)
+        (check-action! (:action t) s))
+      ;; :entry / :exit slots: a single action-ref (keyword or fn).
+      (check-action! (:entry state-node) s)
+      (check-action! (:exit  state-node) s)))
   (fn [{:keys [db frame] :as _cofx} event]
     (let [;; Per Spec 005 §Registration: id comes from event[0] (the
           ;; surrounding reg-event-fx id), NOT from the spec map.

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -1,0 +1,208 @@
+(ns re-frame.nested-validation-test
+  "Per rf2-oz9t — verify-the-gap-first probe for the machine
+  registration-time validator's coverage of :guard / :action keyword
+  references in NESTED states and in non-`:on` slots
+  (`:always`, `:entry`, `:exit`).
+
+  Background: in `re-frame.machines`, `create-machine-handler`
+  validates keyword `:guard` / `:action` references via a manual
+  top-level `doseq` over `(:states machine)`, walking only `:on`
+  transitions. The sibling helper `walk-state-nodes` (used just above
+  for other registration-time validation) walks recursively but is NOT
+  reused for guard/action validation. Spec 005 implies the
+  registration-time validator should cover the full state tree and
+  every transition-bearing slot, not just top-level `:on`.
+
+  These tests pin the observable behaviour. If a misuse passes
+  registration silently and only manifests at runtime, the gap is real
+  and the validator needs to drive off the recursive walker. If the
+  registration throws clearly, the narrow pass is structurally
+  sufficient and a code comment should explain why.
+
+  Each test registers a machine that points at an unregistered
+  keyword from a single misuse site, isolated so the failure mode is
+  unambiguous."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.machines :as machines]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- registration-throws?
+  "Try registering `machine` under `machine-id`. Returns the
+  ExceptionInfo if registration threw, else nil. Quarantines the
+  thrown error so individual tests can assert on its shape."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+;; ---- baseline: TOP-level :on misuse IS caught ----------------------------
+
+(deftest top-level-on-guard-keyword-unresolved
+  (testing "Top-level :on transition with unregistered :guard keyword fails registration (baseline)"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:on {:go [{:target :other
+                                         :guard  :no-such-guard}]}}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-on-guard m)]
+      (is (some? thrown) "top-level :on :guard misuse SHOULD throw at registration")
+      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+          "error category names the unresolved-guard contract")
+      (is (= :no-such-guard (:guard (ex-data thrown)))
+          "ex-data carries the offending guard keyword"))))
+
+(deftest top-level-on-action-keyword-unresolved
+  (testing "Top-level :on transition with unregistered :action keyword fails registration (baseline)"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:on {:go [{:target :other
+                                         :action :no-such-action}]}}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-on-action m)]
+      (is (some? thrown) "top-level :on :action misuse SHOULD throw at registration")
+      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))
+          "error category names the unresolved-action contract")
+      (is (= :no-such-action (:action (ex-data thrown)))
+          "ex-data carries the offending action keyword"))))
+
+;; ---- gap probe: NESTED-state :on -----------------------------------------
+
+(deftest nested-on-guard-keyword-unresolved
+  (testing "Nested-state :on transition with unregistered :guard keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:on {:go [{:target :other
+                                                            :guard  :no-such-guard}]}}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-on-guard m)]
+      (is (some? thrown)
+          "nested-state :on :guard misuse SHOULD throw at registration"))))
+
+(deftest nested-on-action-keyword-unresolved
+  (testing "Nested-state :on transition with unregistered :action keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:on {:go [{:target :other
+                                                            :action :no-such-action}]}}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-on-action m)]
+      (is (some? thrown)
+          "nested-state :on :action misuse SHOULD throw at registration"))))
+
+;; ---- gap probe: :always slot (top-level + nested) -----------------------
+
+(deftest top-level-always-guard-keyword-unresolved
+  (testing "Top-level :always with unregistered :guard keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:always [{:target :other
+                                        :guard  :no-such-guard}]}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-always-guard m)]
+      (is (some? thrown)
+          "top-level :always :guard misuse SHOULD throw at registration"))))
+
+(deftest top-level-always-action-keyword-unresolved
+  (testing "Top-level :always with unregistered :action keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:always [{:target :other
+                                        :action :no-such-action}]}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-always-action m)]
+      (is (some? thrown)
+          "top-level :always :action misuse SHOULD throw at registration"))))
+
+(deftest nested-always-guard-keyword-unresolved
+  (testing "Nested-state :always with unregistered :guard keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:always [{:target :other
+                                                           :guard  :no-such-guard}]}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-always-guard m)]
+      (is (some? thrown)
+          "nested :always :guard misuse SHOULD throw at registration"))))
+
+(deftest nested-always-action-keyword-unresolved
+  (testing "Nested-state :always with unregistered :action keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:always [{:target :other
+                                                           :action :no-such-action}]}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-always-action m)]
+      (is (some? thrown)
+          "nested :always :action misuse SHOULD throw at registration"))))
+
+;; ---- gap probe: :entry / :exit action references -------------------------
+
+(deftest top-level-entry-action-keyword-unresolved
+  (testing "Top-level :entry referencing an unregistered action keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:entry :no-such-action}}}
+          thrown (registration-throws? :rf.nested-validation/top-entry-action m)]
+      (is (some? thrown)
+          "top-level :entry action misuse SHOULD throw at registration"))))
+
+(deftest top-level-exit-action-keyword-unresolved
+  (testing "Top-level :exit referencing an unregistered action keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:exit :no-such-action
+                              :on   {:go :other}}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-exit-action m)]
+      (is (some? thrown)
+          "top-level :exit action misuse SHOULD throw at registration"))))
+
+(deftest nested-entry-action-keyword-unresolved
+  (testing "Nested-state :entry referencing an unregistered action keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:entry :no-such-action}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-entry-action m)]
+      (is (some? thrown)
+          "nested-state :entry action misuse SHOULD throw at registration"))))
+
+(deftest nested-exit-action-keyword-unresolved
+  (testing "Nested-state :exit referencing an unregistered action keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:exit :no-such-action
+                                                 :on   {:go :sibling}}
+                                         :sibling {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-exit-action m)]
+      (is (some? thrown)
+          "nested-state :exit action misuse SHOULD throw at registration"))))


### PR DESCRIPTION
## Outcome (rf2-oz9t — verify-the-gap-first)

**Outcome A: the gap is real.** A probe test exercised 12 misuse sites; only the 2 top-level-`:on` baseline cases threw at registration. The other 10 — nested `:on`, top-level `:always`, nested `:always`, top-level `:entry` / `:exit`, nested `:entry` / `:exit` — passed `reg-machine` silently and only surfaced at runtime.

## What changed

`create-machine-handler` in `implementation/machines/src/re_frame/machines.cljc` previously hand-rolled a `doseq` over `(:states machine)` (top-level only) and only walked each state's `:on` transitions. It now drives off the existing recursive helper `walk-state-nodes` (already used immediately above for `:invoke-all` / `:timeout-ms` validation) and checks every transition-bearing slot the runtime resolves keyword refs through:

- `:on` transition tables (single transition or vector of transitions)
- `:always` transition vectors
- `:entry` single action-ref
- `:exit`  single action-ref

For parallel-region machines, `walk-state-nodes` already iterates every region's state tree; the shared `:guards` / `:actions` maps live at the machine level, so the existing lookup is preserved.

## Test

New JVM test ns `re-frame.nested-validation-test` (12 tests, 16 assertions):

- 2 baseline cases (top-level `:on` :guard / :action) — already caught pre-fix
- 2 nested `:on` cases (:guard, :action)
- 4 `:always` cases (top + nested × :guard + :action)
- 4 `:entry` / `:exit` cases (top + nested × :entry + :exit)

Before this commit: 10 failures (all the non-baseline cases). After this commit: 0 failures.

## Files touched

- `implementation/machines/src/re_frame/machines.cljc` — validator reshaped (≈ +25 / −15 lines, single block in `create-machine-handler`).
- `implementation/machines/test/re_frame/nested_validation_test.clj` — new (regression test).

## Verify

- `clojure -M:test` from `implementation/machines/` — 89 tests / 250 assertions, 0 failures.
- `clojure -M:test` from `implementation/core/` — 183 tests / 824 assertions, 0 failures.
- `npm run test:cljs` from `implementation/` — 498 tests / 1210 assertions, 0 failures.
- `npm run test:elision` from `implementation/` — clean.