### PR TITLE
docs(spec): 9 spec-drift docs fixes — SSR / Instrumentation / Flows / Views / HTTP / trace-events (rf2-5128, rf2-mnb7, rf2-phdy, rf2-g26k, rf2-hief, rf2-m6de, rf2-nsu5, rf2-s9sd, rf2-f3qc, rf2-zkqa)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -229,7 +229,7 @@ This is the family-asymmetry rule applied to views: **render trees use Vars; run
 [counter "Hello"]
 
 ;; runtime lookup — id
-(rf/view :my.ns/counter)             ;; → the registered render fn
+(rf/view :my.ns/counter)             ;; → the wrapped (frame-aware) render fn — see §`view` below
 
 ;; bare [:my.ns/counter "Hello"] in a render tree is NOT a view call —
 ;; it renders as a custom HTML element <my.ns:counter>...</my.ns:counter>
@@ -257,10 +257,10 @@ v1 ships three forms for invoking a registered view. To honour the principle of 
 
 ### `view` — the canonical post-registration lookup
 
-Whatever the call-site shape, `(rf/view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the wrapped (frame-aware) Var-equivalent, re-resolved on every call so hot-reload re-registration is picked up immediately. The other call-site forms are sugar over `view`.
+Whatever the call-site shape, `(rf/view :counter)` is the **canonical lookup** for a registered view's render-fn. It returns the **wrapped (frame-aware) fn that `reg-view` produced** — *not* the raw user fn the caller wrote. Specifically the wrapper carries the frame-injection, source-coord annotation (per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1)), and the lexical `dispatch` / `subscribe` bindings described in [§Shape](#shape). The lookup is re-resolved on every call so hot-reload re-registration is picked up immediately — calling `(rf/view :counter)` twice after a swap returns the new wrapped fn the second time. The other call-site forms are sugar over `view`.
 
 ```clojure
-(rf/view :counter)               ;; → wrapped fn
+(rf/view :counter)               ;; → wrapped (frame-aware) fn — observably equivalent to the Var bound by reg-view
 ((rf/view :counter) "label")     ;; identical observably to: [counter "label"]
 ```
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -132,6 +132,8 @@ The two basic operations on a container. `read-container` is pure; `replace-cont
 (replace-container! container new-value)                ;; → nil; container now holds new-value
 ```
 
+**Nil-container guard (defense-in-depth).** The core's `replace-container!` wrapper guards against the destroy-race case where a write (router `:db` commit, drain rollback, flows recompute, epoch restore, SSR write) arrives after the owning frame has been destroyed and `frame/get-frame-db` has started returning nil. When `container` is nil, the wrapper SKIPS the underlying adapter's `replace-container!` call and emits a `:warning :rf.warning/write-after-destroy` trace (per [009 §Where trace emission lives](009-Instrumentation.md#where-trace-emission-lives)) with `:recovery :no-recovery` — the write is dropped, no exception is thrown. The earlier behaviour (rf2-ft2b reproducer) was an NPE on a background thread; the guard centralises destroy-race handling on the one mutation primitive that every frame app-db write flows through. Adapter implementations may assume `container` is non-nil; the guard is in the core's wrapper, not in the adapter contract.
+
 ### `(subscribe-container container on-change) → unsubscribe-fn`
 
 Optional. Registers a callback that fires *after* `replace-container!` runs. The callback receives `(prev-value, new-value)`.

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -167,6 +167,13 @@ The canonical listener API has one shape:
 
 (rf/remove-trace-cb! key)
 ;; Unsubscribes the listener registered under key. Returns nil.
+
+(rf/clear-trace-cbs!)
+;; Test-time helper: drops all registered raw-trace listeners atomically.
+;; Returns nil. Used by `re-frame.test-support/reset-runtime-fixture` to
+;; restore a clean listener registry between tests; ordinary application
+;; code SHOULD use `remove-trace-cb!` per key. The same dev-only elision
+;; rules apply (production builds drop the registry entirely).
 ```
 
 Conventional keys: `:my-app/recorder`, `:my-app/timing-monitor`, etc.
@@ -299,6 +306,7 @@ The framework emits trace events from these call sites:
 - `epoch.cljc` — `:rf.epoch/snapshotted` per drain-settle, `:rf.epoch/restored` on restore success, `:rf.epoch/db-replaced` on `reset-frame-db!` success (rf2-zq55), plus the six restore-failure categories and the two reset-frame-db! failure categories (`:rf.epoch/reset-frame-db-during-drain`, `:rf.epoch/reset-frame-db-schema-mismatch`), plus `:rf.epoch.cb/silenced-on-frame-destroy` emitted once per `(frame-id, cb-id)` pair on the destroy-cascade boundary (rf2-d656).
 - `views.cljs` — `:view/render` per registered-view render (per [Spec 004 §Render-tree primitives](004-Views.md)).
 - `adapter/context.cljs` — `:rf.error/frame-context-corrupted` (function-component `_currentValue` read observed a non-coercible shape; per rf2-8q66).
+- `substrate/adapter.cljc` — `:warning :rf.warning/write-after-destroy` emitted by the `replace-container!` wrapper when called with a nil container (the frame was destroyed mid-drain or before a scheduled write fired; the underlying adapter's `replace-container!` is NOT invoked). Per [006 §`replace-container!`](006-ReactiveSubstrate.md#read-container-container--value-and-replace-container-container-new-value) and rf2-ft2b.
 - `std_interceptors.cljc` — `:rf.error/unwrap-bad-event-shape`.
 - `http_managed.cljc` — `:warning :rf.http/cljs-only-key-ignored-on-jvm`, `:warning :rf.warning/decode-defaulted`, `:info :rf.http/retry-attempt`, `:info :rf.http/aborted-on-actor-destroy` (per [014 §Abort on actor destroy](014-HTTPRequests.md#abort-on-actor-destroy), rf2-wvkn), `:info :rf.http.interceptor/registered`, `:info :rf.http.interceptor/cleared`, `:error :rf.error/http-interceptor-failed` (request-side interceptor `:before` threw, per [014 §Middleware](014-HTTPRequests.md#middleware), rf2-6y3q), plus the Spec 014 failure categories.
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -265,6 +265,8 @@ The `hydration-payload` is the canonical `:rf/hydration-payload` shape (per [Spe
 
 **Merge policy is `:replace-app-db`.** Server is authoritative for the initial client app-db: the handler sets `:db` to the server's serialised slice, replacing whatever the client bootstrap had pre-seeded. This is locked.
 
+**Server-hash slot at `[:rf/hydration :server-hash]`.** Alongside replacing `:db`, the reference handler stashes the payload's `:rf/render-hash` value under `[:rf/hydration :server-hash]` in the post-hydration `app-db`. This slot is the carrier `verify-hydration!` reads later (after the first client render) to compare against the client-side render-tree hash — see [§Hydration-mismatch detection](#hydration-mismatch-detection). The slot is a runtime-managed `app-db` path; user code SHOULD NOT write to it. The companion `:version` key under `:rf/hydration` carries the payload's `:rf/version` value when present (consumed by `:rf.ssr/check-version`). Implementations that override the reference `:rf/hydrate` handler with their own merge policy MUST preserve the `[:rf/hydration :server-hash]` write (or pass a `:server-hash` opt to `verify-hydration!` per the fn's docstring) — otherwise `verify-hydration!` has nothing to compare against and silently no-ops.
+
 **If the user wants client-only transient state to survive hydration:** the customisation point is *re-registering* `:rf/hydrate` with a custom handler that performs an explicit merge in the user's intended order. The default is replace; opt-in merge is the user's choice and they own the semantics.
 
 **Mismatch detection** between server and client schemas runs as part of `:rf/hydrate`'s `:fx`:
@@ -281,6 +283,7 @@ The payload shape is fixed; implementations may emit additive optional keys (per
 After the first client render, a comparison pass:
 
 - Server emits the rendered string AND a **structural marker** (a hash of the render-tree, computed before stringification) on the root element. Placement: a `data-rf-render-hash="<hex-string>"` attribute on the root view's outermost element. Encoding: lowercase hex of the raw hash bytes; no prefix.
+- **Injection point — first `<tag` opener.** When `render-to-string` is called with `:emit-hash? true`, the attribute is injected on the **first `<tag` opener** in the emitted body string (a regex of shape `<[a-zA-Z][^\s>/]*` — i.e. an opener whose tag-name starts with an ASCII letter). The letter-prefix lookahead is deliberate: it skips a leading `<!DOCTYPE html>` if `:doctype?` was also set, so the attribute lands on the root element rather than on the doctype. The two opts `:doctype?` and `:emit-hash?` compose: the doctype prepends after injection. Other-language ports SHOULD use an equivalent first-element-after-doctype attribute-injection step; the on-wire shape (`data-rf-render-hash="<hex>"` on the outer-most rendered element) is the contract.
 - Client renders the root view, computes the same hash on the client-side render-tree, and compares.
 
 **Hash algorithm (CLJS reference):** the FNV-1a 32-bit hash over a canonical EDN serialisation of the render-tree (depth-first traversal; attribute maps in sorted-key order; nil pruned). FNV-1a is chosen because it is fast, has no platform dependencies (no `crypto`/`SubtleCrypto`), and produces an 8-character hex string that fits comfortably in a `<meta>` / `data-` attribute. Cryptographic strength is not needed — the hash is a tamper-evident structural marker, not a security primitive.
@@ -420,6 +423,8 @@ Lock:
 These defaults are the runtime's; user fx can override any of them. The runtime never interferes with explicit user-supplied values.
 
 ### Head/meta contract
+
+> **Status: deferred — rf2-gr0n.** The `reg-head` / `render-head` / `active-head` surface described in this section is **not shipped in v1**. Per the per-symbol triage at [API.md §Head](API.md), `reg-head` is recorded as a deferred symbol; this section documents the design that lands when the surface is implemented (rf2-3i3m / rf2-pgma / rf2-h96i). v1 implementations rely on the [§Default head when no route declares `:head`](#default-head-when-no-route-declares-head) fallback and on body-tree-embedded `<head>` content; the hash-on-wire path (per [§Hydration-mismatch detection](#hydration-mismatch-detection)) covers head as part of the unified render-tree hash so head-mismatch detection works without `reg-head` having to ship.
 
 The server-rendered HTML must carry head metadata — `<title>`, `<meta>`, `<link>`, JSON-LD — on first byte, because crawlers and link-unfurlers don't run JS. The pattern's commitment: **the head model is data derived from app-db**, not an imperative DOM API.
 

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -140,7 +140,7 @@ Flows form a static dependency graph derivable from their `:path` and `:inputs` 
 - A's path is a prefix of B's input: `A.path = [:foo]`, `B.inputs = [[:foo :bar]]` — B reads inside A's value.
 - B's input is a prefix of A's path: `A.path = [:foo :bar]`, `B.inputs = [[:foo]]` — A's write is part of B's input map.
 
-The runtime topologically sorts the registry by this dependency relation. The sort is **memoised** and invalidated only when a flow is registered, cleared, or re-registered (rare relative to event volume).
+The runtime topologically sorts the registry by this dependency relation. The sort is **not memoised** in v1 — the per-frame flow map is tiny (a handful of nodes) and Kahn's algorithm over it is cheaper than the bookkeeping a memo would need. An earlier sketch carried a memoised topsort with explicit invalidation on every `reg-flow` / `clear-flow`; the memo was removed (per rf2-cd00) once measurement confirmed the unmemoised call is the cheapest correct option at the per-frame node counts v1 targets. Implementations that observe a real bottleneck in topsort cost MAY add a `core.memoize`-style cache keyed on the flow-registry identity, but the contract is just: deterministic order over the dependency graph each drain.
 
 **Cycle detection.** If A depends on B and B depends on A (any indirection), `reg-flow` throws `:rf.error/flow-cycle` at registration time with the cycle path in the error's `:tags`. The error fires before any snapshot is created — caught at registration, not at runtime.
 
@@ -193,8 +193,8 @@ Two reserved fx-ids let event handlers register and clear flows during normal ev
 
 | Fx-id | Args | Effect |
 |---|---|---|
-| `:rf.fx/reg-flow` | A flow map (same shape as `reg-flow`'s argument) | Register the flow against the dispatching frame. Topsort cache invalidated. |
-| `:rf.fx/clear-flow` | A flow id | Clear the flow from the dispatching frame. `dissoc-in` on its `:path` in that frame's `app-db`. Topsort cache invalidated. |
+| `:rf.fx/reg-flow` | A flow map (same shape as `reg-flow`'s argument) | Register the flow against the dispatching frame. Next drain's topsort observes the new node (no cache to invalidate; per [§Topological sort and cycle detection](#topological-sort-and-cycle-detection)). |
+| `:rf.fx/clear-flow` | A flow id | Clear the flow from the dispatching frame. `dissoc-in` on its `:path` in that frame's `app-db`. Next drain's topsort observes the removal. |
 
 ```clojure
 (rf/reg-event-fx :wizard/enter-step-2
@@ -217,7 +217,7 @@ Two reserved fx-ids let event handlers register and clear flows during normal ev
 
 ## Re-registration
 
-`reg-flow` with an already-registered `:id` (against the same frame) performs a **surgical update** — same semantics as every other `reg-*` per [001-Registration §Hot-reload semantics](001-Registration.md#hot-reload-semantics). The new flow's definition replaces the old in `(get @flows frame-id)`; `last-inputs` for `[frame-id flow-id]` is reset (the new flow re-evaluates on the next event regardless of input change); the topsort cache invalidates. In-flight events finish against the resolved handler at the time they entered the drain. Re-registering the same flow id against a *different* frame is not a replacement — it adds an independent definition to the second frame's slot.
+`reg-flow` with an already-registered `:id` (against the same frame) performs a **surgical update** — same semantics as every other `reg-*` per [001-Registration §Hot-reload semantics](001-Registration.md#hot-reload-semantics). The new flow's definition replaces the old in `(get @flows frame-id)`; `last-inputs` for `[frame-id flow-id]` is reset (the new flow re-evaluates on the next event regardless of input change); the next drain's topsort observes the new dependency edges automatically (per [§Topological sort and cycle detection](#topological-sort-and-cycle-detection); v1 does not memoise the sort). In-flight events finish against the resolved handler at the time they entered the drain. Re-registering the same flow id against a *different* frame is not a replacement — it adds an independent definition to the second frame's slot.
 
 ## What flows are NOT
 

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -682,6 +682,18 @@ For test suites that exercise many requests, a higher-level helper ships:
 
 The helper inspects each `:rf.http/managed` invocation's `:request :method` + `:request :url` and routes through the configured reply.
 
+### In-flight registry test helpers
+
+For test suites that need to inspect or reset the in-flight request registry directly (e.g. fixtures that share state across `dispatch-sync` calls, or property-based tests that need a clean slate between iterations), three test-time helpers ship in `re-frame.http-managed`:
+
+| Helper | Signature | Purpose |
+|---|---|---|
+| `clear-all-in-flight!` | `(clear-all-in-flight!)` → nil | Drops both the request-id-keyed and actor-id-keyed in-flight maps. Consumed by `re-frame.test-support/reset-runtime-fixture` to restore a clean registry between tests; the `:http/clear-all-in-flight!` hook is published via the late-bind table so `test-support` can call it without statically requiring the http artefact. |
+| `in-flight-snapshot` | `(in-flight-snapshot)` → map | Reads the current value of the request-id-keyed in-flight map. For tests that need to assert "this request-id is in flight" without poking the atom directly. |
+| `actor-in-flight-snapshot` | `(actor-in-flight-snapshot)` → map | Reads the current value of the actor-id-keyed in-flight map (per [§Abort on actor destroy](#abort-on-actor-destroy) and rf2-wvkn). For tests that need to assert the actor → request-id reverse index. |
+
+These are **test-only** surfaces — not part of the user-facing API for production code paths. Application code SHOULD route through `:rf.http/managed` and the dispatch-shape replies; the helpers exist so test fixtures can observe and reset registry state without reaching into the namespace's atoms.
+
 ## Machine-shape wrapper
 
 Per [rf2-ijm7](#) — `:rf.http/managed` is **also** registered as a child-invokable state machine, so a parent machine can `:invoke` it without writing any glue. The wrapper is **additive** on top of the fx surface: `:fx [[:rf.http/managed args]]` continues to work unchanged ([§The shape](#the-shape) is the canonical user-facing surface); the machine wrapper is a second affordance for callers who are already inside a state-machine envelope and want a child machine they can compose with `:invoke`, `:after`, and the cancellation cascade.

--- a/spec/API.md
+++ b/spec/API.md
@@ -344,6 +344,7 @@ All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Inst
 |---|---|---|---|---|
 | `register-trace-cb!` | Fn | `(register-trace-cb! key callback-fn)` — `callback-fn` receives one trace event per call | v1 (dev-only) | 009 |
 | `remove-trace-cb!` | Fn | `(remove-trace-cb! key)` → nil | v1 (dev-only) | 009 |
+| `clear-trace-cbs!` | Fn | `(clear-trace-cbs!)` → nil — drops all registered listeners; test-time helper consumed by `re-frame.test-support/reset-runtime-fixture` | v1 (dev-only) | 009 |
 | `emit-trace!` | Fn | `(emit-trace! op-type operation tags)` → nil | v1 (dev-only) | 009 |
 | `re-frame.interop/debug-enabled?` | Var | `^boolean` (alias of `goog.DEBUG` on CLJS; `true` on JVM) | v1 | 009 |
 | `re-frame.performance/enabled?` | Var | `^boolean` `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op. See [009 §Performance instrumentation](009-Instrumentation.md#performance-instrumentation) and [Tool-Pair §Performance API consumption](Tool-Pair.md#performance-api-consumption) | v1 | 009 |

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -267,6 +267,8 @@ The `:op-type` vocabulary is **open** — implementations and tools may add new 
 
 The error category schemas in [009 §Error contract](009-Instrumentation.md#error-contract) are *refinements* of TraceEvent for `:op-type :error` events. The unified error/warning envelope is captured by `:rf/error-event` (below).
 
+**Non-error refinements.** A small set of TraceEvent refinements describe `:op-type :event` lifecycle traces that ride the trace stream alongside the error/warning channel. The single one v1 ships is `:rf.frame/drain-aborted` — emitted when a frame's drain loop detects the frame was destroyed mid-cycle and drops remaining queued events. The `:tags` schema is `DrainAbortedTags` (per [§Per-category `:tags` schemas](#per-category-tags-schemas) below), shape `{:category :rf.frame/drain-aborted, :frame <keyword>, :dropped-count <int>}`. Consumers branch on `:operation = :rf.frame/drain-aborted` to filter; the `:op-type :event` discriminator places it alongside ordinary event traces rather than the error/warning channel. Per [002 §Edge cases worth pinning](002-Frames.md#edge-cases-worth-pinning) and [009 §`:op-type` vocabulary](009-Instrumentation.md#op-type-vocabulary).
+
 ### `:rf/error-event`
 
 > **Layer:** Runtime


### PR DESCRIPTION
## Summary

9 pure-docs spec-drift fixes from the 2026-05-12 spec/impl alignment review. Each adds documentation for an impl-shipped surface or refines wording to match impl reality. **No impl code changes.**

## Per-bead

**Spec 011 (SSR)**
- **rf2-5128** — §The `:rf/hydrate` event: documents the `[:rf/hydration :server-hash]` app-db slot. `verify-hydration!` reads from this path. Impl: `implementation/ssr/src/re_frame/ssr.cljc:461-468,488-490`.
- **rf2-mnb7** — §Hydration-mismatch detection: documents the first-tag-injection regex shape for `data-rf-render-hash`. The `[a-zA-Z]` lookahead skips `<!DOCTYPE>`, so `:doctype?` + `:emit-hash?` compose correctly. Impl: `ssr.cljc:319-329`.
- **rf2-phdy** — §Head/meta contract: adds an explicit `(deferred — rf2-gr0n)` status callout so the section doesn't read as v1-shipped.

**Spec 009 (Instrumentation)**
- **rf2-g26k** — Adds `clear-trace-cbs!` to §Listener API and to `API.md` tracing table. Test-time helper consumed by `re-frame.test-support/reset-runtime-fixture`. Impl: `implementation/core/src/re_frame/trace.cljc:50-53`.
- **rf2-hief** — Adds `:rf.warning/write-after-destroy` to §Where trace emission lives (substrate/adapter.cljc row) AND adds the defense-in-depth nil-container guard rationale to Spec 006 §`replace-container!`. Impl: `implementation/core/src/re_frame/substrate/adapter.cljc:88-93`, rf2-ft2b.

**Spec 013 (Flows)**
- **rf2-m6de** — §Topological sort: aligns wording with the post-rf2-cd00 unmemoised reality. The per-frame flow map is tiny enough that Kahn's algorithm beats a memo's bookkeeping; surgical-update note and `:rf.fx/reg-flow` / `clear-flow` fx rows updated to match. Impl: `flows.cljc:99-104`.

**Spec 004 (Views)**
- **rf2-nsu5** — §`view` lookup: clarifies `(rf/view id)` returns the *wrapped* (frame-aware) fn — not the raw user fn — and that the wrapper carries frame-injection, source-coord annotation, and `dispatch` / `subscribe` lexical bindings. Impl: `core.cljc:390-401` returns `(:handler-fn meta)`.

**Spec 014 (HTTPRequests)**
- **rf2-s9sd** — Adds a §In-flight registry test helpers subsection of §Testing documenting `clear-all-in-flight!` / `in-flight-snapshot` / `actor-in-flight-snapshot` as test-only surfaces. Impl: `http_managed.cljc:169-189`.

**Spec-Schemas**
- **rf2-f3qc** — Adds an explicit "Non-error refinements" callout under §`:rf/trace-event` documenting `:rf.frame/drain-aborted` as the v1 non-error refinement that rides the trace stream. The `DrainAbortedTags` schema already lives in §Per-category `:tags` schemas (line 924+); this stitch makes the refinement discoverable from the top-level trace-event section.

**Verification**
- **rf2-zkqa** — Searched `implementation/core/src/re_frame/router.cljc` and the broader impl tree; **no current emit-site for `:rf.frame/drain-aborted` exists**, so there is no spec/impl drift to align. The Spec 009 / Spec-Schemas wording locks the shape ahead of the future emit. Closed as no-drift.

## Verification

- `mkdocs build --strict`: 185 warnings (unchanged baseline; all pre-existing complaints about `spec/*` files not being in nav).
- Cross-references in added text resolve to existing files / anchors.
- No impl files touched.

## Test plan

- [x] `mkdocs build --strict` — warning count unchanged (185).
- [x] All added cross-refs target existing spec headers / anchors.
- [x] Diff scope is `spec/*.md` only — no impl files modified.