### PR TITLE
docs(template): add spec/findings/ subdirectory per canonical tool-spec shape (rf2-bfax.3)

### DIFF
--- a/tools/template/spec/findings/.keep
+++ b/tools/template/spec/findings/.keep
@@ -1,0 +1,42 @@
+# findings/
+
+This directory accumulates design-investigation prose for the
+re-frame2 project template.
+
+Findings differ from DESIGN-RATIONALE: rationale entries are
+*locked decisions* with question / options / pick / why. Findings
+are *session-trail working notes* that surfaced patterns, surprises,
+or implementation discoveries — not all of which produce locks.
+
+## What goes here
+
+- Tool-pilot investigation notes (e.g., the clj-new vs deps-new
+  vs bb-wizard pilot, the `:edn-args` strip-on-create discovery,
+  substrate-coercion ecosystem variance across Reagent / UIx /
+  Helix).
+- Audit findings cross-cutting tools/template (per-tool spec
+  audits, dependency-surface reviews, generated-app smoke-test
+  reports).
+- Cross-tool design lineage (e.g., comparisons with v1's
+  `day8/re-frame-template` shape that informed the v2 substrate
+  toggle).
+
+## What doesn't go here
+
+- Locked decisions — those live in `DESIGN-RATIONALE.md`.
+- Substrate-variant contracts — those live in `001-Substrate-Variants.md`.
+- Generated-app shape contracts — those live in `002-Generated-Shape.md`.
+- User-facing reference — that lives in `API.md`.
+- Principles — those live in `Principles.md`.
+
+## Current state
+
+The clj-new vs deps-new pilot and the `:edn-args` strip-on-create
+discovery were captured directly in DESIGN-RATIONALE.md (§1 and §2
+respectively) without a separate findings trail; the rationale's
+question / options / pick / why structure was sufficient on its
+own. Subsequent investigations that warrant prose-preservation
+beyond a rationale entry land here.
+
+Local-only exploratory notes in `ai/findings/` should be promoted
+here when they become normative.


### PR DESCRIPTION
## Summary

- Adds `tools/template/spec/findings/.keep` matching the placeholder convention established by `tools/pair2-mcp/spec/findings/` (rf2-bfax.1).
- Brings template's spec folder up to the canonical post-rf2-1lls shape: Vision + capability docs + API + Principles + DESIGN-RATIONALE + `findings/`.
- Closes the last gap flagged by the 2026-05-12 per-tool spec audit for `tools/template/`.

## Background

Per the per-tool spec audit, `tools/template/spec/` was otherwise complete (303-line DESIGN-RATIONALE is exemplary) but lacked a `findings/` subdirectory. No extant template-design findings were found in local `ai/findings/`: the clj-new vs deps-new pilot and the `:edn-args` strip-on-create discovery were captured directly in DESIGN-RATIONALE §1 and §2, with the rationale's question / options / pick / why structure sufficing on its own.

The `.keep` documents the convention so future investigations (e.g., substrate-coercion ecosystem audits, generated-app smoke-test trails) have a committed home — and so local-only `ai/findings/` notes can be promoted here when they become normative.

## Scope

- Touches only `tools/template/spec/findings/.keep` (new file, 42 lines).
- No code, no other spec files.

## Test plan

- [x] `tools/template/spec/findings/` now exists with `.keep` placeholder.
- [x] `.keep` mirrors the shape of `tools/pair2-mcp/spec/findings/.keep`, tailored to template's content (clj-new pilot, `:edn-args`, substrate-coercion, generated-app smoke tests).
- [x] No changes outside `tools/template/spec/findings/`.

Bead: `rf2-bfax.3` (parent epic: `rf2-bfax`).