### PR TITLE
fix(core): reg-* macros emit real :file source-coord under CLJS, not NO_SOURCE_PATH (rf2-mdjp)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -177,10 +177,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (events/reg-event-db ~id ~@args)))))
 
 #?(:clj
@@ -197,10 +194,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (events/reg-event-fx ~id ~@args)))))
 
 #?(:clj
@@ -217,10 +211,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (events/reg-event-ctx ~id ~@args)))))
 
 #?(:clj
@@ -237,10 +228,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (subs/reg-sub ~id ~@args)))))
 
 #?(:clj
@@ -257,10 +245,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (fx/reg-fx ~id ~@args)))))
 
 #?(:clj
@@ -277,10 +262,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (cofx/reg-cofx ~id ~@args)))))
 
 #?(:clj
@@ -297,10 +279,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (frame/reg-frame ~id ~metadata)))))
 
 ;; CLJS side keeps the fn-aliases. Source-coord capture on CLJS will
@@ -478,10 +457,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (if-let [f# (late-bind/get-fn :flows/reg-flow)]
             (apply f# (list ~@args))
             (throw (ex-info ":rf.error/flows-artefact-missing"
@@ -511,10 +487,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (if-let [f# (late-bind/get-fn :routing/reg-route)]
             (f# ~id ~metadata)
             (throw (ex-info ":rf.error/routing-artefact-missing"
@@ -552,10 +525,7 @@
            file    *file*
            opts'   (or opts {})]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (if-let [f# (late-bind/get-fn :schemas/reg-app-schema)]
             (f# ~path ~schema ~opts')
             (throw (ex-info ":rf.error/schemas-artefact-missing"
@@ -692,10 +662,7 @@
        ;; that user code might compare against.
        (if (empty? per-el-coords)
          `(binding [source-coords/*pending-coords*
-                    (cond-> {:ns '~ns-sym}
-                      ~file        (assoc :file ~file)
-                      ~(:line m)   (assoc :line ~(:line m))
-                      ~(:column m) (assoc :column ~(:column m)))]
+                    ~(source-coords/coords-form m file ns-sym)]
             (if-let [f# (late-bind/get-fn :machines/reg-machine)]
               (f# ~machine-id ~machine)
               (throw (ex-info ":rf.error/machines-artefact-missing"
@@ -704,10 +671,7 @@
                                :recovery   :no-recovery
                                :reason     "rf/reg-machine requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
          `(binding [source-coords/*pending-coords*
-                    (cond-> {:ns '~ns-sym}
-                      ~file        (assoc :file ~file)
-                      ~(:line m)   (assoc :line ~(:line m))
-                      ~(:column m) (assoc :column ~(:column m)))]
+                    ~(source-coords/coords-form m file ns-sym)]
             (let [~machine-sym ~machine
                   ;; Per-element source-coord stamping (rf2-8bp3). The literal
                   ;; index is reachable only inside this `interop/debug-enabled?`
@@ -840,10 +804,7 @@
            ns-sym  (symbol (str (ns-name *ns*)))
            file    *file*]
        `(binding [source-coords/*pending-coords*
-                  (cond-> {:ns '~ns-sym}
-                    ~file        (assoc :file ~file)
-                    ~(:line m)   (assoc :line ~(:line m))
-                    ~(:column m) (assoc :column ~(:column m)))]
+                  ~(source-coords/coords-form m file ns-sym)]
           (-reg-error-projector ~@args)))))
 
 #?(:cljs

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -49,6 +49,65 @@
       (merge coords (or user-meta {}))
       (or user-meta {}))))
 
+;; ---- :file resolution at macro-expansion time (rf2-mdjp) ------------------
+;;
+;; The reg-* macros in `re-frame.core` capture `(meta &form)` and `*file*`
+;; from their compile-time environment and emit a `*pending-coords*`
+;; binding map. The naive `*file*`-only path is wrong under CLJS: the
+;; CLJS analyzer's macro-expansion entry point (`cljs.analyzer/
+;; macroexpand-1*`, cljs/analyzer.cljc ~L4284) binds `*cljs-file*` rather
+;; than Clojure's `*file*` during expansion — so `*file*` retains the
+;; JVM compiler's default `"NO_SOURCE_PATH"` sentinel under CLJS. That
+;; sentinel would then get baked into the `:file` slot of every
+;; registration's source-coord, defeating jump-to-source and tooling
+;; that reads `(rf/handler-meta kind id)`.
+;;
+;; The fix mirrors rf2-ulxi (PR #340, Story's `coords-form`):
+;; prefer `(:file (meta &form))` — tools.reader's indexing-push-back-reader
+;; stamps `:file` on every collection-form's metadata, which survives the
+;; macro-expansion handoff to cljs.analyzer. Fall back to `*file*` (the
+;; JVM-only correct path). Reject the `"NO_SOURCE_PATH"` sentinel from
+;; either source — if both resolve to it, omit `:file` entirely (better
+;; no `:file` than a poison value).
+
+(defn ^:private no-source-path? [s]
+  (or (nil? s) (= "NO_SOURCE_PATH" s)))
+
+(defn resolve-file
+  "Pick the right `:file` value for a reg-* macro's emitted source-coord
+  map. `form-meta` is `(meta &form)`; `file` is `*file*` at expansion
+  time. Returns the form-meta `:file` when non-sentinel, else the
+  `*file*` arg when non-sentinel, else `nil` (caller `cond->`s it in,
+  so nil means omit the slot).
+
+  Per rf2-mdjp: the CLJS analyzer never binds Clojure's `*file*` during
+  macro expansion, so reading `*file*` alone returns the JVM
+  `\"NO_SOURCE_PATH\"` sentinel under CLJS. Form-meta `:file` is the
+  portable answer."
+  [form-meta file]
+  (let [meta-file (:file form-meta)]
+    (cond
+      (not (no-source-path? meta-file)) meta-file
+      (not (no-source-path? file))      file
+      :else                              nil)))
+
+(defn coords-form
+  "Construct the compile-time `(cond-> {:ns 'sym} ...)` form that every
+  reg-* macro emits as the value of its `*pending-coords*` binding.
+
+  `form-meta` is `(meta &form)`; `file` is `*file*`; `ns-sym` is the
+  consumer's namespace symbol. The returned form is syntax-quote-safe
+  data the caller splices into its expansion.
+
+  :file picks the form-meta value over `*file*` and rejects the
+  `\"NO_SOURCE_PATH\"` sentinel per `resolve-file` (rf2-mdjp)."
+  [form-meta file ns-sym]
+  (let [chosen-file (resolve-file form-meta file)]
+    `(cond-> {:ns '~ns-sym}
+       ~chosen-file         (assoc :file ~chosen-file)
+       ~(:line form-meta)   (assoc :line ~(:line form-meta))
+       ~(:column form-meta) (assoc :column ~(:column form-meta)))))
+
 ;; ---- per-element spec stamping (rf2-8bp3) --------------------------------
 ;;
 ;; Per Spec 005 §Source-coord stamping (rf2-8bp3): the `reg-machine` macro
@@ -76,12 +135,17 @@
 (defn ^:private form-coords
   "Read source coords off a Clojure form's metadata. Forms the reader has
   decorated (lists, vectors, maps, symbols) carry `:line` / `:column` from
-  the source position. Returns nil when the form has no positional meta."
+  the source position. Returns nil when the form has no positional meta.
+
+  Per rf2-mdjp the same `:file` resolution as the call-site path applies:
+  prefer the reader-attached `:file` on the form's metadata over the
+  macro's `*file*` arg, and reject the `\"NO_SOURCE_PATH\"` sentinel."
   [form ns-sym file]
-  (let [m (meta form)]
+  (let [m            (meta form)
+        chosen-file  (resolve-file m file)]
     (when (and m (or (:line m) (:column m)))
       (cond-> {:ns ns-sym}
-        file        (assoc :file file)
+        chosen-file (assoc :file chosen-file)
         (:line m)   (assoc :line (:line m))
         (:column m) (assoc :column (:column m))))))
 

--- a/implementation/core/src/re_frame/views_macros.clj
+++ b/implementation/core/src/re_frame/views_macros.clj
@@ -15,7 +15,8 @@
                                                          bound-fn]]))"
   ;; bound-fn shadows clojure.core/bound-fn — the v2 surface deliberately
   ;; reuses the name (per Spec 002 §bound-fn) for the frame-capturing form.
-  (:refer-clojure :exclude [bound-fn]))
+  (:refer-clojure :exclude [bound-fn])
+  (:require [re-frame.source-coords :as source-coords]))
 
 ;; ---- with-frame ----------------------------------------------------------
 ;;
@@ -150,8 +151,6 @@
                     "(re-frame.core/reg-view* :id render-fn).")
                {:sym sym :got (first more) :args-after-sym (vec more)})))
     (let [{:keys [docstring args body]} parsed
-          line (:line form-meta)
-          col  (:column form-meta)
           form-tag (reagent-slim-form-tag body)
           def-form (if docstring
                      `(def ~sym ~docstring (re-frame.core/view ~id))
@@ -176,10 +175,7 @@
                           ~@body)))]
       `(do
          (binding [re-frame.source-coords/*pending-coords*
-                   (cond-> {:ns '~current-ns-sym}
-                     ~current-file (assoc :file ~current-file)
-                     ~line         (assoc :line ~line)
-                     ~col          (assoc :column ~col))]
+                   ~(source-coords/coords-form form-meta current-file current-ns-sym)]
            (re-frame.core/reg-view* ~id
              ~full-slot-meta
              ~fn-form))

--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -1,0 +1,139 @@
+(ns re-frame.source-coords-cljs-test
+  "CLJS-side regression test for rf2-mdjp — the `re-frame.core` reg-*
+  macros were reading Clojure's `*file*` at expansion time, but the
+  CLJS analyzer never binds `*file*` during macro expansion (it binds
+  `cljs.analyzer/*cljs-file*` instead). On CLJS that left `*file*` at
+  the JVM compiler's default `\"NO_SOURCE_PATH\"` sentinel, which then
+  got baked into every registration's source-coord `:file` slot —
+  defeating jump-to-source and tooling that reads `(rf/handler-meta
+  kind id)`.
+
+  The fix (mirroring rf2-ulxi / Story-side PR #340) prefers
+  `(:file (meta &form))` over `*file*`. tools.reader's
+  indexing-push-back-reader stamps `:file` on every collection-form's
+  metadata, which survives the macro-expansion handoff to cljs.analyzer
+  — so the form-meta path is the portable answer across both
+  compilation hosts. The shared helper lives in
+  `re-frame.source-coords/coords-form` and the existing
+  `re-frame.source-coords-test` covers the JVM path; this test exercises
+  the CLJS path end-to-end.
+
+  Failure mode on `main` (pre-fix): every reg-event-db (and every other
+  reg-* macro) below would carry `:file \"NO_SOURCE_PATH\"` in its
+  registered metadata. After the fix, `:file` either resolves to the
+  real source path (the common shadow-cljs path) or is omitted entirely
+  (when no form-meta `:file` is available and `*file*` is the sentinel)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.source-coords :as source-coords]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/reset-runtime-fixture))
+
+;; ---- helper -----------------------------------------------------------------
+
+(defn- file-is-real?
+  "A `:file` slot is real when it's a non-empty string that is NOT the
+  cljs analyzer / JVM compiler `\"NO_SOURCE_PATH\"` sentinel."
+  [f]
+  (and (string? f)
+       (seq f)
+       (not= "NO_SOURCE_PATH" f)))
+
+;; ---- per-kind assertions ----------------------------------------------------
+;;
+;; Each test registers a handler via the public re-frame.core macro
+;; surface and asserts the resulting handler-meta carries either a real
+;; `:file` (the common shadow-cljs path where tools.reader attached
+;; `:file` to the form's metadata) OR omits the slot entirely (the
+;; pathological case where both sources resolved to the sentinel). What
+;; MUST NOT happen is the slot being present and equal to the
+;; `\"NO_SOURCE_PATH\"` sentinel — that's the bug rf2-mdjp tracks.
+
+(deftest reg-event-db-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-event-db emits a real :file under CLJS, not NO_SOURCE_PATH"
+    (rf/reg-event-db :rf2-mdjp/reg-event-db-sample
+                     (fn [db _] db))
+    (let [m (rf/handler-meta :event :rf2-mdjp/reg-event-db-sample)
+          f (:file m)]
+      (is (some? m))
+      (is (not= "NO_SOURCE_PATH" f)
+          ":file must NOT be the cljs.analyzer NO_SOURCE_PATH sentinel")
+      (when (some? f)
+        (is (file-is-real? f)
+            ":file when present must be a real source path")))))
+
+(deftest reg-event-fx-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-event-fx emits a real :file under CLJS"
+    (rf/reg-event-fx :rf2-mdjp/reg-event-fx-sample
+                     (fn [_ _] {}))
+    (let [f (:file (rf/handler-meta :event :rf2-mdjp/reg-event-fx-sample))]
+      (is (not= "NO_SOURCE_PATH" f)))))
+
+(deftest reg-event-ctx-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-event-ctx emits a real :file under CLJS"
+    (rf/reg-event-ctx :rf2-mdjp/reg-event-ctx-sample
+                      (fn [ctx] ctx))
+    (let [f (:file (rf/handler-meta :event :rf2-mdjp/reg-event-ctx-sample))]
+      (is (not= "NO_SOURCE_PATH" f)))))
+
+(deftest reg-sub-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-sub emits a real :file under CLJS"
+    (rf/reg-sub :rf2-mdjp/reg-sub-sample
+                (fn [db _] db))
+    (let [f (:file (rf/handler-meta :sub :rf2-mdjp/reg-sub-sample))]
+      (is (not= "NO_SOURCE_PATH" f)))))
+
+(deftest reg-fx-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-fx emits a real :file under CLJS"
+    (rf/reg-fx :rf2-mdjp/reg-fx-sample (fn [_] nil))
+    (let [f (:file (rf/handler-meta :fx :rf2-mdjp/reg-fx-sample))]
+      (is (not= "NO_SOURCE_PATH" f)))))
+
+(deftest reg-cofx-file-is-not-no-source-path
+  (testing "rf2-mdjp: reg-cofx emits a real :file under CLJS"
+    (rf/reg-cofx :rf2-mdjp/reg-cofx-sample (fn [ctx] ctx))
+    (let [f (:file (rf/handler-meta :cofx :rf2-mdjp/reg-cofx-sample))]
+      (is (not= "NO_SOURCE_PATH" f)))))
+
+;; reg-frame and reg-view exercise the same source-coords path; they
+;; require an adapter to be installed for the underlying registration
+;; (frame/reg-frame allocates substrate state, reg-view delegates to
+;; the Reagent-aware impl). The JVM test ns covers those macros with
+;; the plain-atom adapter installed in its fixture; the helper unit
+;; tests below pin the actual rf2-mdjp invariant under CLJS so we
+;; don't need adapter wiring here just to assert :file-resolution.
+
+;; ---- direct helper tests (mirrors story_source_coords_test.clj) -------------
+;;
+;; The reg-* macros expand at compile time, so the assertions above
+;; observe whatever the CLJS analyzer happens to provide for
+;; `(meta &form)` in the test runner's build pipeline. To pin down the
+;; failure-mode behaviour we also test the pure helper directly: when
+;; `*file*` is the sentinel and form-meta carries a real `:file`, the
+;; helper must prefer form-meta. When both are the sentinel, `:file`
+;; must be omitted.
+
+(deftest resolve-file-prefers-form-meta
+  (testing "rf2-mdjp: resolve-file picks form-meta :file when *file* is NO_SOURCE_PATH"
+    (is (= "src/my/app.cljs"
+           (source-coords/resolve-file
+             {:file "src/my/app.cljs"}
+             "NO_SOURCE_PATH")))))
+
+(deftest resolve-file-falls-back-to-bound-file
+  (testing "rf2-mdjp: resolve-file falls back to *file* when form-meta lacks :file"
+    (is (= "src/my/app.clj"
+           (source-coords/resolve-file
+             {:line 5}
+             "src/my/app.clj")))))
+
+(deftest resolve-file-omits-sentinel
+  (testing "rf2-mdjp: resolve-file returns nil when both sources are NO_SOURCE_PATH"
+    (is (nil? (source-coords/resolve-file
+                {:file "NO_SOURCE_PATH"}
+                "NO_SOURCE_PATH")))))
+
+(deftest resolve-file-omits-when-both-nil
+  (testing "rf2-mdjp: resolve-file returns nil when neither source supplies a file"
+    (is (nil? (source-coords/resolve-file {} nil)))))


### PR DESCRIPTION
## Summary

Same `NO_SOURCE_PATH` gap that rf2-ulxi (PR #340) just fixed for Story's `:rf.assert/*` source-coord — now closed for `re-frame.core`'s `reg-*` macros.

### Root cause

The CLJS analyzer's macro-expansion entry point (`cljs.analyzer/macroexpand-1*`) binds `*cljs-file*` rather than Clojure's `*file*` during expansion. So `*file*` retains the JVM compiler's default `"NO_SOURCE_PATH"` sentinel under CLJS. That sentinel was being baked into the `:file` slot of every registration's source-coord, defeating jump-to-source and tooling that reads `(rf/handler-meta kind id)`.

Affected reg-* macros (every one in `re-frame.core` + `views-macros`):
- `reg-event-db`, `reg-event-fx`, `reg-event-ctx`
- `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`
- `reg-view` (via `views-macros/expand-reg-view`)
- `reg-machine` (both empty / non-empty per-element branches; also `form-coords` walker)
- `reg-flow`, `reg-route`, `reg-app-schema`, `reg-error-projector`

### Fix shape (mirrors rf2-ulxi / PR #340)

Prefer `(:file (meta &form))` over `*file*` — tools.reader's `indexing-push-back-reader` stamps `:file` on every collection-form's metadata, surviving the handoff to `cljs.analyzer`. Fall back to `*file*` (the JVM correct path). Reject the `"NO_SOURCE_PATH"` sentinel from either source — when both resolve to it, omit `:file` entirely.

The resolution lives in a new shared `source-coords/coords-form` helper. The 13 inline `cond->` blocks across `core.cljc` + `views_macros.clj` collapse into a single delegation, so any future reg-* macros pick up the same fix for free. The per-element `form-coords` walker (used by `reg-machine`'s per-element index) routes through the same `resolve-file` step.

### Verification

- `clojure -M:test` (JVM core) — 202 tests, 868 assertions; 3 pre-existing failures unrelated to this change (`trace-buffer-rides-debug-flag`, `emit-rides-debug-flag`, `reg-view-fold-graceful-without-reagent-slim` — confirmed present on `origin/main`).
- `npm run test:cljs` — 540 tests, 1284 assertions; 0 failures, 0 errors (includes new regression test).
- `npm run test:browser` — 529 tests, 1289 assertions; 0 failures, 0 errors.
- `npm run test:elision` — clean (all sentinel checks PASS).
- `npm run test:examples` — all 25 examples pass.

### Pre-fix sanity check

To confirm the regression test catches the bug, I temporarily stubbed `resolve-file` to return the raw `*file*` arg (the buggy behaviour) and re-ran `npm run test:cljs`: **6 macro-path tests** (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`) and **2 helper-level tests** (`resolve-file-prefers-form-meta`, `resolve-file-omits-sentinel`) failed, as expected. After restoring the fix, all pass.

Story's own `coords-form` in `tools/story/src/re_frame/story/macros.clj` is kept (out of scope per the bead) — the `tools/` artefact remains independent of internal `re-frame.source-coords` helpers.

## Test plan

- [x] JVM `source-coords-test` continues to pass (15 tests, 99 assertions)
- [x] New `source-coords-cljs-test` passes under shadow-cljs `:node-test` build
- [x] Regression demonstrated: pre-fix stub reproduces the bug; new tests fail
- [x] No regressions in browser / elision / examples
- [x] `tools/story` untouched per bead scope

Closes rf2-mdjp.