### PR TITLE
feat(core): rf/with-frame macro form + rf/handlers + rf/frame-ids filter arities (rf2-7whh, rf2-ewku, rf2-t38q)

### DIFF
--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -189,9 +189,8 @@
    (defn handle-request [request]
      (let [f (rf/make-frame {:on-create [:rf/server-init request]})]
        (rf/with-frame f
-         (fn []
-           (let [final-db (rf/get-frame-db f)
-                 hiccup   ((rf/view :app/root))
+         (let [final-db (rf/get-frame-db f)
+               hiccup   ((rf/view :app/root))
                  ;; render-to-string with :emit-hash? embeds
                  ;; data-rf-render-hash="<hex>" on the root element. The
                  ;; client recomputes the hash after its first render and
@@ -220,7 +219,7 @@
                    (pr-str payload)
                    "</script>"
                    "<script src='/main.js'></script>"
-                   "</body></html>")}))))))
+                   "</body></html>")})))))
 
 ;; ============================================================================
 ;; CLIENT ENTRY POINT
@@ -304,7 +303,7 @@
            ;; and not from :rf/default.
            hiccup      ((rf/view :app/root))
            html        (rf/with-frame f
-                         (fn [] (rf/render-to-string hiccup {:emit-hash? true})))
+                         (rf/render-to-string hiccup {:emit-hash? true}))
            render-hash (rf/render-tree-hash hiccup)]
        ;; State was loaded.
        (assert (= 2 (count (:articles final-db))))

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
@@ -418,9 +418,8 @@
       "no dynamic binding → resolves to :rf/default")
   ;; with-frame binds the dynamic var; resolution lands on the bound id.
   (rf/with-frame :alt
-    (fn []
-      (is (= :alt (rf/current-frame))
-          "dynamic-var tier wins over :rf/default")))
+    (is (= :alt (rf/current-frame))
+        "dynamic-var tier wins over :rf/default"))
   ;; After with-frame returns, dynamic var is unbound again.
   (is (= :rf/default (rf/current-frame))
       "with-frame's binding is scoped — dynamic var reverts on exit"))
@@ -698,9 +697,8 @@
   ;; path). Pin the precedence on the JVM-shared resolution path here —
   ;; the React-rendered case is exercised by the previous deftest.
   (rf/with-frame :rf.d4sf/dynamic-tier
-    (fn []
-      (is (= :rf.d4sf/dynamic-tier (rf/current-frame))
-          "with-frame's dynamic-var binding wins over :rf/default"))))
+    (is (= :rf.d4sf/dynamic-tier (rf/current-frame))
+        "with-frame's dynamic-var binding wins over :rf/default")))
 
 (deftest adapter-context-current-frame-tolerates-prop-stringified-keyword
   "rf2-d4sf — the function-component-shape React-context-aware

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -138,7 +138,7 @@
   ;; lives in re-frame.core; CLJS users can write `rf/reg-view` after
   ;; `(:require [re-frame.core :as rf])` without an explicit
   ;; `:require-macros` clause at the call site.
-  #?(:cljs (:require-macros [re-frame.core :refer [reg-view]])))
+  #?(:cljs (:require-macros [re-frame.core :refer [reg-view with-frame]])))
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -929,13 +929,64 @@
       [query-v]
       (subscribe frame query-v))))
 
-(defn with-frame
-  "Run `thunk` with *current-frame* bound to `frame-id`. The macro form
-  in re-frame.views wraps an expression in a thunk; this fn variant
-  is JVM-friendly for tests / SSR / REPL."
-  [frame-id thunk]
-  (binding [frame/*current-frame* frame-id]
-    (thunk)))
+;; with-frame is a macro (per Spec 002 §with-frame and spec/API.md row 74).
+;; Two shapes:
+;;
+;;   Shape 1 — bare keyword (operate on an existing frame):
+;;     (with-frame :scratch body...)
+;;     => (binding [frame/*current-frame* :scratch] body...)
+;;
+;;   Shape 2 — let-binding (create, use, destroy):
+;;     (with-frame [f (make-frame opts)] body...)
+;;     => (let [f (make-frame opts)]
+;;          (try
+;;            (binding [frame/*current-frame* f] body...)
+;;            (finally (destroy-frame f))))
+;;
+;; The discriminator is the first argument: a vector triggers Shape 2;
+;; anything else is Shape 1. The fn-form `(with-frame frame-id thunk)`
+;; is no longer supported — callers wanting a thunk-style wrapper should
+;; write `(with-frame :foo (thunk))` (the thunk call sits inside the
+;; macro body, identical semantics) or call `binding` directly.
+
+#?(:clj
+   (defmacro with-frame
+     "Run `body` with `*current-frame*` bound to the given frame-id.
+     Per Spec 002 §with-frame the macro accepts two shapes:
+
+       (with-frame :keyword body+)
+         Shape 1 — pin `*current-frame*` to the supplied frame-id for the
+         body's duration. The frame is NOT created or destroyed by the
+         macro; the keyword is used as-is.
+
+       (with-frame [sym expr] body+)
+         Shape 2 — evaluate `expr` (typically `(make-frame opts)` or
+         `(reg-frame :id opts)`), bind the result to `sym`, run `body`
+         with `*current-frame*` bound to that frame, and destroy the
+         frame on exit (success or exception).
+
+     The discriminator is the first argument: a vector triggers Shape 2,
+     anything else triggers Shape 1.
+
+     For async closures that fire after the body returns, capture the
+     frame keyword via `bound-fn` / `bound-dispatcher` / `bound-subscriber`
+     — the dynamic binding has unwound by then, and (under Shape 2) the
+     frame has already been destroyed."
+     {:arglists '([frame-id body+] [[sym expr] body+])}
+     [bindings & body]
+     (cond
+       (and (vector? bindings) (= 2 (count bindings)))
+       (let [[sym expr] bindings]
+         `(let [~sym ~expr]
+            (try
+              (binding [frame/*current-frame* ~sym]
+                ~@body)
+              (finally
+                (destroy-frame ~sym)))))
+
+       :else
+       `(binding [frame/*current-frame* ~bindings]
+          ~@body))))
 
 (defn bound-dispatcher
   "Capture the current frame and return a frame-bound dispatch fn that
@@ -950,8 +1001,11 @@
   (subscriber))
 
 ;; ---- view ergonomics (CLJS only) ------------------------------------------
-;; reg-view (the macro), with-frame live in re-frame.views-macros (CLJS-
-;; only macros — users `(:require-macros [re-frame.views-macros :refer ...])`).
+;; reg-view (the macro) lives above as a JVM/CLJS-shared `#?(:clj defmacro)`.
+;; The legacy import path `re-frame.views-macros` continues to provide
+;; `reg-view` and `with-frame` shims that emit the same expansion shape,
+;; so existing examples keep working without an across-the-board sweep
+;; of `:require-macros` imports.
 ;; frame-provider is a Reagent component re-exported here so `rf/frame-provider`
 ;; is the canonical user-facing surface (per Spec 002 §What `frame-provider` is
 ;; and the API.md table); it lives in re-frame.views to keep React/Reagent off

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -11,7 +11,8 @@
   Reserved frame ids:
     :rf/default              — universal default frame (always present)
     :rf.frame/<gensym>       — anonymous instances from make-frame"
-  (:require [re-frame.registrar :as registrar]
+  (:require [clojure.string]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -69,12 +70,33 @@
      :lifecycle (:lifecycle f)}))
 
 (defn frame-ids
-  "All registered, non-destroyed frame ids."
-  []
-  (into #{}
-        (comp (filter (fn [[_ f]] (not (get-in f [:lifecycle :destroyed?]))))
-              (map key))
-        @frames))
+  "All registered, non-destroyed frame ids.
+
+  Two arities:
+    (frame-ids)
+      Return the full id set.
+    (frame-ids ns-prefix)
+      Return the subset whose id-namespace starts with `ns-prefix`
+      (a string). Namespaceless ids (e.g. `:rf/default`'s namespace is
+      `\"rf\"` — keyword-namespace, not value-namespace) are matched
+      against the keyword's `namespace` component; ids with no
+      namespace are excluded.
+
+  Per Spec 002 §The public registrar query API."
+  ([]
+   (into #{}
+         (comp (filter (fn [[_ f]] (not (get-in f [:lifecycle :destroyed?]))))
+               (map key))
+         @frames))
+  ([ns-prefix]
+   (let [prefix (str ns-prefix)]
+     (into #{}
+           (comp (filter (fn [[_ f]] (not (get-in f [:lifecycle :destroyed?]))))
+                 (map key)
+                 (filter (fn [k]
+                           (when-let [ns (namespace k)]
+                             (clojure.string/starts-with? ns prefix)))))
+           @frames))))
 
 (defn get-frame-db
   "Return the underlying app-db container for the frame. Tools and tests

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -162,9 +162,26 @@
 
 (defn handlers
   "All ids registered under kind, with their metadata. Tools, agents,
-  storybook resolution, all use this."
-  [kind]
-  (get @kind->id->metadata kind {}))
+  storybook resolution, all use this.
+
+  Two arities:
+    (handlers kind)
+      Return the full `{id metadata}` map for kind, or `{}` if the kind
+      has no registrations.
+    (handlers kind pred-fn)
+      Same shape, filtered: only entries for which `(pred-fn id meta)`
+      returns truthy are included. Returns `{}` when no entry matches.
+      Tools (storybook resolvers, registry browsers, agent introspection)
+      use this to narrow the result to a per-namespace, per-source-file,
+      or per-marker subset without re-walking the registry map themselves.
+
+  Per Spec 001 §The public registrar query API."
+  ([kind]
+   (get @kind->id->metadata kind {}))
+  ([kind pred-fn]
+   (into {}
+         (filter (fn [[id meta]] (pred-fn id meta)))
+         (get @kind->id->metadata kind {}))))
 
 (defn handler-meta
   "Public alias for lookup. Used by tooling."

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -1,0 +1,224 @@
+(ns re-frame.core-api-additions-test
+  "JVM tests for three core-API additions landed together
+   (rf2-7whh / rf2-ewku / rf2-t38q):
+
+   - `rf/with-frame` macro form (replacing the fn form). Two shapes:
+     bare-keyword (Shape 1) and let-binding (Shape 2). Per Spec 002
+     §with-frame and `spec/API.md` row 74.
+
+   - `(rf/handlers kind pred-fn)` 2-arity filter. Per `spec/API.md`
+     row 304 and Spec 001 §Public registrar query API.
+
+   - `(rf/frame-ids ns-prefix)` 1-arity filter. Per `spec/API.md`
+     row 308 and Spec 002 §The public registrar query API."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.machines]
+            [re-frame.routing]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ===========================================================================
+;; rf2-7whh — with-frame macro form
+;; ===========================================================================
+
+(deftest with-frame-shape-1-bare-keyword
+  (testing "(with-frame :keyword body) binds *current-frame* across body"
+    (rf/reg-frame :wf/alpha {:doc "alpha"})
+    (is (= :rf/default (rf/current-frame))
+        "outside the macro: resolves to :rf/default")
+    (let [observed (rf/with-frame :wf/alpha (rf/current-frame))]
+      (is (= :wf/alpha observed)
+          "inside the macro body: resolves to the bound id"))
+    (is (= :rf/default (rf/current-frame))
+        "after the macro returns: dynamic binding unwinds")))
+
+(deftest with-frame-shape-1-multi-form-body
+  (testing "(with-frame :keyword expr1 expr2 ...) evaluates all body forms,
+            returns the last"
+    (rf/reg-frame :wf/beta {:doc "beta"})
+    (let [side (atom [])
+          result (rf/with-frame :wf/beta
+                   (swap! side conj :first)
+                   (swap! side conj :second)
+                   (rf/current-frame))]
+      (is (= [:first :second] @side)
+          "all body forms were evaluated in order")
+      (is (= :wf/beta result)
+          "the last form's value is returned"))))
+
+(deftest with-frame-shape-1-subscriber-captures-frame
+  (testing "subscriber called inside (with-frame :k ...) captures :k"
+    (rf/reg-frame :wf/left  {:doc "left"})
+    (rf/reg-frame :wf/right {:doc "right"})
+    (rf/reg-event-db :wf/seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-sub :wf/n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:wf/seed 7]  {:frame :wf/left})
+    (rf/dispatch-sync [:wf/seed 99] {:frame :wf/right})
+    (let [sl (rf/with-frame :wf/left  (rf/subscriber))
+          sr (rf/with-frame :wf/right (rf/subscriber))]
+      (is (= 7  @(sl [:wf/n])) ":wf/left subscriber sees :wf/left's :n")
+      (is (= 99 @(sr [:wf/n])) ":wf/right subscriber sees :wf/right's :n"))))
+
+(deftest with-frame-shape-2-let-binding-create-use-destroy
+  (testing "(with-frame [f (make-frame opts)] body) creates, binds, destroys"
+    (let [captured-id (atom nil)
+          observed-current (atom nil)]
+      (rf/with-frame [f (rf/make-frame {:doc "ephemeral"})]
+        (reset! captured-id f)
+        (reset! observed-current (rf/current-frame))
+        (is (= f (rf/current-frame))
+            "inside the body: *current-frame* is the freshly-made id")
+        (is (some? (rf/frame-meta f))
+            "the frame is alive during the body"))
+      (is (some? @captured-id)
+          "the macro yielded a frame id to the body")
+      (is (= @captured-id @observed-current)
+          "the body saw the just-created id as current-frame")
+      (is (nil? (rf/frame-meta @captured-id))
+          "the frame was destroyed on body exit")
+      (is (= :rf/default (rf/current-frame))
+          "*current-frame* reverted after the body"))))
+
+(deftest with-frame-shape-2-destroys-on-exception
+  (testing "(with-frame [f ...] body) destroys the frame even when body throws"
+    (let [captured-id (atom nil)]
+      (try
+        (rf/with-frame [f (rf/make-frame {:doc "ephemeral-throw"})]
+          (reset! captured-id f)
+          (throw (ex-info "boom" {:kind ::boom})))
+        (catch Exception e
+          (is (= ::boom (:kind (ex-data e)))
+              "the body's exception propagates")))
+      (is (some? @captured-id))
+      (is (nil? (rf/frame-meta @captured-id))
+          "the frame is destroyed even on exception"))))
+
+(deftest with-frame-shape-2-on-create-fires-and-state-is-readable
+  (testing "(with-frame [f (make-frame {:on-create [...]})] body) — on-create
+            fires before body, body sees the seeded state, destroy runs after"
+    (rf/reg-event-db :wf/initialise (fn [_ _] {:counter 42}))
+    (let [captured-db (atom nil)]
+      (rf/with-frame [f (rf/make-frame {:on-create [:wf/initialise]})]
+        (reset! captured-db (rf/get-frame-db f)))
+      (is (= {:counter 42} @captured-db)
+          "the body observed the on-create-seeded app-db"))))
+
+;; ===========================================================================
+;; rf2-ewku — (rf/handlers kind pred-fn) filter arity
+;; ===========================================================================
+
+(deftest handlers-1-arity-returns-full-map
+  (testing "(handlers kind) returns the full {id metadata} map"
+    (rf/reg-event-db :hf/one (fn [db _] db))
+    (rf/reg-event-db :hf/two (fn [db _] db))
+    (let [all (rf/handlers :event)]
+      (is (contains? all :hf/one))
+      (is (contains? all :hf/two)))))
+
+(deftest handlers-2-arity-filters
+  (testing "(handlers kind pred-fn) filters by (pred id meta)"
+    (rf/reg-event-db :hf.alpha/one (fn [db _] db))
+    (rf/reg-event-db :hf.alpha/two (fn [db _] db))
+    (rf/reg-event-db :hf.beta/one  (fn [db _] db))
+    (let [alpha-only (rf/handlers :event
+                                  (fn [id _meta]
+                                    (= "hf.alpha" (namespace id))))]
+      (is (= #{:hf.alpha/one :hf.alpha/two}
+             (set (keys alpha-only)))
+          "only :hf.alpha/* survives the predicate")
+      (is (not (contains? alpha-only :hf.beta/one))
+          ":hf.beta/one is filtered out"))))
+
+(deftest handlers-2-arity-pred-receives-id-and-meta
+  (testing "the pred-fn receives [id meta], so meta keys can drive the filter"
+    (rf/reg-event-db :hf/marked   (fn [db _] db))
+    (rf/reg-event-db :hf/unmarked (fn [db _] db))
+    ;; Re-register :hf/marked with extra meta on the slot.
+    (registrar/register! :event :hf/marked
+      (assoc (rf/handler-meta :event :hf/marked) :rf/marker? true))
+    (let [marked (rf/handlers :event
+                              (fn [_id m]
+                                (:rf/marker? m)))]
+      (is (= #{:hf/marked} (set (keys marked)))
+          "only handlers whose metadata satisfies the pred survive"))))
+
+(deftest handlers-2-arity-empty-result
+  (testing "a predicate that matches nothing returns {}"
+    (rf/reg-event-db :hf/one (fn [db _] db))
+    (is (= {} (rf/handlers :event (constantly false)))
+        "no entries match → empty map")))
+
+(deftest handlers-2-arity-unknown-kind-returns-empty
+  (testing "a kind with no registrations returns {} regardless of pred"
+    (is (= {} (rf/handlers :app-schema (constantly true)))
+        "kind has no entries → empty map even when pred is permissive")))
+
+;; ===========================================================================
+;; rf2-t38q — (rf/frame-ids ns-prefix) filter arity
+;; ===========================================================================
+
+(deftest frame-ids-0-arity-returns-full-set
+  (testing "(frame-ids) returns the full set of registered ids"
+    (rf/reg-frame :fi/alpha {})
+    (rf/reg-frame :fi/beta  {})
+    (let [all (rf/frame-ids)]
+      (is (contains? all :fi/alpha))
+      (is (contains? all :fi/beta))
+      (is (contains? all :rf/default)
+          "the default frame is always present"))))
+
+(deftest frame-ids-1-arity-filters-by-prefix
+  (testing "(frame-ids ns-prefix) returns ids whose keyword namespace
+            starts with the prefix string"
+    (rf/reg-frame :fi.story/login  {})
+    (rf/reg-frame :fi.story/signup {})
+    (rf/reg-frame :fi.test/login   {})
+    (let [story-ids (rf/frame-ids "fi.story")]
+      (is (= #{:fi.story/login :fi.story/signup} story-ids)
+          "only :fi.story/* survives the prefix filter")
+      (is (not (contains? story-ids :fi.test/login))
+          ":fi.test/login is excluded"))))
+
+(deftest frame-ids-1-arity-empty-result
+  (testing "a prefix that matches no registered frame returns #{}"
+    (rf/reg-frame :fi/alpha {})
+    (is (= #{} (rf/frame-ids "no-such-ns"))
+        "no namespaces start with this prefix → empty set")))
+
+(deftest frame-ids-1-arity-excludes-destroyed
+  (testing "destroyed frames do not appear in (frame-ids ns-prefix)"
+    (rf/reg-frame :fi.zone/one {})
+    (rf/reg-frame :fi.zone/two {})
+    (rf/destroy-frame :fi.zone/one)
+    (let [zone-ids (rf/frame-ids "fi.zone")]
+      (is (= #{:fi.zone/two} zone-ids)
+          "destroyed :fi.zone/one is filtered out"))))
+
+(deftest frame-ids-1-arity-broader-prefix
+  (testing "a shorter prefix matches any longer matching namespace"
+    (rf/reg-frame :wide.a/one {})
+    (rf/reg-frame :wide.b/two {})
+    (rf/reg-frame :elsewhere/one {})
+    (let [wide-ids (rf/frame-ids "wide")]
+      (is (contains? wide-ids :wide.a/one))
+      (is (contains? wide-ids :wide.b/two))
+      (is (not (contains? wide-ids :elsewhere/one))))))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -252,8 +252,8 @@
     (rf/dispatch-sync [:seed 7]  {:frame :left})
     (rf/dispatch-sync [:seed 99] {:frame :right})
     ;; Capture frame-bound subscribers via with-frame.
-    (let [sl (rf/with-frame :left  (fn [] (rf/subscriber)))
-          sr (rf/with-frame :right (fn [] (rf/subscriber)))]
+    (let [sl (rf/with-frame :left  (rf/subscriber))
+          sr (rf/with-frame :right (rf/subscriber))]
       (is (= 7  @(sl [:n])) "left subscriber sees left's :n")
       (is (= 99 @(sr [:n])) "right subscriber sees right's :n")
       ;; And :rf/default is unaffected.

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -75,11 +75,10 @@
   dependent hash that mirrors what a real client recompute would do."
   [frame-id render-tree]
   (rf/with-frame frame-id
-    (fn []
-      (let [head (first render-tree)]
-        (if-let [view-fn (rf/view head)]
-          (apply view-fn (rest render-tree))
-          render-tree)))))
+    (let [head (first render-tree)]
+      (if-let [view-fn (rf/view head)]
+        (apply view-fn (rest render-tree))
+        render-tree))))
 
 ;; ===========================================================================
 ;; ssr-full-request-lifecycle — the canonical happy path
@@ -146,7 +145,7 @@
       ;; ---- (4) render against the registered root view -------------------
       (let [render-tree   [:pages/articles]
             html          (rf/with-frame server-frame
-                            (fn [] (rf/render-to-string render-tree {:emit-hash? true})))
+                            (rf/render-to-string render-tree {:emit-hash? true}))
             ;; The data-rf-render-hash embedded on the wire is the input-
             ;; tree hash (per render-to-string in ssr.cljc) — stable across
             ;; renders of the same view-ref. The hydration payload below


### PR DESCRIPTION
## Summary

Three impl additions catching `re-frame.core`'s public surface up to what `spec/API.md` and the canonical owner specs already promise. All three are impl-direction fixes (the spec was already correct).

- **rf2-7whh** — replace `(rf/with-frame frame-id thunk)` fn with a macro taking either a bare-keyword shape `(rf/with-frame :foo body+)` or a let-binding shape `(rf/with-frame [sym expr] body+)`. The let-binding shape creates-uses-destroys per Spec 002 §with-frame Shape 2: it evaluates `expr`, binds the result, runs `body` under `*current-frame*`, and destroys the frame on exit (success or exception). Re-exported to CLJS via the existing self-`:require-macros` block. The legacy `re-frame.views-macros/with-frame` remains untouched for back-compat with existing example `:require-macros` imports.

- **rf2-ewku** — add 2-arity `(rf/handlers kind pred-fn)`. The pred is invoked with `[id meta]` and the result is the filtered subset. Promised by `spec/API.md` row 304 and Spec 001 §Public registrar query API; tool authors writing `(rf/handlers :event pred)` no longer hit an arity exception.

- **rf2-t38q** — add 1-arity `(rf/frame-ids ns-prefix)`. Returns the subset of registered, non-destroyed frame ids whose keyword namespace starts with `ns-prefix`. Promised by `spec/API.md` row 308.

The four fn-form `with-frame` callers under `implementation/` and `examples/` are migrated to bare-body shape now that `with-frame` is a macro.

## Test plan

- [x] `clojure -M:test` (JVM) full pass across core/ssr/schemas/machines/routing/flows/http/epoch suites
- [x] `npm run test:cljs` — 529/529 pass
- [x] `npm run test:elision` — clean
- [x] `npm run test:examples` — 25/25 pass
- [x] New `core_api_additions_test.clj` covers Shape 1 (bare keyword), Shape 2 (let-binding create/use/destroy), Shape 2 exception path destroys, `:on-create` runs before body, `handlers` 2-arity filter (full / empty / unknown-kind / pred sees meta), and `frame-ids` 1-arity (full / empty / excludes destroyed / broader prefix)
- [x] Guide ch.02 and ch.10's `(rf/with-frame [f (rf/make-frame ...)] body)` snippets now resolve against the canonical macro at `re-frame.core`