### PR TITLE
feat(trace): widen :dispatch-id to every cascade event — *current-dispatch-id* dynvar in trace.cljc (rf2-g6ih4)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -25,9 +25,15 @@
 ;; process-monotonic :dispatch-id at queue time. When the dispatch is
 ;; emitted as a side-effect of another event's processing (typically inside
 ;; an fx handler running in do-fx), the new dispatch's :parent-dispatch-id
-;; is the in-flight event's :dispatch-id. *current-dispatch-id* tracks the
-;; in-flight dispatch during process-event!; child dispatches read it to
-;; populate :parent-dispatch-id.
+;; is the in-flight event's :dispatch-id.
+;;
+;; The in-flight dispatch is tracked by `re-frame.trace/*current-dispatch-id*`
+;; (per rf2-g6ih4 — moved from this ns so `trace/emit!` can read it and
+;; stamp every trace event emitted inside the cascade with the cascade-
+;; wide id). `process-event!` binds the Var around the inner
+;; `process-event*`; child dispatches read it both to populate
+;; `:parent-dispatch-id` here AND to ride on every emit inside the
+;; cascade.
 ;;
 ;; All of this rides the dev-only trace surface; production builds (where
 ;; interop/debug-enabled? is false at compile time) elide the allocation
@@ -38,8 +44,6 @@
 
 (defn- next-dispatch-id []
   (swap! dispatch-counter inc))
-
-(def ^:dynamic ^:private *current-dispatch-id* nil)
 
 (defn- build-envelope
   "Build the dispatch envelope per Spec 002 §Routing: the dispatch envelope.
@@ -59,7 +63,7 @@
                         emitted from inside another event's processing"
   [event opts]
   (let [dispatch-id        (when interop/debug-enabled? (next-dispatch-id))
-        parent-dispatch-id (when interop/debug-enabled? *current-dispatch-id*)
+        parent-dispatch-id (when interop/debug-enabled? trace/*current-dispatch-id*)
         ;; Per rf2-d4sf consult the `:adapter/current-frame` late-bind
         ;; hook on CLJS so dispatch picks up the React-context tier of
         ;; the resolution chain. Adapters publish the hook at ns-load
@@ -286,9 +290,11 @@
   source order. Per Spec 002 §Drain-loop pseudocode.
 
   This is the inner of `process-event!`; the outer wraps it in a binding
-  of *current-dispatch-id* so child dispatches issued from within fx
-  handlers inherit the in-flight dispatch's id as their
-  :parent-dispatch-id (Spec 009 §Dispatch correlation)."
+  of `trace/*current-dispatch-id*` so (a) child dispatches issued from
+  within fx handlers inherit the in-flight dispatch's id as their
+  `:parent-dispatch-id`, and (b) every trace event emitted inside the
+  cascade carries the cascade's `:dispatch-id` under `:tags` (per
+  Spec 009 §Dispatch correlation and rf2-g6ih4)."
   [envelope]
   (let [{:keys [event frame]} envelope
         event-id              (first event)
@@ -374,9 +380,12 @@
 (defn- process-event!
   "Wrap process-event* in two dynamic bindings:
 
-   1. `*current-dispatch-id*` — so child dispatches issued from within
-      an fx handler inherit this event's `:dispatch-id` as their
-      `:parent-dispatch-id`. Per Spec 009 §Dispatch correlation.
+   1. `trace/*current-dispatch-id*` — so child dispatches issued from
+      within an fx handler inherit this event's `:dispatch-id` as their
+      `:parent-dispatch-id`, AND so every trace event emitted inside
+      the cascade (sub runs, fx-handled, machine transitions, errors)
+      rides the cascade's `:dispatch-id` under `:tags`. Per Spec 009
+      §Dispatch correlation and rf2-g6ih4.
 
    2. `frame/*current-frame*` — bound to the envelope's `:frame` for
       the duration of the handler chain. Per Spec 002 §Dispatch
@@ -396,8 +405,8 @@
       threads the frame), or `:dispatch-later` (frame captured in
       closure) for those paths. Per rf2-l5q3."
   [envelope]
-  (binding [*current-dispatch-id*  (:dispatch-id envelope)
-            frame/*current-frame*  (:frame envelope)]
+  (binding [trace/*current-dispatch-id*  (:dispatch-id envelope)
+            frame/*current-frame*        (:frame envelope)]
     (process-event* envelope)))
 
 (def ^:private drain-depth-default 100)

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -26,8 +26,10 @@
 
   The shape is event-at-a-time, not span-shaped: there is no :start/:end/
   :duration pair and no :child-of parent-id. Cascade correlation rides on
-  :dispatch-id / :parent-dispatch-id under :tags of :event/dispatched
-  events (per Spec 009 §Dispatch correlation)."
+  :dispatch-id under :tags of EVERY event emitted inside a cascade;
+  :parent-dispatch-id rides under :tags of :event/dispatched events only
+  (it documents inter-cascade lineage). Per Spec 009 §Dispatch correlation
+  and rf2-g6ih4."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]))
 
@@ -102,6 +104,47 @@
   Shape: `{:kind <kw> :id <kw> :source-coord {:ns :file :line :column}?}`.
 
   Per rf2-3nn8."
+  nil)
+
+;; ---- *current-dispatch-id* (rf2-g6ih4) ------------------------------------
+;;
+;; Per Spec 009 §Dispatch correlation: `:dispatch-id` is a **cascade-wide**
+;; correlation key. It is allocated when a dispatch is enqueued (per
+;; `router.cljc`) and rides on every trace event emitted **inside** that
+;; dispatch's run-to-completion drain — `:event/dispatched` itself,
+;; `:event/db-changed`, `:rf.fx/handled`, `:sub/run`, `:rf.machine/transition`,
+;; `:rf.error/*`, every emit produced while processing the event.
+;;
+;; The runtime carries the in-flight cascade's id through the dynamic Var
+;; `*current-dispatch-id*` (mirror of `*current-trigger-handler*` per
+;; rf2-3nn8). `router.cljc` binds the Var around `process-event*` so every
+;; downstream emit — including emits produced by user handler code, by
+;; substrate code reacting to a `:db` commit, by fx handlers walking the
+;; `:fx` vector — sees the cascade's id. `emit!` reads the Var and merges
+;; it into the emitted event's `:tags` map when bound and not already
+;; present. Callers that explicitly supply `:dispatch-id` in tags win
+;; (e.g. `emit-dispatched-trace!` stamps its own id; child dispatches
+;; emitted by fx handlers are themselves `:event/dispatched` events with
+;; their own freshly-allocated `:dispatch-id`).
+;;
+;; `:parent-dispatch-id` remains scoped to `:event/dispatched` only — it
+;; documents cascade-from-cascade lineage (which cascade caused this
+;; one), which is per-event-dispatch, not per-trace-event.
+;;
+;; Production elision: when `interop/debug-enabled?` is false the whole
+;; trace surface compiles out via the outer `when` gate in `emit!`, so
+;; the Var read is dead code.
+
+(def ^:dynamic *current-dispatch-id*
+  "The id of the cascade currently being processed by `router.cljc`'s
+  drain. Bound by `router.cljc` around `process-event*` to the in-flight
+  dispatch's `:dispatch-id`. `emit!` reads the Var and merges it into
+  the emitted event's `:tags` when bound and not already present.
+
+  nil outside any drain (e.g. emits produced at registration time, at
+  frame creation, by user code outside a handler).
+
+  Per Spec 009 §Dispatch correlation and rf2-g6ih4."
   nil)
 
 (defn trigger-handler-from-meta
@@ -256,19 +299,35 @@
 
   Per Spec 009 §Core fields: :source is hoisted to the top level of the
   envelope (origin of the trigger — :ui :timer :http :repl :machine).
-  Tags retain everything else."
+  Tags retain everything else.
+
+  Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the runtime is
+  inside a drain processing a dispatch), the in-flight cascade's id is
+  merged into `:tags :dispatch-id`. Callers that supply their own
+  `:dispatch-id` in tags win (the only such caller in the framework is
+  `:event/dispatched`, which stamps its own freshly-allocated id)."
   [op operation tags]
   (when interop/debug-enabled?
-    (let [source   (:source tags)
-          recovery (:recovery tags)
+    (let [source       (:source tags)
+          recovery     (:recovery tags)
           ;; Per Spec 009 §Required top-level fields: :source and
           ;; :recovery (when present) live at the top level of the
           ;; trace event, NOT inside :tags. Hoist them here.
+          cascade-id   *current-dispatch-id*
+          base-tags    (dissoc tags :source :recovery)
+          ;; Per rf2-g6ih4: stamp the cascade's :dispatch-id on every
+          ;; event emitted inside the drain so consumers can group raw
+          ;; trace events by cascade without inferring from sequence.
+          ;; Caller-supplied :dispatch-id wins (`:event/dispatched` and
+          ;; any future emit that needs to override).
+          tags+        (if (and cascade-id (not (contains? base-tags :dispatch-id)))
+                         (assoc base-tags :dispatch-id cascade-id)
+                         base-tags)
           event    (cond-> {:operation operation
                             :op-type   op
                             :id        (next-event-id)
                             :time      (interop/now-ms)
-                            :tags      (dissoc tags :source :recovery)}
+                            :tags      tags+}
                      source   (assoc :source source)
                      recovery (assoc :recovery recovery))]
       (push-to-buffer! event)
@@ -292,17 +351,27 @@
   handler dispatching, cofx injecting, view rendering), the value is
   hoisted to the top-level `:rf.trace/trigger-handler` slot on the
   emitted event. Absent when no handler is in scope (e.g. outermost-
-  dispatch `:rf.error/no-such-handler`)."
+  dispatch `:rf.error/no-such-handler`).
+
+  Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the error fires
+  inside a drain), the in-flight cascade's id is merged into
+  `:tags :dispatch-id` so consumers can correlate the error with the
+  rest of the cascade. Caller-supplied `:dispatch-id` wins."
   [error-operation tags]
   (when interop/debug-enabled?
-    (let [trigger *current-trigger-handler*
-          event   (cond-> {:operation error-operation
-                           :op-type   :error
-                           :id        (next-event-id)
-                           :time      (interop/now-ms)
-                           :tags      (merge {:category error-operation} tags)
-                           :recovery  (:recovery tags :no-recovery)}
-                    trigger (assoc :rf.trace/trigger-handler trigger))]
+    (let [trigger    *current-trigger-handler*
+          cascade-id *current-dispatch-id*
+          base-tags  (merge {:category error-operation} tags)
+          tags+      (if (and cascade-id (not (contains? base-tags :dispatch-id)))
+                       (assoc base-tags :dispatch-id cascade-id)
+                       base-tags)
+          event      (cond-> {:operation error-operation
+                              :op-type   :error
+                              :id        (next-event-id)
+                              :time      (interop/now-ms)
+                              :tags      tags+
+                              :recovery  (:recovery tags :no-recovery)}
+                       trigger (assoc :rf.trace/trigger-handler trigger))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]

--- a/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
+++ b/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.cascade-dispatch-id-test
+  "Per rf2-g6ih4 — `:dispatch-id` is cascade-wide on every trace event.
+
+  Spec 009 §Dispatch correlation locks `:dispatch-id` as a cascade-wide
+  correlation key: it rides on **every** trace event emitted inside a
+  dispatch's run-to-completion drain — `:event/dispatched`,
+  `:event/db-changed`, `:rf.fx/handled`, `:sub/run`,
+  `:rf.machine/transition`, `:rf.error/*`, every emit produced while
+  processing the event. `:parent-dispatch-id` remains scoped to
+  `:event/dispatched` only.
+
+  This file exercises the cascade-wide stamping by dispatching a
+  representative cascade and asserting:
+
+  (a) every non-`:event/dispatched` trace event emitted while a drain
+      is in flight carries `:tags :dispatch-id` matching the cascade
+      that started the drain;
+  (b) child dispatches issued from inside fx handlers get their OWN
+      freshly-allocated `:dispatch-id` on their `:event/dispatched`
+      event (the parent's id rides on `:parent-dispatch-id` instead);
+  (c) `*current-dispatch-id*` is unbound across cascade boundaries —
+      trace events emitted outside any drain (e.g. registration-time
+      trace events, frame creation) carry no `:dispatch-id`.
+
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  "Run `body-fn` with a trace listener attached and return the captured
+  events."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try
+      (body-fn)
+      @seen
+      (finally
+        (rf/remove-trace-cb! ::rec)))))
+
+(defn- events-of [evs predicate]
+  (filter predicate evs))
+
+(defn- dispatch-id [ev] (get-in ev [:tags :dispatch-id]))
+
+;; ---- cascade-wide stamping ------------------------------------------------
+
+(deftest dispatch-id-rides-every-event-in-the-cascade
+  (testing "every trace event emitted while a drain is in flight carries the cascade's :dispatch-id"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-fx :seed
+                     (fn [_ _]
+                       {:db {:n 1}
+                        :fx [[:test/incr :go]]}))
+    (let [fx-fired (atom 0)]
+      (rf/reg-fx :test/incr (fn [_ _] (swap! fx-fired inc)))
+      (let [evs (record-traces
+                  (fn [] (rf/dispatch-sync [:seed] {:frame :test/main})))
+            dispatched (first (events-of evs #(= :event/dispatched (:operation %))))
+            cascade-id (dispatch-id dispatched)
+            ;; Every event we expect inside the cascade.
+            during-drain (->> evs
+                              (filter #(contains? #{:event :event/db-changed
+                                                    :event/do-fx :rf.fx/handled}
+                                                  (:operation %))))]
+        (is (some? cascade-id)
+            "the cascade's :dispatch-id is on the :event/dispatched event")
+        (is (seq during-drain)
+            "we saw events emitted inside the drain")
+        (doseq [ev during-drain]
+          (is (= cascade-id (dispatch-id ev))
+              (str "event " (:operation ev) " carries the cascade's :dispatch-id")))
+        (is (= 1 @fx-fired) "fx ran")))))
+
+(deftest dispatch-id-rides-on-error-events-inside-the-cascade
+  (testing "errors emitted inside the drain carry the cascade's :dispatch-id"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :throws (fn [_ _] (throw (ex-info "oops" {}))))
+    (let [evs        (record-traces
+                       (fn [] (rf/dispatch-sync [:throws] {:frame :test/main})))
+          dispatched (first (events-of evs #(= :event/dispatched (:operation %))))
+          cascade-id (dispatch-id dispatched)
+          err        (first (events-of evs #(= :rf.error/handler-exception (:operation %))))]
+      (is (some? cascade-id))
+      (is (some? err) "the handler-exception fired")
+      (is (= cascade-id (dispatch-id err))
+          ":rf.error/* traces carry the cascade's :dispatch-id"))))
+
+(deftest child-dispatch-gets-its-own-dispatch-id-and-parents-the-outer
+  (testing "child dispatches from inside fx handlers get a fresh :dispatch-id and the parent's id rides on :parent-dispatch-id"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-fx :parent
+                     (fn [_ _]
+                       {:fx [[:dispatch [:child]]]}))
+    (rf/reg-event-db :child (fn [db _] (assoc db :got-child true)))
+    (let [evs        (record-traces
+                       (fn [] (rf/dispatch-sync [:parent] {:frame :test/main})))
+          dispatches (vec (events-of evs #(= :event/dispatched (:operation %))))
+          parent     (first (filter #(= [:parent] (get-in % [:tags :event])) dispatches))
+          child      (first (filter #(= [:child]  (get-in % [:tags :event])) dispatches))]
+      (is (some? parent))
+      (is (some? child))
+      (is (some? (dispatch-id parent)))
+      (is (some? (dispatch-id child)))
+      (is (not= (dispatch-id parent) (dispatch-id child))
+          "child gets its own freshly-allocated :dispatch-id")
+      (is (= (dispatch-id parent)
+             (get-in child [:tags :parent-dispatch-id]))
+          "child's :parent-dispatch-id is the parent cascade's :dispatch-id"))))
+
+(deftest parent-dispatch-id-only-on-event-dispatched
+  (testing ":parent-dispatch-id is scoped to :event/dispatched events only — not on :sub/run, :event/db-changed, :rf.fx/handled, etc."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-fx :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
+    (rf/reg-event-db :inner (fn [db _] (assoc db :v 1)))
+    (let [evs (record-traces
+                (fn [] (rf/dispatch-sync [:outer] {:frame :test/main})))]
+      (doseq [ev evs
+              :when (not= :event/dispatched (:operation ev))]
+        (is (nil? (get-in ev [:tags :parent-dispatch-id]))
+            (str "non-:event/dispatched event " (:operation ev)
+                 " must not carry :parent-dispatch-id"))))))
+
+(deftest dispatch-id-unbound-outside-any-cascade
+  (testing "trace events emitted outside any drain carry no :dispatch-id"
+    ;; Register a frame and emit a handler-registered trace before any
+    ;; dispatch fires — `*current-dispatch-id*` is unbound here, so the
+    ;; trace event has no :dispatch-id stamped.
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-frame :test/outside {})
+        ;; reg-event-db / reg-fx emit :rf.registry/handler-registered traces
+        ;; via the registrar; these fire OUTSIDE any drain.
+        (rf/reg-event-db :foo (fn [db _] db))
+        (let [out-of-band (filter #(or (= :frame/created (:operation %))
+                                       (= :rf.registry/handler-registered (:operation %)))
+                                  @seen)]
+          (is (seq out-of-band) "we saw trace events emitted outside any drain")
+          (doseq [ev out-of-band]
+            (is (nil? (dispatch-id ev))
+                (str "out-of-band event " (:operation ev)
+                     " must NOT carry a :dispatch-id"))))
+        (finally
+          (rf/remove-trace-cb! ::rec))))))
+
+(deftest dispatch-id-is-fresh-across-cascade-boundaries
+  (testing "two sequential dispatches get distinct :dispatch-ids on every event in their respective cascades"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :bump (fn [db _] (update db :n (fnil inc 0))))
+    (let [evs1 (record-traces
+                 (fn [] (rf/dispatch-sync [:bump] {:frame :test/main})))
+          evs2 (record-traces
+                 (fn [] (rf/dispatch-sync [:bump] {:frame :test/main})))
+          ids1 (set (keep dispatch-id evs1))
+          ids2 (set (keep dispatch-id evs2))]
+      (is (= 1 (count ids1))
+          "every emit in the first cascade shares one :dispatch-id")
+      (is (= 1 (count ids2))
+          "every emit in the second cascade shares one :dispatch-id")
+      (is (empty? (clojure.set/intersection ids1 ids2))
+          "the two cascades' :dispatch-ids are disjoint"))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -50,23 +50,24 @@ The runtime emits each trace event at the *moment of interest* with the host clo
 
 ### Dispatch correlation: `:dispatch-id` / `:parent-dispatch-id`
 
-Pair-shaped tools and per-event diagnostics need to correlate the *cascade* a dispatch belongs to — "this `:event/dispatched` was emitted by an effect that ran inside the cascade started by *that* dispatch." The runtime stamps two fields onto every `:event/dispatched` trace event under the top-level `:tags`:
+Pair-shaped tools and per-event diagnostics need to correlate the *cascade* a dispatch belongs to — "this trace event fired inside the cascade started by *that* dispatch." The runtime maintains two distinct correlation channels:
 
 ```clojure
-{:tags {:dispatch-id        <uuid-or-counter>   ;; this dispatch's identity
-        :parent-dispatch-id <uuid-or-counter>}  ;; the dispatch that caused this one (if any)
+{:tags {:dispatch-id        <uuid-or-counter>   ;; the cascade this event belongs to
+        :parent-dispatch-id <uuid-or-counter>}  ;; on :event/dispatched only — the cascade
+                                                ;; that caused THIS dispatch
  ...}
 ```
 
 Semantics:
 
-- **`:dispatch-id`** is allocated by the runtime when a dispatch is enqueued, before routing. Implementations may use a process-monotonic counter, a UUID, or any opaque value with the same uniqueness contract: distinct within a single process for the lifetime of the trace surface. Tools treat it as opaque.
-- **`:parent-dispatch-id`** is set when the dispatch was emitted as a side-effect of another event's processing — typically inside an `fx` handler. Concretely: when an `fx` handler running inside the do-fx phase of dispatch *D₁* invokes `(rf/dispatch ...)`, the runtime records the new dispatch's `:parent-dispatch-id` as *D₁*'s `:dispatch-id`. If the dispatch was initiated outside any in-flight event (a timer, a UI handler, the REPL, the SSR boot path), `:parent-dispatch-id` is absent.
-- **Top-level dispatch.** A dispatch with no `:parent-dispatch-id` is a *root* of a cascade. Pair-shaped tools draw cascade trees by following `:parent-dispatch-id` upward.
-- **The cascade-correlation primitive.** Because the runtime emits event-at-a-time (no `:child-of` span field), `:dispatch-id` / `:parent-dispatch-id` is the only cascade-correlation channel: events queued through the router carry the chain. Tools that want to group raw spans by cascade key off `:dispatch-id` from the relevant `:event/dispatched` event and correlate sibling traces via the `:rf/epoch-record` projections (per [Tool-Pair §Time-travel](Tool-Pair.md#time-travel)).
-- **Production elision.** Both fields ride the trace stream and are elided in production with the rest of the trace surface.
+- **`:dispatch-id` is cascade-wide.** It is allocated by the runtime when a dispatch is enqueued (before routing) and rides on **every** trace event emitted *inside* that dispatch's run-to-completion drain — `:event/dispatched` itself, `:event/db-changed`, `:rf.fx/handled`, `:sub/run`, `:rf.machine/transition`, `:rf.flow/*`, every `:rf.error/*`, and any future op-type the runtime adds. Consumers (Story `group-cascades`, Causa's causality graph, pair2's `cascade-of`, schema-timeline correlation) group raw trace events by `:dispatch-id` directly — no inference from sequence required. The runtime carries the in-flight cascade's id through the dynamic Var `re-frame.trace/*current-dispatch-id*`, bound by `router.cljc` around each event's processing; `emit!` reads the Var and merges it into the event's `:tags` when bound and not already present. Implementations may use a process-monotonic counter, a UUID, or any opaque value with the same uniqueness contract: distinct within a single process for the lifetime of the trace surface. Tools treat it as opaque. Trace events emitted **outside** any in-flight cascade (frame creation at boot, handler registration before any dispatch, REPL evals that don't dispatch) carry no `:dispatch-id`.
+- **`:parent-dispatch-id` is scoped to `:event/dispatched` only.** It documents *cascade-from-cascade lineage* — "this dispatch was emitted as a side-effect of another event's processing" — which is a per-event-dispatch fact, not a per-trace-event fact. Concretely: when an `fx` handler running inside the do-fx phase of dispatch *D₁* invokes `(rf/dispatch ...)`, the runtime records the new dispatch's `:parent-dispatch-id` as *D₁*'s `:dispatch-id` on the new dispatch's `:event/dispatched` event. If the dispatch was initiated outside any in-flight event (a timer, a UI handler, the REPL, the SSR boot path), `:parent-dispatch-id` is absent from `:event/dispatched`. Non-`:event/dispatched` trace events never carry `:parent-dispatch-id` — they belong to a single cascade (their `:dispatch-id`) and the inter-cascade lineage hangs off the cascade root.
+- **Top-level dispatch.** An `:event/dispatched` event with no `:parent-dispatch-id` is a *root* of a cascade. Pair-shaped tools draw cascade trees by walking `:parent-dispatch-id` upward across `:event/dispatched` events; the per-cascade body (every other trace event in that cascade) is the slice of the trace stream sharing the cascade's `:dispatch-id`.
+- **The cascade-correlation primitive.** Because the runtime emits event-at-a-time (no `:child-of` span field), `:dispatch-id` is the only intra-cascade correlation channel and `:parent-dispatch-id` is the only inter-cascade correlation channel. The pair lets tools both (a) group raw spans by cascade and (b) walk lineage between cascades, without consulting the `:rf/epoch-record` projection. Tools that prefer structured per-cascade slices read the assembled `:rf/epoch-record` (per [Tool-Pair §Time-travel](Tool-Pair.md#time-travel)) — the raw `:dispatch-id` channel is the lower-level primitive.
+- **Production elision.** Both fields ride the trace stream and are elided in production with the rest of the trace surface. The dispatch-id allocation counter and the `*current-dispatch-id*` Var read sit inside the `interop/debug-enabled?` gate in `emit!`, so the whole machinery compiles out.
 
-Tools consume these two fields to build dispatch-cascade views: "show me all dispatches descended from `[:user/login ...]`" is a transitive walk over `:parent-dispatch-id`.
+Tools consume these two channels to build cascade views: "show me every fx that ran in this cascade" is a filter on `:dispatch-id` over the raw stream; "show me all dispatches descended from `[:user/login ...]`" is a transitive walk over `:parent-dispatch-id` across `:event/dispatched` events.
 
 ### Origin tagging: `:origin`
 
@@ -1011,7 +1012,7 @@ Multiple listeners may register concurrently. **Listener-invocation order is not
 
 ### Trace correlation across the cascade
 
-Use the `:dispatch-id` / `:parent-dispatch-id` fields under `:tags` on `:event/dispatched` events (per [§Dispatch correlation](#dispatch-correlation-dispatch-id--parent-dispatch-id)). Tools that need cascade trees walk `:parent-dispatch-id` upward. Per-cascade structured projection lives in the assembled `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)).
+Use the `:dispatch-id` field under `:tags` on **every** trace event emitted inside a cascade (per [§Dispatch correlation](#dispatch-correlation-dispatch-id--parent-dispatch-id)). Grouping raw trace events by cascade is a single-key filter — `(filter #(= cascade-id (get-in % [:tags :dispatch-id])) events)`. Tools that need cascade *trees* walk `:parent-dispatch-id` upward across `:event/dispatched` events (the inter-cascade lineage channel). Per-cascade structured projection lives in the assembled `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) — the raw `:dispatch-id` channel is the lower-level primitive.
 
 ### Trace event for app-db changes
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -228,7 +228,7 @@ Universal trace event shape, including error events.
    [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]])
 ```
 
-The runtime emits event-at-a-time, not span-shaped: there is no `:start`/`:end`/`:duration` pair and no `:child-of` parent-id. Cascade correlation rides on `:dispatch-id` / `:parent-dispatch-id` under `:tags` of `:event/dispatched` events (per [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id)). Per-event frame attribution rides under `[:tags :frame]`.
+The runtime emits event-at-a-time, not span-shaped: there is no `:start`/`:end`/`:duration` pair and no `:child-of` parent-id. Cascade correlation rides on `:dispatch-id` under `:tags` of **every** trace event emitted inside a cascade; `:parent-dispatch-id` rides under `:tags` of `:event/dispatched` events only (it documents inter-cascade lineage). Per [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id). Per-event frame attribution rides under `[:tags :frame]`.
 
 The `:op-type` vocabulary is **open** — implementations and tools may add new values additively per [Spec-ulation](Principles.md#spec-ulation). The reserved values used by the framework (in alphabetical order):
 


### PR DESCRIPTION
## Summary

Per Spec 009 §Dispatch correlation. Before this change `:dispatch-id` rode only on `:event/dispatched`; the spec already documented intent (Causa 001-Causality-Graph L26-27) that it should be cascade-wide but the contract didn't lock it. Every downstream consumer (Story `group-cascades`, Causa causality graph, Causa schema-timeline pivot, pair2 `cascade-of`) needed `:dispatch-id` on every event in the cascade so grouping is a single-key filter rather than sequence-inference.

The fix mirrors `*current-trigger-handler*` (rf2-3nn8):

- New `re-frame.trace/*current-dispatch-id*` dynamic Var (public). `router.cljc` binds it around `process-event*` for the duration of each event's processing.
- `trace/emit!` and `trace/emit-error!` read the Var and merge it into `:tags :dispatch-id` when bound and not already present. Caller-supplied `:dispatch-id` wins (so `:event/dispatched` continues to stamp its own freshly-allocated id, and child dispatches get a fresh id with the parent's id on `:parent-dispatch-id`).
- `:parent-dispatch-id` stays scoped to `:event/dispatched` only — it documents inter-cascade lineage, not per-event-trace lineage.
- The old private `router/*current-dispatch-id*` is removed; router binds `trace/*current-dispatch-id*` directly and reads it back when building child envelopes.

Spec 009 §Dispatch correlation rewritten (cascade-wide intra-cascade channel + `:event/dispatched`-only inter-cascade channel). Spec 009 §Trace correlation across the cascade and Spec-Schemas §`:rf/trace-event` updated to match.

A follow-up bead (rf2-wvzgd) will lift Story's `group-cascades` into the framework now that the underlying key is reliable.

## Test plan

- [x] `clojure -M:test` for core (255 tests, 1159 assertions, 0 failures)
- [x] new `cascade_dispatch_id_test.clj` — 6 tests, 31 assertions covering cascade-wide stamping, error-path stamping, child-dispatch freshness, `:parent-dispatch-id` scoping, out-of-cascade absence, and disjoint sequential cascades
- [x] `clojure -M:test` for epoch / flows / http / machines / routing / schemas / ssr / adapters/reagent (all green)
- [x] `npm run test:cljs` (591 tests, 1401 assertions, 0 failures)
- [x] `npm run test:browser` (591 tests, 1428 assertions, 0 failures)
- [x] `npm run test:elision` (PASS — every sentinel present)
- [x] `npm run test:examples` — pre-existing flake on `counter-with-stories` reproduces on origin/main without these changes
- [x] `mkdocs build --strict` — 227 pre-existing warnings reproduce on origin/main; no new warnings from the spec edits