### PR TITLE
refactor(machines): make machine-transition actually pure — allocator-in-snapshot replaces spawn-counter atom (rf2-gr8q)

### DIFF
--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -44,7 +44,9 @@
  {;; The core artefact's tests historically exercised schema-aware,
   ;; machine-aware, routing-aware AND flow-aware paths (every
   ;; reset-runtime fixture rolled the per-frame schema registry, the
-  ;; spawn-counter, the route-registration counter, and the per-frame
+  ;; machines wall-clock-timer table (rf2-gr8q replaced the per-process
+  ;; spawn-counter atom with in-snapshot allocation), the route-
+  ;; registration counter, and the per-frame
   ;; flow registry; many test files require re-frame.schemas to set up
   ;; their data shapes; smoke_test.clj / pattern_smoke_test.clj /
   ;; conformance_test.clj exercise re-frame.machines/reg-machine +

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -64,8 +64,13 @@
             ;; (correct: there is no flow state to preserve).
             ;; re-frame.machines (Spec 005) ships as a separate artefact
             ;; (day8/re-frame2-machines, rf2-xbtj) — the reset fixture
-            ;; touches the machines spawn-counter through the late-bind
-            ;; hook table when the artefact is loaded, no-ops when not.
+            ;; cancels in-flight `:after` wall-clock timers through the
+            ;; late-bind hook table when the artefact is loaded, no-ops
+            ;; when not. Per rf2-gr8q the per-process spawn-counter atom
+            ;; was replaced by in-snapshot allocation; the same late-
+            ;; bind hook name (`:machines/reset-counters!`) is preserved
+            ;; for fixture back-compat but now resets only the wall-
+            ;; clock-timer table.
             ;; re-frame.schemas (Spec 010) ships as a separate artefact
             ;; (day8/re-frame2-schemas, rf2-p7va). The reset fixture
             ;; touches the per-frame schema registry through the
@@ -154,7 +159,9 @@
        reset is late-bound so JVM tests that don't pull them in are
        unaffected).
     3. Disposes the currently-installed substrate adapter.
-    4. Resets the machines spawn-counter.
+    4. Cancels the machines' in-flight `:after` wall-clock timers
+       (per rf2-gr8q the spawn-counter atom is gone; the late-bind
+       hook now resets only the timer table).
     5. Clears trace listeners and adapter warn-once caches
        (`warned-non-dom-roots` across re-frame.views and the helix /
        uix adapters; per rf2-4edk).
@@ -164,9 +171,13 @@
     7. If an `:init-fn` was supplied, invokes it (zero-arg). Use this
        hook for per-suite setup that needs the registrar / adapter live
        — e.g. seeding test data into the just-installed adapter's
-       app-db. (Routing's reg-counter and the machines spawn-counter
-       are reset automatically when their respective artefacts are on
-       the classpath; see steps 4 and the late-bind block above.)
+       app-db. (Routing's reg-counter and the machines wall-clock
+       timer table are reset automatically when their respective
+       artefacts are on the classpath; see step 4 and the late-bind
+       block above. Per rf2-gr8q the machines spawn-counter atom is
+       gone — spawn-id allocation lives in-snapshot now, so per-test
+       isolation is inherited from the registrar / frame snapshot
+       reset rather than from a dedicated reset call.)
     8. Runs the test.
     9. Restores the registrar to the captured snapshot.
    10. Resets `frame/frames` back to `{}` for symmetry, and (when their
@@ -237,11 +248,14 @@
            (reset-li!))
          (when clear-fn (clear-fn))
          (adapter/dispose-adapter!)
-         ;; Late-bind: when the machines artefact is loaded, reset the
-         ;; spawn-counter so id allocation is stable across fixture
-         ;; runs. When it isn't, the hook returns nil and this is a
-         ;; no-op (correct: there is no counter state to reset).
-         ;; Per rf2-xbtj — machines ships in day8/re-frame2-machines.
+         ;; Late-bind: when the machines artefact is loaded, cancel
+         ;; in-flight `:after` wall-clock timers so a stale timer from a
+         ;; sibling test cannot survive into this one. When it isn't,
+         ;; the hook returns nil and this is a no-op (correct: there is
+         ;; no timer state to clear). Per rf2-xbtj — machines ships in
+         ;; day8/re-frame2-machines. Per rf2-gr8q — the spawn-counter
+         ;; atom is gone; this hook now resets only the timer table.
+         ;; The hook name is preserved for fixture-surface back-compat.
          (when-let [reset-counters! (late-bind/get-fn :machines/reset-counters!)]
            (reset-counters!))
          ;; Late-bind: when the routing artefact is loaded, reset the

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -669,7 +669,7 @@
             "each trace carries its machine's last-state")))))
 
 (deftest spawn-id-is-frame-scoped
-  (testing "actor-id allocation is keyed on [frame-id machine-id], not just machine-id"
+  (testing "actor-id allocation is scoped per-parent-snapshot — independent frames don't share an actor-id sequence"
     (let [machine
           ;; Per Spec 005 §Where snapshots live: spec map does NOT carry
           ;; :id; the id comes from the surrounding reg-event-fx id.
@@ -684,18 +684,7 @@
            ;; Per Spec 005 §Declarative :invoke (rf2-een2 / rf2-smba):
            ;; on-spawn callback signature is (fn [data spawned-id] new-data).
            :on-spawn-actions {:record (fn [data _id] data)}}
-          handler (rf/create-machine-handler machine)
-          collect-ids (fn [frame-id]
-                        (let [acc (atom [])]
-                          (rf/reg-fx :spawn.cap
-                                     {:platforms #{:server :client}}
-                                     (fn [_ _] nil))
-                          ;; Inside the handler, capture spawned ids by
-                          ;; intercepting the :rf.machine/spawn fx via a
-                          ;; trace.
-                          acc))
-          ;; Reset counters so this test starts clean.
-          _ ((requiring-resolve 're-frame.machines/reset-counters!))]
+          handler (rf/create-machine-handler machine)]
       (rf/reg-frame :left  {:doc "left"})
       (rf/reg-frame :right {:doc "right"})
       (rf/reg-event-fx :flow handler)
@@ -711,15 +700,24 @@
               "two :rf.machine/spawned traces — one per frame")
           (is (every? #(= :worker %) ids)
               "both spawned the :worker machine")
-          ;; The actor IDs themselves come through the
-          ;; [:rf.machine/spawn args] fx whose args carry :id-prefix and
-          ;; the runtime stamps the id. Frame-scoping is verified via
-          ;; the spawn-counter staying at 1 for each [frame :worker] key.
-          (let [counter @(deref (resolve 're-frame.machines/spawn-counter))]
-            (is (= 1 (get counter [:left :worker]))
-                "left frame's :worker counter is 1 (independent)")
-            (is (= 1 (get counter [:right :worker]))
-                "right frame's :worker counter is 1 (independent)")))))))
+          ;; Per rf2-gr8q the spawn-counter is no longer a per-process
+          ;; atom — it lives inside each parent machine's snapshot at
+          ;; `:rf/spawn-counter`. Frame-scoping is inherited from
+          ;; per-frame app-db isolation: each frame owns its own copy of
+          ;; the :flow machine's snapshot at [:rf/machines :flow]; each
+          ;; copy's counter advances independently. Read the counter
+          ;; from each frame's snapshot directly.
+          (let [snap-left  (get-in (rf/get-frame-db :left)  [:rf/machines :flow])
+                snap-right (get-in (rf/get-frame-db :right) [:rf/machines :flow])]
+            (is (= 1 (get-in snap-left  [:rf/spawn-counter :worker]))
+                "left frame's :flow snapshot counts one :worker spawn")
+            (is (= 1 (get-in snap-right [:rf/spawn-counter :worker]))
+                "right frame's :flow snapshot counts one :worker spawn")
+            ;; Sanity: both allocations are independent — neither
+            ;; reached count 2 (cross-frame contamination).
+            (is (every? #(= 1 (get-in % [:rf/spawn-counter :worker]))
+                        [snap-left snap-right])
+                "the per-frame counters didn't share an allocator")))))))
 
 (deftest spawn-and-destroy-machine-fx
   (testing ":rf.machine/spawn and :rf.machine/destroy traverse fx without :rf.error/no-such-fx"
@@ -844,10 +842,13 @@
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       (rf/dispatch-sync [:test/tiny [:tick]] {:frame f})
       (let [db (rf/get-frame-db f)]
-        (is (= {:state :idle :data {:n 2}}
+        ;; Per rf2-gr8q the snapshot carries `:rf/spawn-counter` seeded
+        ;; by `synthesise-initial-snapshot`. This machine never spawns,
+        ;; so the slot stays empty (`{}`).
+        (is (= {:state :idle :data {:n 2} :rf/spawn-counter {}}
                (get-in db [:rf/machines :test/tiny]))
             "machine snapshot exists at the spec'd path")
-        (is (= {:state :idle :data {:n 2}}
+        (is (= {:state :idle :data {:n 2} :rf/spawn-counter {}}
                (rf/compute-sub [:rf/machine :test/tiny] db))
             ":rf/machine sub returns the same snapshot")))))
 

--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -4,8 +4,7 @@
 ;; Per Spec 005 §State machines the machine grammar
 ;; (`reg-machine`, `create-machine-handler`, `machine-transition`,
 ;; the `:rf/machine` framework sub, the `:rf.machine/spawn` /
-;; `:rf.machine/destroy` effect handlers, the per-process
-;; spawn-counter) ships as a separate
+;; `:rf.machine/destroy` effect handlers) ships as a separate
 ;; Maven artefact so apps that don't register any machines don't drag
 ;; the namespace, the `:rf/machines` app-db slot's runtime support, or
 ;; the machine-transition engine onto the classpath.

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -4,8 +4,7 @@
 ;; Per Spec 005 §State machines the machine grammar
 ;; (`reg-machine`, `create-machine-handler`, `machine-transition`,
 ;; the `:rf/machine` framework sub, the `:rf.machine/spawn` /
-;; `:rf.machine/destroy` effect handlers, the per-process
-;; spawn-counter) ships as a separate
+;; `:rf.machine/destroy` effect handlers) ships as a separate
 ;; Maven artefact so apps that don't register any machines don't drag
 ;; the namespace, the `:rf/machines` app-db slot's runtime support, or
 ;; the machine-transition engine onto the classpath.
@@ -118,12 +117,14 @@
 ;; `:require [re-frame.machines :as machines]`) see the same surface
 ;; they did pre-split.
 
-;; The spawn-counter atom lives in `re-frame.machines.transition` (where
-;; `apply-transition-once` and `next-spawn-id` close over it), but a couple
-;; of smoke tests reach into it directly via `re-frame.machines/spawn-
-;; counter` to assert per-frame allocation. Re-bind here so the existing
-;; test surface keeps resolving.
-(def ^:private spawn-counter transition/spawn-counter)
+;; Per rf2-gr8q the global `spawn-counter` atom is gone. Declarative-
+;; :invoke spawns allocate ids inside the parent snapshot's
+;; `:rf/spawn-counter` slot via `re-frame.machines.transition/
+;; allocate-spawned-id`; hand-emitted spawn fxs allocate from the frame's
+;; app-db slot at `[:rf/spawn-counter <machine-id>]` inside the spawn-fx
+;; db-swap. `machine-transition` is now an honest pure function — no
+;; module-level mutable state, deterministic from its (machine snapshot
+;; event) arguments.
 
 (def reg-machine*           lifecycle-fx/reg-machine*)
 (def create-machine-handler lifecycle-fx/create-machine-handler)
@@ -138,17 +139,26 @@
 (def after-cancel-fx        timer/after-cancel-fx)
 
 (defn reset-counters!
-  "Reset the spawn-counter and the `:after`-timer table so id allocation
-  and timer-handle bookkeeping are stable across fixture runs. Cancels
-  every in-flight `:after` timer the runtime is currently tracking.
+  "Cancel every in-flight `:after` timer the runtime is currently tracking.
 
-  Bridges the two atoms that live in `re-frame.machines.transition`
-  (spawn-counter) and `re-frame.machines.timer` (after-timers); the
-  consumer surface is a single fn here so test fixtures don't need to
-  know the split."
+  Per rf2-gr8q the per-process `spawn-counter` atom is gone — declarative-
+  :invoke spawn-id allocation lives inside the parent snapshot's
+  `:rf/spawn-counter` slot, and hand-emitted-spawn allocation lives inside
+  the frame's app-db at `[:rf/spawn-counter <machine-id>]`. Both reset
+  automatically: per-test snapshot rollback (via test-support's registrar
+  snapshot/restore + frame reset) clears the app-db; per-fixture snapshot
+  input in the conformance harness is hand-built fresh on each call. The
+  only remaining per-process state this fn resets is the wall-clock timer
+  table in `re-frame.machines.timer`.
+
+  The fn name (and the `:machines/reset-counters!` late-bind hook key)
+  is kept for back-compat with the test-support fixture and the small
+  set of test namespaces that call it directly. Conceptually the name
+  is now slightly stale — \"reset wall-clock timers\" would be more
+  accurate — but renaming would churn the fixture surface; the
+  semantics-preserving rename is deferred."
   []
-  (timer/cancel-all-timers!)
-  (reset! transition/spawn-counter {}))
+  (timer/cancel-all-timers!))
 
 ;; ---- machine-internal effect handlers ------------------------------------
 ;;

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
@@ -527,8 +527,17 @@
                           (transition/denormalise-state
                             (transition/initial-cascade machine (transition/state-path decl))
                             decl)))
-        initial    (cond-> {:state initial-state
-                            :data  (or (:data machine) {})}
+        initial    (cond-> {:state            initial-state
+                            :data             (or (:data machine) {})
+                            ;; Per rf2-gr8q: the spawn-id allocator lives
+                            ;; in-snapshot at `:rf/spawn-counter` so that
+                            ;; `machine-transition` is an honest pure
+                            ;; function. The slot is always present on
+                            ;; live snapshots (seeded here at registration
+                            ;; time); pure-call snapshots (the conformance
+                            ;; harness) may omit it — the reducer treats
+                            ;; absent slots as 0 via fnil-update.
+                            :rf/spawn-counter {}}
                      (some? (:meta machine)) (assoc :meta (:meta machine)))]
     (parallel/commit-tags-parallel machine initial)))
 
@@ -999,18 +1008,33 @@
 ;; fx`. Frame isolation is preserved by the snapshot living at
 ;; `[:rf/machines <id>]` inside the spawning frame's app-db.
 
-(defn- compute-actor-id
-  "Resolve the actor id for a spawn. Per Spec 005 §Declarative :invoke
-  Spec-spec keys: `:invoke-id` is an explicit id (per-state singleton);
-  otherwise the runtime allocated id is sourced from the spawn args
-  the transition runner produced via next-spawn-id."
-  [args frame-id]
+(defn- pre-allocated-actor-id
+  "Resolve the pre-allocated actor id carried on the spawn args. Per Spec
+  005 §Declarative :invoke Spec-spec keys: `:invoke-id` is an explicit
+  literal (per-state singleton); `:rf/spawned-id` is stamped by the
+  transition reducer (rf2-gr8q — allocated from the parent snapshot's
+  `:rf/spawn-counter`). Returns nil for hand-emitted
+  `[:rf.machine/spawn args]` fxs that bypass the transition reducer —
+  the caller (spawn-fx) allocates such ids from the frame's app-db
+  spawn-counter slot inside the spawn's db-swap so the allocation
+  shares the same write."
+  [args]
   (or (:invoke-id args)
-      (:rf/spawned-id args)
-      ;; Fallback: re-allocate (shouldn't happen for declarative :invoke,
-      ;; but supports hand-emitted [:rf.machine/spawn args] forms from
-      ;; action :fx).
-      (transition/next-spawn-id frame-id (or (:id-prefix args) (:machine-id args)))))
+      (:rf/spawned-id args)))
+
+(defn- allocate-actor-id-in-db
+  "Hand-emitted-spawn fallback allocator (rf2-gr8q). When the spawn args
+  carry no pre-allocated id (no `:invoke-id`, no `:rf/spawned-id`), this
+  fn bumps the frame's app-db counter at `[:rf/spawn-counter <machine-id>]`
+  and returns `[new-db spawned-id]`. Per rf2-gr8q the global
+  `spawn-counter` atom is gone; the allocator lives where the side-effect
+  belongs — inside the fx-handler's app-db swap — so the pure transition
+  layer stays effect-free."
+  [db machine-id]
+  (let [db' (update-in db [:rf/spawn-counter machine-id] (fnil inc 0))
+        n   (get-in db' [:rf/spawn-counter machine-id])]
+    [db' (keyword (namespace machine-id)
+                  (str (name machine-id) "#" n))]))
 
 (defn- resolve-spawn-machine
   "Resolve the machine spec to register for a spawn. `:machine-id`
@@ -1058,7 +1082,13 @@
       leaf-level `:on :rf.machine/spawned :target ...` transition."
   [{:keys [frame]} args]
   (let [frame-id   (or frame :rf/default)
-        spawned-id (compute-actor-id args frame-id)
+        ;; Per rf2-gr8q: prefer the pre-allocated id (declarative :invoke
+        ;; routes through the transition reducer which bumps the parent
+        ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
+        ;; no pre-allocated id; the frame's app-db spawn-counter slot
+        ;; serves as the fallback allocator, bumped inside the same
+        ;; db-swap as the snapshot install / registry bind below.
+        pre-id     (pre-allocated-actor-id args)
         spec       (resolve-spawn-machine args)
         spec'      (if (and spec (contains? args :data))
                      (assoc spec :data (:data args))
@@ -1070,6 +1100,23 @@
         parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         track?     (and parent-id invoke-id)
+        ;; Resolve the final spawned id: pre-allocated when present;
+        ;; else allocate from app-db inside the swap below. We pre-read
+        ;; the db once so the trace event and reg-machine* call see the
+        ;; same id the snapshot install / registry bind will use. The
+        ;; db-swap re-applies the increment to the (potentially-newer)
+        ;; db at write time — for the JVM atom container the read is
+        ;; consistent because adapter/replace-container! is the only
+        ;; writer during fx drain.
+        container  (frame/get-frame-db frame-id)
+        old-db     (when container (adapter/read-container container))
+        machine-id-for-alloc (or (:id-prefix args) (:machine-id args))
+        [db-after-alloc spawned-id]
+        (cond
+          pre-id        [old-db pre-id]
+          (and old-db machine-id-for-alloc)
+                        (allocate-actor-id-in-db old-db machine-id-for-alloc)
+          :else         [old-db nil])
         ;; Per rf2-ijm7: stamp framework-reserved keys into the spawned
         ;; actor's initial :data so the actor knows its own address
         ;; (:rf/self-id) and, for declarative-:invoke spawns, its
@@ -1095,8 +1142,11 @@
       (reg-machine* spawned-id spec''))
     ;; (3) Initialise the snapshot + (4) bind :system-id + (5) bind the
     ;; runtime-owned spawn registry (atomically under one app-db swap so
-    ;; observers see consistent state).
-    (when-let [container (frame/get-frame-db frame-id)]
+    ;; observers see consistent state). When the spawned id was allocated
+    ;; from the frame's app-db (the hand-emitted-spawn fallback path),
+    ;; `db-after-alloc` already carries the bumped counter — install the
+    ;; snapshot on top of that.
+    (when container
       (let [parallel-child? (and spec'' (parallel/parallel? spec''))
             initial-decl  (:initial spec'')
             initial-state (when spec''
@@ -1121,11 +1171,10 @@
                                   {:state initial-state
                                    :data  (or (:data spec'') {})})
                                 (assoc :rf/bootstrap-pending? true)))
-            old-db        (adapter/read-container container)
             existing      (when system-id
-                            (get-in old-db [:rf/system-ids system-id]))
+                            (get-in db-after-alloc [:rf/system-ids system-id]))
             new-db
-            (cond-> old-db
+            (cond-> db-after-alloc
               spec''     (assoc-in [:rf/machines spawned-id] initial-snap)
               system-id  (assoc-in [:rf/system-ids system-id] spawned-id)
               track?     (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))]

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -153,22 +153,30 @@
     (let [state-map     (:state initial-snapshot)
           region-names  (vec (keys (:regions machine)))
           ordered       (filterv #(contains? state-map %) region-names)]
+      ;; Per rf2-gr8q: thread `:rf/spawn-counter` across regions so any
+      ;; entry-cascade :invoke fires through the shared in-snapshot
+      ;; allocator and the final merged snapshot carries the bumped value.
       (loop [pending     ordered
              cur-data    (:data initial-snapshot)
+             cur-counter (:rf/spawn-counter initial-snapshot)
              new-states  state-map
              acc-fx      []]
         (cond
           (empty? pending)
-          (let [merged (-> initial-snapshot
-                           (assoc :state new-states)
-                           (assoc :data  cur-data))]
+          (let [merged (cond-> (-> initial-snapshot
+                                   (assoc :state new-states)
+                                   (assoc :data  cur-data))
+                         (some? cur-counter)
+                         (assoc :rf/spawn-counter cur-counter))]
             [(commit-tags-parallel machine merged) acc-fx])
 
           :else
           (let [rn          (first pending)
                 region-spec (region-machine machine rn)
-                region-snap {:state (get state-map rn)
-                             :data  cur-data}
+                region-snap (cond-> {:state (get state-map rn)
+                                     :data  cur-data}
+                              (some? cur-counter)
+                              (assoc :rf/spawn-counter cur-counter))
                 step-result (apply-initial-entry-cascade-single region-spec region-snap)]
             (if (and (vector? step-result)
                      (= :re-frame.machines.transition/action-failed (first step-result)))
@@ -177,6 +185,7 @@
                     prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
                 (recur (rest pending)
                        (:data reg-snap)
+                       (:rf/spawn-counter reg-snap)
                        (assoc new-states rn (:state reg-snap))
                        (vec (concat acc-fx prefixed-fx)))))))))
     (apply-initial-entry-cascade-single machine initial-snapshot)))
@@ -204,24 +213,34 @@
         (->> (or (keys (:regions machine)) region-names)
              (filter (fn [rn] (contains? state-map rn)))
              (vec))]
+    ;; Per rf2-gr8q: thread the snapshot's `:rf/spawn-counter` through each
+    ;; region's transition so declarative `:invoke` inside a region bumps
+    ;; the SAME counter the rest of the machine shares. Region snapshots
+    ;; carry the slot in/out alongside `:state` + `:data`, matching the
+    ;; round-trip pattern already used for `:data`.
     (loop [pending    ordered-regions
            cur-data   (:data snapshot)
+           cur-counter (:rf/spawn-counter snapshot)
            new-states state-map
            acc-fx     []]
       (cond
         (empty? pending)
         (let [final-state-map (into {} (for [rn region-names] [rn (get new-states rn)]))
-              merged          (-> snapshot
-                                  (assoc :state final-state-map)
-                                  (assoc :data  cur-data))
+              merged          (cond-> (-> snapshot
+                                          (assoc :state final-state-map)
+                                          (assoc :data  cur-data))
+                                (some? cur-counter)
+                                (assoc :rf/spawn-counter cur-counter))
               merged-tagged   (commit-tags-parallel machine merged)]
           [merged-tagged acc-fx])
 
         :else
         (let [rn          (first pending)
               region-spec (region-machine machine rn)
-              region-snap {:state (get state-map rn)
-                           :data  cur-data}
+              region-snap (cond-> {:state (get state-map rn)
+                                   :data  cur-data}
+                            (some? cur-counter)
+                            (assoc :rf/spawn-counter cur-counter))
               step-result (machine-transition region-spec region-snap event)]
           (if (and (vector? step-result)
                    (= :re-frame.machines.transition/action-failed (first step-result)))
@@ -230,6 +249,7 @@
                   prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
               (recur (rest pending)
                      (:data reg-snap)
+                     (:rf/spawn-counter reg-snap)
                      (assoc new-states rn (:state reg-snap))
                      (vec (concat acc-fx prefixed-fx))))))))))
 

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -5,10 +5,11 @@
   grammar — transition resolution along hierarchical paths, the
   exit/action/entry cascade, the macrostep drain semantics for `:raise`
   and `:always`, and the parallel-region broadcast layer. Everything
-  here is a pure function over the [machine snapshot event] triple
-  except for two deterministic-allocation atoms (`spawn-counter` for
-  declarative `:invoke` actor-id allocation per Spec 005 §Declarative
-  `:invoke`, and the test-time helper that resets it).
+  here is a pure function over the [machine snapshot event] triple —
+  no module-level mutable state. Per rf2-gr8q the declarative-`:invoke`
+  spawn-id allocator lives inside the snapshot under `:rf/spawn-counter`
+  (a per-machine-id integer map); the reducer threads the bumped
+  counter through the returned snapshot.
 
   The fx vectors built here name `:rf.machine/spawn`,
   `:rf.machine/destroy`, `:rf.machine/invoke-all-init`,
@@ -134,28 +135,42 @@
       (f data event {:state (:state snapshot) :meta (:meta snapshot)})
       (f data event))))
 
-;; ---- spawn counter --------------------------------------------------------
+;; ---- spawn-id allocator (in-snapshot) -------------------------------------
 ;;
-;; Per Spec 005 §Declarative :invoke (sugar over spawn): on entry to an
-;; :invoke-bearing state the runtime emits a :rf.machine/spawn fx and
-;; assigns the spawned actor a deterministic id of the form
-;; `<machine-id>#<n>`. The counter is per machine-id so independent
-;; invokes don't cross-contaminate.
+;; Per Spec 005 §Declarative :invoke (sugar over spawn) and rf2-gr8q: on
+;; entry to an :invoke-bearing state the runtime emits a :rf.machine/spawn
+;; fx and assigns the spawned actor a deterministic id of the form
+;; `<machine-id>#<n>`. The counter lives inside the snapshot under the
+;; reserved key `:rf/spawn-counter` — a per-machine-id integer map. This
+;; makes `apply-transition-once` an honest pure function: identical
+;; (machine snapshot event) triples produce identical [next-snapshot
+;; effects] pairs including spawn-id sequencing. Each spawn bumps
+;; the snapshot's counter via update-in and the bumped value is the
+;; allocated id.
+;;
+;; `synthesise-initial-snapshot` (in re-frame.machines.lifecycle-fx)
+;; stamps `{:rf/spawn-counter {}}` on every freshly-registered machine's
+;; initial snapshot so the slot is always present for live runtime
+;; spawns. Hand-built snapshots (the conformance fixtures) may omit the
+;; key — the reducer uses `(fnil inc 0)` so absent slots default to 0.
 
-(defonce spawn-counter
-  ;; Keyed by [frame-id machine-id] so independent frames don't share
-  ;; one actor-id sequence — preserves frame isolation and makes
-  ;; deterministic replay / restore reliable. Pure machine-transition
-  ;; calls (the conformance fixture corpus) pass a sentinel frame.
-  (atom {}))   ;; [frame-id machine-id] → int
+(defn- format-spawn-id
+  "Format a spawned actor id of the form `<machine-id>#<n>` preserving
+  any namespace on the machine-id."
+  [machine-id n]
+  (keyword (namespace machine-id)
+           (str (name machine-id) "#" n)))
 
-(defn next-spawn-id
-  [frame-id machine-id]
-  (let [k [frame-id machine-id]
-        n (-> (swap! spawn-counter update k (fnil inc 0))
-              (get k))]
-    (keyword (namespace machine-id)
-             (str (name machine-id) "#" n))))
+(defn allocate-spawned-id
+  "Pure allocator. Given a snapshot and the spawned actor's machine-id,
+  return `[snap' spawned-id]` where snap' carries the bumped counter at
+  `[:rf/spawn-counter <machine-id>]` and spawned-id is
+  `<machine-id>#<bumped-n>`. Per rf2-gr8q the counter lives in-snapshot
+  so machine-transition is deterministic from its arguments."
+  [snap machine-id]
+  (let [snap' (update-in snap [:rf/spawn-counter machine-id] (fnil inc 0))
+        n     (get-in snap' [:rf/spawn-counter machine-id])]
+    [snap' (format-spawn-id machine-id n)]))
 
 ;; ---- state-path helpers (hierarchical) ------------------------------------
 ;;
@@ -590,10 +605,11 @@
 
 (defn- handle-invoke-spawn
   "Handle the `:invoke` branch of the spawn reducer in apply-transition-once.
-  Allocates the spawned actor id (deterministic via `next-spawn-id`),
-  materialises the `:data` fn-form (Spec 005 §Spec-spec keys / rf2-h131),
-  runs the user's `:on-spawn` advisory callback against `:data`, and emits
-  one `[:rf.machine/spawn args]` fx carrying `:rf/parent-id` /
+  Allocates the spawned actor id deterministically via `allocate-spawned-id`
+  (the counter lives in-snapshot at `[:rf/spawn-counter <machine-id>]` per
+  rf2-gr8q), materialises the `:data` fn-form (Spec 005 §Spec-spec keys /
+  rf2-h131), runs the user's `:on-spawn` advisory callback against `:data`,
+  and emits one `[:rf.machine/spawn args]` fx carrying `:rf/parent-id` /
   `:rf/invoke-id` / `:rf/spawned-id` so the spawn-fx handler can bind the
   runtime-owned spawn-registry slot (rf2-t07u Option A revised).
 
@@ -603,12 +619,16 @@
   (let [inv         (:invoke n)
         machine-id  (:machine-id inv)
         invoke-id   (vec prefix)
-        frame-id    (or (:rf/frame machine) :rf/transition-pure)
-        spawned-id  (or (:invoke-id inv)
-                        (next-spawn-id frame-id machine-id))
+        ;; Allocate the spawned id from the snapshot's counter (rf2-gr8q).
+        ;; When `:invoke-id` is an explicit literal the runtime uses it
+        ;; directly and the counter is NOT bumped.
+        [s-after-alloc spawned-id]
+        (if (:invoke-id inv)
+          [s (:invoke-id inv)]
+          (allocate-spawned-id s machine-id))
         [mat-status mat-data]
         (if (contains? inv :data)
-          (materialise-data (:data inv) s event)
+          (materialise-data (:data inv) s-after-alloc event)
           [:ok nil])]
     (if (= :fail mat-status)
       (reduced
@@ -635,12 +655,12 @@
             ;; runtime tracks the spawn-id itself in [:rf/spawned parent-id
             ;; invoke-id].
             s'          (if on-spawn-fn
-                          (let [data     (:data s)
+                          (let [data     (:data s-after-alloc)
                                 new-data (on-spawn-fn data spawned-id)]
                             (if new-data
-                              (assoc s :data new-data)
-                              s))
-                          s)]
+                              (assoc s-after-alloc :data new-data)
+                              s-after-alloc))
+                          s-after-alloc)]
         [s' (vec (concat acc-fx [[:rf.machine/spawn spawn-args]]))]))))
 
 (defn- handle-invoke-all-spawn
@@ -660,15 +680,22 @@
   (let [inv-all     (:invoke-all n)
         children    (:children inv-all)
         invoke-id   (vec prefix)
-        frame-id    (or (:rf/frame machine) :rf/transition-pure)
-        ;; Allocate per-child ids (deterministic via spawn-counter).
-        children'   (mapv
-                      (fn [child]
-                        (let [machine-id (:machine-id child)
-                              spawned-id (or (:invoke-id child)
-                                             (next-spawn-id frame-id machine-id))]
-                          (assoc child :rf/spawned-id spawned-id)))
-                      children)
+        ;; Allocate per-child ids deterministically via the in-snapshot
+        ;; counter (rf2-gr8q). Thread the snapshot through the children
+        ;; in declaration order so each child bumps the counter for its
+        ;; machine-id and the resulting snapshot carries the final value.
+        [s-after-alloc children']
+        (reduce
+          (fn [[snap acc] child]
+            (let [machine-id (:machine-id child)
+                  [snap' spawned-id]
+                  (if (:invoke-id child)
+                    [snap (:invoke-id child)]
+                    (allocate-spawned-id snap machine-id))]
+              [snap' (conj acc (assoc child :rf/spawned-id spawned-id))]))
+          [s []]
+          children)
+        s           s-after-alloc
         children-map (into {} (map (fn [c] [(:id c) (:rf/spawned-id c)])) children')
         join-state  {:children  children-map
                      :done      #{}

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -1,0 +1,118 @@
+(ns re-frame.machine-transition-purity-test
+  "Per rf2-gr8q. Locks in the contract that `machine-transition` is an
+  honest pure function — identical (machine, snapshot, event) triples
+  produce identical [next-snapshot effects] pairs INCLUDING the spawn-id
+  sequencing inside emitted `:rf.machine/spawn` fx maps.
+
+  Pre-rf2-gr8q the spawn-id allocator was a module-level
+  `(defonce spawn-counter (atom {}))` keyed on `[frame-id machine-id]`
+  in `re-frame.machines.transition`. The function's docstring promised
+  pure / deterministic but the allocator was a side effect: a second
+  identical call returned different spawn-ids (`:worker#2` vs the first
+  call's `:worker#1`). The conformance corpus only worked because the
+  per-fixture `reset-counters!` zeroed the atom between fixtures.
+
+  Post-rf2-gr8q the counter lives inside the snapshot at
+  `:rf/spawn-counter` (a per-machine-id integer map); each spawn bumps
+  the slot via `update-in` and the returned snapshot carries the bumped
+  value. The function is now deterministic from its arguments — the
+  property this test locks in.
+
+  Two flavours of the property:
+
+   1. **Identical args → identical results.** Call
+      `machine-transition` twice with the SAME arguments and assert
+      the returned pair (snapshot + effects vector) is `=` to the
+      first call's pair.
+
+   2. **No global state.** The two calls happen in arbitrary order;
+      neither alters any module-level state that the other observes.
+      Concretely: a third call with a DIFFERENT snapshot starting at
+      counter 0 still allocates `:worker#1`, not `:worker#3`.
+  "
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines :as machines]))
+
+(def auth-flow-spec
+  "A tiny declarative-`:invoke` machine. On `[:submit]` from `:idle` it
+  transitions to `:authenticating`, an :invoke-bearing state that emits
+  one `:rf.machine/spawn` fx for an `:http/post` child."
+  {:initial :idle
+   :data    {}
+   :states  {:idle           {:on {:submit :authenticating}}
+             :authenticating {:invoke {:machine-id :http/post
+                                       :data       {:url "/api/login"}
+                                       :start      [:begin]}
+                              :on    {:auth/succeeded :authenticated
+                                      :auth/failed    :idle}}
+             :authenticated  {}}})
+
+(deftest machine-transition-is-pure
+  (testing "identical args produce identical [next-snapshot effects] pairs"
+    (let [snap     {:state :idle :data {}}
+          event    [:submit]
+          [snap1 fx1] (machines/machine-transition auth-flow-spec snap event)
+          [snap2 fx2] (machines/machine-transition auth-flow-spec snap event)]
+      (is (= snap1 snap2)
+          "two pure-call invocations from the same input produce the same next-snapshot")
+      (is (= fx1 fx2)
+          "two pure-call invocations from the same input produce the same effects vector")
+      ;; The spawn-id allocated by both calls must be byte-identical —
+      ;; pre-rf2-gr8q the second call would have produced `:http/post#2`.
+      (is (= [[:rf.machine/spawn {:machine-id    :http/post
+                                  :id-prefix     :http/post
+                                  :data          {:url "/api/login"}
+                                  :start         [:begin]
+                                  :rf/spawned-id :http/post#1
+                                  :rf/parent-id  :rf/transition-pure
+                                  :rf/invoke-id  [:authenticating]}]]
+             fx1)
+          "the spawn fx carries `:http/post#1` deterministically")
+      (is (= {:state            :authenticating
+              :data             {}
+              :rf/spawn-counter {:http/post 1}}
+             snap1)
+          "the in-snapshot counter advances; the snapshot now carries `:rf/spawn-counter`")))
+
+  (testing "different input snapshots allocate independently — no shared module-level counter"
+    ;; Two separate input snapshots, each starting at counter 0, both
+    ;; allocate `:http/post#1`. Pre-rf2-gr8q the second would have
+    ;; produced `:http/post#2` because the atom carried over.
+    (let [snap-a {:state :idle :data {:tag :a}}
+          snap-b {:state :idle :data {:tag :b}}
+          [_ fx-a] (machines/machine-transition auth-flow-spec snap-a [:submit])
+          [_ fx-b] (machines/machine-transition auth-flow-spec snap-b [:submit])]
+      (is (= :http/post#1 (-> fx-a first second :rf/spawned-id))
+          "first snapshot's spawn is :http/post#1")
+      (is (= :http/post#1 (-> fx-b first second :rf/spawned-id))
+          "second (independent) snapshot's spawn is also :http/post#1 — no shared counter")))
+
+  (testing "a snapshot whose counter is pre-populated keeps allocating from where it left off"
+    ;; This is the in-snapshot allocator contract: the same snapshot
+    ;; threaded through multiple transitions accumulates spawn-id
+    ;; sequencing. We model it by manually pre-stamping the counter at
+    ;; 3 and then driving a transition.
+    (let [snap     {:state            :idle
+                    :data             {}
+                    :rf/spawn-counter {:http/post 3}}
+          [snap' fx] (machines/machine-transition auth-flow-spec snap [:submit])]
+      (is (= :http/post#4 (-> fx first second :rf/spawned-id))
+          "spawn allocates :http/post#4 — bump of the pre-existing 3")
+      (is (= {:http/post 4} (:rf/spawn-counter snap'))
+          "the returned snapshot's counter is at 4"))))
+
+(deftest invoke-all-counter-bumps-per-child
+  (testing ":invoke-all spawns N children — each child of the same machine-id bumps the same counter slot"
+    (let [spec {:initial :idle
+                :data    {}
+                :states  {:idle      {:on {:start :working}}
+                          :working   {:invoke-all
+                                      {:children [{:id :a :machine-id :worker}
+                                                  {:id :b :machine-id :worker}
+                                                  {:id :c :machine-id :worker}]
+                                       :join     :all}
+                                      :on        {:done :ready}}
+                          :ready     {}}}
+          [snap' _fx] (machines/machine-transition spec {:state :idle :data {}} [:start])]
+      (is (= {:worker 3} (:rf/spawn-counter snap'))
+          "three :worker children bumped the slot to 3"))))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1241,6 +1241,17 @@ The runtime snapshot of a machine instance. Per [005 §Snapshot shape](005-State
    ;; [005 §State tags §Snapshot shape change]
    ;; (005-StateMachines.md#snapshot-shape-change)). Per rf2-ee0d.
    [:tags     {:optional true} [:set :keyword]]
+   ;; :rf/spawn-counter is the per-machine-id integer map the runtime uses
+   ;; to deterministically allocate spawned-actor ids inside a pure
+   ;; machine-transition call. Each declarative `:invoke` bump increments
+   ;; the slot under the spawned child's `:machine-id`; the bumped value
+   ;; is the suffix on the allocated id (`<machine-id>#<n>`). The slot is
+   ;; runtime-owned (`:rf/`-namespaced) — user code MUST NOT write to it.
+   ;; Seeded as `{}` by the runtime when a machine first comes into being
+   ;; (`synthesise-initial-snapshot`); pure-call snapshots (the conformance
+   ;; harness's hand-built input snapshots) may omit it — the reducer
+   ;; defaults absent slots to 0 via `fnil`. Per rf2-gr8q.
+   [:rf/spawn-counter {:optional true} [:map-of :keyword :int]]
    [:meta     {:optional true}
     [:map
      [:rf/snapshot-version {:optional true} :int]                          ;; bumped when definition shape changes incompatibly
@@ -1249,11 +1260,12 @@ The runtime snapshot of a machine instance. Per [005 §Snapshot shape](005-State
 
 Stability invariants the implementation upholds (see [005 §Snapshot shape](005-StateMachines.md#snapshot-shape)):
 
-1. `(read-string (pr-str snapshot))` returns an `=`-equal value — no functions, atoms, JS objects in `:data` (or `:tags` — but `:tags` is a set of keywords, both of which are EDN-clean).
+1. `(read-string (pr-str snapshot))` returns an `=`-equal value — no functions, atoms, JS objects in `:data` (or `:tags` — but `:tags` is a set of keywords, both of which are EDN-clean). `:rf/spawn-counter` is a map of keyword→int and round-trips cleanly.
 2. Snapshots represent committed state only; no in-flight microstate is captured.
 3. Hot-reloading a definition does not invalidate snapshots whose `:state` is still a member.
 4. `:rf/snapshot-version` mismatch between snapshot and definition emits `:rf.warning/machine-snapshot-version-mismatch`.
 5. `:tags` is **read-only** for users — actions cannot return `:tags` in their `{:data :fx}` effect map; the runtime owns the slot and recomputes it from `:state` at every commit.
+6. `:rf/spawn-counter` is **read-only** for users (rf2-gr8q) — the runtime owns the slot and bumps it on every declarative-`:invoke` spawn. Apps that need to address a spawned actor by id read it from `[:rf/spawned <parent-id> <invoke-id>]` (the runtime-owned registry) or via `:on-spawn` advisory bookkeeping — never from the counter directly.
 
 **Effect-map note.** A machine handler returns a standard `:rf/effect-map` (`:db` + `:fx`). The action-internal `{:data :fx}` shape is *internal* to the machine handler; the handler lowers `:data` to a single `:db` write at `[:rf/machines <id> :data]` before returning. The closed `:rf/effect-map` contract (`:db` + `:fx` only) is preserved at the handler boundary.
 

--- a/spec/conformance/fixtures/invoke-all-join-all-completes.edn
+++ b/spec/conformance/fixtures/invoke-all-join-all-completes.edn
@@ -15,7 +15,12 @@
 ;;
 ;; Pure-call machine-transition (the conformance harness's runner) carries
 ;; no parent registration, so :rf/parent-id is the sentinel
-;; :rf/transition-pure (matches the spawn-counter sentinel).
+;; :rf/transition-pure.
+;;
+;; Per rf2-gr8q the spawn-id allocator lives inside the snapshot at
+;; `:rf/spawn-counter` (a per-machine-id integer map). A fresh fixture
+;; snapshot starts without the slot; each child spawn bumps its own
+;; machine-id slot so the three children land at #1 each.
 
 {:fixture/id           :machine/invoke-all-join-all-completes
  :fixture/spec-version "1.0"
@@ -55,11 +60,16 @@
      :error  {}}}
    :snapshot     {:state :idle :data {}}
    :event        [:start]
-   :expect-next-snapshot {:state :hydrating :data {}}
+   :expect-next-snapshot {:state            :hydrating
+                          :data             {}
+                          :rf/spawn-counter {:load-config        1
+                                             :load-feature-flags 1
+                                             :load-user-profile  1}}
    :expect-effects
    ;; The runtime emits 1 init fx + N spawn fxs in this order. Spawn-id
-   ;; allocation is deterministic via the spawn-counter (per machine-id);
-   ;; each spawn-id is `:<machine-id>#1` since the counter resets per fixture.
+   ;; allocation is deterministic via the snapshot's `:rf/spawn-counter`
+   ;; (per machine-id) per rf2-gr8q; each spawn-id is `:<machine-id>#1`
+   ;; because each :machine-id has its own counter slot starting from 0.
    [[:rf.machine/invoke-all-init
      {:rf/parent-id :rf/transition-pure
       :rf/invoke-id [:hydrating]

--- a/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
+++ b/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
@@ -44,7 +44,12 @@
      :ready  {}}}
    :snapshot     {:state :idle :data {}}
    :event        [:start]
-   :expect-next-snapshot {:state :working :data {}}
+   ;; Per rf2-gr8q: the in-snapshot `:rf/spawn-counter` advances once per
+   ;; child spawn — all five children share the `:worker` machine-id so
+   ;; the slot lands at 5 after the entry cascade.
+   :expect-next-snapshot {:state            :working
+                          :data             {}
+                          :rf/spawn-counter {:worker 5}}
    :expect-effects
    [[:rf.machine/invoke-all-init
      {:rf/parent-id :rf/transition-pure

--- a/spec/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
+++ b/spec/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
@@ -40,7 +40,13 @@
 ;;
 ;; Pure-call machine-transition (the conformance harness's runner) carries
 ;; no parent registration, so :rf/parent-id is the sentinel
-;; :rf/transition-pure (matches the spawn-counter sentinel).
+;; :rf/transition-pure.
+;;
+;; Per rf2-gr8q the spawn-id allocator lives inside the snapshot at
+;; `:rf/spawn-counter` (a per-machine-id integer map). A fresh fixture
+;; snapshot starts without the slot; the first spawn bumps the slot to
+;; `{:http/post 1}` and `:http/post#1` is allocated. The expected
+;; next-snapshot below reflects that.
 
 {:fixture/id           :machine/invoke-spawn-on-entry-destroy-on-exit
  :fixture/spec-version "1.0"
@@ -81,9 +87,10 @@
    ;; The :on-spawn callback (:auth/record-actor) records the spawn's id at
    ;; :pending. The fixture harness assigns the deterministic id
    ;; :http/post#1 for spawn-fx in test mode.
-   :expect-next-snapshot {:state :authenticating
-                          :data  {:credentials {:user "alice" :pass "secret"}
-                                  :pending     :http/post#1}}
+   :expect-next-snapshot {:state             :authenticating
+                          :data              {:credentials {:user "alice" :pass "secret"}
+                                              :pending     :http/post#1}
+                          :rf/spawn-counter  {:http/post 1}}
    :expect-effects       [[:rf.machine/spawn {:machine-id    :http/post
                                               :id-prefix     :http/post
                                               :data          {:url "/api/login"

--- a/spec/conformance/fixtures/parallel-invoke-scoped-to-region.edn
+++ b/spec/conformance/fixtures/parallel-invoke-scoped-to-region.edn
@@ -37,8 +37,12 @@
                      :states  {:neutral {}}}}}
    :snapshot     {:state {:data :idle :ui :neutral} :data {}}
    :event        [:fetch]
-   :expect-next-snapshot {:state {:data :loading :ui :neutral}
-                          :data  {}}
+   ;; Per rf2-gr8q: the in-snapshot spawn-counter is threaded across
+   ;; regions; entering :loading in the :data region bumps the
+   ;; `:fetcher` slot to 1.
+   :expect-next-snapshot {:state            {:data :loading :ui :neutral}
+                          :data             {}
+                          :rf/spawn-counter {:fetcher 1}}
    :expect-effects
    [[:rf.machine/spawn
      {:machine-id    :fetcher

--- a/spec/conformance/fixtures/spawn-on-spawn-callback.edn
+++ b/spec/conformance/fixtures/spawn-on-spawn-callback.edn
@@ -61,11 +61,13 @@
    :snapshot     {:state :idle :data {}}
    :event        [:go]
    ;; After entering :working, the desugared spawn fx fires and the
-   ;; on-spawn callback installs the deterministic actor id (per
-   ;; machines/next-spawn-id, the first spawn for this machine spec gets
-   ;; :http/post#1) under :data.:born-with-id.
-   :expect-next-snapshot {:state :working
-                          :data  {:born-with-id :http/post#1}}
+   ;; on-spawn callback installs the deterministic actor id (per rf2-gr8q
+   ;; allocate-spawned-id, the first spawn for this machine spec gets
+   ;; :http/post#1) under :data.:born-with-id. The in-snapshot counter
+   ;; at `:rf/spawn-counter` records the bumped value.
+   :expect-next-snapshot {:state            :working
+                          :data             {:born-with-id :http/post#1}
+                          :rf/spawn-counter {:http/post 1}}
    :expect-effects       [[:rf.machine/spawn {:machine-id    :http/post
                                               :id-prefix     :http/post
                                               :data          {:url "/api/x"}

--- a/spec/conformance/fixtures/spawn-tracked-without-data-pending.edn
+++ b/spec/conformance/fixtures/spawn-tracked-without-data-pending.edn
@@ -67,8 +67,12 @@
    :snapshot     {:state :idle :data {}}
    :event        [:submit]
    ;; Snapshot's :data is unchanged — there's no :on-spawn callback, so
-   ;; the parent's :data carries no spawn-related bookkeeping.
-   :expect-next-snapshot {:state :authenticating :data {}}
+   ;; the parent's :data carries no spawn-related bookkeeping. Per
+   ;; rf2-gr8q the spawn-id allocator advances the snapshot's
+   ;; `:rf/spawn-counter` slot — visible at top level alongside `:data`.
+   :expect-next-snapshot {:state            :authenticating
+                          :data             {}
+                          :rf/spawn-counter {:http/post 1}}
    :expect-effects       [[:rf.machine/spawn {:machine-id    :http/post
                                               :id-prefix     :http/post
                                               :data          {:url "/api/login"}

--- a/spec/conformance/fixtures/spawn-with-system-id-then-lookup-resolves.edn
+++ b/spec/conformance/fixtures/spawn-with-system-id-then-lookup-resolves.edn
@@ -44,9 +44,13 @@
  [[:sup/flow [:start]]]
 
  :fixture/expect
- ;; The :worker/proc's gensym'd id is :worker/proc#1 (per next-spawn-id).
- ;; The reverse index records :worker → :worker/proc#1, and the actor's
- ;; snapshot is initialised under [:rf/machines :worker/proc#1].
+ ;; The :worker/proc's gensym'd id is :worker/proc#1 (per rf2-gr8q
+ ;; allocate-spawned-id — the parent snapshot's :rf/spawn-counter slot
+ ;; advances). The reverse index records :worker → :worker/proc#1, and
+ ;; the actor's snapshot is initialised under [:rf/machines :worker/proc#1].
+ ;; The fixture asserts via submap? — the runtime's extra keys
+ ;; (`:rf/spawn-counter`, the actor's framework-stamped `:rf/self-id`
+ ;; etc.) are tolerated.
  {:final-app-db
   {:rf/machines
    {:sup/flow      {:state    :working


### PR DESCRIPTION
## Summary

Per rf2-gr8q's Shape 1 decision (2026-05-12): the module-level `(defonce spawn-counter (atom {}))` in `re-frame.machines.transition` is gone. Spawn-id allocation for declarative `:invoke` / `:invoke-all` now lives inside the parent snapshot at the reserved `:rf/spawn-counter` slot — a per-machine-id integer map bumped via `update-in` inside `apply-transition-once` and returned as part of the new snapshot.

## Before / after

**Before.** `machine-transition`'s docstring promised "Pure function. JVM- and CLJS-runnable, deterministic." but the implementation transitively called `next-spawn-id`, which did `(swap! spawn-counter ...)` on a module-level atom. The conformance corpus only produced deterministic ids because the test fixture's `:machines/reset-counters!` hook zeroed the atom between fixtures — the function itself was not pure.

**After.** `(machine-transition machine snap event)` is deterministic from its arguments — calling it twice with the same triple returns identical `[next-snapshot effects]` pairs including the spawn-id sequencing inside emitted `:rf.machine/spawn` fx maps. The new `re-frame.machine-transition-purity-test` namespace locks the property in.

## Surface changes

- `re-frame.machines.transition`:
  - `spawn-counter` defonce + `next-spawn-id` removed; replaced with the pure `allocate-spawned-id [snap machine-id] -> [snap' spawned-id]` helper.
  - `handle-invoke-spawn` / `handle-invoke-all-spawn` thread the snapshot through allocation.

- `re-frame.machines.parallel`: `parallel-machine-transition` and `apply-initial-entry-cascade` thread `:rf/spawn-counter` across regions (matching how `:data` is threaded).

- `re-frame.machines.lifecycle-fx`:
  - `synthesise-initial-snapshot` stamps `:rf/spawn-counter {}` on every freshly-registered machine snapshot.
  - `compute-actor-id` split into `pre-allocated-actor-id` + `allocate-actor-id-in-db` (the hand-emitted-spawn fallback now bumps `[:rf/spawn-counter <machine-id>]` in the frame's app-db inside the same swap as the snapshot install).

- `re-frame.machines` façade: `spawn-counter` re-export gone. `reset-counters!` kept (with the `:machines/reset-counters!` late-bind hook preserved for fixture back-compat) but now only cancels in-flight `:after` wall-clock timers — no more counter atom to reset.

- `spec/Spec-Schemas.md` §`:rf/machine-snapshot`: optional `:rf/spawn-counter` slot documented as runtime-owned, user-read-only `[:map-of :keyword :int]`.

- Six conformance fixtures asserting `:expect-next-snapshot` after declarative spawn updated to include the bumped `:rf/spawn-counter`.

- New regression test `implementation/machines/test/re_frame/machine_transition_purity_test.clj` asserts: identical args → identical results (including spawn-id sequencing), independent input snapshots allocate from their own counters, pre-populated counters keep their sequencing.

- `implementation/core/test/re_frame/smoke_test.clj` `spawn-id-is-frame-scoped` rewritten to read each frame's parent machine snapshot's `:rf/spawn-counter` slot. `rf-machine-sub`'s expected snapshot updated for the new slot.

## Test plan

- [x] `implementation/machines` `clojure -M:test`: 116 tests / 316 assertions / 0 failures
- [x] `implementation/core` `clojure -M:test`: 226 tests / 1024 assertions / 0 failures (the conformance corpus's 110 runnable fixtures all pass)
- [x] `npm run test:cljs`: 571 tests / 1353 assertions / 0 failures
- [x] `npm run test:browser`: 559 tests / 1345 assertions / 0 failures
- [x] `npm run test:elision`, `test:bundle-isolation`, `test:bundle-comparison`, `test:examples`: all pass
- [x] `implementation/http` and `implementation/routing` `clojure -M:test`: all pass