### PR TITLE
docs(skills): cross-reference :final? / :on-done from Boot, LongRunningWork, WebSocket patterns (rf2-az9n)

### DIFF
--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -140,6 +140,8 @@ No parallel `:loading?` flag; the machine's state IS the UI signal.
 
 **Re-boot.** Rare but supported — dispatch an event the machine handles from any state (or via a wildcard parent `:on`): `:auth.session/expired {:target :authenticating}`. Most apps re-load the page on session expiry instead.
 
+**Final-state handoff (`:final?` / `:on-done`).** When the boot machine is `:invoke`'d by an outer coordinator (e.g. an SSR shell, an embedding host, or a test harness that needs the boot-done signal), mark `:ready` as `:final?` — the parent's `:invoke` receives `:on-done` synchronously when `:ready` is reached, with the optional `:output-key` carrying e.g. the loaded `:user`. The standalone-singleton form (the canonical shape above) should **NOT** use `:final?`: per `:final?` semantics "final means final", a singleton that reaches a `:final?` leaf auto-destroys, taking the snapshot — and therefore `[:app.boot/phase]` / `[:app.boot/state]` subs — with it. Keep `:ready` as an ordinary terminal leaf (`:meta {:terminal? true}`) when the rest of the app subscribes to the boot snapshot post-handoff. See `../reference/state-machines/invoke.md` §Final states for the full surface (constraints, parallel-region semantics, `:rf.machine/done` trace).
+
 **Parameters — the canonical seam.** The boot machine is the ONLY place that reads host globals (`/config` endpoint, build-time env vars, restored session). Once captured into `:data :config`, subsequent phases thread values forward via Pattern-AsyncEffect mechanism 1 (event payload) or mechanism 2 (spawn-spec `:data` fn). Downstream machines never reach into a global from inside an action body.
 
 ## Anti-patterns
@@ -162,6 +164,7 @@ A narrower instance — single-purpose flow machine, same shape — also lives a
 - Full pattern doc, including the auth-machine worked example for the retry-ownership boundary and SSR handoff details → SKILL-REDIRECT.md → *Pattern — Boot*.
 - Frame `:on-create` semantics (atomic entry point) → SKILL-REDIRECT.md → *EP — Frames (002)*.
 - State-machine substrate (`:invoke`, `:after`, restore semantics) → SKILL-REDIRECT.md → *EP — State machines (005)*.
+- `:final?` / `:on-done` / `:output-key` (when boot is `:invoke`'d) → `../reference/state-machines/invoke.md` §Final states.
 - SSR `:rf/server-init` and hydration handoff → SKILL-REDIRECT.md → *EP — SSR (011)*.
 - The retry-ownership boundary → `patterns/managed-http.md` + SKILL-REDIRECT.md → *EP — HTTP requests (014)*.
 

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -167,6 +167,8 @@ The worker machines themselves are lifecycle-agnostic — they do not know React
 
 **Progress UI from the machine.** Register subs on `[:rf/machine <id>]` and project `:data` fields into the view. Each chunk advances `:data.processed` and the next browser tick renders the new value.
 
+**Final-state child completion (`:final?` / `:output-key`).** The child's `:done` state above uses `:entry :dispatch-done` to hand-roll a `[:work/child-done ...]` dispatch back to the parent — that wiring predates rf2's first-class final-state surface. The cleaner shape marks the child's `:done` as `:final? true` with `:output-key :shard-result` and lets the `:invoke-all` join engine recognise child completion natively; the parent receives the result via `:on-child-done`'s payload without a custom dispatch action, and the auto-destroy fires on the same step. For the single-machine chunked variant, mark `:complete` as `:final?` only when the machine is `:invoke`'d by an outer coordinator — singleton chunked machines that support `:reset` back to `:idle` must keep `:complete` as an ordinary terminal leaf (per "final means final", a singleton hitting `:final?` auto-destroys, so `:on {:reset :idle}` would never get a chance to fire). See `../reference/state-machines/invoke.md` §Final states for the parallel-region join semantics and the `:rf.machine/done` trace contract.
+
 ## Anti-patterns
 
 - **Computing in subscriptions.** Subs should be cheap and pure; long compute belongs in event handlers. A sub that takes seconds slows every render that touches it.
@@ -183,6 +185,8 @@ The worker machines themselves are lifecycle-agnostic — they do not know React
 ## Pointer to the spec
 
 Full rationale — including the `:invoke-all` runtime contract, the join-state map layout, alternative `:join` modes (`:any`, `:n-of`), and the migration table from v1's self-redispatch / `:abandonment-required` flag / `^:flush-dom` — lives in *Pattern — Long-running work* and Spec 005 *State machines* (see `SKILL-REDIRECT.md` at the repo root).
+
+The `:final?` / `:on-done` / `:output-key` surface for child completion (see *Final-state child completion* above) is documented at `../reference/state-machines/invoke.md` §Final states.
 
 ---
 

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -151,6 +151,8 @@ Caller-side:
 
 **SSR.** The connection machine no-ops server-side: `:invoke`'s spawn fx is `:platforms #{:client}`, `:after` timers don't schedule under SSR. The server renders `:disconnected` statically; the client hydrates and starts the connection.
 
+**Final-state termination (`:final?` / `:on-done`).** Two opportunities, both restricted to the *child* role. (1) When the WebSocket machine is itself `:invoke`'d by an outer session machine, a terminal-failed branch (e.g. `:permanently-failed`, distinct from the recoverable `:failed` above) can be marked `:final? true` — the parent's `:invoke` `:on-done` then receives a clean unrecoverable-failure signal with the optional `:output-key` carrying the final `:error`, and the auto-destroy tears down the child without the parent dispatching a custom teardown. (2) A child heartbeat / handshake machine `:invoke`'d from `:connected` (see *Heartbeat* / *Subscription protocol* variations) reaches its own `:expired` or `:handshake-failed` terminal state — marking those `:final?` lets the parent observe the sub-failure via `:on-done` instead of requiring the child to dispatch a custom outbound event. The top-level connection machine itself stays recoverable (no `:final?` on `:failed`) because the canonical shape accepts `:ws/connect` from there. See `../reference/state-machines/invoke.md` §Final states for the constraints (leaf-only, no transitions out) and the `:rf.machine/done` trace contract.
+
 ## Anti-patterns
 
 - **Anchoring `:invoke` on `:connecting` instead of `:active`.** Destroys the socket the moment the leaf transitions to `:authenticating`. Lifetime MUST span all three connection leaves.
@@ -167,6 +169,7 @@ Caller-side:
 
 - Full pattern doc, including request-reply correlation worked example, heartbeat variations, anti-patterns, and SSR composition → SKILL-REDIRECT.md → *Pattern — WebSocket*.
 - The state-machine substrate (`:invoke`, `:after`, `:always`, hierarchical states) → SKILL-REDIRECT.md → *EP — State machines (005)*.
+- `:final?` / `:on-done` / `:output-key` (for child-WS or sub-machine termination) → `../reference/state-machines/invoke.md` §Final states.
 - Connection-epoch idiom (the second use of stale-detection in this pattern) → SKILL-REDIRECT.md → *Pattern — Stale detection*.
 
 ---


### PR DESCRIPTION
## Summary

The final-state surface (`:final?` + `:on-done` + `:output-key` + auto-destroy + `:rf.machine/done` trace, landed via rf2-gn80) is documented in `skills/re-frame2/reference/state-machines/invoke.md` §Final states, but none of the pattern leaves where the feature most naturally applies forward-linked to it. This adds a one-paragraph note plus a Pointers entry to each of the three patterns where the lifecycle fits.

## Per-pattern note shape

Each note (a) names the `:final?` / `:on-done` opportunity in the pattern's context, (b) calls out the caveat where it applies, and (c) forward-links to `../reference/state-machines/invoke.md` §Final states.

- **Boot** — added under *Variations* as *Final-state handoff*. Marks `:ready` `:final?` when the boot machine is `:invoke`'d by an outer coordinator (SSR shell, embedding host, test harness). Caveats the standalone-singleton form: "final means final" auto-destroys the snapshot, taking the `[:app.boot/phase]` / `[:app.boot/state]` subs with it — keep an ordinary terminal leaf in that case.
- **LongRunningWork** — added under *Variations* as *Final-state child completion*. The child's `:done` can be `:final? true` + `:output-key`; the `:invoke-all` join engine reads it natively instead of the hand-rolled `:dispatch-done` action. The single-machine chunked variant only uses `:final?` when invoked by an outer coordinator (a `:reset`-supporting singleton must stay non-final).
- **WebSocket** — added under *Variations* as *Final-state termination*. `:final?` applies to the child role only: (1) a child-WS invoked by a parent session machine on a terminal-failed branch, or (2) a sub-heartbeat / handshake machine reaching its terminal state. The top-level connection machine stays recoverable because the canonical shape accepts `:ws/connect` from `:failed`.

Each pattern's *Pointers* section also gains an entry linking directly to `../reference/state-machines/invoke.md` §Final states.

## Files touched

- `skills/re-frame2/patterns/boot.md` — +3 lines
- `skills/re-frame2/patterns/long-running-work.md` — +4 lines
- `skills/re-frame2/patterns/websocket.md` — +3 lines

No refactoring of the patterns themselves — just cross-reference notes.

## Test plan

- [ ] Confirm the relative link `../reference/state-machines/invoke.md` resolves from each pattern leaf (verified during authoring).
- [ ] Confirm no caveat is wrong — in particular the "singleton hitting `:final?` auto-destroys" claim, which is the load-bearing constraint for the Boot and LongRunningWork notes; cross-checked against invoke.md §Singleton symmetry.