### PR TITLE
feat(routing): ship :route/link registered view — close v1-surface spec/impl gap (rf2-uhv2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -639,6 +639,7 @@
 
 (def match-url rf-routing/match-url)
 (def route-url rf-routing/route-url)
+(def route-link rf-routing/route-link)
 
 ;; ---- machine helpers ------------------------------------------------------
 

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -59,3 +59,31 @@
                      :route-id id
                      :recovery :no-recovery
                      :reason   "rf/reg-route requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
+
+(defn route-link
+  "Per Spec 012 §Linking from views and API.md `route-link` row.
+  Registered view at `:route/link` — renders an `<a href=...>` from a
+  registered route id and intercepts plain primary-button clicks to
+  dispatch `:rf/url-requested`. Modifier-key clicks (cmd / ctrl / shift /
+  alt) and middle-click defer to the browser. Late-bound via
+  `:routing/route-link`.
+
+  Shape:
+    [rf/route-link {:to :route-id
+                    :params {...}
+                    :query {...}
+                    :fragment \"...\"
+                    & passthrough-html-attrs} & children]
+
+  The CLJS hook publishes the Reagent-wrapped render fn (returned by
+  `reg-view*`); the JVM hook publishes the SSR-side render fn. Either
+  way `[rf/route-link ...]` in a `.cljc` render tree renders correctly
+  on both platforms."
+  {:arglists '([props & children])}
+  [& args]
+  (if-let [f (late-bind/get-fn :routing/route-link)]
+    (apply f args)
+    (throw (ex-info ":rf.error/routing-artefact-missing"
+                    {:where    'route-link
+                     :recovery :no-recovery
+                     :reason   "rf/route-link requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -35,9 +35,11 @@
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            [re-frame.router :as router]
             [re-frame.source-coords :as source-coords]
             [re-frame.subs :as subs]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            #?@(:cljs [[re-frame.views :as views]])))
 
 ;; ---- url encoding / decoding ---------------------------------------------
 ;;
@@ -914,6 +916,126 @@ unknown strategies as :preserve (no-op)."}
 (subs/reg-sub :rf.route/transition :<- [:rf/route] (fn [route _] (:transition route)))
 (subs/reg-sub :rf.route/error      :<- [:rf/route] (fn [route _] (:error route)))
 
+;; ---- route-link registered view ------------------------------------------
+;;
+;; Per Spec 012 §Linking from views and §Standard runtime events, and the
+;; API.md `route-link` row: a registered view at `:route/link` renders an
+;; `<a href="...">` for a known route-id and intercepts plain primary-button
+;; clicks. Plain left-click (no modifier keys) dispatches
+;; `:rf/url-requested`; modifier-key clicks (cmd / ctrl / shift / alt) and
+;; auxiliary-button clicks (middle-click) defer to the browser so users get
+;; the native open-in-new-tab affordance.
+;;
+;; The view is CLJS-only — anchor rendering is DOM-bound and there is no
+;; meaningful JVM counterpart. The pure helpers `route-url` (URL synthesis)
+;; and the `:rf/url-requested` event handler are both JVM-callable, which
+;; is what the JVM-side tests reach for.
+;;
+;; Frame-handling: the view dispatches via `re-frame.router/dispatch!`,
+;; which captures the frame at call time through the same resolution chain
+;; (dynamic var → React-context → `:rf/default`) every registered view's
+;; auto-injected `dispatch` already uses. Routes themselves are a single
+;; global registry (the `:route` registrar kind), so per-frame routing is
+;; a non-issue at the link layer — the URL string is derived from the
+;; route id alone, and the resulting `:rf/url-requested` lands in the
+;; frame that owned the click.
+
+#?(:cljs
+   (defn- plain-left-click?
+     "Return true when the click event is a plain primary-button click with
+     no modifier keys. Modifier-key or auxiliary-button clicks defer to
+     the browser so users keep open-in-new-tab / open-in-new-window
+     affordances."
+     [e]
+     (and (zero? (.-button e))
+          (not (.-metaKey e))
+          (not (.-ctrlKey e))
+          (not (.-shiftKey e))
+          (not (.-altKey e)))))
+
+#?(:cljs
+   (defn route-link-render
+     "Render fn for the `:route/link` registered view. Exposed (without
+     the registry wrap) so tests can call it directly without going
+     through Reagent's component pipeline.
+
+     Shape:
+       [rf/route-link {:to :route-id
+                       :params {...}
+                       :query {...}
+                       :fragment \"...\"
+                       :on-click <opt user fn>
+                       & passthrough-html-attrs}
+        & children]
+
+     `:to` is the only required key. `:params`, `:query`, and `:fragment`
+     are forwarded to `route-url` for href synthesis. Any other key on the
+     props map is passed through to the underlying `<a>` element (e.g.
+     `:class`, `:title`, `:id`, `:aria-label`).
+
+     If the caller supplies an `:on-click` fn, it is invoked first; when
+     it calls `.preventDefault` (or otherwise the event's
+     `defaultPrevented` is true after it returns) the framework's
+     plain-left-click interception is skipped — the caller has taken
+     responsibility for the navigation. Otherwise the standard rules
+     apply: plain left-click → `preventDefault` + dispatch
+     `:rf/url-requested`; modifier-key or middle-click → no interception."
+     [{:keys [to params query fragment on-click] :as props} & children]
+     (let [base-url (route-url to (or params {}) (or query {}))
+           url      (if (and fragment (not= "" fragment))
+                      (str base-url "#" fragment)
+                      base-url)
+           attrs    (-> props
+                        (dissoc :to :params :query :fragment :on-click)
+                        (assoc :href url
+                               :on-click
+                               (fn [e]
+                                 (when on-click (on-click e))
+                                 (when (and (not (.-defaultPrevented e))
+                                            (plain-left-click? e))
+                                   (.preventDefault e)
+                                   (router/dispatch!
+                                     [:rf/url-requested
+                                      (cond-> {:url url :to to}
+                                        (seq params)   (assoc :params params)
+                                        (seq query)    (assoc :query  query)
+                                        fragment       (assoc :fragment fragment))])))))]
+       (into [:a attrs] children))))
+
+(defn route-link-render-ssr
+   "JVM render fn for `:route/link`. Renders the `<a href=...>` shell
+   without the click-interception logic — server-side rendering has no
+   DOM events to intercept, so the anchor is emitted as-is and clicks
+   on the hydrated page run the CLJS render fn's on-click path. Per
+   Spec 011 the render tree is the contract; this is the JVM half of
+   that contract for the `:route/link` view."
+   [{:keys [to params query fragment] :as props} & children]
+   (let [base-url (route-url to (or params {}) (or query {}))
+         url      (if (and fragment (not= "" fragment))
+                    (str base-url "#" fragment)
+                    base-url)
+         attrs    (-> props
+                      (dissoc :to :params :query :fragment :on-click)
+                      (assoc :href url))]
+     (into [:a attrs] children)))
+
+#?(:cljs
+   (def route-link
+     "Registered view at `:route/link`. Intercepts plain left-clicks and
+     dispatches `:rf/url-requested`; modifier-key clicks defer to the
+     browser. Per Spec 012 §Linking from views and API.md `route-link`
+     row. The underlying render fn is `route-link-render`."
+     (views/reg-view* :route/link
+                      (source-coords/merge-coords {})
+                      route-link-render))
+   :clj
+   ;; JVM: register the SSR-side render fn under :route/link so the
+   ;; registrar carries the slot on both platforms (route-link views in
+   ;; .cljc render trees resolve identically server- and client-side).
+   (registrar/register! :view :route/link
+                        (assoc (source-coords/merge-coords {})
+                               :handler-fn route-link-render-ssr)))
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
 ;; Per rf2-k682 the routing surface ships in `day8/re-frame2-routing`.
@@ -932,3 +1054,11 @@ unknown strategies as :preserve (no-op)."}
 (late-bind/set-fn! :routing/route-url        route-url)
 (late-bind/set-fn! :routing/reset-counters!  reset-counters!)
 (late-bind/set-fn! :routing/route-sub-fn     route-sub-fn)
+
+;; route-link is exposed on both platforms so .cljc render trees that
+;; embed `[rf/route-link ...]` resolve identically server- and client-side.
+;; CLJS publishes the Reagent-wrapped render fn (the one `reg-view*`
+;; returned); JVM publishes the SSR render fn. Late-bind keeps
+;; `re-frame.core` decoupled from this artefact.
+#?(:cljs (late-bind/set-fn! :routing/route-link route-link)
+   :clj  (late-bind/set-fn! :routing/route-link route-link-render-ssr))

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -98,3 +98,25 @@
                 "ex-data carries :route-id from the call site")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
+
+(deftest route-link-raises-when-routing-artefact-missing
+  (testing "rf/route-link raises :rf.error/routing-artefact-missing when the :routing/route-link hook is nil"
+    ;; Per rf2-uhv2 the route-link surface is published through the
+    ;; :routing/route-link late-bind hook (CLJS → Reagent-wrapped render
+    ;; fn; JVM → SSR render fn). Consumers without the routing artefact
+    ;; see the hook unregistered; the wrapper in re-frame.core-routing
+    ;; raises the documented missing-artefact error.
+    (with-hook-as-nil :routing/route-link
+      (fn []
+        (let [thrown (try (rf/route-link {:to :route/probe})
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "route-link throws when the routing artefact is absent")
+          (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
+              "the documented error category appears in the message")
+          (let [data (ex-data thrown)]
+            (is (= 'route-link (:where data))
+                "ex-data carries :where = 'route-link")
+            (is (= :no-recovery (:recovery data))
+                "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -1,0 +1,205 @@
+(ns re-frame.route-link-cljs-test
+  "CLJS tests for the `:route/link` registered view (rf2-uhv2). Covers
+  the click-interception semantics that only run in a JS environment:
+
+  - plain left-click (no modifier keys, button 0) → preventDefault is
+    called AND `:rf/url-requested` is dispatched with the synthesised
+    URL + the route-id + path-params + query.
+  - modifier-key clicks (cmd / ctrl / shift / alt) → preventDefault is
+    NOT called and no event is dispatched; the browser handles the
+    click natively (preserving open-in-new-tab affordances).
+  - auxiliary-button clicks (middle-click, button 1) → same as
+    modifier-key clicks: deferred to the browser.
+  - caller-supplied `:on-click` that calls preventDefault → the
+    framework's interception is skipped.
+
+  These cases run the bare `route-link-render` fn (the one exposed
+  without Reagent's wrapping) against a synthetic event object so the
+  test has no DOM dependency. ns ends in `-cljs-test` so shadow-cljs's
+  `:node-test` build picks it up.
+
+  Per Spec 012 §Linking from views — plain-anchor semantics and
+  API.md `route-link` row's click-rules paragraph."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; Snapshot/restore the registrar around each test (rf2-am9d) — same
+;; pattern as routing_cljs_test.cljs. We do NOT use registrar/clear-all!
+;; on CLJS: it would wipe routing.cljc's ns-load-time registrations
+;; (the :rf.route/* events, the :rf/route reg-sub family, AND the
+;; :route/link registered view), and CLJS has no `require :reload` to
+;; resurrect them. test-support's reset-runtime-fixture snapshots the
+;; registrar and rolls back per-test changes only.
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn routing/reset-counters!}))
+
+;; ---- synthetic event helper --------------------------------------------
+
+(defn- mk-event
+  "Hand-build a JS object the handler can poke at. `:preventDefault`
+  flips `:defaultPrevented` to true so subsequent reads see the change."
+  [{:keys [button meta ctrl shift alt default-prevented]
+    :or {button 0 meta false ctrl false shift false alt false
+         default-prevented false}}]
+  (let [o #js {:button           button
+               :metaKey          meta
+               :ctrlKey          ctrl
+               :shiftKey         shift
+               :altKey           alt
+               :defaultPrevented default-prevented}]
+    (set! (.-preventDefault o)
+          (fn [] (set! (.-defaultPrevented o) true)))
+    o))
+
+(defn- click!
+  "Render route-link with `props`, extract the on-click handler from
+  the hiccup, invoke it against `event`, then return:
+    {:dispatched   <event-vector or nil — the :rf/url-requested event>
+     :prevented?   <boolean — was preventDefault called?>
+     :href         <a's :href>}
+
+  Captures the dispatched event via a trace callback. router/dispatch!
+  enqueues asynchronously, so we read the queued-event trace
+  (`:event/dispatched`) rather than polling the queue drain. This keeps
+  the test independent of the queue's drain timing."
+  [props event]
+  (let [dispatched (atom nil)
+        cb-key     (keyword (gensym "click-capture-"))]
+    (rf/register-trace-cb!
+      cb-key
+      (fn [ev]
+        (when (and (= :event/dispatched (:operation ev))
+                   (vector? (-> ev :tags :event))
+                   (= :rf/url-requested (-> ev :tags :event first)))
+          (reset! dispatched (-> ev :tags :event)))))
+    (try
+      (let [[_ attrs] (routing/route-link-render props)
+            on-click (:on-click attrs)]
+        (on-click event)
+        {:dispatched @dispatched
+         :prevented? (.-defaultPrevented event)
+         :href       (:href attrs)})
+      (finally
+        (rf/remove-trace-cb! cb-key)))))
+
+;; ---- href synthesis (CLJS sanity) --------------------------------------
+
+(deftest route-link-href-synthesis-cljs
+  (testing "the rendered <a> :href matches route-url"
+    (rf/reg-route :route/cart    {:path "/cart"})
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+
+    (let [[_ attrs] (routing/route-link-render {:to :route/cart})]
+      (is (= "/cart" (:href attrs))))
+    (let [[_ attrs] (routing/route-link-render
+                     {:to :route/article :params {:id "intro"}})]
+      (is (= "/articles/intro" (:href attrs))))))
+
+;; ---- plain left-click → preventDefault + dispatch ----------------------
+
+(deftest plain-left-click-intercepts
+  (testing "button 0 + no modifiers → preventDefault + :rf/url-requested"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented? href]}
+          (click! {:to :route/cart} (mk-event {}))]
+      (is (= "/cart" href))
+      (is prevented? "preventDefault was called on plain left-click")
+      (is (= :rf/url-requested (first dispatched))
+          "the dispatched event is :rf/url-requested")
+      (let [payload (second dispatched)]
+        (is (= "/cart" (:url payload)))
+        (is (= :route/cart (:to payload)))))))
+
+(deftest plain-left-click-passes-params-and-query
+  (testing "the dispatched payload carries :params and :query when present"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]
+                                  :query  [:map [:tab :keyword]]})
+    (let [{:keys [dispatched]}
+          (click! {:to     :route/article
+                   :params {:id "intro"}
+                   :query  {:tab "summary"}}
+                  (mk-event {}))
+          payload (second dispatched)]
+      (is (= {:id "intro"} (:params payload))
+          ":params lands in the dispatched payload")
+      (is (= {:tab "summary"} (:query payload))
+          ":query lands in the dispatched payload"))))
+
+;; ---- modifier-key clicks defer to browser ------------------------------
+
+(deftest cmd-click-defers
+  (testing "cmd-click does NOT preventDefault and does NOT dispatch"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart} (mk-event {:meta true}))]
+      (is (not prevented?) "cmd-click leaves the click for the browser")
+      (is (nil? dispatched) "no :rf/url-requested event"))))
+
+(deftest ctrl-click-defers
+  (testing "ctrl-click does NOT preventDefault and does NOT dispatch"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart} (mk-event {:ctrl true}))]
+      (is (not prevented?))
+      (is (nil? dispatched)))))
+
+(deftest shift-click-defers
+  (testing "shift-click does NOT preventDefault and does NOT dispatch"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart} (mk-event {:shift true}))]
+      (is (not prevented?))
+      (is (nil? dispatched)))))
+
+(deftest alt-click-defers
+  (testing "alt-click does NOT preventDefault and does NOT dispatch"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart} (mk-event {:alt true}))]
+      (is (not prevented?))
+      (is (nil? dispatched)))))
+
+(deftest middle-click-defers
+  (testing "middle-click (button 1) does NOT preventDefault and does NOT dispatch"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart} (mk-event {:button 1}))]
+      (is (not prevented?))
+      (is (nil? dispatched)))))
+
+;; ---- caller-supplied :on-click can pre-empt ----------------------------
+
+(deftest caller-on-click-pre-empts-when-preventing-default
+  (testing "if the caller's :on-click calls preventDefault, the framework's interception is skipped"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [custom-fired?   (atom false)
+          custom-on-click (fn [e]
+                            (reset! custom-fired? true)
+                            (.preventDefault e))
+          {:keys [dispatched prevented?]}
+          (click! {:to :route/cart :on-click custom-on-click}
+                  (mk-event {}))]
+      (is @custom-fired? "the caller's on-click ran")
+      (is prevented? "the caller called preventDefault")
+      (is (nil? dispatched)
+          "the framework did NOT dispatch :rf/url-requested when the caller pre-empted"))))
+
+(deftest caller-on-click-runs-but-does-not-block
+  (testing "if the caller's :on-click does NOT preventDefault, the framework still intercepts"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [custom-fired?   (atom false)
+          custom-on-click (fn [_e] (reset! custom-fired? true))
+          {:keys [dispatched prevented?]}
+          (click! {:to :route/cart :on-click custom-on-click}
+                  (mk-event {}))]
+      (is @custom-fired? "the caller's on-click ran")
+      (is prevented? "the framework still called preventDefault")
+      (is (= :rf/url-requested (first dispatched))
+          "the framework dispatched :rf/url-requested"))))

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -1,0 +1,182 @@
+(ns re-frame.route-link-test
+  "JVM tests for the `:route/link` registered view (rf2-uhv2). The view is
+  CLJS-only for the click-interception semantics; this file covers the
+  JVM-portable contract:
+
+  - registry registration — `:route/link` is present in the `:view`
+    registrar kind on both platforms (CLJS via `reg-view*`, JVM via the
+    `routing.cljc` :clj branch).
+  - href synthesis — the SSR-side render fn yields a hiccup tree whose
+    `:href` matches `(route-url to params query)` for the supplied
+    route, with the optional `:fragment` appended after `#`.
+  - HTML-attr passthrough — keys other than `:to` / `:params` / `:query`
+    / `:fragment` / `:on-click` land on the rendered `<a>` element.
+  - missing route — invoking `route-link` with an unregistered `:to` id
+    raises `:rf.error/no-such-route` (the same error `route-url` raises;
+    the link view delegates to `route-url` for URL synthesis).
+  - `:rf/url-requested` lands on `:rf.route/navigate` — dispatching the
+    event the view fires when a plain left-click is intercepted updates
+    the `:rf/route` slice end-to-end. This pins the click→event pipeline
+    at the JVM layer; CLJS tests cover the click handler's modifier-key
+    branching.
+
+  Per Spec 012 §Linking from views — plain-anchor semantics and API.md
+  `route-link` row."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.routing :as routing]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  ((requiring-resolve 're-frame.routing/reset-counters!))
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- registry registration ----------------------------------------------
+
+(deftest route-link-registered-at-route-link-id
+  (testing ":route/link is present in the :view registrar kind"
+    ;; Per API.md `route-link` row and Spec 012 §Linking from views: the
+    ;; routing artefact registers a view at id `:route/link` on
+    ;; ns-load, on both platforms — `.cljc` render trees that embed
+    ;; `[rf/route-link ...]` resolve identically client- and server-side.
+    (is (some? (rf/handler-meta :view :route/link))
+        ":route/link is registered when re-frame.routing is loaded")
+    (is (fn? (:handler-fn (registrar/lookup :view :route/link)))
+        "the registered slot carries a callable :handler-fn")))
+
+;; ---- href synthesis -----------------------------------------------------
+
+(deftest route-link-href-from-route-id
+  (testing "the rendered <a> :href matches route-url for the given :to"
+    (rf/reg-route :route/cart    {:path "/cart"})
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+
+    (let [render  routing/route-link-render-ssr
+          [tag attrs] (render {:to :route/cart})]
+      (is (= :a tag) "renders an <a> element")
+      (is (= "/cart" (:href attrs))
+          ":href is the route-url for :route/cart"))
+
+    (let [[_ attrs] (routing/route-link-render-ssr
+                     {:to :route/article :params {:id "intro"}})]
+      (is (= "/articles/intro" (:href attrs))
+          ":href substitutes :params into the route's :path pattern"))))
+
+(deftest route-link-href-with-query-and-fragment
+  (testing ":query and :fragment are appended to the href"
+    (rf/reg-route :route/search {:path  "/search"
+                                 :query [:map [:q :string]]})
+
+    (let [[_ attrs] (routing/route-link-render-ssr
+                     {:to    :route/search
+                      :query {:q "clojure"}})]
+      (is (= "/search?q=clojure" (:href attrs))
+          ":query lands as ?key=value on the href"))
+
+    (let [[_ attrs] (routing/route-link-render-ssr
+                     {:to       :route/search
+                      :query    {:q "clojure"}
+                      :fragment "results"})]
+      (is (= "/search?q=clojure#results" (:href attrs))
+          ":fragment is appended after #"))
+
+    (let [[_ attrs] (routing/route-link-render-ssr
+                     {:to       :route/search
+                      :fragment ""})]
+      (is (= "/search" (:href attrs))
+          "empty :fragment is treated as no fragment (no trailing #)"))))
+
+;; ---- html-attr passthrough ---------------------------------------------
+
+(deftest route-link-passes-html-attrs-through
+  (testing "props other than :to / :params / :query / :fragment / :on-click pass through"
+    (rf/reg-route :route/home {:path "/"})
+
+    (let [[_ attrs children] (routing/route-link-render-ssr
+                              {:to    :route/home
+                               :class "nav-link"
+                               :id    "home-link"
+                               :title "Home"
+                               :aria-label "Go to home page"}
+                              "Home")]
+      (is (= "/" (:href attrs)) ":href is synthesised")
+      (is (= "nav-link" (:class attrs)) ":class passes through")
+      (is (= "home-link" (:id attrs)) ":id passes through")
+      (is (= "Home" (:title attrs)) ":title passes through")
+      (is (= "Go to home page" (:aria-label attrs)) ":aria-label passes through")
+      (is (nil? (:to attrs)) ":to is consumed (not forwarded to <a>)")
+      (is (nil? (:params attrs)) ":params is consumed")
+      (is (nil? (:query attrs)) ":query is consumed")
+      (is (nil? (:fragment attrs)) ":fragment is consumed")
+      (is (= "Home" children) "children pass through"))))
+
+;; ---- missing route ------------------------------------------------------
+
+(deftest route-link-missing-route-raises
+  (testing "an unregistered :to id raises :rf.error/no-such-route"
+    ;; Per the existing route-url contract (see routing.cljc — the
+    ;; route-url helper throws ex-info ":rf.error/no-such-route" when
+    ;; the route-id has no registered :path). The route-link view
+    ;; delegates href synthesis to route-url, so the same error
+    ;; surfaces from the link layer.
+    (let [thrown (try
+                   (routing/route-link-render-ssr {:to :route/nope})
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown) "route-link raises when :to is unregistered")
+      (is (= ":rf.error/no-such-route" (.getMessage thrown))
+          "the missing-route error keyword matches route-url's contract")
+      (is (= :route/nope (:route-id (ex-data thrown)))
+          "ex-data carries the offending route-id"))))
+
+;; ---- :rf/url-requested → :rf.route/navigate pipeline -------------------
+
+(deftest route-link-click-event-completes-navigation
+  (testing ":rf/url-requested with a route-link's payload navigates"
+    ;; Per Spec 012 §Standard runtime events the click handler emits
+    ;; `:rf/url-requested {:url ... :to ... :params ... :query ...}`.
+    ;; The default `:rf/url-requested` handler classifies via match-url
+    ;; and dispatches `:rf/url-changed`, which updates the :rf/route
+    ;; slice. This test pins the round-trip without a DOM event — the
+    ;; CLJS test covers the click branching that produces the dispatch.
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+
+    ;; Suppress the :client-only :rf.nav/push-url fx on the JVM (matches
+    ;; the pattern in routing_test.clj).
+    (rf/reg-fx :rf.nav/push-url
+               {:platforms #{:server :client}}
+               (fn [_ _] nil))
+
+    ;; Land on /home first so :rf/route has a current id.
+    (rf/dispatch-sync [:rf/url-changed "/"])
+    (is (= :route/home
+           (get-in (rf/get-frame-db :rf/default) [:rf/route :id]))
+        "initial nav lands at :route/home")
+
+    ;; Fire the event a click on `[rf/route-link {:to :route/article :params {:id \"intro\"}}]`
+    ;; would produce.
+    (rf/dispatch-sync [:rf/url-requested
+                       {:url    "/articles/intro"
+                        :to     :route/article
+                        :params {:id "intro"}}])
+    (is (= :route/article
+           (get-in (rf/get-frame-db :rf/default) [:rf/route :id]))
+        ":rf/url-requested with a route-link payload completes the navigation")
+    (is (= {:id "intro"}
+           (get-in (rf/get-frame-db :rf/default) [:rf/route :params]))
+        ":params from the link land in the :rf/route slice")))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -597,18 +597,33 @@ Two named events are part of the routing contract. Implementations register them
 
 These events are the **decision points** for navigation policy. The policy is enumerable and testable: dispatch `[:rf/url-requested {:url "/cart"}]` from a test, observe the resulting `:rf.route/navigate`, no DOM simulation required.
 
-`route-link`'s body becomes:
+`route-link` ships in the routing artefact as a registered view at id `:route/link`. The body:
 
 ```clojure
-(rf/reg-view route-link [{:keys [to params query]} & children]
-  (let [url (rf/route-url to (or params {}) (or query {}))]
-    [:a {:href     url
-         :on-click (fn [e]
-                     (when (plain-left-click? e)        ;; no modifier keys
-                       (.preventDefault e)
-                       (dispatch [:rf/url-requested {:url url :to to :params params :query query}])))}
-     children]))
+(rf/reg-view ^{:rf/id :route/link} route-link
+  [{:keys [to params query fragment on-click] :as props} & children]
+  (let [base-url (rf/route-url to (or params {}) (or query {}))
+        url      (if (and fragment (not= "" fragment))
+                   (str base-url "#" fragment)
+                   base-url)
+        attrs    (-> props
+                     (dissoc :to :params :query :fragment :on-click)
+                     (assoc :href url
+                            :on-click
+                            (fn [e]
+                              (when on-click (on-click e))
+                              (when (and (not (.-defaultPrevented e))
+                                         (plain-left-click? e))   ;; no modifier keys; primary button
+                                (.preventDefault e)
+                                (dispatch [:rf/url-requested
+                                           (cond-> {:url url :to to}
+                                             (seq params) (assoc :params params)
+                                             (seq query)  (assoc :query query)
+                                             fragment     (assoc :fragment fragment))])))))]
+    (into [:a attrs] children)))
 ```
+
+The view exposes three behavioural seams: passthrough attributes (`:class`, `:title`, `:id`, `:aria-label`, …) flow through to the `<a>`; a caller-supplied `:on-click` runs before the framework's interception and can pre-empt it by calling `.preventDefault`; and modifier-key clicks defer to the browser so middle-click / cmd-click / shift-click keep their native open-in-new-tab affordances. `route-url` is the single point where the URL is synthesised, so route-rename and route-shape changes flow into every `route-link` site without per-link edits.
 
 ## Scroll restoration
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -133,9 +133,11 @@ The shared React Context that backs `frame-provider` lives in `re-frame.adapter.
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 |
 | `match-url` | Fn | `(match-url url)` → `{:route-id :params :query :validation-failed?}` or `nil` | v1 | 012 |
 | `route-url` | Fn | `(route-url route-id path-params)` / `(route-url route-id path-params query-params)` → URL string | v1 | 012 |
-| `route-link` | Fn (registered view) | `[rf/route-link {:to :route-id :params {...} :query {...}} & children]` | v1 | 012 |
+| `route-link` | Fn (registered view at `:route/link`) | `[rf/route-link {:to :route-id :params {...} :query {...} :fragment "..." & html-attrs} & children]` | v1 | 012 |
 
 `reg-route` metadata reserved keys: `:doc`, `:path`, `:params`, `:query`, `:query-defaults`, `:query-retain`, `:tags`, `:parent`, `:on-match`, `:on-error`, `:can-leave`, `:scroll`. Canonical detail in [012-Routing.md](012-Routing.md); shape in [Spec-Schemas §`:rf/route-metadata`](Spec-Schemas.md#rfroute-metadata).
+
+`route-link` click rules: a plain primary-button click (no modifier keys, no `defaultPrevented`) calls `.preventDefault` and dispatches `[:rf/url-requested {:url <synthesised> :to <route-id> :params {...} :query {...} :fragment "..."}]`. Modifier-key clicks (cmd / ctrl / shift / alt) and auxiliary-button clicks (middle-click) defer to the browser so the native `href` opens in a new tab. A caller-supplied `:on-click` runs first; if it calls `.preventDefault` (or otherwise leaves `defaultPrevented` true) the framework's interception is skipped. Keys other than `:to` / `:params` / `:query` / `:fragment` / `:on-click` pass through to the underlying `<a>` element. Detailed semantics in [012-Routing.md §Linking from views](012-Routing.md#linking-from-views--plain-anchor-semantics).
 
 Standard route-related events:
 


### PR DESCRIPTION
## Summary

API.md and 012-Routing.md both list `route-link` as a v1 registered view, but the routing artefact never registered it. Apps either rolled their own `reg-view route-link` (see examples/reagent/routing/) or copy-pasted from the spec. This PR ships the view at id `:route/link`, published on both platforms through the `:routing/route-link` late-bind hook (CLJS: Reagent-wrapped render fn; JVM: SSR-side render fn) and re-exported from `re-frame.core` as `rf/route-link`.

## View shape

```clojure
[rf/route-link {:to       :route-id
                :params   {...}     ;; optional path params
                :query    {...}     ;; optional query params
                :fragment "..."     ;; optional URL fragment
                :on-click <user fn> ;; optional caller hook
                & passthrough-html-attrs}   ;; :class, :title, :id, ...
 & children]
```

## Click rules

- **Plain primary-button click**, no modifier keys, `defaultPrevented` false: calls `.preventDefault` and dispatches `:rf/url-requested` with `{:url :to :params :query :fragment}`. The runtime's default handler classifies via `match-url` and routes through `:rf.route/navigate`.
- **Modifier-key clicks** (cmd / ctrl / shift / alt) and **middle-click** (button 1): no `preventDefault`, no dispatch — the browser handles the click natively so users keep open-in-new-tab / open-in-new-window affordances.
- **Caller-supplied `:on-click`** runs first; if it calls `.preventDefault` (or otherwise leaves `defaultPrevented` true) the framework's interception is skipped.

## Per-frame handling

Routes are a single global registry (the `:route` registrar kind), so per-frame routing is a non-issue at the link layer — URL synthesis is route-id-driven. The dispatch goes through the router's standard frame-resolution chain (dynamic var → React-context → `:rf/default`), so the `:rf/url-requested` event lands in the frame that owned the click. No additional frame plumbing required.

## Test plan

- [x] JVM (`route_link_test.clj`): 6 tests / 24 assertions — registry registration, href synthesis (path params, query, fragment), HTML-attr passthrough, missing-route error, end-to-end click → `:rf/url-requested` → `:rf.route/navigate`.
- [x] CLJS (`route_link_cljs_test.cljs`): 10 tests — plain left-click interception (preventDefault + dispatch), modifier-key deferral (cmd / ctrl / shift / alt / middle-click), caller-supplied `:on-click` pre-emption.
- [x] JVM (`late_bind_missing_test.clj`): route-link case added to the missing-artefact contract test.
- [x] `clojure -M:test` in `implementation/routing` — 28 tests / 110 assertions, all passing.
- [x] `clojure -M:test` in `implementation/core` — 235 tests / 1069 assertions, all passing.
- [x] `clojure -M:test` in `implementation/ssr` — 31 tests / 118 assertions, all passing.
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — 581 tests / 1378 assertions, all passing (no regressions from new tests).

## Spec changes

- `spec/API.md` — `route-link` row pinned to `:route/link` registry id; added click-rules paragraph documenting modifier-key deferral and the caller-supplied `:on-click` pre-emption seam.
- `spec/012-Routing.md` §Standard runtime events — tightened the route-link body example to match the shipped impl (passthrough attrs, `:on-click` pre-emption, fragment handling).