### PR TITLE
feat(skills): re-frame2 state-machines leaves (reg-machine, regions, tags, invoke, cancellation) (rf2-a04c)

### DIFF
--- a/skills/re-frame2/reference/state-machines/cancellation.md
+++ b/skills/re-frame2/reference/state-machines/cancellation.md
@@ -1,0 +1,102 @@
+# Cancellation cascade — what happens when an actor is destroyed
+
+## When to load
+
+Reach for this leaf when an `:invoke`d child issues `:rf.http/managed` requests, holds a websocket, or owns any in-flight side effect — and the parent might decide to leave the `:invoke`-bearing state. The cleanup is automatic; this leaf tells you what is guaranteed and what to add by hand for non-HTTP side effects.
+
+## The guarantee
+
+When the runtime destroys a spawned actor by **any** trigger, every in-flight `:rf.http/managed` request the actor had issued is aborted. The trigger list (Spec 005 §Cancellation cascade §The contract, `spec/005-StateMachines.md:2034`):
+
+1. **Parent state exit** — any transition out of the `:invoke`-bearing state.
+2. **Parent's `:after` firing** — wall-clock timeout exits the state; same cascade as (1).
+3. **`:invoke-all` cancel-on-decision** — when the join resolves, surviving siblings are torn down (default `:cancel-on-decision? true`).
+4. **`:invoke-all` parent state exit** — symmetric to (1) but iterates every child the `:children` map tracks.
+5. **Imperative `[:rf.machine/destroy <actor-id>]`** from a user-authored action.
+6. **Frame destroy** — `frame.cljc`'s frame-exit walk destroys each surviving machine, firing the same hook per actor.
+
+The hook is at `:http/abort-on-actor-destroy` (`implementation/machines/src/re_frame/machines.cljc:2410`); the http artefact registers the abort fn at ns-load time. When `re-frame.http-managed` is not on the classpath the hook resolves to nil and the destroy proceeds without HTTP-abort — apps that don't issue managed-HTTP requests pay nothing.
+
+## The abort surfaces
+
+The reply path sees `{:kind :rf.http/aborted :reason :actor-destroyed}` on the standard `:on-failure` callback. For most calling code there's no observable difference from a manual `:rf.http/managed-abort`; the `:reason :actor-destroyed` tag is the discriminator for callers that need to distinguish lifecycle-driven aborts from user-initiated ones.
+
+A trace event `:rf.http/aborted-on-actor-destroy` fires per cancelled request, carrying `:request-id` (when set), `:actor-id` (the destroyed actor address), and `:url`.
+
+## What "in-flight inside an actor" means
+
+A request is in-flight inside actor `<spawned-id>` iff its originating event vector's first element was `<spawned-id>`. The http fx records the `(request-id, actor-id)` tuple in its in-flight registry alongside the abort handle (`spec/005-StateMachines.md:2047`).
+
+A request issued **directly from an ordinary `reg-event-fx` handler** — not via a spawned actor — is NOT tracked by actor-id and is NOT aborted by any state machine destroy. That's deliberate (Spec 005 §Open question — direct dispatches from event handlers): an ordinary handler has no analogous lifecycle peg. If you want HTTP requests bound to a state's lifetime, the answer is **to spawn a child machine that issues them** — the `:invoke` declaration is the explicit binding.
+
+## Canonical worked example
+
+```clojure
+{:authenticating
+ {:invoke {:machine-id :rf.http/managed                ;; child issues the HTTP
+           :data       {:request {:method :post
+                                  :url    "/api/login"
+                                  :body   credentials}}}
+  :after  {30000 :auth-failed}                         ;; wall-clock — spans retries
+  :on     {:succeeded :authenticated
+           :user/cancelled :idle}}}
+```
+
+Three independent triggers all cause the same cleanup:
+
+- User clicks "Cancel" → dispatches `[:auth :user/cancelled]` → exits `:authenticating` → exit cascade emits `:rf.machine/destroy` for the `:rf.http/managed` child → its in-flight HTTP aborts.
+- 30 s passes → `:after` fires → exits `:authenticating` → same exit cascade → HTTP aborts.
+- Frame torn down (e.g., the story is unmounted) → frame-destroy walk destroys every surviving machine → HTTP aborts.
+
+The parent code never named the request-id, never threaded an abort handle. The child's lifetime IS the lifetime of the in-flight HTTP, and the standard exit cascade enforces it on every code path out of the state.
+
+## Cooperative cleanup for non-HTTP side effects
+
+The framework's automatic abort hook covers `:rf.http/managed`. For anything else a child holds — a websocket, a timer, a subscription on an external stream — wire your own cleanup into the child's `:exit` action. Two shapes:
+
+### `:exit` action on the leaf
+
+If the child machine itself owns the resource, the child's leaf-state `:exit` (or its `:invoke`-bearing state's `:exit`) closes it:
+
+```clojure
+{:connected
+ {:entry :ws/open
+  :exit  :ws/close                                    ;; runs on any exit, including parent-destroy
+  :on    {:disconnect :idle}}}
+```
+
+When the parent destroys the child, the child's exit cascade fires `:ws/close` before the snapshot is dissoc'd. The destroy fx (`machines.cljc:2470`) runs the standard exit cascade on the actor's current configuration before unregistering the handler.
+
+### Parent-side `:exit` on the `:invoke`-bearing state
+
+If the parent needs to capture the child's last reported value before tearing it down, declare a parent `:exit` action — it runs **before** the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`, `spec/005-StateMachines.md:1889`):
+
+```clojure
+{:authenticating
+ {:invoke {:machine-id :auth-flow}
+  :exit   (fn [data _]
+            ;; The child's snapshot is still at [:rf/machines <id>]; read it.
+            {:fx [[:analytics/record [:auth-attempt
+                                      (get-in @app-db [:rf/machines :auth-flow#1 :data])]]]})
+  :on     {:succeeded :authenticated
+           :failed    :auth-failed}}}
+```
+
+The auto-destroy runs after the user's `:exit` — wire-level concatenation, not nesting.
+
+## Common gotchas
+
+- **Direct HTTP from `reg-event-fx` is not cancelled.** No actor → no actor-id → no abort. If lifecycle-bound abort matters, push the HTTP into a child machine via `:invoke`. The `:rf.http/managed` machine-shape wrapper exists for exactly this case (Spec 005 §Worked example — declarative login flow).
+- **Cleanup runs even when the child hasn't finished setup.** The auto-destroy hook fires on every exit cascade, including ones that fire before any HTTP succeeded. Your child's `:exit` action must tolerate the "we never made it past `:idle`" case.
+- **No `core.async` channels.** The framework does not use, depend on, or accept core.async in the cancellation path. If your child wraps a stream-shaped external API (a websocket, a Server-Sent Events feed), close the host handle directly from an `:exit` action — don't reach for `core.async/close!`.
+- **`:rf.http/aborted-on-actor-destroy` is a trace event, not an error category.** The reply path sees `:rf.http/aborted` with `:reason :actor-destroyed` — same `:on-failure` callback as any other abort. Don't write `:on-error` handlers that try to discriminate; check the failure map's `:reason` if you care.
+- **Frame-destroy cascades to every machine, every request.** A frame teardown destroys every machine instance in the frame (Spec 002 §Lifecycle), which fires the destroy hook per actor, which aborts every in-flight HTTP they owned. This is the "page navigation cleans up the previous screen" guarantee — you do not need to wire abort calls into route-leave handlers.
+- **`:invoke-all` cancel-on-decision is uniform with single-`:invoke` destroy.** When the join resolves and surviving siblings are torn down, each sibling's HTTP aborts via the same hook. No per-trigger code path; no separate registration.
+
+## Why one mechanism, not two
+
+The same hook fires across every destroy trigger — `:invoke` exit, `:invoke-all` exit, cancel-on-decision, `:after` cascade, frame destroy, imperative destroy. There is no per-trigger HTTP-abort code path. Authors writing an `:invoke`-based child whose body fires `:rf.http/managed` get cleanup automatically, with no `:exit` action threading `:rf.http/managed-abort` calls per known `:request-id` (Spec 005 §Why one mechanism, not two).
+
+## Deeper material
+
+For the full cancellation contract — trace events, the late-bind hook surface, the cross-spec interaction with `:rf.http/managed`'s abort envelope — see `SKILL-REDIRECT.md` → *EP — State machines (005)* §Cancellation cascade and `SKILL-REDIRECT.md` → *EP — HTTP requests (014)* §Abort on actor destroy.

--- a/skills/re-frame2/reference/state-machines/invoke.md
+++ b/skills/re-frame2/reference/state-machines/invoke.md
@@ -1,0 +1,99 @@
+# `:invoke` — declarative child machines
+
+## When to load
+
+Reach for this leaf when a state hosts an asynchronous activity whose lifetime must match the state's lifetime: an HTTP request, a websocket session, a sub-machine running a sub-flow. For wall-clock guards on that activity, use the parent state's `:after`. For "fan out N children and join when done", see `:invoke-all` below. For the cancellation/cleanup contract, see `cancellation.md`.
+
+## Canonical declaration
+
+```clojure
+{:authenticating
+ {:invoke {:machine-id :rf.http/managed
+           :data       {:request {:method :post
+                                  :url    "/api/login"
+                                  :body   credentials}}}
+  :after  {30000 :auth-failed}                       ;; wall-clock guard — spans retries
+  :on     {:succeeded :authenticated
+           :failed    :auth-failed}}}
+```
+
+Spec 005 §Declarative `:invoke` §Worked example (verbatim shape). While the parent machine sits in `:authenticating`, an actor of `:rf.http/managed` exists at `[:rf/machines <id>]`. The runtime spawns it on entry and destroys it on exit (Spec 005 §Desugaring rules; implementation at `implementation/machines/src/re_frame/machines.cljc:796-872`).
+
+## `:invoke` spec keys
+
+| key | purpose | required? |
+|---|---|---|
+| `:machine-id` *or* `:definition` | which machine to spawn (registered id, or inline transition table) | exactly one |
+| `:data` | initial data for the child — literal map or `(fn [snapshot event] data)` | optional |
+| `:on-spawn` | `(fn [data spawned-id] new-data)` — advisory; record the child id in the parent's `:data` if you want | optional |
+| `:start` | event vector dispatched to the newborn after spawn | optional |
+| `:invoke-id` | explicit id instead of gensym (per-state singleton) | optional |
+| `:id-prefix` | base for the gensym'd actor id; defaults to `:machine-id` | optional |
+
+Verbatim from Spec 005 §Spec-spec keys (`spec/005-StateMachines.md:1821`). The runtime stamps `:rf/parent-id` (the parent's registration id) + `:rf/invoke-id` (the absolute prefix-path of the `:invoke`-bearing state node) onto the spawn args so the destroy fx can locate the actor on exit.
+
+## Terminal contract — re-frame2 has no `onDone`
+
+A child reaching a "done" state does **not** automatically signal the parent. There is no `final?: true` marker, no `onDone` callback. The child explicitly dispatches back:
+
+```clojure
+;; Inside the child's terminal-state action:
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :states
+   {:running
+    {:on {:server-ok {:target :done
+                      :action (fn [data _]
+                                {:fx [[:dispatch
+                                       [(:rf/parent-id data)
+                                        [:succeeded (:user-token data)]]]]})}}}
+    :done {}}})
+```
+
+The parent's `:rf/parent-id` is stamped onto the child's `:data` at spawn time (`machines.cljc:2278`, Spec 005 §Runtime stamps on the spawned actor's `:data`). The child reads it and dispatches `[<parent-id> [:succeeded ...]]`; the parent's `:on :succeeded :authenticated` transition fires.
+
+Per Spec 005 §Deliberate omissions vs xstate (`spec/005-StateMachines.md:1922`): the parent reads `(:rf/parent-id data)`; the child dispatches back via the standard `:dispatch` fx. No new mechanism. Same shape as the `:rf.http/managed` wrapper's terminal `:succeeded` / `:failed` events.
+
+## Composition with explicit `:entry` / `:exit`
+
+A state may declare both `:invoke` AND user-supplied `:entry` / `:exit`. Ordering is **wire-level concatenation**: user-entry runs first, then the auto-spawn; user-exit runs first, then the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`; `machines.cljc:889`). The user's `:exit` action gets to read the actor's final snapshot before auto-destroy clears it.
+
+## `:invoke-all` — spawn-and-join
+
+When the parent needs to fan out N children and resume on a join condition (boot hydration, parallel asset loads), use `:invoke-all` (Spec 005 §Spawn-and-join via `:invoke-all`; `spec/conformance/fixtures/invoke-all-join-all-completes.edn`):
+
+```clojure
+{:hydrating
+ {:invoke-all
+  {:children         [{:id :cfg  :machine-id :load-config       :on-spawn :record-cfg}
+                      {:id :user :machine-id :load-user-profile  :on-spawn :record-user}
+                      {:id :dash :machine-id :load-dashboards    :on-spawn :record-dash}]
+   :join             :all                            ;; :all / :any / {:n N} / {:fn pred}
+   :on-child-done    :child/done                     ;; child-keyword the children dispatch on success
+   :on-child-error   :child/error                    ;; child-keyword the children dispatch on failure
+   :on-all-complete  [:assets-loaded]                ;; parent event when :all fires
+   :on-any-failed    [:asset-load-failed]            ;; parent event when any child fails
+   :on-some-complete [:partial-load]}                ;; parent event when :n or :any fires
+
+  :on    {:assets-loaded     :ready
+          :asset-load-failed :error
+          :partial-load      :degraded}}}
+```
+
+Child id is the `:id` field inside each `:children` entry (NOT the `:machine-id`); each child dispatches `[:child/done :cfg & extra]` (or `:child/error`) back to the parent. The runtime intercepts these at the parent's machine boundary, updates join-state at `[:rf/spawned <parent-id> <invoke-id>]`, evaluates the join condition, and fires the resolved parent event — automatically cancelling surviving siblings (`:cancel-on-decision?` defaults to `true`).
+
+Validation happens at registration (`machines.cljc:1653`): `:on-child-done` / `:on-child-error` are required keywords, `:on-all-complete` is required when `:join :all` (the default), `:on-some-complete` is required for `:any` / `{:n N}` / `{:fn pred}`.
+
+## Common gotchas
+
+- **Pick exactly one of `:machine-id` or `:definition`.** Registration rejects both forms or neither (`spec/005-StateMachines.md:1920`).
+- **No `:timeout-ms` on `:invoke` or `:invoke-all`.** Wall-clock guards live on the parent state's `:after`. Use `:after {30000 :timeout-target}` — when the timer fires, the standard exit cascade destroys the in-flight child and the parent transitions. Per rf2-3y3y the `:timeout-ms` slot is dropped; registration throws `:rf.error/invoke-timeout-ms-removed`.
+- **`:on-spawn` is advisory.** Per rf2-t07u Option A revised, the runtime tracks the spawn-id at `[:rf/spawned <parent-id> <invoke-id>]` itself — you no longer need `:on-spawn` to write the id under any specific `:data` slot for destroy to work. Most apps still set `:on-spawn (fn [data id] (assoc data :pending id))` so other transitions can address the child by name.
+- **`:data` is a literal map or `(fn [snap ev] data)` — not arbitrary code.** When the fn form is used, it runs at state entry against the post-action snapshot (`machines.cljc:782`). If it throws, the transition halts with `:rf.error/machine-action-exception` and the snapshot does NOT commit.
+- **`:start` runs after spawn; if absent the runtime dispatches a synthetic `[:rf.machine/spawned]`.** Per rf2-ijm7, every spawned actor receives `[:rf.machine/spawned]` if no `:start` was declared — generic child machines can declare a leaf `:on :rf.machine/spawned :target ...` transition that fires the actor's first work on entry.
+- **Path convention for `:on-spawn`:** the callback receives `:data` directly. Write `(assoc data :pending id)`, not `(assoc-in snap [:data :pending] id)`. Uniform with `:guard` and `:action`.
+- **One `:invoke` per state.** Multiple children per state → refactor into a compound state where each substate invokes one of the actors, or use `:invoke-all`. Validated at registration; `:invoke` + `:invoke-all` together throws `:rf.error/machine-invoke-all-with-invoke` (`machines.cljc:1669`).
+
+## Deeper material
+
+For the full declarative-`:invoke` desugaring rules, composition with hierarchical states, and the `:invoke-all` join-semantics matrix, see `SKILL-REDIRECT.md` → *EP — State machines (005)* §Declarative `:invoke` and §Spawn-and-join via `:invoke-all`. For the canonical worked example exercising `:invoke` + `:after` + hierarchical states, see `SKILL-REDIRECT.md` → *Pattern — WebSocket*.

--- a/skills/re-frame2/reference/state-machines/reg-machine.md
+++ b/skills/re-frame2/reference/state-machines/reg-machine.md
@@ -1,0 +1,150 @@
+# reg-machine — declaring a state machine
+
+## When to load
+
+Reach for this leaf when authoring a `rf/reg-machine` call: the declaration map's keys, the `:guards` / `:actions` lookup tables, how a machine is dispatched into. For parallel regions, tags, `:invoke`, or cancellation, see the sibling leaves.
+
+## Canonical signature
+
+```
+(rf/reg-machine machine-id machine-map)
+```
+
+`reg-machine` is a macro that stamps source coords at the call site and registers the machine as a `:event` handler whose registration metadata carries `:rf/machine? true` (`implementation/core/src/re_frame/core.cljc:634`; the underlying registration fn is `re-frame.machines/reg-machine*`, `implementation/machines/src/re_frame/machines.cljc:2028`). The machine **is** an event handler — dispatch `[machine-id [:event-name & args]]` to drive it.
+
+The `day8/re-frame2-machines` artefact must be on the classpath and `re-frame.machines` required at app boot; without it, calls throw `:rf.error/machines-artefact-missing` (`core.cljc:701`).
+
+## Declaration shape
+
+The basic (non-parallel, non-hierarchical) form:
+
+```clojure
+(require '[re-frame.core :as rf]
+         '[re-frame.machines])     ;; load-time hook registration
+
+(def my-machine
+  {:initial :idle
+   :data    {:attempt 0 :error nil}
+
+   :guards
+   {:has-input?
+    (fn guard-has-input? [data _event]
+      (some? (:input data)))}
+
+   :actions
+   {:bump-attempt
+    (fn action-bump [data _event]
+      {:data (update data :attempt (fnil inc 0))})
+
+    :store-result
+    (fn action-store [data [_ {:keys [value]}]]
+      {:data (assoc data :result value :error nil)})}
+
+   :states
+   {:idle
+    {:on {:start {:target :working
+                  :guard  :has-input?
+                  :action :bump-attempt}}}
+
+    :working
+    {:on {:succeeded {:target :done    :action :store-result}
+          :failed    {:target :idle}}}
+
+    :done {}}})
+
+(rf/reg-machine :my/feature my-machine)
+
+;; Drive it:
+(rf/dispatch [:my/feature [:start]])
+```
+
+The machine map's top-level keys are documented in Spec 005 §Transition table top-level keys: `:initial` (the entry state for non-parallel machines), `:data` (initial shared data), `:guards` and `:actions` (named lookup tables), `:states` (the transition table). For parallel machines, `:type :parallel` + `:regions` replaces `:initial` + `:states` — see `regions.md`.
+
+## State-node shape
+
+Every state node is a map. Recognised slots (see `implementation/machines/src/re_frame/machines.cljc` and Spec 005 §State nodes):
+
+- `:on` — a map of `event-keyword → transition-spec` (see Transitions below).
+- `:entry` / `:exit` — singular action references or fns, fired on entering / leaving the node.
+- `:always` — eventless microstep table (`:always [{:guard ... :target ...} ...]`).
+- `:after` — delayed transition table, `:after {<ms-or-sub-vec-or-fn> <transition-spec>}`.
+- `:invoke` — declarative child spawn (see `invoke.md`).
+- `:invoke-all` — spawn-and-join sugar (see `invoke.md`).
+- `:tags` — a set of keywords describing this state's per-axis intent (see `tags.md`).
+- `:states` + `:initial` — nested compound state (deepest-wins resolution).
+
+## Transition shape
+
+The value under an `:on` event keyword is one of:
+
+```clojure
+{:on {:start :working}}                              ;; bare target keyword
+{:on {:start {:target :working}}}                    ;; explicit map
+{:on {:start {:target :working :action :bump-attempt}}}
+{:on {:start {:target :working :guard  :has-input?}}}
+{:on {:start [{:guard :a? :target :x}                ;; guarded vector — first match wins
+              {:guard :b? :target :y}
+              {:target :z}]}}
+```
+
+The transition's `:target` may be a single keyword (sibling-level) or a vector path (absolute, for cross-level transitions). Per `machines.cljc:344` (`normalise-on-clause`).
+
+## Guards / actions — keyword reference or inline fn
+
+`:guards` and `:actions` at the machine top level are lookup tables. Inside an `:on` transition, `:guard` and `:action` accept **either** a keyword that resolves through those tables, **or** an inline fn:
+
+```clojure
+;; Inline — preferred only for one-line trivialities.
+{:on {:start {:guard  (fn [data _ev] (some? (:input data)))
+              :target :working}}}
+
+;; Keyword reference — preferred for anything non-trivial, because the
+;; registered id appears in trace events and tools can jump-to-source.
+{:on {:start {:guard :has-input? :target :working}}}
+```
+
+Per the inspectability bias (`SKILL.md` cardinal rule 5 / Spec 005 §Inspectability bias): named entries surface in `:rf.machine/*` trace events as the registered keyword, not as an opaque `#object[Function ...]`. Reach for the inline form only when the body is trivial.
+
+### Guard / action contract
+
+Both fns receive `(data event)` — `:data` directly, not the snapshot wrapper. Actions return `{:data new-data :fx [...]}` (either key optional); guards return truthy/falsey. See `implementation/machines/src/re_frame/machines.cljc:146` (`call-guard`) and `:156` (`call-action`).
+
+A 3-arity escape hatch `(fn [data event {:state ... :meta ...}])` exists for introspecting the snapshot's discrete state, but reach for it only when 2-arity cannot express what you need (Spec 005 §3-arity escape hatch).
+
+## Subscribing to a machine
+
+The framework ships two subs:
+
+```clojure
+@(rf/sub-machine :my/feature)                  ;; the whole snapshot
+@(rf/has-tag? :my/feature :loading)            ;; tag containment-bit
+```
+
+`sub-machine` is sugar over `(subscribe [:rf/machine machine-id])` and returns the snapshot map `{:state ... :data ... :tags ...}`. `has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` — see `tags.md`. Both live in `implementation/core/src/re_frame/core.cljc:1076-1098`.
+
+Project off the snapshot with ordinary `reg-sub`:
+
+```clojure
+(rf/reg-sub :feature/data
+  :<- [:rf/machine :my/feature]
+  (fn sub-data [snap _] (get-in snap [:data :result])))
+```
+
+## Querying registered machines
+
+- `(rf/handler-meta :event :my/feature)` — registration metadata, including `:rf/machine? true`, `:rf/machine` (the spec map), `:ns` / `:line` / `:file`.
+- `(re-frame.machines/machines)` — every registered machine-id.
+- `(re-frame.machines/machine-meta :my/feature)` — the spec map back.
+
+## Common gotchas
+
+- **The artefact must be loaded.** `(:require [re-frame.machines])` at the namespace declaring `rf/reg-machine` (or at app boot before any machine call). Forgetting it throws `:rf.error/machines-artefact-missing` with `:recovery :no-recovery`.
+- **`:rf.machine/*` and `:rf/*` are reserved.** Names like `:rf.machine/spawn`, `:rf/machines`, `:rf/spawned`, `:rf/after-epoch` belong to the runtime. Pick your own feature prefix for event keywords.
+- **Guards see `:data`, not the snapshot.** `(fn [data event] ...)` — the body inspects `(:input data)`, not `(get-in snap [:data :input])`. Same for actions.
+- **Actions return an effect map.** `{:data new-data}` (or `{:fx [...]}` or both). Returning a bare data map silently does nothing; `nil` is a no-op.
+- **Use `reg-machine` (macro), not `reg-machine*` (fn).** The macro stamps per-element source coords that tools rely on (`core.cljc:634`, Spec 005 §Source-coord stamping). Reach for `reg-machine*` only for programmatic registration with computed ids.
+- **Re-registration replaces.** Last-write-wins, per the standard registrar semantics; the prior snapshot at `[:rf/machines <id>]` survives (the snapshot is in `app-db`, the spec is in the registrar). Hot-reload survives a machine re-declaration.
+
+## Deeper material
+
+For the full transition-table grammar, guard/action effect-map shape, hierarchical state cascading, and machine-snapshot semantics, see `SKILL-REDIRECT.md` → *EP — State machines (005)*.

--- a/skills/re-frame2/reference/state-machines/regions.md
+++ b/skills/re-frame2/reference/state-machines/regions.md
@@ -1,0 +1,121 @@
+# Regions — single-region machines and parallel regions
+
+## When to load
+
+Reach for this leaf when the feature has more than one orthogonal axis of concern (data + form + mode; connection + auth; filter + feed) and you want one machine to drive them all. For the basic machine declaration, see `reg-machine.md`; for tags (the per-axis query shape that pairs with parallel regions), see `tags.md`.
+
+## Two region shapes
+
+A "region" in re-frame2 has two distinct meanings depending on context:
+
+1. **Single-region machine** — an ordinary `rf/reg-machine` whose declaration is just `{:initial ... :states ...}`. The "region" framing applies when you used a state machine instead of a slice **because the state-keyword IS the lifecycle phase** (Pattern-RemoteData's `:idle / :loading / :fetching / :loaded / :error`, Pattern-Forms' `:neutral / :incorrect / :submitting / :correct`). This is the canonical refactor target when an app's `:status` field is being driven by hand.
+2. **Parallel regions** — a single machine whose `:type :parallel` declaration carries N concurrent regions, each with its own `:initial` and `:states`. Broadcast events flow to every region; each region advances independently. `:data` is shared. `:tags` is the **union** across all active regions.
+
+## Single-region machine — the canonical shape
+
+```clojure
+(def tags-machine
+  {:initial :idle
+   :data    {:tags [] :error nil :loaded-at nil :attempt 0}
+
+   :actions
+   {:set-tags
+    (fn action-set-tags [data [_ {:keys [tags now]}]]
+      {:data (assoc data :tags (vec tags) :error nil :loaded-at now)})}
+
+   :states
+   {:idle     {:tags #{:tags/idle}
+               :on   {:fetch-started :loading}}
+
+    :loading  {:tags #{:tags/loading :tags/in-flight}
+               :on   {:fetch-succeeded {:target :loaded :action :set-tags}
+                      :fetch-failed    :error}}
+
+    :loaded   {:tags #{:tags/loaded}
+               :on   {:fetch-started :fetching}}      ;; revalidate; don't blank
+
+    :fetching {:tags #{:tags/fetching :tags/in-flight :tags/loaded}
+               :on   {:fetch-succeeded {:target :loaded :action :set-tags}
+                      :fetch-failed    :error}}
+
+    :error    {:tags #{:tags/error}
+               :on   {:fetch-started :loading}}}})
+
+(rf/reg-machine :realworld/tags tags-machine)
+```
+
+Verbatim from `examples/reagent/realworld/tags.cljs:71-142`. The slice's separate `:status` keyword disappears; the state IS the status. The view consumes `:tags/in-flight` via `(rf/has-tag? :realworld/tags :tags/in-flight)` instead of a hand-rolled `(or (= :loading status) (= :fetching status))`.
+
+## Parallel regions — the canonical declaration
+
+```clojure
+(def nine-states-machine
+  {:type :parallel
+   :data {:items [] :error nil :archived-at nil}     ;; shared across regions
+
+   :guards   {:empty?     (fn [data _] (zero? (count (:items data))))
+              :too-many?  (fn [data _] (> (count (:items data)) 7))}
+
+   :actions  {:set-items  (fn [data [_ {:keys [items]}]]
+                            {:data (assoc data :items (vec items))})}
+
+   :regions
+   {:data    {:initial :nothing
+              :states  {:nothing   {:tags #{:data/nothing}
+                                    :on   {:fetch-started :loading}}
+                        :loading   {:tags #{:data/loading}
+                                    :on   {:fetch-succeeded {:target :resolving
+                                                             :action :set-items}}}
+                        :resolving {:always [{:guard :empty?    :target :empty}
+                                             {:guard :too-many? :target :too-many}
+                                             {:target :some}]}
+                        :empty     {:tags #{:data/empty}}
+                        :some      {:tags #{:data/some}}
+                        :too-many  {:tags #{:data/too-many}}}}
+
+    :form    {:initial :neutral
+              :states  {:neutral   {:tags #{:form/neutral}
+                                    :on   {:submit-valid   :correct
+                                           :submit-invalid :incorrect}}
+                        :incorrect {:tags #{:form/invalid}}
+                        :correct   {:tags #{:form/success}}}}
+
+    :mode    {:initial :active
+              :states  {:active    {:tags #{:mode/active}
+                                    :on   {:archive :done}}
+                        :done      {:tags #{:mode/done :mode/read-only}}}}}})
+
+(rf/reg-machine :ui/nine-states nine-states-machine)
+```
+
+From `examples/reagent/nine_states/core.cljs:197-333`. Three orthogonal axes, one machine. `(rf/dispatch [:ui/nine-states [:fetch-started]])` reaches **every** region; the `:data` region advances; the `:form` and `:mode` regions ignore the event (their `:on` tables don't list it). The runtime is validated by `validate-parallel!` (`implementation/machines/src/re_frame/machines.cljc:1725`).
+
+## Snapshot shape with parallel regions
+
+For a parallel machine the snapshot's `:state` is a **map** keyed by region-name:
+
+```clojure
+;; Single-region:    {:state :loading                       :data {...} :tags #{...}}
+;; Parallel-region:  {:state {:data :loading :form :neutral :mode :active}
+;;                    :data  {...}
+;;                    :tags  #{:data/loading :form/neutral :mode/active}}
+```
+
+`:data` is shared across regions (same map). `:tags` is the union of every active state's `:tags` set across every region. Per Spec 005 §Parallel regions §Snapshot shape and `machines.cljc:295` (Stage 2 broadens the tag union to cover all active regions).
+
+## Common gotchas
+
+- **`:type :parallel` is mutually exclusive with root `:initial` / `:states`.** Use one or the other at the top level. Registration throws `:rf.error/machine-parallel-bad-shape` if both are present (`machines.cljc:1746`).
+- **Each region needs its own `:initial`.** Region bodies are themselves transition tables; a missing `:initial` keyword is a registration-time error (`machines.cljc:1762`).
+- **Region names are keywords.** `:regions {:data {...} :form {...}}` — not strings, not symbols. Validated at registration (`machines.cljc:1750`).
+- **No nested parallel regions in v1.** A region body declaring its own `:type :parallel` throws `:rf.error/machine-parallel-nested-not-supported` (`machines.cljc:1758`).
+- **Broadcast is to every region.** One event-keyword goes to every region's `:on` table; regions whose tables don't list that event are no-ops for that dispatch. Don't broadcast a region-private event with a generic name — namespace it (`:form/submit-valid`, not `:submit-valid`) to make the per-region intent visible.
+- **`:after` and `:invoke` are scoped per region.** Each region carries its own `:after`-epoch counter at `[:data :rf/after-epoch-by-region <region-name>]` — a sibling region's transition does NOT invalidate this region's in-flight `:after` timers (`machines.cljc:362`, Spec 005 §Per-region `:always` / `:after` / `:invoke` scoping).
+
+## When to reach for parallel regions vs N machines
+
+Per Spec 005 §When to reach for parallel regions: pick parallel regions when the axes (a) share a domain (the same conceptual feature — data + form + mode for a todos screen), (b) need a unified `:data` map, and (c) want a unified tag-set for view queries. Pick N separate `rf/reg-machine` calls when the axes are unrelated lifecycles (a websocket connection + a separate authentication flow + a separate route) that happen to coexist in the app.
+
+## Deeper material
+
+For the full parallel-regions contract — broadcast routing, per-region scoping, capability gating, registration-time validation — see `SKILL-REDIRECT.md` → *EP — State machines (005)* §Parallel regions.

--- a/skills/re-frame2/reference/state-machines/tags.md
+++ b/skills/re-frame2/reference/state-machines/tags.md
@@ -1,0 +1,99 @@
+# Tags — per-state intent + the `has-tag?` query
+
+## When to load
+
+Reach for this leaf when a view needs to ask "is the machine in any in-flight state?" or "is the form read-only?" — without naming the specific state-keyword. Tags are how a state declares its **intent** so views can query the intent, not the state name. Pairs with `regions.md` for the parallel-region tag-union story.
+
+## Canonical declaration
+
+A state node carries a `:tags` slot whose value is a **set of keywords**. There is no separate registration call; the slot is just a key on the state node, processed by the runtime via `compute-tags` (`implementation/machines/src/re_frame/machines.cljc:311`):
+
+```clojure
+{:loading
+ {:tags #{:data/loading :data/in-flight :data/transient}
+  :on   {:fetch-succeeded {:target :loaded :action :set-items}
+         :fetch-failed    :error}}
+
+ :fetching
+ {:tags #{:data/fetching :data/in-flight :data/loaded}
+  :on   {:fetch-succeeded {:target :loaded :action :set-items}}}
+
+ :loaded
+ {:tags #{:data/loaded}
+  :on   {:fetch-started :fetching}}}
+```
+
+Both `:loading` and `:fetching` carry `:data/in-flight` — the view consumes that one tag and doesn't have to disjoin two state-keywords.
+
+## The snapshot's `:tags` slot
+
+The runtime maintains a derived `:tags` slot on the snapshot — the **union** of every currently-active state's tag set:
+
+- **Flat machine** — the single active state's `:tags` set.
+- **Compound (hierarchical)** — the union along the path from root to active leaf.
+- **Parallel-region machine** — the union across every active state in every region (`machines.cljc:295`, Stage 2 / rf2-l67o).
+
+If the union is empty the slot is **elided** entirely (snapshot-size optimisation, `machines.cljc:327` `commit-tags`). The `:rf/machine-snapshot` schema marks `:tags` as `{:optional true}` — both presence (with non-empty set) and absence are valid.
+
+## Querying — `rf/has-tag?`
+
+```clojure
+@(rf/has-tag? :realworld/tags :tags/in-flight)        ;; truthy iff the tag is in the union
+@(rf/has-tag? :ui/nine-states :mode/read-only)
+```
+
+`has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` (`implementation/core/src/re_frame/core.cljc:1084`). The underlying sub (`machines.cljc:2122`) reads `[:rf/machines <id> :tags]` and tests `contains?`. Returns `false` for unknown or not-yet-initialised machines.
+
+The sub is **derived directly off the snapshot's `:tags` slot** — a view that only cares about whether a specific tag is present re-renders only when the containment-bit flips, not on every snapshot mutation. `reg-sub`'s built-in equality dedup carries it.
+
+## Canonical worked example
+
+From `examples/reagent/nine_states/core.cljs:487-512` — a render-priority table consults the tag union and resolves to one render-model keyword:
+
+```clojure
+(def render-priority
+  [{:tag :mode/done       :render :done}             ;; mode region wins outright
+   {:tag :form/success    :render :correct}          ;; form's transient acks next
+   {:tag :form/invalid    :render :incorrect}
+   {:tag :data/loading    :render :loading}          ;; data region's lifecycle
+   {:tag :data/error      :render :error}
+   {:tag :data/empty      :render :empty}
+   {:tag :data/some       :render :some}])
+
+(rf/reg-sub :ui/render
+  :<- [:rf/machine :ui/nine-states]
+  (fn sub-ui-render [snap _]
+    (let [tags (:tags snap)]
+      (some (fn [{:keys [tag render]}]
+              (when (contains? tags tag) render))
+            render-priority))))
+
+;; The root view: one `case`, not nine boolean discriminator subs + a cond.
+[case @(subscribe [:ui/render])
+   :done      [view-done]
+   :loading   [view-loading]
+   :error     [view-error]
+   ;; ...
+   ]
+```
+
+The render-priority table is plain data — adding a tenth case is one row.
+
+## Common gotchas
+
+- **Tags are **sets of keywords** on state nodes — not on transitions, not on the snapshot's `:data`.** A vector or single keyword is coerced to a set (`machines.cljc:303`), but the canonical form is `#{:foo :bar}`.
+- **The state declares intent, not identity.** `:tags #{:loading}` is OK; `:tags #{:my-feature/loading-state}` is overkill. Use the **per-axis** intent (`:data/loading`, `:form/in-flight`, `:mode/read-only`) so views can ask one tag-question that spans multiple states.
+- **Tags compose, but state-keywords don't.** Two states in different regions can both carry `:in-flight` — the union picks them up correctly. Don't try to query the **state-keyword** directly across regions; the snapshot's `:state` is a region-name → state-keyword map (parallel machines) or a single keyword (flat), and view code shouldn't branch on either shape. Branch on tags.
+- **`has-tag?` is a subscription.** Inside a view it's `@(rf/has-tag? ...)`. Inside an event handler it's a `subscribe` deref or a `compute-sub` call (in tests). Don't reach for it inside a `reg-event-db` body — read the snapshot's `:tags` set directly off `db` via `(get-in db [:rf/machines machine-id :tags])` if you need to branch inside an event.
+- **No empty `:tags` slot needed.** A state that doesn't carry tags just omits the key. The runtime elides the snapshot's `:tags` when the union is empty — a snapshot's `(contains? snap :tags)` may be `false` even after the machine has settled.
+- **`:rf/*` and `:rf.machine/*` keyword namespaces are reserved.** Application tag keywords use a feature prefix: `:auth/required`, `:cart/dirty`, `:ws/disconnected`. Don't tag with `:rf/anything`.
+
+## Why tags exist
+
+Per Spec 005 §State tags §What tags are *not*: tags are **not** an additional state machine, not flow-state predicates, not a way to encode transitions. They are a **query convenience** — a view-facing projection of "what does the currently-active configuration mean?" The state machine is still the source of truth; tags are the read-side index.
+
+If a tag would only ever match exactly one state, the tag is redundant — query the state directly (`(= :loading (:state snap))`). Tags earn their tokens by matching N states with a shared intent.
+
+## Deeper material
+
+For the full state-tags contract — declaration shape, snapshot semantics, the rationale vs `:status` slices — see `SKILL-REDIRECT.md` → *EP — State machines (005)* §State tags, and `SKILL-REDIRECT.md` → *Pattern — Nine states* for the canonical worked example.


### PR DESCRIPTION
## Summary

Five leaf reference files for the re-frame2 skill under `skills/re-frame2/reference/state-machines/`:

- `reg-machine.md` (150 lines) — declaration shape, top-level keys, transition shape, guard/action contract, sub-machine / has-tag?, registration metadata
- `regions.md` (121 lines) — single-region (lifecycle-as-state) shape and `:type :parallel` + `:regions` (parallel regions); snapshot shape change
- `tags.md` (99 lines) — `:tags` on state nodes, snapshot tag union (flat / compound / parallel), `rf/has-tag?`, render-priority worked example
- `invoke.md` (99 lines) — declarative `:invoke` spec keys, terminal-state contract (no `onDone`; child dispatches back), `:invoke-all` spawn-and-join
- `cancellation.md` (102 lines) — destroy cascade triggers, the `:http/abort-on-actor-destroy` hook, cooperative `:exit`-action cleanup for non-HTTP

Each leaf cites `implementation/machines/src/re_frame/machines.cljc` (and `core.cljc`) for canonical signatures and lifts mini-examples from `examples/reagent/nine_states/core.cljs` (parallel regions + tags), `examples/reagent/realworld/tags.cljs` (region-shape Pattern-RemoteData), and `spec/conformance/fixtures/invoke-*.edn` (terminal contract). All deep-dive pointers route through `SKILL-REDIRECT.md`.

Audience: CLJS app authors, not implementors. Cut-test applied — no sentences that would also apply to xstate unchanged. Pillar 4 holds: training knowledge assumed, only the re-frame2-specific binding taught.

`SKILL.md` not touched here — the integration pass owns the loading map.

## Test plan

- [ ] All 5 files ≤250 lines (largest is 150; total 571 lines).
- [ ] Signatures grep-able: `rf/reg-machine`, `has-tag?`, `:invoke`, `:type :parallel` all appear in the relevant leaves.
- [ ] Mini-examples grep-able against the source files cited (`nine-states-machine` in `examples/reagent/nine_states/core.cljs:197`, `tags-machine` in `examples/reagent/realworld/tags.cljs:71`).
- [ ] No emojis; no AI attribution.