### PR TITLE
feat(skills): re-frame2 fundamentals leaves (events, subs, fx, cofx, frames, schemas, cycle) (rf2-9tuz)

### DIFF
--- a/skills/re-frame2/reference/fundamentals/cofx.md
+++ b/skills/re-frame2/reference/fundamentals/cofx.md
@@ -1,0 +1,76 @@
+# Coeffects (cofx)
+
+## When to load
+
+Registering a `reg-cofx` handler that injects an input (current time, localStorage value, generated id, ...) into the handler's coeffect map; or attaching one to an event via `inject-cofx`.
+
+## Canonical signature
+
+```clojure
+(rf/reg-cofx :cofx-id           handler-fn)
+(rf/reg-cofx :cofx-id metadata? handler-fn)
+
+;; handler-fn :: (fn [ctx])         -> ctx                  ;; 1-arg form
+;;             | (fn [ctx value])   -> ctx                  ;; 2-arg form (paired with inject-cofx ... value)
+;;
+;; The handler stashes data under (:coeffects ctx). The conventional key
+;; is the cofx-id itself.
+
+(rf/inject-cofx :cofx-id)
+(rf/inject-cofx :cofx-id value)
+```
+
+Verified in `implementation/core/src/re_frame/cofx.cljc:44` (`reg-cofx`) and `cofx.cljc:57` (`inject-cofx`).
+
+`inject-cofx` returns an **interceptor** — pass it in the event's interceptors vector (the positional slot, not the metadata-map):
+
+```clojure
+(rf/reg-event-fx :id
+  [(rf/inject-cofx :now) (rf/inject-cofx :random-id)]   ;; interceptors slot
+  (fn [{:keys [db now random-id]} [_ payload]] ...))
+```
+
+## Standard cofx
+
+The runtime ships `:db` and `:event` — both are already populated on the context before the chain runs (`cofx.cljc:92-104`), so explicitly injecting them is a no-op. They exist for symmetry with v1. Everything else (current time, browser language, localStorage values, ids) is user-registered.
+
+## Canonical mini-example
+
+From `examples/reagent/todomvc/db.cljs`:
+
+```clojure
+(rf/reg-cofx :todo.storage/todos
+  {:doc "Inject the saved TodoMVC items from localStorage into coeffects."}
+  (fn cofx-todo-storage-todos [ctx]
+    (assoc-in ctx [:coeffects :todo.storage/todos]
+              (some-> (.-localStorage js/globalThis)
+                      (.getItem ls-key)
+                      (storage->todos)))))
+```
+
+And the handler that ingests it (`examples/reagent/todomvc/events.cljs`):
+
+```clojure
+(rf/reg-event-fx :todo/initialise
+  [(rf/inject-cofx :todo.storage/todos)]
+  (fn [{:todo.storage/keys [todos]} _]
+    {:db (assoc db/default-db :todos todos)}))
+```
+
+The cofx writes under `[:coeffects :todo.storage/todos]`; the handler destructures the same key off the coeffect map.
+
+## Why coeffects instead of `(.-localStorage ...)` in the handler?
+
+Pure handlers are testable, replayable (for re-frame-pair2 epoch restore), and serialisable (for SSR snapshots). A handler that reads `Date.now()` directly is non-deterministic; the same handler that destructures `now` from coeffects is a pure function of its inputs.
+
+## Common gotchas
+
+- **`inject-cofx` returns an interceptor, not the value.** It must go in the positional interceptors vector, not the metadata-map (the metadata-map's `:interceptors` key is silently dropped — see [events.md](events.md)).
+- **The injected key convention is the cofx-id itself.** Stash under `[:coeffects :my/cofx-id]` so destructuring with `{:my/keys [...]}` works cleanly. If `:spec` validation is declared on the cofx metadata, the validator looks up under the cofx-id key (`cofx.cljc:33-36`).
+- **Order matters.** Interceptors run in vector order; a cofx that depends on another cofx's value must come after it.
+- **Two-arg form is for parameterised injection.** Use `(inject-cofx :random-int max-value)` when the same cofx-id needs a different value per attachment.
+- **Missing registration is a runtime warning, not a throw.** `inject-cofx` of an unregistered id prints `re-frame2: no cofx registered for ...` and continues (`cofx.cljc:78`). Easy to miss — grep for the cofx-id in your registrations on `:rf.error/no-such-fx`-style surprises.
+
+## Deeper material
+
+Cofx validation (`:spec`), the late-bind seam for `:schemas/validate-cofx!`, full coeffect-map shape: `SKILL-REDIRECT.md` → **EP — Schemas (010)**, **Definitive API reference**.

--- a/skills/re-frame2/reference/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/reference/fundamentals/event-state-cycle.md
@@ -1,0 +1,104 @@
+# The event-state cycle
+
+## When to load
+
+Sanity-checking a mental model: tracing what happens between `(rf/dispatch ...)` and the screen updating; debugging why a sub didn't recompute, or why an fx fired out of order.
+
+## The cycle, end-to-end
+
+```
+   dispatch              cofx              handler            do-fx              substrate
+      │                   │                  │                  │                   │
+   ┌──▼──┐            ┌───▼───┐          ┌───▼───┐         ┌────▼────┐        ┌─────▼─────┐
+   │ ev  │  envelope  │ build │  context │  user │ fx-map  │ walk    │ commit │ replace   │ reactions
+   │ vec │ ─────────► │ cofx  │ ───────► │  fn   │ ──────► │ :db then│ ─────► │ container │ ────────► render
+   │     │            │ map   │          │       │         │ each fx │        │           │
+   └─────┘            └───────┘          └───────┘         └─────────┘        └───────────┘
+   queue front                                                                  subs
+                                                                                recompute
+```
+
+## Step by step
+
+**1. Dispatch.** `(rf/dispatch [:event-id args])` builds an envelope `{:event ... :frame ... :dispatch-id ...}` and appends it to the target frame's router queue (`router.cljc:370`). Returns `nil` immediately — non-blocking.
+
+**2. Drain scheduled.** The router schedules a drain via the substrate's microtask hook. `dispatch-sync` (`router.cljc:390`) bypasses the queue and drains immediately — outside-the-runtime callers only (tests, REPL, `:on-create`).
+
+**3. Drain pops envelope.** For each event, the runtime looks up the registered handler's interceptor chain.
+
+**4. Cofx injection.** Each `inject-cofx` interceptor runs in source order; each writes under `[:coeffects :cofx-id]`. The standard `:db` (current `app-db` value) and `:event` (the dispatched vector) are already populated (`cofx.cljc:92-104`).
+
+**5. Validation (dev only).** If the handler carries a `:spec`, the runtime validates the event vector against it. Failure sets `:rf/skip-handler?` on the context and the handler short-circuits (`events.cljc:123-128`). `validate-at-boundary` runs this same check in production.
+
+**6. User handler.** The wrapped handler-fn fires:
+
+- `reg-event-db` receives `(db, event)` → returns `new-db`; runtime stashes under `(:effects ctx :db)`.
+- `reg-event-fx` receives `(cofx, event)` → returns `{:db ... :fx [...]}`; runtime stashes both under `(:effects ctx ...)`.
+- `reg-event-ctx` receives `ctx` → returns `ctx` (advanced).
+
+**7. Effect-shape policing.** Non-`:db`/non-`:fx` top-level keys emit `:rf.error/effect-map-shape` and are dropped (`events.cljc:81`). v2's effect map is closed.
+
+**8. `:db` commits.** `re-frame.substrate.adapter/replace-container!` writes the new value into the frame's app-db container. **Atomic.**
+
+**9. `:fx` walks.** `do-fx` (`fx.cljc:203`) iterates the `[fx-id args]` pairs in source order, synchronously. Each fx-handler runs to completion before the next begins. Errors and unknown ids trace independently — the walk continues.
+
+**10. Subs recompute.** The substrate's reaction graph fires off the container change. Layer-1 subs that read changed paths recompute by `=`; layer-2+ subs cascade topologically. Unchanged-by-`=` values short-circuit cascades.
+
+**11. Views re-render.** Reagent components subscribed to dirty subs re-render. Source-coord metadata captured by `reg-view` lets re-frame-10x / pair point at the originating Var.
+
+**12. Drain continues.** Any `[:dispatch ...]` entries from step 9 are now on the queue. Drain loops until queue is empty (`router.cljc`). Run-to-completion: one dispatch fully settles before the next outside event starts.
+
+## Per-step reference
+
+| Step | Where it lives | Surface |
+|---|---|---|
+| Dispatch / queue | `router.cljc:370-388` | `rf/dispatch`, `rf/dispatch-sync` |
+| Interceptor chain | `events.cljc:111-167` | metadata `:spec`, interceptors vector |
+| Cofx injection | `cofx.cljc:57-89` | `rf/inject-cofx` |
+| Handler invocation | `events.cljc:111-167` | `reg-event-db` / `-fx` / `-ctx` |
+| Effect-map policing | `events.cljc:81-105` | `:rf.error/effect-map-shape` trace |
+| `:db` commit | `subs.cljc` + substrate adapter | atomic via `replace-container!` |
+| `:fx` walk | `fx.cljc:203-225` | `reg-fx`, `:fx-overrides` |
+| Sub recompute | `subs.cljc:166-285` | reaction graph + deferred ref-count cache |
+| Render | adapter (`reagent.cljs`, ...) | `reg-view` |
+
+## Canonical mini-example
+
+From `examples/reagent/counter/core.cljs`, one dispatch exercises the whole cycle:
+
+```clojure
+;; (1) dispatch
+(rf/dispatch-sync [:counter/initialise])
+
+;; (6) handler returns the fx-map
+(rf/reg-event-fx :counter/initialise
+  (fn [_ctx _event]
+    {:db {:count 5}
+     :fx [[:counter/log :initialised]]}))
+
+;; (9) the fx walks; :counter/log is user-registered
+(rf/reg-fx :counter/log
+  (fn [_ctx args] (swap! counter-log conj args)))
+
+;; (10) the sub recomputes; view re-renders
+(rf/reg-sub :count
+  (fn [db _query] (:count db)))
+```
+
+After this single `dispatch-sync`:
+
+- `app-db` is `{:count 5}` (step 8).
+- `counter-log` holds `[:initialised]` (step 9).
+- Any view subscribed to `[:count]` re-renders with `5` (steps 10-11).
+
+## Common gotchas
+
+- **`dispatch` is queued, `dispatch-sync` is immediate.** Calling `dispatch-sync` from inside a handler raises `:rf.error/dispatch-sync-in-handler` — sync drains can't nest.
+- **`:db` always commits before any `:fx` runs.** Within `:fx`, ordering is source order, run-to-completion. You can read the new `app-db` from a fx handler safely.
+- **Subs observe the post-`:db` state.** If a fx dispatches another event, that nested event's coeffects see the already-committed value.
+- **One bad fx does not abort the walk.** Don't write fx handlers that depend on a sibling fx having already succeeded — use a chained dispatch instead.
+- **Run-to-completion is per outer dispatch.** All synchronously-enqueued events from one drain cycle settle before the next outside `dispatch` starts. `dispatch-later` re-enters via the timer; it is not part of the original run-to-completion bracket.
+
+## Deeper material
+
+Drain-depth bounds, the `:rf.epoch/*` projection of one full cycle for re-frame-pair2, microtask scheduling, the interceptor model in full: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — Instrumentation (009)**, **Runtime architecture**, **Tool-Pair contract**.

--- a/skills/re-frame2/reference/fundamentals/events.md
+++ b/skills/re-frame2/reference/fundamentals/events.md
@@ -1,0 +1,73 @@
+# Events
+
+## When to load
+
+Authoring an event handler — `reg-event-db`, `reg-event-fx`, or `reg-event-ctx` — or working out what the dispatched event vector should look like.
+
+## Canonical signatures
+
+Two surfaces: a CLJ `defmacro` (captures `:ns` / `:line` / `:file`) and a CLJS `def` alias to the underlying fn.
+
+```clojure
+(rf/reg-event-db id           handler-fn)                   ;; (db, event) -> new-db
+(rf/reg-event-db id metadata? interceptors? handler-fn)
+
+(rf/reg-event-fx id           handler-fn)                   ;; (cofx, event) -> effect-map
+(rf/reg-event-fx id metadata? interceptors? handler-fn)
+
+(rf/reg-event-ctx id          handler-fn)                   ;; (context) -> context  (advanced)
+```
+
+Verified in `implementation/core/src/re_frame/events.cljc:188-225` (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`) and `implementation/core/src/re_frame/core.cljc:167-224` (the macro layer). `normalise-args` (`events.cljc:171`) accepts:
+
+- `(reg-event-db :id handler)`
+- `(reg-event-db :id {:doc "..." :spec ...} handler)`
+- `(reg-event-db :id [icpt1 icpt2] handler)`
+- `(reg-event-db :id {:doc "..."} [icpt1 icpt2] handler)`
+
+The **metadata-map** is reflective-only (`:doc`, `:spec`, `:tags`, `:platforms`, ...). The **interceptors vector** is positional. Putting `:interceptors` inside the metadata-map silently drops the chain — the runtime emits `:rf.warning/interceptors-in-metadata-map` to flag it (`events.cljc:38`).
+
+## Event vector shape
+
+The dispatched value is a vector `[event-id & args]`. The handler receives the whole vector as its second argument:
+
+```clojure
+(rf/reg-event-db :todo/add
+  (fn [db [_event-id title]]    ;; underscore the id; destructure args
+    (update db :todos conj title)))
+
+(rf/dispatch [:todo/add "buy milk"])
+```
+
+Dispatch is non-blocking — events queue and drain run-to-completion. `dispatch-sync` (`router.cljc:390`) drains immediately and is for outside-the-runtime callers (test setup, REPL); calling it from inside a handler raises `:rf.error/dispatch-sync-in-handler`.
+
+## Canonical mini-example
+
+From `examples/reagent/counter/core.cljs`:
+
+```clojure
+(rf/reg-event-fx :counter/initialise
+  (fn [_ctx _event]
+    {:db {:count 5}
+     :fx [[:counter/log :initialised]]}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :count inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :count dec)))
+```
+
+The `:db` and `:fx` keys are the **only** legal top-level keys in an `fx`-handler return map (see [fx.md](fx.md) for the closed-shape rationale). The `_ctx` parameter is the coeffect map — `{:db <current-db-value> :event <event-vec>}` by default, plus anything `inject-cofx` injected (see [cofx.md](cofx.md)).
+
+## Common gotchas
+
+- **`:dispatch` and `:dispatch-n` are NOT top-level effect keys in v2.** They moved into `:fx` as `[[:dispatch event]]` entries. The runtime emits `:rf.error/effect-map-shape` and drops any non-`:db`/non-`:fx` top-level key (`events.cljc:81`).
+- **`:interceptors` is not a metadata key.** Pass the chain as the positional third argument, not as `{:interceptors [...]}`.
+- **The event vector's first element is the event id.** Always destructure it as `[_ arg1 arg2]` — the id is in `args` because the whole vector is passed.
+- **`reg-event-ctx` is rarely the right tool.** It hands you the raw interceptor context. Use it only when you need to manipulate the chain itself; otherwise `reg-event-db` or `reg-event-fx`.
+- **Metadata-map fields surface to tooling, not to the runtime.** `:doc`, `:spec`, `:tags`, `:platforms` are read by 10x, pair, and the dev-time validator. They do not affect runtime behaviour except where called out (`:spec` for dev validation; `:platforms` on `reg-fx`).
+
+## Deeper material
+
+Full effect-map contract, interceptor chain composition, dispatch envelope shape, the dev-time `:spec` validator: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — Schemas (010)**, **Definitive API reference**.

--- a/skills/re-frame2/reference/fundamentals/frames.md
+++ b/skills/re-frame2/reference/fundamentals/frames.md
@@ -1,0 +1,116 @@
+# Frames
+
+## When to load
+
+Working with multi-frame apps: registering a non-default frame, targeting a dispatch / subscribe at a specific frame, using `frame-provider` to scope a React subtree, or capturing the current frame in an async callback via `bound-dispatcher`.
+
+## What a frame is
+
+A **frame** is an isolated runtime boundary: its own `app-db`, its own router queue, its own sub-cache. Frames are identified by keywords. Every re-frame2 app has at least one — `:rf/default` — registered automatically on `init!`.
+
+Frames are mutable runtime objects, not values. User code holds keywords and lets the framework resolve them.
+
+## Canonical signatures
+
+```clojure
+;; Register / re-register a named frame.
+(rf/reg-frame :frame-id metadata)
+
+;; Anonymous instance (gensym'd id under :rf.frame/*). Returns the id.
+(rf/make-frame metadata)
+
+;; Destroy / reset.
+(rf/destroy-frame :frame-id)
+(rf/reset-frame   :frame-id)        ;; destroy + re-register with same config
+
+;; Inspect.
+(rf/current-frame)                  ;; returns the active frame id
+(rf/get-frame-db :frame-id)         ;; underlying container (for tools / tests)
+```
+
+Verified in `implementation/core/src/re_frame/frame.cljc:146` (`reg-frame`), `:185` (`make-frame`), `:195` (`destroy-frame!`). The public macro layer is `core.cljc:287-304`.
+
+## Frame resolution chain
+
+Three tiers (`frame.cljc:38-51`, `core.cljc:899-909`):
+
+1. **`*current-frame*` dynamic var** — bound by `with-frame`.
+2. **React context** (CLJS only) — read via the `:adapter/current-frame` late-bind hook, populated by the installed adapter under a `frame-provider`.
+3. **`:rf/default`** — fallback when neither of the above applies.
+
+`dispatch` and `subscribe` default `:frame` to `(rf/current-frame)`. To target an explicit frame:
+
+```clojure
+(rf/dispatch  [:foo]      {:frame :stories})
+(rf/subscribe [:my-sub])                          ;; uses current-frame
+```
+
+## Capturing the frame in async callbacks
+
+When you `setTimeout` or hand a callback to a promise, the dynamic var binding is gone by the time it runs. Capture the frame at call time with `bound-dispatcher` / `bound-subscriber`:
+
+```clojure
+(let [d (rf/bound-dispatcher)]
+  (.then promise #(d [:result-arrived %])))
+```
+
+`dispatcher` and `bound-dispatcher` are aliases (`core.cljc:940-945`); use whichever name reads better.
+
+## Canonical mini-example
+
+Per-test isolated frame, from `examples/reagent/login/core.cljs`:
+
+```clojure
+(with-frame [f (rf/make-frame
+                 {:fx-overrides {:rf.http/managed :auth.login/test-canned-success}})]
+  (rf/dispatch-sync [:auth.login/flow [:auth.login/submit
+                                       {:email "user@example.com"
+                                        :password "correct-horse"}]]
+                    {:frame f})
+  (assert (= :authed (rf/compute-sub [:auth.login/state] (rf/get-frame-db f)))))
+```
+
+Each test gets its own frame with its own app-db and its own fx-override map — concurrent tests can run with no cross-contamination.
+
+And configuring `:rf/default` at app boot:
+
+```clojure
+(rf/reg-frame :rf/default
+  {:doc          "Login demo frame."
+   :fx-overrides {:rf.http/managed :rf.http/managed.login-demo}})
+```
+
+## Frame metadata — what goes in it
+
+The metadata map (`frame.cljc:99-130`) accepts:
+
+- `:doc` — one-sentence what-and-why.
+- `:preset` — one of `:default :test :story :ssr-server`; expands at registration into a fixed metadata bundle.
+- `:fx-overrides` — `{original-id replacement-id}`. The fx walk rewrites lookups (`fx.cljc:62-88`); useful for HTTP stubs in tests/stories.
+- `:platform` — `:client` or `:server`; gates fx whose `:platforms` set excludes the active platform.
+- `:drain-depth` — bound on dispatch-cascade depth (default 100; `:story` preset tightens to 16).
+- `:on-create` / `:on-destroy` — event vectors fired synchronously at lifecycle transitions.
+
+User-supplied keys win on conflict with preset expansion.
+
+## `frame-provider` in views
+
+Wraps a Reagent / Helix / UIx subtree so descendants resolve `current-frame` to a chosen id:
+
+```clojure
+[rf/frame-provider {:frame :stories} [my-story-shell]]
+```
+
+`reg-view`-wrapped components participate automatically (the wrapper carries `:contextType`). Plain Reagent fns under a non-default `frame-provider` fall through to `:rf/default` — the runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` to flag the footgun (`adapter/reagent.cljs:140-148`).
+
+## Common gotchas
+
+- **`reg-frame` is atomic and hot-reload safe.** First call creates and runs `:on-create`; subsequent calls perform a **surgical update** of metadata only — existing app-db, sub-cache, queue, machine snapshots all preserved (`frame.cljc:152-183`). Use `reset-frame` for a full destroy+recreate.
+- **`destroy-frame!` cascades.** Active machine snapshots fire `:rf.machine/destroyed-on-frame-exit`; in-flight HTTP requests get an abort hook; sub-cache reactions all dispose. Subsequent dispatch / subscribe raises `:rf.error/frame-destroyed`.
+- **`with-frame` is a CLJS macro AND a JVM-friendly fn.** The macro form (`re-frame.views-macros/with-frame`) wraps an expression; the fn form (`core.cljc:932`) takes a thunk — use the fn from JVM tests / SSR / REPL.
+- **Wrapping plain Reagent fns in a non-default `frame-provider` doesn't bind the frame.** Use `reg-view` so the `:contextType` wiring picks up the provider. Watch for the once-per-handler warning.
+- **`:rf/default` is implicit.** Don't re-`reg-frame :rf/default` unless you specifically want to attach metadata to it — calling it without any is a no-op.
+
+## Deeper material
+
+Frame presets in detail, machine-instance teardown contract, the React-context chain through Reagent / Helix / UIx, `dispatch-to-system`: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — State machines (005)**.

--- a/skills/re-frame2/reference/fundamentals/fx.md
+++ b/skills/re-frame2/reference/fundamentals/fx.md
@@ -1,0 +1,92 @@
+# Effects (fx)
+
+## When to load
+
+Authoring a custom effect handler with `reg-fx`, or working out what to put inside the `:fx` vector returned from `reg-event-fx`.
+
+## Canonical signature
+
+```clojure
+(rf/reg-fx :fx-id           handler-fn)
+(rf/reg-fx :fx-id metadata? handler-fn)
+
+;; handler-fn :: (fn [ctx args]) -> any (return value ignored)
+;;   ctx  :: {:frame <frame-id> :event <originating-event-vector-or-nil>}
+;;   args :: whatever the `:fx` entry put in the second slot
+```
+
+Verified in `implementation/core/src/re_frame/fx.cljc:33`. Metadata may carry:
+
+- `:doc` — one-sentence what-and-why
+- `:spec` — Malli schema for `args` (dev-time validation)
+- `:platforms` — `#{:client :server}`; defaults to both. Fx with mismatched platforms emit `:rf.fx/skipped-on-platform` instead of running.
+
+## The fx-map shape
+
+`reg-event-fx` handlers return a **closed-shape** map. Only two top-level keys are legal:
+
+```clojure
+{:db <new-db>
+ :fx [[:fx-id args]
+      [:fx-id args]
+      ...]}
+```
+
+Each `:fx` entry is a 2-vector: `[fx-id args]`. The runtime walks them in source order, synchronously, after `:db` commits (`fx.cljc:4-9`). Any other top-level key — `:dispatch`, `:dispatch-later`, `:http`, etc — emits `:rf.error/effect-map-shape` and is dropped (`events.cljc:81`). v2 deliberately removed v1's auto-routed top-level effect keys.
+
+The reserved fx-ids the core runtime handles directly (`fx.cljc:10-22`):
+
+| fx-id | args | Effect |
+|---|---|---|
+| `:dispatch` | event-vector | Enqueue at back of frame's router |
+| `:dispatch-later` | `{:ms n :event ev}` | Enqueue after `n` ms |
+| `:rf.fx/reg-flow` / `:rf.fx/clear-flow` | flow spec | (Flows artefact; Spec 013) |
+
+Machine fx-ids (`:rf.machine/spawn`, `:rf.machine/destroy`) ship in `day8/re-frame2-machines`; they register through the same `reg-fx` path when that artefact is loaded.
+
+## Canonical mini-example
+
+From `examples/reagent/todomvc/events.cljs`:
+
+```clojure
+(rf/reg-fx :todo.storage/save
+  {:doc       "Persist the TodoMVC items to localStorage."
+   :platforms #{:client}}
+  (fn fx-todo-storage-save [_ctx todos]
+    (when-let [ls (.-localStorage js/globalThis)]
+      (->> todos
+           vals
+           (mapv #(select-keys % [:id :title :completed]))
+           (clj->js)
+           (js/JSON.stringify)
+           (.setItem ls db/ls-key)))))
+
+;; Called via the fx vector:
+(rf/reg-event-fx :todo/add
+  (fn [{:keys [db]} [_ title]]
+    {:db (assoc-in db [:todos id] {...})
+     :fx [[:todo.storage/save (:todos new-db)]]}))
+```
+
+## Ordering and atomicity
+
+Per `fx.cljc:4-9`:
+
+1. `:db` commits first, atomically.
+2. `:fx` entries process in source order.
+3. Each handler runs synchronously before the next entry begins.
+4. Subscriptions observe the post-`:db` state.
+5. One bad fx (exception, unknown id) traces and the walk continues — does not halt the rest.
+
+## Common gotchas
+
+- **Return shape is closed.** Top-level `:dispatch`, `:dispatch-later`, `:http`, etc. are dropped with a `:rf.error/effect-map-shape` trace. Wrap them inside `:fx`.
+- **Fx handlers receive `(ctx, args)`, not just `args`.** The first arg is `{:frame ... :event ...}`. Ignore it with `_ctx` if you don't need it.
+- **Returning a value from an fx handler does nothing.** Side effects are the point. `:rf.fx/handled` is emitted on success so the epoch projection records the run.
+- **`:platforms #{:client}` makes the fx skip silently on server.** A `:rf.fx/skipped-on-platform` warning fires — fine for browser-only side effects, but check this if a fx mysteriously doesn't run under SSR.
+- **Fx errors are isolated.** A throw inside one fx emits `:rf.error/fx-handler-exception` but does not abort the `:fx` walk. Don't rely on later entries seeing earlier failures.
+- **Override the fx surface per frame**, not globally: `(rf/reg-frame :frame-id {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})`. Used heavily for test stubs and stories (`frame.cljc:115-118`).
+
+## Deeper material
+
+Per-frame fx overrides, the full reserved fx-id table, `:rf.http/managed`, flows, machine fx-ids: `SKILL-REDIRECT.md` → **EP — Frames (002)**, **EP — HTTP requests (014)**, **EP — Flows (013)**.

--- a/skills/re-frame2/reference/fundamentals/schemas.md
+++ b/skills/re-frame2/reference/fundamentals/schemas.md
@@ -1,0 +1,108 @@
+# Schemas
+
+## When to load
+
+Registering a Malli schema for a path in `app-db` with `reg-app-schema`, or attaching the `validate-at-boundary` interceptor to a handler that ingests untrusted data (HTTP responses, websocket messages, query-strings).
+
+## Prerequisite
+
+`reg-app-schema` and the validator surface ship in the optional **`day8/re-frame2-schemas`** artefact (`core.cljc:537-542`). Add it to `deps.edn` and `(:require [re-frame.schemas])` at app boot, otherwise `reg-app-schema` throws `:rf.error/schemas-artefact-missing`.
+
+## Canonical signatures
+
+```clojure
+(rf/reg-app-schema path schema)
+(rf/reg-app-schema path schema opts)              ;; opts :: {:frame :rf/default}
+
+(rf/app-schema-at      path)                       ;; -> schema or nil
+(rf/app-schemas)                                   ;; -> {path schema ...}
+(rf/app-schemas-digest)                            ;; -> stable digest string
+
+(rf/set-schema-validator!  validate-fn-or-map)     ;; swap in non-Malli validator
+(rf/set-schema-explainer!  explain-fn)
+```
+
+Verified: `reg-app-schema` macro at `implementation/core/src/re_frame/core.cljc:527`; the query fns at `:571-597`; the validator seam at `:599-622`.
+
+Registrations are **frame-scoped** — the schema attaches to a path inside one frame's `app-db`. Default frame is `(current-frame)`; pass `{:frame :other}` in `opts` to target another.
+
+## What `:spec` does on a handler
+
+Every `reg-*` macro accepts a `:spec` key in its metadata-map:
+
+```clojure
+(rf/reg-event-db :flight/set-trip-type
+  {:doc "User changed the trip-type combo."
+   :spec [:cat [:= :flight/set-trip-type] [:enum :one-way :return]]}
+  (fn [db [_ trip-type]] (assoc-in db [:flight :trip-type] trip-type)))
+```
+
+In **dev builds** (`re-frame.interop/debug-enabled?` is `true`) the dispatched event vector is validated against the handler's `:spec` before the handler runs. Failure emits `:rf.error/schema-validation-failure` and skips the handler (`spec.cljc:154-238`). In **`:advanced` + `goog.DEBUG=false` production builds** these dev-time call sites are elided.
+
+## `validate-at-boundary` — opt-in production validation
+
+For handlers that **must** validate even in production (HTTP response ingestion, websocket payload, postMessage), attach the boundary interceptor:
+
+```clojure
+(ns my-app.api
+  (:require [re-frame.core :as rf]
+            [re-frame.spec :as spec]))
+
+(rf/reg-event-fx :api/response-received
+  {:spec ApiResponseSchema}
+  [spec/validate-at-boundary]
+  (fn [_ [_ payload]] ...))
+```
+
+`rf/validate-at-boundary` is a re-export (`core.cljc:1188`); either spelling works. The interceptor reuses the handler's existing `:spec` — it does NOT introduce a parallel schema (`spec.cljc:30-31`).
+
+Behaviour matrix (`spec.cljc:36-43`):
+
+- **Dev build** — no-op (step-1 validation already runs).
+- **Production with `:spec`** — runs the same validation inline.
+- **Production with no `:spec`** — no-op + once-per-handler `:rf.warning/boundary-without-spec`.
+
+## Canonical mini-example
+
+From `examples/reagent/7Guis/flight_booker/flight_booker.cljs`:
+
+```clojure
+(def FlightState
+  [:map
+   [:trip-type   [:enum :one-way :return]]
+   [:start-text  :string]
+   [:return-text :string]])
+
+(rf/reg-app-schema [:flight] FlightState)
+
+(rf/reg-event-db :flight/set-trip-type
+  {:doc  "User changed the trip-type combo."
+   :spec [:cat [:= :flight/set-trip-type] [:enum :one-way :return]]}
+  (fn [db [_ trip-type]] (assoc-in db [:flight :trip-type] trip-type)))
+```
+
+The `reg-app-schema` validates `app-db` shape at the `[:flight]` path; the `:spec` on the handler validates the dispatched event vector.
+
+## Swapping the validator
+
+`set-schema-validator!` is the **substitute-Malli seam** (`core.cljc:599-621`). Apps that want to drop the ~24KB gzipped Malli surface in production swap in a hand-written validator at boot:
+
+```clojure
+(rf/set-schema-validator!
+  {:validate (fn [schema value] (my-validator schema value))
+   :explain  (fn [schema value] (my-explainer schema value))})
+
+(rf/set-schema-validator! nil)         ;; disable validation entirely
+```
+
+## Common gotchas
+
+- **`reg-app-schema` is a no-op without the schemas artefact.** The macro emits a `late-bind` lookup; without `re-frame.schemas` loaded, the call throws `:rf.error/schemas-artefact-missing` at runtime, not at compile time. Always require `re-frame.schemas` at app boot if you call this.
+- **`:spec` on a handler validates the event vector, not the `app-db` value.** The schema's first slot is typically `[:cat [:= :event-id] ...]`. For app-db-shape enforcement, use `reg-app-schema`.
+- **Boundary interceptor without `:spec` is a misconfiguration.** Adding `[spec/validate-at-boundary]` to a handler that has no `:spec` metadata emits `:rf.warning/boundary-without-spec` once and passes the dispatch through unchecked.
+- **Boundary validation is dev-OR-prod, never both.** Dev-mode step-1 has already validated by the time the boundary interceptor runs; the boundary becomes the validator in production builds when step-1 is elided.
+- **Schemas are frame-scoped.** Re-registering a schema on the same `[path]` of the same frame replaces; the same path on a different frame is a separate registration.
+
+## Deeper material
+
+Validation-order spec, per-step recovery, digest algorithm, the schemas artefact's full surface, non-Malli validator authoring, machine snapshot schemas: `SKILL-REDIRECT.md` → **EP — Schemas (010)**.

--- a/skills/re-frame2/reference/fundamentals/subs.md
+++ b/skills/re-frame2/reference/fundamentals/subs.md
@@ -1,0 +1,83 @@
+# Subscriptions
+
+## When to load
+
+Authoring `reg-sub`: a layer-1 reader of `app-db`, a layer-2/3 derived sub composed from other subs, or a multi-input signal sub.
+
+## Canonical signature
+
+```clojure
+;; Layer 1: reads app-db directly
+(rf/reg-sub :id
+  (fn [db query-v] ...))
+
+;; Layer 2: single input signal
+(rf/reg-sub :id
+  :<- [:other-sub]
+  (fn [other-val query-v] ...))
+
+;; Layer 2/3: multi-input
+(rf/reg-sub :id
+  :<- [:a]
+  :<- [:b]
+  (fn [[a b] query-v] ...))
+
+;; Optional metadata as first positional arg
+(rf/reg-sub :id {:doc "..." :spec ...} <chain> handler)
+```
+
+Verified in `implementation/core/src/re_frame/subs.cljc:79` (`reg-sub`) and `subs.cljc:49` (`parse-reg-sub-args`). There is **one** registration form in v2 — `reg-sub-raw` is removed (`subs.cljc:80-81`).
+
+Lookup is via `rf/subscribe`:
+
+```clojure
+@(rf/subscribe [:my-sub])
+@(rf/subscribe [:my-sub arg1 arg2])
+```
+
+The query-vector is `[sub-id & args]`. Its first element is the sub id; args ride in the same vector and are destructured in the handler.
+
+## Canonical mini-example
+
+From `examples/reagent/todomvc/subs.cljs`:
+
+```clojure
+(rf/reg-sub :sorted-todos
+  (fn [db _]
+    (:todos db)))                   ;; layer-1: reads app-db
+
+(rf/reg-sub :todos
+  :<- [:sorted-todos]
+  (fn [sorted-todos _]
+    (vals sorted-todos)))           ;; layer-2: chained
+
+(rf/reg-sub :visible-todos
+  :<- [:todos]
+  :<- [:showing]
+  (fn [[todos showing] _]
+    (let [predicate (case showing
+                      :active    (complement :completed)
+                      :completed :completed
+                      identity)]
+      (filter predicate todos))))   ;; layer-2 multi-input
+```
+
+A layer-1 sub touches `app-db` and recomputes when the value it reads changes by `=`. Layer-2+ subs read other subs' values; they recompute when any input signal changes. The signal graph is built lazily — a sub registers as a callable, and the reactive cache materialises on first `subscribe`.
+
+## Cache behaviour
+
+Caching is per-frame, keyed by the query-vector. Disposal is **deferred ref-counting with a 50ms grace period** (`subs.cljc:21-25`). When the last subscriber drops, the cache entry is scheduled for disposal; a new subscriber arriving within the window cancels disposal and reuses the cached value. This is the **only** disposal algorithm — v1's `:safe` / `:no-cache` / `:reactive` / `:forever` lifecycles are gone (`subs.cljc:26-29`).
+
+For tests that need a different grace period: `(rf/configure :sub-cache {:grace-period-ms 0})` — see `subs.cljc:125` (`configure!`).
+
+## Common gotchas
+
+- **No `reg-sub-raw`.** v1's escape-hatch is removed. If you need to compose, layer subs with `:<-`. If you need a one-shot read off `app-db` outside the reactive graph (tests, SSR), use `rf/compute-sub` (`subs.cljc:379`) which returns a value, not a reaction.
+- **Subscribe returns a reaction.** Always deref with `@`. Inside a Reagent view this auto-tracks; outside of a reactive context the deref is a one-shot read and won't update.
+- **The query-vector is the cache key.** `[:my-sub 1]` and `[:my-sub 2]` are distinct cache entries. Re-using the same vector across renders is fine; constructing fresh vectors with identical content is also fine (`=`-equal keys hit the same cache slot).
+- **Signal subs (`:<-`) accept a query-vector, not just an id.** `:<- [:other-sub arg]` is legal and threads the arg through.
+- **Subs run inside the calling frame's context.** Plain Reagent fns under a non-default `frame-provider` may fall through to `:rf/default` — use `reg-view` instead so the frame is captured via React context. See [frames.md](frames.md).
+
+## Deeper material
+
+Sub topology inspection (`sub-topology`), cache snapshots, the disposal algorithm under reconcile, validation against `:spec`: `SKILL-REDIRECT.md` → **EP — Reactive substrate (006)**, **Definitive API reference**.


### PR DESCRIPTION
## Summary

Authors the seven leaf reference files under `skills/re-frame2/reference/fundamentals/`:

| File | Lines | Source(s) cited |
|---|---:|---|
| `events.md` | 73 | `implementation/core/src/re_frame/events.cljc`, `examples/reagent/counter/core.cljs` |
| `subs.md` | 83 | `implementation/core/src/re_frame/subs.cljc`, `examples/reagent/todomvc/subs.cljs` |
| `fx.md` | 92 | `implementation/core/src/re_frame/fx.cljc`, `examples/reagent/todomvc/events.cljs` |
| `cofx.md` | 76 | `implementation/core/src/re_frame/cofx.cljc`, `examples/reagent/todomvc/db.cljs` + `events.cljs` |
| `frames.md` | 116 | `implementation/core/src/re_frame/frame.cljc`, `examples/reagent/login/core.cljs` |
| `schemas.md` | 108 | `implementation/core/src/re_frame/spec.cljc` + `core.cljc`, `examples/reagent/7Guis/flight_booker/flight_booker.cljs` |
| `event-state-cycle.md` | 104 | `implementation/core/src/re_frame/{events,fx,subs,router}.cljc`, `examples/reagent/counter/core.cljs` |

All seven files are between 73 and 116 lines (target ~150, ceiling 250).

## Design constraints honoured

- **Pillar 4** — leaves teach the re-frame2-specific binding only (the macro/fn name, signature, options, common gotchas). No re-explaining what events / pub-sub / effects / schemas ARE.
- **Implementation is ground truth** — every canonical signature is cited against `implementation/core/src/re_frame/*` with file:line references.
- **Examples are canonical** — every mini-example is lifted from `examples/reagent/*`.
- **Deep-dive content redirects** to `SKILL-REDIRECT.md` rather than restating the full API reference.
- **No changes to `SKILL.md`** — the loading map is owned by the integration pass (rf2-l086).
- **No verification step** — leaves do not tell the AI to run tests after writing code.

## Test plan

- [x] All 7 files ≤ 250 lines (max is 116)
- [x] Each cited signature grep-able against `implementation/core/src/re_frame/*`
- [x] Each cited mini-example grep-able against `examples/reagent/*`
- [x] `mkdocs build --strict` warning count unchanged (185 before, 185 after — all pre-existing guide→spec link warnings, none in `skills/re-frame2/`)
- [x] No edits to `SKILL.md`
- [x] `.gitkeep` preserved in `reference/fundamentals/`