### PR TITLE
docs(skills): surface :fx-overrides fn-branch + :rf.trace/trigger-handler + add spec/ folders for 4 skills + reciprocal cross-links (rf2-hmyh, rf2-kvoz, rf2-ze2s, rf2-0ubu)

### DIFF
--- a/skills/re-frame-pair-improver2/spec/authoring-prompt.md
+++ b/skills/re-frame-pair-improver2/spec/authoring-prompt.md
@@ -1,0 +1,111 @@
+# re-frame-pair-improver2 — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame-pair-improver2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame-pair-improver2` skill at `skills/re-frame-pair-improver2/`. The skill helps a user **retrospect on a re-frame-pair2 session** — diagnose friction, classify root causes, propose 2-5 prioritised improvements (plus optional bolder ideas), and optionally draft a bead. The skill defaults to **diagnosis, not contribution**; bead filing is opt-in. The skill is one of the principal feedback loops for the `re-frame-pair2` skill family.*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame-pair-improver2/spec/design.md` — the locked design decisions (L1 through L12). Pillars 1-4 in §2 are non-negotiable. L1 (no re-frame-10x routing) and L2 (no bead filing without approval) are cardinal.*
+> *2. `skills/re-frame-pair-improver2/spec/inputs.md` — the canonical inputs the skill leans on.*
+> *3. `skills/re-frame-pair2/SKILL.md` + `skills/re-frame-pair2/references/` — the sibling skill the user just exercised. The improver reads the parent's friction surface (ops, recipes, errors, hot-reload-protocol).*
+> *4. `skills/re-frame-pair2/spec/design.md` — the sibling's locks. The improver respects these when proposing changes.*
+> *5. `skills/re-frame2/SKILL.md` + `skills/re-frame2/spec/design.md` — the application-authoring sibling (relevant for upstream-routing decisions).*
+> *6. `skills/re-frame-migration/SKILL.md` — the closest structural sibling with an existing `spec/` triad. Voice / shape mirror this.*
+>
+> *Then write the skill at `skills/re-frame-pair-improver2/` with this exact file structure:*
+>
+> ```
+> skills/re-frame-pair-improver2/
+> ├── SKILL.md                            (~170 lines; conversation guide + 6-step workflow)
+> ├── README.md                           (human-facing intro)
+> ├── LICENSE                             (MIT)
+> ├── package.json                        (npm metadata)
+> ├── .claude-plugin/plugin.json          (Claude Code plugin metadata)
+> ├── agents/
+> │   └── openai.yaml                     (alt-host config for non-Claude operation)
+> ├── references/
+> │   ├── analysis-lenses.md              (~140 lines; ten root-cause lenses)
+> │   ├── known-frictions.md              (~120 lines; recurring pain patterns)
+> │   └── issue-template.md               (~90 lines; bead-body template + redaction)
+> └── spec/
+>     ├── design.md
+>     ├── inputs.md
+>     └── authoring-prompt.md
+> ```
+>
+> *Every reference is ≤250 lines (target ~120). SKILL.md is ~170 lines (well under Anthropic's 500-line ceiling).*
+>
+> *SKILL.md walks the six-step analysis workflow:*
+>
+> *1. Reconstruct the session goal.*
+> *2. Build a short timeline of where progress stalled / restarted / detoured.*
+> *3. Extract friction (numbered list; present BEFORE root causes).*
+> *4. Classify the root cause using the ten lenses (briefly; don't force every finding through every lens).*
+> *5. Generate improvements at the right layer (skill / script / runtime / tests / docs / upstream `re-frame2`).*
+> *6. Prioritise — return 2-5 grounded improvements + 0-2 bolder ideas.*
+>
+> *Cardinal guard-rails to bake in (SKILL.md):*
+>
+> *1. **Always start with session analysis.** Do not jump straight to fixes.*
+> *2. **Present friction points before root causes.** Let the user choose which to dig into.*
+> *3. **Default to diagnosis, not contribution.** Do not assume the user wants to file a bead.*
+> *4. **Never file a bead or edit another repo without explicit user approval.***
+> *5. **No re-frame-10x routing.** Time-travel + trace consumption ride on re-frame2's native Tool-Pair surfaces.*
+> *6. **If the best fix is upstream in `re-frame2`, say so.** File against the right repo.*
+>
+> *Output format the skill produces (compact retrospective):*
+>
+> *- `Goal`*
+> *- `Observed friction` (numbered)*
+> *- `Likely root causes`*
+> *- `Improvement ideas` (2-5, each carrying friction / why-not-enough / proposed change / layer / impact)*
+> *- `Bolder ideas` (when warranted; clearly labelled)*
+> *- `Bead candidates` (only if user asks)*
+> *- `Other possibilities` (low-priority leftovers)*
+>
+> *Locks to preserve verbatim:*
+>
+> *- **L1 — No re-frame-10x routing.** Cardinal anti-pattern.*
+> *- **L2 — Never file a bead without explicit user approval.** Cardinal guard-rail.*
+> *- **L3 — Route the fix to the right repo.** `re-frame-pair2` for tool changes; `re-frame2` for upstream contract changes.*
+> *- **L10 — No bead-ids in user-facing skill content.***
+> *- **L11 — Findings stay local.** Don't commit `ai/` or `findings/`.*
+> *- **L12 — Redact secrets before filing.** Bead drafts strip secrets, tokens, internal URLs, unnecessary local paths.*
+>
+> *Frontmatter — the `description` is "pushy" but conversational. Trigger phrases: "how could re-frame-pair2 better support my workflow", "retrospective on a debugging session", "concrete improvement ideas for re-frame-pair2", "draft a bead for re-frame-pair2". The description discriminates against the live-app `re-frame-pair2` skill and the authoring `re-frame2` skill.*
+>
+> *Voice: tight, diagnostic, conversational. Use evidence-grounded findings, not vibes. Use the analysis-lenses table for classification. Use the impact statement to force specificity.*
+>
+> *Don't:*
+>
+> *- Don't propose fixes that route through `re-frame-10x` — L1.*
+> *- Don't file beads autonomously — L2.*
+> *- Don't reduce every problem to "write more docs". Consider product behaviour, tooling, defaults, instrumentation first.*
+> *- Don't confuse a transient local outage with a product gap unless the workflow made recovery harder than it should have.*
+> *- Don't propose vague improvements like "better UX" without naming the concrete missing behaviour.*
+> *- Don't pressure the user to file anything.*
+> *- Don't write `*.md` documentation outside `skills/re-frame-pair-improver2/`.*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't include bead-ids in user-facing leaves.*
+>
+> *Open the PR with title `feat(skills): re-frame-pair-improver2 — pair-session retrospective skill`. PR body lists: the skill structure, the file LoC table, the six-step workflow, the ten lenses, the output format, the relationship to the sibling skills (`re-frame-pair2` — its primary feedback loop; `re-frame2` — for upstream routing).*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the re-frame2 repo and the sibling `re-frame-pair2` skill.
+- The prompt does **not** ask the session to verify the resulting skill against a real retrospective — Mike reads the PR and exercises the skill on a real session afterwards.
+- If `re-frame-pair2`'s surface has changed materially between authoring passes, `references/known-frictions.md` may have stale entries; flag them but don't auto-remove (some entries persist because the pattern is upstream / unaddressable in the pair tool alone).
+
+## When to re-author
+
+- A new common friction pattern emerges (3+ retros surface it) and the existing taxonomy doesn't fit → add a new analysis lens (and update `references/analysis-lenses.md` accordingly), then refresh SKILL.md's step 4 framing.
+- The bead-filing process changes (e.g. `bd` tool surface or routing) → re-derive `references/issue-template.md`.
+- A new feedback channel becomes load-bearing (e.g. GitHub Issues replaces `bd`) → update L3 routing and `references/issue-template.md`.
+- Anthropic skill conventions change materially → reauthor against the new conventions.
+
+Otherwise, edit existing references directly; reauthoring is for major-version updates.

--- a/skills/re-frame-pair-improver2/spec/design.md
+++ b/skills/re-frame-pair-improver2/spec/design.md
@@ -1,0 +1,166 @@
+# re-frame-pair-improver2 — Design
+
+The design rationale and locked decisions for the `re-frame-pair-improver2` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help a user **retrospect on a re-frame-pair2 session** and turn it into a structured product retrospective. The output is a friction analysis, a classification of root causes, and 2-5 concrete improvement ideas — optionally accompanied by a draft bead the user can file against `re-frame-pair2` (or `re-frame2` itself, if the root cause is upstream).
+
+The skill's success criterion: after a session with `re-frame-pair2`, the user invokes this skill and walks away with a clear list of friction points, a credible classification of each, and prioritised improvement ideas — with no speculative beads filed without explicit approval.
+
+## 2. Pillars (locked)
+
+1. **Diagnosis before contribution.** The skill defaults to analysis, not patches. Surfacing findings is the deliverable; filing beads is opt-in and requires explicit user approval.
+2. **Evidence over vibes.** Every friction point cites a concrete moment in the session — retries, clarifications, fallbacks to lower-level tools, stale outputs, empty outputs, mismatched docs, waits, manual workarounds. *"That was annoying"* without an evidence trail isn't actionable.
+3. **Right layer of fix.** A friction might belong in the skill prose, in a structured op, in a runtime instrument, in a default, in a test, or upstream in `re-frame2` itself. The skill walks all the layers before proposing one.
+4. **Creativity after the diagnosis.** Once the friction is named, the skill is permitted (encouraged) to propose **bolder** ideas — workflow redesigns, automated detection, "what would make this feel automatic" — clearly labelled as such.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve them unless explicitly unlocked by Mike.
+
+### L1 — No re-frame-10x routing
+
+Per the parent `re-frame-pair2` skill's L2: re-frame2's pair tooling does not depend on re-frame-10x. The improver MUST NOT propose fixes that route through 10x — time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces (`register-trace-cb`, `register-epoch-cb`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation). This is a cardinal "What to avoid" rule.
+
+### L2 — Never file a bead without explicit user approval
+
+The skill drafts bead text on request; it does not file beads autonomously. After presenting the retrospective, the skill offers to file *only if asked*. Filing is opt-in, not opt-out. This is a cardinal guard-rail.
+
+### L3 — Route the fix to the right repo
+
+- **`re-frame-pair2`** — friction inside the pair tool: SKILL.md, scripts/MCP tools, recipes, structured results, attach/discovery brittleness, cross-platform handling.
+- **`re-frame2`** — friction caused by the framework's Tool-Pair contract: missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings.
+
+The skill is explicit about which repo each draft bead targets. Mis-routing wastes the maintainer's time.
+
+### L4 — Diagnosis-first workflow
+
+The skill walks a six-step analysis: reconstruct goal → build timeline → extract friction → classify root cause → generate improvements at the right layer → prioritise. The order matters; jumping to step 5 without 1-3 produces speculative beads unsupported by session evidence.
+
+### L5 — Use the analysis-lenses taxonomy
+
+`references/analysis-lenses.md` defines ten root-cause lenses (skill structure / skill gap / misleading docs / missing structured op / unreliable op / default-or-fallback / platform bug / validation gap / upstream limitation / context-window issue). Each lens has a question to ask and a typical improvement shape. The skill walks these lenses **briefly** for each finding; doesn't force every finding through every lens.
+
+### L6 — Bolder ideas are labelled
+
+After the grounded fixes, the skill is allowed (and encouraged) to include 1-2 bolder ideas — workflow redesigns, "what would make this feel obvious to a first-time user" — but they are clearly labelled `Bolder ideas` (separate output section) so the user can triage them differently. Bolder ≠ vague; even speculative ideas need a concrete change and a believable path to value.
+
+### L7 — Compact retrospective output shape
+
+When the session has enough evidence, the retro uses these sections:
+- `Goal`
+- `Observed friction` (numbered list, presented first for user steering)
+- `Likely root causes` (one primary per finding; multiple contributors allowed)
+- `Improvement ideas` (2-5 grounded; bolder ideas separated)
+- `Bolder ideas` (if any)
+- `Bead candidates` (only if user asks)
+- `Other possibilities` (low-priority leftovers)
+
+If the session is too thin, the skill says so plainly and asks for either a recap or permission to use a longer conversation as input.
+
+### L8 — Improvement ideas carry layer + impact
+
+For each idea, the skill names:
+- the friction it addresses
+- why `re-frame-pair2` was not enough today
+- the proposed change
+- the layer of change (skill / script / runtime / tests / docs / upstream `re-frame2`)
+- a short impact statement
+
+This forces the improvement to be specific enough to act on.
+
+### L9 — Use `references/known-frictions.md` for pattern matching
+
+When a session resembles a recurring class of pain, the skill consults `references/known-frictions.md` to check whether it's a one-off or a recurring pattern. Recurring patterns get higher priority in the retrospective.
+
+### L10 — No bead-ids in user-facing skill content
+
+`SKILL.md` + `references/` carry no `rf2-XXXX` references. Draft beads written by the skill cite ids the user asks about; the skill itself does not embed ids in its prose. The `spec/` folder may; user-facing content does not.
+
+### L11 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — never commit `ai/` or `findings/`. This skill's commits contain only `skills/re-frame-pair-improver2/**`.
+
+### L12 — Redact secrets before filing
+
+Bead drafts redact secrets, tokens, internal URLs, and unnecessary local file paths. The skill summarises the evidence rather than dumping raw transcript.
+
+## 4. Audience and scope
+
+### In scope
+
+- Users finishing a `re-frame-pair2` session who want a structured retrospective.
+- Friction analysis: direct (user complaints) + indirect (repeated commands, fallback to lower-level tools, manual reconstruction).
+- Classification across the ten lenses in `references/analysis-lenses.md`.
+- Drafting beads against `re-frame-pair2` (tool changes) or `re-frame2` (upstream contract changes).
+- Spotting recurring patterns via `references/known-frictions.md`.
+
+### Out of scope
+
+- Filing beads autonomously — L2.
+- Routing through re-frame-10x — L1.
+- Diagnosing the user's *application code* (that's `re-frame-pair2`'s job, in a live session).
+- Authoring re-frame2 application code — `skills/re-frame2/`.
+- Setting up a project — `skills/re-frame2-setup/`.
+- Migrating from v1 — `skills/re-frame-migration/`.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame-pair-improver2/
+├── SKILL.md                            (~170 lines; the conversation guide + workflow)
+├── README.md                           (human-facing intro)
+├── LICENSE                             (MIT)
+├── package.json                        (npm metadata)
+├── .claude-plugin/plugin.json          (Claude Code plugin metadata)
+├── agents/
+│   └── openai.yaml                     (alt-host config — kept for cross-LLM operation)
+├── references/
+│   ├── analysis-lenses.md              (~140 lines; ten root-cause lenses + improvement shapes)
+│   ├── known-frictions.md              (~120 lines; recurring re-frame-pair2 pain patterns)
+│   └── issue-template.md               (~90 lines; bead-body template, redaction rules)
+└── spec/
+    ├── design.md                       (this file)
+    ├── inputs.md                       (canonical inputs)
+    └── authoring-prompt.md             (one-shot reauthor prompt)
+```
+
+SKILL.md (~170) + 3 references (~350) + spec (~300) ≈ ~820 LoC. Typical session reads SKILL.md (~170) + at most one or two references (`analysis-lenses.md` when classification is hard, `known-frictions.md` when the session smells recurring) = ~310-450 LoC.
+
+## 6. Discovery surface (frontmatter `description`)
+
+The `description` triggers on retrospective / improvement / friction phrases: *"how could re-frame-pair2 better support my workflow"*, *"retrospective on a debugging session"*, *"concrete improvement ideas for re-frame-pair2"*, *"draft a bead for re-frame-pair2"*. The framing is conversational ("Analyze a user's recent work...") — discriminates against the live-app `re-frame-pair2` skill (which triggers on dispatch / app-db / epoch verbs) and against the authoring `re-frame2` skill (which triggers on `reg-*` surfaces).
+
+## 7. Anti-patterns the skill explicitly resists
+
+- **Routing fixes through re-frame-10x** — L1 cardinal rule.
+- **Filing beads without explicit approval** — L2 cardinal rule.
+- **Reducing every problem to "write more docs"** — L5 lenses include skill structure, structured op, default-or-fallback, validation, upstream — not just docs.
+- **Confusing a transient local outage with a product gap** — L4 step 2 (build timeline) separates one-off env issues from recurring patterns.
+- **Proposing vague improvements** ("better UX") without naming the concrete missing behaviour — L8 forces specifics.
+- **Confusing creativity with hand-waving** — L6 bolder ideas need a concrete change and a believable path to value.
+- **Forcing every retro into a code contribution** — L2 again; diagnosis is the deliverable.
+- **Pressuring the user to file anything** — L2 again.
+
+## 8. Why this design diverges from `re-frame-pair2`
+
+- **No structured-op catalogue.** This skill doesn't operate on a live app; it operates on a session transcript.
+- **No `allowed-tools` block in frontmatter.** The skill is conversational; the AI's tools are the default Read/Edit/Write/Grep/Glob set plus `bd create` when filing is opt-in.
+- **No connect-first rule.** No live runtime to connect to.
+- **`agents/openai.yaml` is included.** The skill is portable across LLM hosts; the openai config carries the routing for non-Claude hosts.
+- **No `scripts/` directory.** The skill doesn't ship runtime tooling.
+
+## 9. Open questions (deferred to Mike)
+
+### OQ1 — Should the skill ship a "session capture" helper?
+
+Currently the skill reads the in-conversation transcript. A future helper could snapshot the session to disk (redacted) for offline review. Status: deferred — no clear demand yet.
+
+### OQ2 — Should `known-frictions.md` carry severity tagging?
+
+Currently it lists patterns; ranking by "how often this surfaces" would help triage. Status: deferred — needs evidence from filed beads to rank credibly.
+
+### OQ3 — Should the skill include a "post-mortem of a post-mortem" lens?
+
+If the same friction surfaces across multiple retros, the skill could spot it. Currently the user does this manually by reading `references/known-frictions.md`. Status: deferred until the volume of retros makes the manual approach unwieldy.

--- a/skills/re-frame-pair-improver2/spec/inputs.md
+++ b/skills/re-frame-pair-improver2/spec/inputs.md
@@ -1,0 +1,90 @@
+# re-frame-pair-improver2 — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary input — the user's recent session transcript
+
+The skill operates on the **current or just-finished conversation** — the user's prompts, the AI's tool calls, the structured results, the retries, the clarifications, the fallbacks. This is the raw material. The skill doesn't ingest a transcript file; it reads context that's already in the conversation.
+
+What the skill looks for:
+
+- **Direct friction signals** — the user saying something was frustrating, confusing, slow, brittle, surprising.
+- **Indirect friction signals** — repeated commands, repeated explanations, fallback to lower-level tools (e.g. `repl/eval` when a structured op should have worked), manual reconstruction (the user explaining what they were trying to do twice), hidden prerequisites, brittle environment assumptions, partial results, confusing contracts, missing trust signals.
+- **Almost-worked moments** — what was close to right but required too much expert knowledge or was undiscoverable.
+- **Environment facts** — platform, target repo, live runtime state (which frame, which epoch depth), tooling constraints.
+
+## 2. Secondary input — `skills/re-frame-pair2/`
+
+The sibling skill the user just exercised. The improver reads the parent skill's:
+
+- **`SKILL.md`** — the parent's cardinal rules, primitives, style guidance. Friction often surfaces as "the cardinal rule was right but buried" or "the style guidance didn't fire when it should have".
+- **`references/ops.md` + `references/recipes.md`** — the catalogue the user navigated. Missing ops or missing recipes are first-class findings.
+- **`references/errors.md`** — the error-recovery catalogue. Misleading recovery suggestions are findings.
+- **`references/hot-reload-protocol.md`** — the strict source-edit protocol. Friction here is high-leverage (every source edit triggers it).
+- **`scripts/`** + **MCP server** — the transport surface. Brittleness here breaks every session.
+- **`spec/design.md`** (this skill's neighbour) — the locked decisions. The improver respects locks; doesn't propose changes that contradict them.
+
+## 3. Tertiary input — `references/analysis-lenses.md`
+
+The ten root-cause lenses the skill walks during classification:
+
+| Lens | Question | Typical improvement |
+|------|----------|---------------------|
+| Skill structure | Was the right guidance present but buried? | Promote to guard rail, shorten, reorder, add examples |
+| Skill gap | Was key guidance missing entirely? | Add a recipe, anti-pattern, decision rule |
+| Misleading docs | Did docs suggest the wrong action or trust model? | Correct wording, add warnings, align contracts |
+| Missing structured op | Did the workflow need a first-class op? | Add a script/runtime op or structured field |
+| Unreliable op | Did an op behave ambiguously or brittlely? | Fix behavior, add warnings, strengthen validation |
+| Default or fallback | Was the default path wrong, silent, or unsafe? | Change defaults or automate the safer fallback |
+| Platform bug | Did the workflow break on a specific shell/OS/browser? | Add platform-aware handling or explicit detection |
+| Validation gap | Did this ship because the right fixture/test is missing? | Add test coverage or fixture support |
+| Upstream limitation | Is `re-frame-pair2` working around the wrong abstraction in `re-frame2`? | File a `bd` bead against `re-frame2` |
+| Context-window issue | Did long context or low-salience guidance cause forgetfulness? | Make the guard rail shorter, earlier, stronger |
+
+This is the canonical taxonomy; the improver doesn't invent ad-hoc categories.
+
+## 4. Tertiary input — `references/known-frictions.md`
+
+Hand-curated list of recurring friction patterns the skill has seen across multiple sessions. The improver matches the current session against this list to detect "is this a one-off or a pattern?" Recurring patterns get higher priority in the retrospective.
+
+## 5. Tertiary input — `references/issue-template.md`
+
+The bead-body template the skill uses when the user asks for a draft. Carries:
+
+- The friction summary (1-2 sentences).
+- The evidence (session moments — redacted).
+- The proposed change.
+- The layer (skill / script / runtime / tests / docs / upstream).
+- The impact statement.
+
+Redaction rules are baked in (no secrets, tokens, internal URLs, unnecessary local paths).
+
+## 6. Authoring-discipline inputs
+
+These shape the skill's voice and structure but aren't quoted directly.
+
+- **Mike's standing memory rules** — especially "Findings is local-only", "No AI attribution in commits or PRs", "Always dispatch, don't ask" (the improver does NOT auto-dispatch; L2 explicit guard-rail).
+- **`skills/re-frame-pair2/spec/design.md`** — the sibling's locks. The improver references these when proposing changes; never proposes a change that breaks a lock.
+- **`skills/re-frame2/spec/design.md`** — the parent skill's locks (relevant for upstream-routing).
+- **`agents/openai.yaml`** — the alt-host configuration. The skill is portable across LLM hosts; voice / structure must work in non-Claude hosts too.
+- Anthropic skills guidance — `name` ≤ 64 chars; `description` "pushy" but conversational; SKILL.md under 500 lines; references one level deep.
+
+## 7. What the skill does NOT consume
+
+- **The live re-frame2 app's state.** That's the `re-frame-pair2` skill's domain. The improver works on session transcripts, not on `app-db` snapshots.
+- **The re-frame2 spec corpus.** The improver doesn't need to teach the framework; it just needs to know which surface is missing.
+- **`implementation/**`** — same reasoning.
+- **`docs/guide/**`** — the narrative guide is for application authors learning re-frame2. The improver works one level up.
+- **The user's source repo.** The improver works on the pair-session itself, not on the app under inspection.
+
+## 8. Update procedure
+
+When the pair tool changes:
+
+1. **A new structured op ships in `re-frame-pair2`** → check whether known-frictions has a "missing op" pattern that this resolves; update `known-frictions.md` if so.
+2. **A bash shim is retired / migrated to MCP** → `known-frictions.md` may have entries about shim brittleness; update to reflect.
+3. **A cardinal rule changes in `re-frame-pair2` SKILL.md** → re-read the parent's `spec/design.md`; verify the improver's lens-routing still respects the new lock.
+4. **A new common friction pattern emerges** (3+ retros surface it) → add a row to `known-frictions.md` with the pattern shape and the typical resolution.
+5. **A new analysis lens is named** → add to `analysis-lenses.md` with the canonical question and improvement shape.
+6. **The bead-filing process changes** (e.g. `bd` tool surface changes) → update `issue-template.md`.
+7. **Re-frame2's Tool-Pair contract grows a new surface** (e.g. a new `register-*-cb` hook) → the improver may need to know about it for upstream-routing decisions; check `known-frictions.md` for entries that were "we worked around the missing surface" — they now resolve.

--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -127,4 +127,4 @@ Load at most two references for a single task. If you find yourself wanting thre
 
 ---
 
-*Deep-dive content (full API reference, EP design rationale, spec corpus, migration guide) routes through [`SKILL-REDIRECT.md`](../../SKILL-REDIRECT.md) at the repo root. For authoring re-frame2 code (rather than inspecting a live app), see `skills/re-frame2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`.*
+*Deep-dive content (full API reference, EP design rationale, spec corpus, migration guide) routes through [`SKILL-REDIRECT.md`](../../SKILL-REDIRECT.md) at the repo root. For authoring re-frame2 code (rather than inspecting a live app), see `skills/re-frame2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For porting re-frame2 itself to a different host language or substrate (rather than using the CLJS reference), see `skills/re-frame2-implementor/`.*

--- a/skills/re-frame-pair2/references/errors.md
+++ b/skills/re-frame-pair2/references/errors.md
@@ -11,6 +11,10 @@ Every script returns structured edn like `{:ok? false :reason ...}` rather than 
 - `:no-frames-registered` → no frame is up yet. Tell the user to call `(rf/init!)` (or wait for app boot).
 - `:ambiguous-frame` → multiple frames; ask the user to `frames/select` or pass `--frame :foo`.
 - `:handler-error` inside an epoch → the user's handler threw; surface the `:rf.error/handler-exception` trace event from `(rf/trace-buffer {:op-type :error})`.
+
+## Pointing the user at the offending handler
+
+Every `:rf.error/*` trace event carries `:rf.trace/trigger-handler` — `{:kind :event :id :user/save :source-coord {:ns ... :file ... :line ... :column ...}}` — naming the handler that was executing when the error fired (event, sub, fx, cofx, view, interceptor, or late-bind hook). Report the `:source-coord` as `<file>:<line>` so the user can jump to source; the field is present in production traces too. The field is **absent** for dispatch-time errors where no handler is in scope yet (e.g. `:rf.error/no-such-event`); for those, the `:rf.error/data` is the only handle.
 - `:timed-out? true` on a `dispatch-and-collect` → drain didn't settle in the wait window (a long-running async cascade, or a stuck `:dispatch-later`). Inspect the in-flight cascade via the trace buffer.
 - `:connection :lost` → reconnect by calling `scripts/discover-app.sh` again.
 - Restore failures (`:rf.epoch/restore-*`) → see the time-travel failure table in [ops.md](ops.md#time-travel-epoch-restore).

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -10,6 +10,7 @@ Named procedures the user may ask for. When the user asks a matching question, r
 - ["Post-mortem — how did we get here?"](#post-mortem--how-did-we-get-here)
 - ["What effects fired?"](#what-effects-fired)
 - ["What caused this re-render?"](#what-caused-this-re-render)
+- ["Explain this error" / "What caused this error?"](#explain-this-error--what-caused-this-error)
 - ["Where in the code does this come from?"](#where-in-the-code-does-this-come-from)
 - ["Understand this component" / "What is this thing?"](#understand-this-component--what-is-this-thing)
 - ["Fire the button at file:line"](#fire-the-button-at-fileline)
@@ -75,6 +76,13 @@ For cascaded dispatches: follow `:dispatch-id` / `:parent-dispatch-id` (Spec 009
 ## "What caused this re-render?"
 
 Given a component name or render key, find the latest epoch whose `:renders` includes it. Reverse from there: the sub inputs that invalidated its outputs (visible in `:sub-runs`), then the event that invalidated the sub inputs (the `:trigger-event` of that epoch). For machine-driven renders, also check `:rf/machine` reg-sub activity — machine state changes flow through the sub graph like any other.
+
+## "Explain this error" / "What caused this error?"
+
+1. Pull recent error traces: `(rf/trace-buffer {:op-type :error})`. Each entry is an `:rf.error/*` op with `:rf.error/data`.
+2. Read `:rf.trace/trigger-handler` on the error event — `{:kind :event :id :user/save :source-coord {:ns ... :file ... :line ... :column ...}}`. This is the **handler that was executing when the error fired**, not the throw site inside the framework. Report it as `<kind> :<id> at <file>:<line>` so the user can jump straight to the source — works in production builds (the field is not elided like `:rf.assert/*`).
+3. If the error sits inside a known epoch, cross-check `:trigger-event` and walk the cascade via `:parent-dispatch-id` — the upstream event that queued the offending handler is often the real culprit.
+4. If `:rf.trace/trigger-handler` is **absent**, the error fired at dispatch-time before any handler ran (e.g. `:rf.error/no-such-event` because the registered id is misspelt). The `:rf.error/data` payload — the failing id, the lookup map — is then the only handle; offer to `registrar/list` the matching kind to find a near match.
 
 ## "Where in the code does this come from?"
 

--- a/skills/re-frame-pair2/spec/authoring-prompt.md
+++ b/skills/re-frame-pair2/spec/authoring-prompt.md
@@ -1,0 +1,100 @@
+# re-frame-pair2 — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame-pair2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame-pair2` skill at `skills/re-frame-pair2/`. The skill teaches an AI to **pair-program with a live, running re-frame2 application** — inspect any frame's app-db, dispatch events, hot-swap handlers, walk the trace stream and per-frame epoch ring, time-travel via `restore-epoch`, do DOM-to-source resolution. The skill consumes re-frame2's own Tool-Pair contract (per `spec/Tool-Pair.md` and `spec/009-Instrumentation.md`) — there is **no re-frame-10x dependency**.*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame-pair2/spec/design.md` — the locked design decisions (L1 through L12). Pillars 1-4 in §2 are non-negotiable.*
+> *2. `skills/re-frame-pair2/spec/inputs.md` — the canonical inputs the skill leans on.*
+> *3. `spec/Tool-Pair.md` — the contract the skill consumes.*
+> *4. `spec/009-Instrumentation.md` — the trace-stream / epoch-record / `:rf/op` vocabulary the skill teaches.*
+> *5. `spec/002-Frames.md` — the multi-frame model the skill operates against.*
+> *6. `implementation/core/src/re_frame/{core,trace,epoch,frame}.cljc` — the verified Tool-Pair surfaces.*
+> *7. `skills/re-frame2/SKILL.md` + `skills/re-frame-migration/SKILL.md` — the voice / density / cardinal-rules style to mirror.*
+>
+> *Then write the skill at `skills/re-frame-pair2/` with this exact file structure:*
+>
+> ```
+> skills/re-frame-pair2/
+> ├── SKILL.md                            (~130 lines; router + connect-first rules)
+> ├── README.md                           (human-facing intro)
+> ├── LICENSE                             (MIT)
+> ├── RELEASING.md                        (npm + plugin release notes)
+> ├── STATUS.md                           (development status)
+> ├── package.json                        (npm metadata)
+> ├── .claude-plugin/plugin.json          (Claude Code plugin metadata)
+> ├── references/
+> │   ├── ops.md                          (op catalogue)
+> │   ├── recipes.md                      (named procedures)
+> │   ├── errors.md                       (structured error → English + recovery)
+> │   ├── hot-reload-protocol.md          (source-edit → wait-for-reload protocol)
+> │   ├── migration-from-v1.md            (re-frame-pair v1 → v2 surface map)
+> │   └── mcp-transport.md                (MCP install + bash-shim mapping)
+> ├── scripts/                            (bash shims — deprecated)
+> ├── tests/                              (smoke tests)
+> ├── docs/                               (maintainer docs)
+> └── spec/
+>     ├── design.md
+>     ├── inputs.md
+>     └── authoring-prompt.md
+> ```
+>
+> *Every reference is ≤250 lines. SKILL.md is ~130 lines (well under Anthropic's 500-line ceiling). All references one level deep — no SKILL → A → B chains.*
+>
+> *Frontmatter — `allowed-tools` lists every MCP tool the skill uses (`mcp__re-frame-pair2__discover-app`, `eval-cljs`, `inject-runtime`, `dispatch`, `trace-window`, `watch-epochs`, `tail-build`) plus every bash shim (`Bash(scripts/discover-app.sh *)` etc.) plus the editor tools (`Read`, `Edit`, `Write`, `Grep`, `Glob`). The `description` is "pushy" and lists every re-frame2 surface: `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-trace-cb`, `register-epoch-cb`, `restore-epoch`, plus toolchain (`re-com`, `shadow-cljs`).*
+>
+> *Cardinal rules to bake in (SKILL.md):*
+>
+> *1. **Three primitives, no more** — REPL, trace stream, epoch history. All in re-frame2's Tool-Pair contract.*
+> *2. **No re-frame-10x dependency** — time-travel and trace consumption ride on `register-trace-cb` / `register-epoch-cb` / `epoch-history` / `restore-epoch`.*
+> *3. **Connect first, every session** — `discover-app` before any op. Failures return structured edn; report verbatim, don't improvise workarounds.*
+> *4. **Two modes of changing the app** — REPL changes ephemeral; source edits permanent (must `hot-reload/wait` after).*
+> *5. **Multi-frame model** — mutating ops refuse with `:ambiguous-frame` if more than one frame is registered and none selected. Read ops fall back to `:rf/default` after warning.*
+> *6. **One trace listener and one epoch listener** under `:re-frame-pair2` / `:re-frame-pair2-epoch`. Multi-tool coexistence is the expected default.*
+> *7. **Use the assembled epoch stream by default; reach for the raw trace stream when the projection drops detail.***
+> *8. **Read before you write** — ground a hypothesis in a snapshot / epoch / sub-run before proposing a change.*
+> *9. **Resolve UI references to source first** — `dom/source-at` before speculating about behaviour.*
+> *10. **Surface restore limits** — walk the cascade's already-fired effects before any time-travel experiment.*
+>
+> *Locks to preserve verbatim:*
+>
+> *- **L2 — No re-frame-10x dependency.** Anywhere in the skill.*
+> *- **L9 — No bead-ids in user-facing skill content.** `SKILL.md` + `references/` + `scripts/` carry no `rf2-XXXX` references.*
+> *- **L10 — Findings stay local.** Don't commit `ai/` or `findings/`.*
+> *- **L11 — Resolve UI references to source first.** Style-guidance rule in SKILL.md.*
+> *- **L12 — Surface restore limits.** Style-guidance rule in SKILL.md.*
+>
+> *Voice: tight, declarative, op-shaped. Use tables for op catalogues and routing. Use code blocks for canonical forms. Cite Tool-Pair surfaces (`(rf/register-trace-cb ...)`, `(rf/epoch-history :rf/default)`) verbatim — these are the contract.*
+>
+> *Don't:*
+>
+> *- Don't propose fixes that route through `re-frame-10x` — L2.*
+> *- Don't teach v1 idioms (`re-frame.db`, `dispatch-with`, etc.) — point at `references/migration-from-v1.md`.*
+> *- Don't write `*.md` documentation outside `skills/re-frame-pair2/`.*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't include bead-ids in user-facing leaves.*
+> *- Don't invent alternate vocabulary (e.g. "state graph" for frame). Pillar 2.*
+>
+> *Open the PR with title `feat(skills): re-frame-pair2 — live-app pair-programming skill`. PR body lists: the skill structure, the file LoC table, the cardinal rules, the three primitives, the MCP-vs-bash transport story, the relationship to the sibling skills (`re-frame2` for authoring, `re-frame-pair-improver2` for retrospectives).*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the re-frame2 repo, the `tools/pair2-mcp/` package, and the `scripts/` shim source.
+- The prompt does **not** ask the session to verify the resulting skill against a live app — Mike runs the smoke tests and reviews the PR.
+- If `spec/Tool-Pair.md` has changed significantly between authoring passes, the `references/ops.md` and `references/recipes.md` need re-derivation from the new contract.
+
+## When to re-author
+
+- The Tool-Pair contract gains a new structured surface (e.g. a future `register-machine-cb` or a new projection) → the existing references' coverage is incomplete; rebuild.
+- The MCP server gains or loses tools materially → the `allowed-tools` block and `references/mcp-transport.md` need updates.
+- The bash shims are retired entirely (OQ1 resolves) → strip `scripts/` and the bash entries in `allowed-tools`.
+- Anthropic skill conventions change materially (e.g. `allowed-tools` shape changes) → reauthor against the new conventions.
+- A major class of recipe is added (e.g. machine-replay, sub-cache-eviction) → add a recipe section and an op catalogue row.
+
+Otherwise, edit existing references directly; reauthoring is for major-version updates.

--- a/skills/re-frame-pair2/spec/design.md
+++ b/skills/re-frame-pair2/spec/design.md
@@ -1,0 +1,165 @@
+# re-frame-pair2 — Design
+
+The design rationale and locked decisions for the `re-frame-pair2` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help an AI **pair-program with a live, running re-frame2 application**. The app is running in a browser tab behind `shadow-cljs watch`. The AI's job is to help the developer understand, debug, and modify the app **by operating on the live runtime** — inspecting any frame's `app-db`, dispatching events, hot-swapping handlers, walking the trace stream and the per-frame epoch ring — not just by reading source files.
+
+Crucially, the skill consumes **re-frame2's own Tool-Pair contract** (per `spec/Tool-Pair.md` and `spec/009-Instrumentation.md`). There is **no re-frame-10x dependency** — time-travel, trace streams, and epoch records are first-class re-frame2 surfaces. The skill is one of the principal downstream consumers of those surfaces.
+
+## 2. Pillars (locked)
+
+1. **Correctness — structured ops over `repl/eval`.** Every operation is a named structured call that returns edn (`{:ok? true ...}` / `{:ok? false :reason ...}`). The skill teaches the AI to compose forms and read structured results; the raw `repl/eval` escape hatch exists for probes that don't fit the catalogue.
+2. **Idiomaticness — speak re-frame2's vocabulary.** Dispatch, reg-event-fx, reg-sub, reg-machine, frame, epoch, sub-cache. The AI never invents alternate vocabulary for the same concept.
+3. **Context economy — router skill + on-demand references.** SKILL.md (~130 lines) is the router and the connect-first rules; six references carry per-task depth, loaded at most two at a time.
+4. **Read before you write.** The AI grounds a hypothesis in live data (an epoch, a snapshot, a render entry) **before** proposing a change. Speculation without evidence is the single largest anti-pattern; the skill calls it out repeatedly.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve them unless explicitly unlocked by Mike.
+
+### L1 — Three coupled primitives, no more
+
+Agency runs through three primitives, all in re-frame2's Tool-Pair contract:
+
+1. **The REPL** — a shadow-cljs nREPL session connected to the browser runtime.
+2. **The trace stream** — `(rf/register-trace-cb id cb)` for live events; `(rf/trace-buffer opts)` for the retain-N ring.
+3. **The epoch history** — `(rf/epoch-history frame-id)`, `(rf/register-epoch-cb id cb)`, and `(rf/restore-epoch ...)`.
+
+Every op the skill teaches eventually becomes a ClojureScript form evaluated through the REPL, usually against a helper in the `re-frame-pair2.runtime` namespace the skill injects on connect.
+
+### L2 — No re-frame-10x dependency
+
+Time-travel, trace-stream consumption, and epoch records ride on `re-frame2`'s native Tool-Pair surfaces. The skill never proposes fixes that route through `re-frame-10x`. This is L1 of the sibling `re-frame-pair-improver2` skill too — consistent across the pair family.
+
+### L3 — Two transports, MCP preferred
+
+- **MCP transport** — `mcp__re-frame-pair2__*` tools. Single persistent nREPL connection per session. Preferred.
+- **Bash-shim transport** — `scripts/discover-app.sh` and friends. Deprecated; kept for back-compat sessions where the MCP server isn't installed.
+
+The MCP-vs-shim mapping lives in `references/mcp-transport.md`. The frontmatter `allowed-tools` block lists both surfaces so the skill works either way.
+
+### L4 — Two modes of changing the app
+
+- **REPL changes** are ephemeral; survive hot-reloads of unaffected namespaces but lost on full page reload. Use for probes / experiments / throwaway fixes.
+- **Source edits** are permanent; after any source edit, the AI **must** call `hot-reload/wait` before dispatching or tracing. Otherwise it interacts with pre-reload code and reports misleading results.
+
+This dichotomy is a cardinal rule in SKILL.md. The strict source-edit protocol lives in `references/hot-reload-protocol.md`.
+
+### L5 — Connect first, every session
+
+Before any op, `discover-app` runs. This locates the nREPL port, connects, verifies `interop/debug-enabled?` is true, injects the `re-frame-pair2.runtime` namespace, and checks the session sentinel. Failures return structured edn (`{:ok? false :reason ...}`); the skill reports the failure verbatim, doesn't guess at workarounds. `references/errors.md` carries the failure-mode catalogue.
+
+### L6 — Multi-frame model, operating-frame selection
+
+re-frame2 apps may run multiple named frames (Spec 002). The session caches an operating frame; mutating ops refuse with `:ambiguous-frame` if more than one frame is registered and none selected. Read ops proceed against `:rf/default` after warning. This matches Spec 002 §Frame-presets / lifecycle convention.
+
+### L7 — One trace listener and one epoch listener per skill
+
+The skill registers exactly one trace listener under `:re-frame-pair2` and one epoch listener under `:re-frame-pair2-epoch`. Multi-tool coexistence is the expected default — other listeners (e.g. user-installed ones, 10x in legacy sessions) don't interfere because per Spec 009 §Listener ordering, ordering is not contract.
+
+### L8 — Use the assembled epoch stream by default; reach for the raw trace stream when the projection drops detail
+
+`:sub-runs`, `:renders`, `:effects` are the structured projections — the routing surface. `:trace-events` is the escape hatch when the projection is incomplete (e.g. successful-fx attribution, where the `:effects` projection records only outcomes and the raw stream carries the full picture).
+
+### L9 — No bead-ids in user-facing skill content
+
+`SKILL.md` + `references/` + `scripts/` carry no `rf2-XXXX` references. The `spec/` folder may; user-facing content does not.
+
+### L10 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — never commit `ai/` or `findings/`. This skill's commits contain only `skills/re-frame-pair2/**`.
+
+### L11 — Resolve UI references to source first
+
+When the user mentions a button / view / panel / "the thing I clicked", the AI runs `dom/source-at` **before** speculating about behaviour. Reporting `re-com/button at app/cart/view.cljs:84` grounds the conversation; *"probably the Save button somewhere in the profile view"* doesn't. This is a Style-Guidance rule in SKILL.md.
+
+### L12 — Surface restore limits
+
+Before any time-travel experiment, the AI walks the cascade's effects and tells the user which effects already fired and cannot be reversed. `restore-epoch` is first-class but it rewinds `app-db`, not external side effects (HTTP requests already dispatched, navigation that already happened, etc.).
+
+## 4. Audience and scope
+
+### In scope
+
+- Developers running a re-frame2 app under `shadow-cljs watch` who want pair-programming agency.
+- Inspecting any frame's `app-db`, walking the trace stream, walking the epoch history.
+- Dispatching events from the REPL; hot-swapping handlers; experimenting with reg-* replacements.
+- DOM bridge ops (`dom/source-at`, `dom/fire-click-at-src`).
+- Time-travel (`epoch/restore`).
+- Watch / stream / narrate-live workflows.
+
+### Out of scope
+
+- **Greenfield setup** — `skills/re-frame2-setup/`.
+- **Authoring re-frame2 code from scratch** (vs. modifying live) — `skills/re-frame2/`.
+- **v1→v2 migration** — `skills/re-frame-migration/`.
+- **Porting re-frame2 to a different host** — `skills/re-frame2-implementor/`.
+- **Improving the pair tool itself** — `skills/re-frame-pair-improver2/`.
+- **Apps not using re-frame2's Tool-Pair contract** (e.g. v1 apps, custom adapters that don't install trace-cb / epoch-cb hooks) — out of scope; the skill returns `:missing :re-frame2-tool-pair` on connect.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame-pair2/
+├── SKILL.md                            (router; ~130 lines)
+├── README.md                           (human-facing intro)
+├── LICENSE                             (MIT)
+├── RELEASING.md                        (npm + plugin release notes)
+├── STATUS.md                           (development status)
+├── package.json                        (npm metadata)
+├── .claude-plugin/plugin.json          (Claude Code plugin metadata)
+├── references/
+│   ├── ops.md                          (op catalogue — read/write/trace/DOM/watch/hot-reload/time-travel)
+│   ├── recipes.md                      (named procedures — "explain this dispatch", post-mortem, etc.)
+│   ├── errors.md                       (structured error → English + recovery)
+│   ├── hot-reload-protocol.md          (source-edit → wait-for-reload → re-trace protocol)
+│   ├── migration-from-v1.md            (re-frame-pair v1 → v2 surface map)
+│   └── mcp-transport.md                (MCP install + bash-shim → MCP tool name map)
+├── scripts/                            (bash shims — deprecated, kept for back-compat)
+├── tests/                              (skill smoke tests)
+├── docs/                               (developer docs for the skill maintainer)
+└── spec/
+    ├── design.md                       (this file)
+    ├── inputs.md                       (canonical inputs)
+    └── authoring-prompt.md             (one-shot reauthor prompt)
+```
+
+SKILL.md (~130) + 6 references (~1,000) + spec (~300) ≈ ~1,430 LoC. Typical session reads SKILL.md (~130) + one or two references (~150-300 each) = ~430-720 LoC.
+
+## 6. Discovery surface (frontmatter `description`)
+
+The `description` is "pushy" and lists every surface the live-app workflow exposes: `re-frame2`, `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-trace-cb`, `register-epoch-cb`, `restore-epoch`, plus the toolchain (`re-com`, `shadow-cljs`). The framing is *"pair-program with a live re-frame2 application"* — discriminates against the authoring-only `re-frame2` skill (which triggers on the same surfaces but in code-writing prose).
+
+## 7. Anti-patterns the skill explicitly resists
+
+- **Speculating without evidence.** Style-guidance rule + L8 + L11.
+- **Using `reset!` of a frame's app-db when not surgically needed.** Mentioned explicitly in SKILL.md style guidance.
+- **Routing fixes through re-frame-10x.** L2.
+- **Skipping `discover-app`.** L5; every op starts by checking the session sentinel.
+- **Skipping `hot-reload/wait` after a source edit.** L4; the protocol leaf is the canonical reference.
+- **Inventing alternate vocabulary** for re-frame2 concepts (e.g. "state graph" for "frame", "transition log" for "epoch ring"). Pillar 2.
+- **Asserting completion without grounding in a read.** SKILL.md style guidance — "Validate before proposing".
+
+## 8. Why this design diverges from `re-frame2`
+
+- **No patterns/ directory.** The skill is an op catalogue and a recipe library, not a pattern catalogue.
+- **No decision-trees/ directory.** The decisions are operational ("which op for which task?") and live in the `references/ops.md` and `references/recipes.md` tables.
+- **First-class `allowed-tools` frontmatter.** The MCP transport + bash-shim coexistence requires explicit tool listing.
+- **`scripts/` directory.** The bash-shim transport is a first-class fallback, even though deprecated.
+- **`STATUS.md` + `RELEASING.md`** — the skill ships as both a Claude plugin (`.claude-plugin/plugin.json`) and an npm package (`package.json`), so per-release metadata is load-bearing.
+
+## 9. Open questions (deferred to Mike)
+
+### OQ1 — When to retire the bash-shim transport entirely?
+
+L3 keeps both; the MCP transport is preferred. Once the MCP server is installed in ≥95% of sessions, the bash shims can move to a `legacy/` folder or be removed. Status: monitored; no removal target.
+
+### OQ2 — Should recipes carry severity / leverage tagging?
+
+Currently recipes are listed; an "if you only learn three procedures, learn these three" tier would help new users. Status: deferred — adding tiers risks ranking-by-aesthetics rather than ranking-by-evidence. A future audit against session logs could surface the actual top-N.
+
+### OQ3 — Should the skill ship eval cases (smoke tests for the AI's responses)?
+
+`tests/` exists but only carries connection smoke tests. AI-response evals (e.g. "given this trace, the AI should report X") would tighten the regression-test surface. Status: deferred.

--- a/skills/re-frame-pair2/spec/inputs.md
+++ b/skills/re-frame-pair2/spec/inputs.md
@@ -1,0 +1,69 @@
+# re-frame-pair2 — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary input — re-frame2's Tool-Pair contract
+
+Path: `spec/Tool-Pair.md` (the contract specification) + `spec/009-Instrumentation.md` (the trace-stream / epoch-record surfaces) + `spec/002-Frames.md` (the multi-frame model the skill operates against).
+
+**This is the source of truth.** Every op the skill teaches is a structured call against one of the Tool-Pair surfaces:
+
+- `(rf/register-trace-cb id cb)` / `(rf/trace-buffer opts)` — the trace stream.
+- `(rf/register-epoch-cb id cb)` / `(rf/epoch-history frame-id)` — the assembled epoch stream and per-frame ring.
+- `(rf/restore-epoch ...)` — first-class time-travel.
+- `(rf/frame-ids)` / `(rf/frame-meta id)` — multi-frame inspection.
+- `(rf/app-schemas)` / `(rf/handler-meta kind id)` — registrar reflection (source-coords).
+- `(rf/configure :epoch-history {:depth N})` — ring retention.
+
+The skill is one of the principal downstream consumers of these surfaces.
+
+## 2. Secondary input — `implementation/core/src/re_frame/**`
+
+For verifying that the public surface in `spec/Tool-Pair.md` is wired up in the reference impl:
+
+- `implementation/core/src/re_frame/core.cljc` — the public single-import API; `register-trace-cb`, `trace-buffer`, `register-epoch-cb`, `epoch-history`, `restore-epoch`, `frame-ids`, `frame-meta`, `app-schemas`, `handler-meta`, `configure`.
+- `implementation/core/src/re_frame/trace.cljc` — the trace stream's internals; what op-types are emitted, how `:op-type :error` filtering works.
+- `implementation/core/src/re_frame/epoch.cljc` — the per-frame epoch ring; what fields a `:rf/epoch-record` carries; the structured `:sub-runs` / `:renders` / `:effects` projections.
+- `implementation/core/src/re_frame/frame.cljc` — frame lifecycle; `:rf/default` registration; per-frame router queues.
+
+When `spec/Tool-Pair.md` and `implementation/**` disagree, the implementation wins and a `bd` bead gets filed against the spec.
+
+## 3. Tertiary input — `re-frame-pair2.runtime` namespace
+
+Path: `skills/re-frame-pair2/scripts/runtime.cljs` (or wherever it lives at authoring time).
+
+The skill injects this namespace on connect. It carries helper functions the structured ops compose against (`epoch-diff`, `find-where`, `find-all-where`, etc.). The skill's `references/ops.md` and `references/recipes.md` cite these helpers by name.
+
+## 4. Transport inputs
+
+- **MCP server** — the `mcp__re-frame-pair2__*` tool surface. Lives in `tools/pair2-mcp/` in the re-frame2 repo. The skill's frontmatter `allowed-tools` block lists every MCP tool; `references/mcp-transport.md` explains installation.
+- **Bash shims** — `skills/re-frame-pair2/scripts/*.sh`. Deprecated but kept for back-compat. Each shim has a 1:1 MCP-tool counterpart documented in `references/mcp-transport.md`.
+
+## 5. Authoring-discipline inputs
+
+These shape the skill's voice and structure but aren't quoted directly.
+
+- **`skills/re-frame2/spec/design.md`** — the parent skill's locked design. This skill inherits the four pillars (recipe-shape, idiomaticness, context economy, training-knowledge assumption), the cardinal-rules format, the routing-table convention.
+- **`skills/re-frame-migration/spec/`** + **`skills/re-frame2-implementor/spec/`** — the existing `spec/` triad pattern. Voice / shape mirror these.
+- **`skills/re-frame-pair-improver2/SKILL.md`** — the sibling improver skill that consumes this skill's output. The two are coupled: the improver routes friction back into beads against the pair tool.
+- Anthropic skills guidance — `name` ≤ 64 chars, lowercase + hyphens; `description` "pushy"; SKILL.md under 500 lines; reference files one level deep; `allowed-tools` listing required when the skill uses MCP / Bash tools beyond the defaults.
+
+## 6. What the skill does NOT consume
+
+- **`docs/guide/**`** — the narrative human guide. The skill is for AI-augmented developer sessions; the guide is for learners.
+- **`spec/Pattern-*.md`** — application-authoring patterns. The pair tool operates on running apps; pattern selection is the `re-frame2` skill's concern.
+- **`re-frame-10x`** — explicitly excluded per L2. The pair tool consumes re-frame2's native Tool-Pair surfaces, not 10x's projection.
+- **`implementation/<feature>/**` per-feature artefacts** — except where they install Tool-Pair hooks (most don't; the Tool-Pair surface lives in `implementation/core/`).
+- **`tests/**`** in the re-frame2 repo — the skill teaches operation against running apps, not how to test the framework itself.
+
+## 7. Update procedure
+
+When the Tool-Pair contract changes:
+
+1. **A new trace event op-type ships** → update `references/ops.md`'s op catalogue (if the AI should explicitly query for it); update `references/recipes.md` if a new recipe exposes it.
+2. **`:rf/epoch-record`'s projection set changes** (`:sub-runs` / `:renders` / `:effects` field additions) → update the recipes that walk those projections; L8 may need re-statement.
+3. **`restore-epoch`'s failure modes expand** → update `references/errors.md` and the time-travel recipe in `references/recipes.md`.
+4. **A new structured op ships in the MCP server** → add to `allowed-tools` in SKILL.md frontmatter; add a row to `references/ops.md`; add the 1:1 bash-shim mapping to `references/mcp-transport.md`.
+5. **A bash shim is removed** → update `references/mcp-transport.md`'s mapping table.
+6. **A new failure mode appears in `discover-app`** → add to `references/errors.md`.
+7. **`re-frame2` adds a new `reg-*` kind** (e.g. a future `reg-X`) → check whether the new kind needs a structured op (probably yes if it's user-facing); update `references/ops.md`.

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -38,6 +38,7 @@ Switch to a different skill when:
 - The author has a working re-frame2 project and wants to **write application code** — events, subs, machines, schemas, views, fx. → Use the **`re-frame2`** skill.
 - The author has a running re-frame2 app and wants to **inspect / debug / pair with it live** — dispatch from the REPL, walk app-db, trace events, time-travel. → Use the **`re-frame-pair2`** skill.
 - The author is **migrating from re-frame v1 to v2**. → Use the [`re-frame-migration`](../re-frame-migration/) skill.
+- The author is **implementing re-frame2 itself** in a different host language or substrate (TypeScript, F#, Kotlin, Python, a non-React renderer). → Use the [`re-frame2-implementor`](../re-frame2-implementor/) skill — that one walks the EP corpus and the conformance contract; this skill assumes the CLJS reference is the target.
 
 If the author asks anything beyond greenfield setup (any re-frame2 API question, any design question, any migration question), say so and point them at the right skill.
 

--- a/skills/re-frame2-setup/spec/authoring-prompt.md
+++ b/skills/re-frame2-setup/spec/authoring-prompt.md
@@ -1,0 +1,97 @@
+# re-frame2-setup — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame2-setup` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame2-setup` skill at `skills/re-frame2-setup/`. The skill helps an author **bootstrap a fresh re-frame2 ClojureScript project** from nothing (or close to it) — adds the artefact deps, writes a minimal `shadow-cljs.edn`, lays down a canonical entry namespace with `rf/init!` + the Reagent adapter, and walks the author through their first mounted counter. After the counter mounts, the author switches to `skills/re-frame2/` for code-writing or `skills/re-frame-pair2/` for live pair-programming.*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame2-setup/spec/design.md` — the locked design decisions (L1 through L10). Pillars 1-4 in §2 are non-negotiable. Q14 lock applies (NO verification module).*
+> *2. `skills/re-frame2-setup/spec/inputs.md` — the canonical inputs the skill leans on.*
+> *3. `examples/reagent/counter/` — the canonical first-counter shape (`core.cljs`, `shadow-cljs.edn`, `index.html`). `reference/first-counter.md` is a trimmed version of this example.*
+> *4. `implementation/core/src/re_frame/core.cljc` (for the `rf/init!` contract) + `implementation/reagent/src/re_frame/adapter/reagent.cljs` (for the adapter spec map shape).*
+> *5. `skills/re-frame-migration/SKILL.md` + `skills/re-frame-migration/spec/` — the closest structural sibling with an existing `spec/` triad. Voice / shape mirror this.*
+> *6. `skills/re-frame2/SKILL.md` — the parent skill the author switches to once setup is done. The setup skill's routing-on-exit table points here.*
+>
+> *Then write the skill at `skills/re-frame2-setup/` with this exact file structure:*
+>
+> ```
+> skills/re-frame2-setup/
+> ├── SKILL.md                       (~170 lines; router + canonical greenfield path)
+> ├── README.md                      (human-facing intro)
+> ├── LICENSE                        (MIT)
+> ├── package.json                   (npm metadata)
+> ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+> ├── reference/
+> │   ├── deps-versions.md           (~120 lines; lockstep VERSION; pay-as-you-go artefact table)
+> │   ├── shadow-cljs.md             (~100 lines; minimal build shape, index.html)
+> │   ├── entry-namespace.md         (~120 lines; rf/init! + Reagent root contract)
+> │   └── first-counter.md           (~110 lines; end-to-end worked example)
+> └── spec/
+>     ├── design.md
+>     ├── inputs.md
+>     └── authoring-prompt.md
+> ```
+>
+> *Every reference leaf is ≤250 lines (target ~120). SKILL.md is ~170 lines (under Anthropic's 500-line ceiling). All leaves are one level deep.*
+>
+> *SKILL.md walks the seven canonical steps:*
+>
+> *1. Discover the current artefact VERSION.*
+> *2. Add deps to `deps.edn`.*
+> *3. Add npm deps to `package.json`.*
+> *4. Write `shadow-cljs.edn`.*
+> *5. Write the entry namespace with `(rf/init! reagent-adapter/adapter)` before any render.*
+> *6. Write the first counter (event + sub + reg-view + mount).*
+> *7. Run it and verify.*
+>
+> *Cardinal rules to bake in (these go in SKILL.md):*
+>
+> *1. **Never hardcode artefact versions in suggestions written to disk.** Look them up first.*
+> *2. **All ten artefacts ship at the same VERSION.** Mixing is unsupported.*
+> *3. **Only add the per-feature artefacts the author actually uses.** Core + adapter on day one; the rest pay-as-you-go.*
+> *4. **The Reagent adapter is the default reference substrate.** Unless the author says UIx or Helix, scaffold Reagent.*
+> *5. **Don't write tests for the author.** This skill stops at "the counter mounts".*
+>
+> *Locks to preserve verbatim:*
+>
+> *- **L6 — NO verification module.** No `reference/verify.md`; no "verify before claiming done" hard rule. Done checklist lists conditions; author confirms.*
+> *- **L7 — No bead-ids in user-facing skill content.***
+> *- **L8 — Findings stay local.** Don't commit `ai/` or `findings/`.*
+> *- **L10 — Routing-on-exit table at the end of SKILL.md.** Every adjacent skill listed by name. The author leaves this skill confidently for the next one.*
+>
+> *Frontmatter — the `description` is "pushy" per Anthropic best practice. List every greenfield-trigger phrase: "start a re-frame2 project", "scaffold re-frame2", "how do I set up re-frame2", "add re-frame2 to my repo", "give me a hello-world re-frame2 app". The description explicitly carves out the exit routes (after setup → `re-frame2` for code-writing, `re-frame-pair2` for pair-programming).*
+>
+> *Voice: tight, declarative, recipe-shaped. Use tables for routing; use code blocks for canonical shapes (deps.edn, shadow-cljs.edn, core.cljs). Inline Troubleshooting at the end of SKILL.md for the four most common build failures (classpath miss, missing react, missing `rf/init!`, missing `<div id="app">`).*
+>
+> *Don't:*
+>
+> *- Don't hardcode versions in the leaves — point at `reference/deps-versions.md` for lookup.*
+> *- Don't teach re-frame2's API beyond what the first counter requires.*
+> *- Don't branch into UIx/Helix substrates at greenfield.*
+> *- Don't write `*.md` documentation outside `skills/re-frame2-setup/`.*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't write a verification leaf or verify-before-done hard rule.*
+> *- Don't include bead-ids in user-facing leaves.*
+>
+> *Open the PR with title `feat(skills): re-frame2-setup — greenfield bootstrap skill`. PR body lists: the skill structure, the file LoC table, the cardinal rules, the relationship to the adjacent skills (`re-frame2` for code-writing, `re-frame-pair2` for pair-programming, `re-frame-migration` for v1→v2 migrants, `re-frame2-implementor` for porters).*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the repo and access to `examples/reagent/counter/`.
+- The prompt does **not** ask the session to verify the resulting skill — Mike reads the PR and comments.
+- If the canonical `examples/reagent/counter/` shape has changed between authoring passes, `reference/first-counter.md` needs re-derivation.
+
+## When to re-author
+
+- A new mandatory artefact ships in lockstep (the ten-artefact set grows) → update `reference/deps-versions.md` and the SKILL.md framing.
+- The `re-frame.adapter.reagent` contract changes materially → `reference/entry-namespace.md` and `reference/first-counter.md` need updates.
+- `rf/init!`'s signature changes → all four reference leaves need a sweep.
+- Reagent v3 lands and supplants v2 → re-derive against the v3 counter example.
+- Anthropic skill conventions change materially → reauthor against the new conventions.
+
+Otherwise, edit existing leaves directly; reauthoring is for major-version updates.

--- a/skills/re-frame2-setup/spec/design.md
+++ b/skills/re-frame2-setup/spec/design.md
@@ -1,0 +1,136 @@
+# re-frame2-setup — Design
+
+The design rationale and locked decisions for the `re-frame2-setup` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help an author **bootstrap a fresh re-frame2 ClojureScript project**. The author starts with nothing — or close to it — and ends with a working browser app that compiles under `shadow-cljs watch` and mounts a counter. From there, the author switches to the main `re-frame2` skill for application-code authoring.
+
+The success criterion: `npx shadow-cljs watch app` compiles cleanly, the browser shows a counter, clicking `+` / `-` updates it. The skill stops at that point — anything beyond setup is another skill's job.
+
+## 2. Pillars (locked, derived from `re-frame2`'s four pillars)
+
+The same four pillars as the `re-frame2` skill, scoped to greenfield bootstrap:
+
+1. **Correctness — recipes over explanations.** Walks through the exact deps, the exact `shadow-cljs.edn` shape, the exact entry-namespace contract. The author copies the recipe; doesn't re-derive it. **Q14 lock applies: NO verification module** — the author runs the build; the skill doesn't.
+2. **Idiomaticness — verified against `examples/reagent/counter/` and the canonical artefacts.** The first-counter shape mirrors `examples/reagent/counter/core.cljs` trimmed for greenfield. Dep coords match what `day8/re-frame2` ships.
+3. **Context economy — `SKILL.md` is a router; four one-level-deep leaves carry the depth.** SKILL.md walks the seven-step canonical path; leaves carry per-step depth.
+4. **Assume training knowledge.** The author knows `deps.edn`, `npm`, `shadow-cljs`, what a Reagent component is. The skill teaches only the **re-frame2-specific wiring** — which artefacts to add, the `rf/init!` contract, the order of operations between adapter install and React mount.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve them unless explicitly unlocked by Mike.
+
+### L1 — Never hardcode artefact versions in suggestions written to disk
+
+re-frame2 ships ten Maven artefacts in lockstep at a single VERSION. Versions change. The skill points the author at `reference/deps-versions.md` for lookup; the cardinal rule lives in SKILL.md so it's read on every load. Hardcoded versions in suggestions are a documented anti-pattern.
+
+### L2 — All ten artefacts ship at the same VERSION
+
+The author picks the VERSION once; every `day8/re-frame2-*` dep gets that same version. Mixing versions across artefacts is unsupported. This rule lands in both SKILL.md and `reference/deps-versions.md`.
+
+### L3 — Only add the per-feature artefacts the author actually uses
+
+Core (`day8/re-frame2`) and adapter (`day8/re-frame2-reagent`) are mandatory on day one. Per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) come in **only when the author starts using the feature**. The skill resists the temptation to "add them all defensively" — pay-as-you-go is the contract.
+
+### L4 — The Reagent adapter is the default reference substrate
+
+Unless the author explicitly says UIx or Helix, scaffold against Reagent. The skill does not branch into multi-substrate decision trees at greenfield — Reagent v2 is the canonical default.
+
+### L5 — Don't write tests for the author
+
+The skill stops at "the counter mounts". Anything after that — events, subs, machines, schemas, test-authoring — is the main `re-frame2` skill (which itself defers test-writing to the author per its own Q14 lock).
+
+### L6 — Q14 — NO verification module
+
+Consistent with the `re-frame2` skill: no `reference/verify.md`, no "verify before claiming done" hard rule. The Done checklist in SKILL.md lists the conditions; the author confirms. The skill never asserts completion.
+
+### L7 — No bead-ids in user-facing skill content
+
+`SKILL.md` + `reference/` carry no `rf2-XXXX` references. The `spec/` folder may; user-facing leaves do not.
+
+### L8 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — never commit `ai/` or `findings/`. This skill's commits contain only `skills/re-frame2-setup/**`.
+
+### L9 — Single-import contract from day one
+
+The first-counter recipe imports `re-frame.core` as `rf` and `re-frame.adapter.reagent` as `reagent-adapter`. No private-namespace requires; no `re-frame.db` style reach-ins. The contract the author starts with is the contract the main `re-frame2` skill enforces from there on.
+
+### L10 — Routing table for "anything beyond setup"
+
+SKILL.md ends with an explicit "When the author asks anything beyond setup" routing table. Every adjacent skill is listed by name. The author leaves this skill confidently for the next one rather than stretching this skill to cover authoring questions.
+
+## 4. Audience and scope
+
+### In scope
+
+- Authors starting a new directory (or an existing CLJS project) that needs re-frame2 wiring.
+- The seven canonical steps: discover versions → `deps.edn` → `package.json` → `shadow-cljs.edn` → entry ns → first counter → run.
+- Reagent v2 as the default substrate.
+- Troubleshooting the four most common build failures (classpath miss, missing react, missing `rf/init!`, missing `<div id="app">`).
+
+### Out of scope
+
+- Migrating from re-frame v1 → `skills/re-frame-migration/`.
+- Authoring application code beyond the first counter → `skills/re-frame2/`.
+- Live-runtime debugging → `skills/re-frame-pair2/`.
+- Building re-frame2 in a different host language → `skills/re-frame2-implementor/`.
+- Non-Reagent substrates (UIx, Helix) at greenfield — the skill scaffolds against Reagent; substrate-switch is a separate conversation.
+- Writing tests, registering events, subs, machines, schemas — all the main `re-frame2` skill's job.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame2-setup/
+├── SKILL.md                       (router; ~170 lines)
+├── README.md                      (human-facing intro)
+├── LICENSE                        (MIT)
+├── package.json                   (npm metadata)
+├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
+├── reference/
+│   ├── deps-versions.md           (~120 lines; lockstep VERSION discipline)
+│   ├── shadow-cljs.md             (~100 lines; build shape, index.html)
+│   ├── entry-namespace.md         (~120 lines; rf/init! + Reagent root contract)
+│   └── first-counter.md           (~110 lines; end-to-end worked example)
+└── spec/
+    ├── design.md                  (this file)
+    ├── inputs.md                  (canonical inputs)
+    └── authoring-prompt.md        (one-shot reauthor prompt)
+```
+
+SKILL.md (~170) + 4 reference leaves (~450) + 3 spec files (~250) ≈ ~870 LoC across 10 files. Typical greenfield session reads SKILL.md + 2 reference leaves = ~370 LoC.
+
+## 6. Discovery surface (frontmatter `description`)
+
+The `description` is "pushy" and lists every greenfield-trigger phrase: *"start a re-frame2 project"*, *"scaffold re-frame2"*, *"how do I set up re-frame2"*, *"add re-frame2 to my repo"*, *"give me a hello-world re-frame2 app"*. The description explicitly handles off-task routing: once the counter mounts, the author switches to `re-frame2` for code-writing or `re-frame-pair2` for live pair-programming.
+
+## 7. Anti-patterns the skill explicitly resists
+
+- **Hardcoding artefact versions in suggestions** — L1 cardinal rule.
+- **Mixing versions across the ten artefacts** — L2 cardinal rule.
+- **Adding per-feature artefacts defensively** — L3 cardinal rule + `reference/deps-versions.md`'s "pay-as-you-go" framing.
+- **Branching into UIx/Helix at greenfield** — L4. Substrate-switch is a separate conversation.
+- **Writing tests for the author** — L5 cardinal rule.
+- **Drifting into application-code authoring** — L10 routing table at the end of SKILL.md.
+
+## 8. Why this design diverges from `re-frame2`
+
+- **No patterns/ directory.** Setup is one workflow, not a library of recipes.
+- **No decision-trees/ directory.** The only decision is "which per-feature artefacts do I need on day one?" and lives inline in `reference/deps-versions.md`.
+- **No examples-map.md.** The one example is the first counter, inlined in `reference/first-counter.md`.
+- **Routing table at the end of SKILL.md.** The skill is the *entry point* into the family — the explicit routing-on-exit table tells the author where to go next.
+
+## 9. Open questions (deferred to Mike)
+
+### OQ1 — Should the skill cover UIx / Helix greenfield?
+
+Currently L4 makes Reagent the only greenfield path. A future v0.2 could add `reference/entry-namespace-uix.md` and `reference/entry-namespace-helix.md` once those substrates have a steady greenfield user-base. Status: deferred until there's evidence of demand.
+
+### OQ2 — Should the skill ship a runnable `setup.bb` script?
+
+A `bb`-driven mechanical scaffolder ("generate the four files for me") would shorten the setup loop. Status: deferred — the manual walkthrough is small enough that the agent's session can apply it inline without dedicated tooling.
+
+### OQ3 — Should troubleshooting move to its own leaf?
+
+Currently inlined at the end of SKILL.md (`Troubleshooting`). If it grows beyond ~30 lines, promote to `reference/troubleshooting.md`. Status: monitored; not a blocker.

--- a/skills/re-frame2-setup/spec/inputs.md
+++ b/skills/re-frame2-setup/spec/inputs.md
@@ -1,0 +1,56 @@
+# re-frame2-setup — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary inputs — the canonical greenfield artefacts
+
+The skill teaches a four-file scaffolding (`deps.edn`, `package.json`, `shadow-cljs.edn`, `core.cljs`). Each file's shape is derived from:
+
+- **`day8/re-frame2`'s release artefacts** — the ten Maven coords (`day8/re-frame2`, `day8/re-frame2-reagent`, `day8/re-frame2-schemas`, `day8/re-frame2-machines`, `day8/re-frame2-routing`, `day8/re-frame2-flows`, `day8/re-frame2-http`, `day8/re-frame2-ssr`, `day8/re-frame2-epoch`, plus the test-support artefact). All ship in lockstep at a single VERSION; the skill reads that VERSION at discovery time rather than hardcoding it.
+- **`examples/reagent/counter/`** in the re-frame2 repo — the canonical first-counter shape. `reference/first-counter.md` is a trimmed version of this example.
+- **`examples/reagent/counter/shadow-cljs.edn`** — the canonical `shadow-cljs.edn` shape for a single-page browser app.
+- **`examples/reagent/counter/index.html`** — the canonical `index.html` (`<div id="app">`, `<script src="js/main.js">`).
+- **`day8/re-frame2-reagent`'s adapter export** — `re-frame.adapter.reagent/adapter` (a var holding the adapter spec map). The entry namespace's `(rf/init! reagent-adapter/adapter)` call comes from this surface.
+
+## 2. Secondary input — `implementation/core/src/re_frame/core.cljc`
+
+For the `rf/init!` contract: when it's called, what it expects, why it must run **before any `dispatch` or render**. The entry-namespace leaf walks this contract.
+
+For `re-frame.adapter.reagent`: how the adapter spec map is consumed; why `defonce` matters for the React root.
+
+## 3. Tertiary inputs — `spec/`
+
+Used for *why*, not *what*. Cited by name in design rationale; not quoted in user-facing leaves.
+
+- **`spec/000-Vision.md`** — the AI-first design principles; backs the skill's discipline of minimal scaffolding.
+- **`spec/002-Frames.md`** — `:rf/default` is implicit on `rf/init!`; the setup skill doesn't need to teach frames but mentions the default exists.
+- **`spec/Pattern-Boot.md`** — the canonical boot pattern; relevant once the author moves past first-counter (the SKILL.md routing table points there).
+
+## 4. Authoring-discipline inputs
+
+These shape the skill's voice and structure but aren't quoted directly.
+
+- **`skills/re-frame2/spec/design.md`** — the parent skill's locked design. This skill inherits the four pillars, the Q14 lock, the cardinal-rules format, the single-import contract (L9 here, L8 there).
+- **`skills/re-frame-migration/SKILL.md`** + **`skills/re-frame-migration/spec/`** — the closest structural sibling that already has a `spec/` triad. Voice / shape match this.
+- **`SKILL-REDIRECT.md`** (repo root) — the canonical pointer table for deep-dive content; the skill's routing-on-exit table cross-references it.
+- Anthropic skills guidance — `name` ≤ 64 chars, lowercase + hyphens; `description` "pushy" with explicit "use this skill whenever..." framing; SKILL.md under 500 lines; leaves one level deep; avoid time-sensitive content (deferred to `reference/deps-versions.md` lookup rather than hardcoded VERSIONs).
+
+## 5. What the skill does NOT consume
+
+- **`spec/001-Registration.md` through `spec/014-HTTPRequests.md` (most of the EP corpus)** — the skill doesn't teach the API. Once the counter mounts, the author switches to the `re-frame2` skill, which teaches it.
+- **`docs/guide/**`** — the narrative human guide. Cross-references run through `SKILL-REDIRECT.md`, not into the guide directly.
+- **`implementation/machines/**`** / **`implementation/routing/**`** / etc. — per-feature artefacts. The skill defers them per L3 (pay-as-you-go).
+- **`examples/reagent/{login,boot,nine_states,managed_http_counter,...}/`** — application-pattern examples. The setup skill points at `counter/` only; the others belong to the main `re-frame2` skill.
+- **`tools/**`** — the skill doesn't reach for repo tooling.
+
+## 6. Update procedure
+
+When the artefact set or the greenfield contract changes:
+
+1. **A new artefact is split out** (e.g. a future `day8/re-frame2-stories`) → add a row to `reference/deps-versions.md`'s pay-as-you-go table; mention in SKILL.md if it's commonly needed on day one.
+2. **An existing artefact is renamed or merged** → grep `reference/` for the old name and update; verify the routing table at the end of SKILL.md still resolves correctly.
+3. **`re-frame.adapter.reagent`'s adapter contract changes** (e.g. new keys in the adapter spec map) → update `reference/entry-namespace.md`'s canonical shape; verify `reference/first-counter.md` still compiles.
+4. **`shadow-cljs.edn` greenfield shape changes** (rare — `:target :browser` is very stable) → update `reference/shadow-cljs.md`.
+5. **`rf/init!` signature changes** → update SKILL.md's Step 5 framing and `reference/entry-namespace.md`.
+6. **A new common greenfield failure mode appears** → add a row to SKILL.md's Troubleshooting section (move to a dedicated leaf if it grows past ~30 lines per OQ3).
+7. **The `examples/reagent/counter/` shape changes** → re-derive `reference/first-counter.md` from the example.

--- a/skills/re-frame2/reference/cross-cutting/testing.md
+++ b/skills/re-frame2/reference/cross-cutting/testing.md
@@ -173,6 +173,30 @@ For arbitrary fx, override the registered handler from inside the test — the f
   (is (= [{:items [...]}] @calls)))
 ```
 
+### `:fx-overrides` per-call function value
+
+The dispatch-opts `:fx-overrides` map also accepts **function values** — a one-shot lambda that runs in place of the registered fx-handler for this dispatch only. No registry mutation, nothing to roll back. The signature matches `reg-fx`'s binary contract: `(fn [m args] ...)`, where `m` carries `:frame` (and `:event` when the fx ran from an event handler) and `args` is the fx's arg payload.
+
+```clojure
+(let [calls (atom [])]
+  (rf/dispatch-sync [:cart/save]
+    {:fx-overrides {:app/persist (fn [_m args] (swap! calls conj args))}})
+  (is (= [{:items [...]}] @calls)))
+```
+
+For HTTP stubs, the fn form lets the test return a canned response shape without registering a parallel `:rf.http/managed-canned-success` fx:
+
+```clojure
+(rf/dispatch-sync [:user/login {:email "user@example.com"}]
+  {:fx-overrides {:rf.http/managed
+                  (fn [m args]
+                    (when-let [on-success (:on-success args)]
+                      (rf/dispatch (conj on-success {:status 200 :body {:user "u1"}})
+                                   {:frame (:frame m)})))}})
+```
+
+Per-frame `:fx-overrides` in `reg-frame` accepts the same fn-value form, so a test frame can install a stub once for every dispatch routed to it. The id-keyword form (`{:rf.http/managed :rf.http/managed-canned-success}`) is the portable pattern-level form — use it when the stub is shared across many tests or when SSR / serialisation is in play; reach for the fn form when one test wants a bespoke response.
+
 ## v1 compatibility shim: `run-test-sync`
 
 If you are mechanically porting v1 tests, `ts/run-test-sync` is a body wrapper that snapshot/restores the registrar around the body:

--- a/skills/re-frame2/reference/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/reference/fundamentals/event-state-cycle.md
@@ -91,6 +91,25 @@ After this single `dispatch-sync`:
 - `counter-log` holds `[:initialised]` (step 9).
 - Any view subscribed to `[:count]` re-renders with `5` (steps 10-11).
 
+## Errors carry the triggering handler's source-coord
+
+Every `:rf.error/*` trace event emitted from inside a running handler — event, sub, fx, cofx, view, interceptor `:before` / `:after`, late-bind hook — carries `:rf.trace/trigger-handler` with the source-coord of *that* handler:
+
+```clojure
+{:rf/op :rf.error/no-such-cofx
+ :rf.error/data {:cofx-id :user/profile}
+ :rf.trace/trigger-handler {:kind         :event
+                            :id           :user/save
+                            :source-coord {:ns     "myapp.events"
+                                           :file   "src/myapp/events.cljs"
+                                           :line   142
+                                           :column 3}}}
+```
+
+`:kind` is the registry kind (`:event` / `:sub` / `:fx` / `:cofx` / `:view` / `:interceptor` / `:late-bind`); `:id` is the registered id; `:source-coord` comes from the `reg-*` macro's capture. The field is **present** whenever a handler is currently executing and **absent** for dispatch-time errors like `:rf.error/no-such-event`, where no handler is yet in scope. It is **not elided in production** — production debugging benefits most.
+
+Tooling (re-frame-10x, re-frame-pair2) renders click-to-jump links straight to the offending handler off this field; in tests / REPL the same field surfaces in `(rf/trace-buffer {:op-type :error})`.
+
 ## Common gotchas
 
 - **`dispatch` is queued, `dispatch-sync` is immediate.** Calling `dispatch-sync` from inside a handler raises `:rf.error/dispatch-sync-in-handler` — sync drains can't nest.

--- a/skills/re-frame2/reference/fundamentals/frames.md
+++ b/skills/re-frame2/reference/fundamentals/frames.md
@@ -86,7 +86,7 @@ The metadata map (`frame.cljc:99-130`) accepts:
 
 - `:doc` — one-sentence what-and-why.
 - `:preset` — one of `:default :test :story :ssr-server`; expands at registration into a fixed metadata bundle.
-- `:fx-overrides` — `{original-id replacement-id}`. The fx walk rewrites lookups (`fx.cljc:62-88`); useful for HTTP stubs in tests/stories.
+- `:fx-overrides` — `{original-id replacement-id-or-fn}`. Two value shapes are honoured (`fx.cljc:62-142`): a **keyword** redirects the lookup to another registered fx (portable, SSR-safe pattern-level form), and a **function** `(fn [m args] ...)` runs inline with no registry lookup (one-shot CLJS-reference convenience for test fixtures and story decorators). The id-redirect form is preferred when the stub is reused; the fn form when one test wants a bespoke response without registering a parallel fx. Per-call `:fx-overrides` in `dispatch` / `dispatch-sync` opts accepts the same two shapes.
 - `:platform` — `:client` or `:server`; gates fx whose `:platforms` set excludes the active platform.
 - `:drain-depth` — bound on dispatch-cascade depth (default 100; `:story` preset tightens to 16).
 - `:on-create` / `:on-destroy` — event vectors fired synchronously at lifecycle transitions.

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -1,0 +1,117 @@
+# re-frame2 — Authoring Prompt
+
+A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
+
+## The prompt
+
+> *I'm re-authoring the `re-frame2` skill at `skills/re-frame2/`. The skill teaches an AI to write working re-frame2 ClojureScript application code while spending as little context as possible. It is **authoring-only** — writing new code on the CLJS reference. Adjacent skills handle setup (`re-frame2-setup`), v1→v2 migration (`re-frame-migration`), live-app inspection (`re-frame-pair2`), and porting re-frame2 itself (`re-frame2-implementor`).*
+>
+> *Read these first (in this order):*
+>
+> *1. `skills/re-frame2/spec/design.md` — the locked design decisions (L1 through L11). Pillars 1-4 in §2 are non-negotiable. Q14 lock applies (NO verification module).*
+> *2. `skills/re-frame2/spec/inputs.md` — the canonical inputs the skill leans on (`implementation/**`, `examples/reagent/**`, `spec/**` for design rationale).*
+> *3. `implementation/core/src/re_frame/core.cljc` + `frame.cljc` + `fx.cljc` + `events.cljc` + `subs.cljc` + `test_support.cljc` — the surfaces the skill teaches. Every code snippet in a leaf is verified against these.*
+> *4. `examples/reagent/{counter,login,boot,nine_states,managed_http_counter}/` — the worked examples. The pattern leaves match these shapes.*
+> *5. `skills/re-frame-migration/SKILL.md` + `skills/re-frame2-implementor/SKILL.md` — the voice / density / load-bearing-rules style to mirror. SKILL.md cardinal-rules framing comes from these.*
+> *6. `spec/000-Vision.md` + `spec/Conventions.md` — the AI-first design principles and naming conventions.*
+>
+> *Then write the skill at `skills/re-frame2/` with this exact file structure:*
+>
+> ```
+> skills/re-frame2/
+> ├── SKILL.md                     (~180 lines; the router + cardinal rules)
+> ├── README.md                    (human-facing intro)
+> ├── LICENSE                      (MIT)
+> ├── package.json                 (npm metadata; mirror re-frame-migration pattern)
+> ├── examples-map.md              (pattern → worked-example table)
+> ├── reference/
+> │   ├── fundamentals/
+> │   │   ├── events.md            (reg-event-{db,fx,ctx})
+> │   │   ├── fx.md                (reg-fx, :fx vector shape)
+> │   │   ├── cofx.md              (reg-cofx, inject-cofx)
+> │   │   ├── subs.md              (reg-sub, layered subs, dynamic args, machine subs)
+> │   │   ├── schemas.md           (reg-app-schema, boundary validation)
+> │   │   ├── frames.md            (frame ids, default frame, per-frame config)
+> │   │   ├── event-state-cycle.md (the 12-step walk)
+> │   │   └── project-structure.md (source-tree conventions)
+> │   ├── state-machines/
+> │   │   ├── reg-machine.md       (states, initial, guards, actions)
+> │   │   ├── regions.md           (single-region + :type :parallel)
+> │   │   ├── tags.md              (state tags, has-tag?)
+> │   │   ├── invoke.md            (:invoke, :invoke-all, child-machine result)
+> │   │   └── cancellation.md      (destroy cascade, cleanup contract)
+> │   ├── tooling/
+> │   │   ├── stories.md           (reg-story, story frames)
+> │   │   └── routing.md           (reg-route, :can-leave?, navigation)
+> │   └── cross-cutting/
+> │       ├── testing.md           (reset-runtime-fixture, dispatch-sync, compute-sub)
+> │       └── api-cheatsheet.md    (one-page reg-* signature index)
+> ├── patterns/
+> │   ├── remote-data.md
+> │   ├── forms.md
+> │   ├── boot.md
+> │   ├── websocket.md
+> │   ├── nine-states.md
+> │   ├── managed-http.md
+> │   ├── async-effect.md
+> │   ├── long-running-work.md
+> │   └── stale-detection.md
+> ├── decision-trees/
+> │   ├── pick-a-pattern.md        ("I want to build X — which pattern?")
+> │   └── slice-or-machine.md      ("Should this be a slice, region, or top-level machine?")
+> └── spec/
+>     ├── design.md
+>     ├── inputs.md
+>     └── authoring-prompt.md
+> ```
+>
+> *Every reference / pattern / decision-tree leaf is ≤250 lines (target ~150). SKILL.md is ~180 lines (under Anthropic's 500-line ceiling). All leaves are one level deep — no SKILL → A → B chains.*
+>
+> *Cardinal rules to bake in (these go in SKILL.md):*
+>
+> *1. **Implementation is ground truth.** When `spec/` and `implementation/**` disagree, the implementation wins. Recipes are verified against `implementation/**` + `examples/reagent/**`.*
+> *2. **Recipes over explanations.** The AI reaches for a canonical shape; doesn't derive from first principles.*
+> *3. **Distinguish orchestration from state.** Machines when "what can happen next" depends on mode; slices when state is a field.*
+> *4. **Schemas at boundaries, not everywhere.** `reg-app-schema` for trust-boundary paths.*
+> *5. **Examples in `examples/reagent/**` are canonical.** When a pattern has a worked example, match its shape.*
+> *6. **Frames before globals.** Code talks to a frame; never bypasses `dispatch` / `subscribe`.*
+> *7. **Reserved namespaces are reserved.** `:rf/*` is framework-owned.*
+> *8. **`reg-*` macros over `register-*` functions.** Macros capture source-coords.*
+> *9. **Pillar 4 — assume training knowledge.** Teach only the re-frame2-specific binding.*
+>
+> *Locks to preserve verbatim:*
+>
+> *- **L3 — NO verification module.** No `reference/verify.md`; no "verify before claiming done" hard rule. The author runs tests.*
+> *- **L10 — No bead-ids in user-facing skill content.** `SKILL.md` + `reference/` + `patterns/` + `decision-trees/` carry no `rf2-XXXX` references.*
+> *- **L11 — Findings stay local.** Don't commit `ai/` or `findings/` content.*
+>
+> *Frontmatter — the `description` is "pushy" per Anthropic best practice. List every re-frame2 surface that should trigger discovery: `reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, frames, regions, tags, managed HTTP, RemoteData lifecycles. Plus natural-language phrases: "writing tests for a re-frame2 app", "state-machine-for-HTTP shapes". Carve out the adjacent skills (`re-frame-pair2`, `re-frame2-setup`) explicitly so the AI routes correctly.*
+>
+> *Voice: tight, declarative, recipe-shaped. Use tables for routing; use code blocks for canonical shapes. Cite `implementation/<file>:<line>` in leaves where a surface claim might surprise an AI working from training memory.*
+>
+> *Don't:*
+>
+> *- Don't quote spec text for API surface — that's L1.*
+> *- Don't write `*.md` documentation outside `skills/re-frame2/`.*
+> *- Don't commit `ai/` or `findings/` content.*
+> *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
+> *- Don't write a verification leaf or a verify-before-done hard rule.*
+> *- Don't include bead-ids in user-facing leaves — only in `spec/` (workflow tracking).*
+>
+> *Open the PR with title `feat(skills): re-frame2 — authoring-only skill for writing re-frame2 CLJS code`. PR body lists: the skill structure, the file LoC table, the locks applied, the relationship to the adjacent skills (setup / migration / pair2 / implementor).*
+
+## Notes on the reauthoring contract
+
+- The prompt above is a one-shot — feed it to a fresh session, it produces the skill.
+- The prompt assumes the session has read access to the repo. It does not assume any out-of-repo context.
+- The prompt does **not** ask the session to verify the resulting skill — Mike reads the PR and comments.
+- If `implementation/**` has changed significantly between authoring passes, the leaves' code snippets need re-verification. A reauthoring session walks the implementation afresh.
+
+## When to re-author
+
+- A new registry kind ships in re-frame2 (e.g. a new `reg-X` surface) → the existing leaves' organisation may be wrong; rebuild the routing.
+- A new canonical pattern is named in `spec/Pattern-*.md` → add to `patterns/` and `decision-trees/pick-a-pattern.md`.
+- The Q14 lock or any of L1-L11 changes → the design itself changes; this `spec/` folder needs updating first, then the skill.
+- Anthropic skill conventions change materially → reauthor against the new conventions.
+
+Otherwise, edit the existing leaves directly; reauthoring from scratch is for major-version updates.

--- a/skills/re-frame2/spec/design.md
+++ b/skills/re-frame2/spec/design.md
@@ -1,0 +1,137 @@
+# re-frame2 — Design
+
+The design rationale and locked decisions for the `re-frame2` skill. A future agent could re-author this skill from this folder alone.
+
+## 1. Goal
+
+Help an AI write working re-frame2 ClojureScript application code while spending as little context as possible. Output is `.cljs` / `.cljc` source that compiles, runs, and passes the author's tests. The skill is not a conceptual overview, not a learning guide, not marketing — every decision is judged against: *does this make it more likely the AI produces correct, idiomatic re-frame2 code on the first attempt without burning more context than the task warrants?*
+
+## 2. Pillars (locked)
+
+1. **Correctness — recipes over explanations.** Operationalised guidance ("use a machine when X") over abstract principles. The AI reaches for a canonical shape, doesn't derive one. **Q14 lock applies: NO verification module** — no `reference/verify.md`, no "verify before claiming done" hard rule. The author runs tests; the skill stops at writing the code.
+2. **Idiomaticness — verified against `implementation/**` + `examples/reagent/**`.** The CLJS reference is the source of truth for *what the API is*. The spec corpus is *why*; it's never quoted for surface claims.
+3. **Context economy — distillation discipline.** `SKILL.md` is a router; one-level-deep leaves carry the depth. Every line costs context every time it loads. SKILL.md targets ~300-400 lines (under Anthropic's 500-line ceiling); reference / pattern leaves target ~150, ceiling 250.
+4. **Assume training knowledge — teach only the re-frame2 binding.** The AI already knows what WebSockets, FSMs, optimistic updates, and HTTP retry are. The skill's job is to bridge that to the specific re-frame2 features (`reg-machine`, `:rf.http/managed`, `:fsm/parallel-regions`, etc.). The **cut-test**: if a sentence could be written about React, Vue, or Elm unchanged, it belongs in training data, not this skill.
+
+## 3. Locked decisions
+
+These are not up for re-litigation. A future authoring pass MUST preserve them unless explicitly unlocked by Mike.
+
+### L1 — Implementation is ground truth
+
+For every code snippet in a leaf, the surface (function name, arity, options keyword set) is verified against `implementation/**`. If the spec says X and `implementation/<feature>/src/...` says Y, the implementation wins and a `bd` bead gets filed against the spec.
+
+### L2 — Examples in `examples/reagent/<x>/` are canonical
+
+When a pattern has a worked example, the leaf points at it and matches its shape. The example reflects the implementation as currently shipped.
+
+### L3 — Q14 — NO verification module
+
+Per `ai/findings/re-frame2-skill-design-v2.md` §Q14: the skill does not teach the agent to verify its own output. No `reference/verify.md`, no "verification mandatory before done" hard rule in SKILL.md. The AI applies the recipes; the author runs the tests, the compiler, the app. Running tests is general software practice — Pillar 4 says don't teach what the AI already knows.
+
+### L4 — Two-level routing only
+
+SKILL.md → reference leaf (or pattern leaf, or decision-tree leaf). No SKILL → A → B chains. Every leaf is one level deep so it can be reached with one read.
+
+### L5 — Patterns are recipes, not tutorials
+
+Each `patterns/*.md` opens with load triggers, gives the canonical mini-declaration, names the re-frame2 features used, lists trade-offs, and links to the worked example. No conceptual overviews of HTTP / WebSockets / forms — Pillar 4 forbids it.
+
+### L6 — `:rf/*` namespace is reserved
+
+Application keywords use the app's own namespace (`:cart/`, `:auth/`); `:rf/*` and `:rf.machine/*` / `:rf.epoch/*` / `:rf.http/*` / `:rf.error/*` are framework-owned. This rule lands in SKILL.md cardinal rules so it's read on every load.
+
+### L7 — `reg-*` macros over `register-*` functions
+
+The macros capture source-coords that re-frame-pair2 and re-frame-10x rely on. Functional registrations exist for programmatic / generated cases; recipes always reach for the macro.
+
+### L8 — Frames before globals
+
+Code talks to a frame. Default is `:rf/default`; multi-frame apps pass `{:frame :stories}`. Recipes never import frame internals, never bypass `dispatch` / `subscribe` to mutate state.
+
+### L9 — Schemas at boundaries, not everywhere
+
+`reg-app-schema` is registered for the paths that cross trust boundaries (incoming HTTP payloads, persisted state on restore, machine snapshot restores). Internal slices are not schema-fenced by default.
+
+### L10 — No bead-ids in user-facing skill content
+
+`SKILL.md` and the `reference/` / `patterns/` / `decision-trees/` leaves carry no `rf2-XXXX` references. Bead ids are workflow-tracking and would distract the agent using the skill. This `spec/` folder may reference beads; user-facing leaves do not.
+
+### L11 — Findings stay local
+
+Per Mike's standing memory rule "Findings is local-only" — design exploration happens in `ai/findings/`; never committed. This skill's commits contain only `skills/re-frame2/**`.
+
+## 4. Audience and scope
+
+### In scope
+
+- ClojureScript application authors writing re-frame2 code.
+- The `reg-*` family — `reg-event-{db,fx,ctx}`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`.
+- The canonical patterns — RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection.
+- Frames, regions, tags, machine snapshots, the event-state cycle.
+- Test-authoring (`reset-runtime-fixture`, `dispatch-sync`, `compute-sub`, `with-frame`).
+
+### Out of scope
+
+- **Framework implementation** (how the registrar dispatches, how the machine compiler works) — routes through `SKILL-REDIRECT.md` to EP design.
+- **Greenfield project setup** — `skills/re-frame2-setup/`.
+- **v1→v2 migration** — `skills/re-frame-migration/`.
+- **Live-runtime inspection** — `skills/re-frame-pair2/`.
+- **Building re-frame2 in a different host** — `skills/re-frame2-implementor/`.
+- **Non-CLJS hosts** — the spec is host-agnostic; the skill is not.
+
+## 5. File structure (locked)
+
+```
+skills/re-frame2/
+├── SKILL.md                     (router; ~180 lines)
+├── README.md                    (human-facing intro)
+├── LICENSE                      (MIT)
+├── package.json                 (npm metadata)
+├── examples-map.md              (pattern → worked-example cross-ref)
+├── reference/
+│   ├── fundamentals/            (events, fx, cofx, subs, schemas, frames, event-state-cycle, project-structure)
+│   ├── state-machines/          (reg-machine, regions, tags, invoke, cancellation)
+│   ├── tooling/                 (stories, routing)
+│   └── cross-cutting/           (testing, api-cheatsheet)
+├── patterns/                    (one leaf per canonical pattern)
+├── decision-trees/              (pick-a-pattern, slice-or-machine)
+├── evals/                       (eval harness inputs)
+└── spec/
+    ├── design.md                (this file)
+    ├── inputs.md                (canonical inputs)
+    └── authoring-prompt.md      (one-shot reauthor prompt)
+```
+
+Each reference / pattern / decision-tree leaf is ≤250 lines, target ~150. A typical authoring session reads SKILL.md (~180) + one reference leaf (~150) + one pattern leaf (~150) ≈ ~480 LoC — well under any reasonable context budget.
+
+## 6. Discovery surface (frontmatter `description`)
+
+The `description` is "pushy" per Anthropic best practice — it lists every re-frame2 surface that should trigger discovery: `reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, `frames`, `regions`, `tags`, `managed HTTP`, `RemoteData lifecycles`, plus the natural-language framing "writing tests for a re-frame2 app". The description also explicitly carves out the adjacent skills (`re-frame-pair2`, `re-frame2-setup`) so the AI routes correctly.
+
+## 7. Anti-patterns the skill explicitly resists
+
+- **Re-deriving canonical shapes from first principles.** Cardinal rule "recipes over explanations" + Pillar 1.
+- **Loading three or more leaves for one task.** SKILL.md's loading-map rule: at most two leaves; if a task seems to need three, the request likely spans patterns and should be broken up.
+- **Quoting spec text for API surface.** L1 — the spec is *why*, not *what*.
+- **Using `:rf.*` for application keywords.** Cardinal rule L6.
+- **Schema-fencing every internal key.** Cardinal rule L9.
+- **Bypassing `dispatch` / `subscribe` to mutate state.** Cardinal rule L8 — frames before globals.
+- **Authoring against re-frame v1 idioms by recall.** SKILL.md "How re-frame2 differs from re-frame v1" section: don't re-derive v1 mappings; route to `skills/re-frame-migration/`.
+
+## 8. Why this design diverges from `re-frame-migration`
+
+- **Patterns are first-class** — the migration skill is a workflow over a rule corpus; this skill is a library of authoring recipes.
+- **Decision trees are first-class** — pick-a-pattern + slice-or-machine are the two recurring decisions; the migration skill has only "Type A or Type B?".
+- **`examples-map.md`** — pattern → example cross-reference; the migration skill has no examples surface.
+- **No kickoff prompt** — the AI is already engaged in authoring when this skill loads; there's nothing to bootstrap.
+
+## 9. Open questions (deferred to Mike)
+
+### OQ1 — Should the skill ship eval cases as part of `evals/`?
+
+A growing `evals/` set of input/output pairs would let the skill be regression-tested as the implementation evolves. Status: deferred — `evals/` is bootstrapped but not yet load-bearing.
+
+### OQ2 — When to split per-feature skills out of this one?
+
+Some patterns (state machines, managed HTTP) are growing. A future split into `re-frame2-machines/` or `re-frame2-http/` is possible. Status: not until any single leaf exceeds ~400 LoC consistently.

--- a/skills/re-frame2/spec/inputs.md
+++ b/skills/re-frame2/spec/inputs.md
@@ -1,0 +1,78 @@
+# re-frame2 — Inputs
+
+The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
+
+## 1. Primary input — `implementation/**`
+
+Path: `implementation/core/src/re_frame/**`, `implementation/reagent/src/re_frame/**`, plus per-feature artefacts (`implementation/machines/`, `implementation/routing/`, `implementation/flows/`, `implementation/http/`, `implementation/ssr/`, `implementation/schemas/`, `implementation/epoch/`).
+
+**This is the source of truth.** Every code snippet in `reference/` and `patterns/` is verified against the implementation — the function signatures, the macro shapes, the keyword option sets, the late-bind hook contracts. When the spec disagrees with the implementation, the implementation wins and a `bd` bead is filed against the spec.
+
+Specific files the leaves lean on:
+
+- `implementation/core/src/re_frame/core.cljc` — the public single-import API surface (`reg-event-*`, `reg-sub`, `dispatch`, `subscribe`, `with-frame`, `bound-dispatcher`, etc.).
+- `implementation/core/src/re_frame/frame.cljc` — `reg-frame`, `make-frame`, `destroy-frame`, frame metadata grammar, `:fx-overrides`.
+- `implementation/core/src/re_frame/fx.cljc` — `do-fx`, `:fx-overrides` resolution (id-redirect + fn-value branches), per-call vs per-frame merge.
+- `implementation/core/src/re_frame/events.cljc` + `router.cljc` — event-state cycle, effect-shape policing.
+- `implementation/core/src/re_frame/subs.cljc` — sub graph, layered subs, dynamic args.
+- `implementation/core/src/re_frame/test_support.cljc` — `reset-runtime-fixture`, `dispatch-sequence`, `assert-state`, `compute-sub`, `subscribe-value`, `run-test-sync`.
+- `implementation/core/src/re_frame/substrate/plain_atom.cljc` — JVM-side adapter.
+- `implementation/reagent/src/re_frame/adapter/reagent.cljs` — `frame-provider`, plain-Reagent-fn warning.
+- `implementation/machines/src/re_frame/machines.cljc` — `reg-machine`, `:invoke`, parallel regions, tags.
+- `implementation/http/src/re_frame/http.cljc` — `:rf.http/managed`, failure categories, request stubs.
+
+## 2. Secondary input — `examples/reagent/**`
+
+The worked example for each pattern. Used both as a source of truth for canonical shape and as the destination the leaves point at ("read this for the full worked example").
+
+- `examples/reagent/counter/` — the smallest end-to-end app (event-state cycle).
+- `examples/reagent/login/` — Forms pattern.
+- `examples/reagent/boot/` — Boot pattern.
+- `examples/reagent/nine_states/` — NineStates pattern.
+- `examples/reagent/managed_http_counter/` — ManagedHTTP pattern.
+- `examples/reagent/long_running_work/` (pending) — LongRunningWork pattern.
+- `examples/reagent/websocket/` (pending) — WebSocket pattern.
+
+When an example doesn't yet exist, the relevant pattern leaf inlines a mini-declaration and flags "example app pending".
+
+## 3. Tertiary input — `spec/**`
+
+Used for *why*, not *what*. The leaves cite EPs by name for design rationale (frames, state machines, schemas, instrumentation) but do not quote API surface from the spec — that comes from `implementation/**`.
+
+- `spec/000-Vision.md` — the AI-first design principles; SKILL.md's cardinal-rules framing.
+- `spec/001-Registration.md` — registry kind taxonomy; reserved-namespace rule (cardinal rule L6 / L7).
+- `spec/002-Frames.md` — `:fx-overrides` value shapes, frame-resolution chain, preset expansion.
+- `spec/005-StateMachines.md` — `:invoke`, parallel regions, tags, cancellation cascade.
+- `spec/008-Testing.md` — the `reset-runtime-fixture` contract, test-frame conventions.
+- `spec/009-Instrumentation.md` — `:rf/op` vocabulary, `:rf.error/*` shape, error-handler policy.
+- `spec/010-Schemas.md` — `reg-app-schema`, boundary validation, Malli integration.
+- `spec/014-HTTPRequests.md` — `:rf.http/managed`, failure categories, async cascade.
+- `spec/Conventions.md` — naming, keyword namespaces, source-coord conventions.
+- `spec/Pattern-*.md` — one per canonical pattern; the pattern leaves are operationalisations of these.
+
+## 4. Authoring-discipline inputs
+
+These shape the skill's voice and structure but aren't quoted directly.
+
+- **`ai/findings/re-frame2-skill-design-v2.md`** — the design rationale captured during the v2 redesign. Sources Q14 (no verification module), the four pillars, the cut-test, the routing model.
+- **`skills/re-frame-migration/spec/**`** + **`skills/re-frame2-implementor/spec/**`** — the existing `spec/` triad pattern (design / inputs / authoring-prompt). This skill's spec/ mirrors that shape.
+- **`SKILL-REDIRECT.md`** (repo root) — the canonical pointer table the leaves redirect to for deep-dive content.
+- Anthropic skills guidance — `name` ≤ 64 chars, lowercase + hyphens; `description` "pushy"; SKILL.md under ~500 lines; leaves one level deep; avoid time-sensitive content (deferred to lookup leaves like `reference/deps-versions.md` in the sibling setup skill).
+
+## 5. What the skill does NOT consume
+
+- **`docs/guide/**`** — the narrative human guide. The skill is for AI agents authoring code; the guide is for humans learning the framework. Cross-references run through `SKILL-REDIRECT.md`, not into the guide directly.
+- **`docs/EPs/**`** — EP rationale documents. The leaves cite EPs by name but don't quote them.
+- **`tests/**`** — re-frame2's own test suite. The test-authoring leaf points at `re-frame.test-support` (the public surface), not at how that surface is tested internally.
+- **`tools/**`** — re-frame2's tooling (bd, claudia, etc.). Out of scope for application-authoring guidance.
+
+## 6. Update procedure
+
+When implementation changes land:
+
+1. **New `reg-*` surface added** → add a row to the relevant fundamentals leaf or add a new leaf if a new registry kind is introduced.
+2. **Existing `reg-*` option set changed** → grep `reference/` and `patterns/` for the surface, update every occurrence; file a `bd` bead if the spec lags.
+3. **New canonical pattern added** → write a new `patterns/<name>.md`, add an entry to SKILL.md's pattern table and to `decision-trees/pick-a-pattern.md`. Add a row to `examples-map.md` if a worked example exists.
+4. **Example app moved or renamed** → update `examples-map.md` and every pattern leaf that points at it.
+5. **Spec adds a new EP** → update `SKILL-REDIRECT.md` (the pointer table); add a leaf only if there's a corresponding `reg-*` surface AI agents would author against.
+6. **Reserved-namespace addition** (new `:rf.*/` prefix) → update cardinal rule L6 in SKILL.md if the namespace is one application authors would plausibly try to use.


### PR DESCRIPTION
Bundles four small Skills follow-ups from the 2026-05-12 correctness audit (Review (d)).

## Summary

- **rf2-hmyh (P2)** — Surface the `:fx-overrides` fn-value branch in `skills/re-frame2/reference/cross-cutting/testing.md` (new \"Per-call function value\" subsection with two worked examples — an `:app/persist` recorder and a `:rf.http/managed` stub that dispatches `:on-success`) and clarify both shapes in `skills/re-frame2/reference/fundamentals/frames.md`. Per the closed rf2-ngdp, `implementation/core/src/re_frame/fx.cljc:62-142` now honours the fn-value branch alongside the id-redirect branch.

- **rf2-kvoz (P2)** — Cite `:rf.trace/trigger-handler` on every `:rf.error/*` trace. Adds an \"Errors carry the triggering handler's source-coord\" section to `skills/re-frame2/reference/fundamentals/event-state-cycle.md`; adds the same pointer to `skills/re-frame-pair2/references/errors.md`; adds a new \"Explain this error\" recipe to `skills/re-frame-pair2/references/recipes.md`. Per the closed rf2-3nn8, the field is present whenever a handler is in scope (event/sub/fx/cofx/view/interceptor/late-bind) and is NOT elided in production.

- **rf2-ze2s (P2)** — Adds the per-tool `spec/` folder (design.md + inputs.md + authoring-prompt.md) for the four skills missing it: `re-frame2`, `re-frame2-setup`, `re-frame-pair2`, `re-frame-pair-improver2`. Each triad mirrors the existing one in `re-frame-migration` and `re-frame2-implementor` — pillars, locked decisions, audience/scope, file structure, anti-patterns, and a self-contained one-shot reauthoring prompt. 12 new files, ~50-170 lines each.

- **rf2-0ubu (P3)** — Adds reciprocal pointers to `skills/re-frame2-implementor/` from `skills/re-frame2-setup/SKILL.md` (new row in the \"When NOT to use this skill\" routing table) and `skills/re-frame-pair2/SKILL.md` (footer sentence alongside the existing setup + re-frame2 cross-links). `re-frame2-implementor` already routes back to both — this closes the loop.

## Files touched

- New (12): `skills/{re-frame2,re-frame2-setup,re-frame-pair2,re-frame-pair-improver2}/spec/{design,inputs,authoring-prompt}.md`
- Modified (7): testing.md, frames.md, event-state-cycle.md (re-frame2); errors.md, recipes.md, SKILL.md (re-frame-pair2); SKILL.md (re-frame2-setup)

19 files changed, 1380 insertions(+), 2 deletions(-).

## Verification

- Each example in the new prose was checked against current re-frame2 surfaces: the fn-branch signature `(fn [m args] ...)` matches `fx.cljc:240`; the `:rf.http/managed` stub follows `spec/002-Frames.md:1076-1082` (dispatches `:on-success` as an event vector, not a callback fn).
- `:rf.trace/trigger-handler` shape verified against `spec/Spec-Schemas.md` + the locked Q1-Q4 shape from rf2-3nn8.
- Per-tool spec/ files modeled on `skills/re-frame-migration/spec/` and `skills/re-frame2-implementor/spec/`.
- No bead-id references in user-facing skill prose (only in this PR description and in the new spec/ folders, where workflow tracking is appropriate).