### PR TITLE
chore(docs+evals): cluster-I link fixes + evals.json API-churn refresh (rf2-ehp8, rf2-uimm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ re-frame2 is spec-first and AI-implementable. If you're an LLM landing here to i
 - "Where does `<surface>` live?" → [spec/Ownership.md](spec/Ownership.md).
 - "What's the contract for `<topic>`?" → `spec/<NNN>-<topic>.md`.
 - "How is this tested?" → [spec/conformance/](spec/conformance/) (executable EDN fixtures).
-- "Does the implementation actually do what the spec says?" → [`implementation/core/`](implementation/core/) + [`implementation/adapters/reagent/`](implementation/adapters/reagent/) + the conformance suite.
+- "Does the implementation actually do what the spec says?" → [`implementation/core/deps.edn`](implementation/core/deps.edn) + [`implementation/adapters/reagent/`](implementation/adapters/reagent/) + the conformance suite.
 - "What's the public API?" → [spec/API.md](spec/API.md).
 - "How do I scaffold a `<kind>`?" → [spec/Construction-Prompts.md](spec/Construction-Prompts.md).
 

--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -182,7 +182,7 @@ live. Subsequent tool calls reuse the same socket.
 ## Skill-driven calls
 
 With the pair2 skill loaded (see
-[`../../skills/re-frame-pair2/SKILL.md`](../../skills/re-frame-pair2/SKILL.md)),
+[`../../../skills/re-frame-pair2/SKILL.md`](../../../skills/re-frame-pair2/SKILL.md)),
 agents describe the task in plain language and the skill's
 `SKILL.md` teaches the model which tool to call. The MCP server is
 the transport; the skill is the playbook.


### PR DESCRIPTION
## Summary

Two P4 micro-polish items bundled:

- **rf2-ehp8** — Cluster I single-link polish from docs-crosslink audit 2026-05-12. Two tiny link fixes.
- **rf2-uimm** — Audit `skills/re-frame2/evals/evals.json` against API churn that landed since the evals were authored.

## Changes

### rf2-ehp8 — link fixes

- `README.md` L248: bare `implementation/core/` ref had no README landing; retargeted to `implementation/core/deps.edn` (the artefact's entry point).
- `tools/pair2-mcp/spec/API.md` L185: wrong-depth skill ref. From `tools/pair2-mcp/spec/` to `skills/re-frame-pair2/SKILL.md` needs `../../../` (three levels up), not `../../` (two). Fixed.

Doc-slug check (`python scripts/check_doc_slugs.py`) passes (exit 0).

### rf2-uimm — evals.json audit

Audited the six evals against every surface-change bead listed in rf2-uimm:

- rf2-3nn8 `:rf.trace/trigger-handler`
- rf2-ngdp `:fx-overrides` fn-branch
- rf2-koyp `:schema-validation-failure?` rename (was `:malli-error?`)
- rf2-osxa Spec 010 substrate-agnostic surface
- rf2-mm2a `:rf/interceptor-errors` vector
- rf2-k3bj `:rf.error/effect-handler-bad-return`
- rf2-gn80 `:final?` + `:on-done` + `:output-key`
- rf2-gr8q in-snapshot `:rf/spawn-counter`
- rf2-hzos `reg-view` return-value contract
- rf2-q2yv view-antipatterns + animations
- rf2-7ho2 Story side-table

**Result: no drift.** Every expectation in the six evals targets stable surfaces the listed beads did not touch — `:rf.http/managed`, `reg-machine` + the canonical state-machine grammar, Pattern-RemoteData 5-key slice, Pattern-Forms 7-key slice with `:touched ∨ :submit-attempted?` gating and the two-channel error model, `SKILL-REDIRECT.md` migration routing, and `re-frame2-setup` greenfield routing. None of the churned keywords (`:malli-error?`, `:rf/interceptor-errors`, `:rf.error/effect-handler-bad-return`, `:final?`, `reg-view`, animations, Story, etc.) appear in evals.json.

Each expectation was cross-checked against current `spec/*` and `skills/re-frame2/{patterns,reference}/*` sources. No eval requires update; no follow-up bead filed.

## Test plan

- [x] `python scripts/check_doc_slugs.py` reports 0 broken (exit 0).
- [x] Both relative paths resolve on disk.
- [x] evals.json audited per-entry against current API surface.