### PR TITLE
refactor(examples): migrate reagent/* examples to reagent-slim adapter; counter + login stay classic (rf2-6sy8)

### DIFF
--- a/examples/reagent/7Guis/cells/cells.cljs
+++ b/examples/reagent/7Guis/cells/cells.cljs
@@ -23,13 +23,13 @@
    simple S-expression-flavored calculator (numbers, +, -, *, /, cell refs).
    Excel-style infix is left for a future iteration; the shape of the
    solution doesn't change."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [clojure.set]
             [clojure.string :as str])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
@@ -294,6 +294,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cells/initialise])
   (rdc/render react-root [cells-grid]))

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
@@ -21,13 +21,13 @@
    would naturally live in user/library space (cf. re-frame-undo today).
    This example shows the canonical primitive pattern; productionising it is
    library work, not framework work."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -248,6 +248,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:drawer/initialise])
   (rdc/render react-root [drawer-view]))

--- a/examples/reagent/7Guis/crud/crud.cljs
+++ b/examples/reagent/7Guis/crud/crud.cljs
@@ -18,13 +18,13 @@
    - Derived filtered list                                 (CP-2 with :<-)
    - Schema-bound entity                                   (CP-8)"
   (:require [clojure.string :as str]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -223,6 +223,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:crud/initialise])
   (rdc/render react-root [crud-view]))

--- a/examples/reagent/7Guis/flight_booker/flight_booker.cljs
+++ b/examples/reagent/7Guis/flight_booker/flight_booker.cljs
@@ -20,14 +20,14 @@
    - Layered subs with :<- chains                          (CP-2)
    - Conditional UI driven by sub return values           (CP-4)
    - Smoke test exercising the constraint surface         (CP-1 checklist)"
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -207,6 +207,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:flight/initialise])
   (rdc/render root [flight-booker]))

--- a/examples/reagent/7Guis/temperature/temperature.cljs
+++ b/examples/reagent/7Guis/temperature/temperature.cljs
@@ -19,14 +19,14 @@
    - Pure derivation in subs (Celsius ↔ Fahrenheit)        (CP-2)
    - Schema-bound app-db slice                            (CP-8)"
   (:require [clojure.string :as str]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -174,6 +174,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:temp/initialise])
   (rdc/render root [temperature-converter]))

--- a/examples/reagent/7Guis/timer/timer.cljs
+++ b/examples/reagent/7Guis/timer/timer.cljs
@@ -20,14 +20,14 @@
    - One source of truth (elapsed)                        (state-in-app-db)
    - Layered subs for derived progress %                   (CP-2)
    - Controlled-input slider via dispatch on change       (CP-4)"
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves.
             [re-frame.schemas]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 (def TICK-MS 100)
@@ -201,6 +201,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:timer/initialise])
   (rdc/render root [timer-view]))

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -17,10 +17,10 @@
    framework-shipped `:rf.http/managed-canned-success` per Spec 014
    §Testing, so the canonical reply shape is preserved."
   (:require [clojure.string :as str]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Required for `rf/init!`.
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             ;; Loads the registrar so we can resolve the canned-success
             ;; fx for the per-URL stub below.
             [re-frame.registrar :as registrar]
@@ -116,7 +116,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
 
   ;; Override `:rf.http/managed` on the default frame so every child
   ;; loader's GET routes to the per-URL canned stub above. The

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -23,7 +23,7 @@
   http-managed-*.edn). Playwright's role is the cross-substrate sanity
   check: the same fx, the same reply shape, end-to-end through Reagent
   and Fetch."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             ;; Managed-HTTP ships in day8/re-frame2-http.
@@ -33,7 +33,7 @@
             ;; it, dispatching `:rf.http/managed` would fail with
             ;; :rf.error/no-such-fx.
             [re-frame.http-managed]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; -- App-db shape ------------------------------------------------------------
@@ -198,6 +198,6 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
   (rdc/render root [counter-app]))

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -64,7 +64,7 @@
    and `examples/reagent/7Guis/circle_drawer/circle_drawer.cljs`. In a real
    codebase this would split per CP-6 conventions across schema / events /
    subs / views / machines / tests files."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             ;; The Spec 010 schema-attachment ns lives in
@@ -86,7 +86,7 @@
             ;; :rf.error/no-such-fx.
             [re-frame.http-managed]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
 ;; ============================================================================
@@ -673,7 +673,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   ;; Install the demo override so `:rf.http/managed` calls route to the
   ;; in-process canned-stub fxs above. The example runs standalone — no
   ;; backend required.

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -29,7 +29,7 @@
    the demo entry below installs a canned-stub override so the headless
    smoke and Playwright run without a network."
   (:require [clojure.string :as str]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Managed-HTTP ships in day8/re-frame2-http.
             ;; Requiring re-frame.http-managed at app boot is what
@@ -48,7 +48,7 @@
             ;; :rf.error/ssr-artefact-missing.
             [re-frame.ssr]
             [re-frame.registrar :as registrar]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [realworld.schema]
             [realworld.http]
             [realworld.routing :as routing]
@@ -306,7 +306,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   ;; Override :rf.http/managed on the default frame so all the realworld
   ;; feature HTTP calls land on the demo stub (no real backend required).
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -11,7 +11,7 @@
    - `:rf.route/handle-url-change` for popstate / initial load
    - `:rf.route/id` and `:rf.route/params` for route reads
    - `:rf/url-requested` for user-initiated anchor clicks"
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
             ;; Routing ships in day8/re-frame2-routing.
@@ -19,7 +19,7 @@
             ;; its load-time hook + reg-sub registrations; without it,
             ;; rf/reg-route below throws :rf.error/routing-artefact-missing.
             [re-frame.routing]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.views-macros :refer [reg-view with-frame]]))
 
 ;; ============================================================================
@@ -167,7 +167,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:routing.app/initialise])
   (install-router!)
   (rdc/render react-root [root-view]))

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -53,8 +53,8 @@
             ;; re-exports raise `:rf.error/ssr-artefact-missing`.
             [re-frame.ssr :as ssr]
             #?(:cljs [cljs.reader])
-            #?(:cljs [reagent.dom.client :as rdc])
-            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
+            #?(:cljs [reagent2.dom.client :as rdc])
+            #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -256,7 +256,7 @@
      ;; Pass the adapter spec map directly. There is no
      ;; default-adapter registry — each adapter ns exports an `adapter`
      ;; var the consumer requires and passes here.
-     (rf/init! reagent-adapter/adapter)
+     (rf/init! reagent-slim-adapter/adapter)
      ;; If the page was server-rendered, `:rf/hydrate` replaces app-db with
      ;; the payload's :rf/app-db slice (locked :replace-app-db policy per
      ;; Spec 011 §The :rf/hydrate event). On a "client-only" load (no

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -12,9 +12,9 @@
   → :idle, then a fourth submit that fails the `:under-retry-limit`
   guard and lands at `:locked-out`. The Playwright spec walks through
   exactly that path, so the stub needs to fail every request."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [state-machine-walkthrough.core])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))
 
@@ -90,7 +90,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   ;; Install the canned-failure override on the default frame so every
   ;; `:rf.http/managed` request resolves :failure. The chapter's
   ;; lockout scenario depends on three consecutive failures.

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -1,9 +1,9 @@
 (ns todomvc.core
   (:require [clojure.string :as str]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.views]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [todomvc.db]
             [todomvc.events]
             [todomvc.subs]
@@ -35,7 +35,7 @@
 
 (defn ^:export run []
   ;; Pass the adapter spec map directly — no registry.
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:todo/initialise])
   (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
   (.addEventListener js/window "hashchange"

--- a/examples/reagent/todomvc/views.cljs
+++ b/examples/reagent/todomvc/views.cljs
@@ -1,6 +1,6 @@
 (ns todomvc.views
   (:require [clojure.string :as str]
-            [reagent.core :as reagent]
+            [reagent2.core :as reagent]
             [re-frame.core :as rf]
             [re-frame.views])
   (:require-macros [re-frame.views-macros :refer [reg-view]]))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -34,9 +34,9 @@
 
    Run standalone via `npm run test:examples`; the mock server keeps
    the app self-contained."
-  (:require [reagent.dom.client :as rdc]
+  (:require [reagent2.dom.client :as rdc]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
             [websocket.schema]
@@ -132,7 +132,7 @@
     (rdc/create-root (js/document.getElementById "app"))))
 
 (defn ^:export run []
-  (rf/init! reagent-adapter/adapter)
+  (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:ws.app/initialise])
   (when react-root
     (rdc/render react-root [views/root-view])))


### PR DESCRIPTION
## Summary

Per direction lock (2026-05-12): reagent-slim becomes the primary adapter
for `examples/reagent/*` going forward. Four examples are deliberately
kept on classic Reagent to demonstrate the classic path still works.

## Migrated to reagent-slim (16 examples)

- `boot`
- `managed_http_counter`
- `nine_states`
- `realworld`
- `routing`
- `ssr`
- `state_machine_walkthrough`
- `todomvc`
- `websocket`
- `7Guis/{cells, circle_drawer, crud, flight_booker, temperature, timer}`
- `counter_slim_and_fast` was already slim — unchanged

## Kept on classic Reagent (4 examples)

- `counter` — canonical minimal mount; guide ch.02 reference. Also the
  bundle-comparison control bundle for `scripts/check-counter-slim-and-fast.cjs`
  (the stock-Reagent sentinels need a stock-Reagent bundle to assert
  against; counter is that bundle).
- `login` — canonical state-machine + form example; classic for variety.
- `counter_with_stories` — uses `r/with-let` in the parity-badge
  Form-3 demo. reagent-slim deliberately drops `with-let` (per
  IMPL-SPEC §2.4 / DECISION-7). The example's whole pedagogical point
  is showing the three Form-1/2/3 shapes, so keeping it classic
  preserves the demonstration target rather than rewriting it.
- `long_running_work` — load-bearing `r/with-let` cleanup in the
  work-bench wrapper dispatches `[:work/flow [:cancel]]` on unmount.
  That cleanup is the canonical demo of the parent-unmount cascade
  (Pattern-LongRunningWork's binding claim), not decorative.

## Per-example change shape

Each migrated `core.cljs` / equivalent: mechanical adapter swap.

```clojure
:require [reagent.dom.client :as rdc]
   -> [reagent2.dom.client :as rdc]
:require [re-frame.adapter.reagent :as reagent-adapter]
   -> [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
(rf/init! reagent-adapter/adapter)
   -> (rf/init! reagent-slim-adapter/adapter)
```

Plus `todomvc/views.cljs`: `[reagent.core :as reagent]` → `[reagent2.core :as reagent]`
to keep `(reagent/atom ...)` resolving (the only non-core Reagent surface
used by any migrated example that reagent-slim does ship).

No `shadow-cljs.edn` or per-example `package.json` changes needed —
`adapters/reagent-slim/src` is already on the build's source-paths
because `counter_slim_and_fast` works under the current wiring.

## Verification

All test suites green:

- `npm run test:cljs` — 557 tests, 1318 assertions, 0 fail / 0 err
- `npm run test:browser` — 529 tests, 1289 assertions, 0 fail / 0 err
- `npm run test:browser-prod-elision` — 11 tests, 33 assertions, 0/0
- `npm run test:browser-schemas-boundary-prod` — 5 tests, 7 assertions, 0/0
- `npm run test:bundle-comparison` — PASS (3 contracts all OK)
- `npm run test:bundle-isolation` — PASS
- `npm run test:elision` — PASS
- `npm run test:examples` — every migrated example PASS; every kept-classic
  example PASS. The one unrelated failure (`login-uix`) is pre-existing
  on `origin/main` and outside this PR's scope (`examples/uix/`).

Per-build shadow-cljs compile: zero warnings for every migrated example.

## Test plan

- [x] All 16 migrated examples PASS under `npm run test:examples`
- [x] All 4 kept-classic examples PASS under `npm run test:examples`
- [x] Bundle-comparison contract (counter vs counter-slim-and-fast) preserved
- [x] All other test suites green

## Notes for review

The bead description floats whether `counter` should also move to slim
(to make slim the primary recommendation pedagogically). I left it
classic per the bead's "don't migrate counter in this PR" note — that's
the guide-aware follow-up Mike's call.