### PR TITLE
feat(story): :docs mode — read-only AutoDocs view (rf2-rodx)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -175,44 +175,130 @@ module.exports = {
     const tabsStrip = page.locator('[data-test="story-mode-tabs"]');
     await tabsStrip.waitFor({ state: 'visible', timeout: 5000 });
 
-    const devChip = tabsStrip.locator('[data-mode-tab="dev"]');
-    const docsChip = tabsStrip.locator('[data-mode-tab="docs"]');
-    const testChip = tabsStrip.locator('[data-mode-tab="test"]');
+    // Rename the mode-tab chip handles `modeXxxChip` so they don't
+    // collide with the sidebar tag-filter chips (a `docsChip` variable
+    // re-declared further down in the same arrow function scope is a
+    // JS syntax error — keep the mode-tab handles distinct).
+    const modeDevChip = tabsStrip.locator('[data-mode-tab="dev"]');
+    const modeDocsChip = tabsStrip.locator('[data-mode-tab="docs"]');
+    const modeTestChip = tabsStrip.locator('[data-mode-tab="test"]');
 
     // All three chips must render.
-    await devChip.waitFor({ state: 'visible', timeout: 2000 });
-    await docsChip.waitFor({ state: 'visible', timeout: 2000 });
-    await testChip.waitFor({ state: 'visible', timeout: 2000 });
+    await modeDevChip.waitFor({ state: 'visible', timeout: 2000 });
+    await modeDocsChip.waitFor({ state: 'visible', timeout: 2000 });
+    await modeTestChip.waitFor({ state: 'visible', timeout: 2000 });
 
     // Default mode-tab is :dev — the canvas is up. The :dev chip is
     // active, the other two are not.
-    if ((await devChip.getAttribute('aria-selected')) !== 'true') {
+    if ((await modeDevChip.getAttribute('aria-selected')) !== 'true') {
       throw new Error('expected :dev chip to be aria-selected="true" by default');
     }
-    if ((await docsChip.getAttribute('aria-selected')) !== 'false') {
+    if ((await modeDocsChip.getAttribute('aria-selected')) !== 'false') {
       throw new Error('expected :docs chip to be aria-selected="false" by default');
     }
 
-    // Click Docs → the docs placeholder appears and the :docs chip
-    // becomes active. The canvas (data-test="count") disappears from
-    // <main> because the docs pane replaces it.
-    await docsChip.click();
-    await page
-      .locator('[data-test="story-docs-placeholder"]')
-      .waitFor({ state: 'visible', timeout: 5000 });
-    if ((await docsChip.getAttribute('aria-selected')) !== 'true') {
+    // Click Docs → the docs pane (rf2-rodx — `data-test="story-docs-
+    // view"`) appears and the :docs chip becomes active. The canvas
+    // (data-test="count") disappears from <main> because the docs
+    // pane replaces it.
+    await modeDocsChip.click();
+    const docsView = page.locator('[data-test="story-docs-view"]');
+    await docsView.waitFor({ state: 'visible', timeout: 5000 });
+    if ((await modeDocsChip.getAttribute('aria-selected')) !== 'true') {
       throw new Error('expected :docs chip to be aria-selected="true" after click');
     }
-    if ((await devChip.getAttribute('aria-selected')) !== 'false') {
+    if ((await modeDevChip.getAttribute('aria-selected')) !== 'false') {
       throw new Error('expected :dev chip to flip aria-selected="false" after switching');
     }
 
+    // ----------------------------------------------------------------
+    // 3b-i. :docs mode — AutoDocs view sections (rf2-rodx)
+    // ----------------------------------------------------------------
+    //
+    // The :docs pane composes six sections — header / prose / args /
+    // decorators / parameters / tags — per spec/008. The header MUST
+    // render the parent story id and at least one tag chip; the args
+    // table MUST list every resolved arg with a key/default/doc row;
+    // the tags section MUST forward-link the per-tag chip to the
+    // sidebar tag-filter.
+    await page
+      .locator('[data-test="story-docs-parent-story"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+    await page
+      .locator('[data-test="story-docs-args-table"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+    await page
+      .locator('[data-test="story-docs-decorators-table"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+    await page
+      .locator('[data-test="story-docs-tags-section"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+
+    // The args table for :story.counter/loaded carries the :label
+    // arg (overridden to "Total" on the variant) — the canonical
+    // assertion that the args walk reflects the resolved precedence.
+    const labelRow = page
+      .locator('[data-test="story-docs-args-row"][data-arg-key=":label"]');
+    await labelRow.waitFor({ state: 'visible', timeout: 2000 });
+    const labelRowText = await labelRow.innerText();
+    if (!/Total/.test(labelRowText)) {
+      throw new Error(
+        `expected :label arg row to show "Total" as the resolved default, got: ${labelRowText}`,
+      );
+    }
+
+    // The decorators table MUST include the story-level log-decorator
+    // entry. resolve-decorators surfaces it under :hiccup.
+    const hiccupRow = page
+      .locator('[data-test="story-docs-decorator-row"][data-section="hiccup"]')
+      .first();
+    await hiccupRow.waitFor({ state: 'visible', timeout: 2000 });
+
+    // The tags-section chips MUST forward-link to the sidebar filter.
+    // Click the bottom :test chip; the shell's :tag-filter state slot
+    // gains :test, the chip flips aria-pressed="true".
+    const docsTestTagChip = page
+      .locator('[data-test="story-docs-tag-link"][data-docs-tag="test"]');
+    await docsTestTagChip.waitFor({ state: 'visible', timeout: 2000 });
+    await docsTestTagChip.click();
+    {
+      const start = Date.now();
+      let pressed = null;
+      while (Date.now() - start < 2000) {
+        pressed = await docsTestTagChip.getAttribute('aria-pressed').catch(() => null);
+        if (pressed === 'true') break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (pressed !== 'true') {
+        throw new Error(
+          `expected :test docs tag chip to flip aria-pressed="true" after click, got ${pressed}`,
+        );
+      }
+    }
+    // Toggle back off so the sidebar tag-filter assertions in §4
+    // start from a clean slate (the :tag-filter is shared state).
+    await docsTestTagChip.click();
+    {
+      const start = Date.now();
+      let pressed = null;
+      while (Date.now() - start < 2000) {
+        pressed = await docsTestTagChip.getAttribute('aria-pressed').catch(() => null);
+        if (pressed === 'false') break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (pressed !== 'false') {
+        throw new Error(
+          `expected :test docs tag chip to flip aria-pressed="false" after second click, got ${pressed}`,
+        );
+      }
+    }
+
     // Click Tests → the tests placeholder appears, :test chip active.
-    await testChip.click();
+    await modeTestChip.click();
     await page
       .locator('[data-test="story-tests-placeholder"]')
       .waitFor({ state: 'visible', timeout: 5000 });
-    if ((await testChip.getAttribute('aria-selected')) !== 'true') {
+    if ((await modeTestChip.getAttribute('aria-selected')) !== 'true') {
       throw new Error('expected :test chip to be aria-selected="true" after click');
     }
 

--- a/tools/story/spec/007-Mode-Tabs.md
+++ b/tools/story/spec/007-Mode-Tabs.md
@@ -92,7 +92,9 @@ is a separate concern.
 
 `:dev` → existing canvas / hot-reload / decorators path (unchanged
 from Story v1).
-`:docs` → the docs pane (placeholder until rf2-rodx).
+`:docs` → the docs pane — `re-frame.story.ui.docs/docs-view`
+(rf2-rodx). See [`008-Docs-Mode.md`](008-Docs-Mode.md) for the
+section composition + read-only contract.
 `:test` → the tests pane (placeholder until rf2-qmjo).
 
 ## Per-variant selection + localStorage persistence
@@ -138,8 +140,10 @@ Selectors:
 
 - The strip: `[data-test="story-mode-tabs"]`
 - Each chip: `[data-mode-tab="dev|docs|test"]`
-- Placeholders: `[data-test="story-docs-placeholder"]`,
-  `[data-test="story-tests-placeholder"]`
+- Docs pane root: `[data-test="story-docs-view"]` (rf2-rodx; see
+  [`008-Docs-Mode.md`](008-Docs-Mode.md) for the per-section
+  selectors)
+- Tests placeholder: `[data-test="story-tests-placeholder"]`
 
 ## Visual style
 
@@ -150,8 +154,8 @@ borders, monospace 11px.
 
 ## Out-of-scope at this primitive
 
-- **The `:docs` pane content.** A placeholder div ships now; rf2-rodx
-  ships the real AutoDocs view.
+- **The `:docs` pane content.** Owned by rf2-rodx — see
+  [`008-Docs-Mode.md`](008-Docs-Mode.md) for the section composition.
 - **The `:test` pane content.** A placeholder div ships now; rf2-qmjo
   ships the aggregated pass/fail view.
 - **Workspace mode-tabs.** Workspaces enumerate multiple variants;

--- a/tools/story/spec/008-Docs-Mode.md
+++ b/tools/story/spec/008-Docs-Mode.md
@@ -1,0 +1,230 @@
+# Story — `:docs` Mode Pane
+
+> The read-only AutoDocs-equivalent view that sits behind the `:docs`
+> mode-tab. Composes header, prose, args, decorators, parameters, and
+> tags sections for a single variant. The downstream surface the
+> mode-tabs primitive (rf2-9hc8, spec/007) was built to host.
+
+## Why a dedicated docs pane
+
+The render shell already exposes every datum the docs pane needs —
+the variant body via the registrar, the resolved arg merge via
+`re-frame.story.args/resolve-args`, the decorator stack via
+`re-frame.story.decorators/resolve-decorators`, the workspace
+registry for prose lookups. What was missing was a **read-only
+presentation surface** that gathers them in the same order Storybook
+8's MDX / AutoDocs page does, so a reader can scan a variant's
+contract without driving the controls panel.
+
+The pane is deliberately read-only: editing happens in the Canvas
+(`:dev`) mode's controls panel; switching back from `:docs` restores
+any overrides the user had typed. Docs reflects the variant's
+declared shape, not transient runtime edits.
+
+## Surface
+
+One namespace, one entry point, plus pure helpers for the JVM test
+corpus:
+
+```clojure
+(re-frame.story.ui.docs/docs-view variant-id)   ; CLJS Reagent component
+
+;; pure data → data (JVM-testable):
+(prose-for-variant variant-id)
+  ; → [{:workspace-id ... :body ...} ...]
+(args-rows variant-id resolved-args)
+  ; → [{:key ... :value ... :doc ...} ...]
+(decorator-rows decorator-pack)
+  ; → [{:section :hiccup|:frame-setup|:fx-override|:error
+  ;     :id ... :doc ...} ...]
+(parameter-rows variant-id)
+  ; → [{:key :modes|:substrates|:platforms :value ...} ...]
+(variant-tags variant-id)
+  ; → [<tag> ...]
+```
+
+The render shell's `main-pane` calls `docs/docs-view` when the
+per-variant mode-tab is `:docs`. Selection is owned by the mode-tabs
+primitive; this spec does not touch the chip strip.
+
+## Section composition
+
+The pane renders six sections, top-to-bottom:
+
+| # | Section     | Data source                                                                     | Rendered when                                  |
+|---|-------------|---------------------------------------------------------------------------------|------------------------------------------------|
+| 1 | Header      | variant id, parent-story id, tags, variant `:doc` (or parent `:doc` fallback)   | always                                         |
+| 2 | Prose       | `:body` strings from `:layout :prose` workspaces that reference this variant   | at least one prose block found                 |
+| 3 | Args        | `(args/resolve-args variant-id {:cell-overrides nil})` × variant `:argtypes`    | always (renders "no args resolved" if empty)   |
+| 4 | Decorators  | `(decorators/resolve-decorators variant-id)`                                    | always (renders "no decorators" if empty)      |
+| 5 | Parameters  | variant body's `:modes` / `:substrates` / `:platforms` slots (story fallback)  | always (renders "no … declared" if all empty) |
+| 6 | Tags        | sorted variant tags (parent-story fallback)                                     | always (renders "no tags" if empty)            |
+
+### 1. Header
+
+```
+:story.counter/loaded
+parent story: :story.counter
+[dev] [docs] [test]
+A counter seeded with a non-zero value.
+```
+
+- Variant id as the page `<h1>`.
+- Parent story id below (or `"no parent story registered"` if the
+  variant id has no namespace).
+- Tag chips — the same set rendered in §6, hoisted to the header so
+  readers see them at a glance. Each chip clicks through to
+  `state/toggle-tag-filter`.
+- Variant `:doc` (or parent story `:doc` as fallback) as italic
+  blurb beneath the chips.
+
+### 2. Prose
+
+Story v1's schema deliberately does NOT carry a per-variant `:prose`
+slot — prose belongs to a workspace, not a variant (a Stage-2
+authoring decision per spec/001). The docs pane bridges that:
+
+- Walk every `:layout :prose` workspace.
+- For each workspace whose `:content` references this variant via a
+  `{:type :variant :id <variant-id>}` item, collect the `:body`
+  strings of any `{:type :prose :body "..."}` items in the same
+  workspace.
+- Render each block in source order, prefixed with the workspace id
+  so the reader knows where the prose came from.
+
+If no `:prose` workspace mentions the variant the section is omitted
+entirely (no empty-state placeholder — keeps the page clean).
+
+### 3. Args
+
+A three-column table — `key | default | doc` — sorted by arg-key.
+
+- **key.** The arg's keyword.
+- **default.** The resolved value via
+  `args/resolve-args variant-id {:cell-overrides nil}` — the args
+  the variant renders WITHOUT runtime overrides. Read-only docs
+  shouldn't reflect the user's transient edits in the controls
+  panel.
+- **doc.** The docstring pulled from the variant's (or parent
+  story's) `:argtypes` entry for the key. Supported shapes:
+  - `{:argtypes {:foo {:doc "…"}}}`        → `:doc`
+  - `{:argtypes {:foo {:description "…"}}}` → `:description`
+    (Storybook compat)
+  - `{:argtypes {:foo "…"}}`               → the string itself
+  - anything else                          → `—`
+
+### 4. Decorators
+
+Three-column table — `kind | id | doc` — every entry in the
+`resolve-decorators` pack in apply order:
+
+1. `:hiccup` entries — outermost (story-level) first, innermost
+   (variant-level) last.
+2. `:frame-setup` entries — declared order.
+3. `:fx-override` entries — declared order (collisions resolve
+   last-wins at the runtime, not at presentation).
+4. `:error` entries — any unresolved decorators (`:errors` slot
+   from the pack), surfaced inline so the reader sees what's
+   broken without switching to the trace panel.
+
+### 5. Parameters
+
+re-frame2 does NOT carry Storybook's free-form `:parameters` map on
+variant bodies — the same surface area is covered by three explicit
+slots: `:modes`, `:substrates`, `:platforms`. The docs page collapses
+them into a two-column `key | value` table, falling back to the
+parent story's slot when the variant body declares none.
+
+If all three slots are empty the section renders a "no … declared"
+placeholder rather than vanishing — parameters are an important
+contract surface and silently dropping them would be misleading.
+
+### 6. Tags
+
+Bottom-of-page chip strip — same chips as the header, repeated so a
+reader who has scrolled past the table doesn't have to scroll up to
+forward-link to the sidebar.
+
+Each chip:
+
+- Carries `data-docs-tag="<tag-name>"` for the Playwright spec.
+- Sets `aria-pressed` to reflect the sidebar's current
+  `:tag-filter` membership.
+- Click dispatches `state/toggle-tag-filter` — the same handler the
+  sidebar uses, so the sidebar's tag-row chips and the docs chips
+  stay in lockstep.
+
+## Read-only contract
+
+The pane MUST NOT carry any input elements that mutate args /
+overrides / modes. Switching `:docs` → `:dev` MUST restore the
+canvas as the user left it — same args, same overrides, same modes.
+
+The pane MAY carry buttons that mutate **shell-state filters** (tag
+chips forward-link to `state/toggle-tag-filter`) — the pane is
+read-only with respect to the *variant*, not to the shell's
+sidebar / filter state.
+
+## Test selectors
+
+The Playwright spec drives the pane via `data-test`-prefixed
+selectors so visible labels can be reworded without breaking tests:
+
+| Selector                                              | What                                       |
+|-------------------------------------------------------|--------------------------------------------|
+| `[data-test="story-docs-view"]`                       | The pane root (`<section>` landmark).      |
+| `[data-test="story-docs-parent-story"]`               | Parent-story sub-header.                   |
+| `[data-test="story-docs-doc-blurb"]`                  | The italic variant-`:doc` blurb.           |
+| `[data-test="story-docs-header-tags"]`                | Header tag chip row.                       |
+| `[data-test="story-docs-prose-section"]`              | Prose section (omitted if no prose).       |
+| `[data-test="story-docs-prose-block"]`                | One prose block from a workspace.          |
+| `[data-test="story-docs-args-section"]`               | Args section.                              |
+| `[data-test="story-docs-args-table"]`                 | The args table.                            |
+| `[data-test="story-docs-args-row"]`                   | One arg row; `data-arg-key="<:key>"`.      |
+| `[data-test="story-docs-decorators-section"]`         | Decorators section.                        |
+| `[data-test="story-docs-decorators-table"]`           | Decorators table.                          |
+| `[data-test="story-docs-decorator-row"]`              | One decorator row; `data-section="hiccup"` |
+| `[data-test="story-docs-parameters-section"]`         | Parameters section.                        |
+| `[data-test="story-docs-parameters-table"]`           | Parameters table.                          |
+| `[data-test="story-docs-parameter-row"]`              | One parameter row; `data-param-key`.       |
+| `[data-test="story-docs-tags-section"]`               | Tags section (bottom).                     |
+| `[data-test="story-docs-tag-link"]`                   | Bottom tag chip.                           |
+| `[data-test="story-docs-tag-chip"]`                   | Header tag chip.                           |
+| `data-docs-tag="<tag-name>"`                          | On each chip — match without coupling to visible text. |
+
+## Visual style
+
+Matches the render-shell chrome (rf2-2uwv contrast palette):
+`#b0b0b0` inactive foreground, `#dcdcdc` body text, `#1e1e1e`
+section background, `#2d2d30` table-header background, monospace
+for table content + variant ids, system-ui for prose. The pane
+scrolls inside the `<main>` landmark; the strip sits above it
+(owned by the mode-tabs primitive).
+
+## Out of scope at v1
+
+- **Per-variant `:prose` slot.** Adding `:prose` to the variant
+  schema is its own EDN-shape change — the docs pane piggybacks on
+  workspaces for v1, which keeps the schema closed.
+- **MDX rendering.** The prose body renders as `pre-wrap` plain
+  text. Markdown → hiccup is a separate concern; if a project wants
+  rich rendering it registers a `reg-story-panel` with a custom
+  view. The docs pane's role is to present what's registered, not
+  to introduce a Markdown dependency.
+- **Editable docs.** Read-only is the contract; v2 may add an inline
+  notes affordance but it would be a new shell-state slot, not a
+  mutation of the variant body.
+- **Storybook-style story-level docs pages.** Each variant has its
+  own docs pane in v1 — the parent-story-level rollup
+  (Storybook's `Component.docs`) is a v2 surface. Workspaces already
+  cover the multi-variant rollup use-case.
+
+## Foundational status
+
+Per the rf2-9hc8 / rf2-rodx pair: the docs pane is a **leaf** — it
+consumes the foundation (registrar, args resolution, decorator
+resolution, workspace registry) and surfaces it. It does not
+register new artefact kinds, does not add new shell-state slots, and
+does not change the mode-tabs chip strip. Removing `docs-view`
+restores the placeholder-equivalent empty pane without breaking any
+other surface.

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -10,6 +10,7 @@
 - **[005-SOTA-Features.md](005-SOTA-Features.md)** — Layout-debug overlays; a11y axe-core panel; per-variant QR share; multi-substrate side-by-side; 10x epoch embed stub; production elision under `:advanced`.
 - **[006-MCP-Surface.md](006-MCP-Surface.md)** — The boundary between Story and `tools/story-mcp/`; surfaces Story exposes for the MCP jar; late-bind `reg-story-panel` for tooling embeds.
 - **[007-Mode-Tabs.md](007-Mode-Tabs.md)** — The render-shell's top-of-canvas `:dev` / `:docs` / `:test` switcher; the chrome-level primitive every 2026 component playground ships (rf2-9hc8).
+- **[008-Docs-Mode.md](008-Docs-Mode.md)** — The `:docs` mode pane — read-only AutoDocs-equivalent: header, prose, args, decorators, parameters, tags for the active variant (rf2-rodx).
 - **[API.md](API.md)** — Consolidated public surface for `day8/re-frame2-story`: every `reg-*`, every fn, every fx-id, every cofx-id.
 - **[Principles.md](Principles.md)** — Story-specific non-negotiables — EDN-first first among them — the test new features pass against.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major call was made; the seven rf2-m6tu §6 decisions plus Phase-2 SOTA additions and IMPL-SPEC-emergent calls.

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -1,0 +1,497 @@
+(ns re-frame.story.ui.docs
+  "The `:docs` mode pane — read-only AutoDocs-equivalent for one variant.
+  Per rf2-rodx + spec/008.
+
+  Replaces the `mode-tabs/docs-placeholder` stub that landed with the
+  mode-tabs primitive (rf2-9hc8). The pane composes six sections, in
+  the order Storybook 8's MDX/AutoDocs page presents them:
+
+      ┌──────────────────────────────────────────────────────┐
+      │  Header — variant id · parent story · tags chips      │
+      ├──────────────────────────────────────────────────────┤
+      │  Prose — markdown from a :prose workspace referencing │
+      │           this variant (if any)                       │
+      ├──────────────────────────────────────────────────────┤
+      │  Args  — table of every resolved arg with default +  │
+      │           :doc (from the variant's :argtypes entry)   │
+      ├──────────────────────────────────────────────────────┤
+      │  Decorators — ordered :hiccup / :frame-setup /        │
+      │           :fx-override stack                          │
+      ├──────────────────────────────────────────────────────┤
+      │  Parameters — :modes / :substrates / :platforms       │
+      │           (the variant-level metadata that isn't args  │
+      │           or decorators or tags)                      │
+      ├──────────────────────────────────────────────────────┤
+      │  Tags — clickable chips that toggle the sidebar       │
+      │           `:tag-filter` for the matching tag          │
+      └──────────────────────────────────────────────────────┘
+
+  Read-only — no editing. Args overrides live in the Canvas / Controls
+  pane. Switching from `:docs` back to `:dev` (Canvas) restores any
+  override the user had previously typed in the controls editor.
+
+  ## Pure-data prose lookup
+
+  Prose blocks come from `:layout :prose` workspaces — Story v1 has no
+  per-variant `:prose` slot (a deliberate Stage-2 schema choice; prose
+  belongs to a workspace, not a variant). For the docs view we walk
+  every registered `:prose` workspace and collect the `:body` strings
+  of any `:type :prose` content item whose neighbour `:type :variant`
+  item references this variant. The walk is pure data → data and
+  JVM-testable via `prose-for-variant`.
+
+  ## Elision
+
+  The whole namespace is CLJS-side rendering plus one `.cljc` pure
+  helper (`prose-for-variant`) so JVM tests can cover the workspace
+  walk. The shell's `main-pane` only reaches `docs-view` via the
+  `(when config/enabled? ...)`-gated mount call, so production builds
+  never invoke it — closure DCEs the lot."
+  (:require [re-frame.story.registrar :as registrar]
+            #?@(:cljs [[re-frame.story.args :as args]
+                       [re-frame.story.decorators :as decorators]
+                       [re-frame.story.ui.state :as state]])))
+
+;; ---- pure: prose lookup -------------------------------------------------
+
+(defn prose-for-variant
+  "Walk every registered `:layout :prose` workspace, find any whose
+  `:content` references `variant-id`, and return a vector of
+  `{:workspace-id ... :body ...}` entries for each prose block that
+  sits in the same workspace.
+
+  Pure data → data; JVM-testable. The walk is O(W·C) over the workspace
+  count × content-item count — fine for dev-time use.
+
+  A prose block belongs in the variant's docs view when its host
+  workspace's `:content` list also references the variant somewhere.
+  Storybook's MDX prose is per-component; re-frame2 collapses that to
+  per-workspace, and a workspace that mentions the variant earns its
+  prose."
+  [variant-id]
+  (let [workspaces (registrar/handlers :workspace)]
+    (vec
+      (for [[wid body] (sort-by key workspaces)
+            :when     (and (= :prose (:layout body))
+                           (some (fn [item]
+                                   (and (= :variant (:type item))
+                                        (= variant-id (:id item))))
+                                 (:content body)))
+            item      (:content body)
+            :when     (= :prose (:type item))]
+        {:workspace-id wid
+         :body         (:body item)}))))
+
+;; ---- pure: row composition -----------------------------------------------
+
+(defn args-rows
+  "Compose the rows of the args table.
+
+  Each row is `{:key <arg-key> :value <default> :doc <string-or-nil>}`.
+  The doc string comes from the variant's (or parent story's)
+  `:argtypes` entry — Storybook's `argTypes.<key>.description` —
+  resolved per the same merge precedence as `controls/resolve-argtypes`
+  (variant beats story).
+
+  Pure data → data so the JVM test fixture can cover the merge."
+  [variant-id resolved-args]
+  (let [vb       (registrar/handler-meta :variant variant-id)
+        story-id (when (and (keyword? variant-id) (namespace variant-id))
+                   (keyword (namespace variant-id)))
+        sb       (when story-id (registrar/handler-meta :story story-id))
+        atypes   (merge (:argtypes sb) (:argtypes vb))]
+    (vec
+      (for [[k v] (sort-by key (or resolved-args {}))]
+        {:key   k
+         :value v
+         :doc   (let [entry (get atypes k)]
+                  (cond
+                    (map? entry)    (or (:doc entry) (:description entry))
+                    (string? entry) entry
+                    :else           nil))}))))
+
+(defn decorator-rows
+  "Compose the rows of the decorator-stack table from a
+  `resolve-decorators` pack. Each row is
+
+      {:section :hiccup|:frame-setup|:fx-override
+       :id      <decorator-id>
+       :doc     <:doc on body, or nil>}
+
+  Stage 6's `:errors` slot is shown in a dedicated row group at the
+  bottom (with `:section :error`)."
+  [pack]
+  (let [{:keys [hiccup frame-setup fx-override errors]} (or pack {})]
+    (vec
+      (concat
+        (for [d hiccup]
+          {:section :hiccup :id (:id d) :doc (:doc (:body d))})
+        (for [d frame-setup]
+          {:section :frame-setup :id (:id d) :doc (:doc (:body d))})
+        (for [d fx-override]
+          {:section :fx-override :id (:id d) :doc (:doc (:body d))})
+        (for [e errors]
+          {:section :error :id (:id e) :doc (str (:reason e))})))))
+
+(defn parameter-rows
+  "Compose the rows of the parameters table — the variant-level
+  metadata that's neither args nor decorators nor tags. Per spec/008
+  §Parameters this maps to `:modes` / `:substrates` / `:platforms` on
+  the variant body, plus the story-level defaults.
+
+  Each row is `{:key :modes|:substrates|:platforms
+                 :value <set-or-vector-as-string>}`."
+  [variant-id]
+  (let [vb       (registrar/handler-meta :variant variant-id)
+        story-id (when (and (keyword? variant-id) (namespace variant-id))
+                   (keyword (namespace variant-id)))
+        sb       (when story-id (registrar/handler-meta :story story-id))
+        get-eff  (fn [k] (or (get vb k) (get sb k)))]
+    (vec
+      (keep
+        (fn [k]
+          (let [v (get-eff k)]
+            (when (seq v) {:key k :value v})))
+        [:modes :substrates :platforms]))))
+
+(defn variant-tags
+  "Return the sorted vector of tags on `variant-id`. Falls back to the
+  parent story's `:tags` set if the variant body declares none. Used
+  by both the docs header chips and the bottom-of-page tag picker."
+  [variant-id]
+  (let [vb       (registrar/handler-meta :variant variant-id)
+        story-id (when (and (keyword? variant-id) (namespace variant-id))
+                   (keyword (namespace variant-id)))
+        sb       (when story-id (registrar/handler-meta :story story-id))
+        ts       (or (:tags vb) (:tags sb) #{})]
+    (vec (sort ts))))
+
+(defn parent-story-id
+  "Mirror of `args/parent-story-id` so the JVM-side namespace doesn't
+  need to require the args ns (`args.cljc` requires `config.cljc`
+  which is fine on the JVM but pulls more than we need for the pure
+  helpers here)."
+  [variant-id]
+  (when (and (keyword? variant-id) (namespace variant-id))
+    (keyword (namespace variant-id))))
+
+;; ---- CLJS-side rendering -------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:wrap          {:flex             "1"
+                      :overflow         "auto"
+                      :padding          "20px 28px"
+                      :background       "#1e1e1e"
+                      :color            "#cccccc"
+                      :font-family      "system-ui, sans-serif"
+                      :font-size        "13px"
+                      :line-height      "1.5"}
+      :h1            {:font-family      "monospace"
+                      :font-size        "18px"
+                      :font-weight      "bold"
+                      :color            "white"
+                      :margin           "0 0 4px 0"}
+      :sub           {:color            "#b0b0b0"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :margin-bottom    "10px"}
+      :section       {:margin-top       "24px"}
+      :section-h     {:font-weight      "bold"
+                      :color            "#b0b0b0"
+                      :text-transform   "uppercase"
+                      :font-size        "10px"
+                      :letter-spacing   "0.5px"
+                      :margin-bottom    "8px"
+                      :border-bottom    "1px solid #444"
+                      :padding-bottom   "4px"}
+      :doc-blurb     {:color            "#b0b0b0"
+                      :font-style       "italic"
+                      :margin           "4px 0 12px 0"}
+      :prose-block   {:padding          "12px 16px"
+                      :margin-bottom    "8px"
+                      :background       "#252526"
+                      :border-left      "3px solid #0e639c"
+                      :color            "#dcdcdc"
+                      :font-family      "system-ui, sans-serif"
+                      :white-space      "pre-wrap"}
+      :prose-source  {:color            "#b0b0b0"
+                      :font-family      "monospace"
+                      :font-size        "10px"
+                      :margin-bottom    "4px"}
+      :table         {:width            "100%"
+                      :border-collapse  "collapse"
+                      :font-family      "monospace"
+                      :font-size        "11px"}
+      :th            {:text-align       "left"
+                      :padding          "6px 8px"
+                      :background       "#2d2d30"
+                      :color            "#b0b0b0"
+                      :border-bottom    "1px solid #444"
+                      :text-transform   "uppercase"
+                      :font-size        "10px"
+                      :letter-spacing   "0.5px"}
+      :td            {:padding          "6px 8px"
+                      :border-bottom    "1px solid #2d2d30"
+                      :color            "#dcdcdc"
+                      :vertical-align   "top"}
+      :td-key        {:color            "#9cdcfe"
+                      :white-space      "nowrap"}
+      :td-value      {:color            "#ce9178"
+                      :font-family      "monospace"
+                      :white-space      "pre-wrap"}
+      :td-doc        {:color            "#b0b0b0"
+                      :font-style       "italic"}
+      :section-h-row {:background       "#37373d"
+                      :color            "#b0b0b0"
+                      :text-transform   "uppercase"
+                      :font-size        "10px"
+                      :letter-spacing   "0.5px"}
+      :chip-row      {:display          "flex"
+                      :flex-wrap        "wrap"
+                      :gap              "6px"
+                      :margin-top       "4px"}
+      :chip          {:padding          "3px 9px"
+                      :background       "#37373d"
+                      :color            "#cccccc"
+                      :border           "none"
+                      :border-radius    "10px"
+                      :cursor           "pointer"
+                      :font-family      "monospace"
+                      :font-size        "10px"
+                      :user-select      "none"}
+      :chip-active   {:background       "#0e639c"
+                      :color            "white"}
+      :empty         {:color            "#9a9a9a"
+                      :font-style       "italic"
+                      :padding          "6px 0"}}))
+
+#?(:cljs
+   (defn- pretty-value
+     "Render a default-arg value for the args table. Strings show
+     quoted; everything else uses `pr-str` so keywords / maps / vectors
+     are visibly distinguishable from strings."
+     [v]
+     (cond
+       (nil? v)    "nil"
+       (string? v) (pr-str v)
+       :else       (pr-str v))))
+
+#?(:cljs
+   (defn- header
+     "Render the variant header — id, parent story, tags as chips that
+     forward-link to the sidebar tag filter."
+     [variant-id]
+     (let [shell      @state/shell-state-atom
+           tag-filter (or (:tag-filter shell) #{})
+           tags       (variant-tags variant-id)
+           vb         (registrar/handler-meta :variant variant-id)
+           story-id   (parent-story-id variant-id)
+           sb         (when story-id (registrar/handler-meta :story story-id))
+           vdoc       (:doc vb)
+           sdoc       (:doc sb)]
+       [:div
+        [:h1 {:style (:h1 styles)}
+         (str variant-id)]
+        [:div {:style (:sub styles)
+               :data-test "story-docs-parent-story"}
+         (if story-id
+           (str "parent story: " story-id)
+           "no parent story registered")]
+        (when (seq tags)
+          [:div {:style     (:chip-row styles)
+                 :data-test "story-docs-header-tags"}
+           (for [tag tags]
+             ^{:key tag}
+             [:button
+              {:style    (merge (:chip styles)
+                                (when (contains? tag-filter tag)
+                                  (:chip-active styles)))
+               :data-test       "story-docs-tag-chip"
+               :data-docs-tag   (name tag)
+               :aria-pressed    (if (contains? tag-filter tag) "true" "false")
+               :title           (str "Toggle tag filter for " tag)
+               :on-click
+               (fn [_]
+                 (state/swap-state! state/toggle-tag-filter tag))}
+              (str tag)])])
+        (when (or (seq vdoc) (seq sdoc))
+          [:div {:style     (:doc-blurb styles)
+                 :data-test "story-docs-doc-blurb"}
+           (or vdoc sdoc)])])))
+
+#?(:cljs
+   (defn- prose-section
+     "Render the prose blocks pulled from `:prose` workspaces that
+     reference this variant. Renders nothing when no prose is found —
+     deliberately not a 'no prose' placeholder, the page reads cleaner
+     without it (the args table is the primary docs surface)."
+     [variant-id]
+     (let [entries (prose-for-variant variant-id)]
+       (when (seq entries)
+         [:div {:style     (:section styles)
+                :data-test "story-docs-prose-section"}
+          [:div {:style (:section-h styles)} "Prose"]
+          (for [[i {:keys [workspace-id body]}] (map-indexed vector entries)]
+            ^{:key i}
+            [:div {:data-test "story-docs-prose-block"}
+             [:div {:style (:prose-source styles)}
+              (str "from " workspace-id)]
+             [:div {:style (:prose-block styles)} body]])]))))
+
+#?(:cljs
+   (defn- args-section
+     "Args table — every resolved arg with default + :doc (when an
+     `:argtypes` entry exists)."
+     [variant-id]
+     (let [shell    @state/shell-state-atom
+           eff-args (args/resolve-args
+                      variant-id
+                      {:active-modes (:active-modes shell)
+                       ;; :docs is read-only — overrides are deliberately
+                       ;; left out so the table reflects the variant's
+                       ;; declared shape, not the user's transient edits.
+                       :cell-overrides nil})
+           rows     (args-rows variant-id eff-args)]
+       [:div {:style     (:section styles)
+              :data-test "story-docs-args-section"}
+        [:div {:style (:section-h styles)} "Args"]
+        (if (empty? rows)
+          [:div {:style (:empty styles)} "no args resolved on this variant"]
+          [:table {:style     (:table styles)
+                   :data-test "story-docs-args-table"}
+           [:thead
+            [:tr
+             [:th {:style (:th styles)} "key"]
+             [:th {:style (:th styles)} "default"]
+             [:th {:style (:th styles)} "doc"]]]
+           [:tbody
+            (for [{:keys [key value doc]} rows]
+              ^{:key key}
+              [:tr {:data-test "story-docs-args-row"
+                    :data-arg-key (str key)}
+               [:td {:style (merge (:td styles) (:td-key styles))}
+                (str key)]
+               [:td {:style (merge (:td styles) (:td-value styles))}
+                (pretty-value value)]
+               [:td {:style (merge (:td styles) (:td-doc styles))}
+                (or doc "—")]])]])])))
+
+#?(:cljs
+   (defn- decorators-section
+     "Decorator stack — three groups (hiccup / frame-setup / fx-override)
+     in apply-order. Story-level decorators come first per
+     `resolve-decorators` semantics."
+     [variant-id]
+     (let [pack (decorators/resolve-decorators variant-id)
+           rows (decorator-rows pack)]
+       [:div {:style     (:section styles)
+              :data-test "story-docs-decorators-section"}
+        [:div {:style (:section-h styles)} "Decorators"]
+        (if (empty? rows)
+          [:div {:style (:empty styles)}
+           "no decorators on this variant"]
+          [:table {:style     (:table styles)
+                   :data-test "story-docs-decorators-table"}
+           [:thead
+            [:tr
+             [:th {:style (:th styles)} "kind"]
+             [:th {:style (:th styles)} "id"]
+             [:th {:style (:th styles)} "doc"]]]
+           [:tbody
+            (for [[i {:keys [section id doc]}] (map-indexed vector rows)]
+              ^{:key i}
+              [:tr {:data-test     "story-docs-decorator-row"
+                    :data-section  (name section)}
+               [:td {:style (merge (:td styles) (:td-key styles))}
+                (name section)]
+               [:td {:style (merge (:td styles) (:td-value styles))}
+                (str id)]
+               [:td {:style (merge (:td styles) (:td-doc styles))}
+                (or doc "—")]])]])])))
+
+#?(:cljs
+   (defn- parameters-section
+     "Parameters — `:modes` / `:substrates` / `:platforms` on the
+     variant body, falling back to the parent story. Per spec/008
+     §Parameters re-frame2 collapses Storybook's free-form
+     `:parameters` map into these three explicit slots."
+     [variant-id]
+     (let [rows (parameter-rows variant-id)]
+       [:div {:style     (:section styles)
+              :data-test "story-docs-parameters-section"}
+        [:div {:style (:section-h styles)} "Parameters"]
+        (if (empty? rows)
+          [:div {:style (:empty styles)}
+           "no :modes / :substrates / :platforms declared"]
+          [:table {:style     (:table styles)
+                   :data-test "story-docs-parameters-table"}
+           [:thead
+            [:tr
+             [:th {:style (:th styles)} "key"]
+             [:th {:style (:th styles)} "value"]]]
+           [:tbody
+            (for [{:keys [key value]} rows]
+              ^{:key key}
+              [:tr {:data-test "story-docs-parameter-row"
+                    :data-param-key (name key)}
+               [:td {:style (merge (:td styles) (:td-key styles))}
+                (str key)]
+               [:td {:style (merge (:td styles) (:td-value styles))}
+                (pr-str value)]])]])])))
+
+#?(:cljs
+   (defn- tags-section
+     "Bottom tag picker — clickable chips that forward-link into the
+     sidebar tag filter. Re-uses the controls-panel chip style so the
+     surface feels familiar; selecting a chip dispatches
+     `state/toggle-tag-filter` and the sidebar re-renders with the
+     constrained tree."
+     [variant-id]
+     (let [shell      @state/shell-state-atom
+           tag-filter (or (:tag-filter shell) #{})
+           tags       (variant-tags variant-id)]
+       [:div {:style     (:section styles)
+              :data-test "story-docs-tags-section"}
+        [:div {:style (:section-h styles)} "Tags"]
+        (if (empty? tags)
+          [:div {:style (:empty styles)}
+           "no tags on this variant"]
+          [:div {:style     (:chip-row styles)
+                 :data-test "story-docs-tags-row"}
+           (for [tag tags]
+             ^{:key tag}
+             [:button
+              {:style          (merge (:chip styles)
+                                      (when (contains? tag-filter tag)
+                                        (:chip-active styles)))
+               :data-test      "story-docs-tag-link"
+               :data-docs-tag  (name tag)
+               :aria-pressed   (if (contains? tag-filter tag) "true" "false")
+               :title          (str "Toggle tag filter for " tag)
+               :on-click
+               (fn [_]
+                 (state/swap-state! state/toggle-tag-filter tag))}
+              (str tag)])])])))
+
+#?(:cljs
+   (defn docs-view
+     "Top-level `:docs` mode pane for `variant-id`.
+
+     Renders the six sections (header / prose / args / decorators /
+     parameters / tags) inside a single scrollable container styled
+     to match the render-shell chrome (rf2-2uwv contrast palette).
+
+     Per spec/008 the pane is read-only — no inputs. All editing
+     happens in the `:dev` (Canvas) mode's controls panel."
+     [variant-id]
+     (when variant-id
+       [:section {:style     (:wrap styles)
+                  :data-test "story-docs-view"
+                  :aria-label "Variant documentation"}
+        [header variant-id]
+        [prose-section variant-id]
+        [args-section variant-id]
+        [decorators-section variant-id]
+        [parameters-section variant-id]
+        [tags-section variant-id]])))

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -6,9 +6,9 @@
 
   - `:dev`  — Canvas. The interactive variant render (Story v1 default).
   - `:docs` — Docs. The read-only AutoDocs-equivalent: prose + args
-              table + decorator stack + parameters + tags. The full
-              implementation lands with rf2-rodx; this primitive ships
-              the placeholder.
+              table + decorator stack + parameters + tags. Implemented
+              in `re-frame.story.ui.docs` (rf2-rodx); this primitive
+              owns the chip strip only.
   - `:test` — Tests. The in-canvas aggregated pass/fail summary for the
               variant's interactions / assertions. The full
               implementation lands with rf2-qmjo; this primitive ships
@@ -29,7 +29,7 @@
   to decide which pane renders below the strip:
 
   - `:dev`  → existing canvas / workspace path (unchanged).
-  - `:docs` → `docs-placeholder` (rf2-rodx will replace this).
+  - `:docs` → `re-frame.story.ui.docs/docs-view` (rf2-rodx).
   - `:test` → `tests-placeholder` (rf2-qmjo will replace this).
 
   ## Visual style
@@ -184,21 +184,10 @@
 
 ;; ---- placeholder panes ---------------------------------------------------
 ;;
-;; rf2-rodx (Docs) and rf2-qmjo (Tests) replace these. Until then the
-;; chrome surfaces the contract so users know the mode exists and that
-;; the dedicated view is on the roadmap.
-
-(defn docs-placeholder
-  "Stub for the `:docs` mode pane. Replaced by rf2-rodx."
-  [variant-id]
-  [:div {:style     (:placeholder styles)
-         :data-test "story-docs-placeholder"}
-   [:div {:style {:font-weight "bold" :margin-bottom "8px"}}
-    "Docs view"]
-   [:div "AutoDocs-equivalent (prose + args table + decorator stack + "
-    "parameters + tags) for "
-    [:code (str variant-id)]
-    " coming in rf2-rodx."]])
+;; rf2-rodx (Docs) is now implemented in `re-frame.story.ui.docs`. The
+;; `:test` placeholder remains until rf2-qmjo lands — the chrome
+;; surfaces the contract so users know the mode exists and that the
+;; dedicated view is on the roadmap.
 
 (defn tests-placeholder
   "Stub for the `:test` mode pane. Replaced by rf2-qmjo."

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -44,6 +44,7 @@
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
@@ -267,8 +268,10 @@
 
   Per rf2-9hc8 a Canvas | Docs | Tests mode-tab strip sits at the top
   of the pane when a variant is selected; selection is per-variant and
-  persists across reloads in localStorage. The `:docs` and `:test`
-  panes are placeholders for rf2-rodx / rf2-qmjo respectively; `:dev`
+  persists across reloads in localStorage. Per rf2-rodx the `:docs`
+  pane now renders `docs/docs-view` — the read-only AutoDocs surface
+  composed of header / prose / args / decorators / parameters / tags
+  sections. `:test` remains a placeholder for rf2-qmjo; `:dev`
   preserves the existing canvas / workspace behaviour."
   []
   (let [shell      @state/shell-state-atom
@@ -288,7 +291,7 @@
      (cond
        ws-id    [workspace/workspace-view ws-id]
        variant-id (case mode-tab
-                    :docs [mode-tabs/docs-placeholder variant-id]
+                    :docs [docs/docs-view variant-id]
                     :test [mode-tabs/tests-placeholder variant-id]
                     [canvas/canvas])
        :else

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -22,6 +22,7 @@
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.state :as state]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.sidebar :as sidebar]
@@ -263,7 +264,45 @@
     (is (fn? sidebar/sidebar))
     (is (fn? trace/panel))
     ;; The controls/panel takes a variant-id arg.
-    (is (fn? controls/panel))))
+    (is (fn? controls/panel))
+    ;; rf2-rodx — the :docs mode pane.
+    (is (fn? docs/docs-view))))
+
+(deftest docs-view-returns-hiccup-for-registered-variant
+  (testing "docs-view returns a hiccup vector for a registered variant — the
+            shell can mount it without a thrown ns-resolution error.
+            The CLJS smoke proves the cljs-only `:require` (args /
+            decorators / state) and the section renderers compose."
+    (story/reg-story :story.dv
+      {:doc       "parent for the docs-view smoke."
+       :tags      #{:dev :docs}})
+    (story/reg-variant :story.dv/x
+      {:doc       "a tiny variant."
+       :args      {:label "L"}
+       :argtypes  {:label {:doc "label slot"}}
+       :tags      #{:dev :docs}
+       :events    []})
+    (let [result (docs/docs-view :story.dv/x)]
+      (is (vector? result))
+      ;; Root is a <section> per the read-only contract.
+      (is (= :section (first result))))
+    ;; The fn returns nil when given no variant id (the shell already
+    ;; gates this, but the helper guards itself too).
+    (is (nil? (docs/docs-view nil)))))
+
+(deftest docs-view-section-pure-helpers
+  (testing "the pure section helpers run end-to-end in CLJS too"
+    (story/reg-story :story.dvh
+      {:tags #{:dev :docs}})
+    (story/reg-variant :story.dvh/x
+      {:args      {:greeting "hi"}
+       :argtypes  {:greeting {:doc "the greeting"}}
+       :tags      #{:dev :docs}
+       :events    []})
+    (let [rows (docs/args-rows :story.dvh/x {:greeting "hi"})]
+      (is (= [{:key :greeting :value "hi" :doc "the greeting"}]
+             rows)))
+    (is (= [:dev :docs] (docs/variant-tags :story.dvh/x)))))
 
 ;; ---- canvas: decorator-wrap exception swallow ---------------------------
 ;;

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -22,6 +22,7 @@
             [re-frame.story.config    :as config]
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.docs   :as docs]
             [re-frame.story.ui.state  :as state]
             [re-frame.story.ui.workspace :as workspace]))
 
@@ -266,3 +267,132 @@
 (deftest unknown-layout-empty
   (testing "unknown layouts degrade gracefully"
     (is (= [] (workspace/resolve-layout :Workspace.x/y {:layout :weird})))))
+
+;; ---- docs mode (rf2-rodx) -----------------------------------------------
+
+(deftest docs-parent-story-id
+  (testing "parent-story-id mirrors args/parent-story-id"
+    (is (= :story.foo (docs/parent-story-id :story.foo/bar)))
+    (is (nil? (docs/parent-story-id :no-namespace)))
+    (is (nil? (docs/parent-story-id nil)))))
+
+(deftest docs-variant-tags-falls-back-to-story
+  (testing "variant-tags reads variant :tags first"
+    (story/reg-story :story.t1
+      {:doc "parent" :tags #{:dev :docs}})
+    (story/reg-variant :story.t1/a
+      {:tags #{:dev :test} :events []})
+    (is (= [:dev :test] (docs/variant-tags :story.t1/a))))
+  (testing "variant-tags falls back to the parent story when the variant has none"
+    (story/reg-story :story.t2
+      {:doc "parent" :tags #{:dev :docs}})
+    (story/reg-variant :story.t2/a {:events []})
+    (is (= [:dev :docs] (docs/variant-tags :story.t2/a)))))
+
+(deftest docs-args-rows-pulls-doc-from-argtypes
+  (testing "args-rows surfaces :doc from the variant's :argtypes entry"
+    (story/reg-variant :story.a/x
+      {:args     {:label "Total" :count 0}
+       :argtypes {:label {:doc "The cell label"}}
+       :events   []})
+    (let [rows  (docs/args-rows :story.a/x {:label "Total" :count 0})
+          by-k  (into {} (map (juxt :key identity)) rows)]
+      (is (= 2 (count rows)))
+      (is (= "The cell label" (:doc (get by-k :label))))
+      (is (nil? (:doc (get by-k :count))))
+      (is (= "Total" (:value (get by-k :label))))))
+  (testing "args-rows accepts the Storybook-compat :description key"
+    (story/reg-variant :story.a/desc
+      {:argtypes {:label {:description "Story-compat description slot"}}
+       :events   []})
+    (let [[row] (docs/args-rows :story.a/desc {:label "foo"})]
+      (is (= "Story-compat description slot" (:doc row)))))
+  (testing "args-rows accepts a bare-string :argtypes value"
+    (story/reg-variant :story.a/bare
+      {:argtypes {:label "Short doc"}
+       :events   []})
+    (let [[row] (docs/args-rows :story.a/bare {:label "foo"})]
+      (is (= "Short doc" (:doc row)))))
+  (testing "args-rows merges parent-story :argtypes under variant :argtypes"
+    (story/reg-story :story.p
+      {:argtypes {:label {:doc "from story"}
+                  :count {:doc "from story"}}})
+    (story/reg-variant :story.p/x
+      {:argtypes {:label {:doc "from variant"}}
+       :events   []})
+    (let [rows  (docs/args-rows :story.p/x {:label "L" :count 0})
+          by-k  (into {} (map (juxt :key identity)) rows)]
+      (is (= "from variant" (:doc (get by-k :label))))
+      (is (= "from story"   (:doc (get by-k :count)))))))
+
+(deftest docs-decorator-rows-classifies-by-section
+  (testing "decorator-rows splits the pack into hiccup / frame-setup / fx-override / error rows"
+    (let [pack {:hiccup       [{:id :dec/h1 :body {:kind :hiccup :doc "outer"}}
+                               {:id :dec/h2 :body {:kind :hiccup}}]
+                :frame-setup  [{:id :dec/fs :body {:kind :frame-setup :doc "init"}}]
+                :fx-override  [{:id :dec/fx :body {:kind :fx-override}}]
+                :errors       [{:id :dec/bad :reason "unknown :kind"}]
+                :fingerprints {}}
+          rows (docs/decorator-rows pack)]
+      (is (= 5 (count rows)))
+      (is (= [:hiccup :hiccup :frame-setup :fx-override :error]
+             (mapv :section rows)))
+      (is (= "outer" (-> rows (nth 0) :doc)))
+      (is (= "unknown :kind" (-> rows (nth 4) :doc))))))
+
+(deftest docs-parameter-rows-pulls-three-slots
+  (testing "parameter-rows emits :modes / :substrates / :platforms only when non-empty"
+    (story/reg-variant :story.p1/x
+      {:substrates #{:reagent}
+       :platforms  #{:client}
+       :events     []})
+    (let [rows  (docs/parameter-rows :story.p1/x)
+          by-k  (into {} (map (juxt :key identity)) rows)]
+      (is (= 2 (count rows)))
+      (is (contains? by-k :substrates))
+      (is (contains? by-k :platforms))
+      (is (not (contains? by-k :modes)))))
+  (testing "parameter-rows falls back to the parent story's slots"
+    (story/reg-story :story.p2
+      {:substrates #{:reagent :uix}
+       :platforms  #{:client}})
+    (story/reg-variant :story.p2/x {:events []})
+    (let [rows (docs/parameter-rows :story.p2/x)
+          by-k (into {} (map (juxt :key identity)) rows)]
+      (is (= #{:reagent :uix} (:value (get by-k :substrates))))
+      (is (= #{:client}       (:value (get by-k :platforms)))))))
+
+(deftest docs-prose-for-variant
+  (testing "prose-for-variant returns workspace prose blocks that reference the variant"
+    (story/reg-variant :story.d/x {:events []})
+    (story/reg-variant :story.d/y {:events []})
+    (story/reg-workspace :Workspace.d/intro
+      {:layout  :prose
+       :content [{:type :prose   :body "## How it works"}
+                 {:type :variant :id   :story.d/x}
+                 {:type :prose   :body "Footer note."}]})
+    (let [blocks (docs/prose-for-variant :story.d/x)]
+      (is (= 2 (count blocks)))
+      (is (= "## How it works" (-> blocks first :body)))
+      (is (= :Workspace.d/intro (-> blocks first :workspace-id))))
+    (testing "a variant the workspace doesn't reference picks up nothing"
+      (is (= [] (docs/prose-for-variant :story.d/y)))))
+  (testing "non-prose layouts are ignored entirely"
+    (story/reg-variant :story.dg/x {:events []})
+    (story/reg-workspace :Workspace.dg/grid
+      {:layout :grid :variants [:story.dg/x]})
+    (is (= [] (docs/prose-for-variant :story.dg/x))))
+  (testing "prose blocks ride through in source order across multiple workspaces"
+    (story/reg-variant :story.dm/x {:events []})
+    (story/reg-workspace :Workspace.dm/a
+      {:layout  :prose
+       :content [{:type :prose   :body "alpha"}
+                 {:type :variant :id   :story.dm/x}]})
+    (story/reg-workspace :Workspace.dm/b
+      {:layout  :prose
+       :content [{:type :variant :id   :story.dm/x}
+                 {:type :prose   :body "beta"}]})
+    (let [bodies (mapv :body (docs/prose-for-variant :story.dm/x))]
+      ;; Sorted by workspace id (alphabetic) then content order — :a/a
+      ;; before :b/b.
+      (is (= ["alpha" "beta"] bodies)))))


### PR DESCRIPTION
## Summary

- Replaces the rf2-9hc8 `:docs` mode-tab placeholder with `re-frame.story.ui.docs/docs-view` — the read-only AutoDocs-equivalent pane composed of six sections (header / prose / args / decorators / parameters / tags) per the new spec/008.
- Lands `tools/story/spec/008-Docs-Mode.md` as the normative entry; updates spec/007-Mode-Tabs.md + spec/README.md to forward-link. `mode-tabs.cljs` drops the `docs-placeholder` def (the new view supersedes it) and the shell points the `:docs` case at `docs/docs-view`.
- Pure data → data helpers (`prose-for-variant`, `args-rows`, `decorator-rows`, `parameter-rows`, `variant-tags`) live in the `.cljc` so the JVM corpus covers the walks; the Reagent renderer is CLJS-only.
- Also fixes a duplicate-`const` syntax error in `counter_with_stories.spec.cjs` (preexisting from PR #454 — `docsChip` was declared twice in the same arrow-function scope).

### Section composition

| # | Section     | Data source                                                                     |
|---|-------------|---------------------------------------------------------------------------------|
| 1 | Header      | variant id, parent-story id, tag chips, variant `:doc`                          |
| 2 | Prose       | `:body` strings from `:layout :prose` workspaces that reference the variant     |
| 3 | Args        | `args/resolve-args` (no overrides) × variant/story `:argtypes`                  |
| 4 | Decorators  | `decorators/resolve-decorators` — `:hiccup` / `:frame-setup` / `:fx-override`  |
| 5 | Parameters  | variant `:modes` / `:substrates` / `:platforms` (parent-story fallback)         |
| 6 | Tags        | sorted variant tags — clickable forward-links into the sidebar filter           |

Read-only — no inputs, no overrides. Switching `:docs` → `:dev` restores the canvas as the user left it.

## Test plan

- [x] `clojure -M:test` (`tools/story`) — 162 tests / 424 assertions, 0 failures (+5 deftests / 17 assertions for the docs helpers)
- [x] `npm run test:cljs` — 588 tests / 1390 assertions, 0 failures (+2 deftests for the docs-view smoke)
- [x] `node --check examples/reagent/counter_with_stories/counter_with_stories.spec.cjs` — clean (was failing pre-change due to the duplicate `const docsChip`)
- [ ] `npm run test:examples` — Playwright sub-tests in §3b-i: docs view root, parent-story sub-header, args table with `:label` row, decorators table with `:hiccup` row, tags section, bottom tag chip forward-link (aria-pressed flip + restore)