### PR TITLE
feat: add SKILL-REDIRECT.md at repo root (canonical pointer table for AI skills) (rf2-12gf)

### DIFF
--- a/SKILL-REDIRECT.md
+++ b/SKILL-REDIRECT.md
@@ -1,0 +1,67 @@
+# Skill Redirects
+
+This file is a canonical pointer table for AI skills working in this repo.
+Skills like `re-frame2`, `re-frame2-setup`, and `re-frame-pair2` redirect AI
+agents here when the agent needs deep-dive content beyond the skill's
+recipes: the full API table, EP design rationale, the migration guide, the
+construction-prompt templates, etc.
+
+Skills stay free of hardcoded URLs; this file owns them. If a URL changes,
+update it here once and every skill keeps working.
+
+## Pointers
+
+- **Definitive API reference** → https://day8.github.io/re-frame2/spec/API/
+- **Spec corpus (overview & index)** → https://day8.github.io/re-frame2/spec/
+- **EP design rationale (000 — Vision)** → https://day8.github.io/re-frame2/spec/000-Vision/
+- **EP — Registration (001)** → https://day8.github.io/re-frame2/spec/001-Registration/
+- **EP — Frames (002)** → https://day8.github.io/re-frame2/spec/002-Frames/
+- **EP — Views (004)** → https://day8.github.io/re-frame2/spec/004-Views/
+- **EP — State machines (005)** → https://day8.github.io/re-frame2/spec/005-StateMachines/
+- **EP — Reactive substrate (006)** → https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/
+- **EP — Stories (007)** → https://day8.github.io/re-frame2/spec/007-Stories/
+- **EP — Testing (008)** → https://day8.github.io/re-frame2/spec/008-Testing/
+- **EP — Instrumentation (009)** → https://day8.github.io/re-frame2/spec/009-Instrumentation/
+- **EP — Schemas (010)** → https://day8.github.io/re-frame2/spec/010-Schemas/
+- **EP — SSR (011)** → https://day8.github.io/re-frame2/spec/011-SSR/
+- **EP — Routing (012)** → https://day8.github.io/re-frame2/spec/012-Routing/
+- **EP — Flows (013)** → https://day8.github.io/re-frame2/spec/013-Flows/
+- **EP — HTTP requests (014)** → https://day8.github.io/re-frame2/spec/014-HTTPRequests/
+- **Migration from re-frame v1** → https://day8.github.io/re-frame2/spec/MIGRATION/
+- **Principles** → https://day8.github.io/re-frame2/spec/Principles/
+- **Conventions** → https://day8.github.io/re-frame2/spec/Conventions/
+- **Construction prompts (AI-shaped templates)** → https://day8.github.io/re-frame2/spec/Construction-Prompts/
+- **CP-5 — Machine guide** → https://day8.github.io/re-frame2/spec/CP-5-MachineGuide/
+- **AI audit guidance** → https://day8.github.io/re-frame2/spec/AI-Audit/
+- **Implementor checklist** → https://day8.github.io/re-frame2/spec/Implementor-Checklist/
+- **Runtime architecture** → https://day8.github.io/re-frame2/spec/Runtime-Architecture/
+- **Cross-spec interactions** → https://day8.github.io/re-frame2/spec/Cross-Spec-Interactions/
+- **Ownership model** → https://day8.github.io/re-frame2/spec/Ownership/
+- **Spec schemas** → https://day8.github.io/re-frame2/spec/Spec-Schemas/
+- **Conformance corpus** → https://day8.github.io/re-frame2/spec/conformance/
+- **Tool-Pair contract (live inspection)** → https://day8.github.io/re-frame2/spec/Tool-Pair/
+- **Pattern — Async effect** → https://day8.github.io/re-frame2/spec/Pattern-AsyncEffect/
+- **Pattern — Boot** → https://day8.github.io/re-frame2/spec/Pattern-Boot/
+- **Pattern — Forms** → https://day8.github.io/re-frame2/spec/Pattern-Forms/
+- **Pattern — Long-running work** → https://day8.github.io/re-frame2/spec/Pattern-LongRunningWork/
+- **Pattern — Nine states** → https://day8.github.io/re-frame2/spec/Pattern-NineStates/
+- **Pattern — Remote data** → https://day8.github.io/re-frame2/spec/Pattern-RemoteData/
+- **Pattern — Stale detection** → https://day8.github.io/re-frame2/spec/Pattern-StaleDetection/
+- **Pattern — WebSocket** → https://day8.github.io/re-frame2/spec/Pattern-WebSocket/
+- **Narrative guide (overview)** → https://day8.github.io/re-frame2/guide/README/
+- **Guide — Your first app** → https://day8.github.io/re-frame2/guide/02-your-first-app/
+- **Guide — State machines** → https://day8.github.io/re-frame2/guide/05-state-machines/
+- **Guide — Stories** → https://day8.github.io/re-frame2/guide/14-stories/
+- **Guide — From re-frame v1** → https://day8.github.io/re-frame2/guide/08-from-re-frame-v1/
+- **Guide — Testing** → https://day8.github.io/re-frame2/guide/10-testing/
+- **Guide — Tooling (devtools and pair tools)** → https://day8.github.io/re-frame2/guide/11-devtools-and-pair-tools/
+- **Examples directory (worked apps)** → https://github.com/day8/re-frame2/tree/main/examples/reagent
+- **re-frame-pair2 skill (live inspection)** → https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2
+- **Source code** → https://github.com/day8/re-frame2
+
+## Format
+
+- Flat bullet list with `→` separator
+- No nesting
+- Easy for an AI to scan; easy for a human to read
+- Update when a URL changes or a new skill is added


### PR DESCRIPTION
## Summary

Adds a new file `SKILL-REDIRECT.md` at the repo root: a flat name -> URL table that AI skills (re-frame2, re-frame2-setup, re-frame-pair2, etc.) point agents to when they need deep-dive content beyond the skill's recipes (full API reference, EP design rationale, migration guide, construction prompts, etc.).

Skills stay free of hardcoded URLs; this file owns them. If a URL changes, update it once here and every skill keeps working.

## Why a standalone file

- Smaller load — AI reads only what it needs
- Obvious discovery — filename names exactly what it is
- Reusable by every skill in the repo
- Single source of truth for pointers across skills

## URL derivation

Site is `https://day8.github.io/re-frame2/` (per `mkdocs.yml` `site_url`). The repo's normative spec lives at the repo root in `spec/` and is staged into `docs/spec/` by `bb stage-docs` before `mkdocs build` runs, so `spec/Foo.md` resolves to `<site_url>/spec/Foo/`. Guide pages under `docs/guide/foo.md` resolve to `<site_url>/guide/foo/`.

## Entries included

- API reference (`spec/API.md`)
- Spec corpus overview (`spec/README.md`)
- Every EP — 000 Vision, 001 Registration, 002 Frames, 004 Views, 005 StateMachines, 006 ReactiveSubstrate, 007 Stories, 008 Testing, 009 Instrumentation, 010 Schemas, 011 SSR, 012 Routing, 013 Flows, 014 HTTPRequests
- Migration from re-frame v1 (`spec/MIGRATION.md`)
- Companion docs — Principles, Conventions, Construction-Prompts, CP-5-MachineGuide, AI-Audit, Implementor-Checklist, Runtime-Architecture, Cross-Spec-Interactions, Ownership, Spec-Schemas, conformance corpus, Tool-Pair
- Every Pattern — AsyncEffect, Boot, Forms, LongRunningWork, NineStates, RemoteData, StaleDetection, WebSocket
- Key guide chapters — overview, your first app, state machines, stories, from re-frame v1, testing, tooling
- Examples directory on GitHub
- re-frame-pair2 skill (live inspection) on GitHub
- Source code root

## Sources verified

For each spec/pattern/guide entry, the corresponding source markdown was confirmed to exist under `spec/` or `docs/guide/` and to be listed in `mkdocs.yml`'s `nav`. GitHub-tree URLs were derived from the repo's existing layout (`examples/reagent/`, `skills/re-frame-pair2/`).

## Test plan

- [x] File is at repo root, named exactly `SKILL-REDIRECT.md`
- [x] Only one file added; no other files touched
- [x] Flat bullet list with `→` separator; no nesting
- [x] Each entry's source markdown exists in the repo
- [ ] `mkdocs build --strict` still succeeds (the new file is at the repo root, outside `docs_dir`, so it is not part of the site build)

Closes rf2-12gf