### PR TITLE
refactor(views): split views.cljs into views.{provider, source-coord-annotation, warn-once} (rf2-lh7p)

### DIFF
--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -15,156 +15,49 @@
   to obtain the wrapped fn and use `[(rf/view :id) args]` as the
   hiccup head.
 
-  Per rf2-wbnl this ns no longer statically `:require`s `reagent.core`.
-  The in-flight Reagent component is read through the late-bind hook
-  `:adapter/current-component`, which the active adapter ns publishes
-  at load time. The classic bridge points the hook at
-  `reagent.core/current-component`; the slim adapter points it at
-  `reagent2.core/current-component`. With no adapter installed the
-  hook returns nil and the React-context tier of the resolution chain
-  is skipped — equivalent to a non-Reagent render context, which is
-  what JVM / headless tests already rely on."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+  Per rf2-lh7p the file has been split into three internally-cohesive
+  sub-namespaces; this ns is now the orchestration entry point that
+  ties them together:
+
+    - `re-frame.views.provider`                — frame-provider + the
+                                                 React-context bridge
+                                                 and per-render
+                                                 instance-token
+                                                 machinery
+    - `re-frame.views.source-coord-annotation` — Spec 006 source-coord
+                                                 DOM annotation walk
+    - `re-frame.views.warn-once`               — per-process warn-once
+                                                 caches (non-DOM root,
+                                                 plain-fn-under-non-
+                                                 default-frame)
+
+  The publicly-referenced surface is re-exported via plain `def` aliases
+  below so existing call sites — `re-frame.core/reg-view*`, the test
+  files, the late-bind hook table, and the adapter ns docstrings —
+  continue to resolve through this ns unchanged.
+
+  The `*render-key*` dynamic var lives in THIS ns (rather than under
+  `re-frame.views.provider` alongside the rest of the instance-token
+  machinery) because tests read it via `re-frame.views/*render-key*`
+  from inside a render-fn while the wrapper below binds the same Var.
+  Putting the canonical Var here makes the read and the binding hit
+  identical Vars — a `(def ^:dynamic *render-key* provider/*render-key*)`
+  re-export would create a SECOND Var whose binding the test wouldn't
+  observe."
+  (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
-            [re-frame.source-coords :as source-coords]
-            [re-frame.adapter.context :as adapter-context]
-            [re-frame.trace :as trace]))
+            [re-frame.views.provider :as provider]
+            [re-frame.views.source-coord-annotation :as source-coord]
+            [re-frame.views.warn-once :as warn-once]))
 
-;; ---- the React context for frame propagation -----------------------------
+;; ---- *render-key* (rf2-piag / rf2-t5tx) ----------------------------------
 ;;
-;; Per rf2-3yij Decision 2 the React Context object lives in
-;; `re-frame.adapter.context` so the UIx adapter (and any future
-;; React-shaped adapter) reads the *same* context — not a parallel one.
-;; The Reagent code below references it via the alias rather than
-;; minting a new createContext call.
-
-(def ^:private frame-context adapter-context/frame-context)
-
-(defn- frame-provider-component
-  "The single Reagent component that backs every frame-provider. It takes
-  the frame keyword as its first render-time arg and scopes that keyword
-  to its subtree via React context. One built component services every
-  frame — the keyword lives in the Provider's `:value`, not in a
-  closure."
-  [frame-kw & children]
-  (into [:> (.-Provider frame-context) {:value frame-kw}] children))
-
-(defn build-frame-provider
-  "Used by re-frame.adapter.reagent/register-context-provider. Returns
-  a Reagent component that scopes a frame keyword to its subtree.
-
-  Zero-arity (rf2-4y60): the returned component takes the frame keyword
-  at render time, and a single built component services every frame, so
-  there is nothing to specialise at build time. Substrates whose
-  `register-context-provider` slot receives a frame-keyword on call (per
-  Spec 006 §Frame-provider via React context) discard it and call this
-  with no args."
-  []
-  frame-provider-component)
-
-(defn frame-provider
-  "User-facing Reagent component that scopes a frame keyword to its
-  subtree. Inside the subtree, `(rf/dispatcher)` / `(rf/subscriber)`
-  capture the named frame; reg-view-registered descendants resolve to
-  it via React context.
-
-      [rf/frame-provider {:frame :session}
-       [header]
-       [main-area]
-       [footer]]
-
-  `props` is a map carrying `:frame frame-id`. Children render under
-  that frame (variadic — zero, one, or many).
-
-  When `:frame` is missing or `nil`, falls through to `:rf/default` —
-  matches the no-provider behaviour. This is the defensive default per
-  the rf2-sixo decision; an explicit error would catch typos but would
-  also break tooling-generated trees that elide the prop.
-
-  Per Spec 002 §What `frame-provider` is. `build-frame-provider` is the
-  lower-level substrate hook; this fn is the canonical user-facing
-  surface."
-  [props & children]
-  (let [frame-kw (or (:frame props) :rf/default)]
-    (into [(build-frame-provider) frame-kw] children)))
-
-;; ---- in-flight Reagent component (rf2-wbnl) ------------------------------
-;;
-;; The active adapter (classic bridge or slim) publishes its Reagent build's
-;; `current-component` fn through the `:adapter/current-component` late-bind
-;; hook at ns-load time. This ns must NOT statically `:require [reagent.core]`
-;; — doing so hard-couples views.cljs to stock Reagent and silently shadows
-;; the slim adapter's components in mixed-mode environments. Per the bead's
-;; resolution-chain note: dynamic var → adapter.current-component
-;; (late-bind) → nil. When no adapter has installed the hook the call returns
-;; nil and the React-context tier is skipped.
-
-(defn- current-component
-  "Resolve the in-flight Reagent component via the active adapter's hook.
-  Returns nil when no adapter has registered the hook (JVM / headless
-  builds; no-adapter tests). Per rf2-wbnl."
-  []
-  (when-let [hook (late-bind/get-fn :adapter/current-component)]
-    (hook)))
-
-;; ---- frame resolution at render time -------------------------------------
-
-(def ^:dynamic *current-frame* nil)
-
-(defn current-frame
-  "Resolution chain (per Spec 002 §Reading the frame from React context):
-    1. Dynamic var (set by with-frame).
-    2. Closest enclosing frame-provider via React context.
-    3. :rf/default.
-
-  Reagent-specific: the React-context tier reads `(.-context cmp)` on
-  the in-flight Reagent component. Reagent's class-component machinery
-  surfaces context to components whose `:contextType` matches the
-  context object — that is the wiring `reg-view*` attaches via
-  `{:contextType frame-context}`. Plain Reagent fns lack this wiring,
-  so `(.-context cmp)` is React's empty default — they fall through
-  to `:rf/default`. This narrowness is by design: it is what makes the
-  `:rf.warning/plain-fn-under-non-default-frame-once` warning
-  meaningful (rf2-d3k3 / rf2-d4sf).
-
-  Per rf2-d4sf the keyword/string check tolerates Reagent's
-  prop-stringified shape: when a frame-provider is reached via
-  `[:> Provider {:value :foo} ...]` interop, `convert-prop-value`
-  rewrites `:foo` to `\"foo\"` before React sees it. The shared
-  coercion in `re-frame.adapter.context/coerce-context-value` undoes
-  that stringification so the Reagent path returns a keyword
-  regardless of how the Provider was authored."
-  []
-  (or frame/*current-frame*
-      (when-let [cmp (current-component)]
-        (adapter-context/coerce-context-value (.-context cmp)))
-      :rf/default))
-
-;; ---- per-render identity (rf2-piag / rf2-t5tx) ----------------------------
-;;
-;; Render-trace entries carry a `:render-key` of shape
-;; `[<view-id> <instance-token>]`. Per rf2-t5tx Option C the tuple is the
-;; canonical identity: the view-id (registry keyword) names the kind; the
-;; instance-token disambiguates concurrently-mounted instances of the same
-;; kind. Tokens are minted at mount time from a process-wide counter and
-;; are NOT correlated across runs — they're for in-run instance discrimination
-;; only (per Spec 004 §Render-tree primitives).
-;;
-;; For renders that did not enter through reg-view / reg-view* (plain
-;; Reagent fns), `*render-key*` is unbound at trace-emission time; consumers
-;; treat that as `[:rf.view/anonymous nil]` (per the bead resolution).
-
-(defonce ^:private instance-counter (atom 0))
-
-(defn mint-instance-token!
-  "Return a fresh integer token for a freshly-mounted view instance. The
-  counter is process-wide and monotonic; values are unique within a
-  single process run but carry no cross-run correlation guarantee."
-  []
-  (swap! instance-counter inc))
+;; Bound by the `reg-view*` wrapper below for the duration of each render.
+;; Lives here (the public ns) so `re-frame.views/*render-key*` is the
+;; canonical Var that wrapper-binding and consumer-reads share — see
+;; the ns docstring above for why this can't move under provider.
 
 (def ^:dynamic *render-key*
   "The `:render-key` for the in-flight render — a tuple
@@ -182,20 +75,46 @@
   []
   (or *render-key* [:rf.view/anonymous nil]))
 
-(defn- reagent-component-token
-  "Return the per-component-instance token, minting one on first call.
-  Stored on the Reagent component object as `.-rfInstanceToken` so the
-  same mounted instance reuses the token across re-renders. When called
-  outside a Reagent component (direct invocation in headless tests),
-  mints a fresh token per call — that mirrors the per-mount-fresh
-  semantics for tests that simulate one mount per call."
-  []
-  (if-let [cmp (current-component)]
-    (or (.-rfInstanceToken ^js cmp)
-        (let [tok (mint-instance-token!)]
-          (set! (.-rfInstanceToken ^js cmp) tok)
-          tok))
-    (mint-instance-token!)))
+;; ---- re-exported public surface ------------------------------------------
+;;
+;; Plain `def` aliases for the publicly-referenced ordinary fns / data
+;; surfaces. Each one is reached by external call sites through
+;; `re-frame.views/<name>`:
+;;
+;;   re-frame.adapter.reagent + runtime_cljs_test → frame-provider, build-frame-provider
+;;   late-bind hook table (:adapter/current-frame),
+;;     views-current-component-cljs-test          → current-frame
+;;   render_key_cljs_test, elision_probe          → mint-instance-token!
+;;   source_coord_parity_cljs_test                → #'format-source-coord
+;;   warn_once_fixture_isolation_cljs_test        → clear-warned-non-dom-roots!
+;;   late-bind hook table                         → maybe-warn-plain-fn-under-non-default-frame!,
+;;                                                  clear-plain-fn-warned-pairs!
+;;
+;; Keeping these as plain defs (rather than `:refer`-imported) makes
+;; `#'re-frame.views/<name>` resolve in this ns — the CLJS analyser
+;; tracks each `def` form's Var under the defining ns, so
+;; `:refer` does not surface a Var under the consuming ns. Functions are
+;; resolved by value, so a `def` alias works for invocation; only
+;; dynamic-var binding semantics force the `*render-key*` exception
+;; above.
+
+(def frame-provider provider/frame-provider)
+(def build-frame-provider provider/build-frame-provider)
+(def current-frame provider/current-frame)
+(def mint-instance-token! provider/mint-instance-token!)
+
+(def format-source-coord source-coord/format-source-coord)
+
+(def clear-warned-non-dom-roots! warn-once/clear-warned-non-dom-roots!)
+(def clear-plain-fn-warned-pairs! warn-once/clear-plain-fn-warned-pairs!)
+(def maybe-warn-plain-fn-under-non-default-frame!
+  warn-once/maybe-warn-plain-fn-under-non-default-frame!)
+
+;; The React-context object is consumed by `reg-view*` below (the
+;; `:contextType` static-field) and by the warn-once helpers in
+;; `re-frame.views.warn-once`. Aliased privately here for parity with
+;; the pre-split shape — no external caller reaches for it.
+(def ^:private frame-context provider/frame-context)
 
 (defn- emit-render-trace!
   "Emit a `:view/render` trace event tagged with the in-flight
@@ -211,141 +130,7 @@
     (when-let [emit! (late-bind/get-fn :trace/emit!)]
       (emit! :view :view/render
              {:render-key render-key
-              :frame      (current-frame)}))))
-
-;; ---- source-coord DOM annotation (rf2-z7f7) -------------------------------
-;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) the Reagent
-;; substrate adapter MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"`
-;; on each registered view's root DOM element when `interop/debug-enabled?`
-;; is true. The annotation lets pair-shaped tools (re-frame-pair,
-;; re-frame-10x, IDE jump-to-source) map a clicked DOM node back to the
-;; reg-view call site.
-;;
-;; Contract details:
-;;
-;;   - The id is a registry keyword `<ns>/<sym>`. Combined with the
-;;     captured `:line` / `:column` (from `(meta &form)` at reg-view
-;;     macro-expansion time), the attribute value is
-;;     `<ns>:<sym>:<line>:<col>`. `<col>` is `?` when the column was
-;;     not captured (the column-key is optional per Spec 001).
-;;
-;;   - The wrapper inspects the user's render-fn output:
-;;       * `[:tag {...attrs} & children]` → merge :data-rf2-source-coord
-;;         into attrs.
-;;       * `[:tag & children]` (no attrs map)            → splice an attrs
-;;         map in.
-;;       * `[fn-or-component-or-fragment …]` (head is a fn / class / `:>`
-;;         / React-fragment marker) → SKIP and emit a one-shot warning
-;;         per id. Pair-tool consumers fall back to the registry's
-;;         `:rf/id` for these cases (per Spec 006 §Source-coord
-;;         annotation, documented Fragment exemption).
-;;       * Form-2: when the render-fn returns a fn (`(fn [args] body)`),
-;;         we recurse on the inner-fn's output the next time the wrapper
-;;         is called — Reagent invokes the inner fn during the SAME
-;;         render cycle, but the wrapper's annotation runs OUTSIDE
-;;         Reagent's per-render machinery. The simplest correct shape
-;;         is to wrap the returned fn so the inner output gets walked
-;;         too.
-;;
-;;   - Production elision: every annotation site sits inside
-;;     `(when interop/debug-enabled? ...)` so the closure compiler
-;;     constant-folds the entire branch under `:advanced` +
-;;     `goog.DEBUG=false`. Per Spec 009 §Production builds.
-
-(defn- format-source-coord
-  "Render the registry slot's captured coords as the attribute value
-  shape `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name
-  give us `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured
-  coords (CLJS reg-view macro at expansion time). Per Spec 006
-  §Source-coord annotation."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
-
-(defonce ^:private warned-non-dom-roots (atom #{}))
-
-(defn clear-warned-non-dom-roots!
-  "Reset the warn-once cache for non-DOM-root warnings. Tests use this
-  between cases (via `reset-runtime-fixture` and the chained
-  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
-  encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
-  []
-  (reset! warned-non-dom-roots #{})
-  nil)
-
-(defn- warn-non-dom-root!
-  "Emit a one-shot warning per id that the reg-view'd component returned
-  a non-DOM root (a fn/class component, or a React Fragment). Pair tools
-  fall back to the registry's `:rf/id`; documented exemption per Spec 006
-  §Source-coord annotation."
-  [id head]
-  (when-not (contains? @warned-non-dom-roots id)
-    (swap! warned-non-dom-roots conj id)
-    (when (exists? js/console)
-      (.warn js/console
-        (str "[re-frame] reg-view " id " — root element is "
-             (pr-str head) "; data-rf2-source-coord skipped (Spec 006 "
-             "§Source-coord annotation: pair tools fall back to :rf/id "
-             "for non-DOM roots).")))))
-
-(defn- dom-tag?
-  "True if `head` is a Hiccup DOM-tag keyword. Reagent's React-fragment
-  marker is `:<>`; the `:>` (interop) marker is for arbitrary React
-  components — both are exempt from annotation per Spec 006."
-  [head]
-  (and (keyword? head)
-       (not= :<> head)
-       (not= :> head)))
-
-(defn- inject-source-coord-attr
-  "Walk the user's render-fn output and merge :data-rf2-source-coord
-  into the root element's attrs map. Called from inside the wrapper
-  (gated on interop/debug-enabled?). Returns the (possibly rewritten)
-  hiccup. Non-DOM roots are returned unchanged after a one-shot
-  warning per Spec 006 §Source-coord annotation.
-
-  Form-2: when `out` is a fn, return a fn that recurses on the inner
-  output — Reagent's renderer will call our returned fn just like
-  the user's fn, and we get a chance to annotate the inner hiccup."
-  [id coord-attr out]
-  (cond
-    ;; Form-2: render-fn returned a fn. Wrap so the inner fn's output
-    ;; is also annotated when Reagent calls through.
-    (fn? out)
-    (fn form-2-wrapper [& args]
-      (inject-source-coord-attr id coord-attr (apply out args)))
-
-    ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
-    (and (vector? out) (dom-tag? (first out)))
-    (let [head     (first out)
-          maybe-attrs (second out)]
-      (if (map? maybe-attrs)
-        ;; Existing attrs map — merge in (don't overwrite if user
-        ;; already set it for some reason).
-        (let [merged (if (contains? maybe-attrs :data-rf2-source-coord)
-                       maybe-attrs
-                       (assoc maybe-attrs :data-rf2-source-coord coord-attr))]
-          (into [head merged] (drop 2 out)))
-        ;; No attrs map — splice one in between head and children.
-        (into [head {:data-rf2-source-coord coord-attr}] (rest out))))
-
-    ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
-    ;; with a one-shot warning. Pair tools fall back to :rf/id.
-    :else
-    (do
-      (when (vector? out)
-        (warn-non-dom-root! id (first out)))
-      out)))
+              :frame      (provider/current-frame)}))))
 
 ;; ---- reg-view -------------------------------------------------------------
 
@@ -419,10 +204,10 @@
         wrap-applied?      (some? wrapped-by-adapter)
         render-fn          (if wrap-applied? wrapped-by-adapter render-fn)
         coord-attr (when (and interop/debug-enabled? (not wrap-applied?))
-                     (format-source-coord id metadata))
+                     (source-coord/format-source-coord id metadata))
         wrapped (with-meta
                   (fn frame-aware-view [& args]
-                    (let [tok        (reagent-component-token)
+                    (let [tok        (provider/reagent-component-token)
                           render-key [id tok]]
                       (binding [*render-key* render-key]
                         (emit-render-trace! render-key)
@@ -438,196 +223,8 @@
                         (let [out (performance/mark-and-measure :render id
                                     (apply render-fn args))]
                           (if (and interop/debug-enabled? (not wrap-applied?))
-                            (inject-source-coord-attr id coord-attr out)
+                            (source-coord/inject-source-coord-attr id coord-attr out)
                             out)))))
                   {:contextType frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
-
-;; ---- plain-fn-under-non-default-frame warning (rf2-d3k3) -----------------
-;;
-;; Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-default-
-;; frame warning: a plain Reagent fn (not registered via `reg-view`, so
-;; without the `^{:contextType frame-context}` metadata `reg-view` attaches)
-;; cannot read the surrounding React-context frame. When such a fn renders
-;; inside a non-default `frame-provider` and calls `(rf/subscribe ...)` or
-;; `(rf/dispatch ...)`, the resolution chain falls through to `:rf/default`
-;; — almost certainly not what the author intended.
-;;
-;; The runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` at
-;; most once per `(component-id, non-default-frame-id)` pair, per Spec 004
-;; §The footgun is loud, but at most once per (component, non-default-frame)
-;; pair. Detection sits at subscribe-time per Spec 006 §706: subscribe
-;; consults this helper through the late-bind hook table; the JVM build
-;; never sees this ns and the lookup returns nil there.
-;;
-;; Suppression: a process-wide `defonce` atom set keyed by [component-id
-;; frame-id] pairs. The suppression cache survives hot-reload (`defonce`)
-;; so repeated re-renders of the same plain fn produce exactly one
-;; warning per pair across the JS process. Per Spec 004 §The suppression
-;; cache: destroying and re-creating a frame resets the warning history
-;; for that frame — implemented by `clear-plain-fn-warned-pairs-for-frame!`
-;; which the frame-destroy path can call (today the cache is process-wide
-;; and the helper is exported for tests / future destroy-frame integration).
-;;
-;; Production-elision: every code path is gated on `interop/debug-enabled?`.
-;; Under :advanced + `goog.DEBUG=false` the closure compiler constant-folds
-;; the gate and the entire detection branch, the trace emission, and the
-;; `console.warn` fallback are dead-code-eliminated. Per Spec 009
-;; §Production builds.
-
-(defonce ^:private warned-plain-fn-frame-pairs
-  ;; Set of `[component-id frame-id]` pairs already warned about. Per
-  ;; Spec 004 §The suppression cache.
-  (atom #{}))
-
-(defn clear-plain-fn-warned-pairs!
-  "Reset the warn-once suppression cache. Tests use this between cases
-  so each case starts from a clean slate. Per Spec 004 §The suppression
-  cache."
-  []
-  (reset! warned-plain-fn-frame-pairs #{})
-  nil)
-
-(defn- plain-fn-component-id
-  "Identify the rendering component for warn-once keying. Reagent
-  components carry the user's render-fn as `.-cljsLegacyRender` (form-1)
-  or as the bound fn proper. We prefer `displayName` (which Reagent /
-  React tend to set for named fns), then fall back to the constructor's
-  `name`, then a string repr. The id is opaque text used only as the
-  cache key and the warning's `:fn-name` payload — stable across renders
-  of the same component, distinct across different component fns."
-  [cmp]
-  (or (when-let [n (.-displayName ^js cmp)]
-        (when (and (string? n) (not= "" n)) n))
-      (let [c (.-constructor ^js cmp)
-            n (when c (.-name ^js c))]
-        (when (and (string? n) (not= "" n) (not= "Object" n)) n))
-      (pr-str cmp)))
-
-(defn- read-react-context-frame
-  "Read the value the closest enclosing frame-provider has pushed onto
-  the shared React context. Per rf2-d4sf this is now a thin wrapper
-  around `adapter-context/current-frame` minus the dynamic-var tier —
-  the warn-once detection below has already filtered to the case where
-  `*current-frame*` is unset (Condition 4), so we want the React-
-  context value alone.
-
-  Reagent's `convert-prop-value` (reagent.impl.template) stringifies
-  named values (keywords, symbols) when they are passed as React
-  prop values: `[:> Provider {:value :foo} ...]` reaches React with
-  `value=\"foo\"`, not the keyword. The shared coercion in
-  `re-frame.adapter.context` undoes that conversion so the detection
-  logic sees a keyword regardless of whether the closest Provider was
-  reached via `[:> ...]` interop (stringified) or through a plain-CLJS
-  object path (preserved). The createContext default — `:rf/default`
-  — survives as a keyword because it never passed through Reagent's
-  prop-conversion."
-  []
-  (let [v (.-_currentValue ^js adapter-context/frame-context)]
-    (cond
-      (keyword? v)                  v
-      (and (string? v) (not= "" v)) (keyword v))))
-
-(defn maybe-warn-plain-fn-under-non-default-frame!
-  "Detection per Spec 006 §706 (plain-fn-under-non-default-frame
-  warning). Called from `re-frame.subs/subscribe` after frame
-  resolution; `resolved-frame-id` is the frame the subscribe call
-  routed to.
-
-  Conditions for the warning to fire (all must hold):
-    1. We are mid-render — `(current-component)` returns a component.
-    2. The component is NOT a reg-view-wrapped one — its `contextType`
-       is not the shared `frame-context`. (reg-view-wrapped components
-       carry the `:contextType` so they read the surrounding Provider's
-       value into `(.-context cmp)`; plain fns do not.)
-    3. The closest enclosing Provider names a non-default frame.
-    4. The dynamic `*current-frame*` tier is unset — i.e. no `with-frame`
-       binding shadows the React-context read. When `with-frame` IS set,
-       the plain fn picks up the frame correctly via the dynamic var,
-       and no warning is needed.
-
-  Suppression: warn-once per `[component-id non-default-frame-id]` pair.
-  Subsequent renders of the same plain fn under the same Provider stay
-  silent. Per Spec 004 §at most once per (component, non-default-frame)
-  pair.
-
-  Returns nil. Production builds elide the entire body via the
-  `interop/debug-enabled?` gate the trace surface itself rides — the
-  call site in subs already pays a `(when interop/debug-enabled? ...)`
-  test, so this fn is reached only in dev / JVM (where it is unbound
-  via late-bind and not called)."
-  [resolved-frame-id _query-v]
-  (when interop/debug-enabled?
-    (let [cmp (current-component)]
-      ;; Condition 1: must be mid-render.
-      (when (some? cmp)
-        ;; Condition 2: component must NOT be reg-view-wrapped. The
-        ;; sentinel is the `contextType` static — reg-view's wrapper
-        ;; sets it to `frame-context`; plain fns leave it unset (or
-        ;; React's empty default).
-        (let [ctx-type (some-> ^js cmp .-constructor .-contextType)]
-          (when-not (identical? ctx-type adapter-context/frame-context)
-            ;; Condition 3: closest enclosing Provider names a
-            ;; non-default frame.
-            (let [provider-frame (read-react-context-frame)]
-              (when (and (keyword? provider-frame)
-                         (not= :rf/default provider-frame))
-                ;; Condition 4: no with-frame binding shadowing the
-                ;; React-context read.
-                (when (nil? frame/*current-frame*)
-                  (let [fn-id (plain-fn-component-id cmp)
-                        pair  [fn-id provider-frame]]
-                    (when-not (contains? @warned-plain-fn-frame-pairs pair)
-                      (swap! warned-plain-fn-frame-pairs conj pair)
-                      (let [reason (str "Plain Reagent fns do not pick "
-                                        "up the surrounding frame; their "
-                                        "dispatch/subscribe targets "
-                                        ":rf/default. To capture the "
-                                        "surrounding frame, register the "
-                                        "view via reg-view.")]
-                        (trace/emit! :warning
-                                     :rf.warning/plain-fn-under-non-default-frame-once
-                                     {:fn-name        fn-id
-                                      :rendered-under provider-frame
-                                      :routed-to      resolved-frame-id
-                                      :reason         reason
-                                      :recovery       :warned-and-replaced})
-                        ;; Per Spec 004 §The footgun is loud: in dev,
-                        ;; the runtime also `console.warn`s the first
-                        ;; occurrence. The trace event is the
-                        ;; programmatic surface (10x, re-frame-pair);
-                        ;; the console message is the human-eyeballs
-                        ;; surface.
-                        (when (exists? js/console)
-                          (.warn js/console
-                            (str "[re-frame] :rf.warning/plain-fn-under-"
-                                 "non-default-frame-once — " fn-id
-                                 " rendered under " provider-frame
-                                 "; subscribe/dispatch routed to "
-                                 resolved-frame-id ". " reason)))))))))))))
-    nil))
-
-;; Publish through the late-bind hook table so re-frame.subs (a leaf
-;; namespace, .cljc, JVM-runnable) can call the helper without
-;; statically requiring this CLJS-only ns. JVM builds never load this
-;; file; the lookup returns nil there and subs no-ops the warning
-;; check. Per re-frame.late-bind §Hook keys.
-(late-bind/set-fn! :views/maybe-warn-plain-fn-under-non-default-frame!
-                   maybe-warn-plain-fn-under-non-default-frame!)
-(late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
-                   clear-plain-fn-warned-pairs!)
-
-;; Per rf2-4edk: register a clear of the `warned-non-dom-roots` cache
-;; under the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and this views ns all
-;; contribute a clear-step; `reset-runtime-fixture` invokes the top of
-;; the chain and every contributor's reset runs. Production behaviour
-;; is unchanged: the warn-once `defonce` is still per-process for users;
-;; only test-time clearing is new.
-(let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-  (late-bind/set-fn! :adapter/clear-warn-once-caches!
-    (fn views-clear-warn-once-caches! []
-      (clear-warned-non-dom-roots!)
-      (when previous (previous))
-      nil)))

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -1,0 +1,196 @@
+(ns re-frame.views.provider
+  "Frame-provider component + per-render identity machinery for the
+  Reagent-side views ns. Per rf2-lh7p — split out of `re-frame.views`
+  so the views file stays focused on registration orchestration.
+  Re-frame.views re-exports the publicly-referenced surface
+  (`frame-provider`, `build-frame-provider`, `current-frame`,
+  `mint-instance-token!`, `current-render-key`, `*render-key*`) so
+  existing call sites continue to work unchanged.
+
+  Three cohesive concerns live here:
+
+  1. `frame-provider` — the user-facing Reagent component that scopes
+     a frame keyword to its subtree via React context. The actual
+     React Context object is owned by `re-frame.adapter.context` so
+     adapters across substrates (Reagent / UIx / Helix) read the same
+     context (per rf2-3yij Decision 2). The `build-frame-provider`
+     factory is the lower-level substrate hook the Reagent adapter
+     registers with `register-context-provider`.
+
+  2. Per-render instance-token machinery — `mint-instance-token!`,
+     `reagent-component-token`. Tokens disambiguate concurrently-
+     mounted instances of the same view-kind (Spec 004 §Render-tree
+     primitives, rf2-piag / rf2-t5tx). The `*render-key*` dynamic var
+     itself lives in `re-frame.views` so the wrapper's binding and
+     consumer reads share the same canonical Var.
+
+  3. `current-frame` — the resolution chain that subscribe / dispatch
+     consult to find the surrounding frame at render time
+     (Spec 002 §Reading the frame from React context). It pairs with
+     the `:contextType` static reg-view's wrapper installs on its
+     output (per `re-frame.views`).
+
+  Per rf2-wbnl this ns does NOT statically `:require` `reagent.core`.
+  The in-flight Reagent component is read through the late-bind hook
+  `:adapter/current-component`, which the active adapter ns publishes
+  at load time. The classic bridge points the hook at
+  `reagent.core/current-component`; the slim adapter points it at
+  `reagent2.core/current-component`. With no adapter installed the
+  hook returns nil and the React-context tier of the resolution chain
+  is skipped — equivalent to a non-Reagent render context, which is
+  what JVM / headless tests already rely on."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---- the React context for frame propagation -----------------------------
+;;
+;; Per rf2-3yij Decision 2 the React Context object lives in
+;; `re-frame.adapter.context` so the UIx adapter (and any future
+;; React-shaped adapter) reads the *same* context — not a parallel one.
+;; The Reagent code below references it via the alias rather than
+;; minting a new createContext call.
+
+(def frame-context adapter-context/frame-context)
+
+(defn- frame-provider-component
+  "The single Reagent component that backs every frame-provider. It takes
+  the frame keyword as its first render-time arg and scopes that keyword
+  to its subtree via React context. One built component services every
+  frame — the keyword lives in the Provider's `:value`, not in a
+  closure."
+  [frame-kw & children]
+  (into [:> (.-Provider frame-context) {:value frame-kw}] children))
+
+(defn build-frame-provider
+  "Used by re-frame.adapter.reagent/register-context-provider. Returns
+  a Reagent component that scopes a frame keyword to its subtree.
+
+  Zero-arity (rf2-4y60): the returned component takes the frame keyword
+  at render time, and a single built component services every frame, so
+  there is nothing to specialise at build time. Substrates whose
+  `register-context-provider` slot receives a frame-keyword on call (per
+  Spec 006 §Frame-provider via React context) discard it and call this
+  with no args."
+  []
+  frame-provider-component)
+
+(defn frame-provider
+  "User-facing Reagent component that scopes a frame keyword to its
+  subtree. Inside the subtree, `(rf/dispatcher)` / `(rf/subscriber)`
+  capture the named frame; reg-view-registered descendants resolve to
+  it via React context.
+
+      [rf/frame-provider {:frame :session}
+       [header]
+       [main-area]
+       [footer]]
+
+  `props` is a map carrying `:frame frame-id`. Children render under
+  that frame (variadic — zero, one, or many).
+
+  When `:frame` is missing or `nil`, falls through to `:rf/default` —
+  matches the no-provider behaviour. This is the defensive default per
+  the rf2-sixo decision; an explicit error would catch typos but would
+  also break tooling-generated trees that elide the prop.
+
+  Per Spec 002 §What `frame-provider` is. `build-frame-provider` is the
+  lower-level substrate hook; this fn is the canonical user-facing
+  surface."
+  [props & children]
+  (let [frame-kw (or (:frame props) :rf/default)]
+    (into [(build-frame-provider) frame-kw] children)))
+
+;; ---- in-flight Reagent component (rf2-wbnl) ------------------------------
+;;
+;; The active adapter (classic bridge or slim) publishes its Reagent build's
+;; `current-component` fn through the `:adapter/current-component` late-bind
+;; hook at ns-load time. This ns must NOT statically `:require [reagent.core]`
+;; — doing so hard-couples views.cljs to stock Reagent and silently shadows
+;; the slim adapter's components in mixed-mode environments. Per the bead's
+;; resolution-chain note: dynamic var → adapter.current-component
+;; (late-bind) → nil. When no adapter has installed the hook the call returns
+;; nil and the React-context tier is skipped.
+
+(defn current-component
+  "Resolve the in-flight Reagent component via the active adapter's hook.
+  Returns nil when no adapter has registered the hook (JVM / headless
+  builds; no-adapter tests). Per rf2-wbnl."
+  []
+  (when-let [hook (late-bind/get-fn :adapter/current-component)]
+    (hook)))
+
+;; ---- frame resolution at render time -------------------------------------
+
+(def ^:dynamic *current-frame* nil)
+
+(defn current-frame
+  "Resolution chain (per Spec 002 §Reading the frame from React context):
+    1. Dynamic var (set by with-frame).
+    2. Closest enclosing frame-provider via React context.
+    3. :rf/default.
+
+  Reagent-specific: the React-context tier reads `(.-context cmp)` on
+  the in-flight Reagent component. Reagent's class-component machinery
+  surfaces context to components whose `:contextType` matches the
+  context object — that is the wiring `reg-view*` attaches via
+  `{:contextType frame-context}`. Plain Reagent fns lack this wiring,
+  so `(.-context cmp)` is React's empty default — they fall through
+  to `:rf/default`. This narrowness is by design: it is what makes the
+  `:rf.warning/plain-fn-under-non-default-frame-once` warning
+  meaningful (rf2-d3k3 / rf2-d4sf).
+
+  Per rf2-d4sf the keyword/string check tolerates Reagent's
+  prop-stringified shape: when a frame-provider is reached via
+  `[:> Provider {:value :foo} ...]` interop, `convert-prop-value`
+  rewrites `:foo` to `\"foo\"` before React sees it. The shared
+  coercion in `re-frame.adapter.context/coerce-context-value` undoes
+  that stringification so the Reagent path returns a keyword
+  regardless of how the Provider was authored."
+  []
+  (or frame/*current-frame*
+      (when-let [cmp (current-component)]
+        (adapter-context/coerce-context-value (.-context cmp)))
+      :rf/default))
+
+;; ---- per-render identity (rf2-piag / rf2-t5tx) ----------------------------
+;;
+;; Render-trace entries carry a `:render-key` of shape
+;; `[<view-id> <instance-token>]`. Per rf2-t5tx Option C the tuple is the
+;; canonical identity: the view-id (registry keyword) names the kind; the
+;; instance-token disambiguates concurrently-mounted instances of the same
+;; kind. Tokens are minted at mount time from a process-wide counter and
+;; are NOT correlated across runs — they're for in-run instance discrimination
+;; only (per Spec 004 §Render-tree primitives).
+;;
+;; Note: the `*render-key*` dynamic var and `current-render-key` reader
+;; live in `re-frame.views` (the public ns) rather than here. That keeps
+;; the dynamic-var Var canonical at the public path that tests reach via
+;; `re-frame.views/*render-key*` — see the views.cljs orchestration ns
+;; for the rationale. The mint / per-component-instance machinery does
+;; live here because it owns its own state (`instance-counter`) and the
+;; component-side stamp (`.-rfInstanceToken`).
+
+(defonce ^:private instance-counter (atom 0))
+
+(defn mint-instance-token!
+  "Return a fresh integer token for a freshly-mounted view instance. The
+  counter is process-wide and monotonic; values are unique within a
+  single process run but carry no cross-run correlation guarantee."
+  []
+  (swap! instance-counter inc))
+
+(defn reagent-component-token
+  "Return the per-component-instance token, minting one on first call.
+  Stored on the Reagent component object as `.-rfInstanceToken` so the
+  same mounted instance reuses the token across re-renders. When called
+  outside a Reagent component (direct invocation in headless tests),
+  mints a fresh token per call — that mirrors the per-mount-fresh
+  semantics for tests that simulate one mount per call."
+  []
+  (if-let [cmp (current-component)]
+    (or (.-rfInstanceToken ^js cmp)
+        (let [tok (mint-instance-token!)]
+          (set! (.-rfInstanceToken ^js cmp) tok)
+          tok))
+    (mint-instance-token!)))

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -1,0 +1,111 @@
+(ns re-frame.views.source-coord-annotation
+  "Source-coord DOM annotation walk for the Reagent-side views ns. Per
+  rf2-lh7p — split out of `re-frame.views` so the views file stays
+  focused on registration orchestration. Re-frame.views re-exports the
+  `format-source-coord` helper so the existing test that references
+  `#'re-frame.views/format-source-coord` continues to resolve.
+
+  Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) the
+  Reagent substrate adapter MUST inject
+  `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on each registered
+  view's root DOM element when `interop/debug-enabled?` is true. The
+  annotation lets pair-shaped tools (re-frame-pair, re-frame-10x, IDE
+  jump-to-source) map a clicked DOM node back to the reg-view call
+  site.
+
+  Contract details:
+
+    - The id is a registry keyword `<ns>/<sym>`. Combined with the
+      captured `:line` / `:column` (from `(meta &form)` at reg-view
+      macro-expansion time), the attribute value is
+      `<ns>:<sym>:<line>:<col>`. `<col>` is `?` when the column was
+      not captured (the column-key is optional per Spec 001).
+
+    - The wrapper inspects the user's render-fn output:
+        * `[:tag {...attrs} & children]` → merge :data-rf2-source-coord
+          into attrs.
+        * `[:tag & children]` (no attrs map)            → splice an attrs
+          map in.
+        * `[fn-or-component-or-fragment …]` (head is a fn / class / `:>`
+          / React-fragment marker) → SKIP and emit a one-shot warning
+          per id. Pair-tool consumers fall back to the registry's
+          `:rf/id` for these cases (per Spec 006 §Source-coord
+          annotation, documented Fragment exemption).
+        * Form-2: when the render-fn returns a fn (`(fn [args] body)`),
+          we recurse on the inner-fn's output the next time the wrapper
+          is called — Reagent invokes the inner fn during the SAME
+          render cycle, but the wrapper's annotation runs OUTSIDE
+          Reagent's per-render machinery. The simplest correct shape
+          is to wrap the returned fn so the inner output gets walked
+          too.
+
+    - Production elision: every annotation site sits inside
+      `(when interop/debug-enabled? ...)` so the closure compiler
+      constant-folds the entire branch under `:advanced` +
+      `goog.DEBUG=false`. Per Spec 009 §Production builds."
+  (:require [re-frame.views.warn-once :as warn-once]))
+
+(defn format-source-coord
+  "Render the registry slot's captured coords as the attribute value
+  shape `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name
+  give us `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured
+  coords (CLJS reg-view macro at expansion time). Per Spec 006
+  §Source-coord annotation."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defn- dom-tag?
+  "True if `head` is a Hiccup DOM-tag keyword. Reagent's React-fragment
+  marker is `:<>`; the `:>` (interop) marker is for arbitrary React
+  components — both are exempt from annotation per Spec 006."
+  [head]
+  (and (keyword? head)
+       (not= :<> head)
+       (not= :> head)))
+
+(defn inject-source-coord-attr
+  "Walk the user's render-fn output and merge :data-rf2-source-coord
+  into the root element's attrs map. Called from inside the wrapper
+  (gated on interop/debug-enabled?). Returns the (possibly rewritten)
+  hiccup. Non-DOM roots are returned unchanged after a one-shot
+  warning per Spec 006 §Source-coord annotation.
+
+  Form-2: when `out` is a fn, return a fn that recurses on the inner
+  output — Reagent's renderer will call our returned fn just like
+  the user's fn, and we get a chance to annotate the inner hiccup."
+  [id coord-attr out]
+  (cond
+    ;; Form-2: render-fn returned a fn. Wrap so the inner fn's output
+    ;; is also annotated when Reagent calls through.
+    (fn? out)
+    (fn form-2-wrapper [& args]
+      (inject-source-coord-attr id coord-attr (apply out args)))
+
+    ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
+    (and (vector? out) (dom-tag? (first out)))
+    (let [head     (first out)
+          maybe-attrs (second out)]
+      (if (map? maybe-attrs)
+        ;; Existing attrs map — merge in (don't overwrite if user
+        ;; already set it for some reason).
+        (let [merged (if (contains? maybe-attrs :data-rf2-source-coord)
+                       maybe-attrs
+                       (assoc maybe-attrs :data-rf2-source-coord coord-attr))]
+          (into [head merged] (drop 2 out)))
+        ;; No attrs map — splice one in between head and children.
+        (into [head {:data-rf2-source-coord coord-attr}] (rest out))))
+
+    ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
+    ;; with a one-shot warning. Pair tools fall back to :rf/id.
+    :else
+    (do
+      (when (vector? out)
+        (warn-once/warn-non-dom-root! id (first out)))
+      out)))

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -1,0 +1,250 @@
+(ns re-frame.views.warn-once
+  "Warn-once caches and detection helpers for the Reagent-side views ns.
+  Per rf2-lh7p — split out of `re-frame.views` so the views file stays
+  focused on registration orchestration. Re-frame.views re-exports the
+  publicly-referenced surface (`clear-warned-non-dom-roots!`,
+  `maybe-warn-plain-fn-under-non-default-frame!`,
+  `clear-plain-fn-warned-pairs!`) so existing call sites continue to work
+  unchanged.
+
+  Two cohesive warn-once concerns live here:
+
+  1. Non-DOM-root warning (Spec 006 §Source-coord annotation,
+     documented exemption). When a reg-view'd component returns a
+     non-DOM root (fn/class component or React Fragment) the
+     source-coord walk skips the annotation and emits a one-shot
+     console.warn per id. Pair tools fall back to the registry's
+     `:rf/id`. The `warned-non-dom-roots` defonce holds the per-process
+     set; `reset-runtime-fixture` clears it via the chained
+     `:adapter/clear-warn-once-caches!` hook per rf2-4edk.
+
+  2. Plain-fn-under-non-default-frame warning (Spec 004 §Plain Reagent
+     fns and Spec 006 §706). Detected at subscribe-time; suppression is
+     keyed by `[component-id non-default-frame-id]` pairs. Production
+     builds elide the entire body via the `interop/debug-enabled?`
+     gate."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace]
+            [re-frame.views.provider :as provider]))
+
+;; ---- non-DOM-root warning (rf2-4edk) -------------------------------------
+
+(defonce ^:private warned-non-dom-roots (atom #{}))
+
+(defn clear-warned-non-dom-roots!
+  "Reset the warn-once cache for non-DOM-root warnings. Tests use this
+  between cases (via `reset-runtime-fixture` and the chained
+  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
+  encounter warning cannot silently swallow a later test's same-id
+  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
+  the user-facing warn-once UX is unchanged in production; test-time
+  clearing is the only effect."
+  []
+  (reset! warned-non-dom-roots #{})
+  nil)
+
+(defn warn-non-dom-root!
+  "Emit a one-shot warning per id that the reg-view'd component returned
+  a non-DOM root (a fn/class component, or a React Fragment). Pair tools
+  fall back to the registry's `:rf/id`; documented exemption per Spec 006
+  §Source-coord annotation."
+  [id head]
+  (when-not (contains? @warned-non-dom-roots id)
+    (swap! warned-non-dom-roots conj id)
+    (when (exists? js/console)
+      (.warn js/console
+        (str "[re-frame] reg-view " id " — root element is "
+             (pr-str head) "; data-rf2-source-coord skipped (Spec 006 "
+             "§Source-coord annotation: pair tools fall back to :rf/id "
+             "for non-DOM roots).")))))
+
+;; ---- plain-fn-under-non-default-frame warning (rf2-d3k3) -----------------
+;;
+;; Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-default-
+;; frame warning: a plain Reagent fn (not registered via `reg-view`, so
+;; without the `^{:contextType frame-context}` metadata `reg-view` attaches)
+;; cannot read the surrounding React-context frame. When such a fn renders
+;; inside a non-default `frame-provider` and calls `(rf/subscribe ...)` or
+;; `(rf/dispatch ...)`, the resolution chain falls through to `:rf/default`
+;; — almost certainly not what the author intended.
+;;
+;; The runtime emits `:rf.warning/plain-fn-under-non-default-frame-once` at
+;; most once per `(component-id, non-default-frame-id)` pair, per Spec 004
+;; §The footgun is loud, but at most once per (component, non-default-frame)
+;; pair. Detection sits at subscribe-time per Spec 006 §706: subscribe
+;; consults this helper through the late-bind hook table; the JVM build
+;; never sees this ns and the lookup returns nil there.
+;;
+;; Suppression: a process-wide `defonce` atom set keyed by [component-id
+;; frame-id] pairs. The suppression cache survives hot-reload (`defonce`)
+;; so repeated re-renders of the same plain fn produce exactly one
+;; warning per pair across the JS process. Per Spec 004 §The suppression
+;; cache: destroying and re-creating a frame resets the warning history
+;; for that frame — implemented by `clear-plain-fn-warned-pairs-for-frame!`
+;; which the frame-destroy path can call (today the cache is process-wide
+;; and the helper is exported for tests / future destroy-frame integration).
+;;
+;; Production-elision: every code path is gated on `interop/debug-enabled?`.
+;; Under :advanced + `goog.DEBUG=false` the closure compiler constant-folds
+;; the gate and the entire detection branch, the trace emission, and the
+;; `console.warn` fallback are dead-code-eliminated. Per Spec 009
+;; §Production builds.
+
+(defonce ^:private warned-plain-fn-frame-pairs
+  ;; Set of `[component-id frame-id]` pairs already warned about. Per
+  ;; Spec 004 §The suppression cache.
+  (atom #{}))
+
+(defn clear-plain-fn-warned-pairs!
+  "Reset the warn-once suppression cache. Tests use this between cases
+  so each case starts from a clean slate. Per Spec 004 §The suppression
+  cache."
+  []
+  (reset! warned-plain-fn-frame-pairs #{})
+  nil)
+
+(defn- plain-fn-component-id
+  "Identify the rendering component for warn-once keying. Reagent
+  components carry the user's render-fn as `.-cljsLegacyRender` (form-1)
+  or as the bound fn proper. We prefer `displayName` (which Reagent /
+  React tend to set for named fns), then fall back to the constructor's
+  `name`, then a string repr. The id is opaque text used only as the
+  cache key and the warning's `:fn-name` payload — stable across renders
+  of the same component, distinct across different component fns."
+  [cmp]
+  (or (when-let [n (.-displayName ^js cmp)]
+        (when (and (string? n) (not= "" n)) n))
+      (let [c (.-constructor ^js cmp)
+            n (when c (.-name ^js c))]
+        (when (and (string? n) (not= "" n) (not= "Object" n)) n))
+      (pr-str cmp)))
+
+(defn- read-react-context-frame
+  "Read the value the closest enclosing frame-provider has pushed onto
+  the shared React context. Per rf2-d4sf this is now a thin wrapper
+  around `adapter-context/current-frame` minus the dynamic-var tier —
+  the warn-once detection below has already filtered to the case where
+  `*current-frame*` is unset (Condition 4), so we want the React-
+  context value alone.
+
+  Reagent's `convert-prop-value` (reagent.impl.template) stringifies
+  named values (keywords, symbols) when they are passed as React
+  prop values: `[:> Provider {:value :foo} ...]` reaches React with
+  `value=\"foo\"`, not the keyword. The shared coercion in
+  `re-frame.adapter.context` undoes that conversion so the detection
+  logic sees a keyword regardless of whether the closest Provider was
+  reached via `[:> ...]` interop (stringified) or through a plain-CLJS
+  object path (preserved). The createContext default — `:rf/default`
+  — survives as a keyword because it never passed through Reagent's
+  prop-conversion."
+  []
+  (let [v (.-_currentValue ^js adapter-context/frame-context)]
+    (cond
+      (keyword? v)                  v
+      (and (string? v) (not= "" v)) (keyword v))))
+
+(defn maybe-warn-plain-fn-under-non-default-frame!
+  "Detection per Spec 006 §706 (plain-fn-under-non-default-frame
+  warning). Called from `re-frame.subs/subscribe` after frame
+  resolution; `resolved-frame-id` is the frame the subscribe call
+  routed to.
+
+  Conditions for the warning to fire (all must hold):
+    1. We are mid-render — `(current-component)` returns a component.
+    2. The component is NOT a reg-view-wrapped one — its `contextType`
+       is not the shared `frame-context`. (reg-view-wrapped components
+       carry the `:contextType` so they read the surrounding Provider's
+       value into `(.-context cmp)`; plain fns do not.)
+    3. The closest enclosing Provider names a non-default frame.
+    4. The dynamic `*current-frame*` tier is unset — i.e. no `with-frame`
+       binding shadows the React-context read. When `with-frame` IS set,
+       the plain fn picks up the frame correctly via the dynamic var,
+       and no warning is needed.
+
+  Suppression: warn-once per `[component-id non-default-frame-id]` pair.
+  Subsequent renders of the same plain fn under the same Provider stay
+  silent. Per Spec 004 §at most once per (component, non-default-frame)
+  pair.
+
+  Returns nil. Production builds elide the entire body via the
+  `interop/debug-enabled?` gate the trace surface itself rides — the
+  call site in subs already pays a `(when interop/debug-enabled? ...)`
+  test, so this fn is reached only in dev / JVM (where it is unbound
+  via late-bind and not called)."
+  [resolved-frame-id _query-v]
+  (when interop/debug-enabled?
+    (let [cmp (provider/current-component)]
+      ;; Condition 1: must be mid-render.
+      (when (some? cmp)
+        ;; Condition 2: component must NOT be reg-view-wrapped. The
+        ;; sentinel is the `contextType` static — reg-view's wrapper
+        ;; sets it to `frame-context`; plain fns leave it unset (or
+        ;; React's empty default).
+        (let [ctx-type (some-> ^js cmp .-constructor .-contextType)]
+          (when-not (identical? ctx-type adapter-context/frame-context)
+            ;; Condition 3: closest enclosing Provider names a
+            ;; non-default frame.
+            (let [provider-frame (read-react-context-frame)]
+              (when (and (keyword? provider-frame)
+                         (not= :rf/default provider-frame))
+                ;; Condition 4: no with-frame binding shadowing the
+                ;; React-context read.
+                (when (nil? frame/*current-frame*)
+                  (let [fn-id (plain-fn-component-id cmp)
+                        pair  [fn-id provider-frame]]
+                    (when-not (contains? @warned-plain-fn-frame-pairs pair)
+                      (swap! warned-plain-fn-frame-pairs conj pair)
+                      (let [reason (str "Plain Reagent fns do not pick "
+                                        "up the surrounding frame; their "
+                                        "dispatch/subscribe targets "
+                                        ":rf/default. To capture the "
+                                        "surrounding frame, register the "
+                                        "view via reg-view.")]
+                        (trace/emit! :warning
+                                     :rf.warning/plain-fn-under-non-default-frame-once
+                                     {:fn-name        fn-id
+                                      :rendered-under provider-frame
+                                      :routed-to      resolved-frame-id
+                                      :reason         reason
+                                      :recovery       :warned-and-replaced})
+                        ;; Per Spec 004 §The footgun is loud: in dev,
+                        ;; the runtime also `console.warn`s the first
+                        ;; occurrence. The trace event is the
+                        ;; programmatic surface (10x, re-frame-pair);
+                        ;; the console message is the human-eyeballs
+                        ;; surface.
+                        (when (exists? js/console)
+                          (.warn js/console
+                            (str "[re-frame] :rf.warning/plain-fn-under-"
+                                 "non-default-frame-once — " fn-id
+                                 " rendered under " provider-frame
+                                 "; subscribe/dispatch routed to "
+                                 resolved-frame-id ". " reason)))))))))))))
+    nil))
+
+;; Publish through the late-bind hook table so re-frame.subs (a leaf
+;; namespace, .cljc, JVM-runnable) can call the helper without
+;; statically requiring this CLJS-only ns. JVM builds never load this
+;; file; the lookup returns nil there and subs no-ops the warning
+;; check. Per re-frame.late-bind §Hook keys.
+(late-bind/set-fn! :views/maybe-warn-plain-fn-under-non-default-frame!
+                   maybe-warn-plain-fn-under-non-default-frame!)
+(late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
+                   clear-plain-fn-warned-pairs!)
+
+;; Per rf2-4edk: register a clear of the `warned-non-dom-roots` cache
+;; under the chained `:adapter/clear-warn-once-caches!` hook. The hook
+;; is chained — each adapter (helix, uix) and this views ns all
+;; contribute a clear-step; `reset-runtime-fixture` invokes the top of
+;; the chain and every contributor's reset runs. Production behaviour
+;; is unchanged: the warn-once `defonce` is still per-process for users;
+;; only test-time clearing is new.
+(let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+  (late-bind/set-fn! :adapter/clear-warn-once-caches!
+    (fn views-clear-warn-once-caches! []
+      (clear-warned-non-dom-roots!)
+      (when previous (previous))
+      nil)))


### PR DESCRIPTION
## Summary

Per rf2-lh7p — splits the 569-LoC `implementation/core/src/re_frame/views.cljs` into three internally-cohesive sub-namespaces under `re-frame.views.*`. `re-frame.views` itself becomes a thin orchestration ns that holds `reg-view*` + the `*render-key*` dynamic var and re-exports the publicly-referenced surface so every external call site continues to resolve unchanged.

- **`re-frame.views.provider`** (196 LoC) — `frame-provider`, `build-frame-provider`, `frame-context`, `current-component`, `current-frame` resolution chain, `mint-instance-token!`, `reagent-component-token`.
- **`re-frame.views.source-coord-annotation`** (111 LoC) — `format-source-coord`, `dom-tag?`, `inject-source-coord-attr` (the Spec 006 hiccup walk).
- **`re-frame.views.warn-once`** (250 LoC) — both warn-once caches (non-DOM root, plain-fn-under-non-default-frame) and their helpers, plus the late-bind hook registrations (`:views/...`, the `:adapter/clear-warn-once-caches!` chain step) that wire them into the rest of the system.

`re-frame.views` shrinks from **569 to 230 LoC** (-60%). The `*render-key*` dynamic var stays at the public path because tests read `re-frame.views/*render-key*` from inside a render-fn while the wrapper binds it — a `:refer` or `(def *render-key* provider/*render-key*)` would create a second Var the binding wouldn't reach. Plain `def` aliases handle the ordinary fns (`frame-provider`, `current-frame`, `format-source-coord`, `clear-warned-non-dom-roots!`, etc.) so every external `re-frame.views/<name>` and `#'re-frame.views/<name>` resolves.

Also drops the dead local `def ^:dynamic *current-frame*` in `views.cljs` (the `current-frame` chain reads `frame/*current-frame*` from `re-frame.frame`; the local Var was never referenced anywhere).

## Public API surface

Preserved (every external call site continues to work):

- `re-frame.core/reg-view*` (CLJS delegate) → `re-frame.views/reg-view*`
- `late-bind` hook table (`:adapter/current-frame`, `:views/maybe-warn-plain-fn-under-non-default-frame!`, `:views/clear-plain-fn-warned-pairs!`)
- `re-frame.adapter.reagent` + runtime test → `frame-provider`, `build-frame-provider`
- `warn_once_fixture_isolation_cljs_test` → `clear-warned-non-dom-roots!`
- `render_key_cljs_test`, UIx + Helix parity tests, `elision_probe` → `*render-key*`, `current-render-key`, `mint-instance-token!`
- `source_coord_parity_cljs_test` → `#'re-frame.views/format-source-coord`
- SSR test (`ssr_source_coord_test.clj`) → `(resolve 're-frame.views/reg-view*)`

The recent `clear-warned-non-dom-roots!` chained late-bind wiring from #347 (rf2-4edk) moves to `warn-once.cljs` intact.

## Test plan

- [x] `clojure -M:test` (core) — 226 tests / 1023 assertions, 0 failures
- [x] `npm run test:cljs` — 559 tests / 1324 assertions, 0 failures
- [x] `npm run test:browser` — 559 tests / 1345 assertions, 0 failures
- [x] `npm run test:browser-prod-elision` — 11 tests / 33 assertions, 0 failures (includes the rf2-uwg5 source-coord DOM elision test in `adapters/reagent/test/`)
- [x] `npm run test:elision` — PASS (every absent-sentinel + present-sentinel check green, including `re-frame.views/reg-view*`'s `view/render` trace + `data-rf2-source-coord` injection)
- [x] `npm run test:examples` — all 25 examples PASS