### PR TITLE
fix(story-shell): a11y — landmarks + scrollable keyboard access (rf2-xc65)

### DIFF
--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -296,7 +296,15 @@
        (let [shell      @state/shell-state-atom
              variant-id (:selected-variant shell)
              _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
-         [:div {:style (:wrap styles)}
+         ;; Per rf2-xc65: the canvas wrap is the scrollable container
+         ;; for variant content; `tab-index "0"` makes it keyboard-
+         ;; focusable so axe-core's `scrollable-region-focusable` rule
+         ;; passes. The `<section>` element + aria-label give it a
+         ;; landmark name (it's nested inside the shell's <main> so
+         ;; landmark structure remains: main > section).
+         [:section {:style      (:wrap styles)
+                    :aria-label "Variant canvas"
+                    :tab-index  "0"}
           (if variant-id
             [canvas-inner variant-id]
             [:div {:style (:empty styles)}

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -225,12 +225,20 @@
 
   Stage 6 (rf2-zhwd) adds `panels/render-panels-at-placement` so any
   `reg-story-panel` registration with `:placement :right` appears here.
-  The built-in v1.0 panels (a11y, layout-debug toggles) ride this path."
+  The built-in v1.0 panels (a11y, layout-debug toggles) ride this path.
+
+  Renders as an `<aside>` landmark (per rf2-xc65) so screen readers can
+  jump straight to the inspectors and so axe-core's
+  `region`/`landmark-one-main` rules pass. `tabindex=\"0\"` makes the
+  scrollable container reachable for keyboard users."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
         vis        (:panel-visibility shell)]
-    [:div {:style (:right styles)}
+    [:aside {:style    (:right styles)
+             :role     "complementary"
+             :aria-label "Inspectors"
+             :tab-index "0"}
      (when (:controls vis)
        [controls/panel variant-id])
      (when (and (:scrubber vis) variant-id)
@@ -245,13 +253,18 @@
   "The main content pane — workspace if one is selected, otherwise the
   variant canvas. Stage 6 (rf2-zhwd) appends any registered
   `:bottom`-placement story panels (e.g. the 10x epoch panel stub)
-  below the canvas."
+  below the canvas.
+
+  Renders as a `<main>` landmark (per rf2-xc65) so the rendered variant
+  has a containing landmark and axe-core's `region` /
+  `landmark-one-main` rules pass."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
         ws-id      (:selected-workspace shell)
         vis        (:panel-visibility shell)]
-    [:div {:style (:main styles)}
+    [:main {:style (:main styles)
+            :aria-label "Story canvas"}
      (cond
        ws-id    [workspace/workspace-view ws-id]
        variant-id [canvas/canvas]
@@ -266,7 +279,12 @@
 
 (defn shell
   "The top-level shell component. Composes the sidebar, main pane, and
-  right panel into a three-pane layout."
+  right panel into a three-pane layout.
+
+  Per rf2-xc65 each pane is rendered as a semantic HTML5 landmark
+  (`<nav>` sidebar, `<main>` canvas, `<aside>` inspectors) so axe-core's
+  `region` / `landmark-*` rules pass and screen-reader users can
+  navigate the shell by landmark."
   []
   (r/create-class
     {:display-name "rf-story-shell"

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -136,7 +136,11 @@
 
 (defn sidebar
   "Top-level sidebar component. Reads the registry snapshot + shell
-  state, builds the filtered tree, and renders."
+  state, builds the filtered tree, and renders.
+
+  Per rf2-xc65 the sidebar renders as a `<nav>` landmark with
+  `tabindex=\"0\"` so axe-core's `region` rule passes and keyboard
+  users can focus the scrollable tree."
   []
   (let [shell        @state/shell-state-atom
         registry     (state/registry-snapshot)
@@ -146,7 +150,9 @@
         visible      (state/filter-variants (:variants registry) tag-filter)
         grouped      (state/group-variants-by-story visible)
         workspaces   (:workspaces registry)]
-    [:div {:style (:wrap styles)}
+    [:nav {:style      (:wrap styles)
+           :aria-label "Stories and workspaces"
+           :tab-index  "0"}
      [:div {:style (:header styles)} "Stories"]
      [tag-filter-row (:variants registry) tag-filter]
      (if (empty? grouped)

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -244,7 +244,14 @@
     (fn [variant-id]
       (let [events   @buffer
             cascades (group-cascades events)]
-        [:div {:style (:panel styles)}
+        ;; Per rf2-xc65: the panel wrap is scrollable (`overflow auto`
+        ;; + `max-height 240px`). `tab-index "0"` + an aria-label make
+        ;; it keyboard-focusable and named so axe-core's
+        ;; `scrollable-region-focusable` rule passes.
+        [:div {:style      (:panel styles)
+               :role       "region"
+               :aria-label "Trace cascades"
+               :tab-index  "0"}
          [:div {:style (:title styles)}
           "Trace " (when variant-id (str (pr-str variant-id))) " — "
           (count events) " events, " (count cascades) " cascades"]

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -319,13 +319,21 @@
      (let [body (registrar/handler-meta :workspace workspace-id)]
        (cond
          (nil? body)
-         [:div {:style (:wrap styles)}
+         ;; Per rf2-xc65: workspace wrap is a scrollable container —
+         ;; `tab-index "0"` + aria-label make it focusable and named so
+         ;; axe-core's scrollable-region-focusable rule passes. The
+         ;; `<section>` lives inside the shell's <main> landmark.
+         [:section {:style      (:wrap styles)
+                    :aria-label "Workspace"
+                    :tab-index  "0"}
           [:div {:style (:empty styles)}
            "workspace " (pr-str workspace-id) " is not registered"]]
 
          :else
          (let [cells (resolve-layout workspace-id body)]
-           [:div {:style (:wrap styles)}
+           [:section {:style      (:wrap styles)
+                      :aria-label (str "Workspace " (pr-str workspace-id))
+                      :tab-index  "0"}
             [:div {:style (:title styles)}
              (str (pr-str workspace-id)
                   " (" (name (:layout body)) ")")]

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -214,8 +214,9 @@
       ;; component itself shows up as a vector beginning with the cell
       ;; component fn. We at least confirm the workspace produced
       ;; non-empty grid contents and the cell fn appears as a child.
+      ;; The wrap is a `<section>` landmark per rf2-xc65 (a11y).
       (is (vector? tree))
-      (is (= :div (first tree))))))
+      (is (= :section (first tree))))))
 
 (deftest workspace-view-empty-for-missing-workspace
   (testing "workspace-view renders an empty / not-registered notice for


### PR DESCRIPTION
## Summary

axe-core flagged the Story shell on two rule families when run from the A11Y panel in `counter_with_stories`:

- **region / landmark-one-main** — every pane was a generic `<div>`. The shell now wraps each pane in a semantic landmark:
  - sidebar → `<nav aria-label="Stories and workspaces">`
  - main pane → `<main aria-label="Story canvas">`
  - right inspectors → `<aside role="complementary" aria-label="Inspectors">`
  - canvas / workspace wraps inside `<main>` become `<section>` with aria-labels.
- **scrollable-region-focusable** — the canvas wrap, workspace wrap, trace-panel wrap, sidebar wrap, and right-aside all set `overflow:auto` but were not keyboard-focusable. Each scrollable container now carries `tabindex="0"`.

## Before / after axe-core (shell rules)

| rule | before | after |
| --- | --- | --- |
| `region` (every pane outside a landmark) | 4 nodes | **0** |
| `landmark-one-main` (no `<main>`) | 1 node | **0** |
| `scrollable-region-focusable` (overflow:auto without tabindex) | 1 node | **0** |

Remaining shell-attributable findings (~22 `color-contrast` nodes on `#888`-on-`#252526` muted-label tokens) are filed as **rf2-2uwv** for a follow-up chrome-styling pass — out of scope per the bead's direction-set. User-content findings (input labels on the counter view) belong to the counter-side a11y bead.

## Files touched

- `tools/story/src/re_frame/story/ui/shell.cljs` — root pane components emit landmarks.
- `tools/story/src/re_frame/story/ui/sidebar.cljs` — `<nav>` + tabindex.
- `tools/story/src/re_frame/story/ui/canvas.cljs` — `<section>` wrap + tabindex.
- `tools/story/src/re_frame/story/ui/workspace.cljc` — `<section>` wrap + tabindex.
- `tools/story/src/re_frame/story/ui/trace.cljs` — tabindex on the inner scrollable.
- `tools/story/test/re_frame/story_ui_cljs_test.cljs` — workspace-view root-element assertion updated to `:section`.

## Test plan

- [x] `npm run test:cljs` — 571 tests / 1353 assertions / 0 failures.
- [x] `npm run test:examples` — 25 / 25 PASS, including `counter-with-stories` (shell mounts, variant selection, workspace cells render).
- [x] axe-core 4.10.0 scan of `counter_with_stories/#/stories` with a variant selected: `region`, `landmark-one-main`, `landmark-no-duplicate-main`, `landmark-unique`, and `scrollable-region-focusable` rules now report zero violations on shell elements.
- [x] axe-core scan of the workspace pane (`:Workspace.counter/auto-grid` selected): same five rules clean.