### PR TITLE
docs(pair2-mcp): uplift spec/ — Principles + API + DESIGN-RATIONALE + findings/ to match canonical shape (rf2-bfax.1)

### DIFF
--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -1,0 +1,253 @@
+# API
+
+The consolidated user-facing surface. One-stop reference for
+installing, configuring, launching, and calling pair2-mcp.
+
+This doc is a **reference**; the normative contracts live in the
+per-area specs (000–003). Where the two drift, the per-area spec
+wins.
+
+## Installation
+
+### npm — global install
+
+```bash
+npm install -g @day8/re-frame-pair2-mcp
+```
+
+Provides the `re-frame-pair2-mcp` binary on `$PATH`.
+
+### npm — one-off via npx
+
+```bash
+npx @day8/re-frame-pair2-mcp
+```
+
+No persistent install; useful for trying the server out and for
+CI configurations.
+
+### Project-local install
+
+```bash
+npm install --save-dev @day8/re-frame-pair2-mcp
+```
+
+The binary lands under `node_modules/.bin/re-frame-pair2-mcp`; the
+agent host's `command` slot points there.
+
+## Configuration
+
+### Claude Code
+
+Add to `~/.claude/settings.json` (or per-project
+`.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "re-frame-pair2": {
+      "command": "re-frame-pair2-mcp",
+      "env": {
+        "SHADOW_CLJS_BUILD_ID": "app"
+      }
+    }
+  }
+}
+```
+
+### Cursor / Copilot / other MCP-capable hosts
+
+Same `command` + `env` shape, registered through the host's MCP
+configuration mechanism. The stdio JSON-RPC framing is host-agnostic
+per the [MCP transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SHADOW_CLJS_BUILD_ID` | `"app"` | Default build id passed to `cljs-eval`. Overridable per-op via the `build` argument. |
+| `SHADOW_CLJS_NREPL_PORT` | (unset) | Explicit nREPL port; takes precedence over port-file discovery. |
+| `PAIR2_RUNTIME_PATH` | `skills/re-frame-pair2/scripts/runtime.cljs` | Path the server reads when re-injecting the runtime after a sentinel miss. |
+
+### nREPL port discovery
+
+The server walks the following sources in order:
+
+1. `$SHADOW_CLJS_NREPL_PORT` env var.
+2. `target/shadow-cljs/nrepl.port` (shadow-cljs's standard location).
+3. `.shadow-cljs/nrepl.port`.
+4. `.nrepl-port` (generic nREPL convention).
+
+If none resolve, the server boots in degraded mode (per
+[`001-Wire-Protocol.md`](./001-Wire-Protocol.md) §Degraded boot) and
+returns a structured error on every `tools/call` until the port
+becomes resolvable. No restart needed once shadow-cljs comes up.
+
+## Launch
+
+### As an MCP subprocess (the usual path)
+
+The agent host launches the server when it needs to call a pair2
+tool. No manual start.
+
+### Standalone (for debugging / smoke tests)
+
+```bash
+re-frame-pair2-mcp
+```
+
+Reads JSON-RPC messages on stdin; writes responses on stdout. Type
+`Ctrl+D` (EOF) to close.
+
+### From source
+
+```bash
+git clone https://github.com/day8/re-frame2.git
+cd re-frame2/tools/pair2-mcp
+npm install
+npm run build      # → out/server.js
+node out/server.js
+```
+
+## Tool surface
+
+The seven tools, in the order a typical session uses them. Argument
+schemas and result shapes are specified in
+[`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md).
+
+| Tool | Purpose |
+|---|---|
+| `discover-app` | Health-check the runtime; inject if needed. Run first every session. |
+| `eval-cljs` | Evaluate a CLJS form; returns the EDN value. |
+| `inject-runtime` | Force re-ship of `runtime.cljs` (after editing the runtime source). |
+| `dispatch` | Fire a re-frame event with `:origin :pair`. Modes: queued, sync, trace. |
+| `trace-window` | Return epoch records from the last N ms. |
+| `watch-epochs` | Pull-mode poll for matching epochs since a given id. |
+| `tail-build` | Wait for a hot-reload to land by polling a probe form. |
+
+Each tool's JSONSchema is surfaced via `tools/list` per the MCP
+spec.
+
+## Mode flags (dispatch)
+
+The `dispatch` tool has three modes selected by the `sync` / `trace`
+flags:
+
+| `sync` | `trace` | Mode | Runtime call |
+|---|---|---|---|
+| `false` | `false` | queued | `rf/dispatch` |
+| `true` | `false` | sync | `rf/dispatch-sync` |
+| any | `true` | trace | sync + returns `:rf/epoch-record` |
+
+The trace mode is the workhorse for agent loops: dispatch, see what
+fired, decide next step. See
+[`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md) § `dispatch`.
+
+## Result shape
+
+All tools return EDN inside the MCP `tools/call` `content` text
+slot. The canonical shape:
+
+```clojure
+{:ok?    true | false
+ :value  <op-specific result, when :ok? true>
+ :reason <keyword, when :ok? false>
+ :message "..." (optional human-readable elaboration)
+ ...op-specific keys}
+```
+
+Tool-execution failures (a known tool returning `:ok? false`) use
+`isError: true` per the MCP spec's error-handling guidance; they are
+NOT protocol-level errors. Protocol-level errors (bad JSON, unknown
+method) use JSON-RPC error codes — see
+[`001-Wire-Protocol.md`](./001-Wire-Protocol.md) § JSON-RPC error
+codes.
+
+## First call (smoke test)
+
+After installing the server and configuring Claude Code:
+
+```text
+Agent: tools/call discover-app {}
+Server: {:ok? true
+         :debug-enabled? true
+         :frames [:app/main]
+         :coord-annotation-enabled? true
+         :build-id "app"}
+```
+
+If the health summary comes back `:ok? true`, the connection is
+live. Subsequent tool calls reuse the same socket.
+
+## Skill-driven calls
+
+With the pair2 skill loaded (see
+[`../../skills/re-frame-pair2/SKILL.md`](../../skills/re-frame-pair2/SKILL.md)),
+agents describe the task in plain language and the skill's
+`SKILL.md` teaches the model which tool to call. The MCP server is
+the transport; the skill is the playbook.
+
+## Runtime surfaces consumed (not exposed)
+
+pair2-mcp **consumes** the framework + runtime; it does not expose
+analogues. Listed here for reference:
+
+| Surface | Source | What pair2-mcp reads / writes |
+|---|---|---|
+| `re-frame-pair2.runtime/session-id` | runtime.cljs | Sentinel for re-inject detection. |
+| `re-frame-pair2.runtime/dispatch!` | runtime.cljs | Queued / sync / trace dispatch. |
+| `re-frame-pair2.runtime/trace-window` | runtime.cljs | Last-N-ms epoch lookback. |
+| `re-frame-pair2.runtime/watch-epochs` | runtime.cljs | Poll for epochs after id. |
+| `re-frame-pair2.runtime/probe` | runtime.cljs | Hot-reload landed signal. |
+| `shadow.cljs.devtools.api/cljs-eval` | shadow-cljs | The CLJS bridge over the JVM-side nREPL socket. |
+| `:rf/epoch-record` | framework | The epoch record shape returned by trace mode. |
+| `:origin :pair` (in event tags) | framework | Pair2's dispatches surface in the trace stream distinguishably. |
+
+## Back-compat: the bash shims
+
+The bash shims under `skills/re-frame-pair2/scripts/` continue to
+work; they are not slated for removal. The op vocabulary is
+identical between the two surfaces.
+
+| Bash shim | MCP tool |
+|---|---|
+| `discover-app.sh` | `discover-app` |
+| `eval-cljs.sh` | `eval-cljs` |
+| `inject-runtime.sh` | `inject-runtime` |
+| `dispatch.sh` | `dispatch` |
+| `trace-window.sh` | `trace-window` |
+| `watch-epochs.sh` | `watch-epochs` |
+| `tail-build.sh` | `tail-build` |
+
+Agents may mix shim calls and MCP tool calls in the same workflow
+during the transition. New sessions should prefer the MCP server for
+latency reasons (see
+[`Principles.md`](./Principles.md) § Single persistent nREPL socket).
+
+## Versioning
+
+`@day8/re-frame-pair2-mcp` follows semver. Major changes break the
+tool surface (an op removed or its arg shape changed). Minor adds an
+op or expands an optional arg. Patch fixes a bug without changing
+the contract.
+
+The framework runtime dep (`re-frame-pair2.runtime`) is the
+companion artefact; their majors track together when the op
+vocabulary changes.
+
+## What this doesn't expose
+
+- **No new framework primitives.** No new registries, no new
+  dispatch types, no new effect substrates. The seven ops route
+  through existing `re-frame-pair2.runtime` surfaces. See
+  [`Principles.md`](./Principles.md) § Tool consumes the framework.
+- **No remote-attach protocol.** pair2-mcp is stdio-only; the agent
+  host owns the network plumbing. A custom WebSocket protocol was
+  considered and rejected (per
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) § Lock #2).
+- **No "private" surfaces.** All public ops are listed in
+  [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md); there are no
+  hidden tools, no internal-only endpoints.
+- **No long-running streaming.** MCP isn't a streaming protocol;
+  `watch-epochs` is pull-mode, called repeatedly with the same
+  `since-id` rather than maintaining a server-pushed feed.

--- a/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,373 @@
+# DESIGN-RATIONALE
+
+The direction-setting decisions that shape pair2-mcp. Each entry
+captures:
+
+- **The question** that was being decided.
+- **Options considered.**
+- **The pick** that was locked.
+- **The why** — the reasoning trail.
+- **Date locked** + the locker.
+
+This doc is the load-bearing artefact of the per-tool spec
+convention. It exists so that a future contributor (human or AI) can
+read it and not re-ask the same questions. Where the spec text reads
+"per lock #N in DESIGN-RATIONALE.md", this is where to come.
+
+---
+
+## Lock #1 — Implementation language
+
+**Locked 2026-05-12 (Mike).** **ClojureScript compiled via
+shadow-cljs to a Node `:node-script` target.**
+
+### Question
+
+What language and runtime hosts the MCP server's process?
+
+### Options considered
+
+- **ClojureScript + shadow-cljs → Node.** Compile a `:node-script`
+  artefact; end users install Node only; the compiled output is
+  plain JS. The team runs shadow-cljs daily.
+- **JVM Clojure.** A fat-jar that the agent host launches via
+  `java -jar`. Same language as the framework's reference; reuses
+  the project's Clojure dep set directly.
+- **`nbb` (Node + babashka-flavoured SCI).** Smaller dep surface; no
+  build step. ClojureScript syntax, eval'd at runtime.
+- **Pure babashka.** Same shape as the bash-shim chain's babashka
+  runner. Project-local familiarity.
+- **JavaScript / TypeScript directly.** Idiomatic for an npm MCP
+  server; the SDK's reference impl is in TS.
+
+### Pick
+
+**ClojureScript + shadow-cljs → Node.**
+
+### Why
+
+- **End-user install cost.** Node is widely installed; the JVM is
+  not (Mac/Win/Linux dev machines may or may not have a JDK). End
+  users running `npm install -g @day8/re-frame-pair2-mcp` are paying
+  zero install cost — Node is already there for shadow-cljs.
+- **Cold start.** A JVM-Clojure server pays a 1–2s cold-start cost
+  every time the agent host launches the subprocess. Node + a
+  pre-compiled `.js` artefact starts in ~50ms. Latency matters
+  because the agent host can re-launch the subprocess across IDE
+  restarts.
+- **Tooling maturity.** `nbb` is exciting but the agent host /
+  shadow-cljs / npm MCP SDK interop space is more battle-tested
+  through plain Node. Hitting a `nbb`-specific edge case during a
+  pair-coding session would be costly.
+- **Same-language win.** The team writes ClojureScript daily;
+  shadow-cljs is in the build path of every re-frame2 dev's repo.
+  One more `:node-script` build target is trivial. JavaScript /
+  TypeScript would mean a second language and toolchain.
+- **npm MCP SDK is reachable.** The `@modelcontextprotocol/sdk`
+  npm package works fine via shadow-cljs's CommonJS interop;
+  `StdioServerTransport` provides the framing without us rolling
+  our own.
+
+### Date locked
+
+2026-05-12 (Mike). Pilot established viability earlier the same
+week; lock was on the pilot's results once bencode round-trip and
+stdio JSON-RPC were both proven.
+
+### Trail-of-thought citations
+
+- rf2-5b8e PR #423 (the toolchain pilot — `pilot/` directory is
+  preserved as the smoke harness).
+- Mike's 2026-05-12 locking comment on the PR.
+
+---
+
+## Lock #2 — Agent-host transport
+
+**Locked 2026-05-12 (Mike).** **MCP over stdio.** No custom
+WebSocket protocol.
+
+### Question
+
+How does pair2-mcp speak to agent hosts? MCP, a custom WebSocket,
+an HTTP API, or some other shape?
+
+### Options considered
+
+- **MCP over stdio.** The agent host launches the server as a
+  subprocess; newline-delimited JSON-RPC 2.0 over stdin/stdout per
+  the [MCP stdio transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
+- **Custom WebSocket protocol.** A pair2-specific wire format; the
+  agent host opens a WebSocket; pair2-mcp listens on a known port.
+- **HTTP REST endpoints.** Each op is an HTTP endpoint; agent
+  hosts POST JSON.
+- **MCP over WebSocket.** MCP semantics, WebSocket transport (per
+  the MCP spec's alternate transport).
+
+### Pick
+
+**MCP over stdio.**
+
+### Why
+
+- **Host-agnostic.** MCP is the contract every modern agent host
+  (Claude Code, Cursor, Copilot) already speaks. Implementing MCP
+  once works for all of them. A custom WebSocket would require each
+  host to learn pair2's wire shape — N integrations instead of one.
+- **Stdio is the lowest-friction transport.** No port allocation,
+  no firewall negotiation, no reconnect logic. The agent host owns
+  process lifecycle; when the host exits, the server exits.
+- **The HTTP REST option** doesn't earn its keep — it has the same
+  surface as JSON-RPC but without the request/response correlation
+  semantics, and it requires a port.
+- **WebSocket-as-transport (MCP-flavoured)** adds operational
+  complexity (port, reconnect, security) for benefits the local
+  pair-coding workflow doesn't need.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-5b8e PR #423 description.
+- The pilot proved stdio + JSON-RPC + bencode round-trip end-to-end
+  before this lock; the WebSocket alternative was never built.
+
+---
+
+## Lock #3 — Connection model
+
+**Locked 2026-05-12 (Mike).** **Single persistent nREPL socket** for
+the lifetime of the session. Reconnect-per-op is rejected.
+
+### Question
+
+Does pair2-mcp open a fresh nREPL connection per op (matching the
+bash-shim chain's shape) or hold one persistent socket for the
+session?
+
+### Options considered
+
+- **Reconnect-per-op.** Match the bash-shim chain: open a socket,
+  run the op, close it. No connection state to manage.
+- **Single persistent socket.** Open on first need; hold for the
+  session; multiplex ops by UUID id.
+- **Connection pool.** A small pool of pre-warmed sockets, rotating
+  by op. Useful only if there's concurrency.
+
+### Pick
+
+**Single persistent socket.** Multiplexed by op-id (`{id →
+resolve-fn}` pending map).
+
+### Why
+
+- **Latency.** The bash-shim chain pays ~200–500ms per op for fresh
+  TCP connect + nREPL handshake. A persistent socket pays that
+  cost *once per session* — and a typical pair2 session fires
+  dozens to hundreds of ops. Break-even is one op.
+- **Interactive feel.** Per-op latency drops from ~700ms to ~5–50ms.
+  This is the difference between *batch* (the shim shape) and
+  *interactive* (the MCP shape). The MCP server feels like
+  pair-coding; the shim chain feels like running a script.
+- **Connection state is cheap.** One socket, one pending map, one
+  reader loop. The bencode framing has a known footgun (see
+  `002-nREPL-Transport.md`) which is a one-time implementation
+  cost.
+- **Pool not needed.** The MCP server invokes tools sequentially;
+  there's no concurrency to amortise. A pool would add complexity
+  without benefit.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-5b8e PR #423 description.
+- The bash-shim chain's per-op latency budget was the load-bearing
+  motivation for building pair2-mcp at all.
+
+---
+
+## Lock #4 — Tool catalogue cardinality
+
+**Locked 2026-05-12 (Mike).** **Seven ops**, mirroring the bash-shim
+catalogue exactly.
+
+### Question
+
+How many MCP tools does pair2-mcp expose, and which ones?
+
+### Options considered
+
+- **Mirror the seven bash-shim ops** (`discover-app`, `eval-cljs`,
+  `inject-runtime`, `dispatch`, `trace-window`, `watch-epochs`,
+  `tail-build`).
+- **Lift some shim helpers into ops** (e.g. a `re-inject` shortcut,
+  a `current-frame` accessor, an `assert-runtime` helper). Wider
+  surface; smaller per-op work.
+- **Decompose `dispatch`** into `dispatch-queued`, `dispatch-sync`,
+  `dispatch-trace` — three ops instead of one with mode flags.
+- **Add new ops** (e.g. `subs/cache`, `registrar/list`,
+  `registrar/describe`, `app-db/snapshot`, `app-db/get`,
+  `app-db/reset`) covering surfaces the shims don't.
+
+### Pick
+
+**Seven ops — mirror the bash-shim catalogue.** Identical
+vocabulary, identical contract semantics.
+
+### Why
+
+- **Identical contract eases migration.** Agents and skills that
+  already understand the seven shim ops carry their understanding
+  directly to the MCP server. Skill `SKILL.md` files don't have to
+  be rewritten; the only difference is transport.
+- **Mode flags over op decomposition.** `dispatch` with `sync` /
+  `trace` flags is the existing shim shape and survives in MCP.
+  Three sibling ops would inflate the catalogue without gaining
+  expressiveness.
+- **Additional ops are deferrable.** Surfaces like `subs/cache`,
+  `app-db/snapshot`, `registrar/list` are valuable but every one
+  needs a runtime accessor, an op schema, and a test. Shipping the
+  shim-mirror first proves the transport; expansion lands later
+  when load-bearing demand exists. A `dispatch` + `eval-cljs`
+  combo already covers many of these cases for v1.
+- **Bounded surface eases reasoning.** Seven ops is small enough
+  that the agent host's `tools/list` response is comprehensible at
+  a glance; the user can read it and know what the server does.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-5b8e PR #423 description.
+- The bash-shim catalogue had stabilised at seven ops over multiple
+  iterations before the MCP port; the cardinality was already
+  validated by daily use.
+
+---
+
+## Lock #5 — bencode pinning
+
+**Locked 2026-05-12 (Mike, during pilot).** **`bencode@~2.0.3`**
+pinned via npm. bencode@4+ is rejected.
+
+### Question
+
+Which bencode npm package handles nREPL framing?
+
+### Options considered
+
+- **`bencode@~2.0.3`.** CommonJS export shape; works with
+  shadow-cljs's CommonJS interop out of the box.
+- **`bencode@4+`.** ESM-only; newer maintainer release line.
+- **Roll our own bencode codec.** ~150 LoC of straightforward
+  parsing; zero dependency.
+
+### Pick
+
+**`bencode@~2.0.3`**, pinned with the tilde to admit patch updates
+only.
+
+### Why
+
+- **shadow-cljs CommonJS shim.** `bencode@4+` is ESM-only and
+  immediately fails with `Error: No "exports" main defined` when
+  loaded via shadow-cljs's `:node-script` target. The CommonJS
+  shape of `bencode@2.x` works without ceremony.
+- **bencode footgun discovered during pilot.** `bencode@2`'s
+  `bencode.decode.bytes` attribute is unreliable — sometimes set to
+  the *full* buffer length even when only the first frame was
+  decoded. The correct accessor is `bencode.decode.position`. This
+  is captured in `002-nREPL-Transport.md` § Bencode framing; the
+  pin to a known-good version prevents drift.
+- **Rolling our own** is tempting but the codec is just enough work
+  that getting it wrong (especially around dict ordering and binary
+  payloads) would introduce a class of bugs that the npm package
+  has already solved. Pinning is the lower-effort risk-mitigation.
+
+### Date locked
+
+Pilot phase (early rf2-5b8e). The pin landed when the bencode
+position-vs-bytes footgun was hit; locked at PR #423 merge.
+
+### Trail-of-thought citations
+
+- `tools/pair2-mcp/spec/002-nREPL-Transport.md` § Bencode framing.
+- rf2-5b8e PR #423 description (the position-vs-bytes diagnosis).
+- The pilot's `nrepl_test.cljs` unit tests around partial-frame
+  decoding.
+
+---
+
+## Lock #6 — Bash-shim deprecation cadence
+
+**Locked 2026-05-12 (Mike).** **Both surfaces ship side-by-side.**
+No removal scheduled; shims remain working with deprecation notice.
+
+### Question
+
+When do the bash shims under `skills/re-frame-pair2/scripts/` get
+removed?
+
+### Options considered
+
+- **Remove the shims at MCP-server ship.** One transport going
+  forward; clean break.
+- **Mark deprecated; remove next major.** Explicit removal
+  schedule.
+- **Ship side-by-side indefinitely.** Both work; migration is
+  opt-in per session.
+
+### Pick
+
+**Side-by-side, no removal scheduled.** Shim headers carry a
+deprecation notice pointing to the MCP server; nothing else
+changes.
+
+### Why
+
+- **Migration risk is asymmetric.** Removing the shims could break
+  existing runbooks, skill docs, and personal workflows that
+  reference them. The benefit of removal (less code) is small
+  compared to the cost (someone's session breaking on a Tuesday).
+- **Identical op vocabulary.** The seven MCP tools mirror the
+  seven shim ops exactly. Agents can mix calls in the same workflow
+  during transition — no all-or-nothing switch is required.
+- **MCP server isn't proven across the team yet.** Side-by-side
+  shipping gives the MCP server time to accumulate trust before
+  becoming the only path.
+- **Future removal is cheap.** If/when the MCP server is the
+  obvious answer for every consumer, the shims come out in a
+  later drop. The decision is reversible.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- rf2-5b8e PR #423 description.
+- `tools/pair2-mcp/README.md` § Back-compat with the bash shims.
+
+---
+
+## Summary table
+
+| # | Question | Pick | Date |
+|---|---|---|---|
+| 1 | Implementation language | **ClojureScript + shadow-cljs → Node** | 2026-05-12 |
+| 2 | Agent-host transport | **MCP over stdio** | 2026-05-12 |
+| 3 | Connection model | **Single persistent nREPL socket** | 2026-05-12 |
+| 4 | Tool catalogue cardinality | **Seven ops** (mirror the shim catalogue) | 2026-05-12 |
+| 5 | bencode pinning | **`bencode@~2.0.3`** (CommonJS; position-not-bytes) | 2026-05-12 |
+| 6 | Bash-shim deprecation | **Side-by-side, no removal scheduled** | 2026-05-12 |
+
+These six locks together define pair2-mcp's v0.1.0 surface. Anything
+outside these decisions is up for design discussion; anything inside
+is direction-set and shipped.

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -1,0 +1,144 @@
+# Principles
+
+The load-bearing principles. When a design call has two reasonable
+options, these are the tie-breakers. Implementers and contributors
+should be able to read this doc and reach the same answers
+pair2-mcp already reached.
+
+These are downstream of the framework's [Principles](../../../spec/Principles.md);
+they are *pair2-mcp-specific*. Where they overlap the framework's
+principles, this doc cites instead of repeating.
+
+## Tool consumes the framework; doesn't extend it
+
+pair2-mcp is a **downstream consumer** of re-frame2's existing
+surfaces. It must not add:
+
+- New registries.
+- New dispatch types.
+- New effect substrates.
+- New component substrates.
+
+The seven ops route through the existing `re-frame-pair2.runtime`
+namespace via `cljs-eval`. Nothing new is registered against the
+framework; nothing new is introduced into a consumer app's runtime.
+
+This is the downstream-EPs-consume-foundation rule applied to tools:
+tools observe and exercise what the framework emits and registers;
+they do not invent new substrates.
+
+Concretely: when implementation surfaces a runtime gap (e.g., "I
+want to inspect the epoch ring but the runtime doesn't expose a
+read accessor"), file a `bd` bead against `re-frame-pair2.runtime`
+or the relevant framework spec. Don't bolt a parallel surface onto
+the MCP server.
+
+## MCP, not an IDE plugin
+
+The agent-host integration contract is **Model Context Protocol over
+stdio**, not a per-editor extension.
+
+By implementing MCP, this artefact works with every MCP-capable host
+(Claude Code, Cursor, Copilot, and whatever lands next) without
+per-host plumbing. The cost of one stdio JSON-RPC server is paid
+once; the alternative — N editor extensions, each re-implementing
+the same tool surface — pays the cost N times and ages worse.
+
+A custom WebSocket protocol was considered and rejected for the same
+reason: it would require every agent host to learn pair2's wire
+shape. MCP already exists; pair2-mcp speaks it.
+
+## Single persistent nREPL socket
+
+One TCP socket to the shadow-cljs nREPL is opened on first need and
+held for the lifetime of the session. Subsequent ops reuse the
+socket without reconnecting.
+
+The break-even versus a reconnect-per-op design is one op — and a
+typical pair2 session fires dozens to hundreds. Per-op latency drops
+from ~700ms (bash startup + babashka startup + fresh nREPL connect
+per call) to ~5–50ms (one bencode round-trip on the open socket).
+
+The persistent-socket choice is what makes the MCP server feel
+*interactive* rather than *batch*. It is the load-bearing latency
+decision.
+
+Ops carry a UUID `id`; the connection multiplexes incoming bencode
+frames against a `{id → resolve-fn}` pending map. Concurrent ops
+are correct in principle even though the MCP server currently
+invokes tools sequentially.
+
+## Stage-marker-independent
+
+pair2-mcp must work against any conforming re-frame2 runtime. It
+does not depend on a specific shadow-cljs build configuration, a
+specific stage marker, or a specific re-frame2 release line.
+
+Concretely:
+
+- The `build` argument defaults to `"app"` but is configurable on
+  every op (and via the `SHADOW_CLJS_BUILD_ID` env var).
+- Port discovery walks `$SHADOW_CLJS_NREPL_PORT` → standard shadow
+  paths → `.nrepl-port`. Any of them satisfy the contract.
+- Runtime presence is sentinel-detected (`re-frame-pair2.runtime/session-id`),
+  not version-pinned. A reload re-injects from
+  `skills/re-frame-pair2/scripts/runtime.cljs` (or
+  `$PAIR2_RUNTIME_PATH`).
+- The runtime contract is the shape of the seven ops, not a
+  specific framework version.
+
+A project that adopts a non-default build id, a custom nREPL port,
+or a slightly different shadow layout still gets a working
+pair2-mcp without code changes.
+
+## Degraded boot, not failed boot
+
+If the nREPL port can't be resolved at startup (no port file, no
+env var, shadow-cljs not running yet), the server still boots and
+answers `tools/list`. Every `tools/call` returns a structured
+`:ok? false :reason :nrepl-port-not-found` error so the agent host
+can surface the problem and the user can start shadow-cljs without
+restarting the server.
+
+The agent-host workflow is *don't make the user restart anything*.
+The server's job is to keep working through the gaps and surface a
+useful error when the runtime isn't ready.
+
+## Bash-shim back-compat preserved
+
+The bash shims under `skills/re-frame-pair2/scripts/` continue to
+work and are not slated for removal. Their headers carry a
+deprecation notice pointing here; migration is opt-in per session.
+
+The migration discipline is *additive, not destructive*. Agents can
+mix shim calls and MCP tool calls in the same workflow during the
+transition. Existing skill docs and runbooks that reference the
+shims keep working; nothing breaks because the MCP server shipped.
+
+The op vocabulary (the seven canonical pair2 ops) is identical
+between the two surfaces — only the transport changes. This is what
+makes the back-compat tractable: the contract is the same; the
+plumbing underneath is different.
+
+## Backed by the framework's principles
+
+When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):
+
+- **Regularity over cleverness** — one obvious way to do a thing.
+  The seven op names and shapes are stable.
+- **Named things over anonymous things** — every op has a stable
+  name; every reason keyword in an `:ok? false` response is stable.
+- **Public query surfaces** — pair2-mcp reads only what the
+  framework's public registrar, trace bus, and epoch-history
+  surfaces expose, through the `re-frame-pair2.runtime` namespace.
+- **Deterministic execution** — a `dispatch` op with the same args
+  produces the same effect; no hidden state in the server beyond
+  the connection and the pending-map.
+- **No core.async** — per [`feedback_no_core_async`](../../../AGENTS.md),
+  pair2-mcp does not pull core.async as a dependency or use it as a
+  building block. The async return-shape is JavaScript Promises
+  (the Node host's native async substrate).
+
+pair2-mcp is a downstream artefact of the framework's AI-first
+discipline. The principles above are what *pair2-mcp adds* over the
+framework's baseline; everything below is inherited.

--- a/tools/pair2-mcp/spec/findings/.keep
+++ b/tools/pair2-mcp/spec/findings/.keep
@@ -1,0 +1,33 @@
+# findings/
+
+This directory accumulates design-investigation prose for pair2-mcp.
+
+Findings differ from DESIGN-RATIONALE: rationale entries are
+*locked decisions* with question / options / pick / why. Findings
+are *session-trail working notes* that surfaced patterns, surprises,
+or implementation discoveries — not all of which produce locks.
+
+## What goes here
+
+- Toolchain-pilot session notes (e.g., the bencode position-vs-bytes
+  diagnosis, the shadow-cljs CommonJS interop investigation, the
+  stdio-roundtrip smoke harness).
+- Audit findings cross-cutting pair2-mcp (per-tool spec audits,
+  performance investigations, dependency-surface reviews).
+- Cross-tool design lineage (e.g., comparisons with the bash-shim
+  chain's per-op latency profile that informed the persistent-socket
+  pick).
+
+## What doesn't go here
+
+- Locked decisions — those live in `DESIGN-RATIONALE.md`.
+- Per-tool op contracts — those live in `003-Tool-Catalogue.md`.
+- User-facing reference — that lives in `API.md`.
+- Principles — those live in `Principles.md`.
+
+## Current state
+
+The pilot work that produced pair2-mcp's load-bearing decisions was
+captured inline in PR #423's description (the merged toolchain
+pilot), not in a separate findings doc. Subsequent investigations
+that warrant prose-preservation land here.


### PR DESCRIPTION
## Summary

Bring `tools/pair2-mcp/spec/` up to the canonical per-tool shape established by `tools/10x/spec/`. Previously the sparsest of the five tool spec folders (only Vision + three capability docs); now matches the convention with Principles + API + DESIGN-RATIONALE + findings/.

- **Principles.md** (144 LoC) — load-bearing tie-breakers: tool consumes the framework (no new primitives), MCP not IDE-plugin, single persistent nREPL socket, stage-marker-independent, degraded-not-failed boot, bash-shim back-compat preserved.

- **API.md** (253 LoC) — one-stop install + configure + launch reference. Consolidates material previously split between `README.md` and `003-Tool-Catalogue.md`: env vars, port-discovery walk, the seven tools at a glance, dispatch mode flags, shim-to-MCP op mapping.

- **DESIGN-RATIONALE.md** (373 LoC) — six locks capturing the toolchain-pilot decisions previously trapped only in PR #423's description:
  1. Implementation language — ClojureScript + shadow-cljs → Node (chosen over JVM Clojure / nbb / babashka / TS).
  2. Agent-host transport — MCP over stdio (chosen over custom WebSocket / HTTP / MCP-over-WS).
  3. Connection model — single persistent nREPL socket (chosen over reconnect-per-op / pool).
  4. Tool catalogue cardinality — seven ops (mirror the bash-shim catalogue exactly).
  5. bencode pinning — `~2.0.3` CommonJS (the position-vs-bytes footgun discovered during pilot).
  6. Bash-shim deprecation cadence — side-by-side, no removal scheduled.

- **findings/.keep** — convention placeholder. Pilot findings were captured in PR #423's description; subsequent investigations accumulate here.

Touches only `tools/pair2-mcp/spec/` files. No framework code, no runtime, no tests changed.

## Test plan

- [ ] CI green (markdown-only change; no code paths touched).
- [ ] Visual review of the four new files against `tools/10x/spec/` for voice + density.