### PR TITLE
docs(guide): polish — animations callout, divider sweep, ch.16 reorder, ch.14 pointer, ch.15 §don't-ship trim (rf2-h9rz, rf2-g9vc, rf2-lhck, rf2-uerb, rf2-33xr)

### DIFF
--- a/docs/guide/06-views-and-frames.md
+++ b/docs/guide/06-views-and-frames.md
@@ -159,6 +159,8 @@ If there is no synthetic-event surface for what you need — `setTimeout`, `fetc
 
 Animation is a view-layer concern, but it follows the same rule the rest of this chapter has been making: **state is the truth; the view animates the transition; animation completion is silent unless explicitly modelled in state.** Three regimes cover the space; the regime is chosen by what state actually needs to know.
 
+> **Skim on first read** — animations split into three regimes; come back when you reach for one.
+
 > **Transitions — the 95% case.** State changes; the view re-renders with a different `:class` or `:style`; CSS (or the substrate's animation engine) completes the visual transition silently. No completion event needed — by the time the animation kicks off, `app-db` has already moved on; the visual is catching up. Opacity fades, slide-in / slide-out, accordion expand, list reorder, modal scrim, route transitions all fit. The view binds `:class` / `:style` from a sub; CSS does the interpolation.
 
 > **Continuous loops — physics, games, scroll inertia.** Per-frame state mutation IS the truth. The right shape is a registered fx (e.g. `:ui/raf-loop`) that owns the `requestAnimationFrame` cycle and dispatches a per-frame event carrying delta-time. The fx captures the frame at registration; the event handler updates state; the view renders. Cancellation is a sibling fx that cancels the RAF handle. This is [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md) with `requestAnimationFrame` substituted for HTTP — same six-step shape, same frame-capture discipline.

--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -87,6 +87,8 @@ Two naming conventions worth knowing:
 
 The convention is **stable** and **additive**: new categories adopt one of the five existing prefixes; existing names are never renamed or repurposed.
 
+> **Skim on first read** — the six §Common scenarios are reference for when you hit them; on a linear read, glance at the table and head to §Testing error paths.
+
 ## Listening for errors at runtime
 
 The trace stream is the canonical surface. To attach a listener:
@@ -235,6 +237,12 @@ The projector is the **canonical surface** for mapping raw errors to user-facing
 Full details — when the projector runs, what `:rf/public-error` requires, server-side error events, sanitisation guarantees — live in [Spec 011 §Server error projection](../../spec/011-SSR.md#server-error-projection).
 
 Client-side UX mapping doesn't go through the projector. For client-side error UX — "show a toast when a handler exception fires," "show an inline error on a form when a schema validation fails" — you observe the trace stream (via `register-trace-cb!`) and dispatch an event that updates app-db, the same way you'd react to any other signal.
+
+---
+
+## Reference and advanced topics
+
+The sections that follow are per-topic reference material. Reach for them when the topic comes up. §Common scenarios walks six failure modes end-to-end — read each when you meet it, skim on a first pass. §Testing error paths shows how to assert errors fire in tests. The 10x / pair tooling and "what structured errors buy you" close the chapter.
 
 ## Common scenarios
 

--- a/docs/guide/15-devtools-and-pair-tools.md
+++ b/docs/guide/15-devtools-and-pair-tools.md
@@ -207,23 +207,17 @@ For *when* to reach for this channel — and the four shapes of slowness the cur
 
 ## What re-frame2 does not ship
 
-The contract above is sized to the framework's responsibility. Things that are **not** part of re-frame2 itself:
+The framework commits to stable data shapes and query APIs; tools own presentation, orchestration, and host integration. Outside the framework, in separate artefacts:
 
-- **The Claude integration in `re-frame-pair2`** — prompts, retrieval, model selection. Lives in the skill.
-- **The nREPL middleware** that bridges agent-to-runtime. Specific to the host stack.
-- **The `re-frame-causa` devtools UI.** It will be a separate artefact, consuming the same trace bus you've already met.
-- **DOM-to-source helpers** (`source-at`, `find-by-src`, `fire-click-at-src`). Tool-side; depends on host-specific DOM access.
-- **Skill-shaped retrospective analysis** of pair sessions — `re-frame-pair-improver2` is a separate Claude skill that reviews sessions and proposes improvements to the pair tool itself.
-
-The split is deliberate: the framework commits to **stable data shapes and query APIs**; tools own **presentation, orchestration, and host integration**. Without that split, the framework would own every consumer's roadmap — and would lock out every consumer it didn't already know about.
-
-The narrative is above; the reference below is for tool authors and edge-case investigators — read top-down for the story, jump to the bottom when you need exact shapes.
+- Claude prompts and nREPL middleware in `re-frame-pair2`.
+- The `re-frame-causa` devtools UI, consuming the same trace bus.
+- DOM-to-source helpers and the `re-frame-pair-improver2` skill.
 
 ---
 
-## Reference
+## Reference and advanced topics
 
-The rest of this chapter is the contract: surface shapes, error tables, behaviour against destroyed frames, the failure-mode enumeration for `restore-epoch` and `reset-frame-db!`. Read top-down if you're implementing a tool. Skip past if you're not — the pitch above is the part you need to internalise.
+The sections that follow are per-topic reference material. Reach for them when the topic comes up. The trace-stream, retain-N buffer, epoch records, `restore-epoch` / `reset-frame-db!` failure modes, source-coord attribute format, machine source-coord index, static sub-graph, and behaviour against destroyed frames make up the contract. Read top-down if you're implementing a tool; skip past if you're not — the pitch above is the part you need to internalise.
 
 ### Reference: the trace stream
 

--- a/docs/guide/16-performance.md
+++ b/docs/guide/16-performance.md
@@ -190,91 +190,6 @@ The chunked machine has a canonical shape covered in detail in [chapter 08 §Pat
 
 The v1 idiom for this work — `^:flush-dom` event metadata, self-redispatching `{:dispatch [...]}` tail-call loops — is gone. The chunked machine is the v2 substitute. Reach for it whenever you're tempted to write a `for` loop that holds the thread for more than ~16 ms.
 
-## The `rf:` Performance API surface
-
-The trace bus from [chapter 15](15-devtools-and-pair-tools.md#what-you-get-for-free) is dev-only. For production timing — APM dashboards, in-house perf overlays, "is this page slower in production than in dev?" investigations — re-frame2 ships a second observation channel through the browser's [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing).
-
-When the channel is on, the runtime brackets four hot-path call sites with `performance.mark` / `performance.measure` entries, all stably named under the `rf:` prefix:
-
-| Bucket | Where | Entry name |
-|---|---|---|
-| `:event`  | Event handler invocation (the interceptor chain) | `rf:event:<event-id>` |
-| `:sub`    | Subscription recompute | `rf:sub:<sub-id>` |
-| `:fx`     | Per-fx walk-step (one entry per registered fx that fires) | `rf:fx:<fx-id>` |
-| `:render` | Per-`reg-view` render | `rf:render:<view-id>` |
-
-Keyword namespaces are preserved on the wire:
-
-```
-rf:event:auth/login
-rf:sub:cart/total
-rf:fx:rf.http/managed
-rf:render:my.app/page-header
-```
-
-### Turning it on
-
-The channel is gated on a `goog-define`d boolean — `re-frame.performance/enabled?` — that defaults to `false`. Production builds that don't ask for timing carry zero User-Timing bytes; Closure DCE elides every emit site, every entry-name string, every bracket call.
-
-To flip it on for a build, set the goog-define in your shadow-cljs:
-
-```edn
-{:builds
- {:app
-  {:target           :browser
-   :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
-```
-
-`:advanced` constant-folds the flag at compile time, the gated branch survives, and the brackets become live measurements.
-
-The flag is *independent* of `goog.DEBUG`. The two compose: a dev build can run with trace on (`goog.DEBUG=true`) and perf off (default), a production build can run with trace off (`goog.DEBUG=false`) and perf on, and the four combinations correspond to four sensibly-sized bundles. The perf flag exists precisely so production telemetry doesn't drag in the dev trace surface.
-
-### Reading the entries
-
-Three consumers, in increasing order of how much work you put in:
-
-**Chrome DevTools Performance panel.** Open it, hit record, drive the app, stop. The `rf:` measures render as named bars alongside React renders, network, paint, and layout. The bar's width is its duration; the bar's name is the entry id. No custom UI required — you get a profiler view of "what re-frame2 did and how long it took" for free.
-
-**Ad-hoc inspection in DevTools console.**
-
-```javascript
-performance.getEntriesByType('measure')
-  .filter(e => e.name.startsWith('rf:'))
-  .sort((a, b) => b.duration - a.duration)
-  .slice(0, 20);
-```
-
-That returns the twenty slowest re-frame2 measurements from the most recent profile. The shape of each entry is `{name, startTime, duration, ...}` — standard `PerformanceMeasure` records. Group by `:event` / `:sub` / `:fx` / `:render` (split on the second `:`) to see which buckets are hottest.
-
-**Programmatic, streaming.** Attach a `PerformanceObserver` and forward to your APM:
-
-```javascript
-new PerformanceObserver((list) => {
-  for (const e of list.getEntriesByType('measure')) {
-    if (e.name.startsWith('rf:')) {
-      sendToAPM(e);   // { name, startTime, duration, ... }
-    }
-  }
-}).observe({ type: 'measure', buffered: true });
-```
-
-The `buffered: true` flag delivers entries that fired before the observer was attached — useful for SPAs where the observer mounts after the first cascade has already happened.
-
-### A practical workflow
-
-1. **Don't profile dev builds.** Dev builds run with `goog.DEBUG=true`, which keeps the trace surface live; the trace work itself shows up in the profile and is *not* representative of production. Build with `:advanced` plus the perf flag on, serve the result, profile that.
-2. **Record a representative interaction.** Open DevTools' Performance panel, click record, do the thing that feels slow, stop. The `rf:` measures appear under their own track.
-3. **Find the wide bars first.** The slowest individual measurement is usually where the problem lives. If it's a `rf:render:<view-id>`, the view is too expensive — look at its props (shape #1 above), its sub usage (shape #4), its callbacks (shape #3). If it's a `rf:sub:<sub-id>`, the sub body is doing real work and either its cache is missing or the work itself should chunk.
-4. **Count the narrow bars second.** A single fast bar is fine; a *cloud* of fast bars repeated 200 times is a re-render storm. Filter by event id and count occurrences — if `rf:render:my.app/todo-item` fires 200 times per drain, every drain, that's shape #1.
-
-The Chrome User-Timing entry buffer is bounded (default ~10000 entries). Long-running pages that want every entry should attach the observer and offload to durable storage rather than rely on `getEntriesByType` after the fact.
-
-### What the surface is, and isn't
-
-The `rf:` channel is a *timing* channel. It tells you how long each call took. It does *not* tell you why — the trace bus does that. The two compose: in dev, you run with both on, and you cross-reference a wide `rf:render:foo` bar against the trace event for the dispatch that triggered it. In prod, you run with just `rf:` on, and you let your APM aggregate "render of `foo` is at p99 = 80 ms across last hour."
-
-The perf channel is **CLJS-only**. JVM artefacts (SSR, headless tests, server-side jobs using re-frame2 for state) emit no User-Timing entries — the API is browser-only. JVM profiling uses host profilers (clj-async-profiler, JFR).
-
 ## A worked example — the laggy checklist
 
 A small app: a list of 200 todo items, each with a checkbox. Click a checkbox, the item toggles. With one careless implementation, every click hitches; with three small refactors, the same UI feels instant. The story walks the three shapes from the taxonomy above and shows the cure for each.
@@ -410,6 +325,97 @@ Three refactors, in increasing order of how clever they are:
 3. **Expensive and rare.** Stable callbacks. Apply this only when a profiler proves the renders themselves are the bottleneck and the children are complex enough to feel it.
 
 Climb the ladder in order. Most apps stop on rung one.
+
+---
+
+## Reference and advanced topics
+
+The section that follows is per-topic reference material. Reach for it when the topic comes up. The `rf:` Performance API surface is the prod-friendly timing channel — gated, isolated from the dev trace surface, consumed by Chrome DevTools or a `PerformanceObserver`. Skim it; come back when you're standing up production telemetry.
+
+## The `rf:` Performance API surface
+
+The trace bus from [chapter 15](15-devtools-and-pair-tools.md#what-you-get-for-free) is dev-only. For production timing — APM dashboards, in-house perf overlays, "is this page slower in production than in dev?" investigations — re-frame2 ships a second observation channel through the browser's [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing).
+
+When the channel is on, the runtime brackets four hot-path call sites with `performance.mark` / `performance.measure` entries, all stably named under the `rf:` prefix:
+
+| Bucket | Where | Entry name |
+|---|---|---|
+| `:event`  | Event handler invocation (the interceptor chain) | `rf:event:<event-id>` |
+| `:sub`    | Subscription recompute | `rf:sub:<sub-id>` |
+| `:fx`     | Per-fx walk-step (one entry per registered fx that fires) | `rf:fx:<fx-id>` |
+| `:render` | Per-`reg-view` render | `rf:render:<view-id>` |
+
+Keyword namespaces are preserved on the wire:
+
+```
+rf:event:auth/login
+rf:sub:cart/total
+rf:fx:rf.http/managed
+rf:render:my.app/page-header
+```
+
+### Turning it on
+
+The channel is gated on a `goog-define`d boolean — `re-frame.performance/enabled?` — that defaults to `false`. Production builds that don't ask for timing carry zero User-Timing bytes; Closure DCE elides every emit site, every entry-name string, every bracket call.
+
+To flip it on for a build, set the goog-define in your shadow-cljs:
+
+```edn
+{:builds
+ {:app
+  {:target           :browser
+   :compiler-options {:closure-defines {re-frame.performance/enabled? true}}}}}
+```
+
+`:advanced` constant-folds the flag at compile time, the gated branch survives, and the brackets become live measurements.
+
+The flag is *independent* of `goog.DEBUG`. The two compose: a dev build can run with trace on (`goog.DEBUG=true`) and perf off (default), a production build can run with trace off (`goog.DEBUG=false`) and perf on, and the four combinations correspond to four sensibly-sized bundles. The perf flag exists precisely so production telemetry doesn't drag in the dev trace surface.
+
+### Reading the entries
+
+Three consumers, in increasing order of how much work you put in:
+
+**Chrome DevTools Performance panel.** Open it, hit record, drive the app, stop. The `rf:` measures render as named bars alongside React renders, network, paint, and layout. The bar's width is its duration; the bar's name is the entry id. No custom UI required — you get a profiler view of "what re-frame2 did and how long it took" for free.
+
+**Ad-hoc inspection in DevTools console.**
+
+```javascript
+performance.getEntriesByType('measure')
+  .filter(e => e.name.startsWith('rf:'))
+  .sort((a, b) => b.duration - a.duration)
+  .slice(0, 20);
+```
+
+That returns the twenty slowest re-frame2 measurements from the most recent profile. The shape of each entry is `{name, startTime, duration, ...}` — standard `PerformanceMeasure` records. Group by `:event` / `:sub` / `:fx` / `:render` (split on the second `:`) to see which buckets are hottest.
+
+**Programmatic, streaming.** Attach a `PerformanceObserver` and forward to your APM:
+
+```javascript
+new PerformanceObserver((list) => {
+  for (const e of list.getEntriesByType('measure')) {
+    if (e.name.startsWith('rf:')) {
+      sendToAPM(e);   // { name, startTime, duration, ... }
+    }
+  }
+}).observe({ type: 'measure', buffered: true });
+```
+
+The `buffered: true` flag delivers entries that fired before the observer was attached — useful for SPAs where the observer mounts after the first cascade has already happened.
+
+### A practical workflow
+
+1. **Don't profile dev builds.** Dev builds run with `goog.DEBUG=true`, which keeps the trace surface live; the trace work itself shows up in the profile and is *not* representative of production. Build with `:advanced` plus the perf flag on, serve the result, profile that.
+2. **Record a representative interaction.** Open DevTools' Performance panel, click record, do the thing that feels slow, stop. The `rf:` measures appear under their own track.
+3. **Find the wide bars first.** The slowest individual measurement is usually where the problem lives. If it's a `rf:render:<view-id>`, the view is too expensive — look at its props (shape #1 above), its sub usage (shape #4), its callbacks (shape #3). If it's a `rf:sub:<sub-id>`, the sub body is doing real work and either its cache is missing or the work itself should chunk.
+4. **Count the narrow bars second.** A single fast bar is fine; a *cloud* of fast bars repeated 200 times is a re-render storm. Filter by event id and count occurrences — if `rf:render:my.app/todo-item` fires 200 times per drain, every drain, that's shape #1.
+
+The Chrome User-Timing entry buffer is bounded (default ~10000 entries). Long-running pages that want every entry should attach the observer and offload to durable storage rather than rely on `getEntriesByType` after the fact.
+
+### What the surface is, and isn't
+
+The `rf:` channel is a *timing* channel. It tells you how long each call took. It does *not* tell you why — the trace bus does that. The two compose: in dev, you run with both on, and you cross-reference a wide `rf:render:foo` bar against the trace event for the dispatch that triggered it. In prod, you run with just `rf:` on, and you let your APM aggregate "render of `foo` is at p99 = 80 ms across last hour."
+
+The perf channel is **CLJS-only**. JVM artefacts (SSR, headless tests, server-side jobs using re-frame2 for state) emit no User-Timing entries — the API is browser-only. JVM profiling uses host profilers (clj-async-profiler, JFR).
 
 ## What's not here
 


### PR DESCRIPTION
## Summary

Five guide-polish P3 follow-ups bundled into a single PR. Each chapter touched is isolated; the changes share the theme of reference-half navigability.

- **rf2-h9rz** — ch.06 §Animations: add a one-line 'skim on first read' callout above the three-regimes blockquotes so a first-time reader without animation experience can move past the densest section in the chapter.
- **rf2-g9vc** — ch.11/13/14/15/16/17: unify reference-half dividers to one pattern (`---` + `## Reference and advanced topics` + a one-sentence orientation bridge). ch.14 and ch.16 gain dividers they previously lacked; ch.15's solo `## Reference` is renamed to match.
- **rf2-lhck** — ch.16: move §The `rf:` Performance API surface to *follow* §A worked example — the laggy checklist. The concrete refactor leads; the prod-friendly perf channel becomes the chapter's reference half. Matches the chapter's concrete-then-reference arc.
- **rf2-uerb** — ch.14: after the taxonomy table, add a one-line pointer telling linear readers the six §Common scenarios are reference and to skim to §Testing error paths on a first pass.
- **rf2-33xr** — ch.15 §What re-frame2 does not ship: trim defensive prose to three bullets naming the principle and what lives outside the framework. The detailed split-justification is unnecessary in a long chapter.

Files touched: `docs/guide/06-views-and-frames.md`, `docs/guide/14-errors.md`, `docs/guide/15-devtools-and-pair-tools.md`, `docs/guide/16-performance.md`. (ch.11/13/17 already matched the target pattern; no edits needed.)

## Test plan

- [x] `python -m mkdocs build --strict` warning count unchanged from origin/main baseline (233 lines, all pre-existing spec/ link issues unrelated to this PR)
- [x] All five edits visible in the rendered chapter outlines (`## ` headings)
- [x] ch.16 section order is now: §A worked example → §Reference and advanced topics → §The `rf:` Performance API surface → §What's not here → §What we covered → §Next
- [x] ch.14 section order is now: …§Error projectors → §Reference and advanced topics → §Common scenarios → §Testing error paths…