### PR TITLE
docs: sweep stale in-page anchors in guide + skill files (rf2-64oz)

### DIFF
--- a/docs/guide/09-forms.md
+++ b/docs/guide/09-forms.md
@@ -32,13 +32,13 @@ Each key is doing a specific job — there's no redundancy, and dropping any one
 
 - **`:submitted`** is the *last server-accepted snapshot*. It starts as `nil` and stays `nil` until the first successful submit, at which point it's set to whatever `:draft` was at the time. After that, "is the form dirty?" becomes "does `:draft` differ from `:submitted`?" — the user has unsaved changes. (For profile-edit and settings forms, this is exactly the right question. For login forms, `:submitted` mostly just exists for symmetry.)
 
-- **`:submit-attempted?`** is a boolean that latches `true` on the first submit click and stays `true`. It's how the view decides whether to reveal errors on fields the user hasn't individually touched yet — see the [error-visibility rule](#error-visibility-touched-or-submit-attempted) below.
+- **`:submit-attempted?`** is a boolean that latches `true` on the first submit click and stays `true`. It's how the view decides whether to reveal errors on fields the user hasn't individually touched yet — see the [error-visibility rule](#error-visibility--touched-or-submit-attempted) below.
 
 - **`:status`** is the form's discrete state: `:idle` before any submit, `:submitting` while a submit request is in flight, `:submitted` after success, `:error` after a server rejection. This is the slot the view checks to disable the submit button while a request is pending and to show "Signing in…" instead of "Sign in".
 
 - **`:errors`** is a map from field id to a vector of error messages, plus a reserved `:_form` key for cross-field and submit-time messages that aren't tied to any single field. Both client-side validation results and structured server-side rejections write into this slot — the view doesn't care which validator wrote an entry.
 
-- **`:touched`** is the set of fields the user has interacted with. It grows monotonically during one session of the form (cleared on `:reset`). The view uses it to decide which fields *can* show their errors before the user has clicked submit — see again [the visibility rule](#error-visibility-touched-or-submit-attempted).
+- **`:touched`** is the set of fields the user has interacted with. It grows monotonically during one session of the form (cleared on `:reset`). The view uses it to decide which fields *can* show their errors before the user has clicked submit — see again [the visibility rule](#error-visibility--touched-or-submit-attempted).
 
 - **`:submit-error`** is the *transport* failure slot — network down, 500 with no parseable body, timeout. A single opaque value. The view renders it as a generic "couldn't reach the server" message. Distinct from `:errors`, which holds *renderable validation outcomes* (per-field or `:_form`-level).
 

--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -53,7 +53,7 @@ The optional **`:rf.trace/trigger-handler`** slot names the handler whose execut
 
 Everything else rides under `:tags`, with category-specific keys. The full schema lives in [Spec-Schemas](../../spec/Spec-Schemas.md) under `:rf/trace-event`; the per-category `:tags` shapes are pinned in [Spec-Schemas §Per-category `:tags` schemas](../../spec/Spec-Schemas.md#per-category-tags-schemas).
 
-**Production builds eliminate the trace surface entirely.** No exceptions. The error path described here is dev-only — your release bundles contain zero trace code. Errors that need to reach a monitoring service in production do so through your own `:on-error` policy (below), or through SSR's [error projector](#error-projectors-mapping-errors-to-ux) on the server side.
+**Production builds eliminate the trace surface entirely.** No exceptions. The error path described here is dev-only — your release bundles contain zero trace code. Errors that need to reach a monitoring service in production do so through your own `:on-error` policy (below), or through SSR's [error projector](#error-projectors--mapping-errors-to-ux) on the server side.
 
 ## The error taxonomy
 

--- a/docs/guide/17-routing.md
+++ b/docs/guide/17-routing.md
@@ -110,7 +110,7 @@ The navigation in the example above leaves a slice in `app-db`. The runtime main
 
 The `:rf/route` key is reserved. Path params (`:params`) and query params (`:query`) are distinct maps — captured separately, validated against separate schemas, kept separate in the slice. Consumers that prefer a merged map build one in a derived sub.
 
-`:fragment` carries the URL `#fragment` part. `:nav-token` is the runtime-allocated navigation epoch (see [§Navigation tokens](#navigation-tokens-stale-result-suppression)). Both are runtime-managed; user code reads them through subs.
+`:fragment` carries the URL `#fragment` part. `:nav-token` is the runtime-allocated navigation epoch (see [§Navigation tokens](#navigation-tokens--stale-result-suppression)). Both are runtime-managed; user code reads them through subs.
 
 `:transition` is a tiny FSM driven by the runtime: `:idle` when no navigation is in flight; `:loading` while the active route's `:on-match` events are draining; `:error` if any errors. A global progress bar reads `:rf.route/transition` and renders when it's `:loading`; an error banner reads `:rf.route/error`.
 
@@ -246,7 +246,7 @@ The `:on-match` list is the **enumerable, machine-readable** answer to "what loa
 
 ### Async `:on-match` and stale results — the nav-token in one paragraph
 
-If an `:on-match` event kicks off an async load (HTTP, query, timer) and the user navigates away before it completes, the older load's reply can land *after* the user has moved on and clobber the newer state. Re-frame2's answer is the **navigation token (nav-token)**: each navigation gets a fresh token written into the `:rf/route` slice; an async result is committed only if its carried token still matches the current one. You don't allocate or thread the token by hand — `:on-match` handlers receive it as a cofx, and the runtime drops mismatched results with a `:route.nav-token/stale-suppressed` trace. The mechanism is mostly invisible; you'll meet it when you write an `:on-match` continuation that fetches data. Full walkthrough with a worked example in [§Navigation tokens — stale-result suppression](#navigation-tokens-stale-result-suppression) in the reference half.
+If an `:on-match` event kicks off an async load (HTTP, query, timer) and the user navigates away before it completes, the older load's reply can land *after* the user has moved on and clobber the newer state. Re-frame2's answer is the **navigation token (nav-token)**: each navigation gets a fresh token written into the `:rf/route` slice; an async result is committed only if its carried token still matches the current one. You don't allocate or thread the token by hand — `:on-match` handlers receive it as a cofx, and the runtime drops mismatched results with a `:route.nav-token/stale-suppressed` trace. The mechanism is mostly invisible; you'll meet it when you write an `:on-match` continuation that fetches data. Full walkthrough with a worked example in [§Navigation tokens — stale-result suppression](#navigation-tokens--stale-result-suppression) in the reference half.
 
 ## The `:rf.route/not-found` route
 

--- a/skills/re-frame2/reference/state-machines/invoke.md
+++ b/skills/re-frame2/reference/state-machines/invoke.md
@@ -26,7 +26,7 @@ Spec 005 §Declarative `:invoke` §Worked example (verbatim shape). While the pa
 | `:machine-id` *or* `:definition` | which machine to spawn (registered id, or inline transition table) | exactly one |
 | `:data` | initial data for the child — literal map or `(fn [snapshot event] data)` | optional |
 | `:on-spawn` | `(fn [data spawned-id] new-data)` — advisory; record the child id in the parent's `:data` if you want | optional |
-| `:on-done` | `(fn [data result] new-data)` — fires when the child enters a `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). See [§Final states](#final-states---onDone--output-key) below. | optional |
+| `:on-done` | `(fn [data result] new-data)` — fires when the child enters a `:final?` state; `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). See [§Final states](#final-states--final--on-done--output-key) below. | optional |
 | `:start` | event vector dispatched to the newborn after spawn | optional |
 | `:invoke-id` | explicit id instead of gensym (per-state singleton) | optional |
 | `:id-prefix` | base for the gensym'd actor id; defaults to `:machine-id` | optional |


### PR DESCRIPTION
## Summary

Cross-link audit cluster H. Recent guide heading renames added em-dashes which slugify to `--`, leaving 9 in-page anchor references pointing at the pre-rename single-hyphen slugs. Updated 6 link occurrences across 4 files to match the current pymdownx-produced anchors.

- `09-forms.md` L35/L41: `#error-visibility-touched-or-submit-attempted` -> `#error-visibility--touched-or-submit-attempted`
- `14-errors.md` L56: `#error-projectors-mapping-errors-to-ux` -> `#error-projectors--mapping-errors-to-ux`
- `17-routing.md` L113/L249: `#navigation-tokens-stale-result-suppression` -> `#navigation-tokens--stale-result-suppression`
- `skills/re-frame2/reference/state-machines/invoke.md` L29: `#final-states---onDone--output-key` (mixed-case `onDone` would never slugify) -> `#final-states--final--on-done--output-key`

The skill-file slug was verified by running `pymdownx.slugs.slugify(case='lower')` against the actual heading text.

## Test plan

- [x] `mkdocs build --strict`: 3 stale-anchor `INFO` lines eliminated
- [x] WARNING count unchanged (the 227 remaining warnings are cross-file links to `spec/...` files outside the mkdocs nav — separate audit cluster)
- [x] Touches exactly the 4 files listed in the audit