### PR TITLE
refactor(adapters): extract route-hook! helper into substrate.adapter; deduplicate ~600 LoC across 4 adapters (rf2-l7c6)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -439,124 +439,53 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Per rf2-d4sf: publish the function-component-shape React-context-
-;; aware `current-frame` impl through the late-bind hook so
-;; `re-frame.subs/subscribe` and the dispatch envelope's `:frame`
-;; default consult the React-context tier of the 3-tier resolution
-;; chain (dynamic var → React context → :rf/default). Helix renders
-;; function components — they have no class-component-specific
-;; `(.-context cmp)` slot, so the shared impl in
-;; `re-frame.adapter.context` reads `_currentValue` directly. Helix's
-;; own `use-current-frame` hook is sugar over the same read, so
-;; subscribe / dispatch and `use-context` agree on the active frame.
-;; Reagent registers a different impl (in `re-frame.adapter.reagent`)
-;; that uses `(.-context cmp)` on the in-flight Reagent component.
+;; Each late-bind hook below is routed through `(substrate-adapter/
+;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
+;; (see that fn's docstring for the routing contract). The wrapper runs
+;; this adapter's impl ONLY when the Helix adapter is the (rf/init!)-
+;; installed one; otherwise it chains to the previously-registered
+;; handler.
 ;;
-;; Per rf2-0d35: route `:adapter/current-frame` through the installed
-;; adapter rather than blindly overwriting at ns-load time. In test
-;; bundles that load multiple adapter ns's, a plain `set-fn!` would
-;; mean only the last-loaded adapter's reader survives — see
-;; reagent.cljs for the full rationale.
-(let [previous (late-bind/get-fn :adapter/current-frame)]
-  (late-bind/set-fn! :adapter/current-frame
-    (fn helix-adapter-current-frame-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (adapter-context/function-component-current-frame)
-        (if previous
-          (previous)
-          (frame/current-frame))))))
-
-;; Per rf2-s36l: publish the reactive-substrate surfaces consumed by
-;; `re-frame.interop` through the late-bind hook table. Helix's derived
-;; values (this ns, ~line 124) reify stock `reagent.ratom/IDisposable`
-;; — the cache wiring at `re-frame.subs` calls `interop/add-on-dispose!`
-;; against them and the protocol dispatch finds the reify shape.
-;; Accordingly Helix's hooks delegate to stock Reagent's `r/atom`,
-;; `ratom/make-reaction`, etc. Helix itself ships no reactive-atom
-;; primitive (it is the minimal-React-wrapper niche per rf2-2qit),
-;; so `interop/make-reaction` under a Helix-installed app falls back
-;; to stock Reagent's.
-;;
-;; Per rf2-0d35: route through the installed adapter, mirroring the
-;; `:adapter/current-frame` pattern above. Helix's impl runs only when
-;; the Helix adapter is the `(rf/init!)`-installed one; otherwise the
-;; hook chains to a previously-registered reader.
-(let [previous (late-bind/get-fn :adapter/ratom)]
-  (late-bind/set-fn! :adapter/ratom
-    (fn helix-adapter-ratom-routed [v]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/atom v)
-        (when previous (previous v))))))
-
-(let [previous (late-bind/get-fn :adapter/ratom?)]
-  (late-bind/set-fn! :adapter/ratom?
-    (fn helix-adapter-ratom?-routed [x]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (satisfies? ratom/IReactiveAtom ^js x)
-        (if previous (previous x) false)))))
-
-(let [previous (late-bind/get-fn :adapter/make-reaction)]
-  (late-bind/set-fn! :adapter/make-reaction
-    (fn helix-adapter-make-reaction-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/make-reaction f)
-        (when previous (previous f))))))
-
-(let [previous (late-bind/get-fn :adapter/add-on-dispose!)]
-  (late-bind/set-fn! :adapter/add-on-dispose!
-    (fn helix-adapter-add-on-dispose!-routed [a-ratom f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/add-on-dispose! a-ratom f)
-        (when previous (previous a-ratom f))))))
-
-(let [previous (late-bind/get-fn :adapter/dispose!)]
-  (late-bind/set-fn! :adapter/dispose!
-    (fn helix-adapter-dispose!-routed [a-ratom]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/dispose! a-ratom)
-        (when previous (previous a-ratom))))))
-
-(let [previous (late-bind/get-fn :adapter/reactive?)]
-  (late-bind/set-fn! :adapter/reactive?
-    (fn helix-adapter-reactive?-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/reactive?)
-        (if previous (previous) false)))))
-
-(let [previous (late-bind/get-fn :adapter/after-render)]
-  (late-bind/set-fn! :adapter/after-render
-    (fn helix-adapter-after-render-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/after-render f)
-        (when previous (previous f))))))
-
-;; Per rf2-00li: publish the Helix substrate's `wrap-view` through the
-;; late-bind hook so `re-frame.views/reg-view*` routes registered
-;; render-fns through React.cloneElement-based source-coord injection
-;; instead of the hiccup-shape inline walk (which would mis-classify
-;; React-element output as a non-DOM root). Per rf2-0d35 the impl runs
-;; ONLY when the Helix adapter is the `(rf/init!)`-installed one;
-;; otherwise the hook chains to a previously-registered reader.
-;;
-;; Returns nil when no adapter in the chain is the installed one —
-;; views.cljs reads that as "no substrate-side wrap applied, fall back
-;; to the inline hiccup walk for the Reagent path." This contract
-;; matters when a test bundle loads multiple adapter ns's: every
-;; React-shaped adapter registers a routing closure, but only the
-;; installed one applies its wrap-view; for Reagent (which does NOT
-;; register a wrap-view) the chain bottoms out at nil and the inline
-;; walk runs.
-;;
-;; Production-elision: the inner `wrap-view` body sits inside
-;; `(when interop/debug-enabled? ...)` (per Spec 009 §Production
-;; builds); under :advanced + goog.DEBUG=false the wrapped fn collapses
-;; to the bare user-fn and the cloneElement branch DCEs.
-(let [previous (late-bind/get-fn :adapter/wrap-view)]
-  (late-bind/set-fn! :adapter/wrap-view
-    (fn helix-adapter-wrap-view-routed [id metadata user-fn]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (wrap-view id metadata user-fn)
-        (when previous (previous id metadata user-fn))))))
+;; Hook-specific rationale (Helix-adapter notes):
+;;   :adapter/current-frame  — rf2-d4sf. Helix renders function
+;;     components — they have no class-component (.-context cmp) slot,
+;;     so the shared impl in `re-frame.adapter.context` reads
+;;     `_currentValue` directly. Helix's own `use-current-frame` hook
+;;     is sugar over the same read, so subscribe / dispatch and
+;;     `use-context` agree on the active frame. Chain-bottom fallback
+;;     is `frame/current-frame`.
+;;   :adapter/ratom etc. — rf2-s36l. Helix's derived values reify
+;;     stock reagent.ratom/IDisposable directly, so these hooks
+;;     delegate to stock Reagent's r/atom, ratom/make-reaction, etc.
+;;     Helix itself ships no reactive-atom primitive (it is the
+;;     minimal-React-wrapper niche per rf2-2qit).
+;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
+;;     injection via React.cloneElement (the inline hiccup-walk in
+;;     views.cljs would mis-classify React-element output as a non-DOM
+;;     root). Production-elision: `wrap-view`'s body sits inside
+;;     `(when interop/debug-enabled? ...)` so closure-folds under
+;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+(substrate-adapter/route-hook! adapter :adapter/current-frame
+  adapter-context/function-component-current-frame
+  #(frame/current-frame))
+(substrate-adapter/route-hook! adapter :adapter/ratom
+  r/atom)
+(substrate-adapter/route-hook! adapter :adapter/ratom?
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/make-reaction
+  ratom/make-reaction)
+(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+  ratom/add-on-dispose!)
+(substrate-adapter/route-hook! adapter :adapter/dispose!
+  ratom/dispose!)
+(substrate-adapter/route-hook! adapter :adapter/reactive?
+  ratom/reactive?
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  r/after-render)
+(substrate-adapter/route-hook! adapter :adapter/wrap-view
+  wrap-view)
 
 ;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
 ;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -189,116 +189,45 @@
 ;; artefacts are on the classpath.
 (late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
 
-;; Per rf2-d4sf + IMPL-SPEC §9.6: publish the React-context-aware
-;; current-frame impl through the late-bind hook so subscribe / dispatch
-;; consult the React-context tier of the 3-tier resolution chain. The
-;; rewrite preserves the bridge's class-component context-read shape
-;; (`(.-context cmp)`) per IMPL-SPEC §9.6 — the views.cljs impl works
-;; with reagent-slim's class components without source change.
+;; Each late-bind hook below is routed through `(substrate-adapter/
+;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
+;; (see that fn's docstring for the routing contract). The wrapper runs
+;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
+;; one; otherwise it chains to the previously-registered handler.
 ;;
-;; Per rf2-0d35: route `:adapter/current-frame` through the installed
-;; adapter (same pattern as the bridge ns; see reagent.cljs for the
-;; full rationale). In test bundles that load multiple adapter ns's
-;; the last-loaded would otherwise silently win at the hook regardless
-;; of which adapter was actually `(rf/init!)`-installed.
-(let [previous (late-bind/get-fn :adapter/current-frame)]
-  (late-bind/set-fn! :adapter/current-frame
-    (fn reagent-slim-adapter-current-frame-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (views/current-frame)
-        (if previous
-          (previous)
-          (frame/current-frame))))))
-
-;; Per rf2-wbnl: publish reagent2's `current-component` through the
-;; late-bind hook so `re-frame.views` reads the in-flight component
-;; from the slim adapter's reactive substrate, not from stock
-;; Reagent's. Before rf2-wbnl, views.cljs statically `:require`d
-;; `reagent.core` and called its `current-component` directly — under
-;; the slim adapter that read returned nil for slim-rendered
-;; components, which silently dropped the React-context tier of the
-;; resolution chain (`subscribe`/`dispatch` under a non-default
-;; `frame-provider` routed to `:rf/default`). The classic bridge
-;; installs the same hook against stock Reagent; consumers that
-;; require exactly one of the two adapter ns's see the matching
-;; reader installed.
-;;
-;; Per rf2-0d35: route through the installed adapter (same pattern as
-;; `:adapter/current-frame` above; see reagent.cljs for the full
-;; rationale). The slim adapter's reader runs only when the slim
-;; adapter is the installed one; otherwise fall through to whatever
-;; reader was previously registered by another adapter ns.
-(let [previous (late-bind/get-fn :adapter/current-component)]
-  (late-bind/set-fn! :adapter/current-component
-    (fn reagent-slim-adapter-current-component-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/current-component)
-        (when previous (previous))))))
-
-;; Per rf2-s36l: publish the reactive-substrate surfaces consumed by
-;; `re-frame.interop` through the late-bind hook table. Before rf2-s36l,
-;; `interop.cljs` statically `:require`d stock Reagent and forwarded
-;; every call there — so under the slim adapter the very first
-;; `(interop/add-on-dispose! ...)` (called from the sub-cache's slot
-;; teardown wiring; see Spec 006 §subscription-cache and the rf2-3yij
-;; cross-substrate-cache decision) threw a protocol-dispatch error
-;; because `reagent2.ratom/Reaction` reifies its OWN `IDisposable`
-;; protocol (`reagent2.ratom/IDisposable`), NOT stock Reagent's.
-;; That parked the counter-slim-and-fast Playwright smoke (PR #305,
-;; rf2-5lbx) behind a `skip:` field until this seam landed.
-;;
-;; Per rf2-0d35: route through the installed adapter, mirroring the
-;; `:adapter/current-frame` and `:adapter/current-component` pattern
-;; established for this ns above. The slim adapter's impl runs only
-;; when this adapter is the `(rf/init!)`-installed one; otherwise the
-;; hook chains to the previously-registered reader. This keeps the
-;; stock-Reagent path live in mixed-adapter test bundles even though
-;; both adapter ns's load and call `set-fn!`.
-(let [previous (late-bind/get-fn :adapter/ratom)]
-  (late-bind/set-fn! :adapter/ratom
-    (fn reagent-slim-adapter-ratom-routed [v]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/atom v)
-        (when previous (previous v))))))
-
-(let [previous (late-bind/get-fn :adapter/ratom?)]
-  (late-bind/set-fn! :adapter/ratom?
-    (fn reagent-slim-adapter-ratom?-routed [x]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (satisfies? ratom/IReactiveAtom ^js x)
-        (if previous (previous x) false)))))
-
-(let [previous (late-bind/get-fn :adapter/make-reaction)]
-  (late-bind/set-fn! :adapter/make-reaction
-    (fn reagent-slim-adapter-make-reaction-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/make-reaction f)
-        (when previous (previous f))))))
-
-(let [previous (late-bind/get-fn :adapter/add-on-dispose!)]
-  (late-bind/set-fn! :adapter/add-on-dispose!
-    (fn reagent-slim-adapter-add-on-dispose!-routed [a-ratom f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/add-on-dispose! a-ratom f)
-        (when previous (previous a-ratom f))))))
-
-(let [previous (late-bind/get-fn :adapter/dispose!)]
-  (late-bind/set-fn! :adapter/dispose!
-    (fn reagent-slim-adapter-dispose!-routed [a-ratom]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/dispose! a-ratom)
-        (when previous (previous a-ratom))))))
-
-(let [previous (late-bind/get-fn :adapter/reactive?)]
-  (late-bind/set-fn! :adapter/reactive?
-    (fn reagent-slim-adapter-reactive?-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/reactive?)
-        (if previous (previous) false)))))
-
-(let [previous (late-bind/get-fn :adapter/after-render)]
-  (late-bind/set-fn! :adapter/after-render
-    (fn reagent-slim-adapter-after-render-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/after-render f)
-        (when previous (previous f))))))
+;; Hook-specific rationale (slim-adapter notes):
+;;   :adapter/current-frame  — rf2-d4sf + IMPL-SPEC §9.6. The rewrite
+;;     preserves the bridge's class-component (.-context cmp) shape, so
+;;     re-frame.views/current-frame works unchanged with reagent-slim's
+;;     class components. Chain-bottom fallback is frame/current-frame.
+;;   :adapter/current-component — rf2-wbnl. Wires
+;;     reagent2.core/current-component so re-frame.views resolves the
+;;     in-flight component from the slim substrate (stock Reagent's
+;;     reader would return nil for slim-rendered components).
+;;   :adapter/ratom etc. — rf2-s36l. Wires reagent2.* impls so
+;;     re-frame.interop's reactive-substrate calls dispatch onto
+;;     reagent2.ratom/IDisposable / IReactiveAtom — without this seam
+;;     the very first (interop/add-on-dispose! ...) under the slim
+;;     adapter threw because reagent2.ratom/Reaction does NOT reify
+;;     stock Reagent's IDisposable.
+(substrate-adapter/route-hook! adapter :adapter/current-frame
+  views/current-frame
+  #(frame/current-frame))
+(substrate-adapter/route-hook! adapter :adapter/current-component
+  r/current-component)
+(substrate-adapter/route-hook! adapter :adapter/ratom
+  r/atom)
+(substrate-adapter/route-hook! adapter :adapter/ratom?
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/make-reaction
+  ratom/make-reaction)
+(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+  ratom/add-on-dispose!)
+(substrate-adapter/route-hook! adapter :adapter/dispose!
+  ratom/dispose!)
+(substrate-adapter/route-hook! adapter :adapter/reactive?
+  ratom/reactive?
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  r/after-render)

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -123,155 +123,48 @@
 ;; §Adapter shipping convention (rf2-0hxm).
 (late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
 
-;; Per rf2-d4sf: publish the Reagent-shape React-context-aware
-;; `current-frame` impl through the late-bind hook so
-;; `re-frame.subs/subscribe` and the dispatch envelope's `:frame`
-;; default consult the React-context tier of the 3-tier resolution
-;; chain (dynamic var → React context → :rf/default). Before rf2-d4sf
-;; those call sites called `re-frame.frame/current-frame` directly,
-;; which only honours tiers 1 and 3 — the React-context tier was
-;; implemented in `re-frame.views/current-frame` but never reached by
-;; subscribe / dispatch, so any subscribe / dispatch under a
-;; non-default `frame-provider` silently routed to `:rf/default`.
+;; Each late-bind hook below is routed through `(substrate-adapter/
+;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
+;; (see that fn's docstring for the routing contract). The wrapper runs
+;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
+;; one; otherwise it chains to the previously-registered handler.
 ;;
-;; The Reagent impl uses `(.-context cmp)` on the in-flight Reagent
-;; component — class-component machinery surfaces context only to
-;; components whose `:contextType` matches the context object, so
-;; `reg-view*`-wrapped components route to the surrounding provider's
-;; frame while plain Reagent fns (without the `:contextType` wiring)
-;; fall through to `:rf/default`. That narrowness is what makes
-;; `:rf.warning/plain-fn-under-non-default-frame-once` (rf2-d3k3) a
-;; meaningful warning — only plain fns route to default, and the
-;; warning targets exactly that footgun. UIx / Helix substrates use
-;; `re-frame.adapter.context/function-component-current-frame` which
-;; reads `_currentValue` directly (function components have no
-;; class-context slot).
-;;
-;; Per rf2-0d35: route `:adapter/current-frame` through the installed
-;; adapter rather than blindly overwriting at ns-load time. In test
-;; bundles that load multiple adapter ns's (e.g. the in-tree shadow-cljs
-;; build, which loads reagent + reagent-slim + uix + helix), each
-;; adapter ns publishes its own impl; a plain `set-fn!` means only the
-;; last-loaded adapter's reader survives — and an app installed via
-;; `(rf/init! reagent/adapter)` then silently uses (say) UIx's
-;; `function-component-current-frame` reader, which reads
-;; `_currentValue` directly and breaks the
-;; `plain-fn-under-non-default-frame-once` warning's narrowness contract
-;; (plain Reagent fns should resolve to `:rf/default`, not the
-;; Provider's frame). The wrapper consults
-;; `(substrate-adapter/current-adapter)` and runs THIS adapter's reader
-;; only when this adapter is the installed one; otherwise it chains to
-;; the previously-installed reader (which itself does the same active-
-;; adapter check for ITS adapter). The chain terminates with
-;; `frame/current-frame` when no adapter is installed, preserving the
-;; pre-rf2-d4sf headless / pre-init shape.
-(let [previous (late-bind/get-fn :adapter/current-frame)]
-  (late-bind/set-fn! :adapter/current-frame
-    (fn reagent-adapter-current-frame-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (views/current-frame)
-        (if previous
-          (previous)
-          (frame/current-frame))))))
-
-;; Per rf2-wbnl: publish stock Reagent's `current-component` through
-;; the late-bind hook so `re-frame.views` can read the in-flight
-;; component without statically `:require`ing `reagent.core`. This is
-;; what lets the slim adapter (which ships its own `reagent2.core`
-;; build) install a different `current-component` reader. The classic
-;; bridge wires the hook to stock Reagent's reader; the slim adapter
-;; wires it to `reagent2.core/current-component`. Without this hook,
-;; views.cljs would always call stock Reagent's reader and miss
-;; slim-adapter components in mixed-mode environments.
-;;
-;; Per rf2-0d35: route through the installed adapter (same pattern as
-;; `:adapter/current-frame` above). In test bundles that load BOTH
-;; adapter ns's a plain `set-fn!` would mean only the last-loaded
-;; adapter's reader survives — and the OTHER adapter's render path
-;; silently misses the React-context tier of the frame resolution
-;; chain. Symptom (Stage 4-E regression, rf2-0d35): cross-spec
-;; `plain-fn-under-non-default-frame` asserted 2 warnings, got 0,
-;; because `(current-component)` was reading the slim adapter's
-;; `*current-component*` (always nil during stock Reagent renders) so
-;; the warning's Condition 1 (some? cmp) failed and no warning fired.
-(let [previous (late-bind/get-fn :adapter/current-component)]
-  (late-bind/set-fn! :adapter/current-component
-    (fn reagent-adapter-current-component-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/current-component)
-        (when previous (previous))))))
-
-;; Per rf2-s36l: publish the reactive-substrate surfaces consumed by
-;; `re-frame.interop` (`ratom`, `ratom?`, `make-reaction`,
-;; `add-on-dispose!`, `dispose!`, `reactive?`, `after-render`) through
-;; the late-bind hook table. Before rf2-s36l, `interop.cljs` statically
-;; `:require`d `reagent.core` / `reagent.ratom` and forwarded every call
-;; to stock Reagent's namespace — which silently misrouted slim-adapter
-;; reactions (`reagent2.ratom/Reaction` doesn't reify stock Reagent's
-;; `IDisposable`) and broke the counter-slim-and-fast smoke at first
-;; `subscribe`. Each adapter ns now publishes its substrate's impls
-;; here; this adapter wires the classic bridge to stock Reagent.
-;;
-;; Per rf2-0d35: route through the installed adapter, mirroring the
-;; pattern used by `:adapter/current-frame` and `:adapter/current-
-;; component` above. In test bundles that load multiple adapter ns's
-;; the last-loaded would otherwise silently win at the hook regardless
-;; of which adapter was actually `(rf/init!)`-installed. Each routed
-;; hook runs THIS adapter's impl only when this adapter is the
-;; installed one; otherwise it chains to the previously-registered
-;; reader (which itself does the same active-adapter check for ITS
-;; adapter). The chain terminates with nil when no adapter is
-;; installed — interop.cljs treats nil cleanly (callers either return
-;; nil/false or no-op).
-;;
-;; UIx and Helix adapters reify stock `reagent.ratom/IDisposable` on
-;; their derived values (uix.cljs:121, helix.cljs:124), so they wire
-;; their hooks to the same stock-Reagent impls below.
-(let [previous (late-bind/get-fn :adapter/ratom)]
-  (late-bind/set-fn! :adapter/ratom
-    (fn reagent-adapter-ratom-routed [v]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/atom v)
-        (when previous (previous v))))))
-
-(let [previous (late-bind/get-fn :adapter/ratom?)]
-  (late-bind/set-fn! :adapter/ratom?
-    (fn reagent-adapter-ratom?-routed [x]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (satisfies? ratom/IReactiveAtom ^js x)
-        (if previous (previous x) false)))))
-
-(let [previous (late-bind/get-fn :adapter/make-reaction)]
-  (late-bind/set-fn! :adapter/make-reaction
-    (fn reagent-adapter-make-reaction-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/make-reaction f)
-        (when previous (previous f))))))
-
-(let [previous (late-bind/get-fn :adapter/add-on-dispose!)]
-  (late-bind/set-fn! :adapter/add-on-dispose!
-    (fn reagent-adapter-add-on-dispose!-routed [a-ratom f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/add-on-dispose! a-ratom f)
-        (when previous (previous a-ratom f))))))
-
-(let [previous (late-bind/get-fn :adapter/dispose!)]
-  (late-bind/set-fn! :adapter/dispose!
-    (fn reagent-adapter-dispose!-routed [a-ratom]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/dispose! a-ratom)
-        (when previous (previous a-ratom))))))
-
-(let [previous (late-bind/get-fn :adapter/reactive?)]
-  (late-bind/set-fn! :adapter/reactive?
-    (fn reagent-adapter-reactive?-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/reactive?)
-        (if previous (previous) false)))))
-
-(let [previous (late-bind/get-fn :adapter/after-render)]
-  (late-bind/set-fn! :adapter/after-render
-    (fn reagent-adapter-after-render-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/after-render f)
-        (when previous (previous f))))))
+;; Hook-specific rationale:
+;;   :adapter/current-frame  — rf2-d4sf. React-context tier of the
+;;     3-tier resolution chain. Reagent path uses (.-context cmp) on
+;;     the in-flight Reagent component (class-component machinery), so
+;;     `reg-view*`-wrapped components route to the surrounding
+;;     provider's frame while plain Reagent fns fall through to
+;;     :rf/default — that narrowness makes the
+;;     plain-fn-under-non-default-frame-once warning meaningful.
+;;     Chain-bottom fallback is `frame/current-frame` so headless /
+;;     pre-init shape is preserved.
+;;   :adapter/current-component — rf2-wbnl. Reads stock Reagent's
+;;     in-flight component without hard-binding re-frame.views to
+;;     reagent.core; the slim adapter wires this hook to
+;;     reagent2.core/current-component.
+;;   :adapter/ratom etc. — rf2-s36l. The reactive-substrate surfaces
+;;     consumed by `re-frame.interop`. UIx and Helix adapters reify
+;;     stock reagent.ratom/IDisposable on their derived values, so
+;;     they wire these hooks to the same stock-Reagent impls.
+(substrate-adapter/route-hook! adapter :adapter/current-frame
+  views/current-frame
+  #(frame/current-frame))
+(substrate-adapter/route-hook! adapter :adapter/current-component
+  r/current-component)
+(substrate-adapter/route-hook! adapter :adapter/ratom
+  r/atom)
+(substrate-adapter/route-hook! adapter :adapter/ratom?
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/make-reaction
+  ratom/make-reaction)
+(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+  ratom/add-on-dispose!)
+(substrate-adapter/route-hook! adapter :adapter/dispose!
+  ratom/dispose!)
+(substrate-adapter/route-hook! adapter :adapter/reactive?
+  ratom/reactive?
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  r/after-render)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -432,134 +432,52 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Per rf2-d4sf: publish the function-component-shape React-context-
-;; aware `current-frame` impl through the late-bind hook so
-;; `re-frame.subs/subscribe` and the dispatch envelope's `:frame`
-;; default consult the React-context tier of the 3-tier resolution
-;; chain (dynamic var → React context → :rf/default). UIx renders
-;; function components — they have no class-component-specific
-;; `(.-context cmp)` slot, so the shared impl in
-;; `re-frame.adapter.context` reads `_currentValue` directly. UIx's
-;; own `use-current-frame` hook is sugar over the same read, so
-;; subscribe / dispatch and `use-context` agree on the active frame.
-;; Reagent registers a different impl (in `re-frame.adapter.reagent`)
-;; that uses `(.-context cmp)` on the in-flight Reagent component.
+;; Each late-bind hook below is routed through `(substrate-adapter/
+;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
+;; (see that fn's docstring for the routing contract). The wrapper runs
+;; this adapter's impl ONLY when the UIx adapter is the (rf/init!)-
+;; installed one; otherwise it chains to the previously-registered
+;; handler.
 ;;
-;; Per rf2-0d35: route `:adapter/current-frame` through the installed
-;; adapter rather than blindly overwriting at ns-load time. In test
-;; bundles that load multiple adapter ns's, a plain `set-fn!` would
-;; mean only the last-loaded adapter's reader survives — and an app
-;; installed via `(rf/init! reagent/adapter)` then silently uses (say)
-;; UIx's `function-component-current-frame` reader, which reads
-;; `_currentValue` directly and breaks the
-;; `plain-fn-under-non-default-frame-once` warning's narrowness
-;; contract for plain Reagent fns. The wrapper consults
-;; `(substrate-adapter/current-adapter)` and runs THIS adapter's
-;; reader only when this adapter is the installed one; otherwise it
-;; chains to the previously-installed reader. The chain terminates
-;; with `frame/current-frame` when no adapter is installed.
-(let [previous (late-bind/get-fn :adapter/current-frame)]
-  (late-bind/set-fn! :adapter/current-frame
-    (fn uix-adapter-current-frame-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (adapter-context/function-component-current-frame)
-        (if previous
-          (previous)
-          (frame/current-frame))))))
-
-;; Per rf2-s36l: publish the reactive-substrate surfaces consumed by
-;; `re-frame.interop` through the late-bind hook table. UIx's derived
-;; values (this ns, ~line 121) reify stock `reagent.ratom/IDisposable`
-;; — the cache wiring at `re-frame.subs` calls `interop/add-on-dispose!`
-;; against them and the protocol dispatch finds the reify shape.
-;; Accordingly UIx's hooks delegate to stock Reagent's `r/atom`,
-;; `ratom/make-reaction`, etc. UIx itself ships no reactive-atom
-;; primitive (per the rf2-3yij design), so `interop/make-reaction`
-;; under a UIx-installed app falls back to stock Reagent's
-;; (mostly used by user code paths that interleave Reagent reactions
-;; with UIx components; the UIx adapter's own derived-value impl
-;; never calls back into `interop/make-reaction`).
-;;
-;; Per rf2-0d35: route through the installed adapter, mirroring the
-;; `:adapter/current-frame` pattern above. UIx's impl runs only when
-;; the UIx adapter is the `(rf/init!)`-installed one; otherwise the
-;; hook chains to a previously-registered reader.
-(let [previous (late-bind/get-fn :adapter/ratom)]
-  (late-bind/set-fn! :adapter/ratom
-    (fn uix-adapter-ratom-routed [v]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/atom v)
-        (when previous (previous v))))))
-
-(let [previous (late-bind/get-fn :adapter/ratom?)]
-  (late-bind/set-fn! :adapter/ratom?
-    (fn uix-adapter-ratom?-routed [x]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (satisfies? ratom/IReactiveAtom ^js x)
-        (if previous (previous x) false)))))
-
-(let [previous (late-bind/get-fn :adapter/make-reaction)]
-  (late-bind/set-fn! :adapter/make-reaction
-    (fn uix-adapter-make-reaction-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/make-reaction f)
-        (when previous (previous f))))))
-
-(let [previous (late-bind/get-fn :adapter/add-on-dispose!)]
-  (late-bind/set-fn! :adapter/add-on-dispose!
-    (fn uix-adapter-add-on-dispose!-routed [a-ratom f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/add-on-dispose! a-ratom f)
-        (when previous (previous a-ratom f))))))
-
-(let [previous (late-bind/get-fn :adapter/dispose!)]
-  (late-bind/set-fn! :adapter/dispose!
-    (fn uix-adapter-dispose!-routed [a-ratom]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/dispose! a-ratom)
-        (when previous (previous a-ratom))))))
-
-(let [previous (late-bind/get-fn :adapter/reactive?)]
-  (late-bind/set-fn! :adapter/reactive?
-    (fn uix-adapter-reactive?-routed []
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (ratom/reactive?)
-        (if previous (previous) false)))))
-
-(let [previous (late-bind/get-fn :adapter/after-render)]
-  (late-bind/set-fn! :adapter/after-render
-    (fn uix-adapter-after-render-routed [f]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (r/after-render f)
-        (when previous (previous f))))))
-
-;; Per rf2-00li: publish the UIx substrate's `wrap-view` through the
-;; late-bind hook so `re-frame.views/reg-view*` routes registered
-;; render-fns through React.cloneElement-based source-coord injection
-;; instead of the hiccup-shape inline walk (which would mis-classify
-;; React-element output as a non-DOM root). Per rf2-0d35 the impl runs
-;; ONLY when the UIx adapter is the `(rf/init!)`-installed one;
-;; otherwise the hook chains to a previously-registered reader.
-;;
-;; Returns nil when no adapter in the chain is the installed one —
-;; views.cljs reads that as "no substrate-side wrap applied, fall back
-;; to the inline hiccup walk for the Reagent path." This contract
-;; matters when a test bundle loads multiple adapter ns's: every
-;; React-shaped adapter registers a routing closure, but only the
-;; installed one applies its wrap-view; for Reagent (which does NOT
-;; register a wrap-view) the chain bottoms out at nil and the inline
-;; walk runs.
-;;
-;; Production-elision: the inner `wrap-view` body sits inside
-;; `(when interop/debug-enabled? ...)` (per Spec 009 §Production
-;; builds); under :advanced + goog.DEBUG=false the wrapped fn collapses
-;; to the bare user-fn and the cloneElement branch DCEs.
-(let [previous (late-bind/get-fn :adapter/wrap-view)]
-  (late-bind/set-fn! :adapter/wrap-view
-    (fn uix-adapter-wrap-view-routed [id metadata user-fn]
-      (if (identical? adapter (substrate-adapter/current-adapter))
-        (wrap-view id metadata user-fn)
-        (when previous (previous id metadata user-fn))))))
+;; Hook-specific rationale (UIx-adapter notes):
+;;   :adapter/current-frame  — rf2-d4sf. UIx renders function
+;;     components — they have no class-component (.-context cmp) slot,
+;;     so the shared impl in `re-frame.adapter.context` reads
+;;     `_currentValue` directly. UIx's own `use-current-frame` hook is
+;;     sugar over the same read, so subscribe / dispatch and
+;;     `use-context` agree on the active frame. Chain-bottom fallback
+;;     is `frame/current-frame`.
+;;   :adapter/ratom etc. — rf2-s36l. UIx's derived values reify stock
+;;     reagent.ratom/IDisposable directly, so these hooks delegate to
+;;     stock Reagent's r/atom, ratom/make-reaction, etc. UIx itself
+;;     ships no reactive-atom primitive (per the rf2-3yij design).
+;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
+;;     injection via React.cloneElement (the inline hiccup-walk in
+;;     views.cljs would mis-classify React-element output as a non-DOM
+;;     root). Production-elision: `wrap-view`'s body sits inside
+;;     `(when interop/debug-enabled? ...)` so closure-folds under
+;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+(substrate-adapter/route-hook! adapter :adapter/current-frame
+  adapter-context/function-component-current-frame
+  #(frame/current-frame))
+(substrate-adapter/route-hook! adapter :adapter/ratom
+  r/atom)
+(substrate-adapter/route-hook! adapter :adapter/ratom?
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/make-reaction
+  ratom/make-reaction)
+(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+  ratom/add-on-dispose!)
+(substrate-adapter/route-hook! adapter :adapter/dispose!
+  ratom/dispose!)
+(substrate-adapter/route-hook! adapter :adapter/reactive?
+  ratom/reactive?
+  (constantly false))
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  r/after-render)
+(substrate-adapter/route-hook! adapter :adapter/wrap-view
+  wrap-view)
 
 ;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
 ;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -28,7 +28,8 @@
   (1) explicit > implicit at the call site; (2) the registry is bundle
   weight even when unused — under rf2-agql an app that requires only
   the adapter it needs ships only that adapter's code."
-  (:require [re-frame.trace :as trace]))
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace]))
 
 ;; ---- adapter installation -------------------------------------------------
 
@@ -118,3 +119,51 @@
   (let [a @installed-adapter
         f (:register-context-provider a)]
     (when f (f frame-keyword))))
+
+;; ---- late-bind hook routing (rf2-0d35) ------------------------------------
+;;
+;; Each CLJS adapter (reagent, reagent-slim, uix, helix) publishes ~7-9
+;; late-bind hooks at ns-load time so consumers in core (subs, views,
+;; interop) reach the installed adapter's substrate-specific impls
+;; without a static :require. In test bundles that load multiple adapter
+;; ns's, a plain (late-bind/set-fn! k impl) means only the LAST-LOADED
+;; adapter's impl survives — and an app installed via
+;; `(rf/init! reagent/adapter)` then silently uses (say) UIx's impl,
+;; breaking adapter-specific contracts.
+;;
+;; Per rf2-0d35 the fix is to wrap each adapter's impl in a routing
+;; closure that runs the impl ONLY when this adapter is the
+;; (rf/init!)-installed one; otherwise the closure chains to the
+;; previously-registered handler (which itself does the same
+;; active-adapter check for ITS adapter). The chain terminates with
+;; fallback-fn when no previous handler is registered — typically
+;; `(constantly nil)` (default), `(constantly false)` for predicates,
+;; or `#(frame/current-frame)` for the React-context-tier
+;; `:adapter/current-frame` hook (whose chain-bottom is the
+;; dynamic-var / :rf/default resolution in re-frame.frame).
+
+(defn route-hook!
+  "Install `impl-fn` under late-bind hook `hook-key`, wrapped so the call
+  dispatches to `impl-fn` ONLY when `adapter-spec` is the currently
+  (rf/init!)-installed adapter; otherwise it chains to the previously-
+  registered handler. When no previous handler is registered (this is
+  the first/only adapter to publish this hook), the routed closure
+  returns `(fallback-fn)`.
+
+  Per rf2-0d35. See `spec/006-ReactiveSubstrate.md` for the adapter
+  routing contract.
+
+  3-arg form: defaults `fallback-fn` to `(constantly nil)` — the
+  most common shape across the adapters (nil-fallback semantics).
+  4-arg form: callers pass an explicit thunk for predicate hooks
+  (`(constantly false)`) or the React-context tier
+  (`#(frame/current-frame)`)."
+  ([adapter-spec hook-key impl-fn]
+   (route-hook! adapter-spec hook-key impl-fn (constantly nil)))
+  ([adapter-spec hook-key impl-fn fallback-fn]
+   (let [previous (late-bind/get-fn hook-key)]
+     (late-bind/set-fn! hook-key
+       (fn routed-hook [& args]
+         (if (identical? adapter-spec (current-adapter))
+           (apply impl-fn args)
+           (if previous (apply previous args) (fallback-fn))))))))


### PR DESCRIPTION
## Summary

Each CLJS adapter (reagent, reagent-slim, uix, helix) repeated the same rf2-0d35 routing pattern at its bottom-of-file: 7-9 routed late-bind hooks wrapped in a `(let [previous (late-bind/get-fn k)] ...)` closure that runs THIS adapter's impl only when `(substrate-adapter/current-adapter)` is identical to this adapter, otherwise chains to the previously-installed handler. Per-adapter ~150 lines; ~600 lines of near-identical structural copy across the four.

This PR extracts a `route-hook!` helper into `re-frame.substrate.adapter` (the namespace that already houses `current-adapter` and `install-adapter!`) and rewrites each adapter's bottom-of-file block to use it.

## Helper signature

```clojure
(route-hook! adapter-spec hook-key impl-fn)              ; nil fallback (default)
(route-hook! adapter-spec hook-key impl-fn fallback-fn)  ; explicit thunk
```

- Varargs (`(fn routed-hook [& args] ...)`) so all four arities the call sites need (0-3 args) flow through unchanged.
- `fallback-fn` is a thunk: `(constantly nil)` (default), `(constantly false)` for predicate hooks (`:adapter/ratom?`, `:adapter/reactive?`), and `#(frame/current-frame)` for the React-context-tier `:adapter/current-frame` chain-bottom (preserving the pre-rf2-d4sf headless / pre-init shape).

## Per-adapter LoC delta

| File | Before | After | Δ |
|---|---:|---:|---:|
| `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` | 277 | 170 | -107 |
| `implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs` | 304 | 233 | -71 |
| `implementation/adapters/uix/src/re_frame/adapter/uix.cljs` | 579 | 497 | -82 |
| `implementation/adapters/helix/src/re_frame/adapter/helix.cljs` | 576 | 505 | -71 |
| `implementation/core/src/re_frame/substrate/adapter.cljc` | 120 | 169 | +49 |
| **Net** | | | **-282** |

Each adapter's bottom-of-file block now reads as a flat list of ~10 `route-hook!` calls instead of ~150 lines of repeated let-bindings and routed-closure shells. The per-hook rationale comments (rf2-d4sf, rf2-wbnl, rf2-s36l, rf2-00li) are consolidated into a single comment block above the `route-hook!` calls.

## What didn't change

- `:adapter/clear-warn-once-caches!` chain (uix, helix) is NOT routed and stays as the explicit chain it always was — it intentionally runs every adapter's clear-step regardless of which is installed (per rf2-4edk).
- `:reagent/set-hiccup-emitter!` is a plain `set-fn!` (no routing needed) — unchanged in each adapter.
- Observable behaviour: each routed hook resolves identically to its hand-rolled predecessor.

## Test plan

- [x] `clojure -M:test` on core, reagent, reagent-slim, uix, helix (all green)
- [x] `npm run test:cljs` — 571 tests / 1353 assertions / 0 failures
- [x] `npm run test:browser` — 559 / 1345 / 0
- [x] `npm run test:elision` — PASS
- [x] `npm run test:bundle-isolation` — PASS
- [x] `npm run test:bundle-comparison` — PASS
- [x] `npm run test:examples` — 25/25 PASS