### PR TITLE
fix(interceptor): preserve all errors via :rf/interceptor-errors vector + short-circuit subsequent :before stages (rf2-mm2a)

### DIFF
--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -43,22 +43,40 @@
 
 ;; ---- chain execution ------------------------------------------------------
 
+(defn- record-error
+  "Append `err` to `:rf/interceptor-errors` (preserving prior errors) and
+  set `:rf/interceptor-error` to the FIRST error only. The singleton key
+  is the original cause — tracing code that reads it gets the root failure
+  without surprise. The vector key carries every error in the order they
+  occurred so downstream tooling can surface the full chain of failures."
+  [context err]
+  (let [existing-first (:rf/interceptor-error context)]
+    (cond-> (update context :rf/interceptor-errors (fnil conj []) err)
+      (nil? existing-first) (assoc :rf/interceptor-error err))))
+
 (defn- invoke-before [context interceptor]
-  (if-let [f (:before interceptor)]
-    (try
-      (or (f context) context)
-      (catch #?(:clj Throwable :cljs :default) e
-        (assoc context :rf/interceptor-error
-               {:phase :before :id (:id interceptor) :exception e})))
-    context))
+  ;; Short-circuit: once any :before has failed, skip downstream :before
+  ;; stages. This mirrors the :rf/skip-handler? pattern (events.cljc /
+  ;; cofx.cljc) — partial context shouldn't be propagated to handlers or
+  ;; subsequent validation. The :after pass still runs in execute-chain
+  ;; so interceptors can perform teardown.
+  (if (:rf/interceptor-error context)
+    context
+    (if-let [f (:before interceptor)]
+      (try
+        (or (f context) context)
+        (catch #?(:clj Throwable :cljs :default) e
+          (record-error context
+                        {:phase :before :id (:id interceptor) :exception e})))
+      context)))
 
 (defn- invoke-after [context interceptor]
   (if-let [f (:after interceptor)]
     (try
       (or (f context) context)
       (catch #?(:clj Throwable :cljs :default) e
-        (assoc context :rf/interceptor-error
-               {:phase :after :id (:id interceptor) :exception e})))
+        (record-error context
+                      {:phase :after :id (:id interceptor) :exception e})))
     context))
 
 (defn execute-chain
@@ -70,13 +88,21 @@
        the kind-specific factory; see events.cljc / subs.cljc).
     3. :after of each interceptor in REVERSE declaration order.
 
-  Failures during :before or :after are captured in the context under
-  :rf/interceptor-error and the chain continues — so :after stages can
-  do their cleanup. The drain loop reads :rf/interceptor-error after
-  the chain ends and emits :rf.error/handler-exception (or similar)."
+  Failures during :before or :after are captured in the context:
+    - `:rf/interceptor-error`  — the FIRST error (original cause; what
+                                 tracing code reads).
+    - `:rf/interceptor-errors` — vector of ALL errors in order of
+                                 occurrence (preserves later errors that
+                                 would otherwise be overwritten).
+
+  Once a :before fails, subsequent :before stages are short-circuited
+  (the partial context would be invalid input). The :after pass still
+  runs in full so interceptors can do their cleanup. The drain loop
+  reads :rf/interceptor-error after the chain ends and emits
+  :rf.error/handler-exception (or similar)."
   [interceptors initial-context]
-  (let [;; Apply :before stages in order.
+  (let [;; Apply :before stages in order (short-circuits on first error).
         ctx-after-befores (reduce invoke-before initial-context interceptors)
-        ;; Apply :after stages in reverse order.
+        ;; Apply :after stages in reverse order (always runs for teardown).
         ctx-after-afters  (reduce invoke-after ctx-after-befores (reverse interceptors))]
     ctx-after-afters))

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -336,4 +336,95 @@
       (is (some #(= [:after :c] %) @trail)
           ":after stages downstream of the failing one (in reverse order:
            those reached BEFORE the throw — i.e. :handler's and :c's :after)
-           did execute"))))
+           did execute")))
+
+  (testing "multiple interceptors failing record ALL errors but
+            :rf/interceptor-error remains the FIRST.
+
+            Per rf2-mm2a: prior to the fix, the second `assoc` would
+            clobber the first — the original cause was lost. The fix
+            keeps `:rf/interceptor-error` pinned to the FIRST error
+            (existing tracing reads the root cause) and appends every
+            error in occurrence order to `:rf/interceptor-errors`."
+    (let [;; A :before that throws (interceptor :before-bad), then an
+          ;; :after that throws on the way back out (interceptor :after-bad).
+          ;; The short-circuit means :before-bad's :before fires, but
+          ;; subsequent :before stages are skipped. All :after stages
+          ;; run (teardown contract), so :after-bad's :after will fire.
+          before-bad (interceptor/->interceptor
+                       :id :before-bad
+                       :before (fn [_ctx]
+                                 (throw (ex-info "before blew up"
+                                                 {:src :before-bad}))))
+          after-bad  (interceptor/->interceptor
+                       :id :after-bad
+                       :after  (fn [_ctx]
+                                 (throw (ex-info "after blew up"
+                                                 {:src :after-bad}))))
+          ;; Order: after-bad first so its :after runs LAST (reverse order)
+          ;; AFTER before-bad's :before failure has already stamped the
+          ;; context. That way we exercise the "later error doesn't
+          ;; overwrite earlier" guarantee.
+          chain [after-bad before-bad]
+          final (interceptor/execute-chain chain {:coeffects {} :effects {}})
+          errs  (:rf/interceptor-errors final)
+          first-err (:rf/interceptor-error final)]
+      (is (vector? errs)
+          ":rf/interceptor-errors is a vector")
+      (is (= 2 (count errs))
+          "both errors were recorded — neither was overwritten")
+      (is (= :before (:phase first-err))
+          ":rf/interceptor-error retains the FIRST error (the :before failure)")
+      (is (= :before-bad (:id first-err))
+          ":rf/interceptor-error identifies the FIRST failing interceptor")
+      (is (= [:before :after] (mapv :phase errs))
+          "errors appear in the vector in occurrence order")
+      (is (= [:before-bad :after-bad] (mapv :id errs))
+          "both failing interceptor ids are preserved in order")
+      (is (= first-err (first errs))
+          ":rf/interceptor-error equals the first element of :rf/interceptor-errors")))
+
+  (testing "a failing :before short-circuits subsequent :before stages
+            but :after stages still run (teardown contract).
+
+            Per rf2-mm2a: with the short-circuit, downstream :before
+            stages don't see partial context. The :after pass is
+            unconditional so interceptors can clean up resources their
+            :before claimed."
+    (let [trail (atom [])
+          mk-good (fn [tag]
+                    (interceptor/->interceptor
+                      :id     tag
+                      :before (fn [ctx]
+                                (swap! trail conj [:before tag])
+                                ctx)
+                      :after  (fn [ctx]
+                                (swap! trail conj [:after tag])
+                                ctx)))
+          boom    (interceptor/->interceptor
+                    :id     :boom
+                    :before (fn [_ctx]
+                              (swap! trail conj [:before :boom])
+                              (throw (ex-info "before blew up"
+                                              {:src :boom})))
+                    :after  (fn [ctx]
+                              (swap! trail conj [:after :boom])
+                              ctx))
+          ;; a's :before runs, boom's :before throws, c's :before MUST
+          ;; be skipped (short-circuit). All :after stages run.
+          chain   [(mk-good :a) boom (mk-good :c)]
+          final   (interceptor/execute-chain chain {:coeffects {} :effects {}})]
+      (is (= [[:before :a]
+              [:before :boom]
+              ;; NO [:before :c] — short-circuited.
+              [:after :c]
+              [:after :boom]
+              [:after :a]]
+             @trail)
+          "subsequent :before stages skipped after the failure;
+           every :after still ran in reverse order")
+      (is (= :boom (get-in final [:rf/interceptor-error :id]))
+          "the original :before failure is recorded")
+      (is (= 1 (count (:rf/interceptor-errors final)))
+          "only the one (uncaught) :before error is in the vector —
+           skipped :before stages don't synthesize errors"))))


### PR DESCRIPTION
## Summary

- `invoke-before` / `invoke-after` (`implementation/core/src/re_frame/interceptor.cljc`) wrote `:rf/interceptor-error` unconditionally on catch — a later failure clobbered the earlier root cause. Now errors are appended to a new `:rf/interceptor-errors` vector; `:rf/interceptor-error` is pinned to the FIRST error so existing tracing keeps reading the root cause.
- A failing `:before` now short-circuits subsequent `:before` stages (mirrors the `:rf/skip-handler?` pattern in `events.cljc` / `cofx.cljc`). The `:after` pass still runs in full so interceptors can perform teardown — the documented chain-continues guarantee.

## Why

Found by the 2026-05-12 correctness review (rf2-mm2a). Two related symptoms:

1. If interceptor #2's `:before` fails and stamps an error, then interceptor #1's `:after` also fails, the second `assoc` overwrote the first — the router's `:rf.error/handler-exception` trace surfaced only the LATER error; the original cause was lost.
2. When a `:before` interceptor failed BEFORE a schema-validation interceptor (which sets `:rf/skip-handler?`), the handler-as-interceptor's skip check didn't fire — the handler still ran against partial context, only to be reported as a generic interceptor-error later.

## Test plan

- [x] Added two new sub-tests in `chain-composition` (`implementation/core/test/re_frame/interceptor_test.clj`):
  - Two interceptors fail (`:before` then `:after`): asserts `:rf/interceptor-errors` is a 2-element vector in occurrence order AND `:rf/interceptor-error` stays pinned to the first error.
  - Failing `:before` short-circuits subsequent `:before` stages but `:after` still runs in reverse order.
- [x] Existing `chain-composition` `:after`-throws sub-test still passes (it reads `:rf/interceptor-error` for the singleton-shape, which we preserve).
- [x] Full `core` test suite: 240 tests / 1097 assertions / 0 failures / 0 errors.
- [x] `schemas` test suite: 49 tests / 176 assertions / 0 failures / 0 errors.