### PR TITLE
docs(guide): split ch.08 state-machines — extract Pattern-* walkthroughs to pattern-doc homes (rf2-1aet)

### DIFF
--- a/docs/guide/08-state-machines.md
+++ b/docs/guide/08-state-machines.md
@@ -133,48 +133,40 @@ The fix isn't to write better `cond` clauses. The fix is to step back and notice
     :locked-out  {:meta {:terminal? true}}}})
 ```
 
-This is a **transition table**. It's pure data. You can read it top to bottom and see, immediately:
+This is a **transition table** — pure data, read top to bottom. Five states (`:idle`, `:submitting`, `:error-shown`, `:authed`, `:locked-out`); `:idle` starts; `:auth.login/submit` from `:idle` goes to `:submitting`; from `:submitting`, success → `:authed`, failure → `:error-shown` if `:under-retry-limit` passes, otherwise `:locked-out`. Each `:action` / `:entry` is referenced by id; the named impl lives in the spec's `:guards` / `:actions` map.
 
-- Five states: `:idle`, `:submitting`, `:error-shown`, `:authed`, `:locked-out`.
-- The starting state is `:idle`.
-- From `:idle`, the event `:auth.login/submit` takes us to `:submitting`.
-- From `:submitting`, the event `:auth.login/success` takes us to `:authed`.
-- From `:submitting`, the event `:auth.login/failure` takes us to `:error-shown` if the guard `:under-retry-limit` passes, otherwise to `:locked-out`.
-- Each transition's `:action` and each state's `:entry` are referenced by id; the named guard / action lives in the spec's `:guards` / `:actions` map and runs when the runtime applies the transition.
-
-The whole flow is in one piece of data. You can pretty-print it. You can render it to a graph. You can check it against a schema. You can hand it to an AI and say "here's the auth flow, add a two-factor state between submitting and authed" — the AI has the whole context in front of it.
-
-The runtime takes this data, plus the snapshot of the machine's current state, and applies the transition rules. The runtime — not the developer — is responsible for "if we're in `:submitting` and a `:failure` arrives, check the guard, fire the action, transition to the right next state." The developer is responsible only for *describing the transitions as data*.
+The whole flow is one piece of data. You can pretty-print it, render it to a graph, check it against a schema, or hand it to an AI and say "add a two-factor state between submitting and authed" — the AI has the whole context. The runtime applies the transition rules against the current snapshot; the developer describes the transitions, not the imperative branching.
 
 ## What's in a transition
 
-The grammar is borrowed (with adaptation) from [xstate](https://xstate.js.org/), which is the canonical state-machine library in the JavaScript world. Specifically:
+The grammar is borrowed (with adaptation) from [xstate](https://xstate.js.org/):
 
 - **`:initial`** — the starting state.
-- **`:data`** — extended state that lives alongside the discrete state. Counters, error messages, transient data. (xstate calls this slot "context"; we use `:data` to avoid the existing "context" overloading in re-frame's interceptor pipeline and React-context idioms.)
-- **`:states`** — the state nodes, keyed by name.
-- **`:on`** — for a state, the events it responds to and where they go.
-- **`:target`** — the next state name.
-- **`:guard`** — a predicate that must return true for the transition to fire. A keyword references the spec's `:guards` map; an inline `(fn [data event] ...)` is fine for a one-liner.
-- **`:action`** — fires on this transition. Same shape as `:guard`: keyword reference into `:actions`, or inline fn.
-- **`:entry` / `:exit`** — actions that fire when entering or leaving a state, regardless of which event triggered the transition. Same shape — keyword or inline fn.
-- **`:meta`** — arbitrary user-defined annotations (e.g. `:terminal?`).
-- **`:guards` / `:actions`** (top-level on the spec) — the machine's own named guard / action implementations. Resolution is machine-local; there's no global registry.
+- **`:data`** — extended state alongside the discrete state. Counters, error messages, transient data. (xstate calls this "context"; we use `:data` to avoid the existing "context" overloadings in interceptors and React.)
+- **`:states`** — the state nodes, keyed by name. `:on` (events the state responds to), `:entry` / `:exit` (actions fired on enter / leave regardless of trigger), `:meta` (user annotations like `:terminal?`).
+- **`:target`** — the next state name on a transition.
+- **`:guard`** — a predicate that must return true for a transition to fire. A keyword references the spec's `:guards` map; an inline `(fn [data event] ...)` works for one-liners.
+- **`:action`** — fires on this transition. Same shape as `:guard`.
+- **`:guards` / `:actions`** (top-level) — the machine's own named impls. Resolution is machine-local; there's no global registry.
 
-xstate users will recognise all of this. We deliberately stay close to xstate's vocabulary because (a) it's well-thought-out and (b) AIs already know it. When you ask an AI "give me the state machine for a login flow," it produces something that's already nearly correct in re-frame2's grammar.
+We deliberately stay close to xstate's vocabulary because it's well-thought-out and because AIs already know it — asked for "the state machine for a login flow," they produce something nearly correct in re-frame2's grammar. Four adaptations keep the pattern consistent with the rest of re-frame2:
 
-What we adapt:
-
-- **Machines are event handlers, not actor objects.** xstate has explicit `ActorRef` runtime objects with their own mailboxes. re-frame2 doesn't. A machine is "an event handler whose body interprets a transition table." All events to that machine flow through `dispatch` like any other event; there's no separate sending mechanism.
-- **Effects are returned as data.** xstate's actions can directly call out to the world. re-frame2's actions return effect maps which the runtime interprets — same shape as event handlers.
-- **The snapshot lives in `app-db`.** Every machine's runtime state — its `:state` and `:data` — sits at `[:rf/machines <id>]` in the frame's `app-db`. Not in a parallel registry, not in a per-machine atom. Undo, time-travel, persistence, SSR hydration all extend to machines for free, because their state is in the db.
-- **Guards and actions live with the machine.** Each `create-machine-handler` spec carries its own `:guards` and `:actions` maps. Cross-machine reuse is via Clojure vars, not a global registry. A machine is a self-contained piece of data; reading its spec tells you everything its guards and actions do.
-
-These adaptations keep the pattern consistent with the rest of re-frame2.
+- **Machines are event handlers, not actor objects.** A machine is "an event handler whose body interprets a transition table." All events flow through `dispatch`; there's no separate sending mechanism or `ActorRef`.
+- **Effects are returned as data.** Actions return effect maps the runtime interprets — same shape as ordinary event handlers.
+- **The snapshot lives in `app-db`** at `[:rf/machines <id>]`. Not in a parallel registry, not in a per-machine atom. Undo, time-travel, persistence, and SSR hydration extend to machines for free.
+- **Guards and actions live with the machine.** Each spec carries its own `:guards` and `:actions` maps; cross-machine reuse is via Clojure vars, not a global registry.
 
 ## Wiring a machine into the rest of re-frame
 
-Once the transition table is defined, registering it as an event handler is one line:
+Registering a transition table as an event handler is one line:
+
+```clojure
+(rf/reg-machine :auth.login/flow login-flow)
+```
+
+This is exactly `(reg-event-fx :auth.login/flow (create-machine-handler login-flow))`. The machine's id is `:auth.login/flow`; the snapshot lives at `[:rf/machines :auth.login/flow]` in `app-db`. **You don't pick a path — there is one canonical path.** `create-machine-handler` returns a regular `reg-event-fx`-shaped handler whose body does "look up the snapshot, call `machine-transition`, write back, return the action effects." `machine-transition` is pure, so all the testing and tooling guarantees of regular events apply.
+
+If you need `:doc` or `:interceptors`, use the longer form:
 
 ```clojure
 (rf/reg-event-fx :auth.login/flow
@@ -182,23 +174,9 @@ Once the transition table is defined, registering it as an event handler is one 
   (rf/create-machine-handler login-flow))
 ```
 
-The machine's id is the surrounding `reg-event-fx` id (`:auth.login/flow`). The snapshot lives at `[:rf/machines :auth.login/flow]` in `app-db`; the runtime reads / writes it there. **You don't pick a path — there is one canonical path.**
+`reg-machine` is a **macro**. At expansion it walks the literal spec form and stamps a dev-only coord index under `:rf.machine/source-coords` — what lets pair-tools jump from a clicked transition arrow in a state-diagram visualisation back to the source line. Production builds elide it.
 
-`(rf/create-machine-handler spec)` returns a regular `reg-event-fx`-shaped handler. It does the work of "look up the snapshot, call `machine-transition`, write the new snapshot, return the action effects." `machine-transition` is pure, so all the testing and tooling guarantees of regular events apply to machines.
-
-If you don't need any other registration metadata (no `:doc`, no `:interceptors`), there's a one-step convenience:
-
-```clojure
-(rf/reg-machine :auth.login/flow login-flow)
-```
-
-This is exactly `(reg-event-fx machine-id (create-machine-handler machine))` — same effect, less ceremony.
-
-`reg-machine` is a **macro**. At expansion time it walks the literal spec form and stamps a flat coord index under `:rf.machine/source-coords` on the machine's metadata, keyed by spec-path tuples like `[:guards :form-valid?]`, `[:actions :commit]`, `[:states :form :on :submit]`. The coord index is what lets pair-tools take a clicked transition arrow in a state-diagram visualisation and jump to the source line that wrote it. It's dev-only — production builds elide the index alongside other source-coord annotations.
-
-In day-to-day code you will not see the coord index unless you go looking for it. `(rf/machine-meta :auth.login/flow)` returns it under the `:rf.machine/source-coords` key.
-
-**Initial-state `:entry` fires on machine birth.** When a singleton machine first receives an event, or when an actor is brought into being by `:rf.machine/spawn` / declarative `:invoke`, the runtime cascades into the `:initial` state and runs that state's `:entry` action as part of birth — no self-targeting `:on :rf.machine/spawned` ceremony needed. For compound initial states, every state along the initial cascade fires its `:entry` shallowest-first. So if you want one-shot setup work to run when a machine wakes up — seed `:data`, kick off an HTTP request, register a subscription — put it in the initial state's `:entry`. Earlier drafts of the spec required a workaround for this; the workaround is gone.
+**Initial-state `:entry` fires on machine birth.** When a singleton machine first receives an event — or when an actor is brought into being by `:rf.machine/spawn` / declarative `:invoke` — the runtime cascades into the `:initial` state and runs that state's `:entry` as part of birth. No self-targeting `:on :rf.machine/spawned` ceremony. For compound initial states, every state along the cascade fires its `:entry` shallowest-first. So one-shot setup work — seed `:data`, kick off an HTTP request, register a subscription — goes in the initial state's `:entry`.
 
 ## Dispatching to a machine
 
@@ -211,23 +189,21 @@ Sub-events route via the machine's id and an inner event vector:
 
 The outer keyword is the machine; the inner vector is the event the machine sees. The runtime resolves the inner event against the current state's `:on` map, runs the guard, fires the action, and writes the new snapshot back to `[:rf/machines :auth.login/flow]`.
 
-For HTTP / async callbacks, the convention "build a 2-element template, conj the reply on resolve" works as in any other re-frame fx:
+For HTTP / async callbacks, build a 2-element template and let the runtime conj the reply on resolve:
 
 ```clojure
-;; The :issue-request action returns this fx vector:
 [:rf.http/managed
- {:request    {:method :post :url "/api/login"
-               :request-content-type :json}
+ {:request    {:method :post :url "/api/login" :request-content-type :json}
   :on-success [:auth.login/flow [:auth.login/success]]   ;; 2-element template
   :on-failure [:auth.login/flow [:auth.login/failure]]}]
 
-;; :rf.http/managed appends the reply payload as the last argument, producing
+;; :rf.http/managed appends the reply payload producing
 ;;   [:auth.login/flow [:auth.login/success] {:kind :success :value v}]
 ;; The runtime folds the trailing reply onto the inner event so the action
 ;; sees [:auth.login/success {:kind :success :value v}].
 ```
 
-This "extras-fold" makes the standard fx-callback convention work without ceremony — every async callback ships a value into the machine the same way. (The reply-payload shape — `{:kind :success :value v}` / `{:kind :failure :failure m}` — is the canonical envelope `:rf.http/managed` produces; see [chapter 10 — Doing HTTP requests](10-doing-http-requests.md).)
+This "extras-fold" makes every async callback ship a value into the machine the same way. The reply-payload envelope (`{:kind :success :value v}` / `{:kind :failure :failure m}`) is the canonical `:rf.http/managed` shape — see [chapter 10](10-doing-http-requests.md).
 
 ## Guards and actions
 
@@ -241,78 +217,43 @@ Guards are predicates. They live in the spec's `:guards` map and are referenced 
 
 A guard sees `(fn [data event] boolean)` — `data` is the snapshot's `:data` slot directly. Returning truthy lets the transition fire; returning falsy makes the runtime walk to the next candidate (or fall through to the parent state, if any).
 
-Actions are functions that produce data updates and / or effects. They live in `:actions`:
+Actions are functions producing data updates and / or effects. They live in `:actions`:
 
 ```clojure
 :actions
 {:record-error
  (fn [data [_ {:keys [failure]}]]
-   ;; The inner event vector arrives folded by managed-HTTP's extras-fold
-   ;; as [<event-id> {:kind :failure :failure <reply-map>}] — see
-   ;; §"Dispatching to a machine" above. Destructure on :failure to reach
-   ;; the reply payload itself.
    {:data (-> data
               (update :attempts inc)
-              (assoc :error (or (:message failure) "Login failed.")))})
-
- :issue-request
- (fn [_data [_ creds]]
-   {:fx [[:rf.http/managed
-          {:request    {:method :post
-                        :url    "/api/login"
-                        :body   creds
-                        :request-content-type :json}
-           :on-success [:auth.login/flow [:auth.login/success]]
-           :on-failure [:auth.login/flow [:auth.login/failure]]}]]})}
+              (assoc :error (or (:message failure) "Login failed.")))})}
 ```
 
-An action sees `(fn [data event] effects)` and returns either:
+An action sees `(fn [data event] effects)` and returns either `:data` (a map merged into the existing data slot — last write wins; explicit `nil` clears a key), `:fx` (effects: HTTP, navigation, follow-up dispatches), both, or `nil`. Same contract as an ordinary `reg-event-fx` return.
 
-- `:data` — a map merged into the existing data slot (last write wins on key collision; explicit `nil` clears a key).
-- `:fx` — effects to fire (HTTP, navigation, follow-up dispatches).
-- both, or `nil` for no effects.
-
-Just like ordinary `reg-event-fx` returns. The contract is consistent.
-
-If a guard or action genuinely needs to branch on the current state name — rare — there's an opt-in 3-arity overload that exposes the snapshot's `:state` and `:meta` slots. Stay with 2-arity unless you need it; see [Spec 005 §3-arity escape hatch](../../spec/005-StateMachines.md#3-arity-escape-hatch--state--meta-introspection) for the design rationale and the variadic-fn caveat.
+If a guard or action genuinely needs to branch on the current state name — rare — there's an opt-in 3-arity overload that exposes the snapshot's `:state` and `:meta` slots. Use 2-arity by default; the variadic caveat lives at [Spec 005 §3-arity escape hatch](../../spec/005-StateMachines.md#3-arity-escape-hatch--state--meta-introspection).
 
 ## Reading a machine: `sub-machine`
 
-Views that need to read a machine's current state read it through a sub:
+Views read a machine's current state through a sub:
 
 ```clojure
 @(rf/sub-machine :auth.login/flow)
 ;; → {:state :submitting :data {:attempts 1 :error nil}}
 ```
 
-`sub-machine` is sugar over the framework-shipped `:rf/machine` sub. It returns the snapshot — `{:state :data}` — or `nil` if the machine hasn't been created yet. Views typically destructure the `:state` and switch on it; complex UIs read the `:data` slot too. This is the single supported read path; there's no separate "actor reference" object to thread around.
-
-For convenience, you can build named reg-subs over `[:rf/machine machine-id]` to project the bits you care about:
+`sub-machine` is sugar over the framework-shipped `:rf/machine` sub. It returns the snapshot, or `nil` if the machine hasn't been created yet. Views typically destructure `:state` and switch on it; complex UIs read `:data` too. This is the single supported read path — no "actor reference" object to thread around. For projections, build named reg-subs over `[:rf/machine machine-id]`:
 
 ```clojure
-(rf/reg-sub :auth.login/state
-  (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
-
 (rf/reg-sub :auth.login/submitting?
-  :<- [:auth.login/state]
-  (fn [state _] (= :submitting state)))
+  :<- [:rf/machine :auth.login/flow]
+  (fn [{:keys [state]} _] (= :submitting state)))
 ```
 
-These read the machine's snapshot through normal sub plumbing — Reagent reactions fire on the slice you actually subscribed to.
+Reagent reactions fire on the slice you actually subscribed to.
 
 ## Tagging states
 
-Once a machine grows past a handful of states, views start asking the same question over and over: *"is the machine in any of the loading-ish states right now?"* The 1-of-N read is well-served by `sub-machine` and a `=` check; the *any-of-many* read isn't, and most apps end up inventing one boolean sub per shape they care about:
-
-```clojure
-(rf/reg-sub :auth/loading?
-  :<- [:auth.login/state]
-  (fn [state _] (or (= state :submitting)
-                    (= state :validating)
-                    (= state :refreshing))))
-```
-
-That works until you add a fourth loading-ish state. Then the sub needs to know about it. Then every view that wants the loading indicator needs to know which sub. The view is asking a *predicate* question — "are we loading?" — and a `case`-style read keeps making it look like a discriminator question.
+Once a machine grows past a handful of states, views start asking the same question over and over: *"is the machine in any of the loading-ish states right now?"* The 1-of-N read is well-served by `sub-machine` and a `=` check, but the *any-of-many* read isn't — most apps end up inventing one hand-rolled boolean sub per shape they care about (`(or (= state :submitting) (= state :validating) ...)`). That works until you add a fourth loading-ish state and every view that wants the spinner needs to know which sub to subscribe to. The view is asking a *predicate* question — "are we loading?" — and a `case`-style read keeps making it look like a discriminator.
 
 `:tags` flips that around. A state can declare a set of keywords describing its intent:
 
@@ -342,298 +283,83 @@ The view asks the predicate question directly:
   [view-spinner])
 ```
 
-`(rf/has-tag? machine-id tag)` is sugar over a framework-shipped sub, `:rf/machine-has-tag?`. The signal flips only when the containment bit flips — adding a new loading-ish state later is one `:tags #{:loading}` on the new state node, with no view changes anywhere. The view didn't need to know which states carried the tag; it just asked whether the union contains `:loading`.
+`(rf/has-tag? machine-id tag)` is sugar over the framework-shipped `:rf/machine-has-tag?` sub. The signal flips only when the containment bit flips — adding a new loading-ish state later is one `:tags #{:loading}` on the new state node, with no view changes anywhere. The view never had to know which states carried the tag; it just asked whether the union contains `:loading`. The framework sub composes into higher-level reg-subs the usual way.
 
-For sub chains, the framework sub composes the same way any other reg-sub does — feed it into a higher-level sub that combines the predicate with other inputs:
-
-```clojure
-(rf/reg-sub :auth/show-spinner?
-  :<- [:rf/machine-has-tag? :auth.login/flow :loading]
-  :<- [:ui/spinner-enabled?]
-  (fn [[loading? enabled?] _]
-    (and loading? enabled?)))
-```
-
-A few rules worth knowing up front:
+A few rules:
 
 - **Tags are owned by the runtime.** They are a projection of `:state`. Actions can't write `:tags` in their effect map; you set the state, the tags follow.
-- **Tags compose along the active path.** In a compound machine, every state along root → leaf contributes its `:tags`. If a parent `:authenticated` carries `#{:logged-in}` and its child `:dashboard` carries `#{:home-view}`, the snapshot's `:tags` is `#{:logged-in :home-view}`.
-- **Empty tag-sets vanish.** A machine that declares no `:tags` produces a snapshot with no `:tags` key at all. Pre-tag and post-tag machines with no tag declarations are byte-identical.
-- **`:rf/*` and `:rf.*/*` keyword namespaces are reserved.** Your tags go in your own namespaces — `:auth/...`, `:ui.state/...`, plain keywords like `:loading`. Don't reach for the framework prefix.
+- **Tags compose along the active path.** In a compound machine, every state along root → leaf contributes its `:tags`. A parent `:authenticated` carrying `#{:logged-in}` plus a child `:dashboard` carrying `#{:home-view}` gives a snapshot `:tags` of `#{:logged-in :home-view}`.
+- **Empty tag-sets vanish.** A machine that declares no `:tags` produces a snapshot with no `:tags` key at all.
+- **`:rf/*` / `:rf.*/*` namespaces are reserved.** Use your own — `:auth/...`, `:ui.state/...`, plain keywords like `:loading`.
 
-When to reach for tags: when you're already writing two or three boolean subs that each ask "is the state one of these?" — the third one is the signal. When *not* to reach for tags: when the question really is "which exact state is it?" — that's a `case` on `(:state @(sub-machine ...))`, and tags would only add a layer of indirection.
-
-Tags also have a sweet spot in the [Parallel regions](#parallel-regions) pattern below. When a machine has truly orthogonal axes — data lifecycle, form validity, render mode — tags carry the per-axis intent so view-level queries don't have to know about the cross-product.
-
-Full normative reference: [Spec 005 §State tags](../../spec/005-StateMachines.md#state-tags).
+When to reach for tags: when you're already writing two or three boolean subs that each ask "is the state one of these?" — the third one is the signal. When *not*: when the question really is "which exact state is it?" — that's a `case` on `(:state @(sub-machine ...))`. Tags also have a sweet spot in the [Parallel regions](#parallel-regions) pattern below — they carry per-axis intent so view-level queries don't have to know about the cross-product.
 
 ## What the substrate covers
 
-The shape above — flat states, plain `:on` transitions, `:entry` / `:exit` actions, machine-local `:guards` / `:actions` — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model. A flavour:
+The shape above — flat states, plain `:on` transitions, `:entry` / `:exit` actions, machine-local `:guards` / `:actions` — is enough for many machines. When the flow gets richer, the substrate has more to offer without changing the model:
 
 - **Hierarchical states.** A compound state contains sub-states; entering the parent cascades to its declared `:initial` child; transitions from a deep state can target a sibling or an ancestor and the runtime computes the LCA. Useful when the auth flow has an `:authenticated` super-state with `:cart` / `:browsing` sub-states under it.
-- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or "advance through derived states." Bounded depth, microstep-loop semantics, defined trace events.
-- **Delayed `:after` transitions.** A state can declare "if no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
-- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data rather than as `:entry [:rf.machine/spawn ...]` / `:exit [:rf.machine/destroy ...]`. The child's lifecycle is bound to the parent state.
+- **Eventless `:always` transitions.** A state can fire a transition on entry (or after every event) when a guard becomes true — no event needed. Useful for "drain a queue, transition when empty" or advancing through derived states. Bounded depth, microstep-loop semantics.
+- **Delayed `:after` transitions.** "If no event arrives within N ms, transition to this state." Useful for retry-after-backoff, idle timeouts, debounce-shaped flows. Carries an epoch so cancelled timers don't fire late.
+- **Declarative `:invoke`.** A state can spawn a child machine on entry and destroy it on exit, declared as data. The child's lifetime is bound to the parent state.
 
-Each of these is opt-in — implementations declare which capabilities they support, and the conformance corpus grades against the claimed set. The full grammar is in [Spec 005](../../spec/005-StateMachines.md). The point of mentioning them here is that the model scales: when your machine grows, the substrate has well-named answers ready, and you don't end up smuggling state-machine logic into ordinary event handlers.
+Each is opt-in per the capability matrix. The model scales — when your machine grows, the substrate has well-named answers ready.
 
 ### Capability matrix cross-reference
 
-For advanced readers: the substrate features above each have a **capability-flag** name that ports claim against. The full matrix lives at [Spec 005 §Capability matrix](../../spec/005-StateMachines.md#capability-matrix); the ones this chapter has touched on are:
-
-- `:fsm/parallel-regions` — `:type :parallel` + the `:regions` map (the [Parallel regions](#parallel-regions) section below).
-- `:fsm/tags` — the `:tags` slot on a state node and its tag-union projection on the snapshot.
-- `:fsm/final-states` — `:final?` + `:on-done` + `:output-key`, for states that signal completion.
-- `:fsm/hierarchy`, `:fsm/always`, `:fsm/after`, `:fsm/invoke`, `:actor/spawn-and-join` — compound states, eventless transitions, delayed transitions, child-machine `:invoke`, and `:invoke-all`.
-
-The v1 CLJS reference claims all of the above. A port that doesn't claim a given capability raises `:rf.error/machine-grammar-not-in-v1` on the corresponding key at registration time, rather than silently accepting it.
+For port authors: each substrate feature has a **capability-flag** name (`:fsm/hierarchy`, `:fsm/always`, `:fsm/after`, `:fsm/invoke`, `:fsm/parallel-regions`, `:fsm/tags`, `:fsm/final-states`, `:actor/spawn-and-join`). A port declares its claimed set; a key the port doesn't claim raises `:rf.error/machine-grammar-not-in-v1` at registration time rather than being silently accepted. Full matrix: [Spec 005 §Capability matrix](../../spec/005-StateMachines.md#capability-matrix). The v1 CLJS reference claims all of the above.
 
 ## Patterns that bottom out in machines
 
-Three recurring shapes from [chapter 04](04-events-state-cycle.md) are state machines underneath. All three are pattern docs (convention), not Specs (contract). The shape is worth knowing in outline even if you don't write one today — the moment you reach for `setTimeout`-driven reconnect logic, an `:app/init` event that does six things, or a `for` loop that locks the UI for two seconds, you'll recognise it.
+Three recurring shapes from [chapter 04](04-events-state-cycle.md) are state machines underneath. Each has a dedicated pattern doc — convention, not Spec — that walks the worked example end-to-end. The point of naming them here is that the moment you reach for `setTimeout`-driven reconnect logic, an `:app/init` event that does six things, or a `for` loop that locks the UI for two seconds, you'll recognise the shape and know where to look.
 
 ### Pattern-WebSocket — a connection as a machine
 
-WebSocket, Server-Sent Events, WebRTC peers — anything with retry, backoff, heartbeat, subscriptions, and server-pushed events — is state-machine-shaped:
-
-```text
-:disconnected      ─ws/connect─►   :active / :connecting
-:active /:connecting ─opened─►     :active / :authenticating
-:active /:authenticating ─ok─►     :active / :connected
-:active / *        ─closed─►       :reconnecting ─after backoff─► :active / :connecting
-:reconnecting      ─max retries─►  :failed
-```
-
-`:connecting`, `:authenticating`, and `:connected` sit under one compound parent `:active`. The parent owns the `:invoke` of the child socket actor — its lifetime spans every leaf that dispatches through it, so the actor stays alive across the success-path transitions and is destroyed only when control leaves `:active` (to `:reconnecting`, `:failed`, or `:disconnected`). `:reconnecting` carries the exponential-backoff counter in `:data` and uses a fn-form `:after` delay; subscribed topics live in `:data :subscriptions` and re-issue automatically on entry to `:connected` (so subscriptions survive reconnects). Messages flowing *over* the open connection are ordinary Pattern-AsyncEffect interactions — request-reply with a correlation id, tracked in `:data :in-flight`; the connection machine is the long-lived host that performs the correlation step.
-
-The connection machine composes the locked substrate end-to-end: a hierarchical parent for the actor's lifetime, `:after` for backoff, `:always` for max-retries guards and queue flushing on entry, `:invoke` to spawn the child socket actor that owns the actual `WebSocket` object, and the connection-epoch idiom (the socket actor's gensym'd id IS the epoch) to suppress messages from a torn-down socket. No new mechanism — just one machine exercising every primitive at once. Full walkthrough: [`spec/Pattern-WebSocket.md`](../../spec/Pattern-WebSocket.md).
+WebSocket, Server-Sent Events, WebRTC peers — anything with retry, backoff, heartbeat, subscriptions, and server-pushed events — is state-machine-shaped. The canonical machine has a `:disconnected` initial state, a compound `:active` parent containing `:connecting / :authenticating / :connected` leaves (the parent owns the `:invoke`d socket actor so its lifetime spans the success cascade), a `:reconnecting` state with fn-form `:after` exponential backoff, and a terminal `:failed` state on max retries. Messages *over* the open connection are ordinary Pattern-AsyncEffect interactions correlated through `:data :in-flight`. Full walkthrough — including subscription survival across reconnects, the connection-epoch idiom for suppressing torn-down-socket events, and request-reply correlation — lives at [`spec/Pattern-WebSocket.md`](../../spec/Pattern-WebSocket.md).
 
 ### Pattern-Boot — initialisation as a machine
 
-For trivial boots — one or two steps, no error states, no progress UI — a chain of dispatched events is fine:
-
-```clojure
-(rf/reg-event-fx :app/init
-  (fn [_ _]
-    {:fx [[:dispatch [:config/load]]]}))
-
-(rf/reg-event-fx :config/load
-  (fn [_ _]
-    {:fx [[:rf.http/managed
-           {:request    {:url "/config"}
-            :on-success [:config/loaded]
-            :on-failure [:app/init-failed]}]]}))
-
-(rf/reg-event-fx :config/loaded
-  (fn [{:keys [db]} [_ {:keys [value]}]]
-    {:db (assoc db :config (:body value))
-     :fx [[:dispatch [:app/ready]]]}))
-```
-
-The frame's `:on-create` fires `:app/init`, the chain runs to completion, the UI renders.
-
-Once the boot graph has more than a few steps — auth restoration, profile load, hydration from `localStorage`, route resolution, real-time connect — chained events scatter logic across N unrelated handlers. The canonical answer is a **boot state machine** with named phases:
-
-| State | Meaning |
-|---|---|
-| `:configuring` | Reading static config. |
-| `:authenticating` | Restoring session token; refreshing if needed. |
-| `:loading-profile` | Fetching user profile / feature flags. |
-| `:hydrating` | Applying client-side persistent state. |
-| `:routing` | Resolving the initial route. |
-| `:ready` | Boot complete. (Terminal.) |
-| `:auth-failed` / `:fatal-error` | Per-phase error states. |
-| `:retrying-auth` | Recovery state with `:after` backoff. |
-
-Each phase `:invoke`s the async work; transitions on success / failure; entry actions update the visible-progress slice in `:data`. The boot UI subscribes to the snapshot and renders "Loading config…" / "Signing in…" / "Almost ready…" by state. The whole sequence is one inspectable, testable, traceable machine.
-
-The boot machine is also the canonical seam between **host-supplied static config** (a `/config` endpoint, build-time env vars) and the **running app's dynamic state** — `:configuring` lands the config into `:data`; subsequent states read from `:data :config` and thread values into the next phase's spawn-spec rather than reaching into globals. Full walkthrough including the auth-machine's transport-vs-semantic retry boundary: [`spec/Pattern-Boot.md`](../../spec/Pattern-Boot.md).
+For trivial boots — one or two steps, no progress UI — a chain of dispatched events suffices. Once the boot graph grows to include config load, auth restoration, profile fetch, `localStorage` hydration, and route resolution, the chained-events form scatters logic across N unrelated handlers. The canonical answer is a boot state machine with named phases (`:configuring`, `:authenticating`, `:loading-profile`, `:hydrating`, `:routing`, `:ready`, plus per-phase error and `:retrying-*` states). Each phase `:invoke`s its async work, transitions on success / failure, and updates the visible-progress slice in `:data` so the boot UI can render "Loading config…" / "Signing in…" / "Almost ready…" from the snapshot. The boot machine is also the canonical seam between host-supplied static config and the running app's dynamic state. Full walkthrough including the auth-machine's transport-vs-semantic retry boundary: [`spec/Pattern-Boot.md`](../../spec/Pattern-Boot.md).
 
 ### Pattern-LongRunningWork — CPU-bound work as a chunked machine
 
-A handler with significant CPU-bound work — iterating over a large dataset, encoding / decoding, indexing, parsing, running a simulation step — blocks the dispatch loop and freezes the UI. The browser repaints once per ~16 ms; if a single handler holds the thread longer, animations stutter, clicks queue up, and the app appears hung. The naïve fix — "just do it all in one event handler" — is exactly the shape that earns a *"page unresponsive"* warning.
-
-There are two real answers, and the choice is the first decision you make:
-
-1. **Offload to a Web Worker.** The main thread stays responsive; the work runs at full speed on another thread; progress reports flow back as events. This is the preferred answer whenever the work is serialisable across the worker boundary — see [`spec/Pattern-AsyncEffect.md`](../../spec/Pattern-AsyncEffect.md).
-2. **Chunk and yield on the main thread.** When the work has to run on the main thread — DOM access, framework state, awkward-to-serialise data — split it into small batches and yield between batches. That's a state machine.
-
-The chunked machine has a tiny, canonical shape:
-
-| state | meaning |
-|---|---|
-| `:idle` | Not running. Initial state. |
-| `:processing` | Entry action processes one chunk; updates `:data`. |
-| `:checking-done` | Eventless `:always` decides: complete, yield, or cancel. |
-| `:yielding` | `:after 0` schedules the next chunk so the browser gets a render tick. |
-| `:complete` | Terminal — work finished. |
-| `:cancelled` | Terminal — user requested cancel. |
-
-The cycle is `:processing → :checking-done → :yielding → :processing → …` until `:checking-done` decides the job is done. The `:after 0` in `:yielding` is the load-bearing line — it hands the thread back to the browser between chunks so the progress bar repaints, the cancel button stays clickable, and the rest of the app keeps running.
-
-#### A worked example — count matches across a huge vector
-
-Stretching the counter throughline one last notch: imagine the counter is no longer "increment on click" but "scan a million-record vector and count how many records match a predicate." The result is still a single number; the work to compute it is heavy. We can't compute it inside a sub (subs are read-only and have to stay cheap), and we can't compute it inline in one event handler (the UI would freeze for a second or two). It's a chunked machine.
-
-```clojure
-(rf/reg-machine :counter/scan
-  {:initial :idle
-   :data    {:input      nil
-             :total      0
-             :processed  0
-             :matches    0
-             :chunk-size 5000}
-
-   :guards
-   {:done?      (fn [d _] (>= (:processed d) (:total d)))
-    :more-work? (fn [d _] (<  (:processed d) (:total d)))}
-
-   :actions
-   {:start-scan
-    (fn [_ [_ input opts]]
-      {:data {:input      input
-              :total      (count input)
-              :processed  0
-              :matches    0
-              :chunk-size (:chunk-size opts 5000)}})
-
-    :process-chunk
-    (fn [{:keys [input chunk-size processed matches] :as d} _]
-      (let [end   (min (+ processed chunk-size) (count input))
-            chunk (subvec input processed end)
-            hits  (count (filter big-enough? chunk))]
-        {:data {:processed end
-                :matches   (+ matches hits)}}))}
-
-   :states
-   {:idle
-    {:on {:start {:target :processing :action :start-scan}}}
-
-    :processing
-    {:entry  :process-chunk
-     :always [{:target :checking-done}]}
-
-    :checking-done
-    {:always [{:guard :done?      :target :complete}
-              {:guard :more-work? :target :yielding}]}
-
-    :yielding
-    {:after {0 :processing}
-     :on    {:cancel :cancelled}}
-
-    :complete  {:on {:reset :idle}}
-    :cancelled {:on {:reset :idle}}}})
-```
-
-A million records with `:chunk-size 5000` is 200 chunks. The view dispatches `[:counter/scan [:start big-vector]]`, the machine cycles through `:processing / :checking-done / :yielding` 200 times, and at the end `:complete` holds the final count in `:data :matches`. Between each chunk the browser gets one render tick — the progress bar moves, the cancel button responds.
-
-The progress UI reads from the machine snapshot via `sub-machine`:
-
-```clojure
-(rf/reg-sub :counter.scan/progress
-  :<- [:rf/machine :counter/scan]
-  (fn [{:keys [data]} _]
-    (let [{:keys [processed total]} data]
-      (when (pos? total) (/ processed total)))))   ;; 0.0 .. 1.0
-
-(rf/reg-sub :counter.scan/matches
-  :<- [:rf/machine :counter/scan]
-  (fn [snapshot _] (get-in snapshot [:data :matches])))
-
-(rf/reg-sub :counter.scan/state
-  :<- [:rf/machine :counter/scan]
-  (fn [snapshot _] (:state snapshot)))
-```
-
-The view renders a progress bar from `:counter.scan/progress`, a live running count from `:counter.scan/matches`, and switches its layout on `:counter.scan/state` — a "Cancel" button while `:yielding`, a "Done" affordance while `:complete`. Each `:processing` tick advances both the progress bar and the running count; the user sees the machine *thinking*, not a frozen page followed by a sudden answer.
-
-#### Cancellation is a transition, not a flag
-
-The naïve approach to cancel — set a flag in `app-db` and check it on every chunk — is replaced by the machine. A `:cancel` event handled in the `:yielding` state transitions to `:cancelled`; the next chunk simply doesn't run, because the machine is no longer in `:processing`:
-
-```clojure
-(rf/dispatch [:counter/scan [:cancel]])
-```
-
-The partial result is preserved in `:data` — the view can show "Cancelled at 437,000 of 1,000,000" by reading the snapshot. For the more sophisticated case of a still-pending `:after` timer firing after cancel, [Pattern-StaleDetection](../../spec/Pattern-StaleDetection.md) composes cleanly: the machine's epoch advances on entering `:cancelled` and any in-flight timer carrying the previous epoch is suppressed on receipt.
-
-#### When to choose a worker instead
-
-The chunked-main-thread pattern works, but it isn't free — every browser tick is overhead, and the work runs slower than it would on a dedicated thread. For genuinely heavy CPU work (image processing, large simulations, search indexing, complex analyses), **offload to a Web Worker** via [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md):
-
-- The main thread stays fully responsive — no chunking required.
-- Progress reporting still works — the worker dispatches progress events back.
-- Cancellation is the same epoch-based pattern.
-- The work runs at full thread speed (no ~16 ms overhead between chunks).
-
-The chunked pattern is the right answer when worker offload isn't feasible — DOM access, framework state, awkward-to-serialise data, or work that's *medium-heavy* enough that worker setup costs outweigh the gain. Roughly: if a chunk fits comfortably in 16 ms and you only need a handful of seconds total, chunked-main-thread is simpler; if you're looking at tens of seconds or genuinely thread-bound compute, hand it to a worker.
-
-#### Pitfalls
-
-A few traps the pattern doc calls out explicitly:
-
-- **Computing in subscriptions.** Subs should be cheap and pure; long compute belongs in event handlers. A sub that takes seconds to settle slows every render that touches it. Compute in events, project the result via subs.
-- **Multiple `assoc`s in one handler expecting interleaved renders.** re-frame2 batches per drain — only one render per drain regardless of how many `:db` updates the handler made. The chunked machine is the only way to get intermediate renders, because each chunk is its own dispatch and its own drain.
-- **`:always` cycles without `:after 0` between batches.** A pure `:always` chain hits the `:rf.error/machine-always-depth-exceeded` cap (default 16). The `:yielding` state's `:after 0` resets the depth *and* yields to the browser — that's what's earning its keep.
-- **Input changing mid-process.** The machine's `:data` holds the input vector that `:start-scan` snapshotted. If the source data changes while the scan runs, the machine keeps processing the original snapshot — which is usually what you want. If it isn't, `:reset` and re-start.
-- **Forgetting cancel.** Long jobs need a cancel path. The state-machine shape makes this trivial; ad-hoc self-redispatch loops make it painful.
-
-The v1 idiom for this — `^:flush-dom` event metadata, or self-redispatching `{:dispatch [...]}` "tail call" loops — is gone. The replacement is this machine: explicit states, named transitions, encapsulated `:data`, cancellation as a transition, progress as a snapshot field. Full walkthrough including the `:dispatch-later {:ms 0}` "yield once before one big block" variant: [`spec/Pattern-LongRunningWork.md`](../../spec/Pattern-LongRunningWork.md). For where this pattern sits among the other shapes of performance work in re-frame2 — and the worker-offload alternative — see [16 — Performance](16-performance.md#when-to-reach-for-the-chunked-work-machine).
+A handler with significant CPU-bound work — iterating over a large dataset, encoding / decoding, indexing, parsing, running a simulation step — blocks the dispatch loop and freezes the UI. There are two real answers: **offload to a Web Worker** (the preferred answer whenever the work is serialisable across the worker boundary — see [Pattern-AsyncEffect](../../spec/Pattern-AsyncEffect.md)), or **chunk and yield on the main thread**. The chunked answer is a tiny machine — `:idle / :processing / :checking-done / :yielding / :complete / :cancelled` — cycling `:processing → :checking-done → :yielding → :processing` until done. The load-bearing line is `:yielding`'s `:after 0`, which hands the thread back to the browser between chunks so progress bars repaint and the cancel button stays clickable. Cancellation is a transition (not a flag), the partial result is preserved in `:data`, and the v1 idioms (`^:flush-dom`, self-redispatching `{:dispatch [...]}` loops) are gone. Full walkthrough with the million-record predicate-scan worked example, progress subs, and the worker-offload decision guide: [`spec/Pattern-LongRunningWork.md`](../../spec/Pattern-LongRunningWork.md). See also [16 — Performance](16-performance.md#when-to-reach-for-the-chunked-work-machine) for how this sits among the other shapes of performance work.
 
 ## When to reach for a machine, and when not to
 
-State machines aren't a hammer. Most events in most apps are not state machines — they're simple `(state, event) → state` updates with no flow structure. Don't dress them up as machines.
+State machines aren't a hammer. Most events in most apps are simple `(state, event) → state` updates with no flow structure; don't dress them up as machines.
 
-Reach for a machine when:
+**Reach for one when:** the flow has named, mutually-exclusive stages (your handlers `cond` on a state field — the signal); transitions are conditional on guards (repeated `(when (some-condition? db) ...)` across handlers are guards in disguise); the flow is non-trivial enough to draw on a whiteboard (the diagram *is* the machine — encode it directly).
 
-- **The flow has named, mutually-exclusive stages.** "We're either in this stage or that stage, not both." If your event handlers use `cond` to dispatch on a state field, that's the signal.
-- **Transitions are conditional on guards.** If you have repeated `(when (some-condition? db) ...)` checks across multiple handlers, the conditions are guards in disguise.
-- **The flow is non-trivial enough to draw on a whiteboard.** If you've sketched the state diagram on paper to think through a feature, the diagram is the machine. Encode it directly.
-
-Don't reach for a machine when:
-
-- **The "state" is actually just data.** A list with items isn't a machine. A counter isn't a machine. Don't add machinery you don't need.
-- **There are only two stages.** A boolean `:loading?` flag is fine. Two-state machines are formally machines but practically overkill.
-- **You're trying to enforce a sequence of operations** — that's a different problem (saga / workflow), and re-frame2's drain semantics handle the simple cases without a machine. Reach for machines only when *named states* are the load-bearing concept, not when *named operations* are.
+**Don't reach for one when:** the "state" is just data (a counter, a list of items — no machine needed); there are only two stages (a boolean `:loading?` flag is fine); you're trying to enforce a *sequence of operations* (that's a saga / workflow — re-frame2's drain semantics handle the simple cases). Reach for machines only when *named states* are the load-bearing concept, not when *named operations* are.
 
 ## Headless testing
 
-Because `machine-transition` is pure — and because guards and actions are inline-or-named-in-the-spec functions — you can test a machine without dispatching anything:
+Because `machine-transition` is pure — and guards / actions are inline-or-named-in-the-spec functions — you can test a machine without dispatching anything:
 
 ```clojure
-(deftest login-flow-happy-path
+(deftest login-flow
   (let [s0 {:state :idle :data {:attempts 0 :error nil}}
         [s1 _fx] (rf/machine-transition login-flow s0
                                         [:auth.login/submit {:email "a@b.com"
                                                              :password "..."}])]
     (is (= :submitting (:state s1)))
 
-    (let [[s2 _fx] (rf/machine-transition login-flow
-                                          {:state :submitting :data {:attempts 0}}
-                                          [:auth.login/success {:user {:id 1}}])]
-      (is (= :authed (:state s2))))))
-
-(deftest login-flow-lockout
-  (let [snapshot {:state :submitting :data {:attempts 3}}
-        [s _fx] (rf/machine-transition login-flow snapshot
-                                       [:auth.login/failure {:message "wrong creds"}])]
     ;; attempts has already hit the retry limit; the :under-retry-limit guard
     ;; rejects the first clause, the second clause's :locked-out wins.
-    (is (= :locked-out (:state s)))))
+    (let [[s2 _fx] (rf/machine-transition login-flow
+                                          {:state :submitting :data {:attempts 3}}
+                                          [:auth.login/failure {:message "wrong creds"}])]
+      (is (= :locked-out (:state s2))))))
 ```
 
-These tests run on the JVM. No browser. No network. No mocks. Each one runs in microseconds. You can have hundreds.
-
-This is the testing experience for *flows that are non-trivial* — exactly the case where unit testing usually gets hard. With machines, it stays easy.
+JVM-side. No browser, no network, no mocks. Each test runs in microseconds; you can have hundreds. This is the testing experience for *flows that are non-trivial* — exactly the case where unit testing usually gets hard.
 
 ## Parallel regions
 
-Some pages don't have one axis of state — they have several, all running at once. A todos page has a *data lifecycle* (nothing / loading / empty / some / error), a *form state* (neutral / invalid / valid), and a *mode* (active / archived). Those three axes are orthogonal: the form can be invalid while the data is loading, the mode can be archived while the form happens to be neutral. None of those combinations is illegal; they're just *true at the same time*.
+Some pages don't have one axis of state — they have several, all running at once. A todos page has a *data lifecycle* (nothing / loading / empty / some / error), a *form state* (neutral / invalid / valid), and a *mode* (active / archived). The axes are orthogonal; any cross-product is legal. The naïve modellings both fail: one big flat machine explodes to `3 × 3 × 3 = 27` states; three separate slices in `app-db` pushes cross-axis truths into derived subs.
 
-The naïve modelling — one big flat machine — explodes combinatorially. Three axes of three states each is `3 × 3 × 3 = 27` flat states, and every transition needs to remember which of the other two axes it's leaving alone. The naïve fix — keep the three axes as three separate slices in `app-db` and write derived subs that combine them — leaves you computing cross-axis truths in subscriptions, every page-level UI question becoming a hand-rolled boolean discriminator.
-
-Parallel regions are the substrate answer. A machine can declare `:type :parallel` and a `:regions` map; each region is a full state-tree with its own `:initial` and `:states`, and **every region is active simultaneously**:
+Parallel regions are the substrate answer. A machine declares `:type :parallel` and a `:regions` map; each region is a full state-tree with its own `:initial` and `:states`, and **every region is active simultaneously**:
 
 ```clojure
 (rf/reg-machine :todos/page
@@ -681,32 +407,11 @@ Three regions; three currently-active states; one tag union. Three regions, *not
 
 ### How events flow
 
-When you dispatch an event into a parallel machine, the runtime **broadcasts** it to every region. Each region's currently-active state checks its own `:on` map; the ones that match transition, the ones that don't stay put.
-
-```clojure
-(rf/dispatch [:todos/page [:fetch]])
-;; → :data region transitions :nothing → :loading
-;;   :form region's :neutral doesn't handle :fetch — stays at :neutral
-;;   :mode region's :active doesn't handle :fetch — stays at :active
-
-(rf/dispatch [:todos/page [:archive]])
-;; → :mode region transitions :active → :done
-;;   :data and :form regions stay put
-```
-
-If no region handles the event, the machine emits one `:rf.warning/machine-unhandled-event` — just like a flat machine would. If *any* region handles it, the warning is suppressed.
+A dispatch into a parallel machine **broadcasts** to every region. Each region's active state checks its own `:on` map; matching states transition, non-matching states stay put. `[:todos/page [:fetch]]` advances `:data` from `:nothing` to `:loading` while `:form` and `:mode` ignore it. If no region handles the event, one `:rf.warning/machine-unhandled-event` fires; if any region handles it, the warning is suppressed.
 
 ### Tags compose across regions
 
-The `:tags` slot on a parallel snapshot is the union of every active state's tags **across every region**. Setting the data region to `:loading` while leaving the others alone gives:
-
-```clojure
-{:state {:data :loading :form :neutral :mode :active}
- :data  {:items [] :error nil}
- :tags  #{:data/loading :form/neutral :mode/active}}
-```
-
-`(rf/has-tag? :todos/page :data/loading)` returns true. So does `(rf/has-tag? :todos/page :mode/active)`. The view doesn't need to know which region holds which tag — it asks the predicate question and the runtime walks the active configuration across all regions to answer it.
+The `:tags` slot is the union across every active state in every region. Setting `:data` to `:loading` while leaving the others alone produces `#{:data/loading :form/neutral :mode/active}`; `(rf/has-tag? :todos/page :data/loading)` is true and so is `(rf/has-tag? :todos/page :mode/active)`. The view asks predicate questions without knowing which region holds which tag.
 
 ### One `case`, one render-priority table
 
@@ -742,42 +447,27 @@ The priority table is the only place the page declares "if mode is done, that wi
 
 ### One `:data`, shared
 
-Every region in a parallel machine shares the **same** `:data` blob. There is no per-region `:data` slot. Guards and actions in every region see and write the same map.
-
-That's the design constraint to be aware of. If your three regions genuinely share a domain — a todos page where the data, the form, and the mode all read and write the same `:items` — shared `:data` is what you want. If your regions are *separately scoped* features that just happen to be on the same screen, what you actually want is N separate machines, each at its own `[:rf/machines <id>]`, coordinated through dispatch. The next section covers that pattern; the choice is by domain shape, not by code style.
-
-The simplest test is: *do these axes read and write the same data?* If yes, one parallel machine. If no, N machines.
+Every region in a parallel machine shares the **same** `:data` blob — no per-region slot. Guards and actions in every region see and write the same map. That's the design constraint. If the three regions genuinely share a domain (a todos page where data, form, and mode all read and write the same `:items`), shared `:data` is what you want. If they're separately scoped features that just happen to be on the same screen, what you actually want is N separate machines coordinated through dispatch — the next section.
 
 ### When to reach for parallel regions
 
-- The axes are *orthogonal* — any cross-product is legal, no axis can rule out a state in another axis.
-- The axes *share a domain* — they read and write one `:data` blob.
-- The flat alternative is a combinatorial explosion of states (more than ~6-8 in the cross-product).
-- You're already inventing boolean discriminator subs to combine three independent slices for page-level rendering decisions.
+Reach for them when the axes are orthogonal, share a domain (one `:data` blob), and the flat cross-product would be more than ~6-8 states. *Don't* reach for them when one axis's transition depends on another (that's one axis with compound structure — use a hierarchical machine), when regions don't share data (use N machines), or for a simple "loading flag + data" pair (flat machine, two states).
 
-When *not* to reach for parallel regions:
-
-- Two axes that interact heavily — one transition's `:target` depends on the other axis's current state. That's actually one axis with compound structure; model it as a hierarchical machine.
-- Independent features that don't share data — separate apps' worth of state on one screen. Use N machines.
-- A simple "loading flag + data" pair — that's still a flat machine with a `:loading` and a `:ready` state, no regions needed.
-
-The fully-worked depth example — including all nine of the canonical UI states modelled as one three-region machine — is [Pattern-NineStates](../../spec/Pattern-NineStates.md), with runnable code at `examples/reagent/nine_states/`. The example above is the introduction; the pattern doc is where it expands into a full page-rendering convention.
+The fully-worked depth example — all nine canonical UI states (`Nothing / Loading / Empty / One / Some / Too Many / Incorrect / Correct / Done`) modelled as one three-region machine — is [Pattern-NineStates](../../spec/Pattern-NineStates.md), runnable code at `examples/reagent/nine_states/`.
 
 Full normative reference: [Spec 005 §Parallel regions](../../spec/005-StateMachines.md#parallel-regions).
 
 ## Composing machines
 
-Real apps have more than one machine: an auth machine, a checkout-wizard machine, a websocket-connection machine. They coexist within a frame, each at its own `[:rf/machines <id>]`.
+Real apps have more than one machine — an auth machine, a checkout-wizard machine, a websocket-connection machine — coexisting in a frame, each at its own `[:rf/machines <id>]`. Machines talk to each other through dispatch (the auth machine's `:auth.login/success` action dispatches `[:user/load-profile]`, which a regular `reg-event-fx` handler picks up); there's no special inter-machine messaging.
 
-When machines need to talk to each other, they do so through dispatch — the auth machine's `:auth.login/success` action might dispatch `[:user/load-profile]`, which is handled by a regular `reg-event-fx` handler that updates the user-profile slice. There's no special inter-machine messaging. It's all events, all going through the same queue, all running to completion.
-
-The drain semantics matter here. If an action dispatches a child event, that child event runs *before* subscriptions update. So if a state machine moves through `:idle → :submitting → :authed → :loading-profile → :ready` in a single user click, the view sees only `:idle` (before) and `:ready` (after) — never any in-between flicker. The pattern's commitment to atomic state changes pays off most strongly in flows like this.
+The drain semantics matter. If an action dispatches a child event, that child runs *before* subscriptions update. So if a machine moves through `:idle → :submitting → :authed → :loading-profile → :ready` in a single user click, the view sees only `:idle` (before) and `:ready` (after) — never any in-between flicker. Atomic state changes pay off most strongly in flows like this.
 
 ### Spawning child machines: `:rf.machine/spawn` and `:rf.machine/destroy`
 
-Some machines aren't long-lived singletons. A protocol machine that owns one HTTP request lives only as long as the request. A websocket-pump machine spawns when the connection comes up and exits when it closes. A wizard's per-step subprocess starts and stops with the step. These are **dynamic actors** — gensym'd ids, lifecycle scoped to the parent.
+Some machines aren't long-lived singletons. A protocol machine that owns one HTTP request lives only as long as the request; a websocket-pump machine spawns when the connection comes up and exits when it closes; a wizard's per-step subprocess starts and stops with the step. These are **dynamic actors** — gensym'd ids, lifecycle scoped to the parent.
 
-The canonical fxs for the lifecycle are:
+The canonical lifecycle fxs:
 
 ```clojure
 [:rf.machine/spawn   {:machine-id :request/protocol
@@ -785,83 +475,44 @@ The canonical fxs for the lifecycle are:
 [:rf.machine/destroy actor-id]                ;; tear down by id
 ```
 
-`:rf.machine/spawn` registers a fresh actor (a copy of the spec keyed by a gensym'd id), seeds its `:data`, runs `:on-spawn` against the new id, and queues the optional `:start` event to it. `:rf.machine/destroy` runs the actor's `:exit` action, dissociates its snapshot at `[:rf/machines <actor-id>]`, and clears its handler from the frame-local registry.
+`:rf.machine/spawn` registers a fresh actor (a copy of the spec keyed by a gensym'd id), seeds its `:data`, runs `:on-spawn` against the new id, and queues the optional `:start` event. `:rf.machine/destroy` runs the actor's `:exit` action, dissociates its snapshot, and clears its handler from the frame-local registry.
 
-These are the **only** spelling for lifecycle fx since [PR #175](https://github.com/day8/re-frame2/pull/175). The earlier internal-only `:spawn` / `:destroy-machine` ids are gone — every spawn and destroy uses the `:rf.machine/...` namespace, in alignment with the framework's `:rf.<feature>/...` convention. (If you have a code-search habit of finding `:spawn` strings, switch to `:rf.machine/spawn` — `:spawn` no longer matches.)
-
-For most apps, you do not call `:rf.machine/spawn` directly. The declarative `:invoke` slot on a state node spawns a child on entry and destroys it on exit:
+For most apps you do not call these directly. The declarative `:invoke` slot on a state node spawns a child on entry and destroys it on exit:
 
 ```clojure
 :states
 {:authenticating
  {:invoke {:machine-id :auth/oauth-flow
-           :data       {:provider :github}
-           :on-spawn   :stash-actor-id}
+           :data       {:provider :github}}
   :on {:auth.oauth/success {:target :authenticated
                             :action :store-session}}}
 
  :authenticated
- {:entry :clear-actor-id
-  ;; ... no :invoke — no child to manage in this state
+ {;; ... no :invoke — no child to manage in this state
   }}
 ```
 
-`:invoke` is **registration-time sugar.** `create-machine-handler` walks the spec at construction time and rewrites every `:invoke` slot into entry/exit actions emitting `:rf.machine/spawn` and `:rf.machine/destroy`. The runtime sees only the desugared form — no new mechanics, no new lifecycle event.
-
-#### The runtime-tracked spawn registry
-
-Earlier drafts of the spec asked the user to write the spawned actor-id into a chosen `:data` key (e.g. `:auth-actor`) inside their `:on-spawn` action, then read that key on destroy to pass it to `:rf.machine/destroy`. That contract had a worked-example bug: if you wrote the id into `:auth-actor` but the runtime hardcoded a magic `:pending` key when destroying, your actor would silently leak on every state exit.
-
-That is fixed (per PR #172). The runtime now keeps an internal **spawn registry** at `[:rf/spawned <parent-id> <invoke-id>]` in the spawning frame's `app-db`. When a state with `:invoke` is entered, the runtime writes the spawned actor-id there. On exit, the runtime reads it back and emits the destroy fx with the right id. **You don't have to track the actor-id yourself.**
-
-`:on-spawn` is now **advisory** — you can still write the id into `:data` if your transition table needs it for something, but the runtime no longer relies on you doing so. The auth-flow worked example in this chapter — and in [Spec 005](../../spec/005-StateMachines.md) — works as written, no per-user-bookkeeping required.
-
-```clojure
-;; The runtime tracks this for you. Visible via:
-(get-in (rf/get-frame-db) [:rf/spawned :auth.login/flow :auth-actor])
-;; → :auth/oauth-flow#g42  (the gensym'd actor id)
-```
-
-The slot is sibling to `[:rf/system-ids]` (next section): same per-frame isolation, same revertibility (the slot walks back atomically with `app-db` on a frame revert), same lazy allocation (absent until the first declarative `:invoke` spawn).
+`:invoke` is **registration-time sugar.** `create-machine-handler` rewrites every `:invoke` into entry/exit actions emitting `:rf.machine/spawn` and `:rf.machine/destroy`. The runtime sees only the desugared form — no new mechanics, no new lifecycle event. The spawned actor-id is tracked internally at `[:rf/spawned <parent-id> <invoke-id>]` — **you don't track it yourself**; the runtime reads it back on exit to emit the destroy fx with the right id.
 
 ### Naming machines across the frame: `:system-id`
 
-Sometimes a spawned actor needs to be reached by name from somewhere else — a sibling machine, an event handler, a REPL session — without threading the gensym'd id through `:data`. The opt-in `:system-id` key on a spawn binds the actor to a frame-level reverse index:
+Sometimes a spawned actor needs to be reached by name from somewhere else — a sibling machine, an event handler, a REPL session — without threading the gensym'd id through `:data`. The opt-in `:system-id` key on a spawn (imperative `:rf.machine/spawn` fx or declarative `:invoke`) binds the actor to a frame-level reverse index at `[:rf/system-ids <name>]`:
 
 ```clojure
-;; Imperative spawn (action :fx) with a :system-id binding.
-{:fx [[:rf.machine/spawn {:machine-id :request/protocol
-                          :data       {...}
-                          :system-id  :primary-request}]]}
-
-;; The same key works on declarative :invoke:
 :states
 {:requesting
  {:invoke {:machine-id :request/protocol
            :system-id  :primary-request
            :data       {...}}}}
 
-;; Look it up later:
+;; Look up later:
 (rf/machine-by-system-id :primary-request)
-;; → :request/protocol#g42  (the gensym'd actor-id), or nil if no actor is currently bound
+;; → :request/protocol#g42  (the gensym'd actor-id), or nil if unbound
 ```
 
-`:system-id` is a **frame-level reverse index** that resolves to whichever spawned actor currently owns the name. It lives at `[:rf/system-ids <name>]` in the spawning frame's `app-db` — same place as the snapshot, so it inherits frame revertibility for free.
+Spawn writes the slot and emits `:rf.machine/system-id-bound`; destroy clears it and emits `:rf.machine/system-id-released`; rebinding emits `:rf.error/system-id-collision` (last-write-wins; the previous machine's snapshot remains, just unnamed). With `:system-id` bound, cross-machine dispatch becomes a name lookup: `{:fx [[:dispatch [(rf/machine-by-system-id :primary-request) [:protocol/cancel]]]]}`.
 
-Lifecycle:
-
-- **On spawn** with a `:system-id`, the runtime writes `[:rf/system-ids <name>] = <gensym'd-id>` and emits `:rf.machine/system-id-bound`.
-- **On destroy**, the runtime clears the slot AND emits `:rf.machine/system-id-released`.
-- **A spawn under an already-bound name rebinds** (last-write-wins) and emits `:rf.error/system-id-collision` so observers can see the displacement. The previously-bound machine's snapshot stays at its `[:rf/machines <id>]` slot — just unnamed.
-
-The standard cross-machine pattern still works — `[:fx [[:dispatch [<other-id> [:event]]]]]` addresses any registered id. With `:system-id` bound, the addressing call site becomes a name lookup:
-
-```clojure
-{:fx [[:dispatch [(rf/machine-by-system-id :primary-request)
-                  [:protocol/cancel]]]]}
-```
-
-This is **opt-in** and **orthogonal** to gensym'd ids. Most spawns won't need it. Reach for `:system-id` when you have a stable role (one auth flow, one primary request, one wizard) that other parts of the frame need to talk to by name.
+This is **opt-in** and **orthogonal** to gensym'd ids. Reach for it when you have a stable role — one auth flow, one primary request, one wizard — that other parts of the frame need to talk to by name.
 
 ## A runnable example
 
@@ -869,15 +520,9 @@ The complete login flow from this chapter — including the runnable smoke tests
 
 ## The deeper claim
 
-State machines are a small example of the broader thesis [chapter 12](12-the-dynamic-model.md) makes: **constrained execution models are easier to reason about than free-form ones**.
+State machines are a small example of the broader thesis [chapter 12](12-the-dynamic-model.md) makes: **constrained execution models are easier to reason about than free-form ones**. A finite state machine has, by construction, a small set of reachable states — you can enumerate them, prove things about transitions, render the whole flow as a diagram. A pile of `if` / `cond` clauses spread across event handlers has none of those properties: reachable states are implicit, transitions are scattered, "from this state, what can happen?" requires reading every handler that touches the state field.
 
-A finite state machine has, by construction, a small set of reachable states. You can enumerate them. You can prove things about transitions. You can render the whole flow as a diagram. You can ask "from this state, what can happen?" and the answer is bounded.
-
-A pile of `if` / `cond` clauses spread across event handlers has none of these properties. The reachable states are implicit. The transitions are scattered. There's no diagram. The answer to "from this state, what can happen?" requires reading every handler that touches the state field.
-
-The choice between them isn't a matter of style. It's a matter of which dynamic model you can hold in your head. Machines are smaller models. Smaller models are easier to debug, refactor, extend, and reason about.
-
-When the flow has the shape of a machine, write a machine.
+The choice isn't a matter of style. It's a matter of which dynamic model you can hold in your head. When the flow has the shape of a machine, write a machine.
 
 ## Next
 

--- a/spec/Pattern-LongRunningWork.md
+++ b/spec/Pattern-LongRunningWork.md
@@ -167,6 +167,7 @@ The `:dispatch-later {:ms 0}` schedules through the host clock primitive (via `r
 - **Forgetting cancellation.** Long jobs need a cancel path. The state-machine pattern makes this trivial; ad-hoc loops make it painful.
 - **`:always` cycles without `:after 0` between batches.** A pure `:always` chain hits the `:rf.error/machine-always-depth-exceeded` cap (default 16). The `:yielding` state's `:after 0` resets the depth and yields to the browser.
 - **Trying to make subscriptions "incremental"** instead of computing in events. Subs are read-only projections; chunked work is a write operation that should produce data the subs then read.
+- **Input changing mid-process.** The machine's `:data` holds the input the start-action snapshotted. If the source data changes while the job runs, the machine keeps processing the original snapshot — which is usually what you want. If it isn't, send `:reset` and restart.
 
 ## When to choose worker offload instead
 


### PR DESCRIPTION
## Summary

ch.08 (state machines) was twice the next-largest chapter (886 lines) and overshot a single-sitting read. The three Pattern walkthroughs (WebSocket, Boot, LongRunningWork) each occupied 100+ lines and self-described as 'look up the pattern doc when you hit this shape' — they belong in their pattern-doc homes.

- Each Pattern-* walkthrough collapses into a 3-5 sentence summary + forward-link to `spec/Pattern-*.md` (~190 lines → ~15 lines)
- Chapter prose tightened throughout (pre-alpha; back-compat not a concern)
- `input-changing-mid-process` pitfall migrated from the counter/scan worked example into `spec/Pattern-LongRunningWork.md`'s anti-patterns list
- Substrate teaching (transition tables, guards/actions, snapshot, tags, parallel regions, spawning, `:system-id`) preserved end to end

**ch.08: 886 → 531 lines.**

Incoming anchors from other chapters preserved:

- `#parallel-regions` (from ch.06)
- `#pattern-longrunningwork--cpu-bound-work-as-a-chunked-machine` (from ch.16)

## Test plan

- [x] `python scripts/check_doc_slugs.py --verbose` — no broken anchors
- [x] `mkdocs build --strict` — passes (INFO-level only, no warnings/errors)
- [x] Pattern-doc walkthroughs already comprehensive at `spec/Pattern-{Boot,WebSocket,LongRunningWork}.md` — extraction does not lose content

## Coordination

A note was added to `rf2-6e6yu` (ch.08 spec-refs surgery — gated on `rf2-1foi5`): its per-line disposition table refers to pre-split line numbers and will need re-running by the dispatcher of that bead. Several PARA dispositions for the extracted Pattern-* sections are now N/A.