### PR TITLE
fix(reagent-slim): make-render-method reaction re-runs on app-db change (rf2-u5p5)

### DIFF
--- a/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
+++ b/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
@@ -15,18 +15,11 @@
  * implementation/scripts/check-counter-slim-and-fast.cjs and is
  * already enforced by CI's cljs-bundle-comparison job.
  *
- * rf2-s36l (interop late-binding) and rf2-08t0 (slim wrap-render
- * → as-element seam) both landed in the rf2-s36l PR — the slim
- * adapter now mounts cleanly with the correct IDisposable
- * dispatch and the class render() method returns React elements
- * instead of raw hiccup vectors. With those two fixes, this
- * smoke gets as far as initial render (the displayed count is
- * the seeded 5). What still fails is the click-driven re-render
- * path: `+` clicks update app-db but the displayed count stays
- * at 5. Tracked at **rf2-u5p5** (slim re-render reactive). Until
- * that bead lands the bundle-comparison contract remains the
- * binding S3-008 claim; the runtime smoke is parked behind
- * `skip:` again.
+ * Three seams (rf2-s36l interop late-binding, rf2-08t0 wrap-render
+ * → as-element conversion, rf2-u5p5 reaction `._run` on
+ * subsequent render entries) all combine to make the slim adapter
+ * a drop-in for the bridge: mount, render, and reactive re-render
+ * all match stock Reagent's user-visible behaviour.
  */
 
 const { expectTextEquals } = require('../../scripts/spec-helpers.cjs');
@@ -34,13 +27,6 @@ const { expectTextEquals } = require('../../scripts/spec-helpers.cjs');
 module.exports = {
   name: 'counter-slim-and-fast',
   url: '/counter-slim-and-fast/',
-  // SEE the docstring above. The interop seam (rf2-s36l) and the
-  // wrap-render → as-element seam (rf2-08t0) both landed in the
-  // rf2-s36l PR — initial mount + render is correct. What remains
-  // is the reactive-update path: dispatched events update app-db
-  // but the subscribe Reaction's watch chain doesn't drive a
-  // re-render of the class component. Tracked at rf2-u5p5.
-  skip: 'pending rf2-u5p5 — slim Reaction → React forceUpdate watch chain not firing on app-db change; initial mount + render works post-rf2-s36l/rf2-08t0, click-driven re-render does not. Bundle-comparison contract unaffected.',
   run: async (page) => {
     const span = page.locator('span').first();
     await expectTextEquals(span, '5', 10000);

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -480,27 +480,62 @@
 
   The Reaction is created lazily on first render and cached on the
   instance as `.-cljsRenderRea`. It returns the rendered React element;
-  on subsequent dep-driven recomputes it queues a forceUpdate without
-  needing the result (React's own commit produces the DOM)."
+  on subsequent dep-driven recomputes it queues a forceUpdate via the
+  auto-run callback, and React's commit re-enters this render method
+  which forces a fresh `._run` of the Reaction (rf2-u5p5).
+
+  The shape mirrors stock Reagent's `reagent.impl.component`: a custom
+  auto-run callback that queues a React re-render (does NOT synchronously
+  recompute), and an explicit `._run rea false` on every render entry
+  past the first so the user's render fn sees the latest state. The
+  built-in `_handle-change → auto-run` path does not mark `dirty?`, so
+  a plain `@rea` after a dep change would return the cached prior state.
+  The explicit `._run` re-captures dependencies AND produces the current
+  hiccup. Per IMPL-SPEC §4.4 path 1 + the same call shape stock Reagent
+  uses (`(._run rat false)` at line 289 of upstream
+  `reagent.impl.component`)."
   [render-fn]
   (fn []
     (this-as ^js this
       (binding [*current-component* this]
         (batching/mark-rendered this)
-        (let [rea (or (.-cljsRenderRea this)
-                      (let [r (ratom/make-reaction
-                                #(wrap-render this render-fn)
-                                :auto-run
-                                ;; Custom auto-run: don't synchronously
-                                ;; recompute on dep change; instead queue
-                                ;; a re-render of this React component.
-                                ;; React drives the next render via its
-                                ;; reconciler; the Reaction recomputes
-                                ;; inside that next render.
-                                (fn [_r]
-                                  (batching/queue-render! this)))]
-                        (set! (.-cljsRenderRea this) r)
-                        r))]
+        (let [^js rea (.-cljsRenderRea this)
+              ;; Per rf2-u5p5: first-render path creates the Reaction
+              ;; with a custom auto-run callback that queues a React
+              ;; re-render on dep change. On subsequent renders the
+              ;; Reaction already exists — call `._run` directly to
+              ;; force a fresh deref-capture of the user's render fn so
+              ;; the watching graph rewires AND the hiccup reflects the
+              ;; current state. Without the explicit `._run`, a plain
+              ;; `@rea` returns the cached prior `state` because
+              ;; `_handle-change` with a fn-valued auto-run doesn't set
+              ;; `dirty?` (matching stock Reagent's kernel, which uses
+              ;; this same shape via `run-in-reaction`).
+              hiccup (if (nil? rea)
+                       (let [^js r (ratom/make-reaction
+                                     #(wrap-render this render-fn)
+                                     :auto-run
+                                     ;; Custom auto-run: don't synchronously
+                                     ;; recompute on dep change; instead queue
+                                     ;; a re-render of this React component.
+                                     ;; React drives the next render via its
+                                     ;; reconciler; the Reaction recomputes
+                                     ;; inside that next render via the
+                                     ;; explicit `._run` call below.
+                                     (fn [_r]
+                                       (batching/queue-render! this)))]
+                         (set! (.-cljsRenderRea this) r)
+                         ;; First render: dirty? is true; -deref will
+                         ;; recompute via `._run this false` and return
+                         ;; the freshly captured state.
+                         @r)
+                       ;; Subsequent render: re-run the Reaction so the
+                       ;; user's render fn executes with the latest
+                       ;; subscribed state. `_run` calls `deref-capture`
+                       ;; which rewires the watching graph and updates
+                       ;; the cached state. Mirrors stock Reagent
+                       ;; `reagent.impl.component`'s render path.
+                       (._run rea false))]
           ;; Per rf2-08t0: `wrap-render` (per IMPL-SPEC §5.1) returns
           ;; raw hiccup; React's render() method MUST return a React
           ;; element. Run the deref'd hiccup through the registered
@@ -510,7 +545,7 @@
           ;; extract); we keep the IMPL-SPEC §5.1 shape (wrap-render
           ;; returns hiccup) and move the conversion to the render-
           ;; method boundary instead.
-          (->react-element @rea))))))
+          (->react-element hiccup))))))
 
 (defn- copy-argv-from-props!
   "Read the argv off React's `props` and stash it on `c` as

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/client_cljs_test.cljs
@@ -341,6 +341,49 @@
                      (.call (.. klass -prototype -componentWillUnmount) inst)
                      (done))))))))
 
+(deftest render-second-render-recomputes-reaction-rf2-u5p5
+  (testing "rf2-u5p5: second render after dep change recomputes the Reaction, not returns cached state"
+    ;; Regression for rf2-u5p5: the render path used to do a plain
+    ;; `@cljsRenderRea` on every render. After a dep change, the
+    ;; Reaction's `_handle-change` calls the auto-run callback
+    ;; (queue-render!) but does NOT mark `dirty?` (matching stock
+    ;; Reagent's kernel — only the nil-auto-run path enqueues).
+    ;; So a follow-up `-deref` with `dirty? = false` returns the cached
+    ;; prior state rather than recomputing, and the user-visible count
+    ;; never updates.
+    ;;
+    ;; The fix: on subsequent render entries, call `._run rea false`
+    ;; directly so deref-capture re-runs the user fn with the latest
+    ;; subscribed state. This test would FAIL against the pre-fix
+    ;; render path even though the deref-capture-queues-rerender test
+    ;; passed (that test only verified forceUpdate fired, not that the
+    ;; subsequent render produced updated output).
+    (let [a            (ratom/atom 0)
+          ;; Capture the hiccup produced on each render via a side-
+          ;; channel; the render method returns a React element after
+          ;; `->react-element`, so we read .-cljsArgv-equivalent off the
+          ;; element to verify it carries the current `@a`.
+          last-seen    (atom nil)
+          render-fn    (fn []
+                         (let [v @a]
+                           (reset! last-seen v)
+                           [:div v]))
+          ^js klass    (component/create-class*
+                         {:reagent-render render-fn})
+          inst         (new klass #js {:__rfArgv [render-fn]})]
+      (set! (.-forceUpdate inst) (fn [] nil))
+      ;; First render: reads `a = 0`.
+      (.call (.. klass -prototype -render) inst)
+      (is (= 0 @last-seen) "first render saw a=0")
+      ;; Mutate the dep.
+      (swap! a inc)
+      ;; Simulate React's re-entry: call render() again. Pre-fix this
+      ;; returned cached hiccup (a=0); post-fix it recomputes (a=1).
+      (.call (.. klass -prototype -render) inst)
+      (is (= 1 @last-seen)
+          "second render after dep change saw a=1 (recompute, not cache)")
+      (.call (.. klass -prototype -componentWillUnmount) inst))))
+
 (deftest render-componentwillunmount-disposes-render-reaction
   (testing "componentWillUnmount disposes the per-instance render Reaction"
     (let [a            (ratom/atom 0)


### PR DESCRIPTION
## Summary

The slim adapter's per-component render Reaction never re-ran after a dep change: clicking `+` on the counter-slim-and-fast example updated `app-db` but the displayed count never advanced past the initial seed of 5.

## Root cause

`make-render-method` did `@cljsRenderRea` on every render entry. On the **first** render this triggers `_run` (because `dirty? = true`) — `deref-capture` runs the user's render fn and rewires the watching graph. On a **subsequent** React-driven render after a dep change, the Reaction's `_handle-change` had already fired — but the **fn-valued `auto-run` path** in the kernel calls the queue-render callback **WITHOUT setting `dirty?`** (matching stock Reagent's kernel; only the nil-auto-run path enqueues + marks dirty):

```clj
(_handle-change [this _sender oldval newval]
  (when-not (or (identical? oldval newval) dirty?)
    (if (nil? auto-run)
      (do (set! dirty? true) (rea-enqueue this))
      (if (true? auto-run)
        (._run this false)
        (auto-run this)))))           ;; <-- our queue-render fn, dirty? untouched
```

So the follow-up `-deref` saw `dirty? = false` and returned the cached prior `state` instead of recomputing. The watching graph was wired correctly; the user fn just never re-ran with the new state.

## Fix shape

Mirror stock Reagent's `reagent.impl.component` render path (upstream line 289: `(._run rat false)`). On subsequent render entries, call `(._run rea false)` directly — this re-runs `deref-capture`, rewires the watching graph, AND produces the updated hiccup. First render still goes through `@r` so the initial recompute fires via the standard dirty-path in `-deref`.

```clj
hiccup (if (nil? rea)
         (let [r (ratom/make-reaction ...)]    ;; first render: create + deref
           (set! (.-cljsRenderRea this) r)
           @r)
         (._run rea false))                    ;; subsequent: force recompute
```

## Before / after evidence

`examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs`:
- **Before:** `skip:` block parked the smoke at `rf2-u5p5` — the test would have failed at the first `expectTextEquals(span, '6')` after clicking `+`.
- **After:** smoke runs end-to-end. The `run:` block verifies 5 → 6 → 4 across `+` / `-` clicks.

Test suite run:
- `test:cljs` — 507 tests, 0 failures (was 506 — +1 new regression test)
- `test:browser` — 503 tests, 0 failures
- `test:browser-schemas-boundary-prod` — 5 tests, 0 failures
- `test:bundle-comparison` — PASS (Contract 1/2/3 still green)
- `test:elision` — PASS (sentinel matrix unchanged)
- `test:examples` — `counter-slim-and-fast` SKIP → **PASS**; no regression in other examples
- Slim adapter JVM (`clojure -M:test`) — 11 tests, 0 failures

The new test `render-second-render-recomputes-reaction-rf2-u5p5` in `client_cljs_test.cljs` would have FAILED against the pre-fix code even though the existing `render-deref-capture-queues-rerender-on-dep-change` test passed — the existing test only verified `forceUpdate` fired, not that the subsequent render produced updated output. The new test asserts the user fn observes the new state.

No debug instrumentation kept (the fix path is now load-bearing through the regression test).

## Test plan

- [x] CLJS unit tests pass (`npm run test:cljs`)
- [x] Browser tests pass (`npm run test:browser`)
- [x] Schemas-boundary-prod tests pass
- [x] Bundle-comparison stays green
- [x] Elision sentinel matrix stays green
- [x] Examples suite — counter-slim-and-fast SKIP → PASS
- [x] Slim adapter JVM tests pass