### PR TITLE
feat(skills): re-frame2-setup skill — greenfield project bootstrap (rf2-glc8)

### DIFF
--- a/skills/re-frame2-setup/.claude-plugin/plugin.json
+++ b/skills/re-frame2-setup/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "re-frame2-setup",
+  "version": "0.1.0-alpha.1",
+  "description": "Scaffold a fresh re-frame2 ClojureScript project — deps.edn, shadow-cljs.edn, entry namespace, and a working first counter. A Claude Code Skill, companion to the main re-frame2 skill.",
+  "author": {
+    "name": "day8",
+    "url": "https://github.com/day8"
+  },
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame2-setup"
+  },
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "re-frame",
+    "re-frame2",
+    "reagent",
+    "shadow-cljs",
+    "clojurescript",
+    "scaffold",
+    "greenfield",
+    "day8"
+  ],
+  "skills": [
+    "./SKILL.md"
+  ],
+  "status": "pre-alpha"
+}

--- a/skills/re-frame2-setup/LICENSE
+++ b/skills/re-frame2-setup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -1,0 +1,118 @@
+# re-frame2-setup
+
+A `Skill` that helps `Claude Code` **scaffold a fresh [re-frame2](https://github.com/day8/re-frame2) ClojureScript project** — from an empty directory to a working, mounted counter.
+
+This is the **greenfield bootstrap** companion to the main [`re-frame2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) skill. The two are deliberately separate because:
+
+- The main `re-frame2` skill teaches the re-frame2 **API** — events, subs, machines, schemas, frames, fx, flows, routing, SSR. The content there is stable across re-frame2 releases.
+- Setup, by contrast, moves: artefact versions change, shadow-cljs versions change, React versions change. Pinning that content in the main skill would stale it. `re-frame2-setup` is the home for the moving target, so the main skill can stay clean.
+
+Once the counter mounts, the author switches to the main `re-frame2` skill (for writing application code) or [`re-frame-pair2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) (for live-runtime pair-programming).
+
+## What it covers
+
+The canonical seven-step greenfield path:
+
+1. Discover the current re-frame2 VERSION (the ten artefacts ship in lockstep).
+2. Add `day8/re-frame2` + `day8/re-frame2-reagent` to `deps.edn`.
+3. Add `react`, `react-dom`, `shadow-cljs` to `package.json`. Run `npm install`.
+4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app, plus `public/index.html`.
+5. Write the entry namespace — `(rf/init! reagent-adapter/adapter)`, the Reagent root, `(defn ^:export run [] ...)`.
+6. Write the first counter — registered event, registered sub, `reg-view`-defined view, mount.
+7. Run `shadow-cljs watch app`. Visit the dev server. Click the buttons. Done.
+
+## What it deliberately does NOT cover
+
+- Re-frame2's API surface (events, subs, machines, schemas, ...) — that's the main `re-frame2` skill.
+- Live REPL inspection of the running app — that's [`re-frame-pair2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2).
+- Migrating an existing re-frame v1 codebase to v2 — that's a different problem; see [`MIGRATION.md`](https://github.com/day8/re-frame2/blob/main/spec/MIGRATION.md).
+- Test infrastructure, CI, deployment — out of scope. The author chooses their own.
+- Anything beyond Reagent + shadow-cljs. UIx, Helix, and other build tools are noted only as "swap the adapter ns / pick a different build tool"; the canonical path is Reagent + shadow-cljs.
+
+## Status
+
+Pre-alpha. The skill is authored; it has not yet been exercised against a fresh project end-to-end. The structure mirrors the `re-frame-pair2` skill in this same repo. The content is grounded against the canonical example in `examples/reagent/counter/core.cljs` and the deps shapes from `implementation/core/deps.edn`, `implementation/adapters/reagent/deps.edn`, and `implementation/shadow-cljs.edn`.
+
+## Layout
+
+```
+skills/re-frame2-setup/
+├── SKILL.md
+├── README.md
+├── LICENSE
+├── package.json
+├── .claude-plugin/
+│   └── plugin.json
+└── reference/
+    ├── deps-versions.md
+    ├── shadow-cljs.md
+    ├── entry-namespace.md
+    └── first-counter.md
+```
+
+`SKILL.md` is the router: it walks the seven-step canonical path and links to the leaf in `reference/` whenever depth is useful. The four reference files are each one level deep — Claude reads them in full when the corresponding step needs more detail. No leaf depends on another leaf; they can be read in any order.
+
+## Install the skill in Claude Code
+
+`re-frame2-setup` ships as part of the [`day8/re-frame2`](https://github.com/day8/re-frame2) monorepo. There is no separate npm package or plugin registry entry yet — clone re-frame2 and reference the skill from `skills/re-frame2-setup/`.
+
+### Global — for you, across any project
+
+Symlink (or copy) the skill into your user Claude config:
+
+```bash
+git clone https://github.com/day8/re-frame2.git    # one-time, anywhere
+ln -s "$(pwd)/re-frame2/skills/re-frame2-setup" ~/.claude/skills/re-frame2-setup
+```
+
+Best when you spin up new re-frame2 projects regularly.
+
+### Project-local — for the new project itself
+
+After step 1 of the canonical path (the project directory exists), copy the skill into `.claude/skills/re-frame2-setup/` and commit it. Useful if you want teammates following along on the same project to share the same setup guidance.
+
+```bash
+cd your-new-project
+cp -r /path/to/re-frame2/skills/re-frame2-setup .claude/skills/re-frame2-setup
+git add .claude/skills/re-frame2-setup
+```
+
+## Invoking it in Claude
+
+### Implicit — just ask
+
+The skill's description auto-matches when you talk about starting a new re-frame2 project:
+
+> Start a new re-frame2 project for me in this directory.
+>
+> How do I add re-frame2 to my repo?
+>
+> Scaffold the smallest working re-frame2 app I can extend.
+
+### Explicit — slash command
+
+```
+/re-frame2-setup
+```
+
+…or name it in a prompt:
+
+> Using re-frame2-setup, walk me through bootstrapping a counter app.
+
+### What happens
+
+Claude reads `SKILL.md` and walks the seven-step path. For each step, it reads the matching `reference/` leaf only if the step needs depth (which is most of them, since the leaves carry the actual concrete shapes — `deps.edn` entries, `shadow-cljs.edn`, the entry-ns skeleton, the counter source).
+
+When all seven steps are done and the counter is visible, Claude says so and points you at the main `re-frame2` skill for everything after that.
+
+## Cross-link
+
+- [re-frame2](https://github.com/day8/re-frame2) — the framework itself.
+- [re-frame2 main skill](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) — the API-writing companion skill that takes over once setup is done.
+- [re-frame-pair2](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) — live-runtime pair-programming skill for an already-running re-frame2 app.
+- [Examples directory](https://github.com/day8/re-frame2/tree/main/examples/reagent) — worked re-frame2 apps (counter, login, todomvc, 7GUIs, realworld, ssr, routing).
+- [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) — canonical pointer table to the full spec corpus, guide, API reference, migration guide.
+
+## License
+
+MIT

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: re-frame2-setup
+description: >
+  Scaffolds a fresh re-frame2 ClojureScript project from nothing — adds
+  the artefact dependencies to deps.edn / package.json, writes a minimal
+  shadow-cljs.edn build for a Reagent single-page app, lays down the
+  canonical entry namespace shape (with `rf/init!` + the Reagent adapter),
+  and walks the author through their first mounted counter. Use this skill
+  whenever the user is starting a new re-frame2 project, bootstrapping
+  a greenfield CLJS app from scratch, asking how to add re-frame2 to an
+  empty repo, or wants to scaffold the smallest working re-frame2 setup
+  before writing application code. Once the counter mounts, the user
+  switches to the main `re-frame2` skill for code-writing inside the
+  project, or `re-frame-pair2` for live-runtime pair-programming.
+---
+
+# re-frame2-setup
+
+You are helping an author **bootstrap a fresh re-frame2 ClojureScript project**. The author starts with nothing (or close to nothing — a `deps.edn` they intend to fill in, an empty `package.json`, no source). When you are done, the author has a project that compiles under `shadow-cljs watch`, mounts a working counter in the browser, and is ready for them to switch to the **main `re-frame2` skill** for writing application code.
+
+This skill teaches **only** the re-frame2-specific wiring. It does not teach what `deps.edn`, `npm`, or `shadow-cljs` are — assume the author already knows. It does not teach re-frame2's API (events, subs, machines, schemas, frames, fx, flows, routing, SSR) — that's the main `re-frame2` skill's job.
+
+---
+
+## When to use this skill
+
+Use this skill when **any** of these are true:
+
+- The author has just created a new directory and wants re-frame2 set up in it.
+- The author has an existing CLJS project (Reagent or otherwise) but no re-frame2 wiring yet.
+- The author says any of: *"start a re-frame2 project"*, *"scaffold re-frame2"*, *"how do I set up re-frame2"*, *"add re-frame2 to my repo"*, *"give me a hello-world re-frame2 app"*.
+- A counter / event / sub fails to compile because the build doesn't yet know what `re-frame.core` or `re-frame.adapter.reagent` is.
+
+## When NOT to use this skill
+
+Switch to a different skill when:
+
+- The author has a working re-frame2 project and wants to **write application code** — events, subs, machines, schemas, views, fx. → Use the **`re-frame2`** skill.
+- The author has a running re-frame2 app and wants to **inspect / debug / pair with it live** — dispatch from the REPL, walk app-db, trace events, time-travel. → Use the **`re-frame-pair2`** skill.
+- The author is **migrating from re-frame v1 to v2**. → See [`MIGRATION`](SKILL-REDIRECT.md) (one of the entries in `SKILL-REDIRECT.md` at the repo root).
+
+If the author asks anything beyond greenfield setup (any re-frame2 API question, any design question, any migration question), say so and point them at the right skill.
+
+---
+
+## Cardinal rules
+
+1. **Never hardcode artefact versions in suggestions you write to disk.** re-frame2 ships ten artefacts in lockstep; versions change. Look them up first (see `reference/deps-versions.md`).
+2. **All ten artefacts ship at the same VERSION.** The author picks the version once; every `day8/re-frame2-*` dep gets that same version. Mixing versions across artefacts is unsupported.
+3. **Only add the per-feature artefacts the author actually uses.** Core + adapter are mandatory; schemas / machines / routing / flows / http / ssr / epoch are optional. Defer their inclusion until the author asks for the feature.
+4. **The Reagent adapter is the default reference substrate.** Unless the author explicitly says UIx or Helix, scaffold against Reagent.
+5. **Don't write tests for the author.** This skill stops at "the counter mounts". Anything after that is the main `re-frame2` skill (which itself defers test-writing to the author).
+
+---
+
+## Canonical greenfield path
+
+The author wants a working re-frame2 app from nothing. Walk these steps in order. Each step links to a leaf when depth is useful; otherwise it's self-contained.
+
+### Step 1 — Discover the current artefact versions
+
+re-frame2 ships ten Maven artefacts in lockstep at a single VERSION. Find that VERSION before writing any deps. → See `reference/deps-versions.md` for where to look it up and which artefacts the author needs.
+
+A typical greenfield project needs **only two artefacts on day one**:
+
+- `day8/re-frame2` (the core)
+- `day8/re-frame2-reagent` (the Reagent adapter)
+
+Per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) come in **only when the author starts using that feature**.
+
+### Step 2 — Add the deps to `deps.edn`
+
+Drop the two artefacts into `:deps` under their canonical Maven coordinates. The shape is identical to any other tools.deps project — the only re-frame2-specific bit is the artefact names and the lockstep VERSION discipline. → See `reference/deps-versions.md` §`deps.edn`.
+
+### Step 3 — Add the npm deps to `package.json`
+
+The Reagent adapter requires `react` and `react-dom`. shadow-cljs is the build tool. → See `reference/deps-versions.md` §`package.json`.
+
+Run `npm install`.
+
+### Step 4 — Write the `shadow-cljs.edn` build
+
+A re-frame2 single-page app needs **one browser build entry** — a `:target :browser`, an `:init-fn` pointing at `your-app.core/run`, and a `:source-paths` that includes your `src/` tree. No special compiler options for the basic case. → See `reference/shadow-cljs.md` for the exact shape, the optional `:devtools` block for hot-reload, and the index.html that loads the bundle.
+
+### Step 5 — Write the entry namespace
+
+`your-app/core.cljs` needs three re-frame2-specific moves:
+
+1. `:require [re-frame.core :as rf]` — the core API.
+2. `:require [re-frame.adapter.reagent :as reagent-adapter]` — the substrate adapter ships its adapter map as a var.
+3. Call `(rf/init! reagent-adapter/adapter)` **before any dispatch or render**.
+
+→ See `reference/entry-namespace.md` for the canonical shape, including how `rf/init!` interacts with `rdc/create-root` / `rdc/render`, why `defonce` matters for the React root, and how `(rf/init!)` differs from re-frame v1's implicit boot.
+
+### Step 6 — Write the first counter
+
+A registered event, a registered sub, a registered view (via the `reg-view` macro), and a mount. End-to-end in one file. → See `reference/first-counter.md` for the worked example with explanatory comments. This is the smallest piece of code that exercises every layer (event → handler → app-db change → sub recompute → view re-render).
+
+### Step 7 — Run it and verify
+
+```
+npm install            # if you haven't already
+npx shadow-cljs watch app
+```
+
+Open `http://localhost:<port>/` in a browser (port comes from the `:devtools` block in `shadow-cljs.edn` — typically `:8020`). The counter is visible. Clicking `+` / `-` flips the number. **You're done with setup.**
+
+If the build fails, see *Troubleshooting* below.
+
+---
+
+## Done checklist
+
+Tell the author you're done when **all** of these are true:
+
+- [ ] `deps.edn` lists `day8/re-frame2` and `day8/re-frame2-reagent` at the same VERSION.
+- [ ] `package.json` lists `react`, `react-dom`, and `shadow-cljs` (correct versions, see leaf).
+- [ ] `npm install` has completed without errors.
+- [ ] `shadow-cljs.edn` has exactly one `:builds` entry for the app, with an `:init-fn` pointing at the entry ns.
+- [ ] The entry ns calls `(rf/init! reagent-adapter/adapter)` before any render.
+- [ ] `shadow-cljs watch <build-id>` compiles cleanly.
+- [ ] The browser shows the counter and clicking `+` / `-` updates it.
+
+Then tell the author: *"Setup is done. From here, switch to the **`re-frame2`** skill — it'll teach you re-frame2's API (events, subs, machines, schemas, frames, fx). If you also want to inspect the running app live from the REPL, install **`re-frame-pair2`**."*
+
+---
+
+## Troubleshooting
+
+A few build failures are specific enough to flag here. Everything else, defer to standard CLJS / shadow-cljs / npm guidance — assume the author already knows those tools.
+
+**`Could not locate re-frame/core.cljs`** — the artefact isn't on the classpath. Re-check `deps.edn` (correct artefact name and version) and that `shadow-cljs.edn` reads from `deps.edn` automatically (it does by default; if the author set `:deps {:aliases [...]}` they may have shadowed the default). Run `clj -Stree | grep re-frame2` to confirm the JAR resolved.
+
+**`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` aren't installed (or the wrong major). `npm install react react-dom`. Reagent 2.x requires React 18+.
+
+**Counter doesn't update on click, no errors** — `(rf/init! reagent-adapter/adapter)` wasn't called, or was called after `rdc/render`. The adapter spec map must be installed before any subscription or render runs. Move `rf/init!` to the top of `run`.
+
+**Browser shows a blank page, no errors in console** — `index.html` is missing `<div id="app">`, or the entry ns is looking up a different id. Mismatch between `(js/document.getElementById "app")` and the actual DOM id is by far the most common cause.
+
+**Build compiles but browser console says `Uncaught ReferenceError: re_frame is not defined`** — the `:init-fn` in `shadow-cljs.edn` doesn't match the entry ns / `run` symbol. shadow-cljs needs to find the export; check it's `(defn ^:export run [] ...)` and that `:init-fn your-app.core/run` matches.
+
+If the author hits anything else, point them at the `re-frame2` skill or `SKILL-REDIRECT.md` (the latter has links to the full spec corpus and guide).
+
+---
+
+## Deep dives — reference files
+
+For depth on any step, read the matching leaf — they're all one level deep so you can read them in full:
+
+- **`reference/deps-versions.md`** — How to discover the current re-frame2 VERSION; the lockstep contract; deciding which per-feature artefacts to pull in on day one; the `deps.edn` and `package.json` shape.
+- **`reference/shadow-cljs.md`** — The minimal `shadow-cljs.edn` for a single-page Reagent app; the `index.html` that loads the bundle; `:asset-path` and `:devtools` notes.
+- **`reference/entry-namespace.md`** — The canonical `core.cljs` shape; why `rf/init!` must run before any render; the Reagent root pattern (`defonce` + `rdc/create-root`); the order-of-operations contract.
+- **`reference/first-counter.md`** — End-to-end worked example: a registered event, a registered sub, a `reg-view`-defined view, and the mount. Mirrors `examples/reagent/counter/core.cljs` in the re-frame2 repo, trimmed for greenfield.
+
+---
+
+## When the author asks anything beyond setup
+
+Setup-out-of-scope questions to re-route:
+
+| Author asks... | Route to... |
+|---|---|
+| "How do I write a sub that depends on another sub?" | **`re-frame2`** skill |
+| "How do I add a state machine?" | **`re-frame2`** skill |
+| "How do I structure my events folder?" | **`re-frame2`** skill |
+| "I'm migrating from re-frame v1." | `SKILL-REDIRECT.md` → MIGRATION |
+| "Can I inspect app-db from the REPL?" | **`re-frame-pair2`** skill |
+| "Help me debug why my view isn't re-rendering." | **`re-frame-pair2`** skill |
+| "Are there worked examples I can study?" | `SKILL-REDIRECT.md` → Examples directory |
+| "Where's the API reference?" | `SKILL-REDIRECT.md` → API |
+
+Don't try to answer these here; this skill is greenfield setup only. Pointing the author at the right next skill is more useful than improvising.

--- a/skills/re-frame2-setup/package.json
+++ b/skills/re-frame2-setup/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@day8/re-frame2-setup",
+  "version": "0.1.0-alpha.1",
+  "description": "Scaffold a fresh re-frame2 ClojureScript project — deps.edn, shadow-cljs.edn, entry namespace, and a working first counter. A Claude Code Skill, companion to the main re-frame2 skill.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "claude-code-plugin",
+    "re-frame",
+    "re-frame2",
+    "reagent",
+    "shadow-cljs",
+    "clojurescript",
+    "scaffold",
+    "greenfield",
+    "day8"
+  ],
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup",
+  "bugs": {
+    "url": "https://github.com/day8/re-frame2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame2-setup"
+  },
+  "license": "MIT",
+  "author": "day8 (https://github.com/day8)",
+  "files": [
+    "SKILL.md",
+    "README.md",
+    "LICENSE",
+    "reference/",
+    ".claude-plugin/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/skills/re-frame2-setup/reference/deps-versions.md
+++ b/skills/re-frame2-setup/reference/deps-versions.md
@@ -1,0 +1,109 @@
+# deps-versions
+
+How to choose **which** re-frame2 artefacts to depend on, and **what version** to pin them at.
+
+## Contents
+
+- The lockstep contract
+- The ten artefacts (and which two a greenfield project needs)
+- Discovering the current VERSION
+- `deps.edn` shape
+- `package.json` shape
+- When to add the optional per-feature artefacts
+
+---
+
+## The lockstep contract
+
+re-frame2 ships **ten Maven artefacts in lockstep**: every artefact at the same VERSION, every release. Mixing versions across artefacts is unsupported — the runtime contract between core, adapters, and the per-feature surfaces is checked at boot time and bound to a single coordinated VERSION.
+
+Picking a re-frame2 VERSION for your project means picking it once and using it everywhere a `day8/re-frame2-*` coordinate appears.
+
+## The ten artefacts
+
+| Artefact | Tier | When to add |
+|---|---|---|
+| `day8/re-frame2` | core | **Always.** Registry, drain, fx, dispatch, subscribe, frame-provider, trace, the substrate-adapter contract. |
+| `day8/re-frame2-reagent` | substrate | **Always (for a Reagent app).** The Reagent adapter map. |
+| `day8/re-frame2-uix` | substrate | Instead of `-reagent` if you target UIx. |
+| `day8/re-frame2-helix` | substrate | Instead of `-reagent` if you target Helix. |
+| `day8/re-frame2-schemas` | per-feature | When you call `reg-app-schema` or `reg-event-schema`. |
+| `day8/re-frame2-machines` | per-feature | When you call `reg-machine` or `create-machine-handler`. |
+| `day8/re-frame2-routing` | per-feature | When you dispatch `:rf.route/*` events or register routes. |
+| `day8/re-frame2-flows` | per-feature | When you call `reg-flow`. |
+| `day8/re-frame2-http` | per-feature | When you dispatch `:rf.http/managed`. |
+| `day8/re-frame2-ssr` | per-feature | When you call `render-to-string` server-side. |
+| `day8/re-frame2-epoch` | per-feature | When you call `epoch-history` or `restore-epoch` (also pulled in transitively by `re-frame-pair2`). |
+
+**Greenfield day-one minimum: just `day8/re-frame2` + `day8/re-frame2-reagent`.** Resist adding the others until the author writes code that actually uses them — they're optional by design so apps that don't use them don't pay the classpath cost.
+
+## Discovering the current VERSION
+
+re-frame2 versions look like `0.0.1.alpha`, `0.0.2.alpha`, `1.0.0`, etc. Three places to look, in order of authority:
+
+1. **The repo's `VERSION` file** — `https://github.com/day8/re-frame2/blob/main/VERSION` is the single source of truth that release tags are cut from. The string in this file is the canonical VERSION for the next release.
+2. **`CHANGELOG.md`** — `https://github.com/day8/re-frame2/blob/main/CHANGELOG.md` lists the released VERSIONs with summaries. Use the latest non-unreleased entry.
+3. **The GitHub releases page** — `https://github.com/day8/re-frame2/releases` shows the tags. The latest tag is `v<VERSION>`.
+
+If the author wants the latest released version, read `CHANGELOG.md` and pick the most recent versioned heading that isn't `Unreleased`. If they want the bleeding edge (e.g. they're chasing a fix that hasn't released yet), they may need to use a Git coordinate via `:git/url` + `:git/sha` instead of `:mvn/version`. That's a niche case; default to released `:mvn/version`.
+
+**Never invent a version.** If you can't reach the network to look it up, ask the author to paste the current VERSION rather than guess.
+
+## `deps.edn` shape
+
+A minimal `deps.edn` for a greenfield re-frame2 project:
+
+```clojure
+{:paths ["src"]
+ :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
+         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         day8/re-frame2            {:mvn/version "<VERSION>"}
+         day8/re-frame2-reagent    {:mvn/version "<VERSION>"}}}
+```
+
+Replace `<VERSION>` with the VERSION you discovered above. **Both `day8/re-frame2-*` lines get the same value.**
+
+Notes on the Clojure / ClojureScript versions:
+- The Clojure / ClojureScript versions in the example are what the re-frame2 repo's own examples build against (see `implementation/core/deps.edn`). You can use newer versions if shadow-cljs and Reagent support them; you can probably use slightly older ones too. Start with these.
+- Reagent itself is **already declared as a dep of `day8/re-frame2-reagent`**, so you don't need to add `reagent/reagent` to your `:deps`. It'll be pulled in transitively at whatever version the adapter's `deps.edn` pins.
+
+## `package.json` shape
+
+re-frame2 itself ships no npm code — but Reagent depends on React, and shadow-cljs is the build tool. Minimum `package.json`:
+
+```json
+{
+  "name": "your-app",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "shadow-cljs": "<latest-2.x>",
+    "react": "<latest-18.x>",
+    "react-dom": "<latest-18.x>"
+  }
+}
+```
+
+Discover the latest `shadow-cljs` / `react` / `react-dom` from npm: `npm view shadow-cljs version`, `npm view react version`, `npm view react-dom version`. As a sanity check, the re-frame2 repo's own `implementation/package.json` pins specific versions of each — those are known-good and a reasonable floor if `npm view` returns something newer that gives you trouble.
+
+Reagent 2.x requires React 18+. Don't go below `react@18`.
+
+Then `npm install`.
+
+## When to add the optional per-feature artefacts
+
+The seven per-feature artefacts are pay-as-you-go. Add them **at the moment** the author writes code that calls into them — not before.
+
+| If the author writes... | Add to `deps.edn`... |
+|---|---|
+| `(rf/reg-app-schema ...)` or any `:schema` key in a `reg-*` opts map | `day8/re-frame2-schemas` |
+| `(rf/reg-machine ...)` or `(rf/create-machine-handler ...)` | `day8/re-frame2-machines` |
+| `(rf/reg-route ...)` or dispatches `:rf.route/handle-url-change` | `day8/re-frame2-routing` |
+| `(rf/reg-flow ...)` | `day8/re-frame2-flows` |
+| `[:rf.http/managed ...]` as an `:fx` entry | `day8/re-frame2-http` |
+| Server-side `render-to-string` for SSR | `day8/re-frame2-ssr` |
+| `(rf/epoch-history ...)` or `(rf/restore-epoch ...)` directly | `day8/re-frame2-epoch` |
+
+(The `re-frame-pair2` skill pulls `-epoch` in transitively so live-inspection time-travel works; if the app uses `re-frame-pair2` but doesn't call the epoch surface itself, the author still doesn't need to add `-epoch` to their own `deps.edn` — the skill injects its runtime over nREPL.)
+
+Each artefact registers its own load-time hooks on require, so the only extra step beyond the dep is a `:require` of the artefact's primary namespace from your entry ns or wherever you first call into its API. See the leaf for each feature in the main `re-frame2` skill for the canonical require shape.

--- a/skills/re-frame2-setup/reference/entry-namespace.md
+++ b/skills/re-frame2-setup/reference/entry-namespace.md
@@ -1,0 +1,113 @@
+# entry-namespace
+
+The canonical shape of `your-app/core.cljs` — the entry namespace shadow-cljs's `:init-fn` points at. This file is where re-frame2 wires up to the substrate (Reagent) and to the DOM.
+
+## Contents
+
+- The skeleton
+- Order of operations
+- Why `rf/init!` exists (and why it's explicit)
+- The Reagent root pattern (`defonce` + `rdc/create-root`)
+- Where everything else goes
+- Differences from re-frame v1
+
+---
+
+## The skeleton
+
+```clojure
+(ns your-app.core
+  (:require [reagent.dom.client       :as rdc]
+            [re-frame.core            :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+;; -- mount point ------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+;; -- entry ------------------------------------------------------------------
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rdc/render react-root [root-view]))
+```
+
+That's the whole entry namespace. Events / subs / views go above the mount point, in this same file for a tiny app or in their own namespaces (`your-app.events`, `your-app.subs`, `your-app.views`) and `:require`d here for any non-trivial app.
+
+`root-view` is the top-level registered view. See `first-counter.md` for what it looks like.
+
+## Order of operations
+
+`run` must do these three things, **in this order**, every time:
+
+1. **`(rf/init! reagent-adapter/adapter)`** — install the substrate adapter into the default frame.
+2. **(optional) `(rf/dispatch-sync [:your-app/initialise])`** — seed app-db synchronously before the first render. Most apps want this; some let the views render against an empty app-db and seed on first user interaction.
+3. **`(rdc/render react-root [root-view])`** — mount the React tree.
+
+If you flip 1 and 3, you'll get either a crash (the views call `subscribe` against an uninitialised registry) or — more confusingly — a silent failure where the first render shows nothing and clicking does nothing.
+
+If you flip 2 and 3, the first render sees an empty app-db; usually fine, sometimes triggers a flash of unstyled state.
+
+## Why `rf/init!` exists (and why it's explicit)
+
+re-frame2 splits **the registry** (a process-global handler / sub / fx map) from **the substrate** (Reagent / UIx / Helix / plain atom). The substrate is supplied at boot via an *adapter map*; `rf/init!` is the moment that adapter map becomes the default frame's substrate.
+
+Three consequences:
+
+- **Adapters are values, not magic.** `re-frame.adapter.reagent/adapter` is a regular CLJS var holding a map. `rf/init!` takes that value directly — no global registration, no name-based lookup. Swap it for `re-frame.adapter.uix/adapter` or `re-frame.adapter.helix/adapter` and you have a UIx / Helix app.
+- **`rf/init!` is idempotent in dev but not redundant.** Hot-reload of `core.cljs` will re-invoke `run`; calling `rf/init!` again is safe and resets the default frame's substrate config. Don't try to "guard" it with `defonce` — let it run.
+- **No implicit boot.** Unlike re-frame v1 (where `re-frame.core` had no boot step), re-frame2 requires the explicit `init!`. The reason: multi-substrate support and the per-frame substrate-config model (Spec 006) need to know *which* adapter you want before any subscription resolves. There is no default.
+
+The adapter map carries the substrate's `state-container`, `read-container`, `replace-container!`, `subscribe`, `render`, and hot-reload hooks. You don't construct it; you require the namespace and pass its `adapter` var.
+
+## The Reagent root pattern (`defonce` + `rdc/create-root`)
+
+```clojure
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+```
+
+Two contractual bits:
+
+- **`defonce`** — under shadow-cljs hot-reload, `core.cljs` reloads on every save. Without `defonce`, every reload calls `create-root` again on the same DOM node, and React 18 complains loudly (or, worse, silently mounts two roots that fight each other). `defonce` ensures the root is created exactly once per page load.
+- **`(js/document.getElementById "app")`** — must match the `id` in `index.html`. Mismatch here is the most common cause of a blank page with no console error.
+
+In `run`, `rdc/render` is called against `react-root` (not against the DOM node directly). Both `create-root` and `render` come from `reagent.dom.client` — that's the React 18 entry surface for Reagent 2.x.
+
+## Where everything else goes
+
+In a tiny app, all of this fits in `your-app/core.cljs` above the mount point:
+
+- **Events** — `(rf/reg-event-db ...)`, `(rf/reg-event-fx ...)`
+- **Subscriptions** — `(rf/reg-sub ...)`
+- **Effects** — `(rf/reg-fx ...)` (per-app fx)
+- **Views** — `(reg-view <name> [...] <body>)` (via the `reg-view` macro from `re-frame.views-macros`)
+- **`(rf/dispatch-sync [:your-app/initialise])`** in `run` — the initial seed event
+
+For anything beyond the first counter, split:
+
+```
+src/your_app/
+├── core.cljs        ; the entry ns (this file)
+├── events.cljs      ; reg-event-db / reg-event-fx
+├── subs.cljs        ; reg-sub
+└── views.cljs       ; reg-view-defined views
+```
+
+then `(:require [your-app.events] [your-app.subs] [your-app.views :as views])` in `core.cljs` so the registrations happen at load time. Use `[views/root-view]` in `rdc/render`. The folder shape is a convention; re-frame2 has no opinion about it.
+
+## Differences from re-frame v1
+
+If the author is coming from re-frame v1 (re-frame's first version), three things changed at the entry-namespace layer:
+
+| v1 | v2 |
+|---|---|
+| `(:require [reagent.core :as r])` then `(r/render ...)` | `(:require [reagent.dom.client :as rdc])` then `(rdc/render root [view])` — React 18 surface |
+| No explicit boot — `re-frame.core` was self-installing against Reagent | `(rf/init! reagent-adapter/adapter)` is mandatory; adapter is a value the app supplies |
+| `defn` views — re-frame v1 had no view registration | `reg-view` macro registers views in a per-app registry; auto-injects `dispatch` / `subscribe` |
+| Implicit single global `app-db` | One default frame; multi-frame apps are first-class via `frame-provider` |
+
+The full v1→v2 migration story lives in `MIGRATION.md` (linked from `SKILL-REDIRECT.md` at the repo root). This skill is greenfield-only; if the author has a v1 codebase, point them at migration instead.

--- a/skills/re-frame2-setup/reference/first-counter.md
+++ b/skills/re-frame2-setup/reference/first-counter.md
@@ -1,0 +1,135 @@
+# first-counter
+
+End-to-end worked example: a working re-frame2 counter in one file. This is the smallest piece of code that exercises every layer (event → handler → app-db change → sub recompute → view re-render).
+
+Use it as the body of `src/your_app/core.cljs`. When it mounts and clicks work, **greenfield setup is done** — switch the author to the main `re-frame2` skill for everything else.
+
+## Contents
+
+- The whole file
+- What each block does
+- Verifying it works
+- What to do next
+
+---
+
+## The whole file
+
+```clojure
+(ns your-app.core
+  (:require [reagent.dom.client       :as rdc]
+            [re-frame.core            :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+;; -- Events ----------------------------------------------------------------
+
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:count 0}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :count inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :count dec)))
+
+;; -- Subscriptions ---------------------------------------------------------
+
+(rf/reg-sub :count
+  (fn [db _query] (:count db)))
+
+;; -- Views -----------------------------------------------------------------
+
+(reg-view counter-buttons []
+  [:div
+   [:button {:on-click #(dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em"}} @(subscribe [:count])]
+   [:button {:on-click #(dispatch [:counter/inc])} "+"]])
+
+(reg-view root-view []
+  [:div
+   [:h1 "re-frame2 counter"]
+   [counter-buttons]])
+
+;; -- Mount -----------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:counter/initialise])
+  (rdc/render react-root [root-view]))
+```
+
+That's the entire greenfield app. ~30 lines of substance, every re-frame2 primitive exercised once.
+
+## What each block does
+
+### Events
+
+Three events: an initialiser and two mutations. Each takes the current `db`, returns the next `db`. Pure functions, dispatched through re-frame2's drain so they run in order, one at a time.
+
+`reg-event-db` is the "DB-only" event handler — the handler's return value replaces `app-db` for the registered frame. For events that need to return both a new DB **and** other effects (HTTP requests, navigation, child dispatches), the macro is `reg-event-fx` and the handler returns a map `{:db ... :fx [...]}`. The counter doesn't need that yet.
+
+### Subscriptions
+
+One subscription, `[:count]`, reads `(:count db)`. Views deref it with `@(subscribe [:count])`. Under re-frame2's value-equal recompute suppression (rf2-719e), the sub re-runs only when its inputs change; if the new return value is `=` to the previous one, downstream consumers don't re-render. That suppression is automatic; nothing to configure.
+
+### Views
+
+`reg-view` is a macro that **registers a view** under `(keyword *ns* sym)` — here, `:your-app.core/counter-buttons` and `:your-app.core/root-view`. It also defs a regular CLJS var with the same name so the hiccup `[counter-buttons]` reference works.
+
+Inside the body, two locals are **auto-injected** by the macro:
+
+- `dispatch` — bound to the current frame's `dispatch` fn. Use it like `(dispatch [:counter/inc])`.
+- `subscribe` — bound to the current frame's `subscribe` fn. Use it like `@(subscribe [:count])`.
+
+This is what makes registered views frame-aware without you threading the frame through every component. The macro resolves both at render time against whatever frame is in scope (the default frame, here; `frame-provider` lets multi-frame apps swap it for a subtree).
+
+The result is regular Reagent hiccup. Reagent renders, the React 18 root commits, the DOM updates.
+
+### Mount
+
+`defonce` guards `react-root` against hot-reload. See `entry-namespace.md` for why.
+
+`run`'s three lines (in this order):
+
+1. `(rf/init! reagent-adapter/adapter)` — install the Reagent substrate adapter.
+2. `(rf/dispatch-sync [:counter/initialise])` — seed `app-db` to `{:count 0}` before first render. `dispatch-sync` drains the event synchronously; the `app-db` is committed before `run` returns.
+3. `(rdc/render react-root [root-view])` — mount.
+
+## Verifying it works
+
+```
+shadow-cljs watch app
+```
+
+Wait for the compile to land. The terminal prints something like `[:app] Build completed.`
+
+Visit `http://localhost:8020/` (or whatever `:http-port` you set in `shadow-cljs.edn`).
+
+You should see:
+
+- The heading `re-frame2 counter`
+- The number `0`
+- A `-` button on the left, `+` button on the right
+
+Click `+` — the number becomes `1`. Click `-` — back to `0`. Refresh the page — back to `0` (state lives in app-db, which resets on full reload).
+
+If you see a blank page, open the browser console. Most failures land there with a clear error:
+- `Cannot read property 'getElementById' of undefined` — script ran before DOM was ready; check `index.html` loads `main.js` at the *bottom* of `<body>`.
+- `Could not find frame :rf/default` — `rf/init!` didn't run before render. Check `run` is the `:init-fn` shadow-cljs is calling.
+- `No subscription handler registered for: :count` — registrations didn't run. If you split into multiple namespaces, make sure `core.cljs` `:require`s them so they load.
+
+## What to do next
+
+**Setup is done.** From here, **switch skills**:
+
+- **Writing more code (events, subs, machines, schemas, frames, fx, flows, routing, SSR)** — load the **`re-frame2`** skill. It covers the API surface in modular files; you can load just the pieces relevant to what you're building.
+- **Inspecting the running app live from the REPL** — install the **`re-frame-pair2`** skill. It attaches over nREPL, lets you walk app-db, dispatch from the REPL, hot-swap handlers, time-travel through epoch history.
+
+Both skills are independent of this one and can be loaded individually.
+
+If you want worked examples of more substantial re-frame2 apps before you keep building, the repo's `examples/reagent/` directory has worked apps for: TodoMVC, the seven 7GUIs tasks, login with state machines + managed HTTP, routing, SSR, the nine-states pattern, realworld. Browse them via `SKILL-REDIRECT.md` → Examples directory.

--- a/skills/re-frame2-setup/reference/shadow-cljs.md
+++ b/skills/re-frame2-setup/reference/shadow-cljs.md
@@ -1,0 +1,108 @@
+# shadow-cljs
+
+The minimal `shadow-cljs.edn` build for a greenfield re-frame2 Reagent single-page app, and the matching `index.html`.
+
+## Contents
+
+- Minimal `shadow-cljs.edn`
+- The `index.html` that loads the bundle
+- `:devtools` block (optional, for hot-reload)
+- Production build (`release`)
+- nREPL — only if you'll use `re-frame-pair2`
+- What re-frame2 does NOT need
+
+---
+
+## Minimal `shadow-cljs.edn`
+
+```clojure
+{:source-paths ["src"]
+
+ :dependencies []                       ;; deps come from deps.edn
+
+ :builds
+ {:app
+  {:target     :browser
+   :output-dir "public/js"
+   :asset-path "/js"
+   :modules    {:main {:init-fn your-app.core/run}}}}}
+```
+
+The smallest greenfield build entry. Three things matter for re-frame2:
+
+1. **`:dependencies []`.** shadow-cljs reads `deps.edn` automatically. Don't duplicate the `day8/re-frame2-*` coordinates here; that's where they'd shadow each other if their VERSION ever drifted.
+2. **`:init-fn your-app.core/run`.** shadow-cljs calls this symbol at bundle-init time. The function must be exported (`(defn ^:export run [] ...)`). This is the entry point that calls `(rf/init! reagent-adapter/adapter)` — see `entry-namespace.md`.
+3. **One module.** A single-page re-frame2 app needs exactly one `:modules` entry. Code-splitting is possible later but not part of greenfield.
+
+Substitute `your-app.core/run` with whatever your entry namespace + run symbol actually is. If you call your namespace `myapp.core` and your run fn `start`, this becomes `:init-fn myapp.core/start`.
+
+The build id (`:app` above) is the name you give the build for `shadow-cljs watch <build-id>`. Use anything that reads naturally; `:app` is convention.
+
+## The `index.html` that loads the bundle
+
+A re-frame2 app needs an HTML page that loads the compiled JS and has a mount point. Drop this at `public/index.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>your-app</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="/js/main.js"></script>
+</body>
+</html>
+```
+
+Three contractual bits:
+
+- **`<div id="app"></div>`** — the mount point. Whatever id you use here, the entry ns must call `(js/document.getElementById "<same-id>")`. By convention it's `"app"`.
+- **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows.
+- **`/js/main.js` is an absolute path from site root.** That's correct for shadow-cljs's dev server.
+
+## `:devtools` block (optional, for hot-reload)
+
+Add `:devtools` to enable shadow-cljs's hot-reload + dev server:
+
+```clojure
+:builds
+{:app
+ {:target     :browser
+  :output-dir "public/js"
+  :asset-path "/js"
+  :modules    {:main {:init-fn your-app.core/run}}
+  :devtools   {:http-port 8020
+               :http-root "public"
+               :watch-dir "public"}}}
+```
+
+- `:http-port` — port the dev server listens on. `8020` is convention; pick anything free.
+- `:http-root "public"` — the dev server serves files from this directory. Your `index.html` lives at `public/index.html`.
+- `:watch-dir "public"` — shadow-cljs reloads the browser when any file under here changes (including the compiled `main.js`).
+
+With this block in place, `shadow-cljs watch app` starts the dev server. Visit `http://localhost:8020/` and the browser auto-refreshes on every recompile.
+
+re-frame2 itself **does not need a preload** for hot-reload. shadow-cljs's default behaviour is enough. (`re-frame-pair2` and re-frame v1's `re-frame-10x` were both preloads; re-frame2 ships no preload of its own.)
+
+## Production build (`release`)
+
+`shadow-cljs release app` produces an optimised bundle. No re-frame2-specific config needed.
+
+re-frame2's `:advanced`-compile elision contract (Spec 009) automatically strips dev-only diagnostics (`trace`, `epoch-history`, schema validation at boundary) when `goog.DEBUG` is false — which it is under `:advanced`. The author gets the elision for free; nothing to configure.
+
+## nREPL — only if you'll use `re-frame-pair2`
+
+If the author plans to attach `re-frame-pair2` (the live-inspection skill) to the running app, shadow-cljs's dev build needs nREPL enabled. shadow-cljs **enables nREPL by default** when you run `shadow-cljs watch <build>` — no config change required. The port is written to `target/shadow-cljs/nrepl.port` (or `.shadow-cljs/nrepl.port` depending on version), which is where `re-frame-pair2`'s `discover-app.sh` looks for it.
+
+If you want to pin the port explicitly (e.g. for editor integrations), add a top-level `:nrepl {:port 7002}` to `shadow-cljs.edn`. Not required for greenfield.
+
+## What re-frame2 does NOT need
+
+A few things you might pull in by reflex from other CLJS framework setups that re-frame2 specifically does not require:
+
+- **No `:preloads`** — re-frame2 has no preload analogue to re-frame v1 + re-frame-10x.
+- **No `:closure-defines`** for re-frame2 itself in dev. The single exception is opting into the performance-API instrumentation (Spec 009 §Performance instrumentation) — set `re-frame.performance/enabled? true` only if the author asks for it explicitly. Default dev is fine.
+- **No special compiler options** for dev. `{:compiler-options {:warnings {...}}}` is up to the author.
+- **No SSR build entry** unless the author wants SSR. SSR is opt-in via `day8/re-frame2-ssr` (separate per-feature artefact); the SSR build is a separate `:target :node-script` (or `:target :browser` running in a static-render harness). Out of scope for greenfield.


### PR DESCRIPTION
## Summary

Adds `skills/re-frame2-setup/` — the **greenfield bootstrap** companion to the main `re-frame2` skill (rf2-eipb, merged in #309). The two skills are deliberately separate because setup deals with a moving target (artefact VERSION, shadow-cljs version, React version, npm machinery) and pinning that content in the main skill would stale it. Setup lives here so the main skill can stay clean on the stable API surface.

Walks an author from an empty directory to a working, mounted counter via a canonical seven-step path:

1. Discover the current re-frame2 VERSION (the ten artefacts ship in lockstep)
2. Add `day8/re-frame2` + `day8/re-frame2-reagent` to `deps.edn`
3. Add `react`, `react-dom`, `shadow-cljs` to `package.json`
4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app + `public/index.html`
5. Write the entry namespace — `(rf/init! reagent-adapter/adapter)`, defonce'd Reagent root, `(defn ^:export run [] ...)`
6. Write the first counter — registered event, registered sub, `reg-view`-defined view, mount
7. Run `shadow-cljs watch app`; click the buttons; done

## Layout

```
skills/re-frame2-setup/
├── SKILL.md                       (172 lines — router)
├── README.md                      (overview + install)
├── LICENSE
├── package.json                   (npm distribution)
├── .claude-plugin/plugin.json     (plugin distribution)
└── reference/
    ├── deps-versions.md           (lockstep contract, version discovery, deps.edn + package.json shape)
    ├── shadow-cljs.md             (minimal build, index.html, devtools, nREPL note)
    ├── entry-namespace.md         (rf/init! contract, Reagent root pattern, ordering)
    └── first-counter.md           (end-to-end worked counter)
```

SKILL.md is router-style; the four reference leaves are each one level deep so Claude reads them in full when a step needs depth. All four are under the 250-line ceiling (108–135 each); SKILL.md is well under the 500-line ceiling.

## Deliberately out of scope

- The re-frame2 API surface (events, subs, machines, schemas, etc.) → defers to the `re-frame2` skill
- Live REPL inspection of a running app → defers to `re-frame-pair2`
- v1 → v2 migration → one-line redirect via `SKILL-REDIRECT.md`
- Test infrastructure, CI, deployment → out of scope; the author chooses their own
- UIx / Helix substrates → mentioned as "swap the adapter ns"; the canonical path is Reagent

## Source-of-truth grounding

The deps shapes, the entry-namespace skeleton, and the counter are all grounded against the implementation as currently shipped:

- `implementation/core/deps.edn` — core artefact coordinates, Clojure / CLJS / Reagent baseline versions
- `implementation/adapters/reagent/deps.edn` — Reagent adapter coordinates
- `implementation/shadow-cljs.edn` — example build entries (`:examples/counter` form)
- `examples/reagent/counter/core.cljs` — the canonical entry-namespace shape (verbatim mirror of what the leaf teaches)

Versions are **never hardcoded** — the `deps-versions` leaf teaches the author to look them up from `VERSION` / `CHANGELOG.md` / GitHub releases so the skill does not stale.

## Test plan

- [ ] `mkdocs build --strict` still passes (skill dir is outside `docs_dir`, so should be unaffected)
- [ ] SKILL.md frontmatter parses (`name` lowercase + hyphens, `description` non-empty + ≤1024 chars — measured at 762)
- [ ] Reference files are one level deep from SKILL.md (no nested redirects)
- [ ] Cross-references to `re-frame2` and `re-frame-pair2` skills resolve (both exist in this repo)
- [ ] First-counter source compiles when dropped into a fresh re-frame2 project (manual smoke; not gated on this PR)

Closes rf2-glc8.