### PR TITLE
feat(skills): re-frame2 pattern batch A (nine-states, remote-data, forms) (rf2-p6ut)

### DIFF
--- a/skills/re-frame2/patterns/forms.md
+++ b/skills/re-frame2/patterns/forms.md
@@ -1,0 +1,161 @@
+# Pattern — Forms
+
+The standard form-lifecycle convention. A 7-key slice (or one machine region) carries the form runtime — **draft / submitted / submit-attempted? / status / errors / touched / submit-error** — and seven events drive the lifecycle (**initialise / edit-field / blur-field / submit / submit-success / submit-error / reset**). Per-field error visibility hinges on a single rule: show a field's error when the field is in `:touched` OR `:submit-attempted?` is `true`.
+
+## When to load this leaf
+
+The prompt mentions: a form, validation, "show errors after submit", inline field errors, `:disabled` while submitting, a login / signup / settings / editor screen, or any UI that collects user input and submits it. Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:form-region` of a `reg-machine`) — see §Common variations.
+
+## The re-frame2 features that implement it
+
+- **`reg-app-schema`** for the slice path; **plus** a separate schema for the form's *value* (what the form collects, e.g. `LoginForm`). Two schemas: one for the slice container, one for the draft's shape.
+- **`reg-event-db :form.feature/initialise`** — seed `:draft` with defaults; `:status :idle`.
+- **`reg-event-db :form.feature/edit-field`** — update `:draft`; add the field to `:touched`.
+- **`reg-event-db :form.feature/blur-field`** — add to `:touched` (if not already); run per-field validation.
+- **`reg-event-fx :form.feature/submit`** — run full validation, latch `:submit-attempted? true`, dispatch the request, set `:status :submitting`.
+- **`reg-event-db :form.feature/submit-success` / `:submit-error`** — fold the server reply. **Structured server errors land in `:errors`** (same slot as client-side validation, including the reserved `:_form` key); **transport / non-field failures land in `:submit-error`**. Both set `:status :error`.
+- **Layered convenience subs** — `:field-error` (per-field; shows when touched OR submit-attempted), `:form-errors` (reads `:_form`, always visible), `:dirty?` (draft differs from `:submitted` when non-nil, otherwise from defaults), `:can-submit?` (no errors AND not currently submitting).
+- **(machine variant) `reg-machine` with `:initial :neutral` + states `:neutral :incorrect :submitting :correct` + `:tags`** — the lifecycle as machine states. `:rf/machine-has-tag?` answers `(rf/has-tag? :form-id :form/in-flight)` in place of `:submitting?`.
+
+Two non-obvious rules:
+
+1. **`:_form` is the reserved key inside `:errors`** for form-level errors (cross-field validation, server-returned "credentials invalid"). Always visible whenever present — does not gate on `:touched` or `:submit-attempted?`. Field ids must not collide with `:_form`.
+2. **`:errors` vs `:submit-error`**: structured field errors → `:errors`; unstructured transport failures (network down, 500 with no body, timeout) → `:submit-error`. Same `:status :error`; different render path.
+
+## Canonical declaration — slice form
+
+The dominant shape. Lifted from `spec/Pattern-Forms.md` (mirrored in `examples/reagent/realworld/auth.cljs` for the `:auth :login-form` and `:auth :register-form` slices, and in `examples/reagent/realworld/article_editor.cljs` and `comments.cljs`).
+
+```clojure
+(def FormSlice
+  [:map
+   [:draft             :map]
+   [:submitted         {:default nil}   [:maybe :map]]
+   [:submit-attempted? {:default false} :boolean]
+   [:status            [:enum :idle :submitting :submitted :error]]
+   [:errors            {:default {}}    [:map-of :keyword [:vector :string]]]
+   [:touched           {:default #{}}   [:set :keyword]]
+   [:submit-error      {:default nil}   [:maybe :any]]])
+
+(def LoginForm
+  [:map [:email [:re #".+@.+"]] [:password [:string {:min 8}]]])
+
+(rf/reg-app-schema [:auth :login] FormSlice)
+(rf/reg-app-schema [:auth :login :draft] LoginForm)
+
+(rf/reg-event-fx :form.login/submit
+  (fn [{:keys [db]} _]
+    (let [draft  (get-in db [:auth :login :draft])
+          errors (validate-against LoginForm draft)
+          db'    (assoc-in db [:auth :login :submit-attempted?] true)]
+      (if (empty? errors)
+        {:db (-> db'
+                 (assoc-in [:auth :login :status]       :submitting)
+                 (assoc-in [:auth :login :errors]       {})
+                 (assoc-in [:auth :login :submit-error] nil))
+         :fx [[:rf.http/managed
+               {:request    {:method :post :url "/api/login" :body draft}
+                :on-success [:form.login/submit-success]
+                :on-failure [:form.login/submit-error]}]]}
+        {:db (assoc-in db' [:auth :login :errors] errors)}))))
+
+(rf/reg-sub :form.login/field-error
+  :<- [:form.login/errors]
+  :<- [:form.login/touched]
+  :<- [:form.login/submit-attempted?]
+  (fn [[errs touched submit-attempted?] [_ field-id]]
+    (when (or submit-attempted? (touched field-id))
+      (first (get errs field-id)))))
+
+(rf/reg-sub :form.login/form-errors    ;; reserved :_form key — always visible
+  :<- [:form.login/errors]
+  (fn [errs _] (get errs :_form)))
+
+(rf/reg-sub :form.login/dirty?
+  :<- [:form.login]
+  (fn [{:keys [draft submitted]} _]
+    (not= draft (or submitted login-form-defaults))))
+```
+
+## Canonical declaration — `:form-region` machine form
+
+Used when the form's lifecycle is *part of* a larger page's machine (composes with `patterns/nine-states.md`), or when tag-shaped queries are wanted in place of slice-field comparisons. Lifted from `examples/reagent/realworld/settings.cljs`:
+
+```clojure
+(rf/reg-machine :settings/form
+  {:initial :neutral
+   :data    {:draft initial-draft :errors {} :touched #{} :submit-error nil
+             :submitted nil :loaded-at nil}
+   :actions
+   {:edit-field
+    (fn [d [_ {:keys [field value]}]]
+      {:data (-> d (assoc-in [:draft field] value)
+                   (update :touched (fnil conj #{}) field)
+                   (update :errors  dissoc field)
+                   (assoc  :submit-error nil))})
+    :set-errors
+    (fn [d [_ {:keys [errors]}]]
+      {:data (-> d (assoc :errors errors)
+                   (update :touched (fnil into #{}) (keys errors)))})
+    :begin-submit
+    (fn [d [_ {:keys [submitted]}]]
+      {:data (-> d (assoc :submitted submitted :errors {} :submit-error nil))})
+    :store-user
+    (fn [d [_ {:keys [user]}]]
+      {:data (-> d (assoc :draft (draft-from-user user) :errors {} :submit-error nil))})
+    :set-submit-error
+    (fn [d [_ {:keys [submit-error]}]] {:data (assoc d :submit-error submit-error)})}
+   :states
+   {:neutral    {:tags #{:settings/neutral}
+                 :on {:edit           {:target :neutral    :action :edit-field}
+                      :submit-invalid {:target :incorrect  :action :set-errors}
+                      :submit-valid   {:target :submitting :action :begin-submit}}}
+    :incorrect  {:tags #{:settings/incorrect :form/invalid}
+                 :on {:edit           {:target :neutral    :action :edit-field}
+                      :submit-valid   {:target :submitting :action :begin-submit}}}
+    :submitting {:tags #{:settings/submitting :settings/in-flight :form/transient}
+                 :on {:submit-succeeded {:target :correct   :action :store-user}
+                      :submit-failed    {:target :incorrect :action :set-submit-error}}}
+    :correct    {:tags #{:settings/correct :form/success :form/transient}
+                 :on {:edit {:target :neutral :action :edit-field}}}}})
+```
+
+The lifecycle maps onto state-keywords. The slice's `:status` field disappears. The view's `:submitting?` boolean becomes `(rf/has-tag? :settings/form :settings/in-flight)` — the view doesn't need to know which state-keyword carries the in-flight intent; the tag does. The slice's `:draft` / `:errors` / `:touched` / `:submit-error` / `:submitted` live in the machine's `:data` map.
+
+## When to choose each form
+
+- **Slice form** — single form, no concurrent axes, validation is synchronous, view code is straightforward. The vast majority of cases.
+- **Machine form** — the form is one region of a parallel page machine (composes with `patterns/nine-states.md`); OR the lifecycle wants `:invoke` (e.g. an async per-field validator as a child actor); OR the team wants tag-shaped queries.
+
+Realworld ships both shapes side-by-side. `:auth :login-form`, `:auth :register-form`, `:editor`, `:comment-form` use the slice form; `:settings/form` uses the machine form. The README's "Pattern-Forms — two shapes side-by-side" section has the worked comparison.
+
+## Common variations
+
+- **Async per-field validation** ("is this username taken?"). Compose `SKILL-REDIRECT.md` → *Pattern — Async effect*: fire a feature-specific fx from `:blur-field`; the result event writes into `:errors` under the same field id (so the sync/async paths share the slot). Add a `Pattern-StaleDetection` epoch on the dispatch — the field may have changed by the time the reply lands.
+- **Cross-field validation** (passwords match, end-date ≥ start-date). The validator writes the error under the reserved `:_form` key; the `:form-errors` sub renders it.
+- **Multi-step / wizard.** Pair the form slice with a separate `reg-machine` that owns step transitions; the slice persists across steps.
+- **Optimistic submit.** Navigate away on submit-click; roll back on failure using the optimistic-update form from `patterns/remote-data.md`.
+
+## Worked example
+
+- **Slice form**: `examples/reagent/realworld/auth.cljs` — login + register; `examples/reagent/realworld/article_editor.cljs` — full editor; `examples/reagent/realworld/comments.cljs` — comment form.
+- **Machine form**: `examples/reagent/realworld/settings.cljs` — single-region `reg-machine` with `:neutral / :incorrect / :submitting / :correct`.
+- **Compose with NineStates**: `examples/reagent/nine_states/core.cljs` — `:form` region as one axis of a parallel machine, with the `Incorrect` / `Correct` rendering folded into the page's render-priority.
+
+## Pillar 5 — why error visibility hinges on `submit-attempted? OR touched`
+
+Three options exist for "when do per-field errors show?":
+
+1. **Always** — including blank required fields on the very first render. Hostile.
+2. **Only when touched** — a still-empty required field stays invisibly invalid after a submit attempt. Hidden.
+3. **Touched OR submit-attempted?** — once the user has pressed submit, every error becomes visible regardless of whether that field was individually touched.
+
+(3) is the only option that handles "user pressed submit on a half-filled form". The `:submit-attempted?` latch is `false` until the first submit click, then `true` forever. The `:field-error` convenience sub bakes the rule in; views read `@(subscribe [:form.login/field-error :email])` and don't reason about visibility.
+
+`:_form` (the reserved form-level errors key) is treated differently: always visible whenever present. Cross-field errors and server-rejection banners aren't bound to a single field, so the touched/submit-attempted gate doesn't apply.
+
+## Deeper pointers
+
+- Spec: `SKILL-REDIRECT.md` → *Pattern — Forms* (full slice schema, conformance checklist, async-validation composition, SSR considerations).
+- Substrate: `SKILL-REDIRECT.md` → *EP — Schemas (010)* (boundary validation), *EP — State machines (005)* (machine form).
+- Compose: `patterns/nine-states.md` (the `:form` region of a parallel machine), `patterns/remote-data.md` (the submit's request lifecycle).

--- a/skills/re-frame2/patterns/nine-states.md
+++ b/skills/re-frame2/patterns/nine-states.md
@@ -1,0 +1,122 @@
+# Pattern — NineStates
+
+A page-level rendering convention that makes every legal UI state explicit and testable. The page's render axes are modelled as **parallel regions** of a single `reg-machine`, each region's states carry **tags**, and one **selector sub** consults a **render-priority** table to pick the single render-model keyword the root view's `case` branches on.
+
+## When to load this leaf
+
+The prompt mentions: "nine states", "empty / one / some / too-many", "loading vs error vs success render", "page-level rendering states", "render priority", or a page that needs to render the cardinality of its loaded data distinctly. Also load this leaf when the user wants to combine a data lifecycle with a form lifecycle and a read-only mode in one screen and is asking "where does each state go?".
+
+## The re-frame2 features that implement it
+
+The pattern composes four primitives. Knowing which feature does what is the load-bearing knowledge — the pattern itself is just discipline.
+
+- **`:type :parallel` on a `reg-machine`** — declares the machine has independent **regions** active simultaneously. The snapshot's `:state` is a map keyed by region name. Use one region per orthogonal axis (typically `:data`, `:form`, `:mode`).
+- **`:regions {...}`** — each region is a full state-tree (`:initial`, `:states`, optional `:always` / `:after` / `:invoke`). Transitions are **broadcast** to every region; the run-to-completion drain settles every region before commit.
+- **Shared `:data`** — one `:data` map on the machine, read and written by every region. Region keys never collide; the regions slice into the same blob.
+- **`:tags #{...}` on states** — every state may declare a set of tag keywords. The runtime maintains `(:tags snapshot)` as the union across every active region's active state's tags.
+- **`:rf/machine-has-tag?` framework sub** — answers `(rf/has-tag? :machine-id :some/tag)` as a plain boolean reaction, so views can ask tag-shaped questions without naming any state-keyword.
+- **The render-priority vector + one selector sub** — *application code*, not framework. A vector of `{:tag :render}` pairs consulted in order; the selector sub returns the first `:render` whose `:tag` is in the snapshot's tag union. The priority lives in **data**, not in a `cond` in the root view.
+
+The single rule: declare the axes as regions; tag each state with its axis-level intent; resolve the render selection in **one** selector sub over a data-shaped priority table.
+
+## Canonical declaration
+
+Lifted from `examples/reagent/nine_states/core.cljs`. Three regions; tags on every state; an eventless `:always` cascade picks the cardinality bucket; the priority table is plain data.
+
+```clojure
+(rf/reg-machine :ui/nine-states
+  {:type :parallel
+   :data {:items [] :error nil}
+   :guards
+   {:empty?    (fn [d _] (zero?  (count (:items d))))
+    :one?      (fn [d _] (= 1    (count (:items d))))
+    :too-many? (fn [d _] (> (count (:items d)) too-many-threshold))}
+   :actions
+   {:set-items (fn [d [_ {:keys [items]}]] {:data (assoc d :items (vec items) :error nil)})
+    :set-error (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+   :regions
+   {:data
+    {:initial :nothing
+     :states
+     {:nothing   {:tags #{:data/nothing} :on {:fetch-started :loading}}
+      :loading   {:tags #{:data/loading :data/transient}
+                  :on   {:fetch-succeeded {:target :resolving :action :set-items}
+                         :fetch-failed    {:target :error     :action :set-error}}}
+      :resolving {:always [{:guard :empty?    :target :empty}
+                           {:guard :one?      :target :one}
+                           {:guard :too-many? :target :too-many}
+                           {:target :some}]}
+      :empty     {:tags #{:data/empty}    :on {:fetch-started :loading}}
+      :one       {:tags #{:data/one}      :on {:fetch-started :loading}}
+      :some      {:tags #{:data/some}     :on {:fetch-started :loading}}
+      :too-many  {:tags #{:data/too-many} :on {:fetch-started :loading}}
+      :error     {:tags #{:data/error}    :on {:fetch-started :loading}}}}
+    :form
+    {:initial :neutral
+     :states
+     {:neutral   {:tags #{:form/neutral}
+                  :on   {:submit-valid :correct :submit-invalid :incorrect :edit :neutral}}
+      :incorrect {:tags #{:form/invalid}
+                  :on   {:submit-valid :correct :edit :neutral}}
+      :correct   {:tags #{:form/success :form/transient}
+                  :on   {:edit :neutral}}}}
+    :mode
+    {:initial :active
+     :states {:active {:tags #{:mode/active} :on {:archive :done}}
+              :done   {:tags #{:mode/done :mode/read-only :mode/terminal}}}}}})
+```
+
+The render-priority table and selector sub:
+
+```clojure
+(def render-priority
+  [{:tag :mode/done     :render :done}
+   {:tag :form/success  :render :correct}
+   {:tag :form/invalid  :render :incorrect}
+   {:tag :data/loading  :render :loading}
+   {:tag :data/error    :render :error}
+   {:tag :data/nothing  :render :nothing}
+   {:tag :data/empty    :render :empty}
+   {:tag :data/one      :render :one}
+   {:tag :data/some     :render :some}
+   {:tag :data/too-many :render :too-many}])
+
+(rf/reg-sub :ui/render
+  :<- [:rf/machine :ui/nine-states]
+  (fn [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+```
+
+The root view branches once, in a `case`, on the resolved keyword. Disabled-attribute toggles read tags directly via `(rf/has-tag? :ui/nine-states :mode/read-only)` rather than going through `:ui/render`.
+
+## Canonical rules — short form
+
+1. **Identify the orthogonal axes** (typically `:data` × `:form` × `:mode`). Do not flatten them into one enum — the cross-product explodes.
+2. **One region per axis** under `:regions` of one `:type :parallel` machine. Regions share `:data`; transitions are broadcast.
+3. **Tag every state with its axis-level intent** (`:data/loading`, `:form/invalid`, `:mode/done`, ...). Tags let views ask query-shaped questions without enumerating state-keywords.
+4. **Render selection lives in one selector sub** over a render-priority **vector** (not a priority `cond` in the view). The priority is data — printable, testable, reviewable.
+
+## Common variations
+
+- **Fewer axes.** A static settings panel may only have the `:data` axis. Drop the regions that don't apply; the render-priority vector loses the corresponding entries. The pattern scales down to one region as readily as it scales up.
+- **More axes.** A CRUD panel may add a per-row `:permissions` axis with `:editable` / `:read-only` states. New region + new priority entry + new view branch.
+- **Skip `:correct`.** If success navigates away immediately and there is no visible acknowledgement, the `:form` region collapses to two states (`:neutral ↔ :incorrect`) and the priority table simply never produces `:correct`.
+- **Skip the `:mode` region.** If the page can never become read-only / archived / frozen, drop it entirely.
+- **Worked HTTP integration.** When the `:data` region's lifecycle is fed by a real HTTP request, the `:rf.http/managed` fx's `:on-success` / `:on-failure` dispatches map directly onto `:fetch-succeeded` / `:fetch-failed`. See the spec for the cancellation-cascade and stale-detection composition.
+
+## Worked example
+
+`examples/reagent/nine_states/core.cljs` — the full machine declaration, render-priority table, `:ui/render` selector, per-state views, and headless tests per state. Read it in full for the implementation-as-shipped shape, including how the form slice composes with the `:form` region.
+
+## Pillar 5 — why this shape vs. a `cond` in the view
+
+The render-priority **vector** is the load-bearing move. A priority `cond` in the root view encodes the same priority in **control flow** (clause order); the vector encodes it in **data**. The data shape lets a test pretty-print it, a code review compare two pages side-by-side, and a tooling pass read the priority without parsing the view's body. The selector sub re-runs only when the tag union changes; Reagent dedups on the resolved keyword; the root view re-renders only when the winning render changes — not every time a non-winning region advances.
+
+## Deeper pointers
+
+- Spec: `SKILL-REDIRECT.md` → *Pattern — Nine states* (full rules, transition tables, managed-HTTP integration, render-priority during mid-flight cross-region overlaps).
+- Substrate: `SKILL-REDIRECT.md` → *EP — State machines (005)* (§Parallel regions, §State tags).
+- Lifecycle composition: `patterns/remote-data.md` (the `:data` region) and `patterns/forms.md` (the `:form` region).

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -1,0 +1,131 @@
+# Pattern — RemoteData
+
+The standard request-lifecycle convention. A 5-key slice (or one machine region) tracks **status / data / error / loaded-at / attempt**, and four events drive the lifecycle (**load / loaded / load-failed / reset**). The load-bearing distinction is `:loading` (truly empty, first fetch) vs `:fetching` (revalidate with existing data) — they look identical to a careless UI but feel very different to a user.
+
+## When to load this leaf
+
+The prompt mentions: fetching data from a server, an HTTP request lifecycle, a list/article/feed/profile that needs to load, "spinner vs revalidate", optimistic update, polling, or any feature whose `app-db` will hold "the result of a fetch". Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:data-region` of a `reg-machine`) — see §Common variations.
+
+## The re-frame2 features that implement it
+
+The pattern composes:
+
+- **`reg-app-schema`** — schema-binds the slice path so the slice's shape is enforced at boundaries (per Pillar — schemas at boundaries, not everywhere).
+- **`reg-event-fx` for `:feature/load`** — dispatches the HTTP effect; picks `:loading` vs `:fetching` based on whether prior `:data` exists; bumps `:attempt`.
+- **`reg-event-db` for `:feature/loaded` / `:feature/load-failed`** — folds the reply into the slice. On failure, **prior `:data` is kept**; only `:status` and `:error` change.
+- **`:rf.http/managed` fx** (or the host's HTTP fx) — issues the request; its `:on-success` and `:on-failure` dispatch the lifecycle events.
+- **Layered subs `:feature/status`, `:feature/data`, `:feature/loading?`, `:feature/fetching?`** — convenience subs over the slice. `:loading?` means truly empty + in-flight; `:fetching?` means any in-flight (covers both `:loading` and `:fetching`).
+- **(machine variant) `:initial :idle` + states `:idle :loading :fetching :loaded :error` + `:tags`** — the lifecycle as machine states. `:rf/machine-has-tag?` answers the same question `:loading?` / `:fetching?` did.
+
+The single rule for the lifecycle: **`:loading` and `:fetching` are not interchangeable**. The first means "page is empty, show a spinner"; the second means "data is on screen, refresh in the background, never blank the page". Convenience subs hide the distinction from views that don't care.
+
+## Canonical declaration — slice form
+
+The dominant shape; used wherever an explicit `:status` keyword and Pattern-RemoteData's full 5-key slice is wanted. Lifted from `examples/reagent/realworld/articles.cljs` (one of seven slice-form resources in realworld):
+
+```clojure
+(def RequestSlice
+  [:map
+   [:status    [:enum :idle :loading :fetching :loaded :error]]
+   [:data      {:default nil} :any]
+   [:error     {:default nil} [:maybe :any]]
+   [:loaded-at {:default nil} [:maybe :int]]
+   [:attempt   {:default 0}   :int]])
+
+(rf/reg-app-schema [:articles] RequestSlice)
+
+(rf/reg-event-fx :articles/load
+  (fn [{:keys [db]} _]
+    (let [has-data? (some? (get-in db [:articles :data]))]
+      {:db (-> db
+               (assoc-in  [:articles :status] (if has-data? :fetching :loading))
+               (assoc-in  [:articles :error]  nil)
+               (update-in [:articles :attempt] inc))
+       :fx [[:rf.http/managed
+             {:request    {:method :get :url "/api/articles"}
+              :on-success [:articles/loaded]
+              :on-failure [:articles/load-failed]}]]})))
+
+(rf/reg-event-db :articles/loaded
+  (fn [db [_ {:keys [value]}]]
+    (-> db
+        (assoc-in [:articles :status]    :loaded)
+        (assoc-in [:articles :data]      value)
+        (assoc-in [:articles :error]     nil)
+        (assoc-in [:articles :loaded-at] (current-time-ms)))))
+
+(rf/reg-event-db :articles/load-failed
+  (fn [db [_ {:keys [failure]}]]
+    (-> db
+        (assoc-in [:articles :status] :error)
+        (assoc-in [:articles :error]  failure))))
+
+(rf/reg-sub :articles            (fn [db _] (get db :articles)))
+(rf/reg-sub :articles/status     :<- [:articles] :status)
+(rf/reg-sub :articles/data       :<- [:articles] :data)
+(rf/reg-sub :articles/loading?   :<- [:articles/status] #(= % :loading))
+(rf/reg-sub :articles/fetching?  :<- [:articles/status] #(or (= % :loading) (= % :fetching)))
+```
+
+## Canonical declaration — `:data-region` machine form
+
+Used when the lifecycle is *part of* a larger page's machine (the page already has a `:type :parallel` machine with `:form` / `:mode` axes — see `patterns/nine-states.md`), or when the lifecycle plus a per-region cancellation/`:invoke` are wanted. Lifted from `examples/reagent/realworld/tags.cljs`:
+
+```clojure
+(rf/reg-machine :realworld/tags
+  {:initial :idle
+   :data    {:tags [] :error nil :loaded-at nil :attempt 0}
+   :actions
+   {:bump-attempt (fn [d _] {:data (update d :attempt (fnil inc 0))})
+    :set-tags     (fn [d [_ {:keys [tags now]}]]
+                    {:data (assoc d :tags (vec tags) :error nil :loaded-at now)})
+    :set-error    (fn [d [_ {:keys [failure]}]] {:data (assoc d :error failure)})}
+   :states
+   {:idle     {:tags #{:tags/idle}
+               :on   {:fetch-started {:target :loading :action :bump-attempt}}}
+    :loading  {:tags #{:tags/loading :tags/in-flight :tags/transient}
+               :on   {:fetch-succeeded {:target :loaded :action :set-tags}
+                      :fetch-failed    {:target :error  :action :set-error}}}
+    :fetching {:tags #{:tags/fetching :tags/in-flight :tags/loaded :tags/transient}
+               :on   {:fetch-succeeded {:target :loaded :action :set-tags}
+                      :fetch-failed    {:target :error  :action :set-error}}}
+    :loaded   {:tags #{:tags/loaded}
+               :on   {:fetch-started {:target :fetching :action :bump-attempt}}}
+    :error    {:tags #{:tags/error}
+               :on   {:fetch-started {:target :loading  :action :bump-attempt}}}}})
+```
+
+The lifecycle's status enum maps **one-to-one** onto state-keywords. The slice's `:status` field disappears — the state-keyword IS the status. The `:loading?` / `:fetching?` view booleans become `(rf/has-tag? :realworld/tags :tags/loading)` / `(rf/has-tag? :realworld/tags :tags/in-flight)`.
+
+## When to choose each form
+
+- **Slice form** — single resource, no concurrent axes, no cancellation cascade needed, view code can be host-agnostic. The vast majority of cases.
+- **Machine form** — the lifecycle is one region of a larger parallel machine (composes with `patterns/nine-states.md` and `patterns/forms.md`); OR the request's lifetime should be bound to a parent state (the actor-destroy cancellation cascade fires when the region exits); OR the team wants tag-shaped queries instead of slice-field comparisons.
+
+Realworld ships both shapes side-by-side. `articles`, `feed`, `article`, `comments`, `profile`, `profile.articles`, `profile.favorites` use the slice form; `tags` uses the machine form. The README's "Pattern-RemoteData — two shapes side-by-side" section has the worked comparison.
+
+## Common variations
+
+- **Optimistic updates.** Commit to `:data` *before* the fetch; capture the prior value as part of the rollback event. Pure rollback handler.
+- **Polling.** `:dispatch-later` schedules the next `:load`. Pause/resume via a `:poll-active?` flag.
+- **Retry with backoff.** Read `:attempt` from the slice; compute backoff as a sub. The framework ships no built-in retry — convention only. (For HTTP-specific retry semantics see `:rf.http/managed`'s `:retry` arg in EP 014.)
+- **Stale detection.** Carry an epoch on the dispatched reply event; suppress on mismatch. See `SKILL-REDIRECT.md` → *Pattern — Stale detection*.
+
+## Worked example
+
+- **Slice form**: `examples/reagent/realworld/articles.cljs` — articles list with `?tag=` query, revalidate-on-route, full lifecycle.
+- **Machine form**: `examples/reagent/realworld/tags.cljs` — popular-tags list, single-region `reg-machine`, tag-shaped view queries.
+- **Compose with NineStates**: `examples/reagent/nine_states/core.cljs` — `:data` region as one axis of a parallel machine, with cardinality cascade (`:empty` / `:one` / `:some` / `:too-many`).
+
+## Pillar 5 — why `:loading` vs `:fetching` is non-negotiable
+
+The split exists for one reason: the UI for an empty page mid-load is a spinner; the UI for a page that already has data and is refreshing is not. Without the split, every revalidation flashes a spinner over loaded content. The pattern's `:loading?` and `:fetching?` subs hide the distinction from view code that doesn't care, while making it cheap for view code that does.
+
+`:attempt` increments on **every** fetch (initial load is `1`, first retry `2`, revalidate `3`). One counter answers two questions: "have we ever tried?" (`> 0`) and "how many times have we retried?" (drives backoff). Don't add a parallel retry-only counter — derive it.
+
+## Deeper pointers
+
+- Spec: `SKILL-REDIRECT.md` → *Pattern — Remote data* (full slice schema, `:loading` vs `:fetching` table, optimistic-update rollback, SSR considerations).
+- HTTP fx: `SKILL-REDIRECT.md` → *EP — HTTP requests (014)* (the `:rf.http/managed` surface, retry semantics, failure categories, cancellation cascade).
+- Compose: `patterns/nine-states.md` (the `:data` region of a parallel machine).
+- Stale: `SKILL-REDIRECT.md` → *Pattern — Stale detection* (epoch idiom).


### PR DESCRIPTION
## Summary

Three pattern leaves under `skills/re-frame2/patterns/`, each pointer-shaped per Pillar 4 — they name the re-frame2 features that implement the pattern and lift the canonical declaration from `examples/reagent/`, rather than re-teaching the underlying ideas (orthogonal-axis state, RemoteData lifecycle, form lifecycle) the AI already knows.

- `nine-states.md` (122 lines) — parallel regions + tags + render-priority table. Canonical: `examples/reagent/nine_states/core.cljs`.
- `remote-data.md` (131 lines) — slice form and `:data-region` machine form side-by-side. Slice canonical: `examples/reagent/realworld/articles.cljs`; machine canonical: `examples/reagent/realworld/tags.cljs`.
- `forms.md` (161 lines) — slice form and `:form-region` machine form side-by-side. Slice canonical: `examples/reagent/realworld/auth.cljs`; machine canonical: `examples/reagent/realworld/settings.cljs`.

All three under the 250-line cap (target ~150). Each leaf:

1. **When to load** — load triggers (1-2 sentences)
2. **The re-frame2 features that implement it** — named list (`:fsm/parallel-regions`, `:fsm/tags`, `:data-region`, etc.)
3. **Canonical declaration** — mini-example lifted from the worked example, ≤40 lines
4. **Common variations** — slice vs machine, where applicable
5. **Worked example pointer** — paths into `examples/reagent/`
6. **Spec pointer** via `SKILL-REDIRECT.md`

Cut-test applied throughout: no sentence would survive being rewritten about React Query / Formik / XState.

## Test plan

- [x] Three files exist under `skills/re-frame2/patterns/`
- [x] Each file ≤250 lines (122 / 131 / 161)
- [x] All referenced example paths exist (`examples/reagent/nine_states/core.cljs`, `examples/reagent/realworld/{tags,articles,auth,settings,article_editor,comments}.cljs`)
- [x] Deep-dive pointers route through `SKILL-REDIRECT.md` (no hardcoded URLs)
- [x] `SKILL.md` not touched
- [x] Code blocks lifted from current examples (machine declarations match `nine_states/core.cljs`, `realworld/tags.cljs`, `realworld/settings.cljs`)
- [x] Pillar 4 cut-test applied — no sentence is generic-RemoteData / generic-form / generic-FSM-theory; every sentence names a re-frame2-specific binding (`:tags`, `:rf/machine-has-tag?`, `:_form` reserved key, `:loading` vs `:fetching` split, `submit-attempted? OR touched` visibility rule)

Closes rf2-p6ut.