### PR TITLE
fix(test): stabilise destroy-frame-discards-pending-events flake (rf2-iosc)

### DIFF
--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -86,18 +86,29 @@
   (testing "events queued via async dispatch are not processed once the frame is destroyed"
     (rf/reg-frame :worker {:doc "worker frame"})
     (let [side-effects (atom 0)
-          traces       (atom [])]
+          traces       (atom [])
+          ;; rf2-iosc: async dispatch schedules a drain via interop/next-tick
+          ;; on a single-thread executor. On the JVM that drain can race the
+          ;; main thread — the executor sometimes fires between the two
+          ;; dispatches (or between dispatch and the queue read), draining
+          ;; one or both events before the assertion runs. That made this
+          ;; test flake under load (~1/200 runs in isolation, reliably
+          ;; 1-in-N on CI). We deterministically suppress the drain by
+          ;; intercepting next-tick for the lifetime of the enqueue +
+          ;; queue-read, matching the same with-redefs pattern used by
+          ;; `drain-after-destroy-does-not-npe` below.
+          captured-ticks (atom [])]
       (rf/reg-event-db :tick (fn [db _] (swap! side-effects inc) db))
-      ;; Async dispatch enqueues without draining synchronously — the
-      ;; drain runs on the next tick. Destroy before that tick fires.
       (rf/register-trace-cb! ::pending (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch [:tick] {:frame :worker})
-      (rf/dispatch [:tick] {:frame :worker})
-      ;; Without draining, the queue holds the pending events.
-      (let [router (:router (frame/frame :worker))
-            queue  (:queue @router)]
-        (is (= 2 (count queue))
-            "two events are queued and have NOT yet been processed"))
+      (with-redefs [interop/next-tick (fn [f] (swap! captured-ticks conj f) nil)]
+        (rf/dispatch [:tick] {:frame :worker})
+        (rf/dispatch [:tick] {:frame :worker})
+        ;; With the drain captured (never run), the queue deterministically
+        ;; holds both pending events.
+        (let [router (:router (frame/frame :worker))
+              queue  (:queue @router)]
+          (is (= 2 (count queue))
+              "two events are queued and have NOT yet been processed")))
       ;; Destroy the frame. Per Spec 002 §Destroy: pending events drain
       ;; or get discarded; either way they MUST NOT corrupt state on a
       ;; gone frame, and any later attempt to dispatch traces


### PR DESCRIPTION
## Summary

`re-frame.frame-lifecycle-test/destroy-frame-discards-pending-events` is a
recurring flake: expected 2 events in the queue, occasionally 1 (or 0).
Observed on at least #305, #312, #322 in the last 24 hours.

## Root cause

Async `dispatch` schedules the drain via `interop/next-tick`, which on the
JVM posts onto a single-thread executor. The test's queue-read happens on
the main thread immediately after the two dispatches:

```clj
(rf/dispatch [:tick] {:frame :worker})
(rf/dispatch [:tick] {:frame :worker})
(let [router (:router (frame/frame :worker))
      queue  (:queue @router)]
  (is (= 2 (count queue)) ...))
```

If the executor's `drain!` runs between the two dispatches (or between
the second dispatch and the read), it pops one or both events before the
assertion fires. The race is sensitive to JIT state, GC, and thread
scheduling — rare in isolation, more common under CI's mixed workload.

## Fix

Wrap the dispatch + queue-read in `(with-redefs [interop/next-tick ...])`
so the drain thunk is captured into a local atom and never executed for
the lifetime of the assertion. The queue then deterministically holds
both pending events.

This is the exact pattern already used by `drain-after-destroy-does-not-npe`
in the same file (introduced by the rf2-ft2b fix) — there it captures the
next-tick callback to deterministically force the post-destroy drain race;
here we capture it to deterministically forbid the pre-destroy drain race.

Test-only change. No production source modified.

## Stability evidence

Before the fix, reproduced 5/1000 iterations locally inside a tight
`(test-vars ...)` loop with the full `reset-runtime` fixture overhead.
Failure shape matches CI: `expected (= 2 ...) actual (not (= 2 1))`.

After the fix:

```
$ for i in $(seq 1 50); do clojure -M:test -n re-frame.frame-lifecycle-test; done
# 50 iterations, 0 failures
```

```
$ # 1000-iteration tight loop with reset-runtime fixture invoked per iter
Running 1000 iterations of destroy-frame-discards-pending-events...
Failures: 0 / 1000
```

Full JVM suite (`clojure -M:test`): **183 tests, 824 assertions, 0 failures, 0 errors**.
Full CLJS suite (`npm run test:cljs`): **506 tests, 1242 assertions, 0 failures, 0 errors**.

## Before / after behaviour

- The test still asserts the same three things: (1) two events accumulate
  in the queue before destroy, (2) `destroy-frame` removes the frame, and
  (3) a post-destroy dispatch traces `:rf.error/frame-destroyed`.
- The only behavioural change is *how* the test reaches the queue-read:
  before, by hoping the executor hadn't fired yet; after, by guaranteeing
  it can't.

Closes rf2-iosc.