### PR TITLE
docs(guide): ch.20 Stories — signal optionality at top of chapter (rf2-ayzj)

### DIFF
--- a/docs/guide/20-stories.md
+++ b/docs/guide/20-stories.md
@@ -1,6 +1,8 @@
 # 20 — Stories
 
-You've seen the runtime in chapter 04, the views in chapter 06, the test machinery in chapter 14, and the tooling pitch in chapter 16. This chapter is where they converge.
+> **Optional deep-dive.** This chapter assumes you've absorbed the [events](04-events-state-cycle.md), [views](06-views-and-frames.md), [testing](14-testing.md), and [devtools](16-devtools-and-pair-tools.md) chapters. If you haven't yet, come back later — Stories is a layered surface on top of those, not the next link in the linear sequence.
+
+You've seen the runtime in the [events chapter](04-events-state-cycle.md), the views in the [views chapter](06-views-and-frames.md), the test machinery in the [testing chapter](14-testing.md), and the tooling pitch in the [devtools chapter](16-devtools-and-pair-tools.md). This chapter is where they converge.
 
 [`re-frame2-story`](https://github.com/day8/re-frame2/tree/main/tools/story) is a **frame-aware component playground** — Storybook-flavoured, but built on re-frame2's primitives the whole way down. Each variant of a component runs in its own dedicated frame (chapter 06). Each variant body is plain data, not a function (no `<Counter.story.tsx>` with inline JSX). Args resolve through a three-layer chain. Assertions ride the same `dispatch` pipeline as production events. Time-travel scrubs through `restore-epoch` (chapter 16). When you want to scaffold a new component, you're not reaching for a separate `.stories.tsx` file — you're declaring `reg-story` and `reg-variant` against the same component you're shipping.
 


### PR DESCRIPTION
## Summary

- Add a visible blockquote callout at the top of `docs/guide/20-stories.md` flagging the chapter as an optional deep-dive layered on top of events/views/testing/devtools.
- Rewrite the existing opening sentence to cross-link those four chapters by slug instead of by number, so the chapter survives rf2-aswf's renumber without further edits.
- README already lists ch.20 under "optional deep dives"; this puts the same signal at the top of the chapter itself for readers who arrive cold.

## Callout text

> **Optional deep-dive.** This chapter assumes you've absorbed the [events](04-events-state-cycle.md), [views](06-views-and-frames.md), [testing](14-testing.md), and [devtools](16-devtools-and-pair-tools.md) chapters. If you haven't yet, come back later — Stories is a layered surface on top of those, not the next link in the linear sequence.

## Style choice

Visible `>` blockquote rather than a collapsed `??? note` admonition — a collapsed note would hide the very signal the callout exists to give. Matches the upshot-box pattern used in 01/02/04/09.

## Scope

- Touches only `docs/guide/20-stories.md`. No mkdocs.yml, no other chapters.
- Disjoint from in-flight v1-mega / ch.04 / ch.10 work. Stories stays at slot 20.

## Test plan

- [ ] mkdocs renders the blockquote at the top of ch.20.
- [ ] All four cross-links resolve.