### PR TITLE
docs(tool-spec): sweep bead-id references out of user-facing Vision/Principles/API prose (rf2-bfax.4)

### DIFF
--- a/tools/10x/spec/000-Vision.md
+++ b/tools/10x/spec/000-Vision.md
@@ -148,7 +148,7 @@ relationships among the tools.
 
 ## Status
 
-In design. Spec corpus landed via rf2-1lls (2026-05-12). All 13
-direction-setting decisions are locked — see
+In design. Spec corpus landed 2026-05-12. All 13 direction-setting
+decisions are locked — see
 [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md). Implementation work
 begins after spec ratification.

--- a/tools/10x/spec/003-Machine-Inspector.md
+++ b/tools/10x/spec/003-Machine-Inspector.md
@@ -73,7 +73,7 @@ Per Spec 005 and Spec 009:
 | `:rf.machine/spawned` / `-destroyed` | Render spawn/destroy lifecycle in the parent's chart. |
 | `:rf.machine/done` | Mark `:final?`-state entry, before the auto-destroy. |
 | `:rf.machine/system-id-bound` / `-released` | Surface `:system-id` reverse-index activity in a sidebar. |
-| Source-coord stamping (rf2-8bp3) | Every clickable element jumps to source. |
+| Source-coord stamping | Every clickable element jumps to source. |
 
 ## Selection and switching
 

--- a/tools/10x/spec/010-MCP-Server.md
+++ b/tools/10x/spec/010-MCP-Server.md
@@ -13,10 +13,10 @@ Different tool catalogue.
 
 ## Why a separate jar
 
-Causa-the-panel is human-facing; Causa-MCP is agent-facing. Per the
-rf2-m6tu §6.1 separation lesson (humans and agents ship as distinct
-jars so the MCP server can be loaded without dragging the entire
-Causa UI into the classpath), the two surfaces split:
+Causa-the-panel is human-facing; Causa-MCP is agent-facing. Humans
+and agents ship as distinct jars so the MCP server can be loaded
+without dragging the entire Causa UI into the classpath; the two
+surfaces split:
 
 - **`tools/10x/`** — `day8/re-frame2-causa`. The DOM-injected panel.
   Pulled by `:preloads`. Browser-side artefact.

--- a/tools/10x/spec/011-Launch-Modes.md
+++ b/tools/10x/spec/011-Launch-Modes.md
@@ -204,9 +204,9 @@ in parallel. The panel surfaces the agent's actions (the `:origin
   this — if the agent needs to render a viewer-like surface, it
   composes Causa-MCP tool calls.
 - **No mobile launch mode** (lock #5).
-- **No tablet-responsive standalone viewer** at v1.0. The original
-  rf2-buor design proposed one; the lock-#9 hybrid retires the use
-  case to MCP.
+- **No tablet-responsive standalone viewer** at v1.0. An earlier
+  design proposed one; the lock-#9 hybrid retires the use case to
+  MCP.
 
 ## Default summary
 

--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -104,14 +104,14 @@ Two pieces of committed research informed the design; both live in
 [`findings/`](findings/):
 
 - **Phase 1.** [`findings/re-frame-2-story-feature-set.md`](findings/re-frame-2-story-feature-set.md)
-  — rf2-m6tu (~5,200 words). Per-tool survey of the JS workshop
-  ecosystem (Storybook, Histoire, Ladle, React Cosmos, Lookbook,
-  devcards, workspaces, Pattern Lab); cross-tool pattern synthesis;
+  (~5,200 words). Per-tool survey of the JS workshop ecosystem
+  (Storybook, Histoire, Ladle, React Cosmos, Lookbook, devcards,
+  workspaces, Pattern Lab); cross-tool pattern synthesis;
   re-frame2-specific extensions; v1 feature spec; seven open design
   questions.
 - **Phase 2.** [`findings/re-frame-2-story-sota-refinement.md`](findings/re-frame-2-story-sota-refinement.md)
-  — rf2-94b0 (~5,300 words). Independent SOTA refinement against
-  Phase 1; identified six additions Phase 1 missed (live perf ribbon,
+  (~5,300 words). Independent SOTA refinement against Phase 1;
+  identified six additions Phase 1 missed (live perf ribbon,
   layout-debug trio, mode primitive, variants-grid layout,
   design-token panel, QR sharing).
 

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -19,9 +19,9 @@ Story's own UI shell (sidebar, control panel, trace ribbon, embedded
   exercises the same re-frame primitives Story stories exercise; using
   a substrate the rest of the codebase already validates avoids a
   self-hosting bias.
-- **reagent-slim is still landing.** rf2-5djt (the slim rewrite) is in
-  active implementation. Story should not block on it; once
-  reagent-slim is GA Story can migrate (Stage 8 may revisit).
+- **reagent-slim is still landing.** The slim rewrite is in active
+  implementation. Story should not block on it; once reagent-slim is
+  GA Story can migrate (Stage 8 may revisit).
 - **The UI shell is itself one app's worth of views; substrate
   switches are cheap if done early.** Reagent's API surface is the
   most well-trodden; reducing risk during the initial Stage 4
@@ -150,9 +150,9 @@ no parallel mounting protocol. Five rules govern panel hosting:
    from its own boot.
 
 5. **The 10x embed.** The built-in `:rf.story.panel/epoch` panel
-   registers against a STUB view. The Causa library (`tools/10x/`,
-   rf2-buor) registers the live view under the same
-   `:rf.story.panel/epoch-view` id when present; the shell's
+   registers against a STUB view. The Causa library
+   ([`tools/10x/`](../../10x/)) registers the live view under the
+   same `:rf.story.panel/epoch-view` id when present; the shell's
    late-bind `rf/view` lookup picks Causa's view automatically. If
    Causa is absent the stub renders documenting the contract.
 

--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -1,6 +1,6 @@
 # Template — Vision
 
-> Bead [rf2-lrtc](../../../). Tool [`tools/template/`](../). Artefact
+> Tool [`tools/template/`](../). Artefact
 > `day8/clj-template.re-frame2`.
 >
 > The v2 equivalent of v1's
@@ -55,9 +55,8 @@ and recognises the shape. That continuity is deliberate.
   adapter coord differ.
 - **Counter as canonical example.** The generated counter is the
   same shape the developer reads about in [Guide chapter 03
-  — Your first app](../../../docs/guide/03-your-first-app.md)
-  (rf2-2kzw throughline). What the template emits is what the guide
-  walks through.
+  — Your first app](../../../docs/guide/03-your-first-app.md).
+  What the template emits is what the guide walks through.
 - **Lockstep with the reference implementation's pins.** The
   shadow-cljs / react pins the template emits track
   `implementation/package.json` — the smoke-tested combination is
@@ -85,7 +84,7 @@ and recognises the shape. That continuity is deliberate.
 ## Cross-references
 
 - [`tools/README.md`](../../README.md) — the tools/ convention and
-  the per-tool spec/ folder convention (rf2-bfax).
+  the per-tool spec/ folder convention.
 - [001-Substrate-Variants.md](001-Substrate-Variants.md) — the three
   shipped variants.
 - [002-Generated-Shape.md](002-Generated-Shape.md) — the file tree
@@ -95,4 +94,4 @@ and recognises the shape. That continuity is deliberate.
   was made.
 - [Guide chapter 03 — Your first app](../../../docs/guide/03-your-first-app.md)
   — the worked-example throughline the template's generated counter
-  aligns with (rf2-2kzw).
+  aligns with.

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -6,11 +6,11 @@
 
 ## The three variants
 
-| Substrate | Beads | Default? | View library | Generated `core.cljs` shape |
-|---|---|---|---|---|
-| `:reagent` | (canonical) | yes | Reagent | Reagent component + `r/render` |
-| `:uix` | rf2-3yij | no | UIx | UIx defui + `uix/render-root` |
-| `:helix` | rf2-2qit | no | Helix | Helix defnc + `createRoot` |
+| Substrate | Default? | View library | Generated `core.cljs` shape |
+|---|---|---|---|
+| `:reagent` | yes | Reagent | Reagent component + `r/render` |
+| `:uix` | no | UIx | UIx defui + `uix/render-root` |
+| `:helix` | no | Helix | Helix defnc + `createRoot` |
 
 Reagent is the canonical default — the substrate every re-frame and
 re-frame2 example targets first. UIx and Helix are equally supported;
@@ -99,10 +99,9 @@ shape the developer reads about in:
 - [`examples/helix/counter_helix/`](../../../examples/helix/counter_helix/) —
   the Helix counter.
 
-What the template emits is what the guide walks through (rf2-2kzw
-throughline). A developer who runs `clojure -X:project/new
-:template re-frame2 ...` and then reads Guide chapter 03 sees the
-same code in both places.
+What the template emits is what the guide walks through. A
+developer who runs `clojure -X:project/new :template re-frame2 ...`
+and then reads Guide chapter 03 sees the same code in both places.
 
 ## Future variants
 
@@ -115,8 +114,7 @@ Reserved space — not implemented:
 - **SSR.** Once Spec 011 has a Reagent-side reference implementation
   the template can ship an SSR variant of the counter.
 - **reagent-slim.** Once the substrate-portable reagent-slim adapter
-  exists (rf2-3sk6) the template can ship it as a fourth substrate
-  choice.
+  exists the template can ship it as a fourth substrate choice.
 - **TypeScript port.** Per Spec 000 — re-frame2 is a pattern, not a
   CLJS library. A `create-re-frame2-app` style npm template is
   reserved for a future iteration.

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -44,7 +44,7 @@ This is the same shape the developer reads about in [Guide chapter
 03 — Your first app](../../../docs/guide/03-your-first-app.md) and
 in the [`examples/<substrate>/counter*/`](../../../examples/)
 trees. The template's generated counter and the guide's worked
-example align (rf2-2kzw throughline).
+example align.
 
 ## Resource tree (template-side)
 

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -43,7 +43,7 @@ Every variant emits a working counter. The counter:
   the full cycle: an init event, an action event, a sub, a view
   that dispatches.
 
-This is rf2-2kzw's "counter throughline" principle applied to the
+This is the "counter throughline" principle applied to the
 scaffolding tool. A developer who runs
 `clojure -X:project/new :template re-frame2 :name acme/my-app` and
 then opens the guide sees the same code in both places. No


### PR DESCRIPTION
## Summary

Cross-cutting polish pass identified by the per-tool /spec audit (2026-05-12). Three of five tools had bead-IDs leaking into user-facing Vision / capability / Principles prose. The per-tool spec convention is: DESIGN-RATIONALE.md may cite bead IDs for trail-of-thought lineage; Vision / capability / Principles / API read as evergreen documentation and should not.

Mirrors the docs-sweep pattern applied to the top-level corpus in PR #393.

## Treatment

- **Deleted (wrapper-style):** `(rf2-2kzw throughline)`, `(rf2-bfax)`, `(rf2-2kzw)`, `(rf2-3sk6)`, `(rf2-8bp3)` — cleanly removed.
- **Rewritten (anchoring a claim):** `rf2-lrtc` opening-blockquote (template Vision), `rf2-m6tu`/`rf2-94b0` (story Vision lineage), `rf2-1lls` (10x Vision status), `rf2-5djt` / `rf2-buor` (story render-shell), `rf2-m6tu §6.1` (10x MCP-Server), `rf2-buor` (10x Launch-Modes), `rf2-2kzw` (template Principles) — sentences rewritten to make the claim directly.
- **Table column removed:** `Beads` column in `001-Substrate-Variants.md` (was project-management metadata leaking into the spec).
- **Preserved (literal identifiers / machinery):** `{{rf2-version}}` (Mustache var), `:rf2-version` (EDN keyword), `data-rf2-source-coord` (DOM attribute), URL-fragment anchor in 006-Hydration-Debugger.md that mirrors an in-corpus heading slug.

## Scope

10 files across 3 tools: 10x (4 files), story (2 files), template (4 files). DESIGN-RATIONALE.md and findings/ left untouched per convention. pair2-mcp and story-mcp had no leaks.

## Test plan

- [ ] Verify rendered Markdown reads cleanly (no orphaned punctuation from deletions)
- [ ] Verify all preserved bead-ID-shaped strings are genuinely literal identifiers, not bead refs