### PR TITLE
docs(guide): ch.03 — open with Doing-vs-Causing + Et-tu-React framing (rf2-2cb7)

### DIFF
--- a/docs/guide/03-events-state-cycle.md
+++ b/docs/guide/03-events-state-cycle.md
@@ -12,7 +12,28 @@ That sounds bureaucratic. The payoff is enormous. Let's see why.
 
 ## The problem with side-effects in handlers
 
-The counter from chapter 02 only changed `app-db`. The moment the counter wants to reach outside itself — fetch the next increment from a server, persist its value to localStorage, beep — the temptation is to do the obvious thing right there in the handler:
+### Doing vs causing
+
+Consider the counter's increment handler from chapter 02:
+
+```clojure
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :count inc)))
+```
+
+We can proudly claim that this handler is **pure**: `db` and event in, new `db` out. No I/O, no clock, no globals. Tested in one line.
+
+Notice, though, what made the purity *possible*. Somewhere, *something* has to actually mutate `app-db` so the view re-renders with the new count. That `reset!` is a side-effect — somebody has to do it. The handler stays pure only because the runtime took the side-effect upon itself. The handler **caused** the state change; the runtime **did** it.
+
+Et tu, React? The same trade runs through Reagent. You write a view function that returns a hiccup vector — a pure description of UI. You never imperatively `appendChild`, never `setAttribute`. React (via Reagent) takes the hiccup, diffs against the prior tree, and mutates the DOM on your behalf. The view **caused** the rendering; React **did** it. That's why "your view is a pure function of state" is true at all — somebody else volunteered for the impure work.
+
+re-frame2 generalises this trade to *every* side-effect, not just `app-db` and the DOM. Your handler doesn't fetch HTTP; it returns a value that *says* "an HTTP request should happen." Your handler doesn't write localStorage; it returns a value that says "this key should be written." Your handler doesn't navigate; it returns a value that says "the URL should change." In every case the handler causes; the runtime does.
+
+The handler is the cleanest layer in the system. Every function it calls is pure. Every value it touches is immutable. Every test it has runs in a millisecond, without a browser, without a network, without a clock. The price is that "do X" becomes "return a value describing X." That price is paid once, at one boundary, and the rest of the codebase composes by the rules of pure-function composition — [chapter 09](09-the-dynamic-model.md#v-the-banana-issue) makes the deeper case for why that matters.
+
+### What goes wrong if you don't
+
+The moment the counter wants to reach outside itself — fetch the next increment from a server, persist its value to localStorage, beep — the temptation is to do the obvious thing right there in the handler:
 
 ```clojure
 ;; ❌ Don't do this
@@ -33,7 +54,7 @@ There are at least three problems with this.
 
 **The chain of state changes is invisible.** You can't, from reading the handler, predict what the app will look like after this event resolves. You have to trace through the `.then`, see what it dispatches, find that handler, trace its `.then`, and so on. The "dynamic story" we talked about in [chapter 01](01-why-re-frame2.md) gets harder for every async operation.
 
-The solution: **don't let the handler do the side-effect. Have it describe the side-effect as data.**
+The solution falls out of the framing above: **don't let the handler do the side-effect. Have it describe the side-effect as data, and let the runtime do it.**
 
 ## Effects as data
 


### PR DESCRIPTION
## Summary

Reframes the opener of §"The problem with side-effects in handlers" in `docs/guide/03-events-state-cycle.md` around the **Doing vs Causing** distinction, adapted from v1's `EffectfulHandlers.md`.

### The rhetorical move

1. **Setup**: re-quote the counter's `reg-event-db` handler and "proudly claim" it is pure.
2. **Reveal**: the purity is only possible because *the runtime* took the `reset!` side-effect upon itself. The handler **caused** the state change; the runtime **did** it.
3. **Bridge — "Et tu, React?"**: Reagent makes the same trade with the DOM. A view returns a hiccup description; React does the imperative mutation. "Your view is a pure function of state" is only true because someone else volunteered for the impure work.
4. **Generalise**: re-frame2 extends this trade to *every* side-effect — HTTP, localStorage, navigation. The handler describes; the runtime performs. Handler stays the cleanest layer in the system.
5. **Forward cross-link**: chapter 09 §"V. The Banana Issue" carries the deeper case for why pure-function composition pays off.

### How it slots vs the existing "Don't do this" opener

The existing `js/fetch`-in-handler example is preserved verbatim as a follow-on sub-section ("What goes wrong if you don't"). The new framing now answers *why* the discipline matters before the example shows what breaks without it. The closing pivot — "the solution falls out of the framing above" — now actually has a framing to fall out of.

### Scope

- Touches only `docs/guide/03-events-state-cycle.md`.
- No mkdocs.yml, no other chapters.
- Joe Armstrong banana quote is **not** duplicated — cross-linked to ch.09.
- Single-import contract preserved (no new code blocks, existing snippets unchanged).

§ word count: 244 → 589 (delta +345; new framing block ~345 words, within the 250-400 target).

## Test plan

- [ ] `mkdocs serve` — verify ch.03 renders, both sub-section anchors (`#doing-vs-causing`, `#what-goes-wrong-if-you-dont`) resolve.
- [ ] Click forward cross-link to ch.09 — confirm it lands on the Banana Issue section.
- [ ] Read top-to-bottom — confirm the new opener flows into the existing "Effects as data" section without redundancy.