### PR TITLE
docs(skills): fix wrong-depth ../spec/ refs in re-frame2-implementor.md (rf2-mpod)

### DIFF
--- a/docs/skills/re-frame2-implementor.md
+++ b/docs/skills/re-frame2-implementor.md
@@ -8,9 +8,9 @@ The `re-frame2-implementor` skill is for engineers **building re-frame2 itself**
 
 **Phase 1 — Lock the decisions.** Before any code is written: target host language; substrate / view layer; scope (which optional EPs ship); identity primitive, persistent data structures, reactive substrate, concurrency model, hot-reload, schema mechanism, integration story; the conformance capability tag set the port claims. Captured in a written decision record the engineer commits to the port's repo.
 
-**Phase 2 — Walk the spec corpus.** Implement in dependency order: [001 Registration](../spec/001-Registration.md) → [002 Frames + events + effects + subs](../spec/002-Frames.md) → [006 Reactive substrate](../spec/006-ReactiveSubstrate.md) → [004 Views](../spec/004-Views.md) → [009 Instrumentation](../spec/009-Instrumentation.md). Acceptance gate 1 runs the `:core/*` conformance fixtures. Then optional EPs per the Phase 1 claim. Acceptance gate 2 runs the full claimed-capability fixture set.
+**Phase 2 — Walk the spec corpus.** Implement in dependency order: [001 Registration](../../spec/001-Registration.md) → [002 Frames + events + effects + subs](../../spec/002-Frames.md) → [006 Reactive substrate](../../spec/006-ReactiveSubstrate.md) → [004 Views](../../spec/004-Views.md) → [009 Instrumentation](../../spec/009-Instrumentation.md). Acceptance gate 1 runs the `:core/*` conformance fixtures. Then optional EPs per the Phase 1 claim. Acceptance gate 2 runs the full claimed-capability fixture set.
 
-The authoritative contract is the [spec corpus](../spec/000-Vision.md), with the [Implementor Checklist](../spec/Implementor-Checklist.md) as the decision-ordered companion and the [conformance corpus](../spec/conformance/README.md) as the acceptance test. The CLJS reference at `implementation/` is one worked example, never normative — the skill is explicit about this throughout.
+The authoritative contract is the [spec corpus](../../spec/000-Vision.md), with the [Implementor Checklist](../../spec/Implementor-Checklist.md) as the decision-ordered companion and the [conformance corpus](../../spec/conformance/README.md) as the acceptance test. The CLJS reference at `implementation/` is one worked example, never normative — the skill is explicit about this throughout.
 
 ## When to reach for it
 
@@ -19,7 +19,7 @@ Load this skill when **any** of these are true:
 - The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or one of the broader hosts in the Implementor Checklist).
 - The engineer is implementing re-frame2 against a non-React substrate, a native UI toolkit, a terminal UI, or any rendering surface that isn't React-on-the-browser.
 - The engineer wants to claim "this is a re-frame2 implementation" and needs to know what the claim requires.
-- The engineer is consuming the [Implementor Checklist](../spec/Implementor-Checklist.md) and the [conformance corpus](../spec/conformance/README.md) to verify their work.
+- The engineer is consuming the [Implementor Checklist](../../spec/Implementor-Checklist.md) and the [conformance corpus](../../spec/conformance/README.md) to verify their work.
 
 Do **not** use this skill for:
 
@@ -44,5 +44,5 @@ Two common amendments — *"minimum viable port"* (declare every optional capabi
 - `SKILL.md`: [`skills/re-frame2-implementor/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-implementor/SKILL.md)
 - Kickoff prompt: [`skills/re-frame2-implementor/reference/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-implementor/reference/kickoff-prompt.md)
 - Reference leaves: [`skills/re-frame2-implementor/reference/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-implementor/reference) — `phase-1-decisions.md` (the Phase 1 walkthrough), `decision-record.md` (the fill-in template), `phase-2-impl-order.md` (EP-by-EP order), `reference-impl-tour.md` (descriptive tour of the CLJS reference), `conformance.md` (harness shape + diagnosis), `output-format.md` (agent-output shapes).
-- Authoritative contract: the [spec corpus](../spec/000-Vision.md) + [Implementor Checklist](../spec/Implementor-Checklist.md) + [conformance corpus](../spec/conformance/README.md).
+- Authoritative contract: the [spec corpus](../../spec/000-Vision.md) + [Implementor Checklist](../../spec/Implementor-Checklist.md) + [conformance corpus](../../spec/conformance/README.md).
 - One worked example: the CLJS reference at [`implementation/`](https://github.com/day8/re-frame2/tree/main/implementation) (descriptive, not normative).


### PR DESCRIPTION
## Summary

`docs/skills/re-frame2-implementor.md` sits at depth 2 under the repo root. Reaching the repo-root `spec/` tree therefore needs `../../spec/`, not `../spec/`. Thirteen `../spec/` refs in the file were a depth too shallow and 404'd on GitHub source-tree browsing.

This mirrors the depth-2 convention already in use by `docs/guide/*` pages, which the build-time hook in `mkdocs_hooks.py` rewrites from `../../spec/` to `../spec/` for the staged docs tree (where `spec/` is copied into `docs/spec/`).

## Findings

- 13 link replacements: `](\.\./spec/` -> `](\.\./\.\./spec/`
- `mkdocs build --strict` now WARNs on this file because `mkdocs_hooks.py` only applies the `guide -> spec` rewrite to `guide/*` source paths, not `skills/*`. Extending the hook to handle `skills/*` at the same depth as `guide/*` is a natural follow-up — left out of this PR per the audit's single-file scope constraint.

## Test plan

- [ ] Spot-check a couple of the rewritten links on the GitHub source-tree view (e.g. `docs/skills/re-frame2-implementor.md` -> `spec/000-Vision.md`).
- [ ] Follow up by extending `mkdocs_hooks.py` to apply the existing `../../spec/` -> `../spec/` rewrite to pages whose `src_path` starts with `skills/` (analogous to the existing `guide/` branch). After that, `mkdocs build --strict` should be clean for this file.