### PR TITLE
docs(guide): add coeffects chapter — inject-cofx, reg-cofx, common cofxes (rf2-bbbc)

### DIFF
--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -56,6 +56,8 @@ Three things changed:
 2. The handler is **still pure**. It returns a Clojure map. Every value in that map is just data — strings, keywords, vectors. No `js/fetch`, no callbacks, no promises.
 3. The map describes everything: "set the db to this; *also*, fire a managed HTTP request with these args, and on success dispatch this event, on failure dispatch this one."
 
+The handler's first argument — `{:keys [db]}` — is the **coeffects map**, the symmetric twin of the effect map on the way out. `:db` is the standard input every handler gets for free; the matching surface for handlers that need *other* inputs (the current time, a freshly-minted UUID, a value from `localStorage`) is `inject-cofx`, covered in [chapter 03a](03a-coeffects.md). The core path doesn't need cofx yet — the chapters that follow only destructure `:db` and the event — but the side-track is there the moment a handler wants to read something the runtime hasn't already put under its nose.
+
 Then there are two follow-up handlers, each pure:
 
 ```clojure

--- a/docs/guide/03a-coeffects.md
+++ b/docs/guide/03a-coeffects.md
@@ -1,0 +1,282 @@
+# 03a — Coeffects
+
+Chapter 03 set up the symmetry that re-frame2 leans on: a handler is a pure function from inputs to outputs. The outputs are an **effect map** — `:db`, `:fx`, and friends — describing what the runtime should do next. This chapter is about the matching half on the way in: the **coeffects map**.
+
+Coeffects are the *side-causes*. They're the data a handler reads from the world that isn't `app-db` — the current wall-clock time, a freshly-generated UUID, a value retrieved from `localStorage`, the browser's preferred language. Just as effects keep the handler from *performing* side-effects, coeffects keep the handler from *causing* them — no `(js/Date.)` in the handler body, no `(.getItem js/localStorage ...)`, no `(random-uuid)`. Inputs arrive in the coeffects map; the handler stays a function.
+
+You'll meet this surface the moment an event needs to stamp something with the current time, persist with a new id, or seed itself from a previously-saved value. If you've already seen `(inject-cofx :now)` or `(inject-cofx :todo.storage/todos)` in someone else's code and wondered what it was doing, this chapter is the answer.
+
+It's optional like 04a and 05a — a side-track between 03 and 04. The core path doesn't require writing your own coeffect; `:db` and `:event` are wired in automatically. Pick this up the first time you want a handler to read something the runtime hasn't already put under its nose.
+
+## The side-cause
+
+Re-read the `reg-event-fx` shape from chapter 03 and the first argument changes meaning:
+
+```clojure
+(rf/reg-event-fx :counter/inc
+  (fn [{:keys [db]} _event]
+    {:db (update db :count inc)}))
+```
+
+The handler destructures `:db` out of its first argument. That first argument *is* the coeffects map. Chapter 03 didn't dwell on it because every handler so far has only needed `:db` and `:event`, both of which the runtime stages automatically:
+
+| Coeffect | What it is | Set by |
+|---|---|---|
+| `:db` | The frame's `app-db` value at drain start. | The drain loop, before the interceptor chain runs. |
+| `:event` | The dispatched event vector. | The dispatch envelope. |
+
+These two are always present; you can rely on them being there. Everything beyond `:db` and `:event` — every other piece of "data from outside the handler" — is opt-in, named, and injected by a small piece of machinery: a registered **cofx**, fetched into the coeffects map by an **`inject-cofx`** interceptor.
+
+The symmetry with effects is exact:
+
+| | Inputs | Outputs |
+|---|---|---|
+| **Where** | `:coeffects` | `:effects` |
+| **Built-in** | `:db`, `:event` | `:db` |
+| **Registered** | `reg-cofx` | `reg-fx` |
+| **Identified by** | keyword id | keyword id |
+| **Side-effecty work happens in** | the cofx handler | the fx handler |
+
+A handler reads from `:coeffects`. It writes to `:effects`. The runtime fills `:coeffects` before the handler runs (via cofx handlers); the runtime drains `:effects` after the handler returns (via fx handlers). The handler in the middle stays pure.
+
+## Why a registry, not a function call
+
+The easy thing — and the wrong thing — is to call `(js/Date.)` directly in the handler:
+
+```clojure
+;; ❌ Don't do this
+(rf/reg-event-db :todo/add
+  (fn [db [_ title]]
+    (let [now (js/Date.)
+          id  (random-uuid)]
+      (assoc-in db [:todos id] {:id id :title title :created-at now}))))
+```
+
+Three things are wrong with it, and they're the same three things that were wrong with calling `js/fetch` from a handler in chapter 03:
+
+**The handler isn't pure.** Same inputs no longer produce the same outputs. Calling the handler twice with `({} [:todo/add "buy milk"])` gives a different `:created-at` and a different `:id` each time. The test framework can't pin a value down without monkey-patching `js/Date` and `random-uuid` globally.
+
+**The boundary leaks into the body.** `js/Date` exists in the browser; on the JVM (where you want this handler's tests to run, per [chapter 10](10-testing.md)) it doesn't. Now the handler can't be tested without a CLJS runtime, even though the logic it expresses — "stamp this new todo with a creation time" — is host-neutral.
+
+**There's no override surface.** You can't, for one event, ask "what does the handler do if the time is fixed at noon on January 1st, 2026?" without reaching into `js/Date` itself — every other handler in the same test run gets the same redefinition, and tearing it back down is fiddly.
+
+Cofx fix all three by extracting the impurity into a registered handler with a name:
+
+```clojure
+(rf/reg-cofx :now
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :now] (js/Date.))))
+
+(rf/reg-cofx :new-id
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :new-id] (random-uuid))))
+
+(rf/reg-event-fx :todo/add
+  [(rf/inject-cofx :now)
+   (rf/inject-cofx :new-id)]
+  (fn [{:keys [db now new-id]} [_ title]]
+    {:db (assoc-in db [:todos new-id]
+                   {:id new-id :title title :created-at now})}))
+```
+
+The handler is back to being a pure function. The two impure calls (`js/Date.`, `random-uuid`) are quarantined inside two named cofx handlers. Each can be overridden by re-registering against the same id — which is the whole testing story, [below](#testing-via-cofx-stubs).
+
+## `reg-cofx` — registering an input
+
+A cofx handler is a function from context to context. It receives the full context map (the same one interceptors thread, per [chapter 04a](04a-interceptors.md)) and returns a new context with the cofx value `assoc-in`'d under `[:coeffects <id>]`:
+
+```clojure
+(rf/reg-cofx :now
+  {:doc "Inject the current wall-clock time into coeffects under :now."}
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :now] (js/Date.))))
+```
+
+The convention is to inject under the same keyword you registered with — the cofx id and the coeffect key are the same keyword. The handler is free to inject under a different key, but tooling and validation assume the symmetric case, so deviate only with reason.
+
+`reg-cofx` takes an optional metadata map between the id and the handler — the same shape every other `reg-*` accepts (per [Spec 001](../../spec/001-Registration.md)). `:doc` is the most common metadata key. `:spec` attaches a Malli schema that the runtime validates the injected value against ([Spec 010](../../spec/010-Schemas.md)) — a `:now` cofx with `{:spec [:fn inst?]}` will fail fast if some test stub forgets to return a date.
+
+Two arities exist for the handler fn:
+
+- **Unary** — `(fn [ctx] ...)`. Used when the cofx is parameterless. `:now`, `:new-id`, the TodoMVC `:todo.storage/todos` cofx, the `:browser/lang` cofx — anything where "there's only ever one answer."
+- **Binary** — `(fn [ctx value] ...)`. Used when the cofx is parameterised by a value supplied at the `inject-cofx` call site. The classic example is `:local-store`, which takes the storage key to read from:
+
+```clojure
+(rf/reg-cofx :local-store
+  (fn [ctx storage-key]
+    (assoc-in ctx [:coeffects :local-store]
+              (some-> (.-localStorage js/globalThis)
+                      (.getItem storage-key)))))
+
+;; Used:
+(rf/reg-event-fx :prefs/load
+  [(rf/inject-cofx :local-store "user-prefs")]
+  (fn [{:keys [local-store]} _]
+    {:db (-> (or local-store {}) (parse-prefs))}))
+```
+
+The binary form keeps the *what* (the registered cofx) generic and the *which* (the storage key, the bucket name, the page size) at the call site. One `:local-store` cofx handler serves every event in the app that needs a different key.
+
+## `inject-cofx` — the interceptor
+
+A cofx is registered once and used many times. The use-site is `inject-cofx`, the small interceptor that runs the registered cofx fn on the way in:
+
+```clojure
+(rf/reg-event-fx :todo/add
+  [(rf/inject-cofx :now)]       ;; ← the interceptors slot from ch.03
+  (fn [{:keys [db now]} [_ title]]
+    ...))
+```
+
+`(inject-cofx :now)` returns an interceptor with a `:before` slot only — the cofx is an input, so there's nothing to do on the way out. The `:before` looks up `:now` in the `:cofx` registry, calls its handler with the context (and the second value, if `inject-cofx` was called binary), and the resulting context — now carrying `:now` under `:coeffects` — flows into the next interceptor and eventually the handler.
+
+Two arities, matching `reg-cofx`:
+
+- `(inject-cofx :id)` — no value. The cofx fn is called as `(handler ctx)`.
+- `(inject-cofx :id value)` — passes `value` through. The cofx fn is called as `(handler ctx value)`.
+
+Multiple cofx interceptors compose by listing them in source order:
+
+```clojure
+(rf/reg-event-fx :todo/add
+  [(rf/inject-cofx :now)
+   (rf/inject-cofx :new-id)
+   (rf/inject-cofx :local-store "draft-todo")]
+  (fn [{:keys [db now new-id local-store]} [_ title]]
+    {:db (assoc-in db [:todos new-id]
+                   {:id         new-id
+                    :title      title
+                    :created-at now
+                    :seeded?    (some? local-store)})}))
+```
+
+Each cofx is independent. They run on the way in, in declaration order; by the time the handler runs, all four keys (`:db`, `:event`, `:now`, `:new-id`, `:local-store`) are present in its coeffects map.
+
+A handler shape note worth pinning: **`reg-event-db` doesn't see injected cofx values.** Its handler signature is `(fn [db event] ...)`, not `(fn [coeffects event] ...)` — only `:db` is destructured. If you need a cofx value, the event registers under `reg-event-fx` (or `reg-event-ctx` for the rare cases that want the whole context map). The interceptors slot still works on `reg-event-db` for other purposes — a logger, an undo wrapper — but `inject-cofx` is wasted on it.
+
+## Common cofxes
+
+There's no closed list — every app registers the cofxes it needs. A few recur often enough to be worth naming.
+
+### `:now`
+
+The current wall-clock time. Useful for `:created-at` / `:updated-at` stamps, timeout calculations, age-based decisions:
+
+```clojure
+(rf/reg-cofx :now
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :now] (js/Date.))))
+```
+
+A test that needs deterministic time re-registers it — see [below](#testing-via-cofx-stubs).
+
+### `:new-id` / `:guid`
+
+A freshly-generated UUID for a new entity:
+
+```clojure
+(rf/reg-cofx :new-id
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :new-id] (random-uuid))))
+```
+
+In tests, re-register to return a deterministic id (`#uuid "00000000-0000-0000-0000-000000000001"`) so assertions don't have to fish through generated values.
+
+### `:random-int`
+
+A bounded random integer, parameterised by the upper bound:
+
+```clojure
+(rf/reg-cofx :random-int
+  (fn [ctx upper-bound]
+    (assoc-in ctx [:coeffects :random-int] (rand-int upper-bound))))
+
+;; (rf/inject-cofx :random-int 10)
+```
+
+### `:local-store`
+
+Read a value out of `localStorage` by key. TodoMVC's `:todo.storage/todos` cofx is exactly this shape, scoped to one project-specific key:
+
+```clojure
+(rf/reg-cofx :todo.storage/todos
+  {:doc "Inject the saved TodoMVC items from localStorage into coeffects."}
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :todo.storage/todos]
+              (some-> (.-localStorage js/globalThis)
+                      (.getItem "todos-reframe2")
+                      (parse-todos)))))
+
+(rf/reg-event-fx :todo/initialise
+  [(rf/inject-cofx :todo.storage/todos)]
+  (fn [{:todo.storage/keys [todos]} _]
+    {:db (assoc default-db :todos todos)}))
+```
+
+`examples/reagent/todomvc/db.cljs` and its sibling `events.cljs` exercise the pattern end-to-end. The `:initialise` handler stays pure; the only place `localStorage.getItem` appears in the codebase is inside `reg-cofx`. SSR — where there's no `localStorage` — gets a `nil` for the cofx value because the `some->` short-circuits; the handler degrades gracefully without branching on platform.
+
+## Testing via cofx stubs
+
+This is the payoff. A handler that uses `(inject-cofx :now)` is testable without faking `js/Date`, mocking the clock, or threading a `Clock` argument through every call site. The test re-registers `:now` with a stub before the handler-under-test runs, and the framework's id-redirect picks up the new binding:
+
+```clojure
+(ns my-app.todo-test
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as ts]))
+
+(deftest todo-add-stamps-created-at
+  (ts/with-fresh-registrar
+    ;; Stub the :now cofx to return a fixed instant.
+    (rf/reg-cofx :now
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :now] #inst "2026-01-01T12:00:00.000Z")))
+    (rf/reg-cofx :new-id
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :new-id] #uuid "00000000-0000-0000-0000-000000000001")))
+
+    (rf/with-frame [f (rf/make-frame {})]
+      (rf/dispatch-sync [:todo/add "buy milk"])
+      (let [todo (-> (rf/get-frame-db f)
+                     :todos
+                     (get #uuid "00000000-0000-0000-0000-000000000001"))]
+        (is (= "buy milk" (:title todo)))
+        (is (= #inst "2026-01-01T12:00:00.000Z" (:created-at todo)))))))
+```
+
+Three things to notice:
+
+**The stubs are re-registrations, not mocks.** They live in the same registry as the production cofx handlers; they're addressed by the same keyword id. `inject-cofx` finds the re-registered version with no special test-mode flag. Per-frame and per-call overrides go further still — [Spec 002 §Per-frame and per-call overrides](../../spec/002-Frames.md#per-frame-and-per-call-overrides) covers `:interceptor-overrides` for stubbing the *interceptor itself* (e.g. swapping `:rf/inject-cofx-now` for one frame's events), useful when you want the stub scoped to one frame rather than to the whole test registry.
+
+**`with-fresh-registrar` keeps the stubs scoped.** It snapshots the registrar around the body and restores on exit — production `:now` is intact for the next test. Without it, a test that re-registers `:now` leaves a stub in place for whatever runs next, which is the classic "passes alone, fails together" failure mode covered in [chapter 10 §Registrar isolation](10-testing.md#registrar-isolation-with-fresh-registrar).
+
+**The handler-under-test never knew it was being tested.** It dispatched against a frame, asked for `:now` through `inject-cofx`, got back a fixed instant. No conditional in the handler body. No `if-test?` flag. The handler is the same shape in production and in the test; only the injected value changed.
+
+This idiom generalises: any handler that depends on the outside world via cofx can be deterministically tested by re-registering its cofxes. Time becomes fixed, ids become predictable, `localStorage` returns whatever the test wants. The handler stays a function from values to values.
+
+## Where the seams sit
+
+A short orientation map for everything cofx-related you'll see in re-frame2 code:
+
+- **The cofx fn shape.** `(fn [ctx])` or `(fn [ctx value])`, returning the ctx with `[:coeffects <id>]` assoc'd. The handler runs as an interceptor's `:before`; the [interceptor chapter](04a-interceptors.md) is the deep-dive on why that machinery exists.
+- **The handler's view.** `reg-event-fx`'s first argument is the coeffects map. Destructure `:db`, `:event`, and any injected cofx keys you registered.
+- **`reg-event-db` is unaffected.** `:db` and the event vector only; injected cofxes aren't visible. Promote to `reg-event-fx` if you need them.
+- **`reg-event-ctx`** is the rare third surface — handler receives the full context map (both `:coeffects` and `:effects`). Most cofx-using code doesn't need it; reach for it when you genuinely want to reshape the context itself.
+
+The forward link from [chapter 04a's table](04a-interceptors.md#the-context-map) points here: the `:coeffects` half of the context map is where every input lives, and `inject-cofx` is the canonical way to put something new in it.
+
+## What we covered
+
+- A coeffect is a *side-cause* — data the handler reads from the world that isn't `app-db`. It's the symmetric twin of an effect.
+- `:db` and `:event` are wired in automatically. Everything else is registered with `reg-cofx` and pulled in with `(inject-cofx :id)` in the handler's interceptors slot.
+- `reg-cofx` registers a cofx handler that takes the context (and optionally a value) and returns the context with the cofx value injected under `[:coeffects <id>]`.
+- Multiple cofxes compose by listing multiple `inject-cofx` interceptors in source order.
+- `reg-event-db` doesn't see injected cofx values; use `reg-event-fx` for any handler that needs them.
+- Testing is by re-registration — stub `:now` to return a fixed instant, scope it with `with-fresh-registrar`, and the handler-under-test becomes deterministic.
+
+## Next
+
+- [04 — Views and frames](04-views-and-frames.md) — back to the core path: what's on the screen and how to keep different parts of the app isolated.
+- [04a — Interceptors](04a-interceptors.md) — the wrapping primitive `inject-cofx` is built on. Read this if you want to write a custom interceptor that's *not* a cofx (a logger, an undo wrapper, a recorder).
+- [10 — Testing](10-testing.md) — the registrar-isolation story (`with-fresh-registrar`, `reset-runtime-fixture`) and the per-frame / per-call override surface that complements cofx re-registration.
+- [Spec 002 §Per-frame and per-call overrides](../../spec/002-Frames.md#per-frame-and-per-call-overrides) — the normative surface for `:interceptor-overrides`, including the `:rf/inject-cofx-now` override pattern.

--- a/docs/guide/04a-interceptors.md
+++ b/docs/guide/04a-interceptors.md
@@ -238,7 +238,7 @@ The per-frame chain is **prepended** to the per-handler chain. So an event with 
 
 The framework's three retained helpers — `path`, `unwrap`, `inject-cofx` — are good examples of what `:before` and `:after` can do.
 
-**Adding a coeffect.** [`inject-cofx`](../../spec/002-Frames.md) is the canonical shape: a `:before` that runs a registered cofx fn and merges its result into `:coeffects`. The handler then reads the new value from its cofx map — `reg-event-fx` and `reg-event-ctx` see the full `:coeffects` map as their first argument; `reg-event-db` only sees `db` and the event vector, so it can't read injected cofx values directly (use `reg-event-fx` for any handler that needs them). The cofx mechanism is the subject of its own forthcoming chapter; until that lands, the spec section is the reference.
+**Adding a coeffect.** [`inject-cofx`](03a-coeffects.md) is the canonical shape: a `:before` that runs a registered cofx fn and merges its result into `:coeffects`. The handler then reads the new value from its cofx map — `reg-event-fx` and `reg-event-ctx` see the full `:coeffects` map as their first argument; `reg-event-db` only sees `db` and the event vector, so it can't read injected cofx values directly (use `reg-event-fx` for any handler that needs them). [Chapter 03a — Coeffects](03a-coeffects.md) is the deep-dive on the cofx surface itself; this section just locates it inside the interceptor model.
 
 **Modifying an effect.** An `:after` that walks `[:effects :db]` and applies a transformation lets you write event-handler-agnostic state-shape policy. The `undoable` example above is exactly this: an `:after` that conditionally writes to `[:effects :db :drawer :undo]` after every change.
 

--- a/docs/guide/10-testing.md
+++ b/docs/guide/10-testing.md
@@ -356,6 +356,23 @@ The `->interceptor` primitive used above, the sandwich shape, and the per-frame 
 
 Same shape as `:fx-overrides`; same per-frame / per-call duality. The `nil` value removes the interceptor entirely; a non-nil value substitutes it.
 
+### Stubbing a cofx — deterministic `:now`, predictable ids
+
+A handler that depends on the outside world via `inject-cofx` becomes deterministic by re-registering the cofx against the same id. The stub lives in the same registry the production cofx does; `inject-cofx` finds the override with no special test-mode flag:
+
+```clojure
+(deftest todo-add-stamps-created-at
+  (ts/with-fresh-registrar
+    (rf/reg-cofx :now
+      (fn [ctx] (assoc-in ctx [:coeffects :now] #inst "2026-01-01T12:00:00.000Z")))
+    (rf/with-frame [f (rf/make-frame {})]
+      (rf/dispatch-sync [:todo/add "buy milk"])
+      (is (= #inst "2026-01-01T12:00:00.000Z"
+             (-> (rf/get-frame-db f) :todos first val :created-at))))))
+```
+
+`with-fresh-registrar` scopes the stub to the test body — the production `:now` is intact for the next test. The full cofx surface (`reg-cofx`, `inject-cofx`, common cofxes, the registration shape) is covered in [chapter 03a — Coeffects](03a-coeffects.md); this entry locates the testing idiom within the broader stubbing story.
+
 ## Conformance fixtures
 
 The framework ships a **conformance corpus** — host-agnostic EDN fixtures under `spec/conformance/` — that grades implementations against a single source of truth. Each fixture describes a scenario as data: registrations, an event sequence, expected `app-db` shape, expected trace events. A conformance harness reads the fixture, replays it against an implementation, and asserts the results.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -14,6 +14,8 @@ Chapter **05a — Forms** sits between 05 and 06 as a side-track: not load-beari
 
 Chapter **04a — Interceptors** is a similar side-track between 04 and 05: a deep-dive on the wrapping primitive every `:interceptors` slot in the guide bottoms out on. Most readers can skip it on a first pass — the core path doesn't require writing a custom interceptor. Pick it up the first time you want to wrap a handler (a logger, an undo interceptor, a recorder for tests).
 
+Chapter **03a — Coeffects** is the matching side-track between 03 and 04: the *inputs* half of the handler's contract (`:db`, `:event`, and anything else `inject-cofx` injects). Skip it on a first read if your handlers only need `:db` and the event vector; pick it up the first time you hit `(inject-cofx :now)` in someone else's code, or want to test a handler that depends on the current time / a fresh UUID / a value from `localStorage`.
+
 ### Core path
 
 Read these in order. Each chapter assumes the previous one.
@@ -24,6 +26,7 @@ Read these in order. Each chapter assumes the previous one.
 | 01a | [app-db](01a-app-db.md) | The single immutable map every re-frame2 app pivots around — what it is, why immutable, why per-frame. |
 | 02 | [Your first app](02-your-first-app.md) | The counter, walked through in narrative. |
 | 03 | [Events, state, and the cycle](03-events-state-cycle.md) | The core loop, with side-effects-as-data. |
+| 03a | [Coeffects](03a-coeffects.md) | The matching *inputs* half — `reg-cofx`, `inject-cofx`, the side-causes (current time, GUIDs, localStorage). Optional side-track. |
 | 04 | [Views and frames](04-views-and-frames.md) | What you put on the screen, and how you isolate state. |
 | 04a | [Interceptors](04a-interceptors.md) | The sandwich, the context map, custom `:before` / `:after`. Optional deep-dive. |
 | 05 | [State machines](05-state-machines.md) | When the answer to a flow is a finite state machine. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - "01a — app-db": guide/01a-app-db.md
     - "02 — Your first app": guide/02-your-first-app.md
     - "03 — Events, state, the cycle": guide/03-events-state-cycle.md
+    - "03a — Coeffects": guide/03a-coeffects.md
     - "04 — Views and frames": guide/04-views-and-frames.md
     - "04a — Interceptors": guide/04a-interceptors.md
     - "05 — State machines": guide/05-state-machines.md


### PR DESCRIPTION
## Summary

Adds **ch.03a — Coeffects** as a side-track between ch.03 (Events, state, and the cycle) and ch.04 (Views and frames), parallel in shape to 04a (Interceptors) and 05a (Forms). The chapter teaches the *inputs* half of the handler's contract — the gap the audit's B-NEW-2 entry called out: ch.03 introduces ``{:keys [db]}`` and says "we'll come back to cofx," but never does.

## Slot

``docs/guide/03a-coeffects.md`` — 2,442 words. Chosen over folding into ch.03 because:

- ch.03 is already the longest core-path chapter; the dominoes walkthrough is load-bearing and shouldn't grow.
- Cofx use is optional for the core path (every chapter through 07 only destructures ``:db`` and the event); the side-track shape signals "skip on first read."
- 04a / 05a established the side-track convention; 03a slots naturally beside them.

## What the chapter covers

- Coeffects as the *side-cause* — the symmetric twin of effects, with a side-by-side table making the symmetry concrete.
- ``:db`` and ``:event`` as the wired-in cofxes; everything else is opt-in via ``reg-cofx`` + ``inject-cofx``.
- The "why a registry, not a function call" framing, parallel to ch.03's argument against direct ``js/fetch`` in handlers.
- ``reg-cofx``'s unary and binary handler shapes, with the cofx-fn-receives-context contract from ``implementation/core/src/re_frame/cofx.cljc``.
- ``inject-cofx``'s two arities; multiple cofxes composing in source order; the ``reg-event-db`` gotcha (cofx values aren't visible there — promote to ``reg-event-fx``).
- Common cofxes: ``:now``, ``:new-id`` / ``:guid``, ``:random-int``, ``:local-store``. The TodoMVC ``:todo.storage/todos`` cofx is the worked real-example.
- Testing via cofx stubs — re-register against the same id, scope with ``with-fresh-registrar``, handler-under-test becomes deterministic.
- A worked end-to-end test pairing a ``:todo/add`` event with stubbed ``:now`` and ``:new-id``.

## Forward-reference cleanups

- **ch.03** — adds a pointer from the ``{:keys [db]}`` introduction to 03a (replaces the unkept "we'll come back" promise the audit flagged).
- **ch.04a** — the inject-cofx paragraph's "subject of its own forthcoming chapter; until that lands, the spec section is the reference" is replaced by a link to 03a.
- **ch.10** — adds a "Stubbing a cofx — deterministic ``:now``, predictable ids" entry under §Stubbing fxs, recording events, replacing interceptors.
- **docs/guide/README.md** — 03a description in the side-track preface plus a core-path table row.
- **mkdocs.yml** — nav entry under Guide.

## Sources

- v1's ``Coeffects.md`` — adapted; v2 voice, v2 surface (``ctx`` argument rather than v1's ``(fn [cofx _] ...)`` shape).
- ``spec/002-Frames.md`` — coeffect / context grammar.
- ``spec/API.md`` and ``spec/001-Registration.md`` — ``reg-cofx`` / ``inject-cofx`` signatures.
- ``implementation/core/src/re_frame/cofx.cljc`` — the canonical fn contract (cofx receives full ctx, assoc-in's under ``[:coeffects <id>]``).
- ``examples/reagent/todomvc/db.cljs`` + ``events.cljs`` — the worked real example.

## Discipline

- Single-import contract: ``(:require [re-frame.core :as rf])`` (plus ``re-frame.test-support :as ts`` in the test example).
- No v1-only constructs ported (``enrich``, ``after``, ``on-changes``, ``debug``, ``reg-global-interceptor`` all absent).
- No new surface introduced; chapter teaches the existing ``reg-cofx`` / ``inject-cofx`` shape verbatim.
- No spec gaps surfaced — the chapter could be written entirely against the existing spec and impl.

## Test plan

- [ ] ``mkdocs build`` produces no broken-link warnings against ``docs/guide/03a-coeffects.md`` or its forward refs.
- [ ] All cross-references resolve in the staged docs tree (the four spec-relative links use ``../../spec/`` per the mkdocs_hooks.py contract).
- [ ] The TodoMVC cofx example in the chapter compiles against the same code path the live example uses (``rf/reg-cofx :todo.storage/todos`` ⇒ ``rf/inject-cofx :todo.storage/todos``).