### PR TITLE
fix(mkdocs): extend hook to rewrite ../../spec/ refs for docs/skills/* (rf2-5lcu)

### DIFF
--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -34,7 +34,12 @@ import re
 
 GH_BLOB_BASE = "https://github.com/day8/re-frame2/blob/main"
 
-# Case 1a: guide/* pages link to spec via ../../spec/ — collapse one level.
+# Case 1a: guide/* and skills/* pages link to spec via ../../spec/ — collapse
+# one level. Both trees live at docs/<tree>/X.md (depth 2 below repo root),
+# so from the source tree the correct ref to spec/ is ../../spec/, while in
+# the staged docs_dir (where spec/ is copied to docs/spec/) the correct ref
+# is ../spec/. The rewrite is identical for both trees because they share
+# the same depth.
 _GUIDE_TO_SPEC = re.compile(r'\]\(\.\./\.\./spec/')
 
 # Case 1b: docs-root pages (e.g. docs/release-process.md) link to spec via
@@ -102,15 +107,17 @@ _REWRITES = (
 
 
 def on_page_markdown(markdown, page, config, files):
-    """Rewrite cross-tree links in guide/* and spec/* pages.
+    """Rewrite cross-tree links in guide/*, skills/*, and spec/* pages.
 
-    1. ../../spec/ -> ../spec/   (only on guide/* pages; spec IS staged)
+    1. ../../spec/ -> ../spec/   (on guide/* and skills/* pages; spec IS
+                                  staged into docs/spec/, and both trees
+                                  share the same docs/<tree>/X.md depth)
     2. ../../examples/ and ../examples/  -> https://github.com/.../examples/
     3. ../../README.md and ../README.md  -> https://github.com/.../README.md
     """
     src = page.file.src_path.replace('\\', '/')
 
-    if src.startswith('guide/'):
+    if src.startswith('guide/') or src.startswith('skills/'):
         markdown = _GUIDE_TO_SPEC.sub('](../spec/', markdown)
     elif src.startswith('spec/'):
         # Spec pages link to docs-root pages via ../docs/ — collapse the


### PR DESCRIPTION
## Summary

- `rf2-mpod` (#447) corrected `docs/skills/re-frame2-implementor.md` from `../spec/` to `../../spec/` — the right depth for GitHub source-tree rendering (skill pages live at depth 2 under repo root, same as guide pages).
- That broke `mkdocs build --strict` because `mkdocs_hooks.py` only collapsed the extra `../` for source paths under `docs/guide/*`, not `docs/skills/*`.
- Extend the `guide/`-prefix guard in `on_page_markdown` to also match `skills/` — both trees share the same `docs/<tree>/X.md` depth, so the existing `_GUIDE_TO_SPEC` regex applies unchanged.

## Strict-build before/after

- Before: **13 warnings**, all from `skills/re-frame2-implementor.md`, e.g.
  `link '../../spec/001-Registration.md' ... not found ... Did you mean '../spec/001-Registration.md'?`
- After: **0 warnings**; `Documentation built in 3.50 seconds`.

## Test plan

- [x] `python -m mkdocs build --strict` passes locally with `spec/` staged into `docs/spec/`.
- [x] Built `site/skills/re-frame2-implementor/index.html` body links resolve to `../../spec/<page>/`, and the corresponding `site/spec/<page>/index.html` files exist (spot-checked `001-Registration`, `Implementor-Checklist`, `conformance`).
- [x] Source `docs/skills/re-frame2-implementor.md` still uses `../../spec/` — GitHub source-tree rendering unaffected.

Closes rf2-5lcu.