### PR TITLE
feat(story): :dev / :docs / :test mode-tabs primitive at render-shell top (rf2-9hc8)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -160,6 +160,125 @@ module.exports = {
     await waitForVariantTitle(page, ':story.counter/loaded');
 
     // ====================================================================
+    // 3b. Mode-tabs strip — Canvas | Docs | Tests (rf2-9hc8)
+    // ====================================================================
+    //
+    // The render shell ships a per-variant mode-tabs strip at the top
+    // of the canvas pane (rf2-9hc8). Three chips: Canvas (:dev, default)
+    // | Docs (:docs, rf2-rodx placeholder) | Tests (:test, rf2-qmjo
+    // placeholder). Selection is per-variant and persists across reload
+    // in localStorage under `re-frame.story/active-mode-tab/<variant-id>`.
+    //
+    // The strip renders inside <main>, carries data-test="story-mode-tabs"
+    // and each chip carries data-mode-tab="<id>". Active chips set
+    // aria-selected="true".
+    const tabsStrip = page.locator('[data-test="story-mode-tabs"]');
+    await tabsStrip.waitFor({ state: 'visible', timeout: 5000 });
+
+    const devChip = tabsStrip.locator('[data-mode-tab="dev"]');
+    const docsChip = tabsStrip.locator('[data-mode-tab="docs"]');
+    const testChip = tabsStrip.locator('[data-mode-tab="test"]');
+
+    // All three chips must render.
+    await devChip.waitFor({ state: 'visible', timeout: 2000 });
+    await docsChip.waitFor({ state: 'visible', timeout: 2000 });
+    await testChip.waitFor({ state: 'visible', timeout: 2000 });
+
+    // Default mode-tab is :dev — the canvas is up. The :dev chip is
+    // active, the other two are not.
+    if ((await devChip.getAttribute('aria-selected')) !== 'true') {
+      throw new Error('expected :dev chip to be aria-selected="true" by default');
+    }
+    if ((await docsChip.getAttribute('aria-selected')) !== 'false') {
+      throw new Error('expected :docs chip to be aria-selected="false" by default');
+    }
+
+    // Click Docs → the docs placeholder appears and the :docs chip
+    // becomes active. The canvas (data-test="count") disappears from
+    // <main> because the docs pane replaces it.
+    await docsChip.click();
+    await page
+      .locator('[data-test="story-docs-placeholder"]')
+      .waitFor({ state: 'visible', timeout: 5000 });
+    if ((await docsChip.getAttribute('aria-selected')) !== 'true') {
+      throw new Error('expected :docs chip to be aria-selected="true" after click');
+    }
+    if ((await devChip.getAttribute('aria-selected')) !== 'false') {
+      throw new Error('expected :dev chip to flip aria-selected="false" after switching');
+    }
+
+    // Click Tests → the tests placeholder appears, :test chip active.
+    await testChip.click();
+    await page
+      .locator('[data-test="story-tests-placeholder"]')
+      .waitFor({ state: 'visible', timeout: 5000 });
+    if ((await testChip.getAttribute('aria-selected')) !== 'true') {
+      throw new Error('expected :test chip to be aria-selected="true" after click');
+    }
+
+    // Verify the persisted localStorage record. The mode-tabs primitive
+    // writes under `re-frame.story/active-mode-tab/:story.counter/loaded`.
+    const persistedTab = await page.evaluate(() =>
+      localStorage.getItem('re-frame.story/active-mode-tab/:story.counter/loaded'),
+    );
+    if (persistedTab !== 'test') {
+      throw new Error(
+        `expected localStorage to persist :test after click, got "${persistedTab}"`,
+      );
+    }
+
+    // Reload — the persisted selection must re-hydrate. Re-prime the
+    // help-overlay dismiss flag first so the reloaded shell doesn't
+    // block on the on-boarding overlay (same rationale as the top-of-
+    // run priming).
+    await page.evaluate(() => {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    });
+    await page.reload();
+    await page.evaluate(() => {
+      window.location.hash = '#/stories';
+    });
+    // Re-select /loaded — selection is in-memory only, doesn't persist.
+    await clickVariant(page, '/loaded');
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // After reload + re-select, the :test chip should be re-hydrated as
+    // active and the tests placeholder visible. Poll: hydration from
+    // localStorage runs on the first render of the strip for this
+    // variant, which is the tick after `clickVariant` settles.
+    {
+      const start = Date.now();
+      let restored = false;
+      while (Date.now() - start < 5000) {
+        const sel = await page
+          .locator('[data-test="story-mode-tabs"] [data-mode-tab="test"]')
+          .getAttribute('aria-selected')
+          .catch(() => null);
+        if (sel === 'true') {
+          restored = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!restored) {
+        throw new Error(
+          'mode-tabs primitive did not re-hydrate :test from localStorage after reload',
+        );
+      }
+    }
+    await page
+      .locator('[data-test="story-tests-placeholder"]')
+      .waitFor({ state: 'visible', timeout: 5000 });
+
+    // Switch back to Canvas so the remaining sub-tests see the live
+    // variant render (the args editor / trace / scrubber / a11y panel
+    // / layout-debug assertions all need the canvas mounted).
+    await page
+      .locator('[data-test="story-mode-tabs"] [data-mode-tab="dev"]')
+      .click();
+    await waitForVariantTitle(page, ':story.counter/loaded');
+
+    // ====================================================================
     // 4. Mode-tag filter — :dev / :docs / :test chips
     // ====================================================================
     //

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -6,6 +6,10 @@
 > `mount-shell!` / `unmount-shell!` / `active-shell` lifecycle. The
 > contract Stage 4 implements.
 
+See [`007-Mode-Tabs.md`](007-Mode-Tabs.md) for the `:dev` / `:docs` /
+`:test` mode-tabs primitive that sits at the top of the canvas pane
+(rf2-9hc8).
+
 ## UI shell substrate
 
 Story's own UI shell (sidebar, control panel, trace ribbon, embedded

--- a/tools/story/spec/007-Mode-Tabs.md
+++ b/tools/story/spec/007-Mode-Tabs.md
@@ -1,0 +1,177 @@
+# Story — Mode-Tabs Primitive
+
+> The render-shell's top-of-canvas `:dev` / `:docs` / `:test`
+> switcher. The chrome-level primitive that exposes the three
+> canonical views every 2026 component playground is expected to
+> ship. The contract rf2-9hc8 implements; the surface rf2-rodx
+> (`:docs`) and rf2-qmjo (`:test`) build on.
+
+## Why a mode-tabs primitive
+
+Story already carries every substrate the three canonical modes need:
+
+- `:tags` (per-variant) — `:dev` / `:docs` / `:test` are canonical
+  tags.
+- `:prose` workspace — Markdown-equivalent narrative content.
+- Autodocs panel — args table, decorator stack, parameters, tags.
+- `run-variant-as-test` — programmatic test harness.
+
+What was missing through the Stage-4 — Stage-6 push: a **chrome-level
+switcher** that exposes them as the three canonical views a Storybook-8
+class playground ships. The mode-tabs primitive (rf2-9hc8) is that
+switcher.
+
+Two beads consume the primitive:
+
+- **rf2-rodx — `:docs` mode view.** Read-only AutoDocs-equivalent
+  presentation of the variant's `:prose` workspace + autodocs panel.
+  Replaces the `:docs` placeholder.
+- **rf2-qmjo — `:test` mode view.** In-canvas aggregated pass/fail
+  summary for the variant's interactions / assertions. Replaces the
+  `:test` placeholder.
+
+A third bead — rf2-p0mv — specifies the chrome-level toolbar that
+consumes `reg-mode` tuples (theme / viewport / locale chips). The
+mode-tabs primitive and the toolbar are independent UX axes: tabs
+switch the variant's render mode, the toolbar overrides global
+options inside the canvas pane.
+
+## The three canonical mode-tabs
+
+| Tab id | Label    | Renders                                                          | Owner bead |
+|--------|----------|-------------------------------------------------------------------|------------|
+| `:dev` | Canvas   | The interactive variant render — Story v1's default canvas pane. | rf2-9hc8 (already shipped) |
+| `:docs`| Docs     | AutoDocs-equivalent: prose + args table + decorator stack + parameters + tags. | rf2-rodx |
+| `:test`| Tests    | Aggregated pass/fail summary of `:play` / `:assertions` for the variant. | rf2-qmjo |
+
+`:dev` is the default — selecting a variant without prior selection
+renders the canvas, preserving Story v1 behaviour.
+
+## Surface
+
+The primitive ships as one Reagent component plus a small public API
+in `re-frame.story.ui.mode-tabs`:
+
+```clojure
+(mode-tabs-strip variant-id)        ; the chip strip
+(select-mode-tab! variant-id tab)   ; programmatic switch
+(load-mode-tab! variant-id)         ; read persisted value
+(save-mode-tab! variant-id tab)     ; persist
+(hydrate-from-storage! variant-id)  ; idempotent state-from-LS seed
+```
+
+State helpers in `re-frame.story.ui.state` (pure data → data,
+JVM-testable):
+
+```clojure
+mode-tabs            ; [:dev :docs :test]
+mode-tab-labels      ; {:dev "Canvas" :docs "Docs" :test "Tests"}
+default-mode-tab     ; :dev
+(valid-mode-tab? tab)
+(active-mode-tab state variant-id) ; → :dev|:docs|:test
+(set-active-mode-tab state variant-id tab)
+```
+
+## Shell integration
+
+The render shell's `main-pane` renders the chip strip at the top of
+the `<main>` landmark when a single variant is selected. Workspaces
+(which enumerate multiple variants) do **not** show the mode-tabs
+strip — mode-tabs is a per-variant axis; the workspace layout switcher
+is a separate concern.
+
+```
+┌────────────────────────────────────────┐
+│ Canvas │ Docs │ Tests │                │   ← mode-tabs strip
+├────────────────────────────────────────┤
+│                                        │
+│   <selected mode's pane renders>       │
+│                                        │
+└────────────────────────────────────────┘
+```
+
+`:dev` → existing canvas / hot-reload / decorators path (unchanged
+from Story v1).
+`:docs` → the docs pane (placeholder until rf2-rodx).
+`:test` → the tests pane (placeholder until rf2-qmjo).
+
+## Per-variant selection + localStorage persistence
+
+Selection is **per-variant** — switching variants does not clear
+another variant's mode-tab. The shell state's `:active-mode-tab` slot
+holds the in-memory map `{variant-id → tab}`.
+
+Persistence is via **localStorage**, one key per variant:
+
+```
+re-frame.story/active-mode-tab/:story.counter/loaded   → "test"
+```
+
+The key prefix is `re-frame.story/active-mode-tab/` followed by
+`(str variant-id)`. Mirrors the help overlay's
+`re-frame.story/seen-help-v1` key shape and reuses the same
+defensive `safe-local-storage` pattern — a localStorage failure
+degrades silently to in-memory-only state.
+
+`hydrate-from-storage!` runs on the first render of a variant's strip
+and seeds the in-memory slot if the localStorage record exists and
+the in-memory slot is empty. Idempotent — safe on every render.
+
+## Accessibility
+
+The chip strip is a `role="tablist"`; each chip is a `<button
+role="tab">`. The active chip carries `aria-selected="true"` plus
+`aria-current="page"`. The strip itself carries
+`aria-label="Story mode"` so screen-reader users can jump to it via
+the landmark navigator.
+
+## Test surface
+
+The Playwright spec `examples/reagent/counter_with_stories/
+counter_with_stories.spec.cjs` exercises the primitive end-to-end
+(section 3b): asserts the three chips render, that each click flips
+`aria-selected`, that the matching placeholder renders below the
+strip, that the selection persists to localStorage, and that a
+full page-reload + variant re-select re-hydrates the persisted tab.
+
+Selectors:
+
+- The strip: `[data-test="story-mode-tabs"]`
+- Each chip: `[data-mode-tab="dev|docs|test"]`
+- Placeholders: `[data-test="story-docs-placeholder"]`,
+  `[data-test="story-tests-placeholder"]`
+
+## Visual style
+
+Matches the existing render-shell chrome (rf2-2uwv contrast fixes):
+`#b0b0b0` inactive foreground, white active foreground, `#1e1e1e`
+active background, `#2d2d30` strip background, `1px solid #444`
+borders, monospace 11px.
+
+## Out-of-scope at this primitive
+
+- **The `:docs` pane content.** A placeholder div ships now; rf2-rodx
+  ships the real AutoDocs view.
+- **The `:test` pane content.** A placeholder div ships now; rf2-qmjo
+  ships the aggregated pass/fail view.
+- **Workspace mode-tabs.** Workspaces enumerate multiple variants;
+  mixing mode-tabs into the workspace pane conflates two axes. If
+  workspaces grow a switcher it lives in a separate spec.
+- **Mode-tab registration.** The three tabs are canonical and fixed
+  at v1. If extensibility is needed later (`reg-story-mode-tab` for
+  third-party panes) it lands as a v2 follow-up — for now the primitive
+  is a closed enum.
+
+## Foundational status
+
+Per rf2-9hc8 this primitive is **foundational** — three other beads
+depend on it. The contract guarantees:
+
+1. The chip strip renders above the canvas pane whenever a single
+   variant is selected.
+2. Selection is per-variant and persists across reload.
+3. `:dev` preserves Story v1's exact existing behaviour — no
+   regression to the canvas / hot-reload / decorator paths.
+4. The `:docs` / `:test` panes are pluggable: rf2-rodx / rf2-qmjo
+   replace the placeholders without touching the chip strip, the
+   state slot, or the localStorage key shape.

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -1,0 +1,212 @@
+(ns re-frame.story.ui.mode-tabs
+  "Render-shell `:dev` / `:docs` / `:test` mode-tabs primitive (rf2-9hc8).
+
+  Storybook's chrome ships a top-of-canvas tab strip that switches the
+  variant view between three canonical modes:
+
+  - `:dev`  — Canvas. The interactive variant render (Story v1 default).
+  - `:docs` — Docs. The read-only AutoDocs-equivalent: prose + args
+              table + decorator stack + parameters + tags. The full
+              implementation lands with rf2-rodx; this primitive ships
+              the placeholder.
+  - `:test` — Tests. The in-canvas aggregated pass/fail summary for the
+              variant's interactions / assertions. The full
+              implementation lands with rf2-qmjo; this primitive ships
+              the placeholder.
+
+  ## Primitive surface
+
+  This namespace exposes one rendering entry point:
+
+      (mode-tabs-strip variant-id)
+
+  which renders a horizontal chip strip at the top of the render shell.
+  Selection is per-variant — switching variants does not clear another
+  variant's selection — and persists across reloads via localStorage
+  under the key `re-frame.story/active-mode-tab/<variant-id>`.
+
+  The shell's `main-pane` consults `(state/active-mode-tab state vid)`
+  to decide which pane renders below the strip:
+
+  - `:dev`  → existing canvas / workspace path (unchanged).
+  - `:docs` → `docs-placeholder` (rf2-rodx will replace this).
+  - `:test` → `tests-placeholder` (rf2-qmjo will replace this).
+
+  ## Visual style
+
+  Matches the existing render-shell chrome (rf2-2uwv contrast fixes):
+  `#b0b0b0` inactive foreground, white active foreground, `#1e1e1e`
+  active background. Reuses the shape of the tab-bar/tab/tab-active
+  styles already defined in `re-frame.story.ui.shell`."
+  (:require [re-frame.story.ui.state :as state]))
+
+;; ---- localStorage persistence -------------------------------------------
+;;
+;; Per-variant — the key embeds the variant id so two variants on the
+;; same page can hold distinct mode-tab selections. Mirrors the help
+;; overlay's `safe-local-storage` pattern (defensive against private-mode
+;; browsers, file://, embedded contexts) so a localStorage failure
+;; degrades silently to in-memory-only state.
+
+(def ^:const ls-key-prefix
+  "Prefix for the localStorage key used to persist the active mode-tab
+  per variant. The full key is `<prefix><variant-id-as-string>`."
+  "re-frame.story/active-mode-tab/")
+
+(defn- safe-local-storage
+  "Return `js/window.localStorage` if available, otherwise nil."
+  []
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (try (.-localStorage js/window)
+         (catch :default _ nil))))
+
+(defn- ls-key
+  "Build the localStorage key for `variant-id`. Variant ids are
+  qualified keywords; `str` round-trips them as `\":ns/name\"` which is
+  stable across reloads."
+  [variant-id]
+  (str ls-key-prefix variant-id))
+
+(defn load-mode-tab!
+  "Read the persisted mode-tab for `variant-id` from localStorage.
+  Returns one of `state/mode-tabs` or nil if no record / unparseable."
+  [variant-id]
+  (when-let [ls (safe-local-storage)]
+    (try
+      (let [raw (.getItem ls (ls-key variant-id))]
+        (when (string? raw)
+          (let [tab (keyword raw)]
+            (when (state/valid-mode-tab? tab) tab))))
+      (catch :default _ nil))))
+
+(defn save-mode-tab!
+  "Persist `tab` for `variant-id` in localStorage. Silently no-ops if
+  localStorage is unavailable or `tab` is not a valid mode-tab."
+  [variant-id tab]
+  (when (and (state/valid-mode-tab? tab) variant-id)
+    (when-let [ls (safe-local-storage)]
+      (try (.setItem ls (ls-key variant-id) (name tab))
+           (catch :default _ nil)))))
+
+(defn hydrate-from-storage!
+  "Seed the shell state's `:active-mode-tab` entry for `variant-id` from
+  localStorage if a persisted value exists and the state has no
+  in-memory entry yet. Idempotent — safe to call on every render of the
+  tab strip; only writes when the in-memory slot is empty."
+  [variant-id]
+  (when variant-id
+    (let [shell @state/shell-state-atom]
+      (when-not (contains? (:active-mode-tab shell) variant-id)
+        (when-let [persisted (load-mode-tab! variant-id)]
+          (state/swap-state! state/set-active-mode-tab variant-id persisted))))))
+
+;; ---- selection helper ----------------------------------------------------
+
+(defn select-mode-tab!
+  "Switch the active mode-tab for `variant-id` to `tab`, updating both
+  shell state and localStorage. Public so tests / programmatic callers
+  can drive the switcher without going through the DOM."
+  [variant-id tab]
+  (when (and variant-id (state/valid-mode-tab? tab))
+    (state/swap-state! state/set-active-mode-tab variant-id tab)
+    (save-mode-tab! variant-id tab)))
+
+;; ---- styling -------------------------------------------------------------
+;;
+;; Same visual register as the existing render-shell chrome — see
+;; rf2-2uwv for the contrast fixes that landed `#b0b0b0` as the standard
+;; inactive foreground.
+
+(def ^:private styles
+  {:strip       {:display          "flex"
+                 :background       "#2d2d30"
+                 :border-bottom    "1px solid #444"
+                 :font-family      "monospace"
+                 :font-size        "11px"
+                 :padding          "0"}
+   :tab         {:padding          "6px 14px"
+                 :cursor           "pointer"
+                 :color            "#b0b0b0"
+                 :background       "#2d2d30"
+                 :border           "none"
+                 :border-right     "1px solid #444"
+                 :font-family      "monospace"
+                 :font-size        "11px"
+                 :letter-spacing   "0.3px"}
+   :tab-active  {:color            "white"
+                 :background       "#1e1e1e"
+                 :border-bottom    "1px solid #1e1e1e"
+                 :margin-bottom    "-1px"
+                 :font-weight      "bold"}
+   :placeholder {:padding          "32px"
+                 :color            "#9a9a9a"
+                 :font-style       "italic"
+                 :font-family      "system-ui, sans-serif"
+                 :text-align       "center"
+                 :background       "#1e1e1e"
+                 :flex             "1"}})
+
+;; ---- chip strip ----------------------------------------------------------
+
+(defn mode-tabs-strip
+  "Render the per-variant mode-tab chip strip. Renders nothing when
+  `variant-id` is nil (no variant selected = no canvas to switch).
+
+  Three chips: Canvas (`:dev`) | Docs (`:docs`) | Tests (`:test`). The
+  active chip carries an `aria-current=\"page\"` attribute; each chip
+  carries a `data-mode-tab=\"<id>\"` attribute so the Playwright spec
+  can target chips without coupling to the visible label.
+
+  Per rf2-9hc8 the strip lives directly above the canvas/workspace pane
+  inside `<main>`."
+  [variant-id]
+  (when variant-id
+    ;; Hydrate from localStorage on first render of this variant's
+    ;; strip — idempotent on subsequent renders.
+    (hydrate-from-storage! variant-id)
+    (let [shell  @state/shell-state-atom
+          active (state/active-mode-tab shell variant-id)]
+      [:div {:style       (:strip styles)
+             :role        "tablist"
+             :aria-label  "Story mode"
+             :data-test   "story-mode-tabs"}
+       (for [tab state/mode-tabs]
+         ^{:key tab}
+         [:button
+          {:style          (merge (:tab styles)
+                                  (when (= tab active) (:tab-active styles)))
+           :role           "tab"
+           :aria-selected  (if (= tab active) "true" "false")
+           :aria-current   (when (= tab active) "page")
+           :data-mode-tab  (name tab)
+           :on-click       #(select-mode-tab! variant-id tab)}
+          (get state/mode-tab-labels tab (name tab))])])))
+
+;; ---- placeholder panes ---------------------------------------------------
+;;
+;; rf2-rodx (Docs) and rf2-qmjo (Tests) replace these. Until then the
+;; chrome surfaces the contract so users know the mode exists and that
+;; the dedicated view is on the roadmap.
+
+(defn docs-placeholder
+  "Stub for the `:docs` mode pane. Replaced by rf2-rodx."
+  [variant-id]
+  [:div {:style     (:placeholder styles)
+         :data-test "story-docs-placeholder"}
+   [:div {:style {:font-weight "bold" :margin-bottom "8px"}}
+    "Docs view"]
+   [:div "AutoDocs-equivalent (prose + args table + decorator stack + "
+    "parameters + tags) for "
+    [:code (str variant-id)]
+    " coming in rf2-rodx."]])
+
+(defn tests-placeholder
+  "Stub for the `:test` mode pane. Replaced by rf2-qmjo."
+  [variant-id]
+  [:div {:style     (:placeholder styles)
+         :data-test "story-tests-placeholder"}
+   [:div {:style {:font-weight "bold" :margin-bottom "8px"}}
+    "Tests view"]
+   [:div "Aggregated pass/fail summary of interactions / assertions for "
+    [:code (str variant-id)]
+    " coming in rf2-qmjo."]])

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -45,6 +45,7 @@
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.help :as help]
+            [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
@@ -262,17 +263,34 @@
 
   Renders as a `<main>` landmark (per rf2-xc65) so the rendered variant
   has a containing landmark and axe-core's `region` /
-  `landmark-one-main` rules pass."
+  `landmark-one-main` rules pass.
+
+  Per rf2-9hc8 a Canvas | Docs | Tests mode-tab strip sits at the top
+  of the pane when a variant is selected; selection is per-variant and
+  persists across reloads in localStorage. The `:docs` and `:test`
+  panes are placeholders for rf2-rodx / rf2-qmjo respectively; `:dev`
+  preserves the existing canvas / workspace behaviour."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
         ws-id      (:selected-workspace shell)
-        vis        (:panel-visibility shell)]
+        vis        (:panel-visibility shell)
+        mode-tab   (when variant-id
+                     (state/active-mode-tab shell variant-id))]
     [:main {:style (:main styles)
             :aria-label "Story canvas"}
+     ;; rf2-9hc8: top-of-shell mode-tab strip — only when a single
+     ;; variant is selected (workspaces enumerate multiple variants and
+     ;; have their own layout switcher; mixing mode-tabs into that pane
+     ;; conflates two unrelated UX axes).
+     (when (and variant-id (not ws-id))
+       [mode-tabs/mode-tabs-strip variant-id])
      (cond
        ws-id    [workspace/workspace-view ws-id]
-       variant-id [canvas/canvas]
+       variant-id (case mode-tab
+                    :docs [mode-tabs/docs-placeholder variant-id]
+                    :test [mode-tabs/tests-placeholder variant-id]
+                    [canvas/canvas])
        :else
        [:div {:style {:padding "32px"
                       :color "#9a9a9a"

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -57,7 +57,13 @@
                            registered :story-panel renders in the chrome.
                            Stage 4 ships a vanilla set of panels (trace /
                            scrubber / controls); Stage 6 will register
-                           more via reg-story-panel."
+                           more via reg-story-panel.
+  - `:active-mode-tab`   — {variant-id → :dev | :docs | :test}. Per-variant
+                           mode-tab selection for the render-shell's top
+                           Canvas | Docs | Tests switcher (rf2-9hc8).
+                           Unspecified → :dev (canvas). Persisted in
+                           localStorage under `re-frame.story/active-
+                           mode-tab/<variant-id>`."
   {:selected-variant   nil
    :selected-workspace nil
    :tag-filter         #{}
@@ -67,7 +73,8 @@
    :hot-reload-tick    0
    :fingerprints       {}
    :pinned-snapshots   {}
-   :panel-visibility   {:trace true :scrubber true :controls true}})
+   :panel-visibility   {:trace true :scrubber true :controls true}
+   :active-mode-tab    {}})
 
 ;; ---- pure transition fns (JVM-testable) ----------------------------------
 
@@ -126,6 +133,49 @@
   "Flip a panel's visibility."
   [state panel-id]
   (update-in state [:panel-visibility panel-id] not))
+
+;; ---- mode-tab (rf2-9hc8) -------------------------------------------------
+
+(def mode-tabs
+  "Ordered vector of canonical render-shell mode tabs. Stable id order
+  drives the chip strip's left-to-right layout. `:dev` is the canvas
+  view (rendered by `re-frame.story.ui.canvas`), `:docs` is the
+  read-only AutoDocs-equivalent (rf2-rodx), `:test` is the
+  in-canvas aggregated pass/fail view (rf2-qmjo)."
+  [:dev :docs :test])
+
+(def mode-tab-labels
+  "Human-readable label per mode-tab id. Used by the chip strip."
+  {:dev  "Canvas"
+   :docs "Docs"
+   :test "Tests"})
+
+(def default-mode-tab
+  "Default mode-tab when no per-variant selection is recorded. `:dev`
+  preserves Story v1's existing behaviour — the variant renders in the
+  canvas as soon as it's selected."
+  :dev)
+
+(defn valid-mode-tab?
+  "Is `tab` one of the canonical mode-tabs?"
+  [tab]
+  (boolean (some #{tab} mode-tabs)))
+
+(defn active-mode-tab
+  "Look up the currently-active mode-tab for `variant-id`. Falls back
+  to `default-mode-tab` when no selection is recorded."
+  [state variant-id]
+  (or (get-in state [:active-mode-tab variant-id])
+      default-mode-tab))
+
+(defn set-active-mode-tab
+  "Record the active mode-tab for `variant-id`. `tab` MUST be one of
+  `mode-tabs`; an unrecognised value is silently ignored so callers
+  can't poison the state."
+  [state variant-id tab]
+  (if (valid-mode-tab? tab)
+    (assoc-in state [:active-mode-tab variant-id] tab)
+    state))
 
 ;; ---- pure derivations ----------------------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -121,6 +121,50 @@
           s1 (state/toggle-panel s :trace)]
       (is (= false (get-in s1 [:panel-visibility :trace]))))))
 
+;; ---- mode-tabs (rf2-9hc8) ------------------------------------------------
+
+(deftest mode-tabs-canonical-set
+  (testing "the three canonical mode tabs ship in stable order"
+    (is (= [:dev :docs :test] state/mode-tabs)))
+  (testing "every mode-tab has a human label"
+    (doseq [t state/mode-tabs]
+      (is (string? (get state/mode-tab-labels t))
+          (str "missing label for " t)))))
+
+(deftest mode-tab-default-is-dev
+  (testing "the default mode-tab is :dev (Story v1 canvas)"
+    (is (= :dev state/default-mode-tab)))
+  (testing "active-mode-tab falls back to :dev for unknown variants"
+    (is (= :dev (state/active-mode-tab state/default-shell-state :no/such-variant)))))
+
+(deftest valid-mode-tab?-rejects-noise
+  (is (state/valid-mode-tab? :dev))
+  (is (state/valid-mode-tab? :docs))
+  (is (state/valid-mode-tab? :test))
+  (is (not (state/valid-mode-tab? :canvas)))
+  (is (not (state/valid-mode-tab? :nonsense)))
+  (is (not (state/valid-mode-tab? nil)))
+  (is (not (state/valid-mode-tab? "test"))))
+
+(deftest set-active-mode-tab-roundtrip
+  (testing "set-active-mode-tab records the per-variant selection"
+    (let [s  state/default-shell-state
+          s1 (state/set-active-mode-tab s :story.x/a :docs)]
+      (is (= :docs (state/active-mode-tab s1 :story.x/a)))
+      (is (= :dev  (state/active-mode-tab s1 :story.x/b))
+          "other variants keep the default")))
+  (testing "selections are independent per variant"
+    (let [s  state/default-shell-state
+          s1 (-> s
+                 (state/set-active-mode-tab :story.x/a :docs)
+                 (state/set-active-mode-tab :story.x/b :test))]
+      (is (= :docs (state/active-mode-tab s1 :story.x/a)))
+      (is (= :test (state/active-mode-tab s1 :story.x/b)))))
+  (testing "an invalid tab leaves state untouched"
+    (let [s  state/default-shell-state
+          s1 (state/set-active-mode-tab s :story.x/a :nonsense)]
+      (is (= s s1)))))
+
 ;; ---- pure filter + grouping ---------------------------------------------
 
 (deftest filter-variants-empty-filter


### PR DESCRIPTION
## Summary

- Adds a `Canvas | Docs | Tests` mode-tabs chip strip above the Story render shell's canvas pane (rf2-9hc8). Per the Story SOTA audit (Review h) this was the single biggest gap to SOTA — every substrate already existed (`:tags`, `:prose`, autodocs, `run-variant-as-test`), but no chrome-level UX exposed them as the three canonical views.
- Selection is per-variant, persisted in localStorage under `re-frame.story/active-mode-tab/<variant-id>` with the existing defensive `safe-local-storage` pattern (mirrors the help overlay's storage).
- `:dev` preserves Story v1's exact canvas / hot-reload / decorator behaviour. `:docs` and `:test` ship placeholder panes; **foundational** for rf2-rodx (AutoDocs view), rf2-qmjo (aggregated pass/fail view), and rf2-p0mv (toolbar surface) which replace the placeholders without touching the chip strip, state slot, or LS key.
- Chip strip is `role="tablist"`; chips carry `aria-selected` + `aria-current="page"` + `data-mode-tab="<id>"` for stable test targeting.

## Surface added

- `re-frame.story.ui.mode-tabs/{mode-tabs-strip, select-mode-tab!, load-mode-tab!, save-mode-tab!, hydrate-from-storage!, docs-placeholder, tests-placeholder}`
- `re-frame.story.ui.state/{mode-tabs, mode-tab-labels, default-mode-tab, valid-mode-tab?, active-mode-tab, set-active-mode-tab}` + new `:active-mode-tab` state slot
- Spec: `tools/story/spec/007-Mode-Tabs.md` (new); cross-referenced from `003-Render-Shell.md`

## Test plan

- [x] JVM: 24 unit tests in `re-frame.story-ui-test` (4 new — `mode-tabs-canonical-set`, `mode-tab-default-is-dev`, `valid-mode-tab?-rejects-noise`, `set-active-mode-tab-roundtrip`)
- [x] Full story JVM suite: 156 tests / 395 assertions / 0 failures
- [x] Playwright `counter_with_stories.spec.cjs` section 3b: chip render, click-to-switch, `aria-selected` flips per chip, placeholder visibility per mode, localStorage key written on click, reload + re-select re-hydrates persisted `:test` tab