### PR TITLE
docs(guide): ch.11 — 'the seam vanishes' payoff after hydration-handshake (rf2-g2vb)

### DIFF
--- a/docs/guide/11-server-side.md
+++ b/docs/guide/11-server-side.md
@@ -72,6 +72,14 @@ If you do need client-only transient state to survive hydration — a `:browser/
 
 After this, the client renders. Because it's running with the server-supplied state, its first render produces the same hiccup tree the server rendered, which produces the same HTML — and the existing DOM (from the server-shipped HTML) is matched, not replaced. The transition from server-rendered to interactive is invisible to the user.
 
+## The seam vanishes
+
+Step back from the mechanics for a moment and notice what *isn't* there.
+
+There's no second codebase. No "server views" file. No `if (typeof window === 'undefined')` branches scattered through handlers. No parallel data-loading pipeline that exists only because SSR demanded one. The server-render is your app, run with the same handlers and the same subs and the same views against a frame whose `app-db` was populated by the same setup events you'd dispatch in development. The output happens to be a string rather than a DOM tree. That's the only difference.
+
+This is the claim re-frame2 is making: **SSR is the same code as client render, in another runtime**. Not "with carve-outs." Not "modulo a thin server-only layer." The seam between server and client — the place where, in most SPA stacks, subtle bugs live and where divergence accumulates over time — has been engineered out of the architecture. The reason it could be engineered out is that the architecture committed to pure handlers, pure subs, and a serialisable render-tree before it ever asked the SSR question. The constraints from [chapter 12](12-the-dynamic-model.md) — the ones that made the dynamic story testable and AI-amenable — turn out to be the same constraints that make the app JVM-runnable. SSR isn't a feature bolted on top; it's a corollary of the pattern. If you're coming from v1, where server-side rendering was always something you had to think about separately (see [chapter 18](18-from-re-frame-v1.md)), this is the structural shift: it's not separate any more.
+
 ## Hydration mismatches
 
 Sometimes the first client render doesn't match the server's HTML. This is *the* SSR bug. The causes are usually mundane:


### PR DESCRIPTION
## Summary

Per audit `ai/findings/guide-character-audit-2026-05-12.md §Ch.11` (bead rf2-g2vb): the chapter opened with v1-voice ("subtle bugs lived in the seam") but then went reference-flavoured and never *celebrated* the structural payoff — the seam-vanishing that the architecture had earned. This PR inserts a single voice-restoration section after §The-hydration-handshake, before §Hydration-mismatches.

- New §The seam vanishes — names what *isn't* there (no second codebase, no `typeof window` branches, no parallel pipeline), then makes the explicit claim: **SSR is the same code as client render, in another runtime**.
- Ties the property back to the pure-handlers / pure-subs / serialisable-render-tree commitments from ch.12 — the constraints that made the dynamic story testable are the same constraints that make the app JVM-runnable.
- Cross-references ch.18 for migrators arriving from v1, where SSR was always something you thought about separately.

Voice-from-v1, content-purely-v2. No new surface; narrative half only. Touches `docs/guide/11-server-side.md` only.

## Test plan
- [ ] Read the chapter end-to-end and confirm the new §The-seam-vanishes flows from the hydration handshake and into hydration-mismatches without disrupting either.
- [ ] Confirm no v2-orientation drift: no "single global app-db" framings, no `reg-global-interceptor`, no 10x, no `reg-sub-raw`, no `^:flush-dom`.
- [ ] Confirm cross-refs to ch.12 and ch.18 resolve.