### PR TITLE
feat(skills): re-frame2 decision-trees + examples-map (rf2-g6fh)

### DIFF
--- a/skills/re-frame2/decision-trees/pick-a-pattern.md
+++ b/skills/re-frame2/decision-trees/pick-a-pattern.md
@@ -1,0 +1,131 @@
+# Decision tree — which Pattern-* fits this task?
+
+> **Audience:** authors writing re-frame2 ClojureScript application code.
+> **Use when:** the task description hints at a recurring shape — fetching, submitting, booting, processing, streaming, rendering lifecycle states — and you need to pick the canonical leaf to load.
+
+Patterns compose: most real screens combine two or three of them. This tree picks the *primary* pattern — the one whose shape the feature is built around. Secondary patterns get loaded in their own pass after the primary one is in place.
+
+Each leaf below names the file under [`patterns/`](../patterns/) (the pattern leaf) and the worked example under `examples/reagent/` (when one exists).
+
+## Step 1 — name the shape
+
+Read the prompt for **one** of the following shape-tells. They are mutually exclusive at the level of *primary* role:
+
+| Shape-tell in the prompt | Primary pattern |
+|---|---|
+| "Fetch / GET / load / refresh / reload" — a request whose response writes to `app-db` | RemoteData |
+| "Submit / save / form / validation / required / draft / dirty" — user-edited input crossing a server boundary | Forms |
+| "Boot / init / hydrate / startup / first-load / splash" — the initial-load sequence before the app is interactive | Boot |
+| "WebSocket / SSE / EventSource / live / push / subscribe / channel / heartbeat / reconnect" — long-lived connection | WebSocket |
+| "Retry / backoff / circuit-breaker / 4xx vs 5xx / abort / cancel an in-flight request" — a request with status-aware policy | ManagedHTTP |
+| "Empty state / no-results / one-result / too-many / not-found / forbidden / nine UI states" — render every legal lifecycle distinctly | NineStates |
+| "Fire-and-forget / log / analytics / telemetry / external side-effect with no observable reply" | AsyncEffect |
+| "CPU-bound / heavy / parses / hashes / pegs the main thread / chunked / yields / progress bar" | LongRunningWork |
+| "Cache / freshness / TTL / since / etag / `stale-after-ms` / async-result arrives after state moved on" | StaleDetection |
+
+If you see **two** shape-tells, the dominant one is the one the user names first or the one that owns the data. Pattern composition (e.g. "managed-HTTP retries inside a form submit") is normal — pick the primary, plan the secondary as a follow-up.
+
+## Step 2 — the disambiguation pairs
+
+A few neighbouring patterns share enough vocabulary to get confused. These rules pick the right leaf when both look plausible.
+
+### RemoteData vs ManagedHTTP
+
+Both move data over HTTP. The difference is **who owns the lifecycle vocabulary**.
+
+- **RemoteData** — the `app-db` slice is the protagonist. The feature wants the canonical 5-key slice (`:status` / `:data` / `:error` / `:loaded-at` / `:attempt`) and routes through the four-event lifecycle (`:load → :loaded | :load-failed`). The fx underneath could be `:http`, `:rf.http/managed`, IndexedDB, a wrapped JS library — any AsyncEffect-shaped pipe. Choose RemoteData when the *slice shape* and *state-enum semantics* are the thing.
+- **ManagedHTTP** — the `:rf.http/managed` fx is the protagonist. The feature wants retry-with-backoff, the eight-category failure taxonomy, abort tokens, in-flight de-dup, the encode/decode pipeline. Choose ManagedHTTP when the *fx contract* (its inputs, its replies, its retry policy) is the thing.
+
+If both, **load RemoteData first, ManagedHTTP second** — RemoteData owns the slice; ManagedHTTP plugs into it. The escape hatch into a state-machine-driven HTTP flow (semantic retries that aren't transport-retries) is documented inside the ManagedHTTP leaf.
+
+### Forms vs RemoteData
+
+Both have a status enum. The Forms enum is `:idle | :submitting | :submitted | :error`; the RemoteData enum is `:idle | :loading | :fetching | :loaded | :error`. The names differ because the lifecycles differ.
+
+- **Forms** — there is user input. Pre-submit shape is the form draft; post-submit shape is the server's confirmation. The slice tracks `:draft`, `:submitted`, `:touched`, `:errors`, `:submit-attempted?`. Choose Forms when the prompt mentions fields, validation, dirty state, or submit buttons.
+- **RemoteData** — there is no user input crossing the boundary. The slice holds *what the server told us*, not *what the user is editing*. Choose RemoteData when the prompt is read-only / fetch-only from the user's side.
+
+A form's `:submit` step is usually a Forms-driven dispatch *into* a RemoteData or ManagedHTTP request. The form owns the input lifecycle; the request owns the response lifecycle. Both slices exist; neither is the other.
+
+### AsyncEffect vs RemoteData
+
+- **AsyncEffect** is the *generic* six-step shape (register fx → return `:fx` → post work → reply → dispatch → commit). RemoteData *specialises* it for HTTP with the 5-key slice.
+- Choose **AsyncEffect** for fire-and-forget side effects that do not commit a result to `app-db` — analytics emits, log shipping, browser-notification triggers, `postMessage` to an external system you don't await. There is no slice.
+- Choose **RemoteData** when there *is* a reply that updates the slice. The lifecycle slice is the giveaway.
+
+Anything that *would* have a slice but doesn't have one yet is a RemoteData leaf to author. Anything that genuinely has no observable reply is AsyncEffect.
+
+### WebSocket vs AsyncEffect
+
+- **AsyncEffect** is one-shot: post, reply, done. There is no second message over the same channel.
+- **WebSocket** is long-lived: a connection actor that survives across many messages, with phases (`:disconnected → :connecting → :authenticating → :connected → :reconnecting → :failed`), heartbeats, server pushes without correlation, queued sends when disconnected. The machine *owns the socket*; messages over the socket may themselves be AsyncEffect-shaped (request/reply with a correlation id), but the connection is a state machine.
+
+If the prompt mentions reconnect, heartbeat, subscribe-to-topic, or server push — WebSocket. If a single send-and-receive — AsyncEffect.
+
+### Boot vs RemoteData (multiple)
+
+A boot sequence is many requests, but it is not "multiple RemoteData slices". Boot has:
+
+- **Sequential dependencies** — config before profile before route resolve.
+- **Phase-distinct failure semantics** — a failed step usually halts boot; the user sees an error page, not a partial app.
+- **Visible progress** — the user wants to see "Loading profile…" then "Connecting…".
+- **One-shot per app load** — re-booting is unusual; hot-reload must not re-trigger boot.
+
+If the boot graph is ≤3 steps with no error states and no progress UI, chain events directly (the Boot leaf's "simple form"). Once any of those conditions break, lift the boot into a state machine — the Boot leaf names the canonical state set (`:reading-config → :authenticating → :loading-profile → :hydrating → :resolving-route → :ready | :failed`).
+
+### NineStates vs RemoteData/Forms
+
+NineStates is **not** a substitute for either. It *layers* over them. Choose NineStates when the prompt mentions:
+
+- Designing every render branch a page might show — including empty, one-result, too-many, validation-incorrect, transient-correct, and terminal/done.
+- Wanting tooling-enumerable render states (for stories, for visual regression, for design review).
+- A page that has *both* a data lifecycle (RemoteData) *and* a form lifecycle (Forms) *and* a mode lifecycle (running vs done) — three orthogonal axes.
+
+If the prompt names only one axis (say, just a data fetch), do not reach for NineStates. NineStates pays off when ≥2 axes need to be modelled and rendered independently.
+
+### LongRunningWork vs AsyncEffect
+
+- **AsyncEffect** — the runtime already yields for you. HTTP, IndexedDB, `postMessage` — none of these hold the main thread.
+- **LongRunningWork** — the work is CPU-bound on the main thread (parsing a 50MB file, hashing N items, running a large reduce, simulating physics). The dispatch loop blocks; the browser stops painting.
+
+The LongRunningWork leaf's own decision tree picks between (a) a Web Worker (preferred when the work serialises across the worker boundary, hosted by AsyncEffect or WebSocket) and (b) the main-thread chunked-state-machine pattern (when DOM access or awkward serialisation forces main-thread execution).
+
+### StaleDetection — not a primary choice, an overlay
+
+StaleDetection is rarely the *primary* pattern for a task. It is the **epoch idiom** that overlays RemoteData, WebSocket, or any state-machine that initiates async work which might be superseded before its reply arrives. Choose StaleDetection as a primary pattern only when the explicit task is *"add stale detection to an existing feature"*. Otherwise the relevant pattern leaf (RemoteData, WebSocket, the machine) names where the epoch attaches; StaleDetection is the reference for *how*.
+
+## Step 3 — verify against the example app
+
+Every pattern that has a worked example is verified end-to-end by a Playwright spec. After picking the pattern leaf, point at the example app named in [`examples-map.md`](../examples-map.md) and confirm:
+
+- The slice shape in your task matches the slice shape in the example.
+- The event names in your task scale to the example's `:feature/<verb>` naming.
+- The schema attachment points (`reg-app-schema` invocations) cover the same boundaries.
+
+If the example contradicts the leaf, **the example wins** — re-frame2's cardinal rule is that implementation is ground truth (per SKILL.md §Cardinal rules). File a bead against the spec; don't silently work around.
+
+## Step 4 — load the leaves
+
+| Primary pattern | Leaf to load | Worked example |
+|---|---|---|
+| RemoteData | [`patterns/remote-data.md`](../patterns/remote-data.md) | (inline mini-example) |
+| Forms | [`patterns/forms.md`](../patterns/forms.md) | `examples/reagent/login/` |
+| Boot | [`patterns/boot.md`](../patterns/boot.md) | (pending) |
+| WebSocket | [`patterns/websocket.md`](../patterns/websocket.md) | (pending) |
+| ManagedHTTP | [`patterns/managed-http.md`](../patterns/managed-http.md) | `examples/reagent/managed_http_counter/` |
+| NineStates | [`patterns/nine-states.md`](../patterns/nine-states.md) | `examples/reagent/nine_states/` |
+| AsyncEffect | [`patterns/async-effect.md`](../patterns/async-effect.md) | (inline mini-example) |
+| LongRunningWork | [`patterns/long-running-work.md`](../patterns/long-running-work.md) | (pending) |
+| StaleDetection | [`patterns/stale-detection.md`](../patterns/stale-detection.md) | (inline mini-example) |
+
+Load at most two pattern leaves at a time. If three or more seem necessary, the request probably spans features and should be broken up — author each pattern's leaf in its own pass.
+
+## Step 5 — the state-shape question (separate decision)
+
+After picking the pattern, a second question applies independently: *should the state behind this pattern live as a slice in `app-db`, as a region inside an existing machine, or as a top-level `reg-machine`?* That question is its own decision tree — see [`slice-or-machine.md`](./slice-or-machine.md). Pattern choice and state-shape choice are orthogonal: WebSocket is always a machine; AsyncEffect is usually a slice; RemoteData is a slice unless its retry policy needs a machine.
+
+## Cross-references
+
+- [`slice-or-machine.md`](./slice-or-machine.md) — when to lift state into a machine.
+- [`../examples-map.md`](../examples-map.md) — one-paragraph index of every worked example.
+- [`../SKILL.md`](../SKILL.md) §Decision: which pattern fits? — the same matrix, in the router's own voice.

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -1,0 +1,130 @@
+# Decision tree — slice, region, or top-level machine?
+
+> **Audience:** authors writing re-frame2 ClojureScript application code.
+> **Use when:** you have feature-state to model and need to choose its shape — a key in `app-db` driven by `reg-event-db`, a region inside an existing `reg-machine`, or a brand-new top-level `reg-machine`.
+
+re-frame2 gives you three places to put state. The right choice usually falls out of one or two questions; this tree walks them in priority order. The four state-machine tells are listed first because if any of them holds, the choice is settled.
+
+## The three shapes
+
+| Shape | What it is | When it fits |
+|---|---|---|
+| **Slice** | a key (or sub-tree) inside `app-db`, written by `reg-event-db` and read by `reg-sub`. No FSM grammar. | A field, a list, a flag, a counter — values that change but whose *legal transitions* don't need enforcement. |
+| **Region** | one axis inside an existing `reg-machine` declared with `:type :parallel` and `:regions {...}`. Each region runs its own state-tree. | A sub-concern that is *part of* a larger feature's lifecycle — e.g. a form's submission status inside a screen's load-then-edit lifecycle. |
+| **Top-level machine** | a free-standing `reg-machine`. Its snapshot lives at `[:rf/machines <id>]` in `app-db`. | A feature whose answer to "what can happen next?" depends on the current mode, and which is not a sub-concern of another feature. |
+
+## Step 0 — three sanity questions before the tree
+
+Before walking the tree, rule out the cases where there is no state shape to choose.
+
+1. **Is this a pure derivation?** If the value is a function of other values already in `app-db`, it is a `reg-sub`, not a slice. No state shape needed.
+2. **Is this a transient cofx value?** If the value is computed at dispatch time and used inside one event (e.g. `:rf/now`, a generated id), it is a registered cofx, not state.
+3. **Is this a machine's `:data`?** Per [`spec/005-StateMachines.md` §Naming](../../spec/005-StateMachines.md), each machine carries its own private `:data` map distinct from `app-db`. Extended state local to a machine lives in `:data`, not in a slice.
+
+If none of those apply, walk Step 1.
+
+## Step 1 — the four machine-tells
+
+If any of these is true, use a state machine. They are listed in dominance order — the first one that fires settles the question.
+
+### Tell 1 — multi-step async with phase-distinct transitions
+
+Does the feature pass through ≥3 phases each with their own allowed-next transitions, and do those phases each spawn async work that the next phase depends on?
+
+Examples:
+
+- A WebSocket connection cycling `:disconnected → :connecting → :authenticating → :connected → :reconnecting → :failed`. Each phase has distinct entry actions (open socket / send auth / subscribe to topics / wait on backoff) and distinct allowed events.
+- An app boot that reads config, then authenticates, then loads profile, then resolves the route. Each step depends on the previous; failure semantics are phase-specific.
+- A login flow whose `:submitting` state spawns an HTTP `:invoke` whose success transitions to `:authed` and whose failure transitions to `:incorrect` with a retry counter.
+
+If yes → **machine**. A slice can't enforce "you can't fire `:auth-ok` while in `:disconnected`"; a machine's transition table does.
+
+### Tell 2 — cancellation cascade matters
+
+When state moves on, must in-flight work on the prior state be implicitly cancelled (or its replies silently suppressed)?
+
+Examples:
+
+- A search-as-you-type whose previous request's reply must be discarded when a newer keystroke launched another request.
+- A WebSocket reconnect-backoff timer that must not fire after the user manually re-connected.
+- A long-running batch job whose mid-flight chunks must stop processing when the user navigates away.
+
+If yes → **machine**. Machine snapshots advance `:rf/after-epoch` on every state entry; in-flight `:after` timers and `:invoke` replies carry the captured epoch and are dropped on mismatch (per [`spec/Pattern-StaleDetection.md`](../../spec/Pattern-StaleDetection.md) and [`spec/005-StateMachines.md` §Epoch-based stale detection](../../spec/005-StateMachines.md)). A slice cannot express the cancellation cascade without re-implementing the epoch idiom by hand — at which point you have built a machine in disguise.
+
+### Tell 3 — terminal-state matters
+
+Does the feature have a state from which no further transitions are legal — `:archived`, `:locked-out`, `:cancelled`, `:done` — and does the UI need to render that state distinctly from "active but idle"?
+
+Examples:
+
+- An auth flow with a `:locked-out` state after N failed attempts; the UI must refuse to render the login form.
+- An invoice machine where `:paid` is terminal — no further edits allowed, even by the framework.
+- A read-only archived document whose `:archived` state forbids every editing event.
+
+If yes → **machine**. The `:tags` projection on a machine snapshot (`:auth/locked-out`, `:document/archived`) lets every view query the terminal status with a single sub; a slice with an `:status :archived` keyword has to be re-checked at every event handler.
+
+### Tell 4 — orthogonal axes
+
+Does the feature have ≥2 independent state axes that evolve concurrently — say, data-lifecycle (loading/loaded/error) *and* form-validity (neutral/correct/incorrect) *and* mode (active/done)?
+
+Examples:
+
+- The NineStates pattern is the canonical case: three orthogonal axes (data / form / mode) modelled as three parallel regions.
+- A page that shows live WebSocket updates *and* lets the user edit a draft *and* tracks whether the page is in read-only review mode.
+
+If yes → **machine with `:type :parallel` and `:regions`**. Three axes of three states each shrink from 27 flat states to 9 states across 3 regions. Modelling orthogonal axes as a single flat enum is the AND-state explosion; the machine grammar is the answer.
+
+If none of the four tells fire, the feature is **slice-shaped**. Default to slice unless one of the four holds.
+
+## Step 2 — if it's a machine, is it top-level or a region?
+
+This question only applies after Step 1 picked machine.
+
+Ask: *is this lifecycle a sub-concern of a larger feature's lifecycle, or is it a feature on its own?*
+
+- **Region** — the lifecycle is one axis of a larger feature. A form's submission status (`:idle → :submitting → :submitted | :error`) inside a screen's load-then-edit lifecycle. A page's "data" axis inside a NineStates page. The form is a region of the screen; not its own top-level machine.
+- **Top-level machine** — the lifecycle has its own identity and is shared across features. The auth machine. The WebSocket connection. The boot machine. The router. These are not "part of" another machine; they are sibling concerns.
+
+Rule of thumb: if removing the lifecycle would gut the parent feature, it is a region. If removing the lifecycle would simply remove a sibling concern, it is top-level.
+
+## Step 3 — if it's a slice, where does it live in `app-db`?
+
+This question only applies after Step 1 picked slice.
+
+- **Pattern-slice?** If the slice is the canonical shape of a named pattern (RemoteData's 5-key slice; Forms' 7-key slice), use the pattern's canonical path convention. Pattern leaves name the slot.
+- **Feature-prefix?** Otherwise, the slice belongs at `[:<feature-prefix> ...]` per [`spec/Conventions.md` §Feature-modularity prefix convention](../../spec/Conventions.md). Pick a feature keyword for the app's namespace; never start with `:rf/` (reserved).
+- **Schema?** Register a schema for the slice via `reg-app-schema` only if the slice crosses a trust boundary (incoming HTTP payload, persisted state on restore). Don't schema-fence every internal key (per SKILL.md cardinal rule 4).
+
+## Step 4 — the four tells, restated as a worked checklist
+
+Run through the four tells in order and answer yes/no for the feature at hand. The first yes settles the question.
+
+1. **Multi-step async with phase-distinct transitions?** → machine.
+2. **Cancellation cascade matters?** → machine.
+3. **Terminal-state matters?** → machine.
+4. **Orthogonal axes?** → parallel-region machine.
+5. None of the above? → slice.
+
+If you're between slice and machine and none of the four tells clearly fire, the prompt's *language* is the tie-breaker:
+
+- "Transitions", "modes", "phases", "lifecycle", "can't happen during X", "while connecting", "after submit" → machine.
+- "Field", "value", "filter", "counter", "flag", "current selection", "this list" → slice.
+
+## Step 5 — verify against the implementation
+
+Cardinal rule (per SKILL.md §1): when the spec and `implementation/**` disagree, the implementation wins. After picking a shape, point at the example app that uses the same shape:
+
+- A machine? — see `examples/reagent/login/` (state machine + tags + managed-HTTP), `examples/reagent/state_machine_walkthrough/` (the chapter as runnable code), `examples/reagent/nine_states/` (parallel regions).
+- A slice? — see `examples/reagent/counter/` (the smallest possible slice), `examples/reagent/todomvc/` (a list-of-items slice with editing and filters), the 7GUIs cluster.
+
+If the example contradicts the leaf you'd pick from this tree, **the example wins**. File a bead against the spec; don't silently work around (per Mike's standing directive on file-bead-for-spec-gaps).
+
+## Cross-references
+
+- [`pick-a-pattern.md`](./pick-a-pattern.md) — pattern choice (orthogonal to state-shape choice).
+- [`../reference/state-machines/basics.md`](../reference/state-machines/basics.md) — how to author `reg-machine` (states / initial / guards / actions).
+- [`../reference/state-machines/regions-and-tags.md`](../reference/state-machines/regions-and-tags.md) — parallel regions, tags, cancellation cascade.
+- [`../reference/state-machines/decision-tree.md`](../reference/state-machines/decision-tree.md) — a deeper-level slice/region/machine tree on the reference side.
+- [`../reference/fundamentals/events-and-fx.md`](../reference/fundamentals/events-and-fx.md) — `reg-event-db` / `reg-event-fx` for slice-shaped state.
+- [`../reference/fundamentals/schemas.md`](../reference/fundamentals/schemas.md) — `reg-app-schema` at boundaries.
+- [`../examples-map.md`](../examples-map.md) — example-app index for shape-verification.

--- a/skills/re-frame2/examples-map.md
+++ b/skills/re-frame2/examples-map.md
@@ -1,0 +1,87 @@
+# Examples map — when to point at which `examples/reagent/<x>/`
+
+> **Audience:** authors writing re-frame2 ClojureScript application code.
+> **Use when:** a task lands on a pattern or a primitive whose shape needs to be cross-checked against a known-shipping worked example.
+
+re-frame2's examples are the canonical authoring substrate — per SKILL.md cardinal rule 5, when an example exists for a pattern, **prefer the example's shape over a synthesised one**. The examples reflect the implementation as currently shipped; the spec/EP docs describe *why*, and the example describes *what*.
+
+This file is a one-paragraph-per-example index. It names what each example demonstrates and when to point at it during an authoring task. It deliberately does **not** explain the example's internals — read the source for that. Each paragraph names the *patterns and primitives* the example exercises so a routing decision (e.g. "I want to verify the Pattern-NineStates shape") lands on the right directory in one hop.
+
+The full catalogue (with maturity, build ids, and end-to-end Playwright coverage) lives at [`examples/README.md`](../../examples/README.md). The substrate policy (Reagent is canonical; UIx and Helix ship a smoke-pair) lives at [`spec/Conventions.md` §Adapter shipping convention](../../spec/Conventions.md).
+
+## counter — `examples/reagent/counter/`
+
+The smallest possible re-frame2 app. One `reg-event-db`, one `reg-sub`, one `reg-view` Var, an `:initial-fx` boot dispatch, and a single click. Point at this example when authoring the first event/sub/view of a greenfield feature, when verifying the canonical macro-shapes (`reg-event-db`, `reg-sub`, `reg-view` Form-1 with a Var reference), or when checking the minimum-viable `app-db` schema attachment. Exercises 002 Frames and 004 Views. The pedagogical "hello world" — its shape sets the bar for every other example.
+
+## counter_slim_and_fast — `examples/reagent/counter_slim_and_fast/`
+
+The counter dataflow mounted on the slim Reagent rewrite (`day8/reagent-slim`) — the `reagent2.*` substrate that excludes `reagent.impl.*` and `react-dom/server`. Same six-domino dataflow as `counter/`, but every Reagent import points at `reagent2.*` and `(rf/init!)` takes the slim adapter Var. Point at this example only when the task is about substrate-swap, the bundle-isolation contract (the `check-counter-slim-and-fast.cjs` script in CI), or proving that the slim adapter is API-shape-compatible with the stock Reagent adapter. Not a teaching example — it is the live bundle-comparison target for the slim epic.
+
+## counter_with_stories — `examples/reagent/counter_with_stories/`
+
+The canonical worked example for the Story epic (`tools/story/`, the `day8/re-frame2-story` artefact). The counter with seven `reg-*` Story macros wired end-to-end — `reg-tag`, `reg-mode`, `reg-decorator`, `reg-story-panel`, `reg-story`, `reg-variant`, `reg-workspace` — four variants exercising three of the seven canonical `:rf.assert/*` events plus the built-in `force-fx-stub` decorator. URL-hash-routed: `#/` renders the live counter; `#/stories` mounts the Story playground shell. Point at this example when authoring any Story-substrate code: tag definitions, modes, decorators, variants, workspaces, or the `:rf.assert/*` family. The Stage 8 worked example for the Story epic; exercises 007 Stories, 002 Frames, and 008 Testing.
+
+## login — `examples/reagent/login/`
+
+The single-feature scaffold: everything a typical login flow needs, in one file. Events + subs + views + a state machine + a managed-HTTP demo stub + a Malli machine-snapshot schema + a browserless headless test. Point at this example when authoring **any** feature that combines a state machine with HTTP, or when verifying the shapes of `:auth/busy`, `:auth/authenticated`, and other `:tags`-based view queries (the canonical replacement for boolean-discriminator subs). The canonical home of Pattern-Forms; also the canonical CP-5 / CP-6 / CP-8 worked example. Exercises 005 StateMachines, 014 HTTPRequests, 010 Schemas, and 008 Testing. If you only read one machine-based example, read this one.
+
+## managed_http_counter — `examples/reagent/managed_http_counter/`
+
+A compact Spec 014 demo — a counter where each button issues a `:rf.http/managed` request: success, 4xx failure, retry-recover (canned-stub), and abort. Includes a tiny `/api/` directory served as canned JSON so the example runs without a backend. Point at this example when verifying the canonical shape of an `:rf.http/managed` call, the eight-category `:rf.http/*` failure taxonomy, the retry-with-backoff configuration, the abort-token wiring, or the encode/decode pipeline. The compact, single-feature complement to RealWorld for Spec 014; the canonical Pattern-ManagedHTTP example. Exercises 014 HTTPRequests and Pattern-AsyncEffect.
+
+## nine_states — `examples/reagent/nine_states/`
+
+The nine canonical UI states (Nothing / Loading / Empty / One / Some / Too Many / Incorrect / Correct / Done) for a single domain. One parallel-region machine with three orthogonal regions (data / form / mode), state tags on every state, a render-priority selector sub, and a single `case` in the root view. Pedagogically exhaustive — exercises every machine grammar concept (parallel regions, tags, guards, actions, `:always`, `:after`) inside one focused example. Point at this example when authoring **any** parallel-region machine, or when designing a page that needs to render every legal lifecycle state distinctly. The canonical Pattern-NineStates example; the worked reference for parallel-region tagging and render-priority collapsing. Exercises Pattern-NineStates, Pattern-RemoteData, Pattern-Forms, and 005 StateMachines.
+
+## realworld — `examples/reagent/realworld/`
+
+The de-facto cross-framework benchmark — [RealWorld (Conduit)](https://github.com/gothinkster/realworld). The widest API-surface example in the repo: auth, feeds, routing, comments, editor, profile, favorites, settings, and SSR-hydration glue all sketched on the current API surface. Maturity is **worked scaffold** — it covers breadth, not depth. Point at this example when verifying how the conventions hold up across many features composed in one app (feature-prefix discipline, schema attachment at HTTP boundaries, route-driven data loads, the SSR `:rf/server-init` cofx). Not a teaching example — read individual files (`auth.cljs`, `articles.cljs`, `routing.cljs`) for the relevant cross-cutting shape. Exercises 014 HTTPRequests, 012 Routing, 005 StateMachines, 011 SSR, Pattern-RemoteData, and Pattern-Forms.
+
+## routing — `examples/reagent/routing/`
+
+The three-page worked example for Spec 012 — `reg-route`, `:rf.route/navigate`, anchor clicks via `:rf/url-requested`, route-not-found handling, and the `:can-leave?` guard. The CP-7 worked example. Point at this example when authoring routes, navigating between them, gating navigation with `:can-leave?`, or wiring an anchor's `href` to dispatch a navigation event instead of a browser-default page load. Exercises 012 Routing. Compact and single-purpose; the canonical home of the routing primitives.
+
+## ssr — `examples/reagent/ssr/`
+
+The CP-9 worked example for Spec 011 — minimal SSR + hydration walkthrough. JVM-runnable; the browser side hydrates against a baked `<script id="__rf_payload">` block in the static `index.html` (standing in for a real Clojure server in front). Point at this example when authoring server-rendered views, `:rf/server-init` cofxs, the hydration payload shape, or the SSR-vs-hydration parity check. Exercises 011 SSR and 004 Views. The smallest possible SSR demo — read it alongside `realworld/ssr.cljc` for the broader scaffold.
+
+## state_machine_walkthrough — `examples/reagent/state_machine_walkthrough/`
+
+The runnable companion to `docs/guide/05-state-machines.md` — the guide chapter's login flow rendered as live code, with smoke tests for every section. Browser layer drives the canonical lockout scenario (three failures → `:locked-out`). Point at this example when teaching the machine grammar from scratch, when verifying the chapter's worked shape against the live implementation, or when authoring an event-driven sequence of FSM transitions that needs to be testable from a browser spec. Exercises 005 StateMachines, 014 HTTPRequests, and 008 Testing. Pedagogical sibling of `login/` — same domain, different aim (`login/` is the "single-feature scaffold"; this is the chapter's walkthrough).
+
+## todomvc — `examples/reagent/todomvc/`
+
+The canonical cross-framework benchmark — persistence (localStorage), in-place editing, bulk actions (mark-all-done, clear-completed), remaining-count derivation, and hash-routing filters (`#/`, `#/active`, `#/completed`). Point at this example when verifying a slice-shaped feature with a list of items, a derivation-heavy subscription graph (the filtered list, the remaining count, the all-completed flag), an interceptor-based localStorage persistence pattern, or the integration of `reg-route` with a list-filtering view. Exercises 002 Frames, 004 Views, and 012 Routing. The classic shape benchmark; if a feature looks like "manage a list with filters", this is the shape reference.
+
+## 7Guis — `examples/reagent/7Guis/`
+
+A cluster of six small benchmark apps from the [7GUIs](https://eugenkiss.github.io/7guis/) suite — `temperature/`, `flight_booker/`, `timer/`, `crud/`, `circle_drawer/`, `cells/`. Each app is a focused stress on one shape: bidirectional derivations (`temperature`), form-validity-driven button enablement (`flight_booker`), `:dispatch-later` periodic ticks (`timer`), list-CRUD with selection-as-state (`crud`), undo/redo via a snapshot-on-write interceptor and modal-as-state (`circle_drawer`), and a full formula-graph subscription substrate with cycle detection (`cells`). Point at the 7GUIs cluster when picking the right shape for a small focused concern: a controlled input pair, a Book-button-enables-only-when-valid flow, a periodic-tick UI, list operations with selection, undo/redo, or formula-driven cell propagation. Exercises 004 Views, 002 Frames, 006 ReactiveSubstrate, and Pattern-Forms. See `examples/reagent/7Guis/README.md` for the cluster's own narrative.
+
+## In-flight examples (pending)
+
+Three examples are listed in `examples/README.md` as **pending** worked examples — they accompany pattern leaves that ship with inline mini-examples until their own `examples/reagent/<x>/` directories land:
+
+- **`examples/reagent/boot/` (pending)** — will become the canonical Pattern-Boot example: the multi-step boot sequence (read-config → authenticate → load-profile → hydrate → resolve-route → ready) as a state machine with visible per-phase progress UI and recoverable per-phase failure semantics.
+- **`examples/reagent/websocket/` (pending)** — will become the canonical Pattern-WebSocket example: a state machine that owns the long-lived connection lifecycle (`:disconnected → :connecting → :authenticating → :connected → :reconnecting → :failed`), heartbeat, queued-sends-when-disconnected, re-auth on reconnect, and topic-subscription preservation across reconnects.
+- **`examples/reagent/long_running_work/` (pending)** — will become the canonical Pattern-LongRunningWork example: a CPU-bound batch job (process N items in chunks of 100) running on the main thread via a state machine that yields between chunks with `:after 0`, reports progress through `:data`, and supports user-initiated cancel.
+
+Until these ship, the pattern leaves themselves are the authoritative shape — `patterns/boot.md`, `patterns/websocket.md`, `patterns/long-running-work.md`.
+
+## Adapter smoke-pairs
+
+Per [Spec 006 §Adapter shipping convention](../../spec/006-ReactiveSubstrate.md), the UIx and Helix substrates each ship a curated smoke-pair (counter + login) rather than a 1:1 mirror of the Reagent set. Point at `examples/uix/counter_uix/` and `examples/uix/login_uix/` (and the Helix counterparts at `examples/helix/`) only when authoring against UIx or Helix specifically. The dataflow is identical to the Reagent siblings; only the view layer differs (`defui` for UIx, `defnc` for Helix, plus the `use-subscribe` hook).
+
+## How to use this map during an authoring task
+
+1. Pick the primary pattern from [`decision-trees/pick-a-pattern.md`](./decision-trees/pick-a-pattern.md).
+2. Pick the state shape from [`decision-trees/slice-or-machine.md`](./decision-trees/slice-or-machine.md).
+3. Find the example above whose paragraph names the same pattern + shape combination.
+4. Read the example's source — match its shape; do not re-derive (per SKILL.md cardinal rule 2).
+5. If the example contradicts the pattern leaf, **the example wins** (per SKILL.md cardinal rule 1).
+
+## Cross-references
+
+- [`SKILL.md`](./SKILL.md) — router skill; cardinal rules; loading map.
+- [`examples/README.md`](../../examples/README.md) — the full example catalogue with maturity, build ids, and end-to-end coverage.
+- [`spec/Conventions.md` §Adapter shipping convention](../../spec/Conventions.md) — Reagent-canonical / UIx-Helix-smoke-pair policy.
+- [`patterns/`](./patterns/) — pattern leaves; each names the worked example for its pattern.


### PR DESCRIPTION
## Summary

Adds two operational decision trees and the example-app index that `skills/re-frame2/SKILL.md`'s loading map already points at:

- **`skills/re-frame2/decision-trees/pick-a-pattern.md`** — picks the primary `Pattern-*` leaf for a task (RemoteData / Forms / Boot / WebSocket / ManagedHTTP / NineStates / AsyncEffect / LongRunningWork / StaleDetection). Five steps: name the shape, walk the disambiguation pairs (RemoteData vs ManagedHTTP, Forms vs RemoteData, AsyncEffect vs RemoteData, WebSocket vs AsyncEffect, Boot vs RemoteData-multiple, NineStates vs RemoteData/Forms, LongRunningWork vs AsyncEffect, StaleDetection-as-overlay), verify against the example app, load the leaves, then chain to the state-shape decision.
- **`skills/re-frame2/decision-trees/slice-or-machine.md`** — picks the state shape (slice in `app-db`, region inside an existing machine, top-level `reg-machine`) via the four canonical machine-tells: multi-step async with phase-distinct transitions, cancellation cascade matters, terminal-state matters, orthogonal axes.
- **`skills/re-frame2/examples-map.md`** — one paragraph per `examples/reagent/<x>/` app naming what each example demonstrates and the patterns it exercises. Covers the 12 shipping Reagent examples (counter, counter_slim_and_fast, counter_with_stories, login, managed_http_counter, nine_states, realworld, routing, ssr, state_machine_walkthrough, todomvc, 7Guis) plus the three in-flight examples (boot, websocket, long_running_work) and the UIx/Helix smoke-pairs.

All three files are ≤250 lines (131 / 130 / 87). Cross-links route into `patterns/` and `reference/` leaves where the decision trees end.

## Operational shape

- **Pillar 4** — the decision questions reference re-frame2 vocabulary (machines, regions, tags, fx, schemas, `:rf/after-epoch`, `:rf.http/managed`, `:tags`, `reg-app-schema`, `:invoke`, parallel regions). No re-derived FSM theory; no React-shaped explanations.
- **No verification step** per the bead's locked design.
- **Don't touch SKILL.md** — SKILL.md's loading map already names these files; no edit needed.
- **Examples-map is one paragraph per example** — names patterns and primitives the example exercises, not the example's code.

## Test plan

- [ ] Three files exist under `skills/re-frame2/decision-trees/` and `skills/re-frame2/`.
- [ ] Each file ≤250 lines.
- [ ] Cross-links to pattern leaves and reference leaves resolve (some leaves are still in flight; links target the planned paths).
- [ ] SKILL.md untouched.