### PR TITLE
feat(story): :test mode — in-canvas aggregated test runner (rf2-qmjo)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -293,14 +293,116 @@ module.exports = {
       }
     }
 
-    // Click Tests → the tests placeholder appears, :test chip active.
+    // Click Tests → the test pane (rf2-qmjo — `data-test="story-test-
+    // view"`) appears, :test chip active. The pane auto-runs the
+    // variant on first mount; the :loaded variant carries three
+    // canonical `:rf.assert/*` events in its :play slot, all passing.
     await modeTestChip.click();
-    await page
-      .locator('[data-test="story-tests-placeholder"]')
-      .waitFor({ state: 'visible', timeout: 5000 });
+    const testView = page.locator('[data-test="story-test-view"]');
+    await testView.waitFor({ state: 'visible', timeout: 5000 });
     if ((await modeTestChip.getAttribute('aria-selected')) !== 'true') {
       throw new Error('expected :test chip to be aria-selected="true" after click');
     }
+
+    // ----------------------------------------------------------------
+    // 3b-ii. :test mode — in-canvas aggregated test runner (rf2-qmjo)
+    // ----------------------------------------------------------------
+    //
+    // The :test pane composes four sections — header / summary /
+    // per-test rows / empty-state — per spec/009. For :story.counter/
+    // loaded the :play slot declares three passing assertions, so the
+    // status pill MUST read "3 passed" and the row table MUST list
+    // three rows all with data-status="pass".
+    await page
+      .locator('[data-test="story-test-parent-story"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+    await page
+      .locator('[data-test="story-test-rerun"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
+
+    // The status pill renders after the auto-run resolves — poll
+    // because the run is asynchronous.
+    const statusPill = page.locator('[data-test="story-test-status-pill"]');
+    await statusPill.waitFor({ state: 'visible', timeout: 5000 });
+    {
+      const start = Date.now();
+      let pillText = '';
+      while (Date.now() - start < 5000) {
+        pillText = await statusPill.innerText().catch(() => '');
+        if (/passed/i.test(pillText)) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!/3\s+passed/i.test(pillText)) {
+        throw new Error(
+          `expected the :test pane's status pill to read "3 passed" for :story.counter/loaded, got: "${pillText}"`,
+        );
+      }
+    }
+
+    // The counts row carries the green / red / grey tallies.
+    const counts = page.locator('[data-test="story-test-counts"]');
+    await counts.waitFor({ state: 'visible', timeout: 2000 });
+    const countsText = await counts.innerText();
+    if (!/3\s+passed/.test(countsText) || !/0\s+failed/.test(countsText)) {
+      throw new Error(
+        `expected counts to read "3 passed / 0 failed", got: "${countsText}"`,
+      );
+    }
+
+    // The per-test rows: three rows, all data-status="pass". Each row
+    // labels its canonical :rf.assert/* id.
+    const passRows = page.locator('[data-test="story-test-row"][data-status="pass"]');
+    {
+      const start = Date.now();
+      let n = 0;
+      while (Date.now() - start < 5000) {
+        n = await passRows.count();
+        if (n >= 3) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (n < 3) {
+        throw new Error(
+          `expected at least 3 passing assertion rows for :story.counter/loaded, got ${n}`,
+        );
+      }
+    }
+    // No failing rows for /loaded.
+    const failRows = await page
+      .locator('[data-test="story-test-row"][data-status="fail"]')
+      .count();
+    if (failRows !== 0) {
+      throw new Error(
+        `expected 0 failing rows for :story.counter/loaded, got ${failRows}`,
+      );
+    }
+
+    // The Re-run button re-fires the lifecycle. Click it; the pill
+    // must still read "3 passed" afterwards. Polling because the run
+    // is async; we check both that the button reappears (running?
+    // toggles off) and the pill stays green.
+    await page.locator('[data-test="story-test-rerun"]').click();
+    {
+      const start = Date.now();
+      let recovered = false;
+      while (Date.now() - start < 5000) {
+        const txt = await statusPill.innerText().catch(() => '');
+        if (/3\s+passed/i.test(txt)) {
+          recovered = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!recovered) {
+        throw new Error(
+          'expected status pill to still read "3 passed" after Re-run click',
+        );
+      }
+    }
+
+    // Last-run elapsed badge MUST render once a run has completed.
+    await page
+      .locator('[data-test="story-test-elapsed"]')
+      .waitFor({ state: 'visible', timeout: 2000 });
 
     // Verify the persisted localStorage record. The mode-tabs primitive
     // writes under `re-frame.story/active-mode-tab/:story.counter/loaded`.
@@ -329,7 +431,7 @@ module.exports = {
     await waitForVariantTitle(page, ':story.counter/loaded');
 
     // After reload + re-select, the :test chip should be re-hydrated as
-    // active and the tests placeholder visible. Poll: hydration from
+    // active and the test pane visible. Poll: hydration from
     // localStorage runs on the first render of the strip for this
     // variant, which is the tick after `clickVariant` settles.
     {
@@ -353,7 +455,7 @@ module.exports = {
       }
     }
     await page
-      .locator('[data-test="story-tests-placeholder"]')
+      .locator('[data-test="story-test-view"]')
       .waitFor({ state: 'visible', timeout: 5000 });
 
     // Switch back to Canvas so the remaining sub-tests see the live

--- a/tools/story/spec/007-Mode-Tabs.md
+++ b/tools/story/spec/007-Mode-Tabs.md
@@ -95,7 +95,9 @@ from Story v1).
 `:docs` → the docs pane — `re-frame.story.ui.docs/docs-view`
 (rf2-rodx). See [`008-Docs-Mode.md`](008-Docs-Mode.md) for the
 section composition + read-only contract.
-`:test` → the tests pane (placeholder until rf2-qmjo).
+`:test` → the tests pane — `re-frame.story.ui.test-mode/test-view`
+(rf2-qmjo). See [`009-Test-Mode.md`](009-Test-Mode.md) for the
+status pill / per-row table / Re-run contract.
 
 ## Per-variant selection + localStorage persistence
 
@@ -143,7 +145,9 @@ Selectors:
 - Docs pane root: `[data-test="story-docs-view"]` (rf2-rodx; see
   [`008-Docs-Mode.md`](008-Docs-Mode.md) for the per-section
   selectors)
-- Tests placeholder: `[data-test="story-tests-placeholder"]`
+- Tests pane root: `[data-test="story-test-view"]` (rf2-qmjo; see
+  [`009-Test-Mode.md`](009-Test-Mode.md) for the per-section
+  selectors)
 
 ## Visual style
 
@@ -156,8 +160,9 @@ borders, monospace 11px.
 
 - **The `:docs` pane content.** Owned by rf2-rodx — see
   [`008-Docs-Mode.md`](008-Docs-Mode.md) for the section composition.
-- **The `:test` pane content.** A placeholder div ships now; rf2-qmjo
-  ships the aggregated pass/fail view.
+- **The `:test` pane content.** Owned by rf2-qmjo — see
+  [`009-Test-Mode.md`](009-Test-Mode.md) for the aggregated
+  pass/fail summary, the per-row table, and the Re-run contract.
 - **Workspace mode-tabs.** Workspaces enumerate multiple variants;
   mixing mode-tabs into the workspace pane conflates two axes. If
   workspaces grow a switcher it lives in a separate spec.
@@ -176,6 +181,8 @@ depend on it. The contract guarantees:
 2. Selection is per-variant and persists across reload.
 3. `:dev` preserves Story v1's exact existing behaviour — no
    regression to the canvas / hot-reload / decorator paths.
-4. The `:docs` / `:test` panes are pluggable: rf2-rodx / rf2-qmjo
-   replace the placeholders without touching the chip strip, the
-   state slot, or the localStorage key shape.
+4. The `:docs` / `:test` panes are pluggable: rf2-rodx
+   ([`008-Docs-Mode.md`](008-Docs-Mode.md)) and rf2-qmjo
+   ([`009-Test-Mode.md`](009-Test-Mode.md)) replaced the
+   placeholders without touching the chip strip, the state slot,
+   or the localStorage key shape.

--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -1,0 +1,248 @@
+# Story — `:test` Mode Pane
+
+> The in-canvas aggregated test-runner view that sits behind the
+> `:test` mode-tab. Runs the variant's `:play` sequence + the seven
+> canonical `:rf.assert/*` events; surfaces a status badge, per-row
+> pass/fail/skip, collapsible failure detail, and a re-run button.
+> The downstream surface the mode-tabs primitive (rf2-9hc8, spec/007)
+> was built to host. Mirrors the docs-pane (spec/008) shape.
+
+## Why a dedicated test pane
+
+re-frame2-story already ships the programmatic test harness:
+`run-variant-as-test` (and the more general `run-variant` →
+`:assertions` round-trip per spec/004) drives a variant through its
+four-phase lifecycle and accumulates the seven canonical
+`:rf.assert/*` records on the variant's frame. What was missing
+through the Stage-4 — Stage-6 push: a **chrome-level surface** that
+runs that harness on demand and renders the aggregated pass/fail
+summary inside the playground — the Storybook 8 "Tests" tab
+equivalent.
+
+The pane is deliberately a *reader* of the existing runtime — it
+does not introduce a parallel test framework, a parallel assertion
+vocabulary, or a parallel result schema. Every record it renders
+came out of `run-variant`'s `:assertions` slot exactly as it was
+recorded by `re-frame.story.assertions` (spec/004 §Canonical
+assertion vocabulary). The pane's job is to:
+
+1. Trigger a `run-variant` against the active variant.
+2. Read the `:assertions` vector off the result map.
+3. Render the records as a scannable summary + per-row table.
+4. Offer a re-run button that re-fires the lifecycle.
+
+## Surface
+
+One namespace, one entry point, plus pure helpers for the JVM test
+corpus:
+
+```clojure
+(re-frame.story.ui.test-mode/test-view variant-id)   ; CLJS Reagent component
+
+;; pure data → data (JVM-testable):
+(variant-has-tests? variant-id)
+  ; → boolean — true iff the variant body declares a non-empty :play
+(aggregate-summary assertions)
+  ; → {:total <n> :passed <n> :failed <n>
+  ;    :skipped <n> :all-passed? <bool>}
+(assertion-row assertion)
+  ; → {:assertion :rf.assert/path-equals
+  ;    :status   :pass|:fail|:skip
+  ;    :label    "<:assertion-id> <pr-str payload>"
+  ;    :detail   {:expected ... :actual ... :reason ...}}
+(format-elapsed-ms ms)
+  ; → "12 ms" / "1.2 s"
+(format-timestamp-ms ms)
+  ; → ISO-8601-ish "HH:mm:ss" for the last-run badge
+```
+
+The render shell's `main-pane` calls `test-mode/test-view` when the
+per-variant mode-tab is `:test`. Selection is owned by the mode-tabs
+primitive; this spec does not touch the chip strip.
+
+## Section composition
+
+The pane renders four sections, top-to-bottom:
+
+| # | Section          | Content                                                                  | Rendered when                                  |
+|---|------------------|--------------------------------------------------------------------------|------------------------------------------------|
+| 1 | Header           | variant id + parent-story id + run/elapsed status                        | always                                         |
+| 2 | Summary badge    | overall pass/fail/skip count + "all passed" / "<n> failed" status pill  | a run has executed                             |
+| 3 | Per-test rows    | one row per `:assertions` record — green/red/grey + collapsible detail   | a run has executed AND `:assertions` non-empty |
+| 4 | Empty state      | "No tests registered for this variant" + link to testing recipes         | `:play` slot is empty                          |
+
+### 1. Header
+
+```
+:story.counter/loaded
+parent story: :story.counter
+[ Re-run ]            ran 12:04:23 · 18 ms
+```
+
+- Variant id as the page `<h1>`.
+- Parent story id below.
+- A **Re-run** button on the left dispatches a fresh
+  `run-variant` call against the variant, re-allocates the frame, and
+  swaps the result into the pane's local state. On first mount the
+  pane auto-runs the variant once so the user lands on the result;
+  subsequent visits to the `:test` tab show the most recent result
+  until Re-run is clicked.
+- A last-run timestamp + elapsed duration on the right, both pulled
+  from the result map's `:elapsed-ms` slot and the pane's own
+  capture of `(interop/now-ms)` at run completion.
+
+### 2. Summary badge
+
+A status pill — green when every assertion passed, red when any
+failed, grey when the variant ran but recorded zero assertions
+(possible when `:play` is non-empty but contains only non-assertion
+event dispatches). The pill text is `"N passed"`, `"N failed of M"`,
+or `"no assertions recorded"`.
+
+The pill is followed by a key:
+
+```
+✓ 3 passed  ✗ 0 failed  ⊘ 0 skipped
+```
+
+`:skipped` is the count of records carrying
+`:assertion :rf.assert/skipped` — re-frame2's runtime doesn't
+currently emit this id, but the count slot stays open so future
+spec/004 additions (skip-on-condition) flow through without a pane
+refactor.
+
+### 3. Per-test rows
+
+A three-column table — `status | assertion | detail` — one row per
+record in the result's `:assertions` vector, in execution order
+(the order `re-frame.story.assertions/record!` appended them).
+
+- **status.** A coloured glyph: `●` green for `:passed? true`, `●`
+  red for `:passed? false`. Failures are highlighted both by colour
+  and by the row's background.
+- **assertion.** The canonical id + the formatted `:payload`
+  (Storybook's "assertion label"). Example:
+  `:rf.assert/path-equals [[:count] 7]`.
+- **detail.** For a passing row, the cell is empty; for a failing
+  row, a collapsible disclosure that surfaces `:expected`, `:actual`,
+  and `:reason` from the assertion record. The disclosure is closed
+  by default; click expands.
+
+Source-coord (the `:source` slot per spec/004) is rendered as the
+collapsible's footer when present, so a failing row tells the reader
+exactly which file/line declared the assertion.
+
+### 4. Empty state
+
+When `(variant-has-tests? variant-id)` is false — the variant body's
+`:play` slot is empty or absent — the pane skips the run entirely
+and renders a placeholder:
+
+```
+No tests registered for this variant
+
+Add a :play slot to register assertions.
+See: skills/re-frame2/reference/cross-cutting/testing.md
+```
+
+The link forward-points to the canonical testing recipes leaf so a
+reader knows where to look. The pane renders it as an absolute
+GitHub URL (`https://github.com/day8/re-frame2/blob/main/skills/...`)
+so it resolves from the dev server, the deployed playground, and an
+embedded preview alike — a relative path would resolve relative to
+whichever hash route the playground is on (`#/stories/...`), which
+isn't the repository root.
+
+The pane MUST NOT call `run-variant` in this branch — the runtime
+is happy to short-circuit on an empty `:play`, but skipping the
+call also skips frame allocation, which keeps the pane cheap for
+"browse-only" sessions.
+
+## Run-on-mount + re-run semantics
+
+- **First mount.** The pane records a single run on first mount per
+  variant (per pane lifecycle, not per page-lifecycle — re-mounting
+  the `:test` pane fires a fresh run). The runtime's
+  `:passed-through?` semantics (per spec/004 §Record-don't-throw)
+  guarantee a run never throws; failures land in the assertions
+  vector and the pane renders them.
+- **Re-run.** Re-run dispatches `reset-variant` (per
+  spec/002 §Programmatic API) — the existing runtime entry that
+  tears down + re-allocates the variant frame and re-runs the four-
+  phase lifecycle. Re-run is debounced via a `:running?` flag on the
+  pane's local state so a fast double-click can't fire two parallel
+  runs.
+- **Switching variants.** Switching to a different variant's `:test`
+  tab re-runs (each variant carries its own result slot in the
+  pane's local state, keyed by variant id).
+
+## Read-only contract — same as the docs pane
+
+The pane MUST NOT carry any input elements that mutate args /
+overrides / modes. Switching `:test` → `:dev` MUST restore the
+canvas as the user left it — same args, same overrides, same modes.
+
+The Re-run button mutates **runtime state** (re-allocates the
+variant frame) but not the variant's authoring shape. The shell's
+controls / sidebar / mode picker / panel-visibility state is
+untouched.
+
+## Test selectors
+
+The Playwright spec drives the pane via `data-test`-prefixed
+selectors so visible labels can be reworded without breaking tests:
+
+| Selector                                              | What                                       |
+|-------------------------------------------------------|--------------------------------------------|
+| `[data-test="story-test-view"]`                       | The pane root (`<section>` landmark).      |
+| `[data-test="story-test-parent-story"]`               | Parent-story sub-header.                   |
+| `[data-test="story-test-rerun"]`                      | The Re-run button.                         |
+| `[data-test="story-test-status-pill"]`                | The pass/fail status pill.                 |
+| `[data-test="story-test-counts"]`                     | The "✓ N passed · ✗ N failed · ⊘ N skipped" key. |
+| `[data-test="story-test-elapsed"]`                    | Last-run elapsed duration.                 |
+| `[data-test="story-test-timestamp"]`                  | Last-run timestamp.                        |
+| `[data-test="story-test-table"]`                      | The per-test rows table.                   |
+| `[data-test="story-test-row"]`                        | One assertion row; `data-status="pass\|fail\|skip"` + `data-assertion="<:id>"`. |
+| `[data-test="story-test-row-detail"]`                 | The collapsible detail for a failing row.  |
+| `[data-test="story-test-empty"]`                      | Empty-state placeholder.                   |
+
+## Visual style
+
+Matches the render-shell chrome (rf2-2uwv contrast palette):
+`#b0b0b0` inactive foreground, `#dcdcdc` body text, `#1e1e1e`
+section background, `#2d2d30` table-header background, monospace
+for table content + variant ids, system-ui for prose. Pass /
+fail are the standard `#4ec9b0` (green) / `#f48771` (red); skip
+is `#9a9a9a`. The pane scrolls inside the `<main>` landmark; the
+strip sits above it (owned by the mode-tabs primitive).
+
+## Out of scope at v1
+
+- **Watch-mode auto-re-run.** The shell does not poll the variant
+  for changes and re-run the play sequence on `:hot-reload-tick`
+  drift. The user re-runs explicitly via the button. A watch-mode
+  affordance is a v2 surface — re-frame2's runtime does not yet
+  expose a stable signal for "play sequence content changed
+  since last run", so the v1 contract is "explicit re-run".
+- **Per-assertion timing.** Each record carries an `:elapsed-ms`
+  slot (per spec/004) but the v1 row renderer surfaces only the
+  total. Per-assertion timing flows through the same data path
+  if/when a v2 detail-tab wants it.
+- **Coverage / pass-rate trending.** The pane shows the latest run
+  only. A "last N runs" rollup is a separate surface and would
+  hang off the trace panel, not the `:test` mode.
+- **Hot-reload re-fire.** If the variant's `:play` slot changes on
+  hot-reload, the pane keeps the previous run's record until the
+  user clicks Re-run. The mode-tabs primitive's `:hot-reload-tick`
+  watcher is intentionally not wired through the `:test` pane —
+  re-run is an explicit action, not a hot-reload side effect.
+
+## Foundational status
+
+Per the rf2-9hc8 / rf2-rodx / rf2-qmjo trio: the `:test` pane is a
+**leaf** — it consumes the foundation (the four-phase runtime, the
+seven canonical `:rf.assert/*` events, the `:assertions` record
+schema) and surfaces it. It does not register new artefact kinds,
+does not add new shell-state slots, and does not change the mode-
+tabs chip strip. Removing `test-view` restores the placeholder-
+equivalent empty pane without breaking any other surface.

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -11,6 +11,7 @@
 - **[006-MCP-Surface.md](006-MCP-Surface.md)** — The boundary between Story and `tools/story-mcp/`; surfaces Story exposes for the MCP jar; late-bind `reg-story-panel` for tooling embeds.
 - **[007-Mode-Tabs.md](007-Mode-Tabs.md)** — The render-shell's top-of-canvas `:dev` / `:docs` / `:test` switcher; the chrome-level primitive every 2026 component playground ships (rf2-9hc8).
 - **[008-Docs-Mode.md](008-Docs-Mode.md)** — The `:docs` mode pane — read-only AutoDocs-equivalent: header, prose, args, decorators, parameters, tags for the active variant (rf2-rodx).
+- **[009-Test-Mode.md](009-Test-Mode.md)** — The `:test` mode pane — in-canvas aggregated test runner: status pill, per-row pass/fail, collapsible failure detail, Re-run button (rf2-qmjo).
 - **[API.md](API.md)** — Consolidated public surface for `day8/re-frame2-story`: every `reg-*`, every fn, every fx-id, every cofx-id.
 - **[Principles.md](Principles.md)** — Story-specific non-negotiables — EDN-first first among them — the test new features pass against.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major call was made; the seven rf2-m6tu §6 decisions plus Phase-2 SOTA additions and IMPL-SPEC-emergent calls.

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -10,9 +10,9 @@
               in `re-frame.story.ui.docs` (rf2-rodx); this primitive
               owns the chip strip only.
   - `:test` — Tests. The in-canvas aggregated pass/fail summary for the
-              variant's interactions / assertions. The full
-              implementation lands with rf2-qmjo; this primitive ships
-              the placeholder.
+              variant's interactions / assertions. Implemented in
+              `re-frame.story.ui.test-mode` (rf2-qmjo); this primitive
+              owns the chip strip only.
 
   ## Primitive surface
 
@@ -30,7 +30,7 @@
 
   - `:dev`  → existing canvas / workspace path (unchanged).
   - `:docs` → `re-frame.story.ui.docs/docs-view` (rf2-rodx).
-  - `:test` → `tests-placeholder` (rf2-qmjo will replace this).
+  - `:test` → `re-frame.story.ui.test-mode/test-view` (rf2-qmjo).
 
   ## Visual style
 
@@ -184,18 +184,9 @@
 
 ;; ---- placeholder panes ---------------------------------------------------
 ;;
-;; rf2-rodx (Docs) is now implemented in `re-frame.story.ui.docs`. The
-;; `:test` placeholder remains until rf2-qmjo lands — the chrome
-;; surfaces the contract so users know the mode exists and that the
-;; dedicated view is on the roadmap.
-
-(defn tests-placeholder
-  "Stub for the `:test` mode pane. Replaced by rf2-qmjo."
-  [variant-id]
-  [:div {:style     (:placeholder styles)
-         :data-test "story-tests-placeholder"}
-   [:div {:style {:font-weight "bold" :margin-bottom "8px"}}
-    "Tests view"]
-   [:div "Aggregated pass/fail summary of interactions / assertions for "
-    [:code (str variant-id)]
-    " coming in rf2-qmjo."]])
+;; rf2-rodx (Docs) is implemented in `re-frame.story.ui.docs`; rf2-qmjo
+;; (Tests) is implemented in `re-frame.story.ui.test-mode`. Both
+;; placeholders have been removed — the shell routes the `:docs` /
+;; `:test` cases directly at the dedicated panes. The `:placeholder`
+;; style entry below stays in the styles map in case a future pane
+;; needs an empty-state shape, but no placeholder fn is registered.

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -51,6 +51,7 @@
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.test-mode :as test-mode]
             [re-frame.story.ui.trace :as trace]
             [re-frame.story.ui.workspace :as workspace]))
 
@@ -269,10 +270,12 @@
   Per rf2-9hc8 a Canvas | Docs | Tests mode-tab strip sits at the top
   of the pane when a variant is selected; selection is per-variant and
   persists across reloads in localStorage. Per rf2-rodx the `:docs`
-  pane now renders `docs/docs-view` — the read-only AutoDocs surface
+  pane renders `docs/docs-view` — the read-only AutoDocs surface
   composed of header / prose / args / decorators / parameters / tags
-  sections. `:test` remains a placeholder for rf2-qmjo; `:dev`
-  preserves the existing canvas / workspace behaviour."
+  sections. Per rf2-qmjo the `:test` pane renders `test-mode/test-view`
+  — the in-canvas aggregated pass/fail summary of the variant's
+  `:play` sequence + assertions. `:dev` preserves the existing canvas
+  / workspace behaviour."
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
@@ -292,7 +295,7 @@
        ws-id    [workspace/workspace-view ws-id]
        variant-id (case mode-tab
                     :docs [docs/docs-view variant-id]
-                    :test [mode-tabs/tests-placeholder variant-id]
+                    :test [test-mode/test-view variant-id]
                     [canvas/canvas])
        :else
        [:div {:style {:padding "32px"

--- a/tools/story/src/re_frame/story/ui/test_mode.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode.cljc
@@ -1,0 +1,610 @@
+(ns re-frame.story.ui.test-mode
+  "The `:test` mode pane — in-canvas aggregated test-runner view.
+  Per rf2-qmjo + spec/009.
+
+  Replaces the `mode-tabs/tests-placeholder` stub that landed with the
+  mode-tabs primitive (rf2-9hc8). The pane runs the variant's `:play`
+  sequence via `run-variant`, reads the `:assertions` vector off the
+  result, and renders an aggregated pass/fail summary inside the
+  canvas:
+
+      ┌──────────────────────────────────────────────────────┐
+      │  Header — variant id · parent story · Re-run button   │
+      │           · last-run timestamp + elapsed              │
+      ├──────────────────────────────────────────────────────┤
+      │  Summary badge — status pill (pass/fail/empty) +      │
+      │           ✓ N passed · ✗ N failed · ⊘ N skipped       │
+      ├──────────────────────────────────────────────────────┤
+      │  Per-test table — one row per assertion record, in    │
+      │           execution order; collapsible failure detail │
+      │           surfaces :expected / :actual / :reason +    │
+      │           the source-coord stamping                   │
+      └──────────────────────────────────────────────────────┘
+
+  When the variant body's `:play` slot is empty / absent the pane
+  short-circuits and renders an empty-state placeholder pointing at
+  the canonical testing-recipes leaf (Story doesn't auto-allocate a
+  frame in this branch).
+
+  Read-only — no input mutates args / overrides / modes. The Re-run
+  button mutates **runtime state** (re-allocates the variant frame)
+  but not the variant's authoring shape. Switching from `:test` back
+  to `:dev` restores the canvas exactly as the user left it.
+
+  ## Pure helpers (.cljc)
+
+  The pane's data shaping lives in this namespace as pure data → data
+  fns (`variant-has-tests?`, `aggregate-summary`, `assertion-row`,
+  `format-elapsed-ms`, `format-timestamp-ms`) so the JVM test corpus
+  can cover them without booting the runtime. The Reagent-side
+  rendering + the `run-variant` promise wiring are CLJS-only.
+
+  ## Elision
+
+  CLJS-side rendering plus pure helpers in the `.cljc`. The shell's
+  `main-pane` only reaches `test-view` via the
+  `(when config/enabled? ...)`-gated mount call, so production builds
+  never invoke it — closure DCEs the lot."
+  (:require [re-frame.story.registrar :as registrar]
+            #?@(:cljs [[reagent.core             :as r]
+                       [re-frame.story.runtime   :as runtime]
+                       [re-frame.story.async     :as async]
+                       [re-frame.interop         :as interop]
+                       [re-frame.story.ui.state  :as state]])))
+
+;; ---- pure: parent-story-id ----------------------------------------------
+
+(defn parent-story-id
+  "Mirror of the helper in `re-frame.story.ui.docs/parent-story-id` so
+  this namespace doesn't have to require the docs ns just for one
+  data fn. Keep the surface area minimal."
+  [variant-id]
+  (when (and (keyword? variant-id) (namespace variant-id))
+    (keyword (namespace variant-id))))
+
+;; ---- pure: variant-has-tests? -------------------------------------------
+
+(defn variant-has-tests?
+  "True iff `variant-id`'s registered body declares a non-empty `:play`
+  vector. Used by the pane to gate between the run-and-render path and
+  the empty-state placeholder.
+
+  Pure data → data; JVM-testable."
+  [variant-id]
+  (let [vb (registrar/handler-meta :variant variant-id)]
+    (boolean (seq (:play vb)))))
+
+;; ---- pure: aggregate-summary --------------------------------------------
+
+(defn aggregate-summary
+  "Walk `assertions` (the vector pulled off a `run-variant` result map)
+  and produce the aggregated pass/fail/skip counts:
+
+      {:total       <n>
+       :passed      <n>
+       :failed      <n>
+       :skipped     <n>
+       :all-passed? <bool>}
+
+  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
+  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
+  so spec/004 additions flow through without a pane refactor.
+  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`."
+  [assertions]
+  (let [items     (or assertions [])
+        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
+        skipped   (count (filter skipped? items))
+        active    (remove skipped? items)
+        passed    (count (filter :passed? active))
+        failed    (- (count active) passed)
+        total     (count items)]
+    {:total       total
+     :passed      passed
+     :failed      failed
+     :skipped     skipped
+     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
+
+;; ---- pure: assertion-row ------------------------------------------------
+
+(defn- pretty-payload
+  "Render a `:payload` value for the assertion label. Strings show
+  quoted; everything else uses `pr-str` so keywords / maps / vectors
+  are visibly distinguishable."
+  [v]
+  (cond
+    (nil? v)              ""
+    (and (coll? v)
+         (= 0 (count v))) ""
+    :else                 (pr-str v)))
+
+(defn assertion-row
+  "Project one `:assertions` record into the row shape the per-test
+  table renders. Each row carries:
+
+      {:assertion :rf.assert/path-equals
+       :status    :pass|:fail|:skip
+       :label     \":rf.assert/path-equals [[:count] 7]\"
+       :detail    {:expected ... :actual ... :reason ...
+                   :source <{:file ... :line ...}|nil>}}
+
+  `:detail` is always present so the renderer can read uniformly;
+  the renderer decides whether to surface it (only failing rows
+  expand by default). Pure data → data; JVM-testable.
+
+  Source-coord stamping arrives on the record as either `:source` or
+  `:source-coord` depending on the assertion path that built it
+  (per spec/004 + `re-frame.story.assertions`'s record builders).
+  The row's `:detail :source` slot accepts either."
+  [record]
+  (let [rec      (or record {})
+        passed?  (:passed? rec)
+        aid      (:assertion rec)
+        status   (cond
+                   (= :rf.assert/skipped aid) :skip
+                   passed?                    :pass
+                   :else                      :fail)
+        payload  (or (:payload rec) [])
+        label    (let [p (pretty-payload payload)]
+                   (cond-> (str aid)
+                     (seq p) (str " " p)))]
+    {:assertion aid
+     :status    status
+     :label     label
+     :detail    {:expected (:expected rec)
+                 :actual   (:actual rec)
+                 :reason   (:reason rec)
+                 :source   (or (:source rec) (:source-coord rec))}}))
+
+;; ---- pure: formatting ---------------------------------------------------
+
+(defn format-elapsed-ms
+  "Render an elapsed-ms duration as a short human-readable string.
+  Sub-second durations show `\"<n> ms\"`; one-second-plus durations
+  show `\"<n.n> s\"`. Pure; JVM-testable.
+
+  `nil` / non-number inputs return the empty string so the renderer
+  can interpolate it safely."
+  [ms]
+  (cond
+    (nil? ms)         ""
+    (not (number? ms)) ""
+    (< ms 0)          ""
+    (< ms 1000)       (str (long ms) " ms")
+    :else             (str #?(:clj  (format "%.1f" (double (/ ms 1000.0)))
+                              :cljs (.toFixed (/ ms 1000) 1))
+                           " s")))
+
+(defn format-timestamp-ms
+  "Render an epoch-ms timestamp as a short `HH:mm:ss` clock string for
+  the last-run badge. Pure; JVM-testable.
+
+  Inputs that don't look like a number return the empty string."
+  [ms]
+  (if (not (number? ms))
+    ""
+    #?(:clj
+       (let [zone (java.time.ZoneId/systemDefault)
+             inst (java.time.Instant/ofEpochMilli (long ms))
+             ldt  (java.time.LocalDateTime/ofInstant inst zone)
+             fmt  (java.time.format.DateTimeFormatter/ofPattern "HH:mm:ss")]
+         (.format ldt fmt))
+       :cljs
+       (let [d (js/Date. ms)
+             pad (fn [n] (if (< n 10) (str "0" n) (str n)))]
+         (str (pad (.getHours d)) ":"
+              (pad (.getMinutes d)) ":"
+              (pad (.getSeconds d)))))))
+
+;; ---- CLJS-side rendering -------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:wrap          {:flex             "1"
+                      :overflow         "auto"
+                      :padding          "20px 28px"
+                      :background       "#1e1e1e"
+                      :color            "#cccccc"
+                      :font-family      "system-ui, sans-serif"
+                      :font-size        "13px"
+                      :line-height      "1.5"}
+      :h1            {:font-family      "monospace"
+                      :font-size        "18px"
+                      :font-weight      "bold"
+                      :color            "white"
+                      :margin           "0 0 4px 0"}
+      :sub           {:color            "#b0b0b0"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :margin-bottom    "10px"}
+      :header-row    {:display          "flex"
+                      :justify-content  "space-between"
+                      :align-items      "center"
+                      :gap              "12px"
+                      :margin           "12px 0 8px 0"}
+      :rerun-btn     {:padding          "6px 14px"
+                      :background       "#0e639c"
+                      :color            "white"
+                      :border           "none"
+                      :border-radius    "3px"
+                      :cursor           "pointer"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :letter-spacing   "0.3px"}
+      :rerun-running {:background       "#37373d"
+                      :color            "#b0b0b0"
+                      :cursor           "not-allowed"}
+      :last-run      {:color            "#b0b0b0"
+                      :font-family      "monospace"
+                      :font-size        "10px"}
+      :section       {:margin-top       "16px"}
+      :section-h     {:font-weight      "bold"
+                      :color            "#b0b0b0"
+                      :text-transform   "uppercase"
+                      :font-size        "10px"
+                      :letter-spacing   "0.5px"
+                      :margin-bottom    "8px"
+                      :border-bottom    "1px solid #444"
+                      :padding-bottom   "4px"}
+      :pill-row      {:display          "flex"
+                      :align-items      "center"
+                      :gap              "12px"
+                      :margin-bottom    "8px"}
+      :pill          {:padding          "4px 10px"
+                      :border-radius    "10px"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :font-weight      "bold"
+                      :text-transform   "uppercase"
+                      :letter-spacing   "0.5px"}
+      :pill-pass     {:background       "#1f4d3f"
+                      :color            "#4ec9b0"}
+      :pill-fail     {:background       "#4d1f1f"
+                      :color            "#f48771"}
+      :pill-empty    {:background       "#37373d"
+                      :color            "#b0b0b0"}
+      :counts        {:color            "#b0b0b0"
+                      :font-family      "monospace"
+                      :font-size        "11px"}
+      :count-pass    {:color            "#4ec9b0"}
+      :count-fail    {:color            "#f48771"}
+      :count-skip    {:color            "#9a9a9a"}
+      :table         {:width            "100%"
+                      :border-collapse  "collapse"
+                      :font-family      "monospace"
+                      :font-size        "11px"}
+      :th            {:text-align       "left"
+                      :padding          "6px 8px"
+                      :background       "#2d2d30"
+                      :color            "#b0b0b0"
+                      :border-bottom    "1px solid #444"
+                      :text-transform   "uppercase"
+                      :font-size        "10px"
+                      :letter-spacing   "0.5px"}
+      :td            {:padding          "6px 8px"
+                      :border-bottom    "1px solid #2d2d30"
+                      :color            "#dcdcdc"
+                      :vertical-align   "top"}
+      :td-status     {:width            "20px"
+                      :text-align       "center"
+                      :font-size        "16px"
+                      :line-height      "1"}
+      :status-pass   {:color            "#4ec9b0"}
+      :status-fail   {:color            "#f48771"}
+      :status-skip   {:color            "#9a9a9a"}
+      :row-fail      {:background       "#2a1a1a"}
+      :details-tog   {:cursor           "pointer"
+                      :color            "#9cdcfe"
+                      :background       "none"
+                      :border           "none"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :padding          "0"
+                      :text-decoration  "underline"}
+      :detail-box    {:background       "#252526"
+                      :border-left      "3px solid #f48771"
+                      :padding          "8px 12px"
+                      :margin-top       "6px"
+                      :color            "#dcdcdc"
+                      :font-family      "monospace"
+                      :font-size        "11px"
+                      :white-space      "pre-wrap"}
+      :detail-key    {:color            "#9cdcfe"}
+      :detail-source {:color            "#b0b0b0"
+                      :font-size        "10px"
+                      :margin-top       "4px"}
+      :empty         {:padding          "32px"
+                      :color            "#9a9a9a"
+                      :font-style       "italic"
+                      :font-family      "system-ui, sans-serif"
+                      :text-align       "center"
+                      :background       "#1e1e1e"
+                      :flex             "1"}
+      :empty-link    {:color            "#9cdcfe"
+                      :font-family      "monospace"
+                      :margin-top       "8px"
+                      :display          "block"}}))
+
+;; ---- CLJS local state ----------------------------------------------------
+;;
+;; The pane keeps its own ratom — one map keyed by variant-id. Each
+;; entry carries `{:result <run-variant-result-map>
+;;                 :ran-at-ms <epoch-ms>
+;;                 :running? <bool>
+;;                 :expanded #{<row-index>}}`. Re-run flips :running?
+;; on, calls `runtime/reset-variant`, swaps the result in on resolve.
+
+#?(:cljs
+   (defonce ^:private results-atom (r/atom {})))
+
+#?(:cljs
+   (defn- begin-run!
+     "Mark the variant's slot as running. Returns nothing."
+     [variant-id]
+     (swap! results-atom assoc-in [variant-id :running?] true)))
+
+#?(:cljs
+   (defn- store-result!
+     "Swap a fresh `result` (from `run-variant`) into the variant's
+     slot, clear `:running?`, stamp `:ran-at-ms` with the local clock,
+     and reset the per-row expanded set so a fresh failure detail
+     starts collapsed."
+     [variant-id result]
+     (swap! results-atom assoc variant-id
+            {:result    result
+             :ran-at-ms (interop/now-ms)
+             :running?  false
+             :expanded  #{}})))
+
+#?(:cljs
+   (defn- toggle-expanded!
+     [variant-id idx]
+     (swap! results-atom update-in [variant-id :expanded]
+            (fn [s] (let [s (or s #{})]
+                      (if (contains? s idx)
+                        (disj s idx)
+                        (conj s idx)))))))
+
+#?(:cljs
+   (defn- run-variant-pane!
+     "Drive a fresh `reset-variant` against the variant's frame and
+     swap the result into local state when it resolves. No-ops if
+     the slot already carries `:running?`."
+     [variant-id]
+     (let [shell @state/shell-state-atom
+           opts  {:active-modes   (:active-modes shell)
+                  :cell-overrides nil
+                  :substrate      (:substrate shell)}]
+       (begin-run! variant-id)
+       (-> (runtime/reset-variant variant-id opts)
+           (async/then  (fn [r] (store-result! variant-id r) nil))
+           (async/catch* (fn [_]
+                           ;; Even a rejection clears :running? so the
+                           ;; UI button comes back to "Re-run".
+                           (swap! results-atom assoc-in
+                                  [variant-id :running?] false)
+                           nil))))))
+
+;; ---- CLJS-side: section renderers ---------------------------------------
+
+#?(:cljs
+   (defn- header
+     "Variant id + parent story id + Re-run button + last-run badge."
+     [variant-id]
+     (let [slot       (get @results-atom variant-id)
+           running?   (:running? slot)
+           ran-at-ms  (:ran-at-ms slot)
+           result     (:result slot)
+           elapsed    (:elapsed-ms result)
+           story-id   (parent-story-id variant-id)]
+       [:div
+        [:h1 {:style (:h1 styles)} (str variant-id)]
+        [:div {:style     (:sub styles)
+               :data-test "story-test-parent-story"}
+         (if story-id
+           (str "parent story: " story-id)
+           "no parent story registered")]
+        [:div {:style (:header-row styles)}
+         [:button
+          {:style          (merge (:rerun-btn styles)
+                                  (when running? (:rerun-running styles)))
+           :data-test      "story-test-rerun"
+           :disabled       running?
+           :aria-label     "Re-run the variant's :play sequence"
+           :on-click       (fn [_] (when-not running? (run-variant-pane! variant-id)))}
+          (if running? "Running…" "Re-run")]
+         [:div {:style (:last-run styles)}
+          (when ran-at-ms
+            [:span {:data-test "story-test-timestamp"}
+             (str "ran " (format-timestamp-ms ran-at-ms))])
+          (when (and ran-at-ms elapsed)
+            [:span " · "])
+          (when (number? elapsed)
+            [:span {:data-test "story-test-elapsed"}
+             (format-elapsed-ms elapsed)])]]])))
+
+#?(:cljs
+   (defn- summary-section
+     "Status pill + ✓ / ✗ / ⊘ counts. Renders nothing until at least
+     one run has executed; the renderer composes its own placeholder
+     in that interim state."
+     [variant-id]
+     (let [slot   (get @results-atom variant-id)
+           result (:result slot)]
+       (when result
+         (let [summary (aggregate-summary (:assertions result))
+               {:keys [total passed failed skipped all-passed?]} summary
+               pill-style (cond
+                            (zero? total)  (:pill-empty styles)
+                            all-passed?    (:pill-pass styles)
+                            :else          (:pill-fail styles))
+               pill-text  (cond
+                            (zero? total) "no assertions recorded"
+                            all-passed?   (str passed " passed")
+                            :else         (str failed " failed of " total))]
+           [:div {:style     (:section styles)
+                  :data-test "story-test-summary-section"}
+            [:div {:style (:section-h styles)} "Summary"]
+            [:div {:style (:pill-row styles)}
+             [:span {:style     (merge (:pill styles) pill-style)
+                     :data-test "story-test-status-pill"}
+              pill-text]
+             [:span {:style     (:counts styles)
+                     :data-test "story-test-counts"}
+              [:span {:style (:count-pass styles)} (str "✓ " passed " passed")]
+              "  "
+              [:span {:style (:count-fail styles)} (str "✗ " failed " failed")]
+              "  "
+              [:span {:style (:count-skip styles)} (str "⊘ " skipped " skipped")]]]])))))
+
+#?(:cljs
+   (defn- row-detail
+     "The collapsible failure detail — surfaces :expected, :actual,
+     :reason, and the source-coord stamping."
+     [{:keys [expected actual reason source]}]
+     [:div {:style     (:detail-box styles)
+            :data-test "story-test-row-detail"}
+      (when (some? reason)
+        [:div
+         [:span {:style (:detail-key styles)} "reason: "]
+         (str reason)])
+      (when (or (some? expected) (contains? #{0 false} expected))
+        [:div
+         [:span {:style (:detail-key styles)} "expected: "]
+         (pr-str expected)])
+      (when (or (some? actual) (contains? #{0 false} actual))
+        [:div
+         [:span {:style (:detail-key styles)} "actual:   "]
+         (pr-str actual)])
+      (when (and (map? source) (or (:file source) (:line source)))
+        [:div {:style (:detail-source styles)}
+         (str "at " (:file source)
+              (when (:line source) (str ":" (:line source))))])]))
+
+#?(:cljs
+   (defn- status-glyph
+     [status]
+     (case status
+       :pass [:span {:style (:status-pass styles)} "●"]
+       :fail [:span {:style (:status-fail styles)} "●"]
+       :skip [:span {:style (:status-skip styles)} "○"]
+       [:span {:style (:status-skip styles)} "○"])))
+
+#?(:cljs
+   (defn- rows-section
+     "Per-test rows. Empty when no run has executed; renders nothing
+     when the run recorded zero assertions (the summary pill already
+     told the user)."
+     [variant-id]
+     (let [slot     (get @results-atom variant-id)
+           result   (:result slot)
+           expanded (or (:expanded slot) #{})]
+       (when result
+         (let [rows (mapv assertion-row (:assertions result))]
+           (when (seq rows)
+             [:div {:style     (:section styles)
+                    :data-test "story-test-rows-section"}
+              [:div {:style (:section-h styles)} "Per-test"]
+              [:table {:style     (:table styles)
+                       :data-test "story-test-table"}
+               [:thead
+                [:tr
+                 [:th {:style (merge (:th styles) (:td-status styles))} ""]
+                 [:th {:style (:th styles)} "assertion"]
+                 [:th {:style (:th styles)} "detail"]]]
+               [:tbody
+                (for [[i row] (map-indexed vector rows)]
+                  (let [open? (contains? expanded i)
+                        fail? (= :fail (:status row))]
+                    ^{:key i}
+                    [:tr {:data-test     "story-test-row"
+                          :data-status   (name (:status row))
+                          :data-assertion (str (:assertion row))
+                          :style         (when fail? (:row-fail styles))}
+                     [:td {:style (merge (:td styles) (:td-status styles))}
+                      (status-glyph (:status row))]
+                     [:td {:style (:td styles)}
+                      (:label row)]
+                     [:td {:style (:td styles)}
+                      (cond
+                        fail?
+                        [:div
+                         [:button
+                          {:style    (:details-tog styles)
+                           :on-click (fn [_] (toggle-expanded! variant-id i))
+                           :aria-expanded (if open? "true" "false")}
+                          (if open? "hide detail" "show detail")]
+                         (when open? (row-detail (:detail row)))]
+
+                        (= :skip (:status row))
+                        [:span {:style (:status-skip styles)} "skipped"]
+
+                        :else
+                        "")]]))]]])))))) ;; rows-section closes here
+
+#?(:cljs
+   (defn- empty-state
+     "Placeholder when the variant has no `:play` slot."
+     [variant-id]
+     [:div {:style     (:empty styles)
+            :data-test "story-test-empty"}
+      [:div {:style {:font-weight "bold" :margin-bottom "8px"
+                     :color "#cccccc"}}
+       "No tests registered for this variant"]
+      [:div
+       "Add a "
+       [:code ":play"]
+       " slot to "
+       [:code (str variant-id)]
+       " to register assertions."]
+      [:a {:href       "https://github.com/day8/re-frame2/blob/main/skills/re-frame2/reference/cross-cutting/testing.md"
+           :style      (:empty-link styles)
+           :data-test  "story-test-empty-link"
+           :target     "_blank"
+           :rel        "noopener noreferrer"}
+       "skills/re-frame2/reference/cross-cutting/testing.md"]]))
+
+;; ---- top-level component -------------------------------------------------
+
+#?(:cljs
+   (defn test-view
+     "Top-level `:test` mode pane for `variant-id`.
+
+     On first mount for a variant the pane auto-runs the variant once
+     so the user lands on the result; subsequent visits to the tab
+     show the most recent result until the Re-run button is clicked.
+
+     Returns nil when given no variant id (the shell already gates
+     this, but the helper guards itself too).
+
+     Per spec/009 the pane is read-only — no inputs mutate args /
+     overrides / modes. The Re-run button mutates **runtime state**
+     (re-allocates the variant frame via `reset-variant`) but not
+     the variant's authoring shape."
+     [variant-id]
+     (when variant-id
+       (r/create-class
+         {:display-name "rf-story-test-view"
+          :component-did-mount
+          (fn [_this]
+            ;; Auto-run on first mount per variant. If a slot already
+            ;; exists (returning to the tab without re-mount) we don't
+            ;; re-fire — the user clicks Re-run to refresh.
+            (when (variant-has-tests? variant-id)
+              (when-not (get @results-atom variant-id)
+                (run-variant-pane! variant-id))))
+          :reagent-render
+          (fn [variant-id]
+            (cond
+              (not (variant-has-tests? variant-id))
+              [:section {:style     (:wrap styles)
+                         :data-test "story-test-view"
+                         :aria-label "Variant tests"}
+               [empty-state variant-id]]
+
+              :else
+              [:section {:style     (:wrap styles)
+                         :data-test "story-test-view"
+                         :aria-label "Variant tests"}
+               [header variant-id]
+               [summary-section variant-id]
+               [rows-section variant-id]]))}))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -26,6 +26,7 @@
             [re-frame.story.ui.state :as state]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.sidebar :as sidebar]
+            [re-frame.story.ui.test-mode :as test-mode]
             [re-frame.story.ui.trace :as trace]
             [re-frame.story.ui.workspace :as workspace]))
 
@@ -303,6 +304,43 @@
       (is (= [{:key :greeting :value "hi" :doc "the greeting"}]
              rows)))
     (is (= [:dev :docs] (docs/variant-tags :story.dvh/x)))))
+
+;; ---- :test mode (rf2-qmjo) ----------------------------------------------
+
+(deftest test-view-is-a-fn
+  (testing "test-view is callable from the shell"
+    (is (fn? test-mode/test-view))))
+
+(deftest test-view-empty-state-without-play
+  (testing "test-view renders the empty-state placeholder when the
+            variant body has no :play slot — the variant is registered
+            but declares zero assertions, so no run is fired."
+    (story/reg-variant :story.tv/no-play {:events []})
+    (let [result (test-mode/test-view :story.tv/no-play)]
+      ;; r/create-class returns a fn — Reagent will invoke it during
+      ;; render. We at least confirm the helper returns a non-nil
+      ;; component descriptor.
+      (is (some? result)))
+    (is (nil? (test-mode/test-view nil))
+        "no variant-id = no pane")))
+
+(deftest test-view-pure-helpers
+  (testing "the pure section helpers run end-to-end in CLJS too"
+    (let [summary (test-mode/aggregate-summary
+                    [{:assertion :rf.assert/path-equals :passed? true}
+                     {:assertion :rf.assert/sub-equals  :passed? false}])]
+      (is (= 2 (:total summary)))
+      (is (= 1 (:passed summary)))
+      (is (= 1 (:failed summary)))
+      (is (false? (:all-passed? summary))))
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/path-equals
+                 :payload   [[:k] 1] :passed? true})]
+      (is (= :pass (:status row))))
+    (is (= "12 ms" (test-mode/format-elapsed-ms 12)))
+    (is (= "1.2 s" (test-mode/format-elapsed-ms 1234)))
+    (is (re-matches #"\d{2}:\d{2}:\d{2}"
+                    (test-mode/format-timestamp-ms (.getTime (js/Date.)))))))
 
 ;; ---- canvas: decorator-wrap exception swallow ---------------------------
 ;;

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -24,6 +24,7 @@
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.docs   :as docs]
             [re-frame.story.ui.state  :as state]
+            [re-frame.story.ui.test-mode :as test-mode]
             [re-frame.story.ui.workspace :as workspace]))
 
 ;; ---- fixtures ------------------------------------------------------------
@@ -396,3 +397,131 @@
       ;; Sorted by workspace id (alphabetic) then content order — :a/a
       ;; before :b/b.
       (is (= ["alpha" "beta"] bodies)))))
+
+;; ---- test mode (rf2-qmjo) -----------------------------------------------
+
+(deftest test-mode-parent-story-id
+  (testing "parent-story-id mirrors the docs helper"
+    (is (= :story.foo (test-mode/parent-story-id :story.foo/bar)))
+    (is (nil? (test-mode/parent-story-id :no-namespace)))
+    (is (nil? (test-mode/parent-story-id nil)))))
+
+(deftest test-mode-variant-has-tests?-checks-play-slot
+  (testing "variant-has-tests? is false when :play is absent or empty"
+    (story/reg-variant :story.tm/empty {:events []})
+    (story/reg-variant :story.tm/empty-play {:events [] :play []})
+    (is (not (test-mode/variant-has-tests? :story.tm/empty)))
+    (is (not (test-mode/variant-has-tests? :story.tm/empty-play))))
+  (testing "variant-has-tests? is true when :play carries any event"
+    (story/reg-variant :story.tm/has
+      {:events [] :play [[:rf.assert/path-equals [:count] 0]]})
+    (is (test-mode/variant-has-tests? :story.tm/has)))
+  (testing "variant-has-tests? returns false for an unknown variant-id"
+    (is (not (test-mode/variant-has-tests? :story.tm/unknown)))))
+
+(deftest test-mode-aggregate-summary-counts-pass-fail-skip
+  (testing "aggregate-summary tallies passed / failed / skipped"
+    (let [s (test-mode/aggregate-summary
+              [{:assertion :rf.assert/path-equals :passed? true}
+               {:assertion :rf.assert/path-equals :passed? false}
+               {:assertion :rf.assert/sub-equals  :passed? true}
+               {:assertion :rf.assert/skipped     :passed? false}])]
+      (is (= 4 (:total s)))
+      (is (= 2 (:passed s)))
+      (is (= 1 (:failed s)))
+      (is (= 1 (:skipped s)))
+      (is (false? (:all-passed? s)))))
+  (testing "aggregate-summary's :all-passed? is true only when every
+            non-skipped record passed AND no records were skipped"
+    (let [all-pass (test-mode/aggregate-summary
+                     [{:assertion :rf.assert/path-equals :passed? true}
+                      {:assertion :rf.assert/sub-equals  :passed? true}])]
+      (is (true?  (:all-passed? all-pass)))
+      (is (= 0   (:failed all-pass)))
+      (is (= 0   (:skipped all-pass))))
+    (let [with-skip (test-mode/aggregate-summary
+                      [{:assertion :rf.assert/path-equals :passed? true}
+                       {:assertion :rf.assert/skipped     :passed? false}])]
+      (is (false? (:all-passed? with-skip))
+          "a skipped record disqualifies :all-passed?")))
+  (testing "aggregate-summary on an empty vector returns zeros + :all-passed? false"
+    (let [s (test-mode/aggregate-summary [])]
+      (is (= 0 (:total s)))
+      (is (= 0 (:passed s)))
+      (is (= 0 (:failed s)))
+      (is (= 0 (:skipped s)))
+      (is (false? (:all-passed? s))
+          "zero records = not 'all passed' (the variant ran nothing)")))
+  (testing "aggregate-summary tolerates nil"
+    (let [s (test-mode/aggregate-summary nil)]
+      (is (= 0 (:total s)))
+      (is (false? (:all-passed? s))))))
+
+(deftest test-mode-assertion-row-projection
+  (testing "assertion-row maps a passing record to :status :pass"
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/path-equals
+                 :payload   [[:count] 7]
+                 :passed?   true
+                 :expected  7
+                 :actual    7})]
+      (is (= :pass (:status row)))
+      (is (= :rf.assert/path-equals (:assertion row)))
+      (is (re-find #":rf.assert/path-equals" (:label row)))
+      (is (re-find #"\[\[:count\] 7\]" (:label row)))))
+  (testing "assertion-row maps a failing record to :status :fail + surfaces detail"
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/path-equals
+                 :payload   [[:count] 7]
+                 :passed?   false
+                 :expected  7
+                 :actual    0
+                 :reason    "mismatch"
+                 :source    {:file "stories.cljs" :line 42}})]
+      (is (= :fail (:status row)))
+      (let [d (:detail row)]
+        (is (= 7   (:expected d)))
+        (is (= 0   (:actual   d)))
+        (is (= "mismatch" (:reason d)))
+        (is (= {:file "stories.cljs" :line 42} (:source d))))))
+  (testing "assertion-row maps :rf.assert/skipped to :status :skip"
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/skipped :passed? false})]
+      (is (= :skip (:status row)))))
+  (testing "assertion-row reads :source-coord as a fallback for :source"
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/sub-equals
+                 :passed?   false
+                 :source-coord {:file "f.cljs" :line 9}})]
+      (is (= {:file "f.cljs" :line 9} (-> row :detail :source)))))
+  (testing "assertion-row's :label omits an empty payload"
+    (let [row (test-mode/assertion-row
+                {:assertion :rf.assert/no-warnings
+                 :payload   []
+                 :passed?   true})]
+      (is (= ":rf.assert/no-warnings" (:label row)))))
+  (testing "assertion-row tolerates a fully-empty record without throwing"
+    (let [row (test-mode/assertion-row nil)]
+      (is (= :fail (:status row))
+          "nil record defaults to fail — a missing passed? slot can't be 'pass'")
+      (is (some? (:label row))))))
+
+(deftest test-mode-format-elapsed-ms
+  (testing "format-elapsed-ms switches at the 1s boundary"
+    (is (= "0 ms"   (test-mode/format-elapsed-ms 0)))
+    (is (= "12 ms"  (test-mode/format-elapsed-ms 12)))
+    (is (= "999 ms" (test-mode/format-elapsed-ms 999)))
+    (is (= "1.0 s"  (test-mode/format-elapsed-ms 1000)))
+    (is (= "1.2 s"  (test-mode/format-elapsed-ms 1234))))
+  (testing "format-elapsed-ms tolerates nil / non-numbers / negatives"
+    (is (= "" (test-mode/format-elapsed-ms nil)))
+    (is (= "" (test-mode/format-elapsed-ms "no")))
+    (is (= "" (test-mode/format-elapsed-ms -5)))))
+
+(deftest test-mode-format-timestamp-ms
+  (testing "format-timestamp-ms emits an HH:mm:ss-shaped string"
+    (let [s (test-mode/format-timestamp-ms (System/currentTimeMillis))]
+      (is (re-matches #"\d{2}:\d{2}:\d{2}" s))))
+  (testing "format-timestamp-ms returns empty string for non-numbers"
+    (is (= "" (test-mode/format-timestamp-ms nil)))
+    (is (= "" (test-mode/format-timestamp-ms "no")))))


### PR DESCRIPTION
## Summary

- Replaces the rf2-9hc8 `:test` placeholder with `re-frame.story.ui.test-mode/test-view` — the in-canvas aggregated test-runner pane (status pill, per-row pass/fail, collapsible failure detail, Re-run button) that consumes the existing `run-variant` runtime + the seven canonical `:rf.assert/*` records (spec/004).
- Pure helpers (`variant-has-tests?`, `aggregate-summary`, `assertion-row`, `format-elapsed-ms`, `format-timestamp-ms`, `parent-story-id`) live in `.cljc` so the JVM corpus covers the data shaping; Reagent rendering + the `reset-variant` promise wiring are CLJS-only.
- Specs: `009-Test-Mode.md` lands as the normative entry; `007-Mode-Tabs.md` + spec `README.md` forward-link; `mode-tabs.cljs` drops the placeholder fn and the shell `:test` case points at `test-mode/test-view`.

## Test plan

- [x] 6 new JVM deftests / 32 new assertions in `story_ui_test.clj`: variant-has-tests?, aggregate-summary counts + :all-passed? edges, assertion-row :pass/:fail/:skip projection, payload formatting, :source / :source-coord fallback, format-elapsed-ms ms↔s boundary, format-timestamp-ms HH:mm:ss shape, parent-story-id mirroring.
- [x] 3 new CLJS deftests in `story_ui_cljs_test.cljs`: test-view fn, empty-state without :play, pure helpers end-to-end in CLJS.
- [x] 168 JVM + 591 CLJS tests pass (was 162 / 588).
- [x] Playwright section §3b-ii in `counter_with_stories.spec.cjs`: test-view root + parent-story header + Re-run + status pill "3 passed" for `:story.counter/loaded` + counts row + 3 passing rows + 0 failing + Re-run cycle + elapsed badge. Also swaps the post-reload selector from the removed `story-tests-placeholder` to `story-test-view`.
- [x] Empty-state path uses an absolute GitHub URL to the canonical `skills/re-frame2/reference/cross-cutting/testing.md` recipes leaf.
- [ ] Note: `counter-with-stories` Playwright spec exits with a pre-existing `expected "6" got "5"` failure at the final live-app check (same failure on origin/main, unrelated to this PR — the intermediate `page.reload()` in section 3b loses the counter app-db).