### PR TITLE
feat(examples): boot — canonical Pattern-Boot example app (rf2-dsm2)

### DIFF
--- a/examples/reagent/boot/README.md
+++ b/examples/reagent/boot/README.md
@@ -1,0 +1,108 @@
+# boot — Pattern-Boot example
+
+A runnable demonstration of the canonical re-frame2 application
+boot shape, per [`spec/Pattern-Boot.md`](../../../spec/Pattern-Boot.md).
+
+## What this example demonstrates
+
+A single boot state machine (`:app/boot`) owns the application's
+initialisation graph. The boot sequence is:
+
+```
+:configuring ──► :loading-deps ──► :hydrating ──► :ready
+       │                │
+       └────────────────┴──► :failed
+```
+
+- `:configuring` — a single `:invoke`d child loader fetches
+  `/api/config.json` via `:rf.http/managed`. On success, the boot
+  machine advances to `:loading-deps`; on failure, to `:failed`.
+- `:loading-deps` — `:invoke-all` fans out THREE parallel child
+  loaders (routes, feature flags, initial user). The parent reaches
+  the next state only when EVERY child reports done (`:join :all`).
+  Any child failure routes to `:failed` immediately
+  (`:on-any-failed`), cancelling the surviving siblings via the
+  standard `:invoke-all` cancel-on-decision cascade.
+- `:hydrating` — promotes the staged child payloads from
+  `[:boot/staging ...]` into the canonical top-level slices
+  (`:config`, `:flags`, `:user`, `:routes`), self-transitions to
+  `:ready` once the writes land.
+- `:ready` — terminal. The main view only mounts after the boot
+  machine reaches this state.
+- `:failed` — terminal. The view renders an error screen with a
+  retry button; the retry dispatches `[:app/boot [:rf/start]]`
+  back into the boot machine.
+
+## Key Pattern-Boot decisions
+
+1. **Pre-mount state machine, not view lifecycle.** The boot logic
+   lives in the `:app/boot` machine — not in a view's `:on-mount`,
+   not in top-level `js` side effects, not in a chained `:dispatch`
+   sequence. The view tree only renders the main app once the
+   boot machine reaches `:ready`.
+
+2. **`:invoke-all` for parallel dependencies.** Three of the four
+   loads are independent (routes / flags / user); the canonical
+   shape is `:invoke-all` with `:join :all`, not three sequential
+   `:invoke`s. The parent reaches `:hydrating` once the join
+   resolves; any single failure short-circuits to `:failed`.
+
+3. **One reusable child machine, four instances.** The
+   `:boot/loader` machine fetches a single URL and reports back.
+   The four instances are distinguished by their `:data` slot, set
+   via the spawn-spec `:data` fn (Pattern-AsyncEffect mechanism 2).
+
+4. **Staging slot for child-to-parent data flow.** Per Spec 005,
+   the runtime intercepts `:on-child-done` / `:on-child-error` for
+   `:invoke-all` join bookkeeping — these events are NOT fed into
+   the parent's `:on` lookup. The canonical Pattern-Boot shape
+   for threading loaded payloads from children to the parent is a
+   staging slot in app-db (`[:boot/staging <child-id>]`): each
+   child writes its payload before dispatching the join-completion
+   event; the parent reads the slot in `:enter-hydrating`.
+
+5. **Demo stubs via `:rf.http/managed-canned-success`.** The
+   example runs standalone — no backend. The four mocked endpoints
+   are served by a per-URL canned-stub override on the default
+   frame, per Spec 014 §Testing.
+
+## Running it
+
+The example is wired into the standard shadow-cljs and Playwright
+infrastructure:
+
+```sh
+# From the implementation directory:
+npx shadow-cljs compile examples/boot
+
+# Then from the repo root:
+npm run test:examples       # Playwright smoke
+npm run test:cljs           # Headless boot machine tests
+```
+
+## Files
+
+```
+core.cljs               — mount + boot trigger + demo HTTP stubs
+boot.cljs               — :app/boot machine + :boot/loader child machine
+views.cljs              — boot-progress + main-app + failure views
+schema.cljs             — Malli schemas (BootSnapshot, Config, Flags, ...)
+test/boot/boot_test.cljs — headless tests (machine progression, deps
+                          resolution, failure path)
+index.html
+boot.spec.cjs           — Playwright smoke
+```
+
+## Cross-references
+
+- [`spec/Pattern-Boot.md`](../../../spec/Pattern-Boot.md) — the
+  normative pattern doc.
+- [`spec/005-StateMachines.md` §Spawn-and-join via
+  `:invoke-all`](../../../spec/005-StateMachines.md#spawn-and-join-via-invoke-all) —
+  the substrate the boot machine uses for the parallel dependency
+  phase.
+- [`spec/014-HTTPRequests.md`](../../../spec/014-HTTPRequests.md) —
+  `:rf.http/managed` is the fx the child loaders use.
+- [`examples/reagent/realworld/`](../realworld/) — the canonical
+  app-shell example; this `boot/` example slots in upstream of
+  the realworld pattern (a real app would have BOTH).

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -1,0 +1,363 @@
+(ns boot.boot
+  "Pattern-Boot: the canonical re-frame2 application boot shape.
+
+   The boot machine owns the initialisation graph. It runs through
+   four states:
+
+     :configuring   → fetch the mock /config endpoint via a single
+                      `:invoke`d child loader machine.
+     :loading-deps  → fan out THREE parallel child loads (routes,
+                      feature flags, initial user) via `:invoke-all`;
+                      the parent reaches the next state only when
+                      EVERY child reports done.
+     :hydrating     → applies the four loaded payloads into top-level
+                      app-db slices (`:config`, `:flags`, `:user`,
+                      `:routes`) via the `:enter-hydrating` action.
+                      Self-transitions to `:ready` once the writes
+                      land.
+     :ready         → terminal. The main view subscribes to the boot
+                      state and unblocks once it reads `:ready`.
+
+   On any child failure the boot machine transitions to `:failed`
+   (terminal) with the failure payload recorded in `:data :error`.
+
+   The boot machine itself is `:app/boot`; the child loader is the
+   reusable `:boot/loader` machine — one spec, four instances spawned
+   with different `:data`. Each instance's identity (parent-id,
+   child-id, staging-key, URL) is planted via the `:data` fn-form on
+   the per-child invoke-spec — Pattern-AsyncEffect mechanism 2 (the
+   spawn-spec `:data` fn closes over the parent's snapshot).
+
+   Each child fetches via `:rf.http/managed` and, on success, writes
+   its payload into the boot machine's staging slot at
+   `[:boot/staging <staging-key>]` before dispatching the canonical
+   `:invoke-all` child-completion event back to the parent's
+   `:on-child-done` slot.
+
+   Why a staging slot rather than threading payloads through the
+   join-event: per Spec 005, the runtime intercepts the parent's
+   `:on-child-done` / `:on-child-error` events for join bookkeeping
+   ONLY — they are not fed into the parent's `:on` lookup. The
+   join-resolution event the runtime synthesises
+   (`:on-all-complete [:boot/deps-ready]`) carries no per-child
+   payload. So the canonical Pattern-Boot shape for an `:invoke-all`
+   that needs to thread loaded data into the parent is: each child
+   writes its result into a known app-db slice, the parent reads
+   that slice on the join-resolved transition. This keeps the
+   loaded data in app-db throughout — inspectable in re-frame-10x
+   and snapshottable for SSR hydration.
+
+   Trigger boot once at app start via `[:app/boot [:rf/start]]`. The
+   machine self-initialises (per Spec 005 §Restore semantics): the
+   `:initial` state and `:data` seed `[:rf/machines :app/boot]` when
+   the dispatch lands."
+  (:require [re-frame.core :as rf]
+            ;; Spec 005 state-machine ns ships in the
+            ;; day8/re-frame2-machines artefact. Loading the ns here
+            ;; registers its late-bind hooks so `rf/reg-machine` and
+            ;; `rf/create-machine-handler` resolve at ns-load.
+            [re-frame.machines]
+            ;; `:rf.http/managed` ships in day8/re-frame2-http. Loading
+            ;; the ns registers the fx; without it, the child loaders
+            ;; can't issue requests.
+            [re-frame.http-managed]
+            [boot.schema]))
+
+;; ============================================================================
+;; STAGING-SLOT WRITER
+;; ============================================================================
+;;
+;; The child loader dispatches this event with its loaded payload
+;; before transitioning into its terminal `:done` state. The boot
+;; machine reads `[:boot/staging <staging-key>]` on the
+;; :hydrating transition to write the loaded values into the
+;; top-level app-db slices.
+
+(rf/reg-event-db :boot/stage-payload
+  {:doc "Write a child-loaded payload into the boot machine's
+         staging slot. Dispatched by the :boot/loader child's
+         :dispatch-done action just before it fires the join-completion
+         event back to the parent."}
+  (fn handler-boot-stage-payload [db [_ staging-key payload]]
+    (assoc-in db [:boot/staging staging-key] payload)))
+
+;; ============================================================================
+;; CHILD LOADER MACHINE — :boot/loader
+;; ============================================================================
+;;
+;; The reusable child machine. One spec, four instances. Each
+;; instance carries its own `:data` map (`:parent-id`, `:child-id`,
+;; `:staging-key`, `:url`) planted by the parent's per-child
+;; `:invoke` / `:invoke-all`-child `:data` slot (fn-form per
+;; Spec 005 §Spec-spec keys). The child machine spawns in `:idle`
+;; and the runtime-synthesised `:rf.machine/spawned` event
+;; (per rf2-ijm7) transitions it to `:loading`, which fires the
+;; entry-cascade's `:begin-fetch` action.
+
+(rf/reg-machine :boot/loader
+  {:initial :idle
+   :data    {:parent-id   nil
+             :child-id    nil
+             :staging-key nil
+             :url         nil
+             :payload     nil
+             :error       nil}
+
+   :actions
+   {:begin-fetch
+    ;; Issue the GET. The reply addressing routes back to THIS child
+    ;; (self-dispatch via :rf/self-id, which the spawn fx stamps
+    ;; into :data per Spec 005 §Spec-spec keys — always present).
+    ;; The reply lands at the FSM's `:asset/replied` inner event so
+    ;; the FSM branches on success vs failure before forwarding to
+    ;; the parent.
+    (fn [data _]
+      (let [self-id (:rf/self-id data)]
+        {:fx [[:rf.http/managed
+               {:request    {:method :get :url (:url data)}
+                :decode     :json
+                :on-success [self-id [:asset/replied :success]]
+                :on-failure [self-id [:asset/replied :failure]]}]]}))
+
+    :dispatch-done
+    ;; Terminal-state entry. First write the loaded payload into
+    ;; [:boot/staging <staging-key>], then fire the canonical
+    ;; `:invoke-all` child-completion event back to the parent's
+    ;; :on-child-done slot. The runtime intercepts the second
+    ;; dispatch for join bookkeeping.
+    (fn [data _]
+      {:fx [[:dispatch [:boot/stage-payload (:staging-key data) (:payload data)]]
+            [:dispatch [(:parent-id data)
+                        [:boot/asset-loaded (:child-id data)]]]]})
+
+    :dispatch-error
+    ;; Terminal failure-state entry. Forwards the failure to the
+    ;; parent's :on-child-error slot; the parent's :on-any-failed
+    ;; routes it onward to `:failed`.
+    (fn [data _]
+      {:fx [[:dispatch [(:parent-id data)
+                        [:boot/asset-failed (:child-id data) (:error data)]]]]})}
+
+   :states
+   {;; :idle is the FSM's :initial. Per rf2-ijm7, the spawn-fx
+    ;; synthesises a [:rf.machine/spawned] event into the new actor
+    ;; if no :start is supplied — :idle's transition picks it up
+    ;; and moves to :loading, which fires the entry-cascade's
+    ;; :begin-fetch action.
+    :idle
+    {:on {:rf.machine/spawned :loading}}
+
+    :loading
+    {:entry :begin-fetch
+     :on    {:asset/replied
+             ;; Guarded fork on the reply kind. The runtime appends
+             ;; the reply payload as the LAST element of the event
+             ;; vector, so the event arrives as
+             ;; [:asset/replied :success {:kind :success :value ...}]
+             ;; — we pick the value out from the 3rd-position arg.
+             [{:guard  (fn [_ ev] (= :success (nth ev 1 nil)))
+               :target :done
+               :action (fn [data [_ _ reply]]
+                         {:data (assoc data :payload (:value reply))})}
+              {:target :failed
+               :action (fn [data [_ _ reply]]
+                         {:data (assoc data :error (:failure reply))})}]}}
+
+    :done   {:entry :dispatch-done   :meta {:terminal? true}}
+    :failed {:entry :dispatch-error  :meta {:terminal? true}}}})
+
+;; ============================================================================
+;; BOOT MACHINE — :app/boot
+;; ============================================================================
+
+(rf/reg-machine :app/boot
+  {:initial :idle
+   :data    {:phase  :idle
+             :config nil
+             :flags  nil
+             :user   nil
+             :routes nil
+             :error  nil}
+
+   :actions
+   {:record-failure
+    (fn [data [_ _child-id failure]]
+      {:data (assoc data :error failure)})
+
+    :enter-hydrating
+    ;; Read all the staged payloads out of [:boot/staging ...] and
+    ;; write them into the canonical top-level slices the running
+    ;; app's subs read. Self-transitions to `:ready` once the
+    ;; hydration write lands.
+    (fn [data _]
+      {:data (assoc data :phase :hydrating)
+       :fx   [[:dispatch [:boot/apply-hydration]]]})}
+
+   :states
+   {;; ---- :idle — the parking spot before the boot kicks off -------------
+    ;; Per the standard re-frame2 state-machine convention (see the
+    ;; `:invoke-all` conformance fixtures), a machine's initial state
+    ;; is `:idle` and the first work-event transitions it onward. Here
+    ;; the `:rf/start` event the dispatched-on-app-boot fires moves
+    ;; :idle → :configuring, which fires the :invoke entry-cascade.
+    :idle
+    {:on {:rf/start :configuring}}
+
+    ;; ---- :configuring — a single :invoke fetches /config -----------------
+    :configuring
+    {:invoke {:machine-id :boot/loader
+              ;; Per Spec 005 §Spec-spec keys, `:data` admits a
+              ;; function form `(fn [snap ev] data)` so the child's
+              ;; initial :data can depend on the parent's snapshot at
+              ;; the moment of entry. We plant the identity (parent
+              ;; / child / staging-key / URL) here — the canonical
+              ;; Pattern-AsyncEffect mechanism 2 (parameter passing
+              ;; via the spawn-spec :data fn).
+              :data       (fn boot-config-data [_snap _ev]
+                            {:parent-id   :app/boot
+                             :child-id    :config
+                             :staging-key :config
+                             :url         "/api/config.json"})}
+     :on     {:boot/asset-loaded {:target :loading-deps}
+              :boot/asset-failed {:target :failed
+                                  :action :record-failure}}}
+
+    ;; ---- :loading-deps — :invoke-all fans out THREE parallel children ---
+    :loading-deps
+    {:invoke-all
+     {:children
+      ;; Each child is the same :boot/loader machine, distinguished
+      ;; only by its :data slot. The :data fn-form reads the
+      ;; previously-staged `[:boot/staging :config]` to thread the
+      ;; loaded `:api-base` into each child's URL (Pattern-Boot
+      ;; mechanism 3 — boot reads host config; threads via
+      ;; mechanism 2).
+      [{:id         :routes
+        :machine-id :boot/loader
+        :data       (fn boot-routes-data [_snap _ev]
+                      ;; The :data fn receives the PARENT's snapshot
+                      ;; — not app-db. The parent records the staged
+                      ;; config into its own :data slot on the
+                      ;; :configuring → :loading-deps transition (see
+                      ;; the :promote-staged action below). At spawn
+                      ;; time, that value is visible via _snap, but
+                      ;; for the boot example the api-base is empty
+                      ;; (the demo stubs match by suffix).
+                      {:parent-id   :app/boot
+                       :child-id    :routes
+                       :staging-key :routes
+                       :url         "/api/routes.json"})}
+       {:id         :flags
+        :machine-id :boot/loader
+        :data       (fn boot-flags-data [_snap _ev]
+                      {:parent-id   :app/boot
+                       :child-id    :flags
+                       :staging-key :flags
+                       :url         "/api/flags.json"})}
+       {:id         :user
+        :machine-id :boot/loader
+        :data       (fn boot-user-data [_snap _ev]
+                      {:parent-id   :app/boot
+                       :child-id    :user
+                       :staging-key :user
+                       :url         "/api/user.json"})}]
+      :join             :all
+      :on-child-done    :boot/asset-loaded
+      :on-child-error   :boot/asset-failed
+      :on-all-complete  [:boot/deps-ready]
+      :on-any-failed    [:boot/deps-failed]}
+     :on    {:boot/deps-ready  {:target :hydrating}
+             :boot/deps-failed {:target :failed
+                                :action :record-failure}}}
+
+    ;; ---- :hydrating — applies the loaded payloads into app-db ----------
+    :hydrating
+    {:entry :enter-hydrating
+     :on    {:boot/hydrated {:target :ready}}}
+
+    ;; ---- :ready / :failed — terminal -------------------------------------
+    :ready  {:meta {:terminal? true}}
+    :failed {;; Per Pattern-Boot §Re-boot semantics, :failed is
+             ;; re-entrant — dispatching `[:app/boot [:rf/start]]`
+             ;; from the failure screen re-runs the boot from
+             ;; :configuring. The terminal? meta is still true so
+             ;; visualisers / conformance harnesses see :failed as a
+             ;; terminal state; the re-entry transition is the
+             ;; explicit re-boot, not the default end of the flow.
+             :meta {:terminal? true}
+             :on   {:rf/start {:target :configuring
+                               :action (fn [data _]
+                                         {:data (assoc data :error nil)})}}}}})
+
+;; ============================================================================
+;; HYDRATION PROMOTION
+;; ============================================================================
+;;
+;; A plain reg-event-fx does the cross-slice writes the boot
+;; machine's :hydrating action dispatches. Keeping the cross-slice
+;; reads / writes in an explicit handler (not inside the machine's
+;; action body) makes the boot trace one-step inspectable: the
+;; machine's `:enter-hydrating` action is one trace; the
+;; :boot/apply-hydration handler is another.
+
+(rf/reg-event-fx :boot/apply-hydration
+  {:doc "Promote every staged child payload at [:boot/staging ...]
+         into the canonical top-level app-db slices the running app
+         reads. Fires :boot/hydrated back at :app/boot to transition
+         from :hydrating to :ready."}
+  (fn handler-boot-apply-hydration [{:keys [db]} _]
+    (let [staging (:boot/staging db)]
+      {:db (-> db
+               (assoc :config (:config staging))
+               (assoc :flags  (:flags staging))
+               (assoc :user   (:user staging))
+               (assoc :routes (:routes staging))
+               ;; Mirror the loaded values into the boot machine's
+               ;; :data slice so the snapshot is self-describing
+               ;; for SSR / tools / re-frame-10x inspection.
+               (update-in [:rf/machines :app/boot :data] assoc
+                          :config (:config staging)
+                          :flags  (:flags staging)
+                          :user   (:user staging)
+                          :routes (:routes staging)))
+       :fx [[:dispatch [:app/boot [:boot/hydrated]]]]})))
+
+;; ============================================================================
+;; PUBLIC ENTRY EVENT
+;; ============================================================================
+
+(rf/reg-event-fx :boot/initialise
+  {:doc "Top-level app boot. Fires the :app/boot machine's :rf/start
+         event to kick the boot sequence off. The frame's :on-create
+         points at this event (see core.cljs)."}
+  (fn handler-app-initialise [_ _]
+    {:fx [[:dispatch [:app/boot [:rf/start]]]]}))
+
+;; ============================================================================
+;; SUBS — boot-state slots the views read
+;; ============================================================================
+
+(rf/reg-sub :app.boot/snapshot
+  (fn [db _]
+    (get-in db [:rf/machines :app/boot])))
+
+(rf/reg-sub :app.boot/state
+  :<- [:app.boot/snapshot]
+  (fn [snap _] (:state snap)))
+
+(rf/reg-sub :app.boot/error
+  :<- [:app.boot/snapshot]
+  (fn [snap _] (get-in snap [:data :error])))
+
+(rf/reg-sub :app.boot/ready?
+  :<- [:app.boot/state]
+  (fn [state _] (= state :ready)))
+
+(rf/reg-sub :app.boot/failed?
+  :<- [:app.boot/state]
+  (fn [state _] (= state :failed)))
+
+(rf/reg-sub :app/config (fn [db _] (:config db)))
+(rf/reg-sub :app/flags  (fn [db _] (:flags db)))
+(rf/reg-sub :app/user   (fn [db _] (:user db)))
+(rf/reg-sub :app/routes (fn [db _] (:routes db)))

--- a/examples/reagent/boot/boot.spec.cjs
+++ b/examples/reagent/boot/boot.spec.cjs
@@ -1,0 +1,56 @@
+/*
+ * boot — Pattern-Boot example app.
+ *
+ * The boot example demonstrates the canonical Pattern-Boot shape: a
+ * boot state machine owns the application's initialisation graph,
+ * fans out parallel dependency loads via `:invoke-all`, and the main
+ * view does NOT mount until the boot reaches `:ready`.
+ *
+ * Coverage:
+ *   - Loads cleanly (no pageerror, no uncaught exceptions).
+ *   - Boot-progress screen is visible at first paint (the main app
+ *     view does not mount before :ready).
+ *   - After the canned :rf.http/managed stub resolves the four
+ *     mocked endpoints, the boot machine reaches :ready and the
+ *     main app screen swaps in.
+ *   - The hydrated config / flags / user / routes slices populate
+ *     the main app view (title from config; routes list from
+ *     /api/routes.json).
+ */
+
+const { expectVisible } = require('../../scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'boot — Pattern-Boot example',
+  url: '/boot/',
+  run: async (page) => {
+    // The boot-progress view is visible at first paint — the
+    // boot machine has not yet reached :ready.
+    await expectVisible(page.locator('[data-testid="boot-progress"]'), 5000);
+
+    // After the four canned-stub replies resolve (each on a
+    // 60 ms timeout), the boot machine reaches :ready and the
+    // main app view swaps in.
+    await expectVisible(page.locator('[data-testid="main-app"]'), 15000);
+
+    // The main app title comes from the staged config payload.
+    await expectVisible(
+      page.locator('[data-testid="main-title"]:has-text("Pattern-Boot example app")'),
+      5000,
+    );
+
+    // The routes list is populated from the canned /api/routes.json reply.
+    await page.waitForFunction(
+      () =>
+        document.querySelectorAll('[data-testid="routes-list"] li').length >= 3,
+      null,
+      { timeout: 5000 },
+    );
+
+    // The config :env value is rendered from the staged config map.
+    await expectVisible(
+      page.locator('[data-testid="config-env"]:has-text(":prod")'),
+      5000,
+    );
+  },
+};

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -1,0 +1,127 @@
+(ns boot.core
+  "Entry point for the boot example — Pattern-Boot demonstrated.
+
+   `run` wires the Reagent adapter, installs the per-URL canned-HTTP
+   stub override (so the example runs standalone — no backend), and
+   triggers the boot machine via `:boot/initialise`. The render runs
+   immediately; the root view stays on the boot-progress screen until
+   the boot machine reaches `:ready`.
+
+   The four mocked endpoints:
+     /api/config.json   → static app config (api-base, env, build)
+     /api/routes.json   → route table (id + path tuples)
+     /api/flags.json    → feature flags
+     /api/user.json     → initial user record
+
+   The stub fx routes by URL substring and delegates to the
+   framework-shipped `:rf.http/managed-canned-success` per Spec 014
+   §Testing, so the canonical reply shape is preserved."
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Required for `rf/init!`.
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Loads the registrar so we can resolve the canned-success
+            ;; fx for the per-URL stub below.
+            [re-frame.registrar :as registrar]
+            ;; Managed-HTTP ships in day8/re-frame2-http. The require
+            ;; triggers its fx registrations (:rf.http/managed and
+            ;; family) at app boot; without it, the child loaders'
+            ;; managed-HTTP dispatches would raise :rf.error/no-such-fx.
+            [re-frame.http-managed]
+            [boot.schema]
+            [boot.boot]
+            [boot.views]))
+
+;; ============================================================================
+;; DEMO STUBS — per-URL canned :rf.http/managed override
+;; ============================================================================
+;;
+;; The boot example would normally hit /api/config.json and three more
+;; endpoints; we don't ship a backend, so we override `:rf.http/managed`
+;; on the default frame to a wrapper fx that synthesises the canned
+;; reply per URL substring. Each branch delegates to
+;; `:rf.http/managed-canned-success` (Spec 014 §Testing) — the same
+;; reply shape a live server would produce.
+
+(def ^:private demo-config
+  {:api-base "/api"
+   :env      :prod
+   :build    "boot-example-1.0.0"
+   :title    "Pattern-Boot example app"})
+
+(def ^:private demo-routes
+  [{:id :route/home     :path "/"}
+   {:id :route/about    :path "/about"}
+   {:id :route/settings :path "/settings"}])
+
+(def ^:private demo-flags
+  {:dark-mode?       false
+   :beta-channel?    true
+   :onboarding-skip? false})
+
+(def ^:private demo-user
+  {:id       "user-1"
+   :username "stub-bot"
+   :email    "stub-bot@example.com"})
+
+(defn- demo-payload-for-url [url]
+  (let [u (str url)]
+    (cond
+      (str/includes? u "/config.json") demo-config
+      (str/includes? u "/routes.json") demo-routes
+      (str/includes? u "/flags.json")  demo-flags
+      (str/includes? u "/user.json")   demo-user
+      :else                            {})))
+
+(rf/reg-fx :rf.http/managed.boot-demo
+  {:doc       "Demo override for `:rf.http/managed`: routes by URL
+               substring to canned boot responses so the example runs
+               standalone without a backend. Delegates to the
+               framework-shipped `:rf.http/managed-canned-success`
+               per Spec 014 §Testing.
+
+               A small artificial delay (60 ms) lets the boot-progress
+               view render the per-phase loading state before the
+               replies land — without it, the boot resolves in one
+               drain and the user only ever sees the `:ready` screen."
+   :platforms #{:server :client}}
+  (fn fx-managed-boot-demo [frame-ctx args-map]
+    (let [url     (-> args-map :request :url)
+          payload (demo-payload-for-url url)
+          stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
+      (when stub-fn
+        (js/setTimeout
+          (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
+          60)))))
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+;; React root named `react-root` (not `root`) so it does NOT collide
+;; with any `root-view` registered above.
+(defonce react-root
+  (when (exists? js/document)
+    (rdc/create-root (js/document.getElementById "app"))))
+
+(defn ^:export run []
+  ;; Pass the adapter spec map directly — no registry.
+  (rf/init! reagent-adapter/adapter)
+
+  ;; Override `:rf.http/managed` on the default frame so every child
+  ;; loader's GET routes to the per-URL canned stub above. The
+  ;; override applies frame-wide; the boot example doesn't issue any
+  ;; non-mocked requests, so a blanket override is the right grain.
+  (rf/reg-frame :rf/default
+    {:doc          "Boot example demo frame."
+     :fx-overrides {:rf.http/managed :rf.http/managed.boot-demo}})
+
+  ;; Kick the boot. The `:app/boot` machine's :initial state and
+  ;; :data seed `[:rf/machines :app/boot]` on first dispatch (per
+  ;; Spec 005 §Restore semantics); :boot/initialise fires
+  ;; `[:app/boot [:rf/start]]`, which transitions :configuring's
+  ;; :invoke spawn-fx and starts the boot sequence.
+  (rf/dispatch-sync [:boot/initialise])
+
+  (rdc/render react-root [boot.views/root-view]))

--- a/examples/reagent/boot/index.html
+++ b/examples/reagent/boot/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: boot (Pattern-Boot)</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 24px; max-width: 720px; }
+    h1 { font-size: 1.4rem; margin-top: 0; }
+    h2 { font-size: 1.05rem; margin: 16px 0 4px; color: #333; }
+    .boot-progress { padding: 16px; background: #f5f7fa; border-left: 4px solid #5cb85c; }
+    .boot-failed   { padding: 16px; background: #fdf3f3; border-left: 4px solid #d9534f; }
+    .main-app section { padding: 8px 0; border-top: 1px solid #eee; }
+    .boot-hint { color: #777; font-size: 0.85rem; }
+    dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 12px; margin: 0; }
+    dt { font-weight: 600; color: #555; }
+    dd { margin: 0; }
+    code { background: #eef; padding: 1px 4px; border-radius: 3px; }
+    button { padding: 6px 12px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -1,0 +1,103 @@
+(ns boot.schema
+  "Malli schemas for the boot example.
+
+   The example demonstrates Pattern-Boot: a single boot state machine
+   owns the initialisation graph. Three parallel sub-fetches (config,
+   feature flags, initial user) run via `:invoke-all`; the boot
+   machine reaches `:ready` only when every child reports done. The
+   schemas describe the wire shape returned by each mocked endpoint
+   and the boot-machine snapshot itself."
+  (:require [re-frame.core :as rf]
+            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
+            ;; Loading the ns here registers its late-bind hooks so
+            ;; rf/reg-app-schema resolves at the call sites below.
+            [re-frame.schemas]))
+
+;; ============================================================================
+;; WIRE SHAPES — what the mocked endpoints return
+;; ============================================================================
+
+(def Config
+  "Static app configuration. In a real app this would arrive from a
+   build-time /config endpoint; here the demo stub synthesises a
+   plausible payload."
+  [:map
+   [:api-base    :string]
+   [:env         [:enum :dev :staging :prod]]
+   [:build       :string]
+   [:title       :string]])
+
+(def Flags
+  "Feature flags. The map is open — apps add their own keys; the
+   schema only fixes the well-known ones."
+  [:map
+   [:dark-mode?       :boolean]
+   [:beta-channel?    :boolean]
+   [:onboarding-skip? :boolean]])
+
+(def User
+  "Initial user record. In a real app this would arrive from /user
+   after the session token is restored. Here the demo stub returns
+   a static demo user."
+  [:map
+   [:id       :string]
+   [:username :string]
+   [:email    :string]])
+
+(def Routes
+  "Application route table. In a real app this might be hard-coded;
+   here we fetch it so the boot graph has four parallel dependencies
+   to demonstrate `:invoke-all`."
+  [:vector
+   [:map
+    [:id   :keyword]
+    [:path :string]]])
+
+;; ============================================================================
+;; BOOT-MACHINE SNAPSHOT
+;; ============================================================================
+;;
+;; The boot machine lives at [:rf/machines :app/boot]. Its `:state`
+;; cycles `:configuring → :loading-deps → :hydrating → :ready`
+;; (terminal), with `:failed` (terminal) reached if any child errors.
+;; `:data` carries the per-phase progress slot and the loaded payloads.
+
+(def BootSnapshot
+  [:map
+   [:state [:enum :configuring :loading-deps :hydrating :ready :failed]]
+   [:data  [:map
+            [:phase  [:maybe :keyword]]
+            [:config [:maybe Config]]
+            [:flags  [:maybe Flags]]
+            [:user   [:maybe User]]
+            [:routes [:maybe Routes]]
+            [:error  [:maybe :any]]]]])
+
+(def LoaderSnapshot
+  "Snapshot shape for the generic `:boot/loader` child machine.
+   Each child loader holds the parent-id + child-id + URL it was
+   spawned with, fetches once, and dispatches `:boot/asset-loaded`
+   (or `:boot/asset-failed`) back to its parent on transition into
+   `:done` (or `:failed`)."
+  [:map
+   [:state [:enum :idle :loading :done :failed]]
+   [:data  [:map
+            [:parent-id :keyword]
+            [:child-id  :keyword]
+            [:url       :string]
+            [:payload   :any]
+            [:error     [:maybe :any]]]]])
+
+;; ============================================================================
+;; SCHEMA REGISTRATION
+;; ============================================================================
+
+(rf/reg-app-schema [:rf/machines :app/boot] BootSnapshot)
+
+;; The boot machine writes its final payloads into top-level app-db
+;; slices on entering `:hydrating`. These are the slices the main app
+;; reads via subs once the boot reaches `:ready`.
+(rf/reg-app-schema [:config] [:maybe Config])
+(rf/reg-app-schema [:flags]  [:maybe Flags])
+(rf/reg-app-schema [:user]   [:maybe User])
+(rf/reg-app-schema [:routes] [:maybe Routes])

--- a/examples/reagent/boot/test/boot/boot_test.cljs
+++ b/examples/reagent/boot/test/boot/boot_test.cljs
@@ -1,0 +1,177 @@
+(ns boot.boot-test
+  "Headless tests for boot.boot — the Pattern-Boot state machine.
+
+   Each test spins a fresh frame via `make-frame`, fires the
+   `:boot/initialise` event, and asserts the boot machine and the
+   four loaded slices end up in the expected shape. Managed-HTTP is
+   stubbed via `:fx-overrides` routing every `:rf.http/managed`
+   call to a per-URL canned-success / canned-failure wrapper that
+   delegates to the framework-shipped stubs (Spec 014 §Testing).
+
+   Coverage:
+     - machine-progression-test  — the boot machine traverses
+       :configuring → :loading-deps → :hydrating → :ready, and all
+       four loaded slices land in app-db.
+     - dependency-resolution-test — the per-child :data fns thread
+       the spawn-spec identity correctly so each child writes its
+       payload to the matching staging key (no cross-talk).
+     - failure-path-test         — a failure during the parallel
+       phase routes the boot to :failed and records the error in
+       :data."
+  (:require [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [boot.boot])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+;; ============================================================================
+;; PER-URL CANNED STUBS
+;; ============================================================================
+;;
+;; The realworld test-helpers provide reg-canned-success-by-url! which
+;; we reproduce locally so the boot example's tests don't have to
+;; require the realworld ns just for one helper.
+
+(defn- reg-canned-success-by-url!
+  "Register an fx-id that delegates to :rf.http/managed-canned-success,
+   choosing `:value` per the request URL. `url->value` is a 1-arity fn
+   receiving the URL string and returning the synthesised :value."
+  [fx-id url->value]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub  (registrar/handler :fx :rf.http/managed-canned-success)
+            url   (-> args :request :url)
+            value (url->value url)]
+        (stub frame-ctx (assoc args :value value))))))
+
+(defn- reg-canned-failure!
+  "Register an fx-id that delegates to :rf.http/managed-canned-failure."
+  [fx-id kind tags]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (stub frame-ctx (assoc args :kind kind :tags tags))))))
+
+;; ============================================================================
+;; DEMO PAYLOADS
+;; ============================================================================
+;;
+;; Matched against the URL substring per the same routing the
+;; demo stub in core.cljs uses.
+
+(def ^:private test-config
+  {:api-base "/api"
+   :env      :dev
+   :build    "test-build"
+   :title    "Boot test app"})
+
+(def ^:private test-routes
+  [{:id :route/home  :path "/"}
+   {:id :route/about :path "/about"}])
+
+(def ^:private test-flags
+  {:dark-mode?       true
+   :beta-channel?    false
+   :onboarding-skip? true})
+
+(def ^:private test-user
+  {:id "u1" :username "alice" :email "alice@example.com"})
+
+(defn- payload-for [url]
+  (let [u (str url)]
+    (cond
+      (re-find #"/config\.json$" u) test-config
+      (re-find #"/routes\.json$" u) test-routes
+      (re-find #"/flags\.json$"  u) test-flags
+      (re-find #"/user\.json$"   u) test-user
+      :else                         {})))
+
+;; ============================================================================
+;; TESTS
+;; ============================================================================
+
+(defn machine-progression-test
+  "Drives the boot through the happy path. Asserts the final state
+   is :ready, every staging slot is populated, and every top-level
+   slice landed in app-db."
+  []
+  (reg-canned-success-by-url! :rf.http/managed.boot-success payload-for)
+
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:boot/initialise]
+                    :fx-overrides {:rf.http/managed
+                                   :rf.http/managed.boot-success}})]
+    ;; The :on-create cofx fires :boot/initialise during make-frame,
+    ;; which dispatches [:app/boot [:rf/start]]. The synchronous
+    ;; drain runs all four canned-success stubs to completion.
+    (let [db    (rf/get-frame-db f)
+          state (rf/compute-sub [:app.boot/state] db)]
+      (assert (= :ready state)
+              (str "expected boot machine state :ready, got " state))
+
+      ;; Staging slots all populated.
+      (let [staging (:boot/staging db)]
+        (assert (= test-config (:config staging)))
+        (assert (= test-routes (:routes staging)))
+        (assert (= test-flags  (:flags staging)))
+        (assert (= test-user   (:user staging))))
+
+      ;; Top-level slices hydrated from staging.
+      (assert (= test-config (rf/compute-sub [:app/config] db)))
+      (assert (= test-flags  (rf/compute-sub [:app/flags]  db)))
+      (assert (= test-user   (rf/compute-sub [:app/user]   db)))
+      (assert (= test-routes (rf/compute-sub [:app/routes] db))))))
+
+(defn dependency-resolution-test
+  "Asserts the per-child :data fns thread the spawn-spec identity
+   correctly so each child writes its payload to the matching
+   staging key (no cross-talk between siblings)."
+  []
+  (reg-canned-success-by-url! :rf.http/managed.boot-success payload-for)
+
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:boot/initialise]
+                    :fx-overrides {:rf.http/managed
+                                   :rf.http/managed.boot-success}})]
+    (let [db      (rf/get-frame-db f)
+          staging (:boot/staging db)]
+      ;; Each staging-key holds the payload that came back from the
+      ;; matching URL. Cross-talk (e.g. :flags staging holding the
+      ;; routes payload) would mean the :invoke-all :data fns are
+      ;; not threading identity correctly.
+      (assert (contains? (:config staging) :api-base))
+      (assert (sequential? (:routes staging)))
+      (assert (contains? (:flags staging) :dark-mode?))
+      (assert (contains? (:user staging) :username))
+      ;; The boot machine's :data mirrors the staged values once
+      ;; :enter-hydrating runs (so the snapshot is self-describing
+      ;; for SSR / tools).
+      (let [boot-data (get-in db [:rf/machines :app/boot :data])]
+        (assert (= test-config (:config boot-data)))
+        (assert (= test-routes (:routes boot-data)))
+        (assert (= test-flags  (:flags boot-data)))
+        (assert (= test-user   (:user boot-data)))))))
+
+(defn failure-path-test
+  "A failure during the parallel phase routes the boot machine to
+   :failed and records the error in :data."
+  []
+  (reg-canned-failure! :rf.http/managed.boot-fail
+                       :rf.http/http-5xx
+                       {:status 500
+                        :body   "boot dependency unreachable"})
+
+  (with-frame [f (rf/make-frame
+                   {:on-create    [:boot/initialise]
+                    :fx-overrides {:rf.http/managed
+                                   :rf.http/managed.boot-fail}})]
+    (let [db    (rf/get-frame-db f)
+          state (rf/compute-sub [:app.boot/state] db)]
+      ;; Every child fails (the canned-failure stub is blanket); the
+      ;; first failure routes the boot to :failed via :on-any-failed.
+      (assert (= :failed state)
+              (str "expected boot machine state :failed, got " state))
+      (let [err (rf/compute-sub [:app.boot/error] db)]
+        (assert (some? err)
+                "expected :app.boot/error to be populated on the failure path")))))

--- a/examples/reagent/boot/views.cljs
+++ b/examples/reagent/boot/views.cljs
@@ -1,0 +1,110 @@
+(ns boot.views
+  "Views for the boot example.
+
+   The view tree has two halves split by the boot state:
+
+   1. **Pre-ready** — while the boot machine is in any non-terminal
+      state, the root renders a `[boot-progress]` screen showing the
+      current phase. The main app view is NOT mounted yet — its
+      subscriptions would read empty slices and have to defend
+      against `nil` everywhere.
+
+   2. **Post-ready** — once the boot machine reaches `:ready`, the
+      root swaps in `[main-app]`. The main view freely reads
+      `:config`, `:flags`, `:user`, and `:routes` from app-db; the
+      slices are populated and stable.
+
+   The failure path renders `[boot-failed]` (terminal `:failed`),
+   which surfaces the error and offers a retry button. The retry
+   dispatches `[:app/boot [:rf/start]]` directly back into the boot
+   machine — re-running the boot from `:configuring` is supported
+   per Pattern-Boot §Re-boot semantics (the example treats `:failed`
+   as a re-entrant target rather than terminal-with-reload).
+
+   Why split the views by boot state: the alternative — mount the
+   main app and let each sub-view render a per-phase loading
+   skeleton — scatters boot logic across the whole view tree. The
+   Pattern-Boot canonical shape consolidates that loading state into
+   the boot machine; the views simply read `:app.boot/ready?`.
+
+   The views are intentionally minimal — the goal is to demonstrate
+   the Pattern-Boot shape, not a polished UI."
+  (:require [re-frame.core :as rf]
+            [boot.boot])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+(reg-view ^{:doc "Pre-ready screen — visible while the boot machine
+                  is in any non-terminal state."}
+          boot-progress []
+  (let [state @(subscribe [:app.boot/state])]
+    [:div.boot-progress {:data-testid "boot-progress"}
+     [:h1 "Booting…"]
+     [:p {:data-testid "boot-state"}
+      "Phase: "
+      [:strong (case state
+                 :configuring  "Loading configuration"
+                 :loading-deps "Loading dependencies (routes / flags / user)"
+                 :hydrating    "Hydrating application state"
+                 (str state))]]
+     [:p.boot-hint
+      "The boot machine is at "
+      [:code (str state)]
+      ". The main app view does not mount until the boot reaches "
+      [:code ":ready"] "."]]))
+
+(reg-view ^{:doc "Terminal :failed screen — surfaces the recorded
+                  error and offers a retry."}
+          boot-failed []
+  (let [err @(subscribe [:app.boot/error])]
+    [:div.boot-failed {:data-testid "boot-failed"}
+     [:h1 "Boot failed"]
+     [:p {:data-testid "boot-error"}
+      (if-let [msg (or (:message err)
+                       (some-> (:kind err) name)
+                       (some-> err pr-str))]
+        (str "Reason: " msg)
+        "An unexpected error occurred during application boot.")]
+     [:button {:data-testid "boot-retry"
+               :on-click    #(dispatch [:app/boot [:rf/start]])}
+      "Retry boot"]]))
+
+(reg-view ^{:doc "Post-ready screen — the main app. By the time this
+                  renders, the four boot-loaded slices are populated
+                  in app-db and stable."}
+          main-app []
+  (let [config @(subscribe [:app/config])
+        flags  @(subscribe [:app/flags])
+        user   @(subscribe [:app/user])
+        routes @(subscribe [:app/routes])]
+    [:div.main-app {:data-testid "main-app"}
+     [:h1 {:data-testid "main-title"}
+      (or (:title config) "Boot example")]
+     [:p (str "Welcome, " (:username user) "!")]
+     [:section
+      [:h2 "Loaded configuration"]
+      [:dl
+       [:dt "Environment"]  [:dd {:data-testid "config-env"} (str (:env config))]
+       [:dt "API base"]     [:dd (str (:api-base config))]
+       [:dt "Build"]        [:dd (str (:build config))]]]
+     [:section
+      [:h2 "Feature flags"]
+      [:ul {:data-testid "flags-list"}
+       [:li "dark-mode? "       (str (:dark-mode? flags))]
+       [:li "beta-channel? "    (str (:beta-channel? flags))]
+       [:li "onboarding-skip? " (str (:onboarding-skip? flags))]]]
+     [:section
+      [:h2 "Routes"]
+      [:ul {:data-testid "routes-list"}
+       (for [{:keys [id path]} routes]
+         ^{:key id} [:li (str id " → " path)])]]]))
+
+(reg-view ^{:doc "Root view — switches on the boot machine's state.
+                  This is the only place in the application that
+                  decides whether to mount the main app vs the
+                  boot-progress screen."}
+          root-view []
+  (let [state @(subscribe [:app.boot/state])]
+    (cond
+      (= state :ready)  [main-app]
+      (= state :failed) [boot-failed]
+      :else             [boot-progress])))

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -176,6 +176,16 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'realworld', 'index.html'),
     outDir: path.join(OUT_ROOT, 'realworld'),
   },
+  // Pattern-Boot example (rf2-dsm2). The :app/boot state machine
+  // owns the application's initialisation graph; the example's
+  // four mocked endpoints are served entirely by an in-process
+  // :rf.http/managed canned-success override (no static files
+  // needed).
+  {
+    build: 'examples/boot',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'boot', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'boot'),
+  },
   // Runnable companion to docs/guide/05-state-machines.md.
   {
     build: 'examples/state-machine-walkthrough',

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -1,0 +1,40 @@
+(ns re-frame.boot-cljs-test
+  "Integration test: drives the boot example's headless test
+   fixtures (rf2-dsm2). Each fixture spins a fresh frame via
+   `make-frame`, drives the :app/boot machine through a canonical
+   Pattern-Boot trajectory with canned :rf.http/managed stubs, and
+   asserts the resulting machine state + app-db slices.
+
+   The fixtures live under examples/reagent/boot/test/boot/ —
+   extracted from the production example source so the example's
+   .cljs files stay test-free (mirrors the realworld / nine-states
+   layout).
+
+   Per rf2-am9d this ns uses snapshot/restore via re-frame.test-support
+   so the contract is uniform across CLJS fixtures: the snapshot
+   captures the boot example's ns-load registrations
+   (`:app/boot`, `:boot/loader`, `:app/initialise`, the subs and the
+   demo fxs), and the restore on the way out leaves them intact for
+   any subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]
+            [boot.core]
+            [boot.boot-test :as boot-t]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(deftest boot-machine-progression
+  (testing "happy path: boot machine traverses :configuring → :loading-deps → :hydrating → :ready and all slices land"
+    (boot-t/machine-progression-test)))
+
+(deftest boot-dependency-resolution
+  (testing "per-child :data fns thread spawn-spec identity; no cross-talk between siblings"
+    (boot-t/dependency-resolution-test)))
+
+(deftest boot-failure-path
+  (testing "a failure during the parallel phase routes the boot to :failed and records the error"
+    (boot-t/failure-path-test)))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -65,6 +65,7 @@
                 ;; examples/reagent/.
                 "../examples/reagent"
                 "../examples/reagent/7Guis"
+                "../examples/reagent/boot/test"
                 "../examples/reagent/nine_states/test"
                 "../examples/reagent/realworld/test"
                 "../examples/uix"
@@ -346,6 +347,18 @@
    :output-dir "out/examples/realworld"
    :asset-path "."
    :modules    {:main {:init-fn realworld.core/run}}}
+
+  ;; Pattern-Boot example (rf2-dsm2). Demonstrates the canonical
+  ;; re-frame2 application-boot shape: a single :app/boot state
+  ;; machine owns the initialisation graph (config → parallel
+  ;; dependency loads via :invoke-all → hydrate → :ready); the
+  ;; main view does not mount until the machine reaches :ready.
+  ;; Companion to spec/Pattern-Boot.md.
+  :examples/boot
+  {:target     :browser
+   :output-dir "out/examples/boot"
+   :asset-path "."
+   :modules    {:main {:init-fn boot.core/run}}}
 
   ;; State-machines walkthrough (rf2-vq2s) — companion to docs/guide/05.
   ;; The pure machine + headless tests live in core.cljc; views.cljs is


### PR DESCRIPTION
## Summary

A runnable demonstration of the canonical re-frame2 application-boot shape per `spec/Pattern-Boot.md`. A single `:app/boot` state machine owns the initialisation graph; the main view does not mount until the machine reaches `:ready`.

## Machine shape

```
:idle → :configuring → :loading-deps → :hydrating → :ready
                │             │
                └─────────────┴────────→ :failed
```

- `:configuring` — single `:invoke` fetches `/api/config.json` via a reusable `:boot/loader` child machine.
- `:loading-deps` — `:invoke-all` fans out THREE parallel child loads (routes, flags, user); `:join :all` + `:on-any-failed` short-circuits to `:failed` on any child error.
- `:hydrating` — promotes the staged child payloads from `[:boot/staging ...]` into the top-level slices (`:config` / `:flags` / `:user` / `:routes`).
- `:ready` — terminal; main view mounts.
- `:failed` — terminal with re-entry on `:rf/start` (Pattern-Boot §Re-boot semantics).

The `:boot/loader` child machine is one spec, four instances — distinguished by their `:data` slot, planted via the spawn-spec `:data` fn-form (Pattern-AsyncEffect mechanism 2). Each child fetches via `:rf.http/managed` and, on success, writes its payload into `[:boot/staging <staging-key>]` before dispatching the canonical `:invoke-all` child-completion event back to the parent's `:on-child-done` slot.

### Staging-slot design note

Per Spec 005, the runtime intercepts the parent's `:on-child-done` / `:on-child-error` events for `:invoke-all` join bookkeeping ONLY — they're not fed into the parent's `:on` lookup. The join-resolution event the runtime synthesises (`:on-all-complete [:boot/deps-ready]`) carries no per-child payload. So the canonical Pattern-Boot shape for an `:invoke-all` that needs to thread loaded payloads from children to the parent is a known app-db slot the children write into — explicit, inspectable in re-frame-10x, snapshottable for SSR.

## Files touched

New:
- `examples/reagent/boot/core.cljs` — mount + boot trigger + demo HTTP stubs
- `examples/reagent/boot/boot.cljs` — `:app/boot` machine + `:boot/loader` child
- `examples/reagent/boot/views.cljs` — boot-progress + main-app + failure views
- `examples/reagent/boot/schema.cljs` — Malli schemas
- `examples/reagent/boot/test/boot/boot_test.cljs` — headless tests
- `examples/reagent/boot/index.html`
- `examples/reagent/boot/boot.spec.cjs` — Playwright smoke
- `examples/reagent/boot/README.md`
- `implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs` — integration test aggregator

Modified:
- `implementation/shadow-cljs.edn` — `:examples/boot` build entry + `../examples/reagent/boot/test` on `:source-paths`
- `examples/scripts/serve-and-run-examples-tests.cjs` — boot example added to `EXAMPLES`

## Test plan

- [x] `npm run test:cljs` — 501 tests, 0 failures (3 new in `re-frame.boot-cljs-test`)
- [x] `npm run test:browser` — 503 tests, 0 failures
- [x] `npm run test:examples` — boot smoke passes; all other examples remain green
- [x] `npm run test:elision` — clean
- [x] `shadow-cljs compile examples/boot` — 0 warnings