### PR TITLE
feat(skills): re-frame2 eval harness (rf2-p3qg)

### DIFF
--- a/skills/re-frame2/evals/README.md
+++ b/skills/re-frame2/evals/README.md
@@ -1,0 +1,96 @@
+# `re-frame2` skill — eval harness
+
+This directory holds the evaluation harness for the `re-frame2` authoring skill
+(`skills/re-frame2/SKILL.md` and its leaves). It exists to gate v1.0 of the
+skill: before we publish, every eval here should pass against a fresh Claude
+session loaded with the skill.
+
+## Convention
+
+The harness follows Anthropic's `skill-creator` convention, documented in
+[`anthropics/skills/skills/skill-creator/SKILL.md`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
+and the schema in
+[`anthropics/skills/skills/skill-creator/references/schemas.md`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/references/schemas.md).
+The same shape is described in Anthropic's public best-practices guide:
+[*Skill authoring best practices — Build evaluations first*](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#build-evaluations-first).
+
+A single `evals.json` file holds the eval list. Per Anthropic's schema:
+
+- `skill_name` — must match the skill's frontmatter (`re-frame2`).
+- `evals[]` — one entry per scenario. Each entry has:
+  - `id` — unique integer.
+  - `name` — short kebab-case slug; used as the per-run directory name when
+    the harness is executed.
+  - `prompt` — the user message that exercises the skill.
+  - `expected_output` — a human-readable description of what success looks
+    like (not parsed; it's there to make manual review fast).
+  - `files` — optional list of input files (empty here; every prompt is
+    self-contained).
+  - `expectations` — a list of objectively verifiable statements. The
+    grader (human or scripted) checks each one against the run's output and
+    transcript. This is the field that produces the pass/fail signal.
+
+Two harness extensions on top of the base schema:
+
+- `dimension` — `discovery` | `recipe-correctness` | `routing-correctness`.
+  Lets coverage be measured even when an eval contributes to more than one.
+- `schema_version` — `"1"`. Bump when the eval shape changes in a way that
+  breaks readers.
+
+## Coverage
+
+Six evals, covering the three dimensions the bead called for:
+
+| ID | Name | Dimension | What it probes |
+|---:|---|---|---|
+| 1 | `discovery-no-name-mention-http-lifecycle` | discovery | Prompt mentions ClojureScript / Reagent and a fetch-with-revalidate problem but never says "re-frame2". Does the skill trigger from the description alone, and does the agent produce a Pattern-RemoteData slice with the `:loading` vs `:fetching` split? |
+| 2 | `discovery-state-machine-websocket-lifecycle` | discovery | Prompt mentions a persistent connection with reconnect, backoff, queueing — no skill name. Does the skill trigger, and does the agent load `patterns/websocket.md` + `reference/state-machines/reg-machine.md` and use hierarchical compound state with `:invoke`? |
+| 3 | `recipe-correctness-form-submit-lifecycle` | recipe-correctness | Login-form prompt. Does the output have the 7-key Pattern-Forms slice, the `:touched` ∨ `:submit-attempted?` gating rule, the two-channel error model (structured `:errors` vs transport `:submit-error`), and dual `reg-app-schema` registrations (slice schema + draft-value schema)? |
+| 4 | `recipe-correctness-state-machine-http-region` | recipe-correctness | "Register a state machine for an HTTP request lifecycle." Does the output use `reg-machine` with the five canonical states (`:idle :loading :fetching :loaded :error`), `:tags` for an `:in-flight` query, keyword-referenced actions in the top-level table (inspectability bias), action effect-maps `{:data ...}`, and the `re-frame.machines` artefact require? |
+| 5 | `routing-correctness-v1-migration` | routing-correctness | Prompt is a v1→v2 migration question. Does the agent route to `SKILL-REDIRECT.md` → *Migration from re-frame v1* rather than improvising migration deltas from training memory? |
+| 6 | `routing-correctness-greenfield-scaffold` | routing-correctness | Prompt is "start a new re-frame2 project from scratch". Does the agent defer to the sibling `re-frame2-setup` skill rather than improvising `deps.edn` / `shadow-cljs.edn` from the authoring skill? |
+
+Three is Anthropic's minimum. Six gives two evals per dimension, so any single
+eval can flake without the dimension going dark.
+
+## How to run
+
+The skill-creator workflow ([SKILL.md
+§"Running and evaluating test cases"](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md))
+is the reference. The short version:
+
+1. For each eval, spawn two Claude sessions in parallel:
+   - **with-skill** — `skills/re-frame2/SKILL.md` is loaded.
+   - **baseline** — no skill loaded (just plain Claude).
+2. Capture the agent's response, the tool-call transcript, and any files it
+   produces.
+3. Grade each `expectations[]` entry against the captured output — pass / fail
+   with one-line evidence. Programmatic checks (grep the response for the
+   listed canonical tokens) handle most of them; the routing evals need a
+   short human read of the transcript.
+4. Aggregate into `benchmark.json` per the
+   [skill-creator schema](https://github.com/anthropics/skills/blob/main/skills/skill-creator/references/schemas.md#benchmarkjson)
+   and review the with-skill vs baseline delta. The skill is worth its tokens
+   only if with-skill consistently outperforms baseline on `expectations`
+   pass-rate.
+
+The harness is intentionally tool-agnostic — `evals.json` is just data. Any
+runner that respects the schema works. If we adopt skill-creator's runner
+directly, point it at this directory and the workspace can live alongside
+(`skills/re-frame2-workspace/`) without polluting the skill itself.
+
+## What "pass" means for v1.0
+
+For v1.0 release of `skills/re-frame2/`:
+
+- Every eval's `expectations[]` pass rate ≥ **0.80** with-skill across three
+  runs.
+- The with-skill vs baseline pass-rate delta is **strictly positive** for at
+  least one eval per dimension. (If baseline matches with-skill, the skill is
+  not earning its tokens for that dimension.)
+- No eval shows pathological behaviour (the agent ignoring the skill, hitting
+  a recursion limit, or reading `>3` leaves for a single prompt).
+
+If an eval consistently fails, the fix usually lives in the leaf, not the
+eval — that's the whole point of evaluation-driven development. File a follow-
+up bead against the leaf rather than weakening the assertion.

--- a/skills/re-frame2/evals/evals.json
+++ b/skills/re-frame2/evals/evals.json
@@ -1,0 +1,111 @@
+{
+  "skill_name": "re-frame2",
+  "schema_version": "1",
+  "convention": "anthropics/skills/skill-creator evals.json — per skills/skill-creator/references/schemas.md",
+  "dimensions": [
+    "discovery — does the skill trigger from frontmatter alone on prompts that don't name re-frame2?",
+    "recipe-correctness — does the produced code match the canonical idioms in the relevant leaf (verified by grepping the output for required tokens)?",
+    "routing-correctness — does the agent redirect to SKILL-REDIRECT.md (deep dives, v1 migration) or to the re-frame2-setup skill (greenfield scaffolding) when the prompt calls for it, instead of authoring application source?"
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "name": "discovery-no-name-mention-http-lifecycle",
+      "dimension": "discovery",
+      "prompt": "I'm building a ClojureScript SPA with Reagent. I have a screen that loads a list of articles from /api/articles and re-fetches when the user changes the tag filter. While re-fetching I want to keep the current articles on screen — don't blank the page. How do I structure the state and events for this?",
+      "expected_output": "The agent recognises this as re-frame2 territory from the frontmatter triggers (ClojureScript, Reagent, app-db / events / subs context, fetch-with-revalidate) and consults skills/re-frame2/. It loads patterns/remote-data.md and produces a Pattern-RemoteData slice-form declaration with the :loading vs :fetching split.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked (skill load event observed; or SKILL.md / patterns/remote-data.md is read).",
+        "The output names the re-frame2 reg-* macros explicitly (reg-event-fx for load, reg-event-db for loaded, reg-sub for views).",
+        "The output distinguishes :loading from :fetching as separate status values — uses both keywords and explains the empty-page-spinner vs background-revalidate distinction.",
+        "The output produces a 5-key slice shape matching the canonical declaration: keys include :status, :data, :error, :loaded-at, :attempt (or a clearly equivalent superset).",
+        "The output uses :rf.http/managed (or names the host's HTTP fx surface) — does NOT invent a parallel HTTP layer.",
+        "The output does NOT invoke a separate re-frame v1 reference, nor synthesise its own pattern from first principles."
+      ]
+    },
+    {
+      "id": 2,
+      "name": "discovery-state-machine-websocket-lifecycle",
+      "dimension": "discovery",
+      "prompt": "We've got a real-time dashboard where the browser keeps a persistent connection open to push updates. It needs to handle reconnects with backoff, re-subscribe to topics after reconnect, and queue outgoing messages while disconnected. What's the cleanest way to model this?",
+      "expected_output": "The agent recognises this as a connection-lifecycle prompt (persistent connection, reconnect, backoff, queue) and routes to skills/re-frame2/patterns/websocket.md plus reference/state-machines/reg-machine.md. The produced code uses reg-machine with hierarchical compound state and :invoke for the socket actor.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked.",
+        "The agent reads patterns/websocket.md (or the equivalent canonical pattern leaf), not just SKILL.md.",
+        "The output uses reg-machine (or create-machine-handler) — not a plain reg-event-db slice — to model the connection lifecycle.",
+        "The output declares an :active parent compound state with leaf states (:connecting, :authenticating or similar, :connected) so the socket actor's lifetime spans the parent.",
+        "The output uses :invoke to anchor the socket actor on the parent state, not on a single leaf.",
+        "The output models :reconnecting with backoff via :after (delay) and bumps a retry counter in :data.",
+        "The output does NOT use core.async, manifolds, or any non-re-frame2 reactive primitive."
+      ]
+    },
+    {
+      "id": 3,
+      "name": "recipe-correctness-form-submit-lifecycle",
+      "dimension": "recipe-correctness",
+      "prompt": "Write me a re-frame2 login form. Two fields, email and password. Inline per-field error messages, but errors should only appear after the user blurs the field OR has hit submit. Disable the submit button while a request is in flight. Server can return either a structured field-level error (e.g. password too weak) or a non-field error (e.g. credentials invalid).",
+      "expected_output": "The agent loads patterns/forms.md and produces a Pattern-Forms slice-form declaration. The seven canonical events appear; the :touched / :submit-attempted? gating rule for per-field error visibility is implemented; structured server errors land in :errors and non-field errors in :submit-error (or use the reserved :_form key inside :errors).",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and patterns/forms.md is read.",
+        "The output's form slice has at least these keys: :draft, :status, :errors, :touched, :submit-attempted?, :submit-error — i.e. the canonical 7-key shape (presence test, not exhaustive equality).",
+        "The output's :field-error sub (or equivalent) gates visibility on (or :submit-attempted? (:touched field)) — both touch and submit-attempt are checked.",
+        "The output uses reg-event-fx for :submit and reg-event-db for :edit-field, :blur-field, :submit-success, :submit-error (or equivalent).",
+        "The output distinguishes structured field errors (-> :errors) from non-field / transport failures (-> :submit-error or :_form). The agent acknowledges this two-channel rule explicitly.",
+        "The output registers a reg-app-schema for the slice path AND a separate schema for the form's draft value (two schemas, per the leaf's guidance).",
+        "The output uses :rf.http/managed for the submit fx, with :on-success / :on-failure dispatching the lifecycle events."
+      ]
+    },
+    {
+      "id": 4,
+      "name": "recipe-correctness-state-machine-http-region",
+      "dimension": "recipe-correctness",
+      "prompt": "Register a re-frame2 state machine that drives the lifecycle of an HTTP request to load a popular-tags list. Start :idle, go :loading on first fetch and :fetching on subsequent fetches (keep prior data on screen). On success store the tags. On failure expose the error. Use tags so a view can ask 'is anything in flight right now?' without caring whether it's the first load or a revalidate.",
+      "expected_output": "The agent loads reference/state-machines/reg-machine.md and reference/state-machines/tags.md, and produces a reg-machine declaration with five states (:idle :loading :fetching :loaded :error) and a :tags slot on each state. The :tags/in-flight tag covers both :loading and :fetching. Actions and guards are registered as keyword entries in the top-level lookup tables.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and reference/state-machines/reg-machine.md is read.",
+        "The output calls (rf/reg-machine ...) with a machine-id keyword and a machine-map.",
+        "The machine declares :initial, :data, and :states (or :type :parallel + :regions — but for this prompt :initial + :states is the canonical shape).",
+        "The machine has at least the five canonical states: :idle, :loading, :fetching, :loaded, :error.",
+        "Each in-flight state carries a :tags set that includes a shared 'in-flight'-style tag (e.g. :tags/in-flight) so a single has-tag? query answers 'anything in flight?'.",
+        "Actions are registered as keyword entries in the top-level :actions map and referenced by keyword from transitions (not exclusively inlined as anonymous fns) — the inspectability bias.",
+        "Action functions return an effect-shaped map {:data ...} (and/or {:fx ...}) — not a bare data map.",
+        "The output requires re-frame.machines at the namespace top (the artefact load-hook) OR notes that requirement.",
+        "The output uses neither :rf/* nor :rf.machine/* keyword namespaces for application event names — those are reserved."
+      ]
+    },
+    {
+      "id": 5,
+      "name": "routing-correctness-v1-migration",
+      "dimension": "routing-correctness",
+      "prompt": "I've got a 6-year-old re-frame v1 application. We use re-frame-http-fx, re-frame-async-flow-fx, and a lot of reg-event-db with named interceptors. We want to migrate to re-frame2. Walk me through the migration — what changes, what breaks, what the equivalents are.",
+      "expected_output": "This is migration, not authoring. The agent does NOT write fresh re-frame2 application code in response. Instead it routes the user to SKILL-REDIRECT.md — specifically the 'Migration from re-frame v1' pointer — and consults that doc rather than trying to derive v1→v2 deltas from memory.",
+      "files": [],
+      "expectations": [
+        "The agent does NOT produce a wall of new re-frame2 source code as the primary response.",
+        "The agent points the user at SKILL-REDIRECT.md (or the migration guide URL it carries) for the v1→v2 deltas.",
+        "The agent does NOT re-derive the v1 surface from training memory — it acknowledges that v1→v2 drift makes confident recall unreliable.",
+        "If the agent surfaces specific v2 equivalents for re-frame-http-fx and re-frame-async-flow-fx, it cites them from the redirect target or the relevant pattern leaf (:rf.http/managed, Pattern-AsyncEffect, machines+:invoke) — not from invented memory.",
+        "The agent does NOT load the re-frame2-setup skill (this is a migration, not a greenfield scaffold)."
+      ]
+    },
+    {
+      "id": 6,
+      "name": "routing-correctness-greenfield-scaffold",
+      "dimension": "routing-correctness",
+      "prompt": "I want to start a brand new re-frame2 project from scratch. Empty directory. Set me up — deps.edn, shadow-cljs config, the artefact dependencies, a minimal index.html, the namespace skeleton, and a hello-world view.",
+      "expected_output": "This is project scaffolding, not application authoring. The agent does NOT improvise a deps.edn / shadow-cljs.edn / package.json from inside the re-frame2 skill. It defers to the sibling skill re-frame2-setup, which owns the scaffolding recipe.",
+      "files": [],
+      "expectations": [
+        "The agent recognises this as outside the re-frame2 skill's scope (the 'When NOT to use this skill' table in SKILL.md sends greenfield setup to re-frame2-setup).",
+        "The agent either (a) invokes / hands off to the re-frame2-setup skill, OR (b) explicitly tells the user that skills/re-frame2-setup/ is the right surface for this and does not improvise the scaffold.",
+        "The agent does NOT write a deps.edn or shadow-cljs.edn from scratch out of the re-frame2 skill body.",
+        "The agent does NOT read or cite re-frame v1 setup conventions (lein, re-frame-template) as if they applied — re-frame2 is the v2 line.",
+        "If the agent does sketch any scaffold while handing off, it correctly names the artefact coordinates (day8/re-frame2, day8/re-frame2-machines for state machines) rather than re-frame v1 coordinates."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Authors `skills/re-frame2/evals/` — the evaluation harness for the
`re-frame2` authoring skill. **BLOCKS v1.0** release of the skill: all
nine leaf beads (PRs #312-#321) have merged, but Anthropic's
[best-practices guide](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#build-evaluations-first)
calls for ≥3 evals per skill, and the v2 §9 #10 design entry
gated v1.0 on this harness.

## Eval shape adopted

Anthropic's `skill-creator` convention — `evals/evals.json` with
`skill_name` + `evals[]` where each eval carries `id`, `name`, `prompt`,
`expected_output`, `files`, `expectations[]`. Schema sourced from
[`anthropics/skills/skill-creator/references/schemas.md`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/references/schemas.md)
and matches the data-driven format documented in the platform docs.

Two harness extensions on top of the base schema:

- `dimension` — `discovery` | `recipe-correctness` | `routing-correctness`,
  so coverage stays measurable even when a single eval contributes to
  more than one.
- `schema_version: "1"` — bump when the shape changes.

## Evals authored (six — exceeds the three-eval minimum)

| ID | Name | Dimension | What it covers |
|---:|---|---|---|
| 1 | `discovery-no-name-mention-http-lifecycle` | discovery | Prompt never names re-frame2 but describes fetch-with-revalidate against `/api/articles`. Verifies the skill triggers from frontmatter alone and produces a Pattern-RemoteData slice with the `:loading` vs `:fetching` split. |
| 2 | `discovery-state-machine-websocket-lifecycle` | discovery | Prompt describes a persistent connection lifecycle without naming re-frame2 or state machines. Verifies the skill triggers and the agent uses `reg-machine` with hierarchical compound state + `:invoke` for the socket actor. |
| 3 | `recipe-correctness-form-submit-lifecycle` | recipe-correctness | Login-form prompt. Verifies the 7-key Pattern-Forms slice, the `:touched` ∨ `:submit-attempted?` per-field gating rule, the two-channel error model (structured `:errors` vs transport `:submit-error`), and dual `reg-app-schema` registrations. |
| 4 | `recipe-correctness-state-machine-http-region` | recipe-correctness | "Register a state machine for an HTTP request lifecycle." Verifies five canonical states, the shared `:in-flight` tag, keyword-referenced actions in the top-level lookup table (inspectability bias), action effect-maps, and the `re-frame.machines` artefact require. |
| 5 | `routing-correctness-v1-migration` | routing-correctness | v1→v2 migration question. Verifies the agent routes to `SKILL-REDIRECT.md` → *Migration from re-frame v1* rather than improvising v1→v2 deltas from training memory. |
| 6 | `routing-correctness-greenfield-scaffold` | routing-correctness | "Start a brand new re-frame2 project from scratch." Verifies the agent defers to the sibling `re-frame2-setup` skill instead of improvising `deps.edn` / `shadow-cljs.edn` from the authoring skill's body. |

All three required dimensions are covered with two evals each, so any
single eval can flake without the dimension going dark.

## BLOCKS v1.0

This is the last gate listed against the v1.0 release of
`skills/re-frame2/`. With this PR merged, the only remaining
v1.0 work is the integration pass (rf2-l086) that wires the eval
harness into the loading map in SKILL.md.

## Hot-zone awareness

Touches `skills/re-frame2/evals/` only. No overlap with rf2-l086 (the
integration pass that owns SKILL.md's loading map), rf2-s36l, rf2-yf97,
or rf2-dsm2. If SKILL.md needs to reference the evals from its loading
map, that's the integration pass's job and warrants its own follow-up.

## Test plan

- [x] `evals.json` is valid JSON; six evals; all three dimensions covered.
- [x] No source code touched (`implementation/**` untouched).
- [x] No test code touched.
- [x] Skills live outside `docs_dir: docs`, so `mkdocs build --strict` is unaffected.
- [x] `SKILL.md` not modified — that's the integration pass's surface.
- [ ] (Follow-up, not blocking this PR) Run the harness against a fresh
      Claude session loaded with the skill; benchmark with-skill vs
      baseline; review per the criteria in `evals/README.md`.