### PR TITLE
refactor(examples): 10 best-practice idiom fixes (rf2-ixla + 9 others)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -54,7 +54,17 @@
 
 (rf/reg-fx :rf.http/managed.login-demo
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent and UIx examples' stub."
+               to the Reagent and UIx examples' stub.
+
+               NOTE on the raw js/setTimeout below. The deferred work
+               is an fx invocation (the canned-success / canned-failure
+               stub), not a dispatch, so the framework's
+               `:dispatch-later` path is not a 1:1 swap. The timer is
+               purely demo-stub latency so the `:submitting` UI state
+               is observable. Production app code should never use raw
+               `js/setTimeout` — use `:dispatch-later` so framework
+               time controls (Tool-Pair time-travel,
+               `:dispatch-later` nil-override) still apply."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -62,6 +72,7 @@
           success?  (and login? (= good-password (:password body)))
           ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
           fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      ;; Demo-only artificial latency — see the fx doc above.
       (js/setTimeout
         (fn []
           (cond

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
@@ -155,12 +155,28 @@
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
-(rf/reg-sub :drawer/circles (fn [db _] (get-in db [:drawer :circles])))
-(rf/reg-sub :drawer/dialog  (fn [db _] (get-in db [:drawer :dialog])))
+;; Layer-2 slice sub. The Layer-3 readers below chain off this one via
+;; `:<-`, so the [:drawer ...] traversal happens once per app-db swap
+;; (in `:drawer`) rather than once per dependent recompute. Matches the
+;; realworld layering pattern (`:articles → :articles/data → ...`).
+
+(rf/reg-sub :drawer (fn [db _] (:drawer db)))
+
+(rf/reg-sub :drawer/circles
+  :<- [:drawer]
+  (fn [drawer _] (:circles drawer)))
+
+(rf/reg-sub :drawer/dialog
+  :<- [:drawer]
+  (fn [drawer _] (:dialog drawer)))
+
 (rf/reg-sub :drawer/can-undo?
-  (fn [db _] (seq (get-in db [:drawer :undo]))))
+  :<- [:drawer]
+  (fn [drawer _] (seq (:undo drawer))))
+
 (rf/reg-sub :drawer/can-redo?
-  (fn [db _] (seq (get-in db [:drawer :redo]))))
+  :<- [:drawer]
+  (fn [drawer _] (seq (:redo drawer))))
 
 ;; ============================================================================
 ;; VIEW

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -84,13 +84,22 @@
                A small artificial delay (60 ms) lets the boot-progress
                view render the per-phase loading state before the
                replies land — without it, the boot resolves in one
-               drain and the user only ever sees the `:ready` screen."
+               drain and the user only ever sees the `:ready` screen.
+
+               NOTE on the raw js/setTimeout below. The deferred work
+               is an fx invocation, not a dispatch, so the framework's
+               `:dispatch-later` path is not a 1:1 swap. The timer is
+               purely demo-stub latency; production app code should
+               never use raw `js/setTimeout` (use `:dispatch-later` or
+               drive the fx via a private event whose dispatch is
+               `:dispatch-later`'d, so framework time controls apply)."
    :platforms #{:server :client}}
   (fn fx-managed-boot-demo [frame-ctx args-map]
     (let [url     (-> args-map :request :url)
           payload (demo-payload-for-url url)
           stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
       (when stub-fn
+        ;; Demo-only artificial latency — see the fx doc above.
         (js/setTimeout
           (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
           60)))))

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -88,11 +88,30 @@
             [:payload   :any]
             [:error     [:maybe :any]]]]])
 
+(def BootStagingSlice
+  "Shape of `[:boot/staging]` — the per-child hand-off slot the
+   `:invoke-all` children write into and the parent's
+   `:enter-hydrating` action reads from. Each key is optional because
+   the slot is filled incrementally as children complete; once the
+   join resolves all four keys carry their per-child payloads."
+  [:map
+   [:config {:optional true} [:maybe Config]]
+   [:flags  {:optional true} [:maybe Flags]]
+   [:user   {:optional true} [:maybe User]]
+   [:routes {:optional true} [:maybe Routes]]])
+
 ;; ============================================================================
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
 (rf/reg-app-schema [:rf/machines :app/boot] BootSnapshot)
+
+;; The :invoke-all children stage their payloads into [:boot/staging]
+;; before signalling completion to the parent. The :enter-hydrating
+;; action reads the staging slot and promotes each payload into the
+;; canonical top-level slot below. Registered here so the staging
+;; writes are schema-validated like every other slice.
+(rf/reg-app-schema [:boot/staging] BootStagingSlice)
 
 ;; The boot machine writes its final payloads into top-level app-db
 ;; slices on entering `:hydrating`. These are the slices the main app

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -34,12 +34,35 @@
   (fn [_ctx args]
     (swap! counter-log conj args)))
 
-;; reg-event-fx so the handler can return both `:db` and a `:fx` walk.
-;; Mixing :db and :fx in one handler makes the example exercise every
-;; perf bucket (event handler, sub recompute, fx walk, render) on a
-;; single dispatch — which is what the counter-perf browser smoke
-;; observes. Per Spec 002 §`:fx` ordering: :db commits first, then :fx
-;; walks in source order.
+;; ----------------------------------------------------------------------------
+;; DELIBERATE PERF-BUCKET EXCEPTION — NOT THE CANONICAL :initialise SHAPE
+;;
+;; The canonical re-frame2 :initialise shape is `reg-event-db` returning a
+;; plain seeded db — no `:fx`. This handler is INTENTIONALLY widened to
+;; `reg-event-fx` with both `:db` and `:fx` so the counter-perf
+;; instrumented variant (out/examples/counter-perf — see shadow-cljs.edn)
+;; exercises every perf bucket (event handler, sub recompute, fx walk,
+;; render) on a single dispatch. The browser smoke test
+;; (examples/reagent/counter/counter-perf.spec.cjs) asserts a
+;; `rf:fx:counter/log` performance measure entry exists; the only way
+;; to produce that on init without a user click is to attach the `:fx`
+;; walk to the initialise dispatch itself.
+;;
+;; Per Spec 002 §`:fx` ordering: :db commits first, then :fx walks in
+;; source order.
+;;
+;; READER NOTE — do NOT propagate this `:db + :fx` mix to your own
+;; :initialise handlers. The idiomatic shape is:
+;;
+;;     (rf/reg-event-db :app/initialise
+;;       (fn [_ _] {:count 5}))                            ;; just the seed db
+;;
+;; The widening here exists ONLY so the perf-instrumented build has a
+;; non-empty :fx walk to measure on init. Every other example in the
+;; repo (login, realworld, boot, ...) uses plain `reg-event-db` for
+;; its initialiser.
+;; ----------------------------------------------------------------------------
+
 (rf/reg-event-fx :counter/initialise
   (fn [_ctx _event]
     {:db {:count 5}

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -123,7 +123,19 @@
                so the reply shape (`{:kind :success :value ...}` /
                `{:kind :failure :failure ...}`) lands at the inner
                `:auth.login/success` / `:auth.login/failure` sub-events
-               via the explicit `:on-success` / `:on-failure` form."
+               via the explicit `:on-success` / `:on-failure` form.
+
+               NOTE on the raw js/setTimeout below. The deferred work
+               is an fx invocation (the canned-success / canned-failure
+               stub), not a dispatch, so the framework's
+               `:dispatch-later` path is not a 1:1 swap. The timer is
+               purely demo-stub latency so the `:submitting` UI state
+               is observable. Production app code should never use raw
+               `js/setTimeout` — use `:dispatch-later` (or, for a
+               deferred fx, dispatch-later to a private event whose
+               handler issues the fx) so framework time controls
+               (Tool-Pair time-travel, `:dispatch-later` nil-override)
+               still apply."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -131,8 +143,7 @@
           success?  (and login? (= good-password (:password body)))
           ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
           fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
-      ;; Simulate a small request latency so the :submitting state is
-      ;; observable in the UI before the response lands.
+      ;; Demo-only artificial latency — see the fx doc above.
       (js/setTimeout
         (fn []
           (cond

--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -45,17 +45,18 @@
 
 (defn editor-slice
   "The form's app-db slice. Holds Pattern-Forms shape (draft, baseline,
-   errors, touched, submit-error). The machine carries the state
-   vocabulary; this slice carries the data."
+   errors, touched, submit-attempted?, submit-error). The machine
+   carries the state vocabulary; this slice carries the data."
   ([] (editor-slice nil blank-draft))
   ([slug baseline]
-   {:slug         slug
-    :draft        baseline
-    :baseline     baseline
-    :submitted    nil
-    :errors       {}
-    :touched      #{}
-    :submit-error nil}))
+   {:slug              slug
+    :draft             baseline
+    :baseline          baseline
+    :submitted         nil
+    :errors            {}
+    :touched           #{}
+    :submit-attempted? false
+    :submit-error      nil}))
 
 (defn validate-draft [{:keys [title description body]}]
   (cond-> {}
@@ -224,10 +225,18 @@
           mode   (get-in db [:rf/machines :ui/article-editor :state :mode])
           errors (validate-draft draft)]
       (if (seq errors)
+        ;; Client-side validation failure. Flip :submit-attempted? so
+        ;; per-field error subs (Pattern-Forms §Error visibility)
+        ;; reveal every error even on untouched fields, without the
+        ;; prior workaround of re-touching every error field.
+        ;; Whole-form prompt lives in `:errors :_form`; transport-shape
+        ;; failures still land in `:submit-error` (the HTTP path).
         {:db (-> db
-                 (assoc-in [:editor :errors] errors)
-                 (assoc-in [:editor :submit-error] "Please fix the highlighted fields."))}
+                 (assoc-in [:editor :submit-attempted?] true)
+                 (assoc-in [:editor :errors] (assoc errors :_form "Please fix the highlighted fields."))
+                 (assoc-in [:editor :submit-error] nil))}
         {:db (-> db
+                 (assoc-in [:editor :submit-attempted?] true)
                  (assoc-in [:editor :submitted] draft)
                  (assoc-in [:editor :errors] {})
                  (assoc-in [:editor :submit-error] nil))
@@ -294,6 +303,24 @@
 (rf/reg-sub :editor/errors :<- [:editor] (fn [editor _] (:errors editor)))
 (rf/reg-sub :editor/submit-error :<- [:editor]
   (fn [editor _] (:submit-error editor)))
+
+(rf/reg-sub :editor/field-error
+  {:doc "Per-field validation error. Per Pattern-Forms §Error
+         visibility: reveal every error after the first submit click,
+         OR once the field is :touched."}
+  :<- [:editor]
+  (fn [editor [_ field]]
+    (when (or (:submit-attempted? editor)
+              (contains? (:touched editor) field))
+      (get-in editor [:errors field]))))
+
+(rf/reg-sub :editor/form-error
+  {:doc "Whole-form prompt (the :_form key under :errors) — populated
+         when a submit attempt failed client-side validation."}
+  :<- [:editor]
+  (fn [editor _]
+    (when (:submit-attempted? editor)
+      (get-in editor [:errors :_form]))))
 (rf/reg-sub :editor/dirty?
   :<- [:editor]
   (fn [editor _]
@@ -357,7 +384,10 @@
                    shows the Delete button."}
           editor-form []
   (let [draft        @(subscribe [:editor/draft])
-        errors       @(subscribe [:editor/errors])
+        title-err    @(subscribe [:editor/field-error :title])
+        desc-err     @(subscribe [:editor/field-error :description])
+        body-err     @(subscribe [:editor/field-error :body])
+        form-err     @(subscribe [:editor/form-error])
         submit-error @(subscribe [:editor/submit-error])
         busy?        @(rf/has-tag? :ui/article-editor :editor/busy)
         can-delete?  @(rf/has-tag? :ui/article-editor :editor/can-delete)]
@@ -365,6 +395,8 @@
      [:div.container.page
       [:div.row
        [:div.col-md-10.offset-md-1.col-xs-12
+        (when form-err
+          [:ul.error-messages [:li form-err]])
         (when submit-error
           [:ul.error-messages [:li submit-error]])
         [:form
@@ -380,8 +412,8 @@
              :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :title])
              :on-change   #(dispatch [:editor/edit-field :title (.. % -target -value)])}]
-           (when-let [err (:title errors)]
-             [:div.error-messages err])]
+           (when title-err
+             [:div.error-messages title-err])]
           [:fieldset.form-group
            [:input.form-control
             {:type        "text"
@@ -390,8 +422,8 @@
              :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :description])
              :on-change   #(dispatch [:editor/edit-field :description (.. % -target -value)])}]
-           (when-let [err (:description errors)]
-             [:div.error-messages err])]
+           (when desc-err
+             [:div.error-messages desc-err])]
           [:fieldset.form-group
            [:textarea.form-control
             {:rows        8
@@ -400,8 +432,8 @@
              :disabled    busy?
              :on-blur     #(dispatch [:editor/blur-field :body])
              :on-change   #(dispatch [:editor/edit-field :body (.. % -target -value)])}]
-           (when-let [err (:body errors)]
-             [:div.error-messages err])]
+           (when body-err
+             [:div.error-messages body-err])]
           [:fieldset.form-group
            [:input.form-control
             {:type        "text"

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -28,8 +28,6 @@
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 (defn request-slice [data]
   {:status :idle :data data :error nil :loaded-at nil :attempt 0})
 
@@ -241,13 +239,14 @@
          Spec 014's reply-addressing. Folds the new count into the home
          machine via `:fetch-succeeded`; the `:data` region's
          `:resolving` `:always`-cascade picks `:empty` or `:some`."}
-  (fn [{:keys [db]} [_ {:keys [value]}]]
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
     (let [items (vec (:articles value))]
       {:db (-> db
                (assoc-in [:articles :status] :loaded)
                (assoc-in [:articles :data] items)
                (assoc-in [:articles :error] nil)
-               (assoc-in [:articles :loaded-at] (current-time-ms)))
+               (assoc-in [:articles :loaded-at] now))
        :fx [[:dispatch [:realworld/articles-home
                         [:fetch-succeeded {:items items}]]]]})))
 

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -25,20 +25,22 @@
 ;; ============================================================================
 ;; FX / COFX
 ;; ============================================================================
+;;
+;; One fx for the localStorage seam. Arg shape is `{:token <token-or-nil>}`
+;; — write on truthy, remove on nil. Halving the registrar entries keeps
+;; the localStorage edge a single seam: one fx to mock in tests, one fx
+;; for the machine's `:store-session` and `:clear-session` actions to
+;; call with different args.
 
-(rf/reg-fx :auth.session/store
-  {:doc       "Persist the JWT in localStorage."
+(rf/reg-fx :auth.session/persist
+  {:doc       "Persist (or clear) the JWT in localStorage. Arg `{:token t}`
+               writes the token when truthy; nil removes the key."
    :platforms #{:client}}
-  (fn fx-auth-session-store [_m {:keys [token]}]
+  (fn fx-auth-session-persist [_m {:keys [token]}]
     (when-let [ls (.-localStorage js/globalThis)]
-      (.setItem ls "conduit/jwt" token))))
-
-(rf/reg-fx :auth.session/clear
-  {:doc       "Clear the JWT from localStorage."
-   :platforms #{:client}}
-  (fn fx-auth-session-clear [_m _]
-    (when-let [ls (.-localStorage js/globalThis)]
-      (.removeItem ls "conduit/jwt"))))
+      (if token
+        (.setItem    ls "conduit/jwt" token)
+        (.removeItem ls "conduit/jwt")))))
 
 (rf/reg-cofx :auth.session/token
   {:doc "Inject the saved token (or nil) from localStorage into coeffects."}
@@ -129,7 +131,7 @@
         (let [user (:user value)]
           {:data {:error nil}
            :fx [[:dispatch [:auth/store-session user]]
-                [:auth.session/store {:token (:token user)}]
+                [:auth.session/persist {:token (:token user)}]
                 [:dispatch [:rf.route/navigate :route/home]]]}))
 
       :record-error
@@ -140,7 +142,7 @@
       (fn [_ _]
         {:data {:error nil}
          :fx [[:dispatch [:auth/clear-session]]
-              [:auth.session/clear nil]
+              [:auth.session/persist {:token nil}]
               [:dispatch [:rf.route/navigate :route/home]]]})}
      :states
      {:idle
@@ -187,12 +189,13 @@
 (rf/reg-event-db :auth.login-form/initialise
   (fn [db _]
     (assoc-in db [:auth :login-form]
-              {:draft        login-form-defaults
-               :submitted    nil
-               :status       :idle
-               :errors       {}
-               :touched      #{}
-               :submit-error nil})))
+              {:draft             login-form-defaults
+               :submitted         nil
+               :status            :idle
+               :errors            {}
+               :touched           #{}
+               :submit-attempted? false
+               :submit-error      nil})))
 
 (rf/reg-event-db :auth.login-form/edit-field
   {:spec [:cat [:= :auth.login-form/edit-field] :keyword :string]}
@@ -204,18 +207,21 @@
 (rf/reg-event-fx :auth.login-form/submit
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:auth :login-form :draft])]
-      {:db (assoc-in db [:auth :login-form :status] :submitting)
+      {:db (-> db
+               (assoc-in [:auth :login-form :submit-attempted?] true)
+               (assoc-in [:auth :login-form :status] :submitting))
        :fx [[:dispatch [:auth/flow [:auth/login draft]]]]})))
 
 (rf/reg-event-db :auth.register-form/initialise
   (fn [db _]
     (assoc-in db [:auth :register-form]
-              {:draft        register-form-defaults
-               :submitted    nil
-               :status       :idle
-               :errors       {}
-               :touched      #{}
-               :submit-error nil})))
+              {:draft             register-form-defaults
+               :submitted         nil
+               :status            :idle
+               :errors            {}
+               :touched           #{}
+               :submit-attempted? false
+               :submit-error      nil})))
 
 (rf/reg-event-db :auth.register-form/edit-field
   (fn [db [_ field value]]
@@ -226,7 +232,9 @@
 (rf/reg-event-fx :auth.register-form/submit
   (fn [{:keys [db]} _]
     (let [draft (get-in db [:auth :register-form :draft])]
-      {:db (assoc-in db [:auth :register-form :status] :submitting)
+      {:db (-> db
+               (assoc-in [:auth :register-form :submit-attempted?] true)
+               (assoc-in [:auth :register-form :status] :submitting))
        :fx [[:dispatch [:auth/flow [:auth/register draft]]]]})))
 
 ;; ============================================================================
@@ -267,8 +275,34 @@
 (rf/reg-sub :auth.login-form/draft
   (fn [db _] (get-in db [:auth :login-form :draft])))
 
+(rf/reg-sub :auth.login-form
+  (fn [db _] (get-in db [:auth :login-form])))
+
+(rf/reg-sub :auth.login-form/field-error
+  {:doc "Per-field validation error for the login form. Per
+         Pattern-Forms §Error visibility: reveal every error after the
+         first submit click, OR once a field is :touched."}
+  :<- [:auth.login-form]
+  (fn [form [_ field]]
+    (when (or (:submit-attempted? form)
+              (contains? (:touched form) field))
+      (get-in form [:errors field]))))
+
 (rf/reg-sub :auth.register-form/draft
   (fn [db _] (get-in db [:auth :register-form :draft])))
+
+(rf/reg-sub :auth.register-form
+  (fn [db _] (get-in db [:auth :register-form])))
+
+(rf/reg-sub :auth.register-form/field-error
+  {:doc "Per-field validation error for the register form. Per
+         Pattern-Forms §Error visibility: reveal every error after the
+         first submit click, OR once a field is :touched."}
+  :<- [:auth.register-form]
+  (fn [form [_ field]]
+    (when (or (:submit-attempted? form)
+              (contains? (:touched form) field))
+      (get-in form [:errors field]))))
 
 ;; ============================================================================
 ;; VIEWS

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -13,15 +13,14 @@
             [realworld.routing :as routing])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 (defn comment-form-defaults []
-  {:draft        {:body ""}
-   :submitted    nil
-   :status       :idle
-   :errors       {}
-   :touched      #{}
-   :submit-error nil})
+  {:draft             {:body ""}
+   :submitted         nil
+   :status            :idle
+   :errors            {}
+   :touched           #{}
+   :submit-attempted? false
+   :submit-error      nil})
 
 (defn article-path [slug]
   (str "/articles/" slug))
@@ -63,7 +62,8 @@
          `:rf/reply` merged into the original message map. The handler
          body branches on `(:rf/reply msg)` — one event id, two roles."
    :rf.http/decode-schemas [schema/ArticleResponse]}
-  (fn [{:keys [db]} [_ msg]]
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ msg]]
     (if-let [reply (:rf/reply msg)]
       ;; Reply branch — handle success or failure.
       (case (:kind reply)
@@ -72,7 +72,7 @@
                  (assoc-in [:article :status] :loaded)
                  (assoc-in [:article :data] (:article (:value reply)))
                  (assoc-in [:article :error] nil)
-                 (assoc-in [:article :loaded-at] (current-time-ms)))}
+                 (assoc-in [:article :loaded-at] now))}
 
         :failure
         {:db (-> db
@@ -122,13 +122,14 @@
                           :on-success [:comments/loaded]
                           :on-failure [:comments/load-failed]})]]})))
 
-(rf/reg-event-db :comments/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:comments :status] :loaded)
-        (assoc-in [:comments :data] (vec (:comments value)))
-        (assoc-in [:comments :error] nil)
-        (assoc-in [:comments :loaded-at] (current-time-ms)))))
+(rf/reg-event-fx :comments/loaded
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:comments :status] :loaded)
+             (assoc-in [:comments :data] (vec (:comments value)))
+             (assoc-in [:comments :error] nil)
+             (assoc-in [:comments :loaded-at] now))}))
 
 (rf/reg-event-db :comments/load-failed
   (fn [db [_ {:keys [failure]}]]
@@ -167,10 +168,19 @@
                                  :image     (:image user)
                                  :following false}}]
       (if (str/blank? body)
+        ;; Client-side validation failure. Per Pattern-Forms
+        ;; §:submit-error vs :errors: validation messages live in
+        ;; `:errors` (`:_form` for whole-form, otherwise per-field);
+        ;; `:submit-error` is reserved for transport / non-field
+        ;; HTTP failures. Flip :submit-attempted? so the view's
+        ;; per-field-error sub reveals the :body error even on a
+        ;; fresh, never-:touched textarea.
         {:db (-> db
+                 (assoc-in [:comment-form :submit-attempted?] true)
                  (assoc-in [:comment-form :errors] {:body "Comment body is required."})
-                 (assoc-in [:comment-form :submit-error] "Comment body is required."))}
+                 (assoc-in [:comment-form :submit-error] nil))}
         {:db (-> db
+                 (assoc-in [:comment-form :submit-attempted?] true)
                  (assoc-in [:comment-form :status] :submitting)
                  (assoc-in [:comment-form :submitted] {:body body})
                  (assoc-in [:comment-form :errors] {})
@@ -262,6 +272,19 @@
 (rf/reg-sub :comment-form/submit-error
   (fn [db _] (get-in db [:comment-form :submit-error])))
 
+(rf/reg-sub :comment-form
+  (fn [db _] (:comment-form db)))
+
+(rf/reg-sub :comment-form/field-error
+  {:doc "Per-field validation error for the comment form. Per
+         Pattern-Forms §Error visibility: reveal every error after the
+         first submit click, OR once the field is :touched."}
+  :<- [:comment-form]
+  (fn [form [_ field]]
+    (when (or (:submit-attempted? form)
+              (contains? (:touched form) field))
+      (get-in form [:errors field]))))
+
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================
@@ -295,6 +318,7 @@
         comments       @(subscribe [:comments/data])
         comments-error @(subscribe [:comments/error])
         comment-draft  @(subscribe [:comment-form/draft])
+        body-error     @(subscribe [:comment-form/field-error :body])
         submit-error   @(subscribe [:comment-form/submit-error])
         submitting?    @(subscribe [:comment-form/submitting?])
         current-user   @(subscribe [:auth/user])]
@@ -348,6 +372,8 @@
                 {:type "submit"
                  :disabled submitting?}
                 (if submitting? "Posting…" "Post Comment")]]
+              (when body-error
+                [:div.error-messages body-error])
               (when submit-error
                 [:div.error-messages submit-error])]
              [:p

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -243,7 +243,20 @@
   {:doc       "Demo override for :rf.http/managed: routes by URL to canned
                Conduit-shaped responses so the example runs standalone
                without a backend. Delegates to :rf.http/managed-canned-success
-               with a synthesised :value per Spec 014 §Testing."
+               with a synthesised :value per Spec 014 §Testing.
+
+               NOTE on the raw js/setTimeout below. The deferred work
+               is an fx invocation (`:rf.http/managed-canned-success`),
+               not a dispatch, so the framework's `:dispatch-later`
+               path is not a 1:1 swap. The timer is here ONLY to delay
+               the canned reply long enough for the `:loading` UI state
+               to be observable in the demo; production app code should
+               never use raw `js/setTimeout` — use `:dispatch-later` or
+               (for an fx invocation) drive it through a tiny
+               framework dispatch (e.g. dispatch-later to a private
+               event whose handler issues the fx) so framework time
+               controls (Tool-Pair time-travel, the documented
+               `:dispatch-later` nil-override seam) still apply."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
     (let [url     (-> args-map :request :url)
@@ -253,6 +266,7 @@
       ;; correct reply shape (default reply addressing or explicit
       ;; :on-success — Spec 014 §Reply addressing).
       (when stub-fn
+        ;; Demo-only artificial latency — see the fx doc above.
         (js/setTimeout
           (fn [] (stub-fn frame-ctx (assoc args-map :value payload)))
           20)))))

--- a/examples/reagent/realworld/favorites.cljs
+++ b/examples/reagent/realworld/favorites.cljs
@@ -9,8 +9,6 @@
             [realworld.schema :as schema]
             [realworld.http :as rh]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 (defn request-slice []
   {:status :idle :data [] :error nil :loaded-at nil :attempt 0})
 
@@ -89,12 +87,13 @@
   {:doc "Successful user-feed fetch. Folds the new count into the home
          machine via `:fetch-succeeded`; the `:data` region's
          `:resolving` `:always`-cascade picks `:empty` or `:some`."}
-  (fn [{:keys [db]} [_ {:keys [value]}]]
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
     (let [items (vec (:articles value))]
       {:db (-> db
                (assoc-in [:feed :status] :loaded)
                (assoc-in [:feed :data] items)
-               (assoc-in [:feed :loaded-at] (current-time-ms)))
+               (assoc-in [:feed :loaded-at] now))
        :fx [[:dispatch [:realworld/articles-home
                         [:fetch-succeeded {:items items}]]]]})))
 

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -116,6 +116,26 @@
     out))
 
 ;; ============================================================================
+;; CLOCK COEFFECT — :realworld/now
+;; ============================================================================
+;;
+;; Reading wall-clock time inside a handler makes the handler impure;
+;; the same event applied to the same db at two moments produces two
+;; different `:loaded-at` stamps. Per Spec 002 §Cofx, side-effecting
+;; inputs belong in coeffects so handlers stay pure functions of
+;; `(coeffects, event) → effects`. Pulling the clock into a registered
+;; cofx (rather than calling `(.getTime (js/Date.))` directly) gives
+;; the example a single injection point that tests can override and
+;; SSR can hydrate.
+
+(rf/reg-cofx :realworld/now
+  {:doc "Inject the current wall-clock time (ms since epoch) into
+         coeffects under `:realworld/now`. Use `(rf/inject-cofx
+         :realworld/now)` on any handler that stamps `:loaded-at`."}
+  (fn cofx-realworld-now [coeffects]
+    (assoc coeffects :realworld/now (.getTime (js/Date.)))))
+
+;; ============================================================================
 ;; FAILURE PROJECTION
 ;; ============================================================================
 

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -37,8 +37,6 @@
             [realworld.articles :as articles])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 (defn request-slice []
   {:status :idle :data nil :error nil :loaded-at nil :attempt 0})
 
@@ -184,12 +182,13 @@
                           :on-failure [:profile/load-failed]})]]})))
 
 (rf/reg-event-fx :profile/loaded
-  (fn [{:keys [db]} [_ {:keys [value]}]]
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
     {:db (-> db
              (assoc-in [:profile :status] :loaded)
              (assoc-in [:profile :data] (:profile value))
              (assoc-in [:profile :error] nil)
-             (assoc-in [:profile :loaded-at] (current-time-ms)))
+             (assoc-in [:profile :loaded-at] now))
      :fx [[:dispatch [:ui/profile [:fetch-succeeded]]]]}))
 
 (rf/reg-event-fx :profile/load-failed
@@ -222,12 +221,13 @@
                           :on-success [:profile.articles/loaded]
                           :on-failure [:profile.articles/load-failed]})]]})))
 
-(rf/reg-event-db :profile.articles/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:profile.articles :status] :loaded)
-        (assoc-in [:profile.articles :data] (vec (:articles value)))
-        (assoc-in [:profile.articles :loaded-at] (current-time-ms)))))
+(rf/reg-event-fx :profile.articles/loaded
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:profile.articles :status] :loaded)
+             (assoc-in [:profile.articles :data] (vec (:articles value)))
+             (assoc-in [:profile.articles :loaded-at] now))}))
 
 (rf/reg-event-db :profile.articles/load-failed
   (fn [db [_ {:keys [failure]}]]
@@ -257,12 +257,13 @@
                           :on-success [:profile.favorites/loaded]
                           :on-failure [:profile.favorites/load-failed]})]]})))
 
-(rf/reg-event-db :profile.favorites/loaded
-  (fn [db [_ {:keys [value]}]]
-    (-> db
-        (assoc-in [:profile.favorites :status] :loaded)
-        (assoc-in [:profile.favorites :data] (vec (:articles value)))
-        (assoc-in [:profile.favorites :loaded-at] (current-time-ms)))))
+(rf/reg-event-fx :profile.favorites/loaded
+  [(rf/inject-cofx :realworld/now)]
+  (fn [{:keys [db realworld/now]} [_ {:keys [value]}]]
+    {:db (-> db
+             (assoc-in [:profile.favorites :status] :loaded)
+             (assoc-in [:profile.favorites :data] (vec (:articles value)))
+             (assoc-in [:profile.favorites :loaded-at] now))}))
 
 (rf/reg-event-db :profile.favorites/load-failed
   (fn [db [_ {:keys [failure]}]]

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -177,6 +177,7 @@
    [:status :keyword]
    [:errors :map]
    [:touched [:set :keyword]]
+   [:submit-attempted? {:optional true} :boolean]
    [:submit-error [:maybe :string]]])
 
 (def EditorSlice
@@ -197,6 +198,7 @@
    [:status :keyword]
    [:errors :map]
    [:touched [:set :keyword]]
+   [:submit-attempted? {:optional true} :boolean]
    [:submit-error [:maybe :string]]])
 
 ;; ============================================================================
@@ -228,6 +230,8 @@
 (rf/reg-app-schema [:feed]                     RequestSlice)
 (rf/reg-app-schema [:feed :data]               [:vector Article])
 (rf/reg-app-schema [:comment-form]             FormSlice)
+(rf/reg-app-schema [:auth :login-form]         FormSlice)
+(rf/reg-app-schema [:auth :register-form]      FormSlice)
 (rf/reg-app-schema [:editor]                   EditorSlice)
 ;; The `:settings` slice from the slice-form era is gone; the settings
 ;; form lifecycle is now the `:settings/form` machine (the :form-region

--- a/examples/reagent/realworld/settings.cljs
+++ b/examples/reagent/realworld/settings.cljs
@@ -47,8 +47,6 @@
             [realworld.http :as rh])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 (defn draft-from-user [user]
   {:image    (or (:image user) "")
    :username (or (:username user) "")
@@ -225,11 +223,12 @@
   {:doc "Seed the form draft from the currently-authenticated user.
          Dispatched by the :route/settings :on-match (see routing.cljs)
          and by tests after :auth/store-session."}
-  (fn handler-settings-load [{:keys [db]} _]
+  [(rf/inject-cofx :realworld/now)]
+  (fn handler-settings-load [{:keys [db realworld/now]} _]
     (let [user (get-in db [:auth :user])]
       {:fx [[:dispatch [:settings/form
                         [:load {:user user
-                                :now  (current-time-ms)}]]]]})))
+                                :now  now}]]]]})))
 
 (rf/reg-event-fx :settings/edit-field
   {:doc  "User edited a form field. Broadcasts :edit into the machine —

--- a/examples/reagent/realworld/tags.cljs
+++ b/examples/reagent/realworld/tags.cljs
@@ -36,8 +36,6 @@
             [realworld.schema :as schema]
             [realworld.http :as rh]))
 
-(defn current-time-ms [] (.getTime (js/Date.)))
-
 ;; ============================================================================
 ;; THE MACHINE — :realworld/tags  (one region; Pattern-RemoteData lifecycle)
 ;; ============================================================================
@@ -179,10 +177,11 @@
   {:doc "Successful tags fetch. Folds the list + a load timestamp into
          the machine's `:data` via the `:set-tags` action; the region
          lands in `:loaded`."}
-  (fn handler-tags-loaded [_ [_ {:keys [value]}]]
+  [(rf/inject-cofx :realworld/now)]
+  (fn handler-tags-loaded [{:keys [realworld/now]} [_ {:keys [value]}]]
     {:fx [[:dispatch [:realworld/tags
                       [:fetch-succeeded {:tags (vec (:tags value))
-                                         :now  (current-time-ms)}]]]]}))
+                                         :now  now}]]]]}))
 
 (rf/reg-event-fx :tags/load-failed
   {:doc "Failed tags fetch. Folds a human-readable error message into

--- a/examples/reagent/realworld/test/realworld/auth_test.cljs
+++ b/examples/reagent/realworld/test/realworld/auth_test.cljs
@@ -22,9 +22,8 @@
                                   :image    nil}})
 
   (with-frame [f (rf/make-frame {:on-create    [:auth/initialise]
-                                 :fx-overrides {:rf.http/managed     :rf.http/managed.login-success
-                                                :auth.session/store  :rf/no-op
-                                                :auth.session/clear  :rf/no-op}})]
+                                 :fx-overrides {:rf.http/managed      :rf.http/managed.login-success
+                                                :auth.session/persist :rf/no-op}})]
     (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
 
     (rf/dispatch-sync [:auth/flow [:auth/login {:email "alice@example.com"

--- a/examples/reagent/realworld/test/realworld/core_test.cljs
+++ b/examples/reagent/realworld/test/realworld/core_test.cljs
@@ -19,9 +19,8 @@
 
 (defn app-smoke-test []
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
-                                 :fx-overrides {:rf.http/managed     :rf.http/managed.canned-success-empty
-                                                :auth.session/store  :rf/no-op
-                                                :auth.session/clear  :rf/no-op}})]
+                                 :fx-overrides {:rf.http/managed      :rf.http/managed.canned-success-empty
+                                                :auth.session/persist :rf/no-op}})]
     ;; After init: auth + articles slices and the :realworld/tags
     ;; and :settings/form machine snapshots are present. The tags
     ;; machine replaces the slice-form `:tags` resource; the

--- a/examples/reagent/realworld/test/realworld/settings_test.cljs
+++ b/examples/reagent/realworld/test/realworld/settings_test.cljs
@@ -46,8 +46,7 @@
 
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :rf.http/managed.canned-settings-save
-                                                :auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
+                                                :auth.session/persist :rf/no-op}})]
     ;; After :app/initialise → :settings/initialise → [:reset], the
     ;; machine sits at :neutral with empty :data.
     (let [snap (snapshot (rf/get-frame-db f))]
@@ -110,8 +109,7 @@
                           {:status 500 :body "server error"})
   (with-frame [f (rf/make-frame {:on-create    [:app/initialise]
                                  :fx-overrides {:rf.http/managed    :rf.http/managed.canned-settings-failure
-                                                :auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
+                                                :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"
                                             :username "alice"
@@ -141,8 +139,7 @@
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
   (with-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:auth.session/store :rf/no-op
-                                                :auth.session/clear :rf/no-op}})]
+                                 :fx-overrides {:auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"
                                             :username "alice"

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -51,7 +51,17 @@
 
 (rf/reg-fx :rf.http/managed.login-demo
   {:doc       "Demo override for `:rf.http/managed`. Identical behaviour
-               to the Reagent example's stub."
+               to the Reagent example's stub.
+
+               NOTE on the raw js/setTimeout below. The deferred work
+               is an fx invocation (the canned-success / canned-failure
+               stub), not a dispatch, so the framework's
+               `:dispatch-later` path is not a 1:1 swap. The timer is
+               purely demo-stub latency so the `:submitting` UI state
+               is observable. Production app code should never use raw
+               `js/setTimeout` — use `:dispatch-later` so framework
+               time controls (Tool-Pair time-travel,
+               `:dispatch-later` nil-override) still apply."
    :platforms #{:server :client}}
   (fn fx-managed-login-demo [frame-ctx args-map]
     (let [{:keys [url body]} (:request args-map)
@@ -59,6 +69,7 @@
           success?  (and login? (= good-password (:password body)))
           ok-stub   (registrar/handler :fx :rf.http/managed-canned-success)
           fail-stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      ;; Demo-only artificial latency — see the fx doc above.
       (js/setTimeout
         (fn []
           (cond


### PR DESCRIPTION
## Summary

Apply ten P3 idiom fixes flagged in the 2026-05-12 best-practice review (`ai/findings/best-practice-review-2026-05-12.md`). All changes are example-side; no `implementation/` touches.

## Beads addressed

- **rf2-ixla** — realworld handlers now read time through a registered `:realworld/now` cofx instead of calling `(.getTime (js/Date.))` inline. Pulls the wall-clock side-effect out of every handler that stamps `:loaded-at`, keeping handlers pure for reproducible tests and SSR hydration. Cofx registered in `realworld.http` (per the bead's hint); applied across `articles.cljs`, `comments.cljs`, `favorites.cljs`, `profile.cljs`, `settings.cljs`, `tags.cljs`.
- **rf2-n51c** — documented the `js/setTimeout` exception in the four demo-stub fxs (realworld, boot, login, helix-login, uix-login). Per the bead's option (b): the deferred work is an fx invocation (`:rf.http/managed-canned-success`), not a dispatch, so `:dispatch-later` is not a 1:1 swap. Each call site now carries a NOTE warning readers off copying the pattern into production code.
- **rf2-ctn2** — added `:submit-attempted?` to realworld `:auth :login-form` and `:auth :register-form` slices; flipped on submit; new `:auth.login-form/field-error` and `:auth.register-form/field-error` subs OR on `:submit-attempted?` per Pattern-Forms §Error visibility.
- **rf2-ytde** — same treatment for `:comment-form` and `:editor` slices. Editor's prior re-touch workaround dropped in favour of `:submit-attempted?`-driven reveal; new `:editor/field-error` and `:editor/form-error` subs.
- **rf2-xp9d** — comment-form's blank-body validation message moved off `:submit-error` to `:errors :body`. `:submit-error` reserved for HTTP transport failure path per Pattern-Forms §`:submit-error` vs `:errors`. Article-editor's whole-form prompt moved to `:errors :_form`.
- **rf2-44r1** — registered `FormSlice` schema for `[:auth :login-form]` and `[:auth :register-form]` in realworld. Added optional `:submit-attempted?` to `FormSlice` and `EditorSlice`.
- **rf2-7hju** — added `BootStagingSlice` schema and registered `[:boot/staging]` in the boot example.
- **rf2-bni5** — counter `:counter/initialise` keeps `reg-event-fx` (`:db + :fx`) per the bead's first option: added a prominent comment marking this as a deliberate perf-bucket widening for the instrumented build (`counter-perf`), not the canonical initialiser shape. Notes that idiomatic `:initialise` uses plain `reg-event-db`.
- **rf2-c2dx** — circle-drawer subs layered off a new `:drawer` Layer-2 sub; `:drawer/circles`, `:drawer/dialog`, `:drawer/can-undo?`, `:drawer/can-redo?` chain via `:<-`.
- **rf2-wvvc** — realworld auth collapsed `:auth.session/store` + `:auth.session/clear` into a single `:auth.session/persist` fx (arg shape `{:token <token-or-nil>}`). Tests updated to use the new id.

## Test plan

- [x] `clojure -M:test` (JVM) — passes
- [x] `npm run test:cljs` — 557 tests, 1318 assertions, 0 failures
- [x] `npm run test:browser` — 529 tests, 1289 assertions, 0 failures
- [x] `npm run test:elision` — clean
- [x] `npm run test:examples` (Playwright) — every example smoke passes (25/25)
- [x] `mkdocs build --strict` — no new warnings (185 pre-existing; same on base)

## Notes

- `:rf/now` cofx does NOT ship in `implementation/core` — the bead noted this might require an impl change. Per the constraint, registered example-scoped `:realworld/now` in `realworld.http` instead. No follow-up bead needed (the bead explicitly permits a per-example registration).