### PR TITLE
feat(skills): re-frame2 pattern batch B (websocket, boot, managed-http) (rf2-60kv)

### DIFF
--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -1,0 +1,166 @@
+# Pattern — Boot
+
+Application boot as a chained-async sequence — the canonical state-machine shape for "read config → authenticate → load profile → hydrate → resolve route → ready".
+
+> **Status of the worked example:** `examples/reagent/boot/` is in flight via rf2-dsm2. Until it lands, the canonical declaration below is the source of truth; this leaf will be upgraded to link the example after merge.
+
+## When to use this pattern
+
+Reach for it whenever the app needs more than a one-step bootstrap — sequential dependencies between phases, per-phase failure semantics, visible "Loading profile…" progress, per-phase retry, or an SSR handoff. The boot graph is invisible if scattered across N unrelated event handlers; a state machine names the sequence.
+
+For trivial boots (≤3 steps, no error states, no progress UI), use the simple chained-events form instead — see *§Simple form* below. The canonical state-machine form is for everything past that threshold.
+
+## The re-frame2 features this pattern uses
+
+| Feature | Role here |
+|---|---|
+| `reg-frame` `:on-create` | Atomic entry point — fires `[:app/boot [:rf/start]]` exactly once per frame creation; survives hot-reload (boot does not re-run on namespace re-eval). |
+| `:invoke` per phase | Each phase spawns the phase's async work (e.g. `:http/get` or a domain-specific child machine like `:auth/restore-session`) and transitions on `:succeeded` / `:failed`. |
+| Consolidated `:entry` action | Per Spec 005 §State nodes, `:entry` takes one fn or one registered id — never a vector. Where a phase needs to update `:data` AND dispatch a follow-on, write one action that returns `{:data ..., :fx ...}`. |
+| `:after` (numeric delay) | Retry-with-backoff between failed phase and re-attempt: `:retrying-auth {:after {2000 {:target :authenticating}}}`. |
+| Machine snapshot in `app-db` | The boot machine's `:state` and `:data :phase` are read by the boot UI via subs — one writer, one signal, no parallel progress channel. |
+| `:rf/server-init` + `:rf/hydrate` (SSR) | Server completes the server-meaningful phases; the client's machine reads its initial state from the hydrated snapshot and resumes from there. |
+
+## Canonical declaration (state-machine form)
+
+```clojure
+(rf/reg-event-fx :app/boot
+  (rf/create-machine-handler
+    {:initial :configuring
+     :data    {:phase :configuring :config nil :user nil
+               :error nil :phase-attempt 0}
+
+     :guards
+     {:under-retry-limit? (fn [data _] (< (:phase-attempt data) 3))}
+
+     :actions
+     {:record-config (fn [data [_ config]] {:data (assoc data :config config)})
+      :record-user   (fn [data [_ user]]   {:data (assoc data :user user)})
+      :record-error  (fn [data [_ err]]    {:data (assoc data :error err)})
+      :bump-attempt  (fn [data _]          {:data (update data :phase-attempt inc)})
+
+      ;; CONSOLIDATED :entry — :set-phase + :resolve-initial-route in one fn.
+      ;; :entry slots accept a single fn or registered id, never a vector;
+      ;; compose by writing one action that returns both :data and :fx.
+      :enter-routing
+      (fn [data _]
+        {:data (assoc data :phase :routing :phase-attempt 0)
+         :fx   [[:dispatch [:rf.route/handle-url-change
+                            (.. js/window -location -href)]]]})
+
+      ;; A simpler shape — entry that only updates :data.
+      :phase-configuring (fn [d _] {:data (assoc d :phase :configuring :phase-attempt 0)})
+      :phase-auth        (fn [d _] {:data (assoc d :phase :authenticating)})
+      :phase-profile     (fn [d _] {:data (assoc d :phase :loading-profile)})
+      :phase-hydrate     (fn [d _] {:data (assoc d :phase :hydrating)})}
+
+     :states
+     {;; Each phase :invokes its async work; success / failure transition the
+      ;; machine. The :data fn reads from the boot machine's :data (Pattern-
+      ;; AsyncEffect mechanism 2) — no globals, no app-db reach.
+      :configuring
+      {:entry  :phase-configuring
+       :invoke {:machine-id :rf.http/managed
+                :data       {:request {:method :get :url "/config"} :decode :json}}
+       :on     {:succeeded {:target :authenticating :action :record-config}
+                :failed    {:target :fatal-error    :action :record-error}}}
+
+      :authenticating
+      {:entry  :phase-auth
+       :invoke {:machine-id :auth/restore-session
+                ;; spawn-spec :data fn — thread the auth URL out of :data :config
+                :data       (fn [{:keys [data]} _]
+                              {:auth-url (-> data :config :auth-url)})}
+       :on     {:succeeded {:target :loading-profile}
+                :failed    [{:guard  :under-retry-limit?
+                             :target :retrying-auth
+                             :action :bump-attempt}
+                            {:target :auth-failed :action :record-error}]}}
+
+      :retrying-auth {:after {2000 {:target :authenticating}}}
+
+      :loading-profile
+      {:entry  :phase-profile
+       :invoke {:machine-id :rf.http/managed
+                ;; URL read from loaded config, not hardcoded.
+                :data       (fn [{:keys [data]} _]
+                              {:request {:method :get :url (-> data :config :profile-url)}
+                               :decode  :json})}
+       :on     {:succeeded {:target :hydrating :action :record-user}
+                :failed    {:target :profile-failed :action :record-error}}}
+
+      :hydrating
+      {:entry :phase-hydrate
+       :on    {:hydrate/done {:target :routing}}}
+
+      :routing
+      {:entry :enter-routing
+       :on    {:rf.route/resolved {:target :ready}}}
+
+      :ready          {:meta {:terminal? true}}
+      :auth-failed    {:meta {:terminal? true}}
+      :profile-failed {:meta {:terminal? true}}
+      :fatal-error    {:meta {:terminal? true}}}}))
+```
+
+The frame's `:on-create` dispatches `[:app/boot [:rf/start]]`; the machine self-initialises and runs.
+
+## Simple form — chained events
+
+For ≤3 phases, no error states, no progress UI:
+
+```clojure
+(rf/reg-event-fx :app/init      (fn [_ _]         {:fx [[:dispatch [:config/load]]]}))
+(rf/reg-event-fx :config/load   (fn [_ _]         {:fx [[:rf.http/managed
+                                                          {:request {:url "/config"} :decode :json
+                                                           :on-success [:config/loaded]
+                                                           :on-failure [:app/init-failed]}]]}))
+(rf/reg-event-fx :config/loaded (fn [{:keys [db]} [_ config]]
+                                  {:db (assoc db :config config)
+                                   :fx [[:dispatch [:app/ready]]]}))
+(rf/reg-event-db :app/ready     (fn [db _] (assoc db :app/booted? true)))
+```
+
+Each link is a Pattern-AsyncEffect interaction. Past three links, scatter wins; switch to the state-machine form.
+
+## Variations
+
+**The retry-ownership boundary.** Mixed transport-vs-semantic retry — e.g. an auth machine that handles 401-then-refresh-then-retry — sits at the boundary between `:rf.http/managed` `:retry` (transport: backoff + attempt count) and machine-level transitions (semantic: refresh-then-loop-back-to `:loading-me`). Both compose: the machine's `:invoke` spawns a managed request whose `:retry` slot handles 5xx; the failure event the machine sees has already been through the transport loop. See `patterns/managed-http.md` for the boundary details and worked example.
+
+**Boot UI — single signal.** A view subscribes to `[:app.boot/state]` and `[:app.boot/phase]` and renders against the snapshot:
+
+```clojure
+(rf/reg-sub :app.boot/phase (fn [db _] (get-in db [:rf/machines :app/boot :data :phase])))
+(rf/reg-sub :app.boot/state (fn [db _] (get-in db [:rf/machines :app/boot :state])))
+```
+
+No parallel `:loading?` flag; the machine's state IS the UI signal.
+
+**SSR handoff.** Server-side `:rf/server-init` runs the server-meaningful phases (config, session-from-request, route resolve, server-side fetches). Client-only phases (`:hydrating` from `localStorage`, `:ws/connect`) are skipped via `:platforms #{:client}` on the relevant fxs. The server's last act is to write `[:rf/machines :app/boot :state] = :hydrating` (or `:routing`) into hydrated `app-db`; the client's machine restores into that state per Spec 005 restore semantics and resumes from there. No double-fetch of `/config`.
+
+**Re-boot.** Rare but supported — dispatch an event the machine handles from any state (or via a wildcard parent `:on`): `:auth.session/expired {:target :authenticating}`. Most apps re-load the page on session expiry instead.
+
+**Parameters — the canonical seam.** The boot machine is the ONLY place that reads host globals (`/config` endpoint, build-time env vars, restored session). Once captured into `:data :config`, subsequent phases thread values forward via Pattern-AsyncEffect mechanism 1 (event payload) or mechanism 2 (spawn-spec `:data` fn). Downstream machines never reach into a global from inside an action body.
+
+## Anti-patterns
+
+- **Boot logic in a view's `:on-mount`.** Ties boot to the view tree; not headless-testable; runs at the wrong time relative to hydration.
+- **Boot via top-level `(do ...)` side effects at namespace load.** No tracing, no error handling, no progress UI, and hot-reload re-runs it.
+- **One giant `:app/init` event handler doing five things.** That's the chained-events form scaled past usefulness; the sequence is invisible. Use the machine.
+- **`:entry [:set-phase :resolve-route]`.** `:entry` is singular — one fn or one registered id, never a vector. Consolidate into one action that returns the full `{:data ..., :fx ...}` effects map.
+- **Always starting in `:configuring` under SSR.** Re-fetches config the server already loaded. Make the machine's initial state read from the hydrated snapshot.
+- **Mixing boot logic with running-app logic.** Boot states should be terminal-distinct (`:ready` is the handoff). Don't reuse `:loading-profile` to mean "the user clicked refresh on their profile page."
+
+## Worked example
+
+`examples/reagent/boot/` (pending — in flight via rf2-dsm2). Until merged, treat the canonical declaration above as the source of truth. The follow-on EX-2 bead upgrades this leaf to link the example once shipped.
+
+A narrower instance — single-purpose flow machine, same shape — already lives at `examples/reagent/login/core.cljs` (auth flow as a state machine using `create-machine-handler` and `:invoke`).
+
+## Pointers
+
+- Full pattern doc, including the auth-machine worked example for the retry-ownership boundary and SSR handoff details → SKILL-REDIRECT.md → *Pattern — Boot*.
+- Frame `:on-create` semantics (atomic entry point) → SKILL-REDIRECT.md → *EP — Frames (002)*.
+- State-machine substrate (`:invoke`, `:after`, restore semantics) → SKILL-REDIRECT.md → *EP — State machines (005)*.
+- SSR `:rf/server-init` and hydration handoff → SKILL-REDIRECT.md → *EP — SSR (011)*.
+- The retry-ownership boundary → `patterns/managed-http.md` + SKILL-REDIRECT.md → *EP — HTTP requests (014)*.

--- a/skills/re-frame2/patterns/managed-http.md
+++ b/skills/re-frame2/patterns/managed-http.md
@@ -1,0 +1,169 @@
+# Pattern — ManagedHTTP
+
+`:rf.http/managed` — the canonical HTTP fx for re-frame2. Two affordances on one registrar id: the **fx form** for direct use from event handlers, and the **machine-form wrapper** for `:invoke` from a parent state machine. The contract — args map, failure categories, retry, abort, reply addressing — is identical across both.
+
+> Managed-HTTP is **v1-optional** but shipped in the CLJS reference. It lives in a separate artefact (`day8/re-frame2-http`); requiring `re-frame.http-managed` at app boot is what triggers its load-time fx registrations.
+
+## When to use this pattern
+
+Reach for it for any single-request / single-reply HTTP call. The fx bakes in transport, decoding, retry-with-backoff, abort, schema-driven decode, default reply-addressing, and frame-aware dispatch — so apps don't reinvent these per call site.
+
+| Decision | Form |
+|---|---|
+| Event handler issues a one-off request; reply lands at the same handler or a sibling event | **fx form**: `:fx [[:rf.http/managed args]]` |
+| Parent state machine wants the request tied to a state's lifetime, with auto-abort on state exit and `:after` timeout composition | **machine form**: `:invoke {:machine-id :rf.http/managed :data args}` |
+| Parent state machine needs multiple concurrent requests with a join condition | **machine form** under `:invoke-all` |
+
+Mix freely. Both surfaces coexist under one `:rf.http/managed` id in the registrar.
+
+Out of scope here: streaming responses (chunked / SSE — sibling spec), bidirectional WebSocket (see `patterns/websocket.md`).
+
+## The re-frame2 features this pattern uses
+
+| Feature | Role |
+|---|---|
+| Co-located request and reply (default) | One event handler branches on `(:rf/reply msg)` — initial-dispatch branch issues the request; reply branch handles `{:kind :success :value v}` or `{:kind :failure :failure m}`. |
+| Default reply addressing | Reply re-dispatches to the *originating* event id with `:rf/reply` merged onto the msg. Override with explicit `:on-success` / `:on-failure` for the separate-handler shape; pass `:on-failure nil` to swallow silently. |
+| Schema-driven decode | `:decode <malli-schema>` runs the response through `010`'s decode pipeline; status-check fires BEFORE decode, so a 404 with HTML body classifies as `:rf.http/http-4xx`, never as `:rf.http/decode-failure`. |
+| `:accept` post-decode normalisation | `(fn [decoded] {:ok v} or {:failure m})` lets a structurally-valid 200 surface as a domain failure. |
+| `:retry` — transport-level only | Function of failure category + attempt count; nothing else enters. Semantic retry (refresh-then-retry, body-conditional, app-state-conditional) belongs in a state machine — see *§The retry-ownership boundary*. |
+| `:request-id` abort | Stable `=`-comparable id (keyword, string, vector, uuid); `[:rf.http/managed-abort id]` cancels the in-flight request, dispatching `:rf.http/aborted` via the reply path. |
+| Eight-category failure taxonomy | `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/aborted`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/payload`. Closed set; both forms surface the same shape. |
+| Machine-form wrapper | A child invokable machine of `:rf.http/managed` — `:invoke` it like any other; on the reply the wrapper transitions to `:succeeded` / `:failed` and dispatches `[<parent-id> [:succeeded value]]` / `[<parent-id> [:failed failure]]` back to the parent. Destroying the wrapper aborts the in-flight request. |
+
+## Canonical declaration — fx form
+
+```clojure
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ;; Reply branch — same handler, different path.
+      (case (:kind reply)
+        :success {:db (-> db
+                          (assoc-in [:article :status] :loaded)
+                          (assoc-in [:article :data]   (:value reply))
+                          (assoc-in [:article :error]  nil))}
+        :failure {:db (-> db
+                          (assoc-in [:article :status] :error)
+                          (assoc-in [:article :error]  (:failure reply)))})
+
+      ;; Initial dispatch — issue the request.
+      {:db (-> db
+               (assoc-in [:article :status] :loading)
+               (assoc-in [:article :error]  nil))
+       :fx [[:rf.http/managed
+             {:request {:method :get :url (str "/articles/" slug)}
+              :decode  ArticleResponse           ;; Malli schema → decode + coerce
+              :accept  (fn [decoded]
+                         (if-let [a (:article decoded)]
+                           {:ok a}
+                           {:failure {:reason :missing-article}}))
+              :retry   {:on           #{:rf.http/transport
+                                        :rf.http/http-5xx
+                                        :rf.http/timeout}
+                        :max-attempts 4
+                        :backoff      {:base-ms 250 :factor 2
+                                       :max-ms  5000 :jitter true}}}]]})))
+```
+
+The fx defaults to **reply-to-origin**: the reply lands at `:article/load` (the originating event id) with `:rf/reply` merged onto the msg. The handler's `if-let` branches.
+
+## Canonical declaration — machine-form wrapper
+
+```clojure
+(rf/reg-machine :app/auth
+  {:initial :idle
+   :states
+   {:idle           {:on {:login :authenticating}}
+
+    :authenticating
+    {;; The wrapper actor is alive at [:rf/machines :rf.http/managed#N]
+     ;; while this state is active. Exiting the state destroys the
+     ;; wrapper, which aborts the in-flight request via the
+     ;; :http/abort-on-actor-destroy hook.
+     :invoke {:machine-id :rf.http/managed
+              :data       {:request {:method :get :url "/api/me"}
+                           :decode  :json
+                           :retry   {:on #{:rf.http/transport :rf.http/http-5xx}
+                                     :max-attempts 4
+                                     :backoff {:base-ms 250 :factor 2
+                                               :max-ms 5000 :jitter true}}}}
+     :after  {30000 :timed-out}                   ;; wall-clock guard on the state
+     :on     {:succeeded :authenticated           ;; payload at (:rf/event msg)
+              :failed    :login-failed}}
+
+    :authenticated {} :login-failed {} :timed-out {}}})
+```
+
+The wrapper handles its own `:rf.http/succeeded` / `:rf.http/failed` events internally and dispatches a clean `[parent-id [:succeeded value]]` or `[parent-id [:failed failure]]` to the parent — which the parent's `:on` map treats as ordinary FSM events. No glue code.
+
+**Args carrier.** Every key the fx form's args map accepts may be passed through the parent's `:invoke :data` — `:request`, `:decode`, `:accept`, `:retry`, `:timeout-ms`, `:request-content-type`, etc. **Not passed through**: `:on-success` / `:on-failure` — the wrapper overrides these to route the reply back to itself.
+
+**Multiple concurrent requests under one parent.** Use `:invoke-all`:
+
+```clojure
+{:hydrating
+ {:invoke-all
+  {:children       [{:id :user  :machine-id :rf.http/managed
+                     :data {:request {:url "/api/me"}}}
+                    {:id :prefs :machine-id :rf.http/managed
+                     :data {:request {:url "/api/prefs"}}}]
+   :join           :all
+   :on-all-complete [:hydrate/done]
+   :on-any-failed   [:hydrate/aborted]}}}
+```
+
+Each child wrapper aborts on cancel-on-decision; per-sibling cascade fires the abort hook independently.
+
+## The retry-ownership boundary
+
+A single test: **does the retry decision depend on anything other than failure category and attempt count?**
+
+| Decision | Owner |
+|---|---|
+| "After a 5xx, wait `backoff(N)` and try again." | `:rf.http/managed` `:retry` — transport. |
+| "After a network timeout, retry with backoff." | `:rf.http/managed` `:retry` — transport. |
+| "After a 401, refresh the token, **then** retry." | State machine — semantic. |
+| "Body says `:rate-limited`, wait the hinted delay." | State machine — semantic. |
+| "Retry only if user is still on the page that issued the write." | State machine — semantic. |
+| "Retry boot's failed load-asset, but not if the user navigated away." | State machine — semantic. |
+
+Both layers compose. A machine's `:invoke` spawns a managed request that itself retries 5xx; once that loop terminates, the machine sees a single `:succeeded` / `:failed` event and transitions. No call site has to choose one layer — non-trivial requests configure both.
+
+The full auth-machine worked example demonstrating 5xx-retry-at-transport AND 401-vs-refresh-at-semantic together lives in `patterns/boot.md` (the canonical illustration referenced from the spec).
+
+## Variations
+
+**Reply addressing.** Default is reply-to-origin. Override with explicit `:on-success` / `:on-failure` event vectors for the separate-handler shape. Pass `:on-failure nil` to swallow silently. The dispatched reply event carries the standard `:rf/reply` envelope: `{:kind :success :value v}` or `{:kind :failure :failure m}`.
+
+**Abort.** `:request-id <id>` makes the request abortable: `[:rf.http/managed-abort id]` cancels it; the reply path dispatches `:rf.http/aborted`. External `AbortController` is also supported via `:abort-signal`. The wrapper form aborts automatically on state-exit (`:after` firing, parent transition, `:rf.machine/destroy`) — no manual cancellation slot needed.
+
+**`:body` thunks.** Pass `:body (fn [] big-blob)` to defer body materialisation until after backoff delays elapse. Each retry re-invokes the thunk, so a single-shot stream gets a fresh handle per attempt.
+
+**Schema reflection.** Declare `:rf.http/decode-schemas [Schema1 Schema2]` in the handler's metadata for tooling-time introspection (pair tools, generators). The runtime does NOT cross-check; it is reflective sugar.
+
+**Frame awareness.** Reply dispatches inherit the originating event's `:frame`; the request crosses frame boundaries cleanly. No special-casing.
+
+## Anti-patterns
+
+- **Encoding semantic retry into `:retry :on`.** `:retry` is a function of category + attempt count — that's it. The moment the retry decision needs to inspect the response body, refresh a token, or check app state, lift the call site into a state machine. Bloating `:retry` with predicates hides control flow from traces.
+- **Reaching for the raw `:http` fx when `:rf.http/managed` would do.** `:http` exists for wire-level control (custom transport, raw bytes, idiosyncratic protocols). For the common case, `:rf.http/managed` is the canonical answer and is what pair tools, `:fx-overrides`, and conformance fixtures key off.
+- **Decoding before checking status.** Don't write a custom decode that throws on 4xx — the runtime classifies status BEFORE decode (a 404 with HTML body surfaces as `:rf.http/http-4xx` with raw body at `:body`, never as `:rf.http/decode-failure`). Your `:decode` only runs on 2xx.
+- **Passing `:on-success` / `:on-failure` through the wrapper's `:invoke :data`.** They get overridden — the wrapper routes replies back to itself. Apps that want explicit reply addressing should use the fx form directly; the wrapper is for `:invoke`-orchestrated cases.
+- **Storing the abort handle in `app-db`.** It's not a value. Use `:request-id` (any `=`-comparable value); the runtime holds the handle internally and you abort by id.
+- **Re-implementing exponential backoff with `:dispatch-later`.** That's what `:retry :backoff` is for. The runtime version handles attempt-counter epoch carry, retry-attempt traces, and per-attempt timeout composition; rolling your own bypasses all of it.
+
+## Worked example
+
+`examples/reagent/managed_http_counter/` — counter where each button issues a managed HTTP request and the reply lands back via the default reply-addressing path. Covers the success path (`GET /api/inc.json`), the 404 path (`:rf.http/http-4xx` with HTML body — no `:rf.http/decode-failure` despite `:decode :json` because status-check fires first), the canned-success stub for the retry-recover demo, and `:request-id`-driven cancellation via `:rf.http/managed-abort`.
+
+For the machine-form wrapper in production use, see the auth-flow worked example in `patterns/boot.md`.
+
+## Pointers
+
+- Full spec — args map, request envelope, every key — → SKILL-REDIRECT.md → *EP — HTTP requests (014)*.
+- The eight failure categories, classification order, reply-payload shape → SKILL-REDIRECT.md → *EP — HTTP requests (014)*.
+- Schema-driven decode + `010` integration → SKILL-REDIRECT.md → *EP — Schemas (010)*.
+- Test stubs (`with-managed-request-stubs`) → SKILL-REDIRECT.md → *EP — HTTP requests (014)* §Testing.
+- The retry-ownership worked example → `patterns/boot.md`.
+- `:invoke` substrate the wrapper rides on → SKILL-REDIRECT.md → *EP — State machines (005)*.

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -1,0 +1,170 @@
+# Pattern — WebSocket
+
+Long-lived bidirectional connection lifecycle (WebSocket / SSE / WebRTC peer) modelled as a state machine that owns the socket actor.
+
+> **Status of the worked example:** `examples/reagent/websocket/` is in flight via rf2-yf97. Until it lands, the canonical declaration below is the source of truth; this leaf will be upgraded to link the example after merge.
+
+## When to use this pattern
+
+Reach for it when the connection itself has phases (`:connecting` → `:authenticating` → `:connected` → `:reconnecting` → `:failed`), survives across message boundaries, retries with backoff, manages subscriptions across reconnects, or carries correlation ids for request-reply messages over the open socket.
+
+Do **not** reach for it when the interaction is one request, one reply. That is `Pattern-AsyncEffect` — even when the wire is a single short-lived WebSocket. The discriminator is "does the connection outlive any one message?".
+
+Server-Sent Events (`EventSource`) and WebRTC peer connections share the same lifecycle shape — same pattern, different wire format inside the actor.
+
+## The re-frame2 features this pattern uses
+
+| Feature | Role here |
+|---|---|
+| Hierarchical compound state | `:active` is the parent of `:connecting` / `:authenticating` / `:connected`; **the socket actor's lifetime is anchored on the parent**, so it outlives leaf transitions. |
+| `:invoke` (declarative spawn) | The `:active` parent invokes a `:websocket/socket` child actor that owns the JS `WebSocket` object. Exiting `:active` destroys it; re-entering spawns a fresh one. |
+| `:after` (fn-form delay) | Exponential backoff timer in `:reconnecting`, computed at entry from the current `:retries` and `:base-ms` in `:data`. |
+| `:always` | Max-retries guard on `:reconnecting` entry; queue-flush guard on `:connected` entry. |
+| Parent-level `:on` | `:ws/closed`, `:ws/fatal`, `:ws/send`, `:ws/refresh-token` declared once on `:active` and inherited by every leaf (deepest-wins resolution). |
+| `:guards` / `:actions` (machine-scoped) | `:max-retries-exceeded?`, `:current-socket?` for connection-epoch staleness, `:bump-retry`, `:flush-queue`, etc. |
+| Connection-epoch staleness check | The live socket-actor's `:rf/self-id` is the epoch. Replies carry `:source-socket-id`; the `:current-socket?` guard rejects events from a torn-down prior socket. |
+
+## Canonical declaration
+
+```clojure
+(rf/reg-event-fx :ws/connection
+  (rf/create-machine-handler
+    {:initial :disconnected
+     :data    {:url nil :auth-token nil
+               :retries 0 :max-retries 8
+               :base-ms 1000 :max-backoff-ms 30000
+               :socket-id nil
+               :subscriptions #{}
+               :queue [] :in-flight {} :error nil}
+
+     :guards
+     {:max-retries-exceeded?
+      (fn [data _] (>= (:retries data) (:max-retries data)))
+
+      :has-queued-messages?
+      (fn [data _] (seq (:queue data)))
+
+      :current-socket?
+      ;; Connection-epoch check: reject events from a prior socket actor
+      ;; that may dispatch in flight while the cascade tears it down.
+      (fn [data [_ {:keys [source-socket-id]}]]
+        (= source-socket-id (:socket-id data)))}
+
+     :actions
+     {:record-connection-opts
+      (fn [data [_ {:keys [url auth-token]}]]
+        {:data (assoc data :url url :auth-token auth-token)})
+
+      :refresh-token
+      (fn [data [_ token]] {:data (assoc data :auth-token token)})
+
+      :bump-retry      (fn [data _] {:data (update data :retries inc)})
+      :clear-socket-id (fn [data _] {:data (assoc data :socket-id nil)})
+
+      :on-connected
+      ;; Compound :entry — reset retry counter AND re-subscribe.
+      ;; Per Spec 005 §State nodes, :entry takes one fn or one registered
+      ;; id, never a vector. Consolidate into one action.
+      (fn [data _]
+        {:data (assoc data :retries 0)
+         :fx   (mapv (fn [topic]
+                       [:dispatch [(:socket-id data)
+                                   [:send {:type :subscribe :topic topic}]]])
+                     (:subscriptions data))})
+
+      :flush-queue
+      (fn [data _]
+        {:data (assoc data :queue [])
+         :fx   (mapv (fn [msg] [:dispatch [(:socket-id data) [:send msg]]])
+                     (:queue data))})
+
+      :enqueue-message
+      (fn [data [_ msg]] {:data (update data :queue conj msg)})}
+
+     :states
+     {:disconnected
+      {:on {:ws/connect {:target [:active] :action :record-connection-opts}
+            :ws/send    {:action :enqueue-message}}}
+
+      :active
+      {;; Socket actor anchored on the PARENT, not on :connecting.
+       ;; Lifetime spans :connecting → :authenticating → :connected.
+       :invoke  {:machine-id :websocket/socket
+                 :data       (fn [snap _] {:url        (-> snap :data :url)
+                                           :auth-token (-> snap :data :auth-token)})
+                 :on-spawn   (fn [data id] (assoc data :socket-id id))}
+       :exit    :clear-socket-id
+
+       ;; Parent-level transitions inherited by every leaf.
+       :on      {:ws/closed       {:target :reconnecting :action :bump-retry}
+                 :ws/fatal        {:target :failed}
+                 :ws/send         {:action :enqueue-message}
+                 :ws/refresh-token {:action :refresh-token}}
+
+       :initial :connecting
+       :states
+       {:connecting     {:on {:ws/opened {:target :authenticating}}}
+        :authenticating {:entry :send-auth
+                         :on    {:ws/auth-ok     {:target :connected}
+                                 :ws/auth-failed {:target [:failed]}}}
+        :connected      {:entry  :on-connected
+                         :always [{:guard :has-queued-messages? :action :flush-queue}]
+                         :on     {:ws/received {:guard  :current-socket?
+                                                :action :route-message}
+                                  :ws/send     {:action :send-now}}}}}
+
+      :reconnecting
+      {:always [{:guard :max-retries-exceeded? :target :failed}]
+       ;; fn-form delay — re-evaluated at every :reconnecting entry against
+       ;; the entering snapshot. The :after epoch makes stale timers from
+       ;; prior visits silently no-op on transition out.
+       :after  {(fn [snap]
+                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
+                    (min (* base-ms (Math/pow 2 retries))
+                         max-backoff-ms)))
+                {:target [:active]}}
+       :on     {:ws/connect       {:target [:active] :action :record-connection-opts}
+                :ws/refresh-token {:action :refresh-token}
+                :ws/send          {:action :enqueue-message}}}
+
+      :failed
+      {:on {:ws/connect       {:target [:active] :action :record-connection-opts}
+            :ws/refresh-token {:action :refresh-token}}}}}))
+```
+
+Caller-side:
+
+```clojure
+(rf/dispatch [:ws/connection [:ws/connect {:url        "wss://api.example.com/ws"
+                                           :auth-token (some-token)}]])
+```
+
+## Variations
+
+**Request-reply correlation over the open socket.** Each request gets a `(:request-id (random-uuid))` stamped into the body; an `:in-flight` map in `:data` holds `{request-id {:reply-event ... :timeout-ms ...}}`. The `:connected` `:ws/received` handler branches: body with `:request-id` → look up the in-flight slot, dispatch its `:reply-event`, clear the slot; body without → server push, dispatch `[:ws/handle-message body]`. A `:dispatch-later` per request handles the timeout. Each request-over-socket is a `Pattern-AsyncEffect` interaction; the connection machine performs the correlation step Pattern-AsyncEffect leaves to the caller.
+
+**Heartbeat / keepalive.** `:after` on `:connected` re-arms a periodic ping (`:after {30000 {:target :connected :action :send-ping}}` self-loops, re-arming the timer). A missed pong transitions to `:reconnecting`. Non-trivial cases use a child heartbeat machine `:invoke`d from `:connected`.
+
+**Subscription protocol.** Topics live in `:data :subscriptions` (a set). `:on-connected` re-issues subscribe messages on entry — subscriptions survive reconnects automatically. Runtime sub/unsub events update `:subscriptions` and forward the wire-message in one action.
+
+**Re-authentication on reconnect.** Two paths, both supported by the canonical machine. *Proactive*: auth machine dispatches `[:ws/connection [:ws/refresh-token tok]]`; `:refresh-token` updates `:data`; the next `:active` entry's `:invoke :data` fn picks up the fresh value automatically — no extra wiring. *Reactive*: a reconnect into `:authenticating` fails with `:ws/auth-failed`, lands in `:failed`; the auth machine observes via `sub-machine`, refreshes, and dispatches a fresh `:ws/connect` with new opts.
+
+**SSR.** The connection machine no-ops server-side: `:invoke`'s spawn fx is `:platforms #{:client}`, `:after` timers don't schedule under SSR. The server renders `:disconnected` statically; the client hydrates and starts the connection.
+
+## Anti-patterns
+
+- **Anchoring `:invoke` on `:connecting` instead of `:active`.** Destroys the socket the moment the leaf transitions to `:authenticating`. Lifetime MUST span all three connection leaves.
+- **Storing the `WebSocket` JS object in `app-db`.** Not a value, not serialisable, won't survive snapshot replay. The actor owns it host-side; only the actor id appears in `:data`.
+- **Implementing reconnect via `setTimeout` from inside the fx-handler.** Bypasses the machine, tracing, and stale-detection. Use `:after`.
+- **Skipping `:current-socket?` on `:ws/received`.** A slow `:message` from a torn-down prior socket lands in the new connection's `:in-flight` map — wrong-reply at best, slot-clearing-by-stale-id at worst. The guard is one line; skipping it is the websocket equivalent of a missing routing nav-token.
+- **Treating WebSocket as Pattern-AsyncEffect.** A connection that retries, reconnects, and survives across message boundaries is state-machine-shaped, not request-reply-shaped.
+
+## Worked example
+
+`examples/reagent/websocket/` (pending — in flight via rf2-yf97). Until merged, treat the canonical declaration above as the source of truth. The follow-on EX-1 bead upgrades this leaf to link the example once shipped.
+
+## Pointers
+
+- Full pattern doc, including request-reply correlation worked example, heartbeat variations, anti-patterns, and SSR composition → SKILL-REDIRECT.md → *Pattern — WebSocket*.
+- The state-machine substrate (`:invoke`, `:after`, `:always`, hierarchical states) → SKILL-REDIRECT.md → *EP — State machines (005)*.
+- Connection-epoch idiom (the second use of stale-detection in this pattern) → SKILL-REDIRECT.md → *Pattern — Stale detection*.


### PR DESCRIPTION
## Summary

Three pattern leaves under `skills/re-frame2/patterns/`, each ~170 lines (target ~150, cap 250):

- **`websocket.md`** — connection-lifecycle state machine. `:active` parent anchors `:invoke` so the socket actor outlives the leaf transitions (`:connecting` → `:authenticating` → `:connected`). `:after` fn-form backoff in `:reconnecting`. Connection-epoch staleness via `:current-socket?`. Worked example app in flight via rf2-yf97; leaf upgraded to link after merge.

- **`boot.md`** — chained-async boot as a state machine. Consolidated `:entry` actions (one fn returning `{:data ..., :fx ...}` — `:entry` is singular, never a vector). Per-phase `:invoke` of `:rf.http/managed` or domain child machines. SSR handoff via hydrated snapshot. Simple chained-events form documented for the ≤3-phase case. Worked example app in flight via rf2-dsm2.

- **`managed-http.md`** — BOTH fx form (`:fx [[:rf.http/managed args]]`) AND machine-form wrapper (`:invoke {:machine-id :rf.http/managed :data args}`) on one registrar id. Includes the retry-ownership boundary (transport vs semantic) with the rule-of-thumb table; eight failure categories; classification order (status BEFORE decode). Worked example: `examples/reagent/managed_http_counter/`.

Pillar 4 throughout: no re-teaching of WebSocket lifecycle, boot sequences, or HTTP retry — only the re-frame2-specific binding (which feature implements which idea, canonical declaration shape, the gotchas unique to this framework). Hot-zone: pattern batches A (rf2-p6ut) and C (rf2-e57j) touch different files in the same directory; no overlap.

## Test plan

- [ ] `wc -l skills/re-frame2/patterns/{websocket,boot,managed-http}.md` — each ≤250 lines.
- [ ] `examples/reagent/managed_http_counter/` exists (referenced in managed-http.md).
- [ ] `examples/reagent/login/` exists (referenced in boot.md as the narrower single-flow worked example).
- [ ] Websocket and boot worked-example paths are noted as in-flight via rf2-yf97 / rf2-dsm2 (intentional — leaf upgraded when example app merges).
- [ ] Each leaf follows the shape: when-to-use → re-frame2 features → canonical declaration → variations → anti-patterns → link to worked example → pointer via SKILL-REDIRECT.md.
- [ ] No edits to `SKILL.md`.