### PR TITLE
feat(trace): extend trace-buffer filter vocabulary — severity / event-id / source / origin / dispatch-id / since-ms / pred (rf2-97ah0)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -211,11 +211,42 @@
 (defn trace-buffer
   "Return the trace ring buffer's current contents, oldest first.
 
-  With opts, filters the result. Recognised keys:
-    :operation  — keep only events with this :operation value.
-    :op-type    — keep only events with this :op-type value.
-    :since      — keep only events whose :id is strictly greater than this.
-    :frame      — keep only events whose :tags :frame matches.
+  With opts, filters the result. Recognised keys (all compose AND-wise;
+  an absent key means \"no constraint on that axis\"):
+
+    :operation     — keep only events with this :operation value.
+    :op-type       — keep only events with this :op-type value.
+    :since         — keep only events whose :id is strictly greater than
+                     this. Useful for cursor-based polling.
+    :frame         — keep only events whose `:tags :frame` (or top-level
+                     :frame fallback) matches.
+    :severity      — keep only events whose :op-type matches one of
+                     `:error` / `:warning` / `:info`. Synonym for
+                     `:op-type` restricted to the three severity tiers.
+    :event-id      — keep only events whose `:tags :event-id` matches.
+                     The event-id is the first element of the dispatched
+                     event vector (e.g. `:user/login`).
+    :handler-id    — keep only events whose `:tags :handler-id` matches.
+                     Carried on `:rf.error/handler-exception` and other
+                     handler-scoped emits.
+    :source        — keep only events whose :source (top-level, hoisted
+                     from `:tags :source` by `emit!`) matches. Source
+                     identifies the trigger origin — one of `:ui` /
+                     `:timer` / `:http` / `:repl` / `:machine` /
+                     `:ssr-hydration`. Matched against the top-level slot.
+    :origin        — keep only events whose `:tags :origin` matches.
+                     Origin tags the actor that issued the dispatch
+                     (`:app` / `:pair` / `:story` / `:test` / ...) per
+                     Spec 002 §Dispatch origin tagging.
+    :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
+                     Cascade-wide post rf2-g6ih4 — every emit inside a
+                     drain carries the in-flight cascade's dispatch-id.
+    :since-ms      — keep only events whose :time is strictly greater
+                     than this numeric host-clock timestamp.
+    :between       — `[t0 t1]` two-element vector — keep only events
+                     whose :time falls in [t0, t1] inclusive.
+    :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
+                     the full event map. Returning truthy keeps the event.
 
   Filters compose: every supplied key must match. Returns an empty vector
   in production (the buffer never receives events when interop/debug-enabled?
@@ -226,16 +257,41 @@
   ([opts]
    (if-not interop/debug-enabled?
      []
-     (let [{:keys [operation op-type since frame]} opts
-           pred (fn [ev]
-                  (and (or (nil? operation) (= operation (:operation ev)))
-                       (or (nil? op-type)   (= op-type   (:op-type ev)))
-                       (or (nil? since)     (and (number? (:id ev))
-                                                 (> (:id ev) since)))
-                       (or (nil? frame)
-                           (= frame (or (:frame ev)
-                                        (get-in ev [:tags :frame]))))))]
-       (filterv pred @trace-buffer-state)))))
+     (let [{:keys [operation op-type since frame
+                   severity event-id handler-id source origin
+                   dispatch-id since-ms between pred]} opts
+           [between-t0 between-t1] (when (and (sequential? between)
+                                              (= 2 (count between)))
+                                     between)
+           predicate
+           (fn [ev]
+             (and (or (nil? operation) (= operation (:operation ev)))
+                  (or (nil? op-type)   (= op-type   (:op-type ev)))
+                  (or (nil? since)     (and (number? (:id ev))
+                                            (> (:id ev) since)))
+                  (or (nil? frame)
+                      (= frame (or (:frame ev)
+                                   (get-in ev [:tags :frame]))))
+                  (or (nil? severity) (= severity (:op-type ev)))
+                  (or (nil? event-id)
+                      (= event-id (get-in ev [:tags :event-id])))
+                  (or (nil? handler-id)
+                      (= handler-id (get-in ev [:tags :handler-id])))
+                  (or (nil? source)
+                      (= source (or (:source ev)
+                                    (get-in ev [:tags :source]))))
+                  (or (nil? origin)
+                      (= origin (get-in ev [:tags :origin])))
+                  (or (nil? dispatch-id)
+                      (= dispatch-id (get-in ev [:tags :dispatch-id])))
+                  (or (nil? since-ms)
+                      (and (number? (:time ev))
+                           (> (:time ev) since-ms)))
+                  (or (nil? between-t0)
+                      (and (number? (:time ev))
+                           (<= between-t0 (:time ev) between-t1)))
+                  (or (nil? pred) (pred ev))))]
+       (filterv predicate @trace-buffer-state)))))
 
 (defn clear-trace-buffer!
   "Empty the ring buffer. Tooling uses this between sessions. No-op in

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -195,6 +195,176 @@
              (get-in inner [:tags :parent-dispatch-id]))
           "inner's :parent-dispatch-id == outer's :dispatch-id"))))
 
+;; ---- 1b. Extended filter vocabulary (rf2-97ah0) ----------------------------
+
+(deftest trace-buffer-filter-severity
+  (testing ":severity filters by :op-type tier (:error / :warning / :info)"
+    ;; :rf.error/no-such-handler is a reliable :op-type :error emit.
+    (rf/dispatch-sync [:no-such-event-handler])
+    (let [errs (rf/trace-buffer {:severity :error})]
+      (is (seq errs))
+      (is (every? #(= :error (:op-type %)) errs)
+          ":severity :error narrows to :op-type :error events"))
+    (testing ":severity :warning narrows to :op-type :warning"
+      (let [warns (rf/trace-buffer {:severity :warning})]
+        (is (every? #(= :warning (:op-type %)) warns)
+            (if (seq warns)
+              ":severity :warning narrows correctly"
+              ":severity :warning returns empty when no warnings"))))
+    (testing ":severity composes with :frame"
+      (rf/reg-frame :tb/sev-scope {:doc "severity-scope"})
+      (rf/clear-trace-buffer!)
+      (rf/dispatch-sync [:no-such-event-handler] {:frame :tb/sev-scope})
+      (let [scoped (rf/trace-buffer {:severity :error :frame :tb/sev-scope})]
+        (is (every? #(and (= :error (:op-type %))
+                          (= :tb/sev-scope (or (:frame %)
+                                               (get-in % [:tags :frame]))))
+                    scoped))))))
+
+(deftest trace-buffer-filter-event-id
+  (testing ":event-id filters by :tags :event-id"
+    (rf/reg-event-db :ev/alpha (fn [db _] db))
+    (rf/reg-event-db :ev/beta  (fn [db _] db))
+    (rf/dispatch-sync [:ev/alpha])
+    (rf/dispatch-sync [:ev/beta])
+    (let [alpha (rf/trace-buffer {:event-id :ev/alpha})]
+      (is (seq alpha))
+      (is (every? #(= :ev/alpha (get-in % [:tags :event-id])) alpha)
+          ":event-id filter narrows to one event-id"))
+    (let [beta (rf/trace-buffer {:event-id :ev/beta})]
+      (is (seq beta))
+      (is (every? #(= :ev/beta (get-in % [:tags :event-id])) beta)))))
+
+(deftest trace-buffer-filter-handler-id
+  (testing ":handler-id filters by :tags :handler-id"
+    ;; :rf.error/handler-exception carries :handler-id under :tags.
+    (rf/reg-event-db :ev/throws
+                     (fn [_db _] (throw (ex-info "boom" {}))))
+    (try
+      (rf/dispatch-sync [:ev/throws])
+      (catch Throwable _ nil))
+    (let [hits (rf/trace-buffer {:handler-id :ev/throws})]
+      (is (seq hits) "at least one event carries :handler-id :ev/throws")
+      (is (every? #(= :ev/throws (get-in % [:tags :handler-id])) hits)))))
+
+(deftest trace-buffer-filter-source
+  (testing ":source filters by top-level :source slot (hoisted from :tags)"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:source :repl})
+    (rf/dispatch-sync [:ping] {:source :timer})
+    (let [repl-evs (rf/trace-buffer {:source :repl})]
+      (is (seq repl-evs))
+      (is (every? #(= :repl (or (:source %) (get-in % [:tags :source])))
+                  repl-evs)
+          ":source filter matches top-level slot"))
+    (let [timer-evs (rf/trace-buffer {:source :timer})]
+      (is (seq timer-evs))
+      (is (every? #(= :timer (or (:source %) (get-in % [:tags :source])))
+                  timer-evs)))))
+
+(deftest trace-buffer-filter-origin
+  (testing ":origin filters by :tags :origin"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:origin :pair})
+    (rf/dispatch-sync [:ping] {:origin :story})
+    (let [pair-evs (rf/trace-buffer {:origin :pair})]
+      (is (seq pair-evs))
+      (is (every? #(= :pair (get-in % [:tags :origin])) pair-evs)
+          ":origin :pair narrows to pair-issued cascades"))
+    (let [story-evs (rf/trace-buffer {:origin :story})]
+      (is (seq story-evs))
+      (is (every? #(= :story (get-in % [:tags :origin])) story-evs)))))
+
+(deftest trace-buffer-filter-dispatch-id
+  (testing ":dispatch-id narrows to one cascade (rf2-g6ih4 cascade-wide tag)"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (rf/dispatch-sync [:ping])
+    (let [first-dispatch (->> (rf/trace-buffer)
+                              dispatched-events
+                              first)
+          target-id      (get-in first-dispatch [:tags :dispatch-id])
+          slice          (rf/trace-buffer {:dispatch-id target-id})]
+      (is (number? target-id))
+      (is (seq slice))
+      (is (every? #(= target-id (get-in % [:tags :dispatch-id])) slice)
+          "every event in the slice carries the same :dispatch-id"))))
+
+(deftest trace-buffer-filter-since-ms
+  (testing ":since-ms filters by :time host-clock millisecond bound"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (let [pre-time (-> (rf/trace-buffer) last :time)]
+      ;; Force a small delay so subsequent events have :time strictly >.
+      (Thread/sleep 5)
+      (rf/dispatch-sync [:ping])
+      (let [after (rf/trace-buffer {:since-ms pre-time})]
+        (is (seq after))
+        (is (every? #(> (:time %) pre-time) after)
+            ":since-ms keeps events strictly after the timestamp")))))
+
+(deftest trace-buffer-filter-between
+  (testing ":between [t0 t1] filters to a time window (inclusive)"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (let [t0 (-> (rf/trace-buffer) first :time)
+          t1 (-> (rf/trace-buffer) last  :time)
+          win (rf/trace-buffer {:between [t0 t1]})]
+      (is (seq win))
+      (is (every? #(<= t0 (:time %) t1) win)
+          "every event in the window falls in [t0, t1]"))
+    (testing ":between with a window that excludes everything yields []"
+      (let [win (rf/trace-buffer {:between [0 1]})]
+        (is (= [] win))))))
+
+(deftest trace-buffer-filter-pred
+  (testing ":pred applies an arbitrary predicate"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (let [errors-and-events (rf/trace-buffer {:pred (fn [ev]
+                                                      (#{:event :error}
+                                                       (:op-type ev)))})]
+      (is (seq errors-and-events))
+      (is (every? #(#{:event :error} (:op-type %)) errors-and-events)
+          ":pred narrows to events matching the predicate"))
+    (testing ":pred composes with named axes"
+      (let [evs (rf/trace-buffer {:op-type :event
+                                  :pred    (fn [ev]
+                                             (= :event/dispatched
+                                                (:operation ev)))})]
+        (is (every? #(and (= :event (:op-type %))
+                          (= :event/dispatched (:operation %)))
+                    evs))))))
+
+(deftest trace-buffer-filters-compose-and-wise
+  (testing "every filter axis composes; supplying many narrows further"
+    (rf/reg-event-db :ev/x (fn [db _] db))
+    (rf/dispatch-sync [:ev/x] {:origin :pair :source :repl})
+    ;; :event/dispatched carries :origin and :source (via top-level hoist)
+    ;; but NOT :event-id (it carries the full :event vector). :event-id
+    ;; lives on :event/db-changed and on error emits. Compose four axes
+    ;; that all coexist on :event/dispatched.
+    (let [evs (rf/trace-buffer {:op-type   :event
+                                :operation :event/dispatched
+                                :origin    :pair
+                                :source    :repl})]
+      (is (seq evs))
+      (is (every? #(and (= :event           (:op-type %))
+                        (= :event/dispatched (:operation %))
+                        (= :pair            (get-in % [:tags :origin]))
+                        (= :repl            (or (:source %)
+                                                (get-in % [:tags :source]))))
+                  evs)
+          "all four axes match simultaneously"))
+    (testing ":event-id composes with the other axes on :event/db-changed"
+      (let [evs (rf/trace-buffer {:operation :event/db-changed
+                                  :event-id  :ev/x
+                                  :origin    :pair})]
+        (is (every? #(and (= :event/db-changed (:operation %))
+                          (= :ev/x            (get-in % [:tags :event-id]))
+                          (= :pair            (get-in % [:tags :origin])))
+                    evs))))))
+
 ;; ---- 3. :origin opt --------------------------------------------------------
 
 (deftest origin-defaults-to-app

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -261,9 +261,31 @@ Contract:
 | API | Signature | Notes |
 |---|---|---|
 | `(rf/trace-buffer)` | `() → vector` | Returns the buffer's current contents, oldest-first. Empty when no events have been recorded. |
-| `(rf/trace-buffer opts)` | `(opts) → vector` | Optional filter: `{:operation kw}`, `{:op-type kw}`, `{:since trace-id}`, `{:frame frame-id}`. Filters compose. |
+| `(rf/trace-buffer opts)` | `(opts) → vector` | Optional filter map (see [§Filter vocabulary](#filter-vocabulary) below). Filters compose AND-wise; absent key = no constraint on that axis. |
 | `(rf/clear-trace-buffer!)` | `() → nil` | Empties the buffer. Tooling uses this between sessions. |
 | `(rf/configure :trace-buffer {:depth N})` | `(N) → nil` | Configure depth; default 200 events. `0` disables the ring buffer (synchronous delivery still works). |
+
+#### Filter vocabulary
+
+`(rf/trace-buffer opts)` recognises the following filter keys. All compose AND-wise; an absent key means "no constraint on that axis." Unrecognised keys are ignored (forward-compat: tools may probe new axes; missing support degrades to "no filter").
+
+| Key | Type | Semantics |
+|---|---|---|
+| `:operation` | keyword | Match exact `:operation` value (e.g. `:event/dispatched`, `:rf.fx/handled`). |
+| `:op-type` | keyword | Match exact `:op-type` discriminator (e.g. `:event`, `:fx`, `:error`). |
+| `:since` | number | Keep events whose `:id` is strictly greater than this. Cursor-based polling — read the last event's `:id`, pass on next call. |
+| `:frame` | keyword | Match `:tags :frame` (or top-level `:frame` fallback). |
+| `:severity` | `:error` / `:warning` / `:info` | Synonym for `:op-type` restricted to the three severity tiers. Use this when filtering for the issues feed. |
+| `:event-id` | keyword | Match `:tags :event-id` — the first element of the dispatched event vector (e.g. `:user/login`). Present on `:event/*`, `:rf.error/handler-exception`, `:event/db-changed`, and other event-scoped emits. |
+| `:handler-id` | keyword | Match `:tags :handler-id` — the registered handler's id. Present on handler-error emits. |
+| `:source` | `:ui` / `:timer` / `:http` / `:repl` / `:machine` / `:ssr-hydration` | Match the top-level `:source` slot (hoisted from `:tags :source` by `emit!`). Identifies the trigger origin. |
+| `:origin` | `:app` / `:pair` / `:story` / `:test` / ... | Match `:tags :origin` per [Spec 002 §Dispatch origin tagging](002-Frames.md). Lets tools filter "only my dispatches." |
+| `:dispatch-id` | number | Match `:tags :dispatch-id` — the cascade-wide correlation key. Post rf2-g6ih4, every emit inside a drain carries the in-flight cascade's id, so this filter narrows the buffer to one cascade. |
+| `:since-ms` | number | Keep events whose `:time` (host-clock ms) is strictly greater than this. Pair with the scrubber's "drag time-range" gesture. |
+| `:between` | `[t0 t1]` | Two-element vector — keep events whose `:time` falls in `[t0, t1]` inclusive. |
+| `:pred` | `(fn [ev] → truthy)` | Arbitrary predicate. Receives the full event map. Returning truthy keeps the event. Escape hatch for filters not yet promoted to named keys. |
+
+Filters compose AND-wise — supplying both `:op-type :error` and `:frame :tb/scope` keeps only error events on that frame.
 
 Semantics:
 

--- a/tools/10x/spec/010-MCP-Server.md
+++ b/tools/10x/spec/010-MCP-Server.md
@@ -75,7 +75,7 @@ agent observe, dispatch, time-travel, and inspect.
 
 | Tool | Mirrors Causa panel | Returns |
 |---|---|---|
-| `get-trace-buffer` | Trace timeline | A slice of the trace stream by filter (`:op-type`, `:operation`, `:frame`, `:dispatch-id`, `:origin`, time range). |
+| `get-trace-buffer` | Trace timeline | A slice of the trace stream by filter. Forwards directly to `(rf/trace-buffer opts)`; recognised filter keys are the canonical [Spec 009 §Filter vocabulary](../../../spec/009-Instrumentation.md#filter-vocabulary) — `:operation`, `:op-type`, `:since`, `:frame`, `:severity`, `:event-id`, `:handler-id`, `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`, `:pred`. |
 | `get-epoch-history` | Time-travel scrubber | Per-frame epoch history (vector of `:rf/epoch-record`). |
 | `get-app-db` | App-db inspector | Current value at a frame, optionally at a path. |
 | `get-app-db-diff` | App-db inspector (slice view) | The slice diff for a named epoch (`{:added [...] :modified [...] :removed [...]}`). |


### PR DESCRIPTION
## Summary

- Extend `(rf/trace-buffer opts)` with eight new filter axes: `:severity`, `:event-id`, `:handler-id`, `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`, `:pred`. All compose AND-wise with the existing `:operation` / `:op-type` / `:since` / `:frame` set. Closes consumer-side post-filtering today done by Story, Causa, and pair2.
- Spec 009 §Retain-N trace ring buffer gains a §Filter vocabulary subsection that locks each axis's semantics.
- Tools/10x MCP-Server spec cross-links to the canonical vocabulary so `get-trace-buffer` inherits the expanded axes automatically.

## Motivation

Per `ai/findings/trace-surface-consumer-audit-2026-05-13.md` Finding 3, every downstream consumer (Story `group-cascades`, Causa issues feed / causality-graph / schema-timeline, pair2 `epoch-matches?`) currently post-filters the buffer for axes the framework owns the data for. Lifting these into named filter keys lets each consumer issue narrow queries and drops three divergent post-filter implementations.

## Implementation

`trace-buffer`'s walk was already `filterv pred` with a composed `(and ...)` predicate — each new axis is one additional clause. Production elision behaviour is unchanged: the whole reader sits inside the existing `interop/debug-enabled?` gate.

Public filter map shape (Spec 009 §Filter vocabulary):

| Key | Type | Matched against |
|---|---|---|
| `:operation` | kw | `:operation` |
| `:op-type` | kw | `:op-type` |
| `:since` | num | `:id` (strictly greater) |
| `:frame` | kw | `:tags :frame` |
| `:severity` | `:error`/`:warning`/`:info` | `:op-type` (severity tier) |
| `:event-id` | kw | `:tags :event-id` |
| `:handler-id` | kw | `:tags :handler-id` |
| `:source` | kw | top-level `:source` slot |
| `:origin` | kw | `:tags :origin` |
| `:dispatch-id` | num | `:tags :dispatch-id` |
| `:since-ms` | num | `:time` (strictly greater) |
| `:between` | `[t0 t1]` | `:time` (inclusive range) |
| `:pred` | fn | full event map |

## Test plan

- [x] `clojure -M:test` (264 tests, 1187 assertions, 0/0)
- [x] `npm run test:cljs` (591 tests, 1401 assertions, 0/0)
- [x] `npm run test:browser` (591 tests, 1428 assertions, 0/0)
- [x] `npm run test:elision` PASS
- [x] `npm run test:examples` PASS (all examples)
- [x] `mkdocs build --strict` — pre-existing warnings only (no new ones from this change)
- [x] Nine new deftests in `trace_buffer_test.clj`, one per axis + compose-AND-wise

Bead: rf2-97ah0.