### PR TITLE
fix(story-panels): layout-debug toggle now reflects click; also fix decorator-list duplicate-key warning (rf2-4t5u)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -75,6 +75,28 @@ module.exports = {
   name: 'counter-with-stories',
   url: '/counter-with-stories/',
   run: async (page) => {
+    // The Story shell's first-visit help overlay (rf2-381i) auto-opens
+    // on first visit to #/stories. It carries `role="dialog"
+    // aria-modal="true"` and intercepts pointer events from the
+    // underlying shell — every sidebar / panel / canvas click waits
+    // indefinitely for the dialog to be dismissed. Tests run in a
+    // fresh Playwright context (no persistent localStorage), so the
+    // overlay is ALWAYS present on the first stories-shell mount in a
+    // test run unless the spec dismisses it.
+    //
+    // Persist the "seen" flag now so any subsequent navigation to
+    // #/stories during this run sees the dismissed state at mount
+    // time. The current page is the live counter app under #/, so the
+    // overlay isn't yet rendered — the dismiss-on-mount path takes
+    // over once we navigate to #/stories at step 2.
+    await page.evaluate(() => {
+      try {
+        localStorage.setItem('re-frame.story/seen-help-v1', '1');
+      } catch (_) {
+        /* ignore — private mode, etc. */
+      }
+    });
+
     // ====================================================================
     // 1. Live app at #/ — the original Stage-8 smoke
     // ====================================================================
@@ -436,26 +458,21 @@ module.exports = {
     }
 
     // ====================================================================
-    // 13. Layout-debug toggles — flipping a toggle injects the decorator
+    // 13. Layout-debug toggles — flipping a toggle updates :checked
     // ====================================================================
     //
     // The layout-debug panel ships three toggles (measure / outline /
-    // pseudo). Stage 6 records the toggle in `layout-debug-toggles`
-    // ratom; the rendered overlay is a Stage-6-or-later refinement
-    // (the toggle is informational at the v1 cut). Our surface
-    // assertion: clicking the outline toggle's checkbox flips its
-    // `checked` attribute. No DOM-class plumbing is asserted (the
-    // ratom isn't wired into the canvas render at this stage); the
-    // test just exercises the toggle so a regression that drops the
-    // checkbox surfaces here.
-    // The layout-debug-view panel ships three labelled toggles (measure /
-    // outline / pseudo); each is a [:label] containing a [:input
-    // type=checkbox readOnly]. Per the panel's own docs the v1 toggle is
-    // informational — the state records the user's preference; the
-    // canvas-side render-time merge that turns the preference into an
-    // applied decorator is a Stage-6-or-later refinement. Our surface
-    // assertion: the three toggles render and the click is dispatched
-    // without crashing the shell.
+    // pseudo); each is a <label> containing a <input type="checkbox">.
+    // Per rf2-4t5u the panel is now form-2 with `:on-change` wired on
+    // the input (not `:on-click` on the label), so each user click
+    // flips the toggle state exactly once and the rendered :checked
+    // attribute reflects the post-click state.
+    //
+    // The state itself is informational at v1 — the canvas-side
+    // render-time merge that turns the preference into an applied
+    // decorator is a Stage-6-or-later refinement. The surface
+    // assertion here is purely the round-trip: click → :checked flips
+    // → click again → :checked flips back.
     const outlineLabel = aside
       .locator('label', { hasText: ':rf.story/layout-debug.outline' })
       .first();
@@ -471,12 +488,48 @@ module.exports = {
       );
     }
 
-    // Click the label. The Stage-6 implementation flips the
-    // `layout-debug-toggles` r/atom but doesn't yet wire the toggle
-    // through to the rendered DOM (per the panel's own docstring); we
-    // just confirm the click doesn't crash the shell — the variant
-    // title is still visible afterwards.
+    // Initially every layout-debug toggle is off.
+    if (await outlineToggle.isChecked()) {
+      throw new Error('outline toggle started checked (expected unchecked)');
+    }
+
+    // Click the label — the contained input toggles via its own
+    // :on-change handler. Poll until :checked flips on, in case the
+    // r/atom commit batches through a microtask before React re-renders.
     await outlineLabel.click();
+    {
+      const start = Date.now();
+      let checked = false;
+      while (Date.now() - start < 5000) {
+        checked = await outlineToggle.isChecked();
+        if (checked) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!checked) {
+        throw new Error(
+          'outline toggle did not flip to :checked after clicking its label (rf2-4t5u regression)',
+        );
+      }
+    }
+
+    // Click again — :checked should flip back off.
+    await outlineLabel.click();
+    {
+      const start = Date.now();
+      let checked = true;
+      while (Date.now() - start < 5000) {
+        checked = await outlineToggle.isChecked();
+        if (!checked) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (checked) {
+        throw new Error(
+          'outline toggle did not flip back to unchecked after second click',
+        );
+      }
+    }
+
+    // Shell still alive — variant title still visible.
     await waitForVariantTitle(page, ':story.counter/loaded');
 
     // ====================================================================

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -246,7 +246,15 @@
 
 (defn decorator-list
   "Show the variant's resolved decorator stack. Stage 4 is read-only;
-  Stage 6 adds the disable-by-name routing."
+  Stage 6 adds the disable-by-name routing.
+
+  Per rf2-4t5u: the resolved stack can carry the SAME decorator id more
+  than once — e.g. a story-level decorator and a variant-level
+  decorator may share an id, and `resolve-decorators` concats the
+  `:hiccup` / `:frame-setup` / `:fx-override` packs without
+  de-duping (each pack is a kind-specific layer). React requires
+  unique `key`s in a sibling list, so the row key is the `[index id]`
+  tuple rather than the bare id."
   [variant-id]
   (let [pack  (decorators/resolve-decorators variant-id)
         all   (concat (:hiccup pack) (:frame-setup pack) (:fx-override pack))]
@@ -254,8 +262,8 @@
      [:div {:style (:section-h styles)} "Decorators"]
      (if (empty? all)
        [:div {:style (:empty styles)} "no decorators on this variant"]
-       (for [{:keys [id body]} all]
-         ^{:key id}
+       (for [[i {:keys [id body]}] (map-indexed vector all)]
+         ^{:key [i id]}
          [:div {:style (:row styles)}
           [:span {:style (:label styles)} (str id)]
           [:span (str ":kind " (or (:kind body) "?"))]]))]))

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -173,24 +173,44 @@
 (defn layout-debug-view
   "Layout-debug controls panel. Lists the three layout-debug decorators
   with toggles so the user can enable / disable each at runtime without
-  touching variant body."
-  [variant-id]
-  (let [active (active-layout-debug-decorators variant-id)]
-    [:div {:style (:layout-wrap styles)}
-     [:div {:style (:layout-title styles)} "Layout-debug"]
-     (for [id [layout-debug/id-measure
-               layout-debug/id-outline
-               layout-debug/id-pseudo]]
-       ^{:key id}
-       [:label {:style    (:toggle styles)
-                :on-click (fn [_] (when variant-id
-                                    (toggle-layout-debug! variant-id id)))}
-        [:input {:type     "checkbox"
-                 :checked  (boolean (contains? active id))
-                 :readOnly true}]
-        [:span {:style (:decor-id styles)} (str id)]])
-     [:div {:style (:hint styles)}
-      "toggle adds the decorator at variant render time (per IMPL-SPEC §2.8.6)"]]))
+  touching variant body.
+
+  Form-2 (per rf2-4t5u): the render fn returned by the outer fn derefs
+  `layout-debug-toggles` directly inside the body. The form-2 shape
+  ensures Reagent's reaction-tracking observes the deref at render
+  time — under the registered-view path the user fn is wrapped by
+  `reg-view*`'s `frame-aware-view`, and the panel-host additionally
+  wraps it in `frame-provider-ns-safe` (which calls `r/as-element`
+  on the child). The form-1 shape worked in isolation but didn't
+  re-render through the wrapper chain; the form-2 inner-fn shape is
+  the canonical Reagent idiom that survives nested wrapping.
+
+  Also (rf2-4t5u): the toggle event is wired via `:on-change` on the
+  `<input>` (not `:on-click` on the surrounding `<label>`). Clicking
+  the label propagates an implicit click to the contained input, and
+  a label-side `:on-click` ALSO sees that bubbled click — so the
+  state was being toggled twice per user click and the rendered DOM
+  reverted to its prior shape (the bug's outerHTML-byte-identical
+  symptom). Wiring `:on-change` on the input is the controlled-
+  checkbox idiom and fires exactly once per user click."
+  [_variant-id]
+  (fn [variant-id]
+    (let [active @layout-debug-toggles
+          on-for (get active variant-id #{})]
+      [:div {:style (:layout-wrap styles)}
+       [:div {:style (:layout-title styles)} "Layout-debug"]
+       (for [id [layout-debug/id-measure
+                 layout-debug/id-outline
+                 layout-debug/id-pseudo]]
+         ^{:key id}
+         [:label {:style (:toggle styles)}
+          [:input {:type      "checkbox"
+                   :checked   (boolean (contains? on-for id))
+                   :on-change (fn [_] (when variant-id
+                                        (toggle-layout-debug! variant-id id)))}]
+          [:span {:style (:decor-id styles)} (str id)]])
+       [:div {:style (:hint styles)}
+        "toggle adds the decorator at variant render time (per IMPL-SPEC §2.8.6)"]])))
 
 ;; ---- registration -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two unrelated regressions surfaced by rf2-kljn Playwright coverage of the counter-with-stories example; both fixed here so the layout-debug toggle assertion can be restored to a real `:checked` round-trip.

### 1. Layout-debug toggle never updated `:checked` (panels.cljs)

The panel's three label-wrapped checkboxes appeared to ignore clicks — `outerHTML` was byte-identical before and after click. Two issues compounded:

- **Double-fire**: `:on-click` was on the surrounding `<label>`, with the contained `<input>` carrying `:readOnly`. Clicking the label fires the handler once for the user's direct click AND a second time for the implicit click propagated to the inner `<input>` (which bubbles back to the label). Two toggles per user click — net no change.
- **Form-1 fragility under wrapper chain**: under the registered-view path the panel-host wraps the user fn in `frame-provider-ns-safe` (which calls `r/as-element` on the child). The form-1 shape was fragile through that wrapping; form-2 (outer fn returning an inner render fn that derefs `layout-debug-toggles` directly) is the canonical Reagent idiom that survives.

Fix: convert to **form-2**; move handler from `:on-click` on `<label>` to **`:on-change` on `<input>`**; drop `:readOnly`. Standard controlled-checkbox idiom, fires exactly once per user click.

### 2. decorator-list duplicate-key React warning (controls.cljs)

`resolve-decorators` concats the `:hiccup` / `:frame-setup` / `:fx-override` packs without de-duping. The same decorator id can appear in more than one pack (story-level + variant-level), and the `(for)` was keying the row by bare id — producing React's "Encountered two children with the same key" warning. Fix: key by `[index id]`.

### 3. Playwright assertion restored

Previously weakened to "click doesn't crash" pending this fix; now asserts the surface contract — initial unchecked → click → `:checked` → click → unchecked. Also pre-seeds `re-frame.story/seen-help-v1` in localStorage so the first-visit help overlay (rf2-381i) doesn't intercept pointer events in a fresh test context.

## Test plan

- [x] `npm run test:cljs` — 586 tests, 1384 assertions, 0 failures (all existing unit tests pass)
- [x] `examples/reagent/counter_with_stories/counter_with_stories.spec.cjs` end-to-end Playwright run — PASS, including the restored `:checked` round-trip and no duplicate-key warnings in the console tap.
- [x] Manual verification: layout-debug outline toggle flips `:checked` true on first click, false on second click.