### PR TITLE
docs(spec): spec/013-Flows — reconcile topsort-memoisation contradiction (rf2-gbys)

### DIFF
--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -277,7 +277,7 @@ A flow registered mid-event first fires on the next event drain (one-event lag f
 
 ### Topological sort over registration order (RESOLVED)
 
-Earlier sketch leaned on registration order; topological sort selected because dynamic registration via `:rf.fx/reg-flow` makes registration order dispatch-time-dependent and an unreliable contract. The dependency graph is statically derivable from each flow's `:path` and `:inputs`; the cost of memoised topsort is small relative to event volume.
+Earlier sketch leaned on registration order; topological sort selected because dynamic registration via `:rf.fx/reg-flow` makes registration order dispatch-time-dependent and an unreliable contract. The dependency graph is statically derivable from each flow's `:path` and `:inputs`; recomputing the sort once per drain is cheap at v1's per-frame node counts (a handful of flows, Kahn's algorithm over them is cheaper than memo bookkeeping). The sort is not memoised — per [§Topological sort and cycle detection](#topological-sort-and-cycle-detection); an earlier memoised variant was removed under rf2-cd00 after measurement.
 
 ### One-pass evaluation, not fixed-point iteration (RESOLVED)
 


### PR DESCRIPTION
## Summary
- §Resolved decisions in `spec/013-Flows.md` still justified topological-sort with *\"cost of memoised topsort is small\"*, contradicting §Topological sort and cycle detection (post-rf2-cd00) which states the sort is **not memoised**.
- Impl (`implementation/flows/src/re_frame/flows.cljc` §topo-sort, lines 97-101) confirms unmemoised — a memo was trialled and removed because Kahn's over a tiny per-frame node count beats memo bookkeeping.
- Rewrites the §Resolved decisions paragraph to match the unmemoised design and cross-links §Topological sort and cycle detection. Closes the last drift surfaced by F-20 / rf2-m6de.

## Test plan
- [x] `git diff` confirms touch is limited to `spec/013-Flows.md` §Resolved decisions paragraph.
- [x] Spec is now internally consistent: both §Topological sort and §Resolved decisions agree the sort is not memoised.
- [x] No impl change required — wording catches up with already-correct impl.