### PR TITLE
chore(deps): bump org.clojure/clojure 1.11.1 -> 1.12.0 (rf2-rlpo)

### DIFF
--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -36,7 +36,7 @@
 ;; HTTP decode-schemas or epoch-restore schema validation pull in the
 ;; schemas artefact (which carries Malli) alongside core.
 {:paths ["src"]
- :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
+ :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/clojurescript {:mvn/version "1.11.132"}
          reagent/reagent           {:mvn/version "2.0.1"}}
 

--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -43,7 +43,7 @@
 ;; `clojure -M:test` still routes through shadow-cljs because the
 ;; sources are .cljs and need a CLJS compiler.
 {:paths ["src"]
- :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
+ :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/clojurescript {:mvn/version "1.11.132"}
          applied-science/js-interop {:mvn/version "0.4.2"}
          thheller/shadow-cljs      {:mvn/version "3.4.10"}}


### PR DESCRIPTION
## Summary
- Bumps `org.clojure/clojure` from `1.11.1` to `1.12.0` in the two deps.edn files still pinned to 1.11.1:
  - `implementation/core/deps.edn`
  - `tools/pair2-mcp/deps.edn`
- Aligns these with the template flavors (reagent / uix / helix), which were already on 1.12.0.
- ClojureScript pin (`1.11.132`) left alone — independent surface.

## Verification
JVM suites green locally on 1.12.0:

| suite | tests | assertions |
| --- | --- | --- |
| core | 249 | 1128 |
| schemas | 49 | 176 |
| machines | 116 | 316 |
| flows | 26 | 98 |
| routing | 28 | 110 |
| http | 39 | 150 |
| ssr | 31 | 118 |
| epoch | 59 | 233 |

All 0 failures / 0 errors.

JVM suites green; CLJS verification deferred to CI to avoid the shadow-cljs warm-start hang seen on the previous attempt.

## Test plan
- [x] `clojure -M:test` in each of the 8 implementation subdirectories
- [ ] CI runs `test:cljs` / `test:browser`