### PR TITLE
docs(guide): move ch.01 adds/keeps enumerations to ch.19 as 'what you've now seen' recap (rf2-1kd3)

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -111,23 +111,9 @@ The original re-frame, on which re-frame2 builds, was created over a decade ago 
 
 This isn't an argument by authority. It's an observation that the architectural ideas re-frame2 commits to are well-validated. They're not new. They've shipped real products. They survive contact with reality.
 
-## What re-frame2 adds to the original re-frame
+## What this chapter isn't going to enumerate
 
-If you've used re-frame v1, the pattern above is mostly familiar. What re-frame2 adds:
-
-- **Frames** — multi-instance support. Same handlers, isolated state. Useful for devcards, story tools, server-side rendering, multi-window UIs.
-- **State machines** — adopted from xstate; finite-state, transition-table-driven, headlessly testable. Available when an event handler's logic is naturally a flow.
-- **Flows** — registered, toggleable computed-state declarations. Derived values become named runtime artefacts with explicit inputs, paths, and tooling visibility.
-- **Server-side rendering** — first-class, not a future concession. Views are pure data-producing functions; the render-tree is a serialisable string; hydration is a defined protocol.
-- **Routing as state** — the URL ↔ frame state contract. Routes are registry entries, navigation is an event, `:route` is a sub. The same handler runs server- and client-side.
-- **Schema-attached contracts** — Malli-backed path and payload schemas for events, routes, hydration payloads, and app-db slices. Better runtime diagnostics, migration safety, and stronger AI/tooling guidance.
-- **Deep instrumentation** — every dispatch, render, fx, error, and machine transition emits a structured trace event. Tools (10x, re-frame-pair, AI agents) consume the stream live. Production builds compile it out entirely.
-- **AI-first stance** — every registration carries metadata; the registry is queryable; errors are structured; the spec ships with construction prompts and a conformance corpus an AI can use.
-- **A specification** that's implementable in any language. The pattern stops being "a CLJS thing" and starts being "a thing you can have in TypeScript or Python or Kotlin too." The [Implementor's Checklist](../../spec/Implementor-Checklist.md) is the structured port guide — it walks an implementor through the optional-capability declarations, the host-discretion choices (which PDS library, which scheduler, which trace sink), and the conformance-corpus subset that grades the result.
-
-## What re-frame2 keeps from the original re-frame
-
-Almost everything. The same six dominoes. The same opinionated stance on a single source of truth. The same preference for data over APIs over syntax. The same Clojure-flavoured ethos: open maps, immutable values, stable contracts, late binding. If you've used re-frame v1, you can read re-frame2 code and understand it on the first pass — most of the time without noticing what changed.
+A natural next question is: *what specifically does re-frame2 add on top of v1, and what does it keep?* The honest answer is that the list reads as marketing until you've met the pieces — frames, machines, flows, schema-attached contracts, deep instrumentation, the spec. The guide introduces each in its own chapter. Once you've worked through them, [chapter 19](19-where-next.md) gathers the additions and the inheritances into a single retrospective recap — a sharper read once the names mean something.
 
 > ### Sidebar: where re-frame2 isn't the right fit
 >

--- a/docs/guide/19-where-next.md
+++ b/docs/guide/19-where-next.md
@@ -2,6 +2,26 @@
 
 You've now seen the shape of re-frame2 from twelve angles — the argument, the cycle, views and frames, machines, HTTP, the server side, the v1 migration story, the dynamic-model essay, testing, devtools, and routing. The mental model is in place. A few directions from here.
 
+## What you've now seen
+
+If you came in from re-frame v1, you've now met everything that's new on top of the v1 pattern — and confirmed that almost everything else carries over unchanged. A retrospective tally, now that the names mean something:
+
+**What's new in re-frame2:**
+
+- **Frames** — multi-instance support. Same handlers, isolated state. The substrate for devcards, story tools, SSR, and multi-window UIs.
+- **State machines** — finite-state, transition-table-driven, headlessly testable. Reach for them when an event handler's logic is naturally a flow.
+- **Flows** — registered, toggleable computed-state declarations. Derived values as named runtime artefacts with explicit inputs, paths, and tooling visibility.
+- **Server-side rendering** — first-class. Views are pure data-producing functions; the render-tree is a serialisable string; hydration is a defined protocol.
+- **Routing as state** — URL ↔ frame state. Routes are registry entries, navigation is an event, `:route` is a sub. The same handler runs server- and client-side.
+- **Schema-attached contracts** — Malli-backed path and payload schemas for events, routes, hydration payloads, and app-db slices. Better runtime diagnostics, migration safety, stronger AI guidance.
+- **Deep instrumentation** — every dispatch, render, fx, error, and machine transition emits a structured trace event. Tools consume the stream live; production builds compile it out.
+- **AI-first stance** — every registration carries metadata, the registry is queryable, errors are structured, and the spec ships with construction prompts and a conformance corpus.
+- **A specification** that's implementable in any language. The pattern stops being a CLJS thing and starts being a thing you can have in TypeScript or Python or Kotlin too. The [Implementor's Checklist](../../spec/Implementor-Checklist.md) is the structured port guide.
+
+**What carries over from v1, unchanged:**
+
+Almost everything. The same six dominoes. The same opinionated stance on a single source of truth. The same preference for data over APIs over syntax. The same Clojure-flavoured ethos: open maps, immutable values, stable contracts, late binding. The reason your v1 code reads as v2 code on the first pass — most of the time without you noticing what changed.
+
 ## Build something with it
 
 The fastest way to make the pattern stick is to write code in it. The [worked examples](../../examples/README.md) are a graded sequence — start at the pedagogical end and move toward the benchmarks:


### PR DESCRIPTION
## Summary

- **Ch.01**: Removes the two enumeration sections ("What re-frame2 adds to the original re-frame" / "What re-frame2 keeps from the original re-frame") that previewed features (frames, machines, flows, schema-attached contracts, deep instrumentation, the spec) the reader hadn't yet met. Replaced with a one-paragraph forward-pointer to ch.19's retrospective recap.
- **Ch.19**: Adds a "What you've now seen" recap section right after the intro, reframed in retrospective voice — "you've now met everything that's new" rather than "re-frame2 adds frames...". Same content, different rhetorical move; sharper read once the names mean something.
- The "where re-frame2 isn't the right fit" sidebar (from rf2-opc8) stays in ch.01 as a standalone block before "Where to read next" — it functions as a chapter-level reality check, not specifically as a coda to the removed "keeps" section.

## Word-count delta

- Ch.01: 2534 -> 2261 words (-273)
- Ch.19: 1098 -> 1435 words (+337)

## Test plan

- [ ] `mkdocs serve` renders both chapters cleanly
- [ ] Forward-pointer link from ch.01 to ch.19 resolves
- [ ] Sidebar in ch.01 still reads as standalone in its new position
- [ ] Ch.19 recap reads as retrospective, not preview