### PR TITLE
docs: remove bead-id references from user-facing docs (rf2-6mzo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,38 +179,35 @@ spec/                          Full specification (AI-targeted; the primary arte
   conformance/                 EDN fixture corpus
 docs/
   guide/                       Human-facing guide (marketing voice)
-  release-process.md           Operational doc — multi-artefact release pipeline (rf2-w05l / rf2-ace2)
+  release-process.md           Operational doc — multi-artefact release pipeline
 examples/                      Worked examples
 implementation/                CLJS reference implementation — split into per-artefact subdirs
-                               (per Conventions §Packaging conventions; tier rollout per rf2-0hxm
-                               for the substrate split, rf2-5vjj for the per-feature splits).
+                               (per Conventions §Packaging conventions).
   core/                        day8/re-frame2 — registry, drain, fx, dispatch, subscribe,
                                frame-provider, trace; today still carries machines, flows, routing,
                                http, ssr, schemas, epoch (per-feature splits pending — see
                                Ownership.md "Artefact" column for the per-surface bead).
-  adapters/                    Substrate adapters (rf2-zha9; renamed from substrates/ per
-                               rf2-0imy). Per-feature artefacts (schemas, machines, ...) stay
-                               flat under implementation/ alongside core.
+  adapters/                    Substrate adapters. Per-feature artefacts (schemas, machines, ...)
+                               stay flat under implementation/ alongside core.
     reagent/                   day8/re-frame2-reagent — the Reagent adapter (browser default)
-    uix/                       day8/re-frame2-uix — the UIx adapter (rf2-3yij)
-    helix/                     day8/re-frame2-helix — the Helix adapter (rf2-2qit)
+    uix/                       day8/re-frame2-uix — the UIx adapter
+    helix/                     day8/re-frame2-helix — the Helix adapter
   shadow-cljs.edn              top-level build coordinator: pulls all artefacts onto one classpath
                                for the browser/elision/examples builds
   deps.edn                     top-level build coordinator (clojure-tools): :local/root deps for all
 tools/                         CLJS dev/inspection tools that consume re-frame2's instrumentation
                                API (Spec 009, Tool-Pair). Sibling of implementation/, not part of
-                               it — bundle-isolated from production builds (rf2-e6g9).
-  template/                    day8/clj-template.re-frame2 — clj-new template for new re-frame2 apps
-                               (rf2-lrtc); the v1 re-frame-template's v2 successor. Build-time scaffold.
+                               it — bundle-isolated from production builds.
+  template/                    day8/clj-template.re-frame2 — clj-new template for new re-frame2
+                               apps; the v1 re-frame-template's v2 successor. Build-time scaffold.
   story/                       day8/re-frame2-story — Storybook-flavoured playground (in design)
   story-mcp/                   day8/re-frame2-story-mcp — MCP agent surface for story; separate
-                               jar per rf2-m6tu §6.1 (in design)
+                               jar (in design)
   machines-viz/                day8/re-frame2-machines-viz — XState-style state-chart visualisation
                                (in design)
   machines-viz-mcp/            day8/re-frame2-machines-viz-mcp — MCP surface for machines-viz;
                                likely separate jar (in design)
-  10x/                         day8/re-frame2-10x — re-frame-10x v2 (in design; partial answer to
-                               rf2-tijr's repo-placement question)
+  10x/                         day8/re-frame2-10x — re-frame-10x v2 (in design)
 skills/                        Claude skills (planned; pair-improver and friends)
 ```
 

--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -17,8 +17,6 @@ This chapter is the argument for re-frame2's dynamic model.
 
 > **Derived data, flowing.**
 
-<!-- TODO: water-cycle image when rf2-0epn lands -->
-
 Picture the water cycle. Water moves around a loop — sea to cloud to rain to river to sea — propelled by gravity, evaporation, and convection. Two phases, two directions, one cycle. Nothing in the loop has to decide *that* it moves; the forces handle that. What changes between turns of the cycle is only *what* is moving and *where*.
 
 A re-frame2 app is shaped the same way. Data flows around a loop, and re-frame2 supplies the conveyance — the equivalent of gravity, evaporation, and convection. You don't write the loop. You hang pure functions on it: a function that turns an event into a state change, a function that derives a view from state, a function that turns a state slice into a side-effect. The runtime moves the data between them.

--- a/docs/guide/07-interceptors.md
+++ b/docs/guide/07-interceptors.md
@@ -97,7 +97,7 @@ The handler runs as the last `:before` on the way in. That's not a quirk — it'
 
 Why reverse on the way out? Because each `:after` is the dual of the corresponding `:before`. If `B:before` sets up some state on the context, `B:after` is the natural place to tear that state down. Putting them in reverse order means `B:after` runs *after* `C:after` has finished — `B` was outside `C` on the way in, so it's outside `C` on the way out. The `path` interceptor (covered below) and the `unwrap` interceptor (in [Spec 002 §Standard interceptors](../../spec/002-Frames.md)) both lean on this symmetry — they stash on the way in, restore on the way out.
 
-> **Forward link — the diagram.** A canonical adaptation of v1's `interceptors.png` (the pipeline visualisation showing one event traversing the sandwich) is in flight under bead **rf2-t33c**. When it lands, it'll sit here.
+> **Forward link — the diagram.** A canonical adaptation of v1's `interceptors.png` (the pipeline visualisation showing one event traversing the sandwich) is in flight. When it lands, it'll sit here.
 
 ## A worked example — a logger
 

--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -318,7 +318,7 @@ A missing **cofx** behaves similarly. If `inject-cofx` references an unregistere
     {:db (assoc db :loading? true)}))
 ```
 
-…the framework emits `:rf.error/no-such-cofx` with `:cofx-id :auth/token-from-storage` and `:event-id :user/load`. The interceptor chain continues; the handler runs with the cofx map unchanged (no `:auth/token-from-storage` key). The handler reads `nil` from where it expected a token. Cross-link: this is the structured-trace replacement for v1's `println` warning on missing cofx (rf2-mq9o); the next section shows how to test it.
+…the framework emits `:rf.error/no-such-cofx` with `:cofx-id :auth/token-from-storage` and `:event-id :user/load`. The interceptor chain continues; the handler runs with the cofx map unchanged (no `:auth/token-from-storage` key). The handler reads `nil` from where it expected a token. Cross-link: this is the structured-trace replacement for v1's `println` warning on missing cofx; the next section shows how to test it.
 
 ### Scenario 4 — schema validation at the boundary
 
@@ -381,7 +381,7 @@ The runtime rejects the dispatch and emits:
 
 ## Testing error paths
 
-The pattern: register a trace listener that collects events, run the operation that should fail, assert on the collected traces. This is exactly the shape `re-frame.cofx-test` uses to pin the `:rf.error/no-such-cofx` contract (rf2-mq9o):
+The pattern: register a trace listener that collects events, run the operation that should fail, assert on the collected traces. This is exactly the shape `re-frame.cofx-test` uses to pin the `:rf.error/no-such-cofx` contract:
 
 ```clojure
 (ns my-app.cart-test

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,19 +2,19 @@
 
 > **Type:** Operational doc.
 > **Audience:** maintainers cutting a re-frame2 release.
-> **Authority:** decisions in [rf2-w05l](#) (CI/CD strategy) and the implementation in [rf2-ace2](#) ([.github/workflows/release.yml](../.github/workflows/release.yml)).
+> **Authority:** the [release workflow](../.github/workflows/release.yml) is the source of truth; this doc is its narrative companion.
 
 re-frame2 ships as a coordinated set of Maven artefacts, all driven from a single repo-root [`VERSION`](../VERSION) file. This doc is the operational guide for how a release flows through CI, what gates exist, and how to recover when something goes wrong mid-deploy.
 
 ## Policy
 
-The release pipeline reflects a small set of decisions Mike made up front (rf2-r382). They are recorded here so future contributors don't have to re-derive them from the workflow.
+The release pipeline reflects a small set of decisions Mike made up front. They are recorded here so future contributors don't have to re-derive them from the workflow.
 
 1. **Mechanism — tag-triggered CD, modeled on re-frame v1.** Push a tag matching the [tag glob](#tag-format); the [`release` workflow](../.github/workflows/release.yml) runs end-to-end. Same shape as [re-frame v1's `continuous-deployment-workflow.yml`](https://github.com/day8/re-frame/blob/master/.github/workflows/continuous-deployment-workflow.yml): tag-push trigger, gated test job, `clojure -M:clein deploy`, `softprops/action-gh-release` for the GitHub Release. The differences are structural — re-frame v1 ships one artefact, re-frame2 ships ten — and are documented in [§Topological deploy DAG](#topological-deploy-dag).
 2. **Channel gating — pre-1.0 = alpha/beta, post-1.0 = stable.** Pre-1.0 releases tag as `v0.0.1.alpha` (and `v0.0.1.alpha-N` / `v0.0.2.alpha` etc. for subsequent alphas; the same pattern with `.beta` once we promote). Post-1.0 releases tag as `vX.Y.Z` per Semantic Versioning. The release workflow flags any tag containing `beta`, `alpha`, or `rc` as a GitHub `prerelease` automatically.
 3. **First publish — manual cut, all artefacts together.** Mike triggers the first `v0.0.1.alpha` deploy by hand once the policy text and the workflow have been reviewed against an actual tag. After the first cut, subsequent releases run automatically on tag push. The first cut ships the **full ten-artefact set** (core + schemas + reagent + uix + machines + routing + flows + http + ssr + epoch); no artefact "comes later" — they all ship together at every release per the lockstep contract below.
 4. **Atomic rollback — NOT POLICY.** Clojars does not support yanking a published version, and re-frame2 does not invest in machinery that would make it look like it does. If a deploy fails part-way through, recovery is **bump VERSION + re-tag + re-run** (see [§Recovery from a partial deploy](#recovery-from-a-partial-deploy) for the procedure). The partial-release artefacts from a failed run remain on Clojars, tombstoned-by-supersession; consumers pin the bumped version and pull a coherent set. Manual recovery is acceptable; we do not build atomic-rollback or partial-deploy-replay machinery.
-5. **Artefact set ships together at lockstep VERSION.** All 10 artefacts ship at every release at the same VERSION, sourced from the repo-root [`VERSION`](../VERSION) file. The lockstep contract (rf2-w05l) is enforced before any deploy by [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh). Independent versioning is revisited post-1.0; until then, every published Maven coord moves in lockstep.
+5. **Artefact set ships together at lockstep VERSION.** All 10 artefacts ship at every release at the same VERSION, sourced from the repo-root [`VERSION`](../VERSION) file. The lockstep contract is enforced before any deploy by [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh). Independent versioning is revisited post-1.0; until then, every published Maven coord moves in lockstep.
 
 ## Tag format
 
@@ -40,7 +40,7 @@ There is no `workflow_dispatch` trigger by design: a release commit always carri
 
 ## Topological deploy DAG
 
-Per rf2-w05l's lockstep-versioning decision, all artefacts ship at the same version each release. The DAG reflects the **published-pom** dependency graph (which is much narrower than the in-repo test-classpath graph): every per-feature artefact's published `:deps` declares only `day8/re-frame2` (core); cross-feature references at runtime are wired through `re-frame.late-bind` per [Conventions §Packaging conventions §Independence rule](../spec/Conventions.md#independence-rule).
+Per the lockstep-versioning policy (every artefact ships at the same version each release), the DAG reflects the **published-pom** dependency graph (which is much narrower than the in-repo test-classpath graph): every per-feature artefact's published `:deps` declares only `day8/re-frame2` (core); cross-feature references at runtime are wired through `re-frame.late-bind` per [Conventions §Packaging conventions §Independence rule](../spec/Conventions.md#independence-rule).
 
 ```mermaid
 graph TD
@@ -85,7 +85,7 @@ verify-version-lockstep ──► test ──► deploy-core
                                         github-release
 ```
 
-**Why fan-out (not strict serial).** The decision text describes a topological linearization (`core → schemas → reagent → machines → routing → flows → http → ssr → epoch → uix`); the deps-graph data is wider — every leaf has core as its only re-frame2 dependency. The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The per-feature split set is now closed at seven (schemas, machines, routing, flows, http, ssr, epoch — per [rf2-5vjj](#) Strategy B); the adapter set is two (reagent default, uix per [rf2-3yij](#)); a future Helix adapter ([rf2-2qit](#)) slots in as another leaf when it ships.
+**Why fan-out (not strict serial).** A strict topological linearization (`core → schemas → reagent → machines → routing → flows → http → ssr → epoch → uix`) would suffice; the deps-graph data is wider — every leaf has core as its only re-frame2 dependency. The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The per-feature split set is closed at seven (schemas, machines, routing, flows, http, ssr, epoch); the adapter set is two (reagent default, uix); a future Helix adapter slots in as another leaf when it ships.
 
 ## Pre-flight checklist
 
@@ -93,7 +93,7 @@ Before tagging:
 
 - [ ] All checks green on `main` (the `tests` workflow + any required reviews).
 - [ ] [`VERSION`](../VERSION) file updated to the target version. Single line, no trailing whitespace.
-- [ ] [`spec/MIGRATION.md`](../spec/MIGRATION.md) carries a fresh `M-NN` entry if the release contains a breaking change. (Per rf2-w05l, MIGRATION stays flat through 1.0; numbering is monotonic.)
+- [ ] [`spec/MIGRATION.md`](../spec/MIGRATION.md) carries a fresh `M-NN` entry if the release contains a breaking change. (MIGRATION stays flat through 1.0; numbering is monotonic.)
 - [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated for the release. The GitHub Release body links to it, so it is the canonical narrative.
 - [ ] The tag's commit is the same commit that updates VERSION + MIGRATION + CHANGELOG (one release commit).
 - [ ] Locally green: `./.github/scripts/verify-version-lockstep.sh` passes. (The CI gate runs the same script; running locally first surfaces drift in seconds.)
@@ -160,7 +160,7 @@ Run locally any time:
 
 ## Lockstep versioning policy through 1.0
 
-Per [rf2-w05l](#) §Decision §1: every artefact ships at the same VERSION pre-1.0. Independent versioning is revisited post-1.0. The mechanism:
+Through 1.0, every artefact ships at the same VERSION. Independent versioning is revisited post-1.0. The mechanism:
 
 - single root [`VERSION`](../VERSION) file;
 - every artefact's `:clein/build :version` is the relative path `"../../VERSION"`;
@@ -170,8 +170,6 @@ There is intentionally no per-artefact version override. Adding one would break 
 
 ## Cross-references
 
-- [rf2-w05l](#) — CI/CD strategy decision (parent).
-- [rf2-ace2](#) — implementation bead (this doc + workflow restructure).
 - [.github/workflows/release.yml](../.github/workflows/release.yml) — the release pipeline.
 - [.github/workflows/test.yml](../.github/workflows/test.yml) — PR-time tests including lockstep drift detection.
 - [.github/scripts/verify-version-lockstep.sh](../.github/scripts/verify-version-lockstep.sh) — the lockstep contract script.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,17 +10,17 @@ copyright: Copyright &copy; 2014-2026 Michael Thompson
 
 # All published markdown lives under docs/ at build time. The narrative
 # guide already lives under docs/guide/. The normative spec lives at the
-# repo root in spec/ (rf2-9hft) — `bb stage-docs` (or the docs.yml CI
-# step) copies spec/ into docs/spec/ before `mkdocs build` runs. The
-# staged copies are ignored by git (see .gitignore).
+# repo root in spec/ — `bb stage-docs` (or the docs.yml CI step) copies
+# spec/ into docs/spec/ before `mkdocs build` runs. The staged copies are
+# ignored by git (see .gitignore).
 docs_dir: docs
 site_dir: site
 
 # Build-time hooks. mkdocs_hooks.py rewrites guide/* cross-references
 # from ../../spec/ (correct for GitHub source-tree browsing, where spec/
 # lives at the repo root) to ../spec/ (correct for the staged docs tree
-# this build sees, where spec/ has been copied to docs/spec/). See
-# rf2-qvlf and the comment block at the top of mkdocs_hooks.py.
+# this build sees, where spec/ has been copied to docs/spec/). See the
+# comment block at the top of mkdocs_hooks.py.
 hooks:
   - mkdocs_hooks.py
 


### PR DESCRIPTION
## Summary

Sweep `rf2-xxxx` bead-id references out of user-facing docs. Bead IDs leak from the internal tracker into prose where they are meaningless to readers and date the text.

## Files touched (6)

- `README.md` — filesystem-tree commentary cleaned up
- `docs/release-process.md` — `(rf2-xxxx)` parentheticals stripped; load-bearing sentences rewritten to stand on their own; two dead cross-ref bullets pointing at `(#)` placeholders removed
- `docs/guide/01-why-re-frame2.md` — HTML TODO crumb deleted
- `docs/guide/07-interceptors.md` — forward-link rewritten to drop bead id
- `docs/guide/14-errors.md` — two parenthetical rationale crumbs removed
- `mkdocs.yml` — bead-id rationale removed from YAML comments

## Occurrence breakdown

- **Deleted** (rationale crumb / wrapper): 12
- **Rewritten** (sentence relied on bead-id for meaning): 8
- **Preserved**: 9 occurrences of `data-rf2-source-coord` — that is the real HTML attribute name the framework emits and the reader sees in the inspector, not a bead id; plus one URL-fragment-only occurrence in a spec anchor link (the fragment is invisible to readers; the visible link text is clean)

## Out of scope

- `spec/`, `skills/<skill>/spec/`, `implementation/`, `tools/`, `ai/`, `.beads/` — these legitimately cite bead IDs for rationale.

## Verification

`python -m mkdocs build --strict` — **exit 0**, **0 WARNINGs**, **0 ERRORs**. The remaining INFO-level anchor diagnostics are pre-existing spec-internal cross-link issues, out of scope for this sweep.

## Test plan

- [x] Pattern `\brf2-[a-z0-9]{4,}\b` returns zero matches in `README.md` and `mkdocs.yml`.
- [x] Pattern returns only `data-rf2-source-coord` HTML attributes + one anchor URL fragment under `docs/`.
- [x] Spot-checked 5 edited paragraphs for prose flow — reads cleanly.
- [x] `mkdocs build --strict` exit 0.