### PR TITLE
refactor(epoch): extract check-restore-preconditions! from restore-epoch (rf2-676v)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -625,6 +625,101 @@
   (trace/emit-error! operation
                      (assoc tags :recovery :no-recovery)))
 
+(defn- check-restore-preconditions!
+  "Validate the six documented preconditions for restoring `frame-id`
+  to `epoch-id`. Returns:
+
+    [:ok epoch]  — all checks passed; `epoch` is the resolved history
+                   record whose `:db-after` is the restore target.
+    [:fail kw tags]
+                 — first failing check; `kw` is the trace operation
+                   the caller must emit, `tags` are its tags. No
+                   trace events are emitted from inside this helper —
+                   emission is the caller's job so the
+                   precondition test stays a pure data check.
+
+  Failure modes preserve the exact operation keywords and tag shapes
+  the public surface has always emitted (see `restore-epoch`'s
+  docstring for the catalogue)."
+  [frame-id epoch-id]
+  (let [frame-record (frame/frame frame-id)]
+    (cond
+      ;; (1) Frame registered?
+      (nil? frame-record)
+      [:fail :rf.error/no-such-handler
+       {:kind     :frame
+        :frame-id frame-id}]
+
+      ;; (2) In-flight drain?
+      (let [router (:router frame-record)
+            r      (when router @router)]
+        (and r (or (:in-drain? r) (:in-sync-drain? r))))
+      [:fail :rf.epoch/restore-during-drain
+       {:frame    frame-id
+        :epoch-id epoch-id}]
+
+      :else
+      (let [history (epoch-history frame-id)
+            epoch   (find-epoch frame-id epoch-id)]
+        (cond
+          ;; (3) Epoch present in current history?
+          (nil? epoch)
+          [:fail :rf.epoch/restore-unknown-epoch
+           {:frame        frame-id
+            :epoch-id     epoch-id
+            :history-size (count history)}]
+
+          :else
+          (let [db-target (:db-after epoch)]
+            (cond
+              ;; (4) Schema mismatch?
+              (not (schema-validate-ok? frame-id db-target))
+              ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
+              ;; the trace carries both the digest pinned on the
+              ;; epoch record (recorded) and the current frame's
+              ;; live digest, so pair tools can pinpoint *what
+              ;; changed* about the schema set, not merely *that*
+              ;; it changed.
+              [:fail :rf.epoch/restore-schema-mismatch
+               {:frame                  frame-id
+                :epoch-id               epoch-id
+                :schema-digest-recorded (:schema-digest epoch)
+                :schema-digest-current  (current-schema-digest frame-id)
+                :failing-paths          (failing-paths-for frame-id db-target)}]
+
+              ;; (5) Missing handler referenced from db?
+              (seq (missing-references db-target))
+              [:fail :rf.epoch/restore-missing-handler
+               {:frame    frame-id
+                :epoch-id epoch-id
+                :missing  (missing-references db-target)}]
+
+              ;; (6) Machine snapshot version drift?
+              (some? (machine-version-mismatch db-target))
+              (let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
+                [:fail :rf.epoch/restore-version-mismatch
+                 {:frame            frame-id
+                  :epoch-id         epoch-id
+                  :machine-id       machine-id
+                  :version-recorded recorded
+                  :version-current  current}])
+
+              :else
+              [:ok epoch])))))))
+
+(defn- perform-restore!
+  "Carry out the actual `app-db` rewind once preconditions have passed.
+  Replaces the frame's container with `epoch`'s `:db-after` and emits
+  `:rf.epoch/restored`. Returns `true`."
+  [frame-id epoch]
+  (let [container (frame/get-frame-db frame-id)
+        db-target (:db-after epoch)]
+    (adapter/replace-container! container db-target)
+    (trace/emit! :rf.epoch :rf.epoch/restored
+                 {:frame    frame-id
+                  :epoch-id (:epoch-id epoch)})
+    true))
+
 (defn restore-epoch
   "Rewind the frame's `app-db` to the named epoch's `:db-after`. Emits
   `:rf.epoch/restored` on success.
@@ -643,88 +738,11 @@
   [frame-id epoch-id]
   (if-not interop/debug-enabled?
     false
-    (let [frame-record (frame/frame frame-id)]
-      (cond
-        ;; (1) Frame registered?
-        (nil? frame-record)
-        (do
-          (emit-restore-failure! :rf.error/no-such-handler
-                                 {:kind     :frame
-                                  :frame-id frame-id})
-          false)
-
-        ;; (2) In-flight drain?
-        (let [router (:router frame-record)
-              r      (when router @router)]
-          (and r (or (:in-drain? r) (:in-sync-drain? r))))
-        (do
-          (emit-restore-failure! :rf.epoch/restore-during-drain
-                                 {:frame    frame-id
-                                  :epoch-id epoch-id})
-          false)
-
-        :else
-        (let [history (epoch-history frame-id)
-              epoch   (find-epoch frame-id epoch-id)]
-          (cond
-            ;; (3) Epoch present in current history?
-            (nil? epoch)
-            (do
-              (emit-restore-failure! :rf.epoch/restore-unknown-epoch
-                                     {:frame        frame-id
-                                      :epoch-id     epoch-id
-                                      :history-size (count history)})
-              false)
-
-            :else
-            (let [db-target (:db-after epoch)]
-              (cond
-                ;; (4) Schema mismatch?
-                (not (schema-validate-ok? frame-id db-target))
-                (do
-                  ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
-                  ;; the trace carries both the digest pinned on the
-                  ;; epoch record (recorded) and the current frame's
-                  ;; live digest, so pair tools can pinpoint *what
-                  ;; changed* about the schema set, not merely *that*
-                  ;; it changed.
-                  (emit-restore-failure! :rf.epoch/restore-schema-mismatch
-                                         {:frame                  frame-id
-                                          :epoch-id               epoch-id
-                                          :schema-digest-recorded (:schema-digest epoch)
-                                          :schema-digest-current  (current-schema-digest frame-id)
-                                          :failing-paths          (failing-paths-for frame-id db-target)})
-                  false)
-
-                ;; (5) Missing handler referenced from db?
-                (let [missing (missing-references db-target)]
-                  (seq missing))
-                (do
-                  (emit-restore-failure! :rf.epoch/restore-missing-handler
-                                         {:frame    frame-id
-                                          :epoch-id epoch-id
-                                          :missing  (missing-references db-target)})
-                  false)
-
-                ;; (6) Machine snapshot version drift?
-                (let [m (machine-version-mismatch db-target)]
-                  (some? m))
-                (let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
-                  (emit-restore-failure! :rf.epoch/restore-version-mismatch
-                                         {:frame            frame-id
-                                          :epoch-id         epoch-id
-                                          :machine-id       machine-id
-                                          :version-recorded recorded
-                                          :version-current  current})
-                  false)
-
-                :else
-                (let [container (frame/get-frame-db frame-id)]
-                  (adapter/replace-container! container db-target)
-                  (trace/emit! :rf.epoch :rf.epoch/restored
-                               {:frame    frame-id
-                                :epoch-id epoch-id})
-                  true)))))))))
+    (let [result (check-restore-preconditions! frame-id epoch-id)]
+      (case (first result)
+        :ok   (perform-restore! frame-id (second result))
+        :fail (do (emit-restore-failure! (second result) (nth result 2))
+                  false)))))
 
 ;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
 ;;


### PR DESCRIPTION
## Summary

`restore-epoch`'s body interleaved six precondition tests with the
success path via a nested `cond` — each failing branch emitted a
structured trace and returned `false` inline. Hard to skim, hard to
add a seventh failure mode to. Split into:

- `check-restore-preconditions!` — pure data check, returns
  `[:ok epoch]` or `[:fail kw tags]`. No side effects, no trace
  emissions; the helper is a precondition predicate that hands back
  enough information for the caller to either proceed or report.
- `perform-restore!` — replaces the frame's container with the
  epoch's `:db-after` and emits `:rf.epoch/restored`.
- `restore-epoch` — `interop/debug-enabled?` gate plus a 4-line
  `case` dispatch on the precondition result.

### Six failure modes preserved (operation keyword + tag shape unchanged)

| Mode | Trace operation |
| ---- | --------------- |
| Frame not registered          | `:rf.error/no-such-handler` (kind `:frame`) |
| In-flight drain               | `:rf.epoch/restore-during-drain` |
| Epoch not in history          | `:rf.epoch/restore-unknown-epoch` |
| Schema digest drift           | `:rf.epoch/restore-schema-mismatch` (carries `:schema-digest-recorded` / `:schema-digest-current` / `:failing-paths`) |
| Missing registrar reference   | `:rf.epoch/restore-missing-handler` |
| Machine snapshot version drift| `:rf.epoch/restore-version-mismatch` |

### Return contract

`check-restore-preconditions!` returns one of:

- `[:ok epoch]` — all six checks passed; `epoch` is the resolved
  `epoch-history` record whose `:db-after` is the restore target.
  Passed through to `perform-restore!` so we don't re-walk history
  on the happy path.
- `[:fail kw tags]` — first failing check; `kw` is the trace
  operation the caller emits via `emit-restore-failure!`, `tags`
  are its tags.

`restore-epoch` returns `true` on success, `false` on any failure —
same as before.

### LoC delta on `restore-epoch`

`restore-epoch`'s body shrinks from **~100 lines** of nested `cond`
to **7 lines** of `case` dispatch (-93 LoC on the public defn). Net
file delta is +18 lines because the extracted helpers carry their
own docstrings and the six failure-mode tag shapes now live in their
own labelled blocks instead of being threaded through inline `do`
forms.

### Discipline

- Pure refactor — no public surface change; `restore-epoch`'s
  arglist, docstring, and return contract are identical.
- Internal helpers are `defn-`.
- `.cljc` — JVM + CLJS.
- Disjoint from rf2-gn80 (machines/), rf2-r82g (docs/), rf2-f388 /
  PR #362 (frame.cljc). All changes confined to `implementation/epoch/`.

## Test plan

- [x] `clojure -M:test` (epoch artefact at `implementation/epoch/`):
      59 tests / 233 assertions / 0 failures / 0 errors
- [x] `npm run test:cljs`: 559 tests / 1324 assertions / 0 failures / 0 errors
- [x] `npm run test:browser`: 559 tests / 1345 assertions / 0 failures / 0 errors
- [x] `npm run test:elision`: all six `restore-epoch` failure-mode
      sentinels detected; happy-path `:rf.epoch/restored` sentinel
      detected. `=== PASS ===`