### PR TITLE
feat(skills): re-frame2-implementor — guided two-phase skill for building a new re-frame2 impl (rf2-5xje)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,10 +1,10 @@
 # Skills
 
-> Five Claude Code skills that travel with the re-frame2 repo — for authoring code, bootstrapping a project, migrating from v1, pair-programming with a running app, and running a retrospective on a pairing session.
+> Six Claude Code skills that travel with the re-frame2 repo — for authoring code, bootstrapping a project, migrating from v1, building a new re-frame2 implementation, pair-programming with a running app, and running a retrospective on a pairing session.
 
 A **skill** is a small package of agent-shaped instructions plus optional scripts and reference leaves. When you load a skill into Claude Code (or any other Anthropic-skill-compatible agent), the model picks up its system prompt and its operating contract — so the same conversation that was *"help me write a re-frame2 event handler"* becomes a focused interaction that knows the canonical shapes, the cardinal rules, and where the depth lives.
 
-re-frame2 ships five skills, colocated under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills) in this repo. Each one is self-contained: its own `SKILL.md`, its own `reference/` leaves, its own packaging metadata.
+re-frame2 ships six skills, colocated under [`skills/`](https://github.com/day8/re-frame2/tree/main/skills) in this repo. Each one is self-contained: its own `SKILL.md`, its own `reference/` leaves, its own packaging metadata.
 
 ## How to load a skill
 
@@ -12,13 +12,14 @@ The exact mechanics depend on the agent you're driving. In **Claude Code**, inst
 
 The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) is the single deep-dive index — every skill points at it for spec-corpus depth and EP rationale.
 
-## The five skills
+## The six skills
 
 | Skill | Pitch |
 |---|---|
 | [**re-frame2** (authoring)](re-frame2.md) | Write re-frame2 ClojureScript code — events, subs, fx, machines, schemas, stories, routes, and the canonical patterns. |
 | [**re-frame2-setup**](re-frame2-setup.md) | Bootstrap a fresh re-frame2 ClojureScript project from nothing. Walks the author to a working counter under `shadow-cljs watch`. |
 | [**re-frame-migration** (v1→v2)](re-frame-migration.md) | Migrate an existing re-frame v1.x codebase to re-frame2. Applies the mechanical `M-rules` automatically; flags judgment calls. |
+| [**re-frame2-implementor**](re-frame2-implementor.md) | Build a new re-frame2 implementation in a different host language or substrate. Two-phase workflow — Phase 1 locks the decisions; Phase 2 walks the spec corpus with conformance as the acceptance test. |
 | [**re-frame-pair2**](re-frame-pair2.md) | Pair-program with a live, running re-frame2 app. Dispatch events, inspect `app-db`, walk epochs, hot-swap handlers — all via Tool-Pair contract. |
 | [**re-frame-pair-improver2**](re-frame-pair-improver2.md) | Retrospect a `re-frame-pair2` session. Surfaces friction; proposes targeted improvements; routes upstream beads to re-frame2 when the cause is framework-shaped. |
 
@@ -29,6 +30,7 @@ A quick decision flow:
 - **Starting from nothing?** → `re-frame2-setup`. When the counter mounts, switch to `re-frame2`.
 - **Existing v1 codebase?** → `re-frame-migration`. When the migration report is signed off, switch to `re-frame2`.
 - **Writing new code in an existing v2 project?** → `re-frame2`.
+- **Building a NEW re-frame2 implementation in a different host language or substrate?** → `re-frame2-implementor`.
 - **Debugging or pairing with a running v2 app?** → `re-frame-pair2`.
 - **Just finished a pairing session and noticed friction?** → `re-frame-pair-improver2`.
 
@@ -41,6 +43,7 @@ If a question spans more than one skill, pick the one whose **entry trigger** ma
 | `re-frame2` | [`skills/re-frame2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) |
 | `re-frame2-setup` | [`skills/re-frame2-setup/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup) |
 | `re-frame-migration` | [`skills/re-frame-migration/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration) |
+| `re-frame2-implementor` | [`skills/re-frame2-implementor/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor) |
 | `re-frame-pair2` | [`skills/re-frame-pair2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair2) |
 | `re-frame-pair-improver2` | [`skills/re-frame-pair-improver2/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-pair-improver2) |
 

--- a/docs/skills/re-frame2-implementor.md
+++ b/docs/skills/re-frame2-implementor.md
@@ -1,0 +1,48 @@
+# re-frame2-implementor
+
+> Guides an engineer building a new re-frame2 implementation in a different host language or substrate. Two-phase workflow: Phase 1 locks the load-bearing decisions, Phase 2 walks the spec corpus in dependency order with the conformance corpus as the acceptance test.
+
+## What it does
+
+The `re-frame2-implementor` skill is for engineers **building re-frame2 itself**, not building applications with it. It drives a two-phase workflow that takes an engineer from "I want to port re-frame2 to TypeScript / F# / Rust / native UI / a terminal substrate" to "my port passes the claimed-applicable subset of the conformance corpus."
+
+**Phase 1 — Lock the decisions.** Before any code is written: target host language; substrate / view layer; scope (which optional EPs ship); identity primitive, persistent data structures, reactive substrate, concurrency model, hot-reload, schema mechanism, integration story; the conformance capability tag set the port claims. Captured in a written decision record the engineer commits to the port's repo.
+
+**Phase 2 — Walk the spec corpus.** Implement in dependency order: [001 Registration](../spec/001-Registration.md) → [002 Frames + events + effects + subs](../spec/002-Frames.md) → [006 Reactive substrate](../spec/006-ReactiveSubstrate.md) → [004 Views](../spec/004-Views.md) → [009 Instrumentation](../spec/009-Instrumentation.md). Acceptance gate 1 runs the `:core/*` conformance fixtures. Then optional EPs per the Phase 1 claim. Acceptance gate 2 runs the full claimed-capability fixture set.
+
+The authoritative contract is the [spec corpus](../spec/000-Vision.md), with the [Implementor Checklist](../spec/Implementor-Checklist.md) as the decision-ordered companion and the [conformance corpus](../spec/conformance/README.md) as the acceptance test. The CLJS reference at `implementation/` is one worked example, never normative — the skill is explicit about this throughout.
+
+## When to reach for it
+
+Load this skill when **any** of these are true:
+
+- The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or one of the broader hosts in the Implementor Checklist).
+- The engineer is implementing re-frame2 against a non-React substrate, a native UI toolkit, a terminal UI, or any rendering surface that isn't React-on-the-browser.
+- The engineer wants to claim "this is a re-frame2 implementation" and needs to know what the claim requires.
+- The engineer is consuming the [Implementor Checklist](../spec/Implementor-Checklist.md) and the [conformance corpus](../spec/conformance/README.md) to verify their work.
+
+Do **not** use this skill for:
+
+- Writing application code on the CLJS reference → use [re-frame2](re-frame2.md).
+- Bootstrapping a greenfield app on the CLJS reference → use [re-frame2-setup](re-frame2-setup.md).
+- Migrating a v1 codebase → use [re-frame-migration](re-frame-migration.md).
+- Inspecting / debugging a running v2 app → use [re-frame-pair2](re-frame-pair2.md).
+
+## Kickoff
+
+A paste-ready kickoff prompt ships with the skill at [`skills/re-frame2-implementor/reference/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-implementor/reference/kickoff-prompt.md). The engineer opens a fresh Claude Code session in the root of the port's repo and pastes it verbatim. The session loads the skill on its own and walks Phase 1 first, then Phase 2 EP-by-EP, surfacing decisions back to the engineer at every block.
+
+Excerpted shape (full text in the kickoff file):
+
+> *I'm implementing a new port of re-frame2 in this repo. Walk the implementation workflow end-to-end per the `re-frame2-implementor` skill. The spec corpus is at `<path-to-re-frame2>/spec/`. Phase 1 — walk me through the decision blocks, capture each choice in `DECISIONS.md`. Phase 2 — walk the EP corpus in dependency order (001 → 002 → 006 → 004 → 009 → optional). The spec is the contract; the CLJS reference is one worked example, not normative. No core.async. JVM-runnability for the test surface. Spec gaps file `bd create` beads; never silent extrapolation. Begin with Phase 1.*
+
+Two common amendments — *"minimum viable port"* (declare every optional capability `no` and ship the core only) and *"reference impl tour first"* (read the CLJS tour before locking decisions, treating the tour as descriptive).
+
+## Where the skill lives
+
+- Source: [`skills/re-frame2-implementor/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor)
+- `SKILL.md`: [`skills/re-frame2-implementor/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-implementor/SKILL.md)
+- Kickoff prompt: [`skills/re-frame2-implementor/reference/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-implementor/reference/kickoff-prompt.md)
+- Reference leaves: [`skills/re-frame2-implementor/reference/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor/reference) — `phase-1-decisions.md` (the Phase 1 walkthrough), `decision-record.md` (the fill-in template), `phase-2-impl-order.md` (EP-by-EP order), `reference-impl-tour.md` (descriptive tour of the CLJS reference), `conformance.md` (harness shape + diagnosis), `output-format.md` (agent-output shapes).
+- Authoritative contract: the [spec corpus](../spec/000-Vision.md) + [Implementor Checklist](../spec/Implementor-Checklist.md) + [conformance corpus](../spec/conformance/README.md).
+- One worked example: the CLJS reference at [`implementation/`](https://github.com/day8/re-frame2/tree/main/implementation) (descriptive, not normative).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
     - "re-frame2 (authoring)": skills/re-frame2.md
     - re-frame2-setup: skills/re-frame2-setup.md
     - "re-frame-migration (v1→v2)": skills/re-frame-migration.md
+    - re-frame2-implementor: skills/re-frame2-implementor.md
     - re-frame-pair2: skills/re-frame-pair2.md
     - re-frame-pair-improver2: skills/re-frame-pair-improver2.md
 

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -41,6 +41,7 @@ Route elsewhere when:
 | Start a brand new re-frame2 project from scratch | `skills/re-frame2-setup/` |
 | Write event handlers, subs, machines, schemas, views in a project that is already on v2 | `skills/re-frame2/` |
 | Inspect / dispatch / debug / time-travel a *running* v2 app from the REPL | `skills/re-frame-pair2/` |
+| Build a NEW re-frame2 implementation in a different host language or substrate | `skills/re-frame2-implementor/` |
 | Understand re-frame2's design rationale (EPs, principles, conventions) | `SKILL-REDIRECT.md` at repo root |
 
 If the author has already finished migrating and is now writing new code, hand off to `re-frame2`. This skill exits when the project compiles, tests pass, and Type B items have been resolved.
@@ -162,4 +163,4 @@ If you hit anything else surprising, surface it to the author rather than guessi
 
 ---
 
-*Authoritative breaking-change list: `spec/MIGRATION.md` (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`.*
+*Authoritative breaking-change list: `spec/MIGRATION.md` (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`. For building a new re-frame2 implementation in a different host language or substrate: `skills/re-frame2-implementor/`.*

--- a/skills/re-frame2-implementor/.claude-plugin/plugin.json
+++ b/skills/re-frame2-implementor/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "re-frame2-implementor",
+  "version": "0.1.0-alpha.1",
+  "description": "Guided two-phase workflow for building a new re-frame2 implementation in a different host language or substrate. Phase 1 locks the load-bearing decisions; Phase 2 walks the spec corpus in dependency order. A Claude Code Skill, companion to the application-side re-frame2 skills.",
+  "author": {
+    "name": "day8",
+    "url": "https://github.com/day8"
+  },
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame2-implementor"
+  },
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "re-frame",
+    "re-frame2",
+    "implementor",
+    "port",
+    "specification",
+    "conformance",
+    "day8"
+  ],
+  "skills": [
+    "./SKILL.md"
+  ],
+  "status": "pre-alpha"
+}

--- a/skills/re-frame2-implementor/LICENSE
+++ b/skills/re-frame2-implementor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/re-frame2-implementor/README.md
+++ b/skills/re-frame2-implementor/README.md
@@ -1,0 +1,71 @@
+# re-frame2-implementor
+
+A `Skill` that helps `Claude Code` (or any Anthropic-skill-compatible agent) guide an engineer **building a new re-frame2 implementation** — a port to a different host language or substrate, not an application built on the existing CLJS reference.
+
+This is the **implementor's companion** to the three application-side skills in this repo:
+
+- [`re-frame2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) — for writing application code on the CLJS reference.
+- [`re-frame2-setup`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-setup) — for bootstrapping a fresh greenfield project on the CLJS reference.
+- [`re-frame-migration`](https://github.com/day8/re-frame2/tree/main/skills/re-frame-migration) — for porting an existing re-frame v1 codebase to the CLJS reference.
+
+Where the three application-side skills are about **using** re-frame2, this skill is about **realising** it.
+
+## What it covers
+
+A two-phase workflow:
+
+1. **Phase 1 — Lock the decisions.** Target host language; substrate / view layer; scope (which EPs ship); identity primitive, persistent data structures, reactive substrate, concurrency model, hot-reload, schema mechanism; conformance capability tag set. The engineer produces a single locked-decision record before any code is written.
+2. **Phase 2 — Walk the spec corpus.** Implement in dependency order: EP 001 Registration → 002 Frames (events + effects + subs) → 006 Reactive substrate → 004 Views → 009 Instrumentation → optional EPs per Phase 1 scope. The conformance corpus at `spec/conformance/` is the acceptance test.
+
+## What it deliberately does NOT cover
+
+- **Writing applications** on the existing CLJS reference. That's the main [`re-frame2`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2) skill.
+- **Designing a new pattern.** This skill realises the existing re-frame2 pattern as specified in `spec/`. Engineers proposing a different pattern need a different conversation.
+- **Running tests for the engineer.** Compilation, test runs, conformance harness execution are general software practice — they're the engineer's responsibility, not the skill's.
+
+## How the skill works
+
+The skill is structured around the **spec corpus** at [`spec/`](https://github.com/day8/re-frame2/tree/main/spec) in this repo, and especially around [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) (the decision-ordered companion). The skill:
+
+- Routes the workflow (two phases, ordered).
+- Surfaces the Phase 1 decisions with options per host and trade-offs.
+- Walks the EP corpus in dependency order during Phase 2.
+- Frames the conformance corpus as the acceptance test for "this is a re-frame2 implementation".
+
+It does **not** duplicate spec content. Each reference in the skill cites the spec section or chapter; the full text is read directly from `spec/`.
+
+## Status
+
+Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real port. The structure mirrors the other skills in this repo. The content is grounded against `spec/`, `spec/Implementor-Checklist.md`, and `spec/conformance/README.md`.
+
+## Layout
+
+```
+skills/re-frame2-implementor/
+├── SKILL.md                       # Router (~250 lines)
+├── README.md                      # This file
+├── LICENSE                        # MIT
+├── package.json                   # npm metadata for distribution
+├── .claude-plugin/
+│   └── plugin.json                # Claude Code plugin metadata
+├── reference/
+│   ├── kickoff-prompt.md          # Paste-ready prompt for a fresh session
+│   ├── phase-1-decisions.md       # The Phase 1 walkthrough
+│   ├── decision-record.md         # Fill-in template for the locked decisions
+│   ├── phase-2-impl-order.md      # EP-by-EP implementation order for Phase 2
+│   ├── reference-impl-tour.md     # Guided tour of the CLJS reference impl
+│   ├── conformance.md             # How to consume the conformance corpus
+│   └── output-format.md           # Standard agent-output shape
+└── spec/
+    ├── design.md                  # Locked design decisions
+    ├── inputs.md                  # Canonical inputs the skill leans on
+    └── authoring-prompt.md        # One-shot reauthor prompt
+```
+
+## Source of truth
+
+[`spec/`](https://github.com/day8/re-frame2/tree/main/spec) at the repo root, with [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) as the decision-ordered companion and [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) as the acceptance test. If the skill and the spec disagree, the spec wins.
+
+## Licence
+
+MIT. See [`LICENSE`](LICENSE).

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: re-frame2-implementor
+description: >
+  Guides an engineer building a NEW re-frame2 implementation in a different
+  host language or substrate — TypeScript, F# (Fable), Kotlin/JS, Squint,
+  Scala.js, PureScript, ReScript, Python, Rust, native UI, terminal, or any
+  host where re-frame2's pattern can be realised. Drives a two-phase workflow:
+  Phase 1 locks the load-bearing decisions (target language, substrate,
+  scope, identity primitive, persistent data structures, concurrency model,
+  schema mechanism, hot-reload story), and Phase 2 walks the spec corpus in
+  dependency order (001 Registration → 002 Frames → 006 Reactive substrate →
+  004 Views → optional EPs) with the conformance corpus as the acceptance
+  test. Use this skill whenever the user mentions "porting re-frame2",
+  "implementing re-frame2 in <language>", "writing a re-frame2 runtime",
+  "second re-frame2 implementation", "TypeScript port of re-frame2",
+  "implementor checklist", "conformance corpus", or any phrasing about
+  building re-frame2 itself rather than using it. For building applications
+  ON TOP OF the CLJS reference, use the re-frame2 skill instead; for
+  migrating a v1 codebase, use re-frame-migration.
+---
+
+# re-frame2-implementor
+
+You are helping an engineer **build a new implementation of the re-frame2 pattern** — not a re-frame2 application, but a runtime that other people will then write applications against. The CLJS reference implementation in this repo is a working example of one realisation; this skill walks the engineer through realising another.
+
+The skill is **guidance + workflow** layered on top of the spec corpus at `spec/`. The spec is the contract. The reference impl is one worked example, not normative.
+
+---
+
+## When to use this skill
+
+Use this skill when **any** of these are true:
+
+- The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or any of the other hosts named in `spec/000-Vision.md` — or a host outside that list).
+- The engineer is implementing re-frame2 against a non-React substrate, a native UI toolkit, a terminal UI, or any rendering surface that isn't React-on-the-browser.
+- The engineer wants to claim "this is a re-frame2 implementation" and needs to know what the claim requires.
+- The engineer is consuming `spec/Implementor-Checklist.md` and the [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) corpus to verify their work.
+
+## When NOT to use this skill
+
+Route elsewhere when:
+
+| Engineer intent | Route to |
+|---|---|
+| Write event handlers, subs, machines, views in a project using the CLJS reference | `skills/re-frame2/` |
+| Bootstrap a fresh greenfield app on the CLJS reference | `skills/re-frame2-setup/` |
+| Migrate a re-frame v1 codebase to the CLJS reference | `skills/re-frame-migration/` |
+| Inspect / dispatch / debug a running v2 app | `skills/re-frame-pair2/` |
+| Understand the pattern's rationale (EP narrative, principles) | [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) at repo root |
+
+If the engineer is building **applications** on the reference, hand off to `re-frame2`. This skill is exclusively for engineers building the runtime itself.
+
+---
+
+## Cardinal rules
+
+These hold across every phase of the implementation.
+
+1. **The spec is the contract.** `spec/` is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; file a `bd create` bead against the spec or the reference impl as appropriate.
+2. **Phase 1 before Phase 2.** Decisions made under Phase 1 (host language, substrate, scope, identity primitive, concurrency model) are load-bearing for every line of code written in Phase 2. Lock them in writing before opening an editor. If a Phase 2 step forces a Phase 1 decision to change, *stop*, revise the decision record, and restart that Phase 2 step.
+3. **Implement in dependency order.** EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) are the foundation. The optional EPs (005, 007–014) sit downstream and can be deferred or skipped per Phase 1 scope.
+4. **Substrate-agnostic phrasing in code and docs.** The reference impl is a CLJS+Reagent realisation — keywords as ids, hiccup as render-tree, Reagent ratoms as the reactive container. These are *choices the reference made*. Your port chooses differently and re-frame2 is still re-frame2. Do not write code that assumes "hiccup" or "Reagent" or "keyword" universally; write code that assumes "the identity primitive", "the render-tree", "the reactive container".
+5. **No core.async equivalents.** The CLJS reference does not use core.async, and ports inherit this directive. Async effects schedule via host primitives (Promise / setTimeout / setImmediate / asyncio / tokio); cross-frame work is serialised per frame via the run-to-completion drain. If your host's idiomatic concurrency model is channel-shaped, you may use channels *internally* — but the public dispatch contract is still the run-to-completion drain.
+6. **JVM-runnability for the testing surface.** Where the CLJS reference makes `compute-sub` and `machine-transition` pure-function-callable from JVM, your port's analogue must be callable from a non-substrate test harness. Pure transitions and pure sub computations are the bedrock of the test story.
+7. **Conformance corpus is the acceptance test.** [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) is the verification mechanism. Your port runs the fixtures whose capabilities are a subset of what you've claimed; the score is `passed / claimed-applicable`. A fixture you cannot make pass without consulting outside sources is a **spec gap**, not an implementation gap — file a `bd create` bead against the spec corpus.
+8. **If you find a spec gap, file a bead. Do not paper.** When implementing surfaces a missing surface, an inconsistency, or an undocumented decision, that's a spec finding. Surface it. Do not silently invent an answer; do not extrapolate from "what the reference impl does" if the spec is silent.
+
+---
+
+## The two-phase workflow
+
+### Phase 1 — Lock the decisions
+
+Before any code is written, the engineer walks the **decision walkthrough** at `reference/phase-1-decisions.md` and produces a **decision record** (template: `reference/decision-record.md`). The decisions are:
+
+1. **Target host language** — which language and runtime. The spec scope under `spec/000-Vision.md` names eight first-class JS-cross-compile hosts; the [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) covers more (Python, Rust, Kotlin/native, Swift) — but only the in-scope eight target React+VDOM substrates by default. Any other host language picks its own substrate (Q2).
+2. **Substrate / view layer** — React+VDOM (the spec's default), a native UI toolkit, raw DOM, terminal UI, server-render only, no UI at all.
+3. **Scope — which EPs ship now** — the core EPs (001 / 002 / 006 / 004) are mandatory for any conformance claim. The optional EPs (005 state machines, 007 stories, 008 testing, 009 instrumentation, 010 schemas, 011 SSR, 012 routing, 013 flows, 014 HTTP) are declared yes/no individually per [Implementor-Checklist Part 1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-1--how-complete).
+4. **Foundation choices** — identity primitive, persistent data structures, reactive substrate, effect-handling primitive, concurrency model, hot-reload primitive ([Implementor-Checklist Part 2 §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required)).
+5. **Schema mechanism** — runtime schema layer (Malli / Zod / Pydantic / dry-rb), host-type-system, or none ([Implementor-Checklist §Schemas](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#schemas-if-q4-is-yes)).
+6. **Integration story** — standalone library, framework integration (React Native, SwiftUI, …), or embedded inside a larger runtime.
+7. **Conformance capability tag set** — the union of `:core/*` (mandatory) plus the `:fsm/*` / `:actor/*` / `:routing/*` / `:ssr/*` / `:schemas/*` capability families that match Phase 1 scope.
+
+The output of Phase 1 is a single locked-decision record. It is referenced from every Phase 2 step. The leaf `reference/phase-1-decisions.md` walks the engineer through each decision; `reference/decision-record.md` is the fill-in template.
+
+### Phase 2 — Walk the spec corpus
+
+With Phase 1 locked, the engineer implements in dependency order. Leaf: `reference/phase-2-impl-order.md`.
+
+The walking order:
+
+1. **EP 001 — Registration** ([spec](https://day8.github.io/re-frame2/spec/001-Registration/)). The registrar; closed-kinds discipline; the `reg-*` surface; metadata propagation; hot-reload semantics.
+2. **EP 002 — Frames + events + effects + subscriptions** ([spec](https://day8.github.io/re-frame2/spec/002-Frames/)). Frame as runtime boundary `{state, queue, sub-cache, id}`; per-frame app-db; dispatch envelope; the six-step pipeline; run-to-completion drain; `:db` and `:fx` semantics; sub-cache invalidation.
+3. **EP 006 — Reactive substrate** ([spec](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/)). The adapter contract: six required + two optional + one lifecycle function. Single-adapter-per-process. Revertibility constraints on adapters.
+4. **EP 004 — Views** ([spec](https://day8.github.io/re-frame2/spec/004-Views/)). `reg-view`; render-tree shape (host-chosen, serialisable); frame-provider; source-coord stamping.
+5. **EP 009 — Instrumentation** ([spec](https://day8.github.io/re-frame2/spec/009-Instrumentation/)). Trace event stream; error contract; retain-N ring buffer; production elision. Pattern-required.
+6. **Conformance corpus pass #1** — at this point a port that's claimed `{Q1=no, Q2=no, Q3=no, Q4=via-types-or-no, Q5=no, Q6=no, Q7=no}` can pass the `:core/*` fixtures. This is the first acceptance gate.
+7. **Optional EPs in the order Phase 1 declared yes for** — for each declared-yes capability, implement the matching EP and re-run the matching capability-tagged fixtures. Suggested order if multiple are in scope: 010 Schemas → 008 Testing → 005 State machines → 012 Routing → 011 SSR → 013 Flows → 014 HTTP → 007 Stories.
+
+The leaf `reference/phase-2-impl-order.md` walks each EP with: what to read first, the contract to expose, how the CLJS reference realised it (as **one** example, not normative), what the conformance fixtures check, common spec-gap traps.
+
+---
+
+## Source discipline
+
+Three tiers of input, in this priority:
+
+1. **`spec/`** — the contract. Read in numeric order. Every implementation decision must trace to a normative claim here.
+2. **[`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/)** — the decision-ordered companion. Part 1 (which capabilities ship), Part 2 (per-capability mechanism choices), Part 3 (how to consume the conformance corpus).
+3. **`implementation/`** (the CLJS reference) — a worked example. Useful for "how did *someone* solve X?" Never useful as a contract claim. The reference's specific bindings (keywords, hiccup, Reagent ratoms, Closure dead-code elimination for production elision) are **choices**, not requirements.
+
+If `implementation/` and `spec/` disagree, the spec wins. File a `bd create` bead so the inconsistency is tracked.
+
+---
+
+## Conformance — the acceptance test
+
+The conformance corpus at `spec/conformance/` is host-agnostic data. The harness is ~300 lines per host (per [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus)):
+
+1. Read all `.edn` fixtures in `fixtures/`.
+2. For each fixture, check whether `:fixture/capabilities` is a subset of the port's claimed list.
+3. If yes, bootstrap the runtime, realise handler bodies via the small EDN-handler-body DSL, create a frame, run the dispatches, capture observables, compare.
+4. If no, report as "not exercised."
+5. Aggregate score: `passed / claimed-applicable`.
+
+Hosts without EDN parsing either ship a small reader (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap. The leaf `reference/conformance.md` walks the harness shape and the EDN-handler-body DSL.
+
+The corpus is the **acceptance test for [Goal 2 — AI-implementable from the spec alone](https://day8.github.io/re-frame2/spec/000-Vision/#ai-implementable-from-the-spec-alone)**. A fixture that an implementation cannot reproduce without consulting outside sources is a **spec gap**, not an implementation gap; remediation is to fix the spec corpus, not the implementation.
+
+---
+
+## Kickoff prompt
+
+If the engineer wants to *delegate* the implementation walkthrough to a fresh Claude Code session, there's a paste-ready prompt at `reference/kickoff-prompt.md`. The engineer copies it into a new Claude Code session opened in the root of a fresh repo for their port; the session loads this skill and walks Phase 1 + Phase 2 with the engineer.
+
+This is the typical shape: the implementor wants a focused session to drive the work, asks decisions as they arise, references the spec for every contract claim.
+
+---
+
+## Done checklist
+
+Tell the engineer the implementation is "v1-complete" against the claimed scope when **all** of these are true:
+
+- [ ] Phase 1 decision record is written down, dated, and committed to the port's own repo (as a `DECISIONS.md` or equivalent).
+- [ ] All EPs in scope (per Phase 1) have a working implementation in the port's source tree.
+- [ ] The port's runtime exposes the API contract at [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/), adapted to the host's idiom.
+- [ ] The conformance corpus has been run against the port; the score is `(claimed-applicable) / (claimed-applicable)` — all fixtures whose capabilities are a subset of the port's claim pass.
+- [ ] Any conformance failures that were *not* spec gaps have been fixed in the port.
+- [ ] Any conformance failures that *were* spec gaps have been filed as beads against the spec corpus (`bd create` against the re-frame2 repo).
+- [ ] The port's own README states which capability tags it claims and the conformance score against those tags.
+
+When the checklist passes, the port can claim "re-frame2 implementation, v1-complete against `<capability tag set>`."
+
+---
+
+## Deep dives — reference files
+
+For depth on each step, read the matching leaf — every leaf is one level deep from this SKILL.md:
+
+- **`reference/kickoff-prompt.md`** — A paste-ready prompt to drop into a fresh Claude Code session in the root of the engineer's port repo. ~80 lines.
+- **`reference/phase-1-decisions.md`** — The Phase 1 walkthrough: seven decision blocks, options per host, trade-offs, links into [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) for the canonical option matrices. ~200 lines.
+- **`reference/decision-record.md`** — The fill-in template for the locked-decision record. Reproducible across ports — the engineer copies the template into their own repo, fills in each block. ~120 lines.
+- **`reference/phase-2-impl-order.md`** — EP-by-EP implementation order. For each EP: what to read, the contract to expose, what the CLJS reference did (as an example), what the conformance fixtures check, common spec-gap traps. ~250 lines.
+- **`reference/reference-impl-tour.md`** — A guided tour of the CLJS reference under `implementation/` — what's where, what was a substrate-specific choice, what's pattern-required. Read this when you want to see how *someone* solved a problem, not to find out what re-frame2 requires. ~150 lines.
+- **`reference/conformance.md`** — How to consume the conformance corpus. The harness shape, the EDN-handler-body DSL, capability tagging, how to score, when a failure is a spec gap vs an implementation bug. ~140 lines.
+- **`reference/output-format.md`** — The standard agent-output shape: implementation summary, capability tags claimed, conformance score, decisions made, spec gaps filed. ~120 lines.
+
+---
+
+## Anti-patterns to avoid
+
+A few traps that come up often enough to flag at the top level.
+
+- **Don't copy the reference impl line-by-line and translate.** The reference uses macros for source-coord capture; your host may not have macros. The reference uses Reagent's automatic dependency tracking; your host may need explicit subscriptions. The reference uses keywords; your host may use branded strings. *Copy the contract, not the realisation.*
+- **Don't skip Phase 1.** The decisions made under Phase 1 (especially F2 persistent data structures and F5 concurrency model) propagate through every line of Phase 2 code. Engineers who skip Phase 1 to "just start coding" end up rewriting the foundation halfway through. The decision walkthrough takes one focused session; the rewrite takes weeks.
+- **Don't declare Q1 (state machines) `yes` unless the FSM substrate is genuinely required.** EP 005 is substantial work and gates a large block of code. Smaller ports ship `Q1=no` and add the FSM substrate later — the events/subs/fx/views triad is self-sufficient for many use cases.
+- **Don't ship without conformance.** The corpus is the only objective measure of "is this re-frame2?" Without the corpus passing, the port is "inspired by re-frame2" but not a re-frame2 implementation. Run the harness early; the corpus is also useful as your test suite during development.
+- **Don't invent surfaces the spec is silent on.** If the spec says nothing about hierarchical FSM exit-order semantics in a specific edge case, *file a bead* — don't extrapolate from the CLJS reference. The reference's choice is one realisation; the spec's silence is a gap.
+- **Don't promise the engineer "this skill will write the port for you".** The skill walks the workflow and surfaces the decisions; the engineer (or their Claude session) writes the code. Phase 2 is multi-week work in any host; the skill is the map, not the vehicle.
+
+If you hit anything else surprising, surface it to the engineer rather than guessing. The implementor's agent's job is to walk the spec corpus cleanly and surface every decision back to the engineer — not to make the engineering choices for them.
+
+---
+
+*Authoritative contract: `spec/` corpus (in this repo). Decision-ordered companion: [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/). Conformance corpus: [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance). CLJS reference (worked example): `implementation/`. For application authoring on the reference: `skills/re-frame2/`. For greenfield bootstrap: `skills/re-frame2-setup/`. For v1→v2 migration: `skills/re-frame-migration/`. For live-app inspection: `skills/re-frame-pair2/`.*

--- a/skills/re-frame2-implementor/package.json
+++ b/skills/re-frame2-implementor/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@day8/re-frame2-implementor",
+  "version": "0.1.0-alpha.1",
+  "description": "Guided two-phase workflow for building a new re-frame2 implementation in a different host language or substrate. Phase 1 locks the load-bearing decisions; Phase 2 walks the spec corpus in dependency order. A Claude Code Skill, companion to the application-side re-frame2 skills.",
+  "keywords": [
+    "claude-code",
+    "claude-code-skill",
+    "claude-code-plugin",
+    "re-frame",
+    "re-frame2",
+    "implementor",
+    "port",
+    "specification",
+    "conformance",
+    "day8"
+  ],
+  "homepage": "https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor",
+  "bugs": {
+    "url": "https://github.com/day8/re-frame2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/day8/re-frame2.git",
+    "directory": "skills/re-frame2-implementor"
+  },
+  "license": "MIT",
+  "author": "day8 (https://github.com/day8)",
+  "files": [
+    "SKILL.md",
+    "README.md",
+    "LICENSE",
+    "reference/",
+    "spec/",
+    ".claude-plugin/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/skills/re-frame2-implementor/reference/conformance.md
+++ b/skills/re-frame2-implementor/reference/conformance.md
@@ -1,0 +1,136 @@
+# conformance
+
+How the port consumes the conformance corpus. The corpus is the **acceptance test** for "this is a re-frame2 implementation"; without it passing, the port is "inspired by re-frame2" but not conformant.
+
+The corpus lives at [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) in the re-frame2 repo. The full contract is at [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/). This leaf walks the operational shape — how to build the harness, what the fixtures look like, how to score, when a failure is a spec gap vs an implementation bug.
+
+## What the corpus is
+
+A directory of EDN files, one per fixture, each describing one canonical interaction. Two complementary fixture modes (per [`spec/conformance/README.md` §Fixture format](https://day8.github.io/re-frame2/spec/conformance/#fixture-format)):
+
+- **Mode A — dispatch-driven.** A frame configuration plus initial `app-db`, a sequence of dispatches, and the expected emissions after drain: final `app-db`, sub values, routed effects, trace events. Most fixtures use Mode A.
+- **Mode B — pure / direct-call.** No frame, no dispatch loop. Direct invocations of pure primitives (`machine-transition`, `match-url`, `route-url`, `render-to-string`) with call-local expectations.
+
+Each fixture carries a `:fixture/capabilities` set — the capability tags it exercises. The harness runs every fixture whose capabilities are a subset of the port's claimed list (D7 of the decision record).
+
+## The harness — ~300 lines per host
+
+The contract from [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus):
+
+1. **Read** all `.edn` files in `fixtures/`. If your host has no EDN reader, ship a small one (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap.
+2. **For each fixture**, check whether `:fixture/capabilities ⊆ claimed-capabilities`. If yes, run it; if no, report "not exercised."
+3. **Bootstrap the runtime** per the fixture's `:fixture/registry` (the kinds + ids the fixture expects to be registered).
+4. **Realise the handler bodies** from `:fixture/handlers` via the EDN-handler-body DSL (below).
+5. **Create a frame** per `:fixture/frame-config`.
+6. **Run the dispatches** in `:fixture/dispatches` (Mode A), or the calls in `:fixture/calls` (Mode B).
+7. **Capture observables** — for Mode A: final `app-db`, sub values, trace emissions, effects routed; for Mode B: the call-local expectation.
+8. **Compare** the observables against `:fixture/expect`. Partial-match semantics for trace events; literal match for `app-db`; ordered match for routed effects.
+9. **Report** per-fixture: pass / fail / not-exercised, plus aggregate score: `passed / claimed-applicable`.
+
+The harness is the same shape for every host; the differences are entirely host-mechanical (EDN read, registry bootstrap, frame creation, dispatch invocation).
+
+## The EDN-handler-body DSL
+
+Fixtures describe event-handler and sub bodies as **EDN data**, not host code. The harness reads the data and realises it into native closures.
+
+The DSL is small — ~10 operations cover the common cases:
+
+```clojure
+;; In a fixture:
+:fixture/handlers
+{:event {:counter/inc        [[:update [:count] [:fn :inc]]]
+         :counter/initialise [[:set [:count] 0]]}
+ :sub   {:count             [[:get [:count]]]}}
+```
+
+Each handler body is a vector of operations. Each operation is `[<op> <args...>]`. The harness interprets the operations against the dispatch envelope and returns the result.
+
+Common ops (per the corpus's existing fixtures):
+
+- `[:set path value]` — set `app-db` at `path` to `value`.
+- `[:update path [:fn op]]` — apply `op` (`:inc`, `:dec`, `:not`, …) at `path`.
+- `[:get path]` — read `app-db` at `path` (used in sub bodies).
+- `[:assoc-in path value]`, `[:dissoc-in path]` — path-shaped mutators.
+- `[:dispatch event-vector]` — schedule a dispatch as an effect.
+- `[:fx [...]]` — return a literal `:fx` vector.
+
+The interpreter is ~50 lines per host. The CLJS reference's interpreter lives in `implementation/core/src/re_frame/test_support.cljc`; copy the dispatch-style and adapt the literal-op handlers.
+
+**Spec-gap signal.** When a fixture uses an op that isn't documented anywhere — that's a spec gap. File a `bd create` bead asking for the DSL to be documented in `spec/conformance/README.md`.
+
+## Capability tagging
+
+From [`spec/conformance/README.md` §Capability tagging](https://day8.github.io/re-frame2/spec/conformance/):
+
+```
+:core/*           pattern-required basics — always run
+:fsm/*            FSM-richness axis — flat / hierarchical / always / after / tags / parallel-regions
+:actor/*          actor-model axis — own-state / spawn-destroy / cross-actor-fx / invoke / spawn-and-join / system-id
+:routing/*        Q2 yes
+:ssr/*            Q3 yes
+:schemas/*        Q4 yes (regardless of mechanism)
+```
+
+The decision record's D7 captures the claimed tag set. The harness uses the claim as the filter; only matching fixtures run.
+
+A port that claims `:core/* + :fsm/flat + :actor/own-state` runs every `:core/*` fixture, every `:fsm/flat` fixture, and every `:actor/own-state` fixture — and skips the hierarchical FSM fixtures, the `:invoke` fixtures, the routing fixtures, etc. The skipped fixtures report as "not exercised," not as failures.
+
+## Diagnosis — spec gap vs implementation bug
+
+When a fixture fails, the question is: who's at fault?
+
+**Implementation bug.** The fixture exercises a well-specified surface that the port has implemented incorrectly. Symptoms:
+
+- The spec for the relevant EP is unambiguous about the expected behaviour.
+- Other ports could pass this fixture from the spec alone.
+- The failure is a copy-paste error, a typo, a mistaken mechanism choice.
+
+**Action:** fix the port. The conformance corpus is doing its job — surfacing a bug.
+
+**Spec gap.** The fixture exercises a surface the spec is silent on or ambiguous about. Symptoms:
+
+- The expected behaviour isn't justified by anything in `spec/`.
+- The fixture's expectation seems to reflect a choice the CLJS reference made that isn't normative.
+- An AI armed only with `spec/` + the corpus + this skill couldn't reproduce the expectation without consulting `implementation/`.
+
+**Action:** file a `bd create` bead against the re-frame2 repo. Don't patch the port to match. The spec needs to grow to cover the case; once it does, the port (and every other port) can target the explicit contract.
+
+The framing from [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/) is normative here: *"A fixture an AI cannot reproduce without consulting outside sources is a **spec gap**, not an implementation gap."*
+
+## Running the harness
+
+The mechanics depend on the host. Typical shape:
+
+```
+$ <port-toolchain> conformance run --claimed=":core/* :fsm/flat :actor/own-state"
+
+Loading corpus from ../re-frame2/spec/conformance/fixtures ... 142 fixtures.
+Filtering by claimed capabilities ... 78 applicable, 64 not exercised.
+
+PASS  counter-inc-once                 :core/event-handler :core/sub :core/trace
+PASS  closed-effect-map                :core/event-handler
+FAIL  sub-cache-invalidation           :core/sub :core/substrate
+      Expected: {[:total] 7}
+      Actual:   {[:total] 5}
+PASS  ...
+SKIP  fsm-hierarchical-exit-cascade    :fsm/hierarchical   (not claimed)
+...
+
+Score: 77 / 78 applicable. 1 failure.
+```
+
+Wire the harness into the port's CI; every commit should report the score. Conformance regressions caught at commit time are far cheaper than at release time.
+
+## When the corpus itself is incomplete
+
+The corpus is a living artefact — it grows as the spec grows. If your port implements a surface the corpus has no fixture for (e.g. a specific error category from EP 009, or a `:fsm/tags` interaction), that's not a port-side problem — that's a corpus gap. File a `bd create` bead requesting the missing fixture; ideally include a draft fixture in the bead.
+
+## Reporting conformance
+
+The port's README should state:
+
+- **Claimed capability tags** — copied from D7 of the decision record.
+- **Conformance score** — the most-recent harness result, e.g. `78 / 78 :core/* + :fsm/flat + :actor/own-state`.
+- **Date / commit hash of the corpus** the score was measured against. The corpus changes; pinning the score to a corpus commit lets downstream consumers verify.
+
+This is the public contract: when the score is `N / N`, the port is a conformant re-frame2 implementation against its claim. When it's `N-k / N`, the port is k-fixtures-from-conformant. Either way, the consumer knows where they stand.

--- a/skills/re-frame2-implementor/reference/decision-record.md
+++ b/skills/re-frame2-implementor/reference/decision-record.md
@@ -1,0 +1,161 @@
+# decision-record
+
+A fill-in template for the **Phase 1 locked-decision record**. The engineer copies this template into their port's repo (typically as `DECISIONS.md` at the repo root), fills in each block before any implementation code is written, and commits it.
+
+Every Phase 2 step references this record. If a Phase 2 step forces a Phase 1 decision to change, the record is **revised in writing** before Phase 2 resumes — no silent overrides.
+
+---
+
+## Template — copy from here
+
+```markdown
+# DECISIONS — <port name>
+
+> Phase 1 decision record for the re-frame2 port at <port-repo-url>.
+> Captured before Phase 2 implementation began.
+> Locked: <YYYY-MM-DD>.
+
+## D1. Target host language
+
+- **Host:** <language + version, e.g. "TypeScript 5.4">
+- **Runtime targets:** <e.g. "browser (Chrome 100+), Node 20+">
+- **Build tool:** <e.g. "Vite + tsc">
+
+## D2. Substrate / view layer
+
+- **Substrate:** <e.g. "React 19 + VDOM" / "SwiftUI" / "raw DOM" / "terminal (textual)" / "none — server-only">
+- **Reactive container library:** <e.g. "Solid signals" / "MobX" / "Vue refs" / "hand-rolled signals">
+- **Render-tree shape:** <e.g. "JSX-as-data" / "hiccup-equivalent tuples" / "SwiftUI ViewBuilder" / "ANSI escape vnodes">
+
+## D3. Scope — which EPs ship in v1
+
+| EP | In v1? | Notes |
+|---|---|---|
+| **Required core** (000 / 001 / 002 / 004 / 006 / 009) | yes | non-negotiable |
+| **Q1 — State machines (005)** | <yes / no> | <which sub-capabilities — flat / hierarchical / always / after / tags / parallel-regions> |
+| **Q2 — Routing (012)** | <yes / no> | |
+| **Q3 — SSR (011)** | <yes / no> | |
+| **Q4 — Schemas (010)** | <yes-runtime-schema / yes-via-host-types / no> | <which library if runtime-schema> |
+| **Q5 — Stories (007)** | <yes / no> | usually no for v1 |
+| **Q6 — Tool-Pair adapters** | <yes / no> | |
+| **Q7 — AI-Audit grading** | <yes / no> | |
+
+## D4. Foundation choices
+
+### D4.1 Identity primitive
+
+- **Mechanism:** <e.g. "branded string types with naming convention" / "polymorphic variants" / "sealed-class hierarchies">
+- **Required properties verified:** stable / namespaceable / value-equal / cheap / serialisable / human-readable / reflective — <confirm all seven, name the helper(s) that provide each>
+
+### D4.2 Persistent data structures
+
+- **Library:** <e.g. "Immer" / "im (Rust)" / "pyrsistent" / "native Clojure persistent collections">
+- **Snapshot mechanism:** <e.g. "pointer swap" / "Immer's `produce` drafts" / "deep-copy fallback for X cases">
+
+### D4.3 Reactive substrate
+
+- (Locked in D2.)
+
+### D4.4 Effect-handling primitive
+
+- **Sync default:** <yes — fx run inline when the handler returns / no — different model>
+- **Async re-entry:** <e.g. "Promise.then → :dispatch" / "asyncio task → schedule_dispatch" / "tokio spawn → mpsc sender">
+- **Standard fx the port ships:** <e.g. ":dispatch / :dispatch-later / :http">
+
+### D4.5 Concurrency model
+
+- **Model:** <e.g. "single-threaded JS event loop" / "single-threaded asyncio" / "single-threaded tokio">
+- **Cross-frame serialisation:** <how dispatch is serialised per frame in multi-frame setups>
+- **No core.async confirmation:** <confirm the directive — no channels in the public dispatch contract>
+
+### D4.6 Hot-reload primitive
+
+- **Mechanism:** <e.g. "Vite HMR module boundary at reg-* call sites" / "watch + reimport via importlib.reload" / "compile-replace via dynamic library swap">
+- **State-preservation contract:** <how frame state survives re-registration of `reg-frame`>
+
+## D5. Schema mechanism
+
+- **Answer:** <yes-runtime-schema / yes-via-host-types / no>
+- **Library (if runtime-schema):** <e.g. "Zod" / "Pydantic" / "dry-rb">
+- **Validation timing:** <e.g. "boundary-only, dev-build only, elided by Vite define" / "boundary-only, JIT-compiled to no-op in release">
+- **Open-shape verification:** <how the port enforces open shapes — additive growth, unknown-key tolerance>
+
+## D6. Integration story
+
+- **Model:** <standalone library / framework integration / embedded>
+- **Downstream consumer:** <name the framework / app / process the port plugs into>
+- **Wiring boundary:** <where the consumer's app code meets the port — e.g. "React provider component" / "asyncio loop integration in main.py" / "library API only">
+
+## D7. Conformance capability tag set
+
+The set of capability tags this port claims:
+
+```
+:core/*           (always)
+:fsm/flat         <yes / no>
+:fsm/hierarchical <yes / no>
+:fsm/eventless-always <yes / no>
+:fsm/delayed-after <yes / no>
+:fsm/tags         <yes / no>
+:fsm/parallel-regions <yes / no>
+:actor/own-state  <yes / no>
+:actor/spawn-destroy <yes / no>
+:actor/cross-actor-fx <yes / no>
+:actor/invoke     <yes / no>
+:actor/spawn-and-join <yes / no>
+:actor/system-id  <yes / no>
+:routing/*        <yes / no>
+:ssr/*            <yes / no>
+:schemas/*        <yes / no — pick yes if D5 ≠ no, regardless of mechanism>
+```
+
+Score reporting: this port's score is `passed / claimed-applicable` against the above set.
+
+---
+
+## Open questions parked for Phase 2
+
+<For any decision that you can't lock without seeing the implementation play out, note it here. Better to mark a decision "deferred to Phase 2 step N" than to over-commit at lock time. Each deferred decision must be resolved before the matching Phase 2 step starts.>
+
+- D<n> — <description> — *deferred until Phase 2 step <N: implement EP M>*
+
+---
+
+## Revision log
+
+<Append-only. Each entry: date, the decision that changed, the Phase 2 step that surfaced the need, the new lock.>
+
+- <YYYY-MM-DD> — initial lock.
+```
+
+---
+
+## How to use the template
+
+1. Copy the block between the `## Template — copy from here` heading and the `---` after it.
+2. Paste into `DECISIONS.md` (or equivalent) at the root of the port's repo.
+3. Fill in every `<...>` placeholder. Don't leave any blank — if you don't know, mark it "deferred to Phase 2 step N" in the *Open questions* section and call it out explicitly.
+4. Commit. The record is now load-bearing.
+
+## When to revise the record
+
+Phase 2 will occasionally surface a foundation decision that won't survive contact with the implementation — typically because a host idiom doesn't fit the chosen mechanism cleanly. When this happens:
+
+1. Stop the Phase 2 step that surfaced the issue.
+2. Re-open `DECISIONS.md`.
+3. Append to the *Revision log* with the date, the changed decision, and the Phase 2 step that surfaced it.
+4. Update the decision body to the new lock.
+5. Re-walk the affected portions of Phase 1's downstream decisions if they depended on the changed lock.
+6. Resume Phase 2.
+
+This costs ~30 minutes when caught early. Skipping the revise step and patching the code in flight costs days of cleanup later.
+
+## Why the record matters
+
+Three reasons:
+
+1. **Phase 2 context.** Every Phase 2 step asks "given Phase 1, what does EP N look like in this port?" Without the record written down, the engineer (or their Claude session) re-derives the answer every time — and the answer can drift across sessions.
+2. **Onboarding context.** Future contributors to the port read `DECISIONS.md` before reading code. The decisions are how the code makes sense.
+3. **Conformance reporting.** The port's conformance score is *against the claimed capability set*. The claimed set lives in D7 of this record; the score has no meaning without it.
+
+The record is the contract between Phase 1 and Phase 2.

--- a/skills/re-frame2-implementor/reference/kickoff-prompt.md
+++ b/skills/re-frame2-implementor/reference/kickoff-prompt.md
@@ -1,0 +1,60 @@
+# kickoff-prompt
+
+The paste-ready prompt for kicking off a re-frame2 implementation walkthrough in a fresh Claude Code session.
+
+## When to use this
+
+The engineer is starting a new port of re-frame2 to a different host language or substrate. They want to delegate the workflow to a focused Claude Code session — keeping their own primary session free — and they're sitting in the root of the port's new repository (or an empty workspace).
+
+Steps:
+
+1. The engineer installs this skill — project-level `.claude/skills/re-frame2-implementor/` or globally at `~/.claude/skills/re-frame2-implementor/`.
+2. The engineer clones the re-frame2 repo somewhere reachable so the skill can read `spec/`, `spec/Implementor-Checklist.md`, and `spec/conformance/`. Either alongside their port repo or as a git submodule — whichever fits their workflow.
+3. The engineer opens a fresh Claude Code session in the port's repo root.
+4. The engineer pastes the prompt below verbatim. The session loads the `re-frame2-implementor` skill on its own (the description triggers it) and walks the two phases.
+
+---
+
+## The prompt (paste this verbatim)
+
+> *I'm implementing a new port of re-frame2 in this repo. Walk the implementation workflow end-to-end per the `re-frame2-implementor` skill in this session.*
+>
+> *The re-frame2 spec corpus is at `<path-to-re-frame2>/spec/` (clone https://github.com/day8/re-frame2 locally if you don't already have it). Treat `spec/` as the contract and `<path-to-re-frame2>/implementation/` as one worked example — not as a contract.*
+>
+> *Phase 1 — Lock the decisions. Walk me through `reference/phase-1-decisions.md`. For each decision block, surface the options (citing `spec/Implementor-Checklist.md` Part 2 where it has them), name the trade-offs, and ask me for my choice. Capture every choice in a `DECISIONS.md` at the root of this repo using the template at `reference/decision-record.md`. Do not write any implementation code in Phase 1.*
+>
+> *Phase 2 — Walk the spec corpus. Once Phase 1 is locked, walk `reference/phase-2-impl-order.md` EP by EP in this order: 001 Registration → 002 Frames → 006 Reactive substrate → 004 Views → 009 Instrumentation → then any optional EPs I declared yes for in Phase 1, in the leaf's suggested order. For each EP: read the spec section first, surface the contract the port must expose, surface what the CLJS reference did (as one worked example, not normative), and write the corresponding code in this repo. After 001 / 002 / 006 / 004 / 009 are in place, run the `:core/*` conformance fixtures as the first acceptance gate — this is per `reference/conformance.md`.*
+>
+> *Standing rules for this port:*
+>
+> *- The spec at `<path-to-re-frame2>/spec/` is the contract. The CLJS reference at `<path-to-re-frame2>/implementation/` is one realisation — never normative. When the spec and the reference disagree, the spec wins; file a `bd create` bead against the re-frame2 repo.*
+> *- Substrate-agnostic phrasing. Do not assume "hiccup", "Reagent", or "keyword" universally; use "render-tree", "reactive container", "identity primitive" per the host's choice from my Phase 1 record.*
+> *- No core.async. Async effects schedule via the host's native primitives (Promise, setTimeout, asyncio, tokio, whatever); cross-frame work is serialised per frame via the run-to-completion drain.*
+> *- JVM-runnability for the test surface. `compute-sub` and `machine-transition` analogues must be callable from a non-substrate harness.*
+> *- If you hit a spec gap — a missing surface, an inconsistency, an undocumented decision — `bd create` a bead in the re-frame2 repo and reference it in my port's `DECISIONS.md`. Do not silently extrapolate from the CLJS reference.*
+> *- I run my own builds and tests; you do not run them for me. Run the conformance harness against my port when I ask, and report the score.*
+>
+> *Begin with Phase 1.*
+
+---
+
+## Variations
+
+Two common amendments the engineer may add:
+
+**"Minimum viable port."** Append: *"Declare Q1 (state machines) = no, Q2 (routing) = no, Q3 (SSR) = no, Q4 = via-host-types, Q5 (stories) = no, Q6 (Tool-Pair) = no, Q7 (AI-Audit) = no. I'm shipping the core only — events / subs / fx / views. Re-evaluate the optional capabilities after the `:core/*` corpus passes."*
+
+**"Reference impl tour first."** Append: *"Before Phase 1, walk me through `reference/reference-impl-tour.md`. I want to see how the CLJS reference is organised before locking my own decisions — but treat the tour as descriptive, not normative."*
+
+---
+
+## Why a kickoff prompt at all
+
+The skill description triggers on a wide range of "porting re-frame2" phrasings, but the **opening shape of the implementation** is identical regardless of phrasing — Phase 1 then Phase 2. Giving the engineer a paste-ready prompt:
+
+- Locks the workflow shape the first time, so the session doesn't drift mid-implementation.
+- Makes the "Phase 1 before Phase 2" rule explicit upfront — the session can't skip ahead to coding.
+- Frames the spec as the contract and the reference impl as one example — so the session doesn't mistake the CLJS choices for pattern requirements.
+- Names the standing rules (substrate-agnostic phrasing, no core.async, JVM-runnability, bead-files-not-silent-extrapolation) so they're in the session's context from the first turn.
+
+The prompt is short (under 500 words) so the engineer doesn't lose anything by pasting it verbatim, but rigid enough that a fresh session executing it walks the implementation the same way every time.

--- a/skills/re-frame2-implementor/reference/output-format.md
+++ b/skills/re-frame2-implementor/reference/output-format.md
@@ -1,0 +1,137 @@
+# output-format
+
+The standard agent-output shape for a re-frame2 implementation session. The agent driving Phase 1 and Phase 2 produces these artefacts so the engineer always has a clear handoff at the end of each session and a clear summary at the end of v1.
+
+There are **three shapes**, one per session type:
+
+- **Phase 1 wrap-up** — produced at the end of the Phase 1 walkthrough, when the decision record is locked.
+- **Phase 2 EP wrap-up** — produced at the end of each EP's implementation session, before moving to the next EP.
+- **v1 completion report** — produced after acceptance gate 2 (full claimed-capability conformance pass).
+
+All three keep their summary section under 400 words. Detail goes in attached files (the decision record, the EP-by-EP commits, the conformance report).
+
+---
+
+## Phase 1 wrap-up
+
+Produced at the end of the Phase 1 walkthrough. The decision record is committed; the engineer reads this summary before moving to Phase 2.
+
+```markdown
+## Phase 1 — locked
+
+- **Port name:** <name>
+- **Host:** <D1: language + runtime>
+- **Substrate:** <D2: substrate + reactive container>
+- **Scope (capabilities claimed):**
+  - Required core: yes
+  - Q1 state machines: <yes / no — with sub-capability list if yes>
+  - Q2 routing: <yes / no>
+  - Q3 SSR: <yes / no>
+  - Q4 schemas: <yes-runtime-schema / yes-via-host-types / no>
+  - Q5 stories: <yes / no>
+  - Q6 Tool-Pair: <yes / no>
+  - Q7 AI-Audit: <yes / no>
+- **Identity primitive:** <D4.1 mechanism>
+- **Persistent data structures:** <D4.2 library>
+- **Concurrency model:** <D4.5>
+- **Schema mechanism:** <D5>
+- **Decision record:** committed to `DECISIONS.md` at <commit-hash>.
+
+## Open questions parked for Phase 2
+
+<list any decisions deferred to specific Phase 2 steps>
+
+## Next step
+
+Begin Phase 2 at EP 001 (Registration). Read `spec/001-Registration.md`; expose the registrar API per the decision record's D4 choices.
+```
+
+---
+
+## Phase 2 EP wrap-up
+
+Produced at the end of each EP's implementation session. The session began with "implement EP N"; this is the report at the end.
+
+```markdown
+## EP <N> — <name> — landed
+
+- **Spec read:** `spec/<NNN-Name>.md` (full).
+- **Code:** committed at <commit-hash(es)>. Files touched:
+  - <path/to/file.ext> — <one-line description>
+  - <path/to/file.ext> — <one-line description>
+- **Tests:** <unit tests landed alongside the EP — pass/fail count>.
+- **Conformance fixtures exercised:** <list of capability tags the EP gates; pass/fail count>.
+- **Spec gaps filed (beads):** <list of `bd` ids filed during this EP; one line each>.
+- **Decision-record revisions:** <list any Phase 1 decisions that needed revision; new locks>.
+- **Carry-over to next EP:** <anything intentional left out — partial implementation, deferred edge cases>.
+
+## What surprised me during this EP
+
+<2-4 sentences. Things that didn't match expectations; things harder than expected; things easier than expected. Useful for retrospective learning.>
+
+## Next step
+
+Move to EP <N+1> (<name>). Read `spec/<MMM-Name>.md` first.
+```
+
+The session log is one of these blocks per EP. The engineer reads the chain to track progress; future contributors read it to understand why the port looks the way it does.
+
+---
+
+## v1 completion report
+
+Produced after acceptance gate 2 passes. This is the final report for the port's "v1 release."
+
+```markdown
+## <port-name> v1 — re-frame2 implementation complete
+
+- **Host:** <D1>
+- **Substrate:** <D2>
+- **Claimed capability tag set:**
+  ```
+  :core/*
+  <list of optional tags from D7>
+  ```
+- **Conformance score:** <claimed-applicable> / <claimed-applicable> on corpus commit <corpus-commit-hash>.
+- **Decision record:** `<port-repo>/DECISIONS.md` at <decisions-commit-hash>.
+- **Spec gaps filed (closed and open):**
+  - bd <id> — <one line; closed/open status>.
+  - bd <id> — <one line; closed/open status>.
+- **Per-EP commit chain:** <link to a tag, branch, or commit range covering all of Phase 2>.
+
+## What v1 includes
+
+- <bullet per EP: name + one-line summary>
+
+## What v1 deferred (post-v1 candidates)
+
+- <bullet per deferred capability: name + reason for deferral + estimate of follow-on work>
+
+## Conformance harness command
+
+```
+<exact command to run the harness against this port; reproducible for downstream consumers>
+```
+
+## Acknowledgements
+
+The port follows `spec/` at corpus commit <corpus-commit-hash> in https://github.com/day8/re-frame2. The CLJS reference implementation at `implementation/` in that repo was consulted as one worked example during Phase 2.
+```
+
+---
+
+## Discipline
+
+- **One report per session.** Don't fragment a Phase 1 wrap-up across multiple files; don't write a v1 completion report before gate 2 passes.
+- **Cite commits and corpus hashes.** Both shift; pinning them is what makes the report reproducible.
+- **Don't bury spec gaps in narrative.** Every `bd create` filed during the work goes in the bullet list — not in prose. The bead id is the contract surface.
+- **Don't run the engineer's builds for them.** The agent reports observed conformance scores (when the engineer ran the harness); it doesn't run the harness unbidden. Per the standing rule from the skill design: "running tests is general software practice, not skill-specific."
+
+## What the reports are for
+
+- **The engineer reads them once per session** and knows where the port stands.
+- **Future contributors read them** before reading the port's source code — the reports are the why-this-way navigation.
+- **Downstream consumers** (people considering whether to adopt the port) read the v1 completion report and the conformance score to decide.
+- **The re-frame2 maintainers** read the v1 completion report's spec-gaps section to track what the spec was missing as the port was built — surfaces real-world evidence for spec follow-ups.
+
+These reports are the public surface of "this port exists and conforms." Treat them like contracts.

--- a/skills/re-frame2-implementor/reference/phase-1-decisions.md
+++ b/skills/re-frame2-implementor/reference/phase-1-decisions.md
@@ -1,0 +1,211 @@
+# phase-1-decisions
+
+The Phase 1 walkthrough. Before writing any implementation code, the engineer walks each decision block below and captures the answer in the **decision record** (template at `decision-record.md`).
+
+Every decision in Phase 1 propagates through every line of Phase 2 code. Spending one focused session locking the decisions saves weeks of rewrites later.
+
+## Contents
+
+- D1. Target host language
+- D2. Substrate / view layer
+- D3. Scope — which EPs ship now
+- D4. Foundation choices (identity, persistent data, reactive, effect, concurrency, hot-reload)
+- D5. Schema mechanism
+- D6. Integration story
+- D7. Conformance capability tag set
+
+For each block: the question, what's at stake, options, how to choose, where the spec speaks to it.
+
+---
+
+## D1. Target host language
+
+**The question.** Which host language and runtime does the port target?
+
+**What's at stake.** Every Phase 1 sub-decision (identity primitive, persistent data structures, concurrency model, render-tree shape) is constrained by what the host provides. The choice of host fixes the "shape of the space" the port operates in.
+
+**Options.** [`spec/000-Vision.md`](https://day8.github.io/re-frame2/spec/000-Vision/) names eight first-class **JS-cross-compile + React+VDOM** hosts:
+
+- ClojureScript (the reference)
+- TypeScript / JavaScript
+- Squint
+- Melange / ReScript / Reason
+- Fable (F#)
+- Scala.js
+- PureScript
+- Kotlin/JS
+
+The [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) covers more (Python, Rust, Kotlin/native, Swift, Java), but ports outside the eight above will not target React+VDOM by default — D2 picks an alternative substrate.
+
+**How to choose.** Usually pre-decided by why the engineer started the port. Capture the host and the runtime (e.g. "TypeScript targeting browser + Node 20", "Fable F# targeting .NET 9 and browser", "Rust targeting tokio").
+
+**Where the spec speaks.** [`spec/000-Vision.md`](https://day8.github.io/re-frame2/spec/000-Vision/) §"The pattern (JS-cross-compile-language-agnostic)" and the host-profile matrix. [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) Part 2 enumerates options per host for every foundation decision.
+
+---
+
+## D2. Substrate / view layer
+
+**The question.** What renders the view? What is the reactive container that holds `app-db`?
+
+**What's at stake.** The reactive substrate decision propagates into EP 006 (the adapter contract), EP 004 (the render-tree shape), and the view-rerender trigger.
+
+**Options.** The default for the eight in-scope hosts is **React + VDOM** (per [`spec/000-Vision.md`](https://day8.github.io/re-frame2/spec/000-Vision/) §scope footnote). Other substrates a port may target:
+
+- React + VDOM (the spec's default; the CLJS reference uses Reagent atop React)
+- A native UI toolkit (SwiftUI, Compose, Qt, GTK)
+- Raw DOM (no virtual-DOM library)
+- Terminal UI (TUI)
+- Server-render only (no client view layer)
+- No UI at all (a re-frame2 runtime used as a state-management substrate for a non-UI process)
+
+**How to choose.** Driven by the engineer's deployment target. If targeting one of the eight JS-cross-compile hosts and the deployment is browser/React-Native, React+VDOM is the default. Otherwise pick the substrate that fits the target.
+
+**Trade-offs.** Substrates without auto-tracked reactivity (raw DOM, terminal) require an explicit subscription-binding mechanism that's outside the CLJS reference's shape — the engineer writes more of the wiring by hand. The contract is still six required + two optional + one lifecycle function from EP 006.
+
+**Where the spec speaks.** [`spec/006-ReactiveSubstrate.md`](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/) — the adapter contract. [Implementor-Checklist §F3 Reactive substrate](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f3-reactive-substrate) — options per host.
+
+---
+
+## D3. Scope — which EPs ship now
+
+**The question.** Which optional EPs does this port include in v1?
+
+**What's at stake.** The required core is non-negotiable. Optional EPs are declared yes/no per the [Implementor-Checklist Part 1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-1--how-complete). Each "yes" gates a substantial chunk of additional implementation work.
+
+**Required (every port ships these).** Identity primitive, persistent data structures, registry by `(kind, id)`, event handler contract, closed effect-map shape, subscription system, frame as runtime boundary, run-to-completion drain, view contract, trace event stream, error contract, conformance corpus consumption. Per [Implementor-Checklist Part 1 §Required](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#required-not-gated-every-implementation-ships-these).
+
+**Optional (declare yes/no for each).**
+
+- **Q1 — State machines** ([EP 005](https://day8.github.io/re-frame2/spec/005-StateMachines/)). Substantial. The CLJS reference claims hierarchical compound + `:always` + `:after` + `:fsm/tags` + `:fsm/parallel-regions` + own-state + spawn/destroy + cross-actor `:fx` + declarative `:invoke` + spawn-and-join + `:system-id`. Smaller ports claim less.
+- **Q2 — Routing** ([EP 012](https://day8.github.io/re-frame2/spec/012-Routing/)). `reg-route`, `match-url`, navigation tokens.
+- **Q3 — SSR** ([EP 011](https://day8.github.io/re-frame2/spec/011-SSR/)). `:platforms` metadata, `render-to-string`, hydration-mismatch detection.
+- **Q4 — Schemas** ([EP 010](https://day8.github.io/re-frame2/spec/010-Schemas/)). Three answers, not two: *yes-runtime-schema*, *yes-via-host-types*, *no*.
+- **Q5 — Stories** ([EP 007](https://day8.github.io/re-frame2/spec/007-Stories/)). Storybook/devcards-class tooling. Post-v1 in the CLJS reference too.
+- **Q6 — Tool-Pair adapters** ([Tool-Pair.md](https://day8.github.io/re-frame2/spec/Tool-Pair/)). REPL-attached AI inspection surface.
+- **Q7 — AI-Audit grading** ([AI-Audit.md](https://day8.github.io/re-frame2/spec/AI-Audit/)). Self-grading discipline doc.
+
+**How to choose.** Default to "no" on every optional capability unless the engineer has a concrete consumer that needs it. Smaller v1 surface = faster ship + earlier feedback. Add capabilities post-v1 when consumers ask.
+
+**Where the spec speaks.** [Implementor-Checklist Part 1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-1--how-complete) — the canonical decision table. [Host-profile matrix in 000](https://day8.github.io/re-frame2/spec/000-Vision/#host-profile-matrix) — which capabilities are pattern-required vs CLJS-only vs host-discretion.
+
+---
+
+## D4. Foundation choices
+
+Six sub-decisions, all required, all from [Implementor-Checklist Part 2 §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required). Each propagates through every line of Phase 2 code.
+
+### D4.1 Identity primitive
+
+**The question.** What represents an id?
+
+**What's at stake.** Every queryable, override, trace event, and error category is identified by an id. The runtime looks up, compares, ships, and reflects on ids cheaply.
+
+**Required properties.** Stable, namespaceable, value-equal, cheap, serialisable, human-readable, reflective. Per [`spec/000-Vision.md` §The identity primitive](https://day8.github.io/re-frame2/spec/000-Vision/#the-identity-primitive--required-properties).
+
+**Options.** CLJS keywords (the reference); TS branded strings with interning; Fable polymorphic variants or single-case DUs; Kotlin sealed-class hierarchies or value classes; PureScript newtypes; Scala.js sealed objects or value classes; Python wrapped strings; Rust newtype `Id(&'static str)`.
+
+**Rejected upfront.** UUIDs, integer ids, Java reference-equality classes — all violate one or more required properties.
+
+**Where the spec speaks.** [`spec/000-Vision.md` §The identity primitive — required properties](https://day8.github.io/re-frame2/spec/000-Vision/#the-identity-primitive--required-properties) and the per-host realisation table.
+
+### D4.2 Persistent data structures
+
+**The question.** What does `app-db` (and every snapshot of it) physically live in?
+
+**What's at stake.** Frame state revertibility ([Goal 3 in 000](https://day8.github.io/re-frame2/spec/000-Vision/#frame-state-revertibility)) requires structural sharing. Without persistent structures, snapshot is deep-copy and revert is expensive.
+
+**Options.** Clojure persistent collections (CLJS, Squint); Immer / mori / Immutable.js (JS/TS); pyrsistent (Python); im (Rust); native persistent collections in Fable, PureScript, Scala.js; im.kt or kotlinx.collections.immutable (Kotlin); Swift's COW value types.
+
+**Where the spec speaks.** [Implementor-Checklist §F2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f2-persistent-data-structures).
+
+### D4.3 Reactive substrate
+
+Already locked in D2.
+
+### D4.4 Effect-handling primitive
+
+**The question.** How does the runtime invoke registered effects? Sync vs async?
+
+**Options.** Sync-by-default registered handlers; async effects schedule via host's promise/timeout primitive and re-enter via `:dispatch` after their side effect completes.
+
+**Constraint.** Async effects must NOT escape the run-to-completion drain. Per [`spec/002-Frames.md` §Run-to-completion](https://day8.github.io/re-frame2/spec/002-Frames/).
+
+**Where the spec speaks.** [Implementor-Checklist §F4](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f4-effect-handling-primitive).
+
+### D4.5 Concurrency model
+
+**The question.** Single-threaded event loop vs multi-threaded vs actor-shaped?
+
+**Constraint.** **No core.async.** Per the standing directive — the CLJS reference does not use core.async, ports inherit the directive. Async fx schedule via host primitives. Cross-frame dispatch is serialised per frame.
+
+**Options.** Single-threaded JS event loop (CLJS / JS / TS); single-threaded `asyncio` loop (Python); single-threaded `tokio` executor (Rust); single coroutine context per frame (Kotlin). Multi-threaded ports must serialise dispatch per frame.
+
+**Where the spec speaks.** [`spec/002-Frames.md` §Run-to-completion dispatch drain semantics](https://day8.github.io/re-frame2/spec/002-Frames/). [Implementor-Checklist §F5](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f5-concurrency-model).
+
+### D4.6 Hot-reload primitive
+
+**The question.** How does re-registration surgically replace registry entries without restarting the runtime?
+
+**Options.** figwheel/shadow-cljs (CLJS); Vite HMR (JS/TS); watch+reimport (Python); compile-replace cycle with `dlopen` (Rust); recompile-and-rerun for compiled-only hosts.
+
+**Constraint.** Re-registration emits `:rf.registry/handler-replaced` per [`spec/001-Registration.md` §Hot-reload semantics](https://day8.github.io/re-frame2/spec/001-Registration/). Frame state preserved across re-registration of `reg-frame`.
+
+**Where the spec speaks.** [Implementor-Checklist §F6](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f6-hot-reload-primitive).
+
+---
+
+## D5. Schema mechanism
+
+**The question.** How does the port describe the shapes flowing through the runtime?
+
+**Three answers, not two.**
+
+- **Yes-runtime-schema.** Use a host-native schema library — Malli (CLJS), Zod (JS/TS), Pydantic (Python), dry-rb (Ruby). Validation runs at boundaries in dev; elided in production.
+- **Yes-via-host-types.** Use the host's type system — TypeScript types, F# discriminated unions, Kotlin sealed classes, Rust enums + `serde`, Scala case classes. The compiler enforces shapes at build time; runtime validation is optional.
+- **No.** Skip schemas entirely. Permitted by the spec but rarely the right call — the schema layer is what AI agents read to learn the runtime's shapes.
+
+**Constraint.** **Open shapes** are non-negotiable. Consumers tolerate unknown keys; producers grow shapes additively. Closed records/structs at the runtime-data layer are out per [Goal 5 — Clojure ethos](https://day8.github.io/re-frame2/spec/000-Vision/#goals).
+
+**Where the spec speaks.** [`spec/010-Schemas.md`](https://day8.github.io/re-frame2/spec/010-Schemas/). [Implementor-Checklist §Schemas](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#schemas-if-q4-is-yes).
+
+---
+
+## D6. Integration story
+
+**The question.** Is the port a standalone library? Or does it integrate with a larger framework?
+
+**Options.**
+
+- **Standalone library.** Drop-in for an existing app; the consumer wires the runtime, the substrate adapter, and any per-feature artefacts.
+- **Framework integration.** The port plugs into an existing framework's lifecycle — e.g. React Native, a Phoenix LiveView-like server, a Compose Multiplatform app, a SwiftUI app. The framework's render cycle is the trigger for `re-frame2`'s view recompute.
+- **Embedded.** The runtime is embedded inside a larger non-UI process (a worker, a server, a game loop). No view layer; the port consumes events + subs + fx + app-db as a state-management substrate.
+
+**How to choose.** Driven by the engineer's downstream consumer. Standalone is the lowest-friction starting point.
+
+---
+
+## D7. Conformance capability tag set
+
+**The question.** Given Phase 1's scope, which capability tags from the conformance corpus does the port claim?
+
+**The capability tag families** ([`spec/conformance/README.md` §Capability tagging](https://day8.github.io/re-frame2/spec/conformance/)):
+
+- `:core/*` — pattern-required basics. Every conformant port claims these.
+- `:fsm/*` — FSM-richness axis (claim if D3 Q1 = yes; pick which sub-capabilities — `:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`).
+- `:actor/*` — actor-model axis (claim if D3 Q1 = yes; pick which — `:actor/own-state`, `:actor/spawn-destroy`, `:actor/cross-actor-fx`, `:actor/invoke`, `:actor/spawn-and-join`, `:actor/system-id`).
+- `:routing/*` — claim if D3 Q2 = yes.
+- `:ssr/*` — claim if D3 Q3 = yes.
+- `:schemas/*` — claim if D3 Q4 ≠ no (regardless of mechanism).
+
+The harness runs every fixture whose `:fixture/capabilities` is a subset of the claimed set and skips the rest. The score is `passed / claimed-applicable`.
+
+**Where the spec speaks.** [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/) — full capability tagging table and the harness contract.
+
+---
+
+## After Phase 1
+
+When every decision above has been answered and captured in the decision record:
+
+1. Commit `DECISIONS.md` (the filled-in record) to the port's repo.
+2. Move to Phase 2 — `phase-2-impl-order.md` walks the EP corpus in dependency order, with the Phase 1 record as the source of truth for every host-specific binding.

--- a/skills/re-frame2-implementor/reference/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/reference/phase-2-impl-order.md
@@ -1,0 +1,214 @@
+# phase-2-impl-order
+
+The EP-by-EP implementation walk for Phase 2. Each section names: what to read first, the contract the port must expose, what the CLJS reference did (as **one** worked example, not normative), what the conformance fixtures check, and common spec-gap traps.
+
+The walking order is dependency-driven. Earlier EPs are foundations for later ones; do not skip ahead.
+
+## Walking order
+
+1. EP 001 — Registration
+2. EP 002 — Frames + events + effects + subscriptions
+3. EP 006 — Reactive substrate
+4. EP 004 — Views
+5. EP 009 — Instrumentation
+6. **Acceptance gate 1**: run `:core/*` conformance fixtures
+7. Optional EPs per Phase 1's D3 scope (suggested order below)
+8. **Acceptance gate 2**: run the full claimed-capability fixture set
+
+Each EP is multi-day work. Plan one focused session per EP; don't try to land two in one sitting.
+
+---
+
+## EP 001 — Registration
+
+**Read first.** [`spec/001-Registration.md`](https://day8.github.io/re-frame2/spec/001-Registration/). Plus [Implementor-Checklist §F6 Hot-reload primitive](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f6-hot-reload-primitive) for the re-registration contract.
+
+**The contract.**
+
+- A single registrar — a `(kind, id) → metadata-bearing entry` map.
+- Closed kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:frame`, `:route`, `:machine-action`, `:machine-guard`, plus any kinds gated by optional EPs (e.g. `:story` if Q5 yes).
+- Public `reg-*` surface — one per kind. Each `reg-*` takes id + metadata + handler-or-spec.
+- Registration metadata — `:doc`, source coords (`:ns`/`:line`/`:file` if the host supports source-coord capture), `:tags`, kind-specific keys.
+- Hot-reload semantics: re-registration replaces the entry atomically and emits `:rf.registry/handler-replaced`.
+- Introspection: `(handlers kind)`, `(handler-meta kind id)` per kind.
+
+**What the CLJS reference did (example).** A single atom holding a nested map: `{:event {:id metadata} :sub {...} ...}`. `reg-*` are macros that capture source coords at compile time. Re-registration is `swap!` on the atom. The macros call into functional `register-*` for advanced cases. None of this is normative — your port's mechanics will differ.
+
+**Conformance fixtures.** `:core/registration` family. Verify: register an event → query handlers → handler-meta returns the registered metadata. Re-register → handler-replaced trace fires. Register conflicting id of same kind → policy per the spec.
+
+**Common spec-gap traps.**
+
+- **Source-coord capture.** Hosts without macros (TS at runtime, OCaml-family) capture source coords from stack frames at `reg-*` call time, or via build-time codegen, or omit. The CLJS reference uses macros — that's a choice, not a requirement. Per [`spec/000-Vision.md` §What the pattern does NOT over-commit to](https://day8.github.io/re-frame2/spec/000-Vision/#what-the-pattern-does-not-over-commit-to).
+- **Metadata propagation.** The metadata on a `reg-event-*` registration must be reachable from the trace events fired during the event's drain. The CLJS reference threads `:doc` and source coords through the dispatch envelope; check that your design surfaces the same.
+
+---
+
+## EP 002 — Frames + events + effects + subscriptions
+
+**Read first.** [`spec/002-Frames.md`](https://day8.github.io/re-frame2/spec/002-Frames/) — this is the spec's biggest chapter and most load-bearing. Plan two reads: one for the frame contract, one for the drain semantics.
+
+**The contract.**
+
+- **Frame** is `{state, queue, sub-cache, id}` — an isolated runtime boundary. Multi-instance (per-test, per-request, per-session, default).
+- **Dispatch envelope** is `{event, frame, overrides, trace-id, source}` — an open map.
+- **Event handler contract.** `(state, event) → effects-map`. Pure. The effects map is `{:db <new-state>, :fx [[<fx-id> <args>] ...]}`.
+- **Closed effect-map shape.** Only `:db` and `:fx` at the top level. Per [`spec/Spec-Schemas.md`](https://day8.github.io/re-frame2/spec/Spec-Schemas/) §`:rf/effect-map`.
+- **Six-step pipeline.** Per the EP — coeffect injection → event handler → effects map → fx routing → side-effects → trace.
+- **Run-to-completion drain.** Per frame; an event's cascade settles before the next event is processed. Async fx schedule and re-enter via `:dispatch`.
+- **Subscription system.** Query → value-from-state with stable composition. Layer-1 reads `app-db`; layer-2+ compose via `:<-`. Cache invalidates by `=`-equality.
+- **`reg-frame` is atomic** create-and-register. Frame state is preserved across `reg-frame` re-registration for hot-reload.
+
+**What the CLJS reference did (example).** A frame is a Reagent `r/atom` wrapping a CLJ map plus a Clojure deftype holding queue + sub-cache. Dispatch drains via a synchronous loop that flushes after each event. Subscriptions are Reagent reactions cached in the sub-cache; equality-invalidation is built into Reagent. The reference uses interceptors — chained transforms over the dispatch envelope — as the implementation strategy for the six-step pipeline; per [`spec/Cross-Spec-Interactions.md`](https://day8.github.io/re-frame2/spec/Cross-Spec-Interactions/) interceptors are an implementation detail, not a public contract.
+
+**Conformance fixtures.** `:core/event-handler`, `:core/sub`, `:core/fx`, `:core/frame`, `:core/drain`, `:core/trace`. Verify: dispatch increments a counter → app-db updates; subs over the counter return the new value; `:dispatch` fx re-enters; the drain settles before the next external dispatch.
+
+**Common spec-gap traps.**
+
+- **Closed effect-map shape.** New top-level keys do NOT go in `:db` or `:fx` peer position — they go inside `:fx`. The v1→v2 migration walks this rule under M-8; your port enforces it from the start. Per [`spec/002-Frames.md`](https://day8.github.io/re-frame2/spec/002-Frames/) and the M-8 entry in [`spec/MIGRATION.md`](https://day8.github.io/re-frame2/spec/MIGRATION/).
+- **Run-to-completion vs sync vs async fx.** Sync fx run inline; async fx schedule via host's promise/timeout and re-enter through `:dispatch` after the side effect completes. Async fx must NOT call back into the runtime during the current drain — that would violate run-to-completion.
+- **Sub cache invalidation.** The cache invalidates by value equality on inputs. Identity-only equality (`===` in JS without deep compare; `eq?` in Lisp; reference equality in Java) breaks the contract. Your persistent data structure choice (D4.2) must provide cheap value-equality.
+- **Frame revertibility.** The frame's full state — `app-db` plus any per-frame registry tier — must be revertible by value swap. This propagates the D4.2 (persistent data structures) requirement.
+
+---
+
+## EP 006 — Reactive substrate
+
+**Read first.** [`spec/006-ReactiveSubstrate.md`](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/). All ~990 lines — this EP is the load-bearing contract between the runtime and the view layer.
+
+**The contract.**
+
+- **Six required functions** the adapter must provide: container creation, container read, container replace, sub-cache invalidation hook, render-tree → surface, mount/unmount.
+- **Two optional functions:** server-render-to-string, hydration.
+- **One lifecycle function:** start.
+- **Single-adapter-per-process.** A process binds one adapter at boot; multi-adapter coexistence is post-v1.
+- **Revertibility constraint on adapters.** Adapter-internal state must be derivable from the frame value. No "shadow state" inside the adapter that the frame value can't reproduce on revert. Per [`spec/006-ReactiveSubstrate.md` §Revertibility constraints on adapters](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#revertibility-constraints-on-adapters).
+- **Subscription cache invalidation contract.** Per [`spec/006-ReactiveSubstrate.md` §Subscription cache — contract and operational semantics](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-cache--contract-and-operational-semantics).
+
+**What the CLJS reference did (example).** Two adapters in-tree: `re-frame2-reagent` (browser; atop Reagent + React) and a plain-atom adapter (JVM / SSR). The Reagent adapter uses Reagent's reaction primitive for subs; the plain-atom adapter uses a hand-rolled signal graph. Mount/unmount hook into Reagent's component lifecycle.
+
+**Conformance fixtures.** `:core/substrate` family. Verify: replace-container fires the invalidation hook; subscription cache evicts on input change; revert by container swap restores prior view state.
+
+**Common spec-gap traps.**
+
+- **Revertibility constraint.** Easy to violate inadvertently by stashing per-component state in the adapter that the frame can't reproduce. Audit every adapter-internal cache during EP 006 against the constraint.
+- **Render-trigger semantics.** The trigger must be observably equivalent to "change in `app-db` → recompute affected subs → re-render dependent views". Substrates with their own reactivity model (Solid, Vue, SwiftUI) need to plug into this contract, not subvert it.
+- **Sub lifecycle.** When a view stops reading a sub, the sub should eventually dispose. The mechanism is substrate-dependent (Reagent uses last-deref-disposes-after-a-delay); pick a policy and document it.
+
+---
+
+## EP 004 — Views
+
+**Read first.** [`spec/004-Views.md`](https://day8.github.io/re-frame2/spec/004-Views/).
+
+**The contract.**
+
+- **`reg-view`** registers a view with the registrar. Public surface for declarative view registration.
+- **Pure `(state, props) → render-tree`.** Views are pure functions of their inputs.
+- **Render-tree is serialisable data.** Not opaque host objects with closures. The render-tree must serialise for SSR + view-tree tooling.
+- **Frame-provider.** Views run in the context of a default frame; a view rendered under a non-default frame must opt in. Per [`spec/004-Views.md`](https://day8.github.io/re-frame2/spec/004-Views/) §Frame propagation.
+- **Source-coord stamping.** Where the host supports it, registered views carry source coords for tooling.
+
+**What the CLJS reference did (example).** `reg-view` is a macro that captures source coords, returns a Reagent component, and registers the metadata. Render-tree is hiccup. Frame propagation uses Reagent's component context. Substrate-specific.
+
+**Conformance fixtures.** `:core/view` family. Verify: a registered view reads a sub → mounts → updates when the sub's input changes; the render-tree of a known view matches an expected serialisable shape.
+
+**Common spec-gap traps.**
+
+- **Closed component trees.** A render-tree that includes raw substrate elements with closures (e.g. raw React elements with `useState`) is not serialisable, and breaks SSR + tooling. Keep the render-tree pure data; let the substrate adapter realise it.
+- **Frame propagation.** Views rendered under a non-default frame is a common need (test fixtures, story workspaces, embedded sub-apps). The propagation mechanism is substrate-specific — context for React, environment values for SwiftUI — but the contract is uniform.
+
+---
+
+## EP 009 — Instrumentation
+
+**Read first.** [`spec/009-Instrumentation.md`](https://day8.github.io/re-frame2/spec/009-Instrumentation/).
+
+**The contract.**
+
+- **Trace event stream.** Structured events emitted from well-defined points (event-handler entry/exit, fx invocations, sub computations, errors). Synchronous, in-order, per-emit listener invocation.
+- **Listener registry.** `(register-trace-cb! key callback)` / `(deregister-trace-cb! key)`. Multiple listeners; each gets every event.
+- **Retain-N ring buffer.** Dev-only; tools that attach after events have fired can read recent history.
+- **Error contract.** Structured trace events for runtime failures — handler exceptions, schema validation, drain depth, no-such-handler. `:operation :rf.error/<category>`, `:op-type :error`.
+- **Production elision.** Every emit site, the listener registry, the trace buffer must elide in production builds. Mechanism is host-discretion (Closure DCE for CLJS; Vite `define` for JS/TS; Cargo features for Rust; `__debug__` for Python).
+
+**What the CLJS reference did (example).** A single atom holds the listener registry; emit walks it inline. A separate ring-buffer atom holds the dev-only history. Production elision via `goog-define` + Closure DCE; a CI script verifies dev-only sentinel strings are absent from production bundles.
+
+**Conformance fixtures.** `:core/trace`, `:core/error` families. Verify: dispatching an event emits the expected trace sequence; a handler that throws produces an `:rf.error/handler-exception` trace event; the ring buffer holds the last N events when no listener was registered at emit time.
+
+**Common spec-gap traps.**
+
+- **Listener invocation order.** The spec says "synchronous, in-order, event-at-a-time, exactly once per registered listener". It does NOT specify which listener fires first when multiple are registered. Don't over-commit; don't rely on order in your tests.
+- **Production elision.** The hardest piece. The CLJS reference's CI verifier (sentinel-string scan) is a useful pattern to copy — emit a known string at every dev-only call site, scan production bundles for any occurrence, fail the build if found.
+- **Error category coverage.** Don't miss categories — every catch must fire a trace event, no silent swallow. The spec enumerates the categories (handler-exception, fx-exception, sub-exception, schema-validation, drain-depth, no-such-handler, more). Audit each catch in your port against the list.
+
+---
+
+## Acceptance gate 1 — run `:core/*` conformance
+
+At this point a port with `{Q1=no, Q2=no, Q3=no, Q4=via-host-types-or-no, Q5=no, Q6=no, Q7=no}` is feature-complete against its claim. Run the harness; the `:core/*` fixtures should all pass.
+
+See `conformance.md` for the harness shape, the EDN-handler-body DSL, and what to do when a fixture won't pass.
+
+**If anything fails:** is the failure a spec gap or an implementation bug? The leaf `conformance.md` covers the diagnosis.
+
+---
+
+## Optional EPs (per Phase 1's D3 scope)
+
+For each capability the port declared `yes` for in D3, walk the matching EP. Suggested order if multiple are in scope (each can be done in isolation; the order minimises rework):
+
+### EP 010 — Schemas (if D5 ≠ no)
+
+**Read.** [`spec/010-Schemas.md`](https://day8.github.io/re-frame2/spec/010-Schemas/) and [Implementor-Checklist §Schemas](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#schemas-if-q4-is-yes).
+
+**Contract.** `:spec` registration metadata; `reg-app-schema`; validation at boundaries (handler entry, sub return, fx args, app-db at registered paths); validation-failure trace events; production elision per EP 009.
+
+**Common trap.** Open vs closed shapes — open by default is non-negotiable; opt-in `:closed true` per registration.
+
+### EP 008 — Testing (always recommended)
+
+**Read.** [`spec/008-Testing.md`](https://day8.github.io/re-frame2/spec/008-Testing/).
+
+**Contract.** `with-frame`, `dispatch-sync`, `compute-sub`, `make-restore-fn`, `:fx-overrides`, `:interceptor-overrides`, framework adapter (cljs.test → vitest/pytest/etc.). JVM-runnable for the pure-function surface.
+
+### EP 005 — State machines (if D3 Q1 = yes)
+
+**Read.** [`spec/005-StateMachines.md`](https://day8.github.io/re-frame2/spec/005-StateMachines/) — the spec's largest EP (~2,900 lines). Plan one full session on the read alone before implementing.
+
+**Contract.** `reg-machine`, transition tables, `create-machine-handler`, `:rf/machines` reserved app-db storage, drain extensions for `:raise`/`:always`/`:after`, hierarchy support per D3 Q1's sub-capability list, declarative `:invoke`.
+
+**Capability sub-decisions.** D3 Q1 declared yes/no for each of: `:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`, `:actor/own-state`, `:actor/spawn-destroy`, `:actor/cross-actor-fx`, `:actor/invoke`, `:actor/spawn-and-join`, `:actor/system-id`. Implement only the claimed sub-capabilities; the conformance corpus runs the matching fixture subset.
+
+**Common trap.** Drain extensions interact with EP 002's run-to-completion drain. Plan the integration carefully — `:always` and `:after` are subtle.
+
+### EP 012 — Routing (if D3 Q2 = yes)
+
+**Read.** [`spec/012-Routing.md`](https://day8.github.io/re-frame2/spec/012-Routing/).
+
+**Contract.** `reg-route`, `match-url`, `route-link`, `:rf.nav/push-url` fx, `:rf/pending-navigation`, navigation tokens, fragment handling, `:can-leave?` guard.
+
+### EP 011 — SSR (if D3 Q3 = yes)
+
+**Read.** [`spec/011-SSR.md`](https://day8.github.io/re-frame2/spec/011-SSR/).
+
+**Contract.** `:platforms` metadata on `reg-fx`, `render-to-string`, `:rf/hydrate`, hydration-mismatch detection, `init-platform`.
+
+### EP 013 — Flows (if claimed)
+
+**Read.** [`spec/013-Flows.md`](https://day8.github.io/re-frame2/spec/013-Flows/).
+
+### EP 014 — HTTP (if claimed)
+
+**Read.** [`spec/014-HTTPRequests.md`](https://day8.github.io/re-frame2/spec/014-HTTPRequests/) plus [Pattern-RemoteData](https://day8.github.io/re-frame2/spec/Pattern-RemoteData/) and [Pattern-ManagedHTTP](https://day8.github.io/re-frame2/spec/Pattern-Forms/).
+
+### EP 007 — Stories (if D3 Q5 = yes)
+
+**Read.** [`spec/007-Stories.md`](https://day8.github.io/re-frame2/spec/007-Stories/). Note: post-v1 in the CLJS reference too; expect spec churn.
+
+---
+
+## Acceptance gate 2 — full claimed-capability conformance pass
+
+When every claimed capability is implemented, run the full conformance harness with the capability filter set to D7's claim list. Score must be `claimed-applicable / claimed-applicable`. Any failure that's not a spec gap is a port bug; any spec gap files a `bd create` bead.
+
+When the gate passes, the port is v1-complete against its claim.

--- a/skills/re-frame2-implementor/reference/reference-impl-tour.md
+++ b/skills/re-frame2-implementor/reference/reference-impl-tour.md
@@ -1,0 +1,151 @@
+# reference-impl-tour
+
+A guided tour of the CLJS reference implementation at `implementation/` in the re-frame2 repo. The tour is **descriptive, not normative**. Read this when you want to see how *someone* solved a problem during their port — but never quote it as "what re-frame2 requires." For "what re-frame2 requires", read `spec/`.
+
+## Why this leaf exists
+
+Engineers porting re-frame2 to a new host often want to see a working realisation before locking their own Phase 1 decisions. The CLJS reference is the only one that exists today, so it's the only worked example available. This leaf tours it.
+
+**The tour's job:** name where each EP's code lives in the reference tree, flag which choices were *CLJS-specific* (and therefore not pattern requirements), and surface the per-host alternatives a port might pick instead.
+
+**Not the tour's job:** teach you the spec. The spec teaches the spec. The tour shows how the reference compiled the spec into one realisation.
+
+## Layout
+
+```
+implementation/
+├── core/                    EP 001, 002, 008, 009 — the heart of the runtime
+│   └── src/re_frame/
+│       ├── core.cljc        public API surface (re-exports + macros)
+│       ├── registrar.cljc   EP 001 — the (kind, id) → metadata registry
+│       ├── frame.cljc       EP 002 — frame: {state, queue, sub-cache, id}
+│       ├── events.cljc      EP 002 — event handlers; interceptor chain
+│       ├── fx.cljc          EP 002 — fx registration + invocation
+│       ├── cofx.cljc        EP 002 — coeffect registration + injection
+│       ├── subs.cljc        EP 002 — subscription cache + signal graph
+│       ├── interceptor.cljc EP 002 — interceptor primitives (impl detail)
+│       ├── router.cljc      EP 002 — dispatch routing + drain
+│       ├── views.cljs       EP 004 — view registration
+│       ├── spec.cljc        EP 010 — schema hooks + validation
+│       └── test_support.cljc EP 008 — test fixtures + helpers
+├── adapters/
+│   ├── reagent/             EP 006 — Reagent + React substrate adapter
+│   └── plain-atom/          EP 006 — JVM / SSR / headless substrate adapter
+├── epoch/                   EP 009 — epoch history for time-travel
+├── flows/                   EP 013 — flows (separate artefact)
+├── http/                    EP 014 — Managed HTTP (separate artefact)
+├── machines/                EP 005 — state machine substrate (separate artefact)
+├── routing/                 EP 012 — routing (separate artefact)
+├── schemas/                 EP 010 — Malli integration (separate artefact)
+└── ssr/                     EP 011 — server-side rendering (separate artefact)
+```
+
+The per-feature directories ship as **separate artefacts** in the published library — pay-as-you-go. Your port may bundle some or all into one artefact; the split is a packaging choice, not a contract.
+
+## Walk by EP
+
+### EP 001 — Registration (`core/src/re_frame/registrar.cljc`)
+
+**What you'll find.** A single atom holding a nested map: `{:event {:id metadata} :sub {...} ...}`. `register-kind` / `unregister-kind` / `query-kind` operate on the atom. Re-registration replaces atomically and emits the trace event.
+
+**What's CLJS-specific.**
+
+- The atom + `swap!` model. Your host's mutable cell of choice (a Ref, a RefCell, a StateFlow, a class instance) does the same job.
+- Source-coord capture via macros. The CLJS reference's `reg-event-db` is a macro that records `:ns`/`:line`/`:file` at compile time. Hosts without macros use stack frames, build-time codegen, or omit.
+
+**What's pattern-required.** The registry is data, queryable via the public API. The `(kind, id) → metadata` shape is the contract; the storage mechanism is yours.
+
+### EP 002 — Frames + events + effects + subs (`core/src/re_frame/{frame,events,fx,cofx,subs,router}.cljc`)
+
+**What you'll find.** A frame is a deftype wrapping `r/atom` (Reagent ratom) for the app-db plus mutable fields for the queue and sub-cache. The event handler chain is implemented as **interceptors** — chained transforms over a context map, executed in `:before` and reversed in `:after` order. The dispatch loop runs the interceptor chain to completion before dequeuing the next event.
+
+**What's CLJS-specific.**
+
+- Interceptors as the implementation strategy for the six-step pipeline. They're an internal implementation detail per [`spec/Cross-Spec-Interactions.md`](https://day8.github.io/re-frame2/spec/Cross-Spec-Interactions/); your port can use a different mechanism (a monadic computation, a coroutine, a state machine over the dispatch envelope) so long as the observable contract from EP 002 is preserved.
+- Reagent ratom + auto-tracked subscriptions. Your reactive substrate (D2 / D4.3) decides how this works.
+- `defmulti` for fx resolution. A simple lookup table works too.
+
+**What's pattern-required.** Frame as `{state, queue, sub-cache, id}`; event handler is pure `(state, event) → effects-map`; closed effect-map; run-to-completion drain per frame; subscription cache invalidates by value-equality.
+
+### EP 006 — Reactive substrate (`adapters/{reagent,plain-atom}/`)
+
+**What you'll find.** Two adapters in-tree. The Reagent adapter is browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The plain-atom adapter is JVM-facing — `clojure.core/atom`, hand-rolled signal graph, no render trigger (SSR / headless). Both adapters implement the same six-function contract.
+
+**What's CLJS-specific.**
+
+- Reagent's auto-tracked deref-during-render dependency capture. Your substrate may need explicit subscriptions (Solid: `createMemo`, Vue: `computed`, hand-rolled: explicit `subscribe`/`unsubscribe`).
+- The component-lifecycle integration uses Reagent's lifecycle methods. Other substrates plug into their own.
+
+**What's pattern-required.** The six required functions + two optional + one lifecycle. Single-adapter-per-process. Adapter-internal state derivable from the frame value (revertibility constraint).
+
+### EP 004 — Views (`core/src/re_frame/views.cljs`)
+
+**What you'll find.** `reg-view` is a macro that wraps a function, captures source coords, and registers the wrapper with the registrar. The wrapper plugs into Reagent's component model. Plain Reagent functions (not registered via `reg-view`) still work — they bypass the registry and the frame-propagation contract.
+
+**What's CLJS-specific.**
+
+- Hiccup as the render-tree shape. Your render-tree is yours.
+- The macro-based source-coord capture (same constraint as EP 001).
+- Frame propagation via Reagent component context.
+
+**What's pattern-required.** Pure `(state, props) → render-tree`. Render-tree is serialisable data. `reg-view` is the registry-aware entry point. Frame propagation is supported.
+
+### EP 009 — Instrumentation (`core/src/re_frame/trace.cljc` and related)
+
+**What you'll find.** A listener-registry atom + a ring-buffer atom. Emit walks the registry inline. Production elision via `goog-define :debug-enabled?` + Closure DCE. A CI script (`scripts/check-elision.cjs`) scans production bundles for dev-only sentinel strings; the build fails if any are found.
+
+**What's CLJS-specific.**
+
+- Closure DCE for production elision. JS/TS use Vite's `define` constants and tree-shaking; Rust uses `#[cfg(feature = "trace")]`; Python uses `if __debug__:` and the `-O` flag.
+- The sentinel-string CI verifier is portable — copy the pattern, adapt to your bundler.
+- Chrome Performance API bridge (`performance.mark` / `performance.measure`) is browser-only; alternative profilers per host (clj-async-profiler on JVM, cProfile in Python, `tracing` spans in Rust).
+
+**What's pattern-required.** Trace event stream synchronous + in-order + per-emit. Listener registry. Retain-N ring buffer (dev). Production elision (host's mechanism). Structured error contract with `:operation :rf.error/<category>`.
+
+## Walk by optional artefact
+
+### `epoch/`
+
+EP 009's optional time-travel layer. A frame-state ring buffer keyed by event id; `epoch-history` and `restore-epoch` are the public API. Useful pattern; copy the shape if your port wants time-travel.
+
+### `flows/`
+
+EP 013 implementation. Substrate-independent; the contract lives in 013.
+
+### `http/`
+
+EP 014 implementation + the Managed-HTTP pattern. The `:http` fx wraps a request lifecycle through a registered state machine. Substantial — read `Pattern-ManagedHTTP.md` first.
+
+### `machines/`
+
+EP 005 implementation. Largest non-core artefact. The transition machine, drain extensions for `:always` / `:after`, the `:invoke` contract for child-machine spawning. The CLJS reference uses spec multi-methods + a hand-rolled drain loop.
+
+### `routing/`
+
+EP 012 implementation. Hand-rolled URL matcher with a six-rule precedence cascade; not a third-party routing library. The routing registry plugs into EP 001's registrar — `(handlers :route)` is queryable.
+
+### `schemas/`
+
+EP 010 implementation. Malli is the wire layer; `reg-app-schema` and `:spec` metadata are the public API. Replace Malli with Zod / Pydantic / dry-rb per D5.
+
+### `ssr/`
+
+EP 011 implementation. Pure hiccup → HTML emitter (~200 lines) for the server side; `reagent.dom.client/hydrate` for the client side. The `:platforms` metadata fx-gating is in `core/`, not here — only the render-to-string and hydration helpers live here.
+
+## What this tour deliberately doesn't tell you
+
+- **Which mechanism is correct for your host.** That's Phase 1's job (`phase-1-decisions.md`). The tour names what the CLJS reference did; your port may diverge on every single point and still be a conformant re-frame2 implementation.
+- **How to read the source line-by-line.** This is a map, not a transcription. When the leaf says "the dispatch loop runs the interceptor chain to completion before dequeuing the next event," it doesn't tell you which function in `router.cljc` to read. That's a follow-up: open the file, find the function (it's a fairly small file), read the top-level loop. The tour orients; the source reveals.
+- **What the spec mandates.** That's `spec/`'s job. If anything in the tour reads as a requirement, that's tour-rhetoric leaking. Test every "the reference does X" against `spec/` before committing it to your port's design.
+
+## When to consult the tour
+
+- **Phase 1.** As a sanity check on Phase 1 decisions — "the CLJS reference picked X for D4.5; I'm picking Y because my host gives me Z." The tour grounds the choice.
+- **Phase 2, per EP.** As a starting point for "where would I look to see how to handle the awkward case in EP N?" Open the matching directory above; read the corresponding source file.
+- **Spec gaps.** When a spec section is ambiguous and the tour shows the reference made a specific choice — that's not the spec's choice, that's the reference's. File a `bd create` bead asking for the spec to clarify.
+
+## When NOT to consult the tour
+
+- **As a contract.** Never. The contract is `spec/`. The tour is "one worked example."
+- **As a copy-paste source.** Translating Clojure macros into TS classes line-by-line produces brittle code. Read the contract, design from the contract, then *maybe* peek at the reference for an awkward edge case.
+- **As a teaching resource.** The narrative guide at [`docs/guide/`](https://day8.github.io/re-frame2/guide/README/) is the teaching resource. The tour assumes you've read the spec.

--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -1,0 +1,93 @@
+# re-frame2-implementor — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame2-implementor` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame2-implementor` skill at `skills/re-frame2-implementor/`. The skill guides an engineer building a NEW re-frame2 implementation in a different host language or substrate — not application authoring on the CLJS reference, not v1→v2 migration. The skill is **guidance + two-phase workflow** layered on top of `spec/` — it does not duplicate the spec corpus, it routes / sequences / operationalises consumption of it for the porting task.*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame2-implementor/spec/design.md` — the locked design decisions (L1 through L10) plus the resolutions to the three open questions from the bead. Q14 lock applies (NO verification module). Source of truth is `spec/`. CLJS reference impl is one worked example.*
+> *2. `skills/re-frame2-implementor/spec/inputs.md` — the canonical inputs the skill leans on.*
+> *3. `spec/000-Vision.md`, `spec/Implementor-Checklist.md`, `spec/conformance/README.md` — the three load-bearing spec files.*
+> *4. `skills/re-frame-migration/SKILL.md` + `skills/re-frame-migration/reference/**` — closest structural analogue (workflow skill, has spec/ folder, kickoff-prompt pattern). Mirror the voice / density / load-bearing-rules style.*
+> *5. `skills/re-frame2/SKILL.md` — the canonical authoring pattern. Voice and structure.*
+> *6. `skills/re-frame2-setup/{LICENSE,package.json,.claude-plugin/plugin.json}` — the distribution-metadata triad.*
+>
+> *Then write the skill at `skills/re-frame2-implementor/` with this exact file structure:*
+>
+> ```
+> skills/re-frame2-implementor/
+> ├── SKILL.md                       (router; ~250 lines)
+> ├── README.md                      (~80 lines)
+> ├── LICENSE                        (mirror skills/re-frame-migration/LICENSE)
+> ├── package.json                   (npm metadata; mirror re-frame-migration shape)
+> ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+> └── reference/
+>     ├── kickoff-prompt.md          (~80 lines; paste-ready prompt)
+>     ├── phase-1-decisions.md       (~200 lines; D1-D7 walkthrough)
+>     ├── decision-record.md         (~120 lines; fill-in template)
+>     ├── phase-2-impl-order.md      (~250 lines; EP-by-EP)
+>     ├── reference-impl-tour.md     (~150 lines; descriptive tour of implementation/)
+>     ├── conformance.md             (~140 lines; harness + diagnosis)
+>     └── output-format.md           (~120 lines; three report shapes)
+> ```
+>
+> *Each leaf has a single job; the leaves don't duplicate each other; SKILL.md routes between them. Every leaf is one level deep from SKILL.md (no SKILL → A → B chains).*
+>
+> *Cardinal rules to bake into SKILL.md:*
+>
+> *1. The spec is the contract. `implementation/` is one worked example, not normative.*
+> *2. Phase 1 before Phase 2. Decisions locked in writing before code is written.*
+> *3. Implement in dependency order: 001 → 002 → 006 → 004 → 009 → optional.*
+> *4. Substrate-agnostic phrasing. Don't leak CLJS+Reagent framings as universal.*
+> *5. No core.async. Async fx via host primitives; cross-frame work serialised per frame.*
+> *6. JVM-runnability for the test surface (pure functions stay callable from non-substrate harness).*
+> *7. Conformance corpus is the acceptance test. `passed / claimed-applicable`.*
+> *8. Spec gaps file `bd create` beads; never silent extrapolation from the reference.*
+>
+> *Locks to preserve verbatim (from `spec/design.md`):*
+>
+> *- **L1 — `spec/` is the contract.** Never treat `implementation/` as normative. The tour leaf is the only place CLJS framings live, and even there they're tagged as descriptive.*
+> *- **L2 — Two-phase workflow.** Sequential; not collapsible.*
+> *- **L3 — Q14: NO verification module.** No `reference/verify.md`; no "verify before claiming done" hard rule. The engineer runs their builds; the skill walks the workflow.*
+> *- **L4 — Substrate-agnostic phrasing throughout.** Identity primitive, render-tree, reactive container — generic.*
+> *- **L5 — Conformance corpus is the acceptance test.** The objective measure of "is this re-frame2?"*
+> *- **L6 — Spec gaps file beads.** No silent extrapolation; no patching the spec inline.*
+> *- **L7 — No bead-ids in user-facing content.** SKILL.md / README / reference/ leaves carry no `rf2-XXXX` references.*
+> *- **L8 — Findings stay local.** Don't commit `ai/` or `findings/`.*
+> *- **L9 — No AI attribution.** Commits and PR title/body read as Mike's own work.*
+> *- **L10 — Cross-link bidirectionally.** Update `skills/re-frame2/SKILL.md`, `skills/re-frame-migration/SKILL.md`, `docs/skills/re-frame2-implementor.md` (new), and `mkdocs.yml`.*
+>
+> *Frontmatter — the `description` is "pushy" per Anthropic best practice. List every triggering phrase: "porting re-frame2", "implementing re-frame2 in <language>", "writing a re-frame2 runtime", "second re-frame2 implementation", "TypeScript port of re-frame2", "implementor checklist", "conformance corpus". Plus "any phrasing about building re-frame2 itself rather than using it" framing.*
+>
+> *Voice: tight, declarative, workflow-shaped. Match `skills/re-frame-migration/SKILL.md` density. Use tables for decision-block lookups; use code blocks for harness shapes and decision-record templates. Substrate-agnostic throughout; CLJS bindings only in `reference-impl-tour.md`, and that leaf is explicit-descriptive.*
+>
+> *Don't:*
+>
+> *- Don't write `*.md` documentation outside `skills/re-frame2-implementor/` plus the four cross-link touchpoints (`skills/re-frame2/SKILL.md`, `skills/re-frame-migration/SKILL.md`, `docs/skills/re-frame2-implementor.md`, `mkdocs.yml`).*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't write any verification leaf or verify-before-done hard rule.*
+> *- Don't duplicate `spec/` content — reference it by URL.*
+> *- Don't conflate CLJS reference behaviour with pattern requirements outside the tour leaf.*
+> *- Don't reference rf2-XXXX bead ids in user-facing content.*
+>
+> *Open the PR with title `feat(skills): re-frame2-implementor — guided two-phase skill for building a new re-frame2 impl (rf2-5xje)`. PR body lists: skill structure, the file LoC table, the locks applied, the existing repo material folded in (`spec/Implementor-Checklist.md`, `spec/conformance/`, `spec/000-Vision.md`'s host matrix), cross-link updates made, the three open-questions-resolutions copied from `spec/design.md` §7.*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the re-frame2 repo. It does not assume any out-of-repo context.
+- The prompt does **not** ask the session to verify the resulting skill — the verification is Mike's responsibility (read the files, comment on the PR).
+- If `spec/` has reorganised significantly between authoring passes (renamed EP files, new optional EPs), the URL references throughout the leaves need an updated sweep. The reauthoring session walks `spec/` afresh and rebuilds the references.
+
+## When to re-author from scratch
+
+- `spec/` grows by >2 new EPs → the existing leaves' Phase 1 / Phase 2 walkthrough surfaces are stale; rebuild from scratch.
+- A second reference implementation lands → `reference-impl-tour.md` needs restructuring; rebuilding the leaf is easier than patching.
+- The Q14 lock changes → the design itself changes; this `spec/` folder needs updating first, then the skill.
+- Anthropic skill conventions change materially → reauthor SKILL.md against the new conventions.
+
+Otherwise, edit the existing leaves directly; reauthoring from scratch is for major-version updates.

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -1,0 +1,188 @@
+# re-frame2-implementor — Design
+
+The design rationale and locked decisions for the `re-frame2-implementor` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help an engineer **implement** the re-frame2 pattern in a different host language or substrate — not write applications on the existing CLJS reference, not migrate from re-frame v1, not bootstrap a fresh greenfield project on the reference. Build the runtime itself.
+
+The skill's success criterion: the engineer ends up with a port that claims a specific capability tag set from [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) Part 1, has a written-down decision record covering every Phase 1 choice, and passes the matching subset of the [conformance corpus](https://day8.github.io/re-frame2/spec/conformance/) at `claimed-applicable / claimed-applicable`.
+
+The skill is **guidance + workflow** layered on top of `spec/`. The skill does not duplicate the spec; it routes / sequences / operationalises consumption of it for the specific task of porting.
+
+## 2. Pillars (locked, derived from `ai/findings/re-frame2-skill-design-v2.md`)
+
+The same four pillars as the application-side `re-frame2` skill, adapted to the implementor domain:
+
+1. **Correctness** — workflow over explanations. The skill walks the two phases; the engineer (with their session) makes the decisions. **Q14 lock applies: NO verification module.** The skill never runs the engineer's builds or harness — running them is general software practice.
+2. **Idiomaticness** — verified against `spec/` + `spec/Implementor-Checklist.md` + `spec/conformance/`. The skill is downstream of the spec; if the spec is authoritative, the skill is correct by construction.
+3. **Context economy** — `SKILL.md` is a router; leaves are loaded on demand. The leaves point at spec sections by URL; they don't quote them.
+4. **Assume training knowledge** — the engineer knows what reactive substrates, FSMs, persistent data structures, and EDN are. The skill teaches the **re-frame2-specific binding** — which decisions are foundational, which EPs depend on which, what the conformance corpus is for.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve these unless explicitly unlocked by Mike.
+
+### L1 — `spec/` is the contract; `implementation/` is one worked example
+
+The skill does not treat the CLJS reference as normative. Every "the reference did X" framing in `reference/reference-impl-tour.md` is explicitly tagged as descriptive. Engineers reading the tour are told repeatedly that the spec wins.
+
+**Why**: re-frame2's stated goal is implementability from the spec alone. A skill that conflates the reference with the contract undercuts that goal.
+
+### L2 — Two-phase workflow
+
+Phase 1 locks decisions before any code is written. Phase 2 walks the EP corpus in dependency order. The phases are sequential — Phase 2 cannot start before Phase 1 produces a locked decision record.
+
+**Why**: every Phase 1 decision propagates through every line of Phase 2 code. Engineers who skip Phase 1 to "just start coding" hit foundation-level rewrites halfway through. The phase split is operational, not advisory.
+
+### L3 — Q14 — NO verification module
+
+Per `ai/findings/re-frame2-skill-design-v2.md` §Q14: the skill does not teach the agent to verify its own output. No `reference/verify.md`, no "verification mandatory before done" hard rule. The agent walks the workflow; the engineer runs the builds, the tests, the conformance harness. This matches the `re-frame2` and `re-frame-migration` skills — consistent across the family.
+
+**Why**: running tests is general software practice. Pillar 4 says don't teach what the AI already knows.
+
+### L4 — Substrate-agnostic phrasing throughout
+
+The reference impl is CLJS+Reagent — keywords, hiccup, Reagent ratoms, Closure DCE for elision. These are *choices the reference made*. The skill's voice never leaks them as universal. References to "the identity primitive", "the render-tree", "the reactive container", "the production-elision mechanism" stay generic; the CLJS bindings are surfaced only in `reference/reference-impl-tour.md`, and that leaf is explicit about descriptive-not-normative framing.
+
+**Why**: a TypeScript-port engineer reading the skill should never feel like they're "diverging from re-frame2" when they pick branded strings over keywords. They're not diverging; the keyword choice was never the contract.
+
+### L5 — Conformance corpus is the acceptance test
+
+The skill frames `spec/conformance/` consistently as the **objective measure of "is this re-frame2?"** Not the spec's prose, not the EPs' narrative, not the reference impl's behaviour — the corpus. The leaf `reference/conformance.md` walks the harness shape and the diagnosis algorithm (spec gap vs implementation bug).
+
+**Why**: without the corpus passing, no claim of "this is a re-frame2 implementation" is objectively verifiable. The corpus is the contract surface for downstream consumers.
+
+### L6 — Spec gaps file beads, not silent extrapolations
+
+When implementing surfaces a spec gap — a missing surface, an inconsistency, an undocumented decision — the agent files a `bd create` bead against the re-frame2 repo. Does not silently invent an answer; does not extrapolate from the reference. This matches Mike's standing memory rule "File spec beads for implementation findings".
+
+**Why**: spec gaps are findings. The reference's prior solution to a spec gap was *one engineer's call at one moment*. Treating it as the contract retroactively conflates worked-example and contract — undercutting L1.
+
+### L7 — No bead-ids in user-facing skill content
+
+User-facing skill content (SKILL.md, README.md, the reference/ leaves) carries no `rf2-XXXX` bead-id references. Bead ids are workflow-tracking; they're noise in the skill that the engineer is using. The skill's `spec/` folder may reference beads (workflow / authoring); user-facing leaves do not.
+
+**Why**: the bead-id sweep landed for `docs/`; same discipline applies here.
+
+### L8 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — any exploration of the design happens in `ai/findings/`; never committed. This skill's commit contains only `skills/re-frame2-implementor/**` (plus the cross-link tweaks in the other skills and mkdocs).
+
+### L9 — No AI attribution in commits or PRs
+
+Per Mike's standing memory rule — commits and PR titles/bodies read as Mike's own work. No Co-Authored-By, no "Generated with Claude Code" trailer.
+
+### L10 — Cross-link bidirectionally
+
+The new skill is cross-linked from:
+- `skills/re-frame2/SKILL.md` — one-liner pointing implementors here.
+- `skills/re-frame-migration/SKILL.md` — same.
+- `docs/skills/re-frame2-implementor.md` — new sub-page in the Skills nav.
+- `mkdocs.yml` — new entry in the Skills nav.
+
+Reverse cross-links (this skill → the application-side skills) live in SKILL.md's "When NOT to use this skill" table.
+
+## 4. Audience and scope
+
+### In scope
+
+- Engineers porting re-frame2 to a JS-cross-compile host (TS, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, ReScript / Reason / Melange).
+- Engineers porting to non-JS hosts (Python, Rust, Kotlin/native, Swift, Java).
+- Engineers building re-frame2 against a non-React substrate (native UI, raw DOM, terminal, server-only).
+- Engineers consuming `spec/Implementor-Checklist.md` and `spec/conformance/`.
+
+### Out of scope
+
+- Writing application code on the CLJS reference — that's `skills/re-frame2/`.
+- Bootstrapping a greenfield app on the reference — that's `skills/re-frame2-setup/`.
+- Migrating a v1 codebase to the reference — that's `skills/re-frame-migration/`.
+- Live-runtime inspection of a running v2 app — that's `skills/re-frame-pair2/`.
+- Proposing a *different* pattern — re-frame2's pattern is specified; engineers proposing alternatives need a different conversation.
+- Editing `spec/` — gaps file `bd create` beads; the skill never patches `spec/` inline.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame2-implementor/
+├── SKILL.md                       (router; ~250 lines)
+├── README.md                      (human-facing intro)
+├── LICENSE                        (MIT)
+├── package.json                   (npm metadata)
+├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+├── reference/
+│   ├── kickoff-prompt.md          (paste-ready prompt; ~80 lines)
+│   ├── phase-1-decisions.md       (Phase 1 walkthrough; ~200 lines)
+│   ├── decision-record.md         (fill-in template; ~120 lines)
+│   ├── phase-2-impl-order.md      (EP-by-EP order; ~250 lines)
+│   ├── reference-impl-tour.md     (CLJS tour, descriptive; ~150 lines)
+│   ├── conformance.md             (harness shape, diagnosis; ~140 lines)
+│   └── output-format.md           (agent-output shape; ~120 lines)
+└── spec/
+    ├── design.md                  (this file)
+    ├── inputs.md                  (canonical inputs)
+    └── authoring-prompt.md        (one-shot reauthor prompt)
+```
+
+## 6. Why this leaf split
+
+The seven reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical session loads:
+
+- **Phase 1 walkthrough**: `phase-1-decisions.md` + `decision-record.md`. ~320 LoC.
+- **Phase 2, single EP**: `phase-2-impl-order.md` (one section) + maybe `reference-impl-tour.md` (one section) + maybe `conformance.md`. ~250-400 LoC.
+- **Conformance pass**: `conformance.md` + `output-format.md`. ~260 LoC.
+- **Full v1 ship**: every leaf. ~1,060 LoC.
+
+Worst case is ~1,000 LoC, well under any reasonable context budget; the median Phase 2 step loads ~300 LoC.
+
+## 7. Resolutions to the three open questions in the bead
+
+The bead surfaced three open questions; the skill resolves them as follows.
+
+### OQ1 — Decision-tree vs prose-prompt for Phase 1
+
+**Resolved: prose walkthrough.** `phase-1-decisions.md` is a structured walkthrough — one section per decision block, each section with question / what's at stake / options / how to choose / where the spec speaks. Not a yes/no decision tree.
+
+**Why**: yes/no trees over-simplify the decisions (D4.1 identity primitive has 8+ options per host, not 2; D3 scope has 7 independent questions). A prose walkthrough that names the options + their trade-offs respects the engineer's expertise. The walkthrough is *structured* (consistent block shape per decision) so it's predictable, but the decision is made in prose, not by walking a binary tree.
+
+### OQ2 — Granularity of Phase 2 — one EP at a time, or clusters?
+
+**Resolved: one EP per session, with explicit acceptance gates between groups.** `phase-2-impl-order.md` is structured as one section per EP. Between the foundation cluster (001 / 002 / 006 / 004 / 009) and the optional EPs sits **acceptance gate 1** — running the `:core/*` conformance fixtures. Between full claimed-capability implementation and v1 ship sits **acceptance gate 2** — full claimed-capability conformance pass.
+
+**Why**: per-EP sessions are tractable; per-EP commits are reviewable. The CLJS reference's largest EP (005 State Machines, ~2,900 spec lines) takes multiple sessions in any host, but those sessions are still about *one* EP — the unit is right. Clustering the foundation EPs into "do them all together" would lose the per-EP wrap-up checkpoint, which is where the engineer catches Phase 1 decisions that need revision.
+
+The acceptance gates are operational, not advisory: gate 1 between core + optional means a port can declare v1-core-complete with only the foundation EPs, and gate 2 between optional + ship means the full claim is verified before public release.
+
+### OQ3 — How to annotate CLJS-specific framings when pointing at the reference impl
+
+**Resolved: a dedicated descriptive tour leaf with explicit framing.** `reference/reference-impl-tour.md` is the only leaf that walks the CLJS implementation's structure. It's explicit at the top and bottom that the tour is **descriptive, not normative**; every "the reference did X" is paired with a "what's CLJS-specific" callout and a "what's pattern-required" framing. Engineers consult the tour when they want to see how someone solved a problem; they consult `spec/` and the other leaves when they want to know what's required.
+
+**Why**: separating descriptive (tour) from normative (spec) at the leaf level is the cleanest split. Annotating individual references in other leaves with "this is the CLJS shape; your $LANG will differ on…" would clutter every leaf with the disclaimer and bury the workflow signal. The tour is the place for descriptive framing; the rest of the skill stays in normative voice.
+
+## 8. Where this design diverges from `re-frame2`
+
+- **No patterns/ directory.** Implementation is one workflow per EP, not a set of authoring recipes. The patterns from `Pattern-*.md` are for application authors, not implementors.
+- **No decision-trees/ directory.** Phase 1 is the entire decision tree, captured in `phase-1-decisions.md`. The other Phase 2 decisions are EP-internal and live in `phase-2-impl-order.md`.
+- **No examples-map.md.** The reference impl is the one example; `reference-impl-tour.md` covers it.
+- **The conformance leaf is unique.** The application-side skills don't have a conformance concept — applications run their tests, not a normative corpus. Implementors do.
+- **The kickoff prompt assumes a fresh repo, not an existing codebase.** Application-side skills (`re-frame2`, `re-frame-migration`) attach to an existing project. This skill attaches to a fresh port's repo (or an empty workspace) plus a clone of the re-frame2 repo for the spec.
+
+## 9. Anti-patterns the skill explicitly resists
+
+- **Treating the CLJS reference as normative.** Cardinal rule #1 in SKILL.md; L1 in this design.
+- **Skipping Phase 1.** Cardinal rule #2 in SKILL.md; the kickoff prompt is explicit about Phase 1 before Phase 2.
+- **Inventing surfaces when the spec is silent.** Cardinal rule #8 + the bead-files-not-extrapolation rule in `reference-impl-tour.md` and `conformance.md`.
+- **Skipping the conformance corpus.** L5; the leaf `conformance.md` frames it as the acceptance test.
+- **Bundling CLJS-specific framings into normative voice.** L4; the tour leaf is the only place CLJS framings appear, and even there they're explicitly tagged as descriptive.
+
+## 10. Open questions (deferred to Mike)
+
+These remain open at authoring time:
+
+### OQ4 — Skill `name` — is `re-frame2-implementor` Anthropic-compliant?
+
+Anthropic's current best-practices doc says "consider using" gerund form. `re-frame2-implementor` is a noun phrase. Compliance is "consider," not "must"; the description does the discovery heavy lifting; the noun phrase matches the project-name pattern (`re-frame2`, `re-frame2-setup`, `re-frame-migration`, `re-frame-pair2`). **Recommendation: keep `re-frame2-implementor`.** Status: Mike's call.
+
+### OQ5 — Will the skill stale-detect against the spec corpus?
+
+The skill cites spec sections by URL. If the spec's section headings shift (a routine maintenance event), the skill's cross-references break. **Recommendation**: a periodic audit bead, like the one for `re-frame-migration` against `spec/MIGRATION.md`. **Status**: deferred to v0.2; not blocking v0.1.

--- a/skills/re-frame2-implementor/spec/inputs.md
+++ b/skills/re-frame2-implementor/spec/inputs.md
@@ -1,0 +1,96 @@
+# re-frame2-implementor — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary input — the `spec/` corpus
+
+Path: `spec/` in the re-frame2 repo.
+
+**The spec is the contract.** Every claim the skill makes about what an implementation must do traces to a normative claim in `spec/`. The skill's job is to **route**, **sequence**, and **operationalise** consumption of the corpus for the specific task of porting — not to duplicate it.
+
+The most load-bearing files for the skill:
+
+- **`spec/000-Vision.md`** — the load-bearing decisions framing. The host-profile matrix at §"Host-profile matrix"; the eight-language scope at §"The pattern (JS-cross-compile-language-agnostic)"; the seven required properties of the identity primitive at §"The identity primitive — required properties"; the four hard constraints + fourteen goals at §"Constraints and goals".
+- **`spec/Implementor-Checklist.md`** — the decision-ordered companion. Part 1 (which capabilities ship), Part 2 (per-capability mechanism choices), Part 3 (how to consume the conformance corpus). The skill's `reference/phase-1-decisions.md` is the workflow shape of Part 1 + Part 2; `reference/decision-record.md` is the fill-in shape for the engineer's choices against the table.
+- **`spec/001-Registration.md`** — EP 001. The registry contract. Referenced in `reference/phase-2-impl-order.md`.
+- **`spec/002-Frames.md`** — EP 002. Frames + events + effects + subs. The largest EP after 005; multiple references in `phase-2-impl-order.md`.
+- **`spec/004-Views.md`** — EP 004. The view contract.
+- **`spec/006-ReactiveSubstrate.md`** — EP 006. The adapter contract.
+- **`spec/009-Instrumentation.md`** — EP 009. Trace event stream, error contract, production elision.
+- **`spec/005-StateMachines.md`** — EP 005. Walked in Phase 2 only if D3 Q1 = yes; the spec's largest EP (~2,900 lines).
+- **`spec/conformance/README.md`** — the acceptance test. Capability tagging, the harness shape, the fixture format. The skill's `reference/conformance.md` is the operational walk of this doc.
+- **`spec/API.md`** — the consolidated signatures. Reference target in the SKILL.md done checklist.
+
+The skill cites every spec file by URL (the published docs URL: `https://day8.github.io/re-frame2/spec/<file>/`). Cross-references to specific sections use anchor links.
+
+## 2. Secondary input — the CLJS reference implementation
+
+Path: `implementation/` in the re-frame2 repo.
+
+**The reference is a worked example, not normative.** The skill's `reference/reference-impl-tour.md` is the dedicated tour. The tour describes what the reference did; it does not prescribe what other implementations must do. Engineers reading the tour are told explicitly (top and bottom of the leaf) that the spec wins on any disagreement.
+
+The most load-bearing directories for the tour:
+
+- **`implementation/core/src/re_frame/`** — public API + the heart of EP 001 / 002 / 009.
+- **`implementation/adapters/{reagent,plain-atom}/`** — EP 006's two adapter realisations.
+- **`implementation/{epoch,flows,http,machines,routing,schemas,ssr}/`** — the per-feature artefacts (per the pay-as-you-go split).
+
+The tour names what's in each directory, calls out CLJS-specific choices, and names pattern-required behaviour. The tour does not transcribe source.
+
+## 3. Tertiary inputs
+
+These shape the skill's discipline but aren't quoted directly.
+
+- **`ai/findings/re-frame2-skill-design-v2.md`** — the design rationale for the `re-frame2` skill family. This skill inherits the four pillars, the leaf-loading shape, and the Q14 lock (NO verification module).
+- **`skills/re-frame-migration/`** — the closest structural analogue. Workflow skill; has `spec/` folder; targets a specific task (migration vs implementation); kickoff-prompt pattern. Voice / density / load-bearing-rules style mirrored.
+- **`skills/re-frame2/SKILL.md`** + reference leaves — the canonical example of the authoring pattern. Voice, structure, "cardinal rules" framing all mirror this skill.
+- **`skills/re-frame2-setup/`** — distribution-metadata triad (`LICENSE`, `package.json`, `.claude-plugin/plugin.json`) and README shape.
+- **`SKILL-REDIRECT.md`** (repo root) — the canonical pointer table; this skill's audience is "Section 2 — Implementing the spec".
+- **`docs/the-mayor-method.md`** — methodology context for Mike's AI-first framing. Influences the "the engineer runs their builds; the skill teaches them the workflow" framing (Q14 lock).
+
+## 4. Anthropic skill conventions
+
+Pulled from `https://code.claude.com/docs/en/skills` at authoring time.
+
+The skill conforms to:
+
+- `name` field ≤ 64 chars; lowercase + numbers + hyphens (`re-frame2-implementor`).
+- `description` field is the discovery surface; "pushy" with explicit "use this skill whenever the user mentions" language; lists the triggering phrases ("porting re-frame2", "implementing re-frame2 in <language>", "writing a re-frame2 runtime", "conformance corpus", "implementor checklist").
+- SKILL.md body well under 500 lines.
+- Reference files one level deep from SKILL.md; no SKILL → A → B chains.
+- Forward slashes in paths.
+- Avoid time-sensitive content (deferred to spec-URL lookups rather than hardcoded VERSIONs).
+- Per-tool `spec/` folder (per Mike's standing rule).
+
+## 5. What the skill does NOT consume
+
+These are deliberately out of the loop:
+
+- **`spec/MIGRATION.md`** — that's the migration skill's input. This skill is about new implementations, not v1→v2 migration.
+- **`spec/Construction-Prompts.md`** — that's the authoring-side `re-frame2` skill's input (the per-kind AI templates for application authors writing new code).
+- **`spec/Pattern-*.md`** — application patterns; not relevant to implementors.
+- **`docs/guide/**`** — narrative guide for application authors.
+- **`examples/reagent/**`** — worked example apps; not relevant to implementors.
+- **`implementation/**` source line-by-line** — `reference-impl-tour.md` names directories and surfaces choices, but does not transcribe source.
+
+## 6. Update procedure
+
+When `spec/` changes, the skill needs targeted updates. The audit shape:
+
+1. **New EP added** to `spec/` → add a section to `reference/phase-2-impl-order.md`; if optional, add a row to D3 in `reference/decision-record.md` template and `reference/phase-1-decisions.md`'s D3 block.
+2. **EP renamed / renumbered** → update every spec URL referenced in the leaves.
+3. **`spec/Implementor-Checklist.md` decision added** → add a sub-decision block to `reference/phase-1-decisions.md` and a template field to `reference/decision-record.md`.
+4. **New capability tag** added to `spec/conformance/README.md` → add a row to D7 in `reference/decision-record.md`.
+5. **CLJS reference implementation reorganises** → update `reference/reference-impl-tour.md`'s "Layout" tree and per-EP sections.
+6. **Anthropic skill conventions change materially** → reauthor SKILL.md against the new conventions.
+
+The skill's `phase-1-decisions.md` is the integration point for the Implementor-Checklist; periodic audits grep both files for drift.
+
+## 7. When to re-author from scratch
+
+- **Spec corpus reorganises significantly** (more than ~3 file renames or section restructures) → the existing leaves' URL references are stale; rebuilding from the new spec layout is easier than patching.
+- **The Q14 lock changes** → the design itself changes; this `spec/` folder needs updating first, then the skill.
+- **A second worked reference implementation lands** → the `reference-impl-tour.md` leaf needs restructuring (each impl gets its own tour section, or the tour becomes a per-impl directory).
+- **The conformance corpus's fixture format changes** → `reference/conformance.md` needs a rewrite.
+
+Otherwise, edit the existing leaves directly; reauthoring from scratch is for major-version updates.

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -18,6 +18,7 @@ Load when the task is **writing or editing re-frame2 application source** (`.clj
 | Inspect, debug, or modify a running re-frame2 app | `skills/re-frame-pair2/` |
 | Set up a new re-frame2 project from scratch (deps.edn, shadow-cljs, boot scaffolding) | `skills/re-frame2-setup/` |
 | Migrate an existing re-frame v1 app to v2 | `skills/re-frame-migration/` |
+| Build a NEW re-frame2 implementation in a different host language or substrate | `skills/re-frame2-implementor/` |
 | Understand how the registrar / machine compiler / reactive substrate is implemented | `SKILL-REDIRECT.md` → EP design entries |
 | Read the full API reference, EP rationale, or pattern spec | `SKILL-REDIRECT.md` |
 
@@ -172,4 +173,4 @@ The user runs the test suite, the compiler, and the app. This skill does not run
 
 ---
 
-*This skill targets re-frame2 (the v2 line). For the v1 line, see [re-frame](https://github.com/day8/re-frame). For live-app inspection, see `skills/re-frame-pair2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For migrating a v1 codebase to v2, see `skills/re-frame-migration/`. All deep-dive links route through `SKILL-REDIRECT.md` at the repo root.*
+*This skill targets re-frame2 (the v2 line). For the v1 line, see [re-frame](https://github.com/day8/re-frame). For live-app inspection, see `skills/re-frame-pair2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For migrating a v1 codebase to v2, see `skills/re-frame-migration/`. For building a new re-frame2 implementation in a different host language or substrate, see `skills/re-frame2-implementor/`. All deep-dive links route through `SKILL-REDIRECT.md` at the repo root.*


### PR DESCRIPTION
## Summary

New skill `skills/re-frame2-implementor/` for engineers building a **new re-frame2 implementation** in a different host language or substrate — companion to the three application-side skills (`re-frame2`, `re-frame2-setup`, `re-frame-migration`). Closes rf2-5xje.

## Skill structure

```
skills/re-frame2-implementor/
├── SKILL.md                       (router; 185 LoC)
├── README.md                      (71 LoC)
├── LICENSE                        (MIT, 21 LoC)
├── package.json                   (42 LoC)
├── .claude-plugin/plugin.json     (31 LoC)
├── reference/
│   ├── kickoff-prompt.md          (60 LoC)
│   ├── phase-1-decisions.md       (211 LoC)
│   ├── decision-record.md         (161 LoC)
│   ├── phase-2-impl-order.md      (214 LoC)
│   ├── reference-impl-tour.md     (151 LoC)
│   ├── conformance.md             (136 LoC)
│   └── output-format.md           (137 LoC)
└── spec/
    ├── design.md                  (188 LoC)
    ├── inputs.md                  (96 LoC)
    └── authoring-prompt.md        (93 LoC)
```

**Totals:** 1,797 LoC across 15 files. SKILL.md at 185 LoC (under the 500 Anthropic ceiling). Every leaf ≤250 LoC.

## Design locks applied

From `spec/design.md` in the skill:

- **L1** — `spec/` is the contract; `implementation/` is one worked example, never normative.
- **L2** — Two-phase workflow. Phase 1 locks decisions in writing before Phase 2 code is written. Sequential, not collapsible.
- **L3 (= Q14)** — **NO verification module.** No `reference/verify.md`; no "verify before claiming done" hard rule. The engineer runs their builds; the skill walks the workflow. Consistent with `re-frame2` and `re-frame-migration`.
- **L4** — Substrate-agnostic phrasing throughout. Identity primitive, render-tree, reactive container — generic. CLJS framings only in `reference-impl-tour.md`, and that leaf is explicit-descriptive (top and bottom).
- **L5** — Conformance corpus is the acceptance test. The objective measure of "is this re-frame2?" — covered in `reference/conformance.md`.
- **L6** — Spec gaps file `bd create` beads, never silent extrapolation from the reference.
- **L7** — No bead-id references in user-facing skill content (SKILL.md / README / `reference/`). Bead workflow-tracking lives in `spec/`.
- **L8** — Findings stay local; not committed.
- **L9** — No AI attribution in commits or PR.
- **L10** — Cross-link bidirectionally with the existing skills + docs nav.

## Phase 1 / Phase 2 outline

**Phase 1 — Lock the decisions** (`reference/phase-1-decisions.md`). Seven decision blocks: D1 target host language, D2 substrate / view layer, D3 scope (which optional EPs), D4 foundation choices (identity primitive, persistent data structures, reactive substrate, effect-handling, concurrency model, hot-reload), D5 schema mechanism, D6 integration story, D7 conformance capability tag set. Captured in a `DECISIONS.md` at the port's repo root via the template in `reference/decision-record.md`.

**Phase 2 — Walk the spec corpus** (`reference/phase-2-impl-order.md`). EP-by-EP in dependency order: 001 Registration → 002 Frames + events + effects + subs → 006 Reactive substrate → 004 Views → 009 Instrumentation. **Acceptance gate 1**: run `:core/*` conformance fixtures. Then optional EPs per the Phase 1 claim, suggested order: 010 → 008 → 005 → 012 → 011 → 013 → 014 → 007. **Acceptance gate 2**: full claimed-capability conformance pass.

The conformance corpus at `spec/conformance/` is framed throughout as the **acceptance test** — `passed / claimed-applicable`. Diagnosis algorithm for spec gap vs implementation bug lives in `reference/conformance.md`.

## Cross-link updates

- `skills/re-frame2/SKILL.md` — implementor-skill pointer added to the "When NOT to use this skill" table and the footer.
- `skills/re-frame-migration/SKILL.md` — same.
- `docs/skills/re-frame2-implementor.md` — new sub-page in the Skills nav (brief-pitch pattern matching the other skill sub-pages).
- `docs/skills/index.md` — updated to "six skills" with the new entry in the skill table, the decision flow, and the source-tree table.
- `mkdocs.yml` — new entry in the Skills nav.

## Answers to the three open questions in the bead

**OQ1 — Decision-tree vs prose-prompt for Phase 1.** Prose walkthrough. `phase-1-decisions.md` is structured (one section per decision block — question / what's at stake / options / how to choose / where the spec speaks), but the decision is made in prose, not by walking a binary tree. Yes/no trees over-simplify (D4.1 identity primitive has 8+ options per host, D3 scope has 7 independent questions). The structure is predictable; the answer respects the engineer's expertise.

**OQ2 — Granularity of Phase 2.** One EP per session, with explicit acceptance gates between groups. `phase-2-impl-order.md` is one section per EP. Between the foundation EPs (001 / 002 / 006 / 004 / 009) and the optional EPs sits acceptance gate 1; between full claimed implementation and v1 ship sits acceptance gate 2. Per-EP sessions are tractable and per-EP commits are reviewable; clustering would lose the wrap-up checkpoint where the engineer catches Phase 1 decisions that need revision.

**OQ3 — How to annotate CLJS-specific framings.** A dedicated descriptive tour leaf (`reference/reference-impl-tour.md`) with explicit framing. The tour is the only leaf that walks `implementation/`; it's explicit at the top and bottom that the tour is descriptive, not normative. Every "the reference did X" is paired with a "what's CLJS-specific" callout and a "what's pattern-required" framing. Separating descriptive (tour) from normative (everything else) keeps every other leaf in normative voice — annotating individual references with disclaimer text would clutter every leaf and bury the workflow signal.

## Open follow-on questions parked for Mike

Surfaced in `spec/design.md` §10:

- **OQ4** — Skill name compliance. `re-frame2-implementor` is a noun phrase, not the "consider gerund" Anthropic best-practice. Recommendation: keep — matches the project-name pattern (`re-frame2`, `re-frame2-setup`, `re-frame-migration`). Mike's call.
- **OQ5** — Stale-detect URL references against `spec/` changes. Deferred to v0.2 — a periodic audit bead similar to the migration skill's relationship to `spec/MIGRATION.md`.

## Test plan

- [ ] Render `docs/skills/re-frame2-implementor.md` via `mkdocs build` — verify it appears in the Skills nav and cross-references resolve.
- [ ] Open `skills/re-frame2-implementor/SKILL.md` in a fresh Claude Code session; verify the description triggers on "I'm porting re-frame2 to TypeScript" / "implementing re-frame2 in Rust" / "writing a re-frame2 runtime".
- [ ] Walk a dummy Phase 1 session (e.g. against a Squint port hypothetical) — verify the decision walkthrough produces a fillable `DECISIONS.md`.
- [ ] Spot-check the spec-URL references in the leaves resolve to live anchors on `day8.github.io/re-frame2/spec/`.