### PR TITLE
docs(guide): ch.13 — add with-fresh-registrar vs reset-runtime-fixture choosing rule (rf2-qc5a)

### DIFF
--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -92,7 +92,7 @@ The patterns above isolate `app-db`. They don't isolate the **registrar** — th
     (ts/with-fresh-registrar (test-fn))))
 ```
 
-The companion fn `reset-runtime-fixture` is the same shape extended to per-process state — frames, flows, schemas, trace listeners — and is the standard `:each` fixture for re-frame2 test suites. Use `with-fresh-registrar` when only the registrar might change; use `reset-runtime-fixture` when tests touch trace listeners, schemas, or other process-wide state.
+The companion fn `reset-runtime-fixture` is the same shape extended to per-process state — frames, flows, schemas, trace listeners — and is the standard `:each` fixture for re-frame2 test suites. Use `with-fresh-registrar` when only the registrar might change; use `reset-runtime-fixture` when tests also touch trace listeners, schemas, or other process-wide state.
 
 ## What you actually test
 


### PR DESCRIPTION
## Summary

`docs/guide/13-testing.md` §"Registrar isolation: with-fresh-registrar" introduces both `with-fresh-registrar` and `reset-runtime-fixture` close together. The closing choosing-rule line read "...when tests touch trace listeners, schemas, or other process-wide state" — which doesn't quite parse as a contrast against the with-fresh-registrar case.

Adds "also" so the rule reads as a genuine either/or:

> Use `with-fresh-registrar` when only the registrar might change; use `reset-runtime-fixture` when tests **also** touch trace listeners, schemas, or other process-wide state.

One-word change. Closes rf2-qc5a.

## Test plan

- [x] Visual diff scans cleanly
- [x] Section reads as an explicit choosing rule between the two fixtures