### PR TITLE
feat(story-shell): first-time-user help panel + "?" re-open button (rf2-381i)

### DIFF
--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -1,0 +1,316 @@
+(ns re-frame.story.ui.help
+  "First-time-user help overlay for the Story playground (rf2-381i).
+
+  Renders a modal-style overlay that explains the playground UI:
+
+  - what `:dev` / `:docs` / `:test` mode-tabs do
+  - what the sidebar tree means (stories / variants / workspaces)
+  - what to click first
+  - what each right-panel section shows
+
+  ## Behaviour
+
+  - Shown automatically on first mount unless the user has previously
+    dismissed it (tracked via `localStorage` under the key
+    `re-frame.story/seen-help-v1`).
+  - Re-openable on demand via [[help-button]] — a `?` chip the shell
+    renders in its chrome.
+  - Dismissed by clicking the backdrop, pressing Escape, or clicking
+    the 'Got it' button.
+
+  Local component state (open / not-open) lives in a Reagent ratom
+  inside [[help-host]]; it is intentionally NOT in the shell-state
+  atom — the welcome popup is ephemeral UI, not playground state.
+
+  ## Voice + colour
+
+  Matches the rest of the Story shell chrome: `#252526` panel ground,
+  `#cccccc` body text, `#b0b0b0` muted labels (post rf2-2uwv contrast
+  fixes — all foreground colours meet WCAG AA against the panel
+  ground). Tight bulleted copy — no paragraphs.
+
+  ## Bundle isolation
+
+  Production builds with `re-frame.story.config/enabled?` false never
+  reach this ns; Closure DCE drops the lot."
+  (:require [reagent.core :as r]))
+
+;; ---- localStorage flag --------------------------------------------------
+
+(def ^:const seen-key
+  "localStorage key tracking whether the user has dismissed the help
+  overlay. Bump the trailing version when the help content materially
+  changes so returning users see the refreshed copy once."
+  "re-frame.story/seen-help-v1")
+
+(defn- safe-local-storage
+  "Return js/window.localStorage if available, otherwise nil.
+
+  Browsers can disable localStorage (private-mode quirks, embedded
+  contexts, file:// in some configs) so every access guards. Returns
+  nil rather than throwing — callers degrade to 'always-show'."
+  []
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (try (.-localStorage js/window)
+         (catch :default _ nil))))
+
+(defn seen?
+  "Has the user dismissed the help overlay before? Returns false when
+  localStorage is unavailable (so the overlay shows on every visit in
+  that fallback path — better to over-show than miss the on-boarding)."
+  []
+  (boolean
+    (when-let [ls (safe-local-storage)]
+      (try (some? (.getItem ls seen-key))
+           (catch :default _ false)))))
+
+(defn mark-seen!
+  "Persist the 'dismissed' flag so subsequent visits skip auto-open."
+  []
+  (when-let [ls (safe-local-storage)]
+    (try (.setItem ls seen-key "1")
+         (catch :default _ nil))))
+
+(defn reset-seen!
+  "Clear the dismissed flag. Useful for tests + a future
+  'show me the help again' affordance. Not currently wired to chrome."
+  []
+  (when-let [ls (safe-local-storage)]
+    (try (.removeItem ls seen-key)
+         (catch :default _ nil))))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:backdrop    {:position    "fixed"
+                 :top         0
+                 :left        0
+                 :right       0
+                 :bottom      0
+                 :background  "rgba(0,0,0,0.55)"
+                 :z-index     2000
+                 :display     "flex"
+                 :align-items "center"
+                 :justify-content "center"}
+   :panel       {:background    "#252526"
+                 :color         "#cccccc"
+                 :border        "1px solid #555"
+                 :border-radius "5px"
+                 :box-shadow    "0 8px 32px rgba(0,0,0,0.7)"
+                 :width         "560px"
+                 :max-width     "92vw"
+                 :max-height    "86vh"
+                 :overflow      "auto"
+                 :font-family   "system-ui, sans-serif"
+                 :font-size     "13px"
+                 :line-height   "1.5"}
+   :header      {:display         "flex"
+                 :justify-content "space-between"
+                 :align-items     "center"
+                 :padding         "12px 16px"
+                 :background      "#2d2d30"
+                 :border-bottom   "1px solid #444"}
+   :title       {:color       "#9cdcfe"
+                 :font-weight "bold"
+                 :font-size   "13px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"}
+   :close       {:background  "transparent"
+                 :border      "none"
+                 :color       "#b0b0b0"
+                 :font-size   "16px"
+                 :cursor      "pointer"
+                 :padding     "0 4px"
+                 :line-height "1"}
+   :body        {:padding "16px 20px"}
+   :section-h   {:color          "#b0b0b0"
+                 :font-size      "10px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :margin         "12px 0 6px 0"
+                 :font-weight    "bold"}
+   :section-h-first {:margin-top "0"}
+   :list        {:margin     "0 0 0 18px"
+                 :padding    "0"}
+   :list-item   {:margin-bottom "4px"}
+   :kw          {:color       "#dcdcaa"
+                 :font-family "monospace"}
+   :muted       {:color "#b0b0b0"}
+   :footer      {:display         "flex"
+                 :justify-content "flex-end"
+                 :padding         "12px 16px"
+                 :border-top      "1px solid #444"
+                 :background      "#2d2d30"}
+   :got-it      {:padding       "6px 16px"
+                 :background    "#0e639c"
+                 :color         "white"
+                 :border        "none"
+                 :border-radius "3px"
+                 :cursor        "pointer"
+                 :font-size     "12px"
+                 :font-family   "system-ui, sans-serif"}
+   :help-btn    {:padding       "2px 9px"
+                 :background    "#37373d"
+                 :color         "#9cdcfe"
+                 :border        "1px solid #555"
+                 :border-radius "12px"
+                 :cursor        "pointer"
+                 :font-family   "monospace"
+                 :font-size     "11px"
+                 :line-height   "1.2"}})
+
+;; ---- the panel ----------------------------------------------------------
+
+(defn- kw
+  "Render a keyword-style inline token with the monospace yellow chrome."
+  [s]
+  [:span {:style (:kw styles)} s])
+
+(defn help-content
+  "The body of the help overlay — pure hiccup, factored out so future
+  tests can render it in isolation and so the copy stays in one place.
+
+  Total copy: ~150 words, bulleted, tight."
+  []
+  [:div {:style (:body styles)}
+   [:div {:style (merge (:section-h styles) (:section-h-first styles))}
+    "Mode tabs"]
+   [:ul {:style (:list styles)}
+    [:li {:style (:list-item styles)}
+     [kw ":dev"] " — interactive playground (default; full chrome)."]
+    [:li {:style (:list-item styles)}
+     [kw ":docs"] " — read-only prose view for embedding."]
+    [:li {:style (:list-item styles)}
+     [kw ":test"] " — runs the variant's assertions and reports pass/fail."]]
+
+   [:div {:style (:section-h styles)} "Sidebar (left)"]
+   [:ul {:style (:list styles)}
+    [:li {:style (:list-item styles)}
+     [:b "Stories"] " group related "
+     [:b "variants"] " (the renderable units)."]
+    [:li {:style (:list-item styles)}
+     [:b "Workspaces"] " compose multiple variants into one screen."]
+    [:li {:style (:list-item styles)}
+     "Click a variant for a solo view; click a workspace for the composition."]]
+
+   [:div {:style (:section-h styles)} "Start here"]
+   [:ul {:style (:list styles)}
+    [:li {:style (:list-item styles)}
+     "Pick any variant in the sidebar — the canvas renders it; the right rail unlocks."]]
+
+   [:div {:style (:section-h styles)} "Inspectors (right)"]
+   [:ul {:style (:list styles)}
+    [:li {:style (:list-item styles)}
+     [:b "args"] " edit live arguments; "
+     [:b "modes"] " toggle registered modes; "
+     [:b "decorators"] " show the resolved wrap stack."]
+    [:li {:style (:list-item styles)}
+     [:b "time-travel"] " scrub past epochs; "
+     [:b "trace"] " tails the six-domino cascade per event."]
+    [:li {:style (:list-item styles)}
+     [:b "notes / a11y / layout-debug"] " — author notes, axe-core scan, visual guides."]]
+
+   [:div {:style (:section-h styles)} "Re-open"]
+   [:ul {:style (:list styles)}
+    [:li {:style (:list-item styles)}
+     "Click the " [:span {:style (:kw styles)} "?"]
+     " in the top-right anytime."]]])
+
+(defn- on-key-down
+  "Escape closes the overlay. Bound to a window listener while open."
+  [close!]
+  (fn [^js evt]
+    (when (= "Escape" (.-key evt))
+      (close!))))
+
+(defn help-panel
+  "The overlay itself — backdrop + centred panel. `close!` is the
+  zero-arg fn the parent passes; it's invoked on Got-it / Escape /
+  backdrop click. The component owns the window-level keydown listener
+  via Reagent lifecycle so it cleans up on unmount."
+  [close!]
+  (let [handler (atom nil)]
+    (r/create-class
+      {:display-name "rf-story-help-panel"
+       :component-did-mount
+       (fn [_]
+         (let [f (on-key-down close!)]
+           (reset! handler f)
+           (when (exists? js/window)
+             (.addEventListener js/window "keydown" f))))
+       :component-will-unmount
+       (fn [_]
+         (when-let [f @handler]
+           (when (exists? js/window)
+             (.removeEventListener js/window "keydown" f))))
+       :reagent-render
+       (fn [close!]
+         [:div {:style    (:backdrop styles)
+                :role     "dialog"
+                :aria-modal "true"
+                :aria-label "Story playground help"
+                :on-click (fn [_] (close!))}
+          [:div {:style    (:panel styles)
+                 :on-click (fn [^js e] (.stopPropagation e))}
+           [:div {:style (:header styles)}
+            [:div {:style (:title styles)} "Welcome to the Story playground"]
+            [:button {:style    (:close styles)
+                      :aria-label "Close help"
+                      :on-click (fn [_] (close!))}
+             "x"]]
+           [help-content]
+           [:div {:style (:footer styles)}
+            [:button {:style    (:got-it styles)
+                      :on-click (fn [_] (close!))}
+             "Got it"]]]])})))
+
+;; ---- mounted host: handles first-time auto-open + manual button --------
+
+(defonce ^:private open?
+  ;; Local reactive flag. Reagent ratom so the host re-renders when the
+  ;; help button toggles it. Initial value computed lazily on mount.
+  (r/atom false))
+
+(defn open!
+  "Open the help overlay. Public so other chrome (or tests) can trigger
+  it. Idempotent — opening when already open is a no-op."
+  []
+  (reset! open? true))
+
+(defn close!
+  "Close the help overlay and mark it as seen so subsequent visits
+  skip the auto-open."
+  []
+  (reset! open? false)
+  (mark-seen!))
+
+(defn help-button
+  "The `?` chip — rendered by the shell chrome. Clicking opens the
+  help overlay on demand."
+  []
+  [:button {:style    (:help-btn styles)
+            :title    "Show playground help"
+            :aria-label "Show playground help"
+            :on-click (fn [_] (open!))}
+   "?"])
+
+(defn help-host
+  "The mounted host component — owns the open?/closed? state and
+  decides whether to auto-open on first visit.
+
+  Renders nothing when closed. The host should be mounted at the top
+  of the shell tree so the modal layers above every other pane."
+  []
+  (r/create-class
+    {:display-name "rf-story-help-host"
+     :component-did-mount
+     (fn [_]
+       ;; Auto-open on first visit. Guarded so reseting / re-mounting
+       ;; the shell mid-session (e.g. via hot-reload) doesn't pop the
+       ;; modal again — only fires when no flag is persisted.
+       (when-not (seen?)
+         (reset! open? true)))
+     :reagent-render
+     (fn []
+       (when @open?
+         [help-panel close!]))}))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -44,6 +44,7 @@
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.help :as help]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
@@ -82,7 +83,11 @@
    :tab-active {:color "white"
                 :background "#1e1e1e"
                 :border-bottom "1px solid #1e1e1e"
-                :margin-bottom "-1px"}})
+                :margin-bottom "-1px"}
+   :help-slot {:position "fixed"
+               :top      "8px"
+               :right    "12px"
+               :z-index  1500}})
 
 ;; ---- hot-reload trigger --------------------------------------------------
 
@@ -305,7 +310,13 @@
        [:div {:style (:root styles)}
         [sidebar/sidebar]
         [main-pane]
-        [right-panel]])}))
+        [right-panel]
+        ;; rf2-381i: first-time help overlay + persistent re-open chip.
+        ;; The chip lives in a fixed-position slot so it floats above the
+        ;; right inspector pane regardless of which panels are visible.
+        [:div {:style (:help-slot styles)}
+         [help/help-button]]
+        [help/help-host]])}))
 
 ;; ---- mount / unmount surface ---------------------------------------------
 

--- a/tools/story/test/re_frame/story_help_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_help_cljs_test.cljs
@@ -1,0 +1,60 @@
+(ns re-frame.story-help-cljs-test
+  "CLJS smoke tests for rf2-381i — first-time-user help overlay.
+
+  Covers:
+
+  - `seen?` / `mark-seen!` round-trip against localStorage (browser only).
+  - `reset-seen!` clears the flag.
+  - `help-content` renders as hiccup.
+  - `open!` / `close!` toggle the local open atom.
+
+  The localStorage round-trip is browser-only — on node-test there's no
+  `js/window`, so we guard those assertions on the runtime detection."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.ui.help :as help]))
+
+;; ---- runtime detection ---------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn clear-flag! []
+  (help/reset-seen!)
+  (reset! @#'help/open? false))
+
+(use-fixtures :each {:before clear-flag! :after clear-flag!})
+
+;; ---- localStorage round-trip ---------------------------------------------
+
+(deftest seen-defaults-to-false
+  (testing "seen? is false when localStorage has never been touched"
+    (is (false? (help/seen?)))))
+
+(deftest mark-seen-persists
+  (testing "mark-seen! flips seen? to true (browser only)"
+    (when (browser?)
+      (help/mark-seen!)
+      (is (true? (help/seen?)))
+      (help/reset-seen!)
+      (is (false? (help/seen?))))))
+
+;; ---- hiccup shape --------------------------------------------------------
+
+(deftest help-content-is-hiccup
+  (testing "help-content returns a hiccup vector rooted at :div"
+    (let [out (help/help-content)]
+      (is (vector? out))
+      (is (= :div (first out))))))
+
+;; ---- open / close behaviour ----------------------------------------------
+
+(deftest open-then-close-toggles-atom
+  (testing "open! flips the atom to true; close! flips it back"
+    (help/open!)
+    (is (true? @@#'help/open?))
+    (help/close!)
+    (is (false? @@#'help/open?))
+    (when (browser?)
+      (is (true? (help/seen?))))))


### PR DESCRIPTION
## Summary

- First-time visitors at `/#/stories` had no on-screen guidance for the playground UI. Add a modal-style help overlay that auto-opens on first visit (persisted via `localStorage` under `re-frame.story/seen-help-v1`) and a fixed-position `?` chip in the top-right that re-opens it on demand.
- Copy is tight bulleted hiccup (~150 words) covering mode tabs (`:dev`/`:docs`/`:test`), the sidebar tree (stories/variants/workspaces), where to start, and the right-rail inspector inventory (args/modes/decorators/time-travel/trace/notes/a11y/layout-debug).
- Dismiss interactions: backdrop click, Escape key, or "Got it" button.

## Implementation

- **New** `tools/story/src/re_frame/story/ui/help.cljs` — component + localStorage helpers (`seen?` / `mark-seen!` / `reset-seen!`) + `open!` / `close!` API. Escape-key listener owned by Reagent lifecycle.
- **Modified** `tools/story/src/re_frame/story/ui/shell.cljs` — mounts `help-host` (the modal layer) and `help-button` (`?` chip) inside the shell's reagent-render. The chip lives in a fixed-position slot so it floats above the right inspector pane regardless of which panels are visible.
- **New** `tools/story/test/re_frame/story_help_cljs_test.cljs` — CLJS smoke tests for the localStorage round-trip, `help-content` hiccup shape, and `open!`/`close!` toggle behaviour.

Voice + palette match the rest of the chrome — `#252526` panel ground, `#cccccc` body, `#b0b0b0` muted labels, `#9cdcfe` blue title, `#dcdcaa` yellow monospace tokens. All foreground colours meet WCAG AA against their grounds (post rf2-2uwv).

## Test plan

- [x] `shadow-cljs compile node-test` — 0 failures, 0 errors across 586 tests (incl. new `re-frame.story-help-cljs-test`).
- [x] `shadow-cljs compile browser-test` — builds cleanly; help namespace + test ns both compile.
- [ ] Manual: load `examples/counter-with-stories` at `/#/stories`, confirm overlay auto-opens on first visit, dismisses via Escape / backdrop / Got-it, persists across reload, and re-opens via the `?` chip.