### PR TITLE
docs(skills): fix bare spec/<file>.md paths to be depth-aware (rf2-s3u7)

### DIFF
--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -3,7 +3,7 @@ name: re-frame-migration
 description: >
   Migrates an existing re-frame v1.x ClojureScript codebase to re-frame2.
   Swaps the artefact coord (re-frame/re-frame → day8/re-frame2 + a substrate
-  adapter), applies the mechanical (Type A) rewrites from spec/MIGRATION.md
+  adapter), applies the mechanical (Type A) rewrites from MIGRATION.md
   automatically, and flags the judgment-call (Type B) call sites for human
   review before touching them. Use this skill whenever the user is migrating,
   upgrading, or porting a re-frame v1 project to re-frame2 — phrases like
@@ -19,7 +19,7 @@ description: >
 
 You are helping an author **migrate a ClojureScript codebase from re-frame v1.x to re-frame2**. The author has a project that depends on `re-frame/re-frame` today. When you are done, the project depends on `day8/re-frame2` + a substrate adapter, the mechanical (Type A) rewrites have been applied, and every judgment-call (Type B) call site has been surfaced to the author with the relevant rule cited.
 
-This skill teaches the **migration workflow**. The authoritative list of what changes — the M-rules (required) and O-rules (opt-in modernisations) — lives in `spec/MIGRATION.md` in this repo. **Do not duplicate that content here.** Load `spec/MIGRATION.md` when you start the migration and treat it as the source of truth.
+This skill teaches the **migration workflow**. The authoritative list of what changes — the M-rules (required) and O-rules (opt-in modernisations) — lives in [`MIGRATION.md`](../../spec/MIGRATION.md) in this repo. **Do not duplicate that content here.** Load [`MIGRATION.md`](../../spec/MIGRATION.md) when you start the migration and treat it as the source of truth.
 
 ---
 
@@ -52,14 +52,14 @@ If the author has already finished migrating and is now writing new code, hand o
 
 These hold across every step of the migration.
 
-1. **`spec/MIGRATION.md` is the source of truth.** Every rewrite cites a rule id (`M-N` or `O-N`). If a call site doesn't match any rule, **stop and ask** — do not invent a rule.
+1. **[`MIGRATION.md`](../../spec/MIGRATION.md) is the source of truth.** Every rewrite cites a rule id (`M-N` or `O-N`). If a call site doesn't match any rule, **stop and ask** — do not invent a rule.
 2. **Type A is automatic, Type B is asked-first.** Type A rewrites are mechanical, unambiguous, and observably identical. Apply them without prompting. Type B rewrites depend on intent (timing-sensitive code, dynamic call sites, behaviour-changes-at-the-edge); identify every call site, explain the risk, and **wait for the author's decision** before rewriting.
 3. **Smallest correct diff.** Do not refactor for style. Do not rename things the author didn't ask to rename. Do not add new features (frames, schemas, machines, `reg-view`) unless the author asked for the opt-in modernisations (the `O-N` rules).
-4. **Apply rules in order.** Later rules sometimes depend on earlier ones (e.g. M-0 — the coord swap — is the precondition for everything else). Walk the rules top-to-bottom as listed in `spec/MIGRATION.md`; don't jump.
+4. **Apply rules in order.** Later rules sometimes depend on earlier ones (e.g. M-0 — the coord swap — is the precondition for everything else). Walk the rules top-to-bottom as listed in [`MIGRATION.md`](../../spec/MIGRATION.md); don't jump.
 5. **JVM interop is in scope.** re-frame2 preserves `re-frame.interop` and JVM-side test runs. If the project has `.clj` test runners or JVM-side fixtures, migrate them alongside the CLJS code. Do not silently CLJS-only the project.
 6. **Single-import contract for new code.** Application namespaces use `(:require [re-frame.core :as rf])`. Direct requires of `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` are out-of-contract and get rewritten or flagged per M-1 / M-23.
-7. **If a rule looks ambiguous, file a bead — don't edit `spec/MIGRATION.md` inline.** This skill consumes that doc; it doesn't author it. Surface drift back to the maintainer.
-8. **Do not invent migration rules.** The 40+ M- and O-rules in `spec/MIGRATION.md` were the result of cross-spec review. If something in the codebase doesn't trip a rule, leave it alone and flag for human review.
+7. **If a rule looks ambiguous, file a bead — don't edit [`MIGRATION.md`](../../spec/MIGRATION.md) inline.** This skill consumes that doc; it doesn't author it. Surface drift back to the maintainer.
+8. **Do not invent migration rules.** The 40+ M- and O-rules in [`MIGRATION.md`](../../spec/MIGRATION.md) were the result of cross-spec review. If something in the codebase doesn't trip a rule, leave it alone and flag for human review.
 
 ---
 
@@ -72,14 +72,14 @@ A six-phase walk. Each phase links to a leaf for the detail; the SKILL.md only c
 Before touching anything, gather context. Read in this order:
 
 1. **The codebase's dep file** — `deps.edn`, `project.clj`, `shadow-cljs.edn`, or `bb.edn` — to confirm the project is actually on `re-frame/re-frame` and identify the substrate (Reagent unless told otherwise).
-2. **`spec/MIGRATION.md`** in the re-frame2 repo — the rule table. Skim Part 1 to know which rules exist; you'll reach for them by id during the migration.
+2. **[`MIGRATION.md`](../../spec/MIGRATION.md)** in the re-frame2 repo — the rule table. Skim Part 1 to know which rules exist; you'll reach for them by id during the migration.
 3. **The project's test suite shape** — is it `re-frame-test`-based, `cljs.test`-based, JVM-side, or absent? This tells you what "verified" looks like at the end.
 
 → `reference/setup.md` covers the deps-coord swap (M-0) and the adapter-artefact addition (`day8/re-frame2-reagent` for a Reagent app); these are the precondition for everything else.
 
 ### Phase 2 — Bump the dep (M-0)
 
-Apply M-0 from `spec/MIGRATION.md`: swap the coord from `re-frame/re-frame` to `day8/re-frame2`, **and** add a substrate-adapter artefact (`day8/re-frame2-reagent` for Reagent, `-uix` / `-helix` if the project has already moved off Reagent). Bump and **stop** — try a compile before applying any other rules. The headline expectation in MIGRATION.md is that *most codebases require no further changes*. Verify that against this project before doing more work.
+Apply M-0 from [`MIGRATION.md`](../../spec/MIGRATION.md): swap the coord from `re-frame/re-frame` to `day8/re-frame2`, **and** add a substrate-adapter artefact (`day8/re-frame2-reagent` for Reagent, `-uix` / `-helix` if the project has already moved off Reagent). Bump and **stop** — try a compile before applying any other rules. The headline expectation in MIGRATION.md is that *most codebases require no further changes*. Verify that against this project before doing more work.
 
 → `reference/setup.md` for the per-build-tool shape (`deps.edn` vs `project.clj` vs `shadow-cljs.edn` vs `bb.edn`), the substrate-adapter picker, and what to do if no v2 version has shipped yet.
 
@@ -87,7 +87,7 @@ Apply M-0 from `spec/MIGRATION.md`: swap the coord from `re-frame/re-frame` to `
 
 If Phase 2's compile / test run surfaced failures, sweep the codebase for each M-rule in order. Use the **automated-transforms leaf** for the mechanical (Type A) rewrites and the **guided checklist** for the judgment-call (Type B) ones.
 
-→ `reference/sequencing.md` for the recommended order of rules (matches `spec/MIGRATION.md`'s ordering; restated here so an interrupted migration can pick up).
+→ `reference/sequencing.md` for the recommended order of rules (matches [`MIGRATION.md`](../../spec/MIGRATION.md)'s ordering; restated here so an interrupted migration can pick up).
 
 → `reference/automated-transforms.md` for the Type A patterns — find-and-replace shapes, ns-import rewrites, effect-map key folds — that can be applied without asking.
 
@@ -101,11 +101,11 @@ Run the project's own verification. This skill does not run the tests for the au
 
 ### Phase 5 — Optional opt-in modernisations (only if the author asked)
 
-If — and only if — the author explicitly asked to *modernise* the codebase (not just migrate it), walk the `O-N` rules in `spec/MIGRATION.md`: rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas (O-3), frames (O-4), binary fx (O-5), the canonical event-vector shape (M-19 framed as opt-in), state machines (O-8 / O-9), substrate moves (O-13 / O-14), `:invoke-all` (O-15). These are **never** auto-applied as part of a routine migration — they are stylistic / structural upgrades the author opts into.
+If — and only if — the author explicitly asked to *modernise* the codebase (not just migrate it), walk the `O-N` rules in [`MIGRATION.md`](../../spec/MIGRATION.md): rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas (O-3), frames (O-4), binary fx (O-5), the canonical event-vector shape (M-19 framed as opt-in), state machines (O-8 / O-9), substrate moves (O-13 / O-14), `:invoke-all` (O-15). These are **never** auto-applied as part of a routine migration — they are stylistic / structural upgrades the author opts into.
 
 ### Phase 6 — Report
 
-Produce the migration report per `spec/MIGRATION.md` Part 2 §"Output format for your report" — coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words unless the migration was unusually complex.
+Produce the migration report per [`MIGRATION.md`](../../spec/MIGRATION.md) Part 2 §"Output format for your report" — coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words unless the migration was unusually complex.
 
 → `reference/output-format.md` restates the format with one filled-in example, so the report stays consistent across migrations.
 
@@ -127,10 +127,10 @@ Tell the author the migration is complete when **all** of these are true:
 - [ ] The project compiles cleanly with re-frame2 on the classpath.
 - [ ] All M-rules that tripped in this codebase have been applied (Type A) or had their flagged-for-human-review items resolved by the author (Type B).
 - [ ] The project's existing test suite passes (or, if a test failed pre-migration, it fails identically post-migration — no new test failures introduced).
-- [ ] The migration report (per `spec/MIGRATION.md` Part 2 / `reference/output-format.md`) has been produced and shared with the author.
+- [ ] The migration report (per [`MIGRATION.md`](../../spec/MIGRATION.md) Part 2 / `reference/output-format.md`) has been produced and shared with the author.
 - [ ] Items flagged for human review are explicitly listed in the report — none are left as "todo" without the author's awareness.
 
-When the checklist passes, hand off: *"Migration complete. From here, switch to the **`re-frame2`** skill to write new application code, or **`re-frame-pair2`** to inspect the running app from the REPL. The opt-in modernisations (the `O-N` rules in `spec/MIGRATION.md`) are available whenever you want to adopt them — they are not required to be on v2."*
+When the checklist passes, hand off: *"Migration complete. From here, switch to the **`re-frame2`** skill to write new application code, or **`re-frame-pair2`** to inspect the running app from the REPL. The opt-in modernisations (the `O-N` rules in [`MIGRATION.md`](../../spec/MIGRATION.md)) are available whenever you want to adopt them — they are not required to be on v2."*
 
 ---
 
@@ -140,7 +140,7 @@ For depth on each phase, read the matching leaf — every leaf is one level deep
 
 - **`reference/kickoff-prompt.md`** — A paste-ready prompt the author drops into a fresh Claude Code session to kick the migration off. ~80 lines.
 - **`reference/setup.md`** — M-0 in operational detail: the dep-file shapes (`deps.edn`, `project.clj`, `shadow-cljs.edn`, `bb.edn`), the substrate-adapter picker, the VERSION discovery procedure, and the artefact-split implications (`day8/re-frame2-http` / `-machines` / `-routing` etc. are pay-as-you-go). ~120 lines.
-- **`reference/breaking-changes.md`** — A compressed one-page index of every M-rule and O-rule by trigger surface: when the author asks "is `X` covered?" you grep here, find the rule id, then load that rule's full text from `spec/MIGRATION.md`. ~180 lines.
+- **`reference/breaking-changes.md`** — A compressed one-page index of every M-rule and O-rule by trigger surface: when the author asks "is `X` covered?" you grep here, find the rule id, then load that rule's full text from [`MIGRATION.md`](../../spec/MIGRATION.md). ~180 lines.
 - **`reference/sequencing.md`** — The recommended order to walk the rules. Restated so a partial migration can resume cleanly. ~70 lines.
 - **`reference/automated-transforms.md`** — Type A patterns: the unambiguous mechanical rewrites the agent applies without asking. Shape-by-shape — ns rewrites, effect-map key consolidation, dispatch-with rewrites, framework-keyword consolidation. ~150 lines.
 - **`reference/guided-checklist.md`** — Type B walkthroughs: the judgment-call rewrites. One sub-section per Type B rule (M-3, M-5 dynamic half, M-11, M-17, M-22, ...). Each walks the author through identification, risk explanation, and the decision they need to make. ~140 lines.
@@ -163,4 +163,4 @@ If you hit anything else surprising, surface it to the author rather than guessi
 
 ---
 
-*Authoritative breaking-change list: `spec/MIGRATION.md` (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`. For building a new re-frame2 implementation in a different host language or substrate: `skills/re-frame2-implementor/`.*
+*Authoritative breaking-change list: [`MIGRATION.md`](../../spec/MIGRATION.md) (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`. For building a new re-frame2 implementation in a different host language or substrate: `skills/re-frame2-implementor/`.*

--- a/skills/re-frame-migration/reference/automated-transforms.md
+++ b/skills/re-frame-migration/reference/automated-transforms.md
@@ -2,7 +2,7 @@
 
 Type A patterns: the unambiguous mechanical rewrites the agent applies without asking. Each entry gives the **search shape**, the **rewrite shape**, the **rule id** (so the report cites it correctly), and any **edge case** that promotes a sub-case to Type B.
 
-For the *why* of each rule, see `spec/MIGRATION.md`. This leaf is a shape catalogue, not a rationale.
+For the *why* of each rule, see [`MIGRATION.md`](../../../spec/MIGRATION.md). This leaf is a shape catalogue, not a rationale.
 
 ## Contents
 
@@ -208,7 +208,7 @@ Closed mechanical rename table. Apply across all source files.
 :route/<framework-id>        → :rf.route/<framework-id>
 ```
 
-**Framework `:route/*` ids are the closed list** in `spec/MIGRATION.md` M-20 (`:route/navigate`, `:route/url-changed`, `:route/handle-url-change`, `:route/not-found`, `:route/navigation-blocked`, `:route/continue`, `:route/cancel`, `:route/error`, `:route/transition`, `:route/resolved`, `:route/auth-guard`, `:route/equal`, `:route/chain`).
+**Framework `:route/*` ids are the closed list** in [`MIGRATION.md`](../../../spec/MIGRATION.md) M-20 (`:route/navigate`, `:route/url-changed`, `:route/handle-url-change`, `:route/not-found`, `:route/navigation-blocked`, `:route/continue`, `:route/cancel`, `:route/error`, `:route/transition`, `:route/resolved`, `:route/auth-guard`, `:route/equal`, `:route/chain`).
 
 **User `:route/<name>` ids** are user-defined and left alone (mechanical) or rewritten to a feature prefix (suggested, Type B). The closed framework list is the discriminator.
 
@@ -359,7 +359,7 @@ The `:require` is what triggers the artefact's load-time hook registrations. Wit
 ## What this leaf is NOT
 
 - It is not a complete migration script. Type B rules live in `reference/guided-checklist.md`.
-- It is not a substitute for `spec/MIGRATION.md`'s per-rule rationale — when you apply a rewrite, you cite the rule id; you don't quote the rule's text inline.
+- It is not a substitute for [`MIGRATION.md`](../../../spec/MIGRATION.md)'s per-rule rationale — when you apply a rewrite, you cite the rule id; you don't quote the rule's text inline.
 - It is not exhaustive. The shapes here are the most common Type A trigger patterns. If a call site matches the *intent* of a Type A rule but not the *shape* here, apply the rewrite — the shapes are illustrative.
 
-When the rewrite shape doesn't fit a real call site exactly, **stop and consult the full rule in `spec/MIGRATION.md`**. Don't improvise.
+When the rewrite shape doesn't fit a real call site exactly, **stop and consult the full rule in [`MIGRATION.md`](../../../spec/MIGRATION.md)**. Don't improvise.

--- a/skills/re-frame-migration/reference/breaking-changes.md
+++ b/skills/re-frame-migration/reference/breaking-changes.md
@@ -1,8 +1,8 @@
 # breaking-changes
 
-A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered by a rule?"* — you grep here, find the rule id, then load that rule's full text from `spec/MIGRATION.md`.
+A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered by a rule?"* — you grep here, find the rule id, then load that rule's full text from [`MIGRATION.md`](../../../spec/MIGRATION.md).
 
-**This leaf does not replace `spec/MIGRATION.md`.** It points at it. The authoritative `What to look for` / `What to do` / `Why` per rule lives in MIGRATION.md. Every entry here gives just enough to identify the rule.
+**This leaf does not replace [`MIGRATION.md`](../../../spec/MIGRATION.md).** It points at it. The authoritative `What to look for` / `What to do` / `Why` per rule lives in MIGRATION.md. Every entry here gives just enough to identify the rule.
 
 ## Contents
 
@@ -104,7 +104,7 @@ If a rule is hybrid (A for one shape, B for another), the type column above list
 
 ## What stays the same (do not change)
 
-`spec/MIGRATION.md` has a fully-enumerated *"What stays the same"* section near the end of Part 1. The headline non-changes:
+[`MIGRATION.md`](../../../spec/MIGRATION.md) has a fully-enumerated *"What stays the same"* section near the end of Part 1. The headline non-changes:
 
 - `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` direct invocation — same names, same call shapes.
 - Handler signatures `(fn [db [_ args]] ...)` and `(fn [{:keys [db]} event] ...)`.

--- a/skills/re-frame-migration/reference/guided-checklist.md
+++ b/skills/re-frame-migration/reference/guided-checklist.md
@@ -2,7 +2,7 @@
 
 Type B walkthroughs: the judgment-call rewrites. Each section gives the **identification** (how to find the call sites), the **risk explanation** (what to tell the author), and the **decision shape** (what the author must choose between). The agent identifies and explains; the author decides; the agent then applies.
 
-For Type A patterns, see `reference/automated-transforms.md`. For full rule rationale, see `spec/MIGRATION.md`.
+For Type A patterns, see `reference/automated-transforms.md`. For full rule rationale, see [`MIGRATION.md`](../../../spec/MIGRATION.md).
 
 ## Contents
 

--- a/skills/re-frame-migration/reference/kickoff-prompt.md
+++ b/skills/re-frame-migration/reference/kickoff-prompt.md
@@ -18,17 +18,17 @@ Steps:
 
 > *I'm migrating this ClojureScript codebase from re-frame v1.x to re-frame2. Walk the migration end-to-end per the `re-frame-migration` skill in this session.*
 >
-> *Phase 1 — Orient. Read the dep file (whichever exists: `deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), confirm we're actually on `re-frame/re-frame` today, and identify the substrate (assume Reagent unless the codebase shows otherwise). Then load `spec/MIGRATION.md` from the re-frame2 repo (clone it locally if you don't already have it; `https://github.com/day8/re-frame2` → `spec/MIGRATION.md`) and skim Part 1's rule index so you know what's available.*
+> *Phase 1 — Orient. Read the dep file (whichever exists: `deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), confirm we're actually on `re-frame/re-frame` today, and identify the substrate (assume Reagent unless the codebase shows otherwise). Then load [`MIGRATION.md`](../../../spec/MIGRATION.md) from the re-frame2 repo (clone it locally if you don't already have it; `https://github.com/day8/re-frame2` → [`MIGRATION.md`](../../../spec/MIGRATION.md)) and skim Part 1's rule index so you know what's available.*
 >
 > *Phase 2 — Apply M-0. Swap `re-frame/re-frame` for `day8/re-frame2` + the substrate-adapter coord (`day8/re-frame2-reagent` for Reagent). Then **stop**. Run a compile (`shadow-cljs compile <build>` or `clj -M:dev` or whatever the project's equivalent is). If it compiles, run the tests. Most codebases require no other changes — verify that before doing more work.*
 >
-> *Phase 3 — If anything broke. Sweep the failures against the M-rules in `spec/MIGRATION.md`, in the order they're listed. Apply Type A (mechanical) rules without asking. For Type B (judgment-call) rules, identify every affected call site, explain the risk the rule documents, and **wait for my approval** before rewriting. Cite the rule id (`M-N`) for every change.*
+> *Phase 3 — If anything broke. Sweep the failures against the M-rules in [`MIGRATION.md`](../../../spec/MIGRATION.md), in the order they're listed. Apply Type A (mechanical) rules without asking. For Type B (judgment-call) rules, identify every affected call site, explain the risk the rule documents, and **wait for my approval** before rewriting. Cite the rule id (`M-N`) for every change.*
 >
 > *Phase 4 — Re-verify. Re-compile, re-run tests, smoke-test the running app. Iterate until everything passes.*
 >
 > *Phase 5 — Do NOT apply opt-in modernisations (the `O-N` rules — `reg-view`, frames, schemas, state machines, ...) unless I explicitly ask. The goal is "v1 code compiles and runs on v2," not "v1 code rewritten in v2 style."*
 >
-> *Phase 6 — Report. Produce the migration report per `spec/MIGRATION.md` Part 2 §"Output format for your report": coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words.*
+> *Phase 6 — Report. Produce the migration report per [`MIGRATION.md`](../../../spec/MIGRATION.md) Part 2 §"Output format for your report": coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words.*
 >
 > *Standing rules for this migration:*
 >
@@ -47,7 +47,7 @@ Steps:
 
 Two common amendments the author may add:
 
-**"Also modernise."** Append: *"After Phase 4 verifies clean, walk the `O-N` rules in `spec/MIGRATION.md` and apply the ones that match this codebase: rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas at the boundaries (O-3), `:invoke-all` (O-15) if there's hand-rolled spawn-and-join, framework keyword consolidation (M-20 has an opt-in half). Same Type A / Type B rules — Type B asks first. Stop after each O-rule and let me decide whether to keep the change or revert."*
+**"Also modernise."** Append: *"After Phase 4 verifies clean, walk the `O-N` rules in [`MIGRATION.md`](../../../spec/MIGRATION.md) and apply the ones that match this codebase: rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas at the boundaries (O-3), `:invoke-all` (O-15) if there's hand-rolled spawn-and-join, framework keyword consolidation (M-20 has an opt-in half). Same Type A / Type B rules — Type B asks first. Stop after each O-rule and let me decide whether to keep the change or revert."*
 
 **"Migrate in feature-branch slices."** Append: *"Land each rule-group as its own commit with the M-rule ids in the message. Don't squash. I want the history to read as `M-0`, `M-1+M-5 (mechanical sweep)`, `M-3 (Type B, approved)`, `M-22 (Type B, approved)`, `M-21 mechanical pass`, etc. Each commit should leave the project compiling — break the migration into compilable bisects."*
 
@@ -59,7 +59,7 @@ The skill description triggers on a wide range of v1→v2 phrasings, but the **o
 
 - Locks the workflow shape the first time, so the session doesn't drift mid-migration.
 - Makes the Type B "ask first" rule explicit upfront — the session can't silently rewrite timing-sensitive code.
-- Frames the migration as "bump and verify first" — matching `spec/MIGRATION.md`'s headline expectation that most codebases need no further changes.
-- Reuses the report format from `spec/MIGRATION.md` Part 2 so the report stays consistent across migrations.
+- Frames the migration as "bump and verify first" — matching [`MIGRATION.md`](../../../spec/MIGRATION.md)'s headline expectation that most codebases need no further changes.
+- Reuses the report format from [`MIGRATION.md`](../../../spec/MIGRATION.md) Part 2 so the report stays consistent across migrations.
 
 The prompt is short (under 400 words) so the author doesn't lose anything by pasting it verbatim, but rigid enough that a fresh session executing it walks the migration the same way every time.

--- a/skills/re-frame-migration/reference/output-format.md
+++ b/skills/re-frame-migration/reference/output-format.md
@@ -1,6 +1,6 @@
 # output-format
 
-The migration summary format. The shape from `spec/MIGRATION.md` Part 2 §"Output format for your report" is the source of truth; this leaf restates it with one filled-in example so the summary stays consistent across migrations.
+The migration summary format. The shape from [`MIGRATION.md`](../../../spec/MIGRATION.md) Part 2 §"Output format for your report" is the source of truth; this leaf restates it with one filled-in example so the summary stays consistent across migrations.
 
 ## The format
 
@@ -27,7 +27,7 @@ Keep it **under 300 words** unless the migration was unusually complex.
 ## Discipline
 
 - **One summary per migration.** Even if the migration spanned multiple sessions, the summary is the single artefact the author reads at the end. Don't fragment.
-- **Cite rule ids.** Every change cites the M-N or O-N rule that authorised it. The author can grep `spec/MIGRATION.md` for each id if they want the rationale.
+- **Cite rule ids.** Every change cites the M-N or O-N rule that authorised it. The author can grep [`MIGRATION.md`](../../../spec/MIGRATION.md) for each id if they want the rationale.
 - **No new findings buried in narrative.** If you discover something during the migration that warrants a `bd` bead (spec drift, missing rule, surprising behaviour), file the bead and reference it in the summary — don't bury the finding inside prose.
 - **Items flagged for human review are explicit.** A Type B rule the author **declined** to apply is just as important as one they applied. Both go in the summary.
 
@@ -110,6 +110,6 @@ If there are >10 items in *"Items flagged for human review"*, that's a sign the 
 ## What the summary is for
 
 - **The author reads it once and knows what the migration changed.** No need to read the diff to understand the shape.
-- **The author can audit.** Every change has a rule id; the rule id lets them go back to `spec/MIGRATION.md` and verify.
+- **The author can audit.** Every change has a rule id; the rule id lets them go back to [`MIGRATION.md`](../../../spec/MIGRATION.md) and verify.
 - **The author knows what's still on them.** "Items flagged for human review" is the contract — these are the things the agent declined to action, and they're owned by the author from this point.
 - **The summary goes into the project history.** Drop it as a commit message, a PR description, or a `MIGRATION-NOTES.md` in the project root — whatever the project's convention is. The migration agent doesn't decide where; the author does.

--- a/skills/re-frame-migration/reference/sequencing.md
+++ b/skills/re-frame-migration/reference/sequencing.md
@@ -1,6 +1,6 @@
 # sequencing
 
-The recommended order to walk the migration rules. Restated so a partial migration can resume cleanly without re-reading the full `spec/MIGRATION.md` ordering.
+The recommended order to walk the migration rules. Restated so a partial migration can resume cleanly without re-reading the full [`MIGRATION.md`](../../../spec/MIGRATION.md) ordering.
 
 ## Top-level shape
 
@@ -14,11 +14,11 @@ Phase 2 — Bump (M-0)
             └── failures ────> Phase 3 (sweep) ───> compile + tests ───> Phase 6
 ```
 
-`spec/MIGRATION.md` Part 2 §"Your task" makes the headline expectation explicit: *most codebases require no changes at all beyond M-0*. Verify that against this project before doing anything else.
+[`MIGRATION.md`](../../../spec/MIGRATION.md) Part 2 §"Your task" makes the headline expectation explicit: *most codebases require no changes at all beyond M-0*. Verify that against this project before doing anything else.
 
 ## When failures land — the sweep order
 
-The M-rule numbering in `spec/MIGRATION.md` *is* the sweep order. Walk them low-to-high. Later rules sometimes depend on earlier ones being resolved (M-1 surfaces private-namespace requires; M-15's seeding rewrite assumes the M-1 fix has run; M-21's `on-changes` rewrite assumes the flows artefact M-30 has been added).
+The M-rule numbering in [`MIGRATION.md`](../../../spec/MIGRATION.md) *is* the sweep order. Walk them low-to-high. Later rules sometimes depend on earlier ones being resolved (M-1 surfaces private-namespace requires; M-15's seeding rewrite assumes the M-1 fix has run; M-21's `on-changes` rewrite assumes the flows artefact M-30 has been added).
 
 ### Group 1 — Coord and private namespaces (foundation)
 

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -23,7 +23,7 @@ description: >
 
 You are helping an engineer **build a new implementation of the re-frame2 pattern** — not a re-frame2 application, but a runtime that other people will then write applications against. The CLJS reference implementation in this repo is a working example of one realisation; this skill walks the engineer through realising another.
 
-The skill is **guidance + workflow** layered on top of the spec corpus at `spec/`. The spec is the contract. The reference impl is one worked example, not normative.
+The skill is **guidance + workflow** layered on top of the spec corpus at [`spec/`](../../spec/). The spec is the contract. The reference impl is one worked example, not normative.
 
 ---
 
@@ -31,10 +31,10 @@ The skill is **guidance + workflow** layered on top of the spec corpus at `spec/
 
 Use this skill when **any** of these are true:
 
-- The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or any of the other hosts named in `spec/000-Vision.md` — or a host outside that list).
+- The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or any of the other hosts named in [`spec/000-Vision.md`](../../spec/000-Vision.md) — or a host outside that list).
 - The engineer is implementing re-frame2 against a non-React substrate, a native UI toolkit, a terminal UI, or any rendering surface that isn't React-on-the-browser.
 - The engineer wants to claim "this is a re-frame2 implementation" and needs to know what the claim requires.
-- The engineer is consuming `spec/Implementor-Checklist.md` and the [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) corpus to verify their work.
+- The engineer is consuming [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md) and the [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) corpus to verify their work.
 
 ## When NOT to use this skill
 
@@ -56,7 +56,7 @@ If the engineer is building **applications** on the reference, hand off to `re-f
 
 These hold across every phase of the implementation.
 
-1. **The spec is the contract.** `spec/` is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; file a `bd create` bead against the spec or the reference impl as appropriate.
+1. **The spec is the contract.** [`spec/`](../../spec/) is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; file a `bd create` bead against the spec or the reference impl as appropriate.
 2. **Phase 1 before Phase 2.** Decisions made under Phase 1 (host language, substrate, scope, identity primitive, concurrency model) are load-bearing for every line of code written in Phase 2. Lock them in writing before opening an editor. If a Phase 2 step forces a Phase 1 decision to change, *stop*, revise the decision record, and restart that Phase 2 step.
 3. **Implement in dependency order.** EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) are the foundation. The optional EPs (005, 007–014) sit downstream and can be deferred or skipped per Phase 1 scope.
 4. **Substrate-agnostic phrasing in code and docs.** The reference impl is a CLJS+Reagent realisation — keywords as ids, hiccup as render-tree, Reagent ratoms as the reactive container. These are *choices the reference made*. Your port chooses differently and re-frame2 is still re-frame2. Do not write code that assumes "hiccup" or "Reagent" or "keyword" universally; write code that assumes "the identity primitive", "the render-tree", "the reactive container".
@@ -73,7 +73,7 @@ These hold across every phase of the implementation.
 
 Before any code is written, the engineer walks the **decision walkthrough** at `reference/phase-1-decisions.md` and produces a **decision record** (template: `reference/decision-record.md`). The decisions are:
 
-1. **Target host language** — which language and runtime. The spec scope under `spec/000-Vision.md` names eight first-class JS-cross-compile hosts; the [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) covers more (Python, Rust, Kotlin/native, Swift) — but only the in-scope eight target React+VDOM substrates by default. Any other host language picks its own substrate (Q2).
+1. **Target host language** — which language and runtime. The spec scope under [`spec/000-Vision.md`](../../spec/000-Vision.md) names eight first-class JS-cross-compile hosts; the [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) covers more (Python, Rust, Kotlin/native, Swift) — but only the in-scope eight target React+VDOM substrates by default. Any other host language picks its own substrate (Q2).
 2. **Substrate / view layer** — React+VDOM (the spec's default), a native UI toolkit, raw DOM, terminal UI, server-render only, no UI at all.
 3. **Scope — which EPs ship now** — the core EPs (001 / 002 / 006 / 004) are mandatory for any conformance claim. The optional EPs (005 state machines, 007 stories, 008 testing, 009 instrumentation, 010 schemas, 011 SSR, 012 routing, 013 flows, 014 HTTP) are declared yes/no individually per [Implementor-Checklist Part 1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-1--how-complete).
 4. **Foundation choices** — identity primitive, persistent data structures, reactive substrate, effect-handling primitive, concurrency model, hot-reload primitive ([Implementor-Checklist Part 2 §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required)).
@@ -105,17 +105,17 @@ The leaf `reference/phase-2-impl-order.md` walks each EP with: what to read firs
 
 Three tiers of input, in this priority:
 
-1. **`spec/`** — the contract. Read in numeric order. Every implementation decision must trace to a normative claim here.
-2. **[`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/)** — the decision-ordered companion. Part 1 (which capabilities ship), Part 2 (per-capability mechanism choices), Part 3 (how to consume the conformance corpus).
+1. **[`spec/`](../../spec/)** — the contract. Read in numeric order. Every implementation decision must trace to a normative claim here.
+2. **[`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md)** — the decision-ordered companion. Part 1 (which capabilities ship), Part 2 (per-capability mechanism choices), Part 3 (how to consume the conformance corpus). Site-published version: <https://day8.github.io/re-frame2/spec/Implementor-Checklist/>.
 3. **`implementation/`** (the CLJS reference) — a worked example. Useful for "how did *someone* solve X?" Never useful as a contract claim. The reference's specific bindings (keywords, hiccup, Reagent ratoms, Closure dead-code elimination for production elision) are **choices**, not requirements.
 
-If `implementation/` and `spec/` disagree, the spec wins. File a `bd create` bead so the inconsistency is tracked.
+If `implementation/` and [`spec/`](../../spec/) disagree, the spec wins. File a `bd create` bead so the inconsistency is tracked.
 
 ---
 
 ## Conformance — the acceptance test
 
-The conformance corpus at `spec/conformance/` is host-agnostic data. The harness is ~300 lines per host (per [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus)):
+The conformance corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic data. The harness is ~300 lines per host (per [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus)):
 
 1. Read all `.edn` fixtures in `fixtures/`.
 2. For each fixture, check whether `:fixture/capabilities` is a subset of the port's claimed list.
@@ -143,7 +143,7 @@ Tell the engineer the implementation is "v1-complete" against the claimed scope 
 
 - [ ] Phase 1 decision record is written down, dated, and committed to the port's own repo (as a `DECISIONS.md` or equivalent).
 - [ ] All EPs in scope (per Phase 1) have a working implementation in the port's source tree.
-- [ ] The port's runtime exposes the API contract at [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/), adapted to the host's idiom.
+- [ ] The port's runtime exposes the API contract at [`spec/API.md`](../../spec/API.md), adapted to the host's idiom.
 - [ ] The conformance corpus has been run against the port; the score is `(claimed-applicable) / (claimed-applicable)` — all fixtures whose capabilities are a subset of the port's claim pass.
 - [ ] Any conformance failures that were *not* spec gaps have been fixed in the port.
 - [ ] Any conformance failures that *were* spec gaps have been filed as beads against the spec corpus (`bd create` against the re-frame2 repo).
@@ -158,7 +158,7 @@ When the checklist passes, the port can claim "re-frame2 implementation, v1-comp
 For depth on each step, read the matching leaf — every leaf is one level deep from this SKILL.md:
 
 - **`reference/kickoff-prompt.md`** — A paste-ready prompt to drop into a fresh Claude Code session in the root of the engineer's port repo. ~80 lines.
-- **`reference/phase-1-decisions.md`** — The Phase 1 walkthrough: seven decision blocks, options per host, trade-offs, links into [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) for the canonical option matrices. ~200 lines.
+- **`reference/phase-1-decisions.md`** — The Phase 1 walkthrough: seven decision blocks, options per host, trade-offs, links into [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md) for the canonical option matrices. ~200 lines.
 - **`reference/decision-record.md`** — The fill-in template for the locked-decision record. Reproducible across ports — the engineer copies the template into their own repo, fills in each block. ~120 lines.
 - **`reference/phase-2-impl-order.md`** — EP-by-EP implementation order. For each EP: what to read, the contract to expose, what the CLJS reference did (as an example), what the conformance fixtures check, common spec-gap traps. ~250 lines.
 - **`reference/reference-impl-tour.md`** — A guided tour of the CLJS reference under `implementation/` — what's where, what was a substrate-specific choice, what's pattern-required. Read this when you want to see how *someone* solved a problem, not to find out what re-frame2 requires. ~150 lines.
@@ -182,4 +182,4 @@ If you hit anything else surprising, surface it to the engineer rather than gues
 
 ---
 
-*Authoritative contract: `spec/` corpus (in this repo). Decision-ordered companion: [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/). Conformance corpus: [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance). CLJS reference (worked example): `implementation/`. For application authoring on the reference: `skills/re-frame2/`. For greenfield bootstrap: `skills/re-frame2-setup/`. For v1→v2 migration: `skills/re-frame-migration/`. For live-app inspection: `skills/re-frame-pair2/`.*
+*Authoritative contract: [`spec/`](../../spec/) corpus (in this repo). Decision-ordered companion: [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md). Conformance corpus: [`spec/conformance/`](../../spec/conformance/). CLJS reference (worked example): `implementation/`. For application authoring on the reference: `skills/re-frame2/`. For greenfield bootstrap: `skills/re-frame2-setup/`. For v1→v2 migration: `skills/re-frame-migration/`. For live-app inspection: `skills/re-frame-pair2/`.*

--- a/skills/re-frame2-implementor/reference/conformance.md
+++ b/skills/re-frame2-implementor/reference/conformance.md
@@ -56,7 +56,7 @@ Common ops (per the corpus's existing fixtures):
 
 The interpreter is ~50 lines per host. The CLJS reference's interpreter lives in `implementation/core/src/re_frame/test_support.cljc`; copy the dispatch-style and adapt the literal-op handlers.
 
-**Spec-gap signal.** When a fixture uses an op that isn't documented anywhere — that's a spec gap. File a `bd create` bead asking for the DSL to be documented in `spec/conformance/README.md`.
+**Spec-gap signal.** When a fixture uses an op that isn't documented anywhere — that's a spec gap. File a `bd create` bead asking for the DSL to be documented in [`spec/conformance/README.md`](../../../spec/conformance/README.md).
 
 ## Capability tagging
 

--- a/skills/re-frame2-implementor/reference/output-format.md
+++ b/skills/re-frame2-implementor/reference/output-format.md
@@ -43,7 +43,7 @@ Produced at the end of the Phase 1 walkthrough. The decision record is committed
 
 ## Next step
 
-Begin Phase 2 at EP 001 (Registration). Read `spec/001-Registration.md`; expose the registrar API per the decision record's D4 choices.
+Begin Phase 2 at EP 001 (Registration). Read [`spec/001-Registration.md`](../../../spec/001-Registration.md); expose the registrar API per the decision record's D4 choices.
 ```
 
 ---

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -28,7 +28,7 @@ Migration and deep-dive content are deliberately outside this skill — they liv
 
 These hold across every leaf in this skill.
 
-1. **Implementation is ground truth.** When the spec and `implementation/**` disagree, the implementation wins. Recipes here are verified against `implementation/**` and `examples/reagent/**`, not against `spec/`. Spec is *why*; impl is *what*.
+1. **Implementation is ground truth.** When the spec and `implementation/**` disagree, the implementation wins. Recipes here are verified against `implementation/**` and `examples/reagent/**`, not against [`spec/`](../../spec/). Spec is *why*; impl is *what*.
 2. **Recipes over explanations.** Reach for a canonical shape; do not derive from first principles. If a pattern leaf exists, use the shape it gives; do not invent a parallel one.
 3. **Distinguish orchestration from state.** Use **state machines** (`reg-machine`) when the answer to "what can the system do next" depends on the current mode (connecting / connected / disconnected; idle / submitting / submitted; loading / loaded / error). Use **slices** (a key in `app-db` driven by `reg-event-db`) when state is a field, not a mode. See `decision-trees/slice-or-machine.md`.
 4. **Schemas at boundaries, not everywhere.** Register `reg-app-schema` for the paths that cross trust boundaries (incoming HTTP payloads, persisted state on restore, machine snapshot restores). Do not schema-fence every internal key.
@@ -147,7 +147,7 @@ A short checklist that applies regardless of which leaf you load.
 
 ## How re-frame2 differs from re-frame v1
 
-A one-line redirect for v1-trained context: the migration workflow + breaking-change rule index lives in `skills/re-frame-migration/`; the authoritative rule corpus is `spec/MIGRATION.md` (linked from `SKILL-REDIRECT.md` → *Migration from re-frame v1*). Do not re-derive v1 mappings from training memory — the v1→v2 surface drift is large enough that confident recall is unreliable.
+A one-line redirect for v1-trained context: the migration workflow + breaking-change rule index lives in `skills/re-frame-migration/`; the authoritative rule corpus is [`MIGRATION.md`](../../spec/MIGRATION.md) (linked from `SKILL-REDIRECT.md` → *Migration from re-frame v1*). Do not re-derive v1 mappings from training memory — the v1→v2 surface drift is large enough that confident recall is unreliable.
 
 ## Background reading (optional)
 


### PR DESCRIPTION
## Summary

- SKILL.md files at `skills/<name>/SKILL.md` referenced `spec/MIGRATION.md` / `spec/000-Vision.md` / `spec/Implementor-Checklist.md` / `spec/API.md` / `spec/conformance/` with **bare relative paths**. When a skill is installed as a plugin in another repo, those paths resolve nowhere.
- This PR rewrites the references to depth-aware markdown links: `../../spec/<file>` from depth-1 SKILL.md files, `../../../spec/<file>` from depth-2 reference leaves. Matches the discipline already used in deeper leaves (e.g. `skills/re-frame2/reference/fundamentals/frames.md` uses `../../../../spec/009-Instrumentation.md` from depth 4).
- mkdocs `build --strict` passes — `skills/` is not in `docs_dir`, and `docs/skills/*.md` overview pages already use absolute GitHub URLs.

## Files touched

- `skills/re-frame-migration/SKILL.md` — 13 `spec/MIGRATION.md` → `[`MIGRATION.md`](../../spec/MIGRATION.md)` rewrites.
- `skills/re-frame-migration/reference/{automated-transforms,breaking-changes,guided-checklist,kickoff-prompt,output-format,sequencing}.md` — bare `spec/MIGRATION.md` → `[`MIGRATION.md`](../../../spec/MIGRATION.md)`.
- `skills/re-frame2/SKILL.md` — 2 rewrites (`spec/` corpus + `spec/MIGRATION.md`).
- `skills/re-frame2-implementor/SKILL.md` — 11 rewrites (`spec/000-Vision.md`, `spec/Implementor-Checklist.md`, `spec/API.md`, `spec/conformance/`, plain `spec/`).
- `skills/re-frame2-implementor/reference/{conformance,output-format}.md` — 2 leaf-level rewrites.

Closes rf2-s3u7.

## Test plan

- [x] `python -m mkdocs build --strict` passes (no broken links, no warnings).
- [x] All edits use the markdown-link form `[text](../../spec/<file>.md)` / `[text](../../../spec/<file>.md)` — same shape the existing depth-4 leaves use.
- [x] `docs/skills/*.md` and `SKILL-REDIRECT.md` untouched (they already carry absolute URLs).
- [x] Kickoff-prompt files that intentionally use `<path-to-re-frame2>/spec/` substitution (for engineers who clone re-frame2 alongside their port) are left alone — they are paste-ready prompts, not skill-internal navigation.