### PR TITLE
docs(tools): add per-tool spec/README.md index for navigability (rf2-t0da)

### DIFF
--- a/tools/10x/spec/README.md
+++ b/tools/10x/spec/README.md
@@ -1,0 +1,24 @@
+# Causa (re-frame-10x v2) — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — Causa, the re-frame2 devtools panel; the five canonical questions an app's programmer should answer in seconds.
+- **[001-Causality-Graph.md](001-Causality-Graph.md)** — Causality graph as a peer panel — the deeper-walk view when a cascade spans frames or 30+ events.
+- **[002-Time-Travel.md](002-Time-Travel.md)** — Bottom-rail time-travel scrubber: walk history without disturbing the live app; rewind is explicit and confirmed.
+- **[003-Machine-Inspector.md](003-Machine-Inspector.md)** — Stately-quality state-chart per registered machine, embedded via `tools/machines-viz/`.
+- **[004-App-DB-Diff.md](004-App-DB-Diff.md)** — Slice-centric (not tree-centric) `app-db` panel: only the slices that changed this epoch, plus pinned watches.
+- **[005-Schema-Timeline.md](005-Schema-Timeline.md)** — Temporal surface for silent schema-violation traces from Spec 010 + Spec 009.
+- **[006-Hydration-Debugger.md](006-Hydration-Debugger.md)** — SSR hydration-mismatch debugger: renders the structured Spec 011 emissions no other JS devtool surfaces.
+- **[007-UX-IA.md](007-UX-IA.md)** — Typography, colour tokens, animation timings, keyboard maps, density gradients — the pixels-that-feel-right reference.
+- **[008-Embedding-Contract.md](008-Embedding-Contract.md)** — Per-panel `Panel` component contract so Story (and others) can embed Causa surfaces outside Causa's own chrome.
+- **[009-AI-CoPilot.md](009-AI-CoPilot.md)** — Pull-only Q&A and slash-command surface: never narrates, never authors code, always cites verifiable runtime data.
+- **[010-MCP-Server.md](010-MCP-Server.md)** — Separate `tools/10x-mcp/` jar exposing Causa's surfaces as MCP tools for AI agents.
+- **[011-Launch-Modes.md](011-Launch-Modes.md)** — In-app overlay (`Ctrl+Shift+C`) and standalone-via-MCP remote-attach.
+- **[API.md](API.md)** — Consolidated user-facing reference: installation, configuration, public surface; per-area specs are normative.
+- **[Principles.md](Principles.md)** — Causa-specific load-bearing principles (read-only-by-default, etc.); cites framework `Principles.md` where they overlap.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — The 13 direction-setting decisions: question, options, pick, why, date locked.
+- **[findings/](findings/)** — Exploratory working substrate (Causa UX/UI design, 10x-v2 blank-slate design); audit lineage, not normative.
+
+## How to use
+
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor *why*; the capability docs (001–011) are normative — each owns its surface and is independent of the others bar explicit cross-references. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated reference. `findings/` preserves the audit lineage and is never normative.

--- a/tools/pair2-mcp/spec/README.md
+++ b/tools/pair2-mcp/spec/README.md
@@ -1,0 +1,16 @@
+# re-frame-pair2 MCP server — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — Why an MCP server beats the bash-shim chain: pay cold-connect cost once per session, not per op (~700ms → ~5–50ms).
+- **[001-Wire-Protocol.md](001-Wire-Protocol.md)** — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec; framed by `@modelcontextprotocol/sdk`.
+- **[002-nREPL-Transport.md](002-nREPL-Transport.md)** — Persistent TCP socket to `127.0.0.1:<nrepl-port>`; multiplexed by UUID `id`; held for session lifetime.
+- **[003-Tool-Catalogue.md](003-Tool-Catalogue.md)** — The seven MCP tools mirroring the bash-shim catalogue: `discover-app`, plus six more.
+- **[API.md](API.md)** — Consolidated user-facing reference for installing, configuring, launching, and calling pair2-mcp.
+- **[Principles.md](Principles.md)** — pair2-mcp-specific load-bearing principles, downstream of framework `Principles.md`.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Direction-setting decisions: question, options, pick, why, date locked.
+- **[findings/](findings/)** — Exploratory working substrate; audit lineage, not normative.
+
+## How to use
+
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor *why*; the capability docs (001–003) are normative — they own the wire protocol, nREPL transport, and tool catalogue respectively. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated reference where the per-area specs win on drift. `findings/` preserves the audit lineage and is never normative.

--- a/tools/story-mcp/spec/README.md
+++ b/tools/story-mcp/spec/README.md
@@ -1,0 +1,15 @@
+# Story-MCP — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — What `day8/re-frame2-story-mcp` is, why it ships as a separate jar from `day8/re-frame2-story`, and how it relates to Story's runtime and the Tool-Pair contract.
+- **[001-Wire-Protocol.md](001-Wire-Protocol.md)** — JSON-RPC 2.0 over stdio; the `initialize` handshake; `tools/list` + `tools/call`; the protocol-version pin.
+- **[002-Tool-Registry.md](002-Tool-Registry.md)** — The 16 tools across four categories (Dev / Docs / Testing / Write) — one paragraph orientation per tool.
+- **[003-Write-Surface-Gating.md](003-Write-Surface-Gating.md)** — The `:rf.story-mcp/allow-writes?` config gate: what's gated, how it errors clean rather than no-ops.
+- **[API.md](API.md)** — Consolidated tool surface: per-tool input schema, output shape, error mode; cross-links to the category doc.
+- **[Principles.md](Principles.md)** — story-mcp-specific load-bearing principles, downstream of framework + Story principles.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major design call was made: Cheshire over data.json, independent stage marker, pinned protocol version, opt-in write gate.
+
+## How to use
+
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor the separate-jar choice and the Story-core boundary; the capability docs (001–003) are normative — they own the wire protocol, the tool registry, and the write-surface gating. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated tool-surface reference; per-area specs win on drift. The companion Story surface contract lives at [`../../story/spec/006-MCP-Surface.md`](../../story/spec/006-MCP-Surface.md).

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -1,0 +1,20 @@
+# Story (`day8/re-frame2-story`) — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — What re-frame2-story is for, what it deliberately isn't, and how it relates to the framework's normative [`spec/007-Stories.md`](../../../spec/007-Stories.md).
+- **[001-Authoring.md](001-Authoring.md)** — Registration surface: the seven `reg-*` macros, EDN-first variant contract, inclusion-tag vocabulary, source-coord stamping, macro-time validation.
+- **[002-Runtime.md](002-Runtime.md)** — Per-variant frame allocation; args-precedence resolution; decorator composition; four-phase loader lifecycle; `run-variant` / `reset-variant` / `watch-variant` / `snapshot-identity` / `destroy-variant!`.
+- **[003-Render-Shell.md](003-Render-Shell.md)** — The UI: sidebar, canvas, controls, workspaces, scrubber, trace; five workspace layouts; hot-reload decorator fingerprinting; `mount-shell!` / `unmount-shell!` / `active-shell`.
+- **[004-Assertions.md](004-Assertions.md)** — The seven canonical `:rf.assert/*` events with record-don't-throw semantics; play-sequence execution; `force-fx-stub` decorator.
+- **[005-SOTA-Features.md](005-SOTA-Features.md)** — Layout-debug overlays; a11y axe-core panel; per-variant QR share; multi-substrate side-by-side; 10x epoch embed stub; production elision under `:advanced`.
+- **[006-MCP-Surface.md](006-MCP-Surface.md)** — The boundary between Story and `tools/story-mcp/`; surfaces Story exposes for the MCP jar; late-bind `reg-story-panel` for tooling embeds.
+- **[007-Mode-Tabs.md](007-Mode-Tabs.md)** — The render-shell's top-of-canvas `:dev` / `:docs` / `:test` switcher; the chrome-level primitive every 2026 component playground ships (rf2-9hc8).
+- **[API.md](API.md)** — Consolidated public surface for `day8/re-frame2-story`: every `reg-*`, every fn, every fx-id, every cofx-id.
+- **[Principles.md](Principles.md)** — Story-specific non-negotiables — EDN-first first among them — the test new features pass against.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major call was made; the seven rf2-m6tu §6 decisions plus Phase-2 SOTA additions and IMPL-SPEC-emergent calls.
+- **[findings/](findings/)** — Feature-set research and SOTA refinement working substrate; audit lineage, not normative.
+
+## How to use
+
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor scope and the relationship to framework [`spec/007-Stories.md`](../../../spec/007-Stories.md); the capability docs (001–007) are normative — Stage 2 implements 001, Stage 3 implements 002, and so on. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated public-surface reference. `findings/` preserves the audit lineage and is never normative.

--- a/tools/template/spec/README.md
+++ b/tools/template/spec/README.md
@@ -1,0 +1,15 @@
+# Template (`day8/clj-template.re-frame2`) — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — The v2 equivalent of v1's `day8/re-frame-template`: front-door scaffolding tool for new re-frame2 apps via clj-new.
+- **[001-Substrate-Variants.md](001-Substrate-Variants.md)** — The three substrate variants (`:reagent` default, `:uix`, `:helix`); invocation form; `:edn-args` plumbing rationale.
+- **[002-Generated-Shape.md](002-Generated-Shape.md)** — File layout the template emits; resource tree it reads from; substitution variables threaded through.
+- **[API.md](API.md)** — Consolidated public surface: every invocation form, every argument, every supported flag.
+- **[Principles.md](Principles.md)** — Template-specific design principles (build-time only, never on consumer classpath); WHY for the major decisions lives in DESIGN-RATIONALE.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY behind 000 / 001 / 002 / Principles / API; clj-new over deps-new; beads referenced as rf2-xxxx.
+- **[findings/](findings/)** — Exploratory working substrate; audit lineage, not normative.
+
+## How to use
+
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor scope (clj-new template, build-time-only, alpha-channel `day8/re-frame2-*` coords); the capability docs (001–002) are normative — they own the substrate-variants matrix and the generated file shape. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated invocation reference. `findings/` preserves the audit lineage and is never normative.


### PR DESCRIPTION
## Summary

- Adds a `spec/README.md` index to each of the five `tools/*/spec/` folders so the per-tool spec convention has a single-read navigation entry point.
- Each README lists every spec file with a one-line teaser populated from the file's actual first heading + opening prose (nothing fabricated), then a brief "How to use" paragraph anchoring the reading order: `000-Vision` first, capability docs (00N) normative, `Principles` + `DESIGN-RATIONALE` for the locks, `findings/` as audit lineage.
- Touches only `tools/*/spec/README.md` — 5 new files, 90 lines total, no edits to any existing spec.

## Files

- `tools/10x/spec/README.md` — 24 lines, 12 capability docs + companions
- `tools/pair2-mcp/spec/README.md` — 16 lines, 3 capability docs
- `tools/story-mcp/spec/README.md` — 15 lines, 3 capability docs
- `tools/story/spec/README.md` — 20 lines, 7 capability docs
- `tools/template/spec/README.md` — 15 lines, 2 capability docs

## Test plan

- [ ] Render each README on GitHub and verify every relative link resolves to a real file in the same folder (or the expected cross-folder target for `tools/story/spec/006-MCP-Surface.md` etc.).
- [ ] Confirm teasers accurately reflect each spec file's opening (spot-check 2–3 per tool).
- [ ] Confirm no existing spec file was modified — `git diff origin/main --stat` should show only the 5 new files.