### PR TITLE
docs(guide): ch.08 — move API-design-rationale sidebars to spec/005 reference (rf2-8w2t)

### DIFF
--- a/docs/guide/08-state-machines.md
+++ b/docs/guide/08-state-machines.md
@@ -274,18 +274,7 @@ An action sees `(fn [data event] effects)` and returns either:
 
 Just like ordinary `reg-event-fx` returns. The contract is consistent.
 
-> **Why `:data` is the parameter, not a destructure key.** Most guards and actions only care about the machine's own data — not about its discrete state, not about its meta. Passing `:data` directly keeps the 99% case monomorphic and stops `(fn [{:keys [data]} _] ...)` boilerplate from spreading through your codebase. The body reads `(:attempts data)`, not `(get-in snapshot [:data :attempts])`.
-
-### When a guard or action needs the discrete state
-
-The 3-arity escape hatch — `(fn [data event {:keys [state meta]}] ...)` — is opt-in. Declaring a third parameter signals to the runtime that this fn wants the introspection slot. `state` is the snapshot's discrete state; `meta` is any user `:meta`.
-
-```clojure
-(fn capture-browsing-position [_data _event {:keys [state]}]
-  {:data {:last-browsing-state state}})        ;; the FSM keyword
-```
-
-Unless your guard or action needs to branch on the current state name (genuinely rare), stay with 2-arity. The 3-arity is the explicit signal "I'm doing introspection." The runtime arity-detects on the fn itself — no metadata, no flag.
+If a guard or action genuinely needs to branch on the current state name — rare — there's an opt-in 3-arity overload that exposes the snapshot's `:state` and `:meta` slots. Stay with 2-arity unless you need it; see [Spec 005 §3-arity escape hatch](../../spec/005-StateMachines.md#3-arity-escape-hatch--state--meta-introspection) for the design rationale and the variadic-fn caveat.
 
 ## Reading a machine: `sub-machine`
 
@@ -873,8 +862,6 @@ The standard cross-machine pattern still works — `[:fx [[:dispatch [<other-id>
 ```
 
 This is **opt-in** and **orthogonal** to gensym'd ids. Most spawns won't need it. Reach for `:system-id` when you have a stable role (one auth flow, one primary request, one wizard) that other parts of the frame need to talk to by name.
-
-A note on the 3-arity escape hatch covered earlier: the runtime detects "this fn declared three positional parameters" by inspecting the fn's arglist. **Variadic fns** like `(constantly nil)` or `(fn [& args] ...)` are detected as 2-arity. If you actually want the introspection slot, write a real 3-arity fn rather than reaching for a variadic shorthand — the variadic case is a footgun, not a clever shortcut.
 
 ## A runnable example
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -273,6 +273,8 @@ The 3-arity overload is **opt-in** by declaring a third parameter:
 
 Implementations arity-detect the fn at call time: a fn that declares a fixed 3-arg invocation is called with `[data event {:state :meta}]`; everything else (the canonical 2-arity, plus variadic helpers like `(constantly true)`) is called with `[data event]`. The detection is structural — no metadata needed on the fn — so inline `(fn [data ev ctx] ...)` vs `(fn [data ev] ...)` is the only declaration the user makes.
 
+**Variadic-fn footgun.** Because arity-detection is structural, variadic fns like `(constantly nil)` or `(fn [& args] ...)` are detected as 2-arity and called *without* the introspection slot — even if the body would have used a third positional `ctx`. If you actually want the introspection slot, write a real 3-arity fn (`(fn [data event ctx] ...)`); reaching for a variadic shorthand silently strips the slot. The footgun is intentional: the variadic case is overwhelmingly the "don't care about extra args" idiom (`constantly`, ignoring lambdas), and 2-arity invocation is the safer default.
+
 Compound logic is expressed via function composition or as a named entry in the machine's `:guards` map — the name carries semantic content visualisers and AIs read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-guard`.
 
 ### Actions


### PR DESCRIPTION
## Summary

Progressive-disclosure F14 of the guide audit. Ch.08 carried three
API-design-rationale sidebars that interrupt the chapter's spine with
edge-case discussions. Spec/005 is the natural home — design-rationale
belongs in the reference, not the user-facing guide.

## Sidebars moved

- **"Why `:data` is the parameter, not a destructure key"** blockquote.
  Already covered in spec/005 §Naming and §Guards. Sidebar removed.
- **"### When a guard or action needs the discrete state"** subsection
  (the 3-arity escape hatch). Already covered in spec/005 §Guards
  `#### 3-arity escape hatch` and §Path conventions
  `### 3-arity escape hatch — snapshot introspection`. Subsection
  replaced with a one-line forward-pointer to spec/005.
- **"A note on the 3-arity escape hatch... Variadic fns... a footgun"**
  paragraph (orphaned at the bottom of `:system-id`). The variadic
  detection was already in spec/005; the "footgun, not a clever shortcut"
  framing is added to spec/005 §Guards as a Variadic-fn footgun callout.
  Paragraph removed from ch.08.

## Word-count delta

- `docs/guide/08-state-machines.md`: 8251 → 8068 (-183 words, -2.2%)
- `spec/005-StateMachines.md`: 34969 → 35059 (+90 words, +0.26%)

## Test plan

- [x] Forward-pointer anchor resolves to spec/005's `#### 3-arity escape hatch — :state / :meta introspection` heading
- [x] Removed paragraph at line 866 was orphaned (about 3-arity, sitting under unrelated `:system-id` section)
- [x] Ch.08 narrative reads cleanly across both removal sites