### PR TITLE
docs(guide): rename re-frame-10x -> re-frame-causa across guide chapters (rf2-2734)

### DIFF
--- a/docs/guide/02-app-db.md
+++ b/docs/guide/02-app-db.md
@@ -41,11 +41,11 @@ re-frame2 makes a different choice: **all of your application's state goes in on
 
 3. **One schema validates the whole app.** A [Malli](https://github.com/metosin/malli) schema over app-db is the schema for the entire application's state, and it runs in one place — after every event. A good schema gives more leverage than static types because it can talk about the relationships *between* values, not just the shape of each value alone. (Per [Spec 010](../../spec/010-Schemas.md).)
 
-4. **Undo/redo and time-travel come for free.** Because app-db is immutable, taking a snapshot is taking a *reference* — no copy. Thanks to structural sharing, keeping a ring buffer of the last few hundred app-db values costs almost nothing. Undo/redo becomes a matter of swapping the reference back; time-travel debugging is the same mechanism with a UI on top. re-frame-10x's epoch buffer (per [Spec 009](../../spec/009-Instrumentation.md)) is exactly this.
+4. **Undo/redo and time-travel come for free.** Because app-db is immutable, taking a snapshot is taking a *reference* — no copy. Thanks to structural sharing, keeping a ring buffer of the last few hundred app-db values costs almost nothing. Undo/redo becomes a matter of swapping the reference back; time-travel debugging is the same mechanism with a UI on top. re-frame-causa's epoch buffer (per [Spec 009](../../spec/009-Instrumentation.md)) is exactly this.
 
 Two smaller-but-useful affordances ride along on the same idea:
 
-- **You can `pprint` it; you can `diff` two app-dbs.** Whatever's wrong with the app right now, you can dump its entire state to the REPL and read it; before and after an event, before and after a refactor, before and after a bug, the diff is the whole story. Tools (re-frame-10x, re-frame-pair2) show it to you live.
+- **You can `pprint` it; you can `diff` two app-dbs.** Whatever's wrong with the app right now, you can dump its entire state to the REPL and read it; before and after an event, before and after a refactor, before and after a bug, the diff is the whole story. Tools (re-frame-causa, re-frame-pair2) show it to you live.
 
 - **No question of "where does this state go?"** The answer is always: somewhere in app-db, at a path your feature owns. When you add a `:cart`-feature, its state goes under `:cart`. When you add `:auth`, under `:auth`. The convention is the path.
 
@@ -68,7 +68,7 @@ This buys you three things:
 
 - **No mutation-bug class.** Half of "what's wrong with my app" in mutable-state systems is "something changed state from somewhere I don't expect." In re-frame2, only event handlers change state, and they do it by returning a new value. There is no `db.cart.push(item)` somewhere in your codebase. There can't be.
 
-- **Time-travel debugging that's actually free.** Recording the value of app-db before and after each event is recording two references. The framework keeps a ring buffer of them for the [pair tool](15-devtools-and-pair-tools.md) and [re-frame-10x](15-devtools-and-pair-tools.md) to read.
+- **Time-travel debugging that's actually free.** Recording the value of app-db before and after each event is recording two references. The framework keeps a ring buffer of them for the [pair tool](15-devtools-and-pair-tools.md) and [re-frame-causa](15-devtools-and-pair-tools.md) to read.
 
 The lost flexibility — you can't sneak a mutation in from a corner of the app — is the point. Less flexibility, more inspectability.
 

--- a/docs/guide/10-doing-http-requests.md
+++ b/docs/guide/10-doing-http-requests.md
@@ -160,7 +160,7 @@ The `:decode` key takes:
 
 `:max-attempts` is the total including the first; `1` means no retry. `:on` names which failure categories trigger a retry — `:rf.http/aborted` is never retried regardless. Backoff is exponential with optional ±25% jitter, capped at `:max-ms`.
 
-**Only the final exhausted-retries failure dispatches `:on-failure`.** Intermediate attempts that match `:retry :on` do NOT dispatch the failure handler — the user sees the success reply if any attempt succeeds, and exactly one failure reply (with `:max-attempts` reached) if every attempt fails. For debugging visibility, each intermediate attempt emits a `:rf.http/retry-attempt` trace event. Pair tools and 10x panels surface the per-attempt trace; user code only sees the final outcome.
+**Only the final exhausted-retries failure dispatches `:on-failure`.** Intermediate attempts that match `:retry :on` do NOT dispatch the failure handler — the user sees the success reply if any attempt succeeds, and exactly one failure reply (with `:max-attempts` reached) if every attempt fails. For debugging visibility, each intermediate attempt emits a `:rf.http/retry-attempt` trace event. Pair tools and causa panels surface the per-attempt trace; user code only sees the final outcome.
 
 A common shape in real apps: declare a shared retry policy for read-only data fetches, and *don't* retry user-initiated actions (login, submit, delete — single user-initiated action per click).
 
@@ -268,7 +268,7 @@ For callers coming from a v1 codebase with their own `:http` fx (or `re-frame-ht
 
 ## Reference and tooling
 
-The pieces below are opt-in. A first-pass reader can skip this section; come back when wiring 10x panels, pair tools, or AI scaffolds against the managed-HTTP surface.
+The pieces below are opt-in. A first-pass reader can skip this section; come back when wiring causa panels, pair tools, or AI scaffolds against the managed-HTTP surface.
 
 ### Schema reflection — `:rf.http/decode-schemas`
 

--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -49,7 +49,7 @@ Three fields do the load-bearing work:
 - **`:operation`** is the category — namespaced (`:rf.error/...`, `:rf.warning/...`, `:rf.fx/...`, `:rf.ssr/...`, `:rf.epoch/...`). A consumer that wants "show me only handler exceptions" filters on `:operation :rf.error/handler-exception`.
 - **`:recovery`** is what re-frame2 did *after* the error — `:no-recovery`, `:replaced-with-default`, `:logged-and-skipped`, `:warned-and-replaced`, `:skipped`, `:retried`, `:ignored`. (See [§Recovery semantics](#recovery-semantics) below.)
 
-The optional **`:rf.trace/trigger-handler`** slot names the handler whose execution produced the error and carries its registration-site source-coord. Tools (10x, pair, IDE jump-to-source) consume the coord to render click-to-jump links straight to the offending handler. Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent on outermost-dispatch errors with no handler resolved (e.g. `:rf.error/no-such-handler`).
+The optional **`:rf.trace/trigger-handler`** slot names the handler whose execution produced the error and carries its registration-site source-coord. Tools (causa, pair, IDE jump-to-source) consume the coord to render click-to-jump links straight to the offending handler. Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent on outermost-dispatch errors with no handler resolved (e.g. `:rf.error/no-such-handler`).
 
 Everything else rides under `:tags`, with category-specific keys. The full schema lives in [Spec-Schemas](../../spec/Spec-Schemas.md) under `:rf/trace-event`; the per-category `:tags` shapes are pinned in [Spec-Schemas §Per-category `:tags` schemas](../../spec/Spec-Schemas.md#per-category-tags-schemas).
 
@@ -148,7 +148,7 @@ Two patterns that show up often:
 ;; @errors is a vector of every error/warning since boot.
 ```
 
-This is exactly how re-frame-10x v2 and re-frame-pair2 build their "errors" panel — same listener shape, same filter, richer rendering. The library writes nothing the framework doesn't surface; the trace event *is* the contract.
+This is exactly how re-frame-causa and re-frame-pair2 build their "errors" panel — same listener shape, same filter, richer rendering. The library writes nothing the framework doesn't surface; the trace event *is* the contract.
 
 ## Frame-scoped error policy: `:on-error`
 
@@ -242,7 +242,7 @@ Client-side UX mapping doesn't go through the projector. For client-side error U
 
 ## Reference and advanced topics
 
-The sections that follow are per-topic reference material. Reach for them when the topic comes up. §Common scenarios walks six failure modes end-to-end — read each when you meet it, skim on a first pass. §Testing error paths shows how to assert errors fire in tests. The 10x / pair tooling and "what structured errors buy you" close the chapter.
+The sections that follow are per-topic reference material. Reach for them when the topic comes up. §Common scenarios walks six failure modes end-to-end — read each when you meet it, skim on a first pass. §Testing error paths shows how to assert errors fire in tests. The causa / pair tooling and "what structured errors buy you" close the chapter.
 
 ## Common scenarios
 
@@ -464,11 +464,11 @@ The same shape applies to every `:rf.error/*` category: register a listener, do 
 
 For a test fixture that resets per-frame error listeners across tests, see the `reset-runtime` fixture in [`implementation/core/test/re_frame/cofx_test.clj`](../../implementation/core/test/re_frame/cofx_test.clj) — that's the canonical test harness shape the framework's own suite uses.
 
-## What you'll see in re-frame-10x and re-frame-pair2
+## What you'll see in re-frame-causa and re-frame-pair2
 
-The dev tools — re-frame-10x v2 (per [15 — Tooling](15-devtools-and-pair-tools.md)) and re-frame-pair2 (per [Spec Tool-Pair](../../spec/Tool-Pair.md)) — consume the same trace stream you'd consume with `register-trace-cb!`. The tools subscribe, filter on `:op-type :error`, and render an "errors" panel. There's nothing the tools see that you couldn't see from a listener — the channel is the contract; the tools just paint it.
+The dev tools — re-frame-causa (per [15 — Tooling](15-devtools-and-pair-tools.md)) and re-frame-pair2 (per [Spec Tool-Pair](../../spec/Tool-Pair.md)) — consume the same trace stream you'd consume with `register-trace-cb!`. The tools subscribe, filter on `:op-type :error`, and render an "errors" panel. There's nothing the tools see that you couldn't see from a listener — the channel is the contract; the tools just paint it.
 
-re-frame-10x's epoch buffer (per [Spec 009 §Epoch buffer](../../spec/009-Instrumentation.md)) groups trace events by dispatch cascade. When a cascade errors, the panel surfaces "this dispatch produced this error" with the full cascade tree — useful for the "but where did that fx come from?" debugging step.
+re-frame-causa's epoch buffer (per [Spec 009 §Epoch buffer](../../spec/009-Instrumentation.md)) groups trace events by dispatch cascade. When a cascade errors, the panel surfaces "this dispatch produced this error" with the full cascade tree — useful for the "but where did that fx come from?" debugging step.
 
 ## What structured errors buy you
 
@@ -476,7 +476,7 @@ Stand back from the schema and the tables and look at what's actually changed.
 
 A `try`/`catch` gives you an exception object and the stack that produced it. A `console.error` gives you a string in a log. Both of those are *terminal* — once the error has happened, you've lost the context that produced it, and recovering that context is a manual exercise the next time it happens.
 
-A structured trace event is *substrate*. The same map your dev panel renders is the map your monitoring bridge ships to Sentry, is the map your test asserts on, is the map your SSR projector sanitises for the wire, is the map re-frame-10x's epoch buffer groups by dispatch cascade so you can see "this event produced this error" with the full causal tree around it. Nothing has to be reconstructed; everything has already been recorded in the shape downstream consumers need.
+A structured trace event is *substrate*. The same map your dev panel renders is the map your monitoring bridge ships to Sentry, is the map your test asserts on, is the map your SSR projector sanitises for the wire, is the map re-frame-causa's epoch buffer groups by dispatch cascade so you can see "this event produced this error" with the full causal tree around it. Nothing has to be reconstructed; everything has already been recorded in the shape downstream consumers need.
 
 That's the part `try`/`catch` could never give you. Not because exceptions are wrong — they aren't — but because exceptions are *narrow*: they carry what threw, not what the system was doing when it threw. The trace event carries both. And because the trace event is data — namespaced keywords, plain maps, additive-only schema — every tool that touches it speaks the same language: the dev panel, the monitoring bridge, the test, the projector, the AI in your editor when you paste it in and ask "what does this mean?"
 
@@ -488,7 +488,7 @@ Errors stop being incidents to recover from and start being signals you can rout
 - **[Spec 011 — SSR §Server error projection](../../spec/011-SSR.md#server-error-projection)** — the full story on `reg-error-projector`, the `:rf/public-error` shape, and the server-vs-client error boundary.
 - **[Spec-Schemas](../../spec/Spec-Schemas.md)** — the Malli schema for every trace event (`:rf/trace-event`), including the per-category `:tags` schemas.
 - **[13 — Testing](13-testing.md)** — the broader testing surface; the trace-listener test pattern in this chapter is one of the recipes there.
-- **[15 — Tooling](15-devtools-and-pair-tools.md)** — what re-frame-10x v2 and re-frame-pair2 do with the trace stream, including the errors panel.
+- **[15 — Tooling](15-devtools-and-pair-tools.md)** — what re-frame-causa and re-frame-pair2 do with the trace stream, including the errors panel.
 
 ## Next
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -45,7 +45,7 @@ Read these when the topic comes up — not as part of the linear sequence. They'
 | 12 | [The dynamic-model story](12-the-dynamic-model.md) | You want the long-form essay on *why* less-powerful is more. Skippable for "I just want to write code" readers. |
 | 13 | [Testing](13-testing.md) | You're about to write tests — `re-frame.test-support`, frame fixtures, JVM-vs-CLJS boundary, conformance. |
 | 14 | [Errors and how to handle them](14-errors.md) | The `:rf.error/*` taxonomy, the trace-listener surface, `:on-error` policy per frame, recovery semantics, error projectors, and testing error paths. |
-| 15 | [Tooling](15-devtools-and-pair-tools.md) | The third-pillar pitch: trace bus, epochs, time-travel, source-coords, and the tools that consume them (`re-frame-pair2`, `re-frame2-story`, `re-frame-10x` v2). |
+| 15 | [Tooling](15-devtools-and-pair-tools.md) | The third-pillar pitch: trace bus, epochs, time-travel, source-coords, and the tools that consume them (`re-frame-pair2`, `re-frame2-story`, `re-frame-causa`). |
 | 16 | [Performance](16-performance.md) | Your page feels slow — the four shapes of slowness (big props, deep `=`, inline callbacks, expensive subs), the framework's answers, and the `rf:` User Timing surface. |
 | 17 | [Routing](17-routing.md) | Your app needs URL ↔ state — `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
 | 18 | [From re-frame v1](18-from-re-frame-v1.md) | You're migrating an existing re-frame v1 app. Skip if re-frame2 is your starting point. The chapter is appendix-shaped — deps to bump, the migration skill to run, and the broad categories of breakage to expect. |


### PR DESCRIPTION
## Summary

Per the Causa name-lock, the v2 devtool is `re-frame-causa`. The guide had ~17 stale `re-frame-10x` mentions; this PR sweeps the forward-facing ones to `re-frame-causa` and keeps the historical-anchor references intact as v1-lineage breadcrumbs.

## Per-chapter counts

| Chapter | Renames | Kept (historical) |
|---|---|---|
| 01-why-re-frame2.md | 0 | 1 (successor-to-v1 anchor) |
| 02-app-db.md | 3 | 0 |
| 10-doing-http-requests.md | 2 | 0 |
| 14-errors.md | 7 | 0 |
| 15-devtools-and-pair-tools.md | 0 | 2 (v1 reached into 10x; v1 tool renamed to causa) |
| 18-from-re-frame-v1.md | 0 | 1 (the rename-explainer paragraph) |
| README.md | 1 | 0 |
| **Total** | **13** | **4** |

## Test plan

- [x] `grep -rn 're-frame-10x' docs/guide/` returns only the 4 intended historical-anchor occurrences
- [x] `grep -rn '10x' docs/guide/` returns only those same 4 (no stray `10x panels` left)
- [x] `mkdocs build` introduces zero new warnings vs. `origin/main`
- [x] No `ai/`, `findings/`, or `decision-beads.md` staged

rf2-2734