### PR TITLE
docs(spec): port-omission carve-out + drain! destroyed-check + :rf.frame/* namespace split (rf2-lsl2, rf2-16u8, rf2-jo95)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -225,8 +225,12 @@ Use case: production single-frame app; multi-instance widgets.
 
 | Expansion key | Value | Why |
 |---|---|---|
-| `:fx-overrides` | `{:rf.http/managed :rf.http/managed-canned-success}` | The canonical Spec 014 HTTP fx is redirected to its canned-success stub so test frames don't reach the network. Test code that needs richer stubbing (clock-controlled timers, navigation no-ops) supplies its own `:fx-overrides` per-call or per-frame; the framework does not ship `:rf.test/*` fxs in the v1 closed set. |
+| `:fx-overrides` | `{:rf.http/managed :rf.http/managed-canned-success}` | The canonical Spec 014 HTTP fx is redirected to its canned-success stub so test frames don't reach the network. Test code that needs richer stubbing (navigation no-ops, etc.) supplies its own `:fx-overrides` per-call or per-frame; the framework does not ship `:rf.test/*` fxs in the v1 closed set. |
 | `:drain-depth` | `100` | Explicit value matches the framework default. Surfaced on the expansion so tooling can read "this is a test frame, drain bounded at 100" from `(frame-meta <id>)` without inspecting the global default. |
+
+**Port-omission carve-out.** The `:fx-overrides` entry above redirects a Spec 014 fx-id. Implementations that omit Spec 014 do not register `:rf.http/managed` and therefore cannot redirect it — on such ports the `:test` preset's `:fx-overrides` expansion is `{}` (empty map). The `:drain-depth` entry is unaffected. Conformance: a port that ships Spec 014 MUST expand `:test`'s `:fx-overrides` to the exact pair above; a port that omits Spec 014 MUST expand it to `{}`. Either way, user-supplied metadata wins on conflict per [§Expansion algorithm](#expansion-algorithm).
+
+**Clock stubbing is host-interop, not preset-level.** Tests that need deterministic time replace the interop layer's `now-ms` provider (per [§Interop layer — clock primitives](#interop-layer--clock-primitives--see-spec-005)) — they do not override an fx-id. Machine `:after` timer wake-ups are not registered as a redirectable fx-id, so `:fx-overrides` cannot reach them; the preset deliberately stays silent on time control.
 
 Use case: per-test fixture frames (per [008-Testing](008-Testing.md)).
 
@@ -843,6 +847,16 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
 (defn drain! [frame]
   (try
     (loop [depth 0]
+      ;; Destroyed-frame check fires BEFORE dequeue (per Edge cases #4 below):
+      ;; on detect, drop the remaining queue, emit `:rf.frame/drain-aborted`
+      ;; with the dropped count, and stop. In-flight events finish
+      ;; (run-to-completion); only events not yet dequeued are dropped.
+      (when (:destroyed? (:lifecycle frame))
+        (let [dropped (count @(:queue (:router frame)))]
+          (reset! (:queue (:router frame)) (clojure.lang.PersistentQueue/EMPTY))
+          (trace! :rf.frame/drain-aborted
+                  {:frame (:id frame) :dropped dropped}))
+        (throw ::halt))
       (when (> depth (:drain-depth (:config frame)))
         (raise! :rf.error/drain-depth-exceeded
                 {:frame (:id frame) :depth depth})

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -14,7 +14,8 @@ The previous v1-and-early-v2 scheme used 14 separate top-level prefixes (`:regis
 | Sub-namespace | Used for | Spec |
 |---|---|---|
 | `:rf/*` | Pattern-level events emitted or consumed by the framework (e.g. `:rf/hydrate`, `:rf/server-init`); reserved app-db keys (`:rf/machines`, `:rf/route`); pattern-level effect-map keys; the universal default frame id (`:rf/default`) | 002 / 011 / 012 |
-| `:rf.frame/*` | Frame lifecycle traces and anonymous gensym'd frame ids (e.g. `:rf.frame/123`) | 002 |
+| `:rf.frame/<gensym>` | Anonymous frame-identifier namespace, owned by `make-frame` (e.g. `:rf.frame/123` for a gensym'd frame id). | 002 |
+| `:rf.frame/<operation>` | Frame-lifecycle trace-operation namespace, owned by the router and frame lifecycle (e.g. `:rf.frame/drain-aborted`, `:rf.frame/destroyed`). | 002 / 009 |
 | `:rf.registry/*` | Registrar mutation trace operations (`:rf.registry/handler-registered`, `:rf.registry/handler-cleared`, `:rf.registry/handler-replaced`) | 001 / 009 |
 | `:rf.fx/*` | Effect-resolution advisories (`:rf.fx/skipped-on-platform`, `:rf.fx/override-applied`); reserved fx-ids in machine `:fx` (`:rf.fx/spawn-args`) | 002 / 009 |
 | `:rf.error/*` | Error trace operations (handler exception, sub exception, fx exception, etc.) | 009 |
@@ -69,7 +70,7 @@ Library-owned prefixes do **not** violate the single-root invariant on framework
 
 ### Discipline
 
-- **User-registered ids must not collide.** A user may not `(reg-event-fx :rf/hydrate ...)` to override a framework event without going through the documented `:on-create` / re-registration extension points. The linter rule is: `:rf/*` and any `:rf.X/*` sub-namespace is reserved.
+- **User-registered ids must not collide.** A user may not `(reg-event-fx :rf/hydrate ...)` to override a framework event without going through the documented `:on-create` / re-registration extension points. The linter rule is: `:rf/*` and any `:rf.X/*` sub-namespace is reserved. The rule applies regardless of the segment shape under the sub-namespace — a user registration of either `:rf.frame/<gensym>` (the identifier form) or `:rf.frame/<operation>` (the trace-operation form) is a collision; both rows above sit inside the same closed reserved set.
 - **Library authors choose their own prefixes.** Third-party libraries SHOULD use their library name as a top-level segment (`:reagent/*`, `:re-pressed/*`). Avoid re-using `:rf/*`.
 - **Trace-event `:operation` vocabulary is open by default.** A library may add its own `:my-lib.error/*` / `:my-lib.fx/*` prefix for advisories it emits — but the framework's reserved set is closed (additive only by Spec change).
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -316,7 +316,8 @@ The canonical category vocabulary is fixed-and-additive (Spec-ulation): existing
 | `:rf.epoch/*` | `:error` | Epoch-history restore failures (per [Tool-Pair §Time-travel](Tool-Pair.md#time-travel)) |
 | `:rf.http/*` | `:warning` / `:info` | Managed-HTTP advisories (key-ignored-on-jvm, retry-attempt) per [014](014-HTTPRequests.md) |
 | `:route.nav-token/*` | `:error` | Stale-result-suppression on async navigation (per [012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression)) |
-| `:rf.frame/*` | `:event` | Frame-lifecycle events (e.g. `:rf.frame/drain-aborted` per [002](002-Frames.md)) |
+| `:rf.frame/<operation>` | `:event` | Frame-lifecycle trace operations emitted by the router and frame lifecycle (e.g. `:rf.frame/drain-aborted`, `:rf.frame/destroyed`) per [002](002-Frames.md). |
+| `:rf.frame/<gensym>` | n/a | Identifier namespace, NOT a trace-operation prefix — anonymous frame ids minted by `make-frame` (e.g. `:rf.frame/123`). Carried as the value of the `:frame` key on trace events, never as the `:operation`. Listed here so consumers parsing operation namespaces don't mis-route a gensym'd frame id as an operation. |
 
 ### Per-category `:tags` schemas
 


### PR DESCRIPTION
## Summary

Three small spec-correctness wording cleanups bundled.

- **rf2-lsl2** — Spec 002 §`:test` preset: add a port-omission carve-out so implementations that omit Spec 014 expand the preset's `:fx-overrides` to `{}` (not the documented `:rf.http/managed -> :rf.http/managed-canned-success` pair, which they cannot redirect). Clarify that clock stubbing is host-interop (`now-ms` provider) rather than preset-level — machine `:after` timer wake-ups are not registered as a redirectable fx-id, so `:fx-overrides` cannot reach them; the preset deliberately stays silent on time control.
- **rf2-16u8** — Spec 002 §`drain!` pseudocode: wire the destroyed-frame check into the loop so the code matches §Edge cases #4's normative claim. Before each dequeue the loop checks `(:destroyed? (:lifecycle frame))`; on detect, drop the remaining queue, emit `:rf.frame/drain-aborted` with the dropped count, and stop. In-flight events finish (run-to-completion).
- **rf2-jo95** — Conventions + Spec-Schemas: the `:rf.frame/*` row conflated two distinct namespaces. Split into `:rf.frame/<gensym>` (identifier namespace, owned by `make-frame`) and `:rf.frame/<operation>` (trace-operation namespace, owned by router and frame lifecycle). Pin the linter rule that both forms sit inside the same closed reserved set, and reconcile Spec-Schemas's reserved-op-namespaces table so consumers parsing operation namespaces don't mis-route a gensym'd frame id as an operation.

## Files touched

- `spec/002-Frames.md` — `:test` preset carve-out (+ clock-stubbing clarification); `drain!` pseudocode destroyed-frame check.
- `spec/Conventions.md` — split `:rf.frame/*` row into `<gensym>` and `<operation>` forms; expand the linter-rule line.
- `spec/Spec-Schemas.md` — split the reserved-op-namespaces table entry for `:rf.frame/*` accordingly.

## Test plan

- [x] `mkdocs build --strict` — zero new warnings introduced (236 baseline -> 236 with changes; diff is only the build-directory path line).
- [x] Diff verified against `origin/main` baseline build output.
- [ ] Reviewer eyeballs the three wording edits against the originating findings (`ai/findings/spec-correctness-audit-2026-05-12.md`).