### PR TITLE
docs(spec): pin uniform reg-* return-value contract (returns primary id) across API.md + Conventions.md + per-EP docs (rf2-4far)

### DIFF
--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -46,6 +46,10 @@ The **metadata map** is open (consumers tolerate unknown keys; new keys are adde
 
 For `reg-event-*`, the **interceptor chain is positional** (a separate vector argument between the metadata-map and the handler), NOT a metadata-map key. See §Allowed forms of the middle slot below and [Conventions §`:interceptors` is positional, not metadata](Conventions.md#interceptors-is-positional-not-metadata-reg-event-) for the rationale and the warning the runtime emits when `:interceptors` is mis-placed inside the metadata-map.
 
+### Return value
+
+Every `reg-*` returns its **primary id** — the keyword (or path, for `reg-app-schema`) the caller registered with. The contract is uniform across the family per [Conventions §`reg-*` return-value convention](Conventions.md#reg--return-value-convention). Per-kind surfaces (Specs 002 / 004 / 005 / 010 / 011 / 012 / 013) inherit this without restating it.
+
 Per-kind extensions (e.g., `:on-create` on `reg-frame`, `:path` on `reg-route`) are documented in their respective Specs. Notably `reg-frame`'s metadata-map *does* recognise `:interceptors` (frames have no positional middle slot — per [Spec 002 §`:interceptors`](002-Frames.md#interceptors--add-interceptors-to-a-frames-events)).
 
 ### Allowed forms of the middle slot

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -87,7 +87,7 @@ Three observations:
 ;; dispatch-syncs :todo/initialise into it, returns the keyword.
 ```
 
-Atomic create-and-register. There is no way to obtain an unregistered frame; this matches the rest of re-frame's `reg-*` family and avoids orphan-frame states.
+Atomic create-and-register. There is no way to obtain an unregistered frame; this matches the rest of re-frame's `reg-*` family and avoids orphan-frame states. The return value (the registered frame keyword) follows the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
 
 This section is the **canonical grammar** for `reg-frame` metadata. Subsequent sections — [§Re-registration — surgical update](#re-registration--surgical-update), [§Frame presets](#frame-presets--capability-bundles-for-common-configurations), [§Per-instance frames](#per-instance-frames--anonymous-make-frame) — refer to the keys defined here; they do not re-define them.
 

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -210,6 +210,8 @@ Inside a `reg-view*` body the user must capture the frame explicitly via `(rf/di
 
 The `*` suffix is the standard Clojure idiom for the unsweetened, runtime-callable surface beneath a macro (`let` / `let*`, `fn` / `fn*`). Per [Conventions §`*`-suffix naming](Conventions.md), this convention applies wherever a macro has a fn partner; `reg-view` / `reg-view*` is the only such pair in v1.
 
+Both `reg-view` and `reg-view*` return the registered **id** per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention). For `reg-view`, the macro also defs the supplied symbol as a side effect (per §The canonical form below) — that's an additional behaviour, not a substitute for the return value. Programmatic callers that need both the id and the Var have the id via the return value and the Var via the auto-def.
+
 **Inside a `reg-view` body, the unqualified `dispatch`/`subscribe` always come from the surrounding frame** — the injected closures resolve to whatever frame the surrounding `frame-provider` puts in scope. The underlying contract is explicit-frame addressing (per [002 §View ergonomics](002-Frames.md#view-ergonomics-the-hard-part) and OQ-F-12): views can also target a different frame via `(rf/dispatch event {:frame other})` / `(rf/subscribe query {:frame other})` — the qualified two-arg form bypasses the injection. The injected unqualified form is canonical; the explicit form is the escape hatch for cross-frame work (e.g. a story-tool variant that controls a sibling variant).
 
 The injection mechanism is detailed in [002-Frames.md §What `reg-view` injects](002-Frames.md#what-reg-view-injects).

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -547,6 +547,8 @@ Alongside the underlying `reg-event-fx + create-machine-handler` form (per [§Re
 
 Both forms live in `re-frame.machines` (the `day8/re-frame2-machines` artefact, per [Conventions.md](Conventions.md)) and are re-exported under `re-frame.core` for both JVM and CLJS callers. See [API.md §Machines](API.md#machines) for the canonical API table.
 
+Both forms return `machine-id` per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+
 **Registration-metadata stamp.** Both forms record two keys on the registry slot's metadata map (per [001 §Metadata-map shape](001-Registration.md)):
 
 - `:rf/machine? true` — the discriminator. `(rf/machines)` filters `(handlers :event)` by this flag (per [§Querying machines](#querying-machines)). User-written event handlers do not set this key.

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -59,6 +59,8 @@ Rather than one giant schema for the whole `app-db`, schemas are registered **at
 
 This fits re-frame's grain — code already accesses `app-db` via paths; schemas are similarly path-anchored. Composable. Hot-reload-friendly per slice. Tooling and agents can ask "what's the schema at path P?" and get a precise local answer.
 
+`reg-app-schema` returns its `path` argument — the primary id under which the schema registers in the `:app-schema` kind — per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+
 ### A schema for the whole `app-db`
 
 The empty path `[]` means "the whole `app-db`" — same convention as `get-in`/`assoc-in`. Use it to register a root schema:

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -467,6 +467,8 @@ Lock: head logic is registered with `reg-head`; routes name which head to use vi
 
 `reg-head` adds a new registry kind `:head` (per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set)). The query API surfaces it: `(rf/handlers :head)` returns `id → metadata`; tools can enumerate registered heads.
 
+`reg-head` returns its `id` argument per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+
 The function signature is `(fn [db route] head-model)` — pure, deterministic, no side-effects. Same shape and discipline as a sub. Subscriptions inside head functions are evaluated against the static `app-db` value (same path as views; per `compute-sub`).
 
 #### Default flow
@@ -551,6 +553,8 @@ Lock: **both** a registry-first projector and a `:ssr` config naming which proje
 ```
 
 `reg-error-projector` adds a new registry kind `:error-projector` (per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set)). The query API surfaces it: `(rf/handlers :error-projector)` returns `id → metadata`. The runtime consults exactly one projector per response — the one named in `(rf/configure :ssr {:public-error-id ...})`. If unset, the runtime uses its **default projector** (below).
+
+`reg-error-projector` returns its `id` argument per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
 
 #### Default projector
 

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -14,7 +14,7 @@ The complete routing API surface, for quick audit. Each entry links to its norma
 
 ### Registration
 
-- **`reg-route`** — registers a route. Reserved metadata keys: `:doc`, `:path` (required), `:params`, `:query`, `:query-defaults`, `:query-retain`, `:tags`, `:parent`, `:on-match`, `:on-error`, `:scroll`, `:can-leave`. See [§Reserved route-metadata keys](#reserved-route-metadata-keys) and [§Navigation blocking — pending-nav protocol](#navigation-blocking--pending-nav-protocol) for `:can-leave`.
+- **`reg-route`** — registers a route. Reserved metadata keys: `:doc`, `:path` (required), `:params`, `:query`, `:query-defaults`, `:query-retain`, `:tags`, `:parent`, `:on-match`, `:on-error`, `:scroll`, `:can-leave`. See [§Reserved route-metadata keys](#reserved-route-metadata-keys) and [§Navigation blocking — pending-nav protocol](#navigation-blocking--pending-nav-protocol) for `:can-leave`. Returns its `id` argument per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
 - **Path-pattern grammar** — five productions (literal, named param, optional segment group, splat, root). See [§Path-pattern grammar](#path-pattern-grammar-canonical).
 - **Route ranking** — six-rule cascade for resolving overlapping matches. See [§Route ranking algorithm](#route-ranking-algorithm).
 

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -70,6 +70,8 @@ Optional keys (per the [001-Registration §Registration grammar](001-Registratio
 
 `:inputs` is a positional vector matching `on-changes`. The vector form is short for the common 2–4-input case and the destructure-by-position is straightforward. (A map-keyed alternative was considered — see [§Open questions](#open-questions).)
 
+`reg-flow` returns the flow's `:id` — the primary id under which the flow registers in the `:flow` kind — per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention). The id is carried by the flow-map rather than as a separate positional arg, but the return-value contract is the same as the rest of the `reg-*` family.
+
 `reg-flow` accepts an optional second argument carrying a `:frame` opt — the frame the flow registers against. Default is `(current-frame)` (per [002 §How `:frame` gets attached](002-Frames.md#how-frame-gets-attached), usually `:rf/default` unless the call sits inside a `with-frame` form or under a frame-providing context):
 
 ```clojure

--- a/spec/API.md
+++ b/spec/API.md
@@ -19,6 +19,8 @@
 
 ## Registration
 
+> **Return value.** Every `reg-*` row below returns its **primary id** — the keyword (or path, for `reg-app-schema`) the caller registered with. `reg-flow` returns the `:id` value of its flow-map (the primary id is carried by the map, not a separate arg). Per [Conventions §`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+
 | API | M/Fn | Signature | Status | Spec | Notes |
 |---|---|---|---|---|---|
 | `reg-event-db` | M | `(reg-event-db id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | 002 | Macro for source-coord capture. See [MIGRATION §M-5](MIGRATION.md) for higher-order-use migration. |

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -189,6 +189,22 @@ For now the only pair is `reg-view` / `reg-view*` (per [Spec 004 §reg-view*](00
 
 The convention applies **only where there is a macro tier**. The other `reg-*` registrations (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`) are already plain fns — they need no macro tier and therefore no `*` partner. Adding `reg-event-db*` / etc. would be a pure alias and add no value; that's not done. (See [Cross-Spec-Interactions §Family asymmetry](Cross-Spec-Interactions.md#21-family-asymmetry--only-reg-view-has-a-macro-tier) for why the family is intentionally asymmetric.)
 
+## `reg-*` return-value convention
+
+Every `reg-*` registration surface returns its **primary id** — the keyword (or path, for `reg-app-schema`) the caller registered with. This is uniform across the family: `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` / `reg-frame` / `reg-view` / `reg-view*` / `reg-machine` / `reg-machine*` / `reg-app-schema` / `reg-route` / `reg-flow` / `reg-head` / `reg-error-projector` all return their first positional id argument. `reg-flow` returns the `:id` value of its flow-map (the primary id is carried by the map, not a separate arg); `reg-app-schema` returns its `path` (the path IS the registration id for the `:app-schema` kind, per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set)).
+
+The uniformity is load-bearing. It lets call-site code thread the registration id without a separate literal:
+
+```clojure
+(let [event-id (rf/reg-event-fx :cart.item/add ...)]
+  (rf/dispatch [event-id {:id ...}]))
+
+(let [machine-id (rf/reg-machine :auth.login/flow ...)]
+  (rf/dispatch [machine-id :submit]))
+```
+
+Tooling, generators, and CP scaffolds rely on the return value to chain registrations into wiring code. The contract is **fixed-and-additive**: future `reg-*` surfaces ship with the same return shape.
+
 ## `reg-view` auto-id derivation rule
 
 Per [Spec 004 §reg-view](004-Views.md#reg-view-is-the-multi-frame-contract), the `reg-view` macro auto-derives the registered id from the symbol you supply:


### PR DESCRIPTION
## Summary

Every `reg-*` surface returns its **primary id** — the keyword (or path, for `reg-app-schema`) the caller registered with. The contract was uniformly implemented but undocumented; consumers writing `(let [id (rf/reg-* ...)] ...)` had no spec to lean on. This PR pins the contract.

- New §`reg-*` return-value convention in `spec/Conventions.md` — the canonical statement.
- New §Return value subsection in `spec/001-Registration.md` §Registration grammar.
- Leading note above `spec/API.md` §Registration table.
- One-line reminder in each per-EP doc that defines its own reg-*: `002-Frames` (`reg-frame`), `004-Views` (`reg-view` / `reg-view*`), `005-StateMachines` (`reg-machine` / `reg-machine*`), `010-Schemas` (`reg-app-schema`), `011-SSR` (`reg-head`, `reg-error-projector`), `012-Routing` (`reg-route`), `013-Flows` (`reg-flow`).

`reg-flow` returns its flow-map `:id` rather than a positional arg; `reg-app-schema` returns its `path` (the path IS the registration id under the `:app-schema` kind). The convention is fixed-and-additive — future reg-* surfaces ship with the same return shape.

Spec-only PR. Surfaces audited: `reg-event-db` / `-fx` / `-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `make-frame`, `reg-view`, `reg-view*`, `reg-machine`, `reg-machine*`, `reg-app-schema`, `reg-route`, `reg-flow`, `reg-head`, `reg-error-projector`, `reg-http-interceptor`. Impl review found one deviation (the `reg-view` macro returns the auto-defed Var rather than the id, because its expansion terminates in a `(def sym ...)` form); a follow-up bead carries the impl fix.

## Test plan

- [ ] Cross-references resolve (the new convention link from each spec doc).
- [ ] No stale `reg-*` return-value phrasing remains anywhere in `spec/`.