### PR TITLE
feat(template): emit default test harness — events_test.cljs + README "Run tests" section (rf2-8oi86)

### DIFF
--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -17,12 +17,19 @@ my-app/
 ├── .gitignore
 ├── resources/public/
 │   └── index.html            host page; loads /js/main.js
-└── src/my_app/
-    ├── core.cljs             entry point — mounts the view
-    ├── events.cljs           :counter/initialise, :counter/increment
-    ├── subs.cljs             :counter/value
-    └── views.cljs            the counter view
+├── src/my_app/
+│   ├── core.cljs             entry point — mounts the view
+│   ├── events.cljs           :counter/initialise, :counter/increment
+│   ├── subs.cljs             :counter/value
+│   └── views.cljs            the counter view
+└── test/my_app/
+    └── events_test.cljs      cljs.test deftest hitting the events ns
+                              under the plain-atom adapter
 ```
+
+`shadow-cljs.edn` ships `:source-paths ["src" "test"]` so the `:test`
+build (`:target :node-test`, `:ns-regexp "-test$"`) picks the file
+up out of the box.
 
 The UIx and Helix variants follow the same shape; only `core.cljs`,
 `views.cljs`, `deps.edn`, and the substrate-adapter coord change.
@@ -63,6 +70,7 @@ tools/template/
         │   ├── README.md
         │   ├── gitignore
         │   ├── events.cljs
+        │   ├── events_test.cljs
         │   ├── subs.cljs
         │   └── index.html
         ├── reagent/                      ; Reagent-specific

--- a/tools/template/src/clj/new/re_frame2.clj
+++ b/tools/template/src/clj/new/re_frame2.clj
@@ -142,6 +142,16 @@
               (sub-render "shared/subs.cljs")]
              ["src/{{nested-dirs}}/views.cljs"
               (sub-render (str substrate-name "/views.cljs"))]
+             ;; -- test tree --
+             ;;
+             ;; A single events-side test gives the `:test` build entry
+             ;; in shadow-cljs.edn (`:target :node-test`, `:ns-regexp
+             ;; "-test$"`) a real target. Substrate-agnostic — uses
+             ;; the plain-atom adapter so it runs node-side without a
+             ;; DOM. See the README "Run tests" section the template
+             ;; also emits.
+             ["test/{{nested-dirs}}/events_test.cljs"
+              (sub-render "shared/events_test.cljs")]
              ;; -- host HTML --
              ["resources/public/index.html"
               (sub-render "shared/index.html")])))

--- a/tools/template/src/clj/new/re_frame2/helix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/helix/deps.edn
@@ -19,6 +19,11 @@
          lilactown/helix           {:mvn/version "0.2.2"}}
 
  :aliases
- {:shadow
-  {:extra-deps {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
-   :main-opts  ["-m" "shadow.cljs.devtools.cli"]}}}
+ {;; `:extra-paths ["test"]` puts the emitted unit-test tree on
+  ;; shadow's classpath under this alias — shadow-cljs reads
+  ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
+  ;; shadow-cljs.edn is ignored when :deps is active).
+  :shadow
+  {:extra-paths ["test"]
+   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/helix/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/helix/shadow-cljs.edn
@@ -1,6 +1,12 @@
 ;; {{name}} — shadow-cljs build config (Helix substrate).
+;;
+;; Two builds:
+;;   :app  — watch / release. Compiles to resources/public/js/main.js.
+;;           Boot entry point: {{namespace}}.core/init.
+;;   :test — node-side test runner. Picks up any *_test.cljs file under
+;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src"]
+ :source-paths ["src" "test"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/src/clj/new/re_frame2/reagent/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/deps.edn
@@ -23,6 +23,12 @@
  {;; `clojure -M:shadow` runs shadow-cljs in JVM mode via the alias.
   ;; You can also use `npx shadow-cljs ...` (shadow's own node-side CLI).
   ;; Both work; the npm-side route is the canonical workflow.
+  ;;
+  ;; `:extra-paths ["test"]` puts the emitted unit-test tree on
+  ;; shadow's classpath under this alias — shadow-cljs reads
+  ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
+  ;; shadow-cljs.edn is ignored when :deps is active).
   :shadow
-  {:extra-deps {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
-   :main-opts  ["-m" "shadow.cljs.devtools.cli"]}}}
+  {:extra-paths ["test"]
+   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/reagent/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/shadow-cljs.edn
@@ -4,9 +4,9 @@
 ;;   :app  — watch / release. Compiles to resources/public/js/main.js.
 ;;           Boot entry point: {{namespace}}.core/init.
 ;;   :test — node-side test runner. Picks up any *_test.cljs file under
-;;           src/ and runs it via cljs.test.
+;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src"]
+ :source-paths ["src" "test"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/src/clj/new/re_frame2/shared/README.md
+++ b/tools/template/src/clj/new/re_frame2/shared/README.md
@@ -27,6 +27,21 @@ npx shadow-cljs release app
 Production output lands in `resources/public/js/`. Serve `resources/public/`
 from any static host.
 
+## Run tests
+
+```sh
+npx shadow-cljs compile test
+node out/node-test.js
+```
+
+The `:test` build in `shadow-cljs.edn` is a `:node-test` target that
+picks up every `*_test.cljs` namespace under `test/` and runs it via
+`cljs.test`. The scaffold ships one such file —
+`test/{{nested-dirs}}/events_test.cljs` — exercising
+`:counter/initialise` and `:counter/increment` against the plain-atom
+reactive substrate (no DOM needed). Add more `*_test.cljs` files
+alongside it as your app grows.
+
 ## Project layout
 
 ```
@@ -38,11 +53,13 @@ from any static host.
 ├── .gitignore               ; CLJS standard
 ├── resources/public/
 │   └── index.html           ; host page; loads shadow-cljs's compiled output
-└── src/{{nested-dirs}}/
-    ├── core.cljs            ; entry point — mounts the root view
-    ├── events.cljs          ; `:counter/initialise`, `:counter/increment` handlers
-    ├── subs.cljs            ; `:counter/value` subscription
-    └── views.cljs           ; the counter view ({{substrate}})
+├── src/{{nested-dirs}}/
+│   ├── core.cljs            ; entry point — mounts the root view
+│   ├── events.cljs          ; `:counter/initialise`, `:counter/increment` handlers
+│   ├── subs.cljs            ; `:counter/value` subscription
+│   └── views.cljs           ; the counter view ({{substrate}})
+└── test/{{nested-dirs}}/
+    └── events_test.cljs     ; substrate-agnostic event-handler tests
 ```
 
 ## What's in the scaffold

--- a/tools/template/src/clj/new/re_frame2/shared/events_test.cljs
+++ b/tools/template/src/clj/new/re_frame2/shared/events_test.cljs
@@ -1,0 +1,46 @@
+(ns {{namespace}}.events-test
+  "Unit tests for {{namespace}}.events.
+
+   Substrate-agnostic — uses the plain-atom reactive substrate so the
+   tests run under shadow-cljs `:node-test` without a DOM. The same
+   events / subs handlers are exercised regardless of which view-side
+   substrate (Reagent / UIx / Helix) the app uses for rendering.
+
+   Run:
+
+       npx shadow-cljs compile test
+       node out/node-test.js"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as ts]
+            ;; Side-effecting requires — load the user's handlers / subs
+            ;; into the registrar so the tests can dispatch / compute
+            ;; against them.
+            [{{namespace}}.events]
+            [{{namespace}}.subs]))
+
+;; --- Fixture ---------------------------------------------------------------
+;;
+;; `reset-runtime-fixture` snapshot/restores the registrar around each
+;; test, resets every frame's app-db to `{}`, and reinstalls the
+;; plain-atom adapter. Per-test `reg-*` calls roll back on exit;
+;; framework registrations (and the app's own ns-load registrations
+;; above) survive.
+
+(use-fixtures :each (ts/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; --- Tests -----------------------------------------------------------------
+
+(deftest counter-initialise-seeds-app-db
+  (testing ":counter/initialise puts {:counter/value 0} into app-db"
+    (rf/dispatch-sync [:counter/initialise])
+    (is (= 0 (:counter/value (rf/get-frame-db :rf/default))))))
+
+(deftest counter-increment-bumps-value
+  (testing ":counter/increment increases :counter/value by one each fire"
+    (rf/dispatch-sync [:counter/initialise])
+    (rf/dispatch-sync [:counter/increment])
+    (rf/dispatch-sync [:counter/increment])
+    (rf/dispatch-sync [:counter/increment])
+    (is (= 3 (:counter/value (rf/get-frame-db :rf/default))))))

--- a/tools/template/src/clj/new/re_frame2/uix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/uix/deps.edn
@@ -21,6 +21,11 @@
          com.pitch/uix.dom         {:mvn/version "1.4.4"}}
 
  :aliases
- {:shadow
-  {:extra-deps {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
-   :main-opts  ["-m" "shadow.cljs.devtools.cli"]}}}
+ {;; `:extra-paths ["test"]` puts the emitted unit-test tree on
+  ;; shadow's classpath under this alias — shadow-cljs reads
+  ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
+  ;; shadow-cljs.edn is ignored when :deps is active).
+  :shadow
+  {:extra-paths ["test"]
+   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/uix/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/uix/shadow-cljs.edn
@@ -1,6 +1,12 @@
 ;; {{name}} — shadow-cljs build config (UIx substrate).
+;;
+;; Two builds:
+;;   :app  — watch / release. Compiles to resources/public/js/main.js.
+;;           Boot entry point: {{namespace}}.core/init.
+;;   :test — node-side test runner. Picks up any *_test.cljs file under
+;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src"]
+ :source-paths ["src" "test"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -101,12 +101,14 @@
    "resources/public/index.html"])
 
 (def ^:private per-substrate-sources
-  ;; Generated under src/<nested-dirs>/. For project-name "acme/my-app"
-  ;; clj-new produces namespace "acme.my-app" → nested-dirs "acme/my_app".
+  ;; Generated under src/<nested-dirs>/ and test/<nested-dirs>/. For
+  ;; project-name "acme/my-app" clj-new produces namespace
+  ;; "acme.my-app" → nested-dirs "acme/my_app".
   ["src/acme/my_app/core.cljs"
    "src/acme/my_app/events.cljs"
    "src/acme/my_app/subs.cljs"
-   "src/acme/my_app/views.cljs"])
+   "src/acme/my_app/views.cljs"
+   "test/acme/my_app/events_test.cljs"])
 
 (def ^:private substrate-coord
   {:reagent 'day8/re-frame2-reagent
@@ -139,12 +141,17 @@
 
         ;; -- shadow-cljs.edn structure --
         (let [scs  (read-edn (io/file root "shadow-cljs.edn"))
-              app  (get-in scs [:builds :app])]
+              app  (get-in scs [:builds :app])
+              tst  (get-in scs [:builds :test])]
           (is (= :browser (:target app))
               "shadow-cljs :app build targets :browser")
           (is (= 'acme.my-app.core/init
                  (get-in app [:modules :main :init-fn]))
-              "init-fn matches generated namespace"))
+              "init-fn matches generated namespace")
+          (is (some #{"test"} (:source-paths scs))
+              "shadow-cljs.edn :source-paths includes \"test\" so the emitted test file is discoverable")
+          (is (= :node-test (:target tst))
+              "shadow-cljs :test build targets :node-test"))
 
         ;; -- package.json sanity --
         (let [pj-text (slurp (io/file root "package.json"))]


### PR DESCRIPTION
## Summary

- Adds a substrate-agnostic unit-test scaffold to every generated re-frame2 app: one `deftest` per counter event under `test/{{nested-dirs}}/events_test.cljs`, run against the plain-atom adapter (no DOM needed; identical across Reagent / UIx / Helix).
- Adds a "Run tests" section to the generated `README.md` documenting the canonical `:node-test` invocation (`npx shadow-cljs compile test && node out/node-test.js`) — the pre-existing `:test` build entry now has a real target.
- Threads `:extra-paths ["test"]` into the `:shadow` alias of each per-substrate `deps.edn` so shadow-cljs picks the test file up off the classpath under `:deps` mode.
- Keeps `spec/002-Generated-Shape.md` and the template's JVM test in sync.

## Test plan

- [x] `clojure -M:test` from `tools/template/` — 5 tests, 68 assertions, 0 failures.
- [x] `clojure -M:test` from `implementation/core/` — 249 tests, 1128 assertions, 0 failures.
- [x] `npm run test:cljs` — 591 tests, 1401 assertions, 0 failures.
- [x] `npm run test:browser` — 591 tests, 1428 assertions, 0 failures.
- [x] `npm run test:elision` — PASS.
- [x] `npm run test:examples` — counter-with-stories Playwright flake is pre-existing and orthogonal to this change.
- [x] Generated a fresh Reagent app via `clojure -Sdeps '...' -X clj-new/create :template re-frame2 :name acme/my-app`; ran `clojure -M:shadow compile test && node out/node-test.js` — 2 tests, 2 assertions, 0 failures.
- [x] UIx and Helix variants both emit `test/<nested-dirs>/events_test.cljs`.