### PR TITLE
docs(guide): move test-stubs ch.10->ch.13 + HTTP-v1-migration ch.10->ch.18 (rf2-1jz9, rf2-7tir)

### DIFF
--- a/docs/guide/10-doing-http-requests.md
+++ b/docs/guide/10-doing-http-requests.md
@@ -221,39 +221,7 @@ The reply dispatch lands in the **same frame** the request was issued from. The 
 
 ## Test stubs
 
-Tests want managed-HTTP requests to resolve against canned data, not the network. The framework ships **two canonical stub fxs** plus a higher-level helper.
-
-### Per-request stubs via `:fx-overrides`
-
-```clojure
-;; Success stub — synthesises a success reply.
-(rf/dispatch-sync [:counter/load]
-                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
-
-;; Failure stub — synthesises a failure reply.
-(rf/dispatch-sync [:counter/load]
-                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
-```
-
-The args map is the same shape; the canned-success stub takes a `:value` key (the payload to put under `:rf/reply :value`); the canned-failure stub takes `:kind` and `:tags` for the failure shape. Both stubs reuse the canonical reply envelope, so the test handler's reply branch sees what the live fx would produce.
-
-### `with-managed-request-stubs`
-
-For test suites that exercise many requests:
-
-```clojure
-(rf/with-managed-request-stubs
-  {[:get  "/api/counter"]       {:reply {:ok {:count 5}}}
-   [:get  "/api/does-not-exist"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
-   [:post "/api/counter"]        {:reply {:ok {:count 6}}}}
-  (rf/dispatch-sync [:counter/load])
-  (rf/dispatch-sync [:counter/load-bad])
-  (rf/dispatch-sync [:counter/save]))
-```
-
-The helper inspects each `:rf.http/managed` invocation's `:request :method` + `:request :url` and routes through the configured reply. Wrap a test, run dispatches, assert against the resulting `app-db`. No browser, no network.
-
-The canned-stub fxs gate on `interop/debug-enabled?` — they elide in production builds, so tests pay no production cost.
+For stubbing managed-HTTP requests in tests — the `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs and the `with-managed-request-stubs` helper — see [13 — Testing §Stubbing managed HTTP](13-testing.md#stubbing-managed-http).
 
 ## The standard request-lifecycle slice
 
@@ -296,15 +264,7 @@ The realworld example is a worked sketch — broader than the counter demo, narr
 
 ## Migrating from re-frame v1's ad-hoc HTTP
 
-If you're coming from a re-frame v1 codebase that registered its own `:http` fx — or used `re-frame-http-fx`, `re-frame-fetch-fx`, or one of their cousins — the migration is mechanical:
-
-1. Replace your `[:http {:url ... :on-success ... :on-error ...}]` fx vectors with `[:rf.http/managed {:request {:url ...} :on-success ... :on-failure ...}]`.
-2. Move wire-shape keys (`:method`, `:url`, `:body`, `:headers`, `:params`) inside `:request`.
-3. Rename `:on-error` → `:on-failure`. The reply payload appends as the last argument; destructure `{:keys [value]}` for success, `{:keys [failure]}` for failure.
-4. Adopt the closed `:rf.http/*` failure category set in your error-handling branches — your code that branched on `(:status err)` becomes branching on `(:kind failure)`.
-5. (Optional) Convert per-call success handlers to default reply addressing if the pre-request and post-reply logic naturally co-locate.
-
-The migration is detailed in [`spec/MIGRATION.md` §M-23 (alpha removed)](../../spec/MIGRATION.md#m-23-re-framealpha-is-removed-rf2-7cb2-rf2-s9dn) for callers that depended on the alpha namespace's now-removed query/registration shape, and the per-fx migration is mechanical (Type A) for the standard cases.
+For callers coming from a v1 codebase with their own `:http` fx (or `re-frame-http-fx` / `re-frame-fetch-fx`), see [18 — From re-frame v1 §Migrating an HTTP layer](18-from-re-frame-v1.md#migrating-an-http-layer).
 
 ## Reference and tooling
 

--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -326,6 +326,36 @@ Or a one-shot per-call override:
 
 The override is a **redirect**, not a mock. The same dispatch shape the real fx produces lands in the test handler.
 
+### Stubbing managed HTTP
+
+The generic `:fx-overrides` shape above redirects any fx to a test fn. For `:rf.http/managed` specifically, the framework ships two canonical stub fxs plus a higher-level helper, so tests get the canonical reply envelope without hand-rolling one.
+
+Per-request stub via `:fx-overrides` redirect — the stub fx synthesises a success or failure reply with the same shape the live fx would produce:
+
+```clojure
+(rf/dispatch-sync [:counter/load]
+                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+
+(rf/dispatch-sync [:counter/load]
+                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+```
+
+The args map is the same shape the call site already uses; the canned-success stub takes a `:value` key (the payload to put under `:rf/reply :value`); the canned-failure stub takes `:kind` and `:tags` for the failure shape.
+
+For test suites that exercise many requests against many endpoints, `with-managed-request-stubs` routes each `:rf.http/managed` invocation by `:request :method` + `:request :url`:
+
+```clojure
+(rf/with-managed-request-stubs
+  {[:get  "/api/counter"]        {:reply {:ok {:count 5}}}
+   [:get  "/api/does-not-exist"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
+   [:post "/api/counter"]        {:reply {:ok {:count 6}}}}
+  (rf/dispatch-sync [:counter/load])
+  (rf/dispatch-sync [:counter/load-bad])
+  (rf/dispatch-sync [:counter/save]))
+```
+
+Wrap a test, run dispatches, assert against the resulting `app-db`. No browser, no network. Both canned-stub fxs gate on `interop/debug-enabled?` and elide in production builds — tests pay no production cost. The full contract is in [Spec 014 §Testing](../../spec/014-HTTPRequests.md#testing).
+
 ### Recording dispatched events without firing them
 
 ```clojure

--- a/docs/guide/18-from-re-frame-v1.md
+++ b/docs/guide/18-from-re-frame-v1.md
@@ -51,6 +51,18 @@ These are the broad categories of breakage. The skill identifies and resolves th
 
 If a failure doesn't match any of the above, the skill surfaces it for human review rather than guessing. The cardinal rule is *don't invent migration rules*.
 
+### Migrating an HTTP layer
+
+A concrete instance of "problems you might run into": v1 codebases that registered their own `:http` fx — or used `re-frame-http-fx`, `re-frame-fetch-fx`, or one of their cousins — migrate onto `:rf.http/managed` (see [10 — Doing HTTP requests](10-doing-http-requests.md)). The skill recognises the shape; the rewrite is mechanical (Type A):
+
+1. Add the `day8/re-frame2-http` artefact and `(:require [re-frame.http-managed])` from the namespaces that issue requests (per [`MIGRATION.md` §M-31](../../spec/MIGRATION.md#m-31-managed-http-spec-014-ships-in-a-separate-artefact--day8re-frame2-http)).
+2. Replace `[:http {:url ... :on-success ... :on-error ...}]` fx vectors with `[:rf.http/managed {:request {:url ...} :on-success ... :on-failure ...}]`. Wire-shape keys (`:method`, `:url`, `:body`, `:headers`, `:params`) move inside `:request`.
+3. Rename `:on-error` → `:on-failure`. The reply payload appends as the last argument; destructure `{:keys [value]}` for success, `{:keys [failure]}` for failure.
+4. Adopt the closed `:rf.http/*` failure category set in error-handling branches — code that branched on `(:status err)` becomes branching on `(:kind failure)`.
+5. (Optional modernisation, not required for migration.) Convert per-call success handlers to default reply addressing if the pre-request and post-reply logic naturally co-locate at one event id.
+
+The skill applies steps 1–4 unprompted and stops at step 5 for review.
+
 ## A note on the tooling
 
 `re-frame-10x` — the v1 devtools panel — has been renamed and reimplemented as **`re-frame-causa`** for v2. It is **not** the v1 10x ported to v2; it's a from-scratch reimplementation against re-frame2's own trace bus and epoch-history surfaces (see [15 — Tooling](15-devtools-and-pair-tools.md)). If your v1 project depended on the 10x panel during development, the v2 equivalent is causa, not 10x. The mental model — events, subs, app-db diff, time-travel — carries over; the wiring underneath does not.


### PR DESCRIPTION
## Summary

Two topics moved out of ch.10 (HTTP) to their proper homes:

- **rf2-1jz9** — Managed-HTTP test stubs (`:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` / `with-managed-request-stubs`) moved from ch.10 to **ch.13 Testing** as a new "Stubbing managed HTTP" subsection, slotted next to the generic `:fx-overrides` discussion.
- **rf2-7tir** — Five-step v1 `:http`-fx migration walkthrough moved from ch.10 to **ch.18 From re-frame v1** as a concrete example under "Problems you might run into". Kept tight to fit the post-v1-mega utility-focused frame; cross-links to `MIGRATION.md` §M-31 for the artefact dep.

Ch.10 retains one-line forward-links where each section used to live.

3 files touched: `docs/guide/10-doing-http-requests.md` (-303 words), `docs/guide/13-testing.md` (+202 words), `docs/guide/18-from-re-frame-v1.md` (+185 words). Net -84 words across the guide.

## Test plan

- [ ] mkdocs build clean — no broken anchors on the new cross-links (`13-testing.md#stubbing-managed-http`, `18-from-re-frame-v1.md#migrating-an-http-layer`).
- [ ] Visual scan: ch.10 reads coherently with the two sections collapsed to one-liners; ch.13 and ch.18 read coherently with the new sections in place.