### PR TITLE
feat(skills): re-frame2 tooling leaves (stories, routing) (rf2-4yc1)

### DIFF
--- a/skills/re-frame2/reference/tooling/routing.md
+++ b/skills/re-frame2/reference/tooling/routing.md
@@ -1,0 +1,148 @@
+# Routing — re-frame2 binding
+
+> Authoring `reg-route`, programmatic navigation, link wiring, and the `:can-leave` pending-nav protocol. Assumes you already know what client-side routing is — this leaf only covers re-frame2's specific declarations.
+
+## When to load this leaf
+
+- Author or edit route registrations (`reg-route`).
+- Wire programmatic navigation (`:rf.route/navigate`) or anchor clicks (`:rf/url-requested`).
+- Add a leave-guard (`:can-leave`), `:on-match` data loading, or scroll behaviour.
+- Read the active route in a view via `:rf.route/id` / `:rf.route/params`.
+
+Do **not** load this leaf to learn what routing is — that is training knowledge. Load it for: the route-metadata key set, the slice shape, the event vocabulary, and the can-leave pending-nav protocol that distinguishes re-frame2 from hook-based routers like React Router's `useBlocker`.
+
+## Canonical signatures
+
+The routing artefact ships separately in `day8/re-frame2-routing`. `re-frame.core` does **not** require it; the consuming app must `:require [re-frame.routing]` at boot, or `reg-route` throws `:rf.error/routing-artefact-missing`. Once required, the surface lives on `re-frame.core` (via the late-bind table).
+
+```clojure
+(rf/reg-route id metadata)              ;; metadata keys below
+(rf/route-url route-id path-params)     ;; pure; build URL from id + params
+(rf/route-url route-id path-params query-params)
+(rf/match-url url)                      ;; pure; => {:route-id :params :query :fragment} or nil
+```
+
+Reserved `metadata` keys on `reg-route` (all optional except `:path`): `:doc :path :params :query :query-defaults :query-retain :tags :parent :on-match :on-error :scroll :can-leave`. Application keys may sit alongside in non-`:rf/*` namespaces.
+
+Path-pattern grammar:
+
+```
+/literal      literal segment
+/:name        named param (one segment)
+/*name        splat — greedy across /
+/{ ... }?     optional group; inner /:name is elided in route-url output when absent
+```
+
+## The `:rf/route` slice
+
+The runtime maintains one slice in app-db under `:rf/route`:
+
+```clojure
+{:id         :route/article-detail
+ :params     {:id "intro"}
+ :query      {:tab :comments}
+ :fragment   "section-2"        ;; URL #fragment, or nil
+ :transition :idle              ;; :idle | :loading | :error
+ :error      nil                ;; structured error map when :transition = :error
+ :nav-token  "nav-42"}          ;; per-navigation epoch token
+```
+
+Framework-shipped subs (registered by `re-frame.routing`): `:rf/route` (whole slice), `:rf.route/id`, `:rf.route/params`, `:rf.route/query`, `:rf.route/transition`, `:rf.route/error`.
+
+## Canonical mini-example
+
+Distilled from `examples/reagent/routing/core.cljs`.
+
+```clojure
+(ns app.core
+  (:require [re-frame.core :as rf]
+            [re-frame.routing])              ;; load-time hook + reg-sub registrations
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(rf/reg-route :route/home
+  {:doc "Landing." :path "/"})
+
+(rf/reg-route :route/articles
+  {:doc "Articles list." :path "/articles"})
+
+(rf/reg-route :route/article-detail
+  {:doc "One article."
+   :path "/articles/:id"
+   :params [:map [:id :string]]
+   :on-match [[:article/load]]})            ;; runs after every match; sets :transition :loading
+
+(rf/reg-route :rf.route/not-found              ;; canonical fallback id
+  {:doc "404." :path "/_404"})
+
+;; Anchor that routes through the framework (not a full page reload).
+(reg-view route-link [{:keys [to params]} & children]
+  (let [url (rf/route-url to (or params {}))]
+    [:a {:href url
+         :on-click (fn [e]
+                     (when (and (zero? (.-button e))
+                                (not (.-metaKey e))
+                                (not (.-ctrlKey e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (rf/dispatch [:rf/url-requested {:url url}])))}
+     (into [:span] children)]))
+
+;; Root view dispatches on the route id.
+(reg-view root-view []
+  (case @(rf/subscribe [:rf.route/id])
+    :route/home           [home-page]
+    :route/articles       [articles-page]
+    :route/article-detail [article-detail-page]
+    :rf.route/not-found   [not-found-page]
+    [not-found-page]))
+
+;; Wire popstate + initial load.
+(defn install-router! []
+  (.addEventListener js/window "popstate"
+    (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-url)])))
+  (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
+```
+
+## `:can-leave` — the pending-nav protocol
+
+A route may declare a leave-guard sub. The sub returns `true` when leaving is OK, `false` to block. Convention: the *sub name* describes the positive case, so `false` means "can NOT leave".
+
+```clojure
+(rf/reg-route :editor/article
+  {:path      "/editor/articles/:id"
+   :can-leave [:editor/can-leave?]})         ;; sub-id; (subscribe [sub-id]) => boolean
+
+(rf/reg-sub :editor/can-leave?
+  :<- [:editor/dirty?]
+  (fn [dirty? _] (not dirty?)))              ;; true means "OK to leave"
+```
+
+Flow on `:rf/url-requested`:
+
+1. Runtime evaluates the **current** route's `:can-leave` sub.
+2. **`true`** → proceed; new URL becomes active; `:on-match` runs; nav-token allocates.
+3. **`false`** → block: write `:rf/pending-navigation` `{:id "pn-N" :request {...}}`; emit `:rf.route/navigation-blocked` trace; do NOT push the URL or update the slice.
+4. UI subscribes to `:rf/pending-navigation`, renders a confirm dialog.
+5. User dispatches `[:rf.route/continue pn-id]` (re-issues the original nav, bypassing the guard for this one shot) or `[:rf.route/cancel pn-id]` (clears the slot).
+
+## Common gotchas — re-frame2-specific
+
+- **Routing is a separate artefact.** `re-frame.core` does not transitively require `re-frame.routing`. The consuming app `:require`s it at boot; otherwise `reg-route` throws `:rf.error/routing-artefact-missing`. The reserved `:rf.route/*` and `:rf.nav/*` keyword strings therefore drop out of bundles that don't use routing.
+- **Navigation is an event, not a fn call.** Use `(rf/dispatch [:rf.route/navigate :route/articles])` (programmatic) or `(rf/dispatch [:rf/url-requested {:url ...}])` (anchor clicks). Do NOT call `pushState` directly.
+- **`:on-match` runs every time the route becomes active.** Including first match. It is a vector of event vectors (not fns). On entering a route with `:on-match`, `:rf/route :transition` flips to `:loading`; runtime resets it to `:idle` after the events drain (or `:error` on `:on-error`).
+- **`:on-match` order is locked.** State-update first (slice + nav-token), URL push second, `:on-match` dispatches and `:rf.nav/scroll` third. If the URL update fails, the slice is still consistent.
+- **`:params` and `:query` are separate maps.** Path params come from segments; query params come from `?k=v`. Validated by separate Malli schemas on `reg-route` (`:params` and `:query`). Build a merged map in a derived sub if you want one.
+- **Query coercion is per-key, Malli-driven.** When `:query` is a Malli `[:map [:tab :keyword] [:page :int]]`, string values get coerced (`:int`, `:keyword`, `:boolean`). `:query-defaults` populates absent keys. URL key order is preserved for byte-identical round-trip.
+- **Fragment-only changes do NOT re-fire `:on-match`.** A change limited to `#fragment` updates the slice's `:fragment` field and emits `:route.url/fragment-changed`; `:on-match` is skipped. `:can-leave` DOES run for fragment changes — apps that want to bypass the guard for fragments check the prev/next fragment in the sub.
+- **`:rf.route/not-found` is canonical.** Register it explicitly; unmatched URLs resolve to this id. The runtime falls back to a placeholder and emits `:rf.warning/no-not-found-route` if you don't register one.
+- **Nav-tokens suppress stale results.** Each navigation allocates a fresh `:nav-token` (`"nav-N"`). Async handlers (typically HTTP `:on-success`) capture the token at request time; the runtime suppresses the continuation when the carried token does not match the current slice's. Tests can simulate via `[:rf.test/simulate-http-resolution {:on-success-event [...] :carried-nav-token "nav-3"}]`.
+- **Scroll is declarative.** `:scroll` on the route metadata is one of `:top` (default for forward nav), `:restore` (default for popstate / initial), `:preserve`, or a host-extensible map. Per-call override on `:rf.route/navigate` opts wins. Setting `:scroll false` suppresses the `:rf.nav/scroll` fx entirely.
+- **Multi-frame routing.** The slice, nav-token counter, and saved-scroll map all live in the frame's app-db — each frame has its own routing state. No global router.
+
+## Deeper material
+
+- Full path-pattern grammar, ranking algorithm, query coercion, scroll fx contract → `SKILL-REDIRECT.md` → *EP — Routing (012)*.
+- Worked three-page example (home / list / detail, popstate, headless tests) → `examples/reagent/routing/`.
+- Slice schema (`:rf/route-slice`), pattern schema (`:rf/route-pattern`), rank schema (`:rf/route-rank`) → `SKILL-REDIRECT.md` → *Spec schemas*.
+- Interceptor-based guards (`auth-guard`, redirects), tags-driven policies → *EP — Routing (012)* §Redirects and guards.
+- SSR routing (server frame handles `:rf.route/handle-url-change` on the request URL) → `SKILL-REDIRECT.md` → *EP — SSR (011)*.

--- a/skills/re-frame2/reference/tooling/stories.md
+++ b/skills/re-frame2/reference/tooling/stories.md
@@ -1,0 +1,101 @@
+# Stories — re-frame2 binding
+
+> Authoring `reg-story` / `reg-variant` (and the five other Story `reg-*` macros). Assumes you already know what a component playground / story is — this leaf only covers re-frame2's specific declarations.
+
+## When to load this leaf
+
+- Author or edit a `.cljs` namespace under `<app>/stories/*` that uses `re-frame.story`.
+- Add a variant, decorator, mode, workspace, panel, or tag.
+- Wire a story into the conformance / test harness via the `:play` slot.
+
+Do **not** load this leaf to learn what a story is — that is training knowledge. Load it for: the macro signatures, the `:rf.assert/*` vocabulary, and the no-fn-slots rule that distinguishes re-frame2 stories from Storybook stories.
+
+## Canonical signatures
+
+All seven macros live in `re-frame.story`. All elide to `nil` under `:advanced`.
+
+```clojure
+(story/reg-story     id metadata)   ; parent — inherits down to variants
+(story/reg-variant   id metadata)   ; one cell — pure-data body, no fn slots
+(story/reg-workspace id metadata)   ; layout over N variants (:grid / :variants-grid / :prose / :tabs / :custom)
+(story/reg-decorator id metadata)   ; :hiccup | :frame-setup | :fx-override
+(story/reg-story-panel id metadata) ; right/left/bottom/top pane in the shell
+(story/reg-tag       id metadata)   ; project tag; canonical seven register at load
+(story/reg-mode      id metadata)   ; saved args tuple — each (variant × mode) cell has its own snapshot-identity
+```
+
+Variant `id` grammar: `:story.<dotted.path>/<variant-name>`. Story `id`: `:story.<dotted.path>` (no `/<variant>` suffix). The seven canonical tags — `:dev :docs :test :screenshot :experimental :internal :agent` — register automatically when `re-frame.story` loads; project tags must `reg-tag` before any variant references them, or registration throws `:rf.error/unknown-tag`.
+
+## Canonical mini-example
+
+Distilled from `examples/reagent/counter_with_stories/stories.cljs` — every key shape in one variant per slot.
+
+```clojure
+(ns app.stories.counter
+  (:require [re-frame.story :as story]
+            [app.events]                 ;; ensure event ids exist
+            [app.views]))                ;; ensure view ids exist
+
+(defn register-all! []
+  (story/install-canonical-vocabulary!)   ;; idempotent; registers :rf.assert/* + canonical tags
+
+  (story/reg-story :story.counter
+    {:doc        "The counter."
+     :component  :app.views/counter-card  ;; reg-view id, not a fn
+     :args       {:label "Count"}
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; Inherits :component, :args, :tags from the parent story.
+  (story/reg-variant :story.counter/loaded
+    {:doc    "Seeded with seven."
+     :args   {:label "Total"}            ;; override / extend story args
+     :events [[:counter/initialise 7]]   ;; phase-2 setup; runs before render
+     :play   [[:counter/inc]             ;; phase-4; trace-bus observes these
+              [:rf.assert/path-equals [:count] 8]
+              [:rf.assert/sub-equals  [:count-doubled] 16]
+              [:rf.assert/dispatched? [:counter/inc]]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  (story/reg-decorator :app/log-decorator
+    {:kind :hiccup                       ;; ONLY :hiccup decorators take a closure
+     :wrap (fn [body [_ label]]
+             [:div {:style {:border "1px dashed #888"}} body])})
+
+  (story/reg-mode :Mode.app/dark
+    {:args {:theme :dark}})              ;; deep-merges into variant args at render time
+
+  (story/reg-workspace :Workspace.counter/all
+    {:layout :variants-grid              ;; auto-enumerates :story.counter variants
+     :for    :story.counter
+     :tags   #{:docs}}))
+
+(register-all!)
+```
+
+## Common gotchas — re-frame2-specific
+
+- **No fn slots in variant bodies.** `:events`, `:play`, `:decorators`, `:loaders` carry **event-vectors and ids** — never anonymous functions. The `:rf/variant` schema (in `spec/Spec-Schemas.md`) enforces this; macro-time validation rejects with `:rf.error/variant-shape`. The single legal closure site is a `:hiccup`-kind decorator's `:wrap` slot at the decorator's registration site (not the variant body).
+- **`:events` vs `:play`.** `:events` (phase 2) runs before render; the trace-bus accumulator is NOT yet installed, so `:rf.assert/dispatched?` will not see those events. Put events you want to assert against in `:play` (phase 4). Variant 3 in the counter example demonstrates this — three `[:counter/inc]` dispatches in `:play`, then `[:rf.assert/dispatched? [:counter/inc]]`.
+- **Component is an id, not a fn.** `:component :app.views/counter-card` — the keyword id of a `reg-view`. Story consults the view's registered Malli schema (Spec 010) to auto-derive `:argtypes` for the controls panel; supplying `:argtypes` overrides per-key.
+- **Reference events / views / decorators by id; require their namespaces only to trigger registration.** The stories namespace does not `:refer` view fns — it `:require`s `[app.events] [app.views]` for side-effect loading and uses the keyword ids.
+- **`:rf.assert/*` events record, they do not throw.** The seven canonical assertions append a record to `:assertions` rather than aborting the play sequence. Use `(story/read-assertions variant-id)` and `(story/assertions-passing? result)` from a test runner. See `tools/story/spec/004-Assertions.md`.
+- **`:extends` is resolved at registration time.** A variant inheriting from another merges the parent's body once; cycles raise `:rf.error/extends-cycle` at `reg-variant` time, not at render.
+- **Modes multiply snapshot identity.** Each `(variant × mode)` cell has an independent `snapshot-identity` — visual-regression services iterate cells, not variants. Precedence (lowest to highest): global `configure!` args < mode args < story args < variant args.
+- **Combined form (Form B).** `(reg-story id {:variants {:a {...} :b {...}}})` desugars at macro-expansion time to one `reg-story*` + N `reg-variant*` top-level forms — hot-reload-by-variant still works. The `*`-suffixed runtime helpers are public for programmatic / MCP-driven registration.
+- **Production elision.** Under `:advanced` every `reg-*` and the seven `:rf.assert/*` event-ids drop to `nil` via the `:rf.story/enabled?` goog-define. Do not condition production code on story state.
+
+## Stories as a unit-test substrate
+
+A variant's `:play` slot IS the test. `(story/run-variant :story.counter/loaded)` returns a result map; `(story/read-assertions :story.counter/loaded)` returns the assertion records; `(story/assertions-passing? result)` is the boolean. The play-runner stamps each `:rf.assert/*` entry with its source coord so failures point at the variant body line.
+
+For tests that don't need a render shell, run variants headless from a JVM test (`shadow-cljs run`, deps.edn alias) — the play-runner is platform-agnostic per Spec 011.
+
+## Deeper material
+
+- Authoring grammar in full (every key, every slot) → `SKILL-REDIRECT.md` → *EP — Stories (007)*.
+- Worked example, every macro at least once → `examples/reagent/counter_with_stories/`.
+- The seven `:rf.assert/*` events, semantics + source-stamping → `SKILL-REDIRECT.md` → *EP — Stories (007)* §Assertions.
+- Render shell, panel placement, multi-substrate pane → `SKILL-REDIRECT.md` → *Guide — Stories*.
+- MCP write surface (programmatic registration via `reg-*` helpers) → `SKILL-REDIRECT.md` → *EP — Stories (007)* §MCP Surface.


### PR DESCRIPTION
## Summary

Authors two tooling reference leaves under `skills/re-frame2/reference/tooling/`:

- **`stories.md`** (101 lines): the seven `reg-*` macros from `re-frame.story`, canonical mini-example distilled from `examples/reagent/counter_with_stories/`, the no-fn-slots rule, `:events`-vs-`:play` trace-bus visibility, `:rf.assert/*` record-don't-throw semantics, and Form B desugaring.
- **`routing.md`** (148 lines): `reg-route` + path-pattern grammar, the `:rf/route` slice shape, `:rf.route/navigate` + `:rf/url-requested` + popstate wiring, `:can-leave` pending-nav protocol, nav-token stale suppression, and declarative scroll. Mini-example distilled from `examples/reagent/routing/core.cljs`.

## Design

Per the locked design for this skill (rf2-qumf, Pillar 4): each leaf teaches **only the re-frame2-specific binding**, not what stories or routing are in general. Cut-test applied throughout — every gotcha and signature is specific to re-frame2 (the separate routing artefact + late-bind throw, the variant body data-purity rule enforced by the `:rf/variant` schema, the `:rf.assert/*` vocabulary, etc.).

Deeper material is redirected via `SKILL-REDIRECT.md` — no hardcoded URLs.

Both files target ~150 lines and stay well under the 250-line ceiling.

Closes rf2-4yc1.

## Test plan

- [ ] Stories signatures + identifiers grep-able in `tools/story/spec/001-Authoring.md` and `tools/story/spec/API.md`.
- [ ] Routing signatures + identifiers grep-able in `implementation/routing/src/re_frame/routing.cljc` and `implementation/core/src/re_frame/core.cljc`.
- [ ] Mini-examples lift / distill from `examples/reagent/counter_with_stories/stories.cljs` and `examples/reagent/routing/core.cljs`.
- [ ] Both files within the 250-line ceiling (101 + 148).