### PR TITLE
docs(guide): ch.04 — trim Patterns enumeration to AsyncEffect+RemoteData; move rest to ch.19 (rf2-boc7)

### DIFF
--- a/docs/guide/04-events-state-cycle.md
+++ b/docs/guide/04-events-state-cycle.md
@@ -308,20 +308,14 @@ This is the testing experience that drove people to re-frame in the first place.
 
 ## Patterns: the next layer up
 
-Once you've internalised events-as-data and effects-as-data, you start noticing that real apps have *recurring shapes* on top of those primitives. A feature that loads remote data has a slice and a four-event lifecycle. A form has a draft, a submitted snapshot, a status, per-field errors. An app's boot is a chained sequence with progress UI and fail-fatal points. A WebSocket connection is a state machine that owns a long-lived socket. A handler that posts work to an external system and waits for an asynchronous reply has a six-step shape. CPU-heavy work needs to either yield or move to a worker. Async results that arrive after the user has moved on need to be quietly suppressed.
+Once you've internalised events-as-data and effects-as-data, you start noticing that real apps have *recurring shapes* on top of those primitives. Each recurring shape has been distilled into a **Pattern** doc — convention, not Spec, but canonical naming so codebases and AI scaffolds converge on one answer rather than re-deriving.
 
-Each of these has been distilled into a **Pattern** doc — convention, not Spec, but canonical naming so codebases and AI scaffolds converge on one answer rather than re-deriving:
+Two Patterns bottom out directly on what this chapter covered, so flag them now:
 
-- [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md) — the generic post-work-await-reply shape.
-- [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) — HTTP requests with a standard lifecycle slice.
-- [Pattern-Forms](../../spec/Pattern-Forms.md) — draft/submitted/status/errors as a standard slice. (Guide: [09 — Forms](09-forms.md).)
-- [Pattern-Boot](../../spec/Pattern-Boot.md) — chained init, progress UI, fail-fatal points.
-- [Pattern-WebSocket](../../spec/Pattern-WebSocket.md) — long-lived connection as a state machine.
-- [Pattern-LongRunningWork](../../spec/Pattern-LongRunningWork.md) — chunked yielding or worker offload for CPU-heavy work.
-- [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) — the epoch idiom for ignoring superseded async results.
-- [Pattern-NineStates](../../spec/Pattern-NineStates.md) — making the nine common UI states (`Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many` / `Incorrect` / `Correct` / `Done`) explicit in data so each branch is testable.
+- [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md) — the generic post-work-await-reply shape that the `:rf.http/managed` example above is one instance of.
+- [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) — HTTP requests with a standard lifecycle slice (idle / loading / loaded / error / stale).
 
-The pattern docs are themselves human-readable — closer in voice to this guide than to the Specs. When the shape of a feature you're building matches one of them, read the pattern doc and copy the shape; don't invent a new one.
+The rest of the Pattern catalogue — Forms, Boot, WebSocket, LongRunningWork, StaleDetection, NineStates — is covered in [chapter 19 — Where to go next](19-where-next.md#look-up-a-pattern-by-name), with one-line summaries you can scan when the shape of your problem matches. Read the Pattern doc and copy the shape; don't invent a new one.
 
 ## A note on revertibility
 

--- a/docs/guide/19-where-next.md
+++ b/docs/guide/19-where-next.md
@@ -38,8 +38,13 @@ If you'd like a **frame-aware component playground** alongside the live app — 
 
 When you hit a recurring shape — async work, websockets, forms, remote data, boot — the specification ships a **Pattern doc** for it. Pattern docs are convention, not Spec: they name the canonical answer for shapes that bottom out on the framework's primitives. They're closer in voice to this guide than to the Specs, and they're the right next stop when the shape of your problem matches one of them.
 
+Two are introduced inline in [chapter 04](04-events-state-cycle.md#patterns-the-next-layer-up) because they bottom out on effects-as-data directly:
+
 - [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md) — async work as data, not callbacks. The generic post-work-await-reply shape.
 - [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) — the standard 5-key lifecycle slice for HTTP requests (idle / loading / loaded / error / stale).
+
+The rest — look these up when you hit the matching shape:
+
 - [Pattern-Forms](../../spec/Pattern-Forms.md) — draft / submitted / status / per-field errors as a standard slice. (Guide chapter: [09 — Forms](09-forms.md).)
 - [Pattern-Boot](../../spec/Pattern-Boot.md) — chained app initialisation with progress UI and fail-fatal points.
 - [Pattern-WebSocket](../../spec/Pattern-WebSocket.md) — long-lived connection lifecycle modelled as a state machine.


### PR DESCRIPTION
## Summary

Ch.04 §"Patterns: the next layer up" enumerated eight Pattern docs at the bottom of the chapter (AsyncEffect, RemoteData, Forms, Boot, WebSocket, LongRunningWork, StaleDetection, NineStates). A reader who has just absorbed effects-as-data shouldn't have to absorb eight more conventions on top.

- **ch.04**: keep only the two Patterns that bottom out on this chapter's content directly — **Pattern-AsyncEffect** (the generic post-work-await-reply shape the `:rf.http/managed` example is one instance of) and **Pattern-RemoteData** (the standard HTTP lifecycle slice). One-line each. A forward-pointer says the rest are covered in ch.19.
- **ch.19**: the existing "Look up a pattern by name" section now distinguishes the two Patterns introduced inline in ch.04 from the rest of the catalogue (Forms, Boot, WebSocket, LongRunningWork, StaleDetection, NineStates), framed as "look these up when you hit the matching shape." All eight Pattern doc links remain reachable from ch.19; nothing is removed from the spec.

Word count on ch.04: 3856 → 3714 (−142). Two files touched, no mkdocs/nav changes.

Closes rf2-boc7.

## Test plan

- [ ] `mkdocs build` succeeds with no broken links from ch.04 → ch.19 (`#look-up-a-pattern-by-name`) or ch.19 → ch.04 (`#patterns-the-next-layer-up`).
- [ ] Ch.04 reads cleanly: handler-level discipline, then two grounded Pattern pointers, then a forward to ch.19 — no eight-item dump.
- [ ] Ch.19 "Look up a pattern by name" still surfaces every Pattern doc.