### PR TITLE
feat(trace): :rf.trace/trigger-handler — error events carry triggering-handler source-coord (rf2-3nn8)

### DIFF
--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -29,6 +29,10 @@ re-frame2's stance: that information should never have left. If the runtime know
  :time      1700000000000                     ;; emit time (host clock)
  :source    :ui                               ;; trigger origin (:ui :timer :http ...)
  :recovery  :no-recovery                      ;; what the runtime did after
+ :rf.trace/trigger-handler                    ;; (optional) the in-scope handler
+ {:kind         :event
+  :id           :cart/add-item
+  :source-coord {:ns 'myapp.cart :file "src/myapp/cart.cljs" :line 142 :column 3}}
  :tags      {:category    :rf.error/handler-exception
              :failing-id  :cart/add-item
              :reason      "Event handler `:cart/add-item` threw: ..."
@@ -44,6 +48,8 @@ Three fields do the load-bearing work:
 - **`:op-type`** is the universal severity — `:error` or `:warning`. A consumer that wants "show me everything that failed" filters on `:op-type :error`.
 - **`:operation`** is the category — namespaced (`:rf.error/...`, `:rf.warning/...`, `:rf.fx/...`, `:rf.ssr/...`, `:rf.epoch/...`). A consumer that wants "show me only handler exceptions" filters on `:operation :rf.error/handler-exception`.
 - **`:recovery`** is what re-frame2 did *after* the error — `:no-recovery`, `:replaced-with-default`, `:logged-and-skipped`, `:warned-and-replaced`, `:skipped`, `:retried`, `:ignored`. (See [§Recovery semantics](#recovery-semantics) below.)
+
+The optional **`:rf.trace/trigger-handler`** slot names the handler whose execution produced the error and carries its registration-site source-coord. Tools (10x, pair, IDE jump-to-source) consume the coord to render click-to-jump links straight to the offending handler. Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent on outermost-dispatch errors with no handler resolved (e.g. `:rf.error/no-such-handler`).
 
 Everything else rides under `:tags`, with category-specific keys. The full schema lives in [Spec-Schemas](../../spec/Spec-Schemas.md) under `:rf/trace-event`; the per-category `:tags` shapes are pinned in [Spec-Schemas §Per-category `:tags` schemas](../../spec/Spec-Schemas.md#per-category-tags-schemas).
 

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -67,15 +67,24 @@
   fn returns, if the cofx's metadata carries a :spec, validate the
   injected value. On failure, mark the context with
   :rf/skip-handler? so subsequent handler interceptors short-circuit
-  (recovery: :no-recovery; downstream queue continues)."
+  (recovery: :no-recovery; downstream queue continues).
+
+  Per rf2-3nn8: while the cofx fn body runs, the cofx's own
+  source-coord is the in-scope trigger-handler — errors emitted from
+  inside the cofx point at the cofx definition, not the enclosing
+  event handler. The miss path (`:rf.error/no-such-cofx`) inherits
+  the enclosing event handler's binding (set by the router) — the
+  cofx that doesn't exist has no coord to point at."
   ([cofx-id]
    (interceptor/->interceptor
      :id (keyword (str "cofx-" (name cofx-id)))
      :before
      (fn [ctx]
        (if-let [meta (registrar/lookup :cofx cofx-id)]
-         (-> ((:handler-fn meta) ctx)
-             (maybe-validate-cofx! cofx-id meta))
+         (binding [trace/*current-trigger-handler*
+                   (trace/trigger-handler-from-meta :cofx cofx-id meta)]
+           (-> ((:handler-fn meta) ctx)
+               (maybe-validate-cofx! cofx-id meta)))
          (let [event (interceptor/get-coeffect ctx :event)]
            (trace/emit-error! :rf.error/no-such-cofx
                               {:cofx-id  cofx-id
@@ -88,8 +97,10 @@
      :before
      (fn [ctx]
        (if-let [meta (registrar/lookup :cofx cofx-id)]
-         (-> ((:handler-fn meta) ctx value)
-             (maybe-validate-cofx! cofx-id meta))
+         (binding [trace/*current-trigger-handler*
+                   (trace/trigger-handler-from-meta :cofx cofx-id meta)]
+           (-> ((:handler-fn meta) ctx value)
+               (maybe-validate-cofx! cofx-id meta)))
          (let [event (interceptor/get-coeffect ctx :event)]
            (trace/emit-error! :rf.error/no-such-cofx
                               {:cofx-id    cofx-id

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -168,23 +168,31 @@
     ;; Default: user-registered fx.
     (if-let [meta (registrar/lookup :fx fx-id)]
       (if (fx-runs-on-platform? meta active-platform)
-        (let [ok? (try
-                    ((:handler-fn meta) (cond-> {:frame frame-id}
-                                          origin-event (assoc :event origin-event))
-                                        args)
-                    true
-                    (catch #?(:clj Throwable :cljs :default) e
-                      (let [msg (#?(:clj .getMessage :cljs .-message) e)]
-                        (trace/emit-error! :rf.error/fx-handler-exception
-                                           {:failing-id        fx-id
-                                            :fx-id             fx-id
-                                            :fx-args           args
-                                            :frame             frame-id
-                                            :exception         e
-                                            :exception-message msg
-                                            :reason            (str "Effect handler `" fx-id "` threw: " msg ".")
-                                            :recovery          :no-recovery}))
-                      false))]
+        (let [;; Per rf2-3nn8: bind `*current-trigger-handler*` for the
+              ;; duration of the fx handler's invocation (including the
+              ;; exception path) so error traces emitted from inside
+              ;; the fx body — `:rf.error/fx-handler-exception` here and
+              ;; anything the body itself surfaces — carry the fx
+              ;; handler's source-coord.
+              ok? (binding [trace/*current-trigger-handler*
+                            (trace/trigger-handler-from-meta :fx fx-id meta)]
+                    (try
+                      ((:handler-fn meta) (cond-> {:frame frame-id}
+                                            origin-event (assoc :event origin-event))
+                                          args)
+                      true
+                      (catch #?(:clj Throwable :cljs :default) e
+                        (let [msg (#?(:clj .getMessage :cljs .-message) e)]
+                          (trace/emit-error! :rf.error/fx-handler-exception
+                                             {:failing-id        fx-id
+                                              :fx-id             fx-id
+                                              :fx-args           args
+                                              :frame             frame-id
+                                              :exception         e
+                                              :exception-message msg
+                                              :reason            (str "Effect handler `" fx-id "` threw: " msg ".")
+                                              :recovery          :no-recovery}))
+                        false)))]
           (when ok?
             (emit-handled! fx-id args frame-id)))
         (trace/emit! :warning :rf.fx/skipped-on-platform

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -226,43 +226,53 @@
                               :recovery :replaced-with-default})
 
           :else
-          (let [_            (trace/emit! :event :event
-                                          {:event-id event-id
-                                           :event    event
-                                           :frame    frame
-                                           :source   (:source envelope)
-                                           :trace-id (:trace-id envelope)
-                                           :phase    :run-start})
-                event-ok?    (validate-event! event-id event handler-meta)
-                {:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
-                full-chain   (vec (concat extra-interceptors (:interceptors handler-meta)))
-                initial-ctx  (assemble-initial-ctx envelope frame frame-record fx-overrides)
-                ;; Per Spec 010 §Per-step recovery step 1: when event-payload
-                ;; validation failed the handler is not invoked; the
-                ;; downstream queue continues.
-                ;;
-                ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
-                ;; bracket the handler invocation in performance marks so
-                ;; prod builds with the perf flag enabled produce a
-                ;; `rf:event:<event-id>` measure entry. Default-off; under
-                ;; `:advanced` + `re-frame.performance/enabled?=false` the
-                ;; bracket DCEs and the call collapses to the chain run.
-                final-ctx    (if event-ok?
-                               (performance/mark-and-measure :event event-id
-                                 (interceptor/execute-chain full-chain initial-ctx))
-                               initial-ctx)
-                effects      (:effects final-ctx)
-                error        (:rf/interceptor-error final-ctx)]
-            (when error
-              (emit-handler-exception! error event-id event frame))
-            (commit-db-effect! effects event-id event frame)
-            (run-flows! frame event)
-            (run-fx-effects! effects frame frame-record fx-overrides event)
-            (trace/emit! :event :event
-                         {:event-id event-id
-                          :event    event
-                          :frame    frame
-                          :phase    :run-end})))))))
+          ;; Per rf2-3nn8: bind `*current-trigger-handler*` for the
+          ;; duration of this event's interceptor chain + post-chain
+          ;; phases (db commit, flows, fx walk) so every error trace
+          ;; emitted within the scope carries the triggering handler's
+          ;; source-coord. The trace/trigger-handler-from-meta helper
+          ;; returns nil when no source-coord was stamped (programmatic
+          ;; registration / REPL eval); the binding is then nil and
+          ;; the field is omitted from any emitted error event.
+          (binding [trace/*current-trigger-handler*
+                    (trace/trigger-handler-from-meta :event event-id handler-meta)]
+            (let [_            (trace/emit! :event :event
+                                            {:event-id event-id
+                                             :event    event
+                                             :frame    frame
+                                             :source   (:source envelope)
+                                             :trace-id (:trace-id envelope)
+                                             :phase    :run-start})
+                  event-ok?    (validate-event! event-id event handler-meta)
+                  {:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
+                  full-chain   (vec (concat extra-interceptors (:interceptors handler-meta)))
+                  initial-ctx  (assemble-initial-ctx envelope frame frame-record fx-overrides)
+                  ;; Per Spec 010 §Per-step recovery step 1: when event-payload
+                  ;; validation failed the handler is not invoked; the
+                  ;; downstream queue continues.
+                  ;;
+                  ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
+                  ;; bracket the handler invocation in performance marks so
+                  ;; prod builds with the perf flag enabled produce a
+                  ;; `rf:event:<event-id>` measure entry. Default-off; under
+                  ;; `:advanced` + `re-frame.performance/enabled?=false` the
+                  ;; bracket DCEs and the call collapses to the chain run.
+                  final-ctx    (if event-ok?
+                                 (performance/mark-and-measure :event event-id
+                                   (interceptor/execute-chain full-chain initial-ctx))
+                                 initial-ctx)
+                  effects      (:effects final-ctx)
+                  error        (:rf/interceptor-error final-ctx)]
+              (when error
+                (emit-handler-exception! error event-id event frame))
+              (commit-db-effect! effects event-id event frame)
+              (run-flows! frame event)
+              (run-fx-effects! effects frame frame-record fx-overrides event)
+              (trace/emit! :event :event
+                           {:event-id event-id
+                            :event    event
+                            :frame    frame
+                            :phase    :run-end}))))))))
 
 (defn- process-event!
   "Wrap process-event* in two dynamic bindings:

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -189,30 +189,37 @@
                {:sub-id  query-id
                 :query-v query-v
                 :frame   frame-id})
-  (try
-    (let [computed (performance/mark-and-measure :sub query-id
-                    (if (empty? input-signals)
-                      (body-fn (first in-vals) query-v)
-                      ;; Layer-2+: deliver inputs as a coll if many,
-                      ;; or singleton when only one chain entry.
-                      (if (= 1 (count input-signals))
+  ;; Per rf2-3nn8: bind `*current-trigger-handler*` to the sub's own
+  ;; source-coord for the body-fn invocation + the validation step so
+  ;; any error trace fired during the recompute (the `:rf.error/sub-
+  ;; exception` catch below, schema-validation failures, transitive
+  ;; sub misses) carries the in-flight sub's coord.
+  (binding [trace/*current-trigger-handler*
+            (trace/trigger-handler-from-meta :sub query-id sub-meta)]
+    (try
+      (let [computed (performance/mark-and-measure :sub query-id
+                      (if (empty? input-signals)
                         (body-fn (first in-vals) query-v)
-                        (body-fn (vec in-vals) query-v))))]
-      (maybe-validate-sub-return! computed query-v query-id sub-meta))
-    (catch #?(:clj Throwable :cljs :default) e
-      (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
-        (trace/emit-error!
-          :rf.error/sub-exception
-          {:failing-id        query-id
-           :sub-id            query-id
-           :sub-query         query-v
-           :exception         e
-           :exception-message msg
-           :reason            (str "Subscription `" query-id
-                                   "` threw while computing: "
-                                   msg ". Returning nil.")
-           :recovery          :replaced-with-default}))
-      nil)))
+                        ;; Layer-2+: deliver inputs as a coll if many,
+                        ;; or singleton when only one chain entry.
+                        (if (= 1 (count input-signals))
+                          (body-fn (first in-vals) query-v)
+                          (body-fn (vec in-vals) query-v))))]
+        (maybe-validate-sub-return! computed query-v query-id sub-meta))
+      (catch #?(:clj Throwable :cljs :default) e
+        (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
+          (trace/emit-error!
+            :rf.error/sub-exception
+            {:failing-id        query-id
+             :sub-id            query-id
+             :sub-query         query-v
+             :exception         e
+             :exception-message msg
+             :reason            (str "Subscription `" query-id
+                                     "` threw while computing: "
+                                     msg ". Returning nil.")
+             :recovery          :replaced-with-default}))
+        nil))))
 
 (defn- make-memoised-body
   "Build the compute fn passed to `adapter/make-derived-value` — a

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -59,6 +59,77 @@
 (defn- next-event-id []
   (swap! event-counter inc))
 
+;; ---- trigger-handler (rf2-3nn8) -------------------------------------------
+;;
+;; Per Spec 009 §Error contract: every `:rf.error/*` trace event MAY carry a
+;; `:rf.trace/trigger-handler` field naming the handler whose execution
+;; produced the error. The field is OPTIONAL — it is present when an
+;; in-scope handler can be identified (event handler running, sub
+;; recomputing, fx handler dispatching, cofx injecting, view rendering)
+;; and absent when no handler is in scope (e.g. outermost-dispatch
+;; `:rf.error/no-such-handler`).
+;;
+;; The runtime carries the in-scope handler through the dynamic Var
+;; `*current-trigger-handler*`. Runtime boundaries (the router's
+;; `process-event!`, the sub recompute path, the fx dispatcher, the
+;; cofx injector, the view render wrapper) bind the Var around the
+;; user code they run; `emit-error!` reads the Var and hoists its
+;; value to the top-level `:rf.trace/trigger-handler` slot on the
+;; emitted event when bound.
+;;
+;; Shape (locked, per rf2-3nn8):
+;;
+;;   {:kind         <kw>                  ;; :event / :sub / :fx / :cofx / :view
+;;    :id           <kw>                  ;; the registered handler's id
+;;    :source-coord {:ns     <sym>
+;;                   :file   <string>
+;;                   :line   <int>
+;;                   :column <int>}}      ;; or nil when no source-coord captured
+;;
+;; The field is NOT elided in production — unlike `:rf.assert/*` which
+;; is dev-only, `:rf.error/*` traces ride into prod builds and the
+;; trigger-handler coord rides with them. Per Spec 009 §Production
+;; builds the broader trace surface is dev-only via `interop/debug-
+;; enabled?`; this Var sits inside that gate and naturally elides with
+;; the surrounding error emit when prod-elided.
+
+(def ^:dynamic *current-trigger-handler*
+  "The handler currently in scope for trace emission. Bound by each
+  runtime boundary (router, subs, fx, cofx, views). When bound and an
+  error trace fires, `emit-error!` attaches the value to the event as
+  `:rf.trace/trigger-handler`. nil outside any handler's scope.
+
+  Shape: `{:kind <kw> :id <kw> :source-coord {:ns :file :line :column}?}`.
+
+  Per rf2-3nn8."
+  nil)
+
+(defn trigger-handler-from-meta
+  "Build a `:rf.trace/trigger-handler` value from a registrar meta map.
+  `kind` is the registry kind (`:event`, `:sub`, `:fx`, `:cofx`, `:view`);
+  `id` is the registered id; `meta` is the registrar slot's metadata (as
+  returned by `registrar/lookup`). Picks `:ns` / `:file` / `:line` /
+  `:column` off the meta map (the source-coord stamp lives flat on the
+  meta map per `re-frame.source-coords/merge-coords`).
+
+  Returns nil when no source-coord keys are present on `meta` — the
+  Var stays unbound and the error event omits the field. That covers
+  the programmatic-registration path (the underlying registration fns
+  called directly without the macro wrapping) where coords would be
+  meaningless framework-internal positions.
+
+  Per rf2-3nn8."
+  [kind id meta]
+  (let [coord (cond-> nil
+                (:ns     meta) (assoc :ns     (:ns     meta))
+                (:file   meta) (assoc :file   (:file   meta))
+                (:line   meta) (assoc :line   (:line   meta))
+                (:column meta) (assoc :column (:column meta)))]
+    (when coord
+      {:kind         kind
+       :id           id
+       :source-coord coord})))
+
 ;; ---- retain-N trace ring buffer (dev-only) -------------------------------
 ;;
 ;; Per Spec 009 §Retain-N trace ring buffer. Holds the most recent N completed
@@ -214,15 +285,24 @@
   "Emit a structured error trace event. Per Spec 009 §Error contract:
   `:operation` is the error category (e.g. `:rf.error/handler-exception`),
   `:op-type` is :error, and `:tags` includes `:category`, `:exception`,
-  `:where`, etc."
+  `:where`, etc.
+
+  Per rf2-3nn8: when `*current-trigger-handler*` is bound (a handler is
+  currently in scope — event handler running, sub recomputing, fx
+  handler dispatching, cofx injecting, view rendering), the value is
+  hoisted to the top-level `:rf.trace/trigger-handler` slot on the
+  emitted event. Absent when no handler is in scope (e.g. outermost-
+  dispatch `:rf.error/no-such-handler`)."
   [error-operation tags]
   (when interop/debug-enabled?
-    (let [event {:operation error-operation
-                 :op-type   :error
-                 :id        (next-event-id)
-                 :time      (interop/now-ms)
-                 :tags      (merge {:category error-operation} tags)
-                 :recovery  (:recovery tags :no-recovery)}]
+    (let [trigger *current-trigger-handler*
+          event   (cond-> {:operation error-operation
+                           :op-type   :error
+                           :id        (next-event-id)
+                           :time      (interop/now-ms)
+                           :tags      (merge {:category error-operation} tags)
+                           :recovery  (:recovery tags :no-recovery)}
+                    trigger (assoc :rf.trace/trigger-handler trigger))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -48,6 +48,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
             [re-frame.views.provider :as provider]
             [re-frame.views.source-coord-annotation :as source-coord]
             [re-frame.views.warn-once :as warn-once]))
@@ -205,11 +206,20 @@
         render-fn          (if wrap-applied? wrapped-by-adapter render-fn)
         coord-attr (when (and interop/debug-enabled? (not wrap-applied?))
                      (source-coord/format-source-coord id metadata))
+        ;; Per rf2-3nn8: capture the view's `:rf.trace/trigger-handler`
+        ;; value once at registration time (the registrar `metadata` map
+        ;; carries the source-coord stamp) so each render binds it via
+        ;; the dynamic Var around the user render-fn invocation. Errors
+        ;; emitted during render (subscribe-miss against this frame,
+        ;; sub exception during a render-time deref, etc.) inherit the
+        ;; view's coord as the in-scope trigger handler.
+        view-trigger-handler (trace/trigger-handler-from-meta :view id metadata)
         wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (let [tok        (provider/reagent-component-token)
                           render-key [id tok]]
-                      (binding [*render-key* render-key]
+                      (binding [*render-key* render-key
+                                trace/*current-trigger-handler* view-trigger-handler]
                         (emit-render-trace! render-key)
                         ;; Per Spec 009 §Performance instrumentation
                         ;; (rf2-du3i): every render of a registered view

--- a/implementation/core/test/re_frame/trigger_handler_coord_test.clj
+++ b/implementation/core/test/re_frame/trigger_handler_coord_test.clj
@@ -1,0 +1,206 @@
+(ns re-frame.trigger-handler-coord-test
+  "Per rf2-3nn8 — `:rf.trace/trigger-handler` on `:rf.error/*` trace events.
+
+  Every error trace emitted while a handler is in scope (event, sub, fx,
+  cofx, view) carries an optional top-level `:rf.trace/trigger-handler`
+  field that names the handler whose execution produced the error, along
+  with the handler's registration-site source-coord. Errors emitted
+  outside any handler scope (e.g. the outermost-dispatch
+  `:rf.error/no-such-handler`) omit the field.
+
+  Locked shape (per rf2-3nn8):
+
+    {:kind         :event / :sub / :fx / :cofx / :view
+     :id           <registered-id>
+     :source-coord {:ns <sym> :file <string> :line <int> :column <int>}}
+
+  Q1 — `:rf.trace/trigger-handler` (nested), NOT flat `:rf.handler/source-coord`.
+  Q2 — Optional field; present when handler in scope, absent otherwise.
+  Q3 — Registration-site coord (not call-site).
+  Q4 — NOT elided in production.
+
+  JVM-only here — the dynamic-var binding mechanism is platform-agnostic
+  and CLJS adds no signal beyond the source-coord macro path which
+  rf2-mdjp + rf2-ulxi already cover. Mirror tests under cljs are slim
+  smoke checks driven by the same fixture pattern.
+
+  Source-coord parity with the registrar is established by the
+  `source-coords-test` suite (rf2-k84s); this file only checks that the
+  registrar's stamp is carried onto the emitted error event."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  "Run `body-fn` with a trace listener attached and return the captured
+  events."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- errors-of
+  "Filter captured traces to those whose `:operation` matches the supplied
+  operation keyword."
+  [evs op]
+  (filterv #(and (= :error (:op-type %))
+                 (= op     (:operation %)))
+           evs))
+
+(defn- assert-trigger-shape
+  "Assert the value at `:rf.trace/trigger-handler` on `ev` carries the
+  locked shape — `:kind`, `:id`, and a `:source-coord` map with at
+  least `:ns` / `:file` / `:line` (column may be absent on
+  metadata-stripped registrations)."
+  [ev expected-kind expected-id]
+  (let [t (:rf.trace/trigger-handler ev)]
+    (is (some? t)
+        (str "expected :rf.trace/trigger-handler on " (:operation ev)))
+    (is (= expected-kind (:kind t)))
+    (is (= expected-id   (:id t)))
+    (let [c (:source-coord t)]
+      (is (map? c) ":source-coord present")
+      (is (symbol? (:ns c))   ":ns is a symbol")
+      (is (string? (:file c)) ":file is a string")
+      (is (integer? (:line c)) ":line is an integer"))))
+
+;; ---- Q1 — top-level placement, nested shape -------------------------------
+
+(deftest trigger-handler-rides-at-top-level
+  (testing ":rf.trace/trigger-handler is a top-level field, not nested under :tags"
+    (rf/reg-event-fx :rf2-3nn8/throws
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-3nn8/throws])))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (is (some? exc) "handler-exception trace fired")
+      (is (contains? exc :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives at the top level of the event")
+      (is (not (contains? (:tags exc) :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler does NOT live under :tags"))))
+
+;; ---- Q2 — present when handler in scope -----------------------------------
+
+(deftest event-handler-exception-carries-trigger-handler
+  (testing ":rf.error/handler-exception carries the event handler's coord"
+    (rf/reg-event-fx :rf2-3nn8/throwing-event
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/throwing-event]))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (assert-trigger-shape exc :event :rf2-3nn8/throwing-event))))
+
+(deftest fx-handler-exception-carries-trigger-handler
+  (testing ":rf.error/fx-handler-exception names the fx as the trigger handler,
+   not the enclosing event (the fx body is what threw)"
+    (rf/reg-fx :rf2-3nn8/throwing-fx
+               (fn [_ctx _args] (throw (ex-info "fx boom" {}))))
+    (rf/reg-event-fx :rf2-3nn8/use-throwing-fx
+                     (fn [_cofx _event]
+                       {:fx [[:rf2-3nn8/throwing-fx {}]]}))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/use-throwing-fx]))
+          [exc] (errors-of evs :rf.error/fx-handler-exception)]
+      (assert-trigger-shape exc :fx :rf2-3nn8/throwing-fx))))
+
+(deftest sub-exception-carries-trigger-handler
+  (testing ":rf.error/sub-exception names the failing sub"
+    (rf/reg-sub :rf2-3nn8/throwing-sub
+                (fn [_db _q] (throw (ex-info "sub boom" {}))))
+    (let [evs (record-traces #(deref (rf/subscribe [:rf2-3nn8/throwing-sub])))
+          [exc] (errors-of evs :rf.error/sub-exception)]
+      (assert-trigger-shape exc :sub :rf2-3nn8/throwing-sub))))
+
+(deftest no-such-cofx-carries-enclosing-event-trigger-handler
+  (testing ":rf.error/no-such-cofx — emitted during the event handler chain
+   while no specific cofx is bound (the cofx-id doesn't exist), the
+   enclosing event's coord is what we carry"
+    (rf/reg-event-fx :rf2-3nn8/uses-missing-cofx
+                     [(rf/inject-cofx :rf2-3nn8/no-such-cofx)]
+                     (fn [_cofx _event] {}))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/uses-missing-cofx]))
+          [miss] (errors-of evs :rf.error/no-such-cofx)]
+      (assert-trigger-shape miss :event :rf2-3nn8/uses-missing-cofx))))
+
+(deftest no-such-fx-carries-enclosing-event-trigger-handler
+  (testing ":rf.error/no-such-fx fires from the fx walker while the event
+   handler scope is still bound — the enclosing event's coord is carried"
+    (rf/reg-event-fx :rf2-3nn8/uses-missing-fx
+                     (fn [_cofx _event]
+                       {:fx [[:rf2-3nn8/no-such-fx {}]]}))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/uses-missing-fx]))
+          [miss] (errors-of evs :rf.error/no-such-fx)]
+      (assert-trigger-shape miss :event :rf2-3nn8/uses-missing-fx))))
+
+;; ---- Q2 — negative — absent when no handler is in scope -------------------
+
+(deftest no-such-handler-omits-trigger-handler
+  (testing ":rf.error/no-such-handler fires at outermost dispatch with no
+   handler in scope; :rf.trace/trigger-handler is absent"
+    (let [evs (record-traces
+               #(rf/dispatch-sync [:rf2-3nn8/no-such-event]))
+          [miss] (errors-of evs :rf.error/no-such-handler)]
+      (is (some? miss) "no-such-handler trace fired")
+      (is (not (contains? miss :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler is absent when no handler is in scope"))))
+
+;; ---- Q3 — registration-site coord, not call-site --------------------------
+
+(deftest source-coord-matches-registration-site
+  (testing "the :source-coord under :rf.trace/trigger-handler equals the
+   value the registrar holds on the handler's slot"
+    (rf/reg-event-fx :rf2-3nn8/registration-site
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [reg-meta (rf/handler-meta :event :rf2-3nn8/registration-site)
+          evs      (record-traces
+                    #(rf/dispatch-sync [:rf2-3nn8/registration-site]))
+          [exc]    (errors-of evs :rf.error/handler-exception)
+          coord    (-> exc :rf.trace/trigger-handler :source-coord)]
+      ;; The registrar stamps :ns / :file / :line / :column flat on the
+      ;; meta map; the trigger-handler value picks them up. Compare
+      ;; field-by-field rather than via equality so a future addition
+      ;; to the registrar slot doesn't break the test.
+      (is (= (:ns     reg-meta) (:ns coord)))
+      (is (= (:file   reg-meta) (:file coord)))
+      (is (= (:line   reg-meta) (:line coord)))
+      (is (= (:column reg-meta) (:column coord))))))
+
+;; ---- programmatic registration → no coord -> no trigger-handler -----------
+
+(deftest programmatic-registration-omits-trigger-handler
+  (testing "an event handler registered without the macro (bypassing
+   source-coord capture) emits errors with no :rf.trace/trigger-handler
+   field — better no-data than poison-data"
+    (let [reg-fn (requiring-resolve 're-frame.events/reg-event-fx)]
+      (reg-fn :rf2-3nn8/no-coords
+              (fn [_cofx _event] (throw (ex-info "boom" {})))))
+    (let [evs   (record-traces #(rf/dispatch-sync [:rf2-3nn8/no-coords]))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (is (some? exc))
+      (is (not (contains? exc :rf.trace/trigger-handler))
+          "programmatic registration → no coord → field omitted"))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -609,6 +609,10 @@ All error trace events are open maps with these required keys:
  :time      timestamp                            ;; emit time, host clock
  :source    keyword?                             ;; (when present) the trigger source — :ui, :timer, :http, ...
  :recovery  keyword?                             ;; :no-recovery, :replaced-with-default, :skipped, ...
+ :rf.trace/trigger-handler                       ;; (when present) the in-scope handler at emit time
+   {:kind         #{:event :sub :fx :cofx :view}
+    :id           keyword
+    :source-coord {:ns sym? :file string? :line int? :column int?}}
  :tags      {:category    :rf.error/<category>   ;; same as :operation, for consumer convenience
              :failing-id  any                    ;; the registered id that failed (event id, fx id, sub id, view id, etc.)
              :reason      string                 ;; one-sentence human description
@@ -617,6 +621,29 @@ All error trace events are open maps with these required keys:
 ```
 
 `:source` and `:recovery` are top-level fields hoisted out of `:tags` by the runtime; both are present on every error event. `:frame` rides under `:tags` (every emit site that knows the frame supplies it there). The `:tags` payload's category-specific keys are documented per category below, and each category has a registered Malli schema so consumers can validate / branch on the payload safely.
+
+#### `:rf.trace/trigger-handler` — naming the in-scope handler
+
+The optional top-level `:rf.trace/trigger-handler` slot names the handler whose execution produced the error and carries its registration-site source-coord. Tools (10x, pair, IDE jump-to-source) render click-to-jump links from this field — given an error event, the user lands on the line of code that defined the offending handler.
+
+Coverage is keyed off "is a handler currently in scope at emit time?":
+
+| Emit context | `:rf.trace/trigger-handler` present? | Carries |
+|---|---|---|
+| Inside an event handler's interceptor chain | Yes | The event handler's coord |
+| Inside a cofx fn body | Yes | The cofx's coord |
+| Inside an fx handler body | Yes | The fx handler's coord |
+| Inside a sub recompute (body fn) | Yes | The sub's coord |
+| Inside a view render | Yes | The view's coord |
+| At outermost dispatch with no handler resolved (`:rf.error/no-such-handler`) | No | — |
+| At depth-exceeded drain rollback (`:rf.error/drain-depth-exceeded`) | No | — |
+| At registration-time failures emitted outside any handler | No | — |
+
+The `:source-coord` payload is whatever the registrar slot's metadata holds. Macro-driven registration (`reg-event-*`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-flow`, `reg-route`, `reg-app-schema`, `reg-error-projector`) stamps `:ns` / `:file` / `:line` / `:column` flat onto the meta map at compile time; the trigger-handler builder picks those keys off and re-nests them under `:source-coord`. Programmatic / REPL registrations bypass the macro path and carry no coord — in that case the entire `:rf.trace/trigger-handler` slot is omitted rather than populated with placeholder data (better no field than poison-data).
+
+Production elision: the slot is **NOT separately elided**. The trace surface as a whole is gated by `re-frame.interop/debug-enabled?` per [§Production builds](#production-builds-zero-overhead-zero-code) — when an error trace is emitted at all, the trigger-handler field rides along on it. There is no second gate that selectively drops the field while keeping the rest of the event. Apps that keep the trace surface in production (rare; opt in by setting `goog.DEBUG=true` on the `:advanced` build) get the trigger-handler coord along with every error event. Apps using the default `goog.DEBUG=false` `:advanced` build get neither the field nor the surrounding trace surface — the entire `(when interop/debug-enabled? ...)` branch DCEs.
+
+Consumer access: read `(:rf.trace/trigger-handler error-event)` for the map, `(get-in error-event [:rf.trace/trigger-handler :source-coord])` for the coord, `(get-in error-event [:rf.trace/trigger-handler :id])` for the handler's id. No new namespace is required to read the slot.
 
 ### Error namespace convention — five prefix shapes
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -285,6 +285,15 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
    [:time      :any]                            ;; emit timestamp (host clock)
    [:source    {:optional true} :keyword]
    [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]
+   [:rf.trace/trigger-handler {:optional true}
+                              [:map
+                               [:kind         [:enum :event :sub :fx :cofx :view]]
+                               [:id           :keyword]
+                               [:source-coord [:map
+                                               [:ns     {:optional true} :symbol]
+                                               [:file   {:optional true} :string]
+                                               [:line   {:optional true} :int]
+                                               [:column {:optional true} :int]]]]]
    [:tags      [:map
                 [:category    :keyword]         ;; same value as :operation, for consumer convenience
                 [:failing-id  {:optional true} :any]
@@ -293,6 +302,8 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
 ```
 
 The `:op-type` discriminates severity: `:error` halts or recovers a specific operation; `:warning` is an advisory the runtime emitted alongside continuing default behaviour. Consumers branch on `:op-type` for severity routing and on `:operation` for category-specific handling.
+
+The optional `:rf.trace/trigger-handler` slot (top-level, NOT under `:tags`) names the handler whose execution produced the error and carries its registration-site source-coord. Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent when no handler is in scope (e.g. outermost-dispatch `:rf.error/no-such-handler`, depth-exceeded drain rollback). Source-coord values come from the registrar slot stamped by the kind-specific `reg-*` macro at registration time; programmatic registration paths (the underlying registration fns called without the macro wrapping) carry no coord, in which case the slot is omitted rather than populated with placeholder data. Tools render click-to-jump-to-handler links by reading `[:rf.trace/trigger-handler :source-coord]`. Not elided in production — `:rf.error/*` traces are not elided (unlike `:rf.assert/*`) and this slot rides along with them.
 
 The canonical category vocabulary is fixed-and-additive (Spec-ulation): existing categories cannot be renamed or removed; new categories are added by extending the operation namespace. The current set is enumerated in [009 §Error categories](009-Instrumentation.md#error-categories-initial-set) and reproduced in [API.md §Error contract](API.md#error-contract). Reserved operation namespaces:
 


### PR DESCRIPTION
## Summary

Extend re-frame2 error traces to carry the source-coord of the handler whose execution produced the error. Tools (10x, pair, IDE jump-to-source) consume the slot to render click-to-jump links straight from any `:rf.error/*` event to the offending handler's source. The registrar already stamps `:ns` / `:file` / `:line` / `:column` at registration time; this threads that data through to the emitted error event.

## The four locks

| Q | Lock |
|---|---|
| Q1 Naming | `:rf.trace/trigger-handler` (nested), `:kind` + `:id` alongside the coord. Flattening to `:rf.handler/source-coord` would conflate "what handler" with "where in source". |
| Q2 Coverage | Optional field. Present when a handler is in scope at emit time (event / sub / fx / cofx / view); absent for outermost-dispatch errors with no handler resolved. |
| Q3 Site | Registration-site coord. Call-site coord (the specific `(inject-cofx :foo)` line inside the handler body) is a separate follow-up. |
| Q4 Elision | Not separately elided. The trace surface as a whole remains dev-only via `interop/debug-enabled?`; when an error event is emitted, the field rides along. |

## Mechanism

Single `trace/*current-trigger-handler*` dynamic Var that each runtime boundary binds around the user code it runs. `emit-error!` reads the Var and hoists its value to the top-level `:rf.trace/trigger-handler` slot when bound. The `trigger-handler-from-meta` helper picks `:ns` / `:file` / `:line` / `:column` off the registrar slot's meta map and re-nests them under `:source-coord`; returns nil when no coord was stamped (programmatic registration) so the slot is omitted rather than populated with placeholder data.

## Runtime boundaries that bind

- `router.cljc` — `process-event*` around the interceptor chain + post-chain phases (db commit, flows, fx walk).
- `fx.cljc` — `handle-one-fx` around the user-fx handler call.
- `cofx.cljc` — `inject-cofx` around the cofx fn body (both arities).
- `subs.cljc` — `validate-and-trace` around the sub body-fn invocation.
- `views.cljs` — `reg-view*`'s wrapper around the render-fn call.

Interceptor errors flow up to the router's `:rf.error/handler-exception` emit site, which fires inside the event-runtime binding — so the enclosing handler's coord is what surfaces (interceptors aren't reg-stamped, per the bead's locked design). The `no-such-cofx` / `no-such-fx` paths fire while the enclosing event-handler binding is still active, so they carry the event's coord.

## Spec changes

- `Spec-Schemas.md` §`:rf/error-event` — optional `:rf.trace/trigger-handler` added to the canonical Malli shape with the `:kind` enum, `:id` keyword, and `:source-coord` sub-map.
- `009-Instrumentation.md` §The error event shape — per-context coverage table (present vs absent), registration-site (not call-site) coord choice, "no-poison-data on programmatic registration" rule, production-elision wording.
- `docs/guide/14-errors.md` — user-facing error-event example updated with the new slot and tool-consumption note.

## Files touched

**Spec:** `spec/Spec-Schemas.md`, `spec/009-Instrumentation.md`, `docs/guide/14-errors.md`

**Runtime impl:** `implementation/core/src/re_frame/trace.cljc` (new dynamic Var + helper + emit-error! hoist), `router.cljc`, `fx.cljc`, `cofx.cljc`, `subs.cljc`, `views.cljs`

**Tests:** `implementation/core/test/re_frame/trigger_handler_coord_test.clj` — 9 deftests / 46 assertions covering the four locks (top-level placement; per-kind coord propagation: event handler-exception, fx handler-exception, sub-exception, no-such-cofx, no-such-fx; negative no-such-handler case; programmatic-registration negative case; field-by-field parity with the registrar's source-coord).

## Test plan

- [x] `clojure -M:test` green across core (235 tests), schemas (49), machines (114), routing (21), flows (26), ssr (31), epoch (59), http (39)
- [x] `npm run test:cljs` green (571 tests)
- [x] `npm run test:browser` green (559 tests)
- [x] `npm run test:elision` green — the trace surface still DCEs cleanly in `:advanced` + `goog.DEBUG=false`
- [x] `npm run test:examples` green

## Discipline

- JVM interop preserved — source-coord under JVM continues to use `*file*` / `(meta &form)` at the macro path; the per-boundary binding sits on top and works identically on JVM and CLJS.
- Single-import contract preserved — no new namespace required to read `:rf.trace/trigger-handler` off an error event; it's a plain map key.
- No new registries / dispatch types / effect substrates / component substrates. This bead enriches existing trace events; no new primitive.
- Additive change to the schema — existing error-event consumers that don't read the field are unaffected.