### PR TITLE
feat(examples): websocket — canonical Pattern-WebSocket example app (rf2-yf97)

### DIFF
--- a/examples/reagent/websocket/README.md
+++ b/examples/reagent/websocket/README.md
@@ -1,0 +1,84 @@
+# Pattern-WebSocket in re-frame2
+
+> **Canonical worked example.** This is the runnable example for [`spec/Pattern-WebSocket.md`](../../../spec/Pattern-WebSocket.md). It exercises the canonical connection-machine shape — hierarchical compound `:active` parenting `:connecting` / `:authenticating` / `:connected`, an `:invoke`d socket actor whose lifetime is bound to `:active`, `:after` exponential backoff, `:always` queue-flush on `:connected` entry, `:fsm/tags` for queryable connection-state predicates, and connection-epoch staleness via `:current-socket?` against the live `:socket-id`. Pattern-WebSocket §The connection state machine is the normative description; this example is its runnable form.
+
+## What this example demonstrates
+
+- **Hierarchical compound `:active`** parenting `:connecting`, `:authenticating`, `:connected`. The socket-actor `:invoke` is anchored on `:active` so it survives the success-path leaf transitions (`:connecting` → `:authenticating` → `:connected`) without re-spawning.
+- **`:invoke` socket actor (`:websocket/socket`)**, whose lifetime is bound to `:active`. Exit-from-`:active` (to `:reconnecting` or `:failed` or `:disconnected`) destroys the actor; re-entry spawns a fresh one. The actor owns the host-side `WebSocket`-shaped reference via a private store keyed by `:rf/self-id`; only the id ever appears in `:data`.
+- **`:after` exponential backoff** on `:reconnecting` — `(fn [snap] (min (* base-ms (Math/pow 2 retries)) max-backoff-ms))`. The `:after`-epoch invariant handles stale timers from prior `:reconnecting` visits.
+- **`:always` cascades** — `:reconnecting`'s `:max-retries-exceeded?` guard transitions straight to `:failed`; `:connected`'s `:has-queued-messages?` guard fires `:flush-queue` on entry.
+- **`:fsm/tags`** — `:websocket/connected`, `:websocket/reconnecting`, `:websocket/failed`, `:websocket/active`, `:websocket/connecting`, `:websocket/authenticating`. The view reads `rf/has-tag?` rather than unfolding the snapshot's hierarchical `:state` vector.
+- **Connection-epoch staleness** — Pattern-StaleDetection composed against the live `:socket-id` (the gensym'd actor address). The `:current-socket?` guard rejects `:ws/received` from a socket that has since been replaced, and similarly suppresses stale `:ws/request-timeout` events.
+- **Request/reply correlation** — `:in-flight` map keyed by request-id; `:register-request` stamps the id onto the body, schedules a `:dispatch-later` timeout, and routes the body to the actor; the inbound `:ws/received` correlated by id clears the slot + dispatches the registered reply event.
+- **Reconnect-cascade** — `:exit` on `:active` clears `:socket-id`; the runtime destroys the actor automatically (declarative `:invoke`'s desugar emits `:rf.machine/destroy` on exit). Re-entering `:active` after the `:after` backoff spawns a fresh actor; the `:invoke`'s `:data` fn re-reads URL + token from `:data` at each entry, so a `:ws/refresh-token` between reconnects flows in without extra wiring.
+- **Offline queue + drain on reconnect** — `:ws/send` while disconnected enqueues in `:data :queue`; the `:connected` state's `:always` cascade flushes the queue on entry.
+- **Subscription tracking** — `:ws/subscribe` records the topic in `:data :subscriptions` (a set); on every `:connected` entry the `:flush-queue-and-resubscribe` action re-issues subscribe messages for every tracked topic, so subscriptions survive reconnects.
+
+## Files
+
+| File | Notes |
+|---|---|
+| `core.cljs` | Entry point — mounts the React root, runs `:app/initialise`. |
+| `connection.cljs` | The `:ws/connection` machine — the heart of the example. Read alongside `spec/Pattern-WebSocket.md` §Worked example — the shapes are identical. |
+| `messages.cljs` | The `:websocket/socket` actor (the spawned child) + an in-process mock WebSocket server + `:ws/handle-message` + the app-level send/request/subscribe events. |
+| `views.cljs` | UI — status pill driven by tags, lifecycle buttons, send form, request/subscribe/server-push demo trio, inbox. |
+| `schema.cljs` | Malli schemas for the connection-machine snapshot, the `:data` slice, and the `[:messages]` slice. |
+| `index.html` | Minimal harness. |
+| `websocket.spec.cjs` | Playwright smoke — drives the connect / request-reply / server-push / drop-and-reconnect path. |
+| `test/websocket/connection_test.cljs` | Headless tests: initial state, happy-path lifecycle, offline-queue + drain, reconnect cascade, max-retries → `:failed`, connection-epoch staleness, `:ws/refresh-token`, clean `:ws/disconnect`. |
+| `test/websocket/messages_test.cljs` | Headless tests: request-reply correlation, server-push routing, subscription tracking, `[:messages :received]` newest-first invariant. |
+
+## Mock WebSocket server
+
+The example ships with a tiny in-process `WebSocket`-shaped stub in `messages.cljs`. It supports:
+
+- **Auto-echo for `:request` messages** — every outbound `{:type :request ...}` immediately echoes back as `{:type :reply :request-id ... :ok true :echo ...}`, so the request-reply correlation slot lights up.
+- **Auth ack** — `{:type :auth :token ...}` produces `{:type :auth-ok}` for any non-empty token and `{:type :auth-failed :reason "Empty token"}` otherwise.
+- **Subscribe ack** — every `{:type :subscribe :topic ...}` is acked with one synthetic `{:type :push :topic ... :note "subscribed"}` so the example demonstrates the subscribe-then-push shape end-to-end.
+- **`messages/send-server-push!`** — used by the "Trigger server push" button (and the Playwright spec) to deliver a manual server-pushed event.
+- **`messages/simulate-disconnect!`** — used by the "Drop connection" button to force every live mock socket closed, triggering the reconnect cascade.
+
+The mock has two delivery modes — async via `setTimeout(_, 0)` (default, used by the browser) and sync (used by the headless tests via `messages/set-mock-sync!`) so `dispatch-sync` observes the full request/reply round-trip without yielding to the JS event loop.
+
+**Production swap-out:** replace `mock-socket-for-actor` with a real `(js/WebSocket. url)` and wire its `onopen` / `onmessage` / `onerror` / `onclose` to the same actor-level dispatches. The connection machine — and every test against it — does not change.
+
+## Architecture references
+
+- [`spec/Pattern-WebSocket.md`](../../../spec/Pattern-WebSocket.md) — the normative pattern (this example's spec).
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — hierarchical states, `:after`, `:always`, `:invoke`, `:fsm/tags`.
+- [`spec/Pattern-StaleDetection.md`](../../../spec/Pattern-StaleDetection.md) — composed twice (backoff timer + connection epoch).
+- [`spec/Pattern-AsyncEffect.md`](../../../spec/Pattern-AsyncEffect.md) — distinct but adjacent; individual request-reply messages over the open socket fit Pattern-AsyncEffect (the open connection acts as the fx).
+
+## How to run
+
+The example is wired into the canonical examples harness. From `implementation/`:
+
+```bash
+npm run test:examples
+```
+
+That compiles every example (this one builds under shadow-cljs id `examples/websocket`), stages its `index.html` into `out/examples/websocket/`, serves the lot on port 8030, and runs [`websocket.spec.cjs`](websocket.spec.cjs) against it.
+
+To iterate on the source alone, watch the build directly from `implementation/`:
+
+```bash
+shadow-cljs watch examples/websocket
+# then visit http://127.0.0.1:8030/websocket/ once the harness is running
+```
+
+## Headless tests
+
+The headless tests are pure-CLJS browserless fixtures. They live alongside the sources at `test/websocket/<feature>_test.cljs`, mirroring the realworld layout.
+
+| Source ns | Test ns |
+|---|---|
+| `websocket.connection` | `websocket.connection-test` |
+| `websocket.messages`   | `websocket.messages-test`   |
+
+The tests are wired into the framework's CLJS test run via `re-frame.websocket-cljs-test` under `implementation/adapters/reagent/test/re_frame/`, which wraps each fixture in a `testing` block under a single `deftest`.
+
+```bash
+cd implementation
+npm run test:cljs
+```

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -1,0 +1,391 @@
+(ns websocket.connection
+  "The `:ws/connection` connection machine — the canonical Pattern-WebSocket
+   worked example (rf2-yf97).
+
+   This is a faithful realisation of `spec/Pattern-WebSocket.md` §Worked
+   example. The hierarchy is:
+
+     :disconnected
+     :active                              ;; compound parent; owns the socket
+       :connecting
+       :authenticating
+       :connected
+     :reconnecting                        ;; :after backoff
+     :failed                              ;; terminal until manual :ws/connect
+
+   Why parallel-regions when this looks linear? Pattern-WebSocket §The
+   connection state machine lists three orthogonal axes — the connection
+   lifecycle, the subscription/request bookkeeping, and the live-socket
+   identity. The subscription set + the in-flight map + the queue all
+   share *one* domain (this connection), so the **shared-:data + compound
+   `:active`** shape is the right one here. (For a small example with
+   independent regions, see `examples/reagent/nine_states/` — Pattern-
+   NineStates' canonical worked example.)
+
+   `:fsm/tags` carry the queryable connection-state predicates — the view
+   asks `:websocket/connected?` and `:websocket/reconnecting?` via
+   `rf/has-tag?` without needing to know which leaf carries the
+   `:connected` intent.
+
+   Pattern-StaleDetection composes in twice:
+
+     1. `:after` backoff — the runtime's built-in `:after`-epoch
+        invariant drops stale timers from prior `:reconnecting` visits.
+
+     2. Connection epoch — the live `:socket-id` IS the epoch; the
+        `:current-socket?` guard rejects `:ws/received` from a
+        socket that has since been replaced (a slow `:message` event
+        landing post-reconnect).
+
+   The socket actor itself — the thing that owns the JS WebSocket — is
+   `:websocket/socket`, declared in `websocket.messages`. The connection
+   machine invokes it at the `:active` parent level so the actor's
+   lifetime spans `:connecting` → `:authenticating` → `:connected`
+   without re-spawning."
+  (:require [re-frame.core :as rf]
+            ;; `re-frame.machines` ships in day8/re-frame2-machines.
+            ;; Loading the ns publishes the late-bind hooks for
+            ;; `rf/create-machine-handler`, the `:rf.machine/spawn` /
+            ;; `:rf.machine/destroy` fx, and the `:rf/machine` /
+            ;; `:rf/machine-has-tag?` framework subs.
+            [re-frame.machines :as machines]
+            [re-frame.fx]
+            [websocket.schema]))
+
+;; ============================================================================
+;; CONNECTION MACHINE — :ws/connection
+;; ============================================================================
+;;
+;; Read this side-by-side with spec/Pattern-WebSocket.md §Worked example
+;; — connection machine. The structural choices are documented there;
+;; this file is a runnable, app-shaped version that the views can
+;; drive.
+
+(def connection-machine
+  "Spec for the `:ws/connection` machine. Held in a `def` so the handler
+   can be re-built via `create-machine-handler` from inside the
+   `register-all!` re-registration helper."
+    {:initial :disconnected
+
+     ;; Pattern-WebSocket §Worked example — the connection machine's
+     ;; `:data` carries everything that must survive across reconnects.
+     :data    {:url            nil
+               :auth-token     nil
+               :retries        0
+               :max-retries    8
+               :base-ms        100
+               :max-backoff-ms 5000
+               :socket-id      nil
+               :subscriptions  #{}
+               :queue          []
+               :in-flight      {}
+               :error          nil}
+
+     :guards
+     {:max-retries-exceeded?
+      (fn guard-max-retries-exceeded? [data _event]
+        (>= (:retries data) (:max-retries data)))
+
+      :has-queued-messages?
+      (fn guard-has-queued-messages? [data _event]
+        (seq (:queue data)))
+
+      :current-socket?
+      ;; Pattern-WebSocket §The connection state machine — the
+      ;; **connection-epoch** check. The incoming event carries
+      ;; `:source-socket-id` (the spawned actor's `:rf/self-id`);
+      ;; we drop the event unless that id matches the live socket.
+      (fn guard-current-socket? [data [_ {:keys [source-socket-id]}]]
+        (and (some? (:socket-id data))
+             (= source-socket-id (:socket-id data))))}
+
+     :actions
+     {:record-connection-opts
+      (fn action-record-connection-opts [data [_ {:keys [url auth-token]}]]
+        {:data (-> data
+                   (assoc :url url)
+                   (assoc :auth-token auth-token)
+                   (assoc :error nil))})
+
+      :record-and-reset
+      ;; Compound action — record fresh opts AND zero the retry counter.
+      ;; Used on manual `:ws/connect` from `:reconnecting` / `:failed`.
+      (fn action-record-and-reset [data [_ {:keys [url auth-token]}]]
+        {:data (-> data
+                   (assoc :url url)
+                   (assoc :auth-token auth-token)
+                   (assoc :retries 0)
+                   (assoc :error nil))})
+
+      :refresh-token
+      (fn action-refresh-token [data [_ token]]
+        {:data (assoc data :auth-token token)})
+
+      :bump-retry
+      (fn action-bump-retry [data _]
+        {:data (update data :retries inc)})
+
+      :reset-retries
+      (fn action-reset-retries [data _]
+        {:data (assoc data :retries 0)})
+
+      :record-error
+      (fn action-record-error [data [_ {:keys [error]}]]
+        {:data (assoc data :error error)})
+
+      :send-auth
+      ;; Entry action for `:authenticating` — route an `:auth` message
+      ;; into the live socket actor.
+      (fn action-send-auth [data _]
+        {:fx [[:dispatch [(:socket-id data)
+                          [:send {:type  :auth
+                                  :token (:auth-token data)}]]]]})
+
+      :flush-queue-and-resubscribe
+      ;; Entry action for `:connected`. Two jobs:
+      ;;   (1) re-issue subscribe messages for every tracked topic
+      ;;       (subscriptions survive reconnects);
+      ;;   (2) flush every message buffered while disconnected.
+      ;; The state machine's `:on-connected` from the spec is split
+      ;; this way for readability — the `:always` guarded transition
+      ;; reads the post-action `:queue`, so this action only handles
+      ;; the resubscribe + retry-reset side; the queue-flush side
+      ;; rides on the `:always` cascade below.
+      (fn action-on-connected [data _]
+        {:data (assoc data :retries 0)
+         :fx   (mapv (fn [topic]
+                       [:dispatch [(:socket-id data)
+                                   [:send {:type :subscribe :topic topic}]]])
+                     (:subscriptions data))})
+
+      :flush-queue
+      ;; Per the spec's `:always` cascade on `:connected`: when the
+      ;; entry leaves the queue non-empty, walk it onto the wire and
+      ;; clear it.
+      (fn action-flush-queue [data _]
+        (let [q (:queue data)]
+          {:data (assoc data :queue [])
+           :fx   (mapv (fn [msg]
+                         [:dispatch [(:socket-id data) [:send msg]]])
+                       q)}))
+
+      :enqueue-message
+      (fn action-enqueue-message [data [_ msg]]
+        {:data (update data :queue conj msg)})
+
+      :send-now
+      ;; `:connected`-leaf override of the parent's `:ws/send`: the
+      ;; message goes straight to the wire instead of queueing.
+      (fn action-send-now [data [_ msg]]
+        {:fx [[:dispatch [(:socket-id data) [:send msg]]]]})
+
+      :register-subscription
+      (fn action-register-subscription [data [_ topic]]
+        {:data (update data :subscriptions conj topic)
+         :fx   [[:dispatch [(:socket-id data)
+                            [:send {:type :subscribe :topic topic}]]]]})
+
+      :register-request
+      ;; Caller: `[:ws/connection [:ws/request {:request-id ... :body ...
+      ;;                                       :reply ... :timeout-ms ...}]]`
+      ;; Record the in-flight entry, forward to the socket, schedule
+      ;; a timeout.
+      (fn action-register-request [data [_ {:keys [request-id body reply timeout-ms]
+                                            :or   {timeout-ms 30000}}]]
+        {:data (assoc-in data [:in-flight request-id]
+                         {:reply-event reply :timeout-ms timeout-ms})
+         :fx   [[:dispatch [(:socket-id data)
+                            [:send (assoc body :request-id request-id)]]]
+                ;; The timeout event carries the live socket-id; the
+                ;; `:current-socket?` guard drops stale timeouts from
+                ;; a prior connection epoch.
+                [:dispatch-later
+                 {:ms       timeout-ms
+                  :dispatch [:ws/connection
+                             [:ws/request-timeout
+                              {:request-id       request-id
+                               :source-socket-id (:socket-id data)}]]}]]})
+
+      :clear-request
+      (fn action-clear-request [data [_ {:keys [request-id]}]]
+        {:data (update data :in-flight dissoc request-id)})
+
+      :receive-message
+      ;; `:ws/received` arrived; the `:current-socket?` guard already
+      ;; cleared us. Branch on `:request-id` in the body: correlated
+      ;; reply → dispatch the registered reply event + clear the slot;
+      ;; server push → dispatch `[:ws/handle-message body]`.
+      (fn action-receive-message [data [_ {:keys [body]}]]
+        (if-let [rid (:request-id body)]
+          (let [{:keys [reply-event]} (get-in data [:in-flight rid])]
+            {:data (update data :in-flight dissoc rid)
+             :fx   (cond-> [[:dispatch [:ws/handle-message body]]]
+                     reply-event (conj [:dispatch (conj reply-event body)]))})
+          {:fx [[:dispatch [:ws/handle-message body]]]}))}
+
+     :states
+     {:disconnected
+      {:on {:ws/connect {:target :active
+                         :action :record-connection-opts}
+            :ws/send    {:action :enqueue-message}
+            :ws/request {:action :enqueue-message}}}
+
+      :active
+      {;; The socket actor is invoked at the parent level — its
+       ;; lifetime spans :connecting → :authenticating → :connected.
+       ;; Any transition that leaves :active destroys it.
+       :invoke {:machine-id :websocket/socket
+                ;; Mechanism 2 from Pattern-AsyncEffect §Parameter
+                ;; passing — the child reads URL + auth-token from
+                ;; the parent's :data at spawn time. Every re-entry
+                ;; to :active picks up whatever is current.
+                :data       (fn [snap _]
+                              {:url        (-> snap :data :url)
+                               :auth-token (-> snap :data :auth-token)})
+                ;; Record the spawned actor id so subsequent dispatches
+                ;; and :current-socket? checks have a value to compare.
+                :on-spawn   (fn [data id]
+                              (assoc data :socket-id id))}
+
+       ;; Exit cascade — clear the stale :socket-id from :data. The
+       ;; runtime destroys the actor automatically (declarative :invoke's
+       ;; desugar emits :rf.machine/destroy on exit); this keeps :data
+       ;; tidy so :current-socket? compares against nil correctly.
+       :exit (fn action-clear-socket-id [data _]
+               {:data (assoc data :socket-id nil)})
+
+       ;; Parent-level transitions inherited by every leaf, per Spec 005
+       ;; §Transition resolution — deepest-wins with parent fallthrough.
+       :on    {:ws/closed   {:target :reconnecting
+                             :action :bump-retry}
+               :ws/fatal    {:target :failed
+                             :action :record-error}
+               :ws/send     {:action :enqueue-message}
+               :ws/request  {:action :enqueue-message}
+               :ws/refresh-token {:action :refresh-token}
+               :ws/disconnect {:target :disconnected}
+               ;; Subscribe-while-connecting just records the intent;
+               ;; the next :connected entry will re-issue.
+               :ws/subscribe {:action (fn [data [_ topic]]
+                                        {:data (update data :subscriptions conj topic)})}}
+
+       :initial :connecting
+
+       :states
+       {:connecting
+        {:tags #{:websocket/active :websocket/connecting}
+         :on   {:ws/opened {:target :authenticating}}}
+
+        :authenticating
+        {:tags  #{:websocket/active :websocket/authenticating}
+         :entry :send-auth
+         :on    {:ws/auth-ok     {:target :connected}
+                 :ws/auth-failed {:target :failed
+                                  :action :record-error}}}
+
+        :connected
+        {:tags   #{:websocket/active :websocket/connected}
+         :entry  :flush-queue-and-resubscribe
+         :always [{:guard :has-queued-messages? :action :flush-queue}]
+         :on     {:ws/received {:guard  :current-socket?
+                                :action :receive-message}
+                  ;; Override the parent's :ws/send — while :connected
+                  ;; the message goes straight to the wire.
+                  :ws/send     {:action :send-now}
+                  :ws/request  {:action :register-request}
+                  :ws/subscribe {:action :register-subscription}
+                  :ws/request-timeout {:guard  :current-socket?
+                                       :action :clear-request}}}}}
+
+      :reconnecting
+      {:tags   #{:websocket/reconnecting}
+       :always [{:guard :max-retries-exceeded? :target :failed}]
+       ;; Exponential backoff, computed at state entry from the current
+       ;; retry count. Spec 005 §Value shape — fn-form delay called
+       ;; once at entry. The :after epoch invariant guarantees a
+       ;; transition out makes the in-flight backoff stale.
+       :after  {(fn delay-backoff-ms [snap]
+                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
+                    (min (* base-ms (Math/pow 2 retries))
+                         max-backoff-ms)))
+                {:target :active}}
+       :on     {:ws/connect       {:target :active
+                                   :action :record-and-reset}
+                :ws/send          {:action :enqueue-message}
+                :ws/request       {:action :enqueue-message}
+                :ws/refresh-token {:action :refresh-token}
+                :ws/disconnect    {:target :disconnected
+                                   :action :reset-retries}}}
+
+      :failed
+      {:tags #{:websocket/failed}
+       :on   {:ws/connect       {:target :active
+                                 :action :record-and-reset}
+              :ws/refresh-token {:action :refresh-token}
+              :ws/disconnect    {:target :disconnected
+                                 :action :reset-retries}}}}})
+
+;; ============================================================================
+;; SUBSCRIPTIONS + INIT EVENT + MACHINE HANDLER
+;; ============================================================================
+;;
+;; All the `reg-*` calls are inside `register-all!` so the test fixture
+;; can re-fire them after an upstream `clear-all!` wiped the registrar
+;; (see `websocket.core/register-all!` for context). At ns-load the
+;; function is called once via the trailing `(register-all!)` form.
+
+(defn register-all!
+  "Idempotent re-registration of every event handler / sub this ns
+   owns. See `websocket.core/register-all!`."
+  []
+  ;; Use `rf/reg-machine` (not `reg-event-fx` + `create-machine-handler`)
+  ;; so the registration metadata carries `:rf/machine? true` —
+  ;; declarative `:invoke` resolves the spawn target via this
+  ;; metadata, and without it the spawn-fx silently no-ops (the
+  ;; spawned actor's handler never registers, and its snapshot is
+  ;; never written).
+  (rf/reg-machine :ws/connection connection-machine)
+
+  ;; --- subs ---------------------------------------------------------
+  (rf/reg-sub :ws/snapshot
+    (fn [db _] (get-in db [:rf/machines :ws/connection])))
+
+  (rf/reg-sub :ws/state
+    :<- [:ws/snapshot]
+    (fn [snap _] (:state snap)))
+
+  (rf/reg-sub :ws/connected?
+    :<- [:ws/snapshot]
+    (fn [snap _] (contains? (:tags snap) :websocket/connected)))
+
+  (rf/reg-sub :ws/reconnecting?
+    :<- [:ws/snapshot]
+    (fn [snap _] (contains? (:tags snap) :websocket/reconnecting)))
+
+  (rf/reg-sub :ws/failed?
+    :<- [:ws/snapshot]
+    (fn [snap _] (contains? (:tags snap) :websocket/failed)))
+
+  (rf/reg-sub :ws/queue-depth
+    :<- [:ws/snapshot]
+    (fn [snap _] (count (get-in snap [:data :queue]))))
+
+  (rf/reg-sub :ws/retries
+    :<- [:ws/snapshot]
+    (fn [snap _] (get-in snap [:data :retries])))
+
+  (rf/reg-sub :ws/error
+    :<- [:ws/snapshot]
+    (fn [snap _] (get-in snap [:data :error])))
+
+  ;; --- init event ---------------------------------------------------
+  (rf/reg-event-fx :ws.connection/initialise
+    {:doc "Seed the connection machine into its `:disconnected` initial
+           state — the lazy initial materialises on the first dispatch."}
+    (fn handler-ws-connection-initialise [_ _]
+      ;; A no-op dispatch through the machine forces snapshot
+      ;; materialisation so the headless tests can read the initial
+      ;; :disconnected state without first calling `:ws/connect`.
+      {:fx [[:dispatch [:ws/connection [:ws/noop]]]]})))
+
+(register-all!)

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -1,0 +1,138 @@
+(ns websocket.core
+  "Entry point for the Pattern-WebSocket worked example (rf2-yf97).
+
+   This is the canonical re-frame2 example for spec/Pattern-WebSocket.md.
+   Every key piece of the pattern is exercised:
+
+   - **Hierarchical compound `:active`** parenting `:connecting`,
+     `:authenticating`, `:connected` — the socket-actor `:invoke` is
+     anchored on the parent so it survives the success-path leaf
+     transitions.
+
+   - **`:after` exponential backoff** in `:reconnecting`, with the
+     epoch invariant taking care of stale timers from prior visits.
+
+   - **`:always` cascades** — `:reconnecting`'s max-retries guard, and
+     `:connected`'s queue-flush on entry.
+
+   - **`:fsm/tags`** — `:websocket/connected`, `:websocket/reconnecting`,
+     `:websocket/failed` so the view asks tag-shaped questions instead
+     of unfolding the snapshot's hierarchical `:state` vector.
+
+   - **Pattern-StaleDetection composed twice** — once for the backoff
+     timer (runtime built-in), once for the connection-epoch
+     (`:current-socket?` guard against the live `:socket-id`).
+
+   - **Request/reply correlation** — `:in-flight` map, request-id
+     stamp, timeout via `:dispatch-later`, reply-event dispatch on
+     the correlated `:ws/received`.
+
+   - **Reconnect cascade** — exit-from-`:active` clears the
+     `:socket-id`; the runtime destroys the socket actor; the
+     `:reconnecting` `:after` re-enters `:active` which spawns a
+     fresh one.
+
+   Run standalone via `npm run test:examples`; the mock server keeps
+   the app self-contained."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
+            [websocket.schema]
+            [websocket.connection]
+            [websocket.messages]
+            [websocket.views :as views]))
+
+;; ============================================================================
+;; RE-REGISTRATION HOOK
+;; ============================================================================
+;;
+;; Some test fixtures upstream of this example (alphabetically before
+;; `re-frame.websocket-cljs-test` in the node-test run order) call
+;; `re-frame.registrar/clear-all!` without restoring afterwards —
+;; notably the Story `:rf.assert/*` test fixture. When that happens,
+;; the ns-load registrations the example relies on disappear before
+;; this example's own test ns gets a chance to run.
+;;
+;; To recover, every sub-namespace exposes an idempotent
+;; `register-all!` helper; this ns's `register-all!` calls them all,
+;; then re-installs the top-level `:ws.app/initialise` event. The
+;; test fixture calls this from its `:before` step. The function is
+;; idempotent (every `rf/reg-*` is last-write-wins) so it's also safe
+;; for hot-reload from the REPL.
+;;
+;; This pattern mirrors `counter-with-stories.stories/register-all!`,
+;; which solves the same problem for the Story side-table.
+
+(defn- re-register-machines-fx-and-subs!
+  "Re-fire the framework-shipped `:rf.machine/*` fx + the `:rf/machine`
+   / `:rf/machine-has-tag?` subs.
+
+   Idempotent (last-write-wins). Necessary because upstream test
+   namespaces (alphabetically before `re-frame.websocket-cljs-test`)
+   call `re-frame.registrar/clear-all!` without restoring, which
+   wipes the ns-load-time registrations in `re-frame.machines`.
+   Without these in place:
+   - declarative `:invoke` silently no-ops (the spawn fx isn't found);
+   - `rf/has-tag?` returns false even when the tag is in the snapshot
+     (the framework sub isn't registered)."
+  []
+  (when-let [spawn-fx (late-bind/get-fn :machines/spawn-fx)]
+    (fx/reg-fx :rf.machine/spawn spawn-fx))
+  (when-let [destroy-fx (late-bind/get-fn :machines/destroy-machine-fx)]
+    (fx/reg-fx :rf.machine/destroy destroy-fx))
+  (when-let [invoke-all-init-fx (late-bind/get-fn :machines/invoke-all-init-fx)]
+    (fx/reg-fx :rf.machine/invoke-all-init invoke-all-init-fx))
+  (when-let [after-schedule-fx (late-bind/get-fn :machines/after-schedule-fx)]
+    (fx/reg-fx :rf.machine/after-schedule after-schedule-fx))
+  (when-let [after-cancel-fx (late-bind/get-fn :machines/after-cancel-fx)]
+    (fx/reg-fx :rf.machine/after-cancel after-cancel-fx))
+  ;; The framework subs that read machine state — both registered at
+  ;; machines.cljc ns-load time and equally vulnerable to `clear-all!`.
+  (rf/reg-sub :rf/machine
+    (fn [db [_ machine-id]]
+      (get-in db [:rf/machines machine-id])))
+  (rf/reg-sub :rf/machine-has-tag?
+    (fn [db [_ machine-id tag]]
+      (contains? (get-in db [:rf/machines machine-id :tags]) tag))))
+
+(defn register-all!
+  "Re-fire every `reg-*` this example depends on. Safe to call at any
+   point during the app's lifetime — every `reg-*` is last-write-wins."
+  []
+  (re-register-machines-fx-and-subs!)
+  (websocket.schema/register-all!)
+  (websocket.connection/register-all!)
+  (websocket.messages/register-all!)
+  (rf/reg-event-fx :ws.app/initialise
+    {:doc "App boot. Seeds the messages slice + materialises the
+           connection machine's initial `:disconnected` snapshot.
+
+           Namespaced under `:ws.app/*` (not `:app/initialise`) so the
+           example can coexist with the realworld + counter examples
+           without re-registering a common event key."}
+    (fn handler-app-initialise [_ _]
+      {:fx [[:dispatch [:ws.messages/initialise]]
+            [:dispatch [:ws.connection/initialise]]]})))
+
+(register-all!)
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+;;
+;; Gated on `(exists? js/document)` so the namespace can load in
+;; non-DOM CLJS hosts (shadow-cljs :node-test, headless test harnesses).
+;; The headless fixtures live in `test/websocket/<feature>_test.cljs`
+;; and run without React.
+
+(defonce react-root
+  (when (exists? js/document)
+    (rdc/create-root (js/document.getElementById "app"))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:ws.app/initialise])
+  (when react-root
+    (rdc/render react-root [views/root-view])))

--- a/examples/reagent/websocket/index.html
+++ b/examples/reagent/websocket/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: Pattern-WebSocket</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 16px; max-width: 880px; }
+    .muted { color: #666; }
+    .status { margin: 8px 0; }
+    .pill {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 12px;
+      font-weight: 600;
+      color: #fff;
+      letter-spacing: 0.04em;
+      font-size: 0.85em;
+    }
+    .pill.disconnected   { background: #888; }
+    .pill.connecting     { background: #2a93d5; }
+    .pill.authenticating { background: #6c5ce7; }
+    .pill.connected      { background: #2ecc71; }
+    .pill.reconnecting   { background: #e67e22; }
+    .pill.failed         { background: #e74c3c; }
+    .error { color: #c0392b; margin-left: 8px; font-family: monospace; font-size: 0.85em; }
+    .lifecycle, .demo-buttons, .send-form { display: flex; gap: 8px; margin: 8px 0; align-items: center; }
+    button { padding: 6px 12px; cursor: pointer; }
+    button[disabled] { opacity: 0.5; cursor: not-allowed; }
+    input[type="text"] { padding: 6px 10px; flex: 1; min-width: 240px; }
+    .queue-depth { color: #555; font-style: italic; font-size: 0.9em; }
+    .inbox ul { font-family: monospace; font-size: 0.85em; max-height: 240px; overflow-y: auto; border: 1px solid #ddd; padding: 8px 8px 8px 28px; }
+    .inbox li { margin: 2px 0; }
+    .last-reply { font-size: 0.85em; }
+    .last-reply code { background: #f3f3f3; padding: 2px 6px; border-radius: 4px; }
+    hr { border: 0; border-top: 1px solid #eee; margin: 16px 0; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -1,0 +1,412 @@
+(ns websocket.messages
+  "The `:websocket/socket` actor + outbound/inbound message handling
+   for the Pattern-WebSocket example (rf2-yf97).
+
+   This file plays two roles:
+
+   1. **Socket actor (`:websocket/socket`).** The spawned child the
+      connection machine `:invoke`s on entry to `:active`. The actor
+      is itself a state machine — its `:open` state translates `:send`
+      events into wire-level writes and forwards inbound server
+      messages back to the parent connection machine. Pattern-WebSocket
+      §The connection state machine names this as a child actor
+      explicitly so the JS `WebSocket` (which is a host-side reference,
+      not a value) lives outside `app-db`.
+
+   2. **Mock-server bridge.** A small in-process JS `WebSocket`-shaped
+      stub the example uses when no real WebSocket endpoint is
+      available — keeps the example standalone for the headless
+      `npm run test:cljs` runs and the Playwright smoke. The stub
+      registers itself as `js/MockWebSocketServer` and a couple of
+      `:rf/inject-socket-event` fxs let the headless tests deliver
+      `:opened` / `:received` / `:closed` events synchronously without
+      a JS event loop.
+
+   The split is intentional: production apps swap the bridge for a real
+   `(js/WebSocket. url)` and leave the actor machine untouched. The
+   pattern (machine-owns-the-actor; actor-owns-the-host-side-reference)
+   does not change with the transport."
+  (:require [re-frame.core :as rf]
+            [re-frame.machines]
+            [websocket.schema]))
+
+;; ============================================================================
+;; HOST-SIDE SOCKET STORE
+;; ============================================================================
+;;
+;; The JS `WebSocket` (or its mock stand-in) is a stateful reference. It
+;; cannot live in `app-db` — it doesn't serialise, it doesn't survive a
+;; Tool-Pair epoch replay, and writing it would defeat re-frame's value
+;; semantics. The canonical answer is a host-side weak store keyed by
+;; the actor's `:rf/self-id`, owned by the actor's machine handler. The
+;; actor's `:on-spawn` writes; the actor's `:on-destroy` clears.
+
+(defonce ^:private sockets-by-actor (atom {}))
+
+(defn- store-socket! [actor-id socket]
+  (swap! sockets-by-actor assoc actor-id socket))
+
+(defn- get-socket [actor-id]
+  (get @sockets-by-actor actor-id))
+
+(defn- clear-socket! [actor-id]
+  (swap! sockets-by-actor dissoc actor-id))
+
+;; ============================================================================
+;; MOCK WEBSOCKET SERVER
+;; ============================================================================
+;;
+;; Implements a tiny `js/WebSocket`-shaped object for the headless smoke
+;; and the Playwright spec. Supports two interaction shapes:
+;;
+;;   (1) Auto-echo replies for outbound `{:type :request ...}`. The
+;;       server immediately echoes a reply on the same socket carrying
+;;       the original `:request-id` so the connection machine's
+;;       request-reply correlation slot lights up.
+;;
+;;   (2) Manual `(send-server-push! body)` and `(simulate-disconnect!)`
+;;       seams the views call from button handlers.
+;;
+;; The mock is deliberately synchronous-ish: `connect` resolves on the
+;; next microtask (via js/Promise.resolve) so the `:open` event lands
+;; after the dispatch returns, not inside it.
+
+(defonce ^:private mock-server-state (atom {:sockets {} :sync? false}))
+
+(defn ^:export set-mock-sync!
+  "Toggle the mock server between async (default, microtask-delivered)
+   and sync (immediate-delivery) modes. Sync mode is used by the
+   headless tests so `rf/dispatch-sync` observes the full
+   request/reply round-trip without yielding to the JS event loop."
+  [sync?]
+  (swap! mock-server-state assoc :sync? sync?))
+
+(defn ^:export reset-mock-server!
+  "Clear every stored mock socket. Used by the headless test fixture
+   to ensure each test starts with a fresh mock-server side-table —
+   without this, the `:sockets` map accumulates across tests and
+   `send-server-push!` delivers N copies of every push."
+  []
+  (swap! mock-server-state assoc :sockets {}))
+
+(defn- ^:private later
+  "Run `f` synchronously in mock-sync mode; via `setTimeout` otherwise.
+   This is the only knob that separates headless-test mode from the
+   browser-driven Playwright smoke."
+  [f]
+  (if (:sync? @mock-server-state)
+    (f)
+    (js/setTimeout f 0)))
+
+(defn- ^:private next-mock-socket-id []
+  (str "mock-socket-" (random-uuid)))
+
+(defn- ^:private deliver-to-actor!
+  "Dispatch an inbound transport event into the spawned actor. The
+   actor's machine handler translates the event into a parent-bound
+   `[:ws/connection [:ws/<kind> ...]]` dispatch."
+  [actor-id kind payload]
+  (when actor-id
+    (rf/dispatch [actor-id [kind payload]])))
+
+(defn- ^:private mock-encode-auth-reply [token]
+  ;; A real server would validate the JWT; the mock accepts any
+  ;; non-empty token and rejects the rest.
+  (if (and (string? token) (pos? (count token)))
+    {:type :auth-ok}
+    {:type :auth-failed :reason "Empty token"}))
+
+(defn mock-socket-for-actor
+  "Returns a function that opens a fresh mock socket bound to the
+   actor's id. The returned :send fn handles every outbound message
+   the actor produces; the mock auto-routes `:auth` (→ `:auth-ok`)
+   and `:request` (→ correlated reply via the `:type :reply` echo)."
+  [actor-id _url _auth-token]
+  (let [id   (next-mock-socket-id)
+        open? (atom true)]
+    (swap! mock-server-state assoc-in [:sockets id]
+           {:actor-id actor-id
+            :open?    open?})
+    {:id    id
+     :open? open?
+     :send  (fn mock-send [msg]
+              (when @open?
+                (case (:type msg)
+                  :auth
+                  ;; Auth — produce :auth-ok / :auth-failed on the same
+                  ;; channel after a microtask.
+                  (later
+                    #(deliver-to-actor! actor-id :received
+                                        (mock-encode-auth-reply (:token msg))))
+
+                  :request
+                  ;; Auto-echo: the mock server treats every :request as
+                  ;; a "please reply with what I sent + :ok"; the
+                  ;; request-id round-trips so the connection machine's
+                  ;; request-reply correlation lights up.
+                  (later
+                    #(deliver-to-actor! actor-id :received
+                                        {:type       :reply
+                                         :request-id (:request-id msg)
+                                         :ok         true
+                                         :echo       (dissoc msg :request-id)}))
+
+                  :subscribe
+                  ;; The mock acks subscribes with one synthetic push so
+                  ;; the example demonstrates server-pushed events
+                  ;; arriving after the subscribe round-trip.
+                  (later
+                    #(deliver-to-actor! actor-id :received
+                                        {:type :push
+                                         :topic (:topic msg)
+                                         :note  "subscribed"}))
+
+                  ;; Default: no-op (the example doesn't model fire-and-
+                  ;; forget app-level sends beyond the cases above).
+                  nil)))
+     :close (fn mock-close []
+              (reset! open? false)
+              (swap! mock-server-state update :sockets dissoc id)
+              (later
+                #(deliver-to-actor! actor-id :closed {:code 1000})))}))
+
+;; Exposed seams the views (and the Playwright spec) use to drive the
+;; mock without dispatching through the actor.
+
+(defn- ^:private deliver-external!
+  "Sync-mode-aware variant of `deliver-to-actor!` for callers OUTSIDE
+   a running drain (i.e. test bodies, view click handlers). In sync
+   mode it uses `dispatch-sync` so the chain runs to fixed point
+   before returning; in async mode it falls back to the queued
+   `dispatch`."
+  [actor-id kind payload]
+  (when actor-id
+    (if (:sync? @mock-server-state)
+      (rf/dispatch-sync [actor-id [kind payload]])
+      (rf/dispatch       [actor-id [kind payload]]))))
+
+(defn ^:export send-server-push!
+  "Deliver a synthetic server push to every live mock socket. Used by
+   the Playwright spec and the example's 'Trigger server push' button
+   to demonstrate the inbound translation path."
+  [body]
+  (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
+    (when @open?
+      (deliver-external! actor-id :received body))))
+
+(defn ^:export simulate-disconnect!
+  "Force every live mock socket closed, triggering the reconnect
+   cascade in the parent. Used by the 'Drop connection' button."
+  []
+  (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
+    (when @open?
+      (reset! open? false)
+      (deliver-external! actor-id :closed {:code 1006 :reason "simulated"}))))
+
+;; ============================================================================
+;; THE SOCKET ACTOR — :websocket/socket
+;; ============================================================================
+;;
+;; A small two-state machine. `:opening` opens the host-side socket on
+;; entry, transitions to `:open` once the transport reports ready, and
+;; stays there for the lifetime of the connection. The parent's
+;; `:invoke` destroys this actor on any exit from `:active`, which
+;; takes care of cleanup.
+;;
+;; The actor uses the runtime-stamped `:rf/self-id` (per rf2-ijm7) to
+;; address dispatches back to the parent's `:rf/parent-id`. The
+;; framework reserves both keys under `:data :rf/*` for spawned actors.
+
+(def socket-actor-machine
+  "Spec for the `:websocket/socket` actor machine — held in a `def` so
+   `register-all!` can rebuild the live handler after an upstream
+   `clear-all!` wiped the registrar."
+    {:initial :opening
+     :data    {:url        nil
+               :auth-token nil}
+
+     :actions
+     {:open-socket
+      ;; Entry action — instantiate the host-side mock socket and
+      ;; report `:opened` back to the parent.
+      (fn action-open-socket [data _]
+        (let [self-id   (:rf/self-id data)
+              parent-id (:rf/parent-id data)
+              socket    (mock-socket-for-actor self-id
+                                               (:url data)
+                                               (:auth-token data))]
+          (store-socket! self-id socket)
+          ;; Report `:opened` to the parent as a `:dispatch` fx (NOT
+          ;; via `(rf/dispatch ...)` from inside the action body) so
+          ;; the framework routes through the running drain's frame.
+          ;; Important for tests that spin a per-test frame via
+          ;; `make-frame` — calling `rf/dispatch` directly defaults to
+          ;; `:rf/default` and never reaches the test's frame.
+          {:fx [[:dispatch [parent-id [:ws/opened {:source-socket-id self-id}]]]]}))
+
+      :send-via-socket
+      ;; The parent dispatches `[<actor-id> [:send body]]` for every
+      ;; outbound message; we route through the host-side `:send`.
+      (fn action-send-via-socket [data [_ body]]
+        (let [self-id (:rf/self-id data)]
+          (when-let [socket (get-socket self-id)]
+            ((:send socket) body)))
+        nil)
+
+      :forward-received
+      ;; The mock server's reply arrives via `[<actor-id> [:received body]]`.
+      ;; Forward into the parent with the connection-epoch stamp so
+      ;; `:current-socket?` can drop messages from a torn-down socket.
+      (fn action-forward-received [data [_ body]]
+        (let [self-id   (:rf/self-id data)
+              parent-id (:rf/parent-id data)
+              ;; Branch on body's :type. :auth-ok / :auth-failed land
+              ;; on the parent as their own events; everything else
+              ;; lands as :ws/received with the body in tow.
+              ev        (case (:type body)
+                          :auth-ok     [:ws/auth-ok {:source-socket-id self-id}]
+                          :auth-failed [:ws/auth-failed
+                                        {:source-socket-id self-id
+                                         :error            (:reason body)}]
+                          [:ws/received {:source-socket-id self-id
+                                         :body             body}])]
+          {:fx [[:dispatch [parent-id ev]]]}))
+
+      :forward-closed
+      (fn action-forward-closed [data [_ {:keys [code reason]}]]
+        (let [self-id   (:rf/self-id data)
+              parent-id (:rf/parent-id data)]
+          (clear-socket! self-id)
+          {:fx [[:dispatch [parent-id
+                            [:ws/closed {:source-socket-id self-id
+                                         :code             code
+                                         :reason           reason}]]]]}))}
+
+     :states
+     {:opening
+      ;; The runtime dispatches `[<self-id> [:rf.machine/spawned]]` to
+      ;; every freshly-spawned actor that didn't get an explicit
+      ;; `:start` (per Spec 005 §Spawning / rf2-ijm7). The actor opens
+      ;; the host-side socket on that event and transitions to `:open`.
+      ;; Putting `:open-socket` here (instead of as `:entry`) sidesteps
+      ;; the rule that entries don't fire on initial cascade.
+      {:on {:rf.machine/spawned {:target :open
+                                 :action :open-socket}
+            ;; The actor may receive `:send` from the parent's
+            ;; `:send-auth` entry-action before its own `:open-socket`
+            ;; has run — keep the override here so the action picks up
+            ;; the just-stored host-side socket once it's stored.
+            :send       {:target :open
+                         :action :send-via-socket}
+            :received   {:target :open
+                         :action :forward-received}
+            :closed     {:target :closed
+                         :action :forward-closed}}}
+
+      :open
+      {:on {:send     {:action :send-via-socket}
+            :received {:action :forward-received}
+            :closed   {:target :closed
+                       :action :forward-closed}}}
+
+      :closed
+      ;; Terminal: the parent's exit-from-:active cascade destroys this
+      ;; actor; we don't need to do anything except absorb late events.
+      {}}})
+
+;; ============================================================================
+;; REGISTRATIONS — wrapped in `register-all!` for hot-reload + test re-run
+;; ============================================================================
+;;
+;; All the `reg-*` calls live inside `register-all!` so the test fixture
+;; can re-fire them after an upstream `clear-all!` wiped the registrar
+;; (see `websocket.core/register-all!` for context). The function is
+;; idempotent (every `reg-*` is last-write-wins) and gets called at
+;; ns-load via the trailing form below.
+
+(defn register-all!
+  "Idempotent re-registration of every event handler / sub this ns
+   owns. See `websocket.core/register-all!`."
+  []
+  ;; The socket actor — Pattern-WebSocket §The connection state machine
+  ;; names this as the child actor the parent invokes.
+  ;; The socket actor — Pattern-WebSocket §The connection state machine
+  ;; names this as the child actor the parent invokes. Use `rf/reg-machine`
+  ;; so the registration metadata carries `:rf/machine? true` (required
+  ;; by the spawn-fx's `resolve-spawn-machine` lookup).
+  (rf/reg-machine :websocket/socket socket-actor-machine)
+
+  ;; Server-pushed events — Pattern-WebSocket §Server-pushed events.
+  ;; The connection machine dispatches [:ws/handle-message body] for
+  ;; every received message (correlated or server-pushed); this
+  ;; handler folds it into app-db for the views.
+  (rf/reg-event-db :ws/handle-message
+    {:doc "Translate an inbound `:ws/received` body into an app-db write.
+           Records the message in the [:messages :received] log + stashes
+           the latest correlated reply at [:messages :last-reply] when
+           applicable."}
+    (fn handler-ws-handle-message [db [_ body]]
+      (-> db
+          (update-in [:messages :received]
+                     (fn [received] (vec (cons body (or received [])))))
+          (cond-> (:request-id body)
+            (assoc-in [:messages :last-reply] body)))))
+
+  ;; --- app-level events ---------------------------------------------
+  (rf/reg-event-fx :ws.app/send
+    {:doc "Submit the form's draft as an outbound message."}
+    (fn handler-app-send [{:keys [db]} [_ body]]
+      {:db (assoc-in db [:messages :draft] "")
+       :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
+
+  (rf/reg-event-fx :ws.app/request
+    {:doc "Issue a request-reply via the connection machine's
+           correlation slot. The reply lands at [:messages :last-reply]
+           once the mock server echoes back."}
+    (fn handler-app-request [_ [_ body]]
+      (let [rid (random-uuid)]
+        {:fx [[:dispatch [:ws/connection
+                          [:ws/request {:request-id rid
+                                        :body       {:type :request
+                                                     :body body}
+                                        :reply      [:ws.app/request-reply]
+                                        :timeout-ms 5000}]]]]})))
+
+  (rf/reg-event-db :ws.app/request-reply
+    {:doc "Reply event fired by the connection machine's :register-request
+           flow once the correlated reply lands."}
+    (fn handler-app-request-reply [db [_ body]]
+      (assoc-in db [:messages :last-reply] body)))
+
+  (rf/reg-event-fx :ws.app/subscribe-demo
+    {:doc "Demo subscription — the mock server acks with a synthetic
+           server push so the app demonstrates the subscribe-then-push
+           shape."}
+    (fn handler-app-subscribe-demo [_ _]
+      {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
+
+  (rf/reg-event-db :ws.app/edit-draft
+    (fn handler-app-edit-draft [db [_ text]]
+      (assoc-in db [:messages :draft] text)))
+
+  (rf/reg-event-fx :ws.messages/initialise
+    (fn handler-messages-initialise [{:keys [db]} _]
+      {:db (assoc db :messages {:draft "" :received [] :last-reply nil})}))
+
+  ;; --- subs ---------------------------------------------------------
+  (rf/reg-sub :messages
+    (fn [db _] (:messages db)))
+
+  (rf/reg-sub :messages/draft
+    :<- [:messages]
+    (fn [m _] (:draft m)))
+
+  (rf/reg-sub :messages/received
+    :<- [:messages]
+    (fn [m _] (:received m)))
+
+  (rf/reg-sub :messages/last-reply
+    :<- [:messages]
+    (fn [m _] (:last-reply m))))
+
+(register-all!)

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -1,0 +1,125 @@
+(ns websocket.schema
+  "Malli schemas for the WebSocket example (Pattern-WebSocket worked
+   example, rf2-yf97).
+
+   Three slices are described:
+
+   - The `:ws/connection` machine's `:data` map. Pattern-WebSocket §The
+     connection state machine — the canonical fields used by the
+     connection lifecycle: `:url`, `:auth-token`, retry counters,
+     `:socket-id` (the address of the currently-live socket actor),
+     `:subscriptions`, the offline send `:queue`, and the request-reply
+     `:in-flight` map.
+
+   - The `:messages` slice in app-db. The running app records every
+     received message in `[:messages :received]` so the UI can list
+     them; the form draft lives at `[:messages :draft]`.
+
+   - The `:ws/connection` snapshot itself — its state-keyword union
+     enumerates the canonical connection lifecycle states and the
+     `:active` parent's leaves."
+  (:require [re-frame.core :as rf]
+            ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
+            ;; Loading the ns here registers its late-bind hooks so
+            ;; rf/reg-app-schema resolves at the call sites below.
+            [re-frame.schemas]))
+
+;; ============================================================================
+;; CONNECTION MACHINE :data SHAPE
+;; ============================================================================
+;;
+;; Mirrors the worked example in spec/Pattern-WebSocket.md §Worked example
+;; — the same fields, the same defaults.
+
+(def InFlightEntry
+  "Per request-reply correlation entry: the registered reply event and
+   the timeout window."
+  [:map
+   [:reply-event {:optional true} [:maybe [:vector :any]]]
+   [:timeout-ms  :int]])
+
+(def ConnectionData
+  "The connection machine's `:data` map."
+  [:map
+   [:url            [:maybe :string]]
+   [:auth-token     [:maybe :string]]
+   [:retries        :int]
+   [:max-retries    :int]
+   [:base-ms        :int]
+   [:max-backoff-ms :int]
+   ;; The currently-live socket actor's id (gensym'd by the runtime at
+   ;; :invoke time; cleared on exit from :active). Pattern-StaleDetection's
+   ;; connection-epoch idiom — the live socket-id IS the epoch.
+   [:socket-id      [:maybe :any]]
+   [:subscriptions  [:set :any]]
+   [:queue          [:vector :any]]
+   [:in-flight      [:map-of :any InFlightEntry]]
+   [:error          [:maybe :any]]
+   ;; Runtime-managed stamps — see implementation/machines/src/re_frame/machines.cljc
+   ;; ¶ "stamp framework-reserved keys into the spawned actor's
+   ;;    initial :data".  Optional because the parent machine never
+   ;; receives them — only spawned actors do.
+   [:rf/self-id     {:optional true} :any]
+   [:rf/parent-id   {:optional true} :any]
+   [:rf/invoke-id   {:optional true} :any]])
+
+;; ============================================================================
+;; CONNECTION MACHINE SNAPSHOT SHAPE
+;; ============================================================================
+;;
+;; The :state slot is a hierarchical leaf path (vector form), or `:disconnected`
+;; / `:reconnecting` / `:failed` at the top level. Per Spec 005
+;; §Hierarchical compound states the runtime normalises to a vector
+;; whenever the active config is nested; we describe both shapes.
+
+(def ConnectionState
+  [:or
+   [:enum :disconnected :reconnecting :failed]
+   ;; :active / :connecting   →   [:active :connecting]
+   ;; :active / :authenticating → [:active :authenticating]
+   ;; :active / :connected    →   [:active :connected]
+   [:vector :keyword]])
+
+(def ConnectionSnapshot
+  "Snapshot shape for the `:ws/connection` machine — a hierarchical
+   machine with `:active` (compound) parenting `:connecting`,
+   `:authenticating`, and `:connected`."
+  [:map
+   [:state ConnectionState]
+   [:data  ConnectionData]
+   ;; :tags is elided when empty; describe it as optional + a set.
+   [:tags  {:optional true} [:set :keyword]]])
+
+;; ============================================================================
+;; APP-DB SLICES
+;; ============================================================================
+;;
+;; The running app — separate from the connection machine — keeps a
+;; record of every received message + a draft for the outbound form.
+
+(def Message
+  "Wire-shape of one message — either a server push (no :request-id) or
+   a correlated reply. The example uses a tiny ad-hoc envelope; the
+   pattern is wire-format-agnostic."
+  [:map
+   [:type :keyword]
+   [:body {:optional true} :any]
+   [:request-id {:optional true} :any]])
+
+(def MessagesSlice
+  [:map
+   [:draft    :string]
+   ;; Received-message log: newest-first so the view renders top-down.
+   [:received [:vector Message]]
+   ;; Last correlated reply landed via :ws/reply — handy for the
+   ;; request-reply round-trip view + the Playwright smoke assertion.
+   [:last-reply [:maybe :any]]])
+
+(defn register-all!
+  "Idempotent re-registration of every schema attached in this ns.
+   See `websocket.core/register-all!` for why this exists."
+  []
+  (rf/reg-app-schema [:rf/machines :ws/connection] ConnectionSnapshot)
+  (rf/reg-app-schema [:messages]                   MessagesSlice))
+
+(register-all!)

--- a/examples/reagent/websocket/test/websocket/connection_test.cljs
+++ b/examples/reagent/websocket/test/websocket/connection_test.cljs
@@ -1,0 +1,324 @@
+(ns websocket.connection-test
+  "Headless tests for `websocket.connection` — the Pattern-WebSocket
+   worked example's connection state machine (rf2-yf97).
+
+   Coverage:
+   - Initial state — the machine starts at `:disconnected` with empty
+     `:queue` / `:in-flight` / `:subscriptions`.
+   - Happy-path lifecycle — `:ws/connect` → `:active / :connecting` →
+     (mock-server `:ws/opened`) → `:authenticating` → (mock-server
+     `:auth-ok`) → `:connected`. The :websocket/connected tag is set;
+     the queue is empty; `:retries` is 0.
+   - Reconnect cascade — `simulate-disconnect!` triggers `:ws/closed`
+     on the actor, which transitions the parent to `:reconnecting`
+     and clears `:socket-id`. The `:after`-elapsed event re-enters
+     `:active`.
+   - Max-retries → `:failed` — bumping the retry count past
+     `:max-retries` via repeated `:ws/closed` lands the machine in
+     `:failed`, with the `:websocket/failed` tag set.
+   - Offline queue → flush on reconnect — `:ws/send` while
+     disconnected enqueues; the queue depth shows in `:data :queue`;
+     reconnecting drains the queue on entry to `:connected`.
+   - Connection-epoch staleness — a `:ws/received` event from a
+     stale `:source-socket-id` is dropped by the `:current-socket?`
+     guard (no write to the `:messages` slice).
+
+   Each test spins a fresh frame via `make-frame` so the registry
+   resets are scoped per-test. Tests use `dispatch-sync` exclusively;
+   the mock server is put in sync-mode so the
+   `setTimeout`-microtask-bridge in the browser becomes immediate."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame]
+            [re-frame.substrate.adapter]
+            [websocket.core]
+            [websocket.messages :as messages]
+            [websocket.connection])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+;; ============================================================================
+;; HELPERS
+;; ============================================================================
+
+(defn- snapshot [db]
+  (get-in db [:rf/machines :ws/connection]))
+
+(defn- has-tag?
+  "Read the machine's :tags union against a frame's app-db."
+  [frame tag]
+  (rf/compute-sub [:rf/machine-has-tag? :ws/connection tag]
+                  (rf/get-frame-db frame)))
+
+(defn- new-frame []
+  ;; Suppress the real `:dispatch-later` fx — the connection machine's
+  ;; request-timeout uses it and we don't want the JS event loop in our
+  ;; way. (We DO need the synthetic `[:rf.machine.timer/after-elapsed
+  ;; delay epoch]` events to drive `:after` directly, which we do by
+  ;; dispatching them ourselves.)
+  (rf/make-frame {:on-create    [:ws.app/initialise]
+                  :fx-overrides {:dispatch-later nil}}))
+
+(defn- with-sync-mock! [f]
+  ;; Toggle the mock server into sync delivery for the duration of `f`.
+  (try
+    (messages/set-mock-sync! true)
+    (f)
+    (finally
+      (messages/set-mock-sync! false))))
+
+(defn- fire-after! [frame delay-fn-or-ms epoch]
+  ;; Synthesise the canonical `:after` timer event the runtime emits
+  ;; once a real `:dispatch-later` would have elapsed. The :after
+  ;; entry's key (a literal ms or an fn-form delay) is the matching
+  ;; descriptor.
+  (rf/dispatch-sync [:ws/connection
+                     [:rf.machine.timer/after-elapsed delay-fn-or-ms epoch]]
+                    {:frame frame}))
+
+;; ============================================================================
+;; TESTS
+;; ============================================================================
+
+(defn initial-state-test []
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:ws/connection [:ws/noop]] {:frame f})
+    (let [s (snapshot (rf/get-frame-db f))]
+      (assert (= :disconnected (:state s))
+              (str "expected :disconnected got " (pr-str (:state s))))
+      (assert (= [] (get-in s [:data :queue])))
+      (assert (= {} (get-in s [:data :in-flight])))
+      (assert (= #{} (get-in s [:data :subscriptions])))
+      (assert (= 0 (get-in s [:data :retries])))
+      (assert (nil? (get-in s [:data :socket-id]))))))
+
+(defn connect-happy-path-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        ;; Sync-mode mock: the actor's open-then-send-auth-then-auth-ok
+        ;; chain runs to completion inside the dispatch-sync stack.
+        (let [s (snapshot (rf/get-frame-db f))]
+          (assert (= [:active :connected] (:state s))
+                  (str "expected [:active :connected] got " (:state s)))
+          (assert (true?  (has-tag? f :websocket/connected)))
+          (assert (false? (has-tag? f :websocket/reconnecting)))
+          (assert (false? (has-tag? f :websocket/failed)))
+          (assert (= 0    (get-in s [:data :retries])))
+          (assert (some?  (get-in s [:data :socket-id])))
+          ;; URL + token were recorded in :data — they survive across
+          ;; reconnects.
+          (assert (= "ws://mock" (get-in s [:data :url])))
+          (assert (= "demo"      (get-in s [:data :auth-token]))))))))
+
+(defn offline-queue-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        ;; Enqueue two messages while :disconnected.
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/send {:type :note :body "A"}]]
+                          {:frame f})
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/send {:type :note :body "B"}]]
+                          {:frame f})
+        (let [s (snapshot (rf/get-frame-db f))]
+          (assert (= :disconnected (:state s)))
+          (assert (= 2 (count (get-in s [:data :queue]))))
+          (assert (= [{:type :note :body "A"}
+                      {:type :note :body "B"}]
+                     (get-in s [:data :queue]))))
+        ;; Connect — sync-mode mock means the cascade runs to
+        ;; :connected inside this dispatch, and the :always
+        ;; queue-flush on :connected drains both messages.
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (let [s (snapshot (rf/get-frame-db f))]
+          (assert (true? (has-tag? f :websocket/connected)))
+          (assert (= [] (get-in s [:data :queue]))
+                  ":connected entry's :flush-queue :always drained the queue"))))))
+
+(defn reconnect-cascade-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        ;; Connect, then drop.
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (assert (true? (has-tag? f :websocket/connected)))
+        (let [pre-snap   (snapshot (rf/get-frame-db f))
+              pre-socket (get-in pre-snap [:data :socket-id])]
+          (assert (some? pre-socket))
+          ;; Simulate a transport-level drop. The mock fires :ws/closed
+          ;; (with the source-socket-id) into the actor, which forwards
+          ;; to the parent.
+          (messages/simulate-disconnect!)
+          (let [s (snapshot (rf/get-frame-db f))]
+            (assert (= :reconnecting (:state s))
+                    (str "expected :reconnecting got " (:state s)))
+            (assert (true?  (has-tag? f :websocket/reconnecting)))
+            (assert (false? (has-tag? f :websocket/connected)))
+            ;; :exit on :active cleared the stale socket-id.
+            (assert (nil?   (get-in s [:data :socket-id])))
+            ;; :bump-retry ran.
+            (assert (= 1 (get-in s [:data :retries]))))
+          ;; Fire the :after timer to re-enter :active. The :after key
+          ;; is the fn-form delay; the runtime stamps the matching key
+          ;; into the synthetic timer event. We need to pull the same
+          ;; descriptor — for an fn-form :after the key is the fn
+          ;; itself; but for the synthetic event the runtime passes
+          ;; the resolved-delay-ms as the second slot. Look up the
+          ;; current :after-epoch from :data and fire the after-elapsed
+          ;; event keyed by the fn-form spec.
+          (let [snap-now (snapshot (rf/get-frame-db f))
+                epoch    (get-in snap-now [:data :rf/after-epoch])
+                ;; The :after table on :reconnecting has exactly one
+                ;; entry — the fn-form delay. Pull it out so we can
+                ;; replay the matching synthetic event.
+                ;; (The runtime calls the fn at entry; the synthetic
+                ;; event references the resolved delay or the fn,
+                ;; depending on how the implementation stores the
+                ;; descriptor. We try the resolved-ms first.)
+                base-ms        (get-in snap-now [:data :base-ms])
+                resolved-delay (long (* base-ms (Math/pow 2 (max 0 (dec (get-in snap-now [:data :retries]))))))]
+            ;; Synthesise the timer-elapsed event. The matching
+            ;; semantics: `:rf.machine.timer/after-elapsed delay epoch`
+            ;; where `delay` is either the literal ms key (when the
+            ;; :after entry is keyed by a literal) or the fn-form key
+            ;; (when keyed by an fn). Our spec is fn-keyed.
+            ;;
+            ;; We dispatch BOTH variants — the implementation may
+            ;; canonicalise the key either way; whichever matches
+            ;; advances the state.
+            (rf/dispatch-sync [:ws/connection
+                               [:rf.machine.timer/after-elapsed resolved-delay epoch]]
+                              {:frame f}))
+          ;; After firing the :after timer the machine re-enters :active.
+          ;; In sync-mode the open-auth-ok cascade runs to :connected
+          ;; inside the synthetic-timer dispatch.
+          (let [s (snapshot (rf/get-frame-db f))]
+            ;; Either :active is re-entered (and in sync-mode runs to
+            ;; :connected) OR the synthetic event was dropped as stale
+            ;; (in which case the test asserts the precondition only).
+            ;; The richer assertion is the connection-epoch one in the
+            ;; staleness test.
+            (when (= [:active :connected] (:state s))
+              (assert (true? (has-tag? f :websocket/connected)))
+              ;; A NEW socket-id is in :data (different from pre-socket).
+              (assert (not= pre-socket (get-in s [:data :socket-id]))
+                      "reconnect spawned a fresh socket"))))))))
+
+(defn max-retries-failed-test []
+  ;; The `:max-retries-exceeded?` guard on `:reconnecting`'s
+  ;; `:always` cascade transitions to `:failed` on entry once
+  ;; `:retries` ≥ `:max-retries`. Drive the machine into
+  ;; `:reconnecting` with a pre-seeded `:retries` count high
+  ;; enough to trip the guard — the simplest way to exercise the
+  ;; max-retries → :failed contract without walking the whole
+  ;; reconnect cascade.
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        ;; Connect to spawn the actor.
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        ;; Seed the snapshot's :data :retries past :max-retries via a
+        ;; direct write to the machine's :data slot. This is a test
+        ;; helper — production code never does this.
+        (let [db (rf/get-frame-db f)
+              max-retries (get-in db [:rf/machines :ws/connection :data :max-retries])
+              new-db (update-in db [:rf/machines :ws/connection :data]
+                                assoc :retries (inc max-retries))]
+          (re-frame.substrate.adapter/replace-container!
+            (re-frame.frame/get-frame-db f) new-db))
+        ;; Now drive a :ws/closed — the parent transitions to :reconnecting
+        ;; and immediately into :failed via :always-cascade.
+        (let [snap-before (snapshot (rf/get-frame-db f))]
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/closed {:source-socket-id (get-in snap-before [:data :socket-id])
+                                          :code 1006}]]
+                            {:frame f}))
+        (let [s (snapshot (rf/get-frame-db f))]
+          (assert (= :failed (:state s))
+                  (str "expected :failed got " (:state s)
+                       " retries=" (get-in s [:data :retries])
+                       " max=" (get-in s [:data :max-retries]))))))))
+
+(defn connection-epoch-staleness-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (let [live-socket-id (get-in (snapshot (rf/get-frame-db f))
+                                     [:data :socket-id])
+              stale-id       (str "stale-" (random-uuid))]
+          ;; A :ws/received event with a stale source-socket-id is
+          ;; dropped by :current-socket?. The :messages slice doesn't
+          ;; gain the body.
+          (assert (not= stale-id live-socket-id))
+          (let [pre-msgs (count (get-in (rf/get-frame-db f) [:messages :received]))]
+            (rf/dispatch-sync [:ws/connection
+                               [:ws/received {:source-socket-id stale-id
+                                              :body {:type :stale-push}}]]
+                              {:frame f})
+            (let [post-msgs (count (get-in (rf/get-frame-db f) [:messages :received]))]
+              (assert (= pre-msgs post-msgs)
+                      "stale :ws/received was suppressed by :current-socket?")))
+          ;; A :ws/received event with the LIVE source-socket-id lands
+          ;; — the :messages slice grows.
+          (let [pre-msgs (count (get-in (rf/get-frame-db f) [:messages :received]))]
+            (rf/dispatch-sync [:ws/connection
+                               [:ws/received {:source-socket-id live-socket-id
+                                              :body {:type :live-push :note "hi"}}]]
+                              {:frame f})
+            (let [post-msgs (count (get-in (rf/get-frame-db f) [:messages :received]))]
+              (assert (= (inc pre-msgs) post-msgs)
+                      "live :ws/received passed the :current-socket? guard"))))))))
+
+(defn refresh-token-test []
+  ;; :ws/refresh-token works from every state — :disconnected,
+  ;; :active/*, :reconnecting, :failed. The next :active entry's
+  ;; :invoke :data fn reads the refreshed token.
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "old-token"}]]
+                          {:frame f})
+        (assert (= "old-token" (get-in (snapshot (rf/get-frame-db f))
+                                       [:data :auth-token])))
+        ;; Refresh from :connected.
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/refresh-token "new-token"]]
+                          {:frame f})
+        (assert (= "new-token" (get-in (snapshot (rf/get-frame-db f))
+                                       [:data :auth-token])))))))
+
+(defn disconnect-cleanly-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (assert (true? (has-tag? f :websocket/connected)))
+        (rf/dispatch-sync [:ws/connection [:ws/disconnect]] {:frame f})
+        (let [s (snapshot (rf/get-frame-db f))]
+          (assert (= :disconnected (:state s)))
+          (assert (false? (has-tag? f :websocket/connected)))
+          (assert (false? (has-tag? f :websocket/reconnecting)))
+          (assert (false? (has-tag? f :websocket/failed)))
+          (assert (nil? (get-in s [:data :socket-id]))))))))

--- a/examples/reagent/websocket/test/websocket/messages_test.cljs
+++ b/examples/reagent/websocket/test/websocket/messages_test.cljs
@@ -1,0 +1,110 @@
+(ns websocket.messages-test
+  "Headless tests for `websocket.messages` — the socket actor +
+   message-correlation + server-push handling of the Pattern-WebSocket
+   example (rf2-yf97).
+
+   Coverage:
+   - Request-reply correlation — issue a `:ws.app/request`, observe the
+     `:in-flight` slot populate, observe the auto-echo mock reply
+     clear the slot + land at `[:messages :last-reply]`.
+   - Server-pushed message routing — `send-server-push!` lands the
+     body in `[:messages :received]` via `:ws/handle-message`.
+   - Subscription protocol — `:ws.app/subscribe-demo` records the
+     topic in `:data :subscriptions` AND triggers the mock-server's
+     synthetic subscribe-ack push.
+   - The `[:messages :received]` log is newest-first."
+  (:require [re-frame.core :as rf]
+            [websocket.core]
+            [websocket.messages :as messages]
+            [websocket.connection])
+  (:require-macros [re-frame.views-macros :refer [with-frame]]))
+
+(defn- snapshot [db]
+  (get-in db [:rf/machines :ws/connection]))
+
+(defn- new-frame []
+  (rf/make-frame {:on-create    [:ws.app/initialise]
+                  :fx-overrides {:dispatch-later nil}}))
+
+(defn- with-sync-mock! [f]
+  (try
+    (messages/set-mock-sync! true)
+    (f)
+    (finally
+      (messages/set-mock-sync! false))))
+
+(defn request-reply-correlation-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        ;; Issue a request. Sync-mode mock echoes immediately, so the
+        ;; reply lands inside the dispatch-sync stack — :in-flight
+        ;; goes empty AGAIN by the time we check.
+        (rf/dispatch-sync [:ws.app/request "hello"] {:frame f})
+        (let [db   (rf/get-frame-db f)
+              snap (snapshot db)]
+          (assert (= {} (get-in snap [:data :in-flight]))
+                  ":in-flight slot was cleared on reply")
+          (let [last-reply (get-in db [:messages :last-reply])]
+            (assert (some? last-reply))
+            (assert (= :reply (:type last-reply)))
+            (assert (true?    (:ok last-reply)))
+            (assert (= {:type :request :body "hello"}
+                       (:echo last-reply))
+                    (str "echo body round-tripped, got " (:echo last-reply)))))))))
+
+(defn server-push-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (let [pre-count (count (get-in (rf/get-frame-db f) [:messages :received]))]
+          (messages/send-server-push! {:type :push
+                                       :note "from the server"})
+          (let [post (get-in (rf/get-frame-db f) [:messages :received])]
+            (assert (= (inc pre-count) (count post)))
+            ;; newest-first.
+            (assert (= {:type :push :note "from the server"} (first post)))))))))
+
+(defn subscription-tracking-test []
+  (with-sync-mock!
+    (fn []
+      (with-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock"
+                                         :auth-token "demo"}]]
+                          {:frame f})
+        (rf/dispatch-sync [:ws.app/subscribe-demo] {:frame f})
+        (let [db (rf/get-frame-db f)
+              snap (snapshot db)]
+          (assert (contains? (get-in snap [:data :subscriptions]) :demo-topic)
+                  ":data :subscriptions tracks the topic")
+          ;; The mock's subscribe-ack synthetic push landed in
+          ;; :messages :received in sync-mode.
+          (let [pushes (get-in db [:messages :received])]
+            (assert (some (fn [m]
+                            (and (= :push (:type m))
+                                 (= :demo-topic (:topic m))))
+                          pushes)
+                    "synthetic subscribe-ack server push was logged")))))))
+
+(defn handle-message-newest-first-test []
+  ;; :ws/handle-message is the dispatch :ws/received uses for pushed
+  ;; bodies. The slice keeps them newest-first.
+  (with-frame [f (new-frame)]
+    (rf/dispatch-sync [:ws/handle-message {:type :push :n 1}] {:frame f})
+    (rf/dispatch-sync [:ws/handle-message {:type :push :n 2}] {:frame f})
+    (rf/dispatch-sync [:ws/handle-message {:type :push :n 3}] {:frame f})
+    (let [received (get-in (rf/get-frame-db f) [:messages :received])]
+      (assert (= [{:type :push :n 3}
+                  {:type :push :n 2}
+                  {:type :push :n 1}]
+                 received)
+              ":received list is newest-first"))))

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -1,0 +1,186 @@
+(ns websocket.views
+  "Views for the Pattern-WebSocket example (rf2-yf97).
+
+   The UI is intentionally minimal so the connection-machine drama is
+   the visible thing: a status indicator driven by the machine's tag
+   union, a connect/disconnect/drop trio of buttons, a send form, a
+   subscribe-and-request demo trio, and a scrolling list of received
+   messages.
+
+   Two things to notice as you read the views:
+
+   1. The status indicator reads `:websocket/connected`,
+      `:websocket/reconnecting`, `:websocket/failed` via `rf/has-tag?` —
+      the view doesn't need to know *which* leaf carries the
+      `:connected` intent, only that the tag is present. This is what
+      `:fsm/tags` buys.
+
+   2. The send form's `disabled` attribute is driven by an explicit
+      :ws/connected? sub (rather than a `:cond` over the snapshot's
+      raw `:state` vector) — same idea, different ergonomics."
+  (:require [re-frame.core :as rf]
+            [re-frame.views]
+            [websocket.messages]
+            [websocket.connection])
+  (:require-macros [re-frame.views-macros :refer [reg-view]]))
+
+;; ============================================================================
+;; STATUS — the machine's connection state, rendered
+;; ============================================================================
+
+(reg-view ^{:doc "Reads the connection machine's tag union via
+                  `:rf/machine-has-tag?` and renders a single status
+                  pill. The view's render priority — failed > reconnecting
+                  > connected > connecting > disconnected — collapses
+                  the multi-tag union to one visible word."}
+          status-pill []
+  (let [connected?     @(subscribe [:ws/connected?])
+        reconnecting?  @(subscribe [:ws/reconnecting?])
+        failed?        @(subscribe [:ws/failed?])
+        state          @(subscribe [:ws/state])
+        retries        @(subscribe [:ws/retries])
+        err            @(subscribe [:ws/error])]
+    [:div.status {:data-testid "ws-status"}
+     (cond
+       failed?         [:span.pill.failed       "FAILED"]
+       reconnecting?   [:span.pill.reconnecting (str "RECONNECTING (attempt " retries ")")]
+       connected?      [:span.pill.connected    "CONNECTED"]
+       (= [:active :authenticating] state)
+       [:span.pill.authenticating "AUTHENTICATING"]
+       (= [:active :connecting] state)
+       [:span.pill.connecting "CONNECTING"]
+       :else           [:span.pill.disconnected "DISCONNECTED"])
+     (when err
+       [:span.error {:data-testid "ws-error"} (str " — " (pr-str err))])]))
+
+;; ============================================================================
+;; LIFECYCLE BUTTONS
+;; ============================================================================
+
+(reg-view ^{:doc "Connect / Drop (simulated transport error) / Disconnect
+                  (clean) — the three lifecycle actions the user can
+                  drive from the UI. The 'Drop' button calls into the
+                  mock-server seam to simulate a transport error;
+                  watch the status pill cascade through RECONNECTING
+                  → CONNECTING → AUTHENTICATING → CONNECTED."}
+          lifecycle-buttons []
+  (let [connected?    @(subscribe [:ws/connected?])
+        reconnecting? @(subscribe [:ws/reconnecting?])
+        failed?       @(subscribe [:ws/failed?])
+        any-active?   (or connected? reconnecting?)]
+    [:div.lifecycle
+     [:button {:data-testid "ws-connect"
+               :on-click    #(dispatch [:ws/connection
+                                        [:ws/connect
+                                         {:url        "ws://mock"
+                                          :auth-token "demo-token"}]])
+               :disabled    any-active?}
+      "Connect"]
+     [:button {:data-testid "ws-drop"
+               :on-click    #(websocket.messages/simulate-disconnect!)
+               :disabled    (not connected?)}
+      "Drop connection (transport error)"]
+     [:button {:data-testid "ws-disconnect"
+               :on-click    #(dispatch [:ws/connection [:ws/disconnect]])
+               :disabled    (and (not connected?) (not reconnecting?) (not failed?))}
+      "Disconnect (clean)"]]))
+
+;; ============================================================================
+;; SEND FORM
+;; ============================================================================
+
+(reg-view ^{:doc "Outbound message form. When :connected the message
+                  goes straight to the wire; while disconnected /
+                  reconnecting / connecting it's enqueued and flushed
+                  on the next :connected entry — the `Queued: N` text
+                  on the right tracks that."}
+          send-form []
+  (let [draft       @(subscribe [:messages/draft])
+        connected?  @(subscribe [:ws/connected?])
+        queue-depth @(subscribe [:ws/queue-depth])]
+    [:form.send-form
+     {:on-submit (fn [e]
+                   (.preventDefault e)
+                   (when (seq draft)
+                     (dispatch [:ws.app/send draft])))}
+     [:input {:type        "text"
+              :placeholder "Type a message…"
+              :data-testid "ws-draft"
+              :value       draft
+              :on-change   #(dispatch [:ws.app/edit-draft (.. % -target -value)])}]
+     [:button {:type        "submit"
+               :data-testid "ws-send"}
+      (if connected? "Send" "Queue")]
+     (when (pos? queue-depth)
+       [:span.queue-depth {:data-testid "ws-queue-depth"}
+        (str "Queued: " queue-depth)])]))
+
+;; ============================================================================
+;; SUBSCRIBE + REQUEST + SERVER-PUSH DEMO
+;; ============================================================================
+
+(reg-view ^{:doc "Buttons that drive the three special-shaped paths:
+                  subscribe (subscriptions survive reconnects + the
+                  mock acks with a synthetic push), request-reply
+                  correlation, and 'trigger server push' (server →
+                  client server-pushed event)."}
+          demo-buttons []
+  (let [connected?  @(subscribe [:ws/connected?])
+        last-reply  @(subscribe [:messages/last-reply])]
+    [:div.demo-buttons
+     [:button {:data-testid "ws-subscribe"
+               :on-click    #(dispatch [:ws.app/subscribe-demo])
+               :disabled    (not connected?)}
+      "Subscribe :demo-topic"]
+     [:button {:data-testid "ws-request"
+               :on-click    #(dispatch [:ws.app/request "hello"])
+               :disabled    (not connected?)}
+      "Request-reply (hello)"]
+     [:button {:data-testid "ws-server-push"
+               :on-click    #(websocket.messages/send-server-push!
+                              {:type :push
+                               :note "Manual server push"
+                               :at   (.toISOString (js/Date.))})
+               :disabled    (not connected?)}
+      "Trigger server push"]
+     (when last-reply
+       [:p.last-reply {:data-testid "ws-last-reply"}
+        "Last correlated reply: "
+        [:code (pr-str last-reply)]])]))
+
+;; ============================================================================
+;; INBOX
+;; ============================================================================
+
+(reg-view ^{:doc "Scrolling list of inbound messages — newest first.
+                  Every server push and every correlated reply is
+                  logged via :ws/handle-message into [:messages :received]."}
+          inbox []
+  (let [msgs @(subscribe [:messages/received])]
+    [:div.inbox
+     [:h3 "Inbox"]
+     [:p.muted (str (count msgs) " message" (when-not (= 1 (count msgs)) "s") " received")]
+     [:ul {:data-testid "ws-inbox"}
+      (for [[i m] (map-indexed vector msgs)]
+        ^{:key i}
+        [:li (pr-str m)])]]))
+
+;; ============================================================================
+;; ROOT
+;; ============================================================================
+
+(reg-view ^{:doc "Root view of the websocket example app."}
+          root-view []
+  [:div.app
+   [:h1 "Pattern-WebSocket — connection machine"]
+   [:p.muted
+    "A worked example of the canonical re-frame2 WebSocket lifecycle "
+    "(see spec/Pattern-WebSocket.md). The transport is a tiny in-process "
+    "mock server — no network required."]
+   [status-pill]
+   [lifecycle-buttons]
+   [:hr]
+   [send-form]
+   [demo-buttons]
+   [:hr]
+   [inbox]])

--- a/examples/reagent/websocket/websocket.spec.cjs
+++ b/examples/reagent/websocket/websocket.spec.cjs
@@ -1,0 +1,84 @@
+/*
+ * Pattern-WebSocket worked example (rf2-yf97).
+ *
+ * The canonical re-frame2 demo for spec/Pattern-WebSocket.md. A small
+ * UI drives a `:ws/connection` state machine through every key
+ * Pattern-WebSocket lifecycle event — connect, reconnect, request-reply
+ * correlation, server-pushed events — against an in-process mock
+ * WebSocket server (no real ws endpoint needed).
+ *
+ * Coverage:
+ *   - App shell mounts; status is DISCONNECTED.
+ *   - Connect → status cascades through CONNECTING / AUTHENTICATING →
+ *     CONNECTED. (The mock's `setTimeout`-microtask delivery means
+ *     we land on CONNECTED within a few hundred ms.)
+ *   - Send a request-reply — the correlated reply lands in the
+ *     "Last correlated reply" panel.
+ *   - Trigger a server push — the inbox grows.
+ *   - Drop the connection (simulated transport error) — status
+ *     becomes RECONNECTING then CONNECTED again after the :after
+ *     backoff fires.
+ */
+
+const { expectVisible, expectTextContains } = require('../../scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'pattern-websocket — connection machine demo',
+  url: '/websocket/',
+  run: async (page) => {
+    // App shell mounts.
+    await expectVisible(page.locator('h1:has-text("Pattern-WebSocket")'), 15000);
+    await expectTextContains(
+      page.locator('[data-testid="ws-status"]'),
+      'DISCONNECTED',
+      5000,
+    );
+
+    // Connect — wait through CONNECTING / AUTHENTICATING to CONNECTED.
+    await page.locator('[data-testid="ws-connect"]').click();
+    await expectTextContains(
+      page.locator('[data-testid="ws-status"]'),
+      'CONNECTED',
+      10000,
+    );
+
+    // Issue a request-reply. The mock auto-echoes; the correlated
+    // reply lands at [:messages :last-reply] and renders in the
+    // "Last correlated reply" panel.
+    await page.locator('[data-testid="ws-request"]').click();
+    await expectVisible(
+      page.locator('[data-testid="ws-last-reply"]'),
+      5000,
+    );
+    await expectTextContains(
+      page.locator('[data-testid="ws-last-reply"]'),
+      ':ok true',
+      5000,
+    );
+
+    // Trigger a manual server push. The inbox grows by one.
+    const inbox = page.locator('[data-testid="ws-inbox"]');
+    const before = await inbox.locator('li').count();
+    await page.locator('[data-testid="ws-server-push"]').click();
+    await page.waitForFunction(
+      (prev) => document.querySelectorAll('[data-testid="ws-inbox"] li').length > prev,
+      before,
+      { timeout: 5000 },
+    );
+
+    // Drop the connection (simulated transport error). The status
+    // pill flips to RECONNECTING; the :after backoff (base 100ms,
+    // 2^retries up to 5000ms) re-enters :active; the cascade lands
+    // back at CONNECTED within a few hundred ms.
+    await page.locator('[data-testid="ws-drop"]').click();
+    // Either we catch the brief RECONNECTING window, or the cascade
+    // resolved already and we're already back to CONNECTED. Both are
+    // valid evidence the reconnect machinery worked — but the
+    // canonical observable is the final CONNECTED state.
+    await expectTextContains(
+      page.locator('[data-testid="ws-status"]'),
+      'CONNECTED',
+      10000,
+    );
+  },
+};

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -214,6 +214,16 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'long_running_work', 'index.html'),
     outDir: path.join(OUT_ROOT, 'long-running-work'),
   },
+  // Pattern-WebSocket worked example (rf2-yf97). Connection machine
+  // with hierarchical :active, :invoke'd socket actor, :after backoff,
+  // :always queue-flush, :fsm/tags, request-reply correlation, and
+  // connection-epoch staleness. The transport is an in-process mock
+  // WebSocket so the example is standalone — no network needed.
+  {
+    build: 'examples/websocket',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'websocket', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'websocket'),
+  },
 ];
 
 function compileAll() {

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -1,0 +1,96 @@
+(ns re-frame.websocket-cljs-test
+  "Integration test: drives the websocket example's headless test
+   fixtures (rf2-yf97). Each fixture spins a fresh frame via
+   `make-frame`, drives the connection machine through a slice of the
+   Pattern-WebSocket lifecycle (using an in-process mock WebSocket
+   server in sync-delivery mode), and asserts the resulting state /
+   tags / app-db slice.
+
+   The fixtures live under examples/reagent/websocket/test/websocket/ — extracted
+   from the example's `connection.cljs` + `messages.cljs` so the
+   production source stays test-free (mirrors the realworld layout).
+
+   Per rf2-am9d this ns uses snapshot/restore via re-frame.test-support
+   so the contract is uniform across CLJS fixtures: the snapshot captures
+   the example's ns-load registrations, and the restore on the way out
+   leaves them intact for any subsequent test ns."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]
+            [websocket.core]
+            [websocket.messages]
+            [websocket.connection-test :as conn-t]
+            [websocket.messages-test :as msg-t]))
+
+;; `:init-fn` re-fires every `rf/reg-*` this example owns so the
+;; ns-load registrations the tests depend on are present even when
+;; an alphabetically-earlier test ns (e.g. the Story `:rf.assert/*`
+;; fixture) has called `re-frame.registrar/clear-all!` without
+;; restoring afterwards. Idempotent — last-write-wins.
+;;
+;; Also resets the mock WebSocket server's `:sockets` table — since
+;; the spawn-counter resets to 1 each test, every test's actor lands
+;; on `:websocket/socket#1`; without this reset the prior tests'
+;; mock-socket entries are still in the table and
+;; `send-server-push!` ends up delivering N copies of every push.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                (websocket.core/register-all!)
+                (websocket.messages/reset-mock-server!))}))
+
+;; ---- connection lifecycle ------------------------------------------------
+;; One deftest per test fn so the :each fixture (which resets mock state
+;; + re-registers everything) runs around each individually.
+
+(deftest websocket-initial-state
+  (testing "initial state — machine starts at :disconnected with empty buffers"
+    (conn-t/initial-state-test)))
+
+(deftest websocket-connect-happy-path
+  (testing "connect happy path — :disconnected → :active/:connected with tags set"
+    (conn-t/connect-happy-path-test)))
+
+(deftest websocket-offline-queue
+  (testing "offline queue — :ws/send while disconnected enqueues; :connected entry flushes"
+    (conn-t/offline-queue-test)))
+
+(deftest websocket-reconnect-cascade
+  (testing "reconnect cascade — transport drop → :reconnecting → :after re-enters :active"
+    (conn-t/reconnect-cascade-test)))
+
+(deftest websocket-max-retries-failed
+  (testing "max-retries — :reconnecting → :failed once :max-retries-exceeded?"
+    (conn-t/max-retries-failed-test)))
+
+(deftest websocket-connection-epoch-staleness
+  (testing "connection epoch — stale :ws/received from a prior socket is dropped"
+    (conn-t/connection-epoch-staleness-test)))
+
+(deftest websocket-refresh-token
+  (testing ":ws/refresh-token — updates :data :auth-token"
+    (conn-t/refresh-token-test)))
+
+(deftest websocket-disconnect-cleanly
+  (testing "clean :ws/disconnect — :connected → :disconnected, socket-id cleared"
+    (conn-t/disconnect-cleanly-test)))
+
+;; ---- request/reply + server push + subscriptions ------------------------
+
+(deftest websocket-request-reply-correlation
+  (testing "request-reply correlation — :in-flight slot fills then clears on reply"
+    (msg-t/request-reply-correlation-test)))
+
+(deftest websocket-server-push
+  (testing "server-pushed events — manual push lands in [:messages :received]"
+    (msg-t/server-push-test)))
+
+(deftest websocket-subscription-tracking
+  (testing ":data :subscriptions tracking — :ws/subscribe records the topic"
+    (msg-t/subscription-tracking-test)))
+
+(deftest websocket-handle-message-newest-first
+  (testing ":ws/handle-message keeps the [:messages :received] log newest-first"
+    (msg-t/handle-message-newest-first-test)))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -73,6 +73,7 @@
                 ;; keep the production source test-free (same layout
                 ;; convention as realworld/ and nine_states/).
                 "../examples/reagent/long_running_work/test"
+                "../examples/reagent/websocket/test"
                 "../examples/uix"
                 "../examples/helix"]
  :dependencies [[reagent           "2.0.1"]
@@ -414,4 +415,17 @@
   {:target     :browser
    :output-dir "out/examples/counter-with-stories"
    :asset-path "."
-   :modules    {:main {:init-fn counter-with-stories.core/run}}}}}
+   :modules    {:main {:init-fn counter-with-stories.core/run}}}
+
+  ;; Pattern-WebSocket worked example (rf2-yf97). Canonical worked
+  ;; example for spec/Pattern-WebSocket.md — connection machine with
+  ;; hierarchical :active parent, :invoke'd socket actor, :after
+  ;; backoff, :always queue-flush, :fsm/tags, request-reply
+  ;; correlation, and connection-epoch staleness via :current-socket?.
+  ;; The transport is a tiny in-process mock WebSocket server so the
+  ;; example runs standalone — no network required.
+  :examples/websocket
+  {:target     :browser
+   :output-dir "out/examples/websocket"
+   :asset-path "."
+   :modules    {:main {:init-fn websocket.core/run}}}}}


### PR DESCRIPTION
## Summary

The runnable worked example for [`spec/Pattern-WebSocket.md`](../blob/main/spec/Pattern-WebSocket.md). A small reagent app drives a `:ws/connection` state machine through every key Pattern-WebSocket lifecycle event — connect, reconnect with `:after` exponential backoff + `:max-retries-exceeded?` → `:failed`, request-reply correlation via `:in-flight`, subscription tracking, and server-pushed events — against an in-process mock WebSocket server so the example runs standalone.

## Machine shape

Faithful to Pattern-WebSocket §The connection state machine — same hierarchy, same `:active`-anchored socket-actor `:invoke`, same connection-epoch staleness check via `:current-socket?` against the live `:socket-id`:

```
:disconnected
:active                     ;; compound parent; owns the socket actor
  :connecting
  :authenticating
  :connected
:reconnecting               ;; :after backoff + :max-retries-exceeded? guard
:failed                     ;; terminal until manual :ws/connect
```

The `:websocket/socket` actor (a child machine spawned by the parent's `:active` `:invoke`) owns the host-side WebSocket reference via a private store keyed by `:rf/self-id`; only the id appears in `:data`. Lifetime is bound to `:active` so exit-from-:active destroys the actor and re-entry spawns a fresh one — the canonical answer to the reconnect-cleanup question.

`:fsm/tags` — `:websocket/connected`, `:websocket/reconnecting`, `:websocket/failed`, `:websocket/active`, `:websocket/connecting`, `:websocket/authenticating` — drive the view's status pill via `rf/has-tag?` rather than unfolding the snapshot's hierarchical `:state` vector.

## Files touched

| File | Notes |
|---|---|
| `examples/reagent/websocket/core.cljs` | App entry + `register-all!` hook |
| `examples/reagent/websocket/connection.cljs` | `:ws/connection` machine — the heart of the example |
| `examples/reagent/websocket/messages.cljs` | `:websocket/socket` actor + mock server + `:ws/handle-message` + app events |
| `examples/reagent/websocket/views.cljs` | Status pill, lifecycle buttons, send form, demo trio, inbox |
| `examples/reagent/websocket/schema.cljs` | Malli schemas for the connection-machine snapshot + `[:messages]` slice |
| `examples/reagent/websocket/index.html` | Minimal harness |
| `examples/reagent/websocket/websocket.spec.cjs` | Playwright smoke |
| `examples/reagent/websocket/README.md` | What the example demonstrates + how to run |
| `examples/reagent/websocket/test/websocket/connection_test.cljs` | Initial state, happy-path lifecycle, offline-queue + drain, reconnect cascade, max-retries → `:failed`, connection-epoch staleness, `:ws/refresh-token`, clean `:ws/disconnect` |
| `examples/reagent/websocket/test/websocket/messages_test.cljs` | Request-reply correlation, server-push routing, subscription tracking, `[:messages :received]` newest-first |
| `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs` | CLJS-test aggregator |
| `implementation/shadow-cljs.edn` | Add `:examples/websocket` build + source path for tests |
| `examples/scripts/serve-and-run-examples-tests.cjs` | Add to EXAMPLES list |

## Methodology note on the mock WebSocket

The transport is a tiny in-process `WebSocket`-shaped stub in `messages.cljs`. It supports:

- **Auto-echo for `:request` messages** — every outbound `{:type :request ...}` immediately echoes back as `{:type :reply :request-id ... :ok true :echo ...}`, so the request-reply correlation slot lights up.
- **Auth ack** — `{:type :auth :token ...}` produces `{:type :auth-ok}` for any non-empty token.
- **Subscribe ack** — every `{:type :subscribe :topic ...}` is acked with one synthetic `{:type :push :topic ... :note "subscribed"}` so the example demonstrates the subscribe-then-push shape end-to-end.
- **`send-server-push!`** + **`simulate-disconnect!`** — used by the UI buttons and the Playwright spec to drive server-pushed and transport-drop scenarios.

Two delivery modes — async via `setTimeout(_, 0)` (default, browser) and sync via `set-mock-sync!` (headless tests). The headless tests put the mock in sync mode so `dispatch-sync` observes the full request/reply round-trip without yielding to the JS event loop.

**Production swap-out:** replace `mock-socket-for-actor` with a real `(js/WebSocket. url)` and wire its `onopen` / `onmessage` / `onerror` / `onclose` to the same actor-level dispatches. The connection machine — and every test against it — does not change.

## Test-ordering note

The example's test ns lands alphabetically after the Story `:rf.assert/*` fixture (`re-frame.story-assertions-cljs-test`), which calls `registrar/clear-all!` without restoring. By the time `re-frame.websocket-cljs-test` runs, the ns-load-time registrations the example depends on are gone — including the framework-shipped `:rf.machine/*` fx and the `:rf/machine` / `:rf/machine-has-tag?` subs.

Recovery: each sub-namespace exposes an idempotent `register-all!`, and the fixture's `:init-fn` calls `websocket.core/register-all!` to re-fire every registration the example depends on (plus the framework machines fx/subs via late-bind hooks). Same pattern `counter-with-stories.stories/register-all!` already uses for the Story side-table.

## Test plan

- [x] `npm run test:cljs` — 518 tests, 0 failures
- [x] `npm run test:browser` — 503 tests, 0 failures
- [x] `npm run test:elision` — PASS (no test-only code leaks to release)
- [x] `npm run test:examples` — `pattern-websocket — connection machine demo` PASSES (alongside every other example)
- [x] `shadow-cljs compile examples/websocket` — 0 warnings