### PR TITLE
chore(ci): bump GitHub Actions Node.js from 20 to 24 (rf2-3aks)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -501,7 +501,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -541,7 +541,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -588,7 +588,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -642,7 +642,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -699,7 +699,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -750,7 +750,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -809,7 +809,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 
@@ -865,7 +865,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: implementation/package-lock.json
 


### PR DESCRIPTION
## Summary

- Bumps all 9 `setup-node` steps in `.github/workflows/{test,release}.yml` from Node 20 to Node 24.
- `actions/setup-node@v4` already supports Node 24; no action-version bump required.
- Playwright 1.59.1 (used in tests) is Node-24 compatible (>=1.50 supports it).
- `engines.node` fields elsewhere in the repo (`skills/*/package.json`) are `>=18` and remain compatible.

Mirrors the equivalent change already shipped on re-frame v1's `update-actions-node24` branch.

## Test plan

- [ ] All test.yml jobs green on Node 24 runners
- [ ] release.yml dry-run validates Node 24 install
- [ ] `npm ci` resolves cleanly under Node 24