### PR TITLE
fix(views): reg-view macro returns primary id (matches reg-* return-value contract) (rf2-hzos)

### DIFF
--- a/implementation/core/src/re_frame/views_macros.clj
+++ b/implementation/core/src/re_frame/views_macros.clj
@@ -173,13 +173,20 @@
                         (let [~'dispatch  (re-frame.core/dispatcher)
                               ~'subscribe (re-frame.core/subscriber)]
                           ~@body)))]
+      ;; Per Conventions §`reg-*` return-value convention: every `reg-*`
+      ;; macro returns its primary id. The auto-def is a side effect; the
+      ;; macro's terminal value is `id`. (Without the trailing `id` the
+      ;; `def` would be the last form and the macro would return the Var,
+      ;; not the id — breaking the uniform return-value contract.)
+      ;; Per rf2-hzos.
       `(do
          (binding [re-frame.source-coords/*pending-coords*
                    ~(source-coords/coords-form form-meta current-file current-ns-sym)]
            (re-frame.core/reg-view* ~id
              ~full-slot-meta
              ~fn-form))
-         ~def-form))))
+         ~def-form
+         ~id))))
 
 (defmacro reg-view
   "Register a view as a defn-shape macro. Per Spec 004 §reg-view.

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -587,16 +587,23 @@
                 (tree-seq coll? seq exp))
           "with-frame expansion references *current-frame*"))
     ;; reg-view (defn-shape per Spec 004 §reg-view) defs the symbol and
-    ;; registers under (keyword (str *ns*) (str sym)). The expansion is
-    ;; (do (binding [...] (reg-view* ...)) (def sym (view ...))).
+    ;; registers under (keyword (str *ns*) (str sym)). Per rf2-hzos the
+    ;; expansion is (do (binding [...] (reg-view* ...)) (def sym (view ...)) id)
+    ;; — the terminal id makes the macro return its primary id (matching
+    ;; the reg-* return-value contract pinned in spec/Conventions.md).
     (let [exp (macroexpand `(re-frame.views-macros/reg-view
                               ~'my-widget [] :body))]
       (is (= 'do (first exp))
-          "reg-view expansion starts with do (binding + def)")
-      (let [forms (rest exp)
-            def-form (last forms)]
+          "reg-view expansion starts with do (binding + def + id)")
+      (let [forms    (rest exp)
+            ;; The trailing form is the id (terminal expression). The
+            ;; def is the penultimate form.
+            id-form  (last forms)
+            def-form (last (butlast forms))]
+        (is (keyword? id-form)
+            "the trailing form in the expansion is the registered id (a keyword)")
         (is (= 'def (first def-form))
-            "the trailing form in the expansion is a def")
+            "the penultimate form is the auto-def of the Var")
         (is (= 'my-widget (second def-form))
             "the def binds the symbol the user supplied")))))
 

--- a/implementation/core/test/re_frame/views_macros_test.clj
+++ b/implementation/core/test/re_frame/views_macros_test.clj
@@ -147,6 +147,33 @@
       (is (some? v))
       (is (fn? @v)))))
 
+;; ---- return-value contract (rf2-hzos) ------------------------------------
+;;
+;; Per Conventions §`reg-*` return-value convention: every `reg-*` macro
+;; returns its primary id — the keyword the caller registered with. The
+;; auto-def of the Var is a side effect; the macro's terminal value is
+;; the id.
+
+(deftest reg-view-returns-auto-derived-id
+  (testing "(reg-view sym [args] body) returns the auto-derived id"
+    (let [ret (rf/reg-view ret-auto [n] [:p n])]
+      (is (= :re-frame.views-macros-test/ret-auto ret)
+          "the macro returns (keyword *ns* sym), not the auto-defed Var"))))
+
+(deftest reg-view-returns-metadata-override-id
+  (testing "(reg-view ^{:rf/id :explicit/id} sym [args] body) returns the
+            override id"
+    (let [ret (rf/reg-view ^{:rf/id :explicit/ret-meta} ret-meta [n] [:p n])]
+      (is (= :explicit/ret-meta ret)
+          "the macro returns the :rf/id override, not the auto-derived id
+           and not the auto-defed Var"))))
+
+(deftest reg-view-returns-id-with-docstring
+  (testing "(reg-view sym \"doc\" [args] body) returns the id (docstring
+            does not change the return value)"
+    (let [ret (rf/reg-view ret-doc "the doc" [n] [:p n])]
+      (is (= :re-frame.views-macros-test/ret-doc ret)))))
+
 ;; ---- expansion under the legacy import path ------------------------------
 ;;
 ;; Existing examples use `(:require-macros [re-frame.views-macros :refer
@@ -163,18 +190,27 @@
       ;; Both expansions share their structural skeleton.
       (is (= 'do (first exp-core)))
       (is (= 'do (first exp-vm)))
-      (is (= 'def (first (last exp-core))))
-      (is (= 'def (first (last exp-vm)))))))
+      ;; Per rf2-hzos: the terminal expression is the id (matches the
+      ;; reg-* return-value contract). The penultimate form is the
+      ;; auto-def of the Var.
+      (is (= 'def (first (last (butlast exp-core)))))
+      (is (= 'def (first (last (butlast exp-vm))))))))
 
 ;; ---- expander helpers expose stable shape --------------------------------
 
 (deftest expand-reg-view-helper-shape
-  (testing "vm/expand-reg-view returns a (do binding+def) form"
-    (let [exp (vm/expand-reg-view {:line 1 :column 1}
-                                  'my.ns "my_ns.cljc" 'my-widget '([] [:p]))]
+  (testing "vm/expand-reg-view returns a (do binding+def+id) form. Per
+            rf2-hzos: the terminal expression is the id (so the macro's
+            return value is the id, matching the reg-* return-value
+            contract). The penultimate form is the auto-def of the Var."
+    (let [exp     (vm/expand-reg-view {:line 1 :column 1}
+                                      'my.ns "my_ns.cljc" 'my-widget '([] [:p]))
+          def-form (last (butlast exp))]
       (is (= 'do (first exp)))
-      (is (= 'def (first (last exp))))
-      (is (= 'my-widget (second (last exp))))))
+      (is (= :my.ns/my-widget (last exp))
+          "the terminal expression is the registered id")
+      (is (= 'def (first def-form)))
+      (is (= 'my-widget (second def-form)))))
 
   ;; rf2-atsv regression guard. The bug shape was an outer
   ;; (def x (reg-view :id ...)) wrapper that double-def'd against the


### PR DESCRIPTION
## Summary

- `reg-view` was the only `reg-*` macro that didn't match the uniform "returns primary id" contract pinned in `spec/Conventions.md` §`reg-*` return-value convention. Its expansion ended with `(def sym (re-frame.core/view id))`, so the macro returned the auto-defed Var rather than the id.
- Restructure the `(do ...)` expansion to terminate with the registered id. The auto-def of the Var stays in place as a side effect; only the macro's terminal value changes.
- Surfaced by the rf2-4far audit (closed) of the reg-* return-value contract.

## Expansion change

Before:

```clojure
(do
  (binding [re-frame.source-coords/*pending-coords* ...]
    (re-frame.core/reg-view* id slot-meta fn-form))
  (def sym (re-frame.core/view id)))      ;; returns the Var
```

After:

```clojure
(do
  (binding [re-frame.source-coords/*pending-coords* ...]
    (re-frame.core/reg-view* id slot-meta fn-form))
  (def sym (re-frame.core/view id))
  id)                                      ;; returns the id
```

## Tests

- New: `reg-view-returns-auto-derived-id` — `(reg-view sym [args] body)` returns `:this-ns/sym`.
- New: `reg-view-returns-metadata-override-id` — `(reg-view ^{:rf/id :explicit/id} sym [args] body)` returns the override id.
- New: `reg-view-returns-id-with-docstring` — the docstring slot doesn't change the return value.
- Updated existing expansion-shape assertions in `views_macros_test.clj` and `smoke_test.clj` to point at the penultimate form for the `def` check and assert the terminal form is the id.

## Test plan

- [x] `clojure -M:test` in `implementation/core/` — 243 tests, 1092 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` in `implementation/adapters/reagent-slim/` — 11 tests, 12 assertions, 0 failures, 0 errors (covers the form-tag fold that consumes the expansion via `requiring-resolve`)