### PR TITLE
docs(guide): promote ch.19 §Adapters to its own chapter (rf2-22t1)

### DIFF
--- a/SKILL-REDIRECT.md
+++ b/SKILL-REDIRECT.md
@@ -23,7 +23,7 @@ Audience: `[app]` / `[setup]` / `[mig]` / `[pair]`. API + Guide + MIGRATION + Ex
 - **Definitive API reference** → https://day8.github.io/re-frame2/spec/API/ `[app]` `[setup]` `[impl]`
 - **Migration from re-frame v1** → https://day8.github.io/re-frame2/spec/MIGRATION/ `[app]` `[setup]` `[mig]`
 - **Narrative guide (overview)** → https://day8.github.io/re-frame2/guide/README/ `[setup]`
-- **Guide — Stories** → https://day8.github.io/re-frame2/guide/20-stories/ `[app]`
+- **Guide — Stories** → https://day8.github.io/re-frame2/guide/21-stories/ `[app]`
 - **Examples directory (worked apps)** → https://github.com/day8/re-frame2/tree/main/examples/reagent `[app]` `[setup]` `[impl]`
 - **VERSION (next release string)** → https://github.com/day8/re-frame2/blob/main/VERSION `[setup]` `[mig]`
 - **CHANGELOG** → https://github.com/day8/re-frame2/blob/main/CHANGELOG.md `[setup]` `[mig]`

--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -107,7 +107,7 @@ This isn't an argument by authority. It's an observation that the architectural 
 
 ## What this chapter isn't going to enumerate
 
-A natural next question is: *what specifically does re-frame2 add on top of v1, and what does it keep?* The honest answer is that the list reads as marketing until you've met the pieces — frames[^frames], machines, flows, schema-attached contracts, deep instrumentation, the spec. The guide introduces each in its own chapter. Once you've worked through them, [chapter 19](19-where-next.md) gathers the additions and the inheritances into a single retrospective recap — a sharper read once the names mean something.
+A natural next question is: *what specifically does re-frame2 add on top of v1, and what does it keep?* The honest answer is that the list reads as marketing until you've met the pieces — frames[^frames], machines, flows, schema-attached contracts, deep instrumentation, the spec. The guide introduces each in its own chapter. Once you've worked through them, [chapter 20](20-where-next.md) gathers the additions and the inheritances into a single retrospective recap — a sharper read once the names mean something.
 
 > ### Sidebar: where re-frame2 isn't the right fit
 >

--- a/docs/guide/03-your-first-app.md
+++ b/docs/guide/03-your-first-app.md
@@ -4,7 +4,7 @@ The smallest interesting program is a counter: a number, two buttons, the number
 
 The full source is in [`examples/reagent/counter/core.cljs`](../../examples/reagent/counter/core.cljs). This chapter walks through it section by section, explaining what each piece is doing and *why it's shaped the way it is*. By the end you'll have seen every load-bearing primitive in re-frame2 at least once.
 
-This chapter uses **Reagent** — the canonical CLJS view substrate, the one the rest of the guide uses. (re-frame2 also has UIx and Helix adapters; for adapter comparisons and the `init!` call shape across substrates, see [chapter 19 — Adapters](19-where-next.md#adapters--the-pattern-across-substrates).)
+This chapter uses **Reagent** — the canonical CLJS view substrate, the one the rest of the guide uses. (re-frame2 also has UIx and Helix adapters; for adapter comparisons and the `init!` call shape across substrates, see [chapter 19 — Adapters](19-adapters.md).)
 
 ## What we're building
 
@@ -197,7 +197,7 @@ Four things happen here.
 
 `(rdc/render root [counter])` is the React/Reagent runtime asking "render this hiccup at this root." `[counter]` is hiccup referencing the Var that `reg-view` defed.
 
-Without `init!`, the runtime has no adapter installed and the first `subscribe` / `dispatch` from a view would not know how to wire its reactivity to React. For the call shape across UIx, Helix, and SSR — and why the call is explicit at every call site — see [chapter 19 — Adapters](19-where-next.md#adapters--the-pattern-across-substrates).
+Without `init!`, the runtime has no adapter installed and the first `subscribe` / `dispatch` from a view would not know how to wire its reactivity to React. For the call shape across UIx, Helix, and SSR — and why the call is explicit at every call site — see [chapter 19 — Adapters](19-adapters.md).
 
 ## What just happened
 
@@ -260,7 +260,7 @@ That's it. The shape doesn't change. There's no new primitive to learn. Every ch
 
 This is the real claim of re-frame2: **the cost of new features is bounded by the size of the feature, not by the size of the app**. In a poorly-shaped app, adding a feature requires reading a substantial fraction of the existing code to know where to wire it in. In a re-frame2 app, you read the events, the subs, and the view that touches the area you're changing, and that's enough.
 
-For how this same counter looks under UIx and Helix, what `init!` is doing under the hood, and the slim-Reagent option for ship-size builds, see [chapter 19 — Adapters](19-where-next.md#adapters--the-pattern-across-substrates).
+For how this same counter looks under UIx and Helix, what `init!` is doing under the hood, and the slim-Reagent option for ship-size builds, see [chapter 19 — Adapters](19-adapters.md).
 
 ## Next
 

--- a/docs/guide/04-events-state-cycle.md
+++ b/docs/guide/04-events-state-cycle.md
@@ -315,7 +315,7 @@ Two Patterns bottom out directly on what this chapter covered, so flag them now:
 - [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md) — the generic post-work-await-reply shape that the `:rf.http/managed` example above is one instance of.
 - [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) — HTTP requests with a standard lifecycle slice (idle / loading / loaded / error / stale).
 
-The rest of the Pattern catalogue — Forms, Boot, WebSocket, LongRunningWork, StaleDetection, NineStates — is covered in [chapter 19 — Where to go next](19-where-next.md#look-up-a-pattern-by-name), with one-line summaries you can scan when the shape of your problem matches. Read the Pattern doc and copy the shape; don't invent a new one.
+The rest of the Pattern catalogue — Forms, Boot, WebSocket, LongRunningWork, StaleDetection, NineStates — is covered in [chapter 20 — Where to go next](20-where-next.md#look-up-a-pattern-by-name), with one-line summaries you can scan when the shape of your problem matches. Read the Pattern doc and copy the shape; don't invent a new one.
 
 ## A note on revertibility
 

--- a/docs/guide/17-routing.md
+++ b/docs/guide/17-routing.md
@@ -594,7 +594,7 @@ That's the bet this chapter has been defending: the URL is a sub.
 
 ## Next
 
-- [19 — Where to go next](19-where-next.md) — the chapter wrap-up, with pointers to the worked examples, pattern docs, the API ref, and the spec.
+- [20 — Where to go next](20-where-next.md) — the chapter wrap-up, with pointers to the worked examples, pattern docs, the API ref, and the spec.
 - [Spec 012 — Routing](../../spec/012-Routing.md) — the full normative surface, including the path-pattern grammar's productions, the route ranking cascade, scroll restoration, and the SSR integration story in detail.
 - [chapter 11](11-server-side.md) — how routing folds into SSR.
 - [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) — why nav-tokens are the same shape as `:after`-timer epochs, and the cross-cutting pattern.

--- a/docs/guide/18-from-re-frame-v1.md
+++ b/docs/guide/18-from-re-frame-v1.md
@@ -4,7 +4,7 @@
 
 This is the appendix-shaped chapter for migrators. It tells you which deps move, which skill drives the work, and the broad categories of breakage to expect. The exhaustive rule list lives in [`spec/MIGRATION.md`](../../spec/MIGRATION.md) (40+ M- and O-rules) and is consumed by the migration skill; this chapter does not duplicate it.
 
-If you don't have a v1 codebase to bring across, skip to [19 — Where to go next](19-where-next.md).
+If you don't have a v1 codebase to bring across, skip to [19 — Adapters](19-adapters.md) and [20 — Where to go next](20-where-next.md).
 
 ## Deps to update
 
@@ -71,4 +71,5 @@ The skill applies steps 1–4 unprompted and stops at step 5 for review.
 
 - [`skills/re-frame-migration/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/SKILL.md) — the skill that drives the migration end-to-end.
 - [`spec/MIGRATION.md`](../../spec/MIGRATION.md) — the authoritative rule list. The skill consumes this directly.
-- [19 — Where to go next](19-where-next.md) — once the migration settles, where to head next.
+- [19 — Adapters](19-adapters.md) — substrate-agnostic story, the `init!` call shape, the three adapter packages, the slim-Reagent option.
+- [20 — Where to go next](20-where-next.md) — once the migration settles, where to head next.

--- a/docs/guide/19-adapters.md
+++ b/docs/guide/19-adapters.md
@@ -1,0 +1,74 @@
+# 19 — Adapters
+
+> **If you're skipping this chapter, the upshot:** re-frame2's runtime is substrate-agnostic. Three adapters ship today — Reagent, UIx, and Helix — and you wire one into `init!` at the call site. Pick the one your team already uses; the events/subs/fx primitives are identical across all three.
+
+[Chapter 03](03-your-first-app.md) walked the counter end-to-end on Reagent. This chapter widens the lens. re-frame2's runtime — the registry, the dispatch loop, events, fx, subs, machines — is **substrate-agnostic**. The primitives you've used in `app-db`, in event handlers, and in subs are identical regardless of which substrate is rendering. What differs is how the view layer is wired into React.
+
+## The three substrate adapters
+
+Three adapters are available today:
+
+- **Reagent** — the canonical CLJS reference. Hiccup-shaped views, deref-tracking subscriptions (`@(subscribe ...)`), the substrate the guide uses end-to-end. Pick this if you have no other constraint.
+- **UIx** — a CLJS adapter targeting React function components and hooks idiomatically. Useful if you're integrating with a JS-side codebase that expects React fn-components, or if you want UIx's compile-time JSX-style ergonomics.
+- **Helix** — same shape as UIx in spirit; pick it if your team already uses Helix.
+
+Each ships as its own Maven artefact alongside core (per Strategy B — see [`spec/MIGRATION.md`](../../spec/MIGRATION.md)):
+
+```clojure
+;; deps.edn — Reagent (the canonical "first app" stack)
+{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
+        day8/re-frame2-reagent  {:mvn/version "2.0.0"}
+        reagent                   {:mvn/version "2.0.0"}}}
+
+;; deps.edn — UIx
+{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
+        day8/re-frame2-uix      {:mvn/version "2.0.0"}
+        com.pitch/uix.core       {:mvn/version "..."}}}
+
+;; deps.edn — Helix
+{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
+        day8/re-frame2-helix    {:mvn/version "2.0.0"}
+        lilactown/helix          {:mvn/version "..."}}}
+```
+
+Per the [feature-opt-in story](../../spec/MIGRATION.md), core ships with **none** of the substrate adapters baked in — you add the artefact for the substrate you've picked. The same pattern applies to optional capabilities (state machines, routing, HTTP, schemas, SSR, time-travel) — each ships as its own artefact, and an app that doesn't use a feature doesn't bundle its code.
+
+The `dispatch`, `subscribe`, and `reg-view` primitives are identical across substrates; the difference shows up in the mount call (`reagent.dom.client/render` vs `uix.dom/render-root` vs Helix's mount fn) and in how the view body composes — Reagent uses hiccup, UIx and Helix use their own component DSLs. The pattern survives.
+
+## `init!` and how the adapter gets wired
+
+The line `(rf/init! reagent-adapter/adapter)` in chapter 03's `run` deserves a closer look — it's where the adapter is bound to the runtime.
+
+The call shape is fixed:
+
+```clojure
+;; Pass the adapter you want — explicit, always.
+(rf/init! reagent-adapter/adapter)
+```
+
+Each adapter namespace exports an `adapter` Var (the nine-fn spec map Spec 006 documents). You require the namespace and pass the Var. **Explicit at the call site, every time.** Reading any app's `run` function tells you exactly which adapter the runtime is wired to, with no ns-load side-effects to chase.
+
+Calling `(rf/init!)` with no args (or with a keyword like `:reagent`, or with `nil`) raises `:rf.error/no-adapter-specified` — the only legal call shape is `(rf/init! adapter-map)`. The error message points back at the adapter-ns + adapter-Var pattern so the recovery path is obvious.
+
+The same call shape applies to every adapter — pick the right `adapter` Var and pass it:
+
+```clojure
+(require '[re-frame.adapter.uix :as uix])
+(rf/init! uix/adapter)
+
+(require '[re-frame.adapter.helix :as helix])
+(rf/init! helix/adapter)
+
+(require '[re-frame.ssr :as ssr])   ;; JVM-side server bootstrap
+(rf/init! ssr/adapter)
+```
+
+For a mixed-substrate app — say a build that imports both Reagent and UIx — pick the active adapter by passing the right Var. There is no multi-adapter ambiguity to resolve at boot: only one adapter is ever installed, and the call site names it.
+
+## A slim Reagent for ship-size
+
+For apps where bundle size matters, `re-frame.adapter.reagent-slim` wires re-frame2 to a Reagent rewrite that omits server-rendering and large-runtime parts (no `reagent.impl.*`, no `react-dom/server`). The same counter mounted on it lives at [`examples/reagent/counter_slim_and_fast/`](../../examples/reagent/counter_slim_and_fast/) — the event handlers, subs, and views are byte-for-byte identical to the canonical example; only the requires (`reagent2.dom.client` instead of `reagent.dom.client`) and the adapter Var passed to `init!` change. Reach for it when you've measured a ship-size problem and confirmed the missing capabilities aren't on your hot path.
+
+## Where next
+
+If you've finished the chapters, [20 — Where to go next](20-where-next.md) is the one-screen exit pointer — examples, pattern docs, the API ref, the runtime companion docs, the spec. The reference for the adapter contract itself is [Spec 006 — Reactive substrate](../../spec/006-ReactiveSubstrate.md).

--- a/docs/guide/20-where-next.md
+++ b/docs/guide/20-where-next.md
@@ -1,4 +1,4 @@
-# 19 — Where to go next
+# 20 — Where to go next
 
 You've now seen the shape of re-frame2 from twelve angles — the argument, the cycle, views and frames, machines, HTTP, the server side, the v1 migration story, the dynamic-model essay, testing, devtools, and routing. The mental model is in place. A few directions from here.
 
@@ -32,74 +32,11 @@ The fastest way to make the pattern stick is to write code in it. The [worked ex
 
 Every example ships with a Playwright smoke spec (`<name>.spec.cjs`) — the spec is the executable acceptance test for "this example still works." Use them as templates when you write your own.
 
-If you'd like a **frame-aware component playground** alongside the live app — Storybook-flavoured but built on re-frame2's primitives — chapter [20 — Stories](20-stories.md) walks the surface, and [`examples/reagent/counter_with_stories/`](../../examples/reagent/counter_with_stories/) is the worked example.
+If you'd like a **frame-aware component playground** alongside the live app — Storybook-flavoured but built on re-frame2's primitives — chapter [21 — Stories](21-stories.md) walks the surface, and [`examples/reagent/counter_with_stories/`](../../examples/reagent/counter_with_stories/) is the worked example.
 
-## Adapters — the pattern across substrates
+## Pick a substrate adapter
 
-[Chapter 03](03-your-first-app.md) walked the counter end-to-end on Reagent. Here's the wider picture: re-frame2's runtime — the registry, the dispatch loop, events, fx, subs, machines — is **substrate-agnostic**. The primitives you've used in `app-db`, in event handlers, and in subs are identical regardless of which substrate is rendering. What differs is how the view layer is wired into React.
-
-Three substrate adapters are available today:
-
-- **Reagent** — the canonical CLJS reference. Hiccup-shaped views, deref-tracking subscriptions (`@(subscribe ...)`), the substrate the guide uses end-to-end. Pick this if you have no other constraint.
-- **UIx** — a CLJS adapter targeting React function components and hooks idiomatically. Useful if you're integrating with a JS-side codebase that expects React fn-components, or if you want UIx's compile-time JSX-style ergonomics.
-- **Helix** — same shape as UIx in spirit; pick it if your team already uses Helix.
-
-Each ships as its own Maven artefact alongside core (per Strategy B — see [`spec/MIGRATION.md`](../../spec/MIGRATION.md)):
-
-```clojure
-;; deps.edn — Reagent (the canonical "first app" stack)
-{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
-        day8/re-frame2-reagent  {:mvn/version "2.0.0"}
-        reagent                   {:mvn/version "2.0.0"}}}
-
-;; deps.edn — UIx
-{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
-        day8/re-frame2-uix      {:mvn/version "2.0.0"}
-        com.pitch/uix.core       {:mvn/version "..."}}}
-
-;; deps.edn — Helix
-{:deps {day8/re-frame2          {:mvn/version "2.0.0"}
-        day8/re-frame2-helix    {:mvn/version "2.0.0"}
-        lilactown/helix          {:mvn/version "..."}}}
-```
-
-Per the [feature-opt-in story](../../spec/MIGRATION.md), core ships with **none** of the substrate adapters baked in — you add the artefact for the substrate you've picked. The same pattern applies to optional capabilities (state machines, routing, HTTP, schemas, SSR, time-travel) — each ships as its own artefact, and an app that doesn't use a feature doesn't bundle its code.
-
-The `dispatch`, `subscribe`, and `reg-view` primitives are identical across substrates; the difference shows up in the mount call (`reagent.dom.client/render` vs `uix.dom/render-root` vs Helix's mount fn) and in how the view body composes — Reagent uses hiccup, UIx and Helix use their own component DSLs. The pattern survives.
-
-### `init!` and how the adapter gets wired
-
-The line `(rf/init! reagent-adapter/adapter)` in chapter 03's `run` deserves a closer look — it's where the adapter is bound to the runtime.
-
-The call shape is fixed:
-
-```clojure
-;; Pass the adapter you want — explicit, always.
-(rf/init! reagent-adapter/adapter)
-```
-
-Each adapter namespace exports an `adapter` Var (the nine-fn spec map Spec 006 documents). You require the namespace and pass the Var. **Explicit at the call site, every time.** Reading any app's `run` function tells you exactly which adapter the runtime is wired to, with no ns-load side-effects to chase.
-
-Calling `(rf/init!)` with no args (or with a keyword like `:reagent`, or with `nil`) raises `:rf.error/no-adapter-specified` — the only legal call shape is `(rf/init! adapter-map)`. The error message points back at the adapter-ns + adapter-Var pattern so the recovery path is obvious.
-
-The same call shape applies to every adapter — pick the right `adapter` Var and pass it:
-
-```clojure
-(require '[re-frame.adapter.uix :as uix])
-(rf/init! uix/adapter)
-
-(require '[re-frame.adapter.helix :as helix])
-(rf/init! helix/adapter)
-
-(require '[re-frame.ssr :as ssr])   ;; JVM-side server bootstrap
-(rf/init! ssr/adapter)
-```
-
-For a mixed-substrate app — say a build that imports both Reagent and UIx — pick the active adapter by passing the right Var. There is no multi-adapter ambiguity to resolve at boot: only one adapter is ever installed, and the call site names it.
-
-### A slim Reagent for ship-size
-
-For apps where bundle size matters, `re-frame.adapter.reagent-slim` wires re-frame2 to a Reagent rewrite that omits server-rendering and large-runtime parts (no `reagent.impl.*`, no `react-dom/server`). The same counter mounted on it lives at [`examples/reagent/counter_slim_and_fast/`](../../examples/reagent/counter_slim_and_fast/) — the event handlers, subs, and views are byte-for-byte identical to the canonical example; only the requires (`reagent2.dom.client` instead of `reagent.dom.client`) and the adapter Var passed to `init!` change. Reach for it when you've measured a ship-size problem and confirmed the missing capabilities aren't on your hot path.
+re-frame2's runtime is substrate-agnostic; three view-layer adapters ship today — Reagent, UIx, and Helix. [Chapter 19 — Adapters](19-adapters.md) covers the substrate-agnostic story, the `init!` call shape, the three `deps.edn` lines, and the slim-Reagent option for ship-size builds. Reach for it when you're deciding which adapter to mount, or when you're integrating with a non-Reagent codebase.
 
 ## Look up a pattern by name
 

--- a/docs/guide/21-stories.md
+++ b/docs/guide/21-stories.md
@@ -1,4 +1,4 @@
-# 20 — Stories
+# 21 — Stories
 
 > **Optional deep-dive.** This chapter assumes you've absorbed the [events](04-events-state-cycle.md), [views](06-views-and-frames.md), [testing](13-testing.md), and [devtools](15-devtools-and-pair-tools.md) chapters. If you haven't yet, come back later — Stories is a layered surface on top of those, not the next link in the linear sequence.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -8,7 +8,7 @@ If you're an AI agent or implementor, you want the [specification](../../spec/RE
 
 ## Chapters
 
-The guide is in two parts. The **core path** (chapters 01-11) builds the mental model in sequence — read these in order, end to end, and you have re-frame2. The **optional deep dives** (chapters 12-20) are *à la carte*: read them when the topic comes up, not as the next-link in the linear sequence.
+The guide is in two parts. The **core path** (chapters 01-11) builds the mental model in sequence — read these in order, end to end, and you have re-frame2. The **optional deep dives** (chapters 12-21) are *à la carte*: read them when the topic comes up, not as the next-link in the linear sequence.
 
 Chapter **09 — Forms** sits between 08 and 10 as a side-track: not load-bearing for the mental model the way 08 is, but standard enough that most readers will want it before they reach 10. Skip it on a first read if you like; pick it up the first time you hit a non-trivial form.
 
@@ -49,13 +49,14 @@ Read these when the topic comes up — not as part of the linear sequence. They'
 | 16 | [Performance](16-performance.md) | Your page feels slow — the four shapes of slowness (big props, deep `=`, inline callbacks, expensive subs), the framework's answers, and the `rf:` User Timing surface. |
 | 17 | [Routing](17-routing.md) | Your app needs URL ↔ state — `reg-route`, navigation tokens, `:can-leave`, multi-frame. |
 | 18 | [From re-frame v1](18-from-re-frame-v1.md) | You're migrating an existing re-frame v1 app. Skip if re-frame2 is your starting point. The chapter is appendix-shaped — deps to bump, the migration skill to run, and the broad categories of breakage to expect. |
-| 20 | [Stories](20-stories.md) | You want a Storybook-flavoured playground for your components — `reg-story`, `reg-variant`, the four-phase lifecycle, the `:rf.assert/*` vocabulary, and the agent-facing MCP surface. The narrative companion to [`tools/story/`](../../tools/story/) and [Spec 007 — Stories](../../spec/007-Stories.md). |
+| 19 | [Adapters](19-adapters.md) | You're choosing or wiring a view-layer substrate — Reagent, UIx, or Helix. Covers the substrate-agnostic story, the `init!` call shape, the three adapter packages, and the slim-Reagent option for ship-size builds. |
+| 21 | [Stories](21-stories.md) | You want a Storybook-flavoured playground for your components — `reg-story`, `reg-variant`, the four-phase lifecycle, the `:rf.assert/*` vocabulary, and the agent-facing MCP surface. The narrative companion to [`tools/story/`](../../tools/story/) and [Spec 007 — Stories](../../spec/007-Stories.md). |
 
 ### Close-out
 
 | # | Chapter | What it covers |
 |---|---|---|
-| 19 | [Where to go next](19-where-next.md) | A one-screen exit pointer — examples, pattern docs, the API ref, the runtime companion docs, the spec. Read this when you finish the chapters and want to know "now what?" |
+| 20 | [Where to go next](20-where-next.md) | A one-screen exit pointer — examples, pattern docs, the API ref, the runtime companion docs, the spec. Read this when you finish the chapters and want to know "now what?" |
 
 ### Worked examples
 

--- a/examples/reagent/counter_with_stories/README.md
+++ b/examples/reagent/counter_with_stories/README.md
@@ -96,7 +96,7 @@ implementation symbols. The contract is enforced by:
 
 ## See also
 
-- The guide chapter at [`docs/guide/20-stories.md`](../../../docs/guide/20-stories.md).
+- The guide chapter at [`docs/guide/21-stories.md`](../../../docs/guide/21-stories.md).
 - The Story tool's authoring contract at [`tools/story/spec/`](../../../tools/story/spec/).
 - The normative spec at [`spec/007-Stories.md`](../../../spec/007-Stories.md).
 - The agent-facing MCP surface at [`tools/story-mcp/`](../../../tools/story-mcp/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,8 +79,9 @@ nav:
     - "16 — Performance": guide/16-performance.md
     - "17 — Routing": guide/17-routing.md
     - "18 — From re-frame v1": guide/18-from-re-frame-v1.md
-    - "19 — Where to go next": guide/19-where-next.md
-    - "20 — Stories": guide/20-stories.md
+    - "19 — Adapters": guide/19-adapters.md
+    - "20 — Where to go next": guide/20-where-next.md
+    - "21 — Stories": guide/21-stories.md
 
   - Spec:
     - Overview: spec/README.md

--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -515,5 +515,5 @@ The framework hook is: variants have a stable snapshot identity (`:variant-id` +
 - [`tools/story/`](https://github.com/day8/re-frame2/tree/main/tools/story) — the reference implementation of this spec (`day8/re-frame2-story`).
 - [`tools/story/spec/`](https://github.com/day8/re-frame2/tree/main/tools/story/spec) — the implementation contract (decisions, runtime shape, elision, MCP boundary).
 - [`tools/story-mcp/`](https://github.com/day8/re-frame2/tree/main/tools/story-mcp) — the agent-facing MCP server (`day8/re-frame2-story-mcp`).
-- [Guide chapter 20 — Stories](../docs/guide/20-stories.md) — the narrative walkthrough of this spec.
+- [Guide chapter 21 — Stories](../docs/guide/21-stories.md) — the narrative walkthrough of this spec.
 - [`examples/reagent/counter_with_stories/`](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter_with_stories) — the worked example pivoting on the counter from guide chapters 03–10.

--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -120,7 +120,7 @@ The substantive implementation contract is decomposed into
   snapshot identities; dual-pane SSR support.
 - [`tools/README.md`](../README.md) — the per-tool layout and bundle-isolation
   contract.
-- [Guide chapter 20 — Stories](../../docs/guide/20-stories.md) — the narrative
+- [Guide chapter 21 — Stories](../../docs/guide/21-stories.md) — the narrative
   walkthrough; the friendly entry-point for human readers.
 - [`examples/reagent/counter_with_stories/`](../../examples/reagent/counter_with_stories/) —
   the worked example wiring the seven `reg-*` macros against the canonical


### PR DESCRIPTION
## Summary

- Promote ch.19 §Adapters (~60 lines: substrate-agnostic story, `init!` call shape, three adapter packages, slim-Reagent option) to its own dedicated chapter. Forward-links from ch.03 used to land readers in a "Where to go next" wrap-up chapter — chapter-fit mismatch.
- New chapter ordering at the tail of the guide:
  - **19 — Adapters** (new, lifted from old ch.19 §Adapters)
  - **20 — Where to go next** (renumbered from 19; §Adapters block removed; back-pointer added to the new ch.19)
  - **21 — Stories** (renumbered from 20)
- Forward-links swept across the guide, spec/, tools/, examples/, and SKILL-REDIRECT.md. `mkdocs.yml` nav and `guide/README.md` chapter table updated.

## Test plan

- [x] `python scripts/check_doc_slugs.py --verbose` — no broken anchors
- [x] `mkdocs build --strict` — passes (no new warnings; existing INFO messages unchanged)
- [x] Forward-links sweep: 0 remaining references to `19-where-next.md` or `20-stories.md`
- [x] All three new file slots resolve: `19-adapters.md`, `20-where-next.md`, `21-stories.md`

Context: `ai/findings/guide-excellence-audit-2026-05-12.md §F9`.