### PR TITLE
feat(fx): support :fx-overrides fn-value branch (CLJS-reference richer form per spec/002)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -61,31 +61,85 @@
 
 (defn- resolve-fx-with-overrides
   "Apply fx-id overrides per Spec 002 §Per-frame and per-call overrides.
-  If the override target is registered, use it. If not, emit
-  :rf.error/override-fallthrough and fall back to the original fx-id.
-  Returns the resolved fx-id."
+
+  Three override-value shapes are honoured (per [002 §`:fx-overrides`](spec/002-Frames.md#fx-overrides--replace-fx-handlers)):
+
+    1. **Missing key** — no override; the original fx-id flows through.
+    2. **Keyword value** — id-redirect: the registered fx at the target id
+       runs in place of the original. If the target is not registered,
+       emit `:rf.error/override-fallthrough` and fall back to the original
+       fx-id. This is the **pattern-level**, portable form (SSR-safe).
+    3. **Function value** `(fn [m args] ...)` — CLJS reference convenience
+       for test fixtures and story decorators. The fn runs in place of the
+       registered fx; no registry lookup against the original fx-id is
+       performed. Spec/002 marks this form as a CLJS-reference local
+       affordance (not portable across the wire); the JVM-side reference
+       (this code) supports it too — `.cljc` is single-source.
+
+  Returns the resolved fx-id (keyword); for the fn-value branch, returns
+  the original-fx-id (used only for trace shape — the actual handler
+  invocation goes through `:rf.fx/override-applied` and the synthesised
+  meta returned by `resolved-fx-meta`)."
   [original-fx-id overrides]
-  (if-let [override-target (get overrides original-fx-id)]
-    (if (registrar/lookup :fx override-target)
-      (do
-        (trace/emit! :fx :rf.fx/override-applied
-                     {:from original-fx-id :to override-target})
-        override-target)
-      (do
-        (trace/emit-error! :rf.error/override-fallthrough
-                           {:failing-id     original-fx-id
-                            :overrides-map  overrides
-                            :looked-up-id   override-target
-                            :reason         (str "Override redirected `"
-                                                 original-fx-id
-                                                 "` to `"
-                                                 override-target
-                                                 "`, which is not registered. Using the registered `"
-                                                 original-fx-id
-                                                 "` instead.")
-                            :recovery       :replaced-with-default})
+  (if (contains? overrides original-fx-id)
+    (let [override-target (get overrides original-fx-id)]
+      (cond
+        ;; (3) function value — CLJS-reference convenience.
+        (fn? override-target)
+        (do
+          (trace/emit! :fx :rf.fx/override-applied
+                       {:from original-fx-id :to ::fn-value})
+          original-fx-id)
+
+        ;; (2) id-redirect to a registered fx.
+        (keyword? override-target)
+        (if (registrar/lookup :fx override-target)
+          (do
+            (trace/emit! :fx :rf.fx/override-applied
+                         {:from original-fx-id :to override-target})
+            override-target)
+          (do
+            (trace/emit-error! :rf.error/override-fallthrough
+                               {:failing-id     original-fx-id
+                                :overrides-map  overrides
+                                :looked-up-id   override-target
+                                :reason         (str "Override redirected `"
+                                                     original-fx-id
+                                                     "` to `"
+                                                     override-target
+                                                     "`, which is not registered. Using the registered `"
+                                                     original-fx-id
+                                                     "` instead.")
+                                :recovery       :replaced-with-default})
+            original-fx-id))
+
+        :else
+        ;; Neither fn nor keyword — treat as "no override" and fall
+        ;; through to the original fx. Includes `nil` (documented in
+        ;; spec/002 §`:fx-overrides` as a noop-style placeholder).
         original-fx-id))
     original-fx-id))
+
+(defn- resolved-fx-meta
+  "Return the fx-handler meta to invoke for `original-fx-id` under
+  `overrides`. The fn-value branch synthesises a transient meta that
+  carries the user-supplied lambda as `:handler-fn`; the id-redirect
+  and no-override branches look up the registrar entry under the
+  resolved fx-id.
+
+  Returns `nil` when no handler is resolvable (the caller then emits
+  `:rf.error/no-such-fx`)."
+  [original-fx-id resolved-fx-id overrides]
+  (let [override (get overrides original-fx-id)]
+    (if (and (contains? overrides original-fx-id)
+             (fn? override))
+      ;; Function-value override — synthesise a meta with the user's fn.
+      ;; `:platforms` defaults to both so the fn is callable from JVM and
+      ;; browser tests alike (the override is a test/story affordance —
+      ;; gating it by platform would surprise the test author).
+      {:handler-fn override
+       :platforms  #{:client :server}}
+      (registrar/lookup :fx resolved-fx-id))))
 
 (defn- emit-handled!
   "Emit a `:rf.fx/handled` success trace for a dispatched fx. Per Spec-Schemas
@@ -117,7 +171,8 @@
   `:rf.http/managed` (Spec 014 §Reply addressing) can address replies back
   to the originator without a separate cofx-injection step."
   [frame-id [original-fx-id args] active-platform overrides origin-event]
-  (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)]
+  (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)
+        resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)]
    ;; Per Spec 009 §Performance instrumentation (rf2-du3i): every fx
    ;; invocation — reserved or user-registered — runs inside a perf
    ;; bracket so prod builds with the perf flag enabled produce a
@@ -165,8 +220,13 @@
     ;; by re-frame.machines (day8/re-frame2-machines) via the regular
     ;; reg-fx path and arrive here through the registrar default below.
 
-    ;; Default: user-registered fx.
-    (if-let [meta (registrar/lookup :fx fx-id)]
+    ;; Default: user-registered fx — OR a synthesised meta carrying a
+    ;; function-value override (per `resolved-fx-meta` above; the
+    ;; spec/002 CLJS-reference convenience form). `resolved-meta` was
+    ;; computed once at top of `handle-one-fx` so the case-block fallthrough
+    ;; honours both registry hits and the fn-value override branch without
+    ;; a second lookup.
+    (if-let [meta resolved-meta]
       (if (fx-runs-on-platform? meta active-platform)
         (let [;; Per rf2-3nn8: bind `*current-trigger-handler*` for the
               ;; duration of the fx handler's invocation (including the

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -397,3 +397,119 @@
             "one :rf.error/effect-map-shape trace per offending top-level key")
         (is (= #{:dispatch :http} offending)
             "both legacy keys are flagged")))))
+
+;; ---- 7. :fx-overrides function-value branch -------------------------------
+;;
+;; Per Spec 002 §`:fx-overrides` §Pattern-level contract vs CLJS reference:
+;; the CLJS reference accepts function-valued overrides — `(fn [m args] ...)` —
+;; as a one-off lambda affordance for tests and story fixtures. The signature
+;; matches the registered-fx handler shape, so a user can either point at
+;; another registered fx (id-redirect) or hand a lambda in-line. The pattern-
+;; level contract narrows to id-only for SSR-portability; the CLJS reference
+;; (this code; `.cljc` so JVM tests run too) supports both.
+;;
+;; Spec/002's conceptual resolution sketch (§1080-1088):
+;;   (nil? override)        → no override
+;;   (keyword? override)    → id-redirect via registrar
+;;   (fn? override)         → run the fn in place of the original fx
+;;
+;; The three sub-tests pin the contract:
+;;   1. fn-value runs in place of the original; the original does NOT fire.
+;;   2. id-redirect form (regression: existing pattern-level path still works).
+;;   3. nil-value (or missing key) → no override active; original fires.
+
+(deftest fx-overrides-fn-value-branch
+  (testing "function-value override fires in place of the registered fx"
+    (let [original-fired (atom 0)
+          override-args  (atom nil)
+          override-ctx   (atom nil)]
+      (rf/reg-fx :fx-test/http
+                 {:platforms #{:client :server}}
+                 (fn [_ _] (swap! original-fired inc)))
+      (rf/reg-event-fx :fx-test/issue-request
+        (fn [_ _] {:fx [[:fx-test/http {:method :get :url "/me"}]]}))
+      (rf/dispatch-sync
+        [:fx-test/issue-request]
+        {:fx-overrides {:fx-test/http (fn [m args]
+                                        (reset! override-ctx m)
+                                        (reset! override-args args)
+                                        {:status 200 :body {:user/id 42}})}})
+      (is (= 0 @original-fired)
+          "the registered :fx-test/http MUST NOT fire when overridden by a fn")
+      (is (= {:method :get :url "/me"} @override-args)
+          "the fn override receives the same args the registered fx would")
+      (is (= :rf/default (:frame @override-ctx))
+          "the fn override receives the standard ctx map (frame, optional :event)")))
+
+  (testing "id-redirect form (regression: pattern-level pathway still works)"
+    (let [fired (atom [])]
+      (rf/reg-fx :fx-test/http-redir
+                 {:platforms #{:client :server}}
+                 (fn [_ _] (swap! fired conj :original)))
+      (rf/reg-fx :fx-test/http-redir-stub
+                 {:platforms #{:client :server}}
+                 (fn [_ _] (swap! fired conj :stub)))
+      (rf/reg-event-fx :fx-test/issue-redir
+        (fn [_ _] {:fx [[:fx-test/http-redir {}]]}))
+      (rf/dispatch-sync
+        [:fx-test/issue-redir]
+        {:fx-overrides {:fx-test/http-redir :fx-test/http-redir-stub}})
+      (is (= [:stub] @fired)
+          "the id-redirect form still resolves to the stub fx; the original is not invoked")))
+
+  (testing "nil-valued override falls through to the original fx"
+    ;; Per spec/002 §`:fx-overrides`: a `nil`-or-missing value is treated
+    ;; as "no override active" — `(get overrides id)` returns nil in both
+    ;; cases. The original registered fx fires.
+    (let [fired (atom 0)]
+      (rf/reg-fx :fx-test/http-nil-override
+                 {:platforms #{:client :server}}
+                 (fn [_ _] (swap! fired inc)))
+      (rf/reg-event-fx :fx-test/issue-nil-override
+        (fn [_ _] {:fx [[:fx-test/http-nil-override {}]]}))
+      (rf/dispatch-sync
+        [:fx-test/issue-nil-override]
+        {:fx-overrides {:fx-test/http-nil-override nil}})
+      (is (= 1 @fired)
+          "a nil-valued override is a no-op; the original registered fx fires"))))
+
+(deftest fx-overrides-fn-value-emits-applied-trace
+  (testing "fn-value override emits :rf.fx/override-applied (per spec/009)"
+    (let [traces (collect-traces! ::fn-override-trace)]
+      (rf/reg-fx :fx-test/http-traced
+                 {:platforms #{:client :server}}
+                 (fn [_ _] nil))
+      (rf/reg-event-fx :fx-test/issue-traced
+        (fn [_ _] {:fx [[:fx-test/http-traced {}]]}))
+      (rf/dispatch-sync
+        [:fx-test/issue-traced]
+        {:fx-overrides {:fx-test/http-traced (fn [_ _] :ok)}})
+      (rf/remove-trace-cb! ::fn-override-trace)
+      (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
+        (is (= 1 (count applied))
+            "exactly one :rf.fx/override-applied trace for the fn-value override")
+        (let [t (first applied)]
+          (is (= :fx-test/http-traced (get-in t [:tags :from]))
+              ":from carries the original fx-id"))))))
+
+(deftest fx-overrides-fn-value-receives-origin-event
+  (testing "fn-value override receives :event in ctx when the dispatch carries one"
+    ;; Per Spec 014 §Reply addressing the originating event is threaded
+    ;; through to fx handlers as `:event` on their ctx; the fn-value
+    ;; override branch follows the same code path, so the ctx shape is
+    ;; identical to a registered-fx handler.
+    (let [captured-ctx (atom nil)]
+      (rf/reg-fx :fx-test/http-with-event
+                 {:platforms #{:client :server}}
+                 (fn [_ _] nil))
+      (rf/reg-event-fx :fx-test/issue-with-event
+        (fn [_ _] {:fx [[:fx-test/http-with-event {:url "/x"}]]}))
+      (rf/dispatch-sync
+        [:fx-test/issue-with-event :payload-1]
+        {:fx-overrides {:fx-test/http-with-event
+                        (fn [m _] (reset! captured-ctx m))}})
+      (is (= :rf/default (:frame @captured-ctx))
+          "ctx :frame is present")
+      (is (= [:fx-test/issue-with-event :payload-1]
+             (:event @captured-ctx))
+          "ctx :event is the originating event vector"))))


### PR DESCRIPTION
## Summary

- Implements the `:fx-overrides {<id> (fn [m args] ...)}` fn-value branch promised by spec/002 §`:fx-overrides` (the CLJS-reference convenience for one-off lambdas in tests and story decorators).
- Previously only `{<id> <other-id>}` id-redirect was honoured; fn-values fell through to `:rf.error/override-fallthrough`, silently firing the real fx — including in copy-pasted Testing-chapter examples.
- Refactor splits resolution: `resolve-fx-with-overrides` returns the fx-id for tracing; new `resolved-fx-meta` returns either the registrar meta or a synthesised meta carrying the user's lambda as `:handler-fn`. The existing `handle-one-fx` pipeline (perf bracket, exception isolation, `*current-trigger-handler*` binding, `:event` threading) covers both paths uniformly.

## Test plan

- [x] New: fn-value override fires in place of registered fx; original does NOT fire
- [x] New: fn-value override receives ctx (`:frame`, `:event`) and args matching the registered-fx handler shape
- [x] New: `:rf.fx/override-applied` trace emitted for fn-value (with `:to ::fn-value`)
- [x] New: nil-valued override falls through to the original fx (per spec/002 §1054 "nil = noop")
- [x] Regression: id-redirect form still resolves correctly
- [x] Full clj test suite: 246 tests / 1111 assertions / 0 failures / 0 errors
- [x] Conformance suite: all fixtures pass; `error-override-fallthrough.edn` (id→unregistered-id path) still emits the fallthrough error as before

## Notes

- `.cljc` single-source — works on both JVM and CLJS reference.
- Tool/story-side override registration (`tools/story/src/re_frame/story/frames.cljc`) already uses the id-redirect form by design (stories need wire-portable overrides for snapshotting); no change needed.
- `tools/pair2-mcp/spec/003-Tool-Catalogue.md` example uses id-redirect (MCP-transported); no change needed.
- Spec wording is precise and consistent with the implementation; no edits required.