### PR TITLE
fix: machine :raise + subs unsubscribe correctness (rf2-c0nt, rf2-zikr)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -454,8 +454,16 @@
        (swap! cache
               (fn [m]
                 (if-let [entry (get m k)]
-                  (let [n (dec (or (:ref-count entry) 1))]
-                    (if (<= n 0)
+                  (let [old-n (or (:ref-count entry) 1)
+                        n     (max 0 (dec old-n))]
+                    ;; Only trigger drop-to-zero on the 1→0 transition AND only
+                    ;; when no grace-period timer is already in flight. Calling
+                    ;; `unsubscribe` past zero (idempotent misuse — e.g. cleanup
+                    ;; in both a teardown hook and a `finally`) must not stack
+                    ;; new `pending-dispose` timers on top of the prior handle.
+                    (if (and (= 1 old-n)
+                             (zero? n)
+                             (nil? (:pending-dispose entry)))
                       (do (reset! dropped-to-zero? true)
                           (assoc m k (assoc entry :ref-count 0)))
                       (assoc-in m [k :ref-count] n)))

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -316,3 +316,74 @@
 
     (rf/clear-subscription-cache! :rf/default)
     (is (empty? (cache-keys)))))
+
+;; ---- idempotent unsubscribe (rf2-zikr) ------------------------------------
+;;
+;; Per Spec 006 §Reference counting and disposal: `unsubscribe` is
+;; ref-count-based. Calling it past zero (cleanup in both a teardown hook
+;; and a `finally`) must be idempotent — it must NOT
+;;
+;;   (a) decrement the ref-count into negative territory, OR
+;;   (b) schedule a second `pending-dispose` timer on top of the existing
+;;       handle (leaking the prior handle).
+;;
+;; The fix clamps the decrement at zero and only triggers drop-to-zero on
+;; the 1→0 transition when no pending-dispose is already in flight.
+;;
+;; Pre-fix, the second unsubscribe computed `n = -1`, took the
+;; `(<= n 0)` branch a second time, and called `set-timeout!` again — the
+;; outer swap then overwrote the prior `:pending-dispose` slot, leaking the
+;; original handle. This test asserts the post-fix invariant directly: the
+;; ref-count stays at 0 and the same `:pending-dispose` handle is preserved
+;; across repeated `unsubscribe` calls.
+
+(deftest unsubscribe-past-zero-is-idempotent
+  (testing "calling unsubscribe twice for the same sub-id does not leak pending-dispose handles (rf2-zikr)"
+    (subs/configure! {:grace-period-ms 60000})  ;; long grace; we won't let it fire
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (is (= 1 (entry-ref-count [:n])))
+
+    ;; First unsubscribe — ref-count 1→0, dispose scheduled, handle stashed.
+    (rf/unsubscribe [:n])
+    (is (= 0 (entry-ref-count [:n]))
+        "first unsubscribe lands ref-count at zero")
+    (is (pending-dispose? [:n])
+        "first unsubscribe schedules the dispose timer")
+    (let [handle-after-first
+          (get-in @(:sub-cache (frame/frame :rf/default)) [[:n] :pending-dispose])]
+
+      ;; Second unsubscribe — must be a no-op. Pre-fix this took
+      ;; ref-count to -1 AND scheduled a new timer, overwriting
+      ;; `handle-after-first` and leaking it.
+      (rf/unsubscribe [:n])
+      (is (= 0 (entry-ref-count [:n]))
+          "ref-count clamped at zero — does NOT go negative on extra unsubscribe")
+      (is (pending-dispose? [:n])
+          "the original pending-dispose handle is preserved (not overwritten)")
+      (let [handle-after-second
+            (get-in @(:sub-cache (frame/frame :rf/default)) [[:n] :pending-dispose])]
+        (is (identical? handle-after-first handle-after-second)
+            "the same timer handle is on the slot after the second unsubscribe — no new schedule was made"))
+
+      ;; And a third call for good measure — still idempotent.
+      (rf/unsubscribe [:n])
+      (is (= 0 (entry-ref-count [:n])))
+      (let [handle-after-third
+            (get-in @(:sub-cache (frame/frame :rf/default)) [[:n] :pending-dispose])]
+        (is (identical? handle-after-first handle-after-third)
+            "third unsubscribe still preserves the original handle"))))
+
+  (testing "extra unsubscribe before any subscribe is a complete no-op"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+    ;; No subscribe — the entry doesn't exist; unsubscribe must not throw,
+    ;; must not create an entry, and must not schedule a timer.
+    (rf/unsubscribe [:n])
+    (is (not (contains? (cache-keys) [:n]))
+        "unsubscribe against a missing entry leaves the cache untouched")))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1013,6 +1013,16 @@
 (def ^:private always-depth-limit-default 16)
 (def ^:private raise-depth-limit-default  16)
 
+;; Forward-declared so `drain-raises` can call `machine-transition` directly,
+;; without resorting to `(resolve `machine-transition)` — the anti-pattern
+;; re-frame.late-bind's docstring warns about. Direct call eliminates a per-
+;; raise Var-construction allocation on CLJS and removes the misleading
+;; surface (a reader skimming the body would otherwise infer a cross-namespace
+;; late-bind). The full `(declare machine-transition machine-transition-single)`
+;; further below stays so the parallel-region helpers (which also forward-
+;; reference `machine-transition`) keep compiling.
+(declare machine-transition)
+
 (defn- drain-raises
   "Drain the :raise queue inside fx-vec. Each :raise becomes an inline
   recursive machine-transition call; non-:raise fx pass through to the
@@ -1042,7 +1052,7 @@
           ;; fx vector is appended to the pending list (NOT prepended)
           ;; per Spec 005 §Drain semantics §Level 3 step 3 — the raise
           ;; queue is drained depth-first, but new fx land at the end.
-          (let [step-result ((resolve `machine-transition) machine snap args)]
+          (let [step-result (machine-transition machine snap args)]
             (if (and (vector? step-result)
                      (= ::action-failed (first step-result)))
               ;; Per Spec 005 §Errors: an action throw inside a raised

--- a/implementation/machines/test/re_frame/machines_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_cljs_test.cljs
@@ -908,3 +908,65 @@
       (is (= :winner (:state (snapshot :tags/always))))
       (is (= #{:terminal :celebrate}
              (:tags (snapshot :tags/always)))))))
+
+;; ---- :raise chain on CLJS (rf2-c0nt) --------------------------------------
+;; Per Spec 005 §`:raise`: an `:action` may return `{:fx [[:raise <event-vec>]]}`
+;; to re-enter the same machine pre-commit. The handler in `drain-raises`
+;; recurses through `machine-transition`, so a chain of raises threads through
+;; multiple transitions before the macrostep commits.
+;;
+;; Pre-fix `drain-raises` looked up `machine-transition` with `(resolve …)`.
+;; The fix (rf2-c0nt) drops that indirection in favour of a direct call backed
+;; by an explicit `(declare machine-transition)` forward reference. This test
+;; pins regression coverage for the :raise-chain path on CLJS so that future
+;; refactors of `drain-raises` cannot silently break the recursive entry point.
+(deftest machine-raise-chain-cljs
+  (testing "an action's [:raise <event>] re-enters machine-transition and fires the chained transition (rf2-c0nt)"
+    (let [log (atom [])
+          machine
+          {:initial :idle
+           :data    {}
+           :actions {:bump-then-raise
+                     (fn [_data _ev]
+                       (swap! log conj :bump-action)
+                       ;; Pre-commit raise — should chain into the :go-2 transition.
+                       {:fx [[:raise [:go-2]]]})
+                     :landed
+                     (fn [_data _ev]
+                       (swap! log conj :landed-action)
+                       {})}
+           :states
+           {:idle    {:on {:go-1 {:target :middle :action :bump-then-raise}}}
+            :middle  {:on {:go-2 {:target :final  :action :landed}}}
+            :final   {}}}]
+      (rf/reg-machine :rf2-c0nt/raise-chain machine)
+      (rf/dispatch-sync [:rf2-c0nt/raise-chain [:go-1]])
+      (is (= :final (:state (snapshot :rf2-c0nt/raise-chain)))
+          ":raise chained idle → middle → final in a single macrostep (this is the assertion that fails on main pre-fix because drain-raises' runtime resolve returns nil on CLJS, so the chained transition never fires)")
+      (is (= [:bump-action :landed-action] @log)
+          "both the originating action and the raised transition's action ran")))
+
+  (testing "a 2-deep :raise chain — three transitions in one macrostep"
+    (let [log (atom [])
+          mk-action (fn [k raised-ev]
+                      (fn [_data _ev]
+                        (swap! log conj k)
+                        (if raised-ev
+                          {:fx [[:raise raised-ev]]}
+                          {})))
+          machine
+          {:initial :s0
+           :data    {}
+           :actions {:a1 (mk-action :a1 [:e2])
+                     :a2 (mk-action :a2 [:e3])
+                     :a3 (mk-action :a3 nil)}
+           :states  {:s0 {:on {:e1 {:target :s1 :action :a1}}}
+                     :s1 {:on {:e2 {:target :s2 :action :a2}}}
+                     :s2 {:on {:e3 {:target :s3 :action :a3}}}
+                     :s3 {}}}]
+      (rf/reg-machine :rf2-c0nt/deep-chain machine)
+      (rf/dispatch-sync [:rf2-c0nt/deep-chain [:e1]])
+      (is (= :s3 (:state (snapshot :rf2-c0nt/deep-chain)))
+          "depth-2 :raise chain reached the terminal state in a single macrostep")
+      (is (= [:a1 :a2 :a3] @log)
+          "all three actions fired in raise order"))))


### PR DESCRIPTION
Two P2 correctness fixes from the 2026-05-12 correctness review (`ai/findings/correctness-review-2026-05-12.md`), bundled as a single PR — disjoint files, disjoint surfaces.

## rf2-c0nt — `drain-raises` runtime-resolve anti-pattern

**Where:** `implementation/machines/src/re_frame/machines.cljc`

**Root cause.** `drain-raises` was calling `((resolve `machine-transition) machine snap args)` to recurse into `machine-transition`. The `:raise` recursion does work on both runtimes — the syntax-quoted symbol is namespace-qualified, so `cljs.core/resolve` (a macro) emits a working Var-construction — but the surface is the exact anti-pattern called out in `re-frame.late-bind`'s docstring. A reader skimming the body would infer a cross-namespace late-bind, and the indirection costs a Var allocation per raised event on CLJS.

**Fix.** Replace the `((resolve `…) …)` call with a direct `(machine-transition …)` call, backed by an explicit `(declare machine-transition)` forward reference inserted just before `drain-raises`. The existing forward `(declare machine-transition machine-transition-single)` further down stays — the parallel-region helpers still need it.

**Test added.** `machine-raise-chain-cljs` in `implementation/machines/test/re_frame/machines_cljs_test.cljs` — two sub-tests covering a 1-deep and a 2-deep `:raise` chain through Reagent. Pins regression coverage so a future refactor that re-introduces a genuine runtime-resolve (or a typo'd direct call) breaks loudly on CLJS.

**Note on the bead's pre-fix claim.** The bead description claims `:raise` chains \"silently no-op on CLJS\" pre-fix. That's overstated for this specific call site — because `\`machine-transition` is namespace-qualified at the syntax level, CLJS's `cljs.core/resolve` macro emits a working Var-construction (which is how the existing JVM tests for `:raise` in `smoke_test.clj` already covered the chained-raise path). The fix is still a correctness improvement (eliminates the anti-pattern surface, drops the per-raise allocation, makes future regressions visible), and the new test pins explicit CLJS coverage.

## rf2-zikr — `unsubscribe` ref-count underflow + dispose-timer leak

**Where:** `implementation/core/src/re_frame/subs.cljc`

**Root cause.** `unsubscribe` decremented `:ref-count` past zero on repeated calls. A second `unsubscribe` against an entry already at ref-count 0 computed `n = -1`, re-entered the drop-to-zero branch, scheduled a NEW `set-timeout!`, and the outer `swap!` overwrote the prior `:pending-dispose` handle — leaking the original timer (and possibly firing two `dispose-entry-now!` callbacks for one cache slot).

**Fix.**
- Clamp the decrement at zero — `(max 0 (dec old-n))` — so repeated calls don't drive the count negative.
- Only trigger drop-to-zero on the 1→0 transition AND when no `:pending-dispose` is already in flight. Idempotent.

**Test added.** `unsubscribe-past-zero-is-idempotent` in `implementation/core/test/re_frame/sub_cache_test.clj` — subscribes once, unsubscribes three times in a row, and asserts (a) ref-count stays at 0 (does NOT go negative) and (b) the same `:pending-dispose` handle is preserved across the extra calls (`identical?` over the timer object).

**Fails on `main`, passes after the fix.** Verified locally by stashing the `subs.cljc` change and running the new test — it fails with two distinct `ScheduledFutureTask` identities reported on the `(identical? handle-after-first handle-after-second)` assertion. Re-applying the fix returns it to green.

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 186 tests, 838 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` from `implementation/machines/` — 92 tests, 255 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs` from `implementation/` — 530 tests, 1272 assertions, 0 failures, 0 errors
- [x] `npm run test:elision` from `implementation/` — PASS (every sentinel correct in both prod and control bundles)
- [x] `npm run test:examples` from `implementation/` — PASS across every example (counter / login / cells / circle-drawer / crud / flight-booker / temperature / timer / todomvc / counter-perf / counter-slim-and-fast / counter-with-stories / managed-http-counter / nine-states / realworld / routing / ssr / state-machines / pattern-websocket / counter-uix / login-uix / counter-helix / login-helix / long-running-work)
- [x] New JVM test (`unsubscribe-past-zero-is-idempotent`) verified to fail on `main` pre-fix with the expected timer-handle-identity divergence

## Scope hygiene

- IN: `machines.cljc`, `subs.cljc`, and their `test/` subtrees only.
- OUT: no spec changes — these are pure impl bugs. No touch to `late_bind.cljc`, `core.cljc`, or any other source file.