### PR TITLE
docs(guide): ch.01 — warm up "The story" with water-cycle analogy + "derived data flowing" tagline (rf2-glol)

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -15,6 +15,16 @@ This chapter is the argument for re-frame2's dynamic model.
 
 ## The story
 
+> **Derived data, flowing.**
+
+<!-- TODO: water-cycle image when rf2-0epn lands -->
+
+Picture the water cycle. Water moves around a loop — sea to cloud to rain to river to sea — propelled by gravity, evaporation, and convection. Two phases, two directions, one cycle. Nothing in the loop has to decide *that* it moves; the forces handle that. What changes between turns of the cycle is only *what* is moving and *where*.
+
+A re-frame2 app is shaped the same way. Data flows around a loop, and re-frame2 supplies the conveyance — the equivalent of gravity, evaporation, and convection. You don't write the loop. You hang pure functions on it: a function that turns an event into a state change, a function that derives a view from state, a function that turns a state slice into a side-effect. The runtime moves the data between them.
+
+That's the shape. Here are the stages.
+
 In re-frame2, the only way state changes is this:
 
 1. **Something happens** — a click, a server response, a timer tick. It becomes an *event*: a piece of data describing what happened.


### PR DESCRIPTION
## Summary

Warms up §"The story" in `docs/guide/01-why-re-frame2.md` before it hits the numbered 6-step list. Two changes:

- **Water-cycle analogy as prose warm-up** — two short paragraphs before the 6-step list. Frames re-frame2 as a loop whose conveyance (the equivalent of gravity, evaporation, and convection) is supplied by the runtime; the user hangs pure functions on the loop. Adapted from v1's [a-loop.md](https://github.com/day8/re-frame/blob/master/docs/a-loop.md) — substance preserved, cadence tightened to v2's voice.
- **"Derived data, flowing." as a one-line pull-quote epigraph** under the §The story heading, immediately above the analogy. Unornamented; it lands harder that way.

A bridge sentence — "That's the shape. Here are the stages." — hands off into the existing 6-step list unchanged. Section word count: 391 → 542 (+151).

## Out of scope / deferred

- **Image port deferred.** The water-cycle image (`water-cycle.png`) and the dominoes image (`6dominoes.png`) are tracked under separate beads — **rf2-0epn** and **rf2-0w7h** — and the images aren't in this repo yet. An HTML comment placeholder `<!-- TODO: water-cycle image when rf2-0epn lands -->` sits beside the new prose so a future agent can drop the image in without re-editing copy.

## Files

- `docs/guide/01-why-re-frame2.md` — only this file.

## Test plan

- [ ] mkdocs build is clean (no broken anchors, no link warnings around §The story).
- [ ] Visual read-through of the chapter: epigraph → analogy → 6-step list flows naturally; no double-introduction of the loop concept.
- [ ] Section §The story still ends cleanly into §"Less powerful by design".