### PR TITLE
fix(frame): dispatch captures current-frame at call time, survives async callbacks (rf2-l5q3)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -1,0 +1,296 @@
+(ns re-frame.dispatch-frame-capture-cljs-test
+  "Regression tests for *current-frame* propagation across direct
+  rf/dispatch calls — rf2-l5q3.
+
+  Discovered during rf2-yf97 (websocket example): a handler scoped to
+  frame :A doing `(js/setTimeout #(rf/dispatch [:foo]) 0)` produced a
+  dispatch that landed on :rf/default, not :A. The workaround the
+  example adopted was `:fx [[:dispatch ...]]` — the :dispatch fx in
+  re-frame.fx explicitly threads `{:frame frame-id}` so it survives
+  any async tier.
+
+  This ns nails down the runtime contract for the four patterns a
+  multi-frame app might reach for:
+
+    1. Synchronous direct `rf/dispatch` from inside the handler body.
+    2. `js/setTimeout` deferred direct `rf/dispatch` from inside the
+       handler body (the rf2-yf97 case).
+    3. `:fx [[:dispatch ...]]` from a `reg-event-fx` handler (the
+       documented workaround).
+    4. `:fx [[:dispatch-later {:ms 0 :dispatch ...}]]` and the
+       `(bound-dispatcher)` / `(dispatcher)` capture-at-call-site
+       affordances.
+
+  Per rf2-l5q3 the fix routes through `process-event!`: the drain
+  loop now binds `frame/*current-frame*` to the envelope's `:frame`
+  for the duration of the handler chain, so a synchronous
+  `rf/dispatch` from inside the handler body sees the in-flight
+  event's frame. Async escapes (setTimeout / Promise.then /
+  requestAnimationFrame) still need an explicit-capture affordance —
+  `:fx [[:dispatch ...]]` (canonical), `:dispatch-later`, or
+  `(bound-dispatcher)`. See spec/002-Frames.md §Dispatch and the
+  dynamic-binding tier."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; Per cljs.test: async tests require fixtures supplied as a map
+;; (fn-form fixtures don't suspend across the async body, so the
+;; finally clause runs before the async work completes). Wrap the
+;; snapshot/restore pattern as `{:before :after}`. Mirrors the
+;; tools/story CLJS async-test idiom.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace/clear-trace-cbs!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- seed-frames!
+  "Register two non-default frames and capture per-frame markers in
+  app-db so a test assertion can identify which frame served a
+  dispatch."
+  []
+  (rf/reg-frame :rf-l5q3/tenant-a {:doc "tenant-a frame"})
+  (rf/reg-frame :rf-l5q3/tenant-b {:doc "tenant-b frame"})
+  (rf/reg-event-db :rf-l5q3/seed
+                   (fn [_ [_ marker]] {:marker marker :received []}))
+  (rf/dispatch-sync [:rf-l5q3/seed :rf/default] {:frame :rf/default})
+  (rf/dispatch-sync [:rf-l5q3/seed :tenant-a] {:frame :rf-l5q3/tenant-a})
+  (rf/dispatch-sync [:rf-l5q3/seed :tenant-b] {:frame :rf-l5q3/tenant-b}))
+
+(defn- received
+  "Return the :received vector for a frame's current app-db."
+  [frame-id]
+  (let [db (frame/frame-app-db-value frame-id)]
+    (:received db)))
+
+;; ---- 1. Synchronous direct rf/dispatch ------------------------------------
+;;
+;; A reg-event-fx handler running on :tenant-a calls (rf/dispatch [:landed])
+;; in its body and returns no fx. The expectation: the queued :landed
+;; event lands on :tenant-a (the in-flight handler's frame), not
+;; :rf/default.
+;;
+;; The fix for rf2-l5q3 routes through `process-event!` — the drain
+;; loop binds `frame/*current-frame*` to the envelope's :frame for the
+;; duration of the chain, so a synchronous rf/dispatch from inside the
+;; handler body picks up the right frame.
+
+(deftest sync-dispatch-from-handler-body-routes-to-handlers-frame
+  (testing "rf/dispatch called synchronously from inside a handler routes to that handler's frame"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3/parent
+                     (fn [_ _]
+                       (rf/dispatch [:rf-l5q3/landed])
+                       {}))
+    (rf/reg-event-db :rf-l5q3/landed
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-sync)))
+    ;; Fire the parent under :tenant-a; the synchronous dispatch inside
+    ;; its body MUST route to :tenant-a too. dispatch-sync drains the
+    ;; full cascade before returning.
+    (rf/dispatch-sync [:rf-l5q3/parent] {:frame :rf-l5q3/tenant-a})
+    (is (= [:landed-sync] (received :rf-l5q3/tenant-a))
+        "the :landed event must land on :tenant-a, not :rf/default")
+    (is (empty? (received :rf/default))
+        ":rf/default must NOT have received :landed — the dispatch was scoped to :tenant-a")))
+
+;; ---- 2. setTimeout-deferred direct rf/dispatch ----------------------------
+;;
+;; This is the rf2-yf97 scenario. A handler defers a dispatch via
+;; setTimeout. The setTimeout callback runs on a fresh JS stack — the
+;; dynamic binding established by `process-event!` has long since
+;; been popped. Without an explicit capture the dispatch falls
+;; through to `:rf/default`.
+;;
+;; This test documents the inherent dynamic-scope limit and points
+;; users at the three explicit-capture affordances (`:fx [[:dispatch
+;; ...]]` / `:dispatch-later` / `(bound-dispatcher)`) covered in the
+;; deftests below.
+
+(deftest direct-dispatch-from-set-timeout-falls-through-to-default
+  (testing "raw rf/dispatch from a setTimeout callback escapes *current-frame* — documented gotcha"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3/defer-raw
+                       (fn [_ _]
+                         (js/setTimeout
+                           (fn [] (rf/dispatch [:rf-l5q3/landed-raw]))
+                           0)
+                         {}))
+      (rf/reg-event-db :rf-l5q3/landed-raw
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-raw)))
+      (rf/dispatch-sync [:rf-l5q3/defer-raw] {:frame :rf-l5q3/tenant-a})
+      ;; Wait two macrotasks: one for the setTimeout(0), one for the
+      ;; router's next-tick drain after the queue is appended.
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              ;; Raw rf/dispatch from inside a setTimeout — bindings
+              ;; are gone, the dispatch envelope's :frame falls
+              ;; through to :rf/default. This is the documented
+              ;; gotcha: async-deferred direct dispatches need
+              ;; explicit capture, not dynamic binding. Per Spec 002
+              ;; §Dispatch resolution chain — dynamic var → adapter
+              ;; React-context → :rf/default. setTimeout callbacks
+              ;; satisfy none of the first two tiers.
+              (is (= [:landed-raw] (received :rf/default))
+                  ":landed-raw lands on :rf/default (dynamic binding is dead in the setTimeout callback)")
+              (is (empty? (received :rf-l5q3/tenant-a))
+                  ":tenant-a sees nothing — raw rf/dispatch can't recover the in-flight frame from a setTimeout")
+              (done))
+            10))
+        10))))
+
+;; ---- 3. :fx [[:dispatch ...]] from a setTimeout — workaround --------------
+;;
+;; The fx-walker in re-frame.fx threads `{:frame frame-id}` through to
+;; the :dispatch fx, so a setTimeout-scheduled `:fx` cannot deliver
+;; the dispatch to the wrong frame even if the dynamic var has
+;; escaped. This is the canonical rf2-yf97 workaround.
+;;
+;; Note: re-frame.fx walks :fx during `process-event!`, NOT inside the
+;; setTimeout. So the right pattern is `:fx [[:dispatch-later ...]]`
+;; or a handler that returns `:fx [[:dispatch ...]]` *immediately*.
+;; If the handler manually defers via setTimeout and returns `:fx`,
+;; the :fx walk happens before the timer fires — that's just a
+;; same-tick dispatch. The case we care about is `:dispatch-later`,
+;; tested next.
+
+(deftest fx-dispatch-from-handler-routes-to-handlers-frame
+  (testing ":fx [[:dispatch ...]] routes to the handler's frame — canonical pattern"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3/parent-fx
+                     (fn [_ _]
+                       {:fx [[:dispatch [:rf-l5q3/landed-fx]]]}))
+    (rf/reg-event-db :rf-l5q3/landed-fx
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-fx)))
+    (rf/dispatch-sync [:rf-l5q3/parent-fx] {:frame :rf-l5q3/tenant-a})
+    (is (= [:landed-fx] (received :rf-l5q3/tenant-a))
+        ":fx [[:dispatch ...]] threads the frame through fx/do-fx — lands on :tenant-a")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing")))
+
+;; ---- 4a. :dispatch-later — async with frame capture -----------------------
+;;
+;; `:dispatch-later` in re-frame.fx schedules the dispatch via
+;; interop/set-timeout! and captures `frame-id` in the closure (per
+;; fx.cljc), so the deferred dispatch carries the right frame
+;; regardless of when the timer fires. This is the canonical
+;; async-frame-safe pattern.
+
+(deftest dispatch-later-survives-the-timer
+  (testing ":dispatch-later threads :frame through the closure — survives the async escape"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3/parent-later
+                       (fn [_ _]
+                         {:fx [[:dispatch-later
+                                {:ms    0
+                                 :event [:rf-l5q3/landed-later]}]]}))
+      (rf/reg-event-db :rf-l5q3/landed-later
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-later)))
+      (rf/dispatch-sync [:rf-l5q3/parent-later] {:frame :rf-l5q3/tenant-a})
+      ;; Wait long enough for the setTimeout(0) and the resulting
+      ;; next-tick drain (goog.async.nextTick). Two 50ms macrotasks
+      ;; are belt-and-braces — node's setTimeout(0) has a ~1-4ms
+      ;; floor under default settings, the chained drain another
+      ;; macrotask tick. 100ms is well above both.
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-later] (received :rf-l5q3/tenant-a))
+                  ":dispatch-later landed on :tenant-a even though the timer fired after the binding popped")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            50))
+        50))))
+
+;; ---- 4b. (bound-dispatcher) — async with explicit capture -----------------
+;;
+;; `(rf/bound-dispatcher)` captures the current frame at call time and
+;; returns a dispatch fn that explicitly threads `{:frame ...}` to
+;; every call. This is the same shape `:fx [[:dispatch ...]]` uses
+;; internally — exposed for plain-fn callers (test setup, REPL,
+;; async libraries that don't speak re-frame fx).
+
+(deftest bound-dispatcher-survives-set-timeout
+  (testing "(bound-dispatcher) captures the in-flight frame; the captured fn is safe to call from setTimeout"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3/parent-bound
+                       (fn [_ _]
+                         (let [d (rf/bound-dispatcher)]
+                           (js/setTimeout
+                             (fn [] (d [:rf-l5q3/landed-bound]))
+                             0))
+                         {}))
+      (rf/reg-event-db :rf-l5q3/landed-bound
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-bound)))
+      (rf/dispatch-sync [:rf-l5q3/parent-bound] {:frame :rf-l5q3/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-bound] (received :rf-l5q3/tenant-a))
+                  "(bound-dispatcher) captured :tenant-a at call time; the setTimeout callback dispatches there")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            10))
+        10))))
+
+;; ---- 5. cross-frame isolation hardness check ------------------------------
+;;
+;; Sanity: when a handler on :tenant-a synchronously dispatches and
+;; *another* handler is also running on :tenant-b in a separate
+;; dispatch-sync, neither cascade leaks into the other's frame. The
+;; rf2-l5q3 fix binds *current-frame* per `process-event!`, so the
+;; binding is established and torn down PER EVENT — sibling frames
+;; do not see each other's bindings.
+
+(deftest sync-dispatch-isolation-between-frames
+  (testing "synchronous dispatch from :tenant-a handler stays in :tenant-a; :tenant-b is untouched"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3/fan
+                     (fn [_ [_ payload]]
+                       (rf/dispatch [:rf-l5q3/leaf payload])
+                       {}))
+    (rf/reg-event-db :rf-l5q3/leaf
+                     (fn [db [_ payload]]
+                       (update db :received (fnil conj []) payload)))
+    (rf/dispatch-sync [:rf-l5q3/fan :a-payload] {:frame :rf-l5q3/tenant-a})
+    (rf/dispatch-sync [:rf-l5q3/fan :b-payload] {:frame :rf-l5q3/tenant-b})
+    (is (= [:a-payload] (received :rf-l5q3/tenant-a))
+        ":tenant-a only sees its own :a-payload")
+    (is (= [:b-payload] (received :rf-l5q3/tenant-b))
+        ":tenant-b only sees its own :b-payload")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing — neither cascade leaked")))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -237,12 +237,32 @@
                           :phase    :run-end})))))))
 
 (defn- process-event!
-  "Wrap process-event* in a binding of *current-dispatch-id* so child
-  dispatches issued from within an fx handler inherit this event's
-  :dispatch-id as their :parent-dispatch-id. Per Spec 009 §Dispatch
-  correlation."
+  "Wrap process-event* in two dynamic bindings:
+
+   1. `*current-dispatch-id*` — so child dispatches issued from within
+      an fx handler inherit this event's `:dispatch-id` as their
+      `:parent-dispatch-id`. Per Spec 009 §Dispatch correlation.
+
+   2. `frame/*current-frame*` — bound to the envelope's `:frame` for
+      the duration of the handler chain. Per Spec 002 §Dispatch
+      resolution chain — the dynamic-var tier of the resolution chain
+      MUST cover the in-flight handler body so a synchronous
+      `(rf/dispatch ...)` / `(rf/subscribe ...)` from inside the
+      handler routes to the handler's own frame (not `:rf/default`).
+      Without this binding, the handler body would see the same
+      `*current-frame*` value the original dispatcher saw — typically
+      `nil` for app-level dispatches — and child dispatches would
+      slide to `:rf/default`, silently breaking multi-frame isolation.
+
+      The binding does NOT survive async escapes (setTimeout,
+      Promise.then, requestAnimationFrame): the JS callback fires on
+      a fresh stack with no dynamic binding. Use `(rf/bound-dispatcher)`
+      (capture-at-call-time), `:fx [[:dispatch ...]]` (fx-walker
+      threads the frame), or `:dispatch-later` (frame captured in
+      closure) for those paths. Per rf2-l5q3."
   [envelope]
-  (binding [*current-dispatch-id* (:dispatch-id envelope)]
+  (binding [*current-dispatch-id*  (:dispatch-id envelope)
+            frame/*current-frame*  (:frame envelope)]
     (process-event* envelope)))
 
 ;; ---- outer drain ----------------------------------------------------------

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -279,6 +279,69 @@
                 @traces)
           "expected :rf.error/dispatch-sync-in-handler trace event"))))
 
+(deftest sync-dispatch-from-handler-body-routes-to-handlers-frame
+  ;; Per rf2-l5q3 — the router binds `frame/*current-frame*` to the
+  ;; envelope's :frame for the duration of process-event!, so a
+  ;; synchronous `(rf/dispatch ...)` from inside a handler body picks
+  ;; up the in-flight event's frame (not :rf/default). The CLJS
+  ;; companion `re-frame.dispatch-frame-capture-cljs-test` covers the
+  ;; full matrix (sync, setTimeout, :fx [[:dispatch ...]],
+  ;; :dispatch-later, bound-dispatcher). This JVM test pins the
+  ;; sync-from-handler contract on the substrate-agnostic foundation.
+  (testing "(rf/dispatch ...) called synchronously from inside a handler routes to that handler's frame"
+    (rf/reg-frame :rf-l5q3.jvm/tenant-a {:doc "tenant-a frame"})
+    (rf/reg-frame :rf-l5q3.jvm/tenant-b {:doc "tenant-b frame"})
+    (rf/reg-event-db :rf-l5q3.jvm/seed
+                     (fn [_ _] {:received []}))
+    (rf/dispatch-sync [:rf-l5q3.jvm/seed] {:frame :rf-l5q3.jvm/tenant-a})
+    (rf/dispatch-sync [:rf-l5q3.jvm/seed] {:frame :rf-l5q3.jvm/tenant-b})
+    (rf/dispatch-sync [:rf-l5q3.jvm/seed]) ;; :rf/default
+    (rf/reg-event-fx :rf-l5q3.jvm/parent
+                     (fn [_ _]
+                       (rf/dispatch [:rf-l5q3.jvm/landed])
+                       {}))
+    (rf/reg-event-db :rf-l5q3.jvm/landed
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed)))
+    (rf/dispatch-sync [:rf-l5q3.jvm/parent] {:frame :rf-l5q3.jvm/tenant-a})
+    (is (= [:landed] (:received (rf/get-frame-db :rf-l5q3.jvm/tenant-a)))
+        ":landed event must land on :tenant-a, not :rf/default")
+    (is (empty? (:received (rf/get-frame-db :rf-l5q3.jvm/tenant-b)))
+        ":tenant-b sees nothing")
+    (is (empty? (:received (rf/get-frame-db :rf/default)))
+        ":rf/default sees nothing — the dispatch was scoped to :tenant-a")))
+
+(deftest current-frame-inside-handler-reports-handlers-frame
+  ;; Per rf2-l5q3 — `(rf/current-frame)` consults the dynamic-var tier
+  ;; first. With the router's per-handler binding of
+  ;; `frame/*current-frame*` to the envelope's :frame, the call site
+  ;; reports the handler's frame, not :rf/default. This is the contract
+  ;; that lets `(rf/bound-dispatcher)`, `(rf/dispatcher)`,
+  ;; `(rf/subscriber)`, etc. — all of which capture the value of
+  ;; `(rf/current-frame)` at call time — capture the right frame when
+  ;; called from a handler body. Asserts the observable property
+  ;; directly (avoids the async drain-thread timing the captured-fn
+  ;; invocation would introduce).
+  (testing "(rf/current-frame) inside a handler reports the handler's frame"
+    (rf/reg-frame :rf-l5q3.jvm.cf/tenant-a {:doc "tenant-a frame"})
+    (let [observed-current-frame (atom nil)]
+      (rf/reg-event-fx :rf-l5q3.jvm.cf/observe
+                       (fn [_ _]
+                         (reset! observed-current-frame (rf/current-frame))
+                         {}))
+      (rf/dispatch-sync [:rf-l5q3.jvm.cf/observe]
+                        {:frame :rf-l5q3.jvm.cf/tenant-a})
+      (is (= :rf-l5q3.jvm.cf/tenant-a @observed-current-frame)
+          "(rf/current-frame) inside a handler reports the handler's frame, not :rf/default"))
+    (testing "and a handler running on :rf/default sees :rf/default"
+      (let [observed-current-frame (atom nil)]
+        (rf/reg-event-fx :rf-l5q3.jvm.cf/observe-default
+                         (fn [_ _]
+                           (reset! observed-current-frame (rf/current-frame))
+                           {}))
+        (rf/dispatch-sync [:rf-l5q3.jvm.cf/observe-default])
+        (is (= :rf/default @observed-current-frame))))))
+
 ;; ---- snapshot-of (rf2-vvsh) ----------------------------------------------
 
 (deftest snapshot-of-reads-default-frame-app-db

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -362,8 +362,25 @@ In priority order, where the frame keyword comes from:
 
 1. **Explicit `:frame` in the dispatch opts map.** `(dispatch [:foo] {:frame :todo})` always wins. The opts map's keys flow straight into the dispatch envelope.
 2. **Lexical `dispatch` injected by `reg-view`.** The closure carries the frame keyword resolved from React context at render. (See View Ergonomics, below.) Internally, the injected `dispatch` is `(fn [event] (dispatch event {:frame <captured>}))`.
-3. **Dynamic binding.** Inside `(with-frame :todo ...)` (test/REPL helper), a Clojure dynamic var carries the frame; the bare `(rf/dispatch [:foo])` in the body picks it up. This makes `(with-frame :todo (rf/dispatch [:foo]))` Just Work without an opts map.
+3. **Dynamic binding.** Inside `(with-frame :todo ...)` (test/REPL helper), a Clojure dynamic var carries the frame; the bare `(rf/dispatch [:foo])` in the body picks it up. This makes `(with-frame :todo (rf/dispatch [:foo]))` Just Work without an opts map. **The router establishes the same binding around every running handler** (per [§Dispatches issued from inside a handler body](#dispatches-issued-from-inside-a-handler-body) below), so a synchronous `(rf/dispatch [:foo])` from inside a handler running on `:todo` also resolves to `:todo` — not `:rf/default`.
 4. **Default.** `:rf/default`.
+
+### Dispatches issued from inside a handler body
+
+The router binds the dynamic-var tier of the resolution chain to the in-flight event's `:frame` for the duration of `process-event!`. The contract is:
+
+- **Synchronous dispatch from inside a handler body routes to the handler's frame.** A `reg-event-fx` whose body calls `(rf/dispatch [:child])` and returns `{}` dispatches `:child` to the same frame the parent is running on. The same applies to `(rf/bound-dispatcher)`, `(rf/dispatcher)`, `(rf/subscriber)`, and `(rf/current-frame)` — all of which read the dynamic-var tier first.
+- **Async callbacks escape the binding.** When a handler defers work via `js/setTimeout`, `js/Promise.then`, `requestAnimationFrame`, or any other host-level async primitive, the deferred callback fires on a fresh stack with no dynamic binding. A bare `(rf/dispatch [:child])` from inside the callback falls through to `:rf/default`. This is a fundamental property of dynamic scope — not a bug.
+
+The three frame-safe affordances for async callbacks are, in canonical-first order:
+
+1. **`:fx [[:dispatch event-vec]]`** — the fx walker (`re-frame.fx/do-fx`) calls `(dispatch! event-vec {:frame frame-id})` with `frame-id` already resolved from the in-flight envelope. The dispatch is synchronous with the enclosing handler's drain, so any timer / promise the user wants to schedule should be modelled as a returned effect, not a manual `js/setTimeout`. This is the canonical multi-frame pattern.
+
+2. **`:fx [[:dispatch-later {:ms <n> :event event-vec}]]`** — the `:dispatch-later` fx captures `frame-id` in its closure before scheduling the timer, so the deferred dispatch carries the correct frame regardless of when the timer fires.
+
+3. **`(rf/bound-dispatcher)`** — captures the active frame at call time and returns a closure `(fn [event] (dispatch event {:frame <captured>}))`. Use when the handler must hand a dispatch fn to a non-fx async library (a websocket subscription, a third-party SDK that takes a callback) where neither `:fx` nor `:dispatch-later` fits.
+
+The contract is regression-tested by `re-frame.dispatch-frame-capture-cljs-test` (rf2-l5q3). Pattern-LongRunningWork and Pattern-WebSocket both rely on it.
 
 ### Dispatch origin tagging
 


### PR DESCRIPTION
## Summary

**Outcome A — gap confirmed and fixed.** Discovered during rf2-yf97
(websocket example): a handler running on frame `:A` doing
`(rf/dispatch [:child])` inside its body produced a dispatch that
landed on `:rf/default` instead of `:A`. The same gap applied to
`(rf/bound-dispatcher)`, `(rf/dispatcher)`, `(rf/subscriber)`, and
`(rf/current-frame)` — every surface that reads the dynamic-var tier
of the resolution chain. The `:fx [[:dispatch ...]]` pattern worked
because the fx walker threads `:frame` explicitly; rf2-yf97 adopted
that as a workaround.

## Root cause

`process-event!` bound `*current-dispatch-id*` but **not**
`frame/*current-frame*` around the handler chain. Inside the handler
body, the dynamic-var tier had no binding, so `build-envelope`'s
default-frame lookup fell through to `:rf/default` for any nested
dispatch that did not pass `:frame` explicitly.

## Fix

One-line change in `implementation/core/src/re_frame/router.cljc`:
extend `process-event!`'s `binding` block to include
`frame/*current-frame* (:frame envelope)`. Now every handler runs
with the dynamic-var tier of the resolution chain set to its own
frame.

## Async escape — by design

`setTimeout`, `Promise.then`, `requestAnimationFrame`, and other
host-level async primitives still escape the dynamic binding — that's
the nature of dynamic scope, not a bug. Three frame-safe affordances
cover the async path:

1. **`:fx [[:dispatch event-vec]]`** (canonical) — fx-walker threads
   the frame explicitly.
2. **`:fx [[:dispatch-later {:ms n :event event-vec}]]`** — closure-
   captured frame.
3. **`(rf/bound-dispatcher)`** — capture-at-call-time for non-fx
   callbacks.

Documented in `spec/002-Frames.md §Dispatches issued from inside a
handler body` with the canonical-first ordering.

## Test coverage

- **`re-frame.dispatch-frame-capture-cljs-test`** (new) covers the
  full five-pattern matrix on the Reagent adapter: sync dispatch in
  body, setTimeout-deferred raw dispatch, `:fx [[:dispatch ...]]`,
  `:dispatch-later`, `bound-dispatcher`, plus cross-frame isolation
  under back-to-back `dispatch-sync`.
- **`re-frame.smoke-test`** adds two JVM regressions
  (`sync-dispatch-from-handler-body-routes-to-handlers-frame`,
  `current-frame-inside-handler-reports-handlers-frame`).

## Verification

- `npm run test:cljs` — 512 tests, **0 failures**
- `npm run test:browser` — 512 tests, **0 failures**
- `npm run test:elision` — clean
- `npm run test:examples` — every example PASS
- `clojure -M:test` in `implementation/core/` — 185 tests, **0 new
  failures**. The pre-existing rf2-iosc flake
  (`destroy-frame-discards-pending-events`) is independent of this
  change — reproduced 2/8 times on `origin/main` without my changes.
- Per-artefact JVM tests (machines, flows, routing, http, epoch,
  ssr, schemas) — all clean.

## Test plan

- [x] new test fails on `main`, passes after the fix
- [x] full CLJS suite green
- [x] full browser suite green
- [x] elision probe clean
- [x] all examples PASS (including long-running-work which exercises
  the same surface)
- [x] JVM core + every sub-artefact green
- [x] spec/002-Frames.md updated with the contract + three async
  affordances
- [x] rf2-yf97's `:fx [[:dispatch ...]]` workaround still works (the
  fx path is unchanged)