### PR TITLE
docs(adapters): per-adapter README documents the imperative-escape-hatch surface (rf2-9j2l)

### DIFF
--- a/implementation/adapters/helix/README.md
+++ b/implementation/adapters/helix/README.md
@@ -1,0 +1,81 @@
+# Helix adapter
+
+Maven artefact: `day8/re-frame2-helix`. Target: Helix 0.2.x. Public ns: `re-frame.adapter.helix`.
+
+This adapter implements re-frame2's substrate contract on top of Helix — Will Acton's minimal CLJS React wrapper. Subscriptions are read via the `use-subscribe` hook (returning a plain value, not a reaction); frame context is composed via React context, sharing the same `createContext` object as the Reagent and UIx adapters so frame-provider chains compose across substrates in mixed-substrate apps.
+
+See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics; [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) for the contract this adapter implements.
+
+## Adapter-specific surface
+
+- `re-frame.adapter.helix/use-subscribe` — Helix hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
+- `re-frame.adapter.helix/frame-provider` — provider component that scopes a child tree to a named frame.
+- `re-frame.adapter.helix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
+
+## Imperative escape hatch — when you need a DOM lifecycle
+
+Most views are pure render functions — `defnc` reads subs via `use-subscribe`, returns hiccup-shaped data, done. A small fraction of views genuinely need to own a piece of host DOM lifecycle:
+
+- **Library bridges** — Framer Motion, GSAP, React-Spring, D3 transitions, AmCharts, Vega-Embed, Mapbox, ag-grid, CodeMirror — anything imperative that needs a DOM element handle plus mount / update / unmount hooks.
+- **DOM-listener-bearing widgets** — `addEventListener` for `animationend`, `transitionend`, `resize`, `intersectionobserver`, `mutationobserver`, custom DOM protocols.
+- **Subscribing to non-re-frame data sources** — websocket-driven UI state, browser APIs (`matchMedia`, `geolocation`, `online`/`offline`), third-party state stores.
+
+The escape hatch is **`helix.hooks/use-effect`** — Helix's React `useEffect` wrapper. `use-effect` runs after commit; its body can attach imperative state to the DOM and return a cleanup function that runs on unmount / before the next effect run.
+
+### Spelling
+
+```clojure
+(helix.hooks/use-effect
+  [dep1 dep2 ...]    ;; deps come first in Helix's macro form
+  ;; body — runs after commit; DOM is mounted, refs are populated
+  ;; ... imperative attach ...
+  (fn cleanup []
+    ;; runs on unmount, and before the next effect run when deps change
+    ;; ... imperative detach ...))
+```
+
+Helix's `use-effect` is a macro whose first argument is the deps vector and whose body is the effect (the inverse of UIx's fn-first / deps-last shape). The cleanup function is the last expression in the body.
+
+### Outer / inner pattern
+
+Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` reads subs via `use-subscribe` and produces props; the **inner** `defnc` owns the library lifecycle via `use-effect`. Capture `(rf/dispatcher)` in a `let` above the `use-effect` call so the dispatcher carries the surrounding frame into the effect body.
+
+```clojure
+(ns my-app.tiles
+  (:require [re-frame.core :as rf]
+            [helix.core :as hx :refer [defnc $]]
+            [helix.hooks :as hooks]
+            [helix.dom :as d]))
+
+;; Inner — owns the imperative lifecycle. Plain Helix defnc.
+(defnc tile-inner [{:keys [tile-id]}]
+  (let [ref      (hooks/use-ref nil)
+        dispatch (rf/dispatcher)]   ;; captured at render — carries the frame
+    (hooks/use-effect
+      [tile-id]
+      (let [el       (.-current ref)
+            listener (fn [_evt] (dispatch [:tile/finished-merging tile-id]))]
+        (.addEventListener el "animationend" listener)
+        (fn cleanup []
+          (.removeEventListener el "animationend" listener))))
+    (d/div {:ref ref :class "tile merging"})))
+
+;; Outer — reads subs, hands props to the inner. Registered via reg-view.
+(rf/reg-view board-panel []
+  (let [active-tile-id (re-frame.adapter.helix/use-subscribe [:board/active-tile])]
+    ($ tile-inner {:tile-id active-tile-id})))
+```
+
+Four things matter:
+
+1. **`(rf/dispatcher)` is captured in the `let` above `use-effect`**, not inside the effect body. The dispatcher closes over the frame at render-time; the effect body fires after commit but the closure is already established. Inside the effect body, `dispatch` carries the right frame.
+2. **The cleanup fn is mandatory.** Without it, the listener leaks across re-mounts and across hot-reloads. The cleanup runs on unmount and before each re-run when deps change.
+3. **The deps vector matters.** Include every prop the effect reads so React re-runs the effect when those props change. An empty deps vector means "run once on mount, clean up on unmount."
+4. **Don't call `use-subscribe` inside the effect body.** Hooks must be called at the top of the component body, not inside another hook's callback. Subscribe in the outer (or in the inner's top-level `let`) and pass the value as a dep.
+
+### Cross-references
+
+- [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#views-must-not-attach-native-dom-event-listeners-from-render-bodies) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#views-must-not-own-imperative-library-lifecycles-directly) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in `use-effect`.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(rf/dispatcher)` / `(rf/bound-dispatcher)` at render-time to carry the frame.
+- **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.
+- [Helix 0.2.x docs — `use-effect`](https://github.com/lilactown/helix/blob/master/docs/creating-components.md) — the underlying hook's signature, deps-vector semantics, and stale-closure considerations.

--- a/implementation/adapters/reagent-slim/README.md
+++ b/implementation/adapters/reagent-slim/README.md
@@ -1,0 +1,80 @@
+# reagent-slim adapter
+
+Maven artefact: `day8/re-frame2-reagent-slim`. Target: `reagent2.core` (the slim Reagent fork shipped from this directory). Public ns: `re-frame.adapter.reagent-slim`.
+
+Reagent-slim is the trimmed-down Reagent variant re-frame2's reference adapter targets when re-com's full surface isn't required. Same observable view semantics as the full Reagent adapter; smaller dependency footprint; an empirically-capped Form-3 surface.
+
+See [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) for the design decisions (why this exists, the React 19 floor, the 7-key Form-3 cap, the narrowed `convert-prop-value`, the SSR split). See [`IMPL-SPEC.md`](IMPL-SPEC.md) for the implementation contract.
+
+## Imperative escape hatch — when you need a DOM lifecycle
+
+Most views are Form-1 / Form-2; the canonical surface is `reg-view`. A small fraction of views genuinely need to own a piece of host DOM lifecycle:
+
+- **Library bridges** — Framer Motion, GSAP, D3 transitions, Vega-Embed, Mapbox, ag-grid, CodeMirror, SpreadJS — anything imperative that needs a DOM element plus mount / update / unmount hooks.
+- **DOM-listener-bearing widgets** — `addEventListener` for `animationend`, `transitionend`, `resize`, intersection / mutation observers, custom DOM protocols.
+- **Error boundaries** — `componentDidCatch` is React's class-component-only contract; the slim adapter's 7-key cap permits it precisely because no Form-1 substitute exists.
+- **Pre-commit DOM measurement** — scroll-position restoration via `:get-snapshot-before-update`.
+
+The escape hatch is **Form-3 via `reagent2.core/create-class`** (the slim equivalent of full Reagent's `reagent.core/create-class`), registered through `re-frame.core/reg-view*` per [Spec 004 §Form-3](../../../spec/004-Views.md#form-3-class--out-of-scope-for-the-macro).
+
+### Spelling
+
+```clojure
+(reagent2.core/create-class
+  {:display-name              "<name>"
+   :reagent-render            (fn [props] ...)
+   :component-did-mount       (fn [this] ...)
+   :component-did-update      (fn [this prev-props prev-state snapshot] ...)
+   :component-will-unmount    (fn [this] ...)
+   :get-snapshot-before-update (fn [this prev-props prev-state] ...)
+   :component-did-catch       (fn [this err info] ...)})
+```
+
+The slim adapter enforces a **7-key cap** — these six keys plus `:display-name`. Any other key throws at `create-class` call time. The cap is empirical (the union of what Day8's four production codebases use, plus nothing else); see [`DESIGN-RATIONALE.md` §4](DESIGN-RATIONALE.md) for the framing.
+
+### Outer / inner pattern, with all worked examples
+
+For the full enumeration — the 7-key cap, migration recipes for the keys it excludes, the canonical library-bridge pattern (Google Maps and Vega-Embed walked through end-to-end), error-boundary pattern, scroll-restoration pattern, and the "when NOT to use Form-3" antipattern callouts — see [`FORM-3.md`](FORM-3.md). That document is the single source of truth for Form-3 in the slim adapter; this README is the index.
+
+The skeleton, briefly:
+
+```clojure
+(ns my-app.charts
+  (:require [re-frame.core :as rf]
+            [reagent2.core :as r]))
+
+;; Inner — Form-3, owns the library lifecycle. Registered via reg-view*.
+(rf/reg-view* :my-app.charts/vega-inner
+  (fn [_initial-spec]
+    (let [el-ref        (atom nil)
+          vega-instance (atom nil)
+          dispatch      (rf/dispatcher)]   ;; captured at render — carries the frame
+      (r/create-class
+        {:display-name           "vega-inner"
+         :reagent-render         (fn [_spec] [:div {:ref #(reset! el-ref %)}])
+         :component-did-mount    (fn [this] ...)
+         :component-did-update   (fn [this _ _ _] ...)
+         :component-will-unmount (fn [_this] (some-> @vega-instance .finalize))}))))
+
+;; Outer — Form-1, reads subs, hands props to the inner. Registered via reg-view.
+(rf/reg-view chart-panel []
+  (let [spec @(subscribe [:dashboard/current-spec])]
+    [(rf/view :my-app.charts/vega-inner) spec]))
+```
+
+Four things matter (same as full Reagent — the slim adapter's lifecycle semantics are observably identical):
+
+1. **Per-mount state in closure atoms.** Don't `def` / `defonce` at top-level.
+2. **`:component-will-unmount` is mandatory** — without it the library instance and any listeners it attached leak across re-mounts and hot-reloads.
+3. **`(rf/dispatcher)` is captured during render**, not inside the lifecycle callback. The dispatcher carries the surrounding frame; lifecycle callbacks fire after commit but the closure is established at render-time.
+4. **Subscriptions live in the outer or in `:reagent-render`** — reactive context is undefined inside `:component-did-mount` / `:component-did-update` / `:component-will-unmount`.
+
+### Cross-references
+
+- [`FORM-3.md`](FORM-3.md) — the 7-key cap, all worked examples (library bridge, error boundary, scroll restoration), and migration recipes for out-of-cap keys.
+- [`DESIGN-RATIONALE.md` §4 The 7-key Form-3 cap](DESIGN-RATIONALE.md) — why the cap is what it is (empirical, not aspirational).
+- [`IMPL-SPEC.md` §6](IMPL-SPEC.md) — the implementation contract: validation throw shape, React-class wrapper, lifecycle key → method mapping.
+- [Spec 004 §Form-3 (class — out of scope for the macro)](../../../spec/004-Views.md#form-3-class--out-of-scope-for-the-macro) — why Form-3 ships through `reg-view*` rather than the macro.
+- [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#views-must-not-attach-native-dom-event-listeners-from-render-bodies) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#views-must-not-own-imperative-library-lifecycles-directly) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in Form-3.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(rf/dispatcher)` / `(rf/bound-dispatcher)` at render-time to carry the frame.
+- **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries).

--- a/implementation/adapters/reagent/README.md
+++ b/implementation/adapters/reagent/README.md
@@ -1,0 +1,92 @@
+# Reagent adapter
+
+Maven artefact: `day8/re-frame2-reagent`. Target: Reagent 2.x. Public ns: `re-frame.adapter.reagent`.
+
+This is the canonical CLJS reference adapter — the substrate `reg-view` was designed against. It implements the contract from [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) on top of Reagent's RAtom/Reaction graph and React commit lifecycle.
+
+See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics.
+
+## Imperative escape hatch — when you need a DOM lifecycle
+
+Most views are pure render functions — Form-1 with `reg-view` covers the canonical case. A small fraction of views genuinely need to own a piece of host DOM lifecycle:
+
+- **Library bridges** — Framer Motion, GSAP, D3 transitions, AmCharts, Vega-Embed, Mapbox, ag-grid, CodeMirror, SpreadJS — anything imperative that needs a DOM element handle plus mount / update / unmount hooks.
+- **DOM-listener-bearing widgets** — `addEventListener` for `animationend`, `transitionend`, `resize`, `intersectionobserver`, `mutationobserver`, custom protocols.
+- **Error boundaries** — `componentDidCatch` is React's class-component-only contract.
+- **Pre-commit DOM measurement** — scroll-position restoration via `getSnapshotBeforeUpdate`.
+
+The escape hatch is **Form-3** via [`reagent.core/create-class`](https://reagent-project.github.io/), registered through `re-frame.core/reg-view*` (the plain-fn surface — the `reg-view` macro rejects Form-3 bodies at compile time per [Spec 004 §Form-3](../../../spec/004-Views.md#form-3-class--out-of-scope-for-the-macro)).
+
+### Spelling
+
+```clojure
+(reagent.core/create-class
+  {:display-name           "<name>"
+   :reagent-render         (fn [props] ...)
+   :component-did-mount    (fn [this] ...)
+   :component-did-update   (fn [this prev-props prev-state snapshot] ...)
+   :component-will-unmount (fn [this] ...)})
+```
+
+`(reagent.core/argv this)` returns `[component-fn & user-args]` inside the lifecycle callbacks — destructure to get the current props.
+
+### Outer / inner pattern
+
+Compose Form-3 with the standard outer/inner split: the **outer** view is Form-1 (registered via `reg-view`), reads subscriptions, and produces props; the **inner** view is the Form-3 class component that owns the library's lifecycle. The outer recomputes whenever subs change and feeds new props into the inner; the inner's `:component-did-update` reacts imperatively.
+
+```clojure
+(ns my-app.charts
+  (:require [re-frame.core :as rf]
+            [reagent.core :as r]))
+
+;; Inner — Form-3, owns the library lifecycle. Registered via reg-view*.
+(rf/reg-view* :my-app.charts/vega-inner
+  (fn [_initial-spec]
+    (let [el-ref        (atom nil)
+          vega-instance (atom nil)
+          dispatch      (rf/dispatcher)]   ;; captured at render — carries the frame
+      (r/create-class
+        {:display-name "vega-inner"
+
+         :component-did-mount
+         (fn [this]
+           (let [[_ spec] (r/argv this)]
+             (-> (js/vegaEmbed @el-ref (clj->js spec))
+                 (.then (fn [result] (reset! vega-instance (.-view result)))))))
+
+         :component-did-update
+         (fn [this _ _ _]
+           (let [[_ new-spec] (r/argv this)]
+             (some-> @vega-instance .finalize)
+             (-> (js/vegaEmbed @el-ref (clj->js new-spec))
+                 (.then (fn [result] (reset! vega-instance (.-view result)))))))
+
+         :component-will-unmount
+         (fn [_this]
+           (some-> @vega-instance .finalize)
+           (reset! vega-instance nil)
+           (reset! el-ref nil))
+
+         :reagent-render
+         (fn [_spec]
+           [:div {:ref (fn [el] (reset! el-ref el))}])}))))
+
+;; Outer — Form-1, reads subs, hands props to the inner. Registered via reg-view.
+(rf/reg-view chart-panel []
+  (let [spec @(subscribe [:dashboard/current-spec])]
+    [(rf/view :my-app.charts/vega-inner) spec]))
+```
+
+Four things matter:
+
+1. **The inner owns instance state in closure atoms.** `el-ref` and `vega-instance` are per-mount; don't use top-level `def` or `defonce` here — those leak across mounts.
+2. **Cleanup is mandatory.** `:component-will-unmount` releases the library instance and event listeners. Without it, every navigation that unmounts the chart leaks the library's internal state, listeners, and tile/data caches.
+3. **`(rf/dispatcher)` is captured during render**, not inside the lifecycle callback. The dispatcher carries the surrounding frame; the lifecycle callback fires after commit but the closure is established at render-time, so dispatches from the callback resolve to the right frame.
+4. **Subscriptions live in the outer, not in the lifecycle callbacks.** The inner's `:reagent-render` can deref subs too, but reactive context is undefined inside `:component-did-mount` / `:component-did-update` / `:component-will-unmount` — don't `@(subscribe …)` there.
+
+### Cross-references
+
+- [Spec 004 §Form-3 (class — out of scope for the macro)](../../../spec/004-Views.md#form-3-class--out-of-scope-for-the-macro) — why Form-3 ships through `reg-view*` rather than the macro.
+- [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#views-must-not-attach-native-dom-event-listeners-from-render-bodies) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#views-must-not-own-imperative-library-lifecycles-directly) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in Form-3.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(rf/dispatcher)` / `(rf/bound-dispatcher)` at render-time to carry the frame.
+- **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.

--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -1,0 +1,79 @@
+# UIx adapter
+
+Maven artefact: `day8/re-frame2-uix`. Target: UIx 2.x (hooks-based). Public ns: `re-frame.adapter.uix`.
+
+This adapter implements re-frame2's substrate contract on top of UIx — Pitch's modern, hooks-based CLJS React wrapper. Subscriptions are read via the `use-subscribe` hook (returning a plain value, not a reaction); frame context is composed via React context.
+
+See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics; [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) for the contract this adapter implements.
+
+## Adapter-specific surface
+
+- `re-frame.adapter.uix/use-subscribe` — UIx hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
+- `re-frame.adapter.uix/frame-provider` — provider component that scopes a child tree to a named frame.
+- `re-frame.adapter.uix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
+
+## Imperative escape hatch — when you need a DOM lifecycle
+
+Most views are pure render functions — `defui` reads subs via `use-subscribe`, returns hiccup, done. A small fraction of views genuinely need to own a piece of host DOM lifecycle:
+
+- **Library bridges** — Framer Motion, GSAP, React-Spring, D3 transitions, AmCharts, Vega-Embed, Mapbox, ag-grid, CodeMirror — anything imperative that needs a DOM element handle plus mount / update / unmount hooks.
+- **DOM-listener-bearing widgets** — `addEventListener` for `animationend`, `transitionend`, `resize`, `intersectionobserver`, `mutationobserver`, custom DOM protocols.
+- **Subscribing to non-re-frame data sources** — websocket-driven UI state, browser APIs (`matchMedia`, `geolocation`, `online`/`offline`), third-party state stores.
+
+The escape hatch is **`uix.core/use-effect`** — UIx's React `useEffect` wrapper. `use-effect` runs after commit; its body can attach imperative state to the DOM and return a cleanup function that runs on unmount / before the next effect run.
+
+### Spelling
+
+```clojure
+(uix.core/use-effect
+  (fn []
+    ;; runs after commit — DOM is mounted, refs are populated
+    ;; ... imperative attach ...
+    (fn cleanup []
+      ;; runs on unmount, and before the next effect run when deps change
+      ;; ... imperative detach ...))
+  [dep1 dep2 ...])   ;; dependency vector — re-runs the effect when these change
+```
+
+### Outer / inner pattern
+
+Compose `use-effect` with the standard outer/inner split: the **outer** `defui` reads subs via `use-subscribe` and produces props; the **inner** `defui` owns the library lifecycle via `use-effect`. Capture `(rf/dispatcher)` in a `let` above the `use-effect` call so the dispatcher carries the surrounding frame into the effect body.
+
+```clojure
+(ns my-app.tiles
+  (:require [re-frame.core :as rf]
+            [uix.core :as uix :refer [defui $]]))
+
+;; Inner — owns the imperative lifecycle. Plain UIx defui.
+(defui tile-inner [{:keys [tile-id]}]
+  (let [ref      (uix/use-ref)
+        dispatch (rf/dispatcher)]   ;; captured at render — carries the frame
+    (uix/use-effect
+      (fn []
+        (let [el       (.-current ref)
+              listener (fn [_evt] (dispatch [:tile/finished-merging tile-id]))]
+          (.addEventListener el "animationend" listener)
+          (fn cleanup []
+            (.removeEventListener el "animationend" listener))))
+      [tile-id])
+    ($ :div {:ref ref :class "tile merging"})))
+
+;; Outer — reads subs, hands props to the inner. Registered via reg-view.
+(rf/reg-view board-panel []
+  (let [active-tile-id (re-frame.adapter.uix/use-subscribe [:board/active-tile])]
+    ($ tile-inner {:tile-id active-tile-id})))
+```
+
+Four things matter:
+
+1. **`(rf/dispatcher)` is captured in the `let` above `use-effect`**, not inside the effect body. The dispatcher closes over the frame at render-time; the effect body fires after commit but the closure is already established. Inside the effect body, `dispatch` carries the right frame.
+2. **The cleanup fn is mandatory.** Without it, the listener leaks across re-mounts and across hot-reloads. The cleanup runs on unmount and before each re-run when deps change.
+3. **The deps vector matters.** Include every prop the effect reads so React re-runs the effect when those props change. An empty deps vector means "run once on mount, clean up on unmount."
+4. **Don't call `use-subscribe` inside the effect body.** Hooks must be called at the top of the component body, not inside another hook's callback. Subscribe in the outer (or in the inner's top-level `let`) and pass the value as a dep.
+
+### Cross-references
+
+- [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#views-must-not-attach-native-dom-event-listeners-from-render-bodies) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#views-must-not-own-imperative-library-lifecycles-directly) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in `use-effect`.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(rf/dispatcher)` / `(rf/bound-dispatcher)` at render-time to carry the frame.
+- **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.
+- [UIx 2.x docs — `use-effect`](https://github.com/pitch-io/uix) — the underlying hook's signature, deps-vector semantics, and stale-closure considerations.


### PR DESCRIPTION
## Summary

Each substrate adapter has its own spelling for the Form-3-equivalent lifecycle hook that imperative library bridges (animations via Framer Motion, D3 transitions, GSAP, etc.) reach for. This PR documents the spelling in each adapter's README so library-bridge authors know what to use.

Per-adapter surfaces:

- **Reagent** — Form-3 via `reagent.core/create-class`, registered through `reg-view*`. Worked example walks Vega-Embed wrapping with the standard outer/inner split.
- **Reagent-slim** — Form-3 via `reagent2.core/create-class` under the 7-key cap. README is brief and cross-links to `FORM-3.md` (which already contains the full worked examples) and `DESIGN-RATIONALE.md`.
- **UIx** — `uix.core/use-effect` inside a `defui`. Worked example wraps an `animationend` listener with cleanup.
- **Helix** — `helix.hooks/use-effect` inside a `defnc`. Worked example mirrors UIx with the macro-shaped (deps-first) syntax.

All four READMEs share the same shape: spelling, when to reach for the hatch, outer/inner worked example, and cross-links to spec/004's new View antipatterns section and the broader outer/inner pattern.

## Test plan

- [ ] Markdown anchors in cross-links resolve correctly when rendered on GitHub.
- [ ] Per-adapter spellings match the underlying library APIs (`reagent.core/create-class`, `reagent2.core/create-class`, `uix.core/use-effect`, `helix.hooks/use-effect`).
- [ ] Reagent-slim README correctly defers to the existing `FORM-3.md` rather than duplicating its worked examples.