### PR TITLE
docs(spec): make spec/010-Schemas substrate-agnostic — pluggable validator contract, impl-defined default (rf2-osxa)

### DIFF
--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -1,8 +1,10 @@
-# Spec 010 — Schemas (CLJS reference)
+# Spec 010 — Schemas
 
-> Schemas are how *dynamically typed hosts* describe shape. CLJS is dynamically typed, so it ships a runtime schema layer (Malli). *Statically typed hosts* (TypeScript, Kotlin, Rust, F#) describe shape via the type system instead and may omit a runtime schema library entirely. The pattern requires shape description; the mechanism is host-specific.
+> Schemas are how *dynamically typed hosts* describe shape. CLJS is dynamically typed, so the CLJS reference ships a runtime schema layer (Malli, by default). *Statically typed hosts* (TypeScript, Kotlin, Rust, F#) describe shape via the type system instead and may omit a runtime schema library entirely. The pattern requires shape description; the mechanism is host-specific.
 >
-> This Spec specifies the CLJS reference's shape-description integration: Malli as the schema language, `:spec` metadata on every `reg-*`, path-based `app-db` schemas via `reg-app-schema`. Schemas are **open by default** — consumers tolerate unknown keys; producers add new keys additively; `:closed` is opt-in only at system boundaries. Statically typed hosts express the same open-with-known-keys idiom via index signatures + known fields (`type T = { knownField: string; [k: string]: unknown }`).
+> **Portable contract** (every port): `:spec` metadata on every `reg-*`; path-based `app-db` schemas via `reg-app-schema`; pluggable validator via `set-schema-validator!`; implementation-defined default validator. Schemas are **open by default** — consumers tolerate unknown keys; producers add new keys additively; `:closed` is opt-in only at system boundaries. Statically typed hosts express the same open-with-known-keys idiom via index signatures + known fields (`type T = { knownField: string; [k: string]: unknown }`).
+>
+> **CLJS reference's default validator**: Malli (`malli.core/validate` + `malli.core/explain`), with soft-pass when Malli is absent. Other ports document their own defaults (see [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)).
 
 ## Abstract
 
@@ -14,9 +16,9 @@ A schema describes the *shape* of data flowing through a re-frame app:
 - The data a coeffect injector produces.
 - The structure of `app-db` at any path.
 
-re-frame2 lets users attach a Malli schema to any of these via the `:spec` metadata key on the relevant `reg-*` registration, plus a dedicated `reg-app-schema` API for `app-db`. In dev builds the framework validates against schemas at well-defined points; in production validation elides (or is restricted to system boundaries) to keep the hot path cheap.
+re-frame2 lets users attach a schema to any of these via the `:spec` metadata key on the relevant `reg-*` registration, plus a dedicated `reg-app-schema` API for `app-db`. In dev builds the framework validates against schemas at well-defined points; in production validation elides (or is restricted to system boundaries) to keep the hot path cheap.
 
-Malli is the documented and supported default schema library; users may substitute another (the `:spec` value is opaque to re-frame; only the registered validator function is invoked). See [§Notes — Why Malli](#why-malli) for the rationale, and [§Non-Malli validators — the validator-fn extension point](#non-malli-validators--the-validator-fn-extension-point) for how a host or app substitutes a different validator.
+**The `:spec` value is opaque to re-frame.** The runtime never inspects what's stored in `:spec` directly; every validation site routes through the registered **validator fn** (`set-schema-validator!`, see [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)). The validator chooses the schema language: Malli on the CLJS reference, Zod or similar on a TypeScript port, Pydantic on Python, dry-rb on Ruby, the host's structural-typecheck wrapper on a statically typed port. Substituting a different validator is a single registration call; the rest of this Spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
 
 ## Where schemas attach
 
@@ -73,7 +75,7 @@ Use cases:
 - A simple flat `app-db` shape doesn't warrant per-slice schemas.
 - An umbrella schema documents the overall shape while sub-path schemas detail individual slices.
 
-Open vs closed map semantics is the team's choice; Malli supports both.
+Open vs closed map semantics is the team's choice; every schema language re-frame2 integrates with (Malli on the CLJS reference, Zod / Pydantic / dry-rb / native types on other hosts) supports both.
 
 ### Multiple schemas at the same path
 
@@ -93,7 +95,7 @@ Re-registering a schema at a path replaces the previous one (last-write-wins, sa
 
 **Not every schema failure aborts dispatch.** The recovery depends on *where* the failure occurs: pre-handler failures (event vector, cofx) skip the handler; in-flight fx failures skip just the offending fx; post-handler `app-db` failures roll back the dispatch. Downstream queued events continue draining in every case (per the run-to-completion drain — a single failed event does not poison the queue). The detailed per-step table below is normative; this summary table is its index.
 
-All validation points emit machine-readable errors per [Goal 10 (Strong introspection surface)](000-Vision.md#goals) and the structured error contract in [009 §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/schema-validation-failure` events carry `{:where :event/:sub-return/:app-db/...; :path [...]; :value <bad>; :explanation <Malli explanation>}`.
+All validation points emit machine-readable errors per [Goal 10 (Strong introspection surface)](000-Vision.md#goals) and the structured error contract in [009 §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/schema-validation-failure` events carry `{:where :event/:sub-return/:app-db/...; :path [...]; :value <bad>; :explanation <validator-supplied explanation>}`. The explanation's inner shape is whatever the registered explainer fn returns (a Malli explanation map on the CLJS reference; a Zod issue list on a TS port; etc.); consumers that need to branch on the inner shape inspect the port they're talking to.
 
 ### Validation order on event processing
 
@@ -129,7 +131,7 @@ All registered schemas are checked at every validation point. The intent is to c
 
 ### Production builds
 
-Validation is **elided** by default — schemas remain registered (so tooling can introspect them) but the validation calls are compile-time-eliminated, alongside trace emission. The mechanism: every `validate-*!` body is wrapped in `(when re-frame.interop/debug-enabled? ...)`. `debug-enabled?` is an alias of `goog.DEBUG` (default `true` in dev, `false` in `:advanced` production), so under `:closure-defines {goog.DEBUG false}` the closure compiler constant-folds and DCEs every validation site — the malli call, the trace-error envelope, the human-readable reason string, and every keyword the failure tags carry. See [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) for the full elision contract and the CI verifier that enforces it.
+Validation is **elided** by default — schemas remain registered (so tooling can introspect them) but the validation calls are compile-time-eliminated, alongside trace emission. The mechanism: every `validate-*!` body is wrapped in `(when re-frame.interop/debug-enabled? ...)` on the CLJS reference (other ports use the host's equivalent debug-enabled gate). `debug-enabled?` is an alias of `goog.DEBUG` on CLJS (default `true` in dev, `false` in `:advanced` production), so under `:closure-defines {goog.DEBUG false}` the closure compiler constant-folds and DCEs every validation site — the validator call, the trace-error envelope, the human-readable reason string, and every keyword the failure tags carry. See [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) for the full elision contract and the CI verifier that enforces it.
 
 For users who want production validation at *system boundaries* — typically incoming events from untrusted sources (HTTP responses, websocket messages, postMessage) — re-frame2 ships a `:spec/validate-at-boundary` interceptor that the user adds to specific event handlers. Boundary validation runs even when global validation is elided.
 
@@ -161,7 +163,8 @@ Schemas registered against handlers and `app-db` paths are queryable via the pub
 ;; → {:doc "..." :spec [:cat ...] :ns ... :line ... :file ...}
 
 (rf/app-schema-at [:user])
-;; → UserSchema (the registered Malli schema)
+;; → UserSchema (the registered schema value, in whatever language the
+;;    registered validator interprets — Malli on the CLJS reference)
 
 (rf/app-schemas)
 ;; → {[:user] UserSchema, [:todos] TodosSchema, [:auth] AuthSchema, [] WholeAppDbSchema}
@@ -176,7 +179,7 @@ Tools and agents read these to:
 
 - Render shape information in 10x's panel.
 - Validate intent before dispatching (an agent simulating "what would happen if I dispatch [:auth/login {…}]?" can pre-check against the spec).
-- Generate test data via Malli's generators (`(mg/generate sub-schema)` produces a value matching the sub's return shape).
+- Generate test data via the schema language's generators (e.g. Malli's `mg/generate` on the CLJS reference; Zod's `faker` integrations on a TS port).
 - Generate JSON Schema or OpenAPI from registered schemas — useful for cross-platform contracts.
 - Diff schemas across versions to detect breaking shape changes in app-db structure.
 
@@ -218,17 +221,17 @@ Used by:
 - **Pair tools** — the runtime pair tool can warn when an attached REPL session is talking to a runtime whose schema set has shifted under it.
 - **Cross-host conformance** — a TS client talking to a CLJS server can record digests for replay/snapshot regression.
 
-The digest is **derived data**, not part of the registration shape. Implementations that don't ship a runtime schema layer (some statically typed hosts) may compute it from the type system's structural fingerprint or omit the feature.
+The digest is **derived data**, not part of the registration shape. Implementations that don't ship a runtime schema layer (some statically typed hosts) may compute it from the type system's structural fingerprint or omit the feature. The digest's *output shape* and *input ordering* are normative (so cross-host comparisons stay meaningful); the per-schema *serialisation* is determined by the registered validator's `schema-print` companion fn.
 
 ### Digest algorithm (normative)
 
 The digest must be **cross-runtime reproducible** — a CLJS server and a CLJS client running the same schema set produce the same digest, byte-for-byte. The algorithm below is normative; ports that ship a digest must implement exactly this procedure.
 
-**Inputs.** The frame's registered `app-db` schema set, as a map `{path → schema-value}` where `path` is a vector of keywords (or the empty vector for the root schema) and `schema-value` is the registered schema (a Malli EDN form in the CLJS reference; another data form in non-Malli ports — see [§Non-Malli validators](#non-malli-validators--the-validator-fn-extension-point)).
+**Inputs.** The frame's registered `app-db` schema set, as a map `{path → schema-value}` where `path` is a vector of keywords (or the empty vector for the root schema) and `schema-value` is the registered schema in whatever data form the registered validator interprets (a Malli EDN form on the CLJS reference; another shape on other ports — see [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)).
 
 **Procedure.**
 
-1. **Serialise each schema value to a stable byte sequence.** The serialisation fn (`schema-print`) is supplied alongside the validator fn (per [§Non-Malli validators](#non-malli-validators--the-validator-fn-extension-point)) and must be deterministic — the same schema value always produces the same bytes. The CLJS reference's default uses `pr-str` over the Malli EDN form with map-key ordering normalised (keys sorted by `(compare a b)` after coercing to a comparable representation; printed without metadata). UTF-8 encoded.
+1. **Serialise each schema value to a stable byte sequence.** The serialisation fn (`schema-print`) is supplied alongside the validator fn (per [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point)) and must be deterministic — the same schema value always produces the same bytes. The CLJS reference's default uses `pr-str` over the Malli EDN form with map-key ordering normalised (keys sorted by `(compare a b)` after coercing to a comparable representation; printed without metadata). UTF-8 encoded.
 2. **Hash each schema independently.** Compute `SHA-256(schema-print(schema-value))` for every entry, producing a 32-byte digest per schema.
 3. **Build the per-entry record.** For each `(path, schema-value)`, emit the line `<path-string> <hex-of-sha256-bytes>\n` where:
    - `path-string` is the path printed as `pr-str` of the path vector (e.g. `[:user]`, `[:auth :credentials]`, `[]` for the root). Empty path renders as `[]`.
@@ -250,13 +253,27 @@ The digest must be **cross-runtime reproducible** — a CLJS server and a CLJS c
 (rf/reg-app-schema [:todos]  [:vector :string])
 ```
 
-After the procedure above (using the CLJS reference's `pr-str` serialisation for Malli forms), the digest is deterministic. Conformance fixtures pin a small number of schema sets to expected digest values so port implementations can self-check their digest pipeline.
+After the procedure above (using the CLJS reference's `pr-str` serialisation for Malli forms; a port substituting a different validator will produce a different digest for the same `{path → schema-value}` map iff its `schema-print` produces different bytes — that's the intended cross-port distinction), the digest is deterministic. Conformance fixtures pin a small number of schema sets to expected digest values so port implementations can self-check their digest pipeline.
 
 **Non-schema-layer hosts.** A host whose type system supplies the shape information (TypeScript, Kotlin) and ships no runtime schema layer may compute the digest from a structural fingerprint of its types — but if it does ship a digest, the *output shape* (`"sha256:" + 16 hex chars`) and the *input ordering* (sorted-by-path) must match so cross-host comparisons remain meaningful. Hosts that omit the digest entirely return `nil` from `app-schemas-digest`, and `:rf.ssr/schema-digest-mismatch` is suppressed when either side returns `nil`.
 
-## Non-Malli validators — the validator-fn extension point
+## Default validator and the validator-fn extension point
 
-The runtime never inspects the value stored in `:spec`. Validation always goes through a registered **validator fn**. The CLJS reference splits the surface into two fns — a fast pass/fail check on the hot path and an explainer used only on the failure branch — so the dev-mode validation site stays cheap:
+This section is the **portable normative core** of the schemas surface. Every re-frame2 port — CLJS reference, TypeScript, Python, Rust, whatever — implements these four claims; the rest of the section's prose (and the rest of this Spec) reads in the same shape regardless of which schema language the port's default validator interprets.
+
+### The four normative claims
+
+1. **Apps register schemas via `reg-app-schema`** (path-scoped, per [§`app-db` schemas — path-based](#app-db-schemas--path-based)) and via the `:spec` metadata key on `reg-*` (per [§On every `reg-*`](#on-every-reg-)). These two surfaces are the portable contract every port supplies; both pass the registered schema value through opaquely.
+
+2. **Validation is pluggable via `set-schema-validator!`** (and its companion `set-schema-explainer!`). The runtime never inspects `:spec` directly; every validation site routes through the registered validator fn. Substituting a different validator is a single registration call — the rest of this Spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
+
+3. **The default validator is implementation-defined.** Each port picks a default appropriate to its host: Malli on the CLJS reference, Zod on a TypeScript port, Pydantic on a Python port, dry-rb on a Ruby port, the host's structural-typecheck wrapper on a statically typed port — etc. Ports document their default's schema-language choice in their `README` / implementation-notes; the Spec does not mandate any particular library.
+
+4. **Dependency-absent behaviour is implementation-defined, with a recommended soft-pass default.** When the default validator's underlying library is not present on the classpath / module graph / runtime, the recommended behaviour is to **soft-pass** (treat the value as conforming) so new users aren't blocked by a missing optional dep. Apps that want a hard fail on a missing dep register a stricter validator via `set-schema-validator!`. The soft-pass is a recommendation, not a mandate — a port may choose a different default and document it.
+
+### How the surface works
+
+Validation always goes through a registered **validator fn**. The CLJS reference splits the surface into two fns — a fast pass/fail check on the hot path and an explainer used only on the failure branch — so the dev-mode validation site stays cheap:
 
 ```clojure
 ;; The validator: pass/fail check on the hot path.
@@ -284,34 +301,47 @@ Both fns are registered at boot, before the first `reg-app-schema` or `:spec`-be
 
 ;; (4) Hard no-op: passing nil disables validation everywhere.
 ;;     Every validate-*! site short-circuits without inspecting the
-;;     schema. Apps that want zero validation surface (and zero Malli
-;;     bundle cost) install nil at boot.
+;;     schema. Apps that want zero validation surface (and zero
+;;     schema-library bundle cost) install nil at boot.
 (rf/set-schema-validator! nil)
 ```
 
-The CLJS reference's default validator/explainer pair delegates to Malli (`malli.core/validate` + `malli.core/explain`). Substituting a different validator (a `clojure.spec` adapter, a JSON-Schema validator, a host's structural-typecheck wrapper) is a **single registration call** — the rest of the spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
+### Per-port default
 
-Locked rules:
+Per claim 3 above, each port picks the default validator/explainer pair appropriate to its host. The CLJS reference's default delegates to Malli (`malli.core/validate` + `malli.core/explain`); a TypeScript port might default to Zod; a Python port to Pydantic; a Ruby port to dry-rb. The port's `README` (or implementation-notes file) is the authoritative source for *its* default's identity.
+
+Substituting a different validator — `clojure.spec` instead of Malli, a JSON-Schema validator, the host's structural-typecheck wrapper — is a **single registration call**; the rest of this Spec (when validation runs, what happens on failure, how digests are computed) is unchanged.
+
+### Recommended soft-pass when the default validator's library is absent
+
+When the default validator's underlying library is *not present* (Malli is not on the CLJS classpath; Zod is not in the TS module graph; etc.), the **recommended** behaviour is **soft-pass**: every `validate-*!` site returns `true` (the value is treated as conforming) and no failure trace is emitted. The motivation is new-user friendliness — first-time users who haven't yet decided whether they want runtime validation should not be blocked by a missing optional dependency.
+
+Apps that want a **hard fail** when the default library is absent (a stricter posture suitable for production deploys where a missing dep means a misconfigured bundle) register a stricter validator via `set-schema-validator!`. The hard-fail validator's body is a single throw — the override surface is the same regardless of the failure mode the app prefers.
+
+This recommendation is normative-soft: ports that ship a different default-absent behaviour document the divergence in their README, and apps that depend on the soft-pass behaviour pin it explicitly with their own registered validator.
+
+### Locked rules
 
 - **One validator fn per frame** is in effect at any time. Last-write-wins on re-registration; tools warn if the source coords differ between registrations (same form re-register is benign hot-reload).
 - **The validator fn is pure** — same `(schema, value)` returns the same result. Implementations may memoise but tests must not depend on memoisation.
-- **The validator fn must be production-elidable** alongside `re-frame.interop/debug-enabled?` — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
-- **Schema digests** ([§Schema digest](#schema-digest)) are computed from the schema **values** as serialised by the registered validator's `serialise` companion fn (see [§Schema digest](#schema-digest)) — not from the validator. Two ports using different validators against the same Malli-EDN schemas produce the same digest; two ports using *different* schema languages produce different digests by construction.
+- **The validator fn must be production-elidable** alongside the host's debug-enabled flag (`re-frame.interop/debug-enabled?` on CLJS; the equivalent on other ports) — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
+- **Schema digests** ([§Schema digest](#schema-digest)) are computed from the schema **values** as serialised by the registered validator's `schema-print` companion fn (see [§Schema digest](#schema-digest)) — not from the validator. Two ports using different validators against the same schema-language-EDN-form produce the same digest iff their `schema-print` fns produce identical bytes; two ports using *different* schema languages produce different digests by construction.
 - **`nil` validator means no validation, not "every value fails"**. Setting validator to nil is the documented opt-out — every `validate-*!` site short-circuits to `true` (pass). The schemas mandate stays unchanged at the framework level (apps still attach `:spec` and `reg-app-schema`); only the runtime check is disabled.
 
-What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (Malli for app schemas, JSON-Schema for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
+What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
 
-### Worked example — installing a no-op validator at boot
+### Worked example — installing a no-op validator at boot (CLJS reference)
 
-The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cost-audit.md` §3.7 / §4): an app that doesn't need runtime schema validation can install a no-op at boot and avoid pulling Malli into its production bundle.
+The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cost-audit.md` §3.7 / §4): an app that doesn't need runtime schema validation can install a no-op at boot and avoid pulling the default validator's schema-language library (Malli on the CLJS reference) into its production bundle.
 
 ```clojure
 (ns my-app.core
   (:require [re-frame.core :as rf]
             [re-frame.schemas]   ;; load the schemas artefact (rf2-p7va)
             ;; NOTE: we do NOT (:require [malli.core]) here — the
-            ;; default validator's (resolve 'malli.core/validate) returns
-            ;; nil and the no-op below replaces it entirely.
+            ;; CLJS reference's default validator does
+            ;; (resolve 'malli.core/validate); that returns nil when
+            ;; Malli is absent and the no-op below replaces it entirely.
             ))
 
 ;; Install the no-op BEFORE the first reg-app-schema / :spec metadata.
@@ -336,9 +366,9 @@ The schemas namespace exposes two fns the interceptor calls — `validate-with-r
 
 ## Notes
 
-### Why Malli
+### Why Malli (CLJS reference's default validator)
 
-Malli is the preferred schema library over `clojure.spec`:
+Per claim 3 in [§The four normative claims](#the-four-normative-claims), each port picks its own default. The CLJS reference picks Malli (over `clojure.spec`) for these reasons:
 
 - **Data-first.** Schemas are EDN data, not function calls. Inspectable, transmittable, AI-readable, queryable.
 - **Decomposable.** Schemas compose by reference; sub-schemas can be named and reused.
@@ -346,9 +376,9 @@ Malli is the preferred schema library over `clojure.spec`:
 - **Multi-format generation.** Malli generates JSON Schema, OpenAPI, type signatures, generators for property-based testing.
 - **Modern feature set.** Open/closed maps, regex schemas, function schemas, ref support, transformers.
 
-The `:spec` value is opaque to re-frame; only the registered validator function is invoked. A user wishing to use `clojure.spec` or another library registers the appropriate validator. Malli is the documented and supported default.
+The `:spec` value is opaque to re-frame; only the registered validator function is invoked. A user wishing to use `clojure.spec` or another library registers the appropriate validator. Malli is the documented and supported default *for the CLJS reference*; other ports document their own defaults.
 
-For the bundle-cost tradeoffs of the Malli default and how to opt out, see [§Bundle cost](#bundle-cost) below.
+For the bundle-cost tradeoffs of the CLJS reference's Malli default and how to opt out, see [§Bundle cost](#bundle-cost) below.
 
 ### Bundle cost
 
@@ -379,7 +409,7 @@ The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas`
 - `malli.registry` — composite-registry helpers; ~3 KB gzipped (most lives in `malli.core`).
 - `malli.dev`, `malli.dev.pretty`, `malli.experimental`, `malli.instrument`, `malli.json-schema`, `malli.swagger`, `malli.provider`, `malli.util` — dev-only tooling; never bundle into production code.
 
-**Opt-out path — bypass Malli entirely.** Apps that don't want the Malli bundle install a different validator (or `nil`) via `set-schema-validator!` (per [§Non-Malli validators](#non-malli-validators--the-validator-fn-extension-point) and rf2-froe / PR #237). `set-schema-validator!` with `nil` is the documented hard-no-op: every `validate-*!` site short-circuits to `true`, no validate call ever runs, and the schemas artefact stops carrying a static dependency on Malli. Apps that don't `(:require [malli.core])` themselves pay only the ~5.6 KB schemas-artefact cost.
+**Opt-out path — bypass Malli entirely.** Apps that don't want the Malli bundle install a different validator (or `nil`) via `set-schema-validator!` (per [§Default validator and the validator-fn extension point](#default-validator-and-the-validator-fn-extension-point) and rf2-froe / PR #237). `set-schema-validator!` with `nil` is the documented hard-no-op: every `validate-*!` site short-circuits to `true`, no validate call ever runs, and the schemas artefact stops carrying a static dependency on Malli. Apps that don't `(:require [malli.core])` themselves pay only the ~5.6 KB schemas-artefact cost.
 
 ```clojure
 ;; Apps that want zero runtime validation surface (and zero Malli bundle cost)
@@ -392,7 +422,7 @@ The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas`
 
 ### What schemas don't do
 
-- **They don't enforce non-shape invariants.** Malli describes shapes (this is a string of length ≥ 8; this is a vector of TodoItems). Higher-level invariants (this user's email matches their account; this request's signature is valid) live in handlers, not schemas.
+- **They don't enforce non-shape invariants.** Schemas describe shapes (this is a string of length ≥ 8; this is a vector of TodoItems). Higher-level invariants (this user's email matches their account; this request's signature is valid) live in handlers, not schemas.
 - **They don't replace tests.** Schemas catch shape violations; tests catch behavioural correctness. Both are needed.
 - **They don't make `app-db` rigid.** Open-map schemas are the default; teams opt into closed-map semantics where they want strict typo-prevention.
 
@@ -400,7 +430,7 @@ The typical-app delta is the **~24 KB gzipped headline**: the `re-frame.schemas`
 
 ### Schema-driven generative tests
 
-Malli generators can produce values matching a schema. A natural pattern: "for every event with a `:spec`, generate inputs and run the handler against a fixture frame, asserting `app-db` schemas hold." Documented as a property-based-testing pattern in [008-Testing.md](008-Testing.md).
+Most schema libraries ship generators that produce values matching a schema (Malli on CLJS, Zod with faker integrations on TS, Hypothesis on Python, etc.). A natural pattern: "for every event with a `:spec`, generate inputs and run the handler against a fixture frame, asserting `app-db` schemas hold." Documented as a property-based-testing pattern in [008-Testing.md](008-Testing.md).
 
 ### Schema migration on hot-reload
 
@@ -416,8 +446,8 @@ Apps evolve; `app-db` shapes evolve; schemas evolve. Whether re-frame2 ships a v
 
 ## Resolved decisions
 
-### Non-Malli library support
+### Pluggable validator and implementation-defined default
 
-Substitution is via a single `set-schema-validator!` registration; the `:spec` value is opaque to re-frame; the registered validator interprets it. Malli is the default and supported library; substitution is one call. See [§Non-Malli validators — the validator-fn extension point](#non-malli-validators--the-validator-fn-extension-point).
+The four normative claims in [§The four normative claims](#the-four-normative-claims) are the portable contract: apps register via `reg-app-schema` + `:spec`; validation is pluggable via `set-schema-validator!`; the default is implementation-defined; dependency-absent behaviour is implementation-defined with a recommended soft-pass.
 
-The seam is implemented (rf2-froe): `(rf/set-schema-validator! validate-fn)`, `(rf/set-schema-validator! {:validate ... :explain ...})`, and `(rf/set-schema-explainer! explain-fn)` are all live in `re-frame.core` (re-exporting from `re-frame.schemas`). Default behaviour ships Malli's `validate` / `explain`; passing `nil` to `set-schema-validator!` is the documented hard-no-op for apps that want zero runtime validation surface. The schemas mandate at the framework level (every `reg-*` may attach `:spec`; `reg-app-schema` registers path schemas) is independent of which validator is registered.
+The CLJS reference's expression of these claims (rf2-froe): `(rf/set-schema-validator! validate-fn)`, `(rf/set-schema-validator! {:validate ... :explain ...})`, and `(rf/set-schema-explainer! explain-fn)` are all live in `re-frame.core` (re-exporting from `re-frame.schemas`). The CLJS reference's chosen default delegates to Malli's `validate` / `explain`; soft-pass when Malli is absent on the classpath; hard no-op when `set-schema-validator!` is called with `nil`. Other ports document their own defaults in their READMEs. The schemas mandate at the framework level (every `reg-*` may attach `:spec`; `reg-app-schema` registers path schemas) is independent of which validator is registered.


### PR DESCRIPTION
## Summary

Strips Malli-specific wording from the normative core of `spec/010-Schemas.md` so the spec supports implementations in host languages other than CLJS. The Spec previously read as if Malli were normatively the default schema library; that framing is a portability bug for the `re-frame2-implementor` workflow (TypeScript, Python, Rust, etc. ports).

The Spec now states **four normative claims** as the portable contract:

1. **Apps register schemas via `reg-app-schema`** (path-scoped) and via the `:spec` metadata key on `reg-*` — portable contract.
2. **Validation is pluggable via `set-schema-validator!`** (and `set-schema-explainer!`) — portable override surface.
3. **The default validator is implementation-defined** — each port picks one (Malli on CLJS, Zod on TS, Pydantic on Python, dry-rb on Ruby, etc.).
4. **Dependency-absent behaviour is implementation-defined, with a recommended soft-pass default** — new-user-friendly; hard-fail available via the override.

## Structural changes

- Renamed `§Non-Malli validators` to `§Default validator and the validator-fn extension point`. Restructured to **lead with the four claims** as a sub-section; per-port default and recommended-soft-pass each get their own subsection.
- Re-titled `§Why Malli` to `§Why Malli (CLJS reference's default validator)` to make scope explicit.
- Spec 010's top-level title dropped the `(CLJS reference)` suffix — the normative core is portable; CLJS-specific bits (Malli default, bundle-cost) are clearly bookmarked inside.
- Updated all intra-document anchor references from `#non-malli-validators…` to `#default-validator-and-the-validator-fn-extension-point`. No external callers reference the old anchor.
- Front-matter callout now lists the **portable contract** (every port) separately from the **CLJS reference's default-validator identity**.
- Throughout the Spec, Malli-only wording (`Malli explanation`, `Malli generators`, `Malli describes shapes`, `Malli supports both`, etc.) reframed as schema-language-neutral with Malli named as one example among Zod / Pydantic / dry-rb / native types.

## Impl-notes cross-check

- `implementation/schemas/src/re_frame/schemas.cljc`: existing `default-malli-validate` docstring already documents the soft-pass-when-Malli-absent behaviour. No change needed (per task spec).
- `implementation/schemas/README.md`: does not exist. Docstring is the authoritative impl-side record per task spec.
- **No CLJS reference behaviour change.** The soft-pass behaviour is unchanged; it's now **explicit in the impl notes** rather than implied by spec silence.

## Conformance fixture cross-check

Four schema-related fixtures reviewed:

- `schema-event-payload-validates.edn` — already tagged `:fixture/dynamic-host-only? true`. Portable EDN form.
- `error-schema-failure.edn` — already tagged `:fixture/dynamic-host-only? true`. Portable EDN form `[:int]`.
- `routing-query-string-coercion.edn` — portable `:map` schema form.
- `http-managed-decode-failure.edn` — the `:malli-error?` field in the public failure envelope (per Spec 014 §Failure categories) is a cross-port leak, but it's a **Spec 014 drift**, not 010. Filed as rf2-koyp rather than retagging mid-stream (per task spec direction).

## Sweep result

`grep -i '\bmalli\b' spec/010-Schemas.md`: 47 → 42 occurrences. All remaining mentions are explicitly CLJS-reference-scoped (`(CLJS reference)`, `on the CLJS reference`, `CLJS reference's default`, `CLJS reference's Malli mandate`, etc.). Other spec files (000-Vision, 001-Registration, Implementor-Checklist, Spec-Schemas, etc.) already frame Malli alongside Zod / Pydantic / dry-rb / native types in host-profile tables — no changes needed there.

## Test plan

- [x] `mkdocs build`: pre-existing warnings unchanged (220 in strict mode on both master and this branch — failures are guide/ and skill/ files linking to spec/ which isn't in `nav`; orthogonal to this PR).
- [x] No new broken intra-file anchors; old `#non-malli-validators` anchor not referenced anywhere outside this file.
- [x] CLJS reference implementation behaviour unchanged (no impl files touched).

Closes rf2-osxa.