### PR TITLE
chore(deps): bump org.clojure/clojurescript 1.11.132 -> 1.12.145 (rf2-rlpo)

### DIFF
--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -37,7 +37,7 @@
 ;; schemas artefact (which carries Malli) alongside core.
 {:paths ["src"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
          reagent/reagent           {:mvn/version "2.0.1"}}
 
  :aliases

--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -44,7 +44,7 @@
 ;; sources are .cljs and need a CLJS compiler.
 {:paths ["src"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
          applied-science/js-interop {:mvn/version "0.4.2"}
          thheller/shadow-cljs      {:mvn/version "3.4.10"}}
 

--- a/tools/template/src/clj/new/re_frame2/helix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/helix/deps.edn
@@ -11,7 +11,7 @@
 {:paths ["src"]
 
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-helix      {:mvn/version "{{rf2-version}}"}

--- a/tools/template/src/clj/new/re_frame2/reagent/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/deps.edn
@@ -12,7 +12,7 @@
 {:paths ["src"]
 
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-reagent    {:mvn/version "{{rf2-version}}"}

--- a/tools/template/src/clj/new/re_frame2/uix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/uix/deps.edn
@@ -12,7 +12,7 @@
 {:paths ["src"]
 
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-uix        {:mvn/version "{{rf2-version}}"}


### PR DESCRIPTION
## Summary

- Follow-on to #470 (which bumped `org.clojure/clojure` to 1.12.0). Bumps `org.clojure/clojurescript` 1.11.132 -> 1.12.145 to align the CLJS compiler with the framework's Clojure version.
- Five `deps.edn` files touched: `implementation/core`, `tools/pair2-mcp`, and the three `tools/template/src/clj/new/re_frame2/{reagent,uix,helix}` template files. All other artefacts inherit via `:local/root "core"`.
- Completes the rf2-rlpo bead — framework CI now exercises the same Clojure + CLJS stack the template scaffolds onto new apps.

## Test plan

- [x] `clojure -M:test` across `core`, `schemas`, `machines`, `routing`, `flows`, `http`, `ssr`, `epoch`, `adapters/reagent`, `adapters/reagent-slim` — 632 JVM tests / 2541 assertions, 0 failures
- [x] `npm run test:cljs` (node) — 586 tests, 1384 assertions, 0 failures
- [x] `npm run test:browser` — 586 tests, 1411 assertions, 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:bundle-isolation` — PASS
- [x] `npm run test:bundle-comparison` — PASS
- [x] `npm run test:browser-prod-elision` — Ran 11 tests, 0 failures
- [x] `shadow-cljs release` builds for `examples/counter`, `examples/counter-perf`, `examples/counter-slim-and-fast`, `browser-test-schemas-boundary-prod` — all complete cleanly under CLJS 1.12.145