### PR TITLE
docs(mkdocs): add Skills top-nav tab with brief per-skill sub-pages (rf2-jucc)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,47 @@
+# Skills
+
+> Five Claude Code skills that travel with the re-frame2 repo — for authoring code, bootstrapping a project, migrating from v1, pair-programming with a running app, and running a retrospective on a pairing session.
+
+A **skill** is a small package of agent-shaped instructions plus optional scripts and reference leaves. When you load a skill into Claude Code (or any other Anthropic-skill-compatible agent), the model picks up its system prompt and its operating contract — so the same conversation that was *"help me write a re-frame2 event handler"* becomes a focused interaction that knows the canonical shapes, the cardinal rules, and where the depth lives.
+
+re-frame2 ships five skills, colocated under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills) in this repo. Each one is self-contained: its own `SKILL.md`, its own `reference/` leaves, its own packaging metadata.
+
+## How to load a skill
+
+The exact mechanics depend on the agent you're driving. In **Claude Code**, install a skill by copying its directory into a project-level `.claude/skills/<name>/` (or globally into `~/.claude/skills/<name>/`). Once installed, the skill's `description` triggers it whenever the conversation mentions one of its surfaces — you usually don't need to invoke it explicitly. You can also force-load it with `/skill <name>` if the agent's launcher supports slash-commands for skills.
+
+The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the single deep-dive index — every skill points at it for spec-corpus depth and EP rationale.
+
+## The five skills
+
+| Skill | Pitch |
+|---|---|
+| [**re-frame2** (authoring)](re-frame2.md) | Write re-frame2 ClojureScript code — events, subs, fx, machines, schemas, stories, routes, and the canonical patterns. |
+| [**re-frame2-setup**](re-frame2-setup.md) | Bootstrap a fresh re-frame2 ClojureScript project from nothing. Walks the author to a working counter under `shadow-cljs watch`. |
+| [**re-frame-migration** (v1→v2)](re-frame-migration.md) | Migrate an existing re-frame v1.x codebase to re-frame2. Applies the mechanical `M-rules` automatically; flags judgment calls. |
+| [**re-frame-pair2**](re-frame-pair2.md) | Pair-program with a live, running re-frame2 app. Dispatch events, inspect `app-db`, walk epochs, hot-swap handlers — all via Tool-Pair contract. |
+| [**re-frame-pair-improver2**](re-frame-pair-improver2.md) | Retrospect a `re-frame-pair2` session. Surfaces friction; proposes targeted improvements; routes upstream beads to re-frame2 when the cause is framework-shaped. |
+
+## Picking the right one
+
+A quick decision flow:
+
+- **Starting from nothing?** → `re-frame2-setup`. When the counter mounts, switch to `re-frame2`.
+- **Existing v1 codebase?** → `re-frame-migration`. When the migration report is signed off, switch to `re-frame2`.
+- **Writing new code in an existing v2 project?** → `re-frame2`.
+- **Debugging or pairing with a running v2 app?** → `re-frame-pair2`.
+- **Just finished a pairing session and noticed friction?** → `re-frame-pair-improver2`.
+
+If a question spans more than one skill, pick the one whose **entry trigger** matches and let it route — every skill has a *"when NOT to use this"* table that hands off cleanly.
+
+## Where each one lives
+
+| Skill | Source tree |
+|---|---|
+| `re-frame2` | [`skills/re-frame2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) |
+| `re-frame2-setup` | [`skills/re-frame2-setup/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup) |
+| `re-frame-migration` | [`skills/re-frame-migration/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration) |
+| `re-frame-pair2` | [`skills/re-frame-pair2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) |
+| `re-frame-pair-improver2` | [`skills/re-frame-pair-improver2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2) |
+
+Each sub-page on this tab is a brief discoverability entry-ramp — pitch, triggers, kickoff shape, link to the skill's own `SKILL.md`. The authoritative content always lives in the skill's source tree.

--- a/docs/skills/re-frame-migration.md
+++ b/docs/skills/re-frame-migration.md
@@ -1,0 +1,45 @@
+# re-frame-migration (v1 → v2)
+
+> Migrates an existing re-frame v1.x ClojureScript codebase to re-frame2. Swaps the coord, applies mechanical (Type A) rewrites automatically, and flags judgment-call (Type B) call sites for human review.
+
+## What it does
+
+The `re-frame-migration` skill walks a six-phase migration: **orient** (read the dep file, skim the rule index), **bump M-0** (swap `re-frame/re-frame` → `day8/re-frame2` + a substrate adapter; stop and compile — most codebases need nothing more), **sweep for breakage** against the M-rules, **verify** (compile, tests, smoke), **optional opt-in modernisations** (only if the author asked), and **report** in the format `spec/MIGRATION.md` Part 2 specifies.
+
+The authoritative breaking-change list lives in [`spec/MIGRATION.md`](https://github.com/day8/re-frame2/blob/main/spec/MIGRATION.md). The skill consumes it; it never duplicates or invents rules. **Type A** rewrites (mechanical, unambiguous, observably identical) are applied without asking. **Type B** rewrites (timing-sensitive, dynamic call sites, behaviour-changes-at-the-edge) are flagged with the relevant rule cited, and the skill waits for the author's decision before rewriting.
+
+JVM-side test runners are in scope — re-frame2 preserves `re-frame.interop` and JVM-side test runs. The smallest correct diff is the rule; no stylistic refactoring, no renames the author didn't ask for.
+
+## When to reach for it
+
+Load this skill when **any** of these are true:
+
+- The author has an existing re-frame v1.x project and wants to move to re-frame2.
+- The author mentions migrating, upgrading, porting, or v1→v2 in a re-frame context.
+- The build fails after a dep bump and the cause looks v1-shaped — missing private namespaces, removed interceptors, `dispatch-with`, `re-frame.alpha`, the old effect-map keys.
+- The author asks *"what breaks?"* / *"what changes?"* / *"is my v1 code compatible?"*.
+
+Do **not** use this skill for:
+
+- Greenfield setup → use [re-frame2-setup](re-frame2-setup.md).
+- Writing v2 application code → use [re-frame2](re-frame2.md).
+- Inspecting / debugging a running v2 app → use [re-frame-pair2](re-frame-pair2.md).
+
+## Kickoff
+
+A paste-ready kickoff prompt ships with the skill at [`skills/re-frame-migration/reference/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/reference/kickoff-prompt.md). The author opens a fresh Claude Code session in the root of their v1 project and pastes it verbatim. The session loads the skill on its own and walks the six phases autonomously, surfacing decisions back to the author at the Type B checkpoints.
+
+Excerpted shape (full text in the kickoff file):
+
+> *I'm migrating this ClojureScript codebase from re-frame v1.x to re-frame2. Walk the migration end-to-end per the `re-frame-migration` skill in this session. Phase 1 — Orient. Read the dep file, confirm we're actually on `re-frame/re-frame` today, identify the substrate. Phase 2 — Apply M-0. Swap the coord. **Stop.** Most codebases require no further changes — verify that before doing more work. Phase 3 — If anything broke, sweep the failures against the M-rules. Apply Type A without asking; Type B asks first. Phase 4 — Re-verify. Phase 5 — Do NOT apply opt-in modernisations unless I explicitly ask. Phase 6 — Report (under 300 words).*
+
+The kickoff prompt also names two common amendments — *"also modernise"* (walk the `O-N` rules) and *"migrate in feature-branch slices"* (one commit per rule-group).
+
+## Where the skill lives
+
+- Source: [`skills/re-frame-migration/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration)
+- `SKILL.md`: [`skills/re-frame-migration/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/SKILL.md)
+- Kickoff prompt: [`skills/re-frame-migration/reference/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/reference/kickoff-prompt.md)
+- Reference leaves: [`skills/re-frame-migration/reference/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration/reference) — `setup.md` (M-0 in operational detail), `breaking-changes.md` (one-page index of every rule by trigger surface), `sequencing.md`, `automated-transforms.md` (Type A patterns), `guided-checklist.md` (Type B walkthroughs), `output-format.md` (the migration-report shape).
+- Authoritative rule corpus: [`spec/MIGRATION.md`](https://github.com/day8/re-frame2/blob/main/spec/MIGRATION.md).
+- Narrative companion: [Guide chapter 18 — From re-frame v1](../guide/18-from-re-frame-v1.md).

--- a/docs/skills/re-frame-pair-improver2.md
+++ b/docs/skills/re-frame-pair-improver2.md
@@ -1,0 +1,47 @@
+# re-frame-pair-improver2
+
+> Turns a `re-frame-pair2` session into a product retrospective. Surfaces friction, classifies root causes, proposes 2–5 concrete improvements, and (only on explicit approval) drafts or files beads against the right repo.
+
+## What it does
+
+The `re-frame-pair-improver2` skill is a **meta-skill** for `re-frame-pair2`. It reads the current or just-finished pair-programming session and turns it into a focused retrospective: what was the user actually trying to do; where did the workflow drag, confuse, or frustrate; which problems were one-off environment issues vs recurring product gaps; and 2–5 concrete improvement ideas, prioritized by leverage, including 1–2 bolder ideas when reshaping the workflow would materially improve it.
+
+The skill is **diagnosis first**, contribution second. It presents friction points before root causes, lets the user steer which ones to dig into, and never files a bead or edits another repo without explicit approval. Improvements are routed to the right layer:
+
+- **`re-frame-pair2`** — friction inside the pair tool itself (SKILL.md, scripts, recipes, structured results, attach/discovery brittleness, cross-platform handling).
+- **`re-frame2`** — friction caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` or `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings).
+
+Working style: prefer evidence over vibes (cite concrete moments — retries, clarifications, stale outputs, manual workarounds); separate symptom from cause; notice both direct friction (the user said something was frustrating) and indirect (repeated commands, fallbacks to lower-level tools); be creatively ambitious *after* the diagnosis is clear, labelling speculative ideas plainly. Time-travel and trace-stream consumption stay on re-frame2's own surfaces — no proposals route through `re-frame-10x`.
+
+## When to reach for it
+
+Load this skill when:
+
+- The user asks how `re-frame-pair2` could better support their workflow.
+- The user wants a retrospective on a debugging or pairing session that just happened.
+- The user wants concrete improvement ideas or bead drafts for `re-frame-pair2`.
+
+Do **not** use this skill for:
+
+- Inspecting / debugging a live app → that's [re-frame-pair2](re-frame-pair2.md) itself.
+- Writing new re-frame2 code → use [re-frame2](re-frame2.md).
+- Greenfield setup or v1 migration → use [re-frame2-setup](re-frame2-setup.md) or [re-frame-migration](re-frame-migration.md).
+
+## Kickoff
+
+The skill auto-triggers on retrospective-shaped questions ("how could pair2 do this better?", "what could be improved here?"). To force-load:
+
+```
+/skill re-frame-pair-improver2
+```
+
+The skill's analysis workflow runs in six steps: reconstruct the session goal, build a short timeline of stalls / restarts / detours, extract a numbered friction list (and ask the user which to dig into), classify root causes through ten lenses (skill structure / skill gap / misleading docs / missing structured op / unreliable op / default or fallback / platform bug / validation gap / upstream limitation / context-window issue), generate improvements at the right layer, and prioritize down to 2–5.
+
+Output is a compact retrospective with sections — `Goal`, `Observed friction`, `Likely root causes`, `Improvement ideas`, optional `Bolder ideas`, optional `Bead candidates`. The skill drafts bead bodies on request, but never files without explicit approval.
+
+## Where the skill lives
+
+- Source: [`skills/re-frame-pair-improver2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2)
+- `SKILL.md`: [`skills/re-frame-pair-improver2/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-pair-improver2/SKILL.md)
+- Reference leaves: [`skills/re-frame-pair-improver2/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2/references) — `analysis-lenses.md` (taxonomy when a session has multiple plausible causes), `known-frictions.md` (recurring classes of `re-frame-pair2` pain — useful for sanity-checking whether a friction is one-off or a pattern), `issue-template.md` (bead-body structure).
+- Companion skill: [`re-frame-pair2`](re-frame-pair2.md) — the skill this one retrospects.

--- a/docs/skills/re-frame-pair2.md
+++ b/docs/skills/re-frame-pair2.md
@@ -1,0 +1,54 @@
+# re-frame-pair2
+
+> Pair-program with a live, running re-frame2 application. Attach via nREPL, inspect any frame's `app-db`, dispatch events, hot-swap handlers, walk epochs, and read the trace stream — through re-frame2's own Tool-Pair contract, no `re-frame-10x` dependency.
+
+## What it does
+
+The `re-frame-pair2` skill is the AI pair-programming companion for a running re-frame2 app. The app is up behind `shadow-cljs watch`; the skill attaches to its nREPL session in `:cljs` mode and operates on the live runtime — not just static source files.
+
+Three primitives carry the skill's agency, all part of re-frame2's [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md):
+
+1. **The REPL** — ClojureScript forms evaluated against the real app, usually through helpers in the injected `re-frame-pair2.runtime` namespace.
+2. **The trace stream** — `(rf/register-trace-cb id cb)` for live trace events; `(rf/trace-buffer opts)` for the retain-N ring of recent events.
+3. **The epoch history** — `(rf/epoch-history frame-id)` returns the per-frame ring of `:rf/epoch-record` values, each carrying `:db-before`, `:db-after`, `:trace-events`, and the assembled `:sub-runs` / `:renders` / `:effects` projections.
+
+The skill is **multi-frame aware** (Spec 002 — most apps run with one frame, larger apps run several). It registers exactly **one** trace listener (`:re-frame-pair2`) and one epoch listener (`:re-frame-pair2-epoch`) so it coexists with other tools (e.g. `re-frame-10x` v2) on the same bus. Mutating ops refuse with `:ambiguous-frame` when the operating frame is unclear.
+
+The cardinal rule: **REPL changes are ephemeral, source edits are permanent.** After any source edit, the skill waits on the hot-reload protocol before dispatching or tracing — otherwise you interact with the pre-reload code.
+
+## When to reach for it
+
+Load this skill when the user mentions a **running** re-frame2 app, or any of: `re-frame2`, `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, frame, epoch, interceptor, sub-cache, trace-buffer, `register-trace-cb`, `register-epoch-cb`, `restore-epoch`, re-com, shadow-cljs — *and the question is about the live runtime*, not about writing new code.
+
+Do **not** use this skill for:
+
+- Writing new application code → use [re-frame2](re-frame2.md).
+- Greenfield setup → use [re-frame2-setup](re-frame2-setup.md).
+- Migrating a v1 project → use [re-frame-migration](re-frame-migration.md).
+
+## Kickoff
+
+Every session starts with:
+
+```
+scripts/discover-app.sh
+```
+
+This locates the shadow-cljs nREPL port, connects, switches to `:cljs` mode for the running build, verifies re-frame2 is loaded with `interop/debug-enabled?` true, and injects the runtime namespace. Failures return a structured edn shape like `{:ok? false :missing :re-frame2}` which the skill reports verbatim and routes to the matching recovery in [`references/errors.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-pair2/references/errors.md).
+
+To force-load in Claude Code:
+
+```
+/skill re-frame-pair2
+```
+
+After connect, work in structured ops (read, write, trace, DOM bridge, watch, hot-reload, time-travel) rather than ad-hoc `repl/eval` — the escape hatch is available for probes that don't fit the catalogue.
+
+## Where the skill lives
+
+- Source: [`skills/re-frame-pair2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2)
+- `SKILL.md`: [`skills/re-frame-pair2/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-pair2/SKILL.md)
+- Reference leaves: [`skills/re-frame-pair2/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2/references) — `ops.md` (structured ops catalogue), `recipes.md` (named procedures: *"why didn't my view update?"*, post-mortem, experiment loop), `errors.md` (structured-error → plain-English recovery), `hot-reload-protocol.md`, `migration-from-v1.md`.
+- Tool-Pair contract: [`spec/Tool-Pair.md`](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md).
+- Narrative companion: [Guide chapter 15 — Tooling](../guide/15-devtools-and-pair-tools.md).
+- Retrospective companion skill: [`re-frame-pair-improver2`](re-frame-pair-improver2.md).

--- a/docs/skills/re-frame2-setup.md
+++ b/docs/skills/re-frame2-setup.md
@@ -1,0 +1,40 @@
+# re-frame2-setup
+
+> Scaffolds a fresh re-frame2 ClojureScript project from nothing — deps, npm packages, `shadow-cljs.edn`, entry namespace, first counter — and stops when the counter mounts.
+
+## What it does
+
+The `re-frame2-setup` skill bootstraps a greenfield re-frame2 project. The author starts with nothing (or close to nothing — a `deps.edn` they intend to fill in, an empty `package.json`, no source). When the skill is done, the author has a project that compiles under `shadow-cljs watch`, mounts a working counter in the browser, and is ready to switch to the [`re-frame2`](re-frame2.md) skill for writing application code.
+
+The skill teaches **only** the re-frame2-specific wiring: which artefacts to add, the lockstep VERSION discipline (all ten ship at the same version; mixing is unsupported), the canonical `(rf/init! reagent-adapter/adapter)` entry-namespace shape, and a counter that exercises every layer end-to-end (event → handler → app-db change → sub recompute → view re-render). It does not teach `deps.edn`, `npm`, or `shadow-cljs` themselves — those are assumed.
+
+## When to reach for it
+
+Load this skill when **any** of these are true:
+
+- The author has just created a new directory and wants re-frame2 set up in it.
+- The author has an existing CLJS project but no re-frame2 wiring yet.
+- The author says *"start a re-frame2 project"*, *"scaffold re-frame2"*, *"how do I set up re-frame2"*, *"add re-frame2 to my repo"*, *"give me a hello-world re-frame2 app"*.
+- A counter / event / sub fails to compile because the build doesn't yet know what `re-frame.core` or `re-frame.adapter.reagent` is.
+
+Do **not** use this skill for:
+
+- Writing application code in a project that's already on re-frame2 → use [re-frame2](re-frame2.md).
+- Migrating a re-frame v1 project → use [re-frame-migration](re-frame-migration.md).
+- Inspecting / debugging a running app → use [re-frame-pair2](re-frame-pair2.md).
+
+## Kickoff
+
+The skill auto-triggers on greenfield-setup phrasings. To force-load:
+
+```
+/skill re-frame2-setup
+```
+
+The skill walks seven steps in order: discover the current artefact VERSION, add deps to `deps.edn`, add npm deps to `package.json`, write `shadow-cljs.edn`, write the entry namespace, write the first counter, run and verify. The Reagent adapter is the default reference substrate; UIx and Helix are supported but only on explicit request. The skill stops at *"the counter mounts"* — writing tests, schemas, or further features is the next skill's job.
+
+## Where the skill lives
+
+- Source: [`skills/re-frame2-setup/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup)
+- `SKILL.md`: [`skills/re-frame2-setup/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-setup/SKILL.md)
+- Reference leaves: [`skills/re-frame2-setup/reference/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup/reference) — `deps-versions.md` (how to discover the current VERSION; lockstep contract), `shadow-cljs.md` (the minimal `shadow-cljs.edn` and `index.html` shape), `entry-namespace.md` (the canonical `core.cljs` shape; why `rf/init!` runs first), `first-counter.md` (the worked end-to-end counter).

--- a/docs/skills/re-frame2.md
+++ b/docs/skills/re-frame2.md
@@ -1,0 +1,46 @@
+# re-frame2 (authoring)
+
+> Writes re-frame2 ClojureScript application code — events, subscriptions, effects, frames, state machines, schemas, stories, routing, and the canonical patterns.
+
+## What it does
+
+The `re-frame2` skill is the **authoring** skill for re-frame2: it teaches an agent the re-frame2-specific binding for the ideas the user already knows (events, FSMs, HTTP retry, optimistic updates). It carries the cardinal rules — implementation-is-ground-truth, recipes-over-explanations, frames-before-globals, reserved `:rf/*` namespaces, `reg-*` macros over `register-*` functions — and a one-level-deep map of reference and pattern leaves. The agent loads at most two leaves per task and matches the canonical declaration verbatim rather than deriving a shape from first principles.
+
+Worked examples in `examples/reagent/<x>/` are treated as canonical. Pattern leaves (`patterns/remote-data.md`, `patterns/forms.md`, `patterns/managed-http.md`, ...) name the features the pattern uses, give the canonical mini-declaration, and link to the worked example.
+
+## When to reach for it
+
+Load this skill when the prompt is about **writing or editing re-frame2 application source** — `.cljs` / `.cljc` files. The user does not have to name re-frame2; any of these are sufficient triggers:
+
+- References to `reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`.
+- Mentions of `dispatch`, `subscribe`, `app-db`, frames, regions, tags, the nine UI states.
+- Pattern names: RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection.
+- "Write a test for a re-frame2 handler / sub / machine."
+
+Do **not** use this skill for:
+
+- Greenfield project setup → use [re-frame2-setup](re-frame2-setup.md).
+- Migrating a v1 codebase → use [re-frame-migration](re-frame-migration.md).
+- Inspecting a *running* app → use [re-frame-pair2](re-frame-pair2.md).
+- Reading the full API or EP rationale → follow [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md).
+
+## Kickoff
+
+The skill auto-triggers on any of the surfaces above. No paste-ready prompt is needed for routine authoring tasks — open Claude Code in a project that has the skill installed, ask for what you want in your own words, and the skill loads itself.
+
+For force-loading from a slash-command launcher:
+
+```
+/skill re-frame2
+```
+
+For greenfield-then-author, walk the [re-frame2-setup](re-frame2-setup.md) skill first; when the counter mounts, switch to this one.
+
+## Where the skill lives
+
+- Source: [`skills/re-frame2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2)
+- `SKILL.md`: [`skills/re-frame2/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2/SKILL.md)
+- Reference leaves: [`skills/re-frame2/reference/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/reference) — fundamentals (events, fx, cofx, subs, schemas, frames, project-structure), state-machines (reg-machine, regions, tags, invoke, cancellation), tooling (stories, routing), cross-cutting (testing, API cheatsheet).
+- Pattern leaves: [`skills/re-frame2/patterns/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/patterns) — one leaf per canonical pattern, each with a mini-declaration and a link to the worked example.
+- Decision trees: [`skills/re-frame2/decision-trees/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2/decision-trees) — *slice or machine?*, *pick a pattern*.
+- Worked example map: [`skills/re-frame2/examples-map.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2/examples-map.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,14 @@ nav:
       - Stale detection: spec/Pattern-StaleDetection.md
       - WebSocket: spec/Pattern-WebSocket.md
 
+  - Skills:
+    - Overview: skills/index.md
+    - "re-frame2 (authoring)": skills/re-frame2.md
+    - re-frame2-setup: skills/re-frame2-setup.md
+    - "re-frame-migration (v1→v2)": skills/re-frame-migration.md
+    - re-frame-pair2: skills/re-frame-pair2.md
+    - re-frame-pair-improver2: skills/re-frame-pair-improver2.md
+
   - API:
     - Reference: spec/API.md
 


### PR DESCRIPTION
## Summary

Adds a **Skills** top-nav tab to the docs site, with an overview page and a brief sub-page per skill. Five sub-pages, each ~40-55 lines: pitch, when-to-reach-for-it / when-not-to, kickoff shape, and links into the skill's own source tree on GitHub. The sub-pages are discoverability entry-ramps — the authoritative content stays in each skill's `SKILL.md` under `skills/<name>/`.

### Sub-pages

- `docs/skills/index.md` (47 lines) — Overview: what Claude skills are; how to load them; the five skills with one-line teasers; a quick decision flow; source-tree pointers.
- `docs/skills/re-frame2.md` (46 lines) — authoring skill.
- `docs/skills/re-frame2-setup.md` (40 lines) — greenfield bootstrap skill.
- `docs/skills/re-frame-migration.md` (45 lines) — v1 → v2 migration skill, including an excerpt of the paste-ready kickoff prompt from the skill's `reference/`.
- `docs/skills/re-frame-pair2.md` (54 lines) — live-app pairing skill.
- `docs/skills/re-frame-pair-improver2.md` (47 lines) — retrospective meta-skill.

### Nav slot

`Guide → Spec → Skills → API`. Tools sit between contract (Spec) and reference (API), matching the *"story / system / symbols"* ordering called out on `docs/index.md`.

### Link strategy

`skills/` is not staged into `docs_dir` and is not rewritten by `mkdocs_hooks.py`, so links into skill source trees use absolute `github.com` URLs — matching the existing pattern in `docs/guide/15-devtools-and-pair-tools.md` and `docs/guide/18-from-re-frame-v1.md`. Cross-page links between sub-pages and into `docs/guide/` and `docs/spec/` use plain relative paths.

### mkdocs build --strict

```
RC=0
INFO    -  Documentation built in 2.83 seconds
```

Zero `WARNING` and zero `ERROR` lines introduced. Only pre-existing `INFO`-level missing-anchor notices remain (all on `spec/` content, predating this PR).

## Test plan

- [x] `mkdocs build --strict` passes (RC=0, no warnings, no errors)
- [x] All five new sub-pages render in `site/skills/*/index.html`
- [x] Internal links from `re-frame-pair2.md` → `re-frame-pair-improver2.md`, `guide/15`, etc. resolve in built HTML
- [x] GitHub source links resolve to existing files in `skills/<name>/` and `spec/`
- [x] Touches only `mkdocs.yml` + new files under `docs/skills/`