### PR TITLE
docs(guide): ch.04 — demote Form-1/Form-2 digression off the main flow (rf2-y0qr)

### DIFF
--- a/docs/guide/04-views-and-frames.md
+++ b/docs/guide/04-views-and-frames.md
@@ -68,21 +68,24 @@ Inside a `reg-view` body, two names are available that you didn't import: `dispa
 
 What that buys you: the view's body never says "this frame" out loud. The injected `dispatch`/`subscribe` capture the surrounding frame from the React tree (when wrapped by `frame-provider`) or fall back to the dynamic-var tier or `:rf/default`. The view fn doesn't know which frame it's been instantiated under; the framework routes correctly.
 
-Form-1 views — render fns whose body is a literal hiccup expression — get the auto-inject via the macro's expansion. Form-2 views — render fns that return another fn (the "outer fn closes over args, inner fn does the work" Reagent idiom) — also work, and are the canonical shape when the view needs to capture per-instance state in the closure or maintain a Reagent-local atom for transient UI state. Both shapes are documented in [Spec 004](../../spec/004-Views.md).
-
-```clojure
-;; Form-1 — direct render
-(rf/reg-view counter []
-  [:div @(subscribe [:count])])
-
-;; Form-2 — captures args; useful for setup-once-then-render
-(rf/reg-view labelled-counter [label]
-  (let [mounted-at (js/Date.now)]
-    (fn render [label]
-      [:div label ": " @(subscribe [:count]) " (mounted " mounted-at ")"])))
-```
-
 The macro errors at compile time if you hand it a Form-3 (`reagent.core/create-class`) or a non-literal-fn body — the message points you at the underlying fn `reg-view*` for those rare cases. The compile-time check is the load-bearing piece: it stops the auto-inject from silently doing the wrong thing when the body shape isn't what the macro can rewrite.
+
+??? note "Advanced: which Reagent forms `reg-view` supports (skip on first read)"
+    If you're already familiar with Reagent's Form-1 / Form-2 / Form-3 distinction, this is how the macro handles each. If not, you don't need this yet — come back when the compile-time error above sends you here.
+
+    Form-1 views — render fns whose body is a literal hiccup expression — get the auto-inject via the macro's expansion. Form-2 views — render fns that return another fn (the "outer fn closes over args, inner fn does the work" Reagent idiom) — also work, and are the canonical shape when the view needs to capture per-instance state in the closure or maintain a Reagent-local atom for transient UI state. Form-3 (`reagent.core/create-class`) is not supported by the macro; use the underlying `reg-view*` fn for those rare cases. Both supported shapes are documented in [Spec 004](../../spec/004-Views.md).
+
+    ```clojure
+    ;; Form-1 — direct render
+    (rf/reg-view counter []
+      [:div @(subscribe [:count])])
+
+    ;; Form-2 — captures args; useful for setup-once-then-render
+    (rf/reg-view labelled-counter [label]
+      (let [mounted-at (js/Date.now)]
+        (fn render [label]
+          [:div label ": " @(subscribe [:count]) " (mounted " mounted-at ")"])))
+    ```
 
 ### Views compute hiccup only
 


### PR DESCRIPTION
## Summary

**Option (a) — collapsed admonition.**

`docs/guide/04-views-and-frames.md` §`dispatch and subscribe are auto-injected` opened with a paragraph + 11-line code sample explaining Reagent's Form-1 vs Form-2 distinction — material that interrupts the chapter's flow on `reg-view` for a reader who doesn't yet have the Reagent vocabulary.

- The Form-1/Form-2 paragraph + code sample move into a collapsed `??? note "Advanced: ... (skip on first read)"` admonition (mkdocs-material supports this via the already-enabled `admonition` + `pymdownx.details` extensions).
- The pre-existing compile-time-error sentence is surfaced as the section's closer in the main flow, and its mention of "rare cases / `reg-view*`" naturally points readers who need the digression to the admonition just below.
- Slot: the admonition sits between the `### dispatch and subscribe are auto-injected` section's closer and the `### Views compute hiccup only` section landed by rf2-gvix — that section is untouched.

Rationale: the digression was long enough (1 paragraph + 11-line code block) that an inline "skip this" label would have left the visual interruption in place; collapsing it cleans the flow while keeping the material one click away.

Word-count delta: +1 line of narrative (the admonition's one-sentence preamble), same body content otherwise.

## Test plan
- [ ] `mkdocs serve` renders the collapsed admonition correctly, with click-to-expand showing the Form-1/Form-2 paragraph and code block
- [ ] Section flow reads cleanly without expanding the admonition
- [ ] No other chapters touched; rf2-gvix's "Views compute hiccup only" section unchanged