### PR TITLE
docs(guide): ch.09 — interconnections + events-as-assembly + three mental-model angles (rf2-dvbr, rf2-sq6e, rf2-lo64)

### DIFF
--- a/docs/guide/09-the-dynamic-model.md
+++ b/docs/guide/09-the-dynamic-model.md
@@ -101,6 +101,18 @@ What you gain:
 
 The last one is the load-bearing reward. Everything else flows from it.
 
+### A few useful angles on the same shape
+
+Programmers, by habit, focus on **parts** — the dominoes, the handlers, the views. Systems theorists insist that what makes a system a system is the **lines between the boxes**. re-frame2's contribution is mostly the lines. If parts are functions, then "interconnections between functions" means *composition* — and re-frame2 supplies the composition: queue, interceptor pipeline, signal graph. The boxes are yours. The lines are the architecture.
+
+**Events as assembly language.** Look at the stream of events your app dispatches over a session — `[:user/clicked-save]`, `[:nav/route-changed ...]`, `[:tx/applied ...]`. That collection is a program. It is data. It is executed by a virtual machine you wrote, namely your registered event handlers. Each `reg-event` adds an instruction to the machine's instruction set. Assembly running on an x86, events running on your handler-machine — same idea, same shape. It happens to be a particularly debuggable VM: the program is loggable, the machine is queryable, the execution is run-to-completion.
+
+**Event sourcing.** Once you accept that events are the program, the consequence falls out: events are the source of truth, and `app-db` is a projection. To reproduce any bug you need only the last checkpoint plus the events since. Pure, loggable data — no heap dump, no timing capture. re-frame2's epoch system (chapter 11) makes this concrete: a frame's whole state at any past event is reachable by a pointer swap.
+
+**App-db as the result of a perpetual reduce.** Event handlers have the signature `(state, event) → state`. That is exactly the signature of `reduce`'s combining function. So `app-db` is the running accumulator of `(reduce step initial-db events-so-far)` — where `step` is dispatch over the registered handler set. `app-db` isn't *primary*; it's *temporary storage for the fold*. Events are primary. Elm called this `foldp` — fold-from-the-past — and it is one of the most useful mental models in the framework.
+
+**The whole app as one finite state machine.** Chapter 05 talks about *registered* FSMs — small, explicit, named state machines for pieces of your app. There is a higher-level reading: the whole application is itself an FSM. Events are the triggers, handlers are the transition rules, `app-db`'s value is the current state. The dynamic story collapses to: in state `S`, event `E` arrives, the rules take you to state `S'`. The simplest computational model we have, applied to the whole app.
+
 ## IV. The shape of the bet
 
 There's an asymmetry here that's worth saying out loud.


### PR DESCRIPTION
## Summary

Coordinated drop of three sibling ch.09 framing additions identified in the v1 docs audit (§5 B-IMP-9/10/11). All three live in §III "Less powerful by design" under a new subhead "A few useful angles on the same shape", as a single five-paragraph arc.

## The five paragraphs (in order)

1. **Interconnections** (rf2-dvbr) — Programmers focus on parts; re-frame2's contribution is the lines between the boxes. If parts are functions, interconnections are composition: queue, interceptor pipeline, signal graph.
2. **Events as assembly language** (rf2-sq6e) — Events are the program your app dispatches; registered handlers are the VM that executes it. Same shape as x86/assembly, just a more debuggable machine.
3. **Event sourcing** (rf2-lo64) — Events are the source of truth, `app-db` is a projection. To reproduce a bug you need only a checkpoint + the events since. ch.11's epoch system makes this concrete.
4. **App-db as perpetual reduce** (rf2-lo64) — Event-handler signature `(state, event) → state` is exactly `reduce`'s combining function. `app-db` is the running accumulator. Events are primary; Elm called this `foldp`.
5. **Whole app as one FSM** (rf2-lo64) — Explicitly distinguished from ch.05's *registered* FSMs. The higher-level reading: events are triggers, handlers are transition rules, `app-db`'s value is the current state.

## Ordering rationale

Interconnections is the zoomed-out frame (what re-frame2 *is*). Events-as-assembly names what flows through those interconnections. The three v1 angles (sourcing, reduce, FSM) are consequences of the first two. The arc closes §III before §IV picks up "the shape of the bet."

## Word-count delta

§III "Less powerful by design": **633 → 1027 (+394 words)**. Only `docs/guide/09-the-dynamic-model.md` touched.

## Source material

- v1 `interconnections.md` — rf2-dvbr
- v1 `data-oriented-design.md` — rf2-sq6e
- v1 `historical.md` (event sourcing / reduce / FSM sections) — rf2-lo64

Closes rf2-dvbr, rf2-sq6e, rf2-lo64.