### PR TITLE
feat(skills): re-frame-migration — guided v1→v2 migration skill (rf2-n78f)

### DIFF
--- a/skills/re-frame-migration/.claude-plugin/plugin.json
+++ b/skills/re-frame-migration/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "re-frame-migration",
+  "version": "0.1.0-alpha.1",
+  "description": "Guided v1.x → v2 migration for re-frame ClojureScript codebases — swaps the artefact coord, applies Type A mechanical rewrites, flags Type B judgment calls. A Claude Code Skill, companion to the main re-frame2 and re-frame2-setup skills.",
+  "author": {
+    "name": "day8",
+    "url": "https://github.com/day8"
+  },
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame-migration"
+  },
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "re-frame",
+    "re-frame2",
+    "migration",
+    "upgrade",
+    "reagent",
+    "clojurescript",
+    "day8"
+  ],
+  "skills": [
+    "./SKILL.md"
+  ],
+  "status": "pre-alpha"
+}

--- a/skills/re-frame-migration/LICENSE
+++ b/skills/re-frame-migration/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -1,0 +1,76 @@
+# re-frame-migration
+
+A `Skill` that helps `Claude Code` **migrate an existing re-frame v1.x ClojureScript codebase to [re-frame2](https://github.com/day8/re-frame2)** — from `re-frame/re-frame` deps to `day8/re-frame2`, mechanical rewrites applied automatically, judgment-call call sites flagged for human review.
+
+This is the **migration** companion to the main [`re-frame2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) skill (which writes new application code) and [`re-frame2-setup`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup) (which bootstraps a fresh re-frame2 project). The three skills cover the three orthogonal v2 authoring situations:
+
+- **Greenfield** — `re-frame2-setup`.
+- **Already on v2; writing application code** — `re-frame2`.
+- **Existing v1 codebase; moving to v2** — *this skill*.
+
+## What it covers
+
+The six-phase migration workflow:
+
+1. **Orient** — read the project's dep file; identify the substrate; skim `spec/MIGRATION.md` for the rule index.
+2. **Bump (M-0)** — swap `re-frame/re-frame` for `day8/re-frame2` + a substrate-adapter artefact. **Try a compile.** Most codebases require nothing more.
+3. **Sweep** — if Phase 2 surfaced failures, walk the M-rules in order. Apply Type A (mechanical) without asking; flag Type B (judgment-call) for the author.
+4. **Verify** — author runs their tests; iterate per surfaced failures.
+5. **Opt-in modernisations** (only if requested) — walk the O-rules.
+6. **Report** — produce the migration summary per `spec/MIGRATION.md` Part 2.
+
+## What it deliberately does NOT cover
+
+- The re-frame2 API itself (`reg-event-*`, `reg-sub`, `reg-machine`, frames, schemas, ...) — that's the main `re-frame2` skill.
+- Greenfield setup — that's `re-frame2-setup`.
+- Live-runtime inspection of the running v2 app — that's `re-frame-pair2`.
+- Substrate migration (Reagent → UIx / Helix) — never part of a v1→v2 migration; opt-in via O-13 / O-14.
+- Stylistic refactoring, naming changes, or any rewriting the author didn't ask for.
+- Running the author's tests — that's general software practice, not migration-specific (per the Q14 lock from the `re-frame2` skill design).
+
+## How the skill works
+
+The skill is structured around `spec/MIGRATION.md` in this repo, which is the **authoritative breaking-change list** for re-frame v1.x → re-frame2. The skill:
+
+- Routes the workflow (6 phases).
+- Sequences the rules (which to apply first, what depends on what).
+- Operationalises Type A vs Type B (mechanical vs judgment-call).
+- Produces the final migration summary.
+
+It does **not** duplicate `spec/MIGRATION.md` content. Each rule reference in the skill leaves cites an `M-N` or `O-N` rule id; the full rule text is read directly from MIGRATION.md.
+
+## Status
+
+Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real v1 codebase migration. The structure mirrors the `re-frame2-setup` skill in this same repo. The content is grounded against `spec/MIGRATION.md`, `docs/guide/08-from-re-frame-v1.md`, and `docs/the-mayor-method.md`'s paste-prompt pattern.
+
+## Layout
+
+```
+skills/re-frame-migration/
+├── SKILL.md
+├── README.md
+├── LICENSE
+├── package.json
+├── .claude-plugin/
+│   └── plugin.json
+├── reference/
+│   ├── kickoff-prompt.md          # Paste-ready prompt for a fresh session
+│   ├── setup.md                   # M-0 detail: dep-coord swap, substrate adapter picker
+│   ├── breaking-changes.md        # Rule index keyed to v1 trigger surfaces
+│   ├── sequencing.md              # Recommended rule order
+│   ├── automated-transforms.md    # Type A patterns (mechanical rewrites)
+│   ├── guided-checklist.md        # Type B walkthroughs (judgment-call rewrites)
+│   └── output-format.md           # The migration-summary shape
+└── spec/
+    ├── design.md                  # Locked design decisions
+    ├── inputs.md                  # Canonical inputs the skill leans on
+    └── authoring-prompt.md        # One-shot reauthor prompt
+```
+
+## Source of truth
+
+`spec/MIGRATION.md` at the repo root. Every rule the skill applies cites an `M-N` or `O-N` rule id from that doc. If the skill and MIGRATION.md disagree, MIGRATION.md wins.
+
+## Licence
+
+MIT. See [`LICENSE`](LICENSE).

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: re-frame-migration
+description: >
+  Migrates an existing re-frame v1.x ClojureScript codebase to re-frame2.
+  Swaps the artefact coord (re-frame/re-frame → day8/re-frame2 + a substrate
+  adapter), applies the mechanical (Type A) rewrites from spec/MIGRATION.md
+  automatically, and flags the judgment-call (Type B) call sites for human
+  review before touching them. Use this skill whenever the user is migrating,
+  upgrading, or porting a re-frame v1 project to re-frame2 — phrases like
+  "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under
+  re-frame2", or any prompt referencing a v1 surface (re-frame.db, dispatch-with,
+  reg-global-interceptor, reg-sub-raw, ^:flush-dom, re-frame.alpha, re-frame-test,
+  old top-level :dispatch/:dispatch-n effect-map keys). For greenfield
+  bootstrap, use re-frame2-setup; for writing v2 application code, use the
+  main re-frame2 skill; for live v2-app inspection, use re-frame-pair2.
+---
+
+# re-frame-migration
+
+You are helping an author **migrate a ClojureScript codebase from re-frame v1.x to re-frame2**. The author has a project that depends on `re-frame/re-frame` today. When you are done, the project depends on `day8/re-frame2` + a substrate adapter, the mechanical (Type A) rewrites have been applied, and every judgment-call (Type B) call site has been surfaced to the author with the relevant rule cited.
+
+This skill teaches the **migration workflow**. The authoritative list of what changes — the M-rules (required) and O-rules (opt-in modernisations) — lives in `spec/MIGRATION.md` in this repo. **Do not duplicate that content here.** Load `spec/MIGRATION.md` when you start the migration and treat it as the source of truth.
+
+---
+
+## When to use this skill
+
+Use this skill when **any** of these are true:
+
+- The author has an existing re-frame v1.x project and wants to move to re-frame2.
+- The author mentions migrating, upgrading, porting, or v1→v2 in a re-frame context.
+- The build fails after a dep bump and the cause looks v1-shaped (missing private namespaces, removed interceptors, `dispatch-with`, the alpha namespace, the old effect-map keys).
+- The author asks "what breaks?" / "what changes?" / "is my v1 code compatible?" with re-frame2.
+
+## When NOT to use this skill
+
+Route elsewhere when:
+
+| Author intent | Route to |
+|---|---|
+| Start a brand new re-frame2 project from scratch | `skills/re-frame2-setup/` |
+| Write event handlers, subs, machines, schemas, views in a project that is already on v2 | `skills/re-frame2/` |
+| Inspect / dispatch / debug / time-travel a *running* v2 app from the REPL | `skills/re-frame-pair2/` |
+| Understand re-frame2's design rationale (EPs, principles, conventions) | `SKILL-REDIRECT.md` at repo root |
+
+If the author has already finished migrating and is now writing new code, hand off to `re-frame2`. This skill exits when the project compiles, tests pass, and Type B items have been resolved.
+
+---
+
+## Cardinal rules
+
+These hold across every step of the migration.
+
+1. **`spec/MIGRATION.md` is the source of truth.** Every rewrite cites a rule id (`M-N` or `O-N`). If a call site doesn't match any rule, **stop and ask** — do not invent a rule.
+2. **Type A is automatic, Type B is asked-first.** Type A rewrites are mechanical, unambiguous, and observably identical. Apply them without prompting. Type B rewrites depend on intent (timing-sensitive code, dynamic call sites, behaviour-changes-at-the-edge); identify every call site, explain the risk, and **wait for the author's decision** before rewriting.
+3. **Smallest correct diff.** Do not refactor for style. Do not rename things the author didn't ask to rename. Do not add new features (frames, schemas, machines, `reg-view`) unless the author asked for the opt-in modernisations (the `O-N` rules).
+4. **Apply rules in order.** Later rules sometimes depend on earlier ones (e.g. M-0 — the coord swap — is the precondition for everything else). Walk the rules top-to-bottom as listed in `spec/MIGRATION.md`; don't jump.
+5. **JVM interop is in scope.** re-frame2 preserves `re-frame.interop` and JVM-side test runs. If the project has `.clj` test runners or JVM-side fixtures, migrate them alongside the CLJS code. Do not silently CLJS-only the project.
+6. **Single-import contract for new code.** Application namespaces use `(:require [re-frame.core :as rf])`. Direct requires of `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` are out-of-contract and get rewritten or flagged per M-1 / M-23.
+7. **If a rule looks ambiguous, file a bead — don't edit `spec/MIGRATION.md` inline.** This skill consumes that doc; it doesn't author it. Surface drift back to the maintainer.
+8. **Do not invent migration rules.** The 40+ M- and O-rules in `spec/MIGRATION.md` were the result of cross-spec review. If something in the codebase doesn't trip a rule, leave it alone and flag for human review.
+
+---
+
+## The migration workflow
+
+A six-phase walk. Each phase links to a leaf for the detail; the SKILL.md only carries the workflow shape.
+
+### Phase 1 — Orient
+
+Before touching anything, gather context. Read in this order:
+
+1. **The codebase's dep file** — `deps.edn`, `project.clj`, `shadow-cljs.edn`, or `bb.edn` — to confirm the project is actually on `re-frame/re-frame` and identify the substrate (Reagent unless told otherwise).
+2. **`spec/MIGRATION.md`** in the re-frame2 repo — the rule table. Skim Part 1 to know which rules exist; you'll reach for them by id during the migration.
+3. **The project's test suite shape** — is it `re-frame-test`-based, `cljs.test`-based, JVM-side, or absent? This tells you what "verified" looks like at the end.
+
+→ `reference/setup.md` covers the deps-coord swap (M-0) and the adapter-artefact addition (`day8/re-frame2-reagent` for a Reagent app); these are the precondition for everything else.
+
+### Phase 2 — Bump the dep (M-0)
+
+Apply M-0 from `spec/MIGRATION.md`: swap the coord from `re-frame/re-frame` to `day8/re-frame2`, **and** add a substrate-adapter artefact (`day8/re-frame2-reagent` for Reagent, `-uix` / `-helix` if the project has already moved off Reagent). Bump and **stop** — try a compile before applying any other rules. The headline expectation in MIGRATION.md is that *most codebases require no further changes*. Verify that against this project before doing more work.
+
+→ `reference/setup.md` for the per-build-tool shape (`deps.edn` vs `project.clj` vs `shadow-cljs.edn` vs `bb.edn`), the substrate-adapter picker, and what to do if no v2 version has shipped yet.
+
+### Phase 3 — Sweep for breakage
+
+If Phase 2's compile / test run surfaced failures, sweep the codebase for each M-rule in order. Use the **automated-transforms leaf** for the mechanical (Type A) rewrites and the **guided checklist** for the judgment-call (Type B) ones.
+
+→ `reference/sequencing.md` for the recommended order of rules (matches `spec/MIGRATION.md`'s ordering; restated here so an interrupted migration can pick up).
+
+→ `reference/automated-transforms.md` for the Type A patterns — find-and-replace shapes, ns-import rewrites, effect-map key folds — that can be applied without asking.
+
+→ `reference/guided-checklist.md` for the Type B walkthroughs — `:dispatch` run-to-completion (M-3), `apply`/Var-aliased registration (M-5 dynamic half), `reg-global-interceptor` in a multi-frame context (M-17), `^:flush-dom` (M-16), the `reg-view` macro rewrite (M-22), and the rest.
+
+→ `reference/breaking-changes.md` for a one-page lookup of *every* M- and O-rule keyed to the v1 symbol or pattern that triggers it — useful when the author asks "is this thing I just hit covered by a rule?"
+
+### Phase 4 — Verify
+
+Run the project's own verification. This skill does not run the tests for the author — that's general software practice, not migration-specific. The standard sequence is: re-compile, re-run unit tests, smoke-test the running app for boot / dispatch / sub / hot-reload. If any step fails, identify which rule applies, apply it, and re-verify. Repeat.
+
+### Phase 5 — Optional opt-in modernisations (only if the author asked)
+
+If — and only if — the author explicitly asked to *modernise* the codebase (not just migrate it), walk the `O-N` rules in `spec/MIGRATION.md`: rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas (O-3), frames (O-4), binary fx (O-5), the canonical event-vector shape (M-19 framed as opt-in), state machines (O-8 / O-9), substrate moves (O-13 / O-14), `:invoke-all` (O-15). These are **never** auto-applied as part of a routine migration — they are stylistic / structural upgrades the author opts into.
+
+### Phase 6 — Report
+
+Produce the migration report per `spec/MIGRATION.md` Part 2 §"Output format for your report" — coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words unless the migration was unusually complex.
+
+→ `reference/output-format.md` restates the format with one filled-in example, so the report stays consistent across migrations.
+
+---
+
+## Kickoff prompt (paste-ready)
+
+If the author wants to *delegate* the migration to a fresh Claude session — running this skill against their codebase — there is a paste-ready prompt at `reference/kickoff-prompt.md`. The author copies it into a new Claude Code session opened in the root of their v1 project; the session loads this skill and walks the six phases above autonomously, surfacing decisions back to the author at the Type B checkpoints.
+
+This is the most common shape: the migration is non-trivial enough to want a focused agent context, and the project author wants to keep their own primary session free for the rest of their work.
+
+---
+
+## Done checklist
+
+Tell the author the migration is complete when **all** of these are true:
+
+- [ ] `re-frame/re-frame` is removed from every dep file; `day8/re-frame2` + a substrate-adapter artefact have replaced it at a matching VERSION.
+- [ ] The project compiles cleanly with re-frame2 on the classpath.
+- [ ] All M-rules that tripped in this codebase have been applied (Type A) or had their flagged-for-human-review items resolved by the author (Type B).
+- [ ] The project's existing test suite passes (or, if a test failed pre-migration, it fails identically post-migration — no new test failures introduced).
+- [ ] The migration report (per `spec/MIGRATION.md` Part 2 / `reference/output-format.md`) has been produced and shared with the author.
+- [ ] Items flagged for human review are explicitly listed in the report — none are left as "todo" without the author's awareness.
+
+When the checklist passes, hand off: *"Migration complete. From here, switch to the **`re-frame2`** skill to write new application code, or **`re-frame-pair2`** to inspect the running app from the REPL. The opt-in modernisations (the `O-N` rules in `spec/MIGRATION.md`) are available whenever you want to adopt them — they are not required to be on v2."*
+
+---
+
+## Deep dives — reference files
+
+For depth on each phase, read the matching leaf — every leaf is one level deep so you can read it in full:
+
+- **`reference/kickoff-prompt.md`** — A paste-ready prompt the author drops into a fresh Claude Code session to kick the migration off. ~80 lines.
+- **`reference/setup.md`** — M-0 in operational detail: the dep-file shapes (`deps.edn`, `project.clj`, `shadow-cljs.edn`, `bb.edn`), the substrate-adapter picker, the VERSION discovery procedure, and the artefact-split implications (`day8/re-frame2-http` / `-machines` / `-routing` etc. are pay-as-you-go). ~120 lines.
+- **`reference/breaking-changes.md`** — A compressed one-page index of every M-rule and O-rule by trigger surface: when the author asks "is `X` covered?" you grep here, find the rule id, then load that rule's full text from `spec/MIGRATION.md`. ~180 lines.
+- **`reference/sequencing.md`** — The recommended order to walk the rules. Restated so a partial migration can resume cleanly. ~70 lines.
+- **`reference/automated-transforms.md`** — Type A patterns: the unambiguous mechanical rewrites the agent applies without asking. Shape-by-shape — ns rewrites, effect-map key consolidation, dispatch-with rewrites, framework-keyword consolidation. ~150 lines.
+- **`reference/guided-checklist.md`** — Type B walkthroughs: the judgment-call rewrites. One sub-section per Type B rule (M-3, M-5 dynamic half, M-11, M-17, M-22, ...). Each walks the author through identification, risk explanation, and the decision they need to make. ~140 lines.
+- **`reference/output-format.md`** — The migration-summary shape (the final report the agent produces), with two fully-filled-in worked examples. ~120 lines.
+
+---
+
+## Anti-patterns to avoid
+
+A few traps that come up often enough to flag at the top level.
+
+- **Don't apply Type B rewrites silently.** The Type A / Type B distinction exists precisely because Type B changes can break working code in non-obvious ways. If you find yourself wanting to "just" rewrite a `:dispatch`-inside-a-handler call that depended on the v1 intermediate-render behaviour, stop — that's M-3 (Type B). Identify the call site, explain the run-to-completion change, wait for the author's decision.
+- **Don't bump every dep at once.** Bump *only* the re-frame coord (M-0). Don't update Reagent, React, shadow-cljs, or anything else as part of the migration. If those need updating, they're a separate task with separate failure modes.
+- **Don't add `day8/re-frame2-schemas` (or `-machines`, `-routing`, ...) "to be safe".** The artefact split is pay-as-you-go (per M-27 through M-32). Only add a per-feature artefact when the codebase actually uses that feature; otherwise you're inflating the classpath for no win.
+- **Don't migrate plain-Reagent fns to `reg-view` as part of the v1→v2 migration.** That is O-2 — an opt-in modernisation, never part of the required path. Plain Reagent fns continue to work in v2 (with a runtime warning only if rendered under a non-default frame, per M-11).
+- **Don't touch the `re-frame-test` namespaces eagerly.** They've been renamed to `re-frame.test-support` (M-25); apply the rename as a mechanical pass. Do not rewrite the test bodies themselves unless they trip a separate rule.
+- **Don't claim "migrated" before the report is written.** The report is the contract — it's how the author knows what changed, what's flagged, and what they still own.
+
+If you hit anything else surprising, surface it to the author rather than guessing. The migration agent's job is to do the mechanical work cleanly and ask sharp questions about the rest — not to make the project owner's decisions for them.
+
+---
+
+*Authoritative breaking-change list: `spec/MIGRATION.md` (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`.*

--- a/skills/re-frame-migration/package.json
+++ b/skills/re-frame-migration/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@day8/re-frame-migration",
+  "version": "0.1.0-alpha.1",
+  "description": "Guided v1.x → v2 migration for re-frame ClojureScript codebases — swaps the artefact coord, applies Type A mechanical rewrites, flags Type B judgment calls. A Claude Code Skill, companion to the main re-frame2 and re-frame2-setup skills.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "claude-code-plugin",
+    "re-frame",
+    "re-frame2",
+    "migration",
+    "upgrade",
+    "reagent",
+    "clojurescript",
+    "day8"
+  ],
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration",
+  "bugs": {
+    "url": "https://github.com/day8/re-frame2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame-migration"
+  },
+  "license": "MIT",
+  "author": "day8 (https://github.com/day8)",
+  "files": [
+    "SKILL.md",
+    "README.md",
+    "LICENSE",
+    "reference/",
+    "spec/",
+    ".claude-plugin/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/skills/re-frame-migration/reference/automated-transforms.md
+++ b/skills/re-frame-migration/reference/automated-transforms.md
@@ -1,0 +1,365 @@
+# automated-transforms
+
+Type A patterns: the unambiguous mechanical rewrites the agent applies without asking. Each entry gives the **search shape**, the **rewrite shape**, the **rule id** (so the report cites it correctly), and any **edge case** that promotes a sub-case to Type B.
+
+For the *why* of each rule, see `spec/MIGRATION.md`. This leaf is a shape catalogue, not a rationale.
+
+## Contents
+
+- Dep-coord and namespace rewrites
+- Effect-map consolidation (M-8)
+- Dispatch-shape rewrites (M-4, M-9, M-16)
+- Framework keyword renames (M-20)
+- Interceptor list cleanup (M-21 mechanical half)
+- View / hiccup rewrites (M-22, M-24)
+- Test-namespace rename (M-25)
+- `reg-event-fx` shape (M-26 mechanical half)
+- Init / adapter (M-40, M-38)
+- Per-feature artefact adds (M-27 through M-33)
+
+---
+
+## Dep-coord and namespace rewrites
+
+### M-0 — Dep coord swap
+
+See `reference/setup.md` for the per-build-tool detail. Applied once, in Phase 2.
+
+### M-1 — Private-namespace requires
+
+```clojure
+;; SEARCH
+(:require [re-frame.db :as db])
+(:require [re-frame.db :refer [app-db]])
+(:require [re-frame.router :as router])
+(:require [re-frame.subs :as subs])
+(:require [re-frame.events :as events])
+(:require [re-frame.registrar :as reg])
+
+;; REWRITE
+;; Remove the :require entirely; replace usages per the table:
+@db/app-db           → (rf/get-frame-db :rf/default)
+@re-frame.db/app-db  → (rf/get-frame-db :rf/default)
+(reset! re-frame.db/app-db v) → flag (Type B — see M-15) — propose
+                                 (rf/dispatch-sync [::reset-app-db v])
+(subs/clear-subscription-cache!) → (rf/clear-subscription-cache! :rf/default)
+(reg/get-handler kind id) → (rf/get-handler kind id)
+```
+
+**Edge case → Type B**: `(reset! re-frame.db/app-db ...)` is intent-sensitive (real bypass vs. test reset vs. seeding); promote to M-15 review.
+
+### M-38 — Substrate adapter ns rename
+
+```clojure
+;; SEARCH
+(:require [re-frame.substrate.reagent :as reagent-adapter])
+
+;; REWRITE
+(:require [re-frame.adapter.reagent :as reagent-adapter])
+```
+
+Same for `uix` / `helix` variants.
+
+### M-23 — `re-frame.alpha` removal (mechanical half)
+
+```clojure
+;; SEARCH
+(:require [re-frame.alpha :as rf])  ; or :refer [reg sub]
+
+;; REWRITE — remove the require; rewrite each call site:
+(reg :event-fx :id ...)              → (reg-event-fx :id ...)
+(reg :event-db :id ...)              → (reg-event-db :id ...)
+(reg :event-ctx :id ...)             → (reg-event-ctx :id ...)
+(reg :sub :id ...)                   → (reg-sub :id ...)
+(reg :fx :id ...)                    → (reg-fx :id ...)
+(reg :cofx :id ...)                  → (reg-cofx :id ...)
+(reg :flow :id ...)                  → (reg-flow ...)
+(sub <vector>)                       → (subscribe <vector>)
+(sub {:re-frame/q ::id :param 1})    → (subscribe [::id 1])   ; vectorize the query-map
+```
+
+**Edge case → Type B**: any `:re-frame/lifecycle` annotation in the original — drop the annotation, file a follow-up bead if the user explicitly wanted non-default lifecycle.
+
+### M-25 — `re-frame.test` rename
+
+```clojure
+;; SEARCH
+(:require [re-frame.test :as rf-test])
+(:require [day8.re-frame.test :as rf-test])
+
+;; REWRITE
+(:require [re-frame.test-support :as rf-test])
+```
+
+Helper names (`dispatch-sequence`, `assert-state`, `run-test-sync`) unchanged.
+Also: drop `day8/re-frame-test` from the Maven coords.
+
+---
+
+## Effect-map consolidation (M-8)
+
+The single highest-impact mechanical rewrite. The transformation is structural.
+
+```clojure
+;; SEARCH
+{:db   ...
+ :dispatch       <event-vec>}
+
+{:dispatch-later <map-or-vec-of-maps>}
+
+{:dispatch-n     [<event-vec> ...]}
+
+{:db   ...
+ :<user-fx-id>   <args>}
+
+;; REWRITE — fold every non-:db key into :fx
+{:db ...
+ :fx [[:dispatch <event-vec>]]}
+
+{:fx [[:dispatch-later <map>] ...]}           ; one entry per map in the original vector
+
+{:fx [[:dispatch <e1>] [:dispatch <e2>] ...]} ; one entry per event-vec
+
+{:db ...
+ :fx [[:<user-fx-id> <args>]]}
+```
+
+**Procedure** (sweep first, then per-handler rewrite):
+
+1. Discover the project's user-fx ids: `grep -E "\\(rf/reg-fx\\s+:" -r src/`.
+2. Add the built-ins: `:dispatch`, `:dispatch-later`, `:dispatch-n`.
+3. For each `reg-event-fx` body, walk the returned effect map literal.
+4. For each top-level key other than `:db`:
+   - In the discovered set → rewrite per the rules above.
+   - Not in the set → **flag** (might be a destructure key, not an effect).
+5. If `:fx` already exists, concatenate: existing `:fx` first, new entries after.
+
+**Edge case → flag**: an unknown top-level key. Could be a destructure or a typo'd fx-id.
+
+---
+
+## Dispatch-shape rewrites
+
+### M-4 — `dispatch-with` / `dispatch-sync-with`
+
+```clojure
+;; SEARCH
+(rf/dispatch-with      <event-vec> <opts-shape>)
+(rf/dispatch-sync-with <event-vec> <opts-shape>)
+
+;; REWRITE
+(rf/dispatch      <event-vec> {:fx-overrides <opts-shape>})
+(rf/dispatch-sync <event-vec> {:fx-overrides <opts-shape>})
+```
+
+The `opts-shape` shape carries the same content; only the slot key changes (it now lives inside `:fx-overrides`).
+
+### M-9 — `dispatch-sync` inside a handler
+
+```clojure
+;; SEARCH — lexically inside (reg-event-* :id ... (fn ...))
+(rf/dispatch-sync <event-vec>)
+
+;; REWRITE — move the event into :fx
+{:db ...
+ :fx [[:dispatch <event-vec>]]}
+```
+
+If the handler was `reg-event-db`, promote it to `reg-event-fx` so it can return an `:fx` slot.
+
+### M-16 — `^:flush-dom` metadata
+
+```clojure
+;; SEARCH
+^:flush-dom <event-vec>
+
+;; REWRITE
+;; Wrap in a :dispatch-later fx
+{:fx [[:dispatch-later {:ms 0 :dispatch <event-vec>}]] ...}
+```
+
+Old form:
+```clojure
+{:dispatch ^:flush-dom [:do-work]
+ :db       (assoc db :processing true)}
+```
+
+New form:
+```clojure
+{:db (assoc db :processing true)
+ :fx [[:dispatch-later {:ms 0 :dispatch [:do-work]}]]}
+```
+
+---
+
+## Framework keyword renames (M-20)
+
+Closed mechanical rename table. Apply across all source files.
+
+```
+:re-frame/<x>                → :rf/<x>                  ; alias-survivors
+:registry/<x>                → :rf.registry/<x>
+:machine/<x>                 → :rf.machine/<x>
+:machine.lifecycle/<x>       → :rf.machine.lifecycle/<x>
+:machine.timer/<x>           → :rf.machine.timer/<x>
+:machine.event/<x>           → :rf.machine.event/<x>
+:machine.microstep/<x>       → :rf.machine.microstep/<x>
+:nav/<x>                     → :rf.nav/<x>
+:route/<framework-id>        → :rf.route/<framework-id>
+```
+
+**Framework `:route/*` ids are the closed list** in `spec/MIGRATION.md` M-20 (`:route/navigate`, `:route/url-changed`, `:route/handle-url-change`, `:route/not-found`, `:route/navigation-blocked`, `:route/continue`, `:route/cancel`, `:route/error`, `:route/transition`, `:route/resolved`, `:route/auth-guard`, `:route/equal`, `:route/chain`).
+
+**User `:route/<name>` ids** are user-defined and left alone (mechanical) or rewritten to a feature prefix (suggested, Type B). The closed framework list is the discriminator.
+
+Also rewrite the app-db slice key `[:route]` → `[:rf/route]` and the subscription head `[:route]` → `[:rf/route]`.
+
+### M-35 — actor-lifecycle fx-id rename
+
+```
+[:spawn ...]              → [:rf.machine/spawn ...]
+[:destroy-machine ...]    → [:rf.machine/destroy ...]
+```
+
+---
+
+## Interceptor list cleanup (M-21 mechanical half)
+
+Drop `debug` and `trim-v` from interceptor lists:
+
+```clojure
+;; SEARCH
+(rf/reg-event-fx :foo
+  [rf/debug rf/trim-v <other-interceptors>]
+  <handler>)
+
+;; REWRITE
+(rf/reg-event-fx :foo
+  [<other-interceptors>]
+  <handler>)
+```
+
+If the interceptor list becomes empty after dropping `debug`/`trim-v`, drop the empty vector slot entirely:
+
+```clojure
+(rf/reg-event-fx :foo <handler>)
+```
+
+**`trim-v` reaches M-19 territory** (the handler may have positional destructure). Flag the handler shape — the M-19 sweep handles destructure rewriting separately.
+
+`on-changes` / `enrich` / `after` → Type B, see `reference/guided-checklist.md`.
+
+---
+
+## View / hiccup rewrites
+
+### M-22 — `reg-view` defn-shape
+
+```clojure
+;; SEARCH — keyword-shape call
+(def my-view
+  (rf/reg-view :ns/my-view (fn [args] body)))
+
+;; REWRITE — when the id matches (keyword *ns* "my-view")
+(rf/reg-view my-view [args] body)
+
+;; REWRITE — when the id is explicit and doesn't match auto-derivation
+(rf/reg-view ^{:rf/id :ns/my-view} my-view [args] body)
+```
+
+Inside the body, drop `(rf/dispatcher)` / `(rf/subscriber)` captures — `dispatch` and `subscribe` are auto-injected:
+
+```clojure
+;; SEARCH (inside reg-view body)
+(let [d (rf/dispatcher)
+      s (rf/subscriber)]
+  [:button {:on-click #(d [:inc])} @(s [:count])])
+
+;; REWRITE
+[:button {:on-click #(dispatch [:inc])} @(subscribe [:count])]
+```
+
+**Edge case → flag (Type B)**: body is not a literal `(fn [args] body)` (Var ref, `reagent.core/create-class`, computed `fn`). Use `re-frame.core/reg-view*` (plain-fn surface) and surface to the author.
+
+### M-24 — `rf/h` removal
+
+```clojure
+;; SEARCH — namespaced view keyword nested in hiccup
+(rf/h [:div [:my-app/widget arg]])
+;; REWRITE
+[:div [my-app/widget arg]]    ; Var ref (resolves to the symbol the reg-view macro defed)
+
+;; SEARCH — late-binding intent
+(rf/h [:my-app/widget arg])
+;; REWRITE
+[(rf/view :my-app/widget) arg]
+
+;; SEARCH — HTML-only hiccup wrapped in h
+(rf/h [:div [:p "hello"]])
+;; REWRITE
+[:div [:p "hello"]]
+```
+
+Default to Var-ref form unless the call site comments / context indicate late-binding intent. The reverse migration to `view` is a one-line edit.
+
+---
+
+## `reg-event-fx` shape (M-26 mechanical half)
+
+Drop / rewrite the dropped public surfaces:
+
+```clojure
+(rf/with-trace ...)                  → (rf/emit-trace! op-type operation tags)
+(rf/merge-trace! ...)                → no equivalent; drop or convert to one emit-trace!
+(rf/finish-trace ...)                → drop
+rf/trace-api-version                 → drop (no replacement)
+(rf/purge-event-queue)               → drop (no replacement); rewrite tests to use 008's helpers
+(rf/dispatch-and-settle e)           → (rf/dispatch-sync e)
+@(rf/dispatch-and-settle e)          → (rf/dispatch-sync e)   ; the deref is gone; settle is default
+(rf/spawn-machine spec)              → wrap in event-fx returning {:fx [[:rf.machine/spawn spec]]}
+(rf/destroy-machine id)              → wrap in event-fx returning {:fx [[:rf.machine/destroy id]]}
+```
+
+**Type B → see guided-checklist**: `add-post-event-callback` / `remove-post-event-callback` / `reg-event-error-handler`.
+
+---
+
+## Init / adapter (M-40)
+
+```clojure
+;; SEARCH
+(rf/init!)
+
+;; REWRITE
+(rf/init! reagent-adapter/adapter)   ; or uix-adapter/adapter, helix-adapter/adapter
+```
+
+Pair with M-38's substrate-ns rename so the symbol resolves.
+
+---
+
+## Per-feature artefact adds (M-27 through M-33)
+
+When a per-feature surface is in use, add the dep AND add the `:require` of the implementing namespace to the file where it's used.
+
+| Surface in code | Dep to add | Namespace to require |
+|---|---|---|
+| `reg-app-schema` / `reg-event-schema` | `day8/re-frame2-schemas` | `re-frame.schemas` |
+| `reg-machine` / `sub-machine` | `day8/re-frame2-machines` | `re-frame.machines` |
+| `reg-route` / `:rf.route/*` events | `day8/re-frame2-routing` | `re-frame.routing` |
+| `reg-flow` / `:rf.fx/reg-flow` | `day8/re-frame2-flows` | `re-frame.flows` |
+| `[:rf.http/managed ...]` | `day8/re-frame2-http` | `re-frame.http` |
+| `render-to-string` (SSR) | `day8/re-frame2-ssr` | `re-frame.ssr` |
+| `epoch-history` / `restore-epoch` | `day8/re-frame2-epoch` | `re-frame.epoch` |
+
+The `:require` is what triggers the artefact's load-time hook registrations. Without it the public surface throws `:rf.error/<artefact>-artefact-missing` at the first call.
+
+---
+
+## What this leaf is NOT
+
+- It is not a complete migration script. Type B rules live in `reference/guided-checklist.md`.
+- It is not a substitute for `spec/MIGRATION.md`'s per-rule rationale — when you apply a rewrite, you cite the rule id; you don't quote the rule's text inline.
+- It is not exhaustive. The shapes here are the most common Type A trigger patterns. If a call site matches the *intent* of a Type A rule but not the *shape* here, apply the rewrite — the shapes are illustrative.
+
+When the rewrite shape doesn't fit a real call site exactly, **stop and consult the full rule in `spec/MIGRATION.md`**. Don't improvise.

--- a/skills/re-frame-migration/reference/breaking-changes.md
+++ b/skills/re-frame-migration/reference/breaking-changes.md
@@ -1,0 +1,123 @@
+# breaking-changes
+
+A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered by a rule?"* — you grep here, find the rule id, then load that rule's full text from `spec/MIGRATION.md`.
+
+**This leaf does not replace `spec/MIGRATION.md`.** It points at it. The authoritative `What to look for` / `What to do` / `Why` per rule lives in MIGRATION.md. Every entry here gives just enough to identify the rule.
+
+## Contents
+
+- Required rules (M-N) by trigger surface
+- Opt-in modernisations (O-N) by trigger surface
+- Type A vs Type B at a glance
+- What stays the same (preserved v1 surfaces)
+
+---
+
+## Required (M-rules) by trigger surface
+
+| Trigger in v1 code | Rule | Type | One-line summary |
+|---|---|---|---|
+| `re-frame/re-frame` Maven coord | **M-0** | A | Swap to `day8/re-frame2` + a substrate adapter at the same VERSION. |
+| `(:require [re-frame.db ...])`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar` | **M-1** | A | Private namespaces are off-contract. `@re-frame.db/app-db` → `(rf/get-frame-db :rf/default)`; per-namespace replacements documented inline. |
+| Code asserting subscription return is a Reagent reaction type | M-2 | — | Demoted; see O-6 (opt-in future-proofing). |
+| `:dispatch` inside a handler relied on async behaviour / intermediate render | **M-3** | B | re-frame2 drains run-to-completion. Animation chains, queue-peek tests, intermediate-render dependencies break. Each call site flagged. |
+| `(rf/dispatch-with ...)` / `(rf/dispatch-sync-with ...)` (master users only) | **M-4** | A | Use two-arg `dispatch` / `dispatch-sync` with the opts map. `:fx-overrides` carries the stub-fn slot. |
+| `(apply rf/reg-event-db ...)` or `(def my-reg rf/reg-event-db)` Var-aliasing | **M-5** | A/B | `reg-*` are macros; can't be `apply`d or Var-aliased. Direct calls unaffected. Higher-order patterns need rewriting. |
+| Long synchronous dispatch chains; runtime error `:reason :drain-depth-exceeded` | **M-6** | A | Bump `:drain-depth` on the frame (default 100) or refactor to `:dispatch-later`. |
+| `reg-fx` / `reg-cofx` that touches browser globals (`js/window`, `js/localStorage`) | **M-7** | A | Default `:platforms` is universal. Add `:platforms #{:client}` explicitly for fx that can't run JVM-side / SSR. |
+| Top-level `:dispatch`, `:dispatch-later`, `:dispatch-n`, `:http`, user-fx-id keys in effect maps | **M-8** | A | Fold every non-`:db` key into `:fx`. The effect map is `{:db ... :fx [[fx-id args] ...]}` only. |
+| `rf/dispatch-sync` called *inside* an event handler body | **M-9** | A | Move to `:fx [[:dispatch event]]`. Promote `reg-event-db` to `reg-event-fx` if needed. |
+| User registrations under `:rf/*`, `:rf.machine/*`, `:rf.route/*`, `:rf.nav/*` ... | **M-10** | B | Reserved namespace collision. Rename to the project's own feature prefix unless deliberately overriding a documented extension point. |
+| Plain Reagent fns referenced inside `(rf/frame-provider {:frame <non-default>} ...)` | **M-11** | B | Plain fns silently route subscribe/dispatch to `:rf/default`. Convert to `reg-view` *or* use `(rf/dispatcher)` / `(rf/subscriber)` *or* accept the default-frame routing. |
+| Tests asserting on exact render counts | **M-12** | B | The new sub-cache changes counts (usually fewer renders). Re-baseline test expectations. |
+| `(rf/reg-event-error-handler ...)` | **M-13** | B | Moved to frame-level `:on-error` (per-frame policy) or `register-trace-cb!` (cross-frame observer). Cross-references M-26. |
+| Adopting Spec 012 routing without `:rf.route/not-found` registered | **M-14** | B | Add `(rf/reg-route :rf.route/not-found ...)` + a not-found view. N/A if keeping a third-party router. |
+| `(reset! re-frame.db/app-db {...})` at top level (seeding) | **M-15** | B | Seed via `(rf/reg-frame :rf/default {:on-create [[:app/seed initial]]})`. Pairs with M-1's private-ns rewrite. |
+| `^:flush-dom` event-vector metadata | **M-16** | A | Replace with `:dispatch-later {:ms 0 :dispatch <event-vec>}`. |
+| `(rf/reg-global-interceptor ...)` / `(rf/clear-global-interceptor ...)` | **M-17** | A/B | Single-frame: move to default-frame `:interceptors`. Multi-frame: ask (each-frame / trace-listener / default-frame-only). |
+| `(rf/reg-sub-raw ...)` | **M-18** | B | Four rewrite paths depending on body: read-only-app-db → `reg-sub`; non-app-db source → fx-driven; lifecycle-managing → state machine; side-effecting → anti-pattern, move side effect to handler. |
+| Multi-positional event vectors `[:user/login email password]` | **M-19** | B | Opt-in. Map-payload form is canonical (`[:user/login {:email ... :password ...}]`). Multi-positional continues to work; linter nudges. |
+| `:re-frame/*`, `:machine/*`, `:route/*`, `:nav/*`, `:registry/*` framework keywords | **M-20** | A | Closed mechanical rename table to `:rf/*` / `:rf.machine/*` / `:rf.route/*` / `:rf.nav/*` / `:rf.registry/*`. User-defined `:route/<name>` ids preserved or rewritten to feature prefix per codebase convention. |
+| `rf/debug`, `rf/trim-v`, `rf/on-changes`, `rf/enrich`, `rf/after` interceptors | **M-21** | A/B | `debug` / `trim-v` mechanical drop (the trace surface and M-19 cover them). `on-changes` → flow. `enrich` / `after` → flow OR schema OR `->interceptor` OR registered fx — depends on the body. |
+| `(rf/reg-view :ns/id render-fn)` keyword-shape calls | **M-22** | A | Rewrite to defn-shape: `(rf/reg-view view-name [args] body)`. Drop `(rf/dispatcher)` / `(rf/subscriber)` captures (auto-injected). Use `^{:rf/id ...}` metadata for explicit ids; use `reg-view*` for computed ids / non-fn bodies. |
+| `(:require [re-frame.alpha ...])` — `reg`, `sub`, `reg-sub-lifecycle`, `:re-frame/lifecycle` annotations | **M-23** | A/B | Mechanical: `reg :event-fx` → `reg-event-fx`; query-map `sub` → vector `subscribe`. Drop lifecycle policy annotations (file follow-up bead if a real edge case). |
+| `(rf/h ...)` hiccup walker | **M-24** | A | Var-ref form (`[counter "..."]`) for the common case; `(rf/view :id)` for late-binding; drop the wrapper for HTML-only hiccup. |
+| `(:require [re-frame.test ...])` or `[day8.re-frame.test ...]` | **M-25** | A | Rename to `re-frame.test-support` (helpers `dispatch-sequence` / `assert-state` / `run-test-sync` keep their names). Drop `day8/re-frame-test` Maven coord — ships in core. |
+| `with-trace`, `merge-trace!`, `finish-trace`, `trace-api-version`, `add-post-event-callback`, `remove-post-event-callback`, `purge-event-queue`, `dispatch-and-settle`, `spawn-machine`, `destroy-machine` | **M-26** | A/B | Drift-sweep drops. Each maps to a v2 surface; see the full table inline. `add-post-event-callback` is Type B; the rest mostly A. |
+| `reg-app-schema` / `reg-event-schema` / `:spec` metadata | **M-27** | A | Add `day8/re-frame2-schemas` artefact; user code's API surface in `re-frame.core` is unchanged. |
+| `reg-machine` / `create-machine-handler` / `sub-machine` | **M-28** | A | Add `day8/re-frame2-machines` artefact; require `re-frame.machines` in any namespace using machine surfaces. |
+| `reg-route` / `:rf.route/*` events / `:rf/route` subs | **M-29** | A | Add `day8/re-frame2-routing` artefact; require `re-frame.routing` in any namespace using routing surfaces. |
+| `reg-flow` / `:rf.fx/reg-flow` (including post-M-21 `on-changes` rewrites) | **M-30** | A | Add `day8/re-frame2-flows` artefact; require `re-frame.flows` in any namespace using flow surfaces. |
+| `[:rf.http/managed ...]` fx, child-invokable HTTP machine | **M-31** | A | Add `day8/re-frame2-http` artefact; require `re-frame.http` in any namespace using managed HTTP. |
+| `render-to-string` (server-side SSR) | **M-32** | A | Add `day8/re-frame2-ssr` artefact; require `re-frame.ssr` server-side. |
+| `epoch-history`, `restore-epoch` | **M-33** | A | Add `day8/re-frame2-epoch` artefact; require `re-frame.epoch`. Mostly pulled transitively via `re-frame-pair2`. |
+| Spawned-actor tracking that reads `[:data :pending]` | M-34 | A | Move to runtime-owned `[:rf/spawned ...]` path. Detail in MIGRATION.md. |
+| `:spawn` / `:destroy-machine` fx ids | M-35 | A | Rename to `:rf.machine/spawn` / `:rf.machine/destroy`. |
+| Drift sweep: `:rf/route` cross-spec — no user-side action | M-36 | — | Reconciled; informational only. |
+| Adapter moves to `implementation/adapters/<name>/` — no user-side action | M-37 | — | Informational only. |
+| `(:require [re-frame.substrate.<name>])` | **M-38** | A | Rename to `re-frame.adapter.<name>`. |
+| `reg-http-interceptor` / `clear-http-interceptor` | M-39 | A | Additive request-side middleware; rename per inline table. |
+| `(rf/init!)` with no args | **M-40** | A | Now requires an explicit adapter spec map: `(rf/init! reagent-adapter/adapter)` (or the chosen adapter). |
+| `subscribe` / `dispatch` inside a React context boundary | M-41 | — | Additive: consults React-context tier. No user-side action. |
+| React-19-removed Reagent surfaces (specific list in MIGRATION.md) | M-42 | A | Ship as throw-on-call shims under `day8/reagent-slim`. Mechanical: the shims throw at runtime if used; rewrite per the call-site. |
+| `:invoke-all` slot in machine specs | M-43 | — | Additive; opt-in via O-15. No user-side action for v1→v2 migration. |
+| `:timeout-ms` on `:invoke` / `:invoke-all` | **M-44** | A | Removed. Use the parent state's `:after` timer instead. |
+| `:rf.http/managed` requests from spawned actors | M-45 | — | Additive (abort on actor-destroy). No user-side action. |
+| `:rf.http/managed` as a child-invokable machine | M-46 | — | Additive; the fx form continues to work. |
+| Machine `:tags` slot and `:rf/machine-has-tag?` sub | M-47 | — | Additive. No user-side action. |
+| `:type :parallel` machines with map-shaped `:state` | M-48 | — | Additive. No user-side action. |
+| Snapshot `:state` reader pattern-matching against the third arm (map) | M-49 | — | Additive; widens to a third arm. Readers that pattern-match exhaustively on `:state` may need to widen the dispatch. |
+
+The M-numbered slots that are "informational only" / "additive" / "—" still appear so an agent walking the rule list doesn't get confused by gaps. There is no user-side action required for those rules.
+
+## Opt-in modernisations (O-rules) by trigger surface
+
+The author **must** ask for these. They are never auto-applied as part of a routine v1→v2 migration.
+
+| Trigger / motivation | Rule | One-line summary |
+|---|---|---|
+| Register `:doc` / `:spec` / `:tags` metadata on existing events / subs / fx | **O-1** | Replace plain `[interceptors]` slot with `{:doc ... :spec ... :tags ...}` metadata map + positional `[interceptors]` afterward. |
+| Adopt `reg-view` for plain Reagent fns | **O-2** | Drop `defn`; replace with `(rf/reg-view view-name [args] body)`. Frame-aware. |
+| Add Malli schemas on `app-db` paths and on event payloads | **O-3** | Pull `day8/re-frame2-schemas`; register via `reg-app-schema`. Boundary-only — don't schema-fence every internal key. |
+| Lift a namespaced sub-tree of `app-db` into its own frame | **O-4** | Use `reg-frame :feature-name`; existing `:rf/default`-targeted events stay where they are. Multi-instance enabler. |
+| Update fx handlers to binary form `(fn [m _] ...)` | **O-5** | Future-proofs fx for full multi-frame support; both forms work today. |
+| Future-proof code that introspected Reagent-reaction subscription return types | **O-6** | Drop type checks; use `(rf/subscribe-value [...])` if you need the value outside a reactive context. |
+| `:dispatch-n` to `:fx` | O-7 | Absorbed into M-8 (no longer opt-in). |
+| Adopt the Spec 012 routing surface | **O-8** | If you have a third-party router (reitit/secretary/bidi), this is the move-to-`reg-route` rewrite. Pairs with M-14. |
+| Adopt `:system-id` named-machine addressing | **O-9** | Spec 005 addressing. Useful for multi-instance machines. |
+| Orient against Spec 000's `C-000.NN` contract clauses (implementor-facing) | O-10 | No user-code rewrite. |
+| Switch generated-machine-spec callers from `reg-machine` to `reg-machine*` | O-11 | Source-coord stamping. Codegen pipelines only. |
+| Introspect static sub-graph via `(rf/sub-topology)` | O-12 | Replaces ad-hoc walks of private sub state. |
+| Move from Reagent to UIx via `day8/re-frame2-uix` | **O-13** | Substrate swap. Not part of v1→v2; never auto-applied. |
+| Move from Reagent to Helix via `day8/re-frame2-helix` | **O-14** | Substrate swap. Not part of v1→v2; never auto-applied. |
+| Replace hand-rolled spawn-and-join with `:invoke-all` | **O-15** | Machine modernisation. The hand-rolled form continues to work. |
+
+---
+
+## Type A vs Type B — at a glance
+
+**Type A — apply automatically.** The pattern is unambiguous, the rewrite is structural, the result is observably identical (or strictly better). M-0, M-1, M-4, M-5 (direct half), M-6, M-7, M-8, M-9, M-16, M-17 (single-frame half), M-20, M-21 (`debug` / `trim-v` half), M-22, M-23 (the find-and-replace half), M-24, M-25, M-26 (most), M-27 through M-40 (mostly dep-only adds), M-42.
+
+**Type B — ask before applying.** The rewrite depends on intent the agent cannot recover statically. M-3, M-5 (Var-aliasing half), M-10, M-11, M-12, M-13, M-14, M-15, M-17 (multi-frame half), M-18, M-19, M-21 (`on-changes` / `enrich` / `after` half), M-23 (lifecycle policy half), M-26 (`add-post-event-callback` / error-handler half).
+
+If a rule is hybrid (A for one shape, B for another), the type column above lists `A/B` and the rule's text in MIGRATION.md spells out which half is which.
+
+## What stays the same (do not change)
+
+`spec/MIGRATION.md` has a fully-enumerated *"What stays the same"* section near the end of Part 1. The headline non-changes:
+
+- `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` direct invocation — same names, same call shapes.
+- Handler signatures `(fn [db [_ args]] ...)` and `(fn [{:keys [db]} event] ...)`.
+- `dispatch` / `dispatch-sync` (optional second `opts` arg is additive).
+- `subscribe`; `@(subscribe [...])` deref-to-read pattern.
+- `:<-` chained subs and `reg-sub` sugar variants.
+- `path`, `unwrap`, `inject-cofx` interceptors; `->interceptor` primitive.
+- The `:fx` slot in effect maps (the inner shape `[[fx-id args] ...]`).
+- `make-restore-fn`.
+- `reg-fx` / `reg-cofx` without `:platforms` (defaults to universal).
+- `reg-flow` / `flow<-` / `clear-flow` (in `re-frame.core`; underlying impl ships under `re-frame2-flows`).
+- `re-frame.std-interceptors` namespace.
+- JVM interop layer (`re-frame.interop`).
+- Hot-reload semantics on the default frame.
+
+If a usage doesn't match any M-rule in this table AND isn't on the preserved list, **flag it for human review** rather than guessing. The MIGRATION.md preserved list is non-exhaustive; the M-rule list is the authoritative list of breakages.

--- a/skills/re-frame-migration/reference/guided-checklist.md
+++ b/skills/re-frame-migration/reference/guided-checklist.md
@@ -1,0 +1,300 @@
+# guided-checklist
+
+Type B walkthroughs: the judgment-call rewrites. Each section gives the **identification** (how to find the call sites), the **risk explanation** (what to tell the author), and the **decision shape** (what the author must choose between). The agent identifies and explains; the author decides; the agent then applies.
+
+For Type A patterns, see `reference/automated-transforms.md`. For full rule rationale, see `spec/MIGRATION.md`.
+
+## Contents
+
+- M-3 — run-to-completion drain
+- M-5 — Var-aliased `reg-*`
+- M-10 — reserved-namespace collision
+- M-11 — plain Reagent fns under non-default frames
+- M-12 — render-count test re-baseline
+- M-13 — `reg-event-error-handler`
+- M-14 — `:rf.route/not-found` requirement (only if adopting Spec 012)
+- M-15 — top-level `app-db` seeding
+- M-17 — `reg-global-interceptor` in a multi-frame app
+- M-18 — `reg-sub-raw` rewrite-path picking
+- M-19 — opt-in map-payload migration (only if user asked)
+- M-21 — `on-changes` / `enrich` / `after`
+- M-23 — `:re-frame/lifecycle` annotation drop
+- M-26 — `add-post-event-callback` / `remove-post-event-callback`
+
+---
+
+## M-3 — Run-to-completion drain
+
+**Identify**:
+
+- Every `:dispatch` effect inside an event handler that is paired with a `:db` write the handler also returns (the v1 pattern was "render the intermediate `:db` state, then run the dispatched event on a later tick").
+- Every test that asserts on router-queue contents after `(rf/dispatch ...)`.
+- Every animation chain that uses `:dispatch` to pace frames.
+
+**Risk**: v2's drain runs to completion. The intermediate render between `:db` write and dispatched event no longer happens. Animation pacing via `:dispatch` is broken. Queue-peek tests see an empty queue.
+
+**Decision shape** (per call site):
+
+1. **Intermediate render is required** (e.g. spinner-flash-before-work): restructure so the visible state is its own event; the work runs on a separate `:dispatch-later {:ms 0}`.
+2. **Animation pacing**: convert to `:dispatch-later` with the frame interval, or move to `requestAnimationFrame` via a registered fx.
+3. **Queue-peek test**: rewrite the assertion to check resulting `app-db` state or observed effects, not queue contents.
+4. **Mechanical rewrite is fine**: leave the `:dispatch` as-is; the run-to-completion behaviour is strictly better for this site.
+
+Present every call site with its file:line and the four options; collect the author's choice; apply.
+
+---
+
+## M-5 — Var-aliased `reg-*`
+
+**Identify**:
+
+```clojure
+(def my-reg rf/reg-event-db)         ; capturing the Var as a value
+(apply rf/reg-event-db [:id handler]) ; apply over a macro
+(map #(apply rf/reg-event-db %&) ...) ; same shape inside higher-order code
+```
+
+**Risk**: `reg-*` are macros in v2; they can't be Var-aliased or `apply`d. The code fails at compile time. The fix shape depends on whether the higher-order use was essential (e.g. registering a generated list of handlers) or accidental (capturing the Var "just because").
+
+**Decision shape**:
+
+1. **Refactor to direct invocation**. The author has a list of `[id handler]` pairs; replace `(apply rf/reg-event-db pair)` with a macro of their own that expands to a sequence of direct `reg-event-db` calls.
+2. **Use the functional surface** (where it exists). re-frame2 may expose `reg-machine*` / `reg-view*` partners — plain-fn surfaces that *can* be Var-aliased. For `reg-event-*` / `reg-sub` / `reg-fx` / `reg-cofx`, no such partner ships today. If the author truly needs the functional form, **file a bead** rather than working around.
+
+---
+
+## M-10 — Reserved-namespace collision
+
+**Identify**: every `(reg-* :rf/...)` or `(reg-* :rf.<area>/...)` registration.
+
+**Risk**: `:rf/*` and its sub-namespaces are reserved for framework-owned ids. User registrations under reserved keys silently shadow framework extension points (or get overwritten by them on hot-reload), break tooling discoverability, and lose stability.
+
+**Decision shape** (per call site):
+
+1. **Rename to a feature prefix**. Pick the project's own top-level namespace (e.g. `:cart/...`, `:auth/...`). This is the default move.
+2. **Intentional override** of a documented framework extension point. Confirm with the author that this is deliberate; leave the registration in place; note it in the report.
+3. **Decline**. The author accepts the runtime warning. Rare; document the reasoning in the report.
+
+---
+
+## M-11 — Plain Reagent fns under non-default frames
+
+**Identify**:
+
+1. Find every `(rf/frame-provider {:frame <id>} ...)` whose `<id>` is **not** `:rf/default`.
+2. Walk the hiccup subtree under each such provider. List every Var-referenced function (or anonymous lambda) that is **not** registered via `rf/reg-view`. Cross-reference the `(rf/handlers :view)` registry.
+
+**Risk**: a plain Reagent function rendered inside a non-default frame's `frame-provider` silently routes its internal `(subscribe ...)` / `(dispatch ...)` calls to `:rf/default`. The runtime emits a one-time warning per `(component, frame)` pair, but the bug surfaces at runtime — by then the silent mis-route has been masking behaviour.
+
+**Decision shape** (per component-under-frame pair):
+
+1. **Convert to `reg-view`**. Replace `(defn my-view [args] ...)` with `(rf/reg-view ^{:doc "..."} my-view [args] ...)`. The view picks up the surrounding frame correctly. Recommended.
+2. **Use `(rf/dispatcher)` / `(rf/subscriber)` render-time helpers**. Inside the plain fn body, capture the frame-bound dispatcher / subscriber and replace bare `dispatch` / `subscribe` calls.
+3. **Leave as-is**. The author accepts that the component pins to `:rf/default` regardless of where it renders. Sometimes intentional (a "global" UI primitive); document why.
+
+---
+
+## M-12 — Render-count test re-baseline
+
+**Identify**: tests asserting on exact render counts: `(is (= 3 @render-count))`, `(is (= n (count @render-events)))`, etc.
+
+**Risk**: v2's sub-cache invalidation is tighter. Counts shift — usually fewer renders, occasionally more at boundaries where the new cache is more granular. Behaviour is correct; the assertion is stale.
+
+**Decision shape**: re-baseline. Run the tests; record the new counts; update the expected values. Optionally rewrite the assertion to look at *behaviour* (final state, externally-observable side effects) rather than render counts.
+
+No mechanical rewrite — the author updates the expected numbers.
+
+---
+
+## M-13 — `reg-event-error-handler`
+
+**Identify**: every `(rf/reg-event-error-handler ...)` call site.
+
+**Risk**: v1's process-wide error-handler is gone. The right replacement depends on the role the handler played:
+
+- If it was **per-frame ergonomic policy** ("when an event handler throws in this frame, route to this recovery"), it moves into the frame-level `:on-error` slot on `reg-frame` metadata.
+- If it was a **process-wide observer** (audit logging, metrics, Sentry forwarding), it moves to `register-trace-cb!` filtering on `:op-type :error`.
+
+A v1 codebase that stacked multiple handlers (e.g. one for recovery, one for logging) needs both rewrites at once.
+
+**Decision shape**:
+
+1. Read the handler body. If it modifies state or dispatches recovery events, that's `:on-error` policy.
+2. If it only logs / reports / metrics, that's a trace listener.
+3. If it does both, split the body — recovery to `:on-error`, observation to `register-trace-cb!`.
+
+Present the categorisation; confirm with the author; apply.
+
+---
+
+## M-14 — `:rf.route/not-found` requirement
+
+**Trigger**: only fires if the author is adopting Spec 012's routing surface (i.e. they're applying O-8 or had `reg-route` calls in v1). If they're keeping a third-party router (reitit, secretary, bidi-only), M-14 doesn't apply.
+
+**Identify**: codebase calls `reg-route` but does not register `:rf.route/not-found`.
+
+**Risk**: unknown URLs arrive without a fallback. The runtime emits a warning trace; in production this can be silent. Tooling and SSR rely on `:rf.route/not-found` existing.
+
+**Decision shape**: add the registration. Two pieces:
+
+1. The route: `(rf/reg-route :rf.route/not-found {:path "/*rest" :params [:map [:rest :string]]})`.
+2. A view registered under `:rf.route/not-found` (a basic 404 page; author writes the content).
+
+If the author declines, document the warning in the report.
+
+---
+
+## M-15 — Top-level `app-db` seeding
+
+**Identify**: top-level `(reset! re-frame.db/app-db ...)` or `(swap! re-frame.db/app-db ...)` calls in namespace bodies (run at load time, not inside a function).
+
+**Risk**: M-1 forbids the private-namespace require. But the seeding can't just be deleted — `app-db` no longer starts as a top-level mutable atom in v2; it lives inside the default frame's record and is initialised by the frame's `:on-create` cascade.
+
+**Decision shape**:
+
+1. **Author the `:on-create` event**. `(rf/reg-frame :rf/default {:on-create [[:app/seed initial-state]]})` plus the `[:app/seed initial]` event handler that writes the seed into `app-db`.
+2. **Move the seed to test fixtures only** if the seed is test-specific. (`with-frame` in `re-frame.test-support` accepts an `:initial-db` opt.)
+
+Present the seed value and the proposed rewrite; confirm with the author; apply both the M-1 require-removal and the M-15 `:on-create` rewrite together.
+
+---
+
+## M-17 — `reg-global-interceptor` in a multi-frame app
+
+**Trigger**: only Type B when the codebase has more than one frame. Single-frame codebases hit the Type A rewrite (move to `:rf/default` `:interceptors`).
+
+**Identify**: every `(rf/reg-global-interceptor ...)` AND the codebase has any non-default `reg-frame`.
+
+**Risk**: "global" meant "every frame" in v1 because there was only one frame. In v2 the right scope depends on intent:
+
+- If the interceptor was meant to **apply to every frame** (genuinely cross-frame behaviour modification): replicate in each `reg-frame` `:interceptors` vector. Usually an architectural smell.
+- If the interceptor was **observer-shaped** (audit, telemetry, schema-validation-via-trace): wrong tool; convert to `register-trace-cb!`.
+- If "global" really meant **"the default frame's events"** (a common single-frame habit that shouldn't apply to story/test/SSR frames): scope to `:rf/default` `:interceptors` only.
+
+`clear-global-interceptor` has no v2 replacement: re-register the frame with an updated `:interceptors` vector.
+
+**Decision shape** (per interceptor):
+
+1. Read the interceptor body. Modifies behaviour? Observes only? Both?
+2. Present the three rewrite paths with a recommendation based on the body.
+3. Author confirms; apply.
+
+---
+
+## M-18 — `reg-sub-raw` rewrite-path picking
+
+**Identify**: every `(rf/reg-sub-raw :id ...)`.
+
+**Risk**: `reg-sub-raw` is gone. The substrate has explicit replacements for each legitimate use; some patterns are anti-patterns that v2 deliberately removes (subs with side effects, subs that hold state outside `app-db`).
+
+**Decision shape** — read the raw body and pick:
+
+1. **Body reads only `app-db`**: convert to `reg-sub`. Most call sites hit here. Mechanical when the body is straightforward.
+2. **Body subscribes to a non-app-db reactive source** (WebSocket, timer, external pub/sub): convert to a registered fx that dispatches events; the sub reads `app-db`. See Pattern-AsyncEffect.
+3. **Body manages reaction lifecycle** (explicit track/dispose, on-mount/on-dispose hooks): convert to a state machine. The machine has entry/exit/data lifecycle; the snapshot lives in `app-db`.
+4. **Body has side effects** (writes to `app-db`, fires `dispatch`, mutates external state): anti-pattern. Move the side effect into an event handler; the sub reads the resulting `app-db` state. **Flag as a code-quality finding** alongside the rewrite.
+
+Present the categorisation per call site with the proposed rewrite; the author confirms before each is applied.
+
+---
+
+## M-19 — Opt-in map-payload migration
+
+**Trigger**: **only if the author has explicitly asked for opt-in modernisations.** Never as part of a routine v1→v2 migration.
+
+**Identify**: every multi-positional dispatch / subscribe call. The trigger is intent (the author chooses per-event-id when to migrate); the rewrite is mechanical given good information.
+
+**Risk**: rewriting one side (dispatch site) without the other (registration destructure) breaks the runtime. Rewrites must be atomic per event-id.
+
+**Decision shape** (per event-id):
+
+1. Find the registration for the id. Read the handler's positional destructure: `[_ [_ email password]]` → parameter names `email`, `password`.
+2. Walk every dispatch / subscribe call site for the id.
+3. Propose the rewrite: `(rf/dispatch [:user/login email password])` → `(rf/dispatch [:user/login {:email email :password password}])`; registration's destructure changes to `[_ [_ {:keys [email password]}]]`.
+4. **Flag rather than guess** when:
+   - The handler's destructure is anonymous (`[_ event]` with no inner shape) — agent can't infer names.
+   - The dispatch is built dynamically (`(rf/dispatch (cons :user/login args))`).
+   - Mixed-arity dispatches for the same id (some 2-arg, some 3-arg).
+   - Trivial-arity (`[:counter/inc]`) and single-arg (`[:user-by-id 42]`) — do **not** migrate; they stay as-is.
+
+`unwrap` users are pre-canonical at the call site; only the destructure may need a cleanup.
+
+`trim-v` users: drop `trim-v` from the interceptor list and rewrite the destructure to skip the id slot manually.
+
+---
+
+## M-21 — `on-changes` / `enrich` / `after`
+
+**Identify**: each of these three interceptors in any registration's interceptor list. Apply the M-21 mechanical drops for `debug` / `trim-v` first (in `automated-transforms.md`); these three are Type B.
+
+### `on-changes`
+
+**Risk**: the v1 interceptor is gone. v2 ships flows as the registered, toggleable replacement.
+
+**Decision shape**: rewrite `(rf/on-changes f out-path & in-paths)` as a flow:
+
+```clojure
+(rf/reg-flow
+  {:id     <picked-id>
+   :inputs <in-paths>
+   :output f
+   :path   <out-path>})
+```
+
+The author picks the flow's `:id`; the agent suggests `:legacy/<original-event-id>` as a starting point. Also: add `day8/re-frame2-flows` dep + `(:require [re-frame.flows])`.
+
+### `enrich`
+
+**Risk**: ran an arbitrary fn `:after` the handler; could modify `db`. Three replacement paths:
+
+1. **Computing derived state** → Spec 013 flow. Same rewrite as `on-changes`.
+2. **Post-handler validation** → registered `:spec` per Spec 010 (Malli schema on the registration's metadata map).
+3. **Imperative escape hatch** → custom `->interceptor` with the original body.
+
+Read the `enrich` body and propose the path; author confirms.
+
+### `after`
+
+**Risk**: ran an arbitrary fn `:after` for side effects. Three replacement paths:
+
+1. **Pure side effect, event-shaped** (analytics, logging, telemetry): canonical replacement is a registered fx returned from the handler: `:fx [[:analytics/track ...]]`.
+2. **Must run for every event of a kind**: user-defined `(rf/->interceptor :id :my-thing :after (fn [ctx] ...))`. Named, addressable, queryable.
+3. **Vendor-from-v1**: copy `re-frame.std-interceptors/after` into the project as a 7-line utility. Acceptable if the codebase uses it widely as convention.
+
+Read the body and propose; author confirms.
+
+---
+
+## M-23 — `:re-frame/lifecycle` annotation drop
+
+**Identify**: `:re-frame/lifecycle` keys in `reg-sub` metadata (pre-v1 alpha-namespace usage). The mechanical alpha → core rewrite drops these. Type B comes in if the annotation was non-default (`:no-cache`, `:forever`, `:reactive`).
+
+**Risk**: the v2 sub-cache uses a single algorithm — deferred ref-counting with grace-period. The four v1 lifecycle policies don't exist; specific edge cases that genuinely needed `:no-cache` or `:forever` are uncovered.
+
+**Decision shape**:
+
+1. Drop the annotation; the default policy almost always covers the case.
+2. If the author confirms a real need for the non-default policy (the call site explanation matters), **file a follow-up bead** naming the use case. Don't invent a v2 API. Surface to Mike.
+
+---
+
+## M-26 — `add-post-event-callback` / `remove-post-event-callback`
+
+**Identify**: every `(rf/add-post-event-callback ...)` / `(rf/remove-post-event-callback ...)`.
+
+**Risk**: the v1 per-frame post-event hook is subsumed by the trace listener API in most cases, but if the callback was behaviour-modifying (rare; should have been a frame-level interceptor), the trace listener is the wrong tool.
+
+**Decision shape**:
+
+1. **Observer-shaped callback**: convert to `(rf/register-trace-cb! key cb)`. Trace listeners see every dispatched event; filter on `:operation` for the equivalent.
+2. **Behaviour-modifying callback**: convert to a frame-level interceptor declared in `reg-frame` metadata.
+
+Read the callback body; categorise; propose; author confirms.
+
+---
+
+## Anti-pattern: silent rewrites
+
+The Type B rules exist because the rewrite **cannot** be inferred from the call site alone. If you find yourself wanting to "just rewrite" one of these without asking — stop. The whole point of Type B is that asking is cheaper than rolling back a wrong rewrite.
+
+The only Type B item the agent can apply without asking is when the author has pre-authorised a specific decision shape upfront (e.g. "for every `reg-sub-raw` that only reads `app-db`, just rewrite to `reg-sub`; flag the rest"). Bank those pre-authorisations in the report so the author can audit them.

--- a/skills/re-frame-migration/reference/kickoff-prompt.md
+++ b/skills/re-frame-migration/reference/kickoff-prompt.md
@@ -1,0 +1,65 @@
+# kickoff-prompt
+
+The paste-ready prompt for kicking off a re-frame v1 → re-frame2 migration in a fresh Claude Code session.
+
+## When to use this
+
+The author has an existing re-frame v1.x project. They want to delegate the migration to a focused Claude Code session — keeping their own primary session free — and they're sitting at the project root.
+
+Steps:
+
+1. The author installs this skill in the project (project-level `.claude/skills/re-frame-migration/`) or globally (`~/.claude/skills/re-frame-migration/`).
+2. The author opens a fresh Claude Code session in the project root.
+3. The author pastes the prompt below verbatim. The session loads the `re-frame-migration` skill on its own (the description triggers it) and walks the six phases from `SKILL.md`.
+
+---
+
+## The prompt (paste this verbatim)
+
+> *I'm migrating this ClojureScript codebase from re-frame v1.x to re-frame2. Walk the migration end-to-end per the `re-frame-migration` skill in this session.*
+>
+> *Phase 1 — Orient. Read the dep file (whichever exists: `deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), confirm we're actually on `re-frame/re-frame` today, and identify the substrate (assume Reagent unless the codebase shows otherwise). Then load `spec/MIGRATION.md` from the re-frame2 repo (clone it locally if you don't already have it; `https://github.com/day8/re-frame2` → `spec/MIGRATION.md`) and skim Part 1's rule index so you know what's available.*
+>
+> *Phase 2 — Apply M-0. Swap `re-frame/re-frame` for `day8/re-frame2` + the substrate-adapter coord (`day8/re-frame2-reagent` for Reagent). Then **stop**. Run a compile (`shadow-cljs compile <build>` or `clj -M:dev` or whatever the project's equivalent is). If it compiles, run the tests. Most codebases require no other changes — verify that before doing more work.*
+>
+> *Phase 3 — If anything broke. Sweep the failures against the M-rules in `spec/MIGRATION.md`, in the order they're listed. Apply Type A (mechanical) rules without asking. For Type B (judgment-call) rules, identify every affected call site, explain the risk the rule documents, and **wait for my approval** before rewriting. Cite the rule id (`M-N`) for every change.*
+>
+> *Phase 4 — Re-verify. Re-compile, re-run tests, smoke-test the running app. Iterate until everything passes.*
+>
+> *Phase 5 — Do NOT apply opt-in modernisations (the `O-N` rules — `reg-view`, frames, schemas, state machines, ...) unless I explicitly ask. The goal is "v1 code compiles and runs on v2," not "v1 code rewritten in v2 style."*
+>
+> *Phase 6 — Report. Produce the migration report per `spec/MIGRATION.md` Part 2 §"Output format for your report": coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words.*
+>
+> *Standing rules for this migration:*
+>
+> *- The smallest correct diff. No stylistic refactoring. No renamings I didn't ask for.*
+> *- Apply rules in their listed order — later rules sometimes depend on earlier ones.*
+> *- JVM-side tests (anything in `.clj` test runners) are in scope. Don't silently CLJS-only the project.*
+> *- If you hit a v1 surface that doesn't match any rule, **stop and ask**. Don't invent migration rules.*
+> *- Don't bump any other deps as part of this migration — only re-frame.*
+> *- Don't add per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-http`, ...) unless the codebase actually uses that feature today.*
+>
+> *Begin with Phase 1.*
+
+---
+
+## Variations
+
+Two common amendments the author may add:
+
+**"Also modernise."** Append: *"After Phase 4 verifies clean, walk the `O-N` rules in `spec/MIGRATION.md` and apply the ones that match this codebase: rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas at the boundaries (O-3), `:invoke-all` (O-15) if there's hand-rolled spawn-and-join, framework keyword consolidation (M-20 has an opt-in half). Same Type A / Type B rules — Type B asks first. Stop after each O-rule and let me decide whether to keep the change or revert."*
+
+**"Migrate in feature-branch slices."** Append: *"Land each rule-group as its own commit with the M-rule ids in the message. Don't squash. I want the history to read as `M-0`, `M-1+M-5 (mechanical sweep)`, `M-3 (Type B, approved)`, `M-22 (Type B, approved)`, `M-21 mechanical pass`, etc. Each commit should leave the project compiling — break the migration into compilable bisects."*
+
+---
+
+## Why a kickoff prompt at all
+
+The skill description triggers on a wide range of v1→v2 phrasings, but the **opening shape of the migration** is identical regardless of phrasing — the six phases above. Giving the author a paste-ready prompt:
+
+- Locks the workflow shape the first time, so the session doesn't drift mid-migration.
+- Makes the Type B "ask first" rule explicit upfront — the session can't silently rewrite timing-sensitive code.
+- Frames the migration as "bump and verify first" — matching `spec/MIGRATION.md`'s headline expectation that most codebases need no further changes.
+- Reuses the report format from `spec/MIGRATION.md` Part 2 so the report stays consistent across migrations.
+
+The prompt is short (under 400 words) so the author doesn't lose anything by pasting it verbatim, but rigid enough that a fresh session executing it walks the migration the same way every time.

--- a/skills/re-frame-migration/reference/output-format.md
+++ b/skills/re-frame-migration/reference/output-format.md
@@ -1,0 +1,115 @@
+# output-format
+
+The migration summary format. The shape from `spec/MIGRATION.md` Part 2 §"Output format for your report" is the source of truth; this leaf restates it with one filled-in example so the summary stays consistent across migrations.
+
+## The format
+
+```markdown
+## Migration summary
+
+- re-frame version: <old> → <new>
+- Files modified: <count>
+- Required rules applied: <list of M-N rule IDs, or "none">
+- Opt-in changes applied: <list of O-N rule IDs, or "none, not requested">
+- Verification: <compile/test/run results>
+
+## Items flagged for human review
+
+<list of call sites you found suspicious but did not change, with file:line and a brief explanation>
+
+## Anything unexpected
+
+<observations that don't fit elsewhere>
+```
+
+Keep it **under 300 words** unless the migration was unusually complex.
+
+## Discipline
+
+- **One summary per migration.** Even if the migration spanned multiple sessions, the summary is the single artefact the author reads at the end. Don't fragment.
+- **Cite rule ids.** Every change cites the M-N or O-N rule that authorised it. The author can grep `spec/MIGRATION.md` for each id if they want the rationale.
+- **No new findings buried in narrative.** If you discover something during the migration that warrants a `bd` bead (spec drift, missing rule, surprising behaviour), file the bead and reference it in the summary — don't bury the finding inside prose.
+- **Items flagged for human review are explicit.** A Type B rule the author **declined** to apply is just as important as one they applied. Both go in the summary.
+
+## Worked example A — only Type A rules tripped
+
+A medium-shape migration: a Reagent app with 30 events, 12 subs, no machines, no SSR, three `:dispatch` effect-map entries, one `reg-global-interceptor`, two `dispatch-sync` calls inside handlers, one `^:flush-dom`, no `reg-sub-raw`, no `re-frame.alpha`, has `re-frame-test`.
+
+```markdown
+## Migration summary
+
+- re-frame version: `re-frame/re-frame 1.4.5` → `day8/re-frame2 <VERSION>` + `day8/re-frame2-reagent <VERSION>`
+- Files modified: 14
+- Required rules applied:
+  - M-0 (1 site): deps.edn coord swap.
+  - M-1 (3 sites): private `re-frame.db` requires removed; `@re-frame.db/app-db` → `(rf/get-frame-db :rf/default)` in 3 sites.
+  - M-8 (3 sites): top-level `:dispatch` → `:fx [[:dispatch ...]]`.
+  - M-9 (2 sites): `dispatch-sync` inside handlers → `:fx [[:dispatch ...]]`.
+  - M-16 (1 site): `^:flush-dom` metadata → `:dispatch-later {:ms 0}`.
+  - M-17 (1 site, Type A — single-frame app): `reg-global-interceptor` → default-frame `:interceptors`.
+  - M-20 (4 sites): `:re-frame/default` → `:rf/default`.
+  - M-25 (1 site): `re-frame.test` → `re-frame.test-support`; `day8/re-frame-test` coord dropped.
+  - M-40 (1 site): `(rf/init!)` → `(rf/init! reagent-adapter/adapter)`.
+- Opt-in changes applied: none, not requested.
+- Verification:
+  - Compile: clean.
+  - Tests: 47 pass, 0 fail (pre-migration baseline: 47/0).
+  - Smoke-test: boot OK, dispatch + sub + hot-reload all green.
+
+## Items flagged for human review
+
+None — the codebase tripped only Type A rules.
+
+## Anything unexpected
+
+- `:re-frame/default` appeared 4 times across the codebase; one was a comment string ("uses the :re-frame/default frame"). Not rewritten — comment text only. Flagging in case the author wants comments updated for consistency.
+```
+
+## Worked example B — Type B rules and a flagged test
+
+Same shape but the codebase also had two `reg-sub-raw` calls, a multi-frame structure with a `reg-global-interceptor`, and a render-count assertion in a test.
+
+```markdown
+## Migration summary
+
+- re-frame version: `re-frame/re-frame 1.4.5` → `day8/re-frame2 <VERSION>` + `day8/re-frame2-reagent <VERSION>`
+- Files modified: 18 (+ 2 awaiting author decision)
+- Required rules applied: M-0, M-1 (5 sites), M-8 (7 sites), M-9 (3 sites), M-20 (9 sites), M-25 (1 site), M-40 (1 site).
+- Type B rules applied (with explicit author approval):
+  - M-3 (2 sites): `:dispatch` effects with intermediate-render dependency were both real animation pacing — converted to `:dispatch-later`.
+  - M-17 (1 site, multi-frame): `reg-global-interceptor` was an audit logger — converted to `register-trace-cb!`.
+- Opt-in changes applied: none, not requested.
+- Verification:
+  - Compile: clean.
+  - Tests: 89 pass, 1 fail. Render-count assertion in `views_test.cljs:42` failed (M-12); see flagged items.
+  - Smoke-test: boot OK, dispatch + sub + hot-reload all green.
+
+## Items flagged for human review
+
+- `src/app/subs.cljs:78` — `(reg-sub-raw :live-ticker ...)` body subscribes to a WebSocket stream (M-18 category 2). Proposed rewrite: register a `:ws/connect` fx that dispatches `:ws/tick-received` events; `:live-ticker` becomes a plain `reg-sub` reading `app-db`. **Awaiting author decision**: should the ws-source stay as-is or migrate?
+- `src/app/admin/subs.cljs:104` — `(reg-sub-raw :session-clock ...)` body manages a reaction lifecycle with `r/track!` (M-18 category 3). Proposed rewrite: state machine. **Awaiting author decision**.
+- `test/views_test.cljs:42` — `(is (= 3 @render-count))` (M-12). Re-baselining needed; the new count is 2.
+
+## Anything unexpected
+
+- `day8/re-frame-test` was pinned at `0.1.5` (a pre-release). Replaced cleanly by `re-frame.test-support`; no compatibility issues observed.
+```
+
+## When the output exceeds 300 words
+
+Reasons it might:
+
+- Multi-frame architecture (multiple `reg-global-interceptor` sites with different rewrite paths each).
+- Heavy `reg-sub-raw` use (each call site is a per-decision Type B).
+- Lots of `enrich` / `after` interceptors (each is Type B, each has 3 rewrite paths).
+
+When the output would run long, group similar items: *"15 `:dispatch` rewrites under M-8 — file-level summary at `src/app/events.cljs`"* rather than listing each site individually. The author wants the **shape** of what happened, not a transcription of every line.
+
+If there are >10 items in *"Items flagged for human review"*, that's a sign the migration is fundamentally Type-B-heavy — surface this to the author at the start of the summary rather than burying them in the list.
+
+## What the summary is for
+
+- **The author reads it once and knows what the migration changed.** No need to read the diff to understand the shape.
+- **The author can audit.** Every change has a rule id; the rule id lets them go back to `spec/MIGRATION.md` and verify.
+- **The author knows what's still on them.** "Items flagged for human review" is the contract — these are the things the agent declined to action, and they're owned by the author from this point.
+- **The summary goes into the project history.** Drop it as a commit message, a PR description, or a `MIGRATION-NOTES.md` in the project root — whatever the project's convention is. The migration agent doesn't decide where; the author does.

--- a/skills/re-frame-migration/reference/sequencing.md
+++ b/skills/re-frame-migration/reference/sequencing.md
@@ -1,0 +1,136 @@
+# sequencing
+
+The recommended order to walk the migration rules. Restated so a partial migration can resume cleanly without re-reading the full `spec/MIGRATION.md` ordering.
+
+## Top-level shape
+
+```
+Phase 2 — Bump (M-0)
+   │
+   └──> compile + tests
+            │
+            ├── all green ────> Phase 6 (report). Done.
+            │
+            └── failures ────> Phase 3 (sweep) ───> compile + tests ───> Phase 6
+```
+
+`spec/MIGRATION.md` Part 2 §"Your task" makes the headline expectation explicit: *most codebases require no changes at all beyond M-0*. Verify that against this project before doing anything else.
+
+## When failures land — the sweep order
+
+The M-rule numbering in `spec/MIGRATION.md` *is* the sweep order. Walk them low-to-high. Later rules sometimes depend on earlier ones being resolved (M-1 surfaces private-namespace requires; M-15's seeding rewrite assumes the M-1 fix has run; M-21's `on-changes` rewrite assumes the flows artefact M-30 has been added).
+
+### Group 1 — Coord and private namespaces (foundation)
+
+| Order | Rule | Why first |
+|---|---|---|
+| 1 | **M-0** | Already done in Phase 2. The whole migration runs against the new classpath. |
+| 2 | **M-1** | Every other rule assumes `re-frame.core` is the only allowed re-frame namespace. Private-namespace requires would cause spurious compile errors elsewhere. |
+| 3 | **M-38** | Substrate-adapter ns rename (`re-frame.substrate.<name>` → `re-frame.adapter.<name>`). Codebases that explicitly required the substrate (rare; usually only set up code) hit this. |
+| 4 | **M-40** | `(rf/init!)` requires the adapter spec map. Boot path doesn't compile without it. |
+
+### Group 2 — Macro / value-form / shape rewrites (compile-level)
+
+| Order | Rule | Why here |
+|---|---|---|
+| 5 | **M-5** | `reg-*` are macros now; higher-order use breaks at compile time. Surface before behaviour-shape rules. |
+| 6 | **M-22** | `reg-view` is a defn-shape macro; keyword-shape calls fail to expand. Compile-level. |
+| 7 | **M-23** | `re-frame.alpha` namespace removed. Compile-level (require fails). |
+| 8 | **M-24** | `rf/h` removed. Compile-level (symbol unresolved). |
+| 9 | **M-25** | `re-frame.test` renamed to `re-frame.test-support`. Compile-level. |
+| 10 | **M-26** | Drift-sweep drops — most are symbol-not-found at compile time. The Type B `add-post-event-callback` half waits for behavioural review. |
+
+### Group 3 — Effect map / dispatch shape (compile-or-warning)
+
+| Order | Rule | Why here |
+|---|---|---|
+| 11 | **M-4** | Master's `dispatch-with` / `dispatch-sync-with` removed. Most codebases unaffected. |
+| 12 | **M-8** | Fold top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` / user-fx-id keys into `:fx`. High-impact mechanical rewrite. |
+| 13 | **M-9** | `dispatch-sync` inside handlers → `:fx [[:dispatch ...]]`. |
+| 14 | **M-16** | `^:flush-dom` metadata → `:dispatch-later {:ms 0}`. |
+
+### Group 4 — Reserved-namespace renames (mechanical)
+
+| Order | Rule | Why here |
+|---|---|---|
+| 15 | **M-20** | Framework keyword consolidation. Closed mechanical rename table. Apply before M-10 so M-10's collision audit doesn't false-positive on legacy framework ids. |
+| 16 | **M-10** | Reserved-namespace collision audit. Type B; surfaces user registrations under `:rf/*` for human review. |
+| 17 | **M-35** | Actor-lifecycle fx-id rename (`:spawn` → `:rf.machine/spawn`). |
+| 18 | **M-34** | Spawn-id path rename (`[:data :pending]` → `[:rf/spawned ...]`). |
+
+### Group 5 — Interceptors and registration metadata
+
+| Order | Rule | Why here |
+|---|---|---|
+| 19 | **M-21** | Drop `debug` / `trim-v` (mechanical). Flag `on-changes` / `enrich` / `after` (Type B). |
+| 20 | **M-17** | `reg-global-interceptor` / `clear-global-interceptor` removed. Single-frame: mechanical. Multi-frame: ask. |
+| 21 | **M-7** | `reg-fx` / `reg-cofx` `:platforms` default; add `:platforms #{:client}` for browser-only fx. |
+
+### Group 6 — Run-to-completion / cache / counts (behaviour)
+
+| Order | Rule | Why here |
+|---|---|---|
+| 22 | **M-3** | Dispatch ordering — run-to-completion drain. Type B; flag every `:dispatch` inside a handler and every test asserting queue / intermediate-render shape. |
+| 23 | **M-6** | Drain-depth limit. Most codebases unaffected; runtime-error-triggered. |
+| 24 | **M-12** | Sub-cache invalidation changes render counts. Type B; flag render-count assertions. |
+| 25 | **M-44** | `:timeout-ms` removed from `:invoke` / `:invoke-all`. Use parent state's `:after` timer. |
+
+### Group 7 — Private-state / lifecycle / handler dropouts
+
+| Order | Rule | Why here |
+|---|---|---|
+| 26 | **M-15** | App-db seeding via `:on-create` (pairs with M-1's private-ns rewrite). |
+| 27 | **M-11** | Plain Reagent fns under non-default frames. Type B. Only surfaces in multi-frame apps. |
+| 28 | **M-13** | `reg-event-error-handler` removed. Frame-level `:on-error` or trace listener. Type B. |
+| 29 | **M-18** | `reg-sub-raw` removed. Four rewrite paths (read-only-app-db, fx-driven, machine, anti-pattern). Type B. |
+| 30 | **M-42** | React-19-removed Reagent surfaces (throw-on-call shims). Mechanical rewrite per call site. |
+
+### Group 8 — Per-feature artefact splits (dep-only adds; pair with the feature-trigger rules)
+
+| Order | Rule | Pairs with |
+|---|---|---|
+| 31 | **M-27** | Triggered by `reg-app-schema` / `:spec` keys / `reg-event-schema`. Add `day8/re-frame2-schemas`. |
+| 32 | **M-28** | Triggered by `reg-machine` / `sub-machine`. Add `day8/re-frame2-machines`. |
+| 33 | **M-29** | Triggered by `reg-route` / `:rf.route/*` events. Add `day8/re-frame2-routing`. Pairs with M-14 (the `not-found` requirement). |
+| 34 | **M-30** | Triggered by `reg-flow` or by M-21's `on-changes` rewrite. Add `day8/re-frame2-flows`. |
+| 35 | **M-31** | Triggered by `:rf.http/managed` fx. Add `day8/re-frame2-http`. |
+| 36 | **M-32** | Triggered by `render-to-string` (SSR). Add `day8/re-frame2-ssr`. |
+| 37 | **M-33** | Triggered by `epoch-history` / `restore-epoch`. Add `day8/re-frame2-epoch`. |
+| 38 | **M-39** | If the codebase uses `reg-http-interceptor` / `clear-http-interceptor`. Pairs with M-31. |
+
+### Group 9 — Conditional / opt-trigger rules
+
+| Order | Rule | Trigger |
+|---|---|---|
+| 39 | **M-14** | Only if the user is adopting Spec 012's routing surface (paired with M-29). Otherwise N/A. |
+| 40 | **M-19** | Opt-in shift to map-payload event vectors. Off by default; only run if the user has explicitly asked to modernise. |
+
+## When to pause for human review
+
+The Type B rules each have a documented question. Group them at the end of the sweep and present them in one batch — the author makes all the decisions in a single sitting rather than getting interrupted N times during the migration.
+
+Order of presentation within the batch (most-blocking first):
+
+1. **M-3** — run-to-completion impact: any animation timing, queue-peek tests, intermediate-render dependencies.
+2. **M-18** — `reg-sub-raw` rewrites: each call site needs the user's read on what the raw body is doing.
+3. **M-11** — plain-Reagent fns under non-default frames: each component-frame pair.
+4. **M-17** — multi-frame `reg-global-interceptor`: each-frame vs trace-listener vs default-only.
+5. **M-21** — `on-changes` / `enrich` / `after`: flow / schema / `->interceptor` / fx routing.
+6. **M-10** — reserved-namespace collisions.
+7. **M-5** Var-aliasing — refactor to direct invocation.
+8. **M-13** — `reg-event-error-handler` policy.
+9. **M-12** — render-count test re-baselines.
+10. **M-19** (only if requested) — opt-in map-payload migration per event-id.
+
+Apply all the Type A rewrites first, present the Type B batch second. The author shouldn't have to context-switch every five minutes.
+
+## Resuming a partial migration
+
+If the sweep is interrupted mid-flight:
+
+1. Run a clean compile. The compile errors tell you which group you're stuck in.
+2. Look up the symbol or pattern in `reference/breaking-changes.md`. Find the rule id.
+3. Find the rule's group in this leaf — the groups before it should already be applied; the groups after it haven't started.
+4. Apply the rule. Continue with the rest of its group.
+
+The groups are self-contained — finishing a group before starting the next means each compile-and-test cycle is a meaningful checkpoint. Don't half-apply a group.

--- a/skills/re-frame-migration/reference/setup.md
+++ b/skills/re-frame-migration/reference/setup.md
@@ -1,0 +1,151 @@
+# setup
+
+Operational detail for **M-0 — the dep-coord swap**. This is the precondition for every other rule. Apply this leaf's content first; verify the project compiles; *then* sweep for breakage.
+
+## Contents
+
+- The coord swap (M-0)
+- Per-build-tool shapes
+- Picking the substrate-adapter artefact
+- Discovering the current VERSION
+- The pay-as-you-go artefact split (M-27 through M-32)
+- Edge cases
+
+---
+
+## The coord swap (M-0)
+
+v1 ships as `re-frame/re-frame`. v2 ships as a **pair** of artefacts at the same VERSION:
+
+- `day8/re-frame2` — the core (registry, drain, dispatch, subscribe, fx, the substrate-adapter contract).
+- `day8/re-frame2-<substrate>` — the substrate adapter (`-reagent`, `-uix`, or `-helix`). v1 codebases use Reagent universally, so default to `day8/re-frame2-reagent`.
+
+The two artefacts ship in lockstep — every adapter artefact is versioned identically to core. Mixing versions across them is unsupported.
+
+The `re-frame.core` namespace name and your `(:require [re-frame.core :as rf])` lines are **unchanged**. Only the dep coord moves.
+
+## Per-build-tool shapes
+
+### `deps.edn` (tools.deps)
+
+```clojure
+;; Before
+{:paths ["src"]
+ :deps  {re-frame/re-frame {:mvn/version "1.4.5"}}}
+
+;; After
+{:paths ["src"]
+ :deps  {day8/re-frame2         {:mvn/version "<VERSION>"}
+         day8/re-frame2-reagent {:mvn/version "<VERSION>"}}}
+```
+
+### `project.clj` (Leiningen)
+
+```clojure
+;; Before
+:dependencies [[re-frame "1.4.5"]]
+
+;; After
+:dependencies [[day8/re-frame2         "<VERSION>"]
+               [day8/re-frame2-reagent "<VERSION>"]]
+```
+
+### `shadow-cljs.edn`
+
+```clojure
+;; Before
+{:dependencies [[re-frame/re-frame "1.4.5"]]}
+
+;; After
+{:dependencies [[day8/re-frame2         "<VERSION>"]
+                [day8/re-frame2-reagent "<VERSION>"]]}
+```
+
+If the project's `shadow-cljs.edn` reads deps from `deps.edn` (the default; `:deps true` or unspecified), edit `deps.edn` only — `shadow-cljs.edn` will pick up the change.
+
+### `bb.edn` (Babashka)
+
+```clojure
+;; Before
+{:deps {re-frame/re-frame {:mvn/version "1.4.5"}}}
+
+;; After
+{:deps {day8/re-frame2         {:mvn/version "<VERSION>"}
+        day8/re-frame2-reagent {:mvn/version "<VERSION>"}}}
+```
+
+**Both `day8/re-frame2-*` lines get the same `<VERSION>` value.** The lockstep contract.
+
+## Coords to detect
+
+v1 has shipped under three coord forms over time — match any of them:
+
+```clojure
+re-frame/re-frame {:mvn/version "1.x.x"}     ; deps.edn / shadow-cljs.edn — current canonical form
+re-frame          {:mvn/version "1.x.x"}     ; deps.edn / shadow-cljs.edn — older shorter form
+[re-frame "1.x.x"]                            ; project.clj — Lein vector form
+```
+
+All three become `day8/re-frame2` + the matching adapter artefact.
+
+## Picking the substrate-adapter artefact
+
+| Codebase shape | Adapter to add |
+|---|---|
+| `:require [reagent.core ...]` anywhere in the source tree | `day8/re-frame2-reagent` |
+| `:require [uix.core ...]` and Reagent has been removed | `day8/re-frame2-uix` |
+| `:require [helix.core ...]` and Reagent has been removed | `day8/re-frame2-helix` |
+| No view layer (a backend-only re-frame app, server-side only) | `day8/re-frame2-reagent` is still the safe default; the adapter is lightweight |
+
+If the codebase has **both** Reagent and UIx requires (a phased substrate migration), pick whichever one drives the React root and add only that adapter — the other substrate's views become broken at runtime but that's a separate migration the author has to drive.
+
+## Discovering the current VERSION
+
+Three sources, in order of authority:
+
+1. **`VERSION` file** in the re-frame2 repo (`https://github.com/day8/re-frame2/blob/main/VERSION`) — the string used for the next release.
+2. **`CHANGELOG.md`** (`https://github.com/day8/re-frame2/blob/main/CHANGELOG.md`) — released versions with summaries; pick the most recent non-Unreleased entry.
+3. **GitHub releases page** (`https://github.com/day8/re-frame2/releases`) — the latest tag is `v<VERSION>`.
+
+If the author wants the bleeding edge, use a `:git/url` + `:git/sha` coord instead of `:mvn/version`. Niche; default to released `:mvn/version`.
+
+**Never invent a version.** If the network is unreachable, ask the author to paste the current VERSION rather than guess.
+
+**If no released v2 version exists yet** (pre-publication): leave the dep alone, do not apply any other migration rules, and flag the situation in the report — the author must update the coord manually once a release lands, then re-run the migration.
+
+## The pay-as-you-go artefact split (M-27 through M-32)
+
+re-frame2 splits seven per-feature artefacts out of core. **Add them only when the codebase actually uses the feature.** Do not add them defensively.
+
+| Artefact | Add when codebase uses... |
+|---|---|
+| `day8/re-frame2-schemas` | `reg-app-schema`, `reg-event-schema`, or `:spec` keys in registration metadata (M-27) |
+| `day8/re-frame2-machines` | `reg-machine` (M-28) |
+| `day8/re-frame2-routing` | `reg-route` or dispatches `:rf.route/*` events (M-29) |
+| `day8/re-frame2-flows` | `reg-flow` (M-30) — also where v1's `on-changes` interceptor migrates to |
+| `day8/re-frame2-http` | `[:rf.http/managed ...]` as an `:fx` entry, or `:rf.http/managed` as a child machine (M-31) |
+| `day8/re-frame2-ssr` | `render-to-string` server-side (M-32) |
+| `day8/re-frame2-epoch` | `epoch-history`, `restore-epoch`, or transitively via `re-frame-pair2` (no M-rule; pull only if directly used) |
+
+In practice: most v1 codebases use **none** of these, because none of these features exist in v1. State machines / flows / managed-HTTP / SSR are v2 additions. v1 codebases doing equivalent things by hand stay doing them by hand post-migration; you do **not** rewrite those into the new artefacts as part of the required migration. (Adopting them is opt-in; see the `O-N` rules.)
+
+The one exception is `-flows` — v1's `on-changes` interceptor (one of the removed five, per M-21) migrates to `reg-flow`, so if the codebase used `on-changes`, add `day8/re-frame2-flows` at the same time you apply M-21.
+
+## Edge cases
+
+**`shadow-cljs.edn` with `:dependencies` AND `deps.edn` with `:deps` — which wins?** shadow-cljs reads from both; `:dependencies` in `shadow-cljs.edn` is additive. Update whichever currently holds the `re-frame/re-frame` coord — that's the one in scope. If both hold it (rare), update both.
+
+**Lein with `:profiles` overlays.** If the project pins `re-frame` in `:dependencies` and overrides it in `:profiles {:dev {:dependencies ...}}`, update both — the profile override would otherwise shadow the swap silently.
+
+**`re-frame` as a transitive of another lib (`re-frame-fx`, `day8/re-frame-async-flow-fx`, etc.).** v1-built libs depend on `re-frame/re-frame`; their classpath will trip a coord conflict with `day8/re-frame2`. Two options:
+
+1. Upgrade the lib to a re-frame2-compatible version if one exists.
+2. Exclude `re-frame/re-frame` from the transitive (`:exclusions` in Lein, `:exclusions` in deps.edn) and let `day8/re-frame2` provide `re-frame.core`. This works because v2 keeps the `re-frame.core` namespace; the lib's `:require [re-frame.core :as rf]` lines resolve against v2 instead.
+
+Flag this case in the report — the author owns the decision about whether to upgrade the transitive lib or to exclude.
+
+**Per-feature artefact not yet published.** Same shape as M-0's "no v2 version" edge case: leave the dep alone, flag in the report, the author updates manually when the artefact lands.
+
+---
+
+**Stop after M-0.** Do not start sweeping for other M-rules until you've tried a compile and seen what — if anything — breaks. The expected result for most codebases is that the dep swap is the entire migration. Verify that before sweeping.

--- a/skills/re-frame-migration/spec/authoring-prompt.md
+++ b/skills/re-frame-migration/spec/authoring-prompt.md
@@ -1,0 +1,84 @@
+# re-frame-migration — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame-migration` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame-migration` skill at `skills/re-frame-migration/`. The skill helps a programmer migrate a re-frame v1.x codebase to re-frame2. The skill is **guidance + workflow on top of `spec/MIGRATION.md`** — it does not duplicate the M-rule and O-rule content from MIGRATION.md, it routes / sequences / operationalises them.*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame-migration/spec/design.md` — the locked design decisions (L1 through L10). Q14 lock applies (NO verification module). Source of truth is `spec/MIGRATION.md`.*
+> *2. `skills/re-frame-migration/spec/inputs.md` — the canonical inputs the skill leans on.*
+> *3. `spec/MIGRATION.md` — the breaking-change spec the skill routes around. Part 1 has the rule corpus; Part 2 is the AI-agent execution procedure.*
+> *4. `skills/re-frame2/SKILL.md` + `skills/re-frame2/reference/**` — the voice / density / load-bearing-rules style to mirror.*
+> *5. `skills/re-frame2-setup/SKILL.md` + `skills/re-frame2-setup/{LICENSE,package.json,.claude-plugin/plugin.json}` — the closest structural analogue (per-build-tool detail, distribution metadata triad).*
+>
+> *Then write the skill at `skills/re-frame-migration/` with this exact file structure:*
+>
+> ```
+> skills/re-frame-migration/
+> ├── SKILL.md                       (~190 lines; the router)
+> ├── README.md                      (~70 lines; human-facing intro)
+> ├── LICENSE                        (mirror skills/re-frame2-setup/LICENSE)
+> ├── package.json                   (npm metadata; mirror re-frame2-setup pattern)
+> ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+> └── reference/
+>     ├── kickoff-prompt.md          (~60 lines; paste-ready user prompt)
+>     ├── setup.md                   (~130 lines; M-0 operational detail)
+>     ├── breaking-changes.md        (~180 lines; rule index keyed to v1 triggers)
+>     ├── sequencing.md              (~100 lines; recommended rule order)
+>     ├── automated-transforms.md    (~210 lines; Type A patterns)
+>     ├── guided-checklist.md        (~240 lines; Type B walkthroughs)
+>     └── output-format.md           (~110 lines; migration-summary shape)
+> ```
+>
+> *Each leaf has a single job; the leaves don't duplicate each other; SKILL.md routes between them. Every leaf is one level deep from SKILL.md (no SKILL → A → B chains).*
+>
+> *Cardinal rules to bake in (these go in SKILL.md):*
+>
+> *1. `spec/MIGRATION.md` is the source of truth. The skill cites rule ids; it doesn't quote rule text.*
+> *2. Type A is automatic, Type B is asked-first. Never silently apply a Type B rewrite.*
+> *3. Smallest correct diff. No stylistic refactoring; no opt-in modernisations unless explicitly requested.*
+> *4. Apply rules in order (M-0 first, then walk).*
+> *5. JVM interop is in scope; don't silently CLJS-only the project.*
+> *6. Single-import contract for user code: `(:require [re-frame.core :as rf])`.*
+> *7. If a rule is ambiguous, file a `bd create` bead — don't edit `spec/MIGRATION.md` inline.*
+> *8. Don't invent migration rules.*
+>
+> *Locks to preserve verbatim:*
+>
+> *- **L3 — NO verification module.** No `reference/verify.md`; no "verify before claiming done" hard rule. The agent applies rules; the author runs tests.*
+> *- **L5 — `spec/MIGRATION.md` Part 2 IS the migration prompt.** The kickoff prompt in `reference/kickoff-prompt.md` wraps it; it doesn't replace it.*
+> *- **L7 — Reagent v2 is the default substrate target.** Substrate migration (O-13 / O-14) is never part of a v1→v2 migration.*
+> *- **L9 — Smallest correct diff.** Opt-in modernisations (O-rules) are never auto-applied as part of a routine migration.*
+> *- **L10 — Findings stay local.** Don't commit `ai/` or `findings/` content.*
+>
+> *Frontmatter — the description is "pushy" per Anthropic best practice. List every v1 surface that should trigger discovery: `re-frame.db`, `dispatch-with`, `reg-global-interceptor`, `reg-sub-raw`, `^:flush-dom`, `re-frame.alpha`, `re-frame-test`, old effect-map shape. Plus natural-language phrases: "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2".*
+>
+> *Voice: tight, declarative, recipe-shaped. Match `skills/re-frame2/SKILL.md` density. Use tables for rule lookups; use code blocks for search/rewrite shapes. Cite M-N / O-N rule ids in every leaf — the agent that uses the skill will cite the same ids in the migration report.*
+>
+> *Don't:*
+>
+> *- Don't write `*.md` documentation outside `skills/re-frame-migration/`.*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't write any verification leaf or verify-before-done hard rule.*
+> *- Don't duplicate `spec/MIGRATION.md` content — reference it by rule id and link.*
+>
+> *Open the PR with title `feat(skills): re-frame-migration — guided v1→v2 migration skill`. PR body lists: the skill structure, the file LoC table, the locks applied, the existing repo material folded in (`spec/MIGRATION.md`, `docs/guide/08-from-re-frame-v1.md`, `docs/the-mayor-method.md`'s prompt pattern). Surface open questions OQ1/OQ2/OQ3 from `spec/design.md` in the PR body for Mike to action.*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the repo. It does not assume any out-of-repo context.
+- The prompt does **not** ask the session to verify the resulting skill — the verification is Mike's responsibility (read the files, comment on the PR).
+- If `spec/MIGRATION.md` has changed significantly between authoring passes, the rule indices in `breaking-changes.md` may need an updated sweep. The reauthoring session walks MIGRATION.md afresh and rebuilds the index.
+
+## When to re-author
+
+- MIGRATION.md grows by >5 rules → the existing leaves' indices are stale; rebuild from scratch is easier than patching.
+- The Q14 lock changes → the design itself changes; this `spec/` folder needs updating first, then the skill.
+- Anthropic skill conventions change materially (e.g. SKILL.md size ceiling changes, frontmatter shape changes) → reauthor against the new conventions.
+
+Otherwise, edit the existing leaves directly; reauthoring from scratch is for major-version updates.

--- a/skills/re-frame-migration/spec/design.md
+++ b/skills/re-frame-migration/spec/design.md
@@ -1,0 +1,162 @@
+# re-frame-migration — Design
+
+The design rationale and locked decisions for the `re-frame-migration` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help a programmer migrate an existing re-frame v1.x ClojureScript codebase to re-frame2 with the smallest correct diff. The skill is **guidance + workflow** layered on top of `spec/MIGRATION.md` (the authoritative breaking-change list). The skill does not duplicate MIGRATION.md; it structures the migration around it.
+
+The skill's success criterion: the author runs the migration, ends up on `day8/re-frame2`, the project compiles and tests pass, and every Type B decision the author had to make is documented in the final report.
+
+## 2. Pillars (locked, derived from `ai/findings/re-frame2-skill-design-v2.md`)
+
+The same four pillars as the `re-frame2` skill, adapted to the migration domain:
+
+1. **Correctness** — recipes over explanations. The agent applies the M-rule it cites; it doesn't synthesise novel rewrites. **Q14 lock applies: NO verification module.** The agent doesn't run the author's tests; running tests is general software practice, not migration-specific.
+2. **Idiomaticness** — verified against `spec/MIGRATION.md` (which is itself verified against `implementation/**`). The skill is downstream of MIGRATION.md; if MIGRATION.md is authoritative, the skill is correct by construction.
+3. **Context economy** — SKILL.md is a router; leaves are loaded on demand. The leaves point at MIGRATION.md for the per-rule full text; they don't quote it.
+4. **Assume training knowledge** — the agent knows what re-frame is, what a Maven coord is, what a Reagent root is, what a state machine is. The skill teaches the **v1→v2 binding**: which v1 surface becomes which v2 surface, when the rewrite is automatic vs. when it needs human judgment.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve these unless explicitly unlocked by Mike.
+
+### L1 — `spec/MIGRATION.md` is the source of truth
+
+The skill does **not** duplicate the rule content. Leaves point at MIGRATION.md by rule id (`M-N` / `O-N`). When the author asks "is `X` covered?", the leaf says which rule; the agent reads the full text from MIGRATION.md.
+
+**Why**: MIGRATION.md is maintained as part of the spec corpus. Drift between the skill and the spec would manifest as confusing dual sources. The skill is consumer; the spec is producer.
+
+### L2 — Type A / Type B distinction is operational, not advisory
+
+Type A is applied automatically; Type B halts and asks. This dichotomy comes from MIGRATION.md and the skill enforces it. The agent never silently applies a Type B rewrite. Pre-authorised batch decisions ("apply X to every Y") are allowed but get banked in the report so the author can audit.
+
+### L3 — Q14 — NO verification module
+
+Per `ai/findings/re-frame2-skill-design-v2.md` §Q14: the skill does not teach the agent to verify its own output. No `reference/verify.md`, no "verification mandatory before done" hard rule. The agent applies the rules; the author runs the tests. This matches the `re-frame2` skill's lock — consistent across the skill family.
+
+**Why**: running tests is general software practice. Pillar 4 says don't teach what the AI already knows.
+
+### L4 — No verification claim of "done"; the author confirms
+
+The "Done checklist" in SKILL.md lists the conditions for completion. The skill does not assert completion; it presents the checklist and the author confirms. This is consistent with L3.
+
+### L5 — Migration prompt = `spec/MIGRATION.md` Part 2
+
+Mike's bead surfaced an open question: "Where does the `setup and obviously the migration prompt` material actually live?" Answer: **`spec/MIGRATION.md` itself.** Part 2 of that doc is "Execution procedure ... written in second person to an AI agent performing the migration." It already is the migration prompt — the skill consumes it directly, and the paste-ready kickoff prompt in `reference/kickoff-prompt.md` is a thin wrapper that loads the skill and references MIGRATION.md.
+
+### L6 — JVM interop is in scope
+
+re-frame2 preserves `re-frame.interop`. The skill calls out JVM-side test runs in the cardinal rules and does not silently CLJS-only the project. M-1 / M-25 (test-support rename) etc. apply to `.clj` files the same way they apply to `.cljs`.
+
+### L7 — Reagent v2 is the default substrate target
+
+When the skill picks an adapter to recommend (M-0 substrate-adapter slot), the default is `day8/re-frame2-reagent` unless the codebase shows it has already migrated to UIx or Helix. Substrate migration (O-13 / O-14) is **never** part of a v1→v2 migration; it's a separate concern.
+
+### L8 — Single-import contract for new / migrated code
+
+User code uses `(:require [re-frame.core :as rf])`. The skill rewrites every private-namespace require (M-1, M-23, M-38) to land at this contract. Per-feature artefacts (`-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-schemas`, `-epoch`) require the per-feature namespace (`re-frame.machines`, etc.) **in addition** for hook registration — the contract there is "core single-import for the public API; per-feature requires for hook installation."
+
+### L9 — Smallest correct diff
+
+The skill applies what's required and nothing more. Stylistic refactoring, opt-in modernisations (O-rules), substrate moves — these are out of scope unless the author explicitly opts in. The smallest-diff rule is a cardinal rule in SKILL.md.
+
+### L10 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — any exploration of the design happens in `ai/findings/`; never committed. This skill's commit contains only `skills/re-frame-migration/**`.
+
+## 4. Audience and scope
+
+### In scope
+
+- Re-frame v1.x CLJS codebases moving to re-frame2.
+- JVM-side test infrastructure (`.clj` runners, `re-frame.test` → `re-frame.test-support`).
+- Both Reagent v2 (default) and pre-existing UIx / Helix codebases (the substrate is detected, not migrated).
+- The full M-rule and O-rule surfaces in `spec/MIGRATION.md`.
+
+### Out of scope
+
+- Migrating to a different substrate (Reagent → UIx is O-13; never part of v1→v2).
+- Writing new application code on v2 — that's the `re-frame2` skill.
+- Live-runtime inspection of the running v2 app — that's `re-frame-pair2`.
+- Greenfield project bootstrap — that's `re-frame2-setup`.
+- Authoring opt-in modernisations except when the author explicitly asks.
+- Editing `spec/MIGRATION.md` — gaps file `bd create` beads; the skill never patches MIGRATION.md inline.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame-migration/
+├── SKILL.md                       (router; ~190 lines)
+├── README.md                      (human-facing intro; ~70 lines)
+├── LICENSE                        (MIT, mirrors re-frame2-setup)
+├── package.json                   (npm metadata for distribution)
+├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+├── reference/
+│   ├── kickoff-prompt.md          (~60 lines)
+│   ├── setup.md                   (~130 lines)
+│   ├── breaking-changes.md        (~180 lines)
+│   ├── sequencing.md              (~100 lines)
+│   ├── automated-transforms.md    (~210 lines)
+│   ├── guided-checklist.md        (~240 lines)
+│   └── output-format.md           (~110 lines)
+└── spec/
+    ├── design.md                  (this file)
+    ├── inputs.md                  (the canonical inputs the skill leans on)
+    └── authoring-prompt.md        (one-shot reauthor prompt)
+```
+
+**Totals**: SKILL.md (~190) + 7 reference leaves (~1,030) + 3 spec files (~250) ≈ ~1,470 LoC across 11 files. Every leaf well under the 250-line ceiling; SKILL.md well under the 500-line Anthropic guideline.
+
+## 6. Why the leaf split
+
+The seven reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical migration session loads:
+
+- **Phase 2 (bump-only success)**: `setup.md` + `output-format.md`. ~240 LoC.
+- **Phase 3 (sweep with Type A only)**: `automated-transforms.md` + `breaking-changes.md` + `sequencing.md` + `output-format.md`. ~600 LoC.
+- **Phase 3 (sweep with Type B)**: add `guided-checklist.md`. ~840 LoC.
+- **Full migration (rare)**: all seven leaves. ~1,030 LoC.
+
+Even the worst case is well under any reasonable context budget; the median case is ~25% of the total skill content.
+
+## 7. Anti-patterns the skill explicitly resists
+
+- **Auto-applying Type B rewrites.** Cardinal rule #2 in SKILL.md.
+- **Adding per-feature artefacts defensively.** Cardinal rule + setup.md's "pay-as-you-go" framing.
+- **Migrating to `reg-view` as part of the required migration.** O-2 is opt-in.
+- **Bumping other deps along with the re-frame coord.** Smallest-diff rule.
+- **Inventing new migration rules.** Cardinal rule + setup.md "stop and ask" framing.
+- **Silently CLJS-only-ing a project that had JVM tests.** Cardinal rule L6 + M-25 covers test-runner rename.
+
+## 8. Discovery surface (frontmatter `description`)
+
+The `description` field is the primary trigger. It is deliberately verbose and lists every v1 surface that should trigger discovery:
+
+> `re-frame.db`, `dispatch-with`, `reg-global-interceptor`, `reg-sub-raw`, `^:flush-dom`, `re-frame.alpha`, `re-frame-test`, the old `:dispatch`/`:dispatch-n` effect-map shape
+
+Plus the natural-language phrases: "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2".
+
+The description is "pushy" per Anthropic's best-practices guidance (use this skill whenever the user mentions ...).
+
+## 9. Where this design diverges from `re-frame2`
+
+- **No patterns/ directory.** The migration is a workflow, not a set of authoring recipes.
+- **No decision-trees/ directory.** The single decision tree is "is this Type A or Type B?" and lives in the leaves themselves.
+- **No examples-map.md.** Examples are inside `output-format.md` (filled-in reports).
+- **The kickoff prompt is unique to this skill** — the `re-frame2` skill assumes the agent is already engaged in authoring; the migration skill needs to bootstrap a focused session.
+
+## 10. Open questions (deferred to Mike)
+
+These remain open at authoring time:
+
+### OQ1 — Should the skill ship a runnable `migrate.bb` for mechanical transforms?
+
+**Status**: deferred. The skill ships as pure guidance for v0.1. If post-launch experience shows the automated-transforms leaf is being applied identically across many migrations, a `migrate.bb` script would be a logical next bead — driven by real call-site data.
+
+### OQ2 — Should there be a "before you start" diagnostic that profiles the codebase?
+
+**Status**: deferred. Useful as v0.2 — a profiler that grep-counts every M-rule trigger surface and reports `<N> Type A sites + <M> Type B sites` so the author can size the migration. The shape would be a `reference/profile.md` leaf and a corresponding script. Not blocking v0.1 because the agent can do the profiling inline during Phase 1 (Orient) without dedicated tooling.
+
+### OQ3 — Where does the "migration prompt" material live?
+
+**Resolved (L5 above)**: it's `spec/MIGRATION.md` Part 2. The kickoff prompt in `reference/kickoff-prompt.md` wraps it.

--- a/skills/re-frame-migration/spec/inputs.md
+++ b/skills/re-frame-migration/spec/inputs.md
@@ -1,0 +1,67 @@
+# re-frame-migration — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary input — `spec/MIGRATION.md`
+
+Path: `spec/MIGRATION.md` in the re-frame2 repo.
+
+**This is the source of truth.** Every M-rule and O-rule referenced in the skill's leaves comes from this doc. The skill's job is to **route**, **sequence**, and **operationalise** these rules — not to duplicate them.
+
+Structure of MIGRATION.md the skill depends on:
+
+- **Part 1** — the rule corpus. M-rules (required) M-0 through M-49, plus O-rules (opt-in) O-1 through O-15. Each rule has: type (A/B/hybrid), "What to look for", "What to do", "Why", and inline rule-id cross-refs. The "What stays the same" section near the end of Part 1 is also load-bearing — the skill cites it.
+- **Part 2** — the AI-agent execution procedure. Written in second person to an agent performing the migration. Carries: "Your task", "How to apply rules — Type A vs Type B", "Verification steps", "What you must not do", "Output format for your report", "Maintainer note". The skill's kickoff prompt and output-format leaf both reference Part 2 directly.
+
+When MIGRATION.md adds a new rule, the skill's `breaking-changes.md` index needs a new row. When MIGRATION.md changes a rule's type (Type A → Type B or vice versa), the skill's `sequencing.md` may need to move the rule between groups. When a new per-feature artefact is split out, the skill's `setup.md` "pay-as-you-go" table needs a row. Drift between MIGRATION.md and the skill is the maintenance burden; periodic audits (manual or beadwise) keep them aligned.
+
+## 2. Secondary input — `docs/guide/08-from-re-frame-v1.md`
+
+(Or whatever the current numbering is post-rf2-aqys renumber — at authoring time this was chapter 08; will become chapter 12 after the renumber.)
+
+This is the **human-facing** v1→v2 chapter in the narrative guide. It's not normative for the skill — it's pedagogy aimed at humans reading the guide. Useful as a sanity check that the skill's framing matches the guide's framing. Useful as a place to link to from the kickoff prompt ("if you want the human-readable overview before kicking off the agent, read this chapter first").
+
+## 3. Tertiary inputs
+
+These shape the skill's discipline but aren't quoted directly.
+
+- **`ai/findings/re-frame2-skill-design-v2.md`** — the design rationale for the `re-frame2` skill. The `re-frame-migration` skill inherits the four pillars, the leaf-loading shape, and the Q14 lock (NO verification module) from this doc.
+- **`skills/re-frame2/SKILL.md`** + **`skills/re-frame2/reference/**`** — the canonical example of the authoring pattern. Voice, structure, density, "load-bearing-rules" style all mirror this skill.
+- **`skills/re-frame2-setup/SKILL.md`** + **`skills/re-frame2-setup/reference/**`** — the closest structural analogue. Per-build-tool detail, the `LICENSE`/`package.json`/`.claude-plugin/plugin.json` triad, the README shape.
+- **`docs/the-mayor-method.md`** — the methodology context for how Mike works with AI. Influences the "the user runs their tests; the skill teaches them what's likely to break" framing (Q14 lock).
+- **`SKILL-REDIRECT.md`** (repo root) — the canonical pointer table for AI skills. The migration skill references it as the place for full-API URLs and EP design rationale (rather than duplicating URLs in the leaves).
+
+## 4. Anthropic skill conventions
+
+Pulled from `https://code.claude.com/docs/en/skills` at authoring time.
+
+The skill conforms to:
+
+- `name` field ≤ 64 chars; lowercase + numbers + hyphens (`re-frame-migration`).
+- `description` field is the discovery surface; "pushy" with explicit "use this skill whenever the user mentions" language; lists every v1 surface that should trigger.
+- SKILL.md body well under 500 lines.
+- Reference files one level deep from SKILL.md; no SKILL → A → B chains.
+- Forward slashes in paths.
+- Avoid time-sensitive content (deferred to dep-version lookups via `setup.md` rather than hardcoded VERSIONs).
+- Per-tool `spec/` folder (per Mike's standing rule).
+
+## 5. What the skill does NOT consume
+
+These are deliberately out of the loop:
+
+- **`spec/000-Vision.md`** through **`spec/014-HTTPRequests.md`** (the EP corpus) — the skill doesn't teach re-frame2; the `re-frame2` skill does. The migration skill assumes the author knows v2 conceptually (or will read the EPs separately).
+- **`implementation/**`** — implementation is the ground truth for the `re-frame2` skill (what surfaces exist, what their signatures are). For the migration skill, MIGRATION.md is the ground truth, and MIGRATION.md is itself verified against implementation. The migration skill is downstream of that verification.
+- **`examples/reagent/**`** — worked examples are for authoring new code, not for migrating. The migration skill does not point at examples.
+- **The narrative guide** (other than chapter 08) — too discursive for the migration agent's needs.
+
+## 6. Update procedure
+
+When MIGRATION.md changes, the skill needs targeted updates. The audit shape:
+
+1. **New rule added** to MIGRATION.md → add a row to `reference/breaking-changes.md` and pick its place in `reference/sequencing.md`. If the rule is Type A, add a shape to `reference/automated-transforms.md`. If Type B, add a walkthrough to `reference/guided-checklist.md`.
+2. **Rule's type changed** (A → B or B → A) → move it between `automated-transforms.md` and `guided-checklist.md` and update its row in `breaking-changes.md`.
+3. **Rule removed / strikethrough'd** → mark its row in `breaking-changes.md` with strikethrough; remove the shape / walkthrough.
+4. **New per-feature artefact** split out → add a row to `setup.md`'s pay-as-you-go table and to `automated-transforms.md`'s per-feature add table.
+5. **MIGRATION.md Part 2 changes** (the execution procedure) → audit `reference/kickoff-prompt.md` and `reference/output-format.md` for any phrasing that referenced the old shape.
+
+The skill's `breaking-changes.md` is the integration point — every M-rule and O-rule in MIGRATION.md gets a row. A periodic audit greps both files and reports rules-in-MIGRATION-not-in-skill.

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -37,7 +37,7 @@ Switch to a different skill when:
 
 - The author has a working re-frame2 project and wants to **write application code** — events, subs, machines, schemas, views, fx. → Use the **`re-frame2`** skill.
 - The author has a running re-frame2 app and wants to **inspect / debug / pair with it live** — dispatch from the REPL, walk app-db, trace events, time-travel. → Use the **`re-frame-pair2`** skill.
-- The author is **migrating from re-frame v1 to v2**. → See [`MIGRATION`](SKILL-REDIRECT.md) (one of the entries in `SKILL-REDIRECT.md` at the repo root).
+- The author is **migrating from re-frame v1 to v2**. → Use the [`re-frame-migration`](../re-frame-migration/) skill.
 
 If the author asks anything beyond greenfield setup (any re-frame2 API question, any design question, any migration question), say so and point them at the right skill.
 
@@ -163,7 +163,7 @@ Setup-out-of-scope questions to re-route:
 | "How do I write a sub that depends on another sub?" | **`re-frame2`** skill |
 | "How do I add a state machine?" | **`re-frame2`** skill |
 | "How do I structure my events folder?" | **`re-frame2`** skill |
-| "I'm migrating from re-frame v1." | `SKILL-REDIRECT.md` → MIGRATION |
+| "I'm migrating from re-frame v1." | **`re-frame-migration`** skill |
 | "Can I inspect app-db from the REPL?" | **`re-frame-pair2`** skill |
 | "Help me debug why my view isn't re-rendering." | **`re-frame-pair2`** skill |
 | "Are there worked examples I can study?" | `SKILL-REDIRECT.md` → Examples directory |

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -17,7 +17,7 @@ Load when the task is **writing or editing re-frame2 application source** (`.clj
 |---|---|
 | Inspect, debug, or modify a running re-frame2 app | `skills/re-frame-pair2/` |
 | Set up a new re-frame2 project from scratch (deps.edn, shadow-cljs, boot scaffolding) | `skills/re-frame2-setup/` |
-| Migrate an existing re-frame v1 app to v2 | `SKILL-REDIRECT.md` → *Migration from re-frame v1* |
+| Migrate an existing re-frame v1 app to v2 | `skills/re-frame-migration/` |
 | Understand how the registrar / machine compiler / reactive substrate is implemented | `SKILL-REDIRECT.md` → EP design entries |
 | Read the full API reference, EP rationale, or pattern spec | `SKILL-REDIRECT.md` |
 
@@ -146,7 +146,7 @@ A short checklist that applies regardless of which leaf you load.
 
 ## How re-frame2 differs from re-frame v1
 
-A one-line redirect for v1-trained context: the migration guide and v1→v2 deltas live at `SKILL-REDIRECT.md` → *Migration from re-frame v1*. Do not re-derive v1 mappings from training memory — the v1→v2 surface drift is large enough that confident recall is unreliable.
+A one-line redirect for v1-trained context: the migration workflow + breaking-change rule index lives in `skills/re-frame-migration/`; the authoritative rule corpus is `spec/MIGRATION.md` (linked from `SKILL-REDIRECT.md` → *Migration from re-frame v1*). Do not re-derive v1 mappings from training memory — the v1→v2 surface drift is large enough that confident recall is unreliable.
 
 ## Background reading (optional)
 
@@ -172,4 +172,4 @@ The user runs the test suite, the compiler, and the app. This skill does not run
 
 ---
 
-*This skill targets re-frame2 (the v2 line). For the v1 line, see [re-frame](https://github.com/day8/re-frame). For live-app inspection, see `skills/re-frame-pair2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. All deep-dive links route through `SKILL-REDIRECT.md` at the repo root.*
+*This skill targets re-frame2 (the v2 line). For the v1 line, see [re-frame](https://github.com/day8/re-frame). For live-app inspection, see `skills/re-frame-pair2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For migrating a v1 codebase to v2, see `skills/re-frame-migration/`. All deep-dive links route through `SKILL-REDIRECT.md` at the repo root.*


### PR DESCRIPTION
## Summary

New Claude Code skill at `skills/re-frame-migration/` that helps a programmer migrate an existing re-frame v1.x ClojureScript codebase to re-frame2.

The skill is **guidance + workflow layered on top of `spec/MIGRATION.md`** (the authoritative breaking-change list). It does not duplicate MIGRATION.md content — every rewrite cites an `M-N` or `O-N` rule id; the agent reads the full rule text directly from MIGRATION.md.

Closes rf2-n78f.

## Skill structure

```
skills/re-frame-migration/
├── SKILL.md                       165 LoC — six-phase router
├── README.md                       76 LoC — human-facing intro
├── LICENSE
├── package.json                       — npm distribution metadata
├── .claude-plugin/plugin.json         — Claude Code plugin metadata
├── reference/
│   ├── kickoff-prompt.md           65 LoC — paste-ready prompt
│   ├── setup.md                   151 LoC — M-0 per build tool
│   ├── breaking-changes.md        123 LoC — rule index by trigger
│   ├── sequencing.md              136 LoC — recommended rule order
│   ├── automated-transforms.md    365 LoC — Type A patterns
│   ├── guided-checklist.md        300 LoC — Type B walkthroughs
│   └── output-format.md           115 LoC — migration-summary shape
└── spec/
    ├── design.md                  162 LoC — locked design decisions
    ├── inputs.md                   67 LoC — canonical inputs
    └── authoring-prompt.md         84 LoC — one-shot reauthor prompt
```

Total: ~1,800 LoC across 15 files. SKILL.md well under Anthropic's 500-line ceiling.

## Six-phase migration workflow

1. **Orient** — read dep file, identify substrate, skim `spec/MIGRATION.md`.
2. **Bump M-0** — swap `re-frame/re-frame` → `day8/re-frame2` + adapter, then **stop** and try a compile. Most codebases need nothing more.
3. **Sweep** — walk M-rules in order. Apply Type A automatically; flag Type B for the author.
4. **Verify** — author runs their tests.
5. **Opt-in modernisations** — only if the author asked.
6. **Report** — migration summary per MIGRATION.md Part 2.

## Design locks applied

- **L1** — `spec/MIGRATION.md` is the source of truth. The skill routes / sequences / operationalises; it does not duplicate rule content.
- **L2** — Type A is automatic; Type B is asked-first. Never silently apply a Type B rewrite.
- **L3 (Q14 from `re-frame2-skill-design-v2.md`)** — NO verification module. No `reference/verify.md`; no "verify before done" hard rule. The agent applies rules; the author runs the tests. Consistent with the `re-frame2` skill.
- **L5** — `spec/MIGRATION.md` Part 2 IS the migration prompt. The kickoff prompt in `reference/kickoff-prompt.md` is a thin wrapper that loads the skill and references MIGRATION.md.
- **L7** — Reagent v2 is the default substrate target. Substrate moves (O-13 / O-14) are never part of a v1→v2 migration.
- **L9** — Smallest correct diff. Opt-in modernisations (O-rules) are never auto-applied.

## Existing materials folded in

- **`spec/MIGRATION.md`** — the authoritative rule corpus (M-0 through M-49; O-1 through O-15). The skill cites these by id throughout; `reference/breaking-changes.md` is a one-row-per-rule index keyed to v1 trigger surfaces.
- **`docs/guide/08-from-re-frame-v1.md`** — the narrative v1→v2 chapter. Sanity-checked the skill's framing against the guide.
- **`docs/the-mayor-method.md`** — the paste-prompt pattern (used as the structural model for `reference/kickoff-prompt.md`).
- **`skills/re-frame2/SKILL.md`** + reference leaves — the voice / density / load-bearing-rules style is mirrored.
- **`skills/re-frame2-setup/`** — the closest structural analogue. `LICENSE`, `package.json`, `.claude-plugin/plugin.json` triad copied / adapted.

## Cross-links added

- `skills/re-frame2/SKILL.md` — migration-shaped prompts now route to `skills/re-frame-migration/` (was `SKILL-REDIRECT.md`).
- `skills/re-frame2-setup/SKILL.md` — same redirect updated.

## Open questions for Mike

The bead listed three open questions for the implementing agent to surface. My positions:

1. **Should the skill ship a runnable `migrate.bb` for mechanical transforms?** Deferred. Skill ships as pure guidance for v0.1. If post-launch experience shows the automated-transforms leaf is being applied identically across many migrations, a `migrate.bb` is a logical v0.2 — but driven by real call-site data, not preemptive design. Captured as OQ1 in `spec/design.md`.

2. **Should there be a codebase-profiling diagnostic that reports migrate-by-table vs migrate-by-judgment fractions?** Useful as v0.2. Shape would be a `reference/profile.md` leaf + a small script. Not blocking v0.1 because the agent can do this profiling inline during Phase 1 without dedicated tooling. Captured as OQ2 in `spec/design.md`.

3. **Where does the "migration prompt" material that Mike mentioned actually live?** **Resolved**: it's `spec/MIGRATION.md` itself. Part 2 of that doc is explicitly "Execution procedure ... written in second person to an AI agent performing the migration." The kickoff prompt at `reference/kickoff-prompt.md` is a thin wrapper around it. Captured as L5 (locked) in `spec/design.md`.

No follow-up beads filed — OQ1 and OQ2 are speculative v0.2 ideas that should be driven by real usage, not pre-emptively beaded. OQ3 is resolved.

## Test plan

- [ ] Read SKILL.md end-to-end as if you were a fresh agent — confirm it routes you to the right leaf for each phase.
- [ ] Read `reference/breaking-changes.md` against `spec/MIGRATION.md`'s rule list — confirm every M-N and O-N has a row.
- [ ] Read `reference/setup.md` against `spec/MIGRATION.md` §M-0 — confirm the build-tool shapes match.
- [ ] Read `reference/kickoff-prompt.md` — confirm pasting it into a fresh session would actually trigger the migration workflow.
- [ ] Spot-check that `spec/design.md`'s locks match the standing rules (Q14 NO verification; smallest correct diff; JVM interop in scope; Reagent v2 default).
- [ ] Eventually: run an end-to-end migration of a real v1 codebase against the skill and update the skill from what the run surfaces.