### PR TITLE
test: P3 coverage gaps from 2026-05-12 review — 15 surfaces (rf2-2e6k + 14 others)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -624,6 +624,63 @@ jobs:
       - name: Compile :browser-test-schemas-boundary-prod, serve, and run Playwright runner
         run: npm run test:browser-schemas-boundary-prod
 
+  cljs-browser-prod-elision:
+    name: CLJS (shadow-cljs :browser-test-prod-elision, :advanced + goog.DEBUG=false, rf2-2zdu/rf2-uwg5)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-prod-elision-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-prod-elision-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      # Production-mode CLJS elision smokes:
+      #   - rf2-2zdu: re-frame.trace/emit! must NOT fire under :advanced +
+      #     goog.DEBUG=false; the trace surface is elided so registered
+      #     listeners do not receive events on dispatch.
+      #   - rf2-uwg5: re-frame.views/reg-view*'s source-coord injection
+      #     branch DCEs; a registered view's rendered output carries no
+      #     data-rf2-source-coord attribute.
+      # The JVM tests use `with-redefs` against the JVM-side debug-enabled?
+      # symbol — useful but cannot prove the genuine `:advanced`
+      # constant-fold. This browser-test build closes that gap.
+      - name: Compile :browser-test-prod-elision, serve, and run Playwright runner
+        run: npm run test:browser-prod-elision
+
   cljs-elision:
     name: CLJS production elision (Spec 009, bead rf2-11hn)
     runs-on: ubuntu-latest

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_parity_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_parity_cljs_test.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.adapter.helix-parity-cljs-test
+  "Per Spec 006 §Adapter shipping convention + rf2-2qit Decision 5: the
+  Helix adapter must match the Reagent adapter's render-time contracts
+  for hot-reload, render-key, and source-coord DOM annotation.
+
+  This file is the parity counterpart to:
+    - implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
+    - implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
+    - implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+
+  Per bead rf2-v1y7. The shape mirrors the Reagent tests; each block
+  asserts the Helix adapter respects the same contract.
+
+  ---------------------------------------------------------------------------
+  IMPORTANT (rf2-00li): the source-coord-DOM-annotation test is
+  currently :disabled. Investigation surfaced that the Helix adapter
+  exposes a `wrap-view` fn (helix.cljs:381) that injects
+  `data-rf2-source-coord` on the rendered root, but `reg-view*` (in
+  core.cljc / views.cljs) never calls it. The Reagent adapter wires
+  the annotation inline inside `views/reg-view*`; the Helix-side
+  dispatch is missing. Until rf2-00li lands, a registered Helix view's
+  rendered output carries no source-coord annotation — the test
+  documents the desired contract and points at the bug bead.
+  ---------------------------------------------------------------------------"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views :as views]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- (1) Hot-reload contract ----------------------------------------------
+
+(deftest view-re-register-causes-rerender-helix
+  (testing "after re-registering a view, the next registry lookup returns
+            the new body — the contract underlying hot-reload"
+    (let [observed (atom nil)]
+      (rf/reg-view* :rf.helix-parity-test/probe
+        (fn []
+          (reset! observed :body-v1)
+          :v1-output))
+      ((rf/view :rf.helix-parity-test/probe))
+      (is (= :body-v1 @observed)
+          "v1 body ran on first render")
+
+      ;; Re-register with a DIFFERENT body.
+      (rf/reg-view* :rf.helix-parity-test/probe
+        (fn []
+          (reset! observed :body-v2)
+          :v2-output))
+      ((rf/view :rf.helix-parity-test/probe))
+      (is (= :body-v2 @observed)
+          "after re-registration, the next render mutates observed to v2"))))
+
+;; ---- (2) Render-key contract ----------------------------------------------
+
+(deftest current-render-key-anonymous-fallback-helix
+  (testing "outside a render, current-render-key returns the documented
+            anonymous fallback [:rf.view/anonymous nil]"
+    (is (= [:rf.view/anonymous nil] (views/current-render-key))
+        "current-render-key reads the anonymous fallback outside any render")
+    (is (nil? views/*render-key*)
+        "*render-key* is nil outside any render cycle")))
+
+;; ---- (3) Source-coord DOM annotation helper -------------------------------
+
+(deftest format-source-coord-helper-shape-helix
+  (testing "the Helix adapter's wrap-view fn is callable and dispatches
+            to the user fn"
+    (let [out-from-fn (atom nil)
+          wrapped     (helix-adapter/wrap-view
+                        :rf.helix-parity-test/sample
+                        {:line 42 :column 7}
+                        (fn []
+                          (reset! out-from-fn :ran)
+                          nil))]
+      (is (fn? wrapped) "wrap-view returns a fn")
+      (wrapped)
+      (is (= :ran @out-from-fn)
+          "the wrapped fn invokes the user fn"))))
+
+;; --- (disabled, rf2-00li) — DOM-annotation through reg-view ---------------
+;;
+;; The full contract — `rf/reg-view ...` produces a rendered root with
+;; `data-rf2-source-coord` — depends on reg-view* dispatching through
+;; the installed adapter's wrap-view. As of this commit that wiring is
+;; absent; see rf2-00li. The test contract lives in this commented
+;; block; promote to a deftest after rf2-00li lands.
+;;
+;;   (deftest reg-view-produces-source-coord-annotation-helix
+;;     (testing "Per rf2-00li (pending): reg-view* under the Helix adapter
+;;               injects data-rf2-source-coord on the rendered root via
+;;               (adapter/wrap-view id metadata user-fn)"
+;;       (rf/reg-view* :rf.helix-parity-test/annotated
+;;                     (fn [] [:span "hi"]))
+;;       (let [render (rf/view :rf.helix-parity-test/annotated)
+;;             out    (render)]
+;;         (is (some? out)))))

--- a/implementation/adapters/reagent/test/re_frame/source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_dom_elision_prod_test.cljs
@@ -1,0 +1,111 @@
+(ns re-frame.source-coord-dom-elision-prod-test
+  "Per Spec 006 §Source-coord annotation production-elision contract
+  (bead rf2-uwg5): under `:advanced` + `goog.DEBUG=false`, the
+  reg-view* wrapper's `data-rf2-source-coord` injection branch elides.
+  A registered view's rendered output carries NO source-coord attribute
+  under prod-mode.
+
+  The JVM tests use `with-redefs` on the symbol — useful but doesn't
+  prove the genuine closure-fold contract. This file compiles under
+  `:browser-test-prod-elision` (the dedicated shadow-cljs build with
+  `goog.DEBUG=false` + `:advanced`) so the gate is constant-folded.
+
+  Under that compile:
+    - `views/reg-view*` registers the wrapped fn.
+    - The wrapper's body still calls render-fn (rendering is not gated;
+      only the source-coord injection branch is).
+    - The `(when interop/debug-enabled? ...)` guard around the
+      inject-source-coord-attr call DCEs to its else-branch (which
+      returns the raw render-fn output unchanged).
+
+  Naming convention: files ending in `-prod-test.cljs` are picked up
+  ONLY by the `:browser-test-prod-elision` build (the build's
+  `:ns-regexp` is `-prod-test$`). The default `:browser-test` and
+  `:node-test` builds use regexes `-cljs-test$` and `cljs-test$` and
+  do NOT pick up these files. Running this file under
+  `goog.DEBUG=true` would FAIL — the assertion is 'no annotation',
+  which is only true under prod-mode."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- root-attr
+  "Pull the :data-rf2-source-coord value from the root attrs map of a
+  hiccup vector, or nil if no attrs map or no key. Defensively returns
+  nil (not false) on every branch so the test assertions can use `nil?`."
+  [hiccup]
+  (when (and (vector? hiccup)
+             (map? (second hiccup)))
+    (:data-rf2-source-coord (second hiccup))))
+
+;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
+
+(deftest reg-view-output-has-no-source-coord-under-prod
+  (testing "Per Spec 006 §Source-coord annotation production-elision: a
+            registered view's rendered output carries NO
+            data-rf2-source-coord attribute under :advanced +
+            goog.DEBUG=false. The Closure compiler DCEs the entire
+            (when interop/debug-enabled? ...) branch."
+    (rf/reg-view* :rf.prod-elision-test/no-attr
+                  (fn [] [:span "hi"]))
+    (let [render (rf/view :rf.prod-elision-test/no-attr)
+          out    (render)]
+      (is (vector? out))
+      (is (= :span (first out))
+          "root tag preserved")
+      (is (nil? (root-attr out))
+          "NO data-rf2-source-coord on the rendered root — elision contract holds"))))
+
+(deftest reg-view-with-attrs-has-no-source-coord-under-prod
+  (testing "Even with an existing attrs map on the root, the wrapper does
+            NOT inject data-rf2-source-coord under prod-mode. User attrs
+            pass through; no extra key is added."
+    (rf/reg-view* :rf.prod-elision-test/with-attrs
+                  (fn [] [:div {:class "card" :id "x"} "body"]))
+    (let [render (rf/view :rf.prod-elision-test/with-attrs)
+          out    (render)
+          attrs  (second out)]
+      (is (= :div (first out)))
+      (is (map? attrs))
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (= "x"    (:id    attrs)) "user :id preserved")
+      (is (nil? (:data-rf2-source-coord attrs))
+          "NO data-rf2-source-coord merged in — elision contract holds"))))
+
+(deftest reg-view-form-2-inner-output-has-no-source-coord-under-prod
+  (testing "Form-2 render fns also elide annotation under prod-mode:
+            the inner-fn output passes through unchanged."
+    (rf/reg-view* :rf.prod-elision-test/form-2
+      (fn []
+        (fn inner-render []
+          [:section.f2 "form-2 body"])))
+    (let [wrapper (rf/view :rf.prod-elision-test/form-2)
+          out     (wrapper)]
+      (is (fn? out) "outer wrapper returns a fn (Form-2 shape preserved)")
+      (let [inner-out (out)]
+        (is (vector? inner-out) "inner fn returns hiccup")
+        (is (= :section.f2 (first inner-out)))
+        (is (nil? (root-attr inner-out))
+            "NO data-rf2-source-coord on inner output — elision held through Form-2")))))
+
+(deftest source-coord-literal-absent-from-rendered-output
+  (testing "Defensive cross-check: scanning the rendered hiccup for the
+            literal `data-rf2-source-coord` keyword finds nothing under
+            prod-mode. Pair-tool consumers grep for this attribute; if
+            it leaked it'd break the elision-bundle invariant."
+    (rf/reg-view* :rf.prod-elision-test/literal-check
+                  (fn [] [:p "scan me"]))
+    (let [render (rf/view :rf.prod-elision-test/literal-check)
+          out    (render)
+          ;; Pretty-print and search for the literal key. Under dev-mode
+          ;; this would find `:data-rf2-source-coord "..."` in the
+          ;; attrs map; under prod-mode (here) it must not.
+          flat   (pr-str out)]
+      (is (not (clojure.string/includes? flat "data-rf2-source-coord"))
+          "the literal data-rf2-source-coord does not appear in the
+           rendered output under prod-mode — closure-fold contract holds"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_parity_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_parity_cljs_test.cljs
@@ -1,0 +1,145 @@
+(ns re-frame.adapter.uix-parity-cljs-test
+  "Per Spec 006 §Adapter shipping convention + rf2-3yij Decision 5: the
+  UIx adapter must match the Reagent adapter's render-time contracts for
+  hot-reload, render-key, and source-coord DOM annotation.
+
+  This file is the parity counterpart to:
+    - implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
+    - implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
+    - implementation/adapters/reagent/test/re_frame/source_coord_dom_cljs_test.cljs
+
+  Per bead rf2-v1y7. The shape mirrors the Reagent tests; each block
+  asserts the UIx adapter respects the same contract.
+
+  ---------------------------------------------------------------------------
+  IMPORTANT (rf2-00li): the source-coord-DOM-annotation test is
+  currently :disabled. Investigation surfaced that the UIx adapter
+  exposes a `wrap-view` fn (uix.cljs:375) that injects
+  `data-rf2-source-coord` on the rendered root, but `reg-view*` (in
+  core.cljc / views.cljs) never calls it. The Reagent adapter wires
+  the annotation inline inside `views/reg-view*`; the UIx-side
+  dispatch is missing. Until rf2-00li lands, a registered UIx view's
+  rendered output carries no source-coord annotation — the test
+  documents the desired contract and points at the bug bead.
+  ---------------------------------------------------------------------------"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views :as views]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- (1) Hot-reload contract ----------------------------------------------
+;;
+;; Per Spec 001 §Hot-reload semantics rule 4: re-registering a view at
+;; runtime causes a subsequent registry-driven render to invoke the new
+;; render fn. The Reagent test exercises this through registry lookup
+;; (`rf/view`); the UIx-side contract is identical at the registry
+;; layer — UIx components that call into the re-frame registry to
+;; resolve a view-id pick up the new body on the next render cycle.
+
+(deftest view-re-register-causes-rerender-uix
+  (testing "after re-registering a view, the next registry lookup returns
+            the new body — the contract underlying hot-reload"
+    (let [observed (atom nil)]
+      (rf/reg-view* :rf.uix-parity-test/probe
+        (fn []
+          (reset! observed :body-v1)
+          :v1-output))
+      ;; Resolve via the registry — same lookup the substrate's render
+      ;; cycle would do — and invoke.
+      ((rf/view :rf.uix-parity-test/probe))
+      (is (= :body-v1 @observed)
+          "v1 body ran on first render")
+
+      ;; Re-register with a DIFFERENT body.
+      (rf/reg-view* :rf.uix-parity-test/probe
+        (fn []
+          (reset! observed :body-v2)
+          :v2-output))
+      ;; Next render — fresh registry resolution — runs v2.
+      ((rf/view :rf.uix-parity-test/probe))
+      (is (= :body-v2 @observed)
+          "after re-registration, the next render mutates observed to v2"))))
+
+;; ---- (2) Render-key contract ----------------------------------------------
+;;
+;; Per Spec 004 §Render-tree primitives: `current-render-key` returns
+;; `[<view-id> <instance-token>]` for registered views, and the
+;; documented anonymous fallback `[:rf.view/anonymous nil]` for plain
+;; fns (no reg-view wrapper).
+;;
+;; Outside a render, `*render-key*` is unbound; `current-render-key`
+;; surfaces the anonymous fallback. This contract is independent of
+;; substrate — it lives in `re-frame.views` which both adapters
+;; consume.
+
+(deftest current-render-key-anonymous-fallback-uix
+  (testing "outside a render, current-render-key returns the documented
+            anonymous fallback [:rf.view/anonymous nil]"
+    ;; This is the substrate-agnostic baseline. Both Reagent and UIx
+    ;; rely on views/current-render-key to surface the anonymous
+    ;; tuple when `*render-key*` is unbound; the lookup does not
+    ;; consult the substrate.
+    (is (= [:rf.view/anonymous nil] (views/current-render-key))
+        "current-render-key reads the anonymous fallback outside any render")
+    (is (nil? views/*render-key*)
+        "*render-key* is nil outside any render cycle")))
+
+;; ---- (3) Source-coord DOM annotation contract -----------------------------
+;;
+;; Per Spec 006 §Source-coord annotation: a registered view under
+;; goog.DEBUG=true must produce `data-rf2-source-coord` on its rendered
+;; root DOM element. The Reagent adapter wires this inline in
+;; views/reg-view*; rf2-00li covers the UIx wiring gap.
+;;
+;; The standalone format-source-coord helper IS available — let's pin
+;; the helper's behaviour even though full integration isn't yet wired.
+
+(deftest format-source-coord-helper-shape-uix
+  (testing "the UIx adapter's source-coord format helper produces the
+            canonical <ns>:<sym>:<line>:<col> shape"
+    ;; The helper is private; exercise it indirectly through
+    ;; wrap-view's coord-attr computation. We can't trivially call
+    ;; a private fn, but we can call wrap-view with a known id /
+    ;; metadata and inspect the output. (wrap-view is public per
+    ;; the spec — line 375.)
+    (let [out-from-fn (atom nil)
+          wrapped     (uix-adapter/wrap-view :rf.uix-parity-test/sample
+                                             {:line 42 :column 7}
+                                             (fn []
+                                               (reset! out-from-fn :ran)
+                                               nil))]
+      ;; wrap-view returns a callable; invoke it to confirm it doesn't
+      ;; throw. We can't easily inspect the React.cloneElement output
+      ;; without a real React render context, so the assertion is
+      ;; "wrap-view is a real fn, it accepts the id+metadata+user-fn
+      ;; tuple, and the inner fn ran".
+      (is (fn? wrapped) "wrap-view returns a fn")
+      (wrapped)
+      (is (= :ran @out-from-fn)
+          "the wrapped fn invokes the user fn"))))
+
+;; --- (disabled, rf2-00li) — DOM-annotation through reg-view ---------------
+;;
+;; The full contract — `rf/reg-view ...` produces a rendered root with
+;; `data-rf2-source-coord` — depends on reg-view* dispatching through
+;; the installed adapter's wrap-view. As of this commit that wiring is
+;; absent; see rf2-00li. The test contract lives in this commented
+;; block; promote to a deftest after rf2-00li lands.
+;;
+;;   (deftest reg-view-produces-source-coord-annotation-uix
+;;     (testing "Per rf2-00li (pending): reg-view* under the UIx adapter
+;;               injects data-rf2-source-coord on the rendered root via
+;;               (adapter/wrap-view id metadata user-fn)"
+;;       (rf/reg-view* :rf.uix-parity-test/annotated
+;;                     (fn [] [:span "hi"]))
+;;       (let [render (rf/view :rf.uix-parity-test/annotated)
+;;             out    (render)]
+;;         ;; render returns a React element under UIx, not hiccup; the
+;;         ;; assertion shape depends on the wiring approach. Pin once
+;;         ;; the wiring lands.
+;;         (is (some? out)))))

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -374,3 +374,71 @@
     (rf/dispatch-sync [:tick] {:frame :drain.test/X})
     (is (= 2 (:n (rf/get-frame-db :drain.test/X))))
     (is (= 1 (:n (rf/get-frame-db :drain.test/Y))))))
+
+;; ---- rf2-6guf: drain-depth-exceeded preserves OTHER frames' app-db --------
+;;
+;; Per test-coverage-review-2026-05-12 P3-25: the existing
+;; `drain-depth-exceeded-rolls-back-app-db` only exercises :rf/default. The
+;; broader contract is "rollback is scoped to the FRAME that exceeded the
+;; depth — other frames' app-dbs are untouched, and the depth-exceeded
+;; trace carries the right frame id".
+
+(deftest drain-depth-exceeded-isolated-to-the-overflowing-frame
+  (testing "depth-exceed on frame :B rolls back :B's app-db only; :A's
+            app-db is byte-identical to its pre-dispatch state; the
+            depth-exceeded trace carries :B"
+    (rf/reg-event-db :seed/A (fn [_ _] {:where :A :counter 0 :marker :pristine}))
+    (rf/reg-event-db :seed/B (fn [_ _] {:where :B :counter 0 :marker :pristine}))
+    (rf/reg-frame :drain.iso/A
+                  {:on-create   [:seed/A]
+                   :drain-depth 50})
+    ;; Frame :B has the tight drain-depth so :B's loop event trips it.
+    (rf/reg-frame :drain.iso/B
+                  {:on-create   [:seed/B]
+                   :drain-depth 4})
+
+    ;; Capture :A's pre-dispatch state — this is what we'll compare to.
+    (let [a-pre  (rf/get-frame-db :drain.iso/A)
+          traces (atom [])]
+      (rf/register-trace-cb! ::iso (fn [ev] (swap! traces conj ev)))
+
+      ;; Register a loop event under :B that infinitely self-dispatches.
+      ;; Each iteration writes to :B's :db, so we can see whether the
+      ;; rollback actually fires.
+      (rf/reg-event-fx :loop/B
+        (fn [{:keys [db]} _]
+          {:db {:where :B
+                :counter (inc (:counter db 0))
+                :marker  :mid-cascade}
+           :fx [[:dispatch [:loop/B]]]}))
+
+      ;; Dispatch the loop on :B. This trips the drain-depth limit; :B's
+      ;; app-db rolls back to the pre-drain snapshot.
+      (rf/dispatch-sync [:loop/B] {:frame :drain.iso/B})
+
+      ;; --- (a) :B's app-db is rolled back to its :on-create state.
+      (is (= {:where :B :counter 0 :marker :pristine}
+             (rf/get-frame-db :drain.iso/B))
+          ":B's app-db is rolled back to the pre-drain snapshot")
+
+      ;; --- (b) :A's app-db is byte-identical to its pre-dispatch state.
+      (is (= a-pre (rf/get-frame-db :drain.iso/A))
+          ":A's app-db is untouched (value-equal to pre-dispatch)")
+      (is (= {:where :A :counter 0 :marker :pristine}
+             (rf/get-frame-db :drain.iso/A))
+          ":A's app-db remains exactly its :on-create state")
+
+      ;; --- (c) the depth-exceeded trace carries :B, not :A.
+      (let [hit (some (fn [ev]
+                        (when (= :rf.error/drain-depth-exceeded
+                                 (:operation ev))
+                          ev))
+                      @traces)]
+        (is (some? hit) "drain-depth-exceeded trace was emitted")
+        (is (= :drain.iso/B (get-in hit [:tags :frame]))
+            "the trace's :frame tag is :B (the overflowing frame), not :A")
+        (is (true? (get-in hit [:tags :rollback?]))
+            ":rollback? true tag flags the atomic rollback"))
+
+      (rf/remove-trace-cb! ::iso))))
+

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -579,3 +579,147 @@
                            @recorded)]
         (is (pos? (count warns))
             ":rf.warning/write-after-destroy fired for the post-destroy write")))))
+
+;; ---- rf2-2e6k: frame-ids / frame-meta re-export round-trip ----------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-18: frame-lifecycle exercises read
+;; via direct atom reads. The public re-exports `rf/frame-ids` and
+;; `rf/frame-meta` (core.cljc:1160-1161) are the documented introspection
+;; surface; this test pins their round-trip contract.
+
+(deftest frame-ids-round-trip
+  (testing "(rf/frame-ids) returns every registered, non-destroyed frame id
+            plus :rf/default"
+    (rf/reg-frame :tenants/acme    {:doc "acme tenant"  :preset :default})
+    (rf/reg-frame :tenants/widgets {:doc "widgets co"   :preset :default})
+    (let [ids (rf/frame-ids)]
+      (is (set? ids) "frame-ids returns a set")
+      (is (contains? ids :rf/default)
+          ":rf/default appears alongside user-registered frames")
+      (is (contains? ids :tenants/acme))
+      (is (contains? ids :tenants/widgets))
+      ;; Sanity: a never-registered id is absent.
+      (is (not (contains? ids :tenants/nonexistent))
+          "frame-ids excludes ids that were never registered"))))
+
+(deftest frame-meta-round-trip
+  (testing "(rf/frame-meta id) returns the registered metadata map shape"
+    (rf/reg-frame :tenants/acme {:doc          "acme tenant"
+                                 :preset       :default
+                                 :fx-overrides {:rf.http/managed
+                                                :rf.http/managed-canned-success}})
+    (let [m (rf/frame-meta :tenants/acme)]
+      (is (map? m) "frame-meta returns a map")
+      (is (= :tenants/acme (:id m))
+          ":id reflects the registered frame id")
+      (is (map? (:config m))
+          ":config slot is the metadata map merged into the frame record")
+      (is (= "acme tenant" (get-in m [:config :doc]))
+          "user-supplied :doc round-trips through :config")
+      (is (= {:rf.http/managed :rf.http/managed-canned-success}
+             (get-in m [:config :fx-overrides]))
+          ":fx-overrides round-trips through :config")
+      (is (map? (:lifecycle m))
+          ":lifecycle slot carries the frame's lifecycle map")
+      (is (number? (get-in m [:lifecycle :created-at]))
+          ":lifecycle :created-at is the host clock at reg-frame time"))))
+
+(deftest frame-meta-nonexistent-is-nil
+  (testing "(rf/frame-meta id) on an unregistered id returns nil cleanly
+            (no throw, no warning)"
+    (is (nil? (rf/frame-meta :no-such-frame))
+        "missing frame-id → nil (frame-meta delegates to frame which gates
+         on the registry)")
+    ;; A destroyed frame is also indistinguishable from never-registered
+    ;; per the documented surface — `frame` returns nil for destroyed.
+    (rf/reg-frame :short-lived {:doc "will be destroyed"})
+    (rf/destroy-frame :short-lived)
+    (is (nil? (rf/frame-meta :short-lived))
+        "frame-meta on a destroyed frame returns nil (no resurrection)")))
+
+;; ---- rf2-mwrh: reset-frame! partial-state preservation contract -----------
+;;
+;; Per test-coverage-review-2026-05-12 P3-27: `rf/reset-frame` is re-exported
+;; (core.cljc:438 → frame/reset-frame!) but no test pins what it does. The
+;; impl is `destroy-frame! followed by reg-frame with the same config` —
+;; this test pins the contract that flows from that definition:
+;;   - app-db is reset (fresh container).
+;;   - sub-cache is cleared (sub re-registers against the fresh frame).
+;;   - The config metadata is preserved (same :doc, same :on-create, etc.).
+;;   - :on-create re-runs (the new frame is freshly booted).
+;;   - The frame is still queryable (not in the destroyed state).
+
+(deftest reset-frame-preserves-config-resets-app-db
+  (testing "rf/reset-frame: app-db is reset, config metadata is preserved,
+            :on-create re-runs, frame remains queryable"
+    (let [boot-count (atom 0)]
+      (rf/reg-event-db :seed
+        (fn [_ [_ payload]]
+          (swap! boot-count inc)
+          {:booted? true :payload payload :extra :seeded}))
+      (rf/reg-frame :app/main
+                    {:doc       "frame with on-create"
+                     :on-create [:seed {:hello "world"}]
+                     :fx-overrides {:custom :value}})
+      ;; First :on-create dispatch increments the counter.
+      (is (= 1 @boot-count) ":on-create ran once at reg-frame time")
+      (is (= {:booted? true :payload {:hello "world"} :extra :seeded}
+             (rf/get-frame-db :app/main))
+          "app-db reflects :on-create commit")
+
+      ;; Mutate app-db: a subsequent event extends the value.
+      (rf/reg-event-db :extend (fn [db _] (assoc db :runtime-write? true)))
+      (rf/dispatch-sync [:extend] {:frame :app/main})
+      (is (true? (:runtime-write? (rf/get-frame-db :app/main)))
+          "mutation is visible before reset-frame")
+
+      ;; Capture the original frame record so we can compare.
+      (let [orig-record    (frame/frame :app/main)
+            orig-app-db    (:app-db orig-record)
+            orig-sub-cache (:sub-cache orig-record)
+            orig-router    (:router orig-record)]
+
+        ;; Reset.
+        (rf/reset-frame :app/main)
+
+        ;; After reset: the frame is queryable.
+        (let [new-record (frame/frame :app/main)]
+          (is (some? new-record)
+              "the frame still exists post-reset (not destroyed)")
+          ;; Config metadata preserved: same :doc, same :on-create,
+          ;; same :fx-overrides.
+          (is (= "frame with on-create" (get-in new-record [:config :doc]))
+              ":config :doc preserved across reset")
+          (is (= [:seed {:hello "world"}]
+                 (get-in new-record [:config :on-create]))
+              ":config :on-create preserved across reset")
+          (is (= {:custom :value} (get-in new-record [:config :fx-overrides]))
+              ":config :fx-overrides preserved across reset")
+          ;; The slot identity-replaceable parts are FRESH containers.
+          (is (not (identical? orig-app-db (:app-db new-record)))
+              "app-db container is a fresh allocation post-reset")
+          (is (not (identical? orig-sub-cache (:sub-cache new-record)))
+              "sub-cache atom is fresh post-reset")
+          (is (not (identical? orig-router (:router new-record)))
+              "router atom is fresh post-reset"))
+
+        ;; :on-create re-ran on the fresh frame: counter incremented.
+        (is (= 2 @boot-count)
+            ":on-create re-dispatches against the freshly-registered frame")
+
+        ;; The runtime mutation is gone — fresh app-db reflects only
+        ;; :on-create's commit, not the prior :extend.
+        (is (= {:booted? true :payload {:hello "world"} :extra :seeded}
+               (rf/get-frame-db :app/main))
+            "app-db is reset to :on-create state; runtime writes are gone")
+        (is (nil? (:runtime-write? (rf/get-frame-db :app/main)))
+            "the :extend handler's write is absent — reset wiped runtime state")))))
+
+(deftest reset-frame-on-missing-id-is-noop
+  (testing "rf/reset-frame against an unregistered frame is a silent no-op"
+    ;; frame/reset-frame! only fires when (frame id) returns non-nil.
+    ;; Calling against an unknown id must not throw.
+    (is (nil? (rf/reset-frame :no/such-frame))
+        "reset-frame on a missing id returns nil without throwing")
+    (is (nil? (frame/frame :no/such-frame))
+        "the missing frame is still absent")))

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -1,0 +1,28 @@
+(ns re-frame.prod-elision-runner
+  "Custom browser-test runner for the production-mode elision smoke
+  builds (rf2-2zdu trace listener elision; rf2-uwg5 source-coord
+  DOM annotation elision).
+
+  Mirrors `re-frame.schemas-boundary-prod-runner` (Spec 010 prod-mode
+  smoke runner): the default shadow-cljs `:browser-test` runner-ns
+  `shadow.test.browser` uses `cljs-test-display.core/init!`, which does
+  `(set! root-node-id …)` on a `(goog-define root-node-id …)`. Under
+  `:advanced` Closure rejects re-assignment of a `@define`.
+
+  This runner bypasses cljs-test-display and runs `cljs.test/run-tests`
+  directly. The default cljs.test reporter writes the
+  `Ran N tests containing M assertions.` summary to the browser console
+  (via `*print-fn*` → `console.log`), which is what the Playwright
+  orchestrator (scripts/run-browser-tests.cjs) watches for."
+  (:require [cljs.test :as test]
+            [shadow.test :as st]
+            [shadow.test.env :as env]
+            ;; Pull each prod-mode smoke namespace into the test
+            ;; environment so shadow.test/run-all-tests discovers it.
+            [re-frame.trace-listener-elision-prod-test]
+            [re-frame.source-coord-dom-elision-prod-test]))
+
+(defn ^:export init []
+  (-> (env/get-test-data)
+      (env/reset-test-data!))
+  (st/run-all-tests))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -11,6 +11,11 @@
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
             [re-frame.routing :as routing]
+            ;; Pull http-managed in so its late-bind hooks (in particular
+            ;; :http/reg-http-interceptor) are published — the
+            ;; registry-introspection-round-trip test below exercises
+            ;; reg-http-interceptor. Side-effect require; alias unused.
+            [re-frame.http-managed]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn reset-runtime [test-fn]
@@ -34,6 +39,11 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
+  ;; rf2-o1bp: registry-introspection-round-trip exercises
+  ;; reg-http-interceptor which is late-bound through the http-managed
+  ;; artefact. Reload so the :http/reg-http-interceptor hook is
+  ;; published across runs.
+  (require 're-frame.http-managed :reload)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -994,3 +1004,164 @@
       ;; doctype
       (is (clojure.string/starts-with? (r2s [:html [:body]] {:doctype? true})
                                        "<!DOCTYPE html>")))))
+
+;; ---- rf2-o1bp: registry-summary / handler-ids / handlers / handler-meta ---
+;;
+;; Per test-coverage-review-2026-05-12 P3-17: the introspection re-exports
+;; live at core.cljc:1157-1159 (`handlers`, `handler-meta`, `handler-ids`,
+;; `registry-summary`). They're used inside fixtures and the source-coords
+;; tests but no single deftest pins their cross-kind round-trip. This test
+;; registers handlers across the canonical kinds, then walks the four
+;; introspection surfaces against each.
+
+(deftest registry-introspection-round-trip
+  (testing "rf/registry-summary, rf/handler-ids, rf/handlers, rf/handler-meta
+            cover every registration kind with the documented shape"
+    ;; Capture the per-kind baseline counts BEFORE this test's registrations
+    ;; so framework-shipped entries (the :rf.route/* events, :rf/hydrate,
+    ;; the built-in :error-projector etc.) don't make the count assertions
+    ;; brittle. The contract is "every kind I registered into is reflected
+    ;; with at least the count I added"; the baseline lets us assert that
+    ;; precisely.
+    (let [baseline (rf/registry-summary)]
+
+      ;; ---- :event --------------------------------------------------------
+      (rf/reg-event-db :rf2-o1bp/evt1 (fn [db _] db))
+      (rf/reg-event-fx :rf2-o1bp/evt2 (fn [_ _] {}))
+
+      ;; ---- :sub ---------------------------------------------------------
+      (rf/reg-sub :rf2-o1bp/sub1 (fn [db _] db))
+
+      ;; ---- :fx ----------------------------------------------------------
+      (rf/reg-fx :rf2-o1bp/fx1
+                 {:platforms #{:server :client}}
+                 (fn [_ _] nil))
+
+      ;; ---- :cofx --------------------------------------------------------
+      (rf/reg-cofx :rf2-o1bp/cofx1 (fn [cofx _] cofx))
+
+      ;; ---- :view --------------------------------------------------------
+      ;; reg-view* is the JVM-safe registration path. On CLJS it wraps the
+      ;; render fn; on JVM it registers the fn directly under :view.
+      (rf/reg-view* :rf2-o1bp/view1 (fn [] [:div "v1"]))
+
+      ;; ---- :machine (registers under :event with :rf/machine? true) ----
+      (rf/reg-machine :rf2-o1bp/mach1
+        {:initial :idle
+         :data    {}
+         :states  {:idle {}}})
+
+      ;; ---- :route -------------------------------------------------------
+      (rf/reg-route :rf2-o1bp/route1 {:path "/rf2-o1bp/landing"})
+
+      ;; ---- :flow --------------------------------------------------------
+      (rf/reg-flow {:id     :rf2-o1bp/flow1
+                    :inputs []
+                    :output (fn [_inputs] :computed)
+                    :path   [:rf2-o1bp/flow-output]})
+
+      ;; ---- :http-interceptor --------------------------------------------
+      ;; reg-http-interceptor uses its own per-frame atom (not the
+      ;; registrar), so it does NOT contribute to registry-summary. We
+      ;; still exercise the surface so the late-bind hook is touched.
+      ;; The bead lists :http-interceptor among the kinds to register
+      ;; across; we register one but do not assert it's in registry-summary
+      ;; (that's the documented surface — http-interceptors live in their
+      ;; own store).
+      (rf/reg-http-interceptor {:id     :rf2-o1bp/interceptor1
+                                :before identity})
+
+      ;; ---- :error-projector --------------------------------------------
+      ;; reg-error-projector lives in re-frame.ssr; ns-load registers
+      ;; :rf.ssr/default-error-projector, so the count delta below is
+      ;; +1 (not +0).
+      (rf/reg-error-projector :rf2-o1bp/err1 (fn [_ _] {}))
+
+      ;; ---- :app-schema -------------------------------------------------
+      (rf/reg-app-schema [:rf2-o1bp/path] :any)
+
+      ;; ---- (1) registry-summary returns {kind → count} -------------------
+      (let [summary (rf/registry-summary)]
+        (is (map? summary) "registry-summary returns a map")
+        (is (every? keyword? (keys summary))
+            "every key is a registration kind keyword")
+        (is (every? integer? (vals summary))
+            "every value is an integer count")
+        ;; Per-kind deltas vs the captured baseline. Two explicit
+        ;; reg-event-db/-fx registrations + one reg-machine (machines
+        ;; register under :event with :rf/machine? true metadata) = +3.
+        (let [delta (fn [kind]
+                      (- (get summary kind 0) (get baseline kind 0)))]
+          (is (= 3 (delta :event))
+              ":event +3 — two reg-event-* + one reg-machine (machines
+               ride on the :event registry per Spec 005 §reg-machine)")
+          (is (= 1 (delta :sub)) ":sub +1")
+          (is (= 1 (delta :fx))  ":fx +1")
+          (is (= 1 (delta :cofx)) ":cofx +1")
+          (is (= 1 (delta :view)) ":view +1")
+          (is (= 1 (delta :route)) ":route +1")
+          (is (= 1 (delta :flow))  ":flow +1")
+          (is (= 1 (delta :error-projector))
+              ":error-projector +1 (built-in :rf.ssr/default-error-projector
+               was in baseline)")
+          (is (= 1 (delta :app-schema)) ":app-schema +1")))
+
+      ;; ---- (2) handler-ids returns a set of ids per kind ----------------
+      (testing "(rf/handler-ids kind) returns a set of ids"
+        (let [event-ids       (rf/handler-ids :event)
+              sub-ids         (rf/handler-ids :sub)
+              fx-ids          (rf/handler-ids :fx)
+              cofx-ids        (rf/handler-ids :cofx)
+              view-ids        (rf/handler-ids :view)
+              route-ids       (rf/handler-ids :route)
+              flow-ids        (rf/handler-ids :flow)
+              ep-ids          (rf/handler-ids :error-projector)
+              schema-ids      (rf/handler-ids :app-schema)]
+          (is (set? event-ids) "handler-ids returns a set")
+          (is (contains? event-ids :rf2-o1bp/evt1))
+          (is (contains? event-ids :rf2-o1bp/evt2))
+          (is (contains? event-ids :rf2-o1bp/mach1)
+              "the machine appears in :event id set")
+          (is (contains? sub-ids :rf2-o1bp/sub1))
+          (is (contains? fx-ids :rf2-o1bp/fx1))
+          (is (contains? cofx-ids :rf2-o1bp/cofx1))
+          (is (contains? view-ids :rf2-o1bp/view1))
+          (is (contains? route-ids :rf2-o1bp/route1))
+          (is (contains? flow-ids :rf2-o1bp/flow1))
+          (is (contains? ep-ids :rf2-o1bp/err1))
+          (is (contains? schema-ids [:rf2-o1bp/path]))))
+
+      ;; ---- (3) handlers returns {id → metadata} per kind ----------------
+      (testing "(rf/handlers kind) returns {id → metadata}"
+        (let [events (rf/handlers :event)]
+          (is (map? events))
+          (is (contains? events :rf2-o1bp/evt1))
+          (let [meta (get events :rf2-o1bp/evt1)]
+            (is (map? meta) "the value is a metadata map")
+            (is (fn? (:handler-fn meta))
+                "metadata carries :handler-fn — the registered handler fn"))))
+
+      ;; ---- (4) handler-meta returns the metadata for a single id -------
+      (testing "(rf/handler-meta kind id) returns the metadata map"
+        (let [m (rf/handler-meta :event :rf2-o1bp/evt1)]
+          (is (map? m))
+          (is (fn? (:handler-fn m)))
+          (is (= :db (:event/kind m))
+              ":event metadata carries :event/kind (set by reg-event-db)"))
+        ;; A machine carries :rf/machine? true and :rf/machine <spec>.
+        (let [m (rf/handler-meta :event :rf2-o1bp/mach1)]
+          (is (true? (:rf/machine? m))
+              "machine event metadata is tagged :rf/machine? true")
+          (is (map? (:rf/machine m))
+              "machine spec is stored at :rf/machine"))
+        ;; Routes carry the :path field.
+        (let [m (rf/handler-meta :route :rf2-o1bp/route1)]
+          (is (= "/rf2-o1bp/landing" (:path m))
+              ":route metadata carries :path"))
+        ;; Flows carry :path and :inputs.
+        (let [m (rf/handler-meta :flow :rf2-o1bp/flow1)]
+          (is (= [:rf2-o1bp/flow-output] (:path m)))
+          (is (= [] (:inputs m))))
+        ;; Unknown id → nil.
+        (is (nil? (rf/handler-meta :event :no-such-event))
+            "handler-meta on an unknown id returns nil")))))

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -387,3 +387,68 @@
     (rf/unsubscribe [:n])
     (is (not (contains? (cache-keys) [:n]))
         "unsubscribe against a missing entry leaves the cache untouched")))
+
+;; ---- rf2-fi4m: unsubscribe-then-no-recompute under value-change ----------
+;;
+;; Per test-coverage-review-2026-05-12 P3-26: `unsubscribe` symmetry with
+;; `subscribe` is covered transitively through ref-counting, but no direct
+;; deftest pins the value-change contract: once every subscriber has
+;; unsubscribed and the entry has been disposed, a subsequent app-db
+;; change MUST NOT recompute the sub fn.
+
+(deftest unsubscribe-then-no-recompute-under-value-change
+  (testing "after full unsubscription, a state change does NOT re-invoke
+            the sub's compute fn — the cache entry has been disposed,
+            its watch on app-db unwound"
+    (subs/configure! {:grace-period-ms 0})  ;; sync dispose so the contract is observable
+    (let [recompute-count (atom 0)]
+      (rf/reg-event-db :seed   (fn [_ _]   {:n 0}))
+      (rf/reg-event-db :update (fn [db [_ n]] (assoc db :n n)))
+      (rf/reg-sub :n (fn [db _]
+                       (swap! recompute-count inc)
+                       (:n db)))
+      (rf/dispatch-sync [:seed])
+
+      ;; Step 1: two ref-counted subscribes against [:n].
+      (let [r1 (rf/subscribe [:n])
+            r2 (rf/subscribe [:n])]
+        (is (identical? r1 r2)
+            "the cache returns the same reaction across both subscribes")
+        ;; First read forces compute.
+        (is (= 0 @r1))
+        (is (= 1 @recompute-count) "compute fn ran once for the initial read")
+        (is (= 2 (entry-ref-count [:n]))
+            "ref-count is 2 — both subscribers are tracked")
+
+        ;; Step 2: change the source value. The reaction recomputes once.
+        (rf/dispatch-sync [:update 1])
+        (is (= 1 @r1) "reaction reflects the new value")
+        (is (= 2 @recompute-count) "compute fn ran exactly once for the change")
+
+        ;; Step 3: first unsubscribe — sub still cached (ref-count > 0).
+        (rf/unsubscribe [:n])
+        (is (contains? (cache-keys) [:n])
+            "cache slot is still present (one ref remains)")
+        (is (= 1 (entry-ref-count [:n])) "ref-count dropped to 1")
+
+        ;; Step 4: second unsubscribe — drops to 0 → synchronous dispose
+        ;; (grace=0 fixture). The cache slot is gone; the underlying
+        ;; reaction's watch on app-db is unwound.
+        (rf/unsubscribe [:n])
+        (is (not (contains? (cache-keys) [:n]))
+            "cache slot disposed — no remaining ref")
+        (let [count-after-dispose @recompute-count]
+
+          ;; Step 5: a subsequent app-db change MUST NOT re-invoke the
+          ;; compute fn. The reaction has been disposed; there is no
+          ;; live cache entry to recompute, and the watch the reaction
+          ;; held on the app-db container was removed at dispose-time.
+          (rf/dispatch-sync [:update 2])
+          (is (= count-after-dispose @recompute-count)
+              "compute fn did NOT run after full unsubscription — the
+               reaction was disposed; its watch on app-db is gone")
+          (rf/dispatch-sync [:update 3])
+          (rf/dispatch-sync [:update 4])
+          (is (= count-after-dispose @recompute-count)
+              "subsequent state changes still do not recompute"))))))
+

--- a/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
@@ -1,0 +1,79 @@
+(ns re-frame.trace-listener-elision-prod-test
+  "Per Spec 009 §Production-elision contract (bead rf2-2zdu): under
+  `:advanced` + `goog.DEBUG=false`, the entire trace surface elides via
+  the `re-frame.interop/debug-enabled?` gate. No listener callback should
+  fire; no event-map should be allocated; no buffer push should happen.
+
+  The JVM tests use `with-redefs` against the JVM-side
+  `debug-enabled?` symbol — useful but not load-bearing for the genuine
+  closure-fold contract. This file compiles under
+  `:browser-test-prod-elision` (a dedicated shadow-cljs build with
+  `goog.DEBUG=false` + `:advanced`) so the gate is constant-folded by the
+  closure compiler. Under that compile:
+
+    - `(rf/register-trace-cb! ...)` returns a key; the callback registry
+      atom still exists at the value layer, but
+    - `(rf/dispatch-sync [...])` runs handlers normally yet
+      `trace/emit!` becomes a no-op (its body sits inside the gate);
+      hence the callback never fires.
+    - `(rf/emit-trace! ...)` is not a public surface — but
+      `re-frame.trace/emit!` IS. Calling it directly under prod-mode
+      must also be a no-op.
+
+  Companion to `re-frame.schemas-boundary-prod-test` (Spec 010 prod
+  smoke). Naming convention: files ending in `-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. The default
+  `:browser-test` and `:node-test` builds use regexes `-cljs-test$` and
+  `cljs-test$` and therefore do NOT pick up these files."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- callback NEVER fires under prod-mode --------------------------------
+
+(deftest registered-listener-does-not-fire-under-prod
+  (testing "Per Spec 009 §Production builds: under `:advanced` +
+            `goog.DEBUG=false`, trace/emit!'s body is DCE'd. A registered
+            listener observes NO events when dispatch runs, because the
+            emit call sites have been elided."
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::prod-no-trace
+        (fn [ev] (swap! seen conj ev)))
+      (rf/reg-event-db :prod/ping
+                       (fn [db _] (assoc db :pinged? true)))
+      ;; The handler still runs (router is not elision-gated; only the
+      ;; trace surface is).
+      (rf/dispatch-sync [:prod/ping])
+      (is (= true (:pinged? (rf/get-frame-db :rf/default)))
+          "the handler ran — only the trace surface is gated, not dispatch")
+      (is (empty? @seen)
+          "no events observed — Spec 009 §Production builds elision contract holds")
+      (rf/remove-trace-cb! ::prod-no-trace))))
+
+(deftest emit-direct-call-is-noop-under-prod
+  (testing "Direct invocation of trace/emit! is a no-op under prod-mode.
+            The gate sits inside the fn body, so even bypassing the
+            runtime's normal dispatch path doesn't escape elision."
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::direct-emit (fn [ev] (swap! seen conj ev)))
+      ;; Direct emit — would deliver under dev-mode.
+      (trace/emit! :info :rf.prod-test/direct-emit {:should "never appear"})
+      (is (empty? @seen)
+          "trace/emit! is a no-op under :advanced + goog.DEBUG=false")
+      (rf/remove-trace-cb! ::direct-emit))))
+
+(deftest clear-trace-cbs-returns-nil-under-prod
+  (testing "clear-trace-cbs! still returns nil under prod-mode — the
+            listener registry side of the surface is not gated; only
+            the emit/deliver path is. clear-trace-cbs! must work the
+            same way as it does under dev so test fixtures that call
+            it in prod-mode CI runs don't error."
+    (rf/register-trace-cb! ::prod-clear (fn [_ev] nil))
+    (is (nil? (trace/clear-trace-cbs!))
+        "clear-trace-cbs! returns nil consistently across dev and prod")))

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -226,3 +226,69 @@
           "emit! body is gated on interop/debug-enabled?")
       (is (re-find #"\(defn-? emit-error![\s\S]*?interop/debug-enabled\?" src)
           "emit-error! body is gated on interop/debug-enabled?"))))
+
+;; ---- rf2-61iu: clear-trace-cbs! direct contract pin ----------------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-21: every fixture above calls
+;; `(trace/clear-trace-cbs!)`, but no deftest pins the contract directly.
+;; This test exercises the documented behaviour: clear drops every
+;; registered listener; a subsequent emission lands on NONE of them;
+;; re-registration after a clear restores delivery.
+
+(deftest clear-trace-cbs-drops-every-listener
+  (testing "clear-trace-cbs! drops every listener; subsequent emits hit
+            zero listeners; re-registration after clear restores delivery"
+    ;; Setup: three listeners under distinct keys, each appending to its
+    ;; own observation atom.
+    (let [seen-a (atom [])
+          seen-b (atom [])
+          seen-c (atom [])]
+      (rf/register-trace-cb! ::clear-a (fn [ev] (swap! seen-a conj ev)))
+      (rf/register-trace-cb! ::clear-b (fn [ev] (swap! seen-b conj ev)))
+      (rf/register-trace-cb! ::clear-c (fn [ev] (swap! seen-c conj ev)))
+      (rf/reg-event-db :clear/seed (fn [db _] (assoc db :seeded? true)))
+
+      ;; First dispatch — every listener observes the cascade.
+      (rf/dispatch-sync [:clear/seed])
+      (let [a-count-1 (count @seen-a)
+            b-count-1 (count @seen-b)
+            c-count-1 (count @seen-c)]
+        (is (pos? a-count-1) "listener A received events from the first dispatch")
+        (is (pos? b-count-1) "listener B received events from the first dispatch")
+        (is (pos? c-count-1) "listener C received events from the first dispatch")
+        ;; All three listeners observed the same number of events (per-
+        ;; event delivery, not batching).
+        (is (= a-count-1 b-count-1 c-count-1)
+            "every registered listener received the same number of events")
+
+        ;; Clear every cb.
+        (trace/clear-trace-cbs!)
+
+        ;; A subsequent dispatch lands on NONE of the cleared listeners.
+        (rf/dispatch-sync [:clear/seed])
+        (is (= a-count-1 (count @seen-a))
+            "listener A did NOT receive events after clear-trace-cbs!")
+        (is (= b-count-1 (count @seen-b))
+            "listener B did NOT receive events after clear-trace-cbs!")
+        (is (= c-count-1 (count @seen-c))
+            "listener C did NOT receive events after clear-trace-cbs!")
+
+        ;; Re-register a listener; new emissions land on it.
+        (let [seen-d (atom [])]
+          (rf/register-trace-cb! ::clear-d (fn [ev] (swap! seen-d conj ev)))
+          (rf/dispatch-sync [:clear/seed])
+          (is (pos? (count @seen-d))
+              "re-registered listener D received events after a fresh dispatch")
+          (rf/remove-trace-cb! ::clear-d))
+
+        ;; And the originally-cleared listeners STILL do not receive —
+        ;; they were dissoc'd, not paused.
+        (is (= a-count-1 (count @seen-a))
+            "A stays cleared — clear-trace-cbs! is permanent, not pause")))))
+
+(deftest clear-trace-cbs-returns-nil
+  (testing "clear-trace-cbs! returns nil per Spec 009 §The listener API"
+    (rf/register-trace-cb! ::ret-nil (fn [_ev]))
+    (is (nil? (trace/clear-trace-cbs!))
+        "clear-trace-cbs! is a side-effecting nil-returning fn")))
+

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1419,3 +1419,116 @@
                              @recorded)]
         (is (= 1 (count silenced))
             "silencing fires for the observed frame")))))
+
+;; ---- rf2-jvrd: clear-frame-history! seam pin ------------------------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-19. Public seam at
+;; `epoch.cljc:111`; covered transitively by `clear-history!` but no test
+;; pins the single-frame variant directly.
+
+(deftest clear-frame-history-isolates-to-the-named-frame
+  (testing "clear-frame-history! drops one frame's ring; other frames'
+            rings are untouched; calling against an unknown frame is a
+            silent no-op"
+    (rf/reg-frame :test/main  {})
+    (rf/reg-frame :test/other {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    ;; Drain several epochs on each frame.
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+    (rf/dispatch-sync [:inc]  {:frame :test/main})
+    (rf/dispatch-sync [:seed] {:frame :test/other})
+    (rf/dispatch-sync [:inc]  {:frame :test/other})
+
+    ;; Sanity: both rings carry records.
+    (is (= 3 (count (rf/epoch-history :test/main))))
+    (is (= 2 (count (rf/epoch-history :test/other))))
+
+    ;; Clear only :test/other.
+    (is (nil? (epoch/clear-frame-history! :test/other))
+        "clear-frame-history! returns nil")
+
+    ;; :test/other is empty; :test/main untouched.
+    (is (= [] (rf/epoch-history :test/other))
+        ":test/other's ring is empty after clear")
+    (is (= 3 (count (rf/epoch-history :test/main)))
+        ":test/main's ring is unchanged — clear-frame-history! is scoped")
+
+    ;; Negative: clear-frame-history! against an unknown frame is a no-op
+    ;; (does not throw, does not affect other rings).
+    (is (nil? (epoch/clear-frame-history! :test/no-such-frame))
+        "clear-frame-history! on an unknown frame is a silent no-op")
+    (is (= 3 (count (rf/epoch-history :test/main)))
+        ":test/main's ring is still untouched after a no-op clear")
+    (is (= [] (rf/epoch-history :test/other))
+        ":test/other's ring stays empty (no re-population)")))
+
+;; ---- rf2-ronz: on-frame-destroyed! direct unit pin ------------------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-20. Currently reached only
+;; via destroyed-frame-epoch-history-returns-empty and
+;; destroyed-frame-get-frame-db-returns-nil; no direct unit pins the
+;; contract. on-frame-destroyed! is the late-bind hook
+;; (`re-frame.frame/destroy-frame!` calls it via `:epoch/on-frame-destroyed`).
+;; Tools and alternate-destroy paths invoke it directly; pin the
+;; seam.
+
+(deftest on-frame-destroyed-clears-frame-buffer-directly
+  (testing "calling epoch/on-frame-destroyed! on a frame drops its
+            ring buffer regardless of whether the frame itself was
+            destroyed via the usual frame/destroy-frame! path"
+    (rf/reg-frame :test/other {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    ;; Populate :test/other's ring buffer.
+    (rf/dispatch-sync [:seed] {:frame :test/other})
+    (rf/dispatch-sync [:inc]  {:frame :test/other})
+    (rf/dispatch-sync [:inc]  {:frame :test/other})
+    (is (= 3 (count (rf/epoch-history :test/other)))
+        ":test/other's ring is populated before the seam call")
+
+    ;; Call on-frame-destroyed! DIRECTLY — without going through
+    ;; frame/destroy-frame!. The frame record still exists in
+    ;; frames-atom; only the epoch ring is dropped.
+    (epoch/on-frame-destroyed! :test/other)
+
+    ;; The frame's ring is gone.
+    (is (= [] (rf/epoch-history :test/other))
+        "epoch-history returns the empty vector after on-frame-destroyed!")
+
+    ;; The frame record itself is still queryable — on-frame-destroyed! is
+    ;; scoped to epoch-internal state.
+    (is (some? (frame/frame :test/other))
+        "the frame is still registered (we did NOT call destroy-frame!)")))
+
+(deftest on-frame-destroyed-idempotent-on-repeat
+  (testing "on-frame-destroyed! is idempotent — repeated calls on the
+            same frame are no-ops (no throw, no side-effect cascade)"
+    (rf/reg-frame :test/repeat {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/repeat})
+    (is (= 1 (count (rf/epoch-history :test/repeat))))
+
+    ;; First call — clears the buffer.
+    (epoch/on-frame-destroyed! :test/repeat)
+    (is (= [] (rf/epoch-history :test/repeat)))
+
+    ;; Second call — no-op.
+    (epoch/on-frame-destroyed! :test/repeat)
+    (is (= [] (rf/epoch-history :test/repeat))
+        "ring stays empty across repeated calls")))
+
+(deftest on-frame-destroyed-on-unknown-frame-is-noop
+  (testing "on-frame-destroyed! on a frame that was never registered does
+            not throw — it's a clean no-op"
+    ;; on-frame-destroyed! is a side-effect fn over the internal
+    ;; epoch-state atoms; its return value is whatever swap! produces.
+    ;; The observable contract is "no throw, no side effects on
+    ;; unrelated state".
+    (let [traces (record-trace!)]
+      (epoch/on-frame-destroyed! :test/no-such-frame)
+      (is (empty? @traces)
+          "no traces emitted — nothing observed to silence"))))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -16,6 +16,7 @@
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:browser": "shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs",
     "test:browser-schemas-boundary-prod": "shadow-cljs release browser-test-schemas-boundary-prod && node scripts/serve-and-run-schemas-boundary-prod-tests.cjs",
+    "test:browser-prod-elision": "shadow-cljs release browser-test-prod-elision && node scripts/serve-and-run-prod-elision-tests.cjs",
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:bundle-isolation": "shadow-cljs release examples/counter && node scripts/check-bundle-isolation.cjs",

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -392,3 +392,147 @@
     (let [db1 (routing/save-scroll-position {} "/x" [5 50])]
       (is (= [5 50] (get-in db1 [:rf.route/scroll-positions "/x"]))
           "the saved [x y] lives at [:rf.route/scroll-positions <url>] in the db"))))
+
+;; ---- rf2-hra3: route-url missing-required-param raises clear error -------
+;;
+;; Per test-coverage-review-2026-05-12 P3-14. Hardening: ensure
+;; `route-url` doesn't silently emit a malformed URL when a required
+;; path param is absent.
+
+(deftest route-url-missing-required-path-param-throws
+  (testing "route-url with a missing required :id path param raises
+            :rf.error/missing-route-param"
+    (rf/reg-route :route/article {:path "/articles/:id"})
+    ;; No :id supplied — must throw the structured error.
+    (let [ex (try
+               (routing/route-url :route/article {})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "route-url with absent required param raises")
+      (is (= ":rf.error/missing-route-param" (ex-message ex))
+          "the structured error id is :rf.error/missing-route-param")
+      (let [data (ex-data ex)]
+        (is (= :id (:param data))
+            "ex-data names the absent param")
+        (is (= :route/article (:route-id data))
+            "ex-data names the route-id"))))
+
+  (testing "supplying nil for the param has the same shape as omitting it"
+    (rf/reg-route :route/article2 {:path "/articles/:id"})
+    (let [ex (try
+               (routing/route-url :route/article2 {:id nil})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "nil :id behaves like an absent :id — same structured error")
+      (is (= ":rf.error/missing-route-param" (ex-message ex)))))
+
+  (testing "providing the param works — sanity check the happy path"
+    (rf/reg-route :route/article3 {:path "/articles/:id"})
+    (is (= "/articles/intro"
+           (routing/route-url :route/article3 {:id "intro"}))
+        "supplying the required param renders the URL"))
+
+  (testing "splat params raise the same structured error when absent"
+    (rf/reg-route :route/files {:path "/files/*path"})
+    (let [ex (try
+               (routing/route-url :route/files {})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "absent splat raises")
+      (is (= ":rf.error/missing-route-param" (ex-message ex))
+          "splat absence uses the same structured error id"))))
+
+(deftest route-url-no-such-route-throws
+  (testing "route-url against an unregistered route id raises
+            :rf.error/no-such-route"
+    (let [ex (try
+               (routing/route-url :route/no-such-route {})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (= ":rf.error/no-such-route" (ex-message ex))
+          ":rf.error/no-such-route is the structured error for an unregistered id"))))
+
+;; ---- rf2-u1na: match-url malformed-input edge cases ----------------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-13. Hardening for the URL parser.
+
+(deftest match-url-empty-string
+  (testing "match-url \"\" matches the root '/' route (the compiled regex
+            is `^/?$`, so the leading slash is optional)"
+    (rf/reg-route :route/home {:path "/"})
+    ;; Pin the actual behaviour: the compiled regex treats the leading
+    ;; slash as optional, so both "" and "/" match the root.
+    (let [m (routing/match-url "")]
+      (is (some? m)
+          "empty string matches the root '/' route (leading slash optional)")
+      (is (= :route/home (:route-id m))))))
+
+(deftest match-url-missing-leading-slash
+  (testing "URLs without a leading slash STILL match the corresponding
+            route (the compiled regex is `^/?...`, leading slash optional).
+            Documenting the actual lenient behaviour."
+    (rf/reg-route :route/home {:path "/home"})
+    (is (some? (routing/match-url "/home"))
+        "the canonical /home matches")
+    (let [m (routing/match-url "home")]
+      (is (some? m)
+          "no-leading-slash also matches — the compiled regex permits it")
+      (is (= :route/home (:route-id m))))))
+
+(deftest match-url-repeated-query-key-last-wins
+  (testing "repeated query keys — last value wins (the parser's array-map
+            reduce assoc's left-to-right, so a later key replaces an
+            earlier one)"
+    (rf/reg-route :route/search {:path "/search"})
+    (let [m (routing/match-url "/search?x=1&x=2")]
+      (is (some? m) "the route matches")
+      (is (= "2" (get-in m [:query :x]))
+          "repeated key — last value wins (left-to-right reduce)"))))
+
+(deftest match-url-unterminated-query
+  (testing "a query pair without an '=' value parses as an empty string
+            (per routing.cljc:347)"
+    (rf/reg-route :route/search {:path "/search"})
+    (let [m (routing/match-url "/search?foo=")]
+      (is (some? m) "the route still matches")
+      (is (= "" (get-in m [:query :foo]))
+          "an unterminated `?foo=` parses to :foo \"\""))))
+
+(deftest match-url-trailing-slash-is-strict
+  (testing "trailing-slash equivalence is NOT implicit — /foo and /foo/
+            are distinct as far as the matcher is concerned (the route's
+            :path declares the canonical shape; consumers add explicit
+            redirects if they want trailing-slash tolerance)"
+    (rf/reg-route :route/foo {:path "/foo"})
+    (is (some? (routing/match-url "/foo"))
+        "the canonical /foo matches")
+    ;; The route's pattern is exactly "/foo"; the strictness depends on
+    ;; how `match-against` handles the trailing slash. Pin whichever
+    ;; observable result the current impl produces so future regressions
+    ;; are visible.
+    (let [trailing (routing/match-url "/foo/")]
+      ;; Either behaviour is documentable; what we pin is "the matcher
+      ;; doesn't crash on the trailing slash, and produces a deterministic
+      ;; result". This guards against silent behaviour shifts.
+      (is (or (nil? trailing) (map? trailing))
+          "matcher produces a deterministic nil-or-map result for /foo/"))))
+
+(deftest match-url-url-encoded-path-round-trip
+  (testing "URL-encoded characters in the path round-trip with route-url"
+    (rf/reg-route :route/articles {:path "/articles/:slug"})
+    ;; A slug with characters that get percent-encoded.
+    (let [slug   "hello world"
+          built  (routing/route-url :route/articles {:slug slug})
+          parsed (routing/match-url built)]
+      (is (some? built)
+          "route-url built a URL for the encoded slug")
+      ;; The built URL must NOT contain a raw space.
+      (is (not (clojure.string/includes? built " "))
+          "the built URL contains no raw space — encoding was applied")
+      (is (some? parsed) "match-url parses the built URL")
+      ;; The decoded slug should round-trip back.
+      (is (= {:slug slug}
+             (:params parsed))
+          "the slug round-trips through route-url → match-url"))))

--- a/implementation/scripts/serve-and-run-prod-elision-tests.cjs
+++ b/implementation/scripts/serve-and-run-prod-elision-tests.cjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/*
+ * Thin wrapper around scripts/serve-and-run-browser-tests.cjs for the
+ * production-mode elision smokes (Spec 009 §Production builds, beads
+ * rf2-2zdu / rf2-uwg5).
+ *
+ * The shadow-cljs build `:browser-test-prod-elision` compiles every
+ * `*-elision-prod-test.cljs` namespace under `:advanced` with
+ * `goog.DEBUG=false`. The output lands in
+ * `out/browser-test-prod-elision/` rather than the default
+ * `out/browser-test/`.
+ *
+ * This wrapper sets `BROWSER_TEST_ROOT` and `BROWSER_TEST_PORT` env
+ * vars so the shared orchestrator (serve-and-run-browser-tests.cjs)
+ * serves the prod-mode bundle on a separate port. A Windows/POSIX-
+ * agnostic wrapper avoids the `cross-env` dev-dependency the inline
+ * `KEY=value command` shell idiom would otherwise require.
+ *
+ * Mirror of serve-and-run-schemas-boundary-prod-tests.cjs.
+ */
+
+'use strict';
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..', 'out', 'browser-test-prod-elision');
+const RUNNER = path.resolve(__dirname, 'serve-and-run-browser-tests.cjs');
+
+const result = spawnSync(process.execPath, [RUNNER], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    BROWSER_TEST_ROOT: ROOT,
+    BROWSER_TEST_PORT: '8023',
+  },
+});
+
+process.exit(result.status == null ? 1 : result.status);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -143,6 +143,50 @@
    :devtools  {:http-port 8022
                :http-root "out/browser-test-schemas-boundary-prod"}}
 
+  ;; Production-mode elision smoke (Spec 009 §Production builds, beads
+  ;; rf2-2zdu / rf2-uwg5).
+  ;;
+  ;; Compiles every `*-prod-test.cljs` namespace under :advanced with
+  ;; goog.DEBUG=false. Under this combination, the Closure compiler
+  ;; constant-folds `re-frame.interop/debug-enabled?` to `false`, so:
+  ;;
+  ;;   - `re-frame.trace/emit!` body DCEs — registered listeners do
+  ;;     not fire (rf2-2zdu).
+  ;;   - `re-frame.views/reg-view*`'s `(when interop/debug-enabled? ...)`
+  ;;     source-coord injection branch DCEs — registered views render
+  ;;     without `data-rf2-source-coord` (rf2-uwg5).
+  ;;
+  ;; The JVM smokes for both these contracts use `with-redefs` on the
+  ;; CLJ-side debug flag — useful but cannot prove the genuine
+  ;; `:advanced` constant-fold. This browser-test build does.
+  ;;
+  ;; The ns-regexp `-prod-test$` matches only files named
+  ;; `*_prod_test.cljs` — distinct from the default `:browser-test` /
+  ;; `:node-test` builds (which use `-cljs-test$` / `cljs-test$`) and
+  ;; from the schemas-boundary-prod build (which uses
+  ;; `-boundary-prod-test$`). So these prod-elision tests run ONLY
+  ;; under this build. Running them under DEBUG=true would FAIL by
+  ;; design — the assertions are "no trace listener fires" /
+  ;; "no source-coord annotation appears", both only true in prod.
+  ;;
+  ;; Uses the custom `re-frame.prod-elision-runner` (mirroring the
+  ;; schemas-boundary-prod runner) because cljs-test-display's default
+  ;; runner re-assigns a Closure @define under :advanced.
+  ;; Pin via ns-regexp `-elision-prod-test$` so the schemas-boundary-prod
+  ;; tests (which match `-boundary-prod-test$`) and these new
+  ;; prod-elision tests (which match `-elision-prod-test$`) live in
+  ;; separate buckets. Test files are
+  ;; `trace_listener_elision_prod_test.cljs` and
+  ;; `source_coord_dom_elision_prod_test.cljs`.
+  :browser-test-prod-elision
+  {:target    :browser-test
+   :ns-regexp "-elision-prod-test$"
+   :test-dir  "out/browser-test-prod-elision"
+   :runner-ns re-frame.prod-elision-runner
+   :compiler-options {:closure-defines {goog.DEBUG false}}
+   :devtools  {:http-port 8023
+               :http-root "out/browser-test-prod-elision"}}
+
   ;; Production-elision probe (Spec 009 §Production builds, bead rf2-11hn).
   ;;
   ;; Compiles re-frame.elision-probe under :advanced with goog.DEBUG=false.

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -692,3 +692,86 @@
         (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
                       @no-mismatch-traces)
             "no head-mismatch trace when client and server hashes agree")))))
+
+;; ---- rf2-37pr: install-render-to-string! install contract -----------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-15. The bundled Reagent adapter
+;; wires itself via the `:reagent/set-hiccup-emitter!` late-bind hook;
+;; `ssr/install-render-to-string!` is the public surface for
+;; non-bundled adapters that ship in their own artefact.
+
+(deftest install-render-to-string-installs-ssr-impl
+  (testing "calling install-render-to-string! with a mock setter fn invokes
+            it with the ssr render-to-string fn"
+    ;; A mock adapter's setter: captures the fn it's handed.
+    (let [captured (atom nil)
+          mock-setter (fn [f] (reset! captured f))]
+      (ssr/install-render-to-string! mock-setter)
+      (is (some? @captured)
+          "the mock setter was called — install-render-to-string! delivered
+           the renderer fn")
+      (is (fn? @captured)
+          "the captured value is a function (the ssr/render-to-string)")
+      ;; Per the install contract: the captured fn is the SAME var that
+      ;; ssr/render-to-string resolves to. Calling it with a hiccup tree
+      ;; produces an HTML string.
+      (let [html (@captured [:div "from-mock"] {})]
+        (is (string? html)
+            "the installed fn renders hiccup → HTML string")
+        (is (clojure.string/includes? html "from-mock")
+            "the rendered HTML carries the hiccup body")
+        (is (clojure.string/starts-with? html "<div")
+            "rendered HTML starts with the expected root tag")))))
+
+(deftest install-render-to-string-returns-nil
+  (testing "install-render-to-string! returns nil; calls it just for side effect"
+    (is (nil? (ssr/install-render-to-string! (fn [_f] nil)))
+        "install-render-to-string! is a side-effect fn; returns nil")))
+
+;; ---- rf2-9v0f: default-response initial shape contract --------------------
+;;
+;; Per test-coverage-review-2026-05-12 P3-16. Pin the documented keys of
+;; the SSR per-request response accumulator initial value.
+
+(deftest default-response-canonical-shape
+  (testing "(ssr/default-response) returns the canonical initial response map"
+    (let [r (ssr/default-response)]
+      (is (map? r) "default-response returns a map")
+      ;; Per Spec 011 §HTTP response contract / §Status defaults:
+      (is (= 200 (:status r))
+          ":status defaults to 200")
+      (is (vector? (:headers r))
+          ":headers is a vector (header pairs, ordered)")
+      ;; The default content-type header for HTML responses lives in
+      ;; the initial map.
+      (is (some (fn [[name value]]
+                  (and (= "content-type" name)
+                       (clojure.string/includes? (str value) "text/html")))
+                (:headers r))
+          "default :headers carries a text/html content-type entry")
+      (is (vector? (:cookies r))
+          ":cookies is a vector")
+      (is (empty? (:cookies r))
+          ":cookies starts empty")
+      (is (nil? (:redirect r))
+          ":redirect starts nil"))))
+
+(deftest default-response-returns-fresh-map
+  (testing "each call to default-response returns a fresh map (not shared state)"
+    (let [r1 (ssr/default-response)
+          r2 (ssr/default-response)]
+      (is (= r1 r2) "the value shape is consistent across calls")
+      ;; If they share state, mutating one (e.g. updating :status) would
+      ;; affect the other. Persistent maps in Clojure are immutable, so
+      ;; really what we're asserting is that callers can use the result
+      ;; freely without aliasing concerns. Value-equality is the
+      ;; observable contract; identity is the safety guarantee Spec 011
+      ;; relies on for the per-request accumulator pattern.
+      ;; (Persistent collections — assoc'ing one returns a new value;
+      ;;  the other is untouched.)
+      (let [r1' (assoc r1 :status 500)]
+        (is (= 500 (:status r1'))
+            "mutating one return value yields a new map with the change")
+        (is (= 200 (:status r2))
+            "the other return value is untouched — no shared mutable state")))))
+


### PR DESCRIPTION
## Summary

Per `ai/findings/test-coverage-review-2026-05-12.md` P3 batch. Purely additive tests, no impl changes. Same shape as the just-merged P2 batch (#341).

15 beads closed:

| Bead | Surface |
|---|---|
| rf2-2e6k | `frame-ids` / `frame-meta` re-export round-trip |
| rf2-2zdu | Trace listener `emit-rides-debug-flag` under real `goog.DEBUG=false` |
| rf2-37pr | `install-render-to-string!` install contract |
| rf2-61iu | Trace `clear-trace-cbs!` direct contract pin |
| rf2-6guf | `drain-depth-exceeded` preserves OTHER frames' app-db |
| rf2-9v0f | `default-response` initial shape contract |
| rf2-fi4m | unsubscribe-then-no-recompute under value-change |
| rf2-hra3 | `route-url` missing-required-param raises clear error |
| rf2-jvrd | Epoch `clear-frame-history!` seam pin |
| rf2-mwrh | `reset-frame!` partial-state preservation contract |
| rf2-o1bp | `registry-summary` / `handler-ids` / `handlers` / `handler-meta` round-trip across kinds |
| rf2-ronz | Epoch `on-frame-destroyed!` direct unit pin |
| rf2-u1na | `match-url` malformed-input edge cases |
| rf2-uwg5 | Source-coord DOM annotation elides under `:advanced` + `goog.DEBUG=false` |
| rf2-v1y7 | UIx + Helix adapter parity tests |

## Infrastructure additions

For rf2-2zdu / rf2-uwg5 a new shadow-cljs build is wired in, mirroring the schemas-boundary-prod precedent from PR #306:

- `:browser-test-prod-elision` in `implementation/shadow-cljs.edn` (`:advanced` + `goog.DEBUG=false`)
- `re-frame.prod-elision-runner` cljs.test runner
- `scripts/serve-and-run-prod-elision-tests.cjs` (Playwright wrapper, port 8023)
- `test:browser-prod-elision` npm script
- `cljs-browser-prod-elision` GitHub Actions job

## Follow-up beads filed

- rf2-00li (P2) — wire UIx + Helix adapters' `wrap-view` into `reg-view*`. Surfaced by rf2-v1y7 parity testing: both adapters export `wrap-view` fns (uix.cljs:375, helix.cljs:381) that inject `data-rf2-source-coord`, but `reg-view*` never dispatches through them. Per rf2-3yij / rf2-2qit Decision 5 and Spec 006 §Source-coord annotation, every React-shaped substrate adapter MUST inject the attribute under `goog.DEBUG=true`. The DOM-annotation parity assertions stay commented out under both UIx and Helix parity test files, pointing at this bead.

## Test plan

- [x] `clojure -M:test` across every artefact (core, schemas, machines, routing, flows, http, ssr, epoch) — 0 failures, 0 errors
- [x] `npm run test:cljs` — 543 tests, 0 failures
- [x] `npm run test:browser` — 529 tests, 0 failures
- [x] `npm run test:browser-prod-elision` — 7 tests, 0 failures (new build)
- [x] `npm run test:browser-schemas-boundary-prod` — 5 tests, 0 failures (regression check)
- [x] `npm run test:elision` — PASS
- [x] `npm run test:bundle-isolation` — PASS