### PR TITLE
feat(tools): Causa spec — tools/10x/spec/ structured one-shot-complete corpus (rf2-1lls)

### DIFF
--- a/tools/10x/README.md
+++ b/tools/10x/README.md
@@ -1,0 +1,149 @@
+# tools/10x/
+
+`day8/re-frame2-causa` — **Causa**, the re-frame2 devtools panel.
+*The cascade you can see.*
+
+Causa is the structural successor to [re-frame-10x](https://github.com/day8/re-frame-10x).
+Where v1 organised debugging around the *epoch panel*, Causa organises it
+around the *story a cascade tells* — every dispatch is a node in a graph
+of causes, every state delta is a slice you can scrub, every machine
+transition lands on a chart you can read, every schema violation
+surfaces as an issue you cannot miss.
+
+## What it is
+
+An in-app DOM-injected devtools panel for re-frame2 applications,
+preloaded into dev builds via `:preloads`. Opens on `Ctrl+Shift+C` or
+the floating launcher pill. Production builds elide the entire surface
+through the universal `interop/debug-enabled?` gate — zero bytes
+shipped to consumers.
+
+Causa consumes the re-frame2 instrumentation surface (Spec 009 trace
+bus, Tool-Pair epoch history, the registrar query API) — it adds
+nothing the framework didn't already expose. The 16 panels are
+*presentation* of an already-structured runtime.
+
+A separate jar `tools/10x-mcp/` exposes Causa's surfaces as MCP tools
+for AI agents — same architecture as `tools/pair2-mcp/`, different tool
+catalogue.
+
+## Headline experiences
+
+| Surface | What it does |
+|---|---|
+| **Event-detail panel** (hero) | Lands on every open. The event vector, the diff, the inline mini-graph, fx fired, subs recomputed, renders, duration. Answers the five canonical questions on first paint. |
+| **Causality graph** (peer) | Vertical directed graph keyed by `:dispatch-id` / `:parent-dispatch-id`. The deeper-walk view when the cascade is > 2 hops or spans frames. |
+| **Time-travel scrubber** | Bottom rail. Passive scrubbing rebases the view of history; explicit rewind calls `restore-epoch` with the six failure modes surfaced. |
+| **Slice-centric app-db panel** | The slices that changed, the slices the user pinned. Read-only. |
+| **Machine inspector** | Stately-quality state-chart per machine. Embeds `tools/machines-viz/`. |
+| **Schema-violation timeline** | One row per registered schema; coloured dot per failure with recovery mode. |
+| **Hydration debugger** | Server vs client render-tree side-by-side. Only visible when SSR hydration runs. |
+| **Issues ribbon** | Unified feed: errors + warnings + schema violations + hydration mismatches. |
+| **AI co-pilot** (rail) | Pull-only Q&A and slash commands. Collapsed by default; expand on demand. Ephemeral (no persistence). |
+
+Full panel inventory in [`spec/000-Vision.md`](./spec/000-Vision.md).
+
+## Quick start
+
+### Install
+
+```clojure
+;; deps.edn (dev alias only)
+{:aliases {:dev {:extra-deps {day8/re-frame2-causa {:mvn/version "1.0.0"}}}}}
+```
+
+### Enable
+
+```clojure
+;; shadow-cljs.edn dev build
+{:builds {:app {:devtools {:preloads [day8.re-frame2-causa.preload]}}}}
+```
+
+That's it. The preload registers Causa's listeners under
+`register-trace-cb!` and `register-epoch-cb`, mounts a hidden DOM root,
+and listens for `Ctrl+Shift+C`. No code change in the app itself.
+
+### Launch
+
+| Action | How |
+|---|---|
+| Open | `Ctrl+Shift+C` or click the floating pill (bottom-right) |
+| Close | `Esc` or `Ctrl+Shift+C` again |
+| Pop out to second window | `Ctrl+Shift+P` (same browser, `window.opener` reference) |
+| Open AI co-pilot rail | `Ctrl+Shift+/` |
+| Command palette | `Ctrl+K` |
+
+### Disable
+
+Remove the `:preloads` entry, or set
+`:closure-defines {day8.re-frame2-causa.config/enabled? false}` to
+force-disable in dev.
+
+### MCP (Causa as an agent surface)
+
+```bash
+npm install -g @day8/re-frame2-causa-mcp
+```
+
+Add to `~/.claude/settings.json`:
+
+```json
+{ "mcpServers": { "causa": { "command": "re-frame2-causa-mcp" } } }
+```
+
+Tool catalogue in [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md).
+
+## Spec
+
+The contract lives in [`spec/`](./spec/). The folder is complete enough
+that the tool could be one-shotted from it.
+
+| File | Covers |
+|---|---|
+| [`spec/000-Vision.md`](./spec/000-Vision.md) | Why Causa exists; the 16-panel inventory; the bar it sets. |
+| [`spec/001-Causality-Graph.md`](./spec/001-Causality-Graph.md) | The (peer) causality graph; data model; rendering rules. |
+| [`spec/002-Time-Travel.md`](./spec/002-Time-Travel.md) | Epoch scrubber; replay semantics; read-only posture. |
+| [`spec/003-Machine-Inspector.md`](./spec/003-Machine-Inspector.md) | Embeds `tools/machines-viz/`; transition history; source jumps. |
+| [`spec/004-App-DB-Diff.md`](./spec/004-App-DB-Diff.md) | Slice-centric diff; pinned slices; full-tree escape hatch. |
+| [`spec/005-Schema-Timeline.md`](./spec/005-Schema-Timeline.md) | Per-schema timeline; recovery-mode colouring. |
+| [`spec/006-Hydration-Debugger.md`](./spec/006-Hydration-Debugger.md) | SSR render-tree diff; divergent-node surfacing. |
+| [`spec/007-UX-IA.md`](./spec/007-UX-IA.md) | Layout, interaction, visual language (typography, colour, motion). |
+| [`spec/008-Embedding-Contract.md`](./spec/008-Embedding-Contract.md) | Story-embed contract; the `Panel` component shape. |
+| [`spec/009-AI-CoPilot.md`](./spec/009-AI-CoPilot.md) | Pull-only Q&A; slash commands; ephemeral conversation. |
+| [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md) | `tools/10x-mcp/`; the Causa MCP tool catalogue. |
+| [`spec/011-Launch-Modes.md`](./spec/011-Launch-Modes.md) | In-app overlay + standalone-via-MCP for remote-attach. |
+| [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles (read-only, observation-only, etc.). |
+| [`spec/API.md`](./spec/API.md) | User-facing surface (`init!`, panel mount, MCP tool list). |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The 13 locked decisions: question, options, pick, why. |
+| [`spec/findings/`](./spec/findings/) | The original research docs that anchor the design. |
+
+## File layout
+
+```
+tools/10x/
+├── README.md                                  ; this file
+├── deps.edn                                   ; declares day8/re-frame2-causa
+├── shadow-cljs.edn                            ; build config
+├── spec/                                      ; normative contract (see above)
+├── src/day8/re_frame2_causa/
+│   ├── preload.cljs                           ; registers listeners, mounts DOM
+│   ├── core.cljs                              ; init!, panel mount, settings
+│   ├── panels/                                ; one ns per panel
+│   ├── causality/                             ; graph layout + rendering
+│   ├── ai/                                    ; co-pilot panel, provider abstraction
+│   └── theme/                                 ; design tokens, theming
+└── test/...
+```
+
+## Bundle isolation
+
+Causa lives under `tools/` so the bundle-isolation contract (per
+[`tools/README.md`](../README.md)) holds: nothing in `implementation/`
+may `:require` from Causa. The preload pulls only when shadow-cljs's
+`:devtools` config asks for it; production builds (`goog.DEBUG=false`)
+elide every surface Causa consumes (per Spec 009 §Production builds).
+
+## Status
+
+In design. Spec corpus landed via rf2-1lls (2026-05-12). Implementation
+work begins after the spec ratifies.

--- a/tools/10x/spec/000-Vision.md
+++ b/tools/10x/spec/000-Vision.md
@@ -1,0 +1,154 @@
+# 000-Vision: Causa — the re-frame2 devtools panel
+
+## Why it exists
+
+When a re-frame app misbehaves, the programmer should be able to ask
+five canonical questions and answer them in seconds, with click-to-source
+on every artefact:
+
+1. **Why did this event fire?** (causal-ancestor walk)
+2. **What did that event change?** (`app-db` diff + flow recomputes + machine transitions)
+3. **Why is this subscription returning the wrong value?** (input-chain trace + cache state)
+4. **Why is this view re-rendering?** (subscription invalidation chain + render-key attribution)
+5. **What's currently broken?** (errors, warnings, schema violations, hydration mismatches — surfaced as one feed)
+
+v1 of re-frame-10x answered #1–#4 partially and #5 not really. Causa
+answers all five, in seconds, with click-to-source for every artefact.
+
+re-frame2's instrumentation surface (Spec 009 trace bus, Tool-Pair
+epoch history, source-coord stamping, machine and flow registries)
+emits structured data for every interesting moment. Causa's job is
+*presentation*: render the runtime to the human in the runtime's own
+terms.
+
+## What it is
+
+A re-frame2-native devtools panel that runs **in-app**, preloaded into
+dev builds. The marquee surface is the **event-detail panel** — every
+open lands here. The panel shows the current epoch's event vector, an
+inline mini causality graph, the slices it touched, fx fired, subs
+recomputed, renders, duration. The five canonical questions answer
+themselves on first paint; deeper investigation is one click away.
+
+The 16 panels (enumerated below) are all views over the same trace bus.
+One substrate, many views.
+
+## What it isn't
+
+- **Not** a port of re-frame-10x v1. The shape is new. The lessons are
+  carried forward; the data shape and the substrate are re-frame2's.
+- **Not** a registrar, dispatch, effect, or component layer. Causa is a
+  downstream consumer of re-frame2's existing surfaces — per the
+  feedback that downstream EPs must not add new registries (this is
+  not even an EP; it is a tool).
+- **Not** writeable into `app-db`. Read-only forever. The runtime is
+  the source of truth; pokes from the debugger are out of scope (lock
+  #3 in `DESIGN-RATIONALE.md`).
+- **Not** a session recorder. No export, no import. Sessions are
+  ephemeral (lock #4).
+- **Not** a mobile surface. Desktop only; viewports below 600px refuse
+  to mount (lock #5).
+- **Not** a Chrome extension. In-app DOM injection plus a same-browser
+  pop-out via `window.opener`. Remote-attach lives over MCP, not over
+  a custom WebSocket protocol (lock #9).
+- **Not** part of any production bundle. Per the bundle-isolation
+  contract in `tools/README.md`, dependency arrows flow tool →
+  implementation; Causa is invisible to consumer apps after elision.
+
+## What re-frame2 unlocks
+
+Each row is "new in re-frame2 → new tooling story Causa must tell."
+
+| re-frame2 capability | Causa surface |
+|---|---|
+| **Multi-frame** (Spec 002) | Per-frame panels; frame picker; cross-frame causality. |
+| **Machines** (Spec 005) | Stately-quality state-chart per machine; transition log; `:after`-timer countdown; `:invoke-all` parallel-child viz. |
+| **Flows** (Spec 013) | Flow dependency graph; per-flow recompute heatmap; `:rf.flow/skip` badge. |
+| **Source-coord stamping** (Spec 001 + 006) | Click-to-source on every node, view, machine guard, transition. |
+| **Trace bus** (Spec 009) | The substrate of everything. Causa does not invent its own trace shape. |
+| **Epoch history + `:rf/epoch-record` projections** (Tool-Pair) | First-class time-travel; pre-folded `:sub-runs` / `:renders` / `:effects` mean Causa renders, doesn't refold. |
+| **Six named restore failures** | Structured "this rewind won't work because X" rather than a silent no-op. |
+| **`register-epoch-cb`** | The per-cascade listener routes the causality graph and the event-detail panel. |
+| **Schemas (Malli)** (Spec 010) | Real-time schema-violation feed with the five named recovery modes. |
+| **SSR + hydration** (Spec 011) | Hydration-mismatch debugger; server-vs-client render-tree diff. |
+| **Routing** (Spec 012) | URL ↔ frame state visualisation; nav-token timeline with stale-result suppression in flight. |
+| **`:origin` opt on dispatch** | Filter by actor: "show me only the dispatches Claude issued." |
+| **Production-elision verifier** | Causa runs `npm run test:elision` and warns before deploy if a dev sentinel leaked. |
+
+## The 16-panel inventory
+
+| Panel | What it does | Data source |
+|---|---|---|
+| **Event detail** *(hero)* | The canonical-question-answering panel. Event vector, source, `caused-by` link, inline mini-graph, db-diff, fx fired, subs recomputed, renders, duration. | `register-epoch-cb` + `:rf/epoch-record` projections. |
+| **Causality graph** *(peer)* | Vertical directed graph keyed by `:dispatch-id` / `:parent-dispatch-id`. Click node → detail. Drag time-range → filter. Find-root-cause button. | `(rf/trace-buffer {:op-type :event})` + `register-epoch-cb`. |
+| **Causality strip** | The flat horizontal version of the graph, pinned at the top of every panel. Last 20 dispatches as pills. Always visible. | Same as causality graph. |
+| **Event log** | Per-frame list of dispatched events; group-by-cascade; right-click → "re-dispatch" (with `:origin :causa`). | `(rf/trace-buffer {:op-type :event :frame current-frame})`. |
+| **App-db inspector** | Slice-centric; touched slices first, pinned slices second, full-tree as escape hatch. Read-only. | `(rf/get-frame-db frame-id)` + epoch's changed-paths set. |
+| **Subscription graph** | Force-directed graph of sub dependencies; layer-1/2/3 grouping; click a sub → inputs / outputs / cached value. | `(rf/sub-cache frame-id)` (CLJS-only). |
+| **Effect log** | Every fx invocation; filter by fx-id; outcome (`:ok` / `:error` / `:skipped-on-platform`). | `(rf/trace-buffer {:op-type :fx})` + `:effects` projection. |
+| **Trace timeline** | Raw trace events with timing. Structured filter on `:op-type` / `:operation` / `:frame` / `:dispatch-id` / `:origin`. | `(rf/trace-buffer)` + `PerformanceObserver` on `rf:*` measures. |
+| **Machine inspector** | State-chart per machine; live highlight; transition history scrub; source-coord jump. Embeds `tools/machines-viz/`. | `(rf/machines)` + `[:rf/machines <id>]` + `:rf.machine/*` traces. |
+| **Flow graph** | DAG of registered flows; per-flow recompute heatmap; "marked dormant" indicator. | `(rf/handlers :flow)` + `:rf.flow/*` traces. |
+| **Performance ribbon** | INP, long tasks, layout shifts, re-render counts per epoch. | `PerformanceObserver` watching `rf:*` + browser entries. |
+| **Schema violation timeline** | Per-schema row; coloured dot per failure with recovery mode (skip / rollback / replaced-with-default / re-raised). | `(rf/trace-buffer {:operation :rf.error/schema-validation-failure})`. |
+| **Issues ribbon** | Unified feed: errors, warnings, schema violations, hydration mismatches. Permanent ribbon, not a console line. | All `:op-type :error` / `:warning` / `:rf.ssr/hydration-mismatch` traces. |
+| **Hydration debugger** | Server vs client render-tree side-by-side; divergent-node pulse; render-tree hash bisector. Only visible when SSR hydration ran. | `:rf.ssr/hydration-mismatch` + payload + first client render-tree hash. |
+| **AI co-pilot** | Pull-only Q&A and slash commands; collapsed by default; ephemeral conversation. | Registrar + epoch history + trace buffer + user's LLM. |
+| **Routing inspector** | `:rf/route` as breadcrumb; nav-token timeline with stale-result suppression. | `(rf/sub :rf/route)` + `:route.nav-token/*` traces. |
+| **Settings / filters** | Buffer depths, default frame, theme, AI provider key. Schema'd localStorage; corruption triggers clean reset. | localStorage with `:rf/version` stamp. |
+| **Time-travel scrubber** | Bottom rail; passive scrubbing rebases the view of history; explicit `Rewind here` button calls `restore-epoch`. | `(rf/epoch-history frame-id)` + `restore-epoch` + `reset-frame-db!`. |
+
+v1 of re-frame-10x had ~6 panels. The growth is structural — re-frame2
+emits more, and Causa surfaces it. Sidebar grouping (always-active /
+conditional-with-activity / dormant) keeps the surface from feeling
+cluttered; see [`007-UX-IA.md`](./007-UX-IA.md).
+
+## The bar
+
+A programmer hits `Ctrl+Shift+C`, sees the cascade their last click
+triggered in the event-detail panel, asks "why?" — either in their head
+(answered via `caused-by` and the inline mini-graph) or out loud (to
+the co-pilot) — and has the answer in 5 seconds.
+
+If a panel doesn't help answer "why?" or "what happened?" or "what's
+wrong?", it doesn't ship. Restraint is what keeps the tool
+habit-forming instead of impressive.
+
+## Audience
+
+- **The re-frame programmer mid-feature.** Wants the trace ribbon in
+  their face but unobtrusive; wants click-to-source from anywhere;
+  wants to scrub.
+- **The programmer reading an unfamiliar codebase.** "Why does clicking
+  Save eventually re-render this card three modules over?" — wants the
+  causality graph.
+- **The on-call programmer triaging a production-shaped repro.** Loads
+  a session, scrubs, finds the divergence.
+- **The AI agent driving the runtime.** Doesn't open the UI; consumes
+  the same data through the same primitives via the MCP server. Causa
+  and the agent surfaces are siblings, not parent/child.
+
+## Where Causa fits
+
+Causa is one of three downstream consumers of the same re-frame2
+instrumentation surface:
+
+- **`tools/pair2-mcp/`** — the editor-driven agent surface. Pair-shaped
+  AI workflows over nREPL.
+- **`tools/story/`** — the component playground. Embeds Causa's
+  event-detail panel as a per-variant observability ribbon (per the
+  embedding contract in [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)).
+- **`tools/10x/`** *(this tool)* — the human-driven debugger. Embeds
+  `tools/machines-viz/` for state-chart rendering.
+
+The dependency arrows: Causa → `machines-viz` (for the chart) →
+`implementation/`. Story → Causa (for the embedded panel) →
+`implementation/`. No cycles, no shared registries, no parent/child
+relationships among the tools.
+
+## Status
+
+In design. Spec corpus landed via rf2-1lls (2026-05-12). All 13
+direction-setting decisions are locked — see
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md). Implementation work
+begins after spec ratification.

--- a/tools/10x/spec/001-Causality-Graph.md
+++ b/tools/10x/spec/001-Causality-Graph.md
@@ -1,0 +1,193 @@
+# 001-Causality-Graph
+
+The causality graph is a **peer** panel — first-class, sidebar entry,
+keyboard mnemonic `c`, but **not** the front door. The hero is the
+event-detail panel. The graph is the deeper-walk view when the cascade
+is more than two hops, spans frames, or when triaging a session with
+30+ events.
+
+## Data model
+
+The graph's nodes and edges derive from the trace bus. No new
+instrumentation is added; Causa reads what Spec 009 already emits.
+
+### Nodes
+
+| Node kind | Trace event | What it renders |
+|---|---|---|
+| **Dispatch** | `:op-type :event` with `:operation :event/dispatched` | Event vector, source coords, `:origin`, duration. |
+| **Effect** | `:op-type :fx` | fx-id, args summary, outcome (`:ok` / `:error` / `:skipped-on-platform`). |
+| **Machine transition** | `:op-type :rf.machine/transition` | Machine-id, from-state → to-state. |
+| **Schema violation** | `:op-type :error` with `:operation :rf.error/schema-validation-failure` | Path, recovery mode, one-line cause. |
+| **Hydration mismatch** | `:op-type :error` with `:operation :rf.ssr/hydration-mismatch` | Server vs client render-tree hash diff entry. |
+
+Nodes other than dispatches are *significant traces* — they don't drive
+new edges by themselves; they attach to the dispatch whose cascade they
+ran inside (via the `:dispatch-id` carried on every event's `:tags`).
+
+### Edges
+
+Edges are causal:
+
+- **Parent-child dispatch.** `:parent-dispatch-id` (per Spec 009
+  §Dispatch correlation) links a child dispatch to its parent. The
+  runtime sets `:parent-dispatch-id` when a dispatch is emitted as a
+  side-effect of another event's processing — concretely, when an `fx`
+  handler running inside dispatch D₁ invokes `(rf/dispatch ...)`, the
+  new dispatch carries `:parent-dispatch-id = D₁`.
+
+- **Dispatch contains significant trace.** Every effect, machine
+  transition, schema violation, or hydration mismatch carries its
+  cascade's `:dispatch-id` under `:tags`. Those traces attach inside
+  their dispatch's node rather than spawning their own outbound edge.
+
+- **Top-level root.** A dispatch with no `:parent-dispatch-id` is a
+  *cascade root*. Roots render with a diamond glyph (◆); children
+  render as circles (○).
+
+### Graph identity
+
+The graph is **per-frame plus cross-frame edges**. Each frame is a
+horizontal swimlane; cross-frame fx (per Spec 002) draws an explicit
+arrow from one swimlane to another. No other JS devtool renders this.
+
+## Rendering
+
+The graph lays out top-down (older → newer) on a vertical timeline.
+Frames are horizontal swimlanes; the current frame is fully saturated,
+non-current-frame nodes are greyed.
+
+### Visual encoding
+
+| Encoding | Meaning |
+|---|---|
+| **Glyph** | ◆ root dispatch · ○ child dispatch · ◉ currently selected. |
+| **Fill colour** | `:origin` axis — violet `:app` · indigo `:pair` · cyan `:story`/`:test` · grey `:causa` (Causa's own re-dispatches). |
+| **Border colour** | Status — red border when the cascade contained an error · amber when it contained a warning · default border otherwise. |
+| **Size** | Currently-selected epoch's nodes are slightly larger. |
+| **Background ribbon** | Faint INP-per-frame band; spike-detect at the long-task threshold. |
+
+The colour-only signal is always paired with a glyph or icon (per
+[`007-UX-IA.md`](./007-UX-IA.md) §Visual language) — no encoding is
+colour-alone.
+
+### Layout
+
+- **Vertical axis:** time (older at top, newer at bottom).
+- **Horizontal axis:** frame swimlanes. Active frame on the left;
+  cross-frame arrows traverse swimlanes.
+- **Edge style:** straight lines for in-frame parent → child; curved
+  lines for cross-frame jumps.
+- **Animation:** new edges fade in at 250ms ease-out; the just-landed
+  dispatch's node pulses once for 600ms on entry (respects
+  `prefers-reduced-motion`).
+
+### Buffer caps
+
+The graph reads from the trace buffer, which is bounded by Spec 009
+(default 200 entries). Older dispatches age out of the visible graph
+when they age out of the buffer; a "load older" affordance pulls from
+the buffer's far tail until the buffer's actual oldest is reached.
+
+The graph **caps at the last 200 dispatches by default** (matches the
+trace-buffer depth). Deeper views require an explicit "load older"
+click — Causa never silently lays out more nodes than the user asked
+for.
+
+## Interactions
+
+| Action | Result |
+|---|---|
+| **Click node** | Side panel shows the trace event, `:tags`, source coords, affected sub-cache slots, the resulting `app-db` diff (if a dispatch). |
+| **Right-click node** | Context menu: Re-dispatch · Copy event vector · Open source · Filter graph to this cascade · Pin to scrubber. |
+| **Drag time-range** at top | Filters graph to that range; the rest of Causa synchronises. |
+| **Find root cause** button on a node | Walks `:parent-dispatch-id` upward until a root is reached; highlights the path. |
+| **`f` keyboard shortcut** on a focused node | Filter the graph to that dispatch's cascade only. |
+| **`o`** on a focused node | Open the dispatching code in the editor (via the source-coord URL handler). |
+
+## The inline mini-graph
+
+A 3–5-node version of the graph renders **inside the event-detail
+panel** above the event vector, whenever the current epoch has a
+`:parent-dispatch-id`. The mini-graph is the local cascade — a causal
+breadcrumb. Costs 80px of vertical space.
+
+```
+┌─ event 11 ───────────────────────────────────────────────╮
+│                                                          │
+│      ●  :user/clicked-checkout                           │
+│      │                                                   │
+│      ●  :cart/finalise                                   │
+│      │                                                   │
+│      ●  :cart/http-success                               │
+│      │                                                   │
+│      ◉  :checkout/submit          ← you are here         │
+│                                                          │
+│  ─────────────────────────────────────────────────────── │
+│                                                          │
+│  :checkout/submit                                        │
+│  ...
+```
+
+The mini-graph **renders the chain at a glance** without committing
+the user to opening the full graph view. Click any node in the
+mini-graph → detail rebases to that epoch (no rewind).
+
+## The causality strip
+
+A flat horizontal version of the graph pinned at the top of every
+panel:
+
+```
+◆──○──○──○──○──○──○──○──○──○──●
+```
+
+- 24×24px pills on cosy density, 4px gap. Compact/comfy adjust.
+- Most-recent pill filled in the frame accent; older pills hollow.
+- Cascade roots are diamonds (◆); children are circles (○).
+- Hover → 240ms popover with event vector, source coords, duration,
+  epoch-id.
+- Click → event-detail rebases (no rewind).
+- Right-click → context menu (Replay · Re-dispatch · Copy · Open source · Filter graph to this cascade).
+
+The strip is **always visible**. It carries everyday weight; the full
+graph is one click away when the user needs it.
+
+## Performance
+
+- **Live updates** are debounced to 16ms (one rAF). A burst of 1000
+  events still updates the graph once per frame.
+- **Re-layout** runs incrementally: a new node attaches to its parent
+  without re-flowing the whole graph.
+- **Hover popovers** mount lazily on first hover; cached for the
+  session.
+- **Filter operations** (drag-time-range, find-root-cause, cascade
+  filter) materialise a new node set in memory but never re-fetch from
+  the trace buffer — Causa reads the buffer once at panel mount.
+
+## Empty state
+
+Before any dispatches have landed:
+
+```
+   No cascades yet.
+   Click around your app — every dispatch lands here as a node.
+   Press [ to walk back through history; ] to step forward.
+```
+
+The strip shows a single hollow circle labelled `(boot)` for the
+framework's boot epoch.
+
+## What this doesn't do
+
+- **No re-dispatch from the graph alone.** Re-dispatch fires only from
+  right-click → "Re-dispatch" (a confirmed action) — never from a
+  drag, never from a single click. The runtime is the source of truth;
+  the graph reads from it but does not silently mutate it.
+- **No retroactive correlation.** If a dispatch was emitted before the
+  trace surface knew about it (a cold-boot dispatch before listeners
+  registered), it appears as a root in the graph even if it was
+  actually a child. Causa surfaces no causality it cannot prove.
+- **No edge labels.** Earlier drafts proposed labelling parent → child
+  edges with the fx that caused them. The signal-to-noise was poor
+  (every edge was labelled `:fx [[:dispatch ...]]`). Removed.

--- a/tools/10x/spec/002-Time-Travel.md
+++ b/tools/10x/spec/002-Time-Travel.md
@@ -1,0 +1,173 @@
+# 002-Time-Travel
+
+The time-travel scrubber is pinned to the bottom rail. Its job is to
+let the programmer walk backward and forward through history *without
+disturbing the live app*. Rewinding the runtime is an explicit,
+confirmed action — not a side-effect of scrubbing.
+
+This is the key inversion from re-frame-10x v1. v1's
+`app-db-follows-events?` mode rewound the app as the user scrubbed;
+users accidentally rewound and were surprised. Causa's posture:
+**inspection is the default, rewind is opt-in.**
+
+## Substrate
+
+Causa consumes Tool-Pair's epoch-history surface (per
+[Tool-Pair §Time-travel](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)):
+
+- `(rf/epoch-history frame-id)` — vector of `:rf/epoch-record` values,
+  oldest-first, bounded by `(rf/configure :epoch-history {:depth N})`
+  (default 50).
+- `(rf/restore-epoch frame-id epoch-id)` — rewinds `app-db` to the
+  named epoch's `:db-after`. Emits `:rf.epoch/restored`.
+- `(rf/reset-frame-db! frame-id db-value)` — bypasses cascade,
+  schema-validates against current schemas. Used for "try anyway"
+  when restore would fail.
+
+No new instrumentation; the scrubber renders what the framework
+already records.
+
+## UI shape
+
+The bottom rail (40px on cosy density):
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ ◀◀ ─────────────────●──── ▶▶   :app/main   11/11 epochs   8.2KB   ⚠ 0   ●●●    │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Track** — horizontal, one tick per epoch in the current frame's
+  `epoch-history`. Each tick is 4px wide on cosy density.
+- **Current position** — a violet filled circle. Slides with drag.
+- **`◀◀` / `▶▶`** — jump to oldest / newest.
+- **Right side** — frame name, epoch counter (`current/depth`),
+  scrubber buffer size, issues count, machine-activity dots.
+
+The track is **draggable**. Dragging is a **passive** action — see
+below.
+
+## The passive-scrubbing rule
+
+Dragging the scrubber rebases every panel's view of history. The
+event-detail panel rebases to the dragged-to epoch. The causality
+graph highlights the selected node. The app-db panel shows the
+historical snapshot.
+
+But `(rf/get-frame-db ...)` continues to return the live value. The
+live app behind Causa does **not** rebase visually. The user's mouse
+clicks against the app still hit the live state.
+
+**To actually rewind:** a contextual `Rewind here` button appears
+200ms after a drag ends. Clicking it calls `(rf/restore-epoch frame-id
+target-epoch-id)`. Only then does the framework's `app-db` actually
+move.
+
+The same separation holds for keyboard navigation:
+
+| Key | Action |
+|---|---|
+| `[` | Step the view back one epoch (rebases panels; does **not** rewind). |
+| `]` | Step the view forward. |
+| `Shift+[` / `Shift+]` | Previous / next cascade root. |
+| `0` | Jump view to oldest epoch. |
+| `$` | Jump view to newest. |
+| `Space` | Toggle play (auto-step at 500ms intervals; passive). |
+| `r` (on a focused event) | Rewind to before this event — calls `restore-epoch`. |
+| `Shift+r` | Hard rewind with the six failure modes surfaced as a modal. |
+| `*` | Pin a labelled snapshot at current epoch. |
+
+The mnemonic split: walk = passive, rewind = explicit. `r` does the
+destructive thing; arrow keys / `[` / `]` do not.
+
+## Restore failure modes
+
+`restore-epoch` has six named failure modes (per Tool-Pair §Time-travel).
+Causa surfaces them structurally:
+
+| Failure | `:operation` | UI surface |
+|---|---|---|
+| **Unknown frame** | `:rf.error/no-such-handler` (`:kind :frame`) | Inline error in the rewind modal; "frame `<id>` is not registered." |
+| **Unknown epoch** | `:rf.epoch/restore-unknown-epoch` | "Epoch aged out of history. Increase `:epoch-history :depth` in Settings." |
+| **Schema mismatch** | `:rf.epoch/restore-schema-mismatch` | "This rewind would break because schema `:auth` tightened since the snapshot." Lists `:failing-paths`. Offers `Try anyway` (calls `reset-frame-db!` which bypasses cascade and re-validates against current schemas). |
+| **Missing handler** | `:rf.epoch/restore-missing-handler` | "The recorded app-db references handlers that are no longer registered." Lists missing `{:kind :id}` pairs. |
+| **Version mismatch** | `:rf.epoch/restore-version-mismatch` | "A machine definition moved forward since this snapshot." Names the machine + recorded vs current version. |
+| **Concurrent-drain rejection** | `:rf.epoch/restore-during-drain` | "Wait for the current cascade to settle." Auto-retries once after 100ms. |
+
+All six are surfaced as a modal **before** the user confirms the
+rewind, with a `Cancel` and (where applicable) a `Try anyway` button.
+The modal cites the `:operation` keyword so the user can search the
+spec.
+
+## Pinned snapshots
+
+At any epoch, the user can pin a labelled snapshot via `*` or the pin
+icon. Pinned snapshots appear as labelled chips on the scrubber:
+
+```
+◀◀ ──[before-login]─────[cart-full]──●──── ▶▶
+```
+
+Click a pin → view rebases to that epoch. Right-click → "Rewind to
+this pin" or "Remove pin."
+
+Pins are **session-local**. They live in Causa's in-memory state, not
+in localStorage, not in `app-db`. Reload clears them. (See lock #4
+in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).)
+
+## Buffer fill indicator
+
+The right side of the bottom rail shows `11/50 epochs` — current
+buffer fill versus configured depth. As the fill approaches the cap,
+the indicator goes amber. Hover → tooltip: "Older epochs will age out.
+Increase depth in Settings."
+
+The default depth is 50 (per Tool-Pair). Settings → Performance →
+`epoch-history-depth` lets the user bump to 200 or 1000 for deep
+sessions. The setting calls `(rf/configure :epoch-history {:depth
+N})` live; the new depth takes effect on the next epoch.
+
+## The read-only constraint
+
+Causa never writes to `app-db` outside of explicit user-confirmed
+rewinds. Specifically:
+
+- **No in-place app-db editing.** The app-db panel is read-only (lock
+  #3). The runtime is the source of truth.
+- **No silent rebases.** Scrubbing the view never moves the runtime.
+- **No automatic rewinds.** Causa never says "I see you scrolled —
+  let me rewind for you."
+
+The only writes Causa issues are:
+
+1. `(rf/restore-epoch ...)` — confirmed via `r` shortcut or `Rewind
+   here` button.
+2. `(rf/reset-frame-db! ...)` — confirmed via `Try anyway` in the
+   schema-mismatch modal.
+3. `(rf/dispatch ev opts)` with `:origin :causa` — confirmed via
+   right-click → "Re-dispatch" on a graph node or event-log row.
+
+Every write fires a synthetic visible trace event (`:origin :causa`),
+so subsequent inspection clearly distinguishes Causa-issued state
+changes from app-issued ones.
+
+## Cross-frame scrubbing
+
+The scrubber is **per-frame**. Switching the frame picker re-binds the
+scrubber to the new frame's `epoch-history` and resets the position to
+that frame's newest epoch.
+
+Cross-frame cascades (where dispatch in frame A triggers dispatch in
+frame B) still render in the causality graph regardless of which
+frame's scrubber is active. The graph spans frames; the scrubber does
+not.
+
+## Production elision
+
+Per Spec 009 §Production builds and Tool-Pair §Time-travel, the
+epoch-history machinery is gated on `re-frame.interop/debug-enabled?`
+(aliased to `goog.DEBUG`). Production builds elide the entire surface;
+the scrubber renders an empty state ("no epoch history available; this
+is a production build") if mistakenly loaded.
+
+CI's `npm run test:elision` job verifies the contract.

--- a/tools/10x/spec/003-Machine-Inspector.md
+++ b/tools/10x/spec/003-Machine-Inspector.md
@@ -1,0 +1,184 @@
+# 003-Machine-Inspector
+
+The machine inspector renders a Stately-quality state-chart per
+registered machine, embedded in Causa as one of the 16 panels. The
+state-chart component itself lives in `tools/machines-viz/` —
+Causa embeds it.
+
+## Embedding posture
+
+`tools/machines-viz/` owns the chart component. Causa embeds it. The
+dependency arrow:
+
+```
+tools/10x/  ─requires→  tools/machines-viz/  ─requires→  implementation/machines/
+```
+
+Same direction as Story → Causa (per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). The
+inverse is forbidden: `machines-viz` does **not** depend on Causa, so
+programmers who want a chart without the rest of Causa can pull
+`machines-viz` standalone.
+
+The contract: `machines-viz` exports a `MachineChart` component that
+accepts a `machine-id` and a `frame-id`, renders the chart, handles
+the live-highlight. Causa's machine-inspector panel is a thin wrapper
+that adds the transition-history ribbon and the source-coord jump
+affordance.
+
+```clojure
+;; In Causa's machine-inspector panel namespace:
+(ns day8.re-frame2-causa.panels.machine
+  (:require [day8.re-frame2-machines-viz.chart :as viz]))
+
+(defn machine-inspector-panel [{:keys [machine-id frame-id]}]
+  [:div.causa-machine-inspector
+   [viz/MachineChart {:machine-id machine-id
+                      :frame-id   frame-id
+                      :on-state-click  causa-jump-to-source
+                      :on-transition-click causa-jump-to-transition-history}]
+   [transition-history-ribbon frame-id machine-id]])
+```
+
+## What the panel shows
+
+For the selected machine:
+
+- **A directional state-chart.** Nodes are states (compound states
+  nested visually). Edges are transitions, labelled with their event
+  id.
+- **The current state pulses softly.** Compound states' active child
+  is highlighted recursively.
+- **Hover an edge** → see the guard and action functions; click to
+  jump to source.
+- **`:invoke` / `:invoke-all` spawned children** appear as smaller
+  machines next to their parent, each with their own state.
+- **`:after` timers show a countdown ring** on the source state.
+- **Transition history ribbon** below the chart: a scrubbable list of
+  the last *N* `:rf.machine/transition` events; clicking one rewinds
+  the chart to that microstep.
+
+## Data sources
+
+Per Spec 005 and Spec 009:
+
+| Surface | Used for |
+|---|---|
+| `(rf/machines frame-id)` | Enumerate registered machines (drop-down in panel header). |
+| `[:rf/machines <id>]` slot in `app-db` | Read current snapshot; deref drives the live-highlight. |
+| `:rf.machine/transition` traces | Build the transition-history ribbon. |
+| `:rf.machine.microstep/transition` traces | Microstep replay within an `:always`-driven cascade. |
+| `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | Drive `:after` countdown rings. |
+| `:rf.machine.invoke-all/*` traces | Render `:invoke-all` join state (started, all-completed, some-completed, any-failed). |
+| `:rf.machine/spawned` / `-destroyed` | Render spawn/destroy lifecycle in the parent's chart. |
+| `:rf.machine/done` | Mark `:final?`-state entry, before the auto-destroy. |
+| `:rf.machine/system-id-bound` / `-released` | Surface `:system-id` reverse-index activity in a sidebar. |
+| Source-coord stamping (rf2-8bp3) | Every clickable element jumps to source. |
+
+## Selection and switching
+
+The panel header carries a machine picker — a dropdown over
+`(rf/machines frame-id)`. The dropdown shows machine-id, current
+state, and a tiny activity indicator (filled green if transitioned in
+the last 5s; grey otherwise).
+
+Switching the active frame re-binds the picker to that frame's
+machines. Machines spawned via `:rf.machine/spawn` (dynamic actors)
+appear in the picker with their gensym'd id; named addressing via
+`:system-id` is surfaced as a parenthetical (e.g. `:gensym-42
+(:auth/main)`).
+
+## Transition history ribbon
+
+A horizontal scrubbable list under the chart. Each entry is one
+`:rf.machine/transition`:
+
+```
+[14:32:01 :login    → :authing ] [14:32:02 :authing  → :error  ]
+[14:32:04 :error    → :idle    ] [14:32:11 :idle     → :login  ]
+```
+
+- **Click an entry** → chart rewinds to show the state pre-transition,
+  with the inbound edge highlighted. The rewind is **view-only** (same
+  passive-scrubbing rule as [`002-Time-Travel.md`](./002-Time-Travel.md))
+  — Causa does not call `restore-epoch` from this affordance.
+- **Hover** → tooltip with the triggering event vector and guard
+  result.
+- **Microstep entries** (from `:rf.machine.microstep/transition`) are
+  rendered slightly indented under their outer transition.
+
+## Source-coord integration
+
+Every clickable element on the chart jumps to source:
+
+| Element | Source surface |
+|---|---|
+| State node | `:rf.machine/source-coords {:state <prefix-path>}` — opens the state's registration in the editor. |
+| Edge | `:rf.machine/source-coords {:transition [<from> <event>]}` — opens the transition entry's source line. |
+| Guard | The guard function's `:rf.machine/source-coords {:guard <name>}` — opens its definition. |
+| Action | The action function's `:rf.machine/source-coords {:action <name>}`. |
+
+Source coords are surfaced as copyable `file:line` chips; clicking
+opens the file via the editor URL handler the user configured in
+Settings → Source. No protocol-handler dependency (lock #11 in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)).
+
+When the dispatch coord is missing (e.g., a synthetic dispatch from a
+machine action), Causa falls back to the registered handler's source
+coord with an inline `(?)` annotation that hovers a tooltip ("This
+coord is the handler's; the dispatch was synthesised by `:auth/main`
+at state `:authing`.")
+
+## `:invoke-all` viz
+
+When a state declares `:invoke-all`, the chart shows the N parallel
+children as a horizontal row of mini-machines, each with their own
+state. The join condition (`:all` / `:any` / `{:n N}` / `{:fn ...}`)
+renders as a label below the row.
+
+As children complete or fail, the row updates:
+
+- A child reaching `:final?` colours green and marks `done?`.
+- A child failing colours red and marks `failed?`.
+- When the join resolves, the parent state advances; the children
+  collapse to a summary (`3/5 completed, 2 cancelled`).
+
+## Auto-pan
+
+Large machines (many states, deep nesting) are wider than the panel.
+Causa auto-pans on every transition so the active state stays in
+view. The user can disable auto-pan via the panel header toggle (kept
+state per-machine in localStorage).
+
+## Performance
+
+- **Chart re-layout** runs only on registry change (machine
+  re-registered) or compound-state expand/collapse. Live transitions
+  do not re-layout — they just update node highlights.
+- **`:after` countdown rings** update at 60Hz only when the panel is
+  visible; backgrounded panels pause the countdown render (the timer
+  itself runs at framework-time).
+- **Transition history** virtualises past 200 entries; older entries
+  scroll into view but are not retained in DOM.
+
+## Empty state
+
+When no machines are registered:
+
+```
+   No machines registered.
+   Once your app registers a machine via reg-machine (Spec 005),
+   it will appear here with:
+   • Live state-chart highlighting
+   • Transition history
+   • :after countdown rings
+   → Read about machine integration
+```
+
+## Accessibility
+
+The state-chart is a graph, which is hard for screen readers. v1.0
+ships **without** a chart alt-view; the alt-view is a v1.1
+commitment (per the original v2 design's accessibility plan). Until
+then, the transition-history ribbon and the machines picker are the
+accessible surfaces — both are text-heavy and reach the same data.

--- a/tools/10x/spec/004-App-DB-Diff.md
+++ b/tools/10x/spec/004-App-DB-Diff.md
@@ -1,0 +1,189 @@
+# 004-App-DB-Diff
+
+The app-db panel is **slice-centric**, not tree-centric. Real app-dbs
+run 1–50MB. Rendering the whole tree on every dispatch competes for
+canvas real estate, virtualisation only partly helps, and it isn't
+what programmers want. Programmers want to see **the slices that
+changed in this epoch**, plus a few slices they've pinned for
+watching.
+
+## Default view
+
+A stack of focused slice mini-panels:
+
+```
+┌─ Slice 1: [:cart :items]  (modified) ─────────────┐
+│  before:  [{:id 7 :qty 1}]                        │
+│  after:   [{:id 7 :qty 1} {:id 22 :qty 1}]        │
+└────────────────────────────────────────────────────┘
+
+┌─ Slice 2: [:cart :totals :gross]  (added) ────────┐
+│  added:   $48.00                                  │
+└────────────────────────────────────────────────────┘
+
+┌─ Pinned slices ───────────────────────────────────┐
+│  [:user :auth :status]           :authenticated   │
+│  [:nav :route]                   :app/cart        │
+└────────────────────────────────────────────────────┘
+
+[Show full app-db tree ▸]
+```
+
+The panel never renders the whole tree by default. Slice mini-panels
+are bounded by the size of the touched path. A 50MB `app-db` with
+two touched slices renders the same as a 100KB one.
+
+## Changed-paths derivation
+
+Causa reads `:rf/epoch-record`'s `:db-before` and `:db-after` and
+derives a changed-paths set via structural-sharing diff:
+
+- **PersistentHashMap pointer-equality** at each level — if the
+  pointer is identical, the subtree is unchanged; skip.
+- **Recurse only where pointers differ.** This is O(changed paths),
+  not O(db size).
+- **Emit a sorted vector of `[op path before-value after-value]`
+  triples** where `op` is one of `:added`, `:modified`, `:removed`.
+
+The framework's `:rf/epoch-record` does **not** pre-compute changed
+paths (the runtime stays cheap); Causa runs the diff on the panel's
+first mount per epoch, caches per `:epoch-id`, and discards on epoch
+age-out.
+
+## Colour coding
+
+| Op | Visual |
+|---|---|
+| `:added` | Green left-border; key tagged `(added)`. |
+| `:modified` | Yellow left-border; `before` / `after` side-by-side. |
+| `:removed` | Red left-border; key tagged `(removed)`; value rendered struck-through. |
+
+The diff flash on epoch land is a 400ms tween (yellow → transparent)
+on each newly-touched slice. Respects `prefers-reduced-motion` — the
+tween becomes a static yellow border for 600ms.
+
+## Pinned slices
+
+Right-click any value in the runtime → **Pin this slice**. The path
+persists to localStorage and renders in the Pinned-slices list across
+sessions.
+
+- **Each pin shows the path and current value** (live-updating on
+  every epoch).
+- **Right-click a pin** → Unpin · Edit path · Open source (jumps to the
+  most-recent `reg-event-*` registration that touched this path).
+- **Pin order** is user-controlled (drag to reorder); persisted.
+- **Pins are per-frame.** Switching frames switches the pin set.
+
+## Reserved-keys group
+
+The runtime's reserved app-db keys (`:rf/machines`, `:rf/route`,
+`:rf/system-ids`, `:rf/pending-navigation`, `:rf/spawned`, per
+[Conventions §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys))
+render in a separate `[runtime]` group at the bottom of the panel:
+
+```
+┌─ [runtime] ───────────────────────────────────────┐
+│  :rf/machines            (3 active)               │
+│  :rf/route               :app/cart                │
+│  :rf/system-ids          (1 bound)                │
+└────────────────────────────────────────────────────┘
+```
+
+These are informational; the panel surfaces them clearly marked so
+the programmer recognises them as runtime-owned and doesn't reach for
+"pin this." (A pin attempt on a reserved key shows a warning toast
+suggesting the equivalent panel — e.g., "Use the Machine inspector
+for `:rf/machines`.")
+
+## Full-tree escape hatch
+
+The `Show full app-db tree ▸` row at the bottom expands to fill the
+canvas:
+
+- Virtualised lazy-expand collapsible tree.
+- Only first 100 keys at each level eager-render; deeper levels load
+  on click.
+- Search input at the top filters by path or value substring.
+- Persistent breadcrumb at the top of the tree shows the currently
+  focused path.
+- Path-click → copies the path to clipboard (for pasting into a sub
+  or for a pin).
+
+The full tree is rarely needed; the slice-centric view answers most
+questions.
+
+## Read-only
+
+The app-db panel is **read-only forever** (lock #3 in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)). No in-place edit
+boxes, no "set value" affordances. The runtime is the source of
+truth; pokes from the debugger are out of scope.
+
+The user can:
+
+- Right-click → Copy value
+- Right-click → Copy path
+- Right-click → Pin this slice
+- Right-click → Show me when this changed *(pivots the canvas to a
+  list of epochs that touched the path; see below)*
+
+Not present:
+
+- "Edit value"
+- "Set to..."
+- "Inject"
+- Any text-input that mutates the runtime
+
+If the user wants to mutate `app-db`, they do so via `(rf/dispatch
+...)` from the REPL, or via the Re-dispatch affordance from the event
+log. Causa's writes are funnelled through dispatch (per
+[`002-Time-Travel.md`](./002-Time-Travel.md) §The read-only constraint).
+
+## "Show me when this changed"
+
+The high-leverage right-click affordance. When invoked on any path:
+
+1. Causa walks `epoch-history`, diffs each epoch's `:db-before` and
+   `:db-after`, finds epochs where the path was touched.
+2. The canvas pivots to a list:
+
+   ```
+   Epochs that touched [:cart :items]:
+   ▸ epoch 14   :cart/add-item       added {:id 22 :qty 1}
+   ▸ epoch 11   :cart/clear          removed [{:id 7 :qty 1}]
+   ▸ epoch 8    :cart/add-item       added {:id 7 :qty 1}
+   ▸ epoch 3    :app/boot            set to []
+   ```
+
+3. Clicking an entry → event-detail rebases to that epoch.
+4. Pressing `c` on a focused entry → causality graph filters to that
+   cascade.
+
+This is the affordance that turns "I notice this is wrong" into "show
+me when it became wrong" in two clicks. From a deep cascade, it's
+faster than re-reading the source.
+
+## Performance
+
+- **Diff caching** per `:epoch-id`. A second render of the same epoch
+  is O(1).
+- **Slice virtualisation** for slices whose `after` value is large
+  (e.g., a 10k-entry vector). The slice mini-panel renders the head
+  and tail, with a `… 9970 entries …` ellipsis; click expands.
+- **Pinned-slice deref** is bounded to one path per pin per epoch;
+  pinned slices add O(pins) per epoch, not O(db-size).
+- **Full-tree** virtualises rows past the viewport; never DOM-mounts
+  more than ~80 rows.
+
+## Empty state
+
+Before any dispatches:
+
+```
+   app-db is at the boot value.
+   No diffs yet — every dispatch will land here with the slices
+   it touched.
+```
+
+The pinned-slices area is empty until the user pins something.

--- a/tools/10x/spec/005-Schema-Timeline.md
+++ b/tools/10x/spec/005-Schema-Timeline.md
@@ -1,0 +1,173 @@
+# 005-Schema-Timeline
+
+Silent schema violations are real bugs in disguise. The schema
+violation timeline surfaces them temporally so they become impossible
+to ignore.
+
+## Substrate
+
+Per Spec 010 (Schemas) and Spec 009 §Error contract, every schema
+validation failure emits a trace event:
+
+```clojure
+{:op-type   :error
+ :operation :rf.error/schema-validation-failure
+ :recovery  <one of :skip-handler :skip-fx :rollback-db :replaced-with-default :re-raised>
+ :tags      {:where  <one of :event-coercion :db-shape :fx-shape ...>
+             :path   <path-into-app-db-or-event>
+             :value  <the offending value>
+             :schema <the schema id>
+             :explanation <Malli explanation>
+             :frame  <frame-id>}
+ :time      <ms>}
+```
+
+Causa consumes this stream and renders the timeline.
+
+## Layout
+
+A horizontal timeline along the bottom of the issues feed (when the
+Schemas panel is active, it fills the canvas instead):
+
+```
+                    last 60s →
+:schema/cart-item  ····················●··············●···
+:schema/user-auth  ······●···●·············●····················
+:schema/order      ····················································
+:schema/checkout   ·············●··········●··········●·········●
+```
+
+- **One row per registered schema** (from `(rf/app-schemas
+  frame-id)`).
+- **A dot at the timestamp** where the validation failed.
+- **Colour encodes recovery**:
+
+  | Recovery | Colour |
+  |---|---|
+  | `:skip-handler` | Red. |
+  | `:skip-fx` | Red. |
+  | `:rollback-db` | Red. |
+  | `:replaced-with-default` | Yellow. |
+  | `:re-raised` | Red, with a thicker stroke. |
+
+- **Time axis** scrolls horizontally; default window is the last 60s.
+  Drag-zoom to expand. The Trace-timeline panel governs the same time
+  axis when both are visible — selection synchronises.
+
+## Per-violation detail
+
+Click a dot → side panel:
+
+```
+┌─ schema violation ───────────────────────────────────╮
+│  schema     :schema/user-auth                        │
+│  where      :event-coercion                          │
+│  path       [:auth :email]                           │
+│  value      nil                                      │
+│  expected   string?                                  │
+│  recovery   :replaced-with-default                   │
+│                                                      │
+│  Malli explanation:                                  │
+│    {:schema [:map [:email string?]]                  │
+│     :value {:email nil}                              │
+│     :errors [{:path [:email]                         │
+│               :in   [:email]                         │
+│               :type :malli.core/missing-key          │
+│               :message "missing required key"}]}     │
+│                                                      │
+│  Triggered by:                                       │
+│    epoch 14 — :user/load-profile (epoch 14)          │
+│    [Open in causality graph]                         │
+│                                                      │
+│  Registered at:                                      │
+│    src/cart/schemas.cljs:7                           │
+│    [Open source]                                     │
+╰──────────────────────────────────────────────────────╯
+```
+
+The detail surfaces three actions:
+
+1. **Open in causality graph** — pivots to the graph filtered to the
+   dispatch that caused this violation.
+2. **Open source** — jumps to the `reg-app-schema` call site.
+3. **Show me all violations of this schema** — filters the timeline to
+   the selected row.
+
+## Hover tooltip
+
+Hover a dot → 240ms tooltip with a one-line cause:
+
+```
+at [:auth :email], expected :string, got nil
+```
+
+Cheap-to-read; cheap-to-dismiss; gives the answer without committing
+to a panel pivot.
+
+## The five recovery categories
+
+Per [Spec 010 §Per-step recovery](../../../spec/010-Schemas.md#per-step-recovery):
+
+| Recovery | What the framework did | Causa surface |
+|---|---|---|
+| `:skip-handler` | Handler did not run. | Red dot. Detail explains the handler was skipped; suggests checking the event payload shape. |
+| `:skip-fx` | Specific fx invocation skipped. | Red dot. Detail names the fx-id that was skipped. |
+| `:rollback-db` | `app-db` reverted to pre-handler value. | Red dot. Detail diff shows what *would* have been written. |
+| `:replaced-with-default` | The schema's `:default` substituted for the bad value. | Yellow dot (the framework recovered cleanly). Detail names the default that was used. |
+| `:re-raised` | The validation error was rethrown. | Red dot with a thicker stroke. Detail says "consumed by an error boundary; check the surrounding `:on-error`." |
+
+The five-category palette is **closed** (per Spec 010); Causa does not
+invent additional categories. If a sixth lands via a spec increment,
+the timeline gains a row colour.
+
+## Reading the timeline at a glance
+
+The empty-row signal matters. A row with no dots in the visible window
+is a schema that has not failed recently — which is the desired state.
+A row that goes from empty to one-dot-per-second is a regression.
+
+When a *new* row gains its first violation, the schema-name label
+flashes once (600ms) — the same attention-cue Causa uses for new
+issues. After that, the label rests until cleared.
+
+## Aging out
+
+The timeline reads from the trace buffer (bounded by Spec 009 at 200
+entries). Schema violations age out of the buffer along with everything
+else; the timeline shows only what the buffer remembers.
+
+For deep sessions, the user can bump the trace buffer depth in
+Settings → Performance. Causa never holds a parallel ring buffer for
+schema-violations specifically.
+
+## Performance
+
+- **Render per epoch**: O(visible-violations) — typically 0–5.
+- **Diff per dispatch**: 0 (the timeline reads existing trace events;
+  no extra work on the hot path).
+- **Empty state**: O(0) — the panel renders the rows for registered
+  schemas plus an "all schemas clean" indicator.
+
+## Empty state
+
+When no schemas are registered:
+
+```
+   No schemas registered.
+   Once your app registers schemas via :app-schemas (Spec 010),
+   validation events will appear here:
+   • Schema violations
+   • Path-typed lookups
+   • Schema-replaced-with-default events
+   → Read about schema integration
+```
+
+When schemas are registered but none have failed in the visible window:
+
+```
+   All schemas clean in the last 60s.
+   This is the desired state.
+```
+
+(That second message is deliberate. The empty timeline is a *result*,
+not a problem. Causa says so.)

--- a/tools/10x/spec/006-Hydration-Debugger.md
+++ b/tools/10x/spec/006-Hydration-Debugger.md
@@ -1,0 +1,176 @@
+# 006-Hydration-Debugger
+
+SSR hydration mismatches are structurally hard to debug: the failing
+client render and the failing server render disagree on a tree, the
+console error is one line, and the divergent node is rarely the one
+the error points to. No other JS devtool surfaces this; re-frame2's
+Spec 011 emits structured data, and Causa renders it.
+
+## Visibility
+
+The Hydration panel is **dormant** until at least one
+`:rf.ssr/hydration-mismatch` trace lands. Until then, the sidebar entry
+shows `◌` (dormant marker) and clicking it surfaces an empty state
+("This app does not appear to use SSR hydration").
+
+On first `:rf.ssr/hydration-mismatch`:
+
+- The Hydration sidebar entry's icon flashes red for 600ms.
+- The Issues badge increments.
+- The co-pilot, if open, surfaces a contextual suggestion: "I see a
+  hydration mismatch. Open the Hydration panel?" (no auto-open; user
+  is in control of their canvas).
+
+## Substrate
+
+Per Spec 011 §Hydration equivalence rule, the runtime emits:
+
+```clojure
+{:op-type   :error
+ :operation :rf.ssr/hydration-mismatch
+ :tags      {:path           <hiccup-path-to-divergent-node>
+             :server-tree    <hiccup of server's subtree at this path>
+             :client-tree    <hiccup of client's subtree at this path>
+             :server-hash    <render-tree hash at this path on the server>
+             :client-hash    <render-tree hash at this path on the client>
+             :frame          <frame-id>
+             :view-id        <the view registration that owns this subtree>}}
+```
+
+Plus the SSR payload itself: the runtime stamps the full server
+render-tree onto the document at hydration time (per Spec 011); Causa
+reads it from there. The first client render-tree is captured by
+Causa's preload hook before any user dispatch lands.
+
+## Layout
+
+Side-by-side render-tree view:
+
+```
+┌─ server render ────────────────╮  ┌─ client render ────────────────╮
+│ ▾ [:div.app]                   │  │ ▾ [:div.app]                   │
+│   ▾ [:header]                  │  │   ▾ [:header]                  │
+│     · [:h1 "Welcome, Alice"]   │  │     · [:h1 "Welcome, Alice"]   │
+│   ▾ [:main]                    │  │   ▾ [:main]                    │
+│     ▾ [:section.cart]          │  │     ▾ [:section.cart]          │
+│       · [:p "3 items"]         │  │       · [:p "0 items"]    ← ⚠ │
+│       · [:button "Checkout"]   │  │       · [:button "Checkout"]   │
+╰────────────────────────────────╯  ╰────────────────────────────────╯
+```
+
+The divergent node (`[:p "3 items"]` vs `[:p "0 items"]`) pulses red
+on entry (600ms expand-fade ring) and is flagged with `⚠`. Hovering
+the divergent node shows a tooltip with the render-tree hash at that
+node (bisectable).
+
+## Render-tree hash bisector
+
+Per [Spec 011 §Hydration equivalence rule](../../../spec/011-SSR.md#hydration-equivalence-rule-canonical),
+every parent node has a render-tree hash that summarises its subtree.
+Hashes match at common ancestors and diverge at the first differing
+descendant — this is the bisection property.
+
+Causa renders hashes inline as faint chips on every parent:
+
+```
+▾ [:div.app]              #a12b
+  ▾ [:header]             #c34d  (match)
+  ▾ [:main]               #ef56  (diverges)
+    ▾ [:section.cart]     #78ab  (diverges)
+      · [:p "3 items"]    #cd ← diverges here
+```
+
+The divergence path is highlighted from root to the first differing
+node. Click any hash chip → the panel re-roots at that node (zooms
+into the subtree).
+
+## Multi-mismatch case
+
+Multiple mismatches in a single hydration produce a list at the panel
+top:
+
+```
+3 mismatches in this hydration:
+▸ [:div.app :main :section.cart :p]          server "3 items" vs client "0 items"
+▸ [:div.app :main :section.cart :button]    server "Checkout" vs client "Sign in to checkout"
+▸ [:div.app :footer :p]                      server "© 2026" vs client "© 2025"
+```
+
+Click an entry → side-by-side rebases to that path. Arrow keys walk
+the list.
+
+## Source-coord drilldown
+
+Each mismatch surfaces source coords for the divergent view's
+registration:
+
+```
+Divergent view: cart-summary-view
+  Registered at:  src/cart/views.cljs:42
+  [Open source]
+```
+
+Click `Open source` → editor opens at line 42 via the source-coord URL
+handler (per [Spec 006 §Source-coord annotation](../../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1)).
+
+When the view registration itself has no obvious cause, the panel
+falls back to the dispatch (or `:rf/hydrate` cofx) that produced the
+client-side state — using the same handler-coord fallback as the rest
+of Causa (lock #11 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md));
+surfaced with `(?)` annotation.
+
+## Cause hypothesis
+
+Below the side-by-side, Causa surfaces a one-line hypothesis based on
+the divergence kind:
+
+| Pattern | Hypothesis |
+|---|---|
+| Different text content under the same tag | "App-db state differs between server and client. Check the slice that feeds this view." |
+| Tag differs | "View structure differs. Check conditional rendering — the server may have rendered a different branch." |
+| Attribute differs | "Attribute computed from differing inputs. Check the sub feeding the attribute." |
+| Children missing on client | "View's children render conditionally; the condition differs. Check the gating sub." |
+| Children missing on server | "View bails out on server (e.g., uses `js/window`). Move the dependency into a client-only effect." |
+
+The hypothesis is **a hint, not an answer**. It links to a panel pivot
+that lets the user verify (the relevant sub graph, the relevant
+app-db slice, the relevant cofx trace).
+
+## Frame awareness
+
+Per Spec 002, hydration is per-frame. The Hydration panel shows
+mismatches for the active frame; switching the frame picker
+re-filters. Cross-frame SSR (a server-rendered frame nested inside a
+client-rendered shell) renders both swimlanes; the panel's title bar
+indicates "showing mismatches for `<frame-id>`."
+
+## Production posture
+
+Hydration panel surfaces are dev-only. Per Spec 009, the entire trace
+surface elides in production; the `:rf.ssr/hydration-mismatch` event
+is never emitted in a production build. Causa's panel renders an
+empty state in prod-like builds.
+
+In dev, the panel's first-paint cost is paid only when a mismatch
+fires — the panel's render code is lazy-loaded on first activity
+(per [`007-UX-IA.md`](./007-UX-IA.md) §Bundle splitting).
+
+## Empty states
+
+**No SSR in this app:**
+
+```
+   This app does not appear to use SSR hydration.
+   The Hydration panel surfaces when :rf.ssr/hydration-mismatch
+   events fire — see Spec 011.
+```
+
+**SSR present, no mismatches:**
+
+```
+   Hydration ran cleanly.
+   No mismatches detected on the last hydration.
+```
+
+(Second message is again deliberately a positive result — a clean
+hydration is the goal, not the absence of a result to display.)

--- a/tools/10x/spec/007-UX-IA.md
+++ b/tools/10x/spec/007-UX-IA.md
@@ -1,0 +1,484 @@
+# 007-UX-IA
+
+The user experience, the information architecture, the visual
+language. This doc is what an implementer reads to ship pixels that
+feel right — typography sizes, colour tokens, animation timings,
+keyboard maps, density gradients.
+
+For the *why* behind these picks, see [`Principles.md`](./Principles.md)
+and [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Layout
+
+Causa fills a panel along the **right edge** of the viewport by
+default, taking 40% of the window width (resizable). Right-edge gives
+more vertical real estate for the graph and the event detail than a
+bottom panel.
+
+### The five regions
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                  │
+│  [APP CONTENT — DIMMED 12%, INTERACTIONS PASS THROUGH]                          │
+│                                                                                  │
+├──────────────────────────────────────────────────────────────────────────────────┤
+│ ╭─ CAUSA ───────────────────────────────────────────────────── :app/main ▾ ──╮  │
+│ │ ◆──○──○──○──○──○──○──○──○──○──●        ⚠ 0   ⏵◀ epoch 11/11   ⌘K   ?   ✕ │  │  ← top strip (56px)
+│ ├──────────────────────────────┬────────────────────────────────────────────┤  │
+│ │ ◉ Events                     │ ╭─ event 11 ─────────────────────────────╮ │  │
+│ │ ○ App-db                     │ │ :checkout/submit                       │ │  │
+│ │ ○ Causality                  │ │ source • src/cart/events.cljs:213      │ │  │
+│ │ ○ Subscriptions              │ │ ...                                    │ │  │
+│ │ ○ Machines             ●●●   │ │                                        │ │  │
+│ │ ○ Issues               ●3    │ ╰────────────────────────────────────────╯ │  │  ← canvas
+│ │ ▥ ▥▥ ▥▥▥                    │                                            │  │
+│ │  ↑ density toggle            │                                            │  │
+│ │                              │                                            │  │
+│ │  ↑ sidebar (192px)           │                                            │  │
+│ ╰──────────────────────────────┴────────────────────────────────────────────╯  │
+│ ◀◀ ─────────────────●──── ▶▶   :app/main   11/11 epochs   8.2KB                 │  ← bottom rail (40px)
+╰──────────────────────────────────────────────────────────────────────────────────╯
+```
+
+The five regions:
+
+1. **Top strip** (56px) — causality strip + frame picker + global
+   actions (Issues badge, epoch counter, command palette, help, close).
+2. **Sidebar** (192px) — panel navigation + density toggle.
+3. **Canvas** — the active panel's content.
+4. **Right rail** (when co-pilot open; 320px) — AI co-pilot panel.
+5. **Bottom rail** (40px) — time-travel scrubber + frame info + issues
+   badge.
+
+Below 1200px viewport: sidebar collapses to icons (56px); co-pilot
+rail goes to 0 (overlays canvas when opened).
+
+Below 900px viewport: Causa takes 100% of viewport width.
+
+Below 600px viewport (phones): **Causa refuses to mount** (per lock
+#5). The DOM root creates but the visible UI is a single message
+explaining desktop-only.
+
+## The default landing view
+
+On `Ctrl+Shift+C`:
+
+- Slide-in animation: 320ms from the right edge.
+- First-paint target: under 80ms (Causa is preloaded; the show/hide
+  toggle is a CSS class swap).
+- **Active panel: Events**, showing the most-recent epoch's
+  event-detail.
+- **AI co-pilot: collapsed** (per lock #8). A subtle activation cue
+  marks the rail entry — see below.
+- **Issues feed: collapsed**, with the count badge in the top strip.
+- **Frame picker: shows the active frame** (single-frame apps collapse
+  to static label).
+
+## The AI co-pilot collapsed cue
+
+The co-pilot rail is **closed by default** (lock #8 — the marquee-pull
+of "open by default" was reversed; the principle of an unobtrusive
+debugger won out).
+
+The cue: in the top-strip's right group, a small `◇` glyph in
+co-pilot magenta pulses gently every 8 seconds (single 600ms expand
+on a fade-cycle). The glyph's tooltip on hover: "Ask Causa
+(`Ctrl+Shift+/`)."
+
+The pulse is once-every-8-seconds, not constant — animation
+communicates, not decorates (per §Motion below). The pulse stops
+entirely after the user has used the co-pilot once (Causa remembers
+across the session).
+
+When opened, the rail slides in from the right of the canvas at
+250ms ease-out; the rest of Causa's columns reflow.
+
+## Sidebar groups
+
+Three groups, divider-separated:
+
+```
+┌──────────────────────────────┐
+│ ◉ Events                     │  ← active
+│ ○ App-db                     │
+│ ○ Causality                  │  ← always-active group
+│ ○ Subscriptions              │
+│ ○ Effects                    │
+│ ○ Trace                      │
+│ ─                            │  ← divider
+│ ○ Machines           ●●●     │  ← conditional-with-activity
+│ ○ Flows                      │
+│ ○ Performance                │
+│ ○ Issues             ●3      │
+│ ○ Routes                     │
+│ ─                            │
+│ ○ Schemas            ◌       │  ← dormant
+│ ○ Hydration          ◌       │
+│ ─                            │
+│ ○ Co-pilot           ◇       │  ← cue glyph
+│ ○ Settings                   │
+│ ▥ ▥▥ ▥▥▥                    │  ← density toggle
+└──────────────────────────────┘
+```
+
+### Activity badges
+
+Per item, right-aligned:
+
+| Badge | Meaning |
+|---|---|
+| (no badge) | Always-active panel; no signal needed. |
+| `●` | Activity now or in last 5 seconds. |
+| `●N` | Numeric unread count (3 issues, 5 schema violations). |
+| `●●●` | Multiplicity (3 machines currently running). |
+| `◌` | Dormant — no activity this session. |
+| `◇` | Cue glyph (co-pilot collapsed). |
+
+Badges fade in on first activity (200ms) and **never fade out** — the
+dot persists for the session as a "this panel has data" signal.
+
+### The `+5 more` collapse
+
+When most conditional panels have no activity, the sidebar collapses
+them into a single `+5 more` row above the dormant divider. Click
+expands inline. Solves "the sidebar feels too long" without burying
+anything.
+
+### Right-click → Show all panels
+
+Power-users get the full unsorted list. Persisted per-machine.
+
+## The density slider
+
+Three settings: **compact** / **cosy** / **comfy**. Default **cosy**.
+
+| Setting | Sidebar | Pill | Tick gap | Body type |
+|---|---|---|---|---|
+| **Compact** | 160px | 20px | 4px | -1px |
+| **Cosy** (default) | 192px | 24px | 4px | (baseline) |
+| **Comfy** | 224px | 28px | 6px | +1px |
+
+What does *not* change between densities: icon weights, border radii,
+animation durations, accent colours. Density is a vertical-rhythm
+knob, not a redesign.
+
+## Typography
+
+Two typefaces only:
+
+- **UI sans:** `Inter` (variable, wght 400–700), fallback
+  `system-ui` / `-apple-system` / `Segoe UI`. ~80KB WOFF2. UI chrome,
+  labels, headings.
+- **Data mono:** `JetBrains Mono` (variable, wght 400–700), fallback
+  `ui-monospace` / `SF Mono` / `Menlo`. ~100KB WOFF2. App-db trees,
+  event vectors, source coords, code blocks, EDN.
+
+### Sizes (cosy density)
+
+| Token | Size / line-height / weight | Used for |
+|---|---|---|
+| Display | 16 / 1.4 / 600 | Panel titles |
+| Body | 14 / 1.5 / 400 | Default UI text |
+| Mono body | 13 / 1.45 / 400 | Code, EDN (mono is 1px down to visually match sans) |
+| Caption | 12 / 1.4 / 400 | Hints, secondary labels |
+| Micro | 11 / 1.2 / 600 | Badges, tabs |
+
+Below 10px: refused.
+
+## Colour system
+
+Dark theme default; light theme ships at v1.0; high-contrast variant
+at v1.1. All WCAG AA on text-against-background; AAA on
+high-contrast.
+
+### Dark theme tokens
+
+```
+Surfaces:  bg-0 #0E0F12  (backdrop)
+           bg-1 #15171B  (sidebar, top strip)
+           bg-2 #1B1E24  (panels)
+           bg-3 #232730  (popovers)
+           bg-active #2A2F3D  (hover, selected)
+
+Borders:   subtle #232730  · default #2F3441  · strong #444B5B
+
+Text:      primary #E8EAF0  · secondary #A8AEC0  · tertiary #6B7080  · disabled #494E5A
+
+Accents:   violet  #7C5CFF  brand, current epoch
+           indigo  #5570FF  :pair-origin
+           cyan    #43C3D0  :story / :test origin, info
+           green   #4ADE80  success, additions, machine-active
+           yellow  #FBBF24  warnings, schema-replaced-with-default
+           orange  #FB923C  long-task
+           red     #F87171  errors, schema-violations, hydration-mismatches
+           magenta #E879F9  AI co-pilot highlight
+
+Perf:      fast     #4ADE80  (<16ms)
+           medium   #FBBF24  (16-50)
+           slow     #FB923C  (50-100)
+           blocking #F87171  (>100ms, INP threshold)
+```
+
+Light theme inverts lightness (`bg-0 #FAFBFC`, `bg-1 #F1F3F6`, `bg-2
+#FFFFFF`); accents darken slightly to maintain contrast.
+
+### Colour is never alone
+
+Every coloured marker pairs with a shape or icon:
+
+- Errors → red dot + `!` icon + "Error" label.
+- Schema violations → yellow triangle + path.
+- Pair-origin → indigo + `🔗`.
+- Active machine → green + filled glyph; idle → hollow.
+
+The colour-blind path is reachable without ever relying on hue.
+
+## Spacing scale
+
+4px grid. Everything is a multiple.
+
+| Token | Pixels | Used for |
+|---|---|---|
+| `space-0` | 0 | Collapsed |
+| `space-1` | 4 | Badge-to-text gap |
+| `space-2` | 8 | Default inline gap, button padding |
+| `space-3` | 12 | Section spacing |
+| `space-4` | 16 | Panel padding |
+| `space-5` | 24 | Between sections |
+| `space-6` | 32 | Panel-level separators |
+| `space-8` | 48 | Rare; modal margins |
+
+Border-radius: `radius-sm` 4px (buttons, chips); `radius-md` 8px
+(panels, popovers); `radius-lg` 12px (modals).
+
+## Iconography
+
+Single icon set: **Lucide** (open-source, ~1000 icons). 1.5px stroke.
+Sizes 14 / 16 / 20px (inline / sidebar / modal-header). 100ms hover
+fade to context accent; no size change on hover.
+
+Causa-specific custom glyphs: `◆` cascade root · `●` filled node ·
+`○` hollow node · `◉` selected node · `↺` rewind · `◇` co-pilot cue.
+
+## Motion + animation
+
+Animation communicates, not decorates. Three durations:
+
+| Tier | Range | Used for |
+|---|---|---|
+| **Quick** | 100ms | Hover, focus rings |
+| **Standard** | 200–250ms | Panel switches, scrubber drag-snap, sidebar collapse |
+| **Slow** | 400–600ms | Diff flashes, error pulses, the 320ms Causa slide-in |
+
+Easings: default `cubic-bezier(0.4, 0, 0.2, 1)`; entering
+`cubic-bezier(0, 0, 0.2, 1)`; exiting `cubic-bezier(0.4, 0, 1, 1)`.
+
+Specific motions:
+
+- Panel switch: 180ms cross-fade.
+- Detail diff flash: 400ms yellow → transparent on each touched slice.
+- Error pulse: single 600ms expand-fade red ring (no looping).
+- Machine-active state: 1.2s gentle scale 1.0 → 1.05 → 1.0 (only
+  continuous animation in chrome, only on the machine chart).
+- Co-pilot streaming: typewriter ~25 chars/sec.
+- Co-pilot cue glyph: single 600ms expand-fade every 8 seconds until
+  first use, then stops.
+
+### `prefers-reduced-motion`
+
+All durations clamp to 0 except a 1-frame opacity tween where layout
+needs to settle. The error pulse becomes a static red ring for 1.5s;
+the machine pulse stops entirely; the co-pilot cue glyph stops
+pulsing (the glyph stays visible, statically).
+
+## Keyboard
+
+Every panel is keyboard-reachable. The chrome has a strict tab order:
+top-strip → sidebar → canvas (focus enters the active panel) → bottom
+rail → co-pilot (when open). `Esc` always returns focus to the canvas.
+
+### Global shortcuts
+
+| Key | Action |
+|---|---|
+| `Ctrl+Shift+C` | Toggle Causa |
+| `Ctrl+Shift+P` | Pop out to separate window |
+| `Ctrl+K` | Command palette |
+| `?` | Keyboard cheat-sheet |
+| `,` | Settings |
+| `Esc` | Close modal / collapse popover / focus canvas |
+| `Ctrl+Shift+/` | Toggle co-pilot rail |
+| `Ctrl+F` | Find within active panel |
+
+### Navigation
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Next / previous in any list |
+| `g g` / `G` | Top / bottom |
+| `[` / `]` | Previous / next epoch (passive — does not rewind) |
+| `Shift+[` / `Shift+]` | Previous / next cascade root |
+| `Tab` / `Shift+Tab` | Move between regions |
+
+### Panel jumps (mnemonics)
+
+| Key | Panel |
+|---|---|
+| `e` | Events |
+| `a` | App-db |
+| `c` | Causality graph |
+| `s` | Subscriptions |
+| `f` | Effects (fx) |
+| `t` | Trace |
+| `m` | Machines |
+| `w` | floWs |
+| `p` | Performance |
+| `i` | Issues |
+| `r` | Routes |
+| `S` | Schemas |
+| `h` | Hydration |
+| `/` | Co-pilot (input focused) |
+| `,` | Settings |
+
+### Event actions (when an event is focused)
+
+| Key | Action |
+|---|---|
+| `Enter` | Open detail |
+| `o` | Open source in editor |
+| `R` | Re-dispatch this event |
+| `r` | Rewind to before this event (calls `restore-epoch`) |
+| `Shift+r` | Hard rewind with failure modes surfaced |
+| `f` | Filter the causality graph to this dispatch's cascade |
+| `Ctrl+C` | Copy event vector |
+| `Ctrl+Shift+C` | Copy source coord |
+
+### Scrubber
+
+| Key | Action |
+|---|---|
+| `Space` | Toggle play (passive auto-step at 500ms intervals) |
+| `Shift+Space` | Slow play (1000ms intervals) |
+| `0` | Jump view to oldest |
+| `$` | Jump view to newest |
+| `*` | Pin a snapshot at current epoch |
+
+### Co-pilot
+
+| Key | Action |
+|---|---|
+| `/` (from chrome) | Focus co-pilot input |
+| `Enter` (input focused) | Submit |
+| `Shift+Enter` | New line |
+| `Ctrl+L` | Clear conversation |
+| `Ctrl+P` | Previous question |
+| `Ctrl+N` | Next question |
+
+## Command palette (`Ctrl+K`)
+
+The spine of expert workflows. Centred 560px modal, 50% height.
+
+### Indexed sources
+
+Matched together, recency-weighted, command-boosted:
+
+- Recent events (200-entry buffer; matches event-id + source coord)
+- Registered handlers (id + `:doc`)
+- Frames
+- Machines with current state
+- Flows
+- Subs
+- Panel names
+- Command verbs (Rewind / Re-dispatch / Snapshot / Filter / Pin /
+  Pop-out / Switch frame / …)
+- Settings entries
+- Recent co-pilot questions
+
+Fuzzy match splits on camelCase / kebab-case / namespace boundaries.
+
+### Empty palette is context-aware
+
+With no input, the top of the list shows:
+
+- Actions for the active panel
+- "Open source" / "Rewind here" when an event is selected
+- "Investigate `:rf.error/handler-exception`" when a fresh error
+  landed
+
+### Row shape
+
+40px tall (compact 32, comfy 48): 16px type icon, label,
+right-aligned hint (`epoch 11`, `events.cljs:213`, shortcut). Arrows
+to navigate; Enter invokes; `Ctrl+Enter` invokes in a pop-out.
+
+## Modal layers
+
+Three modal surfaces float over the chrome:
+
+1. **Command palette** (`Ctrl+K`) — 560px centred.
+2. **Keyboard cheat-sheet** (`?`) — 480px modal listing every
+   shortcut.
+3. **Settings** (`,`) — 640×480px modal: Theme · Density ·
+   Keybindings · AI provider · Buffer depths · Frame defaults ·
+   Telemetry (always off; statement of why we don't ship any).
+
+## Discoverability
+
+Three layers, no onboarding tour:
+
+1. **The `?` cheat-sheet.** Modal showing every shortcut.
+   Discoverable from the top strip's `?` icon. On first open, Causa
+   flashes a 800ms violet ring around the `?` icon for one cycle
+   (then never again).
+
+2. **Empty-state hints.** Each empty state shows a contextual
+   keyboard hint ("No events yet. Press `Ctrl+Shift+C` again to
+   close..."). On first event selection, a 4-second auto-dismiss
+   popover suggests "Press `c` for the causality graph."
+
+3. **The command palette itself.** Typing `?` in the palette filters
+   to commands and shows their shortcuts. The palette is the
+   documentation.
+
+We do **not** ship a tour. Causa is a tool, not an experience.
+
+## Bundle splitting
+
+Per-panel lazy loading via shadow-cljs's per-output-target slicing:
+
+- Core (UI shell + Events + App-db + Causality strip): <1.5 MB
+  minified / <500 KB gzipped.
+- AI co-pilot panel: <400 KB extra, lazy-loaded on first open.
+- Machine inspector: <300 KB extra (includes `tools/machines-viz/`),
+  lazy-loaded on first open.
+- Hydration debugger: <100 KB extra, lazy-loaded on first
+  `:rf.ssr/hydration-mismatch`.
+
+The sidebar loads metadata only at boot; opening a panel kicks the
+relevant module.
+
+## Performance budget
+
+The hard rule: **opening Causa must not change observable INP** on a
+typical app.
+
+- Trace bus emission overhead: <2µs per emit (per Spec 009).
+- Causality graph live updates: debounced to 16ms (one rAF). A burst
+  of 1000 events updates the graph once per frame.
+- App-db diff: O(changed paths) via PersistentHashMap pointer-eq.
+- Rendering: every panel virtualises long lists; nothing renders >200
+  rows at once; the causality graph caps at the last 200 dispatches.
+
+If a feature pushes INP, the feature is cut.
+
+## Production posture
+
+The launch pill doesn't render in production builds (per Spec 009 §
+Production builds — `goog.DEBUG=false` elides the entire surface).
+`Ctrl+Shift+C` does nothing. CI verifies via `npm run test:elision`.
+
+In a non-elided dev build running in production-like conditions,
+Causa shows a yellow top banner: "Causa is enabled in this build.
+Disable for production." Single-click dismiss, remembered for the
+session.

--- a/tools/10x/spec/008-Embedding-Contract.md
+++ b/tools/10x/spec/008-Embedding-Contract.md
@@ -1,0 +1,197 @@
+# 008-Embedding-Contract
+
+Causa is consumed by Story (per `spec/007-Stories.md` §6.7) as a
+per-variant observability ribbon. This doc specifies the contract:
+every Causa panel exports a React component (or hiccup-fn equivalent)
+that can be embedded outside Causa's own chrome.
+
+## The contract
+
+Every panel exposes a public `Panel` component that accepts a props
+map:
+
+```clojure
+{:frame    :story.auth/login         ;; which frame to observe
+ :compact? true                      ;; reduced chrome — no sidebar, no header
+ :height   320                       ;; in pixels (optional; default flex)
+ :scope    {:dispatch-id-prefix ...} ;; optional filter to restrict the observation window
+ :on-event #(...)}                   ;; optional callback when the panel emits an event (e.g. click-to-source)
+```
+
+### Props
+
+| Prop | Required | Default | Meaning |
+|---|---|---|---|
+| `:frame` | yes | n/a | The frame-id this panel observes. The panel does not switch frames; the host owns frame selection. |
+| `:compact?` | no | `false` | If true: no sidebar, no top strip, no bottom rail. The panel renders as a self-contained card. |
+| `:height` | no | `nil` (flex) | Fixed height in pixels. Useful for Story variants that want a uniform ribbon height. |
+| `:scope` | no | `nil` | A filter map narrowing what the panel observes. See §Scoping below. |
+| `:on-event` | no | `nil` | A callback `(fn [event-map])` invoked when the panel emits a host-meaningful event (source-coord click, re-dispatch request, etc.). |
+
+### Embedded posture
+
+When embedded (`:compact? true`), the panel:
+
+- Does **not** claim `Ctrl+Shift+C`.
+- Does **not** open its own pop-out window.
+- Does **not** show a "close" button.
+- Does **not** render the sidebar, top strip, or bottom rail.
+- **Does** render its own content area identically to the
+  non-embedded version.
+- **Does** respect the user's density / theme / keybinding preferences
+  (the same localStorage settings drive both modes).
+
+The panel **knows it's embedded** via the `:compact?` flag.
+
+## Scoping
+
+The `:scope` prop narrows the observation window:
+
+```clojure
+{:scope {:dispatch-id-prefix "story-variant-7c2-"  ;; observe only dispatches in this Story variant
+         :since-time         <ms>                  ;; observe only events newer than this
+         :only-origins       #{:app :story}        ;; filter by :origin axis
+         :include-children?  true}}                ;; if true, also observe child cascades
+```
+
+Scoping rules:
+
+- All scope keys are **optional**; absent means "no filter on this
+  axis."
+- Multiple scope keys are **AND-combined**.
+- Scope applies to the panel's data feed: an embedded event-detail
+  panel with `:dispatch-id-prefix "story-variant-..."` only shows
+  events whose `:dispatch-id` starts with that prefix.
+- Scope does **not** filter the trace bus itself — other Causa
+  instances and other consumers see all events. The framework's
+  emission is unchanged.
+
+### Why scoping exists
+
+Story renders multiple variants on one page. Each variant runs in
+its own frame and emits its own dispatches; the embedded ribbon for
+variant A must not show variant B's events. Scoping is the
+mechanism.
+
+## What ships embedded at v1.0
+
+| Panel | v1.0 embeddable? |
+|---|---|
+| **Event detail** | Yes (the primary embed target for Story). |
+| **Causality strip** | Yes. |
+| **App-db inspector** | Yes (compact-mode renders the slice-centric view only; no full-tree escape). |
+| **Issues ribbon** | Yes. |
+| **Performance ribbon** | Yes. |
+| Causality graph | v1.1 — graph rendering is expensive for many small embeds. |
+| Machine inspector | v1.1 — would re-import `tools/machines-viz/` per embed. |
+| Subscription graph | v1.1. |
+| Schema timeline | v1.1. |
+| Hydration debugger | Not embeddable (the panel is contextual to a specific hydration; doesn't compose). |
+| AI co-pilot | Not embeddable (per-page singleton; ephemeral conversation per Causa instance). |
+| Settings | Not embeddable. |
+
+The v1.0 embed set covers Story's needs (per `spec/007-Stories.md`
+§6.7 — Story embeds the **epoch panel** at v1.0). The wider v1.1
+embed set covers Story's planned ribbon expansions.
+
+## How Story wires it in
+
+Per `tools/story/` (when it lands):
+
+```clojure
+(ns day8.story.variants
+  (:require [day8.re-frame2-causa.panels.event-detail :as causa-event]))
+
+(rf/reg-story-panel :story.auth/login
+  {:panels
+   [{:title  "Login form"
+     :render (fn [variant-data] [login-form variant-data])}
+    {:title  "Causa: events"
+     :render (fn [variant-data]
+               [causa-event/Panel
+                {:frame    (:frame variant-data)
+                 :compact? true
+                 :height   320
+                 :scope    {:dispatch-id-prefix (:scope-prefix variant-data)
+                            :include-children?  true}}])}]})
+```
+
+The host (Story) controls layout; Causa supplies the content.
+
+## Hook-style integration
+
+For React-only hosts that don't render Reagent, Causa exposes a
+plain-React surface:
+
+```javascript
+import {EventDetailPanel} from '@day8/re-frame2-causa/panels';
+
+function StoryVariant() {
+  return (
+    <EventDetailPanel
+      frame=":story.auth/login"
+      compact
+      height={320}
+      scope={{dispatchIdPrefix: 'story-variant-7c2-'}}
+    />
+  );
+}
+```
+
+The JS API kebab-cases / camelCases the props (`compact` for
+`:compact?`, `dispatchIdPrefix` for `:dispatch-id-prefix`).
+
+Internally the JS surface delegates to the same Reagent components;
+the JS wrapper is a thin adapter.
+
+## What the host owns
+
+When embedded, the host (Story) owns:
+
+- **Frame selection.** The `:frame` prop is fixed by the host; Causa
+  never re-binds it from inside the embedded panel.
+- **Layout.** Where the embed goes on the page, its surrounding
+  chrome, its size.
+- **Lifecycle.** Mount / unmount on variant change. Causa's panels
+  are pure with respect to their props; they tear down cleanly on
+  unmount.
+- **Event routing.** The host's `:on-event` callback decides what
+  to do with embed-emitted events (open a side panel, log,
+  ignore).
+
+What Causa owns:
+
+- **The panel's content.** What's rendered inside the embed.
+- **Internal state** (selected slice, scroll position, expand/collapse
+  state) — local to the panel instance, not persisted.
+- **Live updates** from the trace bus / epoch history, scoped by the
+  `:scope` prop.
+
+## What this doesn't do
+
+- **No two-way binding.** The host doesn't push state into Causa
+  beyond the props; Causa doesn't push state back beyond
+  `:on-event` callbacks.
+- **No cross-embed coordination.** Two embedded panels on the same
+  page do not share state. Each panel reads the trace bus
+  independently. (The trace bus emits once; multiple subscribers see
+  the same event — the per-panel scope filters happen client-side.)
+- **No standalone styling overrides.** Embedded panels use Causa's
+  theme tokens. The host can wrap them in a container that overrides
+  CSS variables but cannot patch panel internals.
+- **No security boundary.** Causa runs in the host page's JS realm.
+  If the host is untrusted, do not embed Causa.
+
+## Future: third-party panels
+
+v1.0 is **first-party panels only.** No plugin API, no panel registry.
+Third-party-extensible panels are a v2.0 design discussion.
+
+The current contract leaves room: every panel is already a
+self-contained component with a props-only interface. A future
+plugin registry would `:require` a third-party namespace and register
+it under a new sidebar entry with the same `Panel` shape.
+
+No commitment is made about the third-party plugin surface
+shape — the embedding contract above is for the **canonical
+first-party panels**, not for any future third-party kind.

--- a/tools/10x/spec/009-AI-CoPilot.md
+++ b/tools/10x/spec/009-AI-CoPilot.md
@@ -1,0 +1,330 @@
+# 009-AI-CoPilot
+
+The AI co-pilot is a **pull-only** Q&A and slash-command surface for
+asking the runtime questions in natural language. The user types; the
+LLM answers; the LLM cites data the user can verify.
+
+It is **not** a narration mode — Causa never streams chatter at the
+user (lock #10 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)).
+It is **not** a code generator — code authoring belongs to
+re-frame-pair (editor-side authority). It is **not** an oracle — the
+model is a *navigator*; the user is the verifier.
+
+## Default state
+
+Collapsed (lock #8). A subtle cue marks the rail entry in the top
+strip (per [`007-UX-IA.md`](./007-UX-IA.md) §The AI co-pilot
+collapsed cue) — a magenta `◇` glyph that pulses every 8 seconds
+until the user has used the co-pilot once, then stays static.
+
+Toggle: `Ctrl+Shift+/` or click the sidebar `Co-pilot` entry.
+
+## Panel layout
+
+When open, a 320px rail on the right of the canvas:
+
+```
+┌──────────────────────────────────────┐
+│  AI Co-pilot                ⌗ ⛶  ✕  │  ← title, model picker, expand, close
+├──────────────────────────────────────┤
+│  ▸ Why did :checkout/submit fire?    │
+│    It was dispatched by an           │
+│    :fx [[:dispatch ...]] inside the  │
+│    :cart/finalise handler            │
+│    (events.cljs:213). That handler   │
+│    ran because of                    │
+│    :user/clicked-checkout at         │
+│    10:43:21.                         │
+│    [ Open source ] [ Show graph ]    │
+│  ─────────────────────────────────── │
+│  ▸ What's the auth-flow state?       │
+│    :auth/login-flow → :authenticating│
+│    Parent :login is :open. Pending   │
+│    :after timer at 5000ms, 2.1s left.│
+│    [ Open machine chart ]            │
+├──────────────────────────────────────┤
+│ ╭──────────────────────────────────╮ │
+│ │ Ask anything…                  ↑ │ │
+│ ╰──────────────────────────────────╯ │
+│ /slash for commands                  │
+└──────────────────────────────────────┘
+```
+
+Conversation newest-at-bottom. Each turn: question (▸ in violet) →
+response.
+
+## Pull-only model
+
+Causa never sends a token to the LLM unless the user submits a
+question. Specifically:
+
+- **No background narration.** Causa does not periodically describe
+  what's happening to the user. (The original v2 design floated this;
+  it was dropped — lock #10.)
+- **No proactive "I notice..." alerts.** The Issues ribbon and the
+  schema-violation timeline surface anomalies; the co-pilot does not
+  push messages.
+- **No auto-summaries.** Pinning a snapshot does not invite the model
+  to summarise.
+- **No conversation resumption prompts.** When the panel opens after a
+  reload, the conversation area is empty — the model never asks "Do
+  you want me to pick up where we left off?" (Conversations are
+  ephemeral; see below.)
+
+The model speaks only when spoken to.
+
+## Slash commands
+
+Typing `/` at the start of the input opens a dropdown:
+
+| Slash command | What it does |
+|---|---|
+| `/explain <event-id-or-epoch>` | Describe one epoch — the cause, the effect, the state delta. |
+| `/diff <epoch-a> <epoch-b>` | What changed between two epochs? |
+| `/find <pattern>` | Search the trace stream. |
+| `/rewind <event-or-epoch>` | Propose a rewind (executes only on user confirmation). |
+| `/state <machine-id>` | Describe a machine's current state. |
+| `/why <epoch>` | Causal-ancestor walk. |
+| `/whatif <hypothetical>` | Speculative reasoning (the model labels the answer as reasoning, not measurement). |
+| `/clear` | Clear conversation. |
+
+Slash commands are **typed shortcuts** for common questions; the
+model can still answer the same questions in plain English. The slash
+form is faster for power users.
+
+## Provider abstraction
+
+A `⌗` icon next to the panel title opens a dropdown:
+
+- **Claude** (default)
+- **OpenAI**
+- **Gemini**
+- **Local** (Ollama)
+- **Custom** (user-supplied URL + headers)
+
+Each uses the user's API key, configured in Settings → AI Provider.
+Keys are stored **only in localStorage**; never sent to Day8 or to
+any service other than the chosen provider. The Settings panel has a
+"Telemetry" section that exists solely to state this fact.
+
+Switching providers is live; conversation history is sent to the new
+provider as context (the user accepts this by switching).
+
+## System prompt
+
+The system prompt is bundled and editable in Settings. The default:
+
+```
+You are a debugger's assistant.
+
+Context you have:
+- The user is debugging a re-frame2 application.
+- You can read the trace buffer (last 200 events), epoch history (last 50
+  per frame), the current app-db, registered handlers, registered
+  schemas, machine snapshots.
+- The user submits a question or a slash command.
+
+Rules:
+- Cite source coords for every claim (e.g. "events.cljs:213").
+- Reference epoch ids so the user can verify in the panel.
+- Say "I cannot determine that" plainly when you cannot.
+- One action suggestion at a time.
+- Never invent data. If you do not see it in the trace, do not claim it.
+- Short answers; detail only when asked.
+- No preambles, no apologising, no hedging.
+
+When the user asks "why did X fire?", walk :parent-dispatch-id upward
+and return the chain.
+
+When the user asks "what changed?", diff :db-before / :db-after on the
+named epoch.
+
+When the user asks about a machine, read [:rf/machines <id>] in the
+current frame's app-db.
+```
+
+The prompt is user-editable in Settings — `Edit system prompt`. Causa
+ships the default and warns the user that customising the prompt may
+change the model's behaviour.
+
+## Tool / function calling
+
+The co-pilot uses the LLM's function-calling surface to read the
+runtime. Tools the model can call:
+
+| Tool | Reads |
+|---|---|
+| `get-trace-buffer` | A slice of the trace stream by filter. |
+| `get-epoch-history` | Per-frame epoch history. |
+| `get-app-db` | Current value at a frame, optionally at a path. |
+| `get-machine-state` | Snapshot for a named machine. |
+| `get-issues` | Recent errors/warnings/schema-violations. |
+| `get-handlers` | Registered handlers' metadata. |
+| `get-source-coord` | Source coord for a given id. |
+
+These are **read-only**. The model cannot call:
+
+- `restore-epoch`
+- `reset-frame-db!`
+- `dispatch`
+
+…through tool use. The model can *propose* these via action chips
+(`[Rewind to here]`, `[Re-dispatch]`); the user clicks to confirm.
+
+The tool catalogue mirrors what `tools/10x-mcp/` exposes (see
+[`010-MCP-Server.md`](./010-MCP-Server.md)) — the same surface is
+available to local agents (Claude Code, Cursor) over MCP.
+
+## Result formatting
+
+Responses are markdown rendered with:
+
+- **Code blocks** in mono with syntax highlighting (cljs / edn /
+  json).
+- **Source-coord chips.** `src/cart/events.cljs:213` renders as a
+  chip with a `🔗` icon; click opens source.
+- **Action chips.** `[Open source]`, `[Show graph]`, `[Rewind here]`,
+  `[Filter to this cascade]` — inline buttons in the response.
+  Action chips that mutate runtime (rewind, re-dispatch) always
+  require a click.
+- **Embedded data.** Small data structures render with the same
+  chrome as the main panels. 200px max height; expandable.
+- **Mini-graphs.** A causal chain renders as a 5-node mini-graph
+  using the same SVG primitive as the Causality panel.
+
+Responses **stream** (per token, ~25 tokens/sec). First words within
+~600ms of Enter. Respects `prefers-reduced-motion` (instant render).
+
+## Ephemeral conversation
+
+Conversation is **per-session, in-memory only** (lock #12 in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)):
+
+- **Not persisted to localStorage.**
+- **Not exported.**
+- **Cleared on tab reload.**
+- **Cleared on Causa close** (the conversation buffer is part of
+  Causa's mounted state).
+
+The privacy bet beats the utility bet. Conversation may contain
+sensitive app data (user emails, internal handler names, snippets of
+production-shaped repros). Per-session-only is the conservative
+default and aligns with Settings → Telemetry = off.
+
+In-session affordances:
+
+- `Ctrl+L` clears conversation.
+- `Ctrl+P` / `Ctrl+N` walk previous / next questions.
+- `Ctrl+R` searches within the conversation.
+
+## Voice / STT
+
+**Not at v1.0** (lock #13 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)).
+The input is text only. The Web Speech API is implementable but the
+quality is patchy; cloud STT adds cost and latency; v1.0 scope is
+already large.
+
+No mic permission prompts. No `🎙` button in the v1.0 UI.
+
+Voice may ship in v1.1+ if users demand. Pure additive feature.
+
+## When the model is wrong
+
+Three error states:
+
+### API error
+
+Network failure, rate limit, expired key. Panel shows a red banner:
+
+```
+Couldn't reach Claude.
+Retry in 30s? [Retry now] [Switch provider]
+```
+
+The user's question is preserved. The model is not retried
+automatically (Causa never spends the user's tokens unprompted).
+
+### Model says "I don't know"
+
+The system prompt instructs the model to say so plainly. Sample
+response:
+
+```
+I can't determine that from the trace I have access to.
+The trace buffer has the last 200 events. You can see them in the
+Trace panel. [Open Trace]
+```
+
+No hallucination. Failure case is a navigation aid.
+
+### Model is confidently wrong
+
+Hardest case. There is no automatic detection. Mitigation:
+
+- **Every claim the model makes references data the user can
+  verify** — source coords, epoch ids, event vectors.
+- When the model says "epoch 10 dispatched `:cart/finalise`," the
+  user can click that link and see whether it's right.
+- If a claim doesn't link to data, it's a tell.
+
+The failure-mode design: the co-pilot is **a navigator, not an
+oracle.** It points at the data; the user verifies. Every response
+surfaces its evidence.
+
+## Tone / personality
+
+Direct, observational, programmer-to-programmer. No preambles, no
+apologising, no hedging. The system prompt encodes this; the user can
+edit the prompt to taste.
+
+Bad: "Of course! I'd be happy to help you investigate this. Let me
+take a look at the trace and see what I can find..."
+
+Good: "Dispatched at events.cljs:213 by :cart/finalise. Want me to
+open the file?"
+
+## Performance
+
+- **No background work.** The co-pilot consumes zero CPU/network when
+  collapsed or idle.
+- **Streaming reduces perceived latency.** First token within ~600ms;
+  full response in 2-5s for the canonical questions.
+- **Tool-call round-trips happen client-side** (Causa reads its own
+  in-process state and feeds it to the model); no extra server.
+- **Conversation buffer** is in-memory only; never grows beyond ~1MB
+  in practice.
+
+## Empty state
+
+First open, conversation empty:
+
+```
+   Ask Causa anything about this runtime.
+
+   Try:
+   • Why did :checkout/submit fire?
+   • What changed in the last 10 epochs?
+   • Why is :cart/total returning 0?
+   • /state :auth/login-flow
+
+   The co-pilot reads the same data you see —
+   it cites every claim with a source coord or epoch id.
+   Verify before trusting.
+```
+
+The final line is deliberate. The co-pilot is a navigator; the user
+verifies.
+
+## What this doesn't do
+
+- **No narration / live commentary.** The model speaks when spoken
+  to.
+- **No code generation.** Causa is a debugger; code authoring belongs
+  to re-frame-pair.
+- **No persistent memory.** Conversations are session-local.
+- **No agent autonomy.** No "I'll dispatch X for you" — every mutate
+  is a user click.
+- **No telemetry sent to Day8.** Causa never proxies the conversation
+  through a Day8 server; the user's API key calls the user's
+  provider directly.
+- **No voice at v1.0.** Text only.

--- a/tools/10x/spec/010-MCP-Server.md
+++ b/tools/10x/spec/010-MCP-Server.md
@@ -1,0 +1,212 @@
+# 010-MCP-Server
+
+Causa ships an MCP server as a separate jar at `tools/10x-mcp/`. The
+server exposes Causa's surfaces as MCP tools so AI agents (Claude
+Code, Cursor, Copilot) can read and write a live re-frame2 runtime
+without opening Causa's UI.
+
+The architecture mirrors `tools/pair2-mcp/` (per
+[`tools/pair2-mcp/spec/`](../../pair2-mcp/spec/)): a Node-based stdio
+JSON-RPC server, written in ClojureScript, compiled via shadow-cljs
+to a single `.js` file. One persistent nREPL socket per session.
+Different tool catalogue.
+
+## Why a separate jar
+
+Causa-the-panel is human-facing; Causa-MCP is agent-facing. Per the
+rf2-m6tu §6.1 separation lesson (humans and agents ship as distinct
+jars so the MCP server can be loaded without dragging the entire
+Causa UI into the classpath), the two surfaces split:
+
+- **`tools/10x/`** — `day8/re-frame2-causa`. The DOM-injected panel.
+  Pulled by `:preloads`. Browser-side artefact.
+- **`tools/10x-mcp/`** — `day8/re-frame2-causa-mcp`. The MCP server.
+  Pulled by `npm install`. Node-side artefact, attached over nREPL.
+
+Both consume the same re-frame2 instrumentation surface (Spec 009
+trace bus, Tool-Pair epoch history, registrar query API). Neither
+depends on the other.
+
+## Transport
+
+Same as `tools/pair2-mcp/spec/001-Wire-Protocol.md`:
+
+- Newline-delimited JSON-RPC 2.0 over stdio per the
+  [MCP stdio transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
+- One message per line on stdin/stdout. UTF-8. No embedded newlines.
+- npm `@modelcontextprotocol/sdk`'s `StdioServerTransport` provides
+  the framing.
+- stdout reserved for MCP messages; stderr free-form.
+
+Causa-MCP follows the same lifecycle:
+
+1. Agent host launches the server as a subprocess.
+2. Server responds to `initialize` with `protocolVersion`,
+   `capabilities`, `serverInfo`.
+3. `tools/list`, `tools/call` dispatch via the SDK's
+   `setRequestHandler`.
+4. Shutdown: client closes stdin → Node EOF → process exits.
+
+## nREPL bridge
+
+Same as `tools/pair2-mcp/spec/002-nREPL-Transport.md`:
+
+- One TCP socket to `127.0.0.1:<nrepl-port>` held for the session.
+- bencode framing via `bencode@2.0.x` (pinned for CommonJS
+  compatibility).
+- Multiplexing by UUID id over the socket's `pending` map.
+- Port discovery via `$SHADOW_CLJS_NREPL_PORT` → `target/shadow-cljs/nrepl.port`
+  → `.shadow-cljs/nrepl.port` → `.nrepl-port`.
+- Degraded boot if no port is reachable; tools return
+  `{:ok? false :reason :nrepl-port-not-found}`.
+
+Causa-MCP injects a small runtime sentinel (`re-frame2-causa-mcp.runtime/session-id`)
+that tools probe via `cljs-eval`. If the var is empty (e.g., after a
+browser reload), the MCP server re-ships the runtime namespace before
+the actual op runs. Mirrors the bash-shim chain's
+`runtime-already-injected?` check (and the pair2-mcp implementation).
+
+## Tool catalogue
+
+Twelve MCP tools. Each maps to a Causa surface; together they let an
+agent observe, dispatch, time-travel, and inspect.
+
+### Inspection (read-only)
+
+| Tool | Mirrors Causa panel | Returns |
+|---|---|---|
+| `get-trace-buffer` | Trace timeline | A slice of the trace stream by filter (`:op-type`, `:operation`, `:frame`, `:dispatch-id`, `:origin`, time range). |
+| `get-epoch-history` | Time-travel scrubber | Per-frame epoch history (vector of `:rf/epoch-record`). |
+| `get-app-db` | App-db inspector | Current value at a frame, optionally at a path. |
+| `get-app-db-diff` | App-db inspector (slice view) | The slice diff for a named epoch (`{:added [...] :modified [...] :removed [...]}`). |
+| `get-machine-state` | Machine inspector | Current snapshot for a named machine. |
+| `get-machine-list` | Machine inspector | List of registered machines per frame, with current state. |
+| `get-issues` | Issues ribbon | Recent errors / warnings / schema violations / hydration mismatches. |
+| `get-handlers` | (Settings → registry browser) | Registered handlers' metadata (`:doc`, source coords). |
+| `get-source-coord` | Click-to-source | Source coord for a given id (handler, view, machine state, sub). |
+
+### Mutation (user-confirmed equivalents in the UI)
+
+| Tool | Mirrors Causa surface | Behaviour |
+|---|---|---|
+| `restore-epoch` | Bottom-rail Rewind button | Rewinds a frame's `app-db` to the named epoch's `:db-after`. Returns the six failure modes structurally. |
+| `reset-frame-db` | "Try anyway" affordance on schema mismatch | Injects state, bypassing cascade; schema-validates against current schemas. |
+| `dispatch` | Right-click → Re-dispatch | Fires an event tagged `:origin :causa-mcp` (so a separate trace tag distinguishes MCP-issued from in-panel-issued mutations). |
+
+### Why `dispatch` is in the catalogue
+
+Causa-MCP is **the agent face of Causa**. An agent driving Causa-MCP
+is the user's delegate; the user has given consent (by enabling the
+MCP server and giving the agent a key). Dispatch from the agent is
+no more dangerous than dispatch from the agent driving
+`tools/pair2-mcp/` — and we already ship that.
+
+The `:origin :causa-mcp` tag means every dispatch from the MCP
+surface is **visibly distinguishable** in the trace stream — Causa's
+event log shows them in a distinct colour (per
+[`007-UX-IA.md`](./007-UX-IA.md) §Colour system), and post-session
+filters surface them as a group.
+
+## Args and return shapes
+
+Each tool's args / returns follow the same EDN-encoded JSON pattern
+as `tools/pair2-mcp/`:
+
+```jsonc
+// Example: get-app-db
+{ "method": "tools/call",
+  "params": {
+    "name": "get-app-db",
+    "arguments": {
+      "frame": ":app/main",
+      "path": "[:cart :items]"
+    } } }
+
+// Response:
+{ "content": [{ "type": "text",
+                "text": "{:ok? true :value [{:id 7 :qty 1} {:id 22 :qty 1}]}" }],
+  "isError": false }
+```
+
+Tool-execution errors use `isError: true` with a structured EDN
+error map in `content[0].text` — never a protocol-level error.
+
+The full schema of each tool's args is bundled in
+`tools/10x-mcp/src/day8/re_frame2_causa_mcp/tools.cljs` (matching
+the layout in `tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`)
+and surfaced via `tools/list` in MCP-standard JSONSchema form.
+
+## Lifecycle and reconnect
+
+Same as pair2-mcp. A full page reload destroys the CLJS runtime in
+the browser but leaves the JVM-side nREPL socket intact. Every tool
+that needs the runtime calls `ensure-runtime!`:
+
+1. `cljs-eval` `re-frame2-causa-mcp.runtime/session-id`.
+2. If a non-blank string comes back, the runtime is live; proceed.
+3. Otherwise, slurp the canonical `runtime.cljs` (shipped with the
+   MCP jar) and ship it through `cljs-eval`. Then proceed.
+
+No manual reconnect step is needed — page reload → next tool call →
+automatic re-inject → op proceeds.
+
+## Compared to pair2-mcp
+
+| Axis | `tools/pair2-mcp/` | `tools/10x-mcp/` |
+|---|---|---|
+| **Audience** | Editor-side AI workflows (pair-programming). | Debugger-side AI workflows (inspection, time-travel). |
+| **Surface** | 7 tools focused on dispatch / eval / hot-swap / trace. | 12 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch. |
+| **`:origin` tag** | `:pair` | `:causa-mcp` |
+| **Runtime injection** | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
+| **Implementation** | shadow-cljs `:node-script`, npm-published. | Same. |
+| **MCP transport** | stdio JSON-RPC 2.0. | Same. |
+
+Both can coexist in the same session. The agent picks the right tool
+for the workflow: pair2 for "build/edit/test"; causa-mcp for
+"inspect/debug/time-travel."
+
+## Install + configure
+
+```bash
+npm install -g @day8/re-frame2-causa-mcp
+```
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "mcpServers": {
+    "causa": {
+      "command": "re-frame2-causa-mcp",
+      "env": { "SHADOW_CLJS_BUILD_ID": "app" }
+    }
+  }
+}
+```
+
+First-call sanity check:
+
+```text
+Agent: tools/call get-trace-buffer {limit: 10}
+Server: {:ok? true :events [...10 events...]}
+```
+
+## What this doesn't do
+
+- **No GUI rendering.** The MCP server has no UI; it speaks JSON-RPC
+  to its agent host. The Causa panel is unaffected (and need not be
+  open) for the MCP server to work.
+- **No telemetry.** The server transmits nothing to Day8.
+- **No automatic re-dispatch.** Dispatches go through the same gates
+  as pair2-mcp; the agent is the user's delegate.
+- **No conversation history.** The MCP server is stateless across
+  tool calls; conversation state belongs to the agent host.
+
+## Spec scope
+
+This doc is the **contract**, not the implementation. The
+implementation details (shadow-cljs build, the bencode pin, the
+specific tools.cljs shape) follow `tools/pair2-mcp/spec/`'s structure
+and prose; replicating them here would be redundant. When
+`tools/10x-mcp/` lands, it will carry its own `spec/` folder with
+the four pair2-mcp-shape files (000-Vision, 001-Wire-Protocol,
+002-nREPL-Transport, 003-Tool-Catalogue) parameterised for Causa.

--- a/tools/10x/spec/011-Launch-Modes.md
+++ b/tools/10x/spec/011-Launch-Modes.md
@@ -1,0 +1,224 @@
+# 011-Launch-Modes
+
+Causa launches in two complementary ways:
+
+1. **In-app overlay** — the default. Causa preloads into the dev
+   build, mounts a hidden DOM root, and toggles into view on
+   `Ctrl+Shift+C` or via the floating launcher pill.
+
+2. **Standalone via MCP** — the remote-attach story. An AI agent
+   running on the user's machine (or elsewhere) drives Causa-MCP
+   against the user's running browser session; Causa's UI may or
+   may not be open in the browser.
+
+The two modes share the **same data substrate** (the trace bus +
+epoch history) — and the same hard rule applies to both: **the
+runtime is the source of truth**; Causa observes; mutations are
+explicit and user-confirmed.
+
+This is lock #9 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md): a
+**hybrid** approach. No Chrome extension; no custom WebSocket
+remote-attach protocol; the in-app posture covers the local case
+and MCP covers the remote case.
+
+## In-app overlay
+
+### Install
+
+```clojure
+;; shadow-cljs.edn dev build:
+{:builds {:app {:devtools {:preloads [day8.re-frame2-causa.preload]}}}}
+```
+
+The preload registers Causa's listeners under `register-trace-cb!`
+and `register-epoch-cb`, mounts a hidden DOM root, listens for
+`Ctrl+Shift+C`. No code change in the app itself.
+
+Same convention as re-frame-10x v1; muscle-memory transfer is free.
+
+### Disable
+
+Remove the `:preloads` entry, or:
+
+```clojure
+:closure-defines {day8.re-frame2-causa.config/enabled? false}
+```
+
+…to force-disable in dev.
+
+### Launch
+
+| Action | How |
+|---|---|
+| Open | `Ctrl+Shift+C` or click the floating pill |
+| Close | `Esc` or `Ctrl+Shift+C` again |
+| Pop out to second window | `Ctrl+Shift+P` |
+| Open AI co-pilot rail | `Ctrl+Shift+/` |
+
+### The launcher pill
+
+When Causa is closed, a 48×48px circular button sits in the
+bottom-right corner of the viewport (z-index pinned just below modal
+overlays, above app content). The Causa mark centred. Subtle 1px
+violet ring at 60% opacity on idle.
+
+Pulses softly when there's an active error in the issues feed —
+600ms expand-fade pulse, every 4s, **max 3 pulses then stops**. The
+pulse is bounded so a long-lived error doesn't become a perpetual
+animation.
+
+Click → Causa opens (same 320ms slide-in animation as the keyboard
+shortcut).
+
+Right-click → contextual mini-menu: Open · Pop out · Settings · Hide
+button.
+
+The button is **hideable** (Settings option for users who only use
+the keyboard). Hidden state persists per-app in localStorage.
+
+### Pop-out to a second window
+
+`Ctrl+Shift+P` or button right-click → `Pop out`.
+
+Mechanism: `window.open` whose JS realm is connected to the opener's
+via `window.opener`. The pop-out renders into the new window but
+**reads and dispatches against the opener's runtime atoms directly**
+— no `BroadcastChannel`, no `postMessage`, no structured-clone
+serialisation. Same JS realm, no protocol cost.
+
+Constraints inherited from the `window.opener` posture:
+
+- Same-origin required. The pop-out window must not be opened with
+  `noopener` / `noreferrer`.
+- If the user closes the opener window, the pop-out becomes
+  orphaned. Pop-out detects this via `window.opener.closed` and
+  shows a clean "opener gone — close this window" overlay.
+- The pop-out can't survive a hard reload of the opener — atoms get
+  garbage-collected. Pop-out re-bootstraps on opener reload by
+  re-reading `window.opener.causaRuntime`.
+
+Solves the "I want Causa on a second monitor while the app runs
+full-screen" use case.
+
+### Animation
+
+Slide-in from the right edge: 320ms with `cubic-bezier(0, 0, 0.2, 1)`.
+First paint under 80ms (Causa was mounted hidden; toggle is a CSS
+class swap). Respects `prefers-reduced-motion` (instant fade).
+
+App content underneath dims 12% via a CSS overlay; app interactions
+still pass through (pointer-events on the dim overlay are disabled).
+
+## Standalone via MCP
+
+### Mechanism
+
+The MCP server (`tools/10x-mcp/`, per [`010-MCP-Server.md`](./010-MCP-Server.md))
+is an stdio JSON-RPC server launched by the agent host (Claude Code,
+Cursor, etc.) as a subprocess. The server connects over nREPL to the
+running shadow-cljs build (which is connected to the user's browser).
+
+The data path:
+
+```
+AI agent
+  ↓ (MCP / stdio)
+re-frame2-causa-mcp (Node process)
+  ↓ (nREPL / bencode)
+shadow-cljs JVM
+  ↓ (cljs-eval / WebSocket)
+browser running the user's re-frame2 app
+```
+
+The agent sees the **same trace bus and epoch history** that Causa-the-panel
+sees. Tool calls are read-mostly; writes (`restore-epoch`,
+`reset-frame-db`, `dispatch`) are confirmed by the agent host
+(typically Claude Code's tool-permission prompt).
+
+### Remote-attach
+
+The remote case: developer A's machine runs Claude Code; developer
+A's browser runs the app. With MCP attached, A's AI assistant can
+query the runtime. This works **whether or not Causa's panel is
+open** in the browser.
+
+The "developer A's browser, developer B's Claude" case is **not
+directly supported** at v1.0. The MCP server connects to
+`127.0.0.1:<nrepl-port>` by default; cross-machine MCP requires
+agent-host configuration (SSH tunnels, port-forwarding) that lives
+outside Causa's scope. Causa-MCP is the protocol; the network
+plumbing is the user's.
+
+### Why not a Chrome extension
+
+Considered and rejected. The IPC overhead, the sandbox isolation,
+and the manifest-v3 churn aren't worth the marginal "you don't have
+to change build config" benefit. The in-app posture is the right one
+for re-frame2 (lock #9, option (a) considered).
+
+### Why not a custom WebSocket remote-attach protocol
+
+Considered and rejected. Serialising the runtime state across the
+wire is too costly — snapshot identities, machine references,
+sub-graph nodes, source-coord chips don't survive JSON round-trip
+cleanly. The use cases (mobile-from-desktop, cross-machine
+pair-debug) are too narrow to justify the protocol-versioning,
+security, and reconnect-logic surface (lock #9, option (b)
+considered).
+
+The remote case is handled by MCP (which already pays for those
+costs in the agent-host ecosystem) — not by a custom Causa protocol.
+
+### Why not a VS Code panel
+
+Considered and rejected. Editor-embed surface is a category mistake:
+debuggers belong at workstations alongside the app, not inside the
+editor. Where editor integrations are useful (jump-to-source,
+re-dispatch-from-IDE), they go through MCP (per
+[`010-MCP-Server.md`](./010-MCP-Server.md)) — not through a
+VS-Code-specific extension.
+
+## Coexistence
+
+The panel and the MCP server can run simultaneously without
+conflict:
+
+- The trace bus emits once; both subscribers (panel + MCP server's
+  ensure-runtime trace listener) see every event.
+- The epoch-history surface is read-mostly from both.
+- Mutations from the MCP server are tagged `:origin :causa-mcp`;
+  mutations from the panel's re-dispatch affordance are tagged
+  `:origin :causa`. Both are distinguishable in the event log.
+
+A common workflow: the developer has the panel open for direct
+inspection; the AI assistant operates on the same runtime via MCP
+in parallel. The panel surfaces the agent's actions (the `:origin
+:causa-mcp` colour-coding is visible in the strip and event log).
+
+## What this doesn't do
+
+- **No Chrome extension** (rejected, see above).
+- **No VS Code panel** (rejected, see above).
+- **No custom WebSocket remote-attach** (replaced by MCP).
+- **No standalone HTML viewer** at v1.0. The MCP server replaces
+  this — if the agent needs to render a viewer-like surface, it
+  composes Causa-MCP tool calls.
+- **No mobile launch mode** (lock #5).
+- **No tablet-responsive standalone viewer** at v1.0. The original
+  rf2-buor design proposed one; the lock-#9 hybrid retires the use
+  case to MCP.
+
+## Default summary
+
+| User scenario | Mode |
+|---|---|
+| Working locally; want to inspect the runtime | In-app panel (`Ctrl+Shift+C`) |
+| Want a second monitor for Causa | In-app panel + pop-out (`Ctrl+Shift+P`) |
+| Want my AI to inspect / time-travel programmatically | Causa-MCP (configure in agent host) |
+| Want to debug a colleague's browser | Out of scope at v1.0 |
+| Want to debug a mobile browser | Out of scope at v1.0 |
+
+The 95% of cases — local development with in-app inspection — is
+solved by the in-app overlay. The MCP server covers the
+agent-driven case. The remaining 5% (cross-machine, mobile) is
+explicitly out of scope at v1.0.

--- a/tools/10x/spec/API.md
+++ b/tools/10x/spec/API.md
@@ -1,0 +1,254 @@
+# API
+
+The consolidated user-facing surface. Implementer-readable: every
+symbol a consumer of Causa might reach for.
+
+This doc is a **reference**; the normative descriptions live in the
+per-area specs (000–011). Where the two drift, the per-area spec
+wins.
+
+## Installation API
+
+### Preload-style enablement (browser)
+
+```clojure
+;; shadow-cljs.edn — dev build only
+{:builds {:app {:devtools {:preloads [day8.re-frame2-causa.preload]}}}}
+```
+
+The preload:
+
+1. Registers Causa's trace listener via `re-frame.core/register-trace-cb!`.
+2. Registers Causa's epoch listener via `re-frame.core/register-epoch-cb`.
+3. Mounts a hidden `<div id="causa-root">` into `document.body`.
+4. Listens for `Ctrl+Shift+C` (toggle) and the floating-pill click.
+5. Reads localStorage for theme / density / AI-provider settings.
+6. Boots the React root with the closed-by-default panel state.
+
+### Force-disable
+
+```clojure
+:closure-defines {day8.re-frame2-causa.config/enabled? false}
+```
+
+When set false (or in a production build via `goog.DEBUG=false`), the
+preload's entry point is a no-op; no DOM root, no listeners, zero
+bytes after elision.
+
+## Public CLJS API
+
+Causa exposes a small handful of programmatic entry points. Users
+typically interact via the panel; these are for embedding hosts,
+test harnesses, and Settings UIs.
+
+### `day8.re-frame2-causa.core`
+
+```clojure
+(causa/init!)
+;; Mount Causa manually (alternative to :preloads). Idempotent.
+
+(causa/init! opts)
+;; opts: {:default-frame :app/main
+;;        :theme         :dark / :light / :high-contrast
+;;        :density       :compact / :cosy / :comfy
+;;        :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
+;;                        :api-key  "sk-..."     ;; localStorage only; never sent to Day8
+;;                        :model    "claude-3-5-sonnet"
+;;                        :system-prompt "..."}
+;;        :buffer-depths {:trace 200 :epoch 50}}
+
+(causa/open!)        ;; Show the panel programmatically.
+(causa/close!)       ;; Hide the panel programmatically.
+(causa/toggle!)      ;; Toggle.
+(causa/popout!)      ;; Open the same-browser pop-out window.
+
+(causa/active-frame)        ;; Return the frame currently selected in the picker.
+(causa/set-active-frame! :app/main)
+
+(causa/active-panel)        ;; Return the active panel id (one of :events, :app-db, :causality, ...).
+(causa/set-active-panel! :causality)
+
+(causa/load-theme css-string)
+;; Programmatically swap the theme (useful for editor-driven palette sync).
+```
+
+### `day8.re-frame2-causa.panels`
+
+Each panel exports its `Panel` component for embedding (per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md)):
+
+```clojure
+day8.re-frame2-causa.panels.event-detail/Panel
+day8.re-frame2-causa.panels.causality/Panel
+day8.re-frame2-causa.panels.causality-strip/Panel
+day8.re-frame2-causa.panels.event-log/Panel
+day8.re-frame2-causa.panels.app-db/Panel
+day8.re-frame2-causa.panels.subscriptions/Panel
+day8.re-frame2-causa.panels.effects/Panel
+day8.re-frame2-causa.panels.trace/Panel
+day8.re-frame2-causa.panels.machine/Panel
+day8.re-frame2-causa.panels.flow/Panel
+day8.re-frame2-causa.panels.performance/Panel
+day8.re-frame2-causa.panels.schema-timeline/Panel
+day8.re-frame2-causa.panels.issues/Panel
+day8.re-frame2-causa.panels.hydration/Panel
+day8.re-frame2-causa.panels.routing/Panel
+```
+
+Each accepts the props map specified in
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md):
+
+```clojure
+{:frame    :app/main          ;; frame to observe (required)
+ :compact? false              ;; reduced chrome (optional)
+ :height   nil                ;; pixels (optional)
+ :scope    {...}              ;; filter (optional)
+ :on-event #(...)}            ;; emit-event callback (optional)
+```
+
+## Public JS API
+
+For React-only hosts (a JS Story consumer, a non-Reagent app):
+
+```javascript
+import {init, open, close, toggle, popout} from '@day8/re-frame2-causa';
+import {EventDetailPanel, CausalityPanel, /* ... */} from '@day8/re-frame2-causa/panels';
+
+init({defaultFrame: ':app/main', theme: 'dark', density: 'cosy'});
+
+open();
+close();
+toggle();
+popout();
+
+// Embedded panel
+<EventDetailPanel
+  frame=":app/main"
+  compact
+  height={320}
+  scope={{dispatchIdPrefix: 'story-variant-7c2-', includeChildren: true}}
+  onEvent={(evt) => console.log(evt)}
+/>
+```
+
+The JS surface is a thin adapter over the Reagent components; props
+camelCase what the Reagent surface kebab-cases.
+
+## Trace / epoch surfaces (consumed, not exposed)
+
+Causa **consumes** the framework's surfaces. It does not expose
+analogues; users go to the framework for these. Listed here for
+reference:
+
+| Surface | Spec | What Causa reads |
+|---|---|---|
+| `(rf/register-trace-cb! key callback)` | Spec 009 | The trace bus (every operation). |
+| `(rf/register-epoch-cb key callback)` | Tool-Pair | The per-cascade epoch records. |
+| `(rf/trace-buffer)` / `(rf/trace-buffer filter)` | Spec 009 | The bounded trace buffer (default 200). |
+| `(rf/epoch-history frame-id)` | Tool-Pair | The per-frame epoch ring buffer (default 50). |
+| `(rf/restore-epoch frame-id epoch-id)` | Tool-Pair | Used for confirmed rewinds. |
+| `(rf/reset-frame-db! frame-id value)` | Tool-Pair | Used for "try anyway" recovery. |
+| `(rf/get-frame-db frame-id)` | Spec 002 | The app-db panel's live read. |
+| `(rf/compute-sub query-v db)` | Spec 008 | The sub-graph panel's value display. |
+| `(rf/handlers kind)` / `(rf/handler-meta kind id)` | Spec 001 | Registry-browser metadata. |
+| `(rf/frame-ids)` / `(rf/frame-meta id)` | Spec 002 | The frame picker. |
+| `(rf/machines frame-id)` | Spec 005 | The machine inspector dropdown. |
+| `(rf/app-schemas frame-id)` | Spec 010 | The schema-violation timeline rows. |
+| `(rf/sub-cache frame-id)` (CLJS only) | Tool-Pair | The subscription graph. |
+| `:dispatch-id` / `:parent-dispatch-id` (in `:tags`) | Spec 009 | The causality graph edges. |
+| `:origin` (in `:tags`) | Spec 009 | The colour-coding axis. |
+| Source-coord metadata (`:ns` / `:line` / `:column` / `:file`) | Spec 001 / 006 | Click-to-source. |
+| `data-rf2-source-coord` DOM attribute | Spec 006 | DOM-level source-coord (for the rare cases where DOM event → source is needed). |
+
+## MCP API
+
+Per [`010-MCP-Server.md`](./010-MCP-Server.md). The MCP server lives
+at `tools/10x-mcp/` and exposes 12 tools:
+
+| Tool | Kind |
+|---|---|
+| `get-trace-buffer` | read |
+| `get-epoch-history` | read |
+| `get-app-db` | read |
+| `get-app-db-diff` | read |
+| `get-machine-state` | read |
+| `get-machine-list` | read |
+| `get-issues` | read |
+| `get-handlers` | read |
+| `get-source-coord` | read |
+| `restore-epoch` | mutate (user-confirmed) |
+| `reset-frame-db` | mutate (user-confirmed) |
+| `dispatch` | mutate (user-confirmed) |
+
+JSONSchema for each tool's args is surfaced via `tools/list` per the
+MCP spec.
+
+## Settings keys
+
+Settings persist in `localStorage` under the key
+`day8.re-frame2-causa/settings/v1`. Shape (validated by Malli):
+
+```clojure
+{:theme         :dark / :light / :high-contrast
+ :density       :compact / :cosy / :comfy
+ :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
+                 :api-key      "sk-..."
+                 :model        "claude-3-5-sonnet"
+                 :system-prompt "..."
+                 :custom-url   "https://..."     ;; only when :provider = :custom
+                 :custom-headers {"X-..." "..."}}
+ :buffer-depths {:trace 200 :epoch 50}
+ :default-frame :app/main
+ :sidebar-mode  :grouped / :show-all
+ :launcher-pill {:hidden? false}
+ :keybindings   {:toggle ["Ctrl+Shift+C"]   ;; vector for multiple binds
+                 :command-palette ["Ctrl+K"]
+                 ...}}
+```
+
+Corruption (schema fails) → Causa wipes the slot and writes the
+default shape, surfacing a one-time toast: "Settings were corrupted
+and have been reset to defaults."
+
+Per-frame-app-db pinned slices live under a separate key:
+`day8.re-frame2-causa/pinned-slices/<frame-id>/v1`.
+
+```clojure
+{:pinned-slices [{:path [:user :auth :status]
+                  :label "auth status"
+                  :pinned-at 1715518800000}
+                 ...]}
+```
+
+## Trace-event tags Causa emits
+
+When Causa mutates the runtime (rewind, reset, re-dispatch), it
+emits trace events tagged `:origin :causa` (or `:origin :causa-mcp`
+when from the MCP server) so its actions are visible in the trace
+stream.
+
+These ride the framework's existing `:event/dispatched`,
+`:rf.epoch/restored`, etc. operations — no new operation kinds
+invented (per [`Principles.md`](./Principles.md) §Observation only).
+
+## Versioning
+
+`day8/re-frame2-causa` follows semver. Major (1.x → 2.x) changes
+break the public API or the embed contract. Minor (1.0 → 1.1) adds
+panels or surfaces. Patch (1.0.0 → 1.0.1) fixes bugs without
+contract changes.
+
+The framework dep is `~> 1.0` (compatible with re-frame2's first
+stable release). When the framework moves to 2.0, Causa's matching
+major bumps with it.
+
+## What this doesn't expose
+
+- **No plugin registration API.** First-party panels only at v1.0.
+- **No middleware injection.** Causa does not intercept dispatches;
+  it only observes them.
+- **No "private" surfaces** (`/-` namespaces, internal helpers) —
+  callers must not reach for `day8.re-frame2-causa.internal/*`.
+- **No global state mutators** beyond `init!` / `open!` / `close!`
+  / `toggle!` / `set-active-frame!` / `set-active-panel!`. The
+  panel's internal state is encapsulated.

--- a/tools/10x/spec/DESIGN-RATIONALE.md
+++ b/tools/10x/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,734 @@
+# DESIGN-RATIONALE
+
+The 13 direction-setting decisions that shape Causa. Each entry
+captures:
+
+- **The question** that was being decided.
+- **Options considered** that were walked through.
+- **The pick** that was locked.
+- **The why** — the reasoning trail.
+- **Date locked** + the locker.
+
+This doc is the load-bearing artefact of the per-tool spec
+convention. It exists so that a future contributor (human or AI) can
+read it and not re-ask the same questions. Where the spec text reads
+"per lock #N in DESIGN-RATIONALE.md", this is where to come.
+
+The two findings docs in [`findings/`](./findings/) carry the
+session-trail prose. This doc is the consolidated set of locks
+those sessions produced.
+
+---
+
+## Lock #1 — Name
+
+**Locked 2026-05-11 (Mike).** **Causa.** Package: `day8/re-frame2-causa`.
+
+### Question
+
+What does the re-frame-10x successor get called?
+
+### Options considered
+
+- **`re-frame-10x v2`** — keep the original name, signal continuity.
+  The brand has muscle memory. Rejected because v2 is structurally
+  new (the data shape is re-frame2's, not v1's; the hero panel is
+  different; the substrate is the trace bus + epoch history, not
+  v1's parallel ring buffer).
+- **`re-frame-debug`** — descriptive. Rejected for being generic and
+  un-Googleable.
+- **`re-frame2-devtools`** — descriptive. Rejected as above plus
+  awkward.
+- **`Causa`** — Latin for "cause." Single word. Picks up the
+  causality theme directly. The headline reads naturally:
+  "Causa shows the cascade your last click triggered."
+- **`Cascade`** — works thematically but is already a CSS term and
+  blurs in search results.
+- **`Domino`** — re-frame's internal model uses "dominoes" for the
+  six-phase cascade. Considered, rejected as plural/awkward and as
+  it overlaps the framework's existing internal vocabulary.
+
+### Pick
+
+**Causa.** Tagline: *the cascade you can see.*
+
+### Why
+
+- Single word, distinctive, lower-case-friendly.
+- Latin root signals "cause" without saying it three times.
+- Reads naturally in marketing copy and in the panel's title bar.
+- The brand mark (three nodes connected by arrows from one parent)
+  illustrates the cascade gesture without spelling the word.
+- Search-unique — no existing tool of consequence shares the name.
+
+---
+
+## Lock #2 — AI co-pilot
+
+**Locked 2026-05-11 (Mike).** **Ship v1.0.** Pull-only Q&A + slash
+commands. No narration (see lock #10).
+
+### Question
+
+Should Causa ship an AI co-pilot panel at v1.0, or defer to v1.1?
+
+### Options considered
+
+- **Defer to v1.1 (or never).** The AI is a feature, not the pitch;
+  Causa earns its keep on observability alone. Lower v1.0 scope.
+- **Ship at v1.0 as a full co-pilot.** Q&A + slash commands +
+  narration mode (live commentary on the trace stream).
+- **Ship at v1.0 in pull-only form.** Q&A + slash commands only; no
+  narration.
+
+### Pick
+
+**Ship at v1.0 in pull-only form.** The runtime is structured
+enough that an AI can navigate it usefully; not shipping the co-pilot
+at v1 leaves the marquee value on the table. The narration-mode
+variant is dropped (see lock #10).
+
+### Why
+
+- The five canonical questions (per `Principles.md`) are exactly the
+  shape an LLM is good at: walk a graph of structured data, cite
+  the chain. Causa without the co-pilot leaves the canonical
+  questions partially un-answered for users who'd rather ask than
+  click.
+- Cost is bounded: the panel is lazy-loaded (<400 KB extra), the
+  conversation is ephemeral (no persistence cost), and there are
+  no Day8-side services (the user's API key calls the user's
+  provider directly).
+- Pull-only avoids the "AI debugger that thinks for you" failure
+  mode. The model is a navigator pointing at evidence; the user
+  verifies (see lock #10 for the narration carve-out).
+
+### Date locked
+
+2026-05-11 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-buor §10.2 ("AI co-pilot — locked: ship at v1.0; open by
+  default"). Note: the original lock had "open by default"; lock #8
+  below revises that to *collapsed by default*. The shipping-at-v1.0
+  half held.
+
+---
+
+## Lock #3 — App-db editing
+
+**Locked 2026-05-11 (Mike).** **Never.** Read-only forever.
+
+### Question
+
+Should the app-db panel offer in-place editing — type a JSON value
+into a field, the runtime takes it?
+
+### Options considered
+
+- **In-place edit affordance at v1.0.** Right-click a value, edit it,
+  the runtime swallows the change (via `reset-frame-db!`).
+- **In-place edit at v1.1.** Defer the affordance but commit to
+  shipping it.
+- **Never.** App-db is read-only forever; mutations go through
+  `dispatch` (right-click → Re-dispatch) or REPL.
+
+### Pick
+
+**Never.** App-db is read-only forever.
+
+### Why
+
+- The runtime is the source of truth. Pokes from the debugger that
+  bypass dispatch leave the trace stream missing context — Causa
+  panels then can't explain "where did this value come from?"
+- Allowing edits without dispatch breaks the causal-graph property
+  ("every state change is the consequence of a dispatch"). The
+  graph would have to grow a node kind for "user typed a value into
+  the panel," and the cascade story would have a discontinuity.
+- If the user wants to mutate `app-db`, they have two reasonable
+  paths: dispatch an event (via Re-dispatch, the REPL, or a
+  one-off `:fx` from a registered event), or do a `reset-frame-db!`
+  via the MCP server (which is the explicit "I know what I'm
+  doing" path).
+- Removing the affordance simplifies the UX: no edit-mode toggle,
+  no schema-validation-during-edit, no "did this edit succeed?"
+  error surface.
+
+### Date locked
+
+2026-05-11 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-buor §10.4 ("In-place app-db editing — locked: not required").
+
+---
+
+## Lock #4 — Session export
+
+**Locked 2026-05-11 (Mike).** **Never.**
+
+### Question
+
+Should Causa let the user export a session (the trace buffer, the
+epoch history, the pinned snapshots) to a file, and import it later?
+
+### Options considered
+
+- **Export + import at v1.0.** A `Save session` button writes a
+  JSON / EDN file containing the trace stream and epoch history;
+  Causa can open it in a "session viewer" mode.
+- **Export-only at v1.0** (no import). The user can hand the file
+  to a colleague for context.
+- **Never.** If the user reloads, that's a new session; sessions
+  are session-scoped.
+
+### Pick
+
+**Never.** Sessions are session-scoped. No export, no import.
+
+### Why
+
+- The serialised state would be enormous and brittle: snapshot
+  identities, machine references, sub-graph nodes, source-coord
+  chips don't survive JSON round-trip cleanly. The implementation
+  cost is real.
+- The use case (cross-machine session-sharing for triage) is narrow.
+  Where it matters (production-shaped repros), users today take a
+  screen recording and a console log — those are sufficient.
+- "Open a saved session" requires Causa to render against
+  *not-the-live-runtime* — and that fork has its own design surface
+  (read-only mode? frozen scrubber? what about cross-frame
+  cascades that reference machines no longer registered?). Adding
+  it now would balloon scope.
+- Aligns with lock #12 (ephemeral conversation) — the privacy bet
+  consistently beats the utility bet for Causa's data plane.
+
+### Date locked
+
+2026-05-11 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-buor §10.5 ("Session export / import — locked: not required").
+
+---
+
+## Lock #5 — Mobile
+
+**Locked 2026-05-11 (Mike).** **Desktop only.** No mobile, no
+tablet, no phone.
+
+### Question
+
+Does Causa support mobile / tablet / phone viewports?
+
+### Options considered
+
+- **Phone-form-factor Causa.** Pinch-zoom, mobile-first re-layout.
+- **Tablet-responsive Causa.** Below 900px, Causa takes full width;
+  below 600px, a narrow-mode renders the strip + co-pilot only.
+- **Tablet-responsive standalone viewer.** Causa itself stays
+  desktop; a separate viewer page serves remote-attached tablets.
+- **Desktop only.** Below 600px, Causa refuses to mount with a
+  helpful message.
+
+### Pick
+
+**Desktop only.** Below 600px, Causa refuses to mount.
+
+### Why
+
+- Debuggers belong at workstations. The user is reading source,
+  copying paths, jumping between editor and browser — none of which
+  is good ergonomics on a phone.
+- The "tablet for remote inspection" use case is replaced by the
+  MCP server (lock #9) — the agent inspects; the human doesn't
+  need to render Causa on the tablet.
+- Mobile support adds significant UX surface (touch gestures,
+  responsive layout, a separate compact density tier) for narrow
+  benefit.
+- The 600px refusal is user-friendly: instead of cramping the panel,
+  Causa says "this is a desktop debugger" and gets out of the way.
+
+### Date locked
+
+2026-05-11 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-buor §10.9 ("Mobile / phone form factor — locked: not needed
+  ever").
+
+---
+
+## Lock #6 — MCP timing
+
+**Locked 2026-05-12 (Mike).** **Ship at v1.0.** Via
+`tools/10x-mcp/`, mirroring the `tools/pair2-mcp/` pattern.
+
+### Question
+
+When does Causa's MCP server ship — v1.0 or v1.1?
+
+### Options considered
+
+- **Defer to v1.1.** Ship the panel at v1.0; the MCP server later.
+  Less scope at v1.0.
+- **Ship at v1.0.** Causa-MCP launches alongside the panel.
+
+### Pick
+
+**Ship at v1.0.** Via `tools/10x-mcp/`.
+
+### Why
+
+- `tools/pair2-mcp/` (rf2-5b8e #423, shipped 2026-05-12) is the
+  template — fork the project, swap the tool catalogue for Causa's
+  surfaces. Most of the implementation cost is already paid.
+- Enables remote-attach (one browser debugs another) as a v1.0
+  story without paying for a custom WebSocket protocol (lock #9
+  rules that out anyway).
+- The agent-driven workflow ("Claude, walk me back through the last
+  10 epochs that touched `[:cart]`") is high-leverage. Shipping
+  Causa-the-panel without Causa-the-agent-surface would mean the
+  AI assistant case is only partially served at v1.0.
+- The Causa-MCP catalogue is read-mostly (9 read tools, 3 mutate
+  tools); the mutate tools mirror the in-panel right-click
+  affordances. The user's consent model is the same.
+
+### Date locked
+
+2026-05-12 (Mike). Originally deferred 2026-05-11 (per rf2-buor
+§10.7); reversed on 2026-05-12 once pair2-mcp shipped and the
+template existed.
+
+### Trail-of-thought citations
+
+- rf2-buor §10.7 (originally deferred).
+- rf2-buor notes ("#6 MCP timing LOCKED 2026-05-12 (Mike): MCP AT
+  v1.0").
+
+---
+
+## Lock #7 — Hero panel
+
+**Locked 2026-05-12 (Mike).** **Event detail.** Causality graph
+demoted to peer + inline mini-graph.
+
+### Question
+
+What's the hero panel — the one users land in on every `Ctrl+Shift+C`?
+
+### Options considered
+
+- **Causality graph as hero.** The original rf2-buor §4.1 pick. The
+  graph is visually striking; it's a demo-friendly front door.
+- **Event detail as hero.** Land on the most-recent epoch's detail
+  panel — event vector, db-diff, fx fired, subs recomputed.
+- **A composite "summary" panel.** A custom dashboard view that
+  combines the strip, the latest event, the issues count, and a
+  mini-graph.
+
+### Pick
+
+**Event detail as hero.** The causality graph is a peer panel —
+first-class, sidebar entry, keyboard mnemonic `c`, but not the
+front door. The event-detail panel includes an inline mini-graph
+(3–5 nodes) when the current epoch has a `:parent-dispatch-id`.
+
+### Why
+
+- The flat detail-and-strip pair answers every one of the five
+  canonical questions on its own (per Causa's UX design doc §4).
+  The graph view appears in journeys 1 and 2 as a deeper-walk
+  option — but in none of them is it the entry point.
+- This is the difference between **a graph that's visible because
+  the answer is in it** and **a graph that's visible because we
+  made it the front door**. The former earns its keep; the latter
+  is impressive-but-unused.
+- The bet: habit beats demo. Programmers land in the detail panel
+  90% of the time; the graph is the second-click answer when the
+  first click wasn't enough.
+- Low-cost reversal: if usage data later shows programmers spending
+  80% of their time in the graph, Causa self-instruments
+  panel-view durations and reverts.
+- The inline mini-graph keeps the cascade *visible at a glance*
+  inside the detail panel — costs 80px of vertical space; gives the
+  causal breadcrumb without committing to the full graph view.
+
+### Date locked
+
+2026-05-12 (Mike). Originally rf2-buor §4.1 picked graph-as-hero;
+the UX design doc §4 reversed it; Mike locked the reversal
+2026-05-12.
+
+### Trail-of-thought citations
+
+- rf2-buor §4.1 + §10.10 (graph-as-hero, "evaluate in practice").
+- Causa UX design doc §4 ("The decision: demote the graph; the flat
+  event log + causality strip carry the weight").
+- rf2-90d5 notes (Mike's 2026-05-12 lock on the demotion).
+
+---
+
+## Lock #8 — AI panel default state
+
+**Locked 2026-05-12 (Mike).** **Collapsed by default.** Subtle
+activation cue marks the rail entry.
+
+### Question
+
+When Causa opens, is the AI co-pilot rail open or closed?
+
+### Options considered
+
+- **Open by default.** The marquee-pull argument — Causa's pitch
+  hinges on the AI co-pilot being immediately visible.
+- **Closed by default.** A subtle cue (the magenta `◇` glyph
+  pulsing every 8 seconds in the top strip) marks the rail entry.
+- **Open on first use only.** Open for the first session; remember
+  the user's close-choice across sessions.
+
+### Pick
+
+**Collapsed by default.** A subtle activation cue (`◇` magenta
+glyph in the top strip; pulses every 8 seconds until the user uses
+the co-pilot once, then stays static).
+
+### Why
+
+- Causa is a *debugger*, not an AI product. The pull-only co-pilot
+  (lock #10) supports the debugging workflow but is not the
+  workflow itself. Putting it open by default would imply the
+  user came to chat; they didn't, they came to inspect.
+- The collapsed state honours the principle of an unobtrusive
+  debugger. The user's app and the event detail are the primary
+  signal; the co-pilot is a sidecar.
+- The activation cue is the discoverability path: the glyph pulses
+  gently so a new user notices it, then stops once they've engaged.
+- The user can change the default in Settings (Sidebar → Co-pilot
+  open by default), but the ship-default is collapsed.
+
+### Date locked
+
+2026-05-12 (Mike). The Causa UX design doc §12.2 originally locked
+"open by default" on 2026-05-11; Mike reversed it on 2026-05-12 in
+favour of the unobtrusive default.
+
+### Trail-of-thought citations
+
+- Causa UX design doc §12.2 (original "open by default" lock).
+- rf2-90d5 notes (the 2026-05-12 reversal).
+
+---
+
+## Lock #9 — Launch modes
+
+**Locked 2026-05-12 (Mike).** **Hybrid.** In-app overlay (`Ctrl+Shift+C`
+or launcher pill) + standalone-via-MCP for remote-attach.
+
+### Question
+
+How does Causa launch? In-browser only, or with a remote-attach
+mode?
+
+### Options considered
+
+- **(a) In-app only.** DOM injection via `:preloads`; plus a
+  same-browser pop-out via `window.opener`. No remote-attach.
+- **(b) In-app + custom WebSocket remote-attach.** A standalone
+  HTML viewer connects to the running app over a Causa-specific
+  WebSocket protocol. Mobile-from-desktop, cross-machine pair-debug.
+- **(c) Chrome extension.** The IPC-isolated approach. Out of
+  process from the runtime.
+- **(d) Hybrid: in-app overlay + MCP for remote-attach.** In-app is
+  the primary; the agent-driven case is handled by `tools/10x-mcp/`,
+  not by a custom Causa protocol.
+
+### Pick
+
+**(d) Hybrid.** In-app overlay primary; MCP for the agent-driven /
+remote case.
+
+### Why
+
+- **No Chrome extension.** The IPC overhead, the sandbox isolation,
+  and the manifest-v3 churn aren't worth the marginal "you don't
+  have to change build config" benefit.
+- **No custom WebSocket remote-attach.** Serialising the runtime
+  state across the wire is too costly — snapshot identities,
+  machine references, sub-graph nodes, source-coord chips don't
+  survive JSON round-trip cleanly. The use cases (mobile-from-desktop,
+  cross-machine pair-debug) are too narrow to justify the
+  protocol-versioning + security + reconnect-logic surface.
+- **MCP handles the remote/agent case.** Causa-MCP (lock #6) is the
+  protocol; the agent host owns the network plumbing. The user's
+  consent model is already wired.
+- **In-app overlay is the right default.** Zero IPC, runtime is one
+  closure away, same elision contract as the runtime.
+- **`window.opener` pop-out is the second-monitor story.** No
+  serialisation cost, no protocol versioning, no reconnect logic;
+  same JS realm.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-buor §10.3 (original "in-app + same-browser pop-out, no
+  Chrome extension, no standalone HTML viewer").
+- The MCP-at-v1.0 lock (#6) absorbed the remote-attach concern.
+
+---
+
+## Lock #10 — Narrate mode
+
+**Locked 2026-05-12 (Mike).** **Dropped.** AI is pull-only (Q&A,
+slash commands).
+
+### Question
+
+Does the AI co-pilot offer a "narrate mode" — live commentary on
+the trace stream, where the model proactively explains what's
+happening as dispatches land?
+
+### Options considered
+
+- **Ship narrate mode at v1.0.** Live commentary; the model
+  describes each significant trace event in plain English.
+- **Ship narrate mode behind a toggle (off by default).** Power
+  users can flip it on.
+- **Drop narrate mode entirely.** The AI is pull-only — speaks only
+  when the user asks.
+
+### Pick
+
+**Drop.** AI is pull-only.
+
+### Why
+
+- **Privacy.** Live commentary means every interesting trace event
+  becomes an LLM API call. The user's runtime may contain sensitive
+  data — emails, internal handler names, snippets of
+  production-shaped repros. Continuous transmission is the wrong
+  default.
+- **Cost.** Even off-the-shelf-cheap models cost tokens. A typical
+  debug session emits hundreds of significant trace events.
+  Background narration would burn the user's budget invisibly.
+- **UX.** Live commentary is chatter. The user is *debugging*, not
+  reading a podcast. The Issues ribbon and the schema-violation
+  timeline already surface anomalies passively; the user doesn't
+  need a narrator.
+- **Failure mode.** A confidently-wrong narration that the user
+  doesn't read carefully primes them to believe something untrue.
+  Pull-only forces the user to *want* the explanation, which
+  forces them to *engage* with the verification step.
+
+The pull-only model retains the co-pilot's value (Q&A on the
+canonical five questions, slash commands for power-user shortcuts)
+without the narration failure modes.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- The original rf2-buor §4.3 included "watch / narrate" capabilities
+  in the co-pilot description.
+- Mike's 2026-05-12 review dropped narrate mode explicitly.
+
+---
+
+## Lock #11 — Source-coord fallback
+
+**Locked 2026-05-12 (Mike).** **Handler-coord fallback** via
+`:rf.trace/trigger-handler`. Inline `(?)` annotation when the
+dispatch coord is missing.
+
+### Question
+
+When Causa wants to render a click-to-source affordance but the
+dispatch's coord is missing (e.g., a synthetic dispatch from a
+machine action, an `:fx` dispatch from a registered handler with no
+explicit caller coord), what does it render?
+
+### Options considered
+
+- **No fallback.** If the coord is missing, render the chip greyed
+  out / unclickable.
+- **Best-effort caller-walk.** Causa walks the recent trace stream
+  to find the most likely caller (a sibling handler's source).
+- **Handler-coord fallback with annotation.** Causa uses the
+  registered handler's source coord (always present per Spec 001)
+  and renders the chip with a small `(?)` annotation that hovers a
+  tooltip explaining the substitution.
+
+### Pick
+
+**Handler-coord fallback** with `(?)` annotation.
+
+### Why
+
+- Every registration carries a source coord (per Spec 001 §
+  Source-coordinate capture); the handler's coord is always
+  available even when the dispatch's caller is unknown.
+- The fallback is *informative*: clicking jumps to the handler that
+  ran, which is usually what the user wanted anyway ("show me the
+  code that handles this event").
+- The `(?)` annotation prevents the user from thinking the coord is
+  the *dispatching* code when it's actually the *handling* code.
+  Tooltip says: "This coord is the handler's; the dispatch was
+  synthesised by `:auth/main` at state `:authing`."
+- Greying out the chip is worse — the user can't click through to
+  anything, and the surface becomes inert. The fallback at least
+  surfaces *some* relevant source.
+- Walking the trace stream for a guessed caller is fragile and
+  surprises the user when wrong; the handler-coord answer is
+  predictable.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- Surfaced during Causa UX design doc §12.4 ("Source-coord
+  click-through fallback").
+- Mike's 2026-05-12 lock during the same review pass.
+
+---
+
+## Lock #12 — Conversation persistence
+
+**Locked 2026-05-12 (Mike).** **Ephemeral.** No localStorage, no
+save.
+
+### Question
+
+Is the AI co-pilot's conversation history persisted across reloads
+/ sessions?
+
+### Options considered
+
+- **Persist to localStorage** (default on). Conversations survive
+  reloads; cap at 1000 turns; oldest-evict.
+- **Persist with explicit opt-in.** Default off; the user can flip
+  a toggle.
+- **Persist with explicit opt-out.** Default on; the user can
+  disable for a session.
+- **Ephemeral always.** Conversations live only in-memory; cleared
+  on reload, cleared on Causa close.
+
+### Pick
+
+**Ephemeral always.** No localStorage, no save.
+
+### Why
+
+- **Privacy.** Conversations may contain sensitive app data — user
+  emails, internal handler names, production-shaped repros. The
+  user's expectation is that what they discuss with the debugger
+  stays with the debugger session.
+- **Consistency with lock #4 (no session export).** Causa's data
+  plane is consistently session-scoped; the AI conversation
+  follows the same rule.
+- **Simplicity.** No corruption-recovery surface, no version
+  migration for conversation shape, no quota management.
+- **The Settings → Telemetry section's claim** ("Causa stores
+  nothing it doesn't need to") is consistent with ephemeral
+  conversation.
+
+A future v1.1+ could add opt-in persistence if users demand it;
+ephemeral is the conservative ship-default.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- Causa UX design doc §12.5 ("Conversation persistence default —
+  per-session or persistent-with-opt-out?").
+- Mike's 2026-05-12 lock on ephemeral.
+
+---
+
+## Lock #13 — Voice STT
+
+**Locked 2026-05-12 (Mike).** **No at v1.0.** Text-only. No mic
+permission prompts.
+
+### Question
+
+Does the AI co-pilot accept voice input (browser STT via the Web
+Speech API) at v1.0?
+
+### Options considered
+
+- **Ship voice at v1.0.** Click `🎙`, browser-local STT
+  transcribes; the user reviews and submits.
+- **Ship voice behind a Settings toggle (off by default).**
+- **Defer to v1.1+.** Text only at v1.0.
+
+### Pick
+
+**No at v1.0.** Text only.
+
+### Why
+
+- **Web Speech API quality is patchy.** Different browsers, different
+  recognition quality, different language support. A "sometimes
+  works" feature damages user trust.
+- **Cloud STT adds cost + latency** and a service-side dependency
+  Causa doesn't currently have.
+- **v1.0 scope is already large.** 16 panels + co-pilot + MCP
+  server. Voice is purely additive — shipping later costs nothing.
+- **Privacy default.** No mic permission prompts in v1.0
+  onboarding (privacy-default-friendly).
+- **Niche use case.** Power users keyboard-fluent will type faster
+  than they speak. The "hands full / hands-free" case is real but
+  small.
+
+Voice can ship in v1.1+ if users demand it. The text input shape
+is unchanged by adding voice later; pure additive feature.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- Causa UX design doc §8 ("Voice (browser STT) — opt-in").
+- Causa UX design doc §12.6 ("Voice STT at v1 — ship at v1 or
+  defer?").
+- rf2-90d5 notes ("#13 Voice STT LOCKED 2026-05-12 (Mike): NO
+  VOICE AT v1.0").
+
+---
+
+## Summary table
+
+| # | Question | Pick | Date |
+|---|---|---|---|
+| 1 | Name | **Causa** (`day8/re-frame2-causa`) | 2026-05-11 |
+| 2 | AI co-pilot ship timing | **v1.0 pull-only** | 2026-05-11 |
+| 3 | App-db editing | **Never — read-only forever** | 2026-05-11 |
+| 4 | Session export | **Never** | 2026-05-11 |
+| 5 | Mobile | **Desktop only** | 2026-05-11 |
+| 6 | MCP timing | **v1.0 via `tools/10x-mcp/`** | 2026-05-12 |
+| 7 | Hero panel | **Event-detail** (graph demoted to peer) | 2026-05-12 |
+| 8 | AI panel default state | **Collapsed** with subtle cue | 2026-05-12 |
+| 9 | Launch modes | **Hybrid: in-app + MCP** | 2026-05-12 |
+| 10 | Narrate mode | **Dropped — AI is pull-only** | 2026-05-12 |
+| 11 | Source-coord fallback | **Handler-coord with `(?)` annotation** | 2026-05-12 |
+| 12 | Conversation persistence | **Ephemeral** | 2026-05-12 |
+| 13 | Voice STT | **No at v1.0** | 2026-05-12 |
+
+The 13 locks together define the v1.0 surface. Anything outside
+these decisions is up for design discussion; anything inside is
+direction-set and shipped.

--- a/tools/10x/spec/Principles.md
+++ b/tools/10x/spec/Principles.md
@@ -1,0 +1,215 @@
+# Principles
+
+The load-bearing principles. When a design call has two reasonable
+options, these are the tie-breakers. Implementers and contributors
+should be able to read this doc and reach the same answers Causa
+already reached.
+
+These are downstream of the framework's [Principles](../../../spec/Principles.md);
+they are *Causa-specific*. Where they overlap the framework's
+principles, this doc cites instead of repeating.
+
+## Read-only by default, mutate by confirmation
+
+Causa observes the runtime. The runtime is the source of truth. Pokes
+into `app-db`, dispatches, rewinds, schema substitutions — all of
+these require a **user-confirmed action** before they happen.
+
+The mechanism:
+
+- The app-db panel is read-only forever (lock #3).
+- The scrubber rebases panels *passively*; rewinds require the
+  explicit `Rewind here` button or `r` keypress.
+- Re-dispatch is a right-click context-menu action, never a single
+  click.
+- The AI co-pilot proposes actions via clickable chips; clicking is
+  the user's commitment.
+- The MCP server's mutation tools (`restore-epoch`, `reset-frame-db`,
+  `dispatch`) are tagged `:origin :causa-mcp` and surface in the
+  trace stream as distinguishable from app-issued mutations.
+
+This is the v1-of-10x mistake-not-repeated. `app-db-follows-events?`
+was too implicit; users accidentally rewound. Causa's posture:
+**inspection is the default, rewind is opt-in**.
+
+## Observation only — no new runtime surfaces
+
+Causa is a **downstream consumer** of re-frame2's instrumentation
+surface. It must not add:
+
+- New registries.
+- New dispatch types.
+- New effect substrates.
+- New component substrates.
+
+If a Causa panel needs data the framework doesn't emit, the answer is
+to **add to the framework's instrumentation** (via a spec amendment
+in `spec/009-Instrumentation.md`) — not to bolt a parallel surface
+onto Causa.
+
+This is the downstream-EPs-consume-foundation rule (per Mike's
+feedback) applied to tools: tools observe what the framework emits
+and present it; they do not invent new substrates.
+
+Concretely: when the implementation surfaces a spec gap (e.g., "I
+want to render `:invoke-all` join state but the trace events are
+missing a `:child-ids` tag"), file a `bd` bead against the spec.
+Don't silently work around.
+
+## The five canonical questions
+
+Every panel earns its keep by helping answer one of:
+
+1. **Why did this event fire?**
+2. **What did that event change?**
+3. **Why is this subscription returning the wrong value?**
+4. **Why is this view re-rendering?**
+5. **What's currently broken?**
+
+If a panel doesn't help with one of the five, it doesn't ship. The
+discipline keeps the surface from accreting features that *demo*
+well but aren't *habit-forming*.
+
+Restraint is what keeps the tool useful daily instead of impressive
+once.
+
+## Habit beats demo
+
+A graph is striking. A flat panel that answers in one click is
+useful. When the two compete, the flat panel wins.
+
+This is why the event-detail panel is the hero, not the causality
+graph (lock #7). The graph is a peer — first-class, sidebar entry,
+keyboard mnemonic `c` — but the front door is the panel that answers
+in zero clicks.
+
+The bet: programmers land in the detail panel 90% of the time. The
+graph is the second-click answer when the first click wasn't enough.
+If usage data later shows the graph carries more weight than
+predicted, Causa self-instruments (panel-view durations) and the
+decision is reversible. Low-cost reversal.
+
+## Cite the evidence
+
+The AI co-pilot's responses are valuable in proportion to how
+quickly the user can verify them. Every claim references data the
+user can verify:
+
+- Source coords (`events.cljs:213`)
+- Epoch ids (`epoch 10`)
+- Event vectors (`:cart/finalise`)
+- Machine states (`:auth/login-flow → :authenticating`)
+
+If a claim doesn't link to data, it's a tell — and the model is
+hallucinating. The system prompt encodes this discipline; the UX
+surfaces every reference as a clickable chip so verification is
+one click.
+
+The co-pilot is a **navigator, not an oracle**.
+
+## Ephemeral by default
+
+Conversations are session-local (lock #12). Pins are session-local.
+Settings persist (theme, density, AI provider key); content does
+not.
+
+The privacy bet beats the utility bet. The user's runtime may
+contain sensitive data; Causa stores nothing it doesn't need to.
+
+Settings → Telemetry has a section explaining we ship none.
+
+## Animation communicates, not decorates
+
+Three durations: quick (100ms — hover, focus), standard (200–250ms —
+panel switches, scrubber snap), slow (400–600ms — diff flashes, error
+pulses, slide-in).
+
+No looping animations except the machine-active state pulse (1.2s
+heartbeat — only on the active machine's node in the machine chart;
+the only continuous animation in Causa).
+
+Every animation respects `prefers-reduced-motion`. Reduced motion
+clamps durations to 0 except a 1-frame opacity tween where layout
+needs to settle.
+
+The error pulse is single — one 600ms expand-fade on entry, then
+done. No "look at me I'm an error" continuous strobe.
+
+## Colour is never alone
+
+Every coloured marker pairs with a shape or icon (per
+[`007-UX-IA.md`](./007-UX-IA.md) §Colour is never alone). Errors are
+red dots + `!` icons + "Error" labels. Schema violations are yellow
+triangles + paths. Active machines are green + filled glyphs.
+
+The colour-blind path is reachable without hue.
+
+## Production elision is non-negotiable
+
+Causa ships **zero bytes** in production. The trace bus, the epoch
+history, the schema validation, the registrar trace emit — all
+gated on `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`).
+Production builds (`:advanced` + `goog.DEBUG=false`) elide all of it.
+
+Per [Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code).
+CI's `npm run test:elision` job verifies the contract.
+
+Causa contributes its own sentinels to the elision verifier; CI
+blocks any leak.
+
+## Restraint over completeness
+
+16 panels is already a lot. The temptation to add more — DOM
+mutation recording, video replay, AI-generates-tests, code
+generation, marketplace plugins, session export — is real and
+should be resisted.
+
+If the question being answered is in one of the five canonical
+questions, the panel ships. Otherwise: defer to a future version, or
+let another tool own the lane.
+
+(Sentry / Replay.io stay in their lane; Causa stays in re-frame's
+data plane. re-frame-pair owns code authoring; Causa owns
+observation.)
+
+## Frame-first
+
+Multi-frame is a first-class concept. Every panel has a frame
+picker; per-frame buffers are independent; cross-frame causality is
+surfaced explicitly (swimlanes in the graph; coloured rings on the
+strip pills).
+
+v1 of 10x assumed one frame and broke gracefully on multi-frame
+apps. Causa is built frame-first; single-frame apps degrade to
+"the picker is a static label."
+
+## Pull-only AI
+
+The AI co-pilot speaks when spoken to. No narration mode (lock
+#10), no background commentary, no proactive alerts.
+
+The Issues ribbon and the schema-violation timeline are *passive*
+surfaces — they surface anomalies without the model needing to
+explain them. When the user wants explanation, they ask.
+
+This is a privacy choice (no unsolicited LLM calls) and a cost choice
+(no unsolicited tokens) and a UX choice (no chatter the user didn't
+opt into).
+
+## Backed by the framework's principles
+
+When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):
+
+- **Regularity over cleverness** — there's one obvious way to do a
+  thing in Causa, too.
+- **Named things over anonymous things** — every panel has a stable
+  id; every keybind has a stable mnemonic; every action chip has a
+  stable label.
+- **Public query surfaces** — Causa reads only what the framework's
+  public registrar / trace bus / epoch-history surfaces expose.
+- **Deterministic execution** — Causa's rendering is a function of
+  the trace state at panel mount; no hidden side-effects.
+
+Causa is a downstream artefact of the framework's AI-first
+discipline. The principles above are what *Causa adds* over the
+framework's baseline; everything below is inherited.

--- a/tools/10x/spec/findings/causa-ux-design.md
+++ b/tools/10x/spec/findings/causa-ux-design.md
@@ -1,0 +1,814 @@
+# Causa — UX/UI Design
+
+> Bead **rf2-90d5 (P2 research)**. Local-only working draft. **Not committed; not normative.** Companion to [`re-frame-10x-v2-design.md`](re-frame-10x-v2-design.md) (rf2-buor). rf2-buor establishes **what** Causa is; this document designs **how it feels**. Visuals are described in prose plus ASCII layout sketches; every pixel size, colour token, and timing is concrete enough that a programmer can implement against it.
+
+---
+
+## §1 — One-sentence pitch + the canonical 30-second experience
+
+**Pitch.** *Causa shows you the cascade your last click triggered, lets you ask why, and answers in five seconds.*
+
+That's the contract. Open it, see a story, find the surprise, close it.
+
+### The first 30 seconds
+
+The programmer installed Causa's `:preloads` and refreshed. They click around the app, log in, navigate. A button doesn't do what they expected.
+
+**T+0.0s.** `Ctrl+Shift+X`. A 320ms slide-in from the right edge covers 40% of the window. First frame paints in under 80ms — Causa was mounted, just hidden. No splash, no "loading."
+
+**T+0.3s.** They see this:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                  │
+│  [APP CONTENT — DIMMED 12%, INTERACTIONS PASS THROUGH]                          │
+│                                                                                  │
+│                                                                                  │
+│                                                                                  │
+│                                                                                  │
+│                                                                                  │
+├──────────────────────────────────────────────────────────────────────────────────┤
+│ ╭─ CAUSA ───────────────────────────────────────────────────────── :app/main ▾─╮ │
+│ │ ◆──○──○──○──○──○──○──○──○──○──●           ⚠ 0   ⏵◀ epoch 11/11  ⌘K   ?  ✕ │ │
+│ ├──────────────────────────────┬───────────────────────────────────────────────┤ │
+│ │ ◉ Events                     │ ╭─ event 11 ────────────────────────────────╮ │ │
+│ │ ○ App-db                     │ │ :checkout/submit                          │ │ │
+│ │ ○ Causality                  │ │ source • src/cart/events.cljs:213         │ │ │
+│ │ ○ Subscriptions              │ │ origin • :app                             │ │ │
+│ │ ○ Effects                    │ │ caused-by • :cart/finalise (epoch 10)     │ │ │
+│ │ ○ Trace                      │ │                                           │ │ │
+│ │ ○ Machines                   │ │ db-diff   • [:cart :submitting?] → true   │ │ │
+│ │ ○ Flows                      │ │            • [:cart :error] → nil         │ │ │
+│ │ ○ Performance                │ │ fx fired  • :http (POST /orders)          │ │ │
+│ │ ○ Issues                     │ │            • :rf.machine/send → :auth     │ │ │
+│ │ ○ Routes                     │ │ subs run  • 4 recomputed, 18 cached       │ │ │
+│ │ ○ Schemas                    │ │ renders   • 3 views                       │ │ │
+│ │ ○ Hydration                  │ │ duration  • 4.3ms                         │ │ │
+│ │ ○ Co-pilot                   │ ╰───────────────────────────────────────────╯ │ │
+│ │ ○ Settings                   │                                               │ │
+│ ╰──────────────────────────────┴───────────────────────────────────────────────╯ │
+│ ◀◀ ─────────────────●──── ▶▶   :app/main   11 epochs   8.2KB                   │ │
+╰──────────────────────────────────────────────────────────────────────────────────╯
+```
+
+The top strip — the **causality strip** — shows the last 11 dispatches as pills. The rightmost is filled (●), the others are hollow (○). The leftmost has a diamond (◆) marking a cascade root. The frame picker says `:app/main` because there's only one frame.
+
+The main canvas shows the **most recent epoch's detail**: the event vector, where it came from, what caused it, the app-db diff, fx fired, sub recomputes, renders, and timing. Everything important about the last dispatch is in one panel. No graph yet. No scrubber action yet.
+
+**T+1.5s.** Their eye lands on the diff: `[:cart :submitting?] → true`. The dispatch happened. The `caused-by` link reads `:cart/finalise (epoch 10)`.
+
+**T+3s.** They press `[`. The scrubber steps back one epoch. Detail rebases to epoch 10; the causality strip's filled pill slides left. The live app behind Causa **does not** rebase visually — time-travel requires explicit opt-in via the rewind button. (Default is "show me history without affecting the live app." v1 of 10x got this wrong; v2 inverts it.)
+
+**T+5s.** Epoch 10's detail: `:cart/finalise` ran, fx `:http` POSTed `/cart`, completed, dispatched `:checkout/submit`. The chain is there. `]` returns to current. They press `c` (causality view).
+
+**T+6s.** 180ms cross-fade to a vertical graph: epoch 10 at the top, epoch 11 below, edge labelled `:fx [[:dispatch ...]]`. Forks from epoch 10 to `:http POST /cart`, from epoch 11 to `:http POST /orders`.
+
+**T+10s.** Click `:http POST /orders`. Popover: URL, headers, status `pending`. The order request never resolved. *That's* the bug.
+
+**T+12s.** `Esc`. Causa retracts. They open their network panel and find a CORS error.
+
+**Muscle memory built:** `Ctrl+Shift+X` (open) → glance at strip → read detail → `[`/`]` to walk history → `c` for the graph when the chain matters → `Esc` to close. One hand, eyes on the panel, no tool-switching.
+
+---
+
+## §2 — The interface, sketched in prose
+
+Causa fills a panel along the **right edge** of the viewport by default, taking 40% of the window width (resizable). It is **not** a bottom panel because right-edge gives more vertical real estate for the graph and the event detail. The user can pop it out to a separate window (`Ctrl+Shift+P`) or detach the right rail to a separate monitor.
+
+### Top region — causality strip + global filters + frame picker
+
+Pinned. 56px tall on cosy density.
+
+```
+╭─ CAUSA ───────────────────────────────────────────────────── :app/main ▾ ──╮
+│ ◆──○──○──○──○──○──○──○──○──○──●        ⚠ 0   ⏵◀ epoch 11/11   ⌘K   ?   ✕ │
+╰─────────────────────────────────────────────────────────────────────────────╯
+```
+
+**Causality strip (left two-thirds).** Horizontal row of dispatch pills, oldest left, newest right. Each pill 24×24px on cosy density with 4px gap. Most-recent pill filled in the frame's accent (default violet `#7C5CFF`); older pills hollow (1px stroke). Cascade roots (no `:parent-dispatch-id`) are diamonds (◆); children are circles (○). Strip scrolls horizontally (default scrolled to right-edge); buffer 200 deep (Spec 009).
+
+Hover pill → 240ms popover with event vector, source coords, duration, epoch-id. Click → detail panel rebases. Right-click → context menu (Replay, Re-dispatch, Copy, Open source, Filter graph to this cascade).
+
+**Pill colours.** Violet `:app`; indigo `:pair`; cyan `:story`/`:test`; red (cascade contained error); amber (warning / schema-replaced-with-default); grey (registry churn, hidden by default).
+
+**Right side.** Issues badge (`⚠ N`, red+pulse on new), epoch counter (`epoch 11/11`; click for numeric input), `⌘K`, `?`, `✕`.
+
+**Frame picker** in the title bar (`:app/main ▾`). Dropdown over `(rf/frame-ids)`; collapses to static label when there's only one frame.
+
+### Left sidebar — panel navigation + density toggle
+
+Pinned. 192px wide on cosy density; 56px when collapsed (icons only).
+
+```
+┌──────────────────────────────┐
+│ ◉ Events                     │ ← active panel
+│ ○ App-db                     │
+│ ○ Causality                  │
+│ ○ Subscriptions              │
+│ ○ Effects                    │
+│ ○ Trace                      │
+│ ─                            │
+│ ○ Machines           ●●●     │ ← active count
+│ ○ Flows                      │
+│ ○ Performance                │
+│ ○ Issues             ●3      │ ← issues count
+│ ○ Routes                     │
+│ ─                            │
+│ ○ Schemas            ◌       │ ← dormant
+│ ○ Hydration          ◌       │
+│ ─                            │
+│ ○ Co-pilot                   │
+│ ○ Settings                   │
+│ ▥ ▥▥ ▥▥▥                    │ ← density toggle
+└──────────────────────────────┘
+```
+
+Three groups, divider-separated: **hot panels** (Events / App-db / Causality / Subscriptions / Effects / Trace) always at top; **conditional panels** (Machines / Flows / Performance / Issues / Routes) with activity badges; **dormant panels** (Schemas / Hydration) marked `◌` until activity.
+
+**Item shape.** 32px tall; 8px padding. Active item: 2px violet left-border + `bg-active` tint. Hover: 1px grey left-border at 50% opacity. **Badges** to the right: `●` (active, no count), `●3` (numeric count), `●●●` (multiplicity), `◌` (dormant). Density toggle at bottom cycles compact → cosy → comfy; persists to schema'd localStorage.
+
+### Main canvas — whichever panel is active
+
+Fills the remaining space. The active panel's content. The canvas is **everything between the top strip, the sidebar, and the bottom rail**. Scrollable internally; the canvas-internal scroll is independent of the panel chrome.
+
+Every panel has the same chrome:
+- **Title bar** (40px tall): panel name on the left, panel-specific actions on the right (filter chips, refresh, expand).
+- **Content area**: panel-specific. Most panels are split into a list + detail view; the canvas decides the split orientation based on width (vertical split when wide, horizontal when narrow).
+
+### Right rail — AI co-pilot (when open)
+
+Detachable, **closed by default**. Toggled with `Ctrl+Shift+/` or sidebar click. 320px wide on the right side of the canvas. Below 1200px viewport, takes over the full canvas when active.
+
+```
+┌──────────────────────────────────────┐
+│  AI Co-pilot                ⌗ ⛶  ✕  │  ← title, model picker, expand, close
+├──────────────────────────────────────┤
+│  ▸ Why did :checkout/submit fire?    │
+│    It was dispatched by an           │
+│    :fx [[:dispatch ...]] inside the  │
+│    :cart/finalise handler            │
+│    (events.cljs:213). That handler   │
+│    ran because of                    │
+│    :user/clicked-checkout at         │
+│    10:43:21.                         │
+│    [ Open source ] [ Show graph ]    │
+│  ─────────────────────────────────── │
+│  ▸ What's the auth-flow state?       │
+│    :auth/login-flow → :authenticating│
+│    Parent :login is :open. Pending   │
+│    :after timer at 5000ms, 2.1s left.│
+│    [ Open machine chart ]            │
+├──────────────────────────────────────┤
+│ ╭──────────────────────────────────╮ │
+│ │ Ask anything…                  ↑ │ │
+│ ╰──────────────────────────────────╯ │
+│ /slash for commands · 🎙 to dictate  │
+└──────────────────────────────────────┘
+```
+
+Conversation newest-at-bottom. Each turn: question (▸ in violet) → response. Responses contain inline **action chips** that act on the main canvas, **embedded data** (mini app-db trees, tables, source-coord blocks) with the same visual language as panels, and source-coord chips that open in the editor. Input is multiline; `↑` submits, `/` triggers slash commands, `🎙` triggers browser STT.
+
+### Bottom rail — time-travel scrubber + issues badge
+
+Pinned. 40px tall on cosy density.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ ◀◀ ─────────────────●──── ▶▶   :app/main   11/11 epochs   8.2KB   ⚠ 0   ●●●    │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Scrubber (left half).** A horizontal track with one tick per epoch in the current frame's `epoch-history`. The current position is a violet filled circle. `◀◀` jumps to oldest; `▶▶` jumps to newest. The track is **draggable**.
+
+**Default behaviour: passive scrubbing.** Dragging the scrubber **does not** rewind the app — it just rebases the panel's view of history. The detail panel rebases. The graph rebases. App-db panel rebases. But `(rf/get-frame-db ...)` returns the live value still. The user must click `Rewind here` (a contextual button that appears 200ms after a drag ends) to actually call `restore-epoch`.
+
+This is the v1-of-10x mistake-not-repeated. `app-db-follows-events?` was too implicit — users accidentally rewound. v2's posture: **inspection is the default, rewind is opt-in.**
+
+**Right side of bottom rail.** Frame name, epoch counter, scrubber buffer size, issues count, machine activity dots.
+
+**Issues badge** (`⚠ N`). Same as in the top strip — duplicated here for glance-ability. New issues cause a 600ms red pulse.
+
+### Modal layers
+
+Three modal surfaces float over the chrome:
+
+- **Command palette (`Ctrl+K`).** Centred 560px modal, 50% height. Input on top, fuzzy-matched result list grouped by Events / Handlers / Panels / Commands / Settings (see §6 for the full index). Type → filter live → arrows → Enter. The spine of expert workflows.
+- **Keyboard cheat-sheet (`?`).** 480px modal listing every shortcut grouped by category. Static (Ctrl+K covers search).
+- **Settings (`,` from anywhere except a text input).** 640×480px modal: Theme, Density, Keybindings, AI provider, Buffer depths, Frame defaults, Telemetry (always off; statement of why we don't ship any).
+
+### Narrow viewport — what collapses
+
+Below 1200px viewport width:
+- Sidebar collapses to icons-only (56px).
+- Co-pilot rail collapses to 0; the panel takes over the full canvas when opened.
+
+Below 900px viewport width:
+- Causa's panel takes 100% of viewport width (overlays the app).
+
+Below 600px viewport (phones): **Causa refuses to mount.** The DOM root is created but the visible UI is a single message: "Causa needs a larger viewport. Open from a desktop or tablet." This is per the §10.9 lock.
+
+### What's keyboard-reachable
+
+Everything. The chrome has a strict tab order: top-strip controls → sidebar items → canvas content (focus enters the active panel) → bottom rail controls. `Esc` always returns focus to the canvas. The co-pilot rail is in the tab order when open.
+
+---
+
+## §3 — The five canonical user journeys
+
+These are the five experiences Causa earns its keep with. For each, the user starts with Causa **closed**, mid-debugging session.
+
+### Journey 1 — "Why did this event fire?"
+
+User saw `:checkout/submit` dispatch in console; doesn't remember writing code that fires it.
+
+1. `Ctrl+Shift+X`. Causa opens. Rightmost strip pill is `:checkout/submit`. Detail panel: `caused-by • :cart/finalise (epoch 10)`.
+2. Press `c` (causality view). Vertical graph: epoch 11 at bottom, edge `:fx [[:dispatch ...]]` up to epoch 10 (`:cart/finalise`), edge up to epoch 9 (`:cart/http-success`).
+3. Click `:cart/finalise` → popover shows `src/cart/events.cljs:213`. Press `o` → editor opens at line 213. Code reads `:fx [[:dispatch [:checkout/submit]]]`. Answered.
+4. `Esc`.
+
+Three keys (`Ctrl+Shift+X`, `c`, `o`), no mouse, no search. The detail panel answers most of the question by itself; the graph is the deeper-walk option.
+
+### Journey 2 — "What did that event change?"
+
+User notices `[:cart :items]` is unexpectedly empty in app-db.
+
+1. **T+0.** `Ctrl+Shift+X`, click `App-db`. The tree opens with the most recently-changed paths in a fading 400ms yellow flash. `[:cart :items]` is dim — it didn't change in this epoch.
+2. **T+2s.** `Ctrl+F`, type `:items`. The tree filters to `[:cart :items]`. Value: `[]`. Right-click → `Show me when this changed`.
+3. **T+4s.** Canvas pivots to a list of epochs that touched the path. Four entries. Click `:cart/clear` (epoch 3). Detail rebases. The diff shows `[:cart :items] [{:sku "abc" :qty 2}] → []`. The fx list shows `:rf.machine/send → :cart-machine :submit`.
+4. **T+7s.** Press `c` for the causality graph at this epoch. Parent of `:cart/clear` is `:user/clicked-logout`. **Bug found:** logout is clearing the cart unintentionally.
+
+The "show me when this changed" right-click is what turns "I notice this is wrong" into "show me when it became wrong" in two clicks.
+
+### Journey 3 — "Why is this subscription returning the wrong value?"
+
+`:cart/total` returns `0` instead of `42`.
+
+1. `Ctrl+Shift+X` → `Subscriptions`. Canvas shows the sub-dependency graph. Type `:cart/total` in the panel's search.
+2. The graph filters to `:cart/total` and its transitive inputs. Each node shows its current value inline: `:cart/items = []`, `:product/price-map = {...}`, `:cart/items-with-prices = []`, `:cart/total = 0`. The bisection is visual: trace from the wrong output backward to the empty input.
+3. Click `:cart/items`. Side popover: sub source, cache state, most recent recompute trigger (`:cart/clear`). Same root as Journey 2, found from the other direction.
+
+The sub graph reads like a circuit diagram: outputs on top, inputs at the bottom, bad value dim.
+
+### Journey 4 — "Why is this view re-rendering?"
+
+A view re-renders on every keystroke.
+
+1. `Ctrl+Shift+X` → `Performance`. The ribbon shows a bar per epoch; every epoch in the last 30s has one. Typing is causing dispatches.
+2. Press `r` (renders panel). Table of views with re-render counts. `cart-summary-view — 14 renders` is the outlier. Click.
+3. Detail: `:render-key [cart-summary-view "instance-7c2"]`. Subs deref'd: `[:input/draft :cart/items :cart/total]`. Recompute counts across the 14 renders: `:input/draft = 14, :cart/items = 0, :cart/total = 0`. **The view derefs `:input/draft`** — which the user didn't intend.
+4. Open source, find the stray `@(subscribe [:input/draft])`.
+
+Render-key attribution (`:render-key` projection in `:rf/epoch-record :renders`) is the magic. The user doesn't instrument anything; the runtime records what each render derefed.
+
+### Journey 5 — "What's currently broken?"
+
+App feels off, no console error.
+
+1. `Ctrl+Shift+X`. Top-right badge says `⚠ 3`. Press `i`.
+2. Issues panel: a schema violation (`[:auth :email]` expected `:string`, got `nil`, recovery `replaced-with-default`), a hot-reload warning (handler replaced 47 times this session), a long task (epoch 14 took 312ms — INP threshold).
+3. Click the schema violation. Detail shows the Malli explanation, the offending value, and `Show me the dispatch that caused this`. Clicking jumps to the causality graph at that epoch — the dispatch was `:user/load-profile`; the server returned `nil` for `:email`.
+
+The issues feed is a permanent ribbon, not a console one-liner that scrolls past. "Show me the dispatch that caused this" is the high-leverage affordance.
+
+---
+
+## §4 — The causality graph: hero or one-of-many?
+
+**The decision: demote the graph; the flat event log + causality strip carry the weight.** Option (B) in the brief.
+
+Here's why. The flat detail-and-strip pair answers every one of the five canonical journeys above on its own. The graph view appears in journeys 1 and 2 (and Issues drills into it from journey 5) as a deeper-walk option — but in none of them is it the entry point. In every one, the user lands on the flat detail panel, glances, follows a `caused-by` link or a path-changed link, and only opens the graph when the chain is more than two hops long.
+
+This is the difference between **a graph that's visible because the answer is in it** and **a graph that's visible because we made it the front door**. The former earns its keep; the latter is impressive-but-unused.
+
+### What stays of the graph
+
+The causality view is still a first-class panel (sidebar entry, shortcut `c`). It's excellent when the cascade is > 2 hops, spans frames, or when triaging a session with 30 events. It's the right tool for those moments; it's just not the front door.
+
+The graph also lives as a **micro-view inside the event-detail panel**: when the current epoch has a `:parent-dispatch-id`, the detail shows a small inline graph (3–5 nodes) of the local cascade above the event vector — a causal breadcrumb. Costs 80px of vertical space; gives the user the chain at a glance without committing to the full graph view.
+
+```
+┌─ event 11 ───────────────────────────────────────────────╮
+│                                                          │
+│      ●  :user/clicked-checkout                           │
+│      │                                                   │
+│      ●  :cart/finalise                                   │
+│      │                                                   │
+│      ●  :cart/http-success                               │
+│      │                                                   │
+│      ◉  :checkout/submit          ← you are here         │
+│                                                          │
+│  ─────────────────────────────────────────────────────── │
+│                                                          │
+│  :checkout/submit                                        │
+│  source • src/cart/events.cljs:213                       │
+│  origin • :app                                           │
+│  caused-by • :cart/finalise (epoch 10)                   │
+│  …                                                       │
+╰──────────────────────────────────────────────────────────╯
+```
+
+### What fills the hero slot
+
+**The event detail panel** is the hero — the canonical-question-answering one §1 sketched. First thing the user sees, where they land 90% of the time, the panel that decides whether the next click is "found it" or "need to dig." It answers all five canonical questions in one click:
+
+- Q1 (why did this fire?) — `caused-by` + inline mini-graph.
+- Q2 (what changed?) — `db-diff` rows.
+- Q3 (why is this sub stale?) — `subs run` row links to the sub graph at this epoch.
+- Q4 (why re-rendering?) — `renders` row links to render attribution.
+- Q5 (what's broken?) — `issues` row lists schema violations / errors tagged to this epoch.
+
+The graph is the second-click answer when the first click wasn't enough.
+
+### What the demotion means for rf2-buor §6
+
+The 16-panel list survives; the marketing changes. "The cascade you can see" becomes a tagline about *the chain Causa renders inline* (in the detail panel and the strip), not the graph view itself. Causality is a peer panel, not a hero. The graph is still striking when opened — but Causa earns its keep at the detail panel; the graph is the bonus.
+
+**Trade-off acknowledged.** We're trading a demo-friendly front door for a habit-friendly one. The risk: colleagues demo the graph, not the detail panel; marketing loses a screenshot. The bet: habit beats demo. If usage shows programmers spending 80% of their time in the graph, we revisit — Causa can self-instrument panel-view durations. Low-cost reversal.
+
+---
+
+## §5 — Visual language
+
+### Typography
+
+Two typefaces. No more.
+
+- **UI sans:** `Inter` (variable, wght 400–700), fallback `system-ui` / `-apple-system` / `Segoe UI`. ~80KB WOFF2. Used for labels, headings, sidebar, modals, buttons, popovers.
+- **Data mono:** `JetBrains Mono` (variable, wght 400–700), fallback `ui-monospace` / `SF Mono` / `Menlo`. ~100KB WOFF2. Used for app-db trees, event vectors, source coords, code blocks, EDN.
+
+**Sizes (cosy density).** Display 16px/1.4/600 (panel titles); body 14px/1.5/400; mono body 13px/1.45/400 (mono renders larger at equal point size, so 1px down); caption 12px/1.4/400; micro 11px/1.2/600 (badges, tabs). **Compact:** −1px, tighter line-heights (1.3 / 1.35). **Comfy:** +1px, looser (1.6 / 1.55). Below 10px refused.
+
+### Colour system
+
+Two themes (dark default, light second). Both **WCAG AA** minimum on text-against-background; AAA on the high-contrast variant (v1.1 per rf2-buor).
+
+**Dark theme tokens:**
+
+```
+Surfaces:  bg-0 #0E0F12 (backdrop)  bg-1 #15171B (sidebar, top strip)
+           bg-2 #1B1E24 (panels)    bg-3 #232730 (popovers)
+           bg-active #2A2F3D (hover, selected)
+Borders:   subtle #232730  default #2F3441  strong #444B5B
+Text:      primary #E8EAF0  secondary #A8AEC0  tertiary #6B7080  disabled #494E5A
+Accents:   violet  #7C5CFF  brand, current epoch
+           indigo  #5570FF  :pair-origin
+           cyan    #43C3D0  :story/:test origin, info
+           green   #4ADE80  success, additions, machine-active
+           yellow  #FBBF24  warnings, schema-replaced-with-default
+           orange  #FB923C  long-task
+           red     #F87171  errors, schema-violations, hydration-mismatches
+           magenta #E879F9  AI co-pilot highlight
+Perf:      fast #4ADE80 (<16ms)  medium #FBBF24 (16-50)  slow #FB923C (50-100)
+           blocking #F87171 (>100ms, INP threshold)
+```
+
+**Light theme** inverts lightness (`bg-0 #FAFBFC`, `bg-1 #F1F3F6`, `bg-2 #FFFFFF`); accents darkened slightly to maintain contrast. **High-contrast variant** uses pure black/white with maximum-saturation accents.
+
+**Colour is never alone.** Every coloured marker pairs with a shape or icon: errors (red dot + `!` icon + "Error" label), schema violations (yellow triangle + path), pair-origin (indigo + `🔗`), active machine (green + filled glyph; idle: hollow).
+
+### Spacing scale
+
+4px grid. Everything is a multiple.
+
+- `space-0` = 0px (collapsed)
+- `space-1` = 4px (tight, badges-to-text gap)
+- `space-2` = 8px (default inline gap, button padding)
+- `space-3` = 12px (section spacing)
+- `space-4` = 16px (panel padding)
+- `space-5` = 24px (between sections)
+- `space-6` = 32px (panel-level separators)
+- `space-8` = 48px (rare; modal margins)
+
+Border-radius: `radius-sm` 4px (buttons, chips), `radius-md` 8px (panels, popovers), `radius-lg` 12px (modals).
+
+### Iconography
+
+Single icon set: **Lucide** (open-source, ~1000 icons, programmer-friendly). 1.5px stroke. Sizes 14 / 16 / 20px (inline in body, sidebar, modal headers respectively). 100ms hover fade to `accent-violet` or context-sensitive accent; no size change on hover. Causa-specific custom icons: `◆` cascade root, `●` filled node, `○` hollow node, `◉` selected node, `↺` rewind, `🎙` voice.
+
+### Motion + animation
+
+Animation communicates, not decorates. Three durations: **quick** (100ms: hover, focus rings), **standard** (200–250ms: panel switches, scrubber drag-snap, sidebar collapse), **slow** (400–600ms: diff flashes, error pulses, the 320ms Causa slide-in). Easings: default `cubic-bezier(0.4, 0, 0.2, 1)`; entering `cubic-bezier(0, 0, 0.2, 1)`; exiting `cubic-bezier(0.4, 0, 1, 1)`.
+
+Specific motions: panel switch 180ms cross-fade; detail diff flash 400ms yellow→transparent; error pulse single 600ms expand-fade red ring (no looping); machine-active state 1.2s gentle scale 1.0→1.05→1.0 (only continuous animation in chrome, only on the machine chart node); co-pilot streaming typewriter ~25 chars/sec.
+
+**Reduced motion** respects `prefers-reduced-motion: reduce`: all durations clamp to 0 except a 1-frame opacity tween where layout needs to settle. The error pulse becomes a static red ring for 1.5s; the machine-pulse stops entirely.
+
+### Density gradient
+
+Three settings. Affects:
+- **Compact:** font sizes shrink 1px; vertical paddings 50%; sidebar 160px wide; pill 20px; epoch ticks 4px gap.
+- **Cosy** (default): the spec everything else in this doc references.
+- **Comfy:** font sizes grow 1px; vertical paddings 150%; sidebar 224px wide; pill 28px; epoch ticks 6px gap.
+
+What does *not* change between densities: icon weights, border radii, animation durations, accent colours. Density is a vertical-rhythm knob, not a redesign.
+
+### Theming as a token system
+
+All values above are CSS custom properties under a single root. Themes are 50-line CSS files. Users can drop a custom theme via Settings → Theme → Load CSS. Default theme files are bundled; the runtime exposes `(rf.causa/load-theme css-string)` for programmatic loading (handy for editor-driven palette sync).
+
+---
+
+## §6 — Keyboard and command palette
+
+### Shortcut map (complete)
+
+**Global (always active when Causa is open):**
+
+| Key | Action |
+|---|---|
+| `Ctrl+Shift+X` | Toggle Causa |
+| `Ctrl+Shift+P` | Pop out to separate window |
+| `Ctrl+K` | Command palette |
+| `?` | Keyboard cheat-sheet |
+| `,` | Settings |
+| `Esc` | Close modal / collapse popover / focus canvas |
+| `Ctrl+Shift+/` | Toggle co-pilot rail |
+| `Ctrl+F` | Find within active panel |
+
+**Navigation (within Causa, when focus is on chrome or panel):**
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Next / previous in any list (event log, scrubber positions, sidebar) |
+| `g g` | Jump to top |
+| `G` | Jump to bottom |
+| `[` / `]` | Previous / next epoch (rebases detail panel without rewinding live app) |
+| `Shift+[` / `Shift+]` | Previous / next cascade root |
+| `Tab` / `Shift+Tab` | Move between regions (sidebar / canvas / co-pilot) |
+
+**Panel jumps (mnemonics):**
+
+| Key | Panel |
+|---|---|
+| `e` | Events |
+| `a` | App-db |
+| `c` | Causality graph |
+| `s` | Subscriptions |
+| `f` | Effects (fx) |
+| `t` | Trace |
+| `m` | Machines |
+| `w` | floWs |
+| `p` | Performance |
+| `i` | Issues |
+| `r` | Routes |
+| `S` | Schemas |
+| `h` | Hydration |
+| `/` | Co-pilot (with input focused) |
+| `,` | Settings |
+
+(`a` was chosen over `d` for App-db so the more-frequent app-db opens cheaply; `w` over `f` for Flows so `f` stays for fx.)
+
+**Event actions (when an event/epoch is focused):**
+
+| Key | Action |
+|---|---|
+| `Enter` | Open detail |
+| `o` | Open source in editor (URL handler) |
+| `R` | Re-dispatch this event |
+| `r` | Rewind to before this event (calls `restore-epoch`) |
+| `Shift+r` | Hard rewind (with `restore-epoch` failure modes shown) |
+| `f` | Filter the causality graph to this dispatch's cascade |
+| `Ctrl+C` | Copy event vector to clipboard |
+| `Ctrl+Shift+C` | Copy source coord |
+
+**Scrubber:**
+
+| Key | Action |
+|---|---|
+| `Space` | Toggle play (auto-step at 500ms intervals) |
+| `Shift+Space` | Slow play (1000ms intervals) |
+| `0` | Jump to oldest epoch |
+| `$` | Jump to newest epoch |
+| `*` | Pin a snapshot at current epoch |
+
+**Co-pilot:**
+
+| Key | Action |
+|---|---|
+| `/` (from chrome) | Focus co-pilot input |
+| `Enter` (input focused) | Submit |
+| `Shift+Enter` | New line in input |
+| `Ctrl+L` | Clear conversation |
+| `Ctrl+P` | Previous question |
+| `Ctrl+N` | Next question |
+
+### Command palette (`Ctrl+K`)
+
+The spine of expert workflows. Every interaction is reachable from here, fuzzy-search.
+
+**Indexed sources** (matched together, recency-weighted, command-boosted): recent events (200-entry buffer; matches event-id + source coord), registered handlers (id + `:doc`), frames, machines with current state, flows, subs, panel names, command verbs (Rewind / Re-dispatch / Snapshot / Filter / Pin / Pop-out / Switch frame / …), settings entries, recent co-pilot questions. Fuzzy match splits on camelCase / kebab-case / namespace boundaries.
+
+**Empty palette is never empty.** With no input, the top of the list shows context-aware suggestions — actions for the active panel, "Open source" / "Rewind here" when an event is selected, "Investigate :rf.error/handler-exception" when a fresh error landed.
+
+**Rows.** 40px tall (compact 32, comfy 48): 16px type icon, label, right-aligned hint (`epoch 11`, `events.cljs:213`, shortcut). Arrows; Enter invokes; `Ctrl+Enter` invokes in a pop-out.
+
+### How experts move
+
+Hands stay on the keyboard. A common expert pattern:
+- `Ctrl+Shift+X` (open).
+- `Ctrl+K`, type `submit` (palette filters to events containing "submit"), `↓ Enter` (select the second one).
+- Causa jumps to that event's detail. Cascade visible inline.
+- `c` (graph), then `r` (rewind to here).
+
+Total time: ~3 seconds. Three keys + one term.
+
+### Discoverability for new users
+
+Three layers:
+
+1. **The `?` cheat-sheet.** A modal showing every shortcut. Discoverable from the top strip (`?` icon). On first open, Causa flashes a 800ms violet ring around the `?` icon for one cycle (then never again).
+
+2. **Empty-state hints.** When a panel is empty, the empty state shows a contextual keyboard hint: "No events yet. Press `Ctrl+Shift+X` again to close, or click your app." When an event is selected for the first time, a popover (4-second auto-dismiss) suggests "Press `c` for the causality graph."
+
+3. **The command palette itself.** Typing `?` in the palette filters to commands and shows their shortcuts. The palette is the doc.
+
+We do not ship a tour or onboarding flow. Per the §11 anti-temptations: Causa is a tool, not an experience.
+
+---
+
+## §7 — Empty states and edge cases
+
+### First-time use
+
+Before the user has interacted with the app, the main canvas shows:
+
+```
+┌─ event 0 ─────────────────────────────────────────────────╮
+│   Causa is watching.                                       │
+│   No events yet. Click around your app — every dispatch   │
+│   will land here.                                          │
+│                                                           │
+│   ▸ Open the keyboard cheat-sheet                  ?      │
+│   ▸ Open the command palette                       ⌘K     │
+│   ▸ Try the co-pilot                              ⌃⇧/     │
+│                                                           │
+│   Tip: ] jumps to the most-recent epoch from anywhere.    │
+╰───────────────────────────────────────────────────────────╯
+```
+
+The strip shows a single hollow circle labelled `(boot)` for the framework's boot epoch. The sidebar shows hot panels at top, conditional panels dimmed, dormant panels (Schemas, Hydration) marked with `◌`. After first interaction, the tips disappear; "No events yet" persists until first dispatch.
+
+### No errors / no schema violations / no SSR
+
+These panels still appear in the sidebar with `◌`. Clicking shows a graceful empty state explaining the feature and linking to docs. Example for Schemas:
+
+```
+   No schemas registered.
+   Once your app registers schemas via :app-schemas (Spec 010),
+   validation events will appear here:
+   • Schema violations
+   • Path-typed lookups
+   • Schema-replaced-with-default events
+   → Read about schema integration
+```
+
+No marketing — just a pointer for users who didn't know the feature exists.
+
+### Many panels are empty most of the time — the discoverability problem
+
+Per rf2-buor's §Self-criticism. 16 panels, ~6 always-active, ~5 conditional, ~5 dormant. The risk: **the sidebar feels cluttered; dormant panels feel like dead weight.**
+
+Solution (concrete):
+
+1. **Three sidebar groups, separated by dividers.**
+   - **Always-active** (Events / App-db / Causality / Subscriptions / Effects / Trace): always shown, always pinned at top.
+   - **Conditional with activity** (Machines / Flows / Performance / Issues / Routes): shown when activity has occurred in the session, marked with activity badges. When no activity, collapsed under a `+5 more` row.
+   - **Always-dormant** (Schemas / Hydration / Co-pilot / Settings): shown but visually de-emphasised (`text-tertiary` colour, `◌` indicator) until activity occurs.
+
+2. **Right-click sidebar → "Show all panels."** Power-users get the full list. Persisted.
+
+3. **Activity-driven re-sorting (off by default; opt-in in Settings).** "Surface most-active panels at top." Helpful for users with one machine-heavy app and another schema-heavy app.
+
+4. **The `+5 more` row.** Above the always-dormant divider, a single row collapses unused conditional panels. Clicking expands inline. This solves "the sidebar feels too long" without burying anything.
+
+### Long debug sessions — when does it feel sluggish?
+
+Causa's targets (per rf2-buor §8):
+- Trace buffer 200 entries.
+- Epoch history 50 per frame.
+- App-db diff O(changed paths).
+- Causality graph caps at 200 dispatches.
+
+When the user is approaching limits:
+- **Epoch history fill ratio** shown in the bottom rail (`11/50 epochs` early in session; `49/50 epochs` near full). Hover → "Older epochs will age out. Increase depth in Settings.")
+- **Trace buffer fill** is visible in the Trace panel (`190/200`).
+- When **a single epoch's render takes > 50ms** (the causality graph re-laying out, the app-db tree expanding a 100k-node sub-tree), Causa shows a one-time toast: "Rendering is slowing. Consider reducing scrubber range or filtering events." Click → opens Settings → Performance.
+
+We **do not** ship a "Causa is using N% of your runtime" indicator. The runtime cost is fixed (Spec 009 guarantees µs-scale) and a percentage indicator would imply the user has a per-cycle decision to make. They don't.
+
+### Multi-frame apps — 1 / 3 / 10 frames
+
+- **1 frame:** picker is a static label (`:app/main`). No dropdown clutter.
+- **3 frames:** picker is a dropdown with current at top and recent-event timestamps for the others. Switching re-binds every panel in <200ms.
+- **10 frames** (Story apps, multi-frame SaaS): dropdown becomes a search box; type-to-filter; most-recently-active at top. A "show all frames" button opens a Frames panel listing every frame's epoch count, last activity, current state.
+
+**Cross-frame events.** When a dispatch in frame A causes a dispatch in frame B (cross-frame fx per Spec 002), the causality graph shows both frames as swimlanes with explicit cross-lane arrows. Causality strip pills get a thin coloured ring indicating frame. No other JS tool can render this.
+
+### Frame destroyed mid-look
+
+Per Tool-Pair's destroyed-frame contract. The panel shows a banner ("Frame `:story.auth/login-form` was destroyed"), the picker auto-switches to the next-most-recently-active frame, the bottom rail shows "Last epoch: 11. Buffer aged out 0 epochs." The panel is not auto-closed — the user can still scrub the destroyed frame's history.
+
+### Production builds
+
+Per Spec 009, Causa's surface elides in prod (`goog.DEBUG=false`). The launch button doesn't render; `Ctrl+Shift+X` does nothing. CI verifies via `npm run test:elision`. In a non-elided dev build running in production-like conditions, Causa shows a yellow top banner: "Causa is enabled in this build. Disable for production." Single-click dismiss, remembered for the session.
+
+---
+
+## §8 — AI co-pilot UX specifics
+
+The co-pilot panel is **detachable**, **rail-by-default**, **never full-screen-mandatory**.
+
+### Input affordances
+
+**Primary: text.** A multiline `<textarea>`-equivalent (auto-grows to 8 lines). Submit on `Enter` (without modifiers). `Shift+Enter` for new line. Maximum 1000 characters; soft warning at 800.
+
+**Slash commands.** Typing `/` at the start opens a command dropdown:
+- `/explain <event-id-or-epoch>` — describe one epoch.
+- `/diff <epoch-a> <epoch-b>` — what changed between two epochs?
+- `/find <pattern>` — search the trace stream.
+- `/rewind <event-or-epoch>` — propose a rewind (executes on confirmation).
+- `/state <machine-id>` — describe a machine's current state.
+- `/why <epoch>` — causal-ancestor walk.
+- `/whatif <hypothetical>` — speculative reasoning (the model warns it's reasoning, not measuring).
+- `/clear` — clear conversation.
+
+**Voice (browser STT).** A `🎙` button next to the submit arrow. Click → uses `webkitSpeechRecognition` / `SpeechRecognition` API. Streaming transcription appears in the input field. Click again or press `Esc` to stop. Voice is **not** sent to a server; the browser does the transcription. Defaults off; opt-in per session.
+
+### Result formatting
+
+Responses are markdown rendered with:
+
+- **Code blocks** in mono with syntax highlighting (cljs / edn / json).
+- **Source-coord chips.** `src/cart/events.cljs:213` renders as a chip with a `🔗` icon; click opens the source.
+- **Action chips.** `[Open source]`, `[Show graph]`, `[Rewind here]`, `[Filter to this cascade]` — inline buttons in the response.
+- **Embedded data.** Small data structures (an app-db slice, a 5-row table) render with the same chrome as the main panels. 200px max height; expandable.
+- **Mini-graphs.** A causal chain renders as a 5-node mini graph using the same SVG primitive as the Causality panel; click opens the full panel filtered to that cascade.
+
+Responses are **streamed** (per token, ~25 tokens/sec). First words within ~600ms of Enter. Respects `prefers-reduced-motion`.
+
+### Conversation history
+
+**Per-session by default** (cleared on reload). Optional cross-session persistence to localStorage (opt-in; capped at 1000 turns; oldest evict). Default is per-session because conversation may contain sensitive app data.
+
+`Ctrl+P` / `Ctrl+N` walk previous/next questions. `Ctrl+R` searches within conversation (distinct from global `Ctrl+F`).
+
+### Provider switching
+
+A `⌗` icon next to the panel title opens a dropdown: Claude (default), OpenAI, Gemini, Local (Ollama), Custom. Each uses the user's API key, configured in Settings → AI Provider. Keys are stored locally only. Switching is live; conversation history is sent to the new provider as context.
+
+### Tone / personality
+
+**Direct, observational, programmer-to-programmer.** No preambles, no apologising, no hedging. The system prompt encodes: "You are a debugger's assistant. The user wants answers, not conversation. Cite source coords. Say 'I can't determine that' plainly when you can't. One action at a time. Never invent data. Short answers; detail only when asked." User-editable in Settings → AI Provider → System prompt.
+
+### When the agent is wrong
+
+Three error states:
+
+1. **API error** ("rate limit hit", "network failure"). The panel shows a red banner: "Couldn't reach Claude. Retry in 30s? [Retry now] [Switch provider]." The user's question is preserved.
+
+2. **Model says "I don't know."** The model returns "I can't determine that from the trace I have access to. The trace buffer has the last 200 events. You can see them in the Trace panel. [Open Trace]." No hallucination. Failure case is a navigation aid.
+
+3. **Model is confidently wrong.** Hardest case. The user has to recognise this — there's no automatic detection. Mitigation: every claim the model makes references data the user can verify (source coords, epoch ids, event vectors). When the model says "epoch 10 dispatched `:cart/finalise`," the user can click that link and see whether it's right. If a claim doesn't link to data, it's a tell.
+
+The **failure mode design**: the co-pilot is **a navigator, not an oracle.** It points at the data; the user verifies. We design every response to surface its evidence.
+
+---
+
+## §9 — Empty-panel discoverability
+
+Covered in §7 (the third group treatment, the `+5 more` collapse, the right-click "Show all panels"). Two reinforcing details:
+
+### Activity badges as the primary signal
+
+Each conditional or dormant panel shows an activity indicator:
+- `●` (filled): activity now or in last 5 seconds.
+- `●N` (numbered): unread count (3 issues, 5 schema violations).
+- `●●●`: multiplicity (3 machines currently running).
+- (hollow `◌`): no activity this session.
+- (no badge): always-active panel (Events / App-db / etc.).
+
+Badges fade in (200ms) on first activity; never fade out — the dot persists for the session as a "this panel has data" signal.
+
+### Power-user enable-all
+
+Settings → Sidebar → **"Show all panels even when dormant"** (toggle). Persisted per-machine. For programmers who want every option on screen.
+
+The hidden assumption to surface: **most users want the simpler view.** The default is "hide what isn't doing anything." The toggle is for the rare user who wants visibility into every option.
+
+### Dormant-but-suggested
+
+Some panels can be dormant *and* highly relevant. Example: a user is debugging a hydration mismatch but hasn't opened the Hydration panel yet. When `:rf.ssr/hydration-mismatch` first fires:
+- The Hydration sidebar entry's icon flashes red for 600ms.
+- The Issues badge increments.
+- The Co-pilot, if active, suggests "I see a hydration mismatch. Open the Hydration panel? [Yes]."
+
+We **don't** auto-open panels. The user is in control of their canvas. We just flag.
+
+---
+
+## §10 — Visual identity
+
+### The mark
+
+A single icon: **three nodes connected by arrows from one parent**. The cascade gesture, abstracted.
+
+```
+       ●
+      ╱│╲
+     ● ● ●
+```
+
+Stroke: 2px. Nodes are 5px circles, filled in the accent violet. Connecting strokes arc slightly downward (a 4px curve) rather than running straight — gives the icon a sense of motion, like the cascade is unfolding.
+
+At favicon size (16×16), the curves disappear; it becomes three filled dots with straight lines. At 32×32, the curves return. At 256×256 (README hero), the icon is a confident gesture: one parent node, three children, the violet of `:origin :pair` carried through (per the rf2-buor §12 visual identity lock).
+
+### The wordmark
+
+**Causa** in Inter, 800 weight, all-lowercase, with a slight letter-spacing tightening (-0.02em). Below it, in 14px 400 weight, the tagline: *the cascade you can see.* (Italicised, dimmer.)
+
+Logo + wordmark stack uses:
+- Light backgrounds: violet `#7C5CFF` icon, charcoal `#1B1E24` text.
+- Dark backgrounds: violet `#9B7EFF` (a brighter violet for contrast), white text.
+
+### The Causa launch button
+
+In re-frame apps, the launch button is a small floating action — when Causa is closed, a 48×48px circular button in the bottom-right corner of the viewport (z-index pinned just below modal overlays, above app content). The icon centred. Subtle 1px violet ring at 60% opacity on idle. Pulses softly when there's an active error in the issues feed (600ms expand-fade pulse, every 4s, max 3 pulses then stops).
+
+`Ctrl+Shift+X` is the primary; the button is the discoverable secondary.
+
+Click → Causa opens (same animation as keyboard shortcut). Right-click → contextual mini-menu (Open / Pop out / Settings / Hide button).
+
+The button itself is **hideable** (settings option for users who only use keyboard). Hidden state persists per-app.
+
+### The favicon
+
+When the standalone viewer is running (remote-attach mode), the page favicon is the mark. 16×16 and 32×32 sizes; both PNG. The 32×32 version uses the curved connecting strokes; the 16×16 falls back to straight lines.
+
+### Standalone viewer chrome
+
+The standalone HTML page (per rf2-buor §8) has its own chrome:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  ●╲│╱●  Causa                                          ⌗ Connected to localhost:9710  │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  [ the standard Causa layout fills the rest of the page ]                    │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+A title bar with the mark, the wordmark, and the WebSocket connection indicator. Connected = green dot; Reconnecting = amber spinner; Disconnected = red dot + "Reconnect" button. The rest of the page is the standard Causa layout.
+
+### README hero image
+
+A 1200×630px PNG (Open Graph dimensions). Dark theme. The mark on the left at 256×256, the wordmark + tagline below. On the right, a screenshot of Causa mid-session: the causality strip, an event detail panel, and a fragment of the co-pilot showing "It was dispatched by an `:fx [[:dispatch ...]]` inside the `:cart/finalise` handler..." The screenshot is real (not mocked); generated from a sample app shipped in `examples/`.
+
+No marketing copy in the image. The product is the screenshot.
+
+---
+
+## §11 — What this design deliberately doesn't do
+
+Temptations rejected:
+
+- **No telemetry sent home.** Causa transmits nothing to Day8, Anthropic, or anywhere. The co-pilot calls the user's chosen provider directly with the user's API key. Settings has a "Telemetry" section that exists solely to state this.
+- **No AI-generates-code.** The co-pilot reads state and explains causality. It does not write tests, handlers, sub functions, or code. Code generation belongs to re-frame-pair (editor-side authority).
+- **No video / session replay.** No DOM mutation recording, no frame-by-frame visual replay. The scrubber is event-driven time-travel, not visual time-travel. (Sentry / Replay.io stay in their lane; Causa stays in re-frame's data plane.)
+- **No "AI debugger that thinks for you."** The co-pilot is a navigator pointing at evidence; the user decides. Never framed as "Causa figures out the bug."
+- **No mobile / phone surface** (§10.9 lock). < 600px refuses to mount.
+- **No Chrome extension** (§10.3 lock).
+- **No session export / import** (§10.5 lock).
+- **No fork-from-here** (§10.5 lock).
+- **No in-place app-db editing** (§10.4 lock).
+- **No onboarding tour.** The empty state is the onboarding. The cheat-sheet is the manual.
+- **No dark patterns.** No "rate Causa," no upsell, no marketplace.
+- **No third-party plugins at v1.** Every panel is first-party. (Future versions may expose a panel-registration API.)
+
+---
+
+## §12 — Open questions for Mike
+
+Decisions that require Mike's call, not a designer's:
+
+**§12.1 Detail-panel-as-hero (§4).** This design demotes the causality graph from hero to peer. The bet: habit beats demo. The risk: the graph is the screenshot people love; demoting it costs marketing. If you'd rather flip it (graph as default canvas, detail as side popover), the design rearranges cleanly.
+
+**§12.2 Co-pilot default state.** **Locked 2026-05-11: open by default.** The marquee-pull argument wins — Causa's pitch hinges on the AI co-pilot being immediately visible, not hidden behind a shortcut. User can close the rail (it remembers the choice across the session).
+
+**§12.3 The launch button (§10).** A 48×48px floating button in the bottom-right when Causa is closed. Discoverable secondary to `Ctrl+Shift+X`. Some JS devtools don't ship one (Redux, Vue). Keep, drop, or default-hidden-with-settings-toggle?
+
+**§12.4 Source-coord click-through fallback.** Editors with URL handlers (`vscode://`, `idea://`) work out of the box. Editors without (Vim, Emacs, Sublime) fall back to "copy coord to clipboard." Is clipboard enough, or do we ship per-editor preset configurations in Settings?
+
+**§12.5 Conversation persistence default.** Per-session (cleared on reload) in this design — opt-in to localStorage. Privacy bet vs. utility bet. Per-session or persistent-with-opt-out?
+
+**§12.6 Voice STT at v1.** Fully implementable (browser-local, no service dependency) but niche. Ship at v1 or defer to v1.1 to reduce launch surface?
+
+---
+
+## Closing — the bar
+
+The bar this design sets: a programmer hits `Ctrl+Shift+X`, sees the cascade their last click triggered in the detail panel, asks "why?" — either in their head (and finds it via `caused-by` + the inline mini-graph) or out loud (to the co-pilot) — and has the answer in 5 seconds. Causa earns its keep at that bar.
+
+If a panel doesn't help answer "why?" or "what happened?" or "what's broken?", it doesn't ship. We could pile features. Restraint is what keeps the tool habit-forming instead of impressive.
+
+The headline isn't "we built a 16-panel debugger." The headline is "the cascade you can see — and the question you can ask."
+
+— end of UX design draft —

--- a/tools/10x/spec/findings/re-frame-10x-v2-design.md
+++ b/tools/10x/spec/findings/re-frame-10x-v2-design.md
@@ -1,0 +1,615 @@
+# re-frame-10x v2 — Design From a Blank Slate
+
+> Bead **rf2-buor (P2 research).** Local-only working draft for Mike to iterate on. **Not committed; not normative; not a port.** The exercise: imagine re-frame-10x's successor with re-frame2's instrumentation as the substrate and 2026-class devtools expectations as the bar. Be bold; flag what's speculative.
+>
+> Companion docs: [`re-frame-2-story-feature-set.md`](re-frame-2-story-feature-set.md) (rf2-m6tu) and [`re-frame-2-story-sota-refinement.md`](rf2-94b0). Substrate this consumes: [Spec 009 Instrumentation](../spec/009-Instrumentation.md), [Spec Tool-Pair](../spec/Tool-Pair.md), [Spec 002 Frames](../spec/002-Frames.md), [Spec 005 Machines](../spec/005-StateMachines.md), [Spec 013 Flows](../spec/013-Flows.md), [Spec 011 SSR](../spec/011-SSR.md), [Spec 010 Schemas](../spec/010-Schemas.md), [Spec 012 Routing](../spec/012-Routing.md), [Spec Runtime-Architecture](../spec/Runtime-Architecture.md).
+
+## TL;DR — one paragraph
+
+**Causa** (the locked name; was working title for re-frame-10x v2) is a re-frame2-native debugger that treats every drain cycle as a **causal narrative** — an event, the cascade it triggered, the state delta it produced, the subs and views that recomputed, the effects that fired, the machines that transitioned, the schema checks that ran. The marquee surface is a **causality graph** keyed by `:dispatch-id` / `:parent-dispatch-id`, scrubbable across epochs, navigable across frames, with click-to-source on every node and a built-in AI co-pilot that can answer "why did this fire?" in plain English. v1's 10x organised around the epoch panel; v2 organises around the *story* a cascade tells — and reuses re-frame2's pre-folded `:rf/epoch-record` projections (`:sub-runs` / `:renders` / `:effects`) so the framework does the work and the tool renders it. Machine state-charts, flow heatmaps, schema timelines, hydration diff, performance ribbon, and the AI co-pilot are all panels over the same trace bus; one substrate, many views.
+
+---
+
+## §1 Problem statement
+
+### What re-frame-10x v2 is for
+
+**A debugger that explains the runtime to the human in the runtime's own terms.** When a re-frame app misbehaves, the debugger should let the programmer ask — and answer — five canonical questions:
+
+1. **Why did this event fire?** (causal-ancestor walk)
+2. **What did that event change?** (`app-db` diff + flow recomputes + machine transitions)
+3. **Why is this subscription returning the wrong value?** (input-chain trace + cache state)
+4. **Why is this view re-rendering?** (subscription invalidation chain + render-key attribution)
+5. **What's currently broken?** (errors, warnings, schema violations, hydration mismatches — surfaced as one feed)
+
+v1 of 10x answered #1–#4 partially and #5 not really. The bar in 2026 is **all five, answerable in seconds, with click-to-source for every artefact**.
+
+### Who uses it
+
+- **The re-frame programmer mid-feature.** Building, breaking, fixing. Wants the trace ribbon in their face but unobtrusive; wants click-to-source from anywhere; wants to scrub.
+- **The re-frame programmer reading an unfamiliar codebase.** "Why does clicking *Save* eventually re-render this card three modules over?" Wants a causal graph.
+- **The on-call programmer triaging a production-shaped repro.** Wants to load a session, scrub, find the divergence.
+- **The AI agent driving the runtime via re-frame-pair / Story / MCP surfaces.** Doesn't open the UI itself but consumes the same data through the same primitives — re-frame-10x v2 and the agent surfaces are siblings, not parent/child.
+
+### What jobs it does that nothing else does well
+
+- **Causal cascades across frames.** Redux DevTools is single-store; XState Inspector is per-machine; React DevTools is component-shaped. None of them shows the full cascade: dispatch → handler → fx → re-dispatch → machine transition → flow recompute → sub recompute → render. re-frame2 sees all of it; 10x v2 *shows* all of it.
+- **Time-travel that survives schema evolution.** re-frame2's `restore-epoch` has six named failure modes (per [Tool-Pair §Time-travel](../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)). 10x v2 surfaces those failures structurally — "this rewind would break because schema `:auth` tightened since the snapshot."
+- **Live machine state on a stately-quality chart, embedded in the same surface as event traces.** Stately Inspector is great; it's also a separate tab in a separate tool. 10x v2 unifies it with the event log so a click on `:rf.machine/transition` jumps to the chart with the source state pre-highlighted.
+- **SSR/hydration debugging.** The render-tree hash diff per epoch, server-vs-client view side-by-side. No JS debugger does this because none of the JS frameworks make hydration mismatches structurally observable.
+
+**One-line pitch:** *Causa is a causality-graph debugger that answers "why did this happen?" for re-frame2 apps, built on Spec 009's trace bus and Tool-Pair's epoch contract.*
+
+---
+
+## §2 Lessons from the original re-frame-10x
+
+### What v1 did well — preserve
+
+- **Epoch as the unit of debugging.** v1's biggest correct call: organise UI around drain-settle boundaries, not raw trace events. The mental model — "every dispatch produces an epoch; an epoch tells a story" — is load-bearing. v2 keeps this and goes further (cascades that span epochs via `:parent-dispatch-id`).
+- **In-app, not Chrome-extension.** v1 lives in the DOM, talks to the runtime via direct function calls, has zero IPC latency. Chrome extensions pay for sandbox isolation in latency and capability. v2 inherits the in-app posture.
+- **Single keyboard shortcut to open.** `Ctrl+Shift+X` is muscle memory now. Keep it.
+- **The five-panel skeleton** — app-db / subs / event / trace / timing — covers the right surfaces; v2 grows it but doesn't rip it out.
+- **`app-db-follows-events?` mode.** The "scroll through epochs and watch app-db change" gesture is the single highest-value 10x affordance. v2 makes it the default.
+- **`:closure-defines` elision.** Zero production bytes. Non-negotiable; v2 inherits the contract (and gets it free from Spec 009's universal `interop/debug-enabled?` gate).
+
+### Where v1 hit limits — improve
+
+- **Single-frame assumption baked into the data shape.** v1 has `(rf/get-app-db)` and `(rf/sub :status)` — no frame parameter. Multi-frame apps fall off the model. v2 is frame-first: every panel has a frame picker; the epoch buffer is per-frame; the causality graph spans frames.
+- **No causal correlation across dispatch cascades.** v1 shows a flat event list; figuring out that event B was dispatched by event A's `:fx [[:dispatch [...]]]` requires reading the event handler. v2 has `:dispatch-id` / `:parent-dispatch-id` (per [Spec 009 §Dispatch correlation](../spec/009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id)) — causality is data, not detective work.
+- **App-db diff is shallow and slow on big dbs.** v1's diff highlights changed keys but doesn't handle deep nested change well; on a 50MB app-db it's noticeable. v2 uses structural-sharing diff (PersistentHashMap pointer-equality at each level) — O(changed paths), not O(db size).
+- **Subscription view is hard to read at scale.** v1 lists every sub run with timing; on a complex app this is hundreds of rows. v2 collapses by sub-id with hit/miss/recompute counts, expands to per-run on click, and uses `:rf/epoch-record`'s `:sub-runs` projection (per [Tool-Pair §Time-travel](../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)) so the framework does the folding.
+- **The trace panel is a firehose.** v1's raw trace stream is hard to filter; the search is substring-y; long sessions get sluggish. v2 has structured filters (`:op-type`, `:operation`, `:frame`, `:dispatch-id`, `:origin`) routed off Spec 009's stable vocabulary, plus a saved-filter library.
+- **No notion of "what's broken right now."** v1 has no error feed. Failed dispatches surface as a console.error if you happen to be looking. v2 has a permanent **issues ribbon** (errors + warnings + schema violations + hydration mismatches) that flashes on new entries.
+- **Pop-out window is half-broken.** Cross-window input issues, focus-stealing, doesn't survive reload. v2's "pop out" is a real second window driven by `BroadcastChannel` (same browser, in-process).
+- **Settings persistence in localStorage gets corrupted.** Multiple GitHub issues. v2 stores settings under a schema'd shape with a `:rf/version` stamp; corruption triggers a clean reset with a user-visible notice.
+
+### Known pain points — fix
+
+- **"Why did this event fire?" requires reading the source.** Causal-ancestor walk is the single largest UX win in v2.
+- **"Why is this sub returning stale?"** v1 shows the value but not the input chain. v2: click a sub, see its layer-1/2/3 inputs and their values, walk upward.
+- **"Why is this view re-rendering?"** v1 shows `:view/render` events. v2 attributes via `:render-key` ([Spec 004 §Render-tree primitives](../spec/004-Views.md#render-tree-primitives)) and shows the subscription invalidation that triggered the re-render.
+- **Hot-reload churn.** Every save re-registers handlers; v1's event log fills with `:registry/handler-replaced` noise. v2 has a "hide registry churn" toggle (default on during dev sessions).
+- **`dispatch-sync` inside a handler errors are confusing.** v2 surfaces them as a first-class **issue card** with a fix-it suggestion ("convert to `:fx [[:dispatch [...]]]`").
+
+### Features that piled up but never landed — consider
+
+From scanning v1's issue tracker and the wiki:
+
+- **External event timeline integration** (network requests, RAF, long tasks) — v2 has the **performance ribbon** (§4).
+- **Subscription dependency graph viz** — v2 has the **subscription graph panel** (§6).
+
+### Performance constraints
+
+v1's tracing cost is real on hot dispatches. v2 inherits Spec 009's compile-time elision (zero prod cost), but at *dev* time we need to be careful:
+
+- **Trace buffer depth defaults to 200** (per Spec 009). 10x v2's UI never reads from anywhere else for "recent history" — no parallel ring buffer. Configurable to 1000 for deep sessions.
+- **Epoch history depth defaults to 50** (per Tool-Pair). Configurable. 10x v2 shows the depth and a "fill ratio" so users know if they're aging out epochs faster than they're inspecting them.
+- **Sub-cache panel** never holds references to cached values longer than the rendering frame (avoid extending sub lifetimes via the debugger).
+- **App-db viewer** virtualises deep trees (lazy expansion past 100 keys).
+- **The causality graph view** caps at the last 200 dispatches by default (matches trace buffer); deeper views require explicit "load older."
+
+---
+
+## §3 What re-frame2 unlocks
+
+The framework grew capabilities since v1 that fundamentally change what's debuggable. Each row below is "new in re-frame2 → new tooling story 10x v2 must tell."
+
+| re-frame2 capability | New tooling story |
+|---|---|
+| **Multi-frame** ([002](../spec/002-Frames.md)) | Per-frame panels with a frame picker; cross-frame causality graph; the same sub-id can have different values in different frames and the tool must show this. |
+| **Machines** ([005](../spec/005-StateMachines.md)) | Stately-quality state-chart per machine, live-highlighted; transition log keyed by machine; `:invoke-all` parallel-child viz; `:after` timer countdown indicators; microstep replay. |
+| **Flows** ([013](../spec/013-Flows.md)) | Flow dependency graph; per-flow recompute count; "this flow ran *N* times this session" heatmap; the `:rf.flow/skip` (rf2-719e value-equal recompute suppression) badge so devs can see when flows are correctly *not* running. |
+| **Source-coord stamping** ([001](../spec/001-Registration.md), [006](../spec/006-ReactiveSubstrate.md)) | **Click-to-source everywhere.** Every registered id, every DOM node (via `data-rf2-source-coord`), every machine guard/action/transition (via `:rf.machine/source-coords`). Source location surfaced as copyable `file:line` chips — the user opens the file in their editor of choice. No protocol-handler dependency. |
+| **Trace bus** ([009](../spec/009-Instrumentation.md)) | The substrate of everything. Open shape, stable vocabulary, `:op-type` discriminator. 10x v2 does not invent its own trace shape — it consumes Spec 009. |
+| **Epoch history + `:rf/epoch-record` projections** ([Tool-Pair](../spec/Tool-Pair.md)) | First-class time-travel; per-frame epoch scrubber; pre-folded `:sub-runs` / `:renders` / `:effects` so the tool doesn't refold the raw trace. |
+| **`reset-frame-db!`** ([Tool-Pair §Pair-tool writes](../spec/Tool-Pair.md#pair-tool-writes--state-injection)) | "Edit app-db live" affordance — type a JSON value into the panel, the runtime takes it. Records a synthetic epoch so the change is undoable. |
+| **Six named restore failures** | Structured "this rewind won't work because X" rather than a silent no-op. |
+| **`register-epoch-cb`** | The assembled-per-cascade listener is what 10x v2 routes off; cheaper than raw-stream re-folding. |
+| **Tool-Pair surface** | 10x v2 *and* re-frame-pair *and* Story consume the same primitives. No 10x dependency from the agent tools. 10x v2 is a peer, not a parent. |
+| **Schemas (Malli)** ([010](../spec/010-Schemas.md)) | Real-time schema-violation feed with five named recovery modes; "the schema for this path is X" tooltip on every app-db key; live `app-schemas-digest` shown so devs notice schema drift between dev and SSR. |
+| **SSR + hydration** ([011](../spec/011-SSR.md)) | Hydration-mismatch debugger — server render tree vs client render tree, structural diff, click-to-source on the divergent node. The `:rf.ssr/hydration-mismatch` trace is the entry point. |
+| **Routing** ([012](../spec/012-Routing.md)) | URL ↔ frame state visualisation; the `:rf/route` slice rendered as a breadcrumb above the app-db tree; nav-token timeline showing stale-result suppression in flight. |
+| **`:origin` opt on dispatch** | Filter the event log by actor ("show me only the dispatches Claude issued this session"). Pair-tool / Story / human dispatches are all distinguishable. |
+| **Performance API (`rf:*` `User Timing` measures)** | The performance ribbon reads `PerformanceObserver` directly — no re-frame2 API call needed; works in prod too if the opt-in flag is on. |
+| **Production-elision verifier** | 10x v2 can run `npm run test:elision` in-process and show "your build will ship *N* bytes of dev-only sentinels" — i.e. detect leaks before deploy. |
+
+The architectural shift: in v1, 10x had to *invent* observability surfaces because the runtime had few. In v2, the runtime emits structured data for every interesting moment; 10x's job is *presentation*.
+
+---
+
+## §4 Headline experiences (the marquee features)
+
+Seven bold things. Each one is something a programmer should stop and say "wait, what?" at.
+
+### 4.1 Causality graph view
+
+The hero feature. A directed graph where:
+
+- **Nodes** are dispatches (one per `:event/dispatched` trace), effects (one per `:fx` outcome), and significant traces (machine transitions, schema violations, hydration mismatches).
+- **Edges** are causal: `:parent-dispatch-id` links a child dispatch to its parent; an effect node's edge points to the dispatch it ran inside; a machine transition node's edge points to the event that triggered it.
+- **Colours** encode `:op-type`. Errors are red and pulse for 3 seconds when they land. Pair-tool dispatches (`:origin :pair`) get a violet halo.
+- **Click a node** → side panel shows the trace event, its `:tags`, the source coords, the affected sub-cache slots, the resulting `app-db` diff (if it was a dispatch).
+- **Drag a time range** at the top → graph filters to that range; the rest of 10x synchronises.
+- **A "find root cause" button** on any node walks upward until it hits a dispatch with no `:parent-dispatch-id` and highlights the path.
+
+*What it literally looks like:* a vertical timeline on the left (each tick is a dispatch); horizontal swimlanes per frame; arrows from parent dispatches to children; colour-coded dots for fx-handled / machine-transition / schema-violation; a faint background ribbon showing INP per frame. The whole graph is laid out top-down (older → newer); errors get a thick red border; the currently-selected epoch's nodes are slightly larger.
+
+*What I'm trading away:* this view is dense. Programmers used to a linear event log will need a moment. The mitigation is the **causality strip** — a flat horizontal version pinned at the top of every panel, so the graph is always one click away but never in the way.
+
+### 4.2 Time-travel scrubber
+
+A horizontal scrubber pinned to the bottom of the window. Drag left → app-db reverts; drag right → state advances. Scope is the current session — if the user reloads, that's a new session and the scrubber starts fresh.
+
+- **Per-epoch step** — every dispatch produces an epoch you can scrub to; the app-db tree, the event detail panel, and the causality graph all rebase live as you move.
+- **Pinned snapshots** — at any epoch, click a pin icon to capture a labelled snapshot to the scrubber's chip strip. Useful for "this is the state I want to come back to."
+- **Schema-mismatch handling**: if a restore would fail (per the six failure modes in [Tool-Pair §Time-travel](../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)), the scrubber shows the failure as an overlay with a "try anyway" affordance that loads the snapshot via `reset-frame-db!` (which bypasses cascade and schema-validates against the *current* schemas).
+
+*Trade-off:* the scrubber is bounded by `epoch-history` depth (default 50). Deeper sessions need to bump the depth in settings; beyond that, older epochs age out.
+
+### 4.3 AI co-pilot panel
+
+A pinned-right panel: a chat input above a scrollable result area. The co-pilot reads the same surfaces every other panel reads — `epoch-history`, `(rf/get-frame-db ...)`, `(rf/handlers ...)`, the trace bus — and answers programmer questions about the running app in natural language. Examples:
+
+- *"Why did `:checkout/submit` fire?"* → walks `:parent-dispatch-id` upward; returns "dispatched by `:fx [[:dispatch ...]]` inside `:cart/finalise` (events.cljs:213). That ran because of `:user/clicked-checkout` at 10:43:21. Want me to open the source?"
+- *"What's the current state of the auth flow?"* → reads `[:rf/machines :auth/login-flow]`; returns the snapshot; links to the machine inspector with that state highlighted.
+- *"Show me every dispatch that touched `[:cart :items]`."* → walks epoch history; diffs each `:db-after`; returns the filtered list.
+- *"Why is this view re-rendering when I click that button?"* → traces dispatch → db change → sub invalidations → re-renders; attributes by `:render-key`.
+
+The co-pilot is **frame-aware** (knows which frame the human is looking at), **epoch-aware** (knows the scrubber position), and **registrar-aware** (can read every registration's `:doc`, `:spec`, source coords).
+
+Calls the user's chosen LLM via their own API key, configured in Settings → AI Provider. The system prompt is wired with `(rf/handlers ...)` / `(rf/handler-meta ...)` / `(rf/app-schemas-digest ...)` shape so the model inherits framework conventions without being told. Default provider: Claude; swappable to OpenAI / Gemini / local Ollama / custom via a provider abstraction.
+
+Open by default (per UX §12.2 lock). Toggled via `Ctrl+Shift+/`; user can close the rail and Causa remembers the choice across the session.
+
+*Trade-off:* an AI panel in a debugger feels gimmicky if it's bolted on. The play is to make the co-pilot *cheaper than reading the source*. If it's not faster than `Ctrl+F`, it dies. The bar: 5 seconds from question to actionable answer for the five canonical questions in §1.
+
+### 4.4 Machine inspector with live state-chart highlighting
+
+Embedded XState-Inspector-quality visualisation. Built on the same primitives `tools/machines-viz/` will use ([per `tools/README.md`](../tools/README.md)). The relationship: 10x v2 *embeds* machines-viz's chart component as a panel (registered via the cross-tool embedding contract, mirroring how Story embeds 10x's epoch panel — see §9).
+
+What you see:
+
+- A directional state-chart of the active machine. Nodes are states (compound states nested visually). Edges are transitions, labelled with their event id.
+- The **current state pulses softly**. Compound states' active child is highlighted recursively.
+- **Hover an edge** → see the guard and action functions; click to jump to source.
+- **`:invoke` / `:invoke-all` spawned children appear as smaller machines next to their parent**, each with their own state.
+- **`:after` timers show a countdown ring** on the source state.
+- **Transition history** ribbon below the chart: a scrubbable list of the last *N* `:rf.machine/transition` events; clicking one rewinds the chart to that microstep.
+- **Source-coord stamping** ([rf2-8bp3](../spec/Tool-Pair.md#state-machine-source-coord-stamping-rf2-8bp3)) means every clickable element jumps to source.
+
+*Trade-off:* this is dense if the machine is large. We adopt Stately's expand/collapse compound-state idiom; we also auto-pan to the active state.
+
+### 4.5 App-db panel — slice-centric, not tree-centric
+
+Real app-dbs run 1–50MB. Rendering the whole tree on every dispatch is wrong: it competes for canvas real estate, virtualisation only partly helps, and **it's not what programmers actually want**. Programmers want to see **the slices that changed in this event**, plus a few slices they've pinned for watching.
+
+So the default view is exactly that — a stack of focused slice-mini-panels:
+
+```
+┌─ Slice 1: [:cart :items]  (modified) ─────────────┐
+│  before:  [{:id 7 :qty 1}]                        │
+│  after:   [{:id 7 :qty 1} {:id 22 :qty 1}]        │
+└────────────────────────────────────────────────────┘
+
+┌─ Slice 2: [:cart :totals :gross]  (added) ────────┐
+│  added:   $48.00                                  │
+└────────────────────────────────────────────────────┘
+
+┌─ Pinned slices ───────────────────────────────────┐
+│  [:user :auth :status]           :authenticated   │
+│  [:nav :route]                   :app/cart        │
+└────────────────────────────────────────────────────┘
+
+[Show full app-db tree ▸]
+```
+
+Properties:
+
+- **Touched-slices** come from `:rf/epoch-record`'s precomputed changed-paths set. Each mini-panel renders the path's `:db-before` + `:db-after` values side-by-side, with colour-coding (green added, yellow modified, red removed).
+- **Pinned slices** are user-watched paths. Right-click any value in the runtime → "Pin this slice"; the path is persisted to localStorage and rendered in this list across sessions.
+- **Reserved keys** (`:rf/machines`, `:rf/route`, `:rf/system-ids`, `:rf/pending-navigation`) get a clearly-marked `[runtime]` group at the bottom — they're informational; pinned-slice etiquette suggests not pinning them.
+- **Show full app-db tree ▸** is the escape hatch. Clicking expands the panel to the full canvas, renders the tree as a virtualised lazy-expand collapsible (only first 100 keys at each level eager-render). Includes a search input + persistent breadcrumb. Used rarely; the slice-centric view answers most questions.
+- **Read-only.** In-place editing was considered and rejected (§10.4 lock) — the runtime is the source of truth.
+
+Why this works for any app-db size: the panel **never tries to render the whole tree by default**. Slice mini-panels are bounded by the size of the touched path (typically a few keys deep). A 50MB app-db with two touched slices renders the same as a 100KB one with two touched slices.
+
+### 4.6 Schema-violation timeline (Spec 010 surfacing)
+
+A horizontal timeline along the bottom of the issues feed, one row per registered schema. When a schema validation fails:
+
+- A dot appears on that schema's row at the timestamp.
+- Colour encodes recovery: skip-handler / skip-fx / rollback-db / replaced-with-default / re-raised (the [Spec 010 §Per-step recovery](../spec/010-Schemas.md#per-step-recovery) categories).
+- Click the dot → side panel shows `:where`, `:path`, `:value`, the Malli explanation.
+- **Hover the dot** → tooltip shows a one-line cause ("at `[:auth :email]`, expected `:string`, got `nil`").
+
+This is the kind of thing programmers don't realise is happening — silent schema violations are real bugs in disguise. Surfacing them temporally makes them impossible to ignore.
+
+### 4.7 Hydration mismatch debugger (Spec 011 surfacing)
+
+Only visible when an SSR hydration runs. Shows:
+
+- A side-by-side render: server's render tree (deserialised from the payload) and the client's first render tree.
+- **Divergent nodes pulse red.** The server tree marks where the client's tree took a different shape; structural diff (per the [Spec 011 §Hydration equivalence rule](../spec/011-SSR.md#hydration-equivalence-rule-canonical)).
+- The **render-tree hash** is shown for both sides at every parent so the divergence is bisectable.
+- A drop-down picks the failing node; the right pane shows source coords for the divergent view registration.
+
+*Trade-off:* this only matters to SSR apps. We collapse to a one-line "no hydration mismatches" indicator otherwise.
+
+---
+
+## §5 Information architecture
+
+### Where Causa lives — **in-app, with one pop-out mode**
+
+**Default:** in-app DOM injection (v1's posture). One JS bundle pulled in via `:preloads` in dev; toggled via `Ctrl+Shift+X`. Zero IPC; the runtime is one closure away.
+
+**Pop-out — separate window, same browser.** Triggered by a button; opens a `window.open` whose JS realm is connected to the opener's via the `window.opener` reference. The pop-out renders into the new window but **reads and dispatches against the opener's runtime atoms directly** — no `BroadcastChannel`, no `postMessage`, no structured-clone serialisation. The pop-out's React tree is its own root inside the new window; Reagent reactions are re-established on top of the opener's source atoms via deref. Solves the "I want Causa on a second monitor while the app runs full-screen" use case.
+
+Constraints inherited from the `window.opener` posture:
+
+- Same-origin required. The pop-out window must not be opened with `noopener` / `noreferrer`.
+- If the user closes the opener window, the pop-out becomes orphaned (the runtime is gone). Pop-out detects this via `window.opener.closed` and shows a clean "opener gone — close this window" overlay.
+- The pop-out can't survive a hard reload of the opener — atoms it was reading get garbage-collected. Pop-out re-bootstraps on opener reload by re-reading `window.opener.causaRuntime` (or whichever public handle Causa exposes).
+
+We **do not** ship a Chrome extension. The IPC overhead, the sandbox isolation, and the manifest-v3 churn aren't worth the marginal "you don't have to change build config" benefit. The in-app posture is the right one for re-frame2.
+
+We **do not** ship a standalone HTML viewer / remote-attach over WebSocket either. Serialising the runtime state across the wire is too costly (snapshot identities, machine references, sub-graph nodes, source-coord chips — none of these survive a JSON round-trip cleanly), and the use cases (mobile-from-desktop, cross-machine pair-debug) are too narrow to justify the protocol-versioning + security + reconnect-logic surface. The in-app + window.opener pop-out story covers the 95% case.
+
+We also **do not** ship a VS Code panel — no editor-embed surface in any tier. Editor integrations go through the MCP channel (per §10.7, deferred decision) when they're needed.
+
+### Default landing view
+
+When a programmer hits `Ctrl+Shift+X`, they see:
+
+- **The causality strip** pinned across the top: the last 20 dispatches as horizontal pills, the rightmost one in flight.
+- **The current epoch's event detail** centred in the canvas: event vector, source, the slices it touched (rendered as slice mini-panels per §4.5), effects emitted, machines transitioned, schema status.
+- **The AI co-pilot rail** open by default on the right (per §4.3 + UX §12.2).
+- **The issues feed** as a collapsed strip at the bottom, with a count badge.
+- **The frame picker** in the top-right (showing the active frame; click to switch).
+- **The pinned-slices list** in a left-rail strip (collapsed unless the user has pinned any) — always-visible watched paths and their current values.
+
+The default is "what just happened, in this frame, right now." No graph, no scrubber, no full app-db tree — those are one click away.
+
+### Frame switching
+
+The frame picker is a dropdown of `(rf/frame-ids)` (per [Spec 002 §Public registrar query API](../spec/002-Frames.md#the-public-registrar-query-api)). Switching:
+
+- Re-binds every panel's frame context.
+- The scrubber rebases on the new frame's `epoch-history`.
+- The issues feed filters to the new frame (with a "show all frames" toggle).
+- The causality graph spans frames regardless (cross-frame cascades are interesting), but greys out non-current-frame nodes.
+
+### Navigation idiom — vertical sidebar over horizontal tabs
+
+10x v1's horizontal tab bar limits panel names to short keywords. v2 uses a **left sidebar with icons + labels**, expandable. This scales better as panels grow (we end up with ~14 panels by v1.0). The sidebar collapses to icons-only on narrow screens; the panel area fills the rest.
+
+---
+
+## §6 Specific panels — the canonical surface
+
+| Panel | What it does | Data source | Key affordances |
+|---|---|---|---|
+| **Causality graph** | The hero view (§4.1). Visualises dispatch cascades as a directed graph. | `register-epoch-cb` for new edges; `(rf/trace-buffer {:op-type :event})` for backfill. | Click-node-to-detail; drag-time-window; find-root-cause; filter-by-`:origin`. |
+| **Causality strip** | The horizontal flat version of the causality graph, pinned at the top of every panel. | Same as above. | Click an event pill → jump to the full causality graph at that node. |
+| **Event log** | The canonical 10x v1 panel. Per-frame list of dispatched events, oldest-first or newest-first. | `(rf/trace-buffer {:op-type :event :frame current-frame})`. | Click → expand to show cofx, fx, db-diff. Group-by-cascade. Right-click → "re-dispatch." |
+| **App-db inspector** | The current value of `app-db`, with diff highlight (§4.5). Read-only. | `(rf/get-frame-db frame-id)` + epoch's `:db-before`. | Collapse-to-changed; bookmark a path. |
+| **Subscription graph** | A force-directed graph of sub dependencies for the active frame; layer-1/2/3 grouping. | `(rf/sub-cache frame-id)` (CLJS-only, per Tool-Pair). | Click a sub → see inputs / outputs / cached value; "what subs read from this app-db path?" |
+| **Effect log** | Every fx invocation across the trace buffer. | `(rf/trace-buffer {:op-type :fx})` + `:rf/epoch-record :effects` projection. | Filter by fx-id; show outcome (`:ok`/`:error`/`:skipped-on-platform`); inspect args. |
+| **Trace timeline** | Raw trace events with timing, performance-API-style. | `(rf/trace-buffer)` + Spec 009 `User Timing` measures. | Structured filter; saved-filter library; export-as-JSON. |
+| **Machine inspector** | Stately-quality state-chart per machine (§4.4). Embeds `tools/machines-viz/`. | `(rf/machines)` + per-machine snapshot at `[:rf/machines <id>]` + `:rf.machine/transition` traces. | Live highlight; transition history scrub; source-coord jump. |
+| **Flow graph** | A DAG of registered flows; per-flow recompute heatmap. | `(rf/handlers :flow)` + `:rf.flow/*` traces (per Spec 013). | "How often did this flow skip?"; "what triggered the last recompute?"; mark a flow as dormant. |
+| **Performance ribbon** | INP, long tasks, layout shifts, re-render counts, per epoch. | `PerformanceObserver` watching `rf:*` entries + browser's own `event` / `layout-shift` entries. | Hover an epoch → see its INP; spike-detect; "show me the longest 10 cascades this session." |
+| **Schema violation timeline** | (§4.6). | `(rf/trace-buffer {:operation :rf.error/schema-validation-failure})`. | Drill-down to Malli explanation; jump-to-`reg-app-schema` source. |
+| **Issues ribbon** | A unified feed of errors + warnings + schema violations + hydration mismatches. | All `:op-type :error` / `:warning` / `:rf.ssr/hydration-mismatch` traces. | "Mark resolved"; "snooze for this session"; click → causality-graph rewind to that moment. |
+| **Hydration debugger** | (§4.7). | `:rf.ssr/hydration-mismatch` traces + payload + first client render-tree hash. | Side-by-side; click-to-source on divergent node. |
+| **AI co-pilot** | (§4.3). Chat over the runtime; reads epochs / app-db / handlers; cites source coords. | The registrar + epoch history + trace buffer + user's question + LLM provider (default Claude). | Chat; saved prompts; provider switching; open-by-default rail. |
+| **Routing inspector** | The `:rf/route` slice as a breadcrumb + nav-token timeline. | `(rf/sub :rf/route)` + `:route.nav-token/*` traces. | "Why did this nav fail?"; pending-navigation surfacing. |
+| **Settings / filters** | A panel for configuring depths, default frame, theme, AI provider key, etc. | localStorage with schema'd shape (per §2 lessons). | "Reset to defaults" — never gets stuck. |
+| **Time-travel scrubber** | Pinned at the bottom of the window; (§4.2). Session-local (no export/import). | `(rf/epoch-history frame-id)` + `restore-epoch` + `reset-frame-db!`. | Drag-to-rewind; pin a labelled snapshot; schema-mismatch overlay. |
+
+That's 16 panels. v1 had ~6. The growth is structural — re-frame2 emits more, and Causa surfaces it.
+
+---
+
+## §7 Visual + interaction design heuristics
+
+### Density gradient — default vs expert mode
+
+10x v1's UI is dense. v2 has a **density slider** (compact / cosy / comfortable). Default to cosy. The causality graph and the machine chart have their own visual-detail toggles independent of the global density.
+
+A **"glance mode" toggle** collapses everything to:
+
+- The causality strip pinned at the top (last 20 dispatches).
+- The issues ribbon (always visible if there are issues).
+- The frame picker.
+
+Glance mode is for "I'm not actively debugging but I want the runtime to whisper at me when something is wrong."
+
+### Typography
+
+- A single variable-weight sans for UI chrome (Inter or system-ui).
+- A monospaced font for data display (JetBrains Mono / IBM Plex Mono / system mono).
+- App-db trees, trace events, source coords — all monospace.
+- Headers, panel chrome, labels — sans.
+
+Font size: 13/14px default; configurable. Resist tiny.
+
+### Colour and theme
+
+Dark by default (the v1 community already prefers dark). Light theme ships at v1.0; a `prefers-color-scheme` toggle picks initial state. High-contrast mode is a v1.1 commitment.
+
+Encoding:
+- **Red** = errors, schema violations, hydration mismatches.
+- **Yellow** = warnings, schema-replaced-with-default.
+- **Green** = success, additions.
+- **Blue** = info, modifications.
+- **Violet** = pair-tool / AI-issued dispatches (`:origin :pair` / `:claude`).
+- **Grey** = neutral, registry churn, hidden-by-filter.
+
+The palette is **WCAG AA contrast against both backgrounds**. We don't rely on colour alone (icons + text labels accompany every coloured marker).
+
+### Keyboard navigation
+
+Every panel is navigable without the mouse.
+
+- `?` opens a key-binding cheat-sheet overlay.
+- `Ctrl+Shift+X` toggles 10x.
+- `Ctrl+K` opens a command palette (jump-to-panel, jump-to-event, jump-to-source).
+- `j`/`k` next/previous in any list view (event log, scrubber, trace timeline, issues feed).
+- `[`/`]` previous/next epoch (mirrors the scrubber).
+- `Esc` collapses popovers.
+
+The command palette is the spine. It's how power-users move.
+
+### Screen-reader story
+
+The trace timeline and the event log are the most-accessible-by-default — they're text-heavy. The causality graph and the machine chart need ARIA `aria-label`s on every interactive node and a **textual alternative view** (a focus-ordered list rendering of the graph with the same hierarchical relationships). v1.0 ships the alt-view for causality; the machine chart's alt-view is a v1.1 commitment (it's harder — hierarchical compound states need careful ARIA structure).
+
+### Mobile
+
+Does 10x v2 consider mobile use? **Mostly no, with a narrow exception.**
+
+10x is a debugger and debugging happens at a workstation. We don't make the in-app 10x panel responsive to <600px viewports.
+
+The exception: the **remote-attach viewer** (§5) running on a tablet, observing a session running on a phone via WebSocket. This is a 5%-use-case but the standalone HTML viewer should at least be tablet-friendly (>=900px). v1.0 ships tablet-responsive viewer; phone-form-factor 10x is explicitly out of scope.
+
+### Animation discipline
+
+Animation is communicating, not decorating.
+
+- Diff flashes: 400ms tween.
+- Causality graph edge entries: 250ms ease-out.
+- Errors: a single 600ms pulse on entry, no continuous animation.
+- Machine-chart state pulse: 1.2s slow heartbeat (subtle).
+- Everything else: instant.
+
+A **"reduced motion"** toggle (respecting `prefers-reduced-motion`) kills all animation; we don't ship a non-toggleable shake-or-pulse-anywhere.
+
+---
+
+## §8 Deployment + delivery
+
+### Chrome extension vs in-app
+
+**In-app (default), with a same-browser pop-out via `window.opener`.** No Chrome extension at any tier; no remote-attach over WebSocket. The reasons (recap):
+
+- Zero IPC latency vs the runtime.
+- No manifest-v3 churn.
+- Same elision contract as the runtime — `goog.DEBUG=false` strips Causa entirely.
+- The same-browser pop-out covers the "I want Causa on a second monitor" use case via `window.opener` direct reference — no serialisation cost, no protocol versioning, no reconnect logic.
+- Remote-attach (cross-machine, mobile-from-desktop) is out of scope per §10.3 — too costly to serialise the runtime state across a network wire.
+
+### Bundle size budget
+
+The elision contract (Spec 009 §Production builds) gives us a hard guarantee: **0 bytes in production**, full stop. CI's `npm run test:elision` job (which 10x v2 inherits — its sentinels join the runtime's) blocks any leak.
+
+In dev mode, the bundle target is:
+
+- Core Causa (UI shell + the 16 panels): **<1.5 MB minified, <500 KB gzipped.** Less than v1's bundle by a wide margin via aggressive code-splitting per-panel.
+- The AI co-pilot panel: **<400 KB extra**, lazy-loaded on first open.
+- The machine inspector chart: **<300 KB extra**, lazy-loaded.
+
+We achieve this via shadow-cljs's per-output target slicing — every panel is a separate module; the sidebar loads metadata only; opening a panel kicks the relevant module.
+
+### Performance overhead budget
+
+Acceptable cost on the running app:
+
+- **Trace bus emission overhead:** measured in microseconds per event (per Spec 009). 10x v2 adds <2µs per emit (one listener invocation + a `cons` onto a transient batch).
+- **Causality graph live updates:** debounced to 16ms (one rAF). A burst of 1000 events still updates the graph once per frame.
+- **App-db diff:** O(changed paths) via PersistentHashMap pointer-eq. Negligible on dbs <10MB; bounded by the change set.
+- **Rendering:** every panel virtualises long lists; nothing renders >200 rows at once; the causality graph caps at the last 200 dispatches.
+
+The hard rule: **opening 10x v2 must not change observable INP** on a typical app. If it does, we cut features until it doesn't.
+
+### Install / enable / disable
+
+```clojure
+;; In shadow-cljs.edn dev build:
+{:builds {:app {:devtools {:preloads [day8.re-frame2-10x.preload]}}}}
+```
+
+That's it. The preload registers under `register-trace-cb!` and `register-epoch-cb`, mounts a hidden DOM root, listens for `Ctrl+Shift+X`. No code change in the app itself.
+
+Disabling: remove the `:preloads` entry, or set `:closure-defines {day8.re-frame2-10x.config/enabled? false}` to force-disable even in dev.
+
+We follow v1's preload convention exactly — muscle memory transfer is free.
+
+---
+
+## §9 Cross-tool cohesion
+
+### Story embeds 10x's epoch panel (already decided)
+
+From [`re-frame-2-story-feature-set.md`](re-frame-2-story-feature-set.md) §6.7 and §4.4: Story registers a story-panel that embeds 10x v2's epoch panel as the variant's observability ribbon.
+
+**The embedding contract** (this design): every 10x v2 panel exports a **`Panel`** React component (or hiccup-fn equivalent) that accepts:
+
+```clojure
+{:frame    :story.auth/login          ;; which frame to observe
+ :compact? true                       ;; reduced chrome — no sidebar, no header
+ :height   320                        ;; in pixels, optional
+ :scope    {:dispatch-id-prefix ...}} ;; optional filter to restrict the observation window
+```
+
+Story's `reg-story-panel` wires the embedded panel into the variant page. The contract is: the 10x v2 panel **knows it's embedded** (so it doesn't claim Ctrl+Shift+X, doesn't open its own pop-out, doesn't show a "close" button), but otherwise renders identically.
+
+10x v2 exposes the **embedded epoch panel** at v1.0. The embedded causality graph and embedded machine inspector ship at v1.1 (so Story can embed them too if it wants).
+
+### machines-viz overlap
+
+`tools/machines-viz/` and 10x v2's machine inspector both render state-charts. The relationship: **machines-viz owns the chart component; 10x v2 embeds it** as one of its 17 panels. Same direction as Story → 10x.
+
+The contract: `machines-viz` exports a `MachineChart` component that accepts a machine-id and a frame-id, renders the chart, handles the live-highlight. 10x v2's machine inspector panel is a thin wrapper that adds the transition-history ribbon and the source-coord jump affordance. machines-viz can be used without 10x v2 (programmer who only wants a chart); 10x v2 *depends* on machines-viz for the chart rendering.
+
+### re-frame-pair2 overlap
+
+re-frame-pair2 is AI-driven (an LLM integration via nREPL). Causa is human-driven with an embedded AI co-pilot. **Where they meet:**
+
+- Both consume the same Spec 009 / Tool-Pair surfaces. Neither depends on the other.
+- The **AI co-pilot panel in Causa** (§4.3) uses the same primitives as the pair tool — `(rf/handlers ...)`, `(rf/epoch-history ...)`, `(rf/get-frame-db ...)`, `register-trace-cb!`. The difference is the user surface: Causa lives in the browser; pair2 lives in the editor / REPL.
+- A future enhancement: Causa's co-pilot delegates to a running pair2 nREPL session if one is detected. The co-pilot becomes a thin chat shell over the pair tool's full capability. v2 commitment (per §10.8, still open), not v1.
+
+### MCP surface
+
+**10x v2 ships `tools/10x-mcp/`** (a separate jar, mirroring `tools/story-mcp/`). The MCP server exposes:
+
+- `get-trace-buffer` — slice of the trace stream by filter.
+- `get-epoch-history` — per-frame epoch history.
+- `get-app-db` — current value at a frame, optionally at a path.
+- `get-machine-state` — current snapshot for a named machine.
+- `get-issues` — recent errors/warnings/schema-violations.
+- `restore-epoch` — rewind a frame.
+- `reset-frame-db` — inject state.
+- `dispatch` — fire an event (with `:origin :mcp`).
+
+This is largely **the same surface as `tools/story-mcp/`**, because Story's MCP and 10x v2's MCP both ultimately surface the Tool-Pair contract. The split exists for jar-bundle isolation and per-tool release cadence; the tools converge on a common MCP-tool vocabulary. v1.1.
+
+We *don't* duplicate the pair tool's MCP — re-frame-pair2's MCP (if it ships one) is editor-focused; 10x's MCP is debugger-focused. Both can coexist; agents pick the one their workflow needs.
+
+---
+
+## §10 Open design questions for Mike
+
+Each as a §X.Y with my recommendation + the alternative.
+
+### §10.1 Name
+
+**Locked 2026-05-11: Causa.** Artefact `day8/re-frame2-causa`. Tagline: *"the cascade you can see."*
+
+### §10.2 AI co-pilot
+
+**Locked 2026-05-11: ship at v1.0; open by default.** The runtime is structured enough that an AI can navigate it; not shipping the co-pilot at v1 leaves the marquee value on the table. Panel hits Claude via the user's API key (no service-side dependency); swappable provider abstraction supports OpenAI / Gemini / local Ollama. Earlier "drop entirely" call was reverted same day — co-pilot is back as one of the marquee features.
+
+### §10.3 Deployment posture
+
+**Locked 2026-05-11: in-app DOM injection + same-browser pop-out via `window.opener`.** No Chrome extension at any tier. No standalone HTML viewer / remote-attach over WebSocket — the serialisation cost (runtime atoms, reactions, sub-graph, machine references) is too high, and the use cases (mobile-from-desktop, cross-machine pair-debug) too narrow. BroadcastChannel was considered for the pop-out wire but hits the same structured-clone problem; `window.opener` direct reference is the clean answer (same JS realm, no serialisation).
+
+### §10.4 In-place app-db editing affordance
+
+**Locked 2026-05-11: not required.** The runtime is the source of truth; pokes at app-db from the debugger are out of scope. App-db panel is read-only.
+
+### §10.5 Session export / import
+
+**Locked 2026-05-11: not required.** If the user reloads, that's a new session. Scrubber scope is the current session only.
+
+### §10.6 Embedded vs free-standing relationship with machines-viz
+
+**Locked 2026-05-11: Causa embeds machines-viz's chart.** §9 covers this. Both ship from `tools/` with per-jar cadence (per [`tools/README.md`](../tools/README.md)); machines-viz is `re-frame2-machines-viz`; Causa deps in it at a `~> 1.x` version range.
+
+### §10.7 MCP shipping at v1.0 vs v1.1
+
+**Deferred 2026-05-11.** Decision punted to a later read.
+
+### §10.8 Pair2 delegation in co-pilot
+
+**Open.** With co-pilot back (§10.2), this is on the table again. Recommendation: defer to v2 — the co-pilot has its own chat via direct LLM API; pair2 delegation is an "if a pair2 nREPL session is running, route through it" optimisation, not blocking for v1. Awaiting Mike's call.
+
+### §10.9 Mobile / phone form factor
+
+**Locked 2026-05-11: not needed ever.** Tablet-responsive standalone viewer at v1.0; no phone-form-factor Causa, no future commitment. Debuggers belong at workstations.
+
+### §10.10 Causality graph as hero feature (raised in self-criticism)
+
+**Locked 2026-05-11: ship as hero; evaluate in practice.** Risk acknowledged (visually striking ≠ habit-forming; programmers may keep reaching for the flat event log). Mitigation is the always-pinned causality strip (flat horizontal version) — graph is one click away but the strip carries everyday weight. v1.0 launches with the graph as the hero; if user behaviour shows the strip is doing the real work, demote the graph from hero to one of the 16 panels in v1.1.
+
+---
+
+## §11 Roadmap
+
+### v1.0 — "the cascade you can see"
+
+The thesis ships: causality graph (hero), AI co-pilot (open-by-default rail), time-travel scrubber (session-local), machine inspector (via machines-viz), slice-centric app-db panel (read-only), schema violation timeline, issues ribbon. All 16 panels listed in §6. Same-browser pop-out via `window.opener`. WCAG AA contrast. Reduced-motion respect.
+
+Explicit non-goals at v1.0: Chrome extension, standalone HTML viewer / remote-attach over WebSocket (out of scope per §10.3), VS Code panel (never — editor integrations go via MCP if/when it ships), MCP server (deferred per §10.7), machine-inspector alt-view, mobile phone form factor (out of scope per §10.9), in-place app-db editing (out of scope per §10.4), session export/import (out of scope per §10.5), fork-from-here.
+
+### v1.1 — "extend the reach"
+
+- Embedded causality graph + embedded machine inspector for Story.
+- Pop-out 2-monitor mode polished.
+- High-contrast theme.
+- Machine inspector alt-view (screen-reader).
+- Per-frame error policy surfacing (showing the `:on-error` registered for each frame).
+
+(MCP server is on the table for v1.1 but the call is deferred — see §10.7.)
+
+### v2.0 — "the editor partner"
+
+- Pair2 delegation in the co-pilot (per §10.8, still open).
+- Editor-driven debugging (Cursor / Claude Code can request Causa to focus a frame, run a query, via the MCP channel when it ships).
+- Programmable saved-filter library (write your own filter functions, save them, share them).
+- Differential `app-db` snapshots — a "this app-db diverges from baseline" mode for property testing.
+
+---
+
+## §12 Voice + naming
+
+### Name
+
+**Locked:** **Causa**. Artefact `day8/re-frame2-causa`. Tagline: *"the cascade you can see."*
+
+### Visual identity
+
+- A single mark: an arrow forking from one node into three nodes (the cascade). Works at favicon size; works as the launch button in 10x v2 itself.
+- The default theme is dark with a violet accent (echoing `:origin :pair` violet — every cause has an origin).
+- One typeface (Inter or system-ui) plus one monospace (JetBrains Mono / system mono).
+- No mascots, no skeuomorphism, no cute.
+
+### Voice
+
+The README, the tagline, the marketing copy: **direct, observational, programmer-to-programmer.**
+
+> *"You dispatched. Then five things happened. Causa shows you which one was the one."*
+
+Not "magical." Not "AI-powered" as the headline (the AI is a feature, not the pitch). Not "revolutionary." Tools that hype themselves get used briefly; tools that respect their users get used daily.
+
+Compare:
+
+- **Bad:** "AI-Powered Debugging for Modern Front-Ends: Causa Reimagines What's Possible."
+- **Good:** "Open Causa. Click the event you didn't expect. Read what fired it. Close Causa."
+
+---
+
+## Self-criticism
+
+Where this design is speculative or weak:
+
+- **The causality graph as the hero feature is a launch-and-learn call.** Risk: programmers keep using the flat event log because that's what they know, and the graph becomes a pretty-but-unused tab. Mitigation: the causality strip (the flat horizontal version) is always pinned, so the graph is always one click away but never blocking. v1.0 ships with the graph as the hero; v1.1 demotes if usage data shows the strip is doing the real work. (Decision locked in §10.10.)
+- **The AI co-pilot is a bet on 2026 maturity.** If Claude / OpenAI / etc. APIs stop being cheap-and-fast, or if the model can't actually do the five canonical question types reliably, the panel becomes vaporware. Mitigation: the co-pilot is a panel, not a foundation — the rest of Causa functions if it's disabled.
+- **16 panels is a lot.** v1 had ~6 and was already complex. The mitigation is the sidebar IA (§5) plus the command palette, but discoverability of less-used panels (flow graph, routing inspector) is a real risk.
+- **The remote-attach mode requires a WebSocket endpoint in the running app**, which is dev-only but still real code we're asking the runtime to ship. It needs to be opt-in (a `(rf/configure :remote-debug {:enabled? true :port 9710})` knob); we haven't fully spec'd the wire format.
+- **The performance ribbon's INP attribution to specific cascades is heuristic.** Browser INP is measured per user-interaction; mapping that to a re-frame2 cascade requires correlating timestamps. There will be edge cases where the attribution is wrong.
+- **The 16 panels listed in §6 are mostly real but a few are conditional.** "Routing inspector" is real (Spec 012 emits the traces). "Hydration debugger" only fires for SSR apps. The default landing-view UX needs to gracefully handle "this app doesn't use most of these panels" (auto-hide empty panels from the sidebar; show them under a "more" pull-out).
+
+---
+
+## Closing — the bar
+
+The bar this design sets: a programmer hits `Ctrl+Shift+X`, sees the cascade their last click triggered, asks "why?", and has the answer in 5 seconds. Causa earns its keep at that bar.
+
+If a panel doesn't help answer "why?" or "what happened?" or "what's wrong?", it doesn't ship. We could pile features (the rolling Storybook MCP / a11y / coverage / theme story is real for component workshops; 10x v2's lane is *debugging the runtime*). Restraint is what keeps the tool habit-forming instead of impressive.
+
+The headline isn't "we built a better trace panel." The headline is "we built the debugger re-frame2 deserves — one that explains the runtime to the human in the runtime's own terms, with an AI co-pilot for when explaining isn't enough."
+
+— end of design draft —


### PR DESCRIPTION
## Summary

Decomposes the Causa (re-frame-10x v2) design from monolithic findings
docs into a normative per-tool `/spec/` folder. Mirrors the structure
that landed for `tools/pair2-mcp/spec/` (rf2-5b8e, #423).

All 13 direction-set decisions are locked and documented in
`DESIGN-RATIONALE.md` with question / options / pick / why / date.

## File tree

```
tools/10x/
├── README.md                                  one-page pitch + install + launch
├── spec/
│   ├── 000-Vision.md                          why Causa exists; 16-panel inventory; the bar
│   ├── 001-Causality-Graph.md                 the (peer) causality graph; data model; rendering
│   ├── 002-Time-Travel.md                     epoch scrubber; passive-vs-explicit; six failure modes
│   ├── 003-Machine-Inspector.md               embeds tools/machines-viz/; transition history
│   ├── 004-App-DB-Diff.md                     slice-centric diff; pinned slices; read-only
│   ├── 005-Schema-Timeline.md                 per-schema timeline; recovery-mode colouring
│   ├── 006-Hydration-Debugger.md              SSR render-tree diff; divergent-node bisector
│   ├── 007-UX-IA.md                           layout / interaction / visual language
│   ├── 008-Embedding-Contract.md              Panel component contract (Story embed)
│   ├── 009-AI-CoPilot.md                      pull-only Q&A; slash commands; ephemeral
│   ├── 010-MCP-Server.md                      tools/10x-mcp/ catalogue + lifecycle
│   ├── 011-Launch-Modes.md                    in-app overlay + standalone-via-MCP
│   ├── Principles.md                          load-bearing Causa-specific principles
│   ├── API.md                                 consolidated user-facing surface
│   ├── DESIGN-RATIONALE.md                    13 locks: question / options / pick / why / date
│   └── findings/
│       ├── re-frame-10x-v2-design.md          original "what" design doc (~615 lines)
│       └── causa-ux-design.md                 original UX/UI design doc (~814 lines)
```

5,470 lines added across 18 files. Voice + density matched against
`tools/pair2-mcp/spec/`.

## DESIGN-RATIONALE coverage of the 13 locks

Every entry carries question + options considered + pick + why + date locked.

| # | Decision | Pick | Date |
|---|---|---|---|
| 1 | Name | Causa (`day8/re-frame2-causa`) | 2026-05-11 |
| 2 | AI co-pilot ship timing | v1.0 pull-only | 2026-05-11 |
| 3 | App-db editing | Never — read-only forever | 2026-05-11 |
| 4 | Session export | Never | 2026-05-11 |
| 5 | Mobile | Desktop only | 2026-05-11 |
| 6 | MCP timing | v1.0 via `tools/10x-mcp/` | 2026-05-12 |
| 7 | Hero panel | Event-detail (graph demoted to peer) | 2026-05-12 |
| 8 | AI panel default state | Collapsed with subtle cue | 2026-05-12 |
| 9 | Launch modes | Hybrid: in-app + MCP | 2026-05-12 |
| 10 | Narrate mode | Dropped — AI is pull-only | 2026-05-12 |
| 11 | Source-coord fallback | Handler-coord with `(?)` annotation | 2026-05-12 |
| 12 | Conversation persistence | Ephemeral | 2026-05-12 |
| 13 | Voice STT | No at v1.0 | 2026-05-12 |

## Findings docs moved from local-only to committed

The two anchor research docs:

- `re-frame-10x-v2-design.md` (the WHAT — 16-panel inventory, feature scope)
- `causa-ux-design.md` (the HOW — layout, interaction, visual language)

…moved from `ai/findings/` (gitignored / local-only) to
`tools/10x/spec/findings/` (committed). The `ai/findings/` copies
deleted post-move; only the committed versions remain.

## Test plan

- [ ] Spec corpus reads cleanly start-to-finish for a fresh AI tasked
      with building Causa from nothing (the one-shot-completeness bar).
- [ ] Every "per lock #N in DESIGN-RATIONALE.md" reference in the
      per-area specs resolves.
- [ ] No bead-id references in user-facing prose (000-Vision, 001-011,
      Principles, API). Bead IDs are confined to DESIGN-RATIONALE's
      trail-of-thought citations.
- [ ] Voice / density consistent with `tools/pair2-mcp/spec/`.
- [ ] Findings docs deleted from `ai/findings/` (local-only); same
      content present under `tools/10x/spec/findings/` (committed).