### PR TITLE
fix(machines): spawn cascade fires initial-state :entry actions (rf2-0z73)

### DIFF
--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -284,24 +284,24 @@
 
      :states
      {:opening
-      ;; The runtime dispatches `[<self-id> [:rf.machine/spawned]]` to
-      ;; every freshly-spawned actor that didn't get an explicit
-      ;; `:start` (per Spec 005 §Spawning / rf2-ijm7). The actor opens
-      ;; the host-side socket on that event and transitions to `:open`.
-      ;; Putting `:open-socket` here (instead of as `:entry`) sidesteps
-      ;; the rule that entries don't fire on initial cascade.
-      {:on {:rf.machine/spawned {:target :open
-                                 :action :open-socket}
-            ;; The actor may receive `:send` from the parent's
-            ;; `:send-auth` entry-action before its own `:open-socket`
-            ;; has run — keep the override here so the action picks up
-            ;; the just-stored host-side socket once it's stored.
-            :send       {:target :open
-                         :action :send-via-socket}
-            :received   {:target :open
-                         :action :forward-received}
-            :closed     {:target :closed
-                         :action :forward-closed}}}
+      ;; Per Spec 005 §Initial-state `:entry` fires on machine bootstrap
+      ;; (rf2-0z73): the initial-state's `:entry` action runs once as
+      ;; part of bringing the actor to life. We open the host-side
+      ;; socket on bootstrap and transition immediately to `:open` via
+      ;; the `:always` slot once the socket is stored.
+      ;;
+      ;; The actor may also receive `:send` from the parent's
+      ;; `:send-auth` entry-action before its own bootstrap entry has
+      ;; settled — the `:send` override here picks up the just-stored
+      ;; host-side socket as soon as it lands.
+      {:entry :open-socket
+       :always [{:target :open}]
+       :on    {:send       {:target :open
+                            :action :send-via-socket}
+               :received   {:target :open
+                            :action :forward-received}
+               :closed     {:target :closed
+                            :action :forward-closed}}}
 
       :open
       {:on {:send     {:action :send-via-socket}

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -1696,9 +1696,16 @@
    :initial :requesting
    :states
    {:requesting
-    {:on {:rf.machine/spawned {:action :fire-request}
-          :rf.http/succeeded  {:target :succeeded :action :record-value}
-          :rf.http/failed     {:target :failed    :action :record-failure}}}
+    ;; Per rf2-0z73: initial-state `:entry` actions fire on spawn as
+    ;; part of the bootstrap cascade — the canonical re-frame2 shape
+    ;; for "do this when the actor first runs". Pre-rf2-0z73 this
+    ;; entry-on-spawn was emulated via `:on :rf.machine/spawned
+    ;; :action :fire-request` (the synthetic event spawn-fx dispatches
+    ;; when no explicit `:start` was supplied); that workaround is no
+    ;; longer needed.
+    {:entry :fire-request
+     :on    {:rf.http/succeeded  {:target :succeeded :action :record-value}
+             :rf.http/failed     {:target :failed    :action :record-failure}}}
 
     :succeeded
     {:entry :dispatch-done

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1168,6 +1168,121 @@
 
       :else fx)))
 
+;; ---- initial-state entry cascade (rf2-0z73) -------------------------------
+;;
+;; Per Spec 005 §Initial cascading and §Entry/exit cascading along the
+;; LCA, every state's `:entry` action fires when its state is entered.
+;; The "initial state" is no exception — when a machine first comes into
+;; existence (singleton on first dispatch, or spawned actor on
+;; `:rf.machine/spawn`), the initial state's `:entry` actions fire as
+;; part of bringing the machine to life. For a compound initial cascade
+;; (`:initial` chain descending through nested states), EVERY state
+;; along that cascade fires its `:entry` shallowest-first.
+;;
+;; Pre-rf2-0z73, neither bootstrap path ran initial `:entry` actions.
+;; The websocket example (rf2-yf97) and the `:rf.http/managed` machine-
+;; shape wrapper both worked around the gap by declaring an `:on
+;; :rf.machine/spawned` transition on the initial state that targeted
+;; itself with an `:action`. That workaround is no longer needed —
+;; initial `:entry` now fires as part of the bootstrap cascade.
+;;
+;; The cascade re-uses `apply-transition-once` by synthesising a
+;; "transition from the empty path to the initial leaf". With
+;; `src-path = []`, `lca-len = 0`, so nothing exits and every node from
+;; root to the initial leaf has its `:entry` action run (plus
+;; `:rf.machine/spawn` / `:rf.machine/invoke-all-init` / `:after-schedule`
+;; fx emitted for `:invoke` / `:invoke-all` / `:after` declarations on
+;; any node in the cascade).
+
+(defn- apply-initial-entry-cascade-single
+  "Bootstrap entry cascade for a flat / compound (non-parallel) machine.
+  Re-uses `apply-transition-once` by passing a snapshot whose `:state`
+  is the empty path `[]` and a synthetic transition whose `:target` is
+  the initial leaf path. With src-path `[]` the LCA is the empty
+  prefix, so nothing exits, no transition action runs (no `:action`
+  slot), and the entry cascade fires for every state from root to leaf.
+
+  Per Spec 005 §State paths: flat machines carry `:state` as a keyword;
+  compound and parallel machines carry it as a vector path. The
+  `:target` form fed into `apply-transition-once` matches the original
+  `:state` form so the post-bootstrap snapshot's `:state` keeps its
+  declared shape — a flat machine remains keyword-stated even after
+  the bootstrap cascade, which keeps existing tests / fixtures that
+  pattern-match on `(= :idle (:state snap))` working."
+  [machine initial-snapshot]
+  (let [original-state (:state initial-snapshot)
+        target-leaf    (state-path original-state)
+        ghost-snap     (assoc initial-snapshot :state [])
+        ;; The synthetic event a user's :entry / :on-spawn action may
+        ;; observe via the 3-arity ctx during the bootstrap cascade.
+        ;; A dedicated sentinel keeps the event distinguishable from
+        ;; user events for any future introspection use; no machine
+        ;; surface currently dispatches on it.
+        boot-event     [:rf.machine/bootstrap]
+        ;; Pass the target in the same shape the original snapshot
+        ;; carried — keyword for flat machines (so the post-cascade
+        ;; snapshot stays keyword-stated), vector for compound
+        ;; machines. apply-transition-once's `new-state` branch
+        ;; honours both forms.
+        boot-target    (if (keyword? original-state)
+                         original-state
+                         (vec target-leaf))
+        boot-transition {:target    boot-target
+                         :decl-path []}]
+    (apply-transition-once machine ghost-snap boot-event boot-transition)))
+
+(defn- apply-initial-entry-cascade
+  "Synthesise the bootstrap entry cascade for `machine` against the
+  freshly-synthesised `initial-snapshot` (the `{:state <initial-leaf>
+  :data <initial-data>}` map the handler boundary built when the
+  snapshot was first materialised). Returns `[new-snapshot fx-vec]`,
+  or the `[::action-failed info]` sentinel if any `:entry` action
+  in the cascade threw.
+
+  For flat / compound machines, delegates to
+  `apply-initial-entry-cascade-single`.
+
+  For parallel-region machines (`:type :parallel`), iterates regions in
+  declaration order, running each region's bootstrap cascade against a
+  synthetic per-region snapshot ({:state <region-initial> :data
+  <shared>}). The shared `:data` threads sequentially through regions
+  (matching `parallel-machine-transition`'s broadcast semantics — a
+  later region's `:entry` sees earlier regions' `:data` writes). Each
+  region's fx is prefixed with the region name via
+  `prefix-region-invoke-id` so per-region tracking slots stay distinct."
+  [machine initial-snapshot]
+  (if (parallel? machine)
+    (let [state-map     (:state initial-snapshot)
+          region-names  (vec (keys (:regions machine)))
+          ordered       (filterv #(contains? state-map %) region-names)]
+      (loop [pending     ordered
+             cur-data    (:data initial-snapshot)
+             new-states  state-map
+             acc-fx      []]
+        (cond
+          (empty? pending)
+          (let [merged (-> initial-snapshot
+                           (assoc :state new-states)
+                           (assoc :data  cur-data))]
+            [(commit-tags-parallel machine merged) acc-fx])
+
+          :else
+          (let [rn          (first pending)
+                region-spec (region-machine machine rn)
+                region-snap {:state (get state-map rn)
+                             :data  cur-data}
+                step-result (apply-initial-entry-cascade-single region-spec region-snap)]
+            (if (and (vector? step-result)
+                     (= ::action-failed (first step-result)))
+              step-result
+              (let [[reg-snap reg-fx] step-result
+                    prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
+                (recur (rest pending)
+                       (:data reg-snap)
+                       (assoc new-states rn (:state reg-snap))
+                       (vec (concat acc-fx prefixed-fx)))))))))
+    (apply-initial-entry-cascade-single machine initial-snapshot)))
+
 (declare machine-transition machine-transition-single)
 
 (defn- parallel-machine-transition
@@ -1930,7 +2045,32 @@
           ;; configuration. Elision-safe — both forms drop the slot when
           ;; the union is empty.
           initial    (commit-tags-parallel machine initial)
-          snapshot   (or (get-in db path) initial)
+          ;; Per rf2-0z73: detect "first event for this machine" so the
+          ;; initial-state's `:entry` actions fire as part of bringing
+          ;; the machine to life. Two flavours:
+          ;;
+          ;;   - Singleton path: `(get-in db path)` is `nil` — the
+          ;;     snapshot is being lazily synthesised right now. Mark
+          ;;     the freshly-synthesised initial as bootstrap-pending.
+          ;;
+          ;;   - Spawn path: `spawn-fx` pre-seeded the snapshot at
+          ;;     `[:rf/machines <spawned-id>]` and stamped
+          ;;     `:rf/bootstrap-pending? true` so the actor's first
+          ;;     dispatch (the synthetic `[:rf.machine/spawned]` event
+          ;;     OR the user-supplied `:start`) sees the marker and
+          ;;     runs the cascade before processing the event.
+          ;;
+          ;; In both cases the marker is dissoc'd after the cascade
+          ;; runs, so subsequent dispatches see a normal snapshot.
+          existing-snap (get-in db path)
+          needs-bootstrap? (or (nil? existing-snap)
+                               (true? (:rf/bootstrap-pending? existing-snap)))
+          snapshot   (cond
+                       (nil? existing-snap)
+                       (assoc initial :rf/bootstrap-pending? true)
+
+                       :else
+                       existing-snap)
           ;; Sub-event routing per Spec 005 §Registration. The outer
           ;; event is [:machine-id <inner-event> & extra-args]. Extra
           ;; args are conj'd onto the inner event — the convention
@@ -1964,12 +2104,68 @@
           ;; state's :after slot, whose synthetic
           ;; :rf.machine.timer/after-elapsed event flows through the
           ;; standard pick-after-transition path.
-          intercepted (intercept-invoke-all-event machine db path snapshot machine-id inner-event)]
-      (if intercepted
+          intercepted (intercept-invoke-all-event machine db path snapshot machine-id inner-event)
+          ;; Per rf2-0z73: when the snapshot is bootstrap-pending, run
+          ;; the initial-state entry cascade once before processing the
+          ;; user event. The cascade may emit `:rf.machine/spawn` /
+          ;; `:after-schedule` fx for any `:invoke` / `:after` declared
+          ;; on the initial-cascade path. Bootstrap fx flow OUT of the
+          ;; handler ahead of any fx the user event produces — entry
+          ;; happens-before user event handling. Per Spec 005 §Errors,
+          ;; a throw inside an initial-entry action halts the bootstrap
+          ;; identically to a throw inside any other entry cascade: no
+          ;; snapshot commits, no fx flow, and a single
+          ;; `:rf.error/machine-action-exception` trace fires.
+          [boot-snap boot-fx :as boot-result]
+          (cond
+            (and needs-bootstrap? (not intercepted))
+            (apply-initial-entry-cascade machine snapshot)
+
+            :else
+            [snapshot []])
+          boot-failed? (and (vector? boot-result)
+                            (= ::action-failed (first boot-result)))
+          ;; The snapshot the user event sees: post-bootstrap and with
+          ;; the `:rf/bootstrap-pending?` marker dissoc'd. (Marker is on
+          ;; the input snapshot, not on `boot-snap` — `apply-transition-
+          ;; once` threads `:data` writes through but copies the rest
+          ;; of the snapshot unchanged.)
+          post-boot-snap (when-not boot-failed?
+                           (dissoc boot-snap :rf/bootstrap-pending?))]
+      (cond
+        intercepted
         ;; The event was a join-protocol event; the intercept did its
         ;; bookkeeping in app-db and set up the resolution dispatch.
         intercepted
-        (let [step-result (machine-transition machine snapshot inner-event)]
+
+        boot-failed?
+        ;; The initial-entry cascade itself threw. Emit the same
+        ;; `:rf.error/machine-action-exception` trace any other
+        ;; entry-cascade throw produces and halt — no `:db`, no `:fx`.
+        (let [info       (second boot-result)
+              ex         (:exception info)
+              ex-msg     #?(:clj  (when ex (.getMessage ^Throwable ex))
+                            :cljs (when ex (.-message ex)))
+              ex-data    (when ex (ex-data ex))
+              action-ref (:action-ref info)]
+          (trace/emit-error! :rf.error/machine-action-exception
+                             {:machine-id        machine-id
+                              :action-id         action-ref
+                              :state-path        (:state-path info)
+                              :transition        (:transition info)
+                              :event             [:rf.machine/bootstrap]
+                              :failing-id        machine-id
+                              :handler-id        machine-id
+                              :frame             (or frame :rf/default)
+                              :exception         ex
+                              :exception-message ex-msg
+                              :exception-data    ex-data
+                              :reason            "Machine initial-entry action threw."
+                              :recovery          :no-recovery})
+          {})
+
+        :else
+        (let [step-result (machine-transition machine post-boot-snap inner-event)]
       ;; Per Spec 005 §Errors and Cross-Spec-Interactions §11 — Machine
       ;; action throws: when the cascade halted on an action exception,
       ;; emit `:rf.error/machine-action-exception` (NOT the generic
@@ -2003,6 +2199,7 @@
           ;; snapshot at [:rf/machines machine-id] is preserved.
           {})
         (let [[next-snapshot fx] step-result
+              merged-fx (vec (concat boot-fx fx))
               new-db (assoc-in db path next-snapshot)]
           (trace/emit! :machine :rf.machine/transition
                        {:machine-id  machine-id
@@ -2021,7 +2218,7 @@
                           :after      next-snapshot
                           :frame      (or frame :rf/default)}))
           {:db new-db
-           :fx fx}))))))) ;; close: inner if, let step-result, outer if, let with snapshot/inner-event, fn, defn
+           :fx merged-fx}))))))) ;; close: inner if, let step-result, cond, let with snapshot/inner-event, fn, defn
 
 ;; ---- reg-machine* — plain-fn surface (rf2-8bp3) ---------------------------
 
@@ -2327,10 +2524,21 @@
                             ;; spawned actor's snapshot. For parallel-
                             ;; region children, commit-tags-parallel
                             ;; unions across every region.
-                            (commit-tags-parallel
-                              spec''
-                              {:state initial-state
-                               :data  (or (:data spec'') {})}))
+                            ;;
+                            ;; Per rf2-0z73: also stamp
+                            ;; `:rf/bootstrap-pending? true` so the
+                            ;; spawned actor's first event (the
+                            ;; synthetic `[:rf.machine/spawned]` OR the
+                            ;; user-supplied `:start`) triggers the
+                            ;; initial-state entry cascade before
+                            ;; processing the event. The handler
+                            ;; boundary dissocs the marker after
+                            ;; running the cascade.
+                            (-> (commit-tags-parallel
+                                  spec''
+                                  {:state initial-state
+                                   :data  (or (:data spec'') {})})
+                                (assoc :rf/bootstrap-pending? true)))
             old-db        (adapter/read-container container)
             ;; Detect collision BEFORE the swap so we can emit the
             ;; error trace with the displaced binding's id.

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -1,0 +1,142 @@
+(ns re-frame.initial-entry-test
+  "Per rf2-0z73. Verifies whether a machine's **initial-state `:entry`
+  actions** fire when the machine first comes into existence — both for
+  top-level singleton machines (registered via `reg-machine`) and for
+  spawned actors (via declarative `:invoke` or imperative
+  `[:rf.machine/spawn ...]`).
+
+  Surfaced from rf2-yf97 (the websocket example) and the
+  `:rf.http/managed` machine-shape wrapper: both work around an apparent
+  gap by declaring `:on :rf.machine/spawned :action ...` on the initial
+  state instead of relying on the natural `:entry` slot. If `:entry`
+  doesn't fire on initial state, every Pattern doc and worked example
+  that assumes the canonical `:entry` shape is misleading.
+
+  Three scenarios under test, mirroring the three ways a machine first
+  comes into existence:
+
+   1. **Top-level singleton machine** — registered via `reg-machine`,
+      first dispatched event arrives. The initial state's `:entry`
+      action should fire as part of bringing the machine to life.
+
+   2. **Spawned actor via declarative `:invoke`** — parent enters an
+      `:invoke`-bearing state; the spawn fx allocates the child, seeds
+      its snapshot at `[:rf/machines <spawned-id>]`. The child's initial
+      state's `:entry` action should fire as the spawn cascade runs.
+
+   3. **Compound initial cascade** — initial state is itself a compound
+      whose `:initial` chain descends through nested states. EVERY
+      state along the initial cascade should fire its `:entry` action
+      shallowest-first (per Spec 005 §Initial cascading)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.machines :as machines]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- snapshot
+  [machine-id]
+  (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
+
+;; ---- (1) singleton-machine initial :entry firing -------------------------
+
+(deftest singleton-initial-entry-fires-on-first-dispatch
+  (testing "a singleton machine's initial-state :entry action fires when the machine first runs"
+    (let [calls (atom [])
+          spec  {:initial :idle
+                 :data    {}
+                 :actions
+                 {:on-enter-idle (fn [data _event]
+                                   (swap! calls conj :idle-entry)
+                                   {:data (assoc data :idle-entered? true)})}
+                 :states
+                 {:idle  {:entry :on-enter-idle
+                          :on    {:go {:target :next}}}
+                  :next  {}}}]
+      (rf/reg-machine :rf2-0z73/singleton spec)
+      ;; First dispatch — the machine snapshot is synthesised here, and
+      ;; the inner event `[:go]` triggers the :idle→:next transition.
+      ;; If initial :entry fires, :on-enter-idle should have been
+      ;; invoked exactly once before the transition out of :idle.
+      (rf/dispatch-sync [:rf2-0z73/singleton [:go]])
+      (is (= [:idle-entry] @calls)
+          "the initial state's :entry action fired exactly once on machine first-event")
+      (is (true? (get-in (snapshot :rf2-0z73/singleton) [:data :idle-entered?]))
+          ":entry action's :data write is visible in the committed snapshot")
+      (is (= :next (:state (snapshot :rf2-0z73/singleton)))
+          "the transition out of :idle still happens — :entry runs before, not in place of"))))
+
+;; ---- (2) spawned-actor initial :entry firing ------------------------------
+
+(deftest spawned-initial-entry-fires-on-spawn
+  (testing "a spawned actor's initial-state :entry action fires during the spawn cascade"
+    (let [calls (atom [])
+          ;; Register a side-effecting fx the child's :entry will emit
+          ;; via :fx. The fx records its argument so the test can
+          ;; observe it. Per Spec 002 §Effect handler signature the
+          ;; handler is `(fn [ctx args] ...)` — the ctx slot carries
+          ;; `:frame` and (when supplied) `:event`.
+          _     (rf/reg-fx :rf2-0z73/record
+                           (fn [_ctx arg] (swap! calls conj arg)))
+          child {:initial :requesting
+                 :data    {}
+                 :actions
+                 {:fire-request (fn [_data _event]
+                                  {:fx [[:rf2-0z73/record :child-entry-fired]]})}
+                 :states
+                 {:requesting {:entry :fire-request}}}
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:invoke {:machine-id :rf2-0z73/child}
+                             :on    {:done :idle}}}}]
+      (rf/reg-machine :rf2-0z73/child  child)
+      (rf/reg-machine :rf2-0z73/parent parent)
+      (rf/dispatch-sync [:rf2-0z73/parent [:start]])
+      ;; Outcome verification: the child's :entry should have fired
+      ;; exactly once on spawn.
+      (is (= [:child-entry-fired] @calls)
+          "spawned child's initial-state :entry action fired exactly once during spawn"))))
+
+;; ---- (3) compound-initial cascade fires every :entry shallowest-first -----
+
+(deftest compound-initial-cascade-fires-every-entry
+  (testing "a compound initial cascade fires every state's :entry shallowest-first"
+    (let [calls (atom [])
+          spec  {:initial :outer
+                 :data    {}
+                 :actions
+                 {:enter-outer (fn [data _ev]
+                                 (swap! calls conj :outer)
+                                 {:data (update data :seen (fnil conj []) :outer)})
+                  :enter-mid   (fn [data _ev]
+                                 (swap! calls conj :mid)
+                                 {:data (update data :seen (fnil conj []) :mid)})
+                  :enter-leaf  (fn [data _ev]
+                                 (swap! calls conj :leaf)
+                                 {:data (update data :seen (fnil conj []) :leaf)})}
+                 :states
+                 {:outer {:entry   :enter-outer
+                          :initial :mid
+                          :states
+                          {:mid  {:entry   :enter-mid
+                                  :initial :leaf
+                                  :states
+                                  {:leaf {:entry :enter-leaf
+                                          :on    {:go :elsewhere}}}}
+                           :elsewhere {}}}}}]
+      (rf/reg-machine :rf2-0z73/compound spec)
+      (rf/dispatch-sync [:rf2-0z73/compound [:go]])
+      (is (= [:outer :mid :leaf] @calls)
+          "every state in the initial cascade fired :entry shallowest-first, exactly once"))))

--- a/implementation/machines/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_cljs_test.cljs
@@ -117,15 +117,21 @@
       ;; The runtime cascades the declared :initial through compound
       ;; :initial chains on first-snapshot synthesis (rf2-m1tv), so the
       ;; first event dispatches against the deepest leaf without us
-      ;; having to seed the snapshot manually.
+      ;; having to seed the snapshot manually. Per rf2-0z73, the
+      ;; initial-state cascade ALSO fires every state's :entry action
+      ;; on first-event bootstrap (shallowest-first along the initial
+      ;; chain) — so the log accumulates :enter-auth + :enter-dash
+      ;; BEFORE the sibling-leaf transition kicks in.
       (reset! log [])
       ;; Sibling-leaf transition. LCA is :authenticated; only the leaf
-      ;; exit/entry hooks fire — the parent's :enter-auth must NOT re-fire.
+      ;; exit/entry hooks fire for the transition itself — the parent's
+      ;; :enter-auth runs ONCE during the bootstrap cascade and does
+      ;; NOT re-fire on the sibling transition (LCA is :authenticated).
       (rf/dispatch-sync [:auth/flow [:open-settings]])
       (is (= [:authenticated :settings] (:state (snapshot :auth/flow)))
           "snapshot moved to the sibling leaf")
-      (is (= [:exit-dash :enter-set] @log)
-          "only leaf-level exit/entry fired — LCA parent did NOT re-enter")))
+      (is (= [:enter-auth :enter-dash :exit-dash :enter-set] @log)
+          "initial-cascade :entry actions fired on bootstrap (:enter-auth + :enter-dash) followed by the sibling-leaf exit/entry (:exit-dash + :enter-set). The LCA parent's :enter-auth fires ONCE on bootstrap, not on the LCA-bounded sibling transition.")))
 
   (testing "deepest-wins — leaf overrides parent for same event id"
     (let [log (atom [])

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -858,6 +858,28 @@ Targeting `[:authenticated]` lands the snapshot at `[:authenticated :dashboard]`
 
 A compound state without `:initial` is a registration error — emits `:rf.error/machine-compound-state-missing-initial` at registration time and, in the CLJS reference with schema validation enabled, fails the registration.
 
+#### Initial-state `:entry` fires on machine bootstrap (rf2-0z73)
+
+When a machine **first comes into existence** — a singleton on its first dispatched event, or a spawned actor on `:rf.machine/spawn` — the initial-state cascade's `:entry` actions fire **once, shallowest-first**, as part of bringing the machine to life. For a flat machine that means the single initial state's `:entry` runs; for a compound machine with a multi-level `:initial` chain, **every** state along the chain runs its `:entry` in shallowest-first order.
+
+```clojure
+{:initial :outer
+ :states  {:outer {:entry   :enter-outer        ;; fires on bootstrap
+                   :initial :mid
+                   :states  {:mid  {:entry   :enter-mid     ;; fires on bootstrap
+                                    :initial :leaf
+                                    :states  {:leaf {:entry :enter-leaf}}}}}}}
+;; bootstrap log: [:enter-outer :enter-mid :enter-leaf]
+```
+
+The bootstrap cascade composes with **all** the slots the entry cascade carries — `:invoke`, `:invoke-all`, `:after` on any node along the initial chain emit their corresponding fx (`:rf.machine/spawn`, `:rf.machine/invoke-all-init`, `:after-schedule`) at bootstrap time. So a `:requesting` initial state that declares `:entry :fire-request` AND `:invoke {:machine-id :rf.http/managed ...}` has the entry action run AND the child machine spawned, before the actor's first user-routed event arrives.
+
+For singleton machines the bootstrap fx flow out as part of the **first event's** handler return value (the bootstrap cascade and the first event's transition cascade share the same `:fx` accumulator). For spawned actors the bootstrap fires when the runtime dispatches the actor's first event — the synthetic `[:rf.machine/spawned]` per [§Synthetic `[:rf.machine/spawned]` on spawn (rf2-ijm7)](#synthetic-rfmachinespawned-on-spawn-rf2-ijm7), or the user-supplied `:start` per [§Spawn-spec keys](#spawn-spec-keys).
+
+**Error semantics.** A throw inside any initial-`:entry` action halts the bootstrap identically to a throw inside any other entry cascade: the snapshot does NOT commit, no `:fx` flow, and a single `:rf.error/machine-action-exception` trace fires (per [§Errors](#errors)). The pre-bootstrap state — no snapshot at `[:rf/machines <id>]` — is preserved.
+
+**Migration note.** Pre-rf2-0z73, initial-state `:entry` actions did NOT fire on bootstrap. Generic child machines that needed to do work on spawn worked around it by declaring `:on :rf.machine/spawned :action :fire-request` on the initial state (the synthetic event the runtime dispatches per rf2-ijm7). Post-rf2-0z73 the canonical shape is `:entry :fire-request` — the `:rf.machine/spawned` workaround still works (it just resolves as a no-op transition through the standard `:on` lookup), but new code should prefer `:entry`.
+
 ### Target resolution — vector vs keyword
 
 A transition's `:target` admits **two forms**:
@@ -1665,15 +1687,21 @@ Imperative `:rf.machine/spawn` from a user's `:fx` (the rare boot-time form per 
 
 ### Synthetic `[:rf.machine/spawned]` on spawn (rf2-ijm7)
 
-Per [rf2-ijm7](#) — when `[:rf.machine/spawn ...]` does NOT carry an explicit `:start` event, the runtime dispatches a synthetic `[<spawned-id> [:rf.machine/spawned]]` to the new actor as its first event. This gives generic re-usable child machines (e.g. the [Spec 014 §Machine-shape wrapper](014-HTTPRequests.md#machine-shape-wrapper) for `:rf.http/managed`) a stable hook to declare a leaf-level transition that fires the actor's first work on spawn:
+Per [rf2-ijm7](#) — when `[:rf.machine/spawn ...]` does NOT carry an explicit `:start` event, the runtime dispatches a synthetic `[<spawned-id> [:rf.machine/spawned]]` to the new actor as its first event.
+
+> **Note (rf2-0z73).** This synthetic event was originally introduced (rf2-ijm7) so generic child machines could declare a leaf-level `:on :rf.machine/spawned :action ...` to fire their first work on spawn — covering the gap that initial-state `:entry` actions did not fire on bootstrap. Per [§Initial-state `:entry` fires on machine bootstrap (rf2-0z73)](#initial-state-entry-fires-on-machine-bootstrap-rf2-0z73), `:entry` now does fire on bootstrap, so `:entry :fire-request` is the canonical shape. The synthetic `[:rf.machine/spawned]` event still flows (preserving back-compat for any machine that declares `:on :rf.machine/spawned ...`), but new code should prefer the `:entry` form.
 
 ```clojure
+;; Canonical post-rf2-0z73 shape:
+:requesting {:entry :fire-request}
+
+;; Pre-rf2-0z73 workaround (still supported, but no longer the canonical shape):
 :requesting {:on {:rf.machine/spawned {:action :fire-request}}}
 ```
 
 Machines that don't handle `:rf.machine/spawned` see the event as a benign no-op — it walks the leaf→root resolution chain, finds no match, and the snapshot is unchanged (per [§Transition resolution — deepest-wins with parent fallthrough](#transition-resolution--deepest-wins-with-parent-fallthrough)).
 
-When the spawn DOES carry `:start`, the runtime dispatches `[<spawned-id> <start>]` instead — the existing behaviour, unchanged. The two paths are mutually exclusive; an actor receives one of `:rf.machine/spawned` OR the user's `:start`, never both.
+When the spawn DOES carry `:start`, the runtime dispatches `[<spawned-id> <start>]` instead — the existing behaviour, unchanged. The two paths are mutually exclusive; an actor receives one of `:rf.machine/spawned` OR the user's `:start`, never both. In both cases the initial-state `:entry` cascade runs BEFORE the first event's `:on` lookup, so `:entry` actions on the initial state fire regardless of which kick-off mode the spawn used.
 
 ### Top-level boot-time spawn (rare)
 


### PR DESCRIPTION
## Outcome

**Outcome A** — the gap was real. A failing test in `implementation/machines/test/re_frame/initial_entry_test.clj` confirmed that pre-fix, **no** initial-state `:entry` actions fired on either bootstrap path (singleton or spawned-actor). The fix is in `implementation/machines/src/re_frame/machines.cljc`.

## What the test caught

Three failing assertions (one per bootstrap shape):

1. **Singleton flat machine** — `:entry :on-enter-idle` on `:initial :idle` did not fire on first dispatch. `(@calls)` was `[]`, not `[:idle-entry]`.
2. **Spawned actor via `:invoke`** — child's `:entry :fire-request` on `:initial :requesting` did not fire during the spawn cascade. `(@calls)` was `[]`, not `[:child-entry-fired]`.
3. **Compound initial cascade** — none of the `:enter-outer` / `:enter-mid` / `:enter-leaf` cascaded `:entry` actions fired. `(@calls)` was `[]`, not `[:outer :mid :leaf]`.

All three now pass.

## The fix shape

A `:rf/bootstrap-pending?` marker on the freshly-synthesised snapshot tells `create-machine-handler` to run a one-shot `apply-initial-entry-cascade` before processing the user event:

- **Singleton path** — when `(get-in db path)` is `nil`, the handler synthesises the initial snapshot with `:rf/bootstrap-pending? true` stamped on it.
- **Spawn path** — `spawn-fx` pre-seeds the actor's snapshot with `:rf/bootstrap-pending? true` so the first dispatched event (the synthetic `[:rf.machine/spawned]` OR the user-supplied `:start`) triggers the cascade.

`apply-initial-entry-cascade` re-uses `apply-transition-once` by synthesising a transition from the empty path `[]` to the initial leaf. With src-path `[]` and `lca-len = 0`, nothing exits, no transition action runs, and **every** node from root to leaf runs its `:entry` action — `:invoke`, `:invoke-all`, and `:after` slots on any cascaded node emit their corresponding fx (`:rf.machine/spawn`, `:rf.machine/invoke-all-init`, `:rf.machine/after-schedule`) at bootstrap time. Parallel-region machines iterate per-region with `prefix-region-invoke-id` prefixing, matching `parallel-machine-transition`'s broadcast contract.

Errors halt the bootstrap with the same `:rf.error/machine-action-exception` semantics any other entry-cascade throw uses — no `:db`, no `:fx`, snapshot uncommitted.

## Workaround removals

The bead specifically called out two workaround sites; both are now updated to use the canonical `:entry` shape:

- **`implementation/http/src/re_frame/http_managed.cljc`** — `:requesting {:entry :fire-request ...}` replaces the pre-rf2-0z73 `:on :rf.machine/spawned {:action :fire-request}` shape.
- **`examples/reagent/websocket/messages.cljs`** (`:websocket/socket` actor) — `:opening {:entry :open-socket :always [{:target :open}] ...}` replaces the pre-rf2-0z73 `:on :rf.machine/spawned {:target :open :action :open-socket}` shape.

Back-compat: the `:on :rf.machine/spawned` workaround still works for any caller that hasn't migrated — it resolves as a normal `:on` lookup on the synthetic spawn event.

## Spec updates

- New subsection in `spec/005-StateMachines.md` under `§Initial-state cascading`: `#### Initial-state :entry fires on machine bootstrap (rf2-0z73)`. Documents the contract (every state's `:entry` along the initial cascade fires shallowest-first), the composition with `:invoke` / `:invoke-all` / `:after`, the error semantics, and the migration note for the pre-rf2-0z73 workaround.
- Note added to `§Synthetic [:rf.machine/spawned] on spawn (rf2-ijm7)` clarifying that the synthetic event is now a back-compat hook, with `:entry` being the canonical shape post-rf2-0z73.

## Verification

- `clojure -M:test` (machines, core, http, flows, routing, ssr, epoch, schemas) — 100 + 183 + 35 + 26 + 9 + 27 + 55 + 46 = **481 JVM tests, all pass**
- `npm run test:cljs` — **518 CLJS tests, all pass**
- `npm run test:elision` — **PASS**
- `npm run test:examples` — **all examples pass including `pattern-websocket — connection machine demo`**

One existing assertion in `machines_cljs_test.cljs` (`machine-hierarchical-cljs`) was updated to reflect the new contract — the test now correctly asserts `[:enter-auth :enter-dash :exit-dash :enter-set]` (initial-cascade entries followed by sibling-leaf transition) rather than `[:exit-dash :enter-set]` (which was the buggy pre-rf2-0z73 behaviour).