### PR TITLE
fix(story): install play-runner trace listener before loader phase (rf2-v2g9)

### DIFF
--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -276,6 +276,20 @@
                  ;; Phase 0: allocate frame, run :frame-setup decorators,
                  ;; drive lifecycle to :mounting.
                  (frames/allocate! variant-id decorator-stack)
+                 ;; Install the play-runner's per-frame trace listener
+                 ;; BEFORE the loader phase begins (rf2-v2g9). The
+                 ;; listener feeds the assertions module's dispatched-
+                 ;; events accumulator, which `:loaders-complete-when`'s
+                 ;; vector form consults to gate the loaders-complete
+                 ;; transition. Installing it post-loaders (the original
+                 ;; Stage 5 placement) means the vector form sees an
+                 ;; empty accumulator during the loader phase and never
+                 ;; matches. We seed the accumulators here so the
+                 ;; listener has a clean slot to write into; `execute-
+                 ;; play!` resets them again at play start so play-time
+                 ;; assertion semantics ("during play") are preserved.
+                 (assertions/reset-trace-accumulators! variant-id)
+                 (play/install-trace-listener! variant-id)
                  ;; Phase 1: loaders.
                  (run-loaders! variant-id)
                  ;; Phase 2: events.

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -204,22 +204,56 @@
       {:loaders                [[:test/load-a] [:test/load-b]]
        :loaders-complete-when  [[:test/load-a] [:test/load-b]]
        :events                 []})
-    ;; Dispatched-events accumulator is populated by the trace bus; we
-    ;; need the play-runner's listener to feed it before the predicate
-    ;; runs. Stage 5's loaders-complete-when evaluation is invoked from
-    ;; run-loaders! AFTER the loader dispatches, so the dispatched
-    ;; accumulator must already contain the loader events. We seed
-    ;; manually here because the trace listener is play-scoped — Stage 5
-    ;; treats the vector form as a permissive 'progress when seen';
-    ;; lifecycle still progresses regardless via the runtime layer.
+    ;; Per rf2-v2g9, the play-runner's trace listener now installs
+    ;; before the loader phase, so the dispatched-events accumulator
+    ;; observes loader-phase events and the vector predicate can match.
     (let [r (async/deref-blocking (story/run-variant :story.loaders/vector) 5000)]
-      ;; The runtime always proceeds past loaders into events, regardless
-      ;; of the predicate's result — the predicate gates only the
-      ;; loaders-complete *transition*. The result here verifies the
-      ;; full flow ran without an exception.
       (is (true? (-> r :app-db :a?)))
-      (is (true? (-> r :app-db :b?))))
+      (is (true? (-> r :app-db :b?)))
+      (is (= :ready (:lifecycle r))
+          "vector form's loaders-complete-when fires once both loaders run, transitioning the lifecycle to :ready"))
     (story/destroy-variant! :story.loaders/vector)))
+
+(deftest loaders-complete-when-vector-trace-listener-installed-pre-loaders
+  ;; rf2-v2g9 — the play-runner's per-frame trace listener installs
+  ;; BEFORE the loader phase so `:loaders-complete-when`'s vector form
+  ;; can match against the dispatched-events accumulator. Before the
+  ;; fix the listener installed at play start (after loaders ran) and
+  ;; the predicate never matched — the loader phase stayed in
+  ;; `:loading`. This test pins that lifecycle to `:ready` and
+  ;; verifies the accumulator was populated with the loader event.
+  (testing "the loaders-complete-when vector form matches loader-phase dispatches"
+    (rf/reg-event-db :fixture/loaded
+      (fn [db _] (assoc db :fixture-loaded? true)))
+    (story/reg-variant :story.v2g9/loader-vector
+      {:loaders               [[:fixture/loaded]]
+       :loaders-complete-when [[:fixture/loaded]]
+       :events                []})
+    (let [r (async/deref-blocking
+              (story/run-variant :story.v2g9/loader-vector) 5000)]
+      (is (true? (-> r :app-db :fixture-loaded?))
+          "the loader event ran")
+      (is (= :ready (:lifecycle r))
+          "the loader phase advanced to :ready — the predicate saw the loader event"))
+    (story/destroy-variant! :story.v2g9/loader-vector)))
+
+(deftest loaders-complete-when-vector-without-listener-stalls
+  ;; rf2-v2g9 — negative companion to the fix. We simulate the pre-fix
+  ;; behaviour by clearing the listener-fed accumulator between the
+  ;; loader dispatch and the predicate evaluation, then re-running the
+  ;; predicate directly. With an empty accumulator the vector form is
+  ;; false — which is the bug the fix prevents in the live pipeline.
+  (testing "vector form with an empty accumulator (pre-fix simulation) returns false"
+    (let [frame-id :story.v2g9/stalled
+          body {:loaders-complete-when [[:fixture/loaded]]}]
+      (reset! assertions/dispatched-events-accumulator {})
+      (is (false? (loaders/evaluate-complete-when frame-id body))
+          "predicate is false when the accumulator has no record of the required event")
+      ;; And once the listener-fed accumulator carries the event, the
+      ;; predicate flips to true (the post-fix observable).
+      (assertions/record-dispatched! frame-id [:fixture/loaded])
+      (is (true? (loaders/evaluate-complete-when frame-id body))
+          "predicate is true once the trace listener has fed the accumulator"))))
 
 (deftest loaders-complete-when-evaluate-vector-form
   (testing "vector-of-events evaluation reads the assertions dispatched-events accumulator"


### PR DESCRIPTION
## Root cause

The Story play-runner's per-frame trace listener was installed at the start of phase-4 play, *after* `run-loaders!` had already dispatched the loader events. The `:loaders-complete-when` vector form (`[[:event-a] [:event-b]]`) consults `re-frame.story.assertions/dispatched-events-accumulator` to decide whether the loader phase is complete — and that accumulator is populated by that very listener. On a fresh frame the accumulator was empty during the loader phase, so the vector predicate never matched, `loaders/finish-loaders!` was never called, and variants relying on the vector form stalled in `:loading` instead of advancing to `:ready`.

A standing comment in `story_play_test.clj` flagged exactly this gap:

> we need the play-runner's listener to feed it before the predicate runs ... the trace listener is play-scoped — Stage 5 treats the vector form as a permissive 'progress when seen'; lifecycle still progresses regardless via the runtime layer.

That comment was a workaround. The bead `rf2-v2g9` calls it as Stage 6 refinement: install the listener earlier.

## Fix

`run-variant` (in `tools/story/src/re_frame/story/runtime.cljc`) now calls

    (assertions/reset-trace-accumulators! variant-id)
    (play/install-trace-listener! variant-id)

immediately after `frames/allocate!`, before `run-loaders!`. The listener captures loader-phase dispatches into the accumulator, so the vector predicate matches at `loaders/evaluate-complete-when` time and `loaders/finish-loaders!` fires.

`execute-play!` still resets the accumulators at play start, so existing play-time semantics for `:rf.assert/dispatched?` / `:rf.assert/no-warnings` / `:rf.assert/effect-emitted` (each scoped to "during play") are preserved. `execute-play!`'s `finally` block still tears the listener down at play end. Listener install is idempotent (stable id, replaces on second call).

## Tests

- Strengthened existing `loaders-complete-when-vector` to pin `:lifecycle :ready` (it previously asserted only that the loader events ran, since the lifecycle was knowingly broken).
- Added `loaders-complete-when-vector-trace-listener-installed-pre-loaders` — a focused regression test mirroring the bead's repro: a single loader dispatches `:fixture/loaded`; the predicate waits on the same event; lifecycle must reach `:ready`.
- Added `loaders-complete-when-vector-without-listener-stalls` as a negative companion that exercises the predicate directly against an empty / populated accumulator, locking in the predicate semantics independently of the runtime wire-up.

## Before / after

With the runtime change reverted, the two new lifecycle assertions fail:

    FAIL in (loaders-complete-when-vector)
    expected: (= :ready (:lifecycle r))
      actual: (not (= :ready :loading))

    FAIL in (loaders-complete-when-vector-trace-listener-installed-pre-loaders)
    expected: (= :ready (:lifecycle r))
      actual: (not (= :ready :loading))

With the fix applied, the full suite is green: 147 story JVM tests, 498 CLJS tests, elision probe clean.

## Scope

- Touched: `tools/story/src/re_frame/story/runtime.cljc`, `tools/story/test/re_frame/story_play_test.clj`.
- No changes outside `tools/story/`.

## Test plan

- [x] `clojure -M:test` in `tools/story/` — 147 tests, 358 assertions, 0 failures.
- [x] `npm run test:cljs` (implementation/) — 498 tests, 1210 assertions, 0 failures.
- [x] `npm run test:elision` (implementation/) — all sentinels pass.
- [x] `clojure -M:test` in `implementation/core/` — 183 tests, 824 assertions, 0 failures.
- [x] Verified the new lifecycle assertions FAIL with the runtime fix reverted (red), PASS with it applied (green).

Closes rf2-v2g9.