### PR TITLE
docs(guide): remove generic 'Just because you can' quote from ch.01 + ch.12 (rf2-d2l5)

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -44,10 +44,6 @@ re-frame2 chose less flexibility on purpose.
 
 ## Less powerful by design
 
-There's a quote in the original re-frame docs:
-
-> Just because you can, doesn't mean you should.
-
 This is the philosophical centre of re-frame2. The pattern is **deliberately less powerful** than the host language it sits inside. You can't write an event handler that suspends mid-flight. You can't have two handlers touch state simultaneously. Side-effects are not free: every effect goes through a registered, named, queryable interpreter. State changes are not free either: every change goes through an event, which has a name, a registration, and (optionally) a schema describing its shape.
 
 When you give up power, you gain something specific in return: **an execution model you can fully model in your head**. The host language is Turing complete, but the library is not — and that's the point. No dependency-array decisions, no escape hatches. Every higher-order concept (state machines[^machines], async effects, SSR) inherits the same shape rather than escaping it.

--- a/docs/guide/12-the-dynamic-model.md
+++ b/docs/guide/12-the-dynamic-model.md
@@ -66,12 +66,6 @@ The whole pattern is a deliberate cascade of restrictions. The goal isn't to be 
 
 ## III. Less powerful by design
 
-There is a famous quote in the re-frame docs:
-
-> Just because you can, doesn't mean you should.
-
-It applies more deeply than it might first appear.
-
 Programming languages, especially the modern ones, are designed to be *capable*. You can do anything. You can mutate any variable from any place. You can suspend any function with `await`. You can spawn arbitrary side-effects from arbitrary call sites. These capabilities are intoxicating when you're learning the language. They feel like power, and they are.
 
 But power, in this context, is **the right to do anything**. And the right to do anything, exercised thoughtlessly, becomes the obligation, when reading code, **to consider that anything might have happened**.


### PR DESCRIPTION
## Summary

The aphorism "Just because you can, doesn't mean you should." appeared in two guide chapters:

- `docs/guide/01-why-re-frame2.md:49`
- `docs/guide/12-the-dynamic-model.md:71`

It's a generic, well-worn line — not re-frame-specific and not earning its place. The surrounding prose already makes the same argument more vividly. Drop the lead-in + blockquote in both chapters; the paragraphs that follow stand cleanly without it.

## Scope

- ch.01 `Less powerful by design` section: removed 3 lines (lead-in + quote + blank line). Section now opens directly with "This is the philosophical centre of re-frame2."
- ch.12 `III. Less powerful by design` section: removed 5 lines (lead-in + quote + post-quote single-sentence paragraph "It applies more deeply than it might first appear."). Section now opens directly with the "Programming languages, especially the modern ones..." paragraph.

Refs `rf2-d2l5`.