### PR TITLE
feat(skills): re-frame2 pattern batch C (async-effect, long-running-work, stale-detection) (rf2-e57j)

### DIFF
--- a/skills/re-frame2/patterns/async-effect.md
+++ b/skills/re-frame2/patterns/async-effect.md
@@ -1,0 +1,128 @@
+# Pattern — Async Effect
+
+The canonical "external work + dispatched reply" shape every async-effecting feature follows in re-frame2.
+
+## When to load this leaf
+
+Load when the task is:
+
+- Authoring an fx that posts work to an *external* system (HTTP, Web Worker, IndexedDB, WebAuthn, WebSocket message-send, a native bridge, an LLM call, geolocation, sensors).
+- Integrating a Promise-, callback-, or message-channel-based API with re-frame2.
+- The user says "fire off X and dispatch the result back" or "register an fx for Y".
+- Composing with Pattern-RemoteData (the request-lifecycle slice on top of this shape) or Pattern-StaleDetection (epoch-suppressed replies).
+
+Do NOT load for:
+
+- A long-lived connection lifecycle (retry, backoff, heartbeat). That's Pattern-WebSocket — the connection is state-machine-shaped; *messages over* an established connection fit this pattern.
+- CPU-bound work on the main thread without an external substrate. That's Pattern-LongRunningWork.
+
+## The shape
+
+Six steps; each instance fills in the concrete external system. The shape is invariant — only the substrate changes.
+
+1. Register an fx with `reg-fx`.
+2. The event handler returns `:fx [[:my-fx args]]`.
+3. The fx-handler posts work to the external system. No `app-db` write.
+4. The external system replies asynchronously on its own channel.
+5. A listener (closure registered inside the fx, or a one-time listener registered at boot) translates the reply into `rf/dispatch` of a named event, carrying the captured `:frame`.
+6. The dispatched event handler updates state from the result.
+
+## re-frame2 features this pattern uses
+
+| Feature | Role here |
+|---|---|
+| `reg-fx` | Registers the outgoing effect handler. |
+| `:fx` vector in handler returns | The event handler declares the work as data. |
+| Frame capture in async closures | The fx reads `:frame` off its first-arg map and threads it into the reply `dispatch` so the result lands in the originating frame, not `:rf/default`. |
+| Plain `reg-event-db` / `reg-event-fx` | The reply handlers — nothing special; the reply is just an event. |
+
+## Canonical declaration
+
+The HTTP instance — the most common substrate. Replace `perform-http-request` with `postMessage` (Web Worker), `indexedDB.open(...).onsuccess` (IDB), or any other reply-channel API; the shape is identical.
+
+```clojure
+(rf/reg-fx :http
+  {:doc       "Issue an HTTP request. On completion, dispatch :on-success or :on-error."
+   :platforms #{:server :client}}
+  (fn fx-http [m {:keys [method url body on-success on-error]}]
+    (let [frame-id (:frame m)]
+      (-> (perform-http-request method url body)
+          (.then  (fn [resp] (when on-success
+                               (rf/dispatch (conj on-success resp)
+                                            {:frame frame-id}))))
+          (.catch (fn [err]  (when on-error
+                               (rf/dispatch (conj on-error err)
+                                            {:frame frame-id}))))))))
+
+(rf/reg-event-fx :articles/load
+  (fn handler-articles-load [{:keys [db]} _]
+    {:db (assoc-in db [:articles :status] :loading)
+     :fx [[:http {:method     :get
+                  :url        "/api/articles"
+                  :on-success [:articles/loaded]
+                  :on-error   [:articles/load-failed]}]]}))
+
+(rf/reg-event-db :articles/loaded
+  (fn [db [_ articles]]
+    (-> db
+        (assoc-in [:articles :status] :loaded)
+        (assoc-in [:articles :data]   articles))))
+
+(rf/reg-event-db :articles/load-failed
+  (fn [db [_ err]]
+    (-> db
+        (assoc-in [:articles :status] :error)
+        (assoc-in [:articles :error]  err))))
+```
+
+The first argument to the fx-handler is the runtime context map; read `:frame` off it. Re-frame2 will not auto-route an async dispatch from an fx — capture explicitly.
+
+## Parameter passing — where the args come from
+
+The fx's args come from one of three sources. Pick by the lifetime of the value; they compose.
+
+| Lifetime | Mechanism |
+|---|---|
+| Per-dispatch / per-user-action | Event payload — caller passes opts in the event vector, handler threads them into the fx's args map. |
+| Derived from parent machine state at spawn time | Spawn-spec `:data` fn — the child receives values pre-populated; no dispatch hop. |
+| Fixed for app lifetime, sourced from host config | Boot reads config into `app-db`; subsequent dispatches thread it via mechanism 1 or 2. |
+
+Do NOT hardcode runtime values in the fx registration's options map — registration is one-shot at app load; the fx args map is per-call. Do NOT read host globals (`js/window.__CONFIG__`, `(api/current-token)`) from inside the fx-handler; thread them in via one of the three mechanisms above so Tool-Pair epoch replay sees them.
+
+## Variations
+
+**Listener registered at boot.** When the reply channel is a single broadcast surface (a Web Worker's `onmessage`, a Service Worker `MessageChannel`, a native bridge), register the listener once at boot — it dispatches a correlation-keyed event; the fx-handler just posts and includes a correlation id in the payload.
+
+```clojure
+(defn install-worker-listener! [worker]
+  (set! (.-onmessage worker)
+        (fn [msg-event]
+          (let [{:keys [reply-event payload]} (js->clj (.-data msg-event) :keywordize-keys true)]
+            (rf/dispatch (conj reply-event payload))))))
+
+(rf/reg-fx :worker/post
+  (fn fx-worker-post [_ {:keys [op args reply-event]}]
+    (.postMessage @worker-instance #js {:op op :args args :reply-event reply-event})))
+```
+
+**Streaming / multi-reply.** LLM-style or SSE-style where each chunk is a separate dispatch. Each emission is a normal dispatched event; the receiving handler appends to a buffer slice. The fx posts once; the reply channel fires N events. Pattern-RemoteData's `:streaming` lifecycle layers on top.
+
+**Fire-and-forget.** Logging, analytics, beacon writes — the caller may omit `:on-success` / `:on-error`. The fx-handler should treat both as nilable (see the `when on-success` / `when on-error` guards above).
+
+**Composes with Pattern-StaleDetection.** When the dispatcher may have moved on by reply time, the caller captures an epoch at dispatch and threads it into `:on-success` / `:on-error`. The receiving handler compares carried vs current; suppress on mismatch. See `patterns/stale-detection.md`.
+
+## Anti-patterns
+
+- **Mutating `app-db` from inside the fx-handler.** The fx posts work and registers a listener; it does not write state. State writes live in the dispatched reply handler.
+- **Implicit dispatching from inside the fx.** Always require the caller to pass `:on-success` / `:on-error` explicitly — that's the only place a reader can find where the reply lands.
+- **Closures as event payload.** Reply events must serialise (for SSR hydration, Tool-Pair epoch replay, trace events). Pass ids and data; the handler closes over its own context.
+- **Forgetting to capture `:frame`.** An async dispatch fired without `{:frame frame-id}` lands in the default frame. Tests that target a non-default frame will silently see no state change. Always read `:frame` off the first-arg map and pass it through.
+- **Treating WebSockets as Async Effect.** Long-lived connections with retry / backoff / subscription state are state-machine-shaped; use Pattern-WebSocket. Individual *messages* over an established connection fit this pattern.
+
+## Worked example
+
+No standalone example app — the HTTP instance appears in `examples/reagent/login/` (the `:http` fx + reply-driven state machine) and `examples/reagent/managed_http_counter/` (the `:rf.http/managed` fx, the substrate's batteries-included version of this pattern). For the full async-fx + lifecycle slice, see Pattern-RemoteData and Pattern-ManagedHTTP.
+
+## Pointer to the spec
+
+Full rationale, the architectural properties that make the shape work, and the complete list of concrete instances (HTTP, workers, sockets, IDB, crypto, native bridges, LLMs, sensors) live in *Pattern — Async effect* (see `SKILL-REDIRECT.md` at the repo root).

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -1,0 +1,185 @@
+# Pattern — Long-Running Work
+
+Cancellable spawn-and-join coordination via `:invoke-all` — one parent coordinates N parallel children that yield to the browser between chunks.
+
+## When to load this leaf
+
+Load when the task is:
+
+- Processing a CPU-bound workload that can be split into independent shards (slice of dataset, region of image, batch of records).
+- The user mentions "process in chunks", "parallel workers", "progress bar that updates while it runs", or "must be cancellable".
+- Wiring cancellation to a React unmount or a route change so an in-flight job stops cleanly.
+
+Do NOT load for:
+
+- I/O-bound work — HTTP, IndexedDB, file system. Those already yield; use Pattern-AsyncEffect.
+- A single chunked computation with no parallelism — the chunked-state-machine variant (one machine, `:processing` → `:yielding` → `:processing`) covers it; see *Variation: single-machine chunked* below.
+- Heavy CPU work that can be offloaded — prefer a Web Worker via Pattern-AsyncEffect. The pattern below is the *fallback* for work that must stay on the main thread or decomposes into parallel shards.
+
+## The shape
+
+One parent coordinator machine spawns N children declaratively via `:invoke-all`. Each child processes its own shard in chunks, yielding via `:after` between chunks. Children dispatch `:progress` back to the parent. When all N report done, the runtime fires the parent's `:on-all-complete` keyword. Cancellation is a transition out of the `:working` state — the standard exit cascade tears down every surviving child.
+
+## re-frame2 features this pattern uses
+
+| Feature | Role here |
+|---|---|
+| `reg-machine` | Both the parent coordinator and the child processor. |
+| `:invoke-all` | The parent's spawn-and-join declaration on the `:working` state. The runtime owns the join-state map at `[:rf/spawned <parent-id> [<state>]]`. |
+| `:after` | The child's browser-yield seam between chunks. The runtime clock-driven timer is torn down automatically when the child is destroyed. |
+| `:always` | The child's `:processing → :checking-done` advance; first-match-wins guards branch to `:done` or `:yielding`. |
+| Cancellation cascade | Exiting `:working` (by user `:cancel`, by `:on-all-complete`, by frame destroy) fires one `:rf.machine/destroy` fx whose handler tears down every surviving child. |
+| Internal self-transitions | `:progress` is handled with no `:target` — the action runs but `:exit` / `:entry` don't fire, so the join cascade isn't disturbed. |
+
+## Canonical declaration
+
+The parent + child pair. The parent spawns one child per shard; each child processes its shard in chunks; the parent records progress; the runtime resolves the join.
+
+```clojure
+;; THE CHILD
+(rf/reg-machine :work/processor
+  {:initial :idle
+   :data    {:shard nil :total 0 :processed 0 :tick-ms 50}
+
+   :guards  {:done?      (fn [data _] (>= (:processed data) (:total data)))
+             :more-work? (fn [data _] (<  (:processed data) (:total data)))}
+
+   :actions
+   {:process-one
+    (fn [data _]
+      (let [shard         (:shard data)
+            new-processed (inc (:processed data))]
+        {:data (assoc data :processed new-processed)
+         :fx   [[:dispatch [:work/flow [:progress shard new-processed (:total data)]]]]}))
+
+    :dispatch-done
+    (fn [data _]
+      {:fx [[:dispatch [:work/flow [:work/child-done (:shard data)]]]]})}
+
+   :states
+   {:idle           {:on    {:rf.machine/spawned :processing}}
+    :processing     {:entry  :process-one
+                     :always [{:target :checking-done}]}
+    :checking-done  {:always [{:guard :done?      :target :done}
+                              {:guard :more-work? :target :yielding}]}
+    :yielding       {:after  {(fn [snap] (-> snap :data :tick-ms)) :processing}}
+    :done           {:meta {:terminal? true} :entry :dispatch-done}}})
+
+;; THE PARENT COORDINATOR
+(rf/reg-machine :work/flow
+  {:initial :idle
+   :data    {:shards [:s1 :s2 :s3] :total 100 :progress {} :outcome nil}
+
+   :actions
+   {:reset-progress  (fn [data _] {:data (assoc data :progress (zipmap (:shards data) (repeat 0)))})
+    :record-progress (fn [data [_ shard processed _total]]
+                       {:data (assoc-in data [:progress shard] processed)})
+    :stamp-outcome   (fn [data [ev]] {:data (assoc data :outcome (case ev
+                                                                   :work/all-done :complete
+                                                                   :cancel        :cancelled
+                                                                   :work/any-failed :error
+                                                                   (:outcome data)))})}
+
+   :states
+   {:idle
+    {:on {:start {:target :working :action :reset-progress}}}
+
+    :working
+    {:invoke-all
+     {:children [{:id :s1 :machine-id :work/processor
+                  :data {:shard :s1 :total 100 :processed 0 :tick-ms 50}}
+                 {:id :s2 :machine-id :work/processor
+                  :data {:shard :s2 :total 100 :processed 0 :tick-ms 50}}
+                 {:id :s3 :machine-id :work/processor
+                  :data {:shard :s3 :total 100 :processed 0 :tick-ms 50}}]
+      :join             :all
+      :on-child-done    :work/child-done
+      :on-child-error   :work/child-error
+      :on-all-complete  [:work/all-done]
+      :on-any-failed    [:work/any-failed]}
+     :on {:progress        {:action :record-progress}            ;; internal self-transition
+          :work/all-done   {:target :complete  :action :stamp-outcome}
+          :work/any-failed {:target :error     :action :stamp-outcome}
+          :cancel          {:target :cancelled :action :stamp-outcome}}}
+
+    :complete   {:on {:reset {:target :idle :action :reset-progress}}}
+    :cancelled  {:on {:reset {:target :idle :action :reset-progress}
+                      :start {:target :working :action :reset-progress}}}
+    :error      {:on {:reset {:target :idle :action :reset-progress}}}}})
+```
+
+The child's `:on {:rf.machine/spawned :processing}` is the auto-kick: when no explicit `:start` action is supplied in the invoke-spec, the runtime synthesises `[:rf.machine/spawned]` on spawn, and the child transitions itself into the work loop.
+
+The parent's `:progress` entry under `:on` omits `:target` — that is an internal self-transition. The action runs but the `:invoke-all` exit cascade does *not* fire, so children stay alive between progress reports.
+
+## Cancellation contract
+
+Cancellation is a state transition; the substrate does the rest. Three exit paths into `:cancelled` / `:complete` / `:error` all trigger the same cascade:
+
+```clojure
+;; User clicks Cancel:
+(rf/dispatch [:work/flow [:cancel]])
+
+;; React unmount via reagent's r/with-let cleanup:
+(r/with-let [_ nil]
+  [work-bench-ui]
+  (finally
+    (rf/dispatch [:work/flow [:cancel]])))
+```
+
+When the parent transitions out of `:working`, the desugared `:invoke-all` `:exit` fires one `:rf.machine/destroy` fx carrying `:rf/invoke-all true`; the destroy fx handler reads `[:rf/spawned :work/flow [:working] :children]` and tears down every surviving child. Each torn-down child's pending `:after` timer is cancelled automatically — the worker does NOT resume after the delay elapses.
+
+The worker machines themselves are lifecycle-agnostic — they do not know React exists. The one seam where UI lifecycle touches the machine is the single `:cancel` dispatch in the unmount cleanup.
+
+## Variations
+
+**Single-machine chunked (no parallelism).** When the workload is one stream rather than N shards, drop `:invoke-all` and run `:processing` / `:checking-done` / `:yielding` on the parent itself:
+
+```clojure
+:states
+{:idle           {:on {:start {:target :processing :action :init-job}}}
+ :processing     {:entry  :process-chunk
+                  :always [{:target :checking-done}]}
+ :checking-done  {:always [{:guard :done?      :target :complete}
+                           {:guard :more-work? :target :yielding}]}
+ :yielding       {:after {0 :processing}
+                  :on    {:cancel :cancelled}}
+ :complete       {:on {:reset :idle}}
+ :cancelled      {:on {:reset :idle}}}
+```
+
+`:after {0 :processing}` schedules the next chunk after one browser tick — enough for repaint, not enough for perceptible delay. `:cancel` only needs to be declared on `:yielding`; the user cannot click cancel while the JS thread is in `:processing` anyway.
+
+**Worker offload.** Genuinely heavy work (image processing, search indexing, simulations) belongs in a Web Worker via Pattern-AsyncEffect. The worker dispatches progress events back; cancellation is still epoch-based (Pattern-StaleDetection). The chunked-main-thread pattern is for cases where worker offload isn't feasible — DOM access required, awkward-to-serialise data, framework state that can't cross the boundary cheaply.
+
+**One-shot heavy block (replaces v1's `^:flush-dom`).** When you want a modal to render *before* a one-shot heavy computation, `:dispatch-later {:ms 0 :dispatch ...}` gives the browser a render tick between the modal-show event and the work event. No state machine needed.
+
+```clojure
+(rf/reg-event-fx :process/start
+  (fn [{:keys [db]} _]
+    {:db (assoc db :processing? true)
+     :fx [[:dispatch-later {:ms 0 :dispatch [:process/run]}]]}))
+
+(rf/reg-event-fx :process/run
+  (fn [{:keys [db]} _]
+    {:db (assoc db :processing? false :result (heavy-block-fn db))}))
+```
+
+**Progress UI from the machine.** Register subs on `[:rf/machine <id>]` and project `:data` fields into the view. Each chunk advances `:data.processed` and the next browser tick renders the new value.
+
+## Anti-patterns
+
+- **Computing in subscriptions.** Subs should be cheap and pure; long compute belongs in event handlers. A sub that takes seconds slows every render that touches it.
+- **Multiple `assoc`s in one handler expecting interleaved renders.** Re-frame2 batches per drain — only one render per drain regardless of how many `:db` updates within. Splitting into chunks via the state-machine pattern is the only way to get intermediate renders.
+- **Manual chunk-state in `app-db` with `setTimeout`.** A state machine fits the chunked-progression structure cleanly: explicit states, named transitions, encapsulated `:data`, automatic timer teardown on cancel. Ad-hoc `setTimeout` loops re-derive everything `:after` already provides.
+- **Forgetting cancellation.** Long jobs need a cancel path. The exit cascade makes it trivial; not declaring `:cancel` on `:working` leaves the user with a runaway loop.
+- **`:always` cycles without `:after 0` between batches.** A pure `:always` chain hits the `:rf.error/machine-always-depth-exceeded` cap (default 16). The `:yielding` state's `:after` resets the depth and yields to the browser.
+- **Per-child bookkeeping in the parent's `:data`.** The `:invoke-all` runtime owns the join-state at `[:rf/spawned <parent-id> [<state>]]`. Re-implementing `:children` / `:done` / `:resolved?` in the parent's own `:data` re-derives what's already there.
+
+## Worked example
+
+`examples/reagent/long_running_work/` — three parallel `:work/processor` children coordinated by `:work/flow`. The Show / Hide button mounts and unmounts a wrapper component whose `r/with-let` cleanup dispatches `[:work/flow [:cancel]]`; this is the canonical wire-up of React unmount to the cancellation cascade. The example carries a Playwright smoke and a headless `cljs-test`.
+
+## Pointer to the spec
+
+Full rationale — including the `:invoke-all` runtime contract, the join-state map layout, alternative `:join` modes (`:any`, `:n-of`), and the migration table from v1's self-redispatch / `:abandonment-required` flag / `^:flush-dom` — lives in *Pattern — Long-running work* and Spec 005 *State machines* (see `SKILL-REDIRECT.md` at the repo root).

--- a/skills/re-frame2/patterns/stale-detection.md
+++ b/skills/re-frame2/patterns/stale-detection.md
@@ -1,0 +1,128 @@
+# Pattern — Stale Detection
+
+The cross-cutting epoch idiom re-frame2 uses to silently ignore async results from a superseded state. Capture an epoch, carry it through, check on receipt, suppress on mismatch.
+
+## When to load this leaf
+
+Load when the task is:
+
+- An async dispatch from a state container that may have moved on by reply time (a `:after` timer firing after the user left and re-entered the state; an HTTP load completing after the user navigated to a different route; a debounced lookup completing after the user typed another keystroke).
+- The user says "ignore stale results", "don't apply old data", "what if the user navigates away mid-request", or "I keep seeing the previous load's data flicker in".
+- Composing with Pattern-AsyncEffect, Pattern-LongRunningWork, Pattern-WebSocket, or any state machine that uses `:after`.
+
+Do NOT load for:
+
+- A reply whose event id is unique to its request (`:auth/succeeded`, `:cart/loaded`). Re-frame's standard "unhandled event" fallback already drops it cleanly when the receiving state has moved past handling it. The epoch is needed only when the *same event id* may be dispatched against *different state instances* of the same container.
+- Cancellation as an optimisation (saving bandwidth or CPU). That's an `AbortController` concern, not stale-detection. The epoch handles correctness regardless.
+
+## The shape
+
+Five steps, owned by the state container that initiates the async work.
+
+1. The container holds an epoch (a counter or a unique token) on its own slice of `app-db`.
+2. The epoch advances on every life event of the container — state transition, route change, connection reset, the start of a new async cycle.
+3. The async dispatch captures the *current* epoch and threads it through the reply event payload (or via cofx).
+4. On receipt, the handler compares carried-epoch to current-epoch.
+5. **Match → commit.** State has not been superseded; apply normally. **Mismatch → suppress.** Emit a structured `:<feature>/stale-<reason>` trace event for visibility, leave state unchanged.
+
+## re-frame2 features this pattern uses
+
+| Feature | Role here |
+|---|---|
+| Dispatched-event reply channel | The seam where the epoch is carried. The async result re-enters the runtime as a named event whose payload includes the captured epoch. |
+| Atomic snapshot commits | `app-db` transitions atomically per drained event. The carried epoch and current epoch are both unambiguous values; comparison is deterministic. |
+| Identifiable state containers | `[:rf/machines <id>]`, `[:route]`, frame ids, spawned actor ids — every container in re-frame2 is named, so the epoch lives on the container, not in a global registry. |
+| State-machine `:after` (substrate-owned epoch) | The runtime already advances a per-state epoch on entry / re-entry and the after-fired event handler suppresses on mismatch automatically. Application code only sees `:rf.machine.timer/stale-after` trace events. |
+| Routing nav-tokens (substrate-owned epoch) | The router advances a nav-token on each route change; route-scoped async loads carry it; the receiving handler suppresses on mismatch. |
+
+For substrate-owned epochs (`:after` timers, nav-tokens), the application gets the pattern for free; no manual epoch threading needed. The application-level shape below is for *user-owned* epochs — fields the application advances itself.
+
+## Canonical declaration — application-owned epoch
+
+A search-as-you-type input where each keystroke spawns a lookup; only the latest lookup's result should commit.
+
+```clojure
+(rf/reg-event-fx :search/key-typed
+  (fn handler-search-key-typed [{:keys [db]} [_ query]]
+    (let [next-epoch (inc (get-in db [:search :epoch] 0))]
+      {:db (-> db
+               (assoc-in [:search :query] query)
+               (assoc-in [:search :epoch] next-epoch)
+               (assoc-in [:search :status] :loading))
+       :fx [[:http {:method     :get
+                    :url        (str "/api/search?q=" query)
+                    :on-success [:search/results-received next-epoch]
+                    :on-error   [:search/load-failed       next-epoch]}]]})))
+
+(rf/reg-event-fx :search/results-received
+  (fn handler-search-results-received [{:keys [db]} [_ carried-epoch results]]
+    (let [current-epoch (get-in db [:search :epoch] 0)]
+      (if (= carried-epoch current-epoch)
+        {:db (-> db
+                 (assoc-in [:search :status] :loaded)
+                 (assoc-in [:search :results] results))}
+        ;; Mismatch — supersede. Drop the result; emit a trace event.
+        {:fx [[:rf/trace-event {:operation :search/stale-result
+                                :tags      {:carried carried-epoch
+                                            :current current-epoch}}]]}))))
+```
+
+Three load-bearing points:
+
+- The `:key-typed` handler **advances** the epoch (writes `next-epoch` into `app-db`) and **captures** it into the reply event in the same drain. The reply will be compared against whatever the epoch is *at receive time*, which may be a later value if more keystrokes have arrived.
+- The reply handler reads the *current* epoch fresh from `db`, not from any closure capture. The carried epoch is a literal in the event vector; the current epoch lives where the container does.
+- On mismatch the handler emits a `:<feature>/stale-<reason>` trace event so tools (re-frame-pair2's epoch buffer, the trace timeline) see the family at a glance. The shape `:search/stale-result` follows the family-naming convention; the specific event name is owned by the feature.
+
+## Trace-event naming
+
+Every stale-detection trace event uses the family shape:
+
+```
+:<feature>/stale-<reason>
+```
+
+| Trace event | Feature | Reason |
+|---|---|---|
+| `:rf.machine.timer/stale-after` | State-machine `:after` timer | Epoch mismatch on timer expiry (state was exited then re-entered) |
+| `:route.nav-token/stale-suppressed` | Routing async result | Carried nav-token does not match current route's nav-token |
+| `:search/stale-result` (your feature) | Per-feature | Application-owned epoch mismatch on reply |
+
+Tools subscribe to `:.*/stale-.*` to surface "a thing should have happened but didn't because state moved on" symptoms across substrates.
+
+## Variations
+
+**Substrate-owned epoch — `:after` timers.** No application work required. The state machine substrate advances `[:rf/machines <id> :epoch]` on every entry / re-entry of the `:after`-bearing state and the substrate-emitted handler suppresses on mismatch. Application-level code sees only the trace event `:rf.machine.timer/stale-after`.
+
+**Substrate-owned epoch — routing.** Same story for route-scoped async loads. The router threads a `nav-token` through the load event payload; the receiver compares against `[:route :nav-token]`. Application code follows the same shape as the search example above but uses the router-supplied token rather than a hand-rolled counter.
+
+**Cofx-injected epoch.** When the dispatching site doesn't know which epoch to carry — e.g., generic logging middleware or a cross-cutting effect — register a cofx that reads the current epoch from the relevant container and injects it. The reply handler reads the carried value off the event payload as before. The dispatcher doesn't need to know about epochs at all.
+
+**Cancellation as optimisation.** Hosts that *do* support cancellation (`AbortController`, ScheduledFuture cancel) MAY layer it on top — abort to save bandwidth/CPU. But correctness does not depend on it. The work *does* complete; the result *does* arrive; the runtime *does* process the dispatch. The result just gets silently discarded at the commit-validation stage. That's correct behaviour with no cancellation infrastructure required.
+
+## Ownership
+
+The state container that **initiates** the async work owns the counter. There is no global epoch; there is no framework-level registry of epochs.
+
+- A state-machine instance owns the epoch for its `:after` timers (substrate-owned).
+- The current route owns the epoch for in-flight loads scoped to that route (substrate-owned).
+- A search input owns the epoch for its in-flight lookups (application-owned — example above).
+- A websocket connection owns its connection-epoch for messages received over it (Pattern-WebSocket).
+
+The owner is also responsible for *advancing* — typically in the same handler that performs the life event. Advance first, then capture; the reply will be compared against whatever value lives in the container at receive time.
+
+## Anti-patterns
+
+- **Comparing epochs across containers.** The counter is well-defined within a single container; comparing a `:search/:epoch` against a `:route/:nav-token` is meaningless. Each container owns its own.
+- **Capturing the epoch in a closure rather than the event payload.** Events must serialise (for SSR hydration, Tool-Pair epoch replay, trace events). Put the carried epoch in the event vector.
+- **Implementing a global cancellation registry.** The reason re-frame2 does NOT introduce a `:cancel-dispatch-later` primitive is that every async-shaped feature would grow its own cancellation surface. The epoch is portable across timers, HTTP, sockets, workers, and timers — no per-feature plumbing.
+- **Not advancing the epoch on every life event.** If only some transitions bump it, a "later" reply may still match an "older" container instance because the counter didn't move. Advance on every event that ought to supersede in-flight work.
+- **Skipping the trace event on mismatch.** Suppression must be observable, or "should have happened but didn't" becomes silent. Emit `:<feature>/stale-<reason>` whenever you drop.
+- **Re-deriving the substrate's epoch.** If `:after` already handles staleness, do not also carry an app-level epoch for the same timer. The substrate already advances per entry / re-entry.
+
+## Worked example
+
+No standalone example app — every state machine using `:after` is an inline example (the substrate-owned variant), and the routing example in `examples/reagent/routing/` exercises the nav-token variant. The substrate's behaviour is verified by the conformance suite under `spec/conformance/fixtures/` (look for the `stale-after` and `nav-token` fixtures).
+
+## Pointer to the spec
+
+Full rationale — including the architectural properties that make the pattern work, the trace-event family-naming rule, the ownership table for every container type, and the worked example of applying the pattern to a hypothetical `:debounced-input` substrate — lives in *Pattern — Stale detection* (see `SKILL-REDIRECT.md` at the repo root). The first instance of the pattern (substrate-owned `:after` epoch) is in Spec 005 §Epoch-based stale detection; the second (routing nav-tokens) is in Spec 012 §Navigation tokens.


### PR DESCRIPTION
## Summary

Adds three pattern leaves to the re-frame2 authoring skill under `skills/re-frame2/patterns/`:

- `async-effect.md` — canonical "register fx, post work, dispatch reply" shape with HTTP as the worked instance. Variations for boot-time listeners, streaming/multi-reply, and fire-and-forget. Parameter-passing mechanisms (event payload, spawn-spec `:data` fn, boot-time host config).
- `long-running-work.md` — cancellable spawn-and-join via `:invoke-all`. Parent coordinator + child processor declarations; cancellation cascade through the desugared `:exit` and `:rf.machine/destroy` fx; single-machine chunked variation for non-parallel workloads; worker-offload pointer. References `examples/reagent/long_running_work/`.
- `stale-detection.md` — capture-carry-check-suppress epoch idiom. Application-owned epoch example (search-as-you-type); substrate-owned variants (`:after` timers, routing nav-tokens) where re-frame2 gives the pattern for free; trace-event family-naming rule (`:<feature>/stale-<reason>`).

Each leaf follows the established pattern-leaf shape: when-to-load triggers → re-frame2 features used → canonical declaration verified against `implementation/**` and `examples/reagent/**` → variations → anti-patterns → worked example → pointer to spec via `SKILL-REDIRECT.md`.

Sizes: 128, 185, 128 lines (all under the 250-line cap; target ~150).

Pillar 4 honoured throughout — these leaves teach the re-frame2-specific binding (which feature implements which idea, the gotcha unique to this framework) and assume the reader already knows what async effects, cancellation cascades, and stale-data detection are in the abstract.

## Test plan

- [ ] `skills/re-frame2/patterns/async-effect.md`, `long-running-work.md`, `stale-detection.md` each render correctly in the docs renderer (no broken intra-skill links).
- [ ] Pattern names referenced in `skills/re-frame2/SKILL.md` (rows of the "Patterns" loading-map table) resolve to these files.
- [ ] Sibling pattern leaf agents (rf2-p6ut, rf2-60kv) touch different files — no merge conflict.

Resolves bead rf2-e57j.