### PR TITLE
fix(story-shell): a11y color-contrast — chrome labels meet WCAG AA on dark background (rf2-2uwv)

### DIFF
--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -194,7 +194,7 @@
                  :align-items "center"
                  :margin-bottom "8px"}
    :section-h   {:font-weight "bold"
-                 :color "#888"
+                 :color "#b0b0b0"
                  :text-transform "uppercase"
                  :font-size "10px"
                  :letter-spacing "0.5px"}
@@ -207,8 +207,8 @@
                  :font-size "10px"}
    :run-busy    {:background "#666"
                  :cursor "wait"}
-   :status      {:color "#888" :font-size "10px" :margin-top "4px"}
-   :empty       {:color "#666" :font-style "italic" :padding "4px 0"}
+   :status      {:color "#b0b0b0" :font-size "10px" :margin-top "4px"}
+   :empty       {:color "#9a9a9a" :font-style "italic" :padding "4px 0"}
    :violation   {:padding "6px 8px"
                  :margin "4px 0"
                  :border-left "3px solid"
@@ -282,7 +282,7 @@
      [:div {:style (:v-desc styles)} (.-description v)]
      (when first-target
        [:div {:style (:v-target styles)} (str "→ " first-target)])
-     [:div {:style {:color "#666" :font-size "10px"}}
+     [:div {:style {:color "#9a9a9a" :font-size "10px"}}
       (str ":" (.-id v) " · " (or impact "moderate"))]]))
 
 (defn panel

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -77,7 +77,7 @@
               :border "1px solid #3c3c3c"
               :border-radius "4px"
               :padding "12px"}
-   :empty    {:color "#666"
+   :empty    {:color "#9a9a9a"
               :font-style "italic"
               :text-align "center"
               :padding "32px"}
@@ -228,10 +228,10 @@
      [:div {:style (:title styles)}
       [:span (str (pr-str variant-id))]
       (when view-id
-        [:span {:style {:color "#666" :margin-left "8px"}}
+        [:span {:style {:color "#9a9a9a" :margin-left "8px"}}
          (str "→ " (pr-str view-id))])
       (when multi?
-        [:span {:style {:color "#888" :margin-left "8px"
+        [:span {:style {:color "#b0b0b0" :margin-left "8px"
                         :font-size "10px" :font-weight "normal"}}
          (str " (substrates: "
               (str/join ", " (map name (sort-by name substrates)))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -41,7 +41,7 @@
                  :border-top "1px solid #444"}
    :section     {:margin-bottom "12px"}
    :section-h   {:font-weight "bold"
-                 :color "#888"
+                 :color "#b0b0b0"
                  :text-transform "uppercase"
                  :font-size "10px"
                  :letter-spacing "0.5px"
@@ -79,7 +79,7 @@
                  :cursor "pointer"
                  :font-size "10px"
                  :margin-top "8px"}
-   :empty       {:color "#666" :font-style "italic"}})
+   :empty       {:color "#9a9a9a" :font-style "italic"}})
 
 ;; ---- pure: argtype inference --------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -132,7 +132,7 @@
   (let [resolved (rf/view view-id)]
     (if resolved
       [resolved eff-args]
-      [:div {:style {:color "#888" :font-style "italic"}}
+      [:div {:style {:color "#b0b0b0" :font-style "italic"}}
        (str ":component " (pr-str view-id) " is not registered as a view")])))
 
 (defn install-reagent-substrate!

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -69,7 +69,7 @@
                   :text-transform "uppercase"
                   :font-size "10px"
                   :letter-spacing "0.5px"}
-   :stub-body    {:color "#888"
+   :stub-body    {:color "#b0b0b0"
                   :line-height "1.5"}
    :stub-code    {:padding "8px"
                   :background "#1e1e1e"
@@ -85,7 +85,7 @@
                   :font-size "11px"
                   :border-top "1px solid #444"}
    :layout-title {:font-weight "bold"
-                  :color "#888"
+                  :color "#b0b0b0"
                   :text-transform "uppercase"
                   :font-size "10px"
                   :letter-spacing "0.5px"
@@ -97,7 +97,7 @@
                   :cursor "pointer"
                   :user-select "none"}
    :decor-id     {:color "#9cdcfe"}
-   :hint         {:color "#666"
+   :hint         {:color "#9a9a9a"
                   :font-style "italic"
                   :font-size "10px"
                   :margin-top "6px"}})
@@ -244,7 +244,7 @@
                  :padding "4px 10px"
                  :background "#2d2d30"
                  :border-bottom "1px solid #444"
-                 :color "#888"
+                 :color "#b0b0b0"
                  :font-family "monospace"
                  :font-size "10px"
                  :text-transform "uppercase"
@@ -281,7 +281,7 @@
          [:div
           [:div {:style (:panel-head host-styles)}
            [:span (:title body)]
-           [:span {:style {:color "#666"}} (str pid)]]
+           [:span {:style {:color "#9a9a9a"}} (str pid)]]
           (if view-fn
             ;; rf2-zme7: scope the panel view's subscribe / dispatch to
             ;; the active variant's frame. The namespace-preserving
@@ -290,7 +290,7 @@
             ;; context boundary (rf2-c5jz).
             [canvas/frame-provider-ns-safe {:frame variant-id}
              [view-fn variant-id]]
-            [:div {:style {:padding "8px" :color "#888"
+            [:div {:style {:padding "8px" :color "#b0b0b0"
                            :font-style "italic" :font-size "10px"}}
              (str "panel " (pr-str pid)
                   " has no registered :render view (" (pr-str view-id) ")")])]))]))

--- a/tools/story/src/re_frame/story/ui/scrubber.cljs
+++ b/tools/story/src/re_frame/story/ui/scrubber.cljs
@@ -93,7 +93,7 @@
                  :gap "8px"}
    :slider      {:flex "1"}
    :label       {:min-width "80px"
-                 :color "#888"}
+                 :color "#b0b0b0"}
    :chip-row    {:display "flex"
                  :flex-wrap "wrap"
                  :gap "4px"
@@ -111,7 +111,7 @@
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-size "10px"}
-   :empty       {:color "#666" :font-style "italic"}})
+   :empty       {:color "#9a9a9a" :font-style "italic"}})
 
 ;; ---- public component ----------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -45,7 +45,7 @@
                :font-family   "monospace"
                :font-size     "11px"
                :color         "#cccccc"}
-   :url-label {:color "#888"
+   :url-label {:color "#b0b0b0"
                :margin-bottom "4px"
                :text-transform "uppercase"
                :font-size "9px"

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -77,7 +77,7 @@
                :font-size "11px"}
    :tab       {:padding "6px 12px"
                :cursor "pointer"
-               :color "#888"
+               :color "#b0b0b0"
                :border-right "1px solid #444"}
    :tab-active {:color "white"
                 :background "#1e1e1e"
@@ -270,7 +270,7 @@
        variant-id [canvas/canvas]
        :else
        [:div {:style {:padding "32px"
-                      :color "#666"
+                      :color "#9a9a9a"
                       :font-style "italic"
                       :text-align "center"}}
         "Select a variant or workspace from the sidebar."])

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -44,7 +44,7 @@
                   :margin-bottom "4px"}
    :section      {:padding "12px 0 4px 12px"
                   :font-weight "bold"
-                  :color "#888"
+                  :color "#b0b0b0"
                   :text-transform "uppercase"
                   :font-size "10px"
                   :letter-spacing "0.5px"}
@@ -70,7 +70,7 @@
                   :cursor "pointer"
                   :color "#cccccc"}
    :variant-row-active {:background "#094771" :color "white"}
-   :empty        {:color "#666"
+   :empty        {:color "#9a9a9a"
                   :font-style "italic"
                   :padding "8px 12px"}})
 

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -200,14 +200,14 @@
                   :overflow "hidden"
                   :text-overflow "ellipsis"
                   :white-space "nowrap"}
-   :header       {:font-weight "bold" :color "#888"}
+   :header       {:font-weight "bold" :color "#b0b0b0"}
    :event-cell   {:color "#dcdcaa"}
    :handler-cell {:color "#4ec9b0"}
    :fx-cell      {:color "#ce9178"}
    :effect-cell  {:color "#ce9178"}
    :sub-cell     {:color "#b5cea8"}
    :render-cell  {:color "#c586c0"}
-   :empty        {:color "#666" :font-style "italic"}})
+   :empty        {:color "#9a9a9a" :font-style "italic"}})
 
 ;; ---- view ----------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -137,7 +137,7 @@
                       :line-height "1.5"}
       :prose-flow    {:display "flex"
                       :flex-direction "column"}
-      :empty         {:color "#666"
+      :empty         {:color "#9a9a9a"
                       :font-style "italic"
                       :padding "24px"
                       :text-align "center"}}))
@@ -204,12 +204,12 @@
         [:div {:style (:cell-title styles)}
          [:span (pr-str variant-id)]
          (when view-id
-           [:span {:style {:color "#888" :margin-left "8px"
+           [:span {:style {:color "#b0b0b0" :margin-left "8px"
                            :font-weight "normal"}}
             (str "→ " (pr-str view-id))])]
         (cond
           (nil? view-id)
-          [:div {:style {:color "#888" :font-style "italic"
+          [:div {:style {:color "#b0b0b0" :font-style "italic"
                          :padding "8px 0"}}
            "variant has no :component registered — register one on the story or variant body"]
 
@@ -236,7 +236,7 @@
                   [resolved-view eff-args]
                   (:hiccup decorator-pack)
                   eff-args)]]
-              [:div {:style {:color "#888" :font-style "italic"
+              [:div {:style {:color "#b0b0b0" :font-style "italic"
                              :padding "8px 0"}}
                (str ":component " (pr-str view-id)
                     " is not registered as a view")])))


### PR DESCRIPTION
## Summary

- Bumps Story-shell chrome foreground tokens to clear WCAG AA 4.5:1 on the dark panel backgrounds (`#252526`, `#2d2d30`, `#1e1e1e`).
- `#888` → `#b0b0b0` (6.16-7.60:1 across the three backgrounds) on every panel's `:section-h` label, sidebar `:section`, shell tabs, scrubber `:label`, panel-host header strip, etc.
- `#666` → `#9a9a9a` (4.75-5.86:1) on hint/empty/idle text, panel-id badge, status lines.

## Contrast math

`#252526` rel-luminance ≈ 0.02125 · `#2d2d30` ≈ 0.02765 · `#1e1e1e` ≈ 0.01298.

`#b0b0b0` rel-luminance ≈ 0.4287:
- vs `#252526`: 6.71:1 (AA + AAA)
- vs `#2d2d30`: 6.16:1 (AA + AAA)
- vs `#1e1e1e`: 7.60:1 (AAA)

`#9a9a9a` rel-luminance ≈ 0.3185:
- vs `#252526`: 5.17:1 (AA)
- vs `#2d2d30`: 4.75:1 (AA)
- vs `#1e1e1e`: 5.86:1 (AA)

## Out of scope

- Non-text uses of `#888`/`#666` left intact: `:run-busy` button background, `:impact-minor` border-left-color, and the axe-overlay outline-color rule — those are not contrast-bound.
- Counter-side a11y (rf2-4763) and shell landmarks (rf2-xc65) already landed; this bead closes the remaining `color-contrast` axe rule.

## Test plan

- [x] `clojure -M:test` in `tools/story/` — 152 tests, 0 failures.
- [ ] Boot `examples/reagent/counter_with_stories/` playground; click the A11Y panel's `run`; confirm `color-contrast` violations drop to 0 (or only user-content nodes remain).

Closes rf2-2uwv.