### PR TITLE
docs(mkdocs): explicitly enable search plugin (rf2-5790)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,15 @@ theme:
     - content.code.annotate
     - content.code.copy
 
+# Material bundles the `search` plugin and enables it by default when no
+# `plugins:` block is declared. We declare it explicitly (rf2-5790) so the
+# search affordance — load-bearing for navigating a 7000+ line guide — stays
+# wired up across future MkDocs/Material versions that may flip the default.
+# Any future plugin addition (e.g. minify, redirects) must keep `- search`
+# in the list, otherwise search silently disappears.
+plugins:
+  - search
+
 extra:
   social:
     - icon: fontawesome/brands/github-alt


### PR DESCRIPTION
## Summary

- Adds an explicit ``plugins: [search]`` block to ``mkdocs.yml``.
- Material currently bundles the search plugin and enables it by default when no ``plugins:`` block is declared, so the published site already shows a working search box — this change locks the behaviour in so future MkDocs/Material default changes can't silently strip search.
- Search is load-bearing for navigating a 7000+ line guide across 20 chapters.

## Verification

- ``mkdocs build --strict`` succeeds both before and after the change.
- ``site/search/search_index.json`` is emitted at 2,912,078 bytes with 1,922 indexed docs (identical before/after).
- Spot-checks against the index find hits for ``frame``, ``dispatch``, and ``machine``.
- ``site/index.html`` includes the Material ``md-search`` markup.

## Test plan

- [x] ``python -m mkdocs build --strict`` runs cleanly on the staged tree.
- [x] ``site/search/search_index.json`` exists and contains expected terms.
- [x] Rendered HTML contains the Material search box markup.

Closes rf2-5790.