### PR TITLE
test(examples): expand counter_with_stories Playwright coverage — sidebar, mode tabs, panels, time-travel, a11y (rf2-kljn)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -1,5 +1,5 @@
 /*
- * Counter-with-stories example — Playwright smoke test (Story Stage 8).
+ * Counter-with-stories example — Playwright spec.
  *
  * Two surfaces in one bundle, hash-routed:
  *
@@ -7,10 +7,15 @@
  *                 same assertions as examples/reagent/counter, scoped
  *                 to a different starting value (5) and the parity
  *                 badge.
- *   - #/stories — the Story shell. We confirm the shell mounts
- *                 (the rf-story-shell react-class display-name
- *                 places enough hooks for a robust selector via the
- *                 sidebar root element).
+ *   - #/stories — the Story shell. The original Stage-8 smoke verified
+ *                 the shell mounts and a single variant renders. This
+ *                 spec also exercises every interactive surface of the
+ *                 playground — sidebar navigation, mode-tag filtering,
+ *                 workspace cell mounting, time-travel scrubber, trace
+ *                 panel, a11y panel, layout-debug toggles, args editor,
+ *                 mode picker, decorator list, save-layout button —
+ *                 one assertion per surface so each one is exercised
+ *                 by the smoke (rf2-kljn).
  *
  * The deep CLJS assertions on the Story registry (every reg-* macro
  * landed, play sequences pass, mount/unmount round-trip) live in
@@ -19,13 +24,60 @@
  * end-to-end on a real Chromium.
  */
 
-const { expectTextEquals } = require('../../scripts/spec-helpers.cjs');
+const {
+  expectTextEquals,
+  expectVisible,
+} = require('../../scripts/spec-helpers.cjs');
+
+/* ------------------------------------------------------------------
+ * Helpers — Story-shell selectors are stable across versions because
+ * the shell renders inline-styled <div>s, not CSS-class-named nodes,
+ * so we anchor on stable text content (variant ids, panel titles, the
+ * canvas's `:variant.x/y → :view-id` header) and `data-test` attributes
+ * the counter views emit.
+ * ------------------------------------------------------------------ */
+
+/** Click a sidebar variant row by its leading-slash label (e.g. "/loaded"). */
+async function clickVariant(page, slashName) {
+  // The sidebar emits one `text=/<name>` row per variant; the canvas
+  // emits the same name inside the variant-id-as-keyword title
+  // ("/clicked-three-times" appears inside ":story.counter/clicked-three-times"),
+  // so we scope to the <nav> landmark.
+  const row = page.getByRole('navigation').getByText(slashName, { exact: false }).first();
+  await row.waitFor({ state: 'visible', timeout: 10000 });
+  await row.click();
+}
+
+/** Click a sidebar workspace row by its keyword id (e.g. ":Workspace.counter/auto-grid"). */
+async function clickWorkspace(page, wsKeyword) {
+  const row = page.getByRole('navigation').getByText(wsKeyword, { exact: false }).first();
+  await row.waitFor({ state: 'visible', timeout: 10000 });
+  await row.click();
+}
+
+/** Wait for the canvas to title itself with a particular variant id. */
+async function waitForVariantTitle(page, variantKeyword) {
+  await page
+    .getByText(variantKeyword, { exact: false })
+    .first()
+    .waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/** Wait until the page contains at least one counter `[data-test="count"]` cell. */
+async function waitForCounterCell(page) {
+  await page.locator('[data-test="count"]').first().waitFor({
+    state: 'visible',
+    timeout: 10000,
+  });
+}
 
 module.exports = {
   name: 'counter-with-stories',
   url: '/counter-with-stories/',
   run: async (page) => {
-    // ---- 1. Live app at # = root ----
+    // ====================================================================
+    // 1. Live app at #/ — the original Stage-8 smoke
+    // ====================================================================
     //
     // The counter renders with :count 5 (seeded by the run fn's
     // dispatch-sync of [:counter/initialise 5]). The parity badge
@@ -41,117 +93,440 @@ module.exports = {
     await expectTextEquals(count, '6');
     await expectTextEquals(parity, 'even');
 
-    // ---- 2. Switch to the Story shell ----
+    // ====================================================================
+    // 2. Switch to the Story shell at #/stories
+    // ====================================================================
     //
     // Navigate to #/stories. The Story shell mounts a fresh React
-    // root over the #app node. We verify by waiting for the
-    // sidebar's known root layout. The shell uses a flexbox row
-    // root with the rf-story-shell display-name; a tagged selector
-    // is robust enough — we look for the placeholder text that
-    // renders when no variant is selected.
+    // root over the #app node. We verify by waiting for the placeholder
+    // text the shell renders when no variant is selected.
     await page.evaluate(() => {
       window.location.hash = '#/stories';
     });
 
-    // The shell renders a placeholder string in its main pane when
-    // no variant has been selected. The string is stable across
-    // versions — bundled in tools/story/src/re_frame/story/ui/shell.cljs.
     await page
-      .getByText(/Select a variant or workspace from the sidebar/i, {
-        exact: false,
-      })
+      .getByText(/Select a variant or workspace from the sidebar/i, { exact: false })
       .first()
       .waitFor({ state: 'visible', timeout: 10000 });
 
-    // ---- 2b. Click a variant directly — no workspace first (rf2-zme7) ----
-    //
-    // Regression for rf2-zme7. Mike's repro: open the Story playground,
-    // click a variant row in the sidebar WITHOUT first clicking a
-    // workspace; the page used to blank because the canvas's
-    // `decorated-view` call propagated any `:wrap` exception up the
-    // Reagent tree, unmounting the shell. The fix is
-    // `canvas/safe-decorated-view` — exceptions become an inline error
-    // block alongside the uncoated body.
-    //
-    // We click /clicked-three-times, the variant that registers the
-    // largest decorator stack (story-level + variant-level
-    // log-decorator references), and assert the canvas mounts content
-    // rather than blanking.
-    await page.locator('text=/clicked-three-times').first().click();
+    // Sanity: the three landmarks the shell ships are reachable by role.
+    // (rf2-xc65: <nav> sidebar, <main> canvas, <aside> inspectors.) These
+    // also anchor the helpers above.
+    await expectVisible(page.getByRole('navigation'), 5000);
+    await expectVisible(page.getByRole('main'), 5000);
+    await expectVisible(page.getByRole('complementary'), 5000);
 
-    // The canvas titles itself with the variant id (pr-str'd as a
-    // keyword) and follows with the view-id arrow + share button. The
-    // variant id text suffices — it only appears in the canvas frame
-    // header, not the sidebar row (which uses the leading-slash form
-    // `/clicked-three-times`).
-    await page
-      .getByText(':story.counter/clicked-three-times', { exact: false })
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
+    // ====================================================================
+    // 3. Sidebar navigation — variants (rf2-zme7 + rf2-kljn)
+    // ====================================================================
+    //
+    // Click each variant in turn and verify the canvas re-renders with
+    // that variant's title. Regression for rf2-zme7 lives here: clicking
+    // a variant directly (without first selecting a workspace) used to
+    // blank the page because the canvas's `decorated-view` propagated
+    // any `:wrap` exception up the Reagent tree.
+    await clickVariant(page, '/clicked-three-times');
+    await waitForVariantTitle(page, ':story.counter/clicked-three-times');
 
-    // The variant's render output also reaches the DOM — the
-    // log-decorator from rf2-zme7 (after the fix) wraps the body and
-    // both story-level + variant-level label strings appear.
+    // The variant's log-decorator wraps the body and surfaces both
+    // story-level + variant-level label strings (rf2-zme7).
+    await expectVisible(page.getByText(/decorator: story-level/i).first(), 5000);
+    await expectVisible(page.getByText(/decorator: variant-level/i).first(), 5000);
+
+    // Switching to a second variant keeps the shell mounted.
+    await clickVariant(page, '/loaded');
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // ====================================================================
+    // 4. Mode-tag filter — :dev / :docs / :test chips
+    // ====================================================================
+    //
+    // The sidebar's tag-filter row exposes every registered Story tag
+    // as a clickable chip; the seven canonical tags (:dev :docs :test
+    // :screenshot :experimental :internal :agent) plus this example's
+    // custom :counter-with-stories/canonical are present. Clicking a
+    // chip constrains the tree to variants whose :tags set intersects
+    // the active set. The :save-stubbed variant carries #{:dev :test};
+    // the :loaded variant carries the canonical tag.
+    //
+    // We exercise the filter by toggling :test on, asserting that a
+    // :dev-only variant (none here — every variant tags :dev) and a
+    // :screenshot-tagged variant disappear, then toggling back off.
+    // The pragmatic surface assertion is that flipping a chip changes
+    // which sidebar rows render — and re-flipping restores them.
+    const navRoot = page.getByRole('navigation');
+
+    // Capture the row count for ":docs"-tagged variants (every Story
+    // variant tags :docs except :save-stubbed). Toggle :docs ON; the
+    // :save-stubbed row must disappear.
+    const docsChip = navRoot.locator('text=":docs"').first();
+    await docsChip.waitFor({ state: 'visible', timeout: 5000 });
+    await docsChip.click();
+
+    // After clicking, only :docs-tagged variants remain. The
+    // :save-stubbed variant carries #{:dev :test} (no :docs) so its
+    // sidebar row should no longer be visible.
+    //
+    // We tolerate a race: the filter may take a tick to apply, so use
+    // a small polling loop.
+    {
+      const start = Date.now();
+      let visible = true;
+      while (Date.now() - start < 5000) {
+        visible = await navRoot
+          .getByText('/save-stubbed', { exact: false })
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (!visible) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (visible) {
+        throw new Error(
+          ':docs tag filter did not hide /save-stubbed (tags-mismatch surface)',
+        );
+      }
+    }
+
+    // Toggle the chip back OFF so subsequent assertions see every row.
+    await docsChip.click();
+    await navRoot.getByText('/save-stubbed', { exact: false }).first().waitFor({
+      state: 'visible',
+      timeout: 5000,
+    });
+
+    // ====================================================================
+    // 5. Workspace mounting — :Workspace.counter/all-states (rf2-zme7)
+    // ====================================================================
+    //
+    // Second half of rf2-zme7: clicking a workspace mounts every
+    // variant cell with a working counter inside (each cell scoped to
+    // its own per-variant frame). The auto-grid workspace renders four
+    // counter-card views — we assert at least four [data-test="count"]
+    // spans appear under the workspace pane.
+    await clickWorkspace(page, ':Workspace.counter/all-states');
+    await waitForVariantTitle(page, ':Workspace.counter/all-states');
+    await waitForCounterCell(page);
+
+    // Each of the four variants renders a counter-card → at least four
+    // data-test="count" cells. We can't assert exactly four because
+    // when the live app's counter-card also bled into the DOM via a
+    // prior route the locator picks up extras; >=4 keeps the assertion
+    // load-bearing without being brittle.
+    //
+    // The workspace mounts each cell asynchronously (run-variant
+    // resolves through a microtask + a hot-reload tick before the
+    // cell's first render). Poll until the cell count settles at >=4.
+    {
+      const start = Date.now();
+      let cellCount = 0;
+      while (Date.now() - start < 10000) {
+        cellCount = await page.locator('[data-test="count"]').count();
+        if (cellCount >= 4) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      if (cellCount < 4) {
+        throw new Error(
+          `expected >= 4 counter cells in :Workspace.counter/all-states, got ${cellCount}`,
+        );
+      }
+    }
+
+    // ====================================================================
+    // 6. Workspace switching — :Workspace.counter/auto-grid
+    // ====================================================================
+    //
+    // Switching workspaces refreshes the cells (different layout id but
+    // the same four variants enumerated automatically). We re-assert
+    // the cell count and the workspace title.
+    await clickWorkspace(page, ':Workspace.counter/auto-grid');
+    await waitForVariantTitle(page, ':Workspace.counter/auto-grid');
+    await waitForCounterCell(page);
+
+    // ====================================================================
+    // 7. Args editor — overriding :label on /loaded
+    // ====================================================================
+    //
+    // Re-select the /loaded variant so the right-pane controls panel
+    // shows its args editor. The /loaded variant overrides :label to
+    // "Total"; we'll change it from the editor and confirm the canvas
+    // re-renders with the new value.
+    //
+    // The controls panel renders a row per arg-key; each row is a
+    // <span> label + a widget. For :string-shaped args (label is
+    // inferred :string) the widget is a text input. We grab the input
+    // adjacent to the ":label" label.
+    await clickVariant(page, '/loaded');
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // The args editor sits inside the right-side <aside>. There is one
+    // ":label" row exposing an <input type="text"> with the current
+    // value "Total" (variant-level override).
+    const aside = page.getByRole('complementary');
+    const labelInput = aside.locator('input[type="text"]').first();
+    await labelInput.waitFor({ state: 'visible', timeout: 5000 });
+
+    // Edit the value and confirm the canvas re-renders with the new
+    // label text. The :counter-label view inside counter-card prints
+    // the resolved label verbatim.
+    await labelInput.fill('Edited');
+    await expectVisible(
+      page.getByRole('main').getByText('Edited', { exact: false }).first(),
+      5000,
+    );
+
+    // A "reset overrides" button appears once :cell-overrides has an
+    // entry; clicking it restores the variant's declared :args.
+    const resetBtn = aside.getByRole('button', { name: /reset overrides/i }).first();
+    await resetBtn.click();
+    await expectVisible(
+      page.getByRole('main').getByText('Total', { exact: false }).first(),
+      5000,
+    );
+
+    // ====================================================================
+    // 8. Mode picker — :Mode.app/dark and :Mode.app/light chips
+    // ====================================================================
+    //
+    // The mode picker exposes every registered mode as a toggleable
+    // chip in the right pane. Toggling a mode flips its entry in
+    // `:active-modes`; the chip swaps to the active style.
+    //
+    // We click `:Mode.app/dark`, confirm the chip is now styled active,
+    // then click again to deactivate. The DOM doesn't expose the
+    // active-state via class (inline-styled), so we instead verify the
+    // mode appears as a clickable chip and that clicking it does not
+    // crash the shell (the canvas stays mounted with its variant title).
+    const darkModeChip = aside.getByText(':Mode.app/dark', { exact: false }).first();
+    await darkModeChip.waitFor({ state: 'visible', timeout: 5000 });
+    await darkModeChip.click();
+    // Canvas should still be mounted and titled with the same variant.
+    await waitForVariantTitle(page, ':story.counter/loaded');
+    // Toggle back off so subsequent assertions get a clean active-modes set.
+    await darkModeChip.click();
+
+    // ====================================================================
+    // 9. Decorator list — read-only listing in the controls panel
+    // ====================================================================
+    //
+    // The decorator list section enumerates the variant's resolved
+    // decorator stack. The :loaded variant inherits :counter-with-
+    // stories/log-decorator from its parent story; the list must
+    // surface that id. (The Stage-4 list is read-only — Stage 6 adds
+    // the disable-by-name toggle; we just assert the list rendered.)
+    await expectVisible(
+      aside.getByText(':counter-with-stories/log-decorator', { exact: false }).first(),
+      5000,
+    );
+
+    // ====================================================================
+    // 10. Trace panel — six-domino capture on dispatch
+    // ====================================================================
+    //
+    // The trace panel registers a listener against the variant's frame
+    // on selection (see shell.cljs `ensure-listeners-for-variant!`).
+    // Clicking the canvas's "+" button dispatches `:counter/inc` —
+    // the trace listener buckets it into a cascade and the panel's
+    // title bumps its event count above zero.
+    const main = page.getByRole('main');
+    await main.locator('[data-test="inc"]').first().click();
+
+    // The trace panel's title is "Trace <variant-id> — N events, M cascades".
+    // We wait until the count is non-zero.
     await page
-      .getByText(/decorator: story-level/i)
+      .getByText(/Trace .* — [1-9][0-9]* events/i)
       .first()
       .waitFor({ state: 'visible', timeout: 5000 });
+
+    // ====================================================================
+    // 11. Time-travel panel — slider scrub reverts state
+    // ====================================================================
+    //
+    // The scrubber panel reads the variant frame's epoch-history. After
+    // a click on "+" there are at least two epochs (initial + inc), so
+    // the slider has a non-trivial range. Scrubbing to the first epoch
+    // reverts :count visibly inside the canvas.
+    //
+    // The scrubber's title is "Time travel <variant-id> — N epochs".
     await page
-      .getByText(/decorator: variant-level/i)
+      .getByText(/Time travel .* — [1-9][0-9]* epochs/i)
       .first()
       .waitFor({ state: 'visible', timeout: 5000 });
 
-    // Switching between variants directly (no workspace) keeps the
-    // shell mounted — pick /loaded next and assert its title surfaces.
-    await page.locator('text=/loaded').first().click();
-    await page
-      .getByText(':story.counter/loaded', { exact: false })
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
+    // Grab the slider — there's exactly one <input type="range"> in the
+    // right pane (the scrubber's), so this selector is unambiguous.
+    const slider = aside.locator('input[type="range"]').first();
+    await slider.waitFor({ state: 'visible', timeout: 5000 });
 
-    // ---- 2c. Click a workspace — variant cells render (rf2-zme7) ----
+    // Record the current displayed count, then drive the slider to its
+    // min and confirm the visible count changed. The slider commits on
+    // mouseup via :on-mouse-up; Playwright's fill() doesn't fire that,
+    // so we set the value via DOM and dispatch the events the panel
+    // listens for explicitly.
+    const canvasCount = main.locator('[data-test="count"]').first();
+    const beforeText = (await canvasCount.textContent()) || '';
+
+    await slider.evaluate((el) => {
+      const native = el;
+      native.value = String(native.min || 0);
+      native.dispatchEvent(new Event('input', { bubbles: true }));
+      native.dispatchEvent(new Event('change', { bubbles: true }));
+      // The scrubber commits on mouseup, not change — fire it directly.
+      native.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    // After scrubbing back, the count should differ from `beforeText`
+    // (the variant initialised at 7; after one inc it's 8; scrubbing
+    // back to epoch 0 returns it to 7). Poll a brief window so any
+    // re-render delay smooths out.
+    {
+      const start = Date.now();
+      let afterText = beforeText;
+      while (Date.now() - start < 5000) {
+        afterText = (await canvasCount.textContent()) || '';
+        if (afterText !== beforeText) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (afterText === beforeText) {
+        throw new Error(
+          `time-travel scrub did not visibly change :count (still "${afterText}")`,
+        );
+      }
+    }
+
+    // ====================================================================
+    // 12. A11y panel — clicking "run" produces a status update
+    // ====================================================================
     //
-    // Second half of rf2-zme7. Mike's screenshot of #/stories with
-    // :Workspace.counter/auto-grid selected showed every variant card
-    // rendering empty: title + "variant frame: <id>" stub, no counter
-    // UI inside. Root cause: workspace.cljc's `variant-cell` was a
-    // Stage-4-era stub that never called `rf/view` — it shipped a
-    // label and a placeholder div instead of invoking the registered
-    // view in the variant's allocated frame. The fix is the new
-    // `variant-cell` Reagent component that mounts the variant's
-    // frame via `run-variant` and renders `(rf/view :counter-with-
-    // stories.views/counter-card)` wrapped in `frame-provider` so each
-    // cell's subscriptions scope to its own per-variant app-db.
+    // The a11y panel exposes a "run" button. Clicking it kicks off the
+    // axe-core lazy-load + scan. The panel's status line transitions
+    // from "click run to scan the rendered output" to "fetching
+    // axe-core…" → "scanning…" → "N violation(s) found". We don't
+    // assert which violations land (varies by environment); we assert
+    // that the run was kicked off — the status text changes away from
+    // the idle copy.
     //
-    // Assertion: after clicking :Workspace.counter/auto-grid, the
-    // workspace renders four variant cards and each card contains
-    // counter-buttons (look for the `[data-test="count"]` span the
-    // counter-buttons view emits). Each cell's count reflects its
-    // variant's `:events` slot — variant-isolated app-db.
-    await page.locator('text=/auto-grid').first().click();
+    // The panel is registered under :rf.story.panel/a11y with title
+    // "a11y" rendered in the panel-head. Its run button has accessible
+    // name "run" (transitions to "re-run" / "retry" after a scan).
+    const runBtn = aside.getByRole('button', { name: /^(run|re-run|retry)$/i }).first();
+    await runBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await runBtn.click();
 
-    // The workspace titles itself with the workspace id + layout.
-    await page
-      .getByText(':Workspace.counter/auto-grid', { exact: false })
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
+    // The status copy starts as "click run to scan the rendered output"
+    // and transitions through "fetching axe-core…" / "scanning…" /
+    // "N violation(s) found". We poll for the transition off the idle
+    // copy — if the status remains "click run …" the click was
+    // ineffective.
+    {
+      const start = Date.now();
+      let stillIdle = true;
+      while (Date.now() - start < 15000) {
+        stillIdle = await aside
+          .getByText(/click run to scan the rendered output/i)
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (!stillIdle) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      if (stillIdle) {
+        throw new Error('a11y panel run did not transition off idle status');
+      }
+    }
 
-    // Each variant cell renders the counter-card view. The view emits
-    // a `[data-test="count"]` span; we expect at least one of those to
-    // appear in the workspace pane. Without the rf2-zme7 fix every
-    // cell rendered the stub div and zero data-test=count elements
-    // existed under the workspace.
-    await page
-      .locator('[data-test="count"]')
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
+    // ====================================================================
+    // 13. Layout-debug toggles — flipping a toggle injects the decorator
+    // ====================================================================
+    //
+    // The layout-debug panel ships three toggles (measure / outline /
+    // pseudo). Stage 6 records the toggle in `layout-debug-toggles`
+    // ratom; the rendered overlay is a Stage-6-or-later refinement
+    // (the toggle is informational at the v1 cut). Our surface
+    // assertion: clicking the outline toggle's checkbox flips its
+    // `checked` attribute. No DOM-class plumbing is asserted (the
+    // ratom isn't wired into the canvas render at this stage); the
+    // test just exercises the toggle so a regression that drops the
+    // checkbox surfaces here.
+    // The layout-debug-view panel ships three labelled toggles (measure /
+    // outline / pseudo); each is a [:label] containing a [:input
+    // type=checkbox readOnly]. Per the panel's own docs the v1 toggle is
+    // informational — the state records the user's preference; the
+    // canvas-side render-time merge that turns the preference into an
+    // applied decorator is a Stage-6-or-later refinement. Our surface
+    // assertion: the three toggles render and the click is dispatched
+    // without crashing the shell.
+    const outlineLabel = aside
+      .locator('label', { hasText: ':rf.story/layout-debug.outline' })
+      .first();
+    const outlineToggle = outlineLabel.locator('input[type="checkbox"]');
+    await outlineToggle.waitFor({ state: 'visible', timeout: 5000 });
 
-    // ---- 3. Switch back to the live app ----
+    // All three layout-debug toggles must render (measure / outline /
+    // pseudo). The aside hosts exactly three <label>s — one per toggle.
+    const labelCount = await aside.locator('label').count();
+    if (labelCount !== 3) {
+      throw new Error(
+        `expected 3 layout-debug toggle <label>s in the aside, got ${labelCount}`,
+      );
+    }
+
+    // Click the label. The Stage-6 implementation flips the
+    // `layout-debug-toggles` r/atom but doesn't yet wire the toggle
+    // through to the rendered DOM (per the panel's own docstring); we
+    // just confirm the click doesn't crash the shell — the variant
+    // title is still visible afterwards.
+    await outlineLabel.click();
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // ====================================================================
+    // 14. Save-layout button — clicks without crashing
+    // ====================================================================
+    //
+    // The save-layout button is a Stage-4 stub: clicking emits a
+    // console.log only. We confirm the button exists, click it, and
+    // afterwards the shell is still mounted (the canvas variant title
+    // and the run-button both stay visible).
+    const saveBtn = aside.getByRole('button', { name: /save layout as :Workspace/i }).first();
+    await saveBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await saveBtn.click();
+    // Shell still alive — variant title still on the page.
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // ====================================================================
+    // 15. Project-custom :Panel.counter-with-stories/notes panel
+    // ====================================================================
+    //
+    // Stage 6's panel-host renders every registered :story-panel whose
+    // placement matches the slot. The project's :Panel.counter-with-
+    // stories/notes registration sets :render to :counter-with-stories.
+    // views/parity-badge — so the rendered output is the parity badge
+    // (data-test="parity"). One parity badge already renders inside the
+    // canvas-card; the panel-host produces a SECOND parity-badge node
+    // for the panel slot. We assert there are at least two.
+    {
+      const start = Date.now();
+      let parityCount = 0;
+      while (Date.now() - start < 5000) {
+        parityCount = await page.locator('[data-test="parity"]').count();
+        if (parityCount >= 2) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (parityCount < 2) {
+        throw new Error(
+          `expected the :Panel.counter-with-stories/notes panel to render an extra parity-badge (got ${parityCount} total)`,
+        );
+      }
+    }
+
+    // ====================================================================
+    // 16. Switch back to the live app — counter survives
+    // ====================================================================
     //
     // Hash-change back to the live app; counter should reappear.
-    // We re-create the React root inside `mount-app!` so the count
-    // re-renders against the surviving app-db state (which still
-    // says :count 6 after the click above).
+    // The live app re-creates its React root inside `mount-app!` and
+    // re-renders against the surviving app-db (which still says
+    // :count 6 after the click at step 1).
     await page.evaluate(() => {
       window.location.hash = '#/';
     });


### PR DESCRIPTION
## Summary

Beef up the `counter_with_stories` Playwright spec from a smoke test (mount + a single variant render) to a fuller surface sweep that exercises every interactive panel of the Story playground chrome — so a regression in any of them surfaces in the examples test run.

## Surfaces covered

One assertion per surface (depth still lives in the node-test cljs suite):

- Live-app smoke (count + parity round-trip — unchanged).
- Hash-route into `#/stories` + landmark sanity (`<nav>`/`<main>`/`<aside>` reachable by role).
- Sidebar variant navigation (including the rf2-zme7 regression — clicking a variant without first selecting a workspace).
- Tag-filter chip flipping `:docs` on/off — the tag-mismatched `/save-stubbed` row hides.
- Workspace cell mounting on `:Workspace.counter/all-states` (>=4 `[data-test='count']` cells) and switching to `:Workspace.counter/auto-grid`.
- Args editor edits `:label` and confirms the canvas re-renders; the 'reset overrides' button restores the declared value.
- Mode picker chip click round-trip on `:Mode.app/dark`.
- Decorator list surfaces the inherited `:counter-with-stories/log-decorator` id.
- Trace panel — `+` click bumps the panel's event count off zero.
- Time-travel scrubber slider scrub visibly reverts `:count`.
- A11y panel — `run` click transitions status off idle (axe-core kicked off; violation content not asserted).
- Layout-debug panel — three toggles render and click doesn't crash.
- Save-layout button click doesn't crash the shell.
- Project-custom `:Panel.counter-with-stories/notes` panel renders a second parity-badge in the right pane.
- Hash back to `#/` — the live app's count survives.

Helper fns at the top scope sidebar selectors to the `<nav>` landmark so canvas-side text matches don't bleed into navigation clicks. All waits poll explicit DOM signals — no `sleep`-style flake bait.

## Note: rf2-4t5u filed

While writing the spec, the layout-debug toggle clicks were observed not to update their rendered `<input checked>` attribute (the `r/atom` flips, but the panel-host's `frame-provider-ns-safe` wrap appears to break Reagent's deref tracking). Filed rf2-4t5u with a repro. The spec asserts only that the toggle renders and the click doesn't crash — fixing the feedback wiring is out of scope for rf2-kljn.

## Test plan

- [x] `npm run test:examples` passes locally (25 of 25, including `counter-with-stories`).
- [x] No new flakes — every wait polls a DOM signal with a bounded timeout, no arbitrary `sleep`s.
- [x] Existing rf2-zme7 regression coverage retained.