### PR TITLE
chore(deps): bump metosin/malli 0.13.0 → current stable (rf2-zyiy)

### DIFF
--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -25,7 +25,7 @@
 ;; entry points at ns-load time; core looks them up at call time.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}
-         metosin/malli   {:mvn/version "0.13.0"}}
+         metosin/malli   {:mvn/version "0.20.1"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -77,7 +77,7 @@
                 "../examples/uix"
                 "../examples/helix"]
  :dependencies [[reagent           "2.0.1"]
-                [metosin/malli     "0.13.0"]
+                [metosin/malli     "0.20.1"]
                 [com.pitch/uix.core "1.4.4"]
                 [com.pitch/uix.dom  "1.4.4"]
                 [lilactown/helix   "0.2.2"]]

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -41,7 +41,7 @@
          ;; pin matches implementation/shadow-cljs.edn's :dependencies
          ;; entry so the top-level CLJS test build (`npm run test:cljs`)
          ;; resolves a single Malli on the classpath.
-         metosin/malli           {:mvn/version "0.13.0"}}
+         metosin/malli           {:mvn/version "0.20.1"}}
 
  :aliases
  {:test {:extra-paths ["test"]


### PR DESCRIPTION
## Summary
- Bumps `metosin/malli` from `0.13.0` (late-2023) to `0.20.1` (current stable on Clojars as of 2026-03-06).
- Three pins move together so a single Malli resolves on the CLJS classpath (per the explanatory comment in `tools/story/deps.edn`):
  - `implementation/schemas/deps.edn` — boundary-validation hot-path's dependency.
  - `implementation/shadow-cljs.edn` — top-level CLJS test build.
  - `tools/story/deps.edn` — Story tool's three-level args/argtypes derivation.
- No source changes; Malli's public API at the surfaces re-frame2 uses (`m/validate`, `m/explain`, `:registry`) is back-compatible across 0.13 → 0.20.

## Test plan
- [x] `clojure -M:test` in `implementation/schemas` — 49 tests / 176 assertions, 0 failures.
- [x] `clojure -M:test` in `implementation/core` — 249 tests / 1128 assertions, 0 failures.
- [x] `clojure -M:test` in `tools/story` — 156 tests / 395 assertions, 0 failures.
- [x] `npm run test:cljs` (node-test) — 586 / 1384.
- [x] `npm run test:browser` — 586 / 1411.
- [x] `npm run test:browser-schemas-boundary-prod` (advanced + `goog.DEBUG=false`) — 5 / 7.
- [x] `npm run test:elision` — sentinel probe `=== PASS ===`.