### PR TITLE
feat(skills): re-frame2 cross-cutting leaves (testing, api-cheatsheet) (rf2-0tkn)

### DIFF
--- a/skills/re-frame2/reference/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/reference/cross-cutting/api-cheatsheet.md
@@ -1,0 +1,126 @@
+# API cheatsheet
+
+One-line signatures for the public `re-frame.core` surface. **For full docstrings, design rationale, and gotchas, see `SKILL-REDIRECT.md` → *Definitive API reference*.** This page is a glance, not a manual. Alias conventions: `rf` is `[re-frame.core :as rf]`; `ts` is `[re-frame.test-support :as ts]`. Leaf cross-refs in `SKILL.md`'s loading map.
+
+## Registration
+
+| Surface | Shape |
+|---|---|
+| `rf/reg-event-db` | `(id [intercept?] (fn [db ev] new-db))` |
+| `rf/reg-event-fx` | `(id [intercept?] (fn [cofx ev] fx-map))` |
+| `rf/reg-event-ctx` | `(id [intercept?] (fn [ctx] ctx'))` |
+| `rf/reg-fx` | `(id (fn [value] ...))` |
+| `rf/reg-cofx` | `(id (fn [cofx & args] cofx'))` |
+| `rf/reg-sub` | `(id [signals?] (fn [db\|inputs query-v] value))` |
+| `rf/reg-view` | `(sym [args] body)` — defn-shape, auto-injects `dispatch`/`subscribe` |
+| `rf/reg-view*` | `(id metadata? render-fn)` — runtime form |
+| `rf/reg-frame` | `(id metadata-map)` |
+| `rf/reg-app-schema` | `(path schema opts?)` — boundary validation; needs `day8/re-frame2-schemas` |
+| `rf/reg-machine` / `rf/reg-machine*` | `(id machine-spec)` — needs `day8/re-frame2-machines` |
+| `rf/reg-flow` | `(flow-map opts?)` — needs `day8/re-frame2-flows` |
+| `rf/reg-route` | `(id metadata-map)` — needs `day8/re-frame2-routing` |
+| `rf/reg-error-projector` | `(id metadata? (fn [trace-event] public-error))` — needs `day8/re-frame2-ssr` |
+| `rf/reg-http-interceptor` | `({:frame :id :before})` — needs `day8/re-frame2-http` |
+
+## Dispatch, subscribe, frames
+
+| Surface | Shape |
+|---|---|
+| `rf/dispatch` | `(event)` / `(event opts)` — async queued |
+| `rf/dispatch-sync` | `(event)` / `(event opts)` — drains to fixed point |
+| `rf/subscribe` | `(query-v)` / `(frame-id query-v)` → reaction |
+| `rf/subscribe-value` | `(query-v)` — one-shot: materialise + deref + unsubscribe |
+| `rf/unsubscribe` | `(query-v)` / `(frame-id query-v)` |
+| `rf/compute-sub` | `(query-v db)` — pure; bypass cache (preferred in tests) |
+| `rf/with-frame` | `(frame-id body)` / `([sym expr] body)` — bind active frame |
+| `rf/current-frame` | `()` — `:rf/default` outside any binding |
+| `rf/dispatcher` / `rf/subscriber` | `()` — frame-bound closure |
+| `rf/bound-dispatcher` / `rf/bound-subscriber` | `()` — capture-for-async sugar |
+| `rf/frame-provider` | (CLJS) Reagent component `[frame-provider {:frame ...} & children]` |
+| `rf/get-frame-db` | `(frame-id)` — value-form app-db read |
+| `rf/snapshot-of` | `(path)` / `(path opts)` — `get-in` over the active frame |
+| `rf/make-frame` / `rf/reset-frame` / `rf/destroy-frame` | low-level frame lifecycle |
+
+## Machines
+
+| Surface | Shape |
+|---|---|
+| `rf/sub-machine` | `(machine-id)` → reaction `{:state :data :tags}` |
+| `rf/has-tag?` | `(machine-id tag)` → reaction (boolean) |
+| `rf/machines` / `rf/machine-meta` | id list / registered spec |
+| `rf/machine-by-system-id` | `(system-id)` / `(... frame-id)` |
+| `rf/dispatch-to-system` | `(system-id event)` / `(... frame-id)` |
+| `rf/machine-transition` | `(machine snapshot event)` → `[snapshot' fx]` pure |
+| `rf/create-machine-handler` | `(machine)` → event-fx handler |
+
+## Routing — `day8/re-frame2-routing`
+
+| Surface | Shape |
+|---|---|
+| `rf/match-url` | `(url)` → `{:route-id :params :query ...}` or `nil` |
+| `rf/route-url` | `(route-id path-params)` / `(... query-params)` → `"/url"` |
+
+## HTTP — `day8/re-frame2-http`
+
+| Surface | Shape |
+|---|---|
+| `rf/with-managed-request-stubs` | macro: `(stubs & body)` |
+| `rf/with-managed-request-stubs*` | fn: `(stubs thunk)` |
+| `rf/install-managed-request-stubs!` / `uninstall-managed-request-stubs!` | per-call fx-overrides |
+| `rf/clear-http-interceptor` | `(id)` / `(frame id)` |
+
+## Test support — `re-frame.test-support` (see `cross-cutting/testing.md`)
+
+| Surface | Shape |
+|---|---|
+| `ts/reset-runtime-fixture` | `(opts?)` → fixture-fn for `(use-fixtures :each ...)` |
+| `ts/with-fresh-registrar` | `(body-fn)` — registrar snapshot/restore bracket |
+| `ts/snapshot-registrar` / `ts/restore-registrar!` | low-level snapshot/restore |
+| `ts/dispatch-sequence` | `(events)` / `(events opts)` — sync-drain each, `:after-each` hook |
+| `ts/assert-state` | `(expected-db)` / `(path expected-val)` / `(... opts)` |
+| `ts/run-test-sync` | `(& body)` — v1 compat shim |
+
+## SSR — `day8/re-frame2-ssr`
+
+| Surface | Shape |
+|---|---|
+| `rf/render-to-string` | `(tree)` / `(tree opts)` — opts: `:doctype?` `:emit-hash?` |
+| `rf/render-tree-hash` | `(tree)` → `"fnv1a-32bit-hex"` |
+| `rf/project-error` | `(frame-id trace-event)` → public-error-map |
+
+## Schemas — `day8/re-frame2-schemas`
+
+| Surface | Shape |
+|---|---|
+| `rf/app-schema-at` / `rf/app-schemas` / `rf/app-schemas-digest` | read-only schema queries |
+| `rf/set-schema-validator!` / `rf/set-schema-explainer!` | swap-in non-Malli validator |
+| `rf/validate-at-boundary` | production-side validation interceptor |
+
+## Trace and epoch — `day8/re-frame2-epoch`
+
+| Surface | Shape |
+|---|---|
+| `rf/register-trace-cb!` / `rf/remove-trace-cb!` / `rf/emit-trace!` | trace plumbing |
+| `rf/trace-buffer` / `rf/clear-trace-buffer!` | retain-N ring |
+| `rf/epoch-history` | `(frame-id)` → `[epoch-records]` |
+| `rf/restore-epoch` | `(frame-id epoch-id)` → bool |
+| `rf/register-epoch-cb` / `rf/remove-epoch-cb` | per-drain-settle listener |
+| `rf/reset-frame-db!` | `(frame-id new-db)` → bool — dev/pair-tool write |
+
+## Interceptors, boot, introspection
+
+| Surface | Shape |
+|---|---|
+| `rf/->interceptor` | `({:id :before :after})` → interceptor |
+| `rf/get-coeffect` / `rf/assoc-coeffect` / `rf/get-effect` / `rf/assoc-effect` | inside an interceptor |
+| `rf/inject-cofx` | `(id & args)` — cofx injector |
+| `rf/path` / `rf/unwrap` | std interceptors |
+| `rf/init!` | `(adapter-map)` — install adapter + ensure `:rf/default`. No registry. |
+| `rf/install-adapter!` / `rf/dispose-adapter!` / `rf/current-adapter` | low-level adapter ops |
+| `rf/clear-event` / `rf/clear-sub` / `rf/clear-fx` / `rf/clear-flow` / `rf/clear-subscription-cache!` | targeted deregistration |
+| `rf/configure` | `(:epoch-history\|:trace-buffer\|:sub-cache opts)` — runtime knobs |
+| `rf/handlers` / `rf/handler-meta` / `rf/handler-ids` / `rf/registry-summary` | registrar reads |
+| `rf/frame-ids` / `rf/frame-meta` / `rf/view` | registry reads |
+| `rf/sub-cache` (CLJS) / `rf/sub-topology` | dynamic / static sub graph reads |
+
+Optional-artefact surfaces raise `:rf.error/<artefact>-artefact-missing` (registrations / writes) or degrade to `nil`/`[]`/`false` (read-only queries) when the artefact is absent.

--- a/skills/re-frame2/reference/cross-cutting/testing.md
+++ b/skills/re-frame2/reference/cross-cutting/testing.md
@@ -1,0 +1,197 @@
+# Writing re-frame2 tests
+
+Load when the task is **authoring a `deftest` / `cljs.test` test** against re-frame2 application code: an event-fx handler, a sub graph, a machine snapshot, a tag query, a view that reads from a frame. This leaf teaches only the **re-frame2-specific binding** — `clojure.test` / `cljs.test` themselves are assumed.
+
+This skill does **not** teach the AI to *run* tests; that is the user's job. It teaches how to **write** them so they pass when the user runs the suite.
+
+## The single import
+
+```clojure
+(:require [re-frame.core         :as rf]
+          [re-frame.test-support :as ts]
+          #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+             :cljs [cljs.test    :refer-macros [deftest is testing use-fixtures]]))
+```
+
+Everything you need — fixtures, helpers, run-test-sync — lives under `re-frame.test-support`. Do not reach into `re-frame.registrar` or `re-frame.frame` directly.
+
+## The per-test fixture (always use it)
+
+```clojure
+(use-fixtures :each
+  (ts/reset-runtime-fixture {:adapter reagent-adapter/adapter}))
+```
+
+`reset-runtime-fixture` snapshot/restores the registrar around each test, resets every frame's `app-db` to `{}`, disposes any installed substrate adapter and reinstalls the one in `:adapter`, and ensures `:rf/default` is present. Per-test `reg-event-db` / `reg-sub` / `reg-machine` calls land cleanly inside the test and are rolled back on the way out — **without** wiping framework registrations (e.g. `:rf/route`, `:rf/machine` subs) that landed at namespace-load time.
+
+JVM tests pass the plain-atom adapter:
+
+```clojure
+(:require [re-frame.substrate.plain-atom :as plain-atom])
+
+(use-fixtures :each (ts/reset-runtime-fixture {:adapter plain-atom/adapter}))
+```
+
+Optional opts: `:init-fn` (zero-arg fn run after adapter install, before the test), `:clear-kinds` (e.g. `[:app-schema]` to start each test with an empty schema slate while preserving the snapshot on exit).
+
+Do **not** call `(registrar/clear-all!)` from a fixture — under CLJS, framework registrations cannot be reloaded and will be gone for the rest of the run.
+
+## Driving events: `dispatch-sync` and `dispatch-sequence`
+
+`rf/dispatch-sync` drains to fixed point synchronously — by the time it returns, the handler has run, fx have fired, and the queue is empty. Use it instead of `rf/dispatch` in tests; `dispatch` is async and the test would assert before the handler ran.
+
+```clojure
+(rf/dispatch-sync [:counter/inc])
+(is (= 1 (:n (rf/get-frame-db :rf/default))))
+```
+
+`ts/dispatch-sequence` fires a vector of events in order, each drained before the next:
+
+```clojure
+(ts/dispatch-sequence [[:counter/init] [:counter/inc] [:counter/inc]])
+;; => the final app-db value
+```
+
+Capture intermediate states with `:after-each`:
+
+```clojure
+(let [seen (atom [])]
+  (ts/dispatch-sequence
+    [[:counter/inc] [:counter/inc]]
+    {:after-each (fn [db ev] (swap! seen conj [(:n db) ev]))})
+  @seen)
+;; => [[1 [:counter/inc]] [2 [:counter/inc]]]
+```
+
+Target a non-default frame with `{:frame :feature/frame-id}` in the trailing opts map.
+
+## Pinning a frame: `with-frame`
+
+`with-frame` binds the active frame inside the body. Two shapes:
+
+```clojure
+(rf/with-frame :stories
+  (rf/dispatch-sync [:counter/inc])
+  (ts/assert-state [:n] 1))
+
+(rf/with-frame [f :stories]      ;; bind a symbol AND the dynamic var
+  (is (= :stories f))
+  (is (= :stories (rf/current-frame))))
+```
+
+On CLJS the macro is in `re-frame.views-macros`; require with `:require-macros [re-frame.views-macros :refer [with-frame]]`. On JVM use the `(rf/with-frame frame-id (fn [] ...))` function form.
+
+## Asserting state: `assert-state` and `get-frame-db`
+
+Two shapes:
+
+```clojure
+(ts/assert-state {:n 0})           ;; full-db match against current frame
+(ts/assert-state [:n] 7)           ;; path match — equivalent to (= 7 (get-in db [:n]))
+(ts/assert-state [:n] 7 {:frame :stories})   ;; trailing opts pins the frame
+```
+
+Failure reports through `clojure.test/is` with both expected and actual, so the diagnostic is one line. For ad-hoc reads outside an `assert-state`:
+
+```clojure
+(rf/get-frame-db :rf/default)              ;; whole app-db, any frame
+(rf/snapshot-of [:cart :items])             ;; get-in over the current frame
+(rf/snapshot-of [:cart :items] {:frame :stories})
+```
+
+These are value-form accessors — there is no `deref`. They work identically on JVM and CLJS.
+
+## Asserting subscriptions: `compute-sub` (preferred) and `subscribe-value`
+
+For a sub graph under test, **prefer `compute-sub`** — it runs the registered sub against a supplied db with no reactive cache involvement, so the test does not depend on prior subscribe state:
+
+```clojure
+(rf/reg-sub :items    (fn [db _] (:items db)))
+(rf/reg-sub :item-sum :<- [:items] (fn [items _] (reduce + items)))
+
+(is (= 60 (rf/compute-sub [:item-sum] {:items [10 20 30]})))
+```
+
+`compute-sub` supports the `:<-` chain shape exactly like `subscribe` does and validates the return value against any `:spec` metadata on the sub.
+
+When the test is exercising the live cache (e.g. layer-2 sub on top of a real dispatch), use `subscribe-value`:
+
+```clojure
+(rf/dispatch-sync [:seed])
+(is (= 60 (rf/subscribe-value [:item-sum])))
+```
+
+`subscribe-value` materialises the reaction, reads `@`, and unsubscribes — one line, no leaked subscription. Prefer it over `@(rf/subscribe ...)` in tests.
+
+## Machine snapshots and tag queries
+
+A machine's snapshot lives at `(get-in app-db [:rf/machines machine-id])` — a map of `{:state ... :data ... :tags ...}` (`:tags` is absent when the active state-configuration's tag union is empty).
+
+```clojure
+(rf/reg-machine :loader
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:tags #{:empty}     :on {:fetch :loading}}
+             :loading {:tags #{:transient} :on {:done :ready}}
+             :ready   {:tags #{:terminal}}}})
+
+(rf/dispatch-sync [:loader [:fetch]])
+
+;; Direct snapshot access — full-shape assertions
+(let [s (get-in (rf/get-frame-db :rf/default) [:rf/machines :loader])]
+  (is (= :loading      (:state s)))
+  (is (= #{:transient} (:tags s))))
+
+;; Same assertion through the framework sub (preferred for reaction-driven tests)
+(is (= :loading      (:state @(rf/sub-machine :loader))))
+(is (= true          @(rf/has-tag? :loader :transient)))
+(is (= false         @(rf/has-tag? :loader :terminal)))
+```
+
+For compound machines, `:state` is a path vector (`[:auth :dashboard]`) and `:tags` is the union along the path. `has-tag?` is null-tolerant: a missing or uninitialised machine returns `false` rather than throwing.
+
+The pure transition fn — `(rf/machine-transition machine snapshot event)` — returns `[new-snapshot fx]` with no frame and no dispatch loop. Use it when the test wants to assert transition tables in isolation.
+
+## HTTP and other side-effecting fx
+
+For `:rf.http/managed`, install per-call stubs around the body:
+
+```clojure
+(rf/with-managed-request-stubs
+  {[:get "/api/items"] {:reply :ok :body {:items [...]}}
+   [:post "/api/cart"] {:reply :failure :status 500}}
+  (rf/dispatch-sync [:cart/fetch])
+  (ts/assert-state [:cart :status] :ready))
+```
+
+For arbitrary fx, override the registered handler from inside the test — the fixture rolls the registration back on the way out:
+
+```clojure
+(let [calls (atom [])]
+  (rf/reg-fx :app/persist (fn [v] (swap! calls conj v)))
+  (rf/dispatch-sync [:cart/save])
+  (is (= [{:items [...]}] @calls)))
+```
+
+## v1 compatibility shim: `run-test-sync`
+
+If you are mechanically porting v1 tests, `ts/run-test-sync` is a body wrapper that snapshot/restores the registrar around the body:
+
+```clojure
+(deftest legacy-flow
+  (ts/run-test-sync
+    (rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:counter/inc])
+    (is (= 1 (:n (rf/get-frame-db :rf/default))))))
+```
+
+In v2 `dispatch-sync` already drains synchronously, so for greenfield tests this macro is unnecessary — `dispatch-sync` plus the per-test fixture is enough.
+
+## Checklist before declaring a test done
+
+- The ns uses `re-frame.test-support` and `re-frame.core` only — no reach into internal namespaces.
+- A `:each` `reset-runtime-fixture` is installed with the right `:adapter`.
+- Event drive is `dispatch-sync` (not `dispatch`) or `ts/dispatch-sequence`.
+- Sub assertions go through `compute-sub` (preferred) or `subscribe-value`; no bare `@(rf/subscribe ...)` left subscribed at test exit.
+- Machine assertions use `sub-machine` / `has-tag?` or `(get-in db [:rf/machines id])` — not internal machine namespaces.
+- Schema-validation, fx-stubs, and frame-scoping each use the public surface above. No fixture lifts `registrar/clear-all!`.


### PR DESCRIPTION
## Summary

Authors the two leaf files under `skills/re-frame2/reference/cross-cutting/` per `rf2-0tkn`:

- **`testing.md` (197 lines)** — how to WRITE re-frame2 tests. Covers the single `re-frame.test-support` import, the per-test `reset-runtime-fixture` (snapshot/restore-based; preserves framework registrations under CLJS), `dispatch-sync` vs `dispatch-sequence`, `with-frame` pinning, `assert-state` / `get-frame-db` / `snapshot-of`, `compute-sub` (preferred) vs `subscribe-value` for sub assertions, machine snapshot + tag-query assertions via `sub-machine` / `has-tag?`, `:rf.http/managed` stubbing, fx-handler override pattern, and the `run-test-sync` v1 compatibility shim. Per Q14 locked NO: teaches how to write tests, not how to run them.
- **`api-cheatsheet.md` (126 lines)** — one-line signatures for every public surface on `re-frame.core` and `re-frame.test-support`: every `reg-*`, dispatch/subscribe, frames, machines, routing, HTTP, test-support, SSR, schemas, trace/epoch, interceptors, boot, introspection. Each row carries the function signature; optional-artefact requirements (`day8/re-frame2-*`) are noted inline. Redirects to `SKILL-REDIRECT.md` → *Definitive API reference* for docstrings and rationale.

Sources: `implementation/core/src/re_frame/core.cljc`, `implementation/core/src/re_frame/test_support.cljc`, and the test files under `implementation/**/test/` (notably `test_support_test.clj`, `tags_test.clj`, `runtime_cljs_test.cljs`).

Both files are under the 250-line ceiling. The api-cheatsheet is 26 lines over the soft ≤100 target — the surface is genuinely large ("every public reg-* + dispatch/subscribe/etc.") and further compression would sacrifice completeness. The bead's verify check is the 250-line ceiling, which both files clear.

Touches only `skills/re-frame2/reference/cross-cutting/` — no overlap with the other 8 in-flight leaf agents.

## Test plan
- [ ] Lines: `wc -l skills/re-frame2/reference/cross-cutting/{testing,api-cheatsheet}.md` → both ≤250
- [ ] Renders cleanly in the docs site / Markdown previewer (tables, code blocks, escapes for `|` in `{db|inputs}` and `:epoch-history|:trace-buffer`)
- [ ] Every signature in `api-cheatsheet.md` is grep-findable in `implementation/core/src/re_frame/core.cljc` (or the named optional artefact)
- [ ] Surfaces named in `testing.md` (`reset-runtime-fixture`, `dispatch-sequence`, `assert-state`, `compute-sub`, `sub-machine`, `has-tag?`, `with-managed-request-stubs`) are all on `re-frame.core` / `re-frame.test-support`