### PR TITLE
fix(examples/counter-with-stories): a11y — button labels + contrast (rf2-4763)

### DIFF
--- a/examples/reagent/counter_with_stories/views.cljs
+++ b/examples/reagent/counter_with_stories/views.cljs
@@ -46,20 +46,27 @@
   (let [hint? (r/atom false)]
     (fn []
       [:div
+       ;; aria-label gives the "-" glyph an accessible name (rf2-4763); axe-core's
+       ;; `button-name` rule passes on visible text, but the glyph alone reads
+       ;; literally as "minus" to a screen reader — `aria-label` provides intent.
        [:button {:on-mouse-enter #(reset! hint? true)
                  :on-mouse-leave #(reset! hint? false)
                  :on-click       #(dispatch [:counter/dec])
+                 :aria-label     "Decrement count"
                  :data-test      "dec"}
         "-"]
        [:span {:style {:margin "0 1em" :min-width "2em" :display "inline-block" :text-align "center"}
                :data-test "count"}
         @(subscribe [:count])]
-       [:button {:on-click  #(dispatch [:counter/inc])
-                 :data-test "inc"}
+       [:button {:on-click   #(dispatch [:counter/inc])
+                 :aria-label "Increment count"
+                 :data-test  "inc"}
         "+"]
        ;; Hint span always renders; toggling visibility (not unmount) reserves
        ;; layout space so the card width stays stable on hover (rf2-bnn7).
-       [:span {:style {:margin-left "1em" :font-size "11px" :color "#888"
+       ;; Colour darkened from #888 (3.54:1) to #595959 (7.0:1) to clear WCAG AA
+       ;; contrast for normal text — rf2-4763.
+       [:span {:style {:margin-left "1em" :font-size "11px" :color "#595959"
                        :visibility (if @hint? "visible" "hidden")}}
         "(demo: hint state is component-local, not in app-db)"]])))
 


### PR DESCRIPTION
## Summary
Fix axe-core violations on the live counter view, surfaced via the Story playground's A11Y panel.

- **button-name** — +/- buttons render single-glyph text only; add `aria-label='Decrement count'` / `'Increment count'` so screen readers announce intent rather than a literal 'minus'/'plus'.
- **color-contrast** — hover-hint span used `#888` on white (3.54:1), failing WCAG AA's 4.5:1 floor for normal text. Darken to `#595959` (7.0:1) — clears AA + AAA, still reads as 'secondary' visually.

Scope: `examples/reagent/counter_with_stories/views.cljs` only. Sibling Story-shell a11y violations are tracked separately.

Bead: rf2-4763.

## Test plan
- [ ] `npm run test:cljs` — counter-with-stories integration suite passes
- [ ] `npm run test:examples` — Playwright smoke (`data-test` selectors preserved)
- [ ] Manual: load `/counter-with-stories/#/stories`, open A11Y panel, click 'run' — counter-view violations gone