### PR TITLE
feat(examples): long_running_work — canonical Pattern-LongRunningWork example app (rf2-o9fg)

### DIFF
--- a/examples/reagent/long_running_work/README.md
+++ b/examples/reagent/long_running_work/README.md
@@ -1,0 +1,151 @@
+# Long-running work — Pattern-LongRunningWork worked example
+
+A re-frame2 worked example demonstrating
+[`spec/Pattern-LongRunningWork.md`](../../../spec/Pattern-LongRunningWork.md)'s
+`:invoke-all` shape: cancellable long-running operations decomposed
+into N parallel worker machines, with progress reporting and a
+cooperative cancellation cascade that fires on **every** exit path —
+including the user navigating away mid-flight.
+
+This example complements the chunked-state-machine shape Pattern-LongRunningWork
+describes for single-worker work. When the work decomposes into
+independent shards, the same cooperative-yield idiom composes
+naturally over `:invoke-all` — one parent coordinator, N children, one
+declarative spawn-and-join.
+
+## What this example demonstrates
+
+- **Declarative spawn-and-join** via [`:invoke-all`](../../../spec/005-StateMachines.md#spawn-and-join-via-invoke-all)
+  (rf2-6vmw). The parent `:work/flow` machine spawns 3 `:work/processor`
+  children in parallel; the runtime owns the join state at
+  `[:rf/spawned :work/flow [:working]]`. No per-child bookkeeping in
+  the parent's `:data` — the runtime fires
+  `:on-all-complete` when the last child reports done.
+
+- **Cooperative cancellation cascade**. Exiting the parent's `:working`
+  state — by user `:cancel`, by `:on-all-complete`, by frame destroy,
+  by `:after` (not exercised here, but the same machinery applies) —
+  fires one `:rf.machine/destroy` fx whose handler tears down every
+  surviving child. Each torn-down child's in-flight `:after` timers
+  go with it; per Spec 005 §Cancellation cascade, in-flight
+  `:rf.http/managed` requests would also abort (not used here).
+
+- **Cooperative browser yielding**. Each child processes one item per
+  `:processing` entry; `:always` advances to `:checking-done`;
+  `:yielding`'s `:after` schedules the next chunk after a runtime-clock
+  delay so the browser gets a render tick between chunks. The same
+  `:after` is what gets cancelled cleanly when the parent transitions
+  out of `:working` — a stale timer firing after cancel does NOT
+  drive a transition (per [§Epoch-based stale detection](../../../spec/005-StateMachines.md#epoch-based-stale-detection)).
+
+- **Per-step progress reporting**. The child dispatches
+  `[:work/flow [:progress shard-id processed total]]` on every chunk;
+  the parent's `:working` state handles `:progress` as an
+  **internal self-transition** (no `:target` per [§Internal vs external
+  self-transitions](../../../spec/005-StateMachines.md#self-transitions)) so
+  the action runs without re-firing the `:invoke-all` entry-cascade
+  (which would otherwise re-spawn the children — anti-pattern).
+
+- **Parent-unmount cascade**. The view wrapper's `r/with-let` cleanup
+  dispatches `[:work/flow [:cancel]]`. This is the **only** point
+  where the UI lifecycle peeks through into the machine — the
+  workers are React-agnostic. The pattern composes cleanly with any
+  hosting React tree.
+
+## The machine shape
+
+```
+:work/flow                                   (parent coordinator)
+  :idle           ──[:start]──> :working
+  :working
+    :invoke-all  three children (one per shard)
+                 :join :all
+                 :on-child-done :work/child-done
+                 :on-all-complete [:work/all-done]
+                 :on-any-failed  [:work/any-failed]
+    :on
+      :progress         (internal self-transition; updates :data)
+      :work/all-done    → :complete
+      :work/any-failed  → :error
+      :cancel           → :cancelled
+  :complete       ──[:reset]──> :idle
+  :cancelled      ──[:reset]──> :idle
+  :error          ──[:reset]──> :idle
+```
+
+```
+:work/processor                              (child worker; one per shard)
+  :idle           ──[:rf.machine/spawned]──> :processing
+  :processing     :entry :process-one  (dispatches :progress to parent)
+                  :always  → :checking-done
+  :checking-done  :always  → :done | :yielding   (guarded)
+  :yielding       :after   → :processing  (browser-tick yield)
+  :done           :meta {:terminal? true}
+                  :entry :dispatch-done  (dispatches :work/child-done)
+  :cancelled      :meta {:terminal? true}
+                  (never reached via transition — cancellation
+                   cascades via :rf.machine/destroy fx)
+```
+
+## File layout
+
+```
+examples/reagent/long_running_work/
+  core.cljs       app entry point + :app/initialise
+  worker.cljs     :work/processor + :work/flow registrations
+  views.cljs      controls, progress bar, shard breakdown,
+                  work-bench wrapper (the with-let cleanup
+                  fires the unmount cascade)
+  schema.cljs     malli schemas for the parent + child snapshots
+  index.html      static host page (mounted by core/run)
+  long_running_work.spec.cjs   Playwright smoke
+  test/long_running_work/
+    worker_test.cljs           headless fixtures
+  README.md       this file
+```
+
+The integration test that wraps the headless fixtures lives at
+[`implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs`](../../../implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs).
+Same wrapping pattern as `nine-states-cljs-test` and `realworld-cljs-test`.
+
+## How to run
+
+From `implementation/`:
+
+```bash
+# Playwright smoke (compiles, stages, serves, runs the .spec.cjs).
+npm run test:examples
+
+# Headless cljs-test (runs all the *-cljs-test under
+# implementation/adapters/reagent/test/, including the long-running-work
+# integration).
+npm run test:browser
+```
+
+To iterate against a live browser:
+
+```bash
+npx shadow-cljs watch examples/long-running-work
+# Then open the URL the watch command prints.
+```
+
+Direct fixture invocation from a CLJS REPL:
+
+```clojure
+(require '[long-running-work.core])             ;; loads the example
+(require '[long-running-work.worker-test :as t])
+(t/test-spawn-cascade)
+(t/test-happy-path-join)
+(t/test-cancel-cascade)
+(t/test-parent-unmount-cascade)
+(t/test-reset-after-cancel)
+```
+
+## Cross-references
+
+- [`spec/Pattern-LongRunningWork.md`](../../../spec/Pattern-LongRunningWork.md) — the pattern.
+- [`spec/005-StateMachines.md` §Spawn-and-join via `:invoke-all`](../../../spec/005-StateMachines.md#spawn-and-join-via-invoke-all) — the substrate.
+- [`spec/005-StateMachines.md` §Cancellation cascade](../../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts) — the cancel contract.
+- [`spec/conformance/fixtures/invoke-all-*.edn`](../../../spec/conformance/fixtures/) — the runtime contract these examples sit on.
+- [`examples/reagent/realworld/`](../realworld/) — the layout convention this example mirrors.
+- [`examples/reagent/nine_states/`](../nine_states/) — single-machine sibling example using `:fsm/tags`.

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -1,0 +1,98 @@
+(ns long-running-work.core
+  "Entry point for the long-running-work example.
+
+   What this example demonstrates (per Pattern-LongRunningWork's
+   :invoke-all shape — the spec/Pattern-LongRunningWork.md guidance
+   when the work decomposes into parallel sub-tasks rather than a
+   single chunked machine):
+
+   - **Declarative spawn-and-join** — one parent coordinator spawns N
+     parallel workers via `:invoke-all` and joins on `:all`. No
+     per-child bookkeeping in the parent's `:data` — the runtime
+     owns the join state at `[:rf/spawned :work/flow [:working]]`.
+   - **Cooperative cancellation cascade** — exiting the `:working`
+     state (by user `:cancel`, by `:on-all-complete`, by frame
+     destroy, by `:after`) fires one `:rf.machine/destroy` fx whose
+     handler tears down every surviving child. Each torn-down child's
+     in-flight `:after` timers / HTTP requests go with it (per Spec
+     005 §Cancellation cascade).
+   - **Progress reporting** — each child dispatches a `:progress`
+     event back to the parent on every chunk; the parent's internal
+     self-transition updates `:data :progress`; the view's
+     `:work/progress-fraction` sub recomputes and the bar updates.
+   - **Parent-unmount cascade** — the React component wrapping the
+     work-bench dispatches `[:work/flow [:cancel]]` in its
+     `r/with-let` cleanup. The dispatch is the only point where the
+     UI lifecycle touches the machine; the cascade does the rest.
+
+   Files:
+
+     core.cljs    mount + boot (this file)
+     worker.cljs  the :work/processor child machine and the
+                  :work/flow parent coordinator (the :invoke-all
+                  declaration is here)
+     views.cljs   UI components — controls, progress bar, shard
+                  breakdown, root, plus the work-bench wrapper whose
+                  with-let cleanup triggers the unmount cascade
+     schema.cljs  malli schemas for the parent + child snapshots
+
+   Run from `implementation/`:
+
+     npm run test:examples       (Playwright smoke + headless tests)
+     shadow-cljs watch examples/long-running-work
+                                  (iterate against a live browser)
+
+   Headless tests:
+
+     npm run test:browser        (runs every example's cljs-test;
+                                  includes long-running-work-cljs-test
+                                  under implementation/adapters/reagent/test/
+                                  re_frame/long_running_work_cljs_test.cljs)"
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; re-frame.machines ships in day8/re-frame2-machines.
+            ;; Loading the ns registers the :invoke-all init / spawn /
+            ;; destroy fx handlers and the framework `:rf/machine` sub.
+            ;; Both worker.cljs (the :work/flow + :work/processor
+            ;; registrations) and views.cljs (the work-bench wrapper)
+            ;; transitively require this — declared explicitly here
+            ;; for the smoke-load story.
+            [re-frame.machines]
+            [long-running-work.schema]
+            [long-running-work.worker]
+            [long-running-work.views :as views])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+;; ============================================================================
+;; INITIALISATION
+;; ============================================================================
+;;
+;; The :on-create event fans out to the per-feature initialisers.
+;; `:work/initialise` resets the parent flow machine to :idle;
+;; `:ui/initialise` seeds the Show/Hide toggle to true.
+
+(rf/reg-event-fx :app/initialise
+  {:doc "App boot. Fans out to per-feature initialisers."}
+  (fn handler-app-initialise [_ _]
+    {:fx [[:dispatch [:work/initialise]]
+          [:dispatch [:ui/initialise]]]}))
+
+;; ============================================================================
+;; MOUNT  (CLJS reference; client-only)
+;; ============================================================================
+;;
+;; React root is `react-root` (avoid colliding with `root-view`).
+;; Gated on (exists? js/document) so the ns is safe to require under
+;; :node-test / JVM smoke / headless cljs-test contexts.
+
+(defonce react-root
+  (when (exists? js/document)
+    (rdc/create-root (js/document.getElementById "app"))))
+
+(defn ^:export run []
+  ;; Pass the adapter spec map directly — no registry.
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:app/initialise])
+  (when react-root
+    (rdc/render react-root [views/root-view])))

--- a/examples/reagent/long_running_work/index.html
+++ b/examples/reagent/long_running_work/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: long-running work</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 0; background: #fafafa; }
+    button { padding: 6px 12px; cursor: pointer; }
+    button[disabled] { cursor: not-allowed; opacity: 0.5; }
+    code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/long_running_work/long_running_work.spec.cjs
+++ b/examples/reagent/long_running_work/long_running_work.spec.cjs
@@ -1,0 +1,152 @@
+/*
+ * Long-running-work example — Pattern-LongRunningWork smoke.
+ *
+ * Demonstrates :invoke-all spawn-and-join with cooperative
+ * cancellation:
+ *
+ *   - Initial render: state = :idle, progress = 0 / 300 items.
+ *   - Click Start: state → :working; the parent's :invoke-all
+ *     entry-cascade spawns 3 child :work/processor machines; each
+ *     yields between chunks via :after, dispatching :progress
+ *     events back to the parent. Progress bar advances visibly.
+ *   - Click Cancel mid-flight: state → :cancelled; the exit
+ *     cascade fires :rf.machine/destroy with :rf/invoke-all true;
+ *     every surviving child is torn down. Partial progress is
+ *     preserved (the parent's :stamp-outcome action records
+ *     :outcome :cancelled).
+ *   - Reset: returns to :idle, clearing the per-shard progress.
+ *   - Hide / Show: unmounting the work-bench fires :cancel via
+ *     the view's r/with-let cleanup; the cascade tears every
+ *     in-flight child down. Re-Show resumes from :idle.
+ *
+ * The browser is the place we *prove* the cascade is live: a
+ * mid-flight cancel actually stops the workers (the progress
+ * snapshot just before cancel does not advance after). The
+ * headless tests (re-frame.long-running-work-cljs-test) cover
+ * the machine-side invariants; this smoke covers the
+ * machine ↔ React ↔ browser-clock wiring.
+ */
+
+const { expectTextEquals, expectTextContains, expectVisible } =
+  require('../../scripts/spec-helpers.cjs');
+
+async function readProgressDone(page) {
+  const label = page.locator('[data-testid="progress-label"]');
+  const text  = (await label.textContent()) || '';
+  // Shape: "Progress: 42 / 300 items"
+  const m = text.match(/Progress:\s+(\d+)\s+\/\s+(\d+)/);
+  if (!m) throw new Error(`unexpected progress label: ${text}`);
+  return { done: parseInt(m[1], 10), total: parseInt(m[2], 10) };
+}
+
+module.exports = {
+  name: 'long-running-work',
+  url: '/long-running-work/',
+  run: async (page) => {
+    // --- Initial render: :idle, 0/300 -----------------------------------------
+    const stateValue = page.locator('[data-testid="state-value"]');
+    await expectTextEquals(stateValue, 'idle', 10000);
+
+    const initial = await readProgressDone(page);
+    if (initial.done !== 0 || initial.total !== 300) {
+      throw new Error(
+        `initial progress should be 0/300, got ${initial.done}/${initial.total}`,
+      );
+    }
+
+    // --- Start: the parent transitions :working, workers start dispatching ---
+    await page.getByTestId('start').click();
+    await expectTextEquals(stateValue, 'working');
+
+    // Wait for visible progress — at 50ms / item, the bar should
+    // tick past 1 within a couple of hundred ms. We poll until the
+    // counter goes above zero or time out.
+    const start = Date.now();
+    let progress;
+    while (Date.now() - start < 5000) {
+      progress = await readProgressDone(page);
+      if (progress.done > 0) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!progress || progress.done <= 0) {
+      throw new Error(
+        `expected progress to advance past 0 within 5s; got ${progress && progress.done}/${progress && progress.total}`,
+      );
+    }
+
+    // --- Cancel mid-flight: workers stop, state → :cancelled ------------------
+    await page.getByTestId('cancel').click();
+    await expectTextEquals(stateValue, 'cancelled');
+
+    // The recorded :outcome is :cancelled, visible in the status line.
+    await expectTextContains(
+      page.locator('[data-testid="outcome-value"]'),
+      'cancelled',
+    );
+
+    // The progress snapshot at cancel-time is preserved (NOT zero,
+    // NOT 300). Read the current done-count and assert it hasn't
+    // advanced beyond what we just saw — if the cascade had failed
+    // to destroy the workers, the bar would continue to advance.
+    const cancelledAt = await readProgressDone(page);
+    if (cancelledAt.done <= 0) {
+      throw new Error('progress should be > 0 immediately after cancel');
+    }
+    if (cancelledAt.done >= cancelledAt.total) {
+      throw new Error('cancel should fire before the work completes');
+    }
+
+    // Wait a beat and re-read — if the cascade is broken, in-flight
+    // :after timers would keep firing and the bar would continue
+    // to advance. With the cascade live, it stays put.
+    await new Promise((r) => setTimeout(r, 500));
+    const afterPause = await readProgressDone(page);
+    if (afterPause.done !== cancelledAt.done) {
+      throw new Error(
+        `progress should stay frozen after cancel; was ${cancelledAt.done}, now ${afterPause.done}`,
+      );
+    }
+
+    // --- Reset: back to :idle, progress cleared -------------------------------
+    await page.getByTestId('reset').click();
+    await expectTextEquals(stateValue, 'idle');
+    const reset = await readProgressDone(page);
+    if (reset.done !== 0) {
+      throw new Error(`reset should clear progress to 0; got ${reset.done}`);
+    }
+
+    // --- Unmount cascade: hide the work-bench mid-flight ---------------------
+    // Start work again, let it advance a little, then click
+    // "Hide work-bench". The wrapper's r/with-let cleanup
+    // dispatches [:work/flow [:cancel]]; the cascade fires.
+    await page.getByTestId('start').click();
+    await expectTextEquals(stateValue, 'working');
+    // Wait for visible progress.
+    {
+      const t0 = Date.now();
+      while (Date.now() - t0 < 5000) {
+        const p = await readProgressDone(page);
+        if (p.done > 0) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+    await page.getByTestId('toggle-bench').click();
+    // The bench is unmounted; its DOM is gone. Click Show to
+    // re-mount, and assert the machine is in :cancelled — i.e. the
+    // unmount cleanup did dispatch :cancel, the cascade ran, and
+    // the parent state reflects it.
+    await page.getByTestId('toggle-bench').click();
+    await expectTextEquals(stateValue, 'cancelled');
+    await expectTextContains(
+      page.locator('[data-testid="outcome-value"]'),
+      'cancelled',
+    );
+
+    // After re-show, the progress bar shows the snapshot at cancel
+    // time — preserved across the unmount/remount.
+    const afterRemount = await readProgressDone(page);
+    if (afterRemount.done <= 0) {
+      throw new Error('progress should be preserved across unmount/remount');
+    }
+  },
+};

--- a/examples/reagent/long_running_work/schema.cljs
+++ b/examples/reagent/long_running_work/schema.cljs
@@ -1,0 +1,92 @@
+(ns long-running-work.schema
+  "Malli schemas for the long-running-work example.
+
+   The example shows Pattern-LongRunningWork's `:invoke-all` shape:
+   a parent coordinator machine spawns N child workers in parallel,
+   each child reports progress back to the parent via dispatch, and
+   the parent's :invoke-all-bearing state is exited (by `:complete`,
+   `:cancel`, or unmount) which cascades a teardown to every surviving
+   child.
+
+   Two snapshots live in `:rf/machines` at runtime:
+
+   - `:work/flow`       — the parent coordinator. Tracks per-shard
+                          progress in `:data :progress` and the chunk
+                          size / total in `:data :total`.
+   - `:work/processor`  — the child machine type. Each child gets a
+                          gensym'd id (e.g. `:work/processor#1`)
+                          assigned by the runtime at spawn time.
+
+   The shapes are stamped as `reg-app-schema` so writes to those paths
+   are boundary-validated in development (Spec 010)."
+  (:require [re-frame.core :as rf]
+            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
+            ;; Loading the ns here registers its late-bind hooks so
+            ;; rf/reg-app-schema resolves below.
+            [re-frame.schemas]))
+
+;; ============================================================================
+;; SHARD-PROGRESS MAP — the parent's :data :progress slot
+;; ============================================================================
+;;
+;; A map of shard-id keyword → items processed (an integer). The parent
+;; updates this on every `:progress` event a child dispatches. The
+;; aggregate-progress sub sums the values and divides by the total.
+
+(def ProgressMap
+  [:map-of :keyword :int])
+
+;; ============================================================================
+;; PARENT SNAPSHOT — :work/flow
+;; ============================================================================
+;;
+;; Shape:
+;;   {:state    <:idle | :working | :complete | :cancelled | :error>
+;;    :data     {:total      <int>           ;; items per shard
+;;               :shards     [<keyword> ...]  ;; which shards are spawned
+;;               :progress   {<shard-id> <items-done>}
+;;               :outcome    <:complete | :cancelled | :error | nil>}
+;;    :tags     #{...}}                       ;; runtime-owned union
+
+(def FlowSnapshot
+  [:map
+   [:state [:enum :idle :working :complete :cancelled :error]]
+   [:data  [:map
+            [:total    :int]
+            [:shards   [:vector :keyword]]
+            [:progress ProgressMap]
+            [:outcome  [:maybe [:enum :complete :cancelled :error]]]]]])
+
+;; ============================================================================
+;; CHILD SNAPSHOT — :work/processor (one instance per shard)
+;; ============================================================================
+;;
+;; Shape:
+;;   {:state    <:idle | :processing | :checking-done | :yielding | :done | :cancelled>
+;;    :data     {:shard      <keyword>          ;; the parent-assigned id
+;;               :total      <int>               ;; items in this shard
+;;               :processed  <int>               ;; how many done so far
+;;               :tick-ms    <int>               ;; ms between chunks (browser yield)}
+;;    :tags     #{...}}
+
+(def ProcessorSnapshot
+  [:map
+   [:state [:enum :idle :processing :checking-done :yielding :done :cancelled]]
+   [:data  [:map
+            [:shard     :keyword]
+            [:total     :int]
+            [:processed :int]
+            [:tick-ms   :int]]]])
+
+;; ============================================================================
+;; SCHEMA REGISTRATION (Spec 010 §Path-based attachment)
+;; ============================================================================
+
+(rf/reg-app-schema [:rf/machines :work/flow] FlowSnapshot)
+;; The :work/processor children get gensym'd ids (e.g. :work/processor#1);
+;; we register a wildcard-style schema on the prefix so the rebound
+;; per-instance snapshots are validated against the same shape. The
+;; framework's path-based attachment walks the path; the per-instance
+;; id falls outside the registered prefix and is not boundary-checked
+;; directly — that's intentional, the dispatched-by-runtime spawn fx
+;; writes a known-good shape.

--- a/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
+++ b/examples/reagent/long_running_work/test/long_running_work/worker_test.cljs
@@ -1,0 +1,221 @@
+(ns long-running-work.worker-test
+  "Headless tests for the long-running-work example's parent
+   coordinator + child workers.
+
+   Three flows, all browserless via `make-frame` + `dispatch-sync`:
+
+     1. **Spawn cascade.** :start transitions :idle → :working;
+        the runtime emits :rf.machine/invoke-all-init + 3
+        :rf.machine/spawn fxs; the join-state's :children map at
+        [:rf/spawned :work/flow [:working]] is populated.
+
+     2. **Happy-path join completion.** Synthesise three
+        [:work/flow [:work/child-done :sN]] events; the runtime
+        intercepts each, updates :done; on the third the join
+        condition resolves and dispatches [:work/all-done] into
+        the parent, which transitions :working → :complete and
+        stamps :outcome :complete.
+
+     3. **Mid-flight cancellation cascade.** :start, then a few
+        `:progress` events to simulate partial work, then `:cancel`;
+        the parent transitions :working → :cancelled; the
+        :invoke-all exit cascade fires :rf.machine/destroy with
+        :rf/invoke-all true; the join-state slot at
+        [:rf/spawned :work/flow [:working]] is torn down.
+
+     4. **Parent-unmount cascade.** Same path as (3) but the
+        :cancel event arrives via the view's r/with-let cleanup
+        rather than the user clicking Cancel. The headless test
+        synthesises the same dispatch and asserts the same
+        cascade. The view-level wiring is exercised by the
+        Playwright smoke (long_running_work.spec.cjs)."
+  (:require [cljs.test :refer-macros [is]]
+            [re-frame.core :as rf]
+            [long-running-work.worker])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+;; ============================================================================
+;; HELPERS
+;; ============================================================================
+
+(defn- snapshot
+  "Read the parent's machine snapshot from a frame's app-db."
+  [frame]
+  (get-in (rf/get-frame-db frame) [:rf/machines :work/flow]))
+
+(defn- join-state
+  "Read the runtime-owned join-state slot at
+   [:rf/spawned :work/flow [:working]]. Returns nil after the
+   cascade has cleared it."
+  [frame]
+  (get-in (rf/get-frame-db frame) [:rf/spawned :work/flow [:working]]))
+
+(defn- new-frame
+  "Spin up a fresh test frame. We dispatch :work/flow [:reset] inside the
+   :on-create rather than going through the :app/initialise fanout so the
+   test ns doesn't transitively depend on long-running-work.core (which
+   pulls in Reagent's DOM-only namespaces and a defonce root-creation).
+   Both reach the same end-state: parent machine at :idle with cleared
+   :data."
+  []
+  (rf/make-frame {:on-create [:work/flow [:reset]]}))
+
+;; ============================================================================
+;; (1) SPAWN CASCADE — :start spawns 3 children
+;; ============================================================================
+
+(defn test-spawn-cascade []
+  (with-frame [f (new-frame)]
+    ;; After :app/initialise, the parent is :idle with progress all-zero.
+    (let [snap (snapshot f)]
+      (is (= :idle (:state snap)))
+      (is (= {:s1 0 :s2 0 :s3 0} (-> snap :data :progress)))
+      (is (nil? (join-state f))))                            ;; not yet allocated
+
+    ;; :start transitions :idle → :working; the runtime emits
+    ;; :rf.machine/invoke-all-init + 3 :rf.machine/spawn fxs. The
+    ;; init fx seeds the join-state map at
+    ;; [:rf/spawned :work/flow [:working]] with :children mapping
+    ;; each user-supplied id (:s1/:s2/:s3) to the gensym'd
+    ;; spawned-id (:work/processor#N).
+    (rf/dispatch-sync [:work/flow [:start]] {:frame f})
+    (let [snap (snapshot f)
+          js   (join-state f)]
+      (is (= :working (:state snap)))
+      ;; The runtime allocated a join-state slot at
+      ;; [:rf/spawned :work/flow [:working]] keyed by user id.
+      (is (map? js))
+      (is (= #{:s1 :s2 :s3} (set (keys (:children js)))))
+      (is (false? (:resolved? js)))
+      (is (empty?  (:done js)))
+      (is (empty?  (:failed js))))))
+
+;; ============================================================================
+;; (2) HAPPY-PATH JOIN COMPLETION — synthesised :on-child-done events
+;; ============================================================================
+
+(defn test-happy-path-join []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:work/flow [:start]] {:frame f})
+
+    ;; The child machines would normally drive themselves to :done
+    ;; via :after-yield loops and dispatch :work/child-done on entry
+    ;; to their terminal state. dispatch-sync doesn't fire :after
+    ;; timers, so for the headless test we synthesise the
+    ;; child-done events directly. The runtime's intercept logic
+    ;; (intercept-invoke-all-event in re-frame.machines) treats
+    ;; them identically — the events arrive at the parent's
+    ;; handler boundary either way.
+
+    (rf/dispatch-sync [:work/flow [:work/child-done :s1]] {:frame f})
+    ;; After the first :work/child-done, the join state's :done
+    ;; carries :s1; the join condition (:all of 3) hasn't resolved
+    ;; yet so :resolved? stays false and the parent is still :working.
+    (let [snap (snapshot f)
+          js   (join-state f)]
+      (is (= :working   (:state snap)))
+      (is (= #{:s1}     (:done js)))
+      (is (false?       (:resolved? js))))
+
+    (rf/dispatch-sync [:work/flow [:work/child-done :s2]] {:frame f})
+    (is (= #{:s1 :s2} (:done (join-state f))))
+    (is (= :working   (:state (snapshot f))))
+
+    ;; Third child done — :all resolves. The runtime sets :resolved?
+    ;; true, builds per-sibling cancel fx for survivors (none, since
+    ;; this was the last child), and dispatches [:work/flow
+    ;; [:work/all-done]]. The parent's :working :on table catches
+    ;; :work/all-done → :complete (with :stamp-outcome action).
+    (rf/dispatch-sync [:work/flow [:work/child-done :s3]] {:frame f})
+    (let [snap (snapshot f)]
+      (is (= :complete (:state snap)))
+      (is (= :complete (-> snap :data :outcome)))
+      ;; The cascade tore down the invoke-all slot: after the exit
+      ;; from :working, the destroy fx clears [:rf/spawned
+      ;; :work/flow [:working]].
+      (is (nil? (join-state f))))))
+
+;; ============================================================================
+;; (3) MID-FLIGHT CANCELLATION CASCADE — :cancel tears every child down
+;; ============================================================================
+
+(defn test-cancel-cascade []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:work/flow [:start]] {:frame f})
+
+    ;; Simulate partial progress from each shard. The action's
+    ;; internal-self transition updates :data :progress without
+    ;; exit/entry.
+    (rf/dispatch-sync [:work/flow [:progress :s1 30 100]] {:frame f})
+    (rf/dispatch-sync [:work/flow [:progress :s2 50 100]] {:frame f})
+    (rf/dispatch-sync [:work/flow [:progress :s3 10 100]] {:frame f})
+
+    (let [snap (snapshot f)]
+      (is (= :working (:state snap)))
+      (is (= {:s1 30 :s2 50 :s3 10} (-> snap :data :progress)))
+      ;; The aggregate-progress sub: (30+50+10)/(3*100) = 90/300.
+      (is (= 90  (rf/compute-sub [:work/items-done]   (rf/get-frame-db f))))
+      (is (= 300 (rf/compute-sub [:work/total-items] (rf/get-frame-db f)))))
+
+    ;; User clicks Cancel. The parent transitions :working →
+    ;; :cancelled; the :invoke-all desugared :exit fires one
+    ;; :rf.machine/destroy fx with :rf/invoke-all true; the
+    ;; destroy fx handler iterates the join-state's :children map
+    ;; and tears each surviving child down, then clears the
+    ;; [:rf/spawned :work/flow [:working]] slot.
+    (rf/dispatch-sync [:work/flow [:cancel]] {:frame f})
+    (let [snap (snapshot f)]
+      (is (= :cancelled (:state snap)))
+      (is (= :cancelled (-> snap :data :outcome)))
+      ;; The destroy cascade cleared the join-state slot.
+      (is (nil? (join-state f)))
+      ;; Partial :progress is preserved on the parent's :data
+      ;; (cancellation is cooperative; the parent decides what to
+      ;; do with the partial result). The view shows where each
+      ;; shard got to at the moment of cancel.
+      (is (= {:s1 30 :s2 50 :s3 10}
+             (-> snap :data :progress))))))
+
+;; ============================================================================
+;; (4) PARENT-UNMOUNT CASCADE — :cancel dispatched from the view cleanup
+;; ============================================================================
+;;
+;; The view's r/with-let cleanup dispatches [:work/flow [:cancel]]
+;; on component unmount. From the parent machine's perspective this
+;; is identical to a user-driven Cancel button click — the headless
+;; test exercises that contract by dispatching the same event.
+;;
+;; The Playwright spec (long_running_work.spec.cjs) exercises the
+;; *actual* React unmount path against a live browser; this test
+;; pins the machine-side invariant.
+
+(defn test-parent-unmount-cascade []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:work/flow [:start]] {:frame f})
+    (is (= :working (:state (snapshot f))))
+
+    ;; The work-bench component's with-let finally clause runs on
+    ;; React unmount. The headless test bypasses React and dispatches
+    ;; the same event the cleanup would dispatch.
+    (rf/dispatch-sync [:work/flow [:cancel]] {:frame f})
+
+    (let [snap (snapshot f)]
+      (is (= :cancelled (:state snap)))
+      (is (= :cancelled (-> snap :data :outcome)))
+      (is (nil? (join-state f))))))
+
+;; ============================================================================
+;; (5) RESET ROUND-TRIP — :cancelled → :idle clears progress for re-run
+;; ============================================================================
+
+(defn test-reset-after-cancel []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:work/flow [:start]]               {:frame f})
+    (rf/dispatch-sync [:work/flow [:progress :s1 42 100]] {:frame f})
+    (rf/dispatch-sync [:work/flow [:cancel]]              {:frame f})
+
+    (rf/dispatch-sync [:work/flow [:reset]] {:frame f})
+    (let [snap (snapshot f)]
+      (is (= :idle (:state snap)))
+      (is (= {:s1 0 :s2 0 :s3 0} (-> snap :data :progress)))
+      (is (nil? (-> snap :data :outcome))))))

--- a/examples/reagent/long_running_work/views.cljs
+++ b/examples/reagent/long_running_work/views.cljs
@@ -1,0 +1,210 @@
+(ns long-running-work.views
+  "Views for the long-running-work example.
+
+   Three pieces:
+
+   - The control panel: Start / Cancel / Reset / Hide buttons.
+   - The progress bar: aggregate fraction of items done across all
+     shards.
+   - The per-shard breakdown: small bar per worker so the reader can
+     see the three parallel children making independent progress.
+
+   The 'Hide' button toggles a wrapper component that mounts /
+   unmounts the work-bench. When the wrapper unmounts, its
+   `r/with-let` cleanup fires a `:cancel` event into `:work/flow`.
+   This is the canonical 're-frame2 way' to wire cooperative
+   cancellation to a React lifecycle boundary: a registered event
+   that the parent's :working state handles by transitioning out,
+   triggering the standard exit cascade (which destroys every
+   spawned child). The worker machines themselves are
+   lifecycle-agnostic — they don't know anything about React. The
+   one place the React lifecycle peeks through is this single
+   dispatch in the wrapper's cleanup."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [long-running-work.worker])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+;; ============================================================================
+;; SUB-COMPONENTS
+;; ============================================================================
+
+(reg-view ^{:doc "Aggregate progress bar. Reads the :work/progress-fraction
+                  sub (0.0 .. 1.0) and draws a div whose width scales."}
+          progress-bar []
+  (let [frac     @(subscribe [:work/progress-fraction])
+        done     @(subscribe [:work/items-done])
+        total    @(subscribe [:work/total-items])
+        state    @(subscribe [:work/flow-state])
+        percent  (int (* 100 (or frac 0)))]
+    [:div.progress-bar-wrapper
+     {:style {:margin "1em 0"}}
+     [:div {:style {:display "flex" :justify-content "space-between" :margin-bottom "4px"}}
+      [:span {:data-testid "progress-label"}
+       (str "Progress: " done " / " total " items")]
+      [:span {:data-testid "progress-percent"} (str percent " %")]]
+     [:div {:style {:width "100%" :height "20px"
+                    :background "#eee" :border-radius "4px"
+                    :overflow "hidden"}}
+      [:div {:data-testid "progress-fill"
+             :style {:width (str percent "%")
+                     :height "100%"
+                     :background (case state
+                                   :complete  "#4caf50"
+                                   :cancelled "#ff9800"
+                                   :error     "#f44336"
+                                   :working   "#2196f3"
+                                   "#9e9e9e")
+                     :transition "width 60ms linear"}}]]]))
+
+(reg-view ^{:doc "Per-shard breakdown. Three little bars, one per
+                  worker, so the reader can see the parallel children
+                  making independent progress."}
+          shard-breakdown []
+  (let [progress @(subscribe [:work/progress-map])
+        total    (-> @(subscribe [:work/flow-data]) :total)]
+    [:div.shard-breakdown
+     {:style {:margin "1em 0"}}
+     [:h3 "Per-shard progress"]
+     (for [[shard-id processed] (sort progress)]
+       ^{:key shard-id}
+       [:div {:style {:display "flex" :align-items "center" :gap "8px" :margin "4px 0"}}
+        [:span {:style {:font-family "monospace" :min-width "40px"}
+                :data-testid (str "shard-label-" (name shard-id))}
+         (name shard-id)]
+        [:div {:style {:flex 1 :height "10px" :background "#eee" :border-radius "3px"}}
+         [:div {:data-testid (str "shard-fill-" (name shard-id))
+                :style {:width  (str (if (pos? total)
+                                       (int (* 100 (/ processed total)))
+                                       0) "%")
+                        :height "100%"
+                        :background "#3f51b5"
+                        :transition "width 60ms linear"}}]]
+        [:span {:style {:font-family "monospace" :min-width "60px" :text-align "right"}
+                :data-testid (str "shard-counter-" (name shard-id))}
+         (str processed " / " total)]])]))
+
+(reg-view ^{:doc "Status line — shows the parent machine's :state and
+                  the recorded :outcome (the terminal-state badge)."}
+          status-line []
+  (let [state   @(subscribe [:work/flow-state])
+        outcome @(subscribe [:work/outcome])]
+    [:p {:data-testid "status-line"}
+     [:strong "State: "]
+     [:span {:data-testid "state-value"} (when state (name state))]
+     (when outcome
+       [:span {:style {:margin-left "1em"}}
+        [:strong "Outcome: "]
+        [:span {:data-testid "outcome-value"} (name outcome)]])]))
+
+(reg-view ^{:doc "Control panel. Start / Cancel / Reset.
+
+                  - Start: dispatches [:work/flow [:start]] — parent
+                           transitions :idle → :working, spawns 3
+                           children via :invoke-all.
+                  - Cancel: dispatches [:work/flow [:cancel]] — parent
+                           transitions :working → :cancelled, the
+                           exit cascade emits :rf.machine/destroy for
+                           every surviving child (per the
+                           :invoke-all desugared :exit).
+                  - Reset: dispatches [:work/flow [:reset]] — returns
+                           the parent to :idle with cleared :progress."}
+          controls []
+  (let [running? @(subscribe [:work/running?])
+        state    @(subscribe [:work/flow-state])
+        idle?    (= state :idle)]
+    [:div.controls
+     {:style {:display "flex" :gap "8px" :margin "1em 0"}}
+     [:button {:data-testid "start"
+               :disabled    (not idle?)
+               :on-click    #(dispatch [:work/flow [:start]])}
+      "Start work"]
+     [:button {:data-testid "cancel"
+               :disabled    (not running?)
+               :on-click    #(dispatch [:work/flow [:cancel]])}
+      "Cancel"]
+     [:button {:data-testid "reset"
+               :disabled    (or running? idle?)
+               :on-click    #(dispatch [:work/flow [:reset]])}
+      "Reset"]]))
+
+;; ============================================================================
+;; WORK-BENCH WRAPPER — demonstrates the unmount cascade
+;; ============================================================================
+
+(reg-view ^{:doc "The work-bench — the actual demo widget. This is the
+                  view that *gets unmounted* when the user clicks
+                  'Hide'. Its `r/with-let` cleanup is the load-bearing
+                  hook for the unmount cascade: on unmount, it
+                  dispatches [:work/flow [:cancel]] into the parent
+                  machine. The parent's :working state's :cancel
+                  transition exits :working, the :invoke-all
+                  desugared :exit fires :rf.machine/destroy for every
+                  surviving child, and the work goes away cleanly.
+
+                  The worker machines themselves don't know anything
+                  about React — they're host-agnostic. The only
+                  place the React lifecycle peeks through is this
+                  one dispatch in the cleanup."}
+          work-bench []
+  (r/with-let [_ nil]
+    [:div.work-bench
+     {:style {:padding "1em" :border "1px solid #ccc" :border-radius "6px"}}
+     [:h2 "Long-running work"]
+     [:p "Three workers process 100 items each in parallel.
+          Each worker yields to the browser between chunks via "
+      [:code ":after"] " so the UI stays responsive."]
+     [status-line]
+     [controls]
+     [progress-bar]
+     [shard-breakdown]]
+    ;; Reagent's with-let cleanup runs on component unmount. The
+    ;; only thing this needs to do is dispatch :cancel into the
+    ;; parent flow machine; the machine's :working :cancel
+    ;; transition takes care of the rest.
+    (finally
+      (dispatch [:work/flow [:cancel]]))))
+
+;; ============================================================================
+;; ROOT VIEW — Show/Hide toggle around the work-bench
+;; ============================================================================
+;;
+;; The Show/Hide toggle is an *app-db boolean*, not part of the
+;; :work/flow machine. The machine has nothing to do with the
+;; component's visibility. The view either renders work-bench (which
+;; on mount activates the worker pipeline once the user clicks
+;; Start) or it doesn't. When the user clicks Hide while work is
+;; running, the component unmounts → with-let's finally → dispatch
+;; :cancel → parent exits :working → cascade tears every child down.
+
+(rf/reg-event-db :ui/initialise
+  (fn [db _]
+    (assoc db :ui {:show-bench? true})))
+
+(rf/reg-event-db :ui/toggle-bench
+  (fn [db _]
+    (update-in db [:ui :show-bench?] not)))
+
+(rf/reg-sub :ui/show-bench?
+  (fn [db _] (get-in db [:ui :show-bench?] true)))
+
+(reg-view ^{:doc "Top-level root. A Show/Hide button and the
+                  conditionally-rendered work-bench. Unmounting the
+                  bench is what triggers the cascade — see work-bench
+                  above."}
+          root-view []
+  (let [show? @(subscribe [:ui/show-bench?])]
+    [:div.app
+     {:style {:max-width "700px" :margin "2em auto"
+              :font-family "sans-serif"}}
+     [:h1 "re-frame2 — Pattern-LongRunningWork"]
+     [:p "Demonstrates "
+      [:code ":invoke-all"]
+      ": one parent coordinator, N parallel workers, declarative
+       spawn-and-join with cooperative cancellation."]
+     [:button {:data-testid "toggle-bench"
+               :on-click    #(dispatch [:ui/toggle-bench])
+               :style       {:margin "0 0 1em 0"}}
+      (if show? "Hide work-bench (cancels & unmounts)" "Show work-bench")]
+     (when show?
+       [work-bench])]))

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -1,0 +1,411 @@
+(ns long-running-work.worker
+  "The worker + parent-coordinator machines for the long-running-work
+   example.
+
+   Pattern-LongRunningWork's `:invoke-all`-shape: the parent coordinator
+   spawns N children via :invoke-all; each child processes its own shard
+   cooperatively (yielding to the browser between chunks via `:after`);
+   children dispatch `:progress` events back to the parent for UI; on
+   completion each child dispatches the parent's `:on-child-done`
+   keyword. When all N report done the runtime fires the parent's
+   `:on-all-complete`. The user can `:cancel` mid-flight; the parent
+   transitions out of `:working` and the standard exit cascade tears
+   down every surviving child via `:rf.machine/destroy` fx — including
+   any in-flight `:after` timers a worker had pending.
+
+   This is the canonical re-frame2 expression of:
+
+     - 'Run N parallel tasks and join on all done.'
+     - 'Show progress.'
+     - 'Cancellation must be reliable on EVERY exit path —
+        including the user navigating away mid-flight.'
+
+   Why one parent + N children rather than one big chunked machine: each
+   shard is independent, parallelisable, and lets the demo show *both*
+   join semantics (`:on-all-complete`) AND the cascade-teardown contract
+   (`:cancel-on-decision?` defaults to true; `:work/flow` `:cancel`
+   transition exits the state and the desugared :exit fires the
+   per-child destroy)."
+  (:require [re-frame.core :as rf]
+            ;; The Spec 005 state-machine ns lives in the
+            ;; day8/re-frame2-machines artefact. Loading the ns here
+            ;; registers its late-bind hooks so rf/reg-machine
+            ;; (called below at ns-load) and the `:rf/machine` /
+            ;; `:rf/machine-has-tag?` framework subs resolve.
+            [re-frame.machines]
+            [long-running-work.schema]))
+
+;; ============================================================================
+;; CONSTANTS
+;; ============================================================================
+
+(def items-per-shard
+  "How many mock items each child processes per shard. Three shards
+   running in parallel at 50ms/item produces a ~5-second job that's
+   long enough to demonstrate progress visibly and short enough to
+   keep the Playwright smoke fast."
+  100)
+
+(def default-tick-ms
+  "Wall-clock delay between chunks for the live UI. The child's
+   `:yielding` state declares `:after {tick-ms :processing}` so the
+   browser gets a render tick between chunks. Lifted to a named const
+   so headless tests can override it via the child's `:data :tick-ms`
+   (set from the parent's per-child invoke-spec :data)."
+  50)
+
+(def parent-id
+  "The parent coordinator machine's registered id. Children hard-code
+   this in their dispatch-back so they can address the parent without
+   any per-child plumbing. Per Spec 005 §Child completion protocol:
+   for static `:invoke-all` declarations the parent-id is a literal
+   in the parent's source, so the child simply hard-codes it."
+  :work/flow)
+
+;; ============================================================================
+;; THE CHILD MACHINE — :work/processor
+;; ============================================================================
+;;
+;; Each child processes its own shard in chunks. One item per
+;; `:processing` entry; one browser-tick yield between chunks via
+;; `:yielding` + `:after`; per-step progress dispatched back to the
+;; parent so the UI's progress bar updates between chunks.
+;;
+;; The state graph:
+;;
+;;     :idle           — initial; on spawn the runtime dispatches
+;;                       [:rf.machine/spawned], which transitions
+;;                       us to :processing.
+;;     :processing     — entry processes one item, bumps :processed,
+;;                       dispatches :progress to the parent. The :always
+;;                       cascade routes to :checking-done.
+;;     :checking-done  — eventless decision: done? → :done; else
+;;                       → :yielding.
+;;     :yielding       — :after {tick-ms :processing} schedules the
+;;                       next chunk after one browser tick.
+;;     :done           — terminal. :entry dispatches :on-child-done to
+;;                       the parent. The parent's exit cascade tears
+;;                       this child down once :on-all-complete fires.
+;;     :cancelled      — never reached cooperatively: cancellation
+;;                       cascades from the parent via :rf.machine/destroy.
+;;                       Included for shape-completeness / observability.
+
+(def processor-machine
+  {:doc "Process one shard of items in chunks. Cooperative yield via
+         `:after` between chunks; progress reported via :progress event
+         to the parent; terminal `:done` state dispatches the parent's
+         :on-child-done keyword (`:work/child-done`)."
+
+   :initial :idle
+
+   ;; The :data is materialised from the parent's per-child invoke-spec
+   ;; :data slot at spawn time (see :work/flow below). :shard is the
+   ;; user-supplied id keyword the parent assigned (`:s1`/`:s2`/`:s3`);
+   ;; :total is the shard size; :tick-ms is the per-chunk yield delay.
+   :data    {:shard     nil
+             :total     0
+             :processed 0
+             :tick-ms   default-tick-ms}
+
+   :guards
+   {:done?
+    ;; Have we processed every item in this shard?
+    (fn guard-done? [data _event]
+      (>= (:processed data) (:total data)))
+
+    :more-work?
+    (fn guard-more-work? [data _event]
+      (< (:processed data) (:total data)))}
+
+   :actions
+   {:process-one
+    ;; Process one item. In a real app this is whatever the per-item
+    ;; computation is (encoding, parsing, indexing, ...). For this
+    ;; demo we just bump the counter — the load-bearing thing the
+    ;; example shows is the yield + progress-reporting + cancellation
+    ;; shape, not the per-item work.
+    ;;
+    ;; The action also dispatches a :progress event back to the
+    ;; parent so the UI's progress bar updates between chunks. The
+    ;; parent's :on map handles :progress as a self-transition with
+    ;; an action that updates :data :progress.
+    (fn action-process-one [data _event]
+      (let [shard         (:shard data)
+            new-processed (inc (:processed data))]
+        {:data (assoc data :processed new-processed)
+         :fx   [[:dispatch [parent-id [:progress shard new-processed (:total data)]]]]}))
+
+    :dispatch-done
+    ;; Terminal action: dispatch the parent's :on-child-done keyword.
+    ;; The runtime intercepts the event at the parent's machine
+    ;; boundary and updates the join state at
+    ;;   [:rf/spawned :work/flow [:working] :done]
+    ;; The second-position arg is the user-supplied shard id (e.g.
+    ;; :s1) so the parent can address which child completed.
+    (fn action-dispatch-done [data _event]
+      (let [shard (:shard data)]
+        {:fx [[:dispatch [parent-id [:work/child-done shard]]]]}))}
+
+   :states
+   {:idle
+    ;; The runtime synthesises [:rf.machine/spawned] (rf2-ijm7) when
+    ;; no explicit :start is supplied; declaring it as an :on entry
+    ;; lets the child auto-kick into :processing on spawn.
+    {:tags #{:work/idle}
+     :on   {:rf.machine/spawned :processing}}
+
+    :processing
+    ;; Process one item, then immediately re-evaluate the work via
+    ;; the :always cascade.
+    {:tags  #{:work/running :work/cancellable}
+     :entry :process-one
+     :always [{:target :checking-done}]}
+
+    :checking-done
+    ;; Eventless decision: done → :done; more work → :yielding.
+    ;; :always evaluates first-match-wins; the :done? / :more-work?
+    ;; guards are mutually exclusive so the order doesn't matter
+    ;; semantically.
+    {:always [{:guard :done?      :target :done}
+              {:guard :more-work? :target :yielding}]}
+
+    :yielding
+    ;; The canonical browser-yield seam. :after carries a runtime
+    ;; clock-driven delay; the standard cancellation cascade (the
+    ;; parent's `:exit` action) tears down the in-flight timer on
+    ;; child-destroy, so a worker cancelled mid-yield does NOT
+    ;; resume after the delay elapses.
+    ;;
+    ;; The :after key is a (fn [snap] ms) form per Spec 005
+    ;; §Value shape — reads the per-child :tick-ms out of :data so
+    ;; tests / callers can stagger or zero-out the delay.
+    {:tags  #{:work/running :work/cancellable :work/yielding}
+     :after {(fn after-tick-ms [snap]
+               (or (-> snap :data :tick-ms) default-tick-ms))
+             :processing}}
+
+    :done
+    ;; Terminal. Dispatch the parent's :on-child-done keyword as the
+    ;; child's last act. The exit cascade then tears the child down
+    ;; once the parent's :on-all-complete fires.
+    {:meta  {:terminal? true}
+     :tags  #{:work/done}
+     :entry :dispatch-done}
+
+    :cancelled
+    ;; Never reached by ordinary child transitions — the cancellation
+    ;; cascade destroys the child via :rf.machine/destroy fx (per
+    ;; Spec 005 §Cancellation cascade) rather than transitioning it
+    ;; here. Kept in the spec for tag completeness and for code paths
+    ;; that may later route cancellation as an event into the child.
+    {:meta {:terminal? true}
+     :tags #{:work/cancelled}}}})
+
+(rf/reg-machine :work/processor processor-machine)
+
+;; ============================================================================
+;; THE PARENT COORDINATOR — :work/flow
+;; ============================================================================
+;;
+;; Three children, one parent, one declarative :invoke-all entry. The
+;; parent has no per-child bookkeeping in :data beyond the aggregated
+;; :progress map (the user wants to see it; the runtime doesn't read
+;; it). The :children / :done / :failed / :resolved? join-state map
+;; lives in app-db under [:rf/spawned :work/flow [:working]] — runtime
+;; owned per Spec 005 §Spawn-id tracking.
+
+(def shards
+  "The shard ids this demo processes in parallel. Three is enough to
+   show the parallelism and the join; small enough to keep the UI
+   readable. Each shard is just a label here — in a real app it would
+   be a chunk of work (a slice of a dataset, a region of an image,
+   ...) the worker knows how to process."
+  [:s1 :s2 :s3])
+
+(def flow-machine
+  {:doc "Parent coordinator. Spawns one :work/processor per shard via
+         :invoke-all; joins on :all; cancels mid-flight on :cancel
+         or on the parent's :working state being exited by any means
+         (including user-driven unmount → :cancel dispatch from the
+         component's :will-unmount cleanup)."
+
+   :initial :idle
+
+   :data    {:total    items-per-shard
+             :shards   shards
+             :progress (zipmap shards (repeat 0))
+             :outcome  nil}
+
+   :actions
+   {:reset-progress
+    (fn action-reset-progress [data _event]
+      {:data (assoc data
+                    :progress (zipmap (:shards data) (repeat 0))
+                    :outcome  nil)})
+
+    :record-progress
+    ;; Self-transition action — a child dispatched
+    ;;   [:work/flow [:progress :s1 5 100]]
+    ;; and the parent records the per-shard progress so the view's
+    ;; aggregate-progress sub recomputes.
+    (fn action-record-progress [data [_ shard-id processed _total]]
+      {:data (assoc-in data [:progress shard-id] processed)})
+
+    :stamp-outcome
+    ;; Stamp :outcome on entry to a terminal state so the UI can show
+    ;; "Complete" / "Cancelled" / "Failed" without a separate sub. The
+    ;; action's event payload's first element is the matching
+    ;; transition event keyword (`:work/all-done` / `:cancel`
+    ;; / `:work/any-failed`); we just record it as the outcome.
+    (fn action-stamp-outcome [data [event-kw & _]]
+      {:data (assoc data :outcome
+                    (case event-kw
+                      :work/all-done    :complete
+                      :cancel           :cancelled
+                      :work/any-failed  :error
+                      ;; default: keep current
+                      (:outcome data)))})}
+
+   :states
+   {:idle
+    ;; Initial state. :start kicks off the work; :reset returns from
+    ;; a terminal state back here.
+    {:tags #{:flow/idle}
+     :on   {:start {:target :working :action :reset-progress}
+            :reset {:target :idle    :action :reset-progress}}}
+
+    :working
+    ;; The :invoke-all-bearing state. On entry the runtime emits one
+    ;; :rf.machine/invoke-all-init fx (seeds the join-state map) plus
+    ;; N :rf.machine/spawn fxs (one per child). On exit (by ANY
+    ;; transition including :cancel / :work/all-done), the runtime
+    ;; emits a single :rf.machine/destroy fx carrying :rf/invoke-all
+    ;; true; the destroy fx handler reads the join-state's :children
+    ;; map and tears each surviving child down.
+    ;;
+    ;; The :progress event is the per-step report from a child. It's
+    ;; a self-transition (same target :working) with an action that
+    ;; updates :data :progress. Because :progress is NOT the parent's
+    ;; :on-child-done / :on-child-error keyword, it is NOT intercepted
+    ;; by the :invoke-all join machinery — the runtime feeds it
+    ;; straight into the parent's :on lookup.
+    {:tags #{:flow/working}
+     :invoke-all
+     {:children [{:id :s1 :machine-id :work/processor
+                  :data {:shard :s1 :total items-per-shard :processed 0 :tick-ms default-tick-ms}}
+                 {:id :s2 :machine-id :work/processor
+                  :data {:shard :s2 :total items-per-shard :processed 0 :tick-ms default-tick-ms}}
+                 {:id :s3 :machine-id :work/processor
+                  :data {:shard :s3 :total items-per-shard :processed 0 :tick-ms default-tick-ms}}]
+      :join             :all
+      ;; The keywords children dispatch back. The runtime intercepts
+      ;; events whose inner-event-id matches these and updates the
+      ;; join-state at [:rf/spawned :work/flow [:working]].
+      :on-child-done    :work/child-done
+      :on-child-error   :work/child-error
+      ;; The events the runtime dispatches into the parent when the
+      ;; join resolves. The parent's :on table below handles each.
+      :on-all-complete  [:work/all-done]
+      :on-any-failed    [:work/any-failed]}
+     :on    {;; Progress reports — INTERNAL self-transition (no :target):
+             ;; the action runs but :exit / :entry do NOT fire, so the
+             ;; :invoke-all entry cascade does not re-spawn children and
+             ;; the exit cascade does not tear them down. Per Spec 005
+             ;; §Transitions §Internal vs external self-transitions: omit
+             ;; :target for internal-self.
+             :progress        {:action :record-progress}
+             ;; Join-resolution events. The runtime dispatches these
+             ;; into the parent when :on-all-complete / :on-any-failed
+             ;; resolve; the parent's transition handles them as
+             ;; ordinary state transitions.
+             :work/all-done   {:target :complete  :action :stamp-outcome}
+             :work/any-failed {:target :error     :action :stamp-outcome}
+             ;; Cooperative user-driven cancellation. The transition
+             ;; exits :working; the desugared :invoke-all exit fires
+             ;; one :rf.machine/destroy fx with :rf/invoke-all true;
+             ;; the destroy fx handler tears down every surviving
+             ;; child.
+             :cancel          {:target :cancelled :action :stamp-outcome}}}
+
+    :complete
+    {:meta {:terminal? false}
+     :tags #{:flow/complete :flow/terminal}
+     :on   {:reset {:target :idle :action :reset-progress}}}
+
+    :cancelled
+    {:tags #{:flow/cancelled :flow/terminal}
+     :on   {:reset {:target :idle :action :reset-progress}
+            :start {:target :working :action :reset-progress}}}
+
+    :error
+    {:tags #{:flow/error :flow/terminal}
+     :on   {:reset {:target :idle :action :reset-progress}
+            :start {:target :working :action :reset-progress}}}}})
+
+(rf/reg-machine :work/flow flow-machine)
+
+;; ============================================================================
+;; SUBSCRIPTIONS — slice readers + aggregate progress
+;; ============================================================================
+
+(rf/reg-sub :work/flow-snapshot
+  :<- [:rf/machine :work/flow]
+  (fn [snap _] snap))
+
+(rf/reg-sub :work/flow-state
+  :<- [:work/flow-snapshot]
+  (fn [snap _] (:state snap)))
+
+(rf/reg-sub :work/flow-data
+  :<- [:work/flow-snapshot]
+  (fn [snap _] (:data snap)))
+
+(rf/reg-sub :work/progress-map
+  :<- [:work/flow-data]
+  (fn [data _] (:progress data {})))
+
+(rf/reg-sub :work/total-items
+  :<- [:work/flow-data]
+  (fn [data _]
+    (* (count (:shards data)) (:total data 0))))
+
+(rf/reg-sub :work/items-done
+  :<- [:work/progress-map]
+  (fn [progress _]
+    (reduce + 0 (vals progress))))
+
+(rf/reg-sub :work/progress-fraction
+  {:doc "Aggregate progress, 0.0 .. 1.0. The view's progress bar
+         multiplies by 100 to render."}
+  :<- [:work/items-done]
+  :<- [:work/total-items]
+  (fn [[done total] _]
+    (if (pos? total)
+      (/ done total)
+      0)))
+
+(rf/reg-sub :work/outcome
+  :<- [:work/flow-data]
+  (fn [data _] (:outcome data)))
+
+(rf/reg-sub :work/running?
+  :<- [:work/flow-state]
+  (fn [state _] (= state :working)))
+
+(rf/reg-sub :work/spawn-registry-children
+  {:doc "Read the runtime-owned :children map under the parent's
+         :invoke-all slot. Used by the headless tests to assert
+         the spawn cascade fired. Returns nil when no :invoke-all
+         is active (i.e. before :start or after the cascade has
+         torn it down)."}
+  (fn sub-work-spawn-registry-children [db _]
+    (get-in db [:rf/spawned :work/flow [:working] :children])))
+
+;; ============================================================================
+;; INITIALISATION
+;; ============================================================================
+
+(rf/reg-event-fx :work/initialise
+  {:doc "Boot the parent machine to its :idle state."}
+  (fn handler-work-initialise [_ _]
+    {:fx [[:dispatch [:work/flow [:reset]]]]}))

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -196,6 +196,14 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'counter_with_stories', 'index.html'),
     outDir: path.join(OUT_ROOT, 'counter-with-stories'),
   },
+  // Pattern-LongRunningWork worked example (rf2-o9fg) —
+  // :invoke-all spawn-and-join with progress reporting and a
+  // cooperative cancellation cascade on parent-unmount.
+  {
+    build: 'examples/long-running-work',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'long_running_work', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'long-running-work'),
+  },
 ];
 
 function compileAll() {

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -1,0 +1,56 @@
+(ns re-frame.long-running-work-cljs-test
+  "Integration test: drives the long-running-work example's headless
+   test fixtures (rf2-o9fg). Each fixture spins a fresh frame via
+   `make-frame`, walks the :work/flow parent through a flow
+   (spawn cascade, happy-path join, mid-flight cancel, parent
+   unmount, reset round-trip), and asserts the resulting
+   [:rf/machines :work/flow] snapshot + the runtime-owned
+   [:rf/spawned :work/flow [:working]] join-state slot.
+
+   The fixtures live under examples/reagent/long_running_work/test/
+   long_running_work/worker_test.cljs — mirrors the realworld /
+   nine_states test-extraction pattern so the production source
+   stays test-free.
+
+   Per rf2-am9d this ns uses snapshot/restore via re-frame.test-support
+   so the contract is uniform across CLJS fixtures — the snapshot
+   captures the example's ns-load registrations (the :work/flow
+   parent + :work/processor child machines and the views' framework
+   subs), and the restore on the way out leaves them intact for any
+   subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]
+            ;; Require the worker ns directly — its ns-load reg-machine
+            ;; calls install :work/flow + :work/processor + the related
+            ;; subs. We don't need long-running-work.core (the entry
+            ;; point) since the integration tests bypass mount and
+            ;; React entirely; the views ns is exercised by the
+            ;; Playwright smoke.
+            [long-running-work.worker]
+            [long-running-work.worker-test :as wt]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(deftest long-running-work-spawn-cascade
+  (testing ":start spawns 3 children via :invoke-all and seeds the join-state"
+    (wt/test-spawn-cascade)))
+
+(deftest long-running-work-happy-path-join
+  (testing "synthesised :on-child-done events resolve the :all join and stamp :complete"
+    (wt/test-happy-path-join)))
+
+(deftest long-running-work-cancel-cascade
+  (testing "mid-flight :cancel tears down every surviving child via the :invoke-all exit"
+    (wt/test-cancel-cascade)))
+
+(deftest long-running-work-parent-unmount-cascade
+  (testing "view-unmount path: same :cancel dispatch from r/with-let cleanup"
+    (wt/test-parent-unmount-cascade)))
+
+(deftest long-running-work-reset-round-trip
+  (testing ":cancelled → :reset returns the parent to :idle with cleared :progress"
+    (wt/test-reset-after-cancel)))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -67,6 +67,11 @@
                 "../examples/reagent/7Guis"
                 "../examples/reagent/nine_states/test"
                 "../examples/reagent/realworld/test"
+                ;; rf2-o9fg — long-running-work example's fixtures live
+                ;; under examples/reagent/long_running_work/test/ to
+                ;; keep the production source test-free (same layout
+                ;; convention as realworld/ and nine_states/).
+                "../examples/reagent/long_running_work/test"
                 "../examples/uix"
                 "../examples/helix"]
  :dependencies [[reagent           "2.0.1"]
@@ -366,6 +371,18 @@
    :output-dir "out/examples/ssr"
    :asset-path "."
    :modules    {:main {:init-fn ssr.core/run}}}
+
+  ;; Pattern-LongRunningWork worked example (rf2-o9fg) —
+  ;; :invoke-all spawn-and-join with progress reporting and
+  ;; cooperative cancellation on parent-unmount. The parent
+  ;; coordinator :work/flow spawns three :work/processor children
+  ;; via :invoke-all; each child yields between chunks via :after;
+  ;; cancellation cascades via the desugared :exit fx.
+  :examples/long-running-work
+  {:target     :browser
+   :output-dir "out/examples/long-running-work"
+   :asset-path "."
+   :modules    {:main {:init-fn long-running-work.core/run}}}
 
   ;; Story Stage 8 (rf2-c9mm) — the canonical counter with the seven
   ;; `reg-*` Story macros wired up. URL-hash-routed: `#/` renders


### PR DESCRIPTION
## Summary

Adds `examples/reagent/long_running_work/` — a runnable Reagent example
demonstrating Pattern-LongRunningWork's `:invoke-all` shape: a parent
coordinator machine spawns three parallel worker machines, each worker
yields between chunks via `:after`, dispatches per-chunk `:progress`
back to the parent for UI, and dispatches the parent's
`:on-child-done` keyword on completion. The parent joins on `:all`;
the exit cascade tears every surviving worker down whenever the
`:working` state is exited (user `:cancel`, `:on-all-complete`, or the
work-bench component unmounting via its `r/with-let` cleanup).

Pairs with [`spec/Pattern-LongRunningWork.md`](spec/Pattern-LongRunningWork.md)
and the rf2-er0t conformance fixtures shipped in
[`spec/conformance/fixtures/invoke-all-*.edn`](spec/conformance/fixtures/).

## What the example demonstrates

- **Declarative spawn-and-join** via `:invoke-all`. The parent
  `:work/flow` declares three children with `:join :all`; the runtime
  owns the join state at `[:rf/spawned :work/flow [:working]]`. No
  per-child bookkeeping in the parent's `:data`.

- **Cooperative cancellation cascade**. Exiting `:working` by **any**
  path (`:cancel`, `:on-all-complete`, frame destroy) fires one
  `:rf.machine/destroy` fx whose handler tears every surviving child
  down. Each torn-down worker's in-flight `:after` timer goes with it.

- **Cooperative browser yielding**. Each child processes one item per
  `:processing` entry; `:yielding`'s `:after` schedules the next chunk
  after a configurable delay so the browser gets a render tick
  between chunks.

- **Per-step progress reporting**. Children dispatch
  `[:work/flow [:progress shard-id processed total]]` per chunk; the
  parent's `:working` state handles `:progress` as an **internal
  self-transition** (no `:target`) so the action runs without
  re-firing the `:invoke-all` entry-cascade.

- **Parent-unmount cascade**. The work-bench wrapper's `r/with-let`
  cleanup dispatches `[:work/flow [:cancel]]`. This is the **only**
  point where the UI lifecycle peeks through into the machine — the
  worker machines are React-agnostic.

## Machine shape

```
:work/flow (parent)              :work/processor (child; one per shard)
  :idle  → :working                :idle           → :processing
  :working :invoke-all             :processing     → :checking-done
            (3 children;           :checking-done  → :done | :yielding
             :join :all)           :yielding (:after) → :processing
          :on                      :done (:entry dispatches :work/child-done)
            :progress
            :work/all-done
            :work/any-failed
            :cancel
  :complete | :cancelled | :error
```

## Files touched

- New: `examples/reagent/long_running_work/{core,worker,views,schema}.cljs`
- New: `examples/reagent/long_running_work/{index.html,README.md}`
- New: `examples/reagent/long_running_work/long_running_work.spec.cjs`
- New: `examples/reagent/long_running_work/test/long_running_work/worker_test.cljs`
- New: `implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs`
- Modified: `implementation/shadow-cljs.edn` (+1 build entry, +1 source path)
- Modified: `examples/scripts/serve-and-run-examples-tests.cjs` (+1 EXAMPLES entry)

## Test plan

- [x] `npm run test:cljs` — 503 tests, 0 failures
- [x] `npm run test:browser` — 503 tests, 0 failures (includes the new `re-frame.long-running-work-cljs-test` ns)
- [x] `npm run test:examples` — `long-running-work` smoke **PASS** (including the cancel-cascade + unmount-cascade invariants)
- [x] `npm run test:elision` — clean
- [x] `shadow-cljs compile examples/long-running-work` — zero warnings

Cancellation-cascade evidence: the Playwright smoke clicks Cancel
mid-flight, reads the progress snapshot, waits 500ms, and reasserts
the snapshot unchanged — if the `:rf.machine/destroy` cascade missed
any worker, the in-flight `:after` timers would keep firing and the
bar would advance. With the cascade live, it stays put. Same path
exercised via the Hide/Show toggle (component unmount →
`r/with-let` cleanup → `:cancel` dispatch → cascade).