### PR TITLE
docs(spec): add Spec-ulation section to Principles — anchor target for 9 cross-refs (rf2-tzt2)

### DIFF
--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -32,7 +32,7 @@ Every registration takes the same shape:
 
 The **id** is an instance of the [identity primitive](000-Vision.md#the-identity-primitive--required-properties).
 
-The **metadata map** is open (consumers tolerate unknown keys; new keys are added additively per [Spec-ulation](Principles.md)). The standard keys are:
+The **metadata map** is open (consumers tolerate unknown keys; new keys are added additively per [Spec-ulation](Principles.md#spec-ulation)). The standard keys are:
 
 | Key | Type | Required? | Meaning |
 |---|---|---|---|

--- a/spec/Principles.md
+++ b/spec/Principles.md
@@ -90,6 +90,21 @@ Constrained models are deliberately less powerful and therefore much easier to r
 
 Data DSLs are strictly preferred over string DSLs because data composes, diffs, lints, validates, and round-trips cleanly; strings do none of those. See [§Rationale — the application as a virtual machine](#rationale--the-application-as-a-virtual-machine) below.
 
+### Spec-ulation
+
+**Principle:** contracts are **fixed-and-additive** — existing names, keys, and values cannot be renamed, repurposed, or removed; new ones are added by extension. Growth is additive; the existing surface is stable.
+
+The term echoes Rich Hickey's *Spec-ulation* keynote: a healthy system grows by **accretion** (new optional keys, new vocabulary values, new operations) and **relaxation** (loosening a requirement), never by **breakage** (renaming a key, tightening a contract, removing a value). Consumers tolerate unknown keys and unknown vocabulary values; producers add new keys/values without coordinating a breaking change. Spec-ulation is the discipline that lets independent tools, libraries, and AI-generated code keep working as the framework evolves.
+
+Concretely, the Spec applies the rule to every cross-cutting vocabulary and every open map:
+
+- **Open maps with optional keys.** Registration metadata maps, frame configs, error `:tags`, epoch records, snapshot records — all open. New optional keys arrive additively; existing keys hold their meaning. Closed maps are reserved for boundary-validation cases ([Construction-Prompts.md §Schemas grow additively](Construction-Prompts.md)).
+- **Reserved-and-additive vocabularies.** The reserved `app-db` keys, the reserved `fx-id` set, the `:op-type` vocabulary, the error-category namespaces, and the `configure` knob set are all **fixed-and-additive**: names already in the table cannot be repurposed; new names are added by Spec change ([Conventions §Reserved app-db keys](Conventions.md#reserved-app-db-keys), [Spec-Schemas §Trace event](Spec-Schemas.md), [API §configure](API.md)).
+- **Open vocabularies extended by users.** The `:op-type` vocabulary is **open** — implementations and tools may add new values additively ([Spec-Schemas §Trace event](Spec-Schemas.md)). The framework reserves a namespace prefix (`:rf.*`); user code stays out of that prefix and is otherwise free to extend.
+- **Closed surfaces require a Spec-ulation increment.** A surface that is intentionally closed for v1 (e.g. the pair-tool restore failure categories) can only grow by an explicit Spec change — never by silent extension at runtime ([Tool-Pair §Future-compat commitments](Tool-Pair.md)).
+
+The cost is verbosity at the design margin (you cannot rename a misnamed key once it ships; you must deprecate-and-add). The benefit is exactly what AI-generated code, downstream tools, and long-lived applications need: a contract that doesn't move under them. Spec-ulation is the stability discipline that makes the rest of the AI-first principles — public query surfaces, machine-readable errors, schemas-on-the-wire — durable across versions.
+
 ## The deliverable principle
 
 ### Construction prompts as a deliverable

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -231,7 +231,7 @@ Universal trace event shape, including error events.
 
 The runtime emits event-at-a-time, not span-shaped: there is no `:start`/`:end`/`:duration` pair and no `:child-of` parent-id. Cascade correlation rides on `:dispatch-id` / `:parent-dispatch-id` under `:tags` of `:event/dispatched` events (per [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id)). Per-event frame attribution rides under `[:tags :frame]`.
 
-The `:op-type` vocabulary is **open** — implementations and tools may add new values additively per [Spec-ulation](Principles.md). The reserved values used by the framework (in alphabetical order):
+The `:op-type` vocabulary is **open** — implementations and tools may add new values additively per [Spec-ulation](Principles.md#spec-ulation). The reserved values used by the framework (in alphabetical order):
 
 | `:op-type` | Used for | Spec |
 |---|---|---|
@@ -952,7 +952,7 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:dropped-count :int]])
 ```
 
-Pattern-level: every implementation registers an equivalent set of schemas. The category vocabulary is fixed-and-additive per [Spec-ulation](Principles.md): existing categories cannot be renamed or removed; new categories appear additively.
+Pattern-level: every implementation registers an equivalent set of schemas. The category vocabulary is fixed-and-additive per [Spec-ulation](Principles.md#spec-ulation): existing categories cannot be renamed or removed; new categories appear additively.
 
 The schemas above are *open* (Malli's default `[:map ...]`) — consumers receive payloads that conform to the listed keys plus any additive keys the implementation adds. Validation against these schemas is non-fatal in dev: a `validate` failure is logged via the same trace stream (per [009](009-Instrumentation.md)) but does not abort the consumer. In production, both validation and the trace stream are compile-time elided (per [009](009-Instrumentation.md) lead claim and [Spec 000 C-000.35](000-Vision.md)) — there is no runtime validation cost and no trace emission.
 

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -448,7 +448,7 @@ The framework is **infrastructure-complete** for AI-tool consumption: data shape
 
 ## Future-compat commitments
 
-Per the philosophy of [Spec-ulation](Principles.md), the pair-tool runtime contract grows additively:
+Per the philosophy of [Spec-ulation](Principles.md#spec-ulation), the pair-tool runtime contract grows additively:
 
 - **Trace event categories** are stable; new categories are added with new `:operation` keywords.
 - **Registry query API** signatures are stable; new query functions are additive.


### PR DESCRIPTION
## Summary

- ``spec/Principles.md`` was cited 9 times as ``[Spec-ulation](Principles.md)`` (or in prose as ``(Spec-ulation)``), but the term **Spec-ulation** appeared nowhere as a heading on that page — the link target did not resolve to a section.
- Add a new ``### Spec-ulation`` section under **The foundational principles** in ``Principles.md``. The section defines the term (fixed-and-additive contracts: accretion + relaxation, never breakage; echoing Rich Hickey's *Spec-ulation* keynote), enumerates the four concrete applications already at work in the spec corpus, and cross-links representative citation sites (Conventions, Spec-Schemas, API, Tool-Pair, Construction-Prompts).
- Update the four ``[Spec-ulation](Principles.md)``-style link citations (in ``001-Registration.md``, ``Spec-Schemas.md`` x2, ``Tool-Pair.md``) to use the explicit ``#spec-ulation`` anchor so navigation lands at the section. The five prose-only ``(Spec-ulation)`` references in 000-Vision x2, API, Conventions, Construction-Prompts, Spec-Schemas, and Tool-Pair are unchanged — they are deliberate parenthetical references, not links.

## Term definition (verbatim from the new section)

> **Principle:** contracts are **fixed-and-additive** — existing names, keys, and values cannot be renamed, repurposed, or removed; new ones are added by extension. Growth is additive; the existing surface is stable.

## Test plan

- [x] ``cd re-frame2 && cp -r spec docs/spec && mkdocs build --strict`` — exits 0, no WARNING or ERROR.
- [x] All four updated link citations resolve to the new ``#spec-ulation`` anchor (verified by inspecting the generated ``site/spec/Principles/index.html``: ``<h3 id="spec-ulation">Spec-ulation</h3>``).
- [x] The five prose-only ``(Spec-ulation)`` references are untouched; they remain inline parenthetical glosses, not navigation targets.

Bead: rf2-tzt2.