### PR TITLE
refactor(http): rename :malli-error? to :schema-validation-failure? in decode-failure envelope (rf2-koyp)

### DIFF
--- a/implementation/http/src/re_frame/http_transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http_transport_cljs.cljc
@@ -316,7 +316,7 @@
                                 (encoding/failure-map :rf.http/decode-failure
                                                       {:body-text body-text
                                                        :cause     (.-message e)
-                                                       :malli-error? (boolean (:malli-error? d))})))))
+                                                       :schema-validation-failure? (boolean (:malli-error? d))})))))
 
                         :else
                         ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx

--- a/implementation/http/src/re_frame/http_transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http_transport_jvm.cljc
@@ -309,7 +309,7 @@
                                             (encoding/failure-map :rf.http/decode-failure
                                                                   {:body-text body-text
                                                                    :cause (.getMessage e)
-                                                                   :malli-error? (boolean (:malli-error? d))})))))
+                                                                   :schema-validation-failure? (boolean (:malli-error? d))})))))
 
                                     :else
                                     ;; Non-2xx that didn't fall in 4xx/5xx (e.g.

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -315,7 +315,7 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 | `:rf.http/timeout` | Per-attempt timeout fired | `:elapsed-ms`, `:limit-ms` |
 | `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (the raw response text — decode is skipped on non-2xx; see [§Classification order](#classification-order)), `:headers` |
 | `:rf.http/http-5xx` | Non-2xx 5xx response | same as `:http-4xx` |
-| `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (Malli error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:malli-error?` |
+| `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (schema validation error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:schema-validation-failure?` |
 | `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. The user's failure map sits at `:detail`; `:decoded` carries the pre-`:accept` decoded value for context. | `:detail` (user's verbatim failure map), `:decoded` |
 | `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal` | `:request-id` (if any), `:reason` (`:user` / `:request-id-superseded`) |
 

--- a/spec/conformance/fixtures/http-managed-decode-failure.edn
+++ b/spec/conformance/fixtures/http-managed-decode-failure.edn
@@ -38,7 +38,7 @@
                  :failure {:kind         :rf.http/decode-failure
                            :body-text    "{not-valid-json"
                            :cause        "JSON syntax error"
-                           :malli-error? false}}]]]}}
+                           :schema-validation-failure? false}}]]]}}
 
  :fixture/frame-config
  {:on-create    []
@@ -53,7 +53,7 @@
                       :failure {:kind         :rf.http/decode-failure
                                 :body-text    "{not-valid-json"
                                 :cause        "JSON syntax error"
-                                :malli-error? false}}}}
+                                :schema-validation-failure? false}}}}
 
   :trace-emissions
   [{:operation :event :tags {:event-id :articles/list}}


### PR DESCRIPTION
## Summary

Spec 014's `:rf.http/decode-failure` envelope embedded Malli's identity in its `:malli-error?` field. A TS port using Zod, a Python port using Pydantic, etc. should not have to surface a Malli-named key in the cross-port HTTP failure envelope. Rename the public envelope field to `:schema-validation-failure?` — port-neutral and descriptive of the semantic.

- Spec 014 §Failure categories: `:malli-error?` -> `:schema-validation-failure?` in the tags column for `:rf.http/decode-failure`
- Both transports (cljs + jvm) translate the internal `:malli-error?` ex-info detail to `:schema-validation-failure?` on the public envelope; the CLJS reference impl still detects "this was a Malli rejection" internally via the ex-data, but the envelope name is port-neutral
- Conformance fixture `http-managed-decode-failure.edn` updated in both the canned-failure dispatch arg and the `:final-app-db` expectation

Follow-up from rf2-osxa's Spec 010 substrate-agnostic work. Spec-Schemas.md does not reference the field. Guide ch.10 does not display the envelope shape. API.md's decode-failure row does not list field-level tags.

## Test plan

- [x] `implementation/core` test suite passes (240 tests, 1087 assertions)
- [x] `implementation/http` test suite passes (39 tests, 150 assertions)
- [x] Conformance fixture loads cleanly
- [x] Remaining `:malli-error?` occurrences are internal ex-info carriers in `http_encoding.cljc` plus the two transport read-sites — the public envelope no longer surfaces Malli identity