### PR TITLE
chore(pair2-mcp): normalise tools/ shape — add deps.edn + LICENSE (rf2-druw)

### DIFF
--- a/tools/pair2-mcp/LICENSE
+++ b/tools/pair2-mcp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2026 Michael Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -1,0 +1,53 @@
+;; @day8/re-frame-pair2-mcp — MCP (Model Context Protocol) server for
+;; re-frame-pair2 (rf2-drd9 parent epic; this file added by rf2-druw to
+;; normalise tools/ shape).
+;;
+;; ## Why this artefact's deps.edn is shaped differently to its siblings
+;;
+;; The other tools/ artefacts (tools/template/, tools/story/,
+;; tools/story-mcp/) ship as JVM Maven jars to Clojars and carry a
+;; :clein/build alias for that release path. This artefact is the
+;; exception: re-frame-pair2-mcp ships as a Node binary on npm —
+;; ClojureScript is compiled to a single self-contained `out/server.js`
+;; via shadow-cljs and published as `@day8/re-frame-pair2-mcp`. There
+;; is no Clojars publish path and no JVM-side consumer. End users
+;; install Node only; the compiled JS has no Clojure dependency.
+;;
+;; Why a deps.edn nonetheless?
+;;   1. Repo uniformity. Per tools/README.md "each tool gets its own
+;;      subdirectory, structured like the per-adapter jars". A
+;;      deps.edn declares the artefact-as-such and gives any future
+;;      JVM-side surface a home to land in without retro-fitting.
+;;   2. shadow-cljs deps resolution. shadow-cljs reads :paths +
+;;      :dependencies from this file when present, keeping the source
+;;      of truth in one place rather than split between deps.edn and
+;;      shadow-cljs.edn's own :dependencies vector.
+;;   3. Tooling discoverability. clj-kondo, cljfmt, IDEs and similar
+;;      surface tools all expect deps.edn at the artefact root; its
+;;      absence is friction that the rest of tools/ doesn't suffer.
+;;
+;; ## Bundle isolation
+;;
+;; Per tools/README.md the dependency arrow flows tool → implementation
+;; (and never the reverse). This artefact has no `:local/root` dep on
+;; `implementation/` because it does not :require any re-frame2 source:
+;; it terminates the agent host's stdio channel and bridges to a
+;; separately-running re-frame app's nREPL socket. The runtime injection
+;; (`runtime.cljs`) ships from the pair2 skill, not from here.
+;;
+;; ## Tests
+;;
+;; The canonical test entry-point is `npm test` (which invokes
+;; `shadow-cljs compile server-test && node out/server-test.js`).
+;; The `:test` alias here is a thin shim for habit / IDE consistency:
+;; `clojure -M:test` still routes through shadow-cljs because the
+;; sources are .cljs and need a CLJS compiler.
+{:paths ["src"]
+ :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
+         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         applied-science/js-interop {:mvn/version "0.4.2"}
+         thheller/shadow-cljs      {:mvn/version "3.4.10"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :main-opts   ["-m" "shadow.cljs.devtools.cli" "compile" "server-test"]}}}


### PR DESCRIPTION
## Summary

`tools/pair2-mcp/` was structurally inconsistent with the rest of `tools/` (per repo audit rf2-druw):

- **No `deps.edn`** — every other tool (`template`, `story`, `story-mcp`) has one.
- **No `LICENSE` file** at the artefact root, despite `package.json` `files:` declaring `LICENSE` — npm would silently drop the missing entry on publish.

Two files added; nothing changes for existing builds.

## Changes

1. **`tools/pair2-mcp/LICENSE`** — verbatim copy of the repo-root `license.txt` (MIT, "Copyright (c) 2015-2026 Michael Thompson"). The `package.json` `files:` array entry now resolves, so `npm publish` will ship the license alongside `out/server.js` and `README.md`.

2. **`tools/pair2-mcp/deps.edn`** — minimal shape with explanatory header. Unlike sibling tools this artefact is Node-only (ships as `@day8/re-frame-pair2-mcp` on npm; there is no Clojars publish path and no JVM consumer), so there is **no `:clein/build` alias**. The header documents why the file earns its keep nonetheless: repo uniformity (per `tools/README.md`'s "each tool gets its own subdirectory" convention), shadow-cljs deps resolution, and IDE/clj-kondo discoverability. A `:test` alias points at the existing cljs test source under `test/`.

## shadow-cljs version coordination

`tools/pair2-mcp/package.json` pins `shadow-cljs ^3.4.10`; `implementation/` pins `2.28.20`. This PR **leaves pair2-mcp at 3.4.10** — version consistency between `tools/pair2-mcp/` and `implementation/` arrives when **rf2-9cek** lands the implementation bump to 3.x. Once that PR merges, both surfaces will share a major-version pin.

## Verification

`clojure -Spath` from `tools/pair2-mcp/` resolves cleanly with shadow-cljs 3.4.10 + clojurescript 1.11.132 + applied-science/js-interop 0.4.2 — no conflicts, no warnings. Canonical test driver remains `npm test` (which runs `shadow-cljs compile server-test && node out/server-test.js`).

## Test plan

- [x] `clojure -Spath` resolves with no errors in `tools/pair2-mcp/`
- [x] `LICENSE` content matches root `license.txt` byte-for-byte (modulo platform line endings)
- [x] `package.json` `files:` array now references files that all exist (`out/server.js` is build-produced; the other two — `README.md`, `LICENSE` — both present)
- [ ] (No CI changes; existing `npm test` path unaffected.)