### PR TITLE
docs(spec): acknowledge Story's side-table; preserve closed-kinds discipline in spec/001 + spec/007 (rf2-7ho2)

### DIFF
--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -100,6 +100,8 @@ The registrar is a `(kind, id) → metadata` map. The `kind` keyword identifies 
 
 > Machine guards and actions are **NOT** a registry kind — they are **machine-scoped**, declared in each machine's `:guards` / `:actions` maps inside the `create-machine-handler` spec. See [005 §Registration](005-StateMachines.md#registration--the-machine-is-the-event-handler).
 
+> **Downstream tools needing kind-shaped registration own their own side-tables.** The framework registrar's `kinds` set stays closed; tools like Story (`tools/story/`) maintain their own internal registries (e.g. `tools.story.registry/*`) and expose query surfaces via bridge fns. The closed-kinds discipline keeps the framework boundary stable; per-tool side-tables stay scoped to the tool that owns them.
+
 ## The handler function
 
 A named function is preferred.

--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -442,9 +442,9 @@ The stories library's tool surface is **extensible by registering panels**. A pa
    :render    :a11y/inspector-view})        ;; id of a reg-view
 ```
 
-Panels are registered against the story-tool's own registry; the tool reads `(rf/handlers :story-panel)` and lays them out. Same shape as everything else in re-frame2 — registry + metadata.
+Panels are registered against the story-tool's own registry; the tool reads `(story/handlers :story-panel)` and lays them out. Same shape as everything else in re-frame2 — registry + metadata.
 
-The framework registrar already supports new kinds via the existing reg- machinery (per [001-Registration.md](001-Registration.md)); panels do not require a new framework primitive.
+Story maintains its kind-shaped registrations in a tool-owned side-table at `tools.story.registry/*`. This is internal to the `tools/story/` artefact and stays out of production bundles. The bridge fn `story/handlers` exposes the §Public-query-surfaces parity (e.g. `(story/handlers :story)` enumerates the side-table). The framework registrar's closed-kinds discipline ([001-Registration.md](001-Registration.md)) is preserved — Story does not register with `re-frame.registrar`.
 
 ## What the framework supplies vs. what the library adds
 


### PR DESCRIPTION
## Summary

spec/007-Stories.md ~line 447 promised that "the framework registrar already supports new kinds via the existing `reg-` machinery". The framework registrar's `kinds` set is in fact **closed** (see `spec/001-Registration.md` §Registry model + the implementation's `re_frame/registrar.cljc`). Stage 2 (rf2-32dk) reconciled the tension by giving Story a tool-owned side-table at `tools.story.registry/*` with a `story/handlers` bridge fn for spec/007 §Public-query-surfaces parity. This PR updates the spec wording to match what shipped.

## Edits

### spec/007-Stories.md §Story-tool extension hook (line 447)

Replaced:

> The framework registrar already supports new kinds via the existing reg- machinery (per 001-Registration.md); panels do not require a new framework primitive.

With:

> Story maintains its kind-shaped registrations in a tool-owned side-table at `tools.story.registry/*`. This is internal to the `tools/story/` artefact and stays out of production bundles. The bridge fn `story/handlers` exposes the §Public-query-surfaces parity (e.g. `(story/handlers :story)` enumerates the side-table). The framework registrar's closed-kinds discipline ([001-Registration.md](001-Registration.md)) is preserved — Story does not register with `re-frame.registrar`.

Plus a tiny consistency tweak: switched the example one paragraph earlier from `(rf/handlers :story-panel)` to `(story/handlers :story-panel)`, so the example uses the bridge fn the new paragraph names.

### spec/001-Registration.md §Registry model

Added a clarifying paragraph immediately after the existing "Machine guards and actions are NOT a registry kind" callout:

> **Downstream tools needing kind-shaped registration own their own side-tables.** The framework registrar's `kinds` set stays closed; tools like Story (`tools/story/`) maintain their own internal registries (e.g. `tools.story.registry/*`) and expose query surfaces via bridge fns. The closed-kinds discipline keeps the framework boundary stable; per-tool side-tables stay scoped to the tool that owns them.

## Sweep results

`grep -n "registrar.*kinds\|new kind\|new registry kind"` across `spec/`:

- spec/011-SSR.md adds `:head` and `:error-projector` — both already in the closed kind-set in spec/001 §Registry model (lines 95-96). Consistent.
- spec/005-StateMachines.md line 2425 explicitly avoids adding a new kind ("derived views over the existing event registry, not a new registry kind"). Consistent.
- spec/Conventions.md mentions registration-related namespaces and reserved ids; no contradicting claim about open kinds. Consistent.
- spec/001 line 185 (the v1-reference blockquote in §Hot-reload semantics) says "machine actions/guards are new registry kinds" — this contradicts §Registry model + line 101's explicit "NOT a registry kind" callout. Out of scope for this PR; filed as `bd rf2-f9h3`.

## Implementation alignment

`tools/story/` matches the new wording:

- Side-table lives in `tools/story/src/re_frame/story/registrar.cljc` (the ns docstring already cites bd rf2-7ho2 and the closed-kinds rationale).
- `tools/story/src/re_frame/story.cljc` exposes `story/handlers`, `story/handler-meta`, `story/ids` as the bridge to the side-table.
- No registrations cross into `re-frame.registrar` for `:story`, `:variant`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`.

## Constraints honoured

- No impl, no tests — spec wording only.
- No bead-id citations in the *new* spec prose.
- Pre-existing `mkdocs build --strict` warnings unchanged by this PR (the `spec/` tree isn't part of the docs site).