### PR TITLE
feat(template): dev ergonomics bundle — .editorconfig + .clj-kondo + plain CSS + dev/ + README sections (rf2-r2jqo)

### DIFF
--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -25,6 +25,19 @@ substrate-adapter wired against re-frame2, a host HTML page, a
 shadow-cljs build, and a worked counter mirroring
 [`examples/<substrate>/counter*/`](../../../examples/).
 
+The **canonical emit set** also includes the 2026-standard dev
+ergonomics:
+[`.editorconfig`](../src/clj/new/re_frame2/shared/editorconfig),
+a stub [`.clj-kondo/config.edn`](../src/clj/new/re_frame2/shared/clj-kondo/config.edn),
+a `dev/` tree
+([`dev/user.clj`](../src/clj/new/re_frame2/shared/dev/user.clj) for the JVM-side
+`(user/refresh)` workflow and
+[`dev/scratch.cljs`](../src/clj/new/re_frame2/shared/dev/scratch.cljs) for REPL-driven
+`(rf/dispatch …)` experiments), and a minimal plain stylesheet at
+[`resources/public/css/app.css`](../src/clj/new/re_frame2/shared/resources/public/css/app.css).
+Rationale: see
+[ai/findings re-frame2-template-design §6](../../../ai/findings/) (Mike-locked SHIP 2026-05-12).
+
 ## Lineage
 
 v1's `day8/re-frame-template` was a lein-template — the same posture,

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -15,16 +15,24 @@ my-app/
 ├── package.json              react + react-dom + shadow-cljs
 ├── README.md                 "run shadow-cljs watch app; open localhost:8280"
 ├── .gitignore
+├── .editorconfig             2-space, LF, trim trailing, final newline
+├── .clj-kondo/
+│   └── config.edn            empty default; lint rules slot in here
 ├── resources/public/
-│   └── index.html            host page; loads /js/main.js
+│   ├── index.html            host page; loads /js/main.js + /css/app.css
+│   └── css/app.css           three-rule plain stylesheet
 ├── src/my_app/
 │   ├── core.cljs             entry point — mounts the view
 │   ├── events.cljs           :counter/initialise, :counter/increment
 │   ├── subs.cljs             :counter/value
 │   └── views.cljs            the counter view
-└── test/my_app/
-    └── events_test.cljs      cljs.test deftest hitting the events ns
-                              under the plain-atom adapter
+├── test/my_app/
+│   └── events_test.cljs      cljs.test deftest hitting the events ns
+│                             under the plain-atom adapter
+└── dev/
+    ├── user.clj              JVM-side (user/refresh) workflow entry
+    └── scratch.cljs          REPL scratch ns for (rf/dispatch …)
+                              experiments against the running app
 ```
 
 `shadow-cljs.edn` ships `:source-paths ["src" "test"]` so the `:test`
@@ -68,11 +76,18 @@ tools/template/
     └── re_frame2/                        ; resource tree (Mustache templates)
         ├── shared/                       ; substrate-agnostic files
         │   ├── README.md
-        │   ├── gitignore
+        │   ├── gitignore                 ; emitted as .gitignore
+        │   ├── editorconfig              ; emitted as .editorconfig
+        │   ├── clj-kondo/
+        │   │   └── config.edn            ; emitted under .clj-kondo/
         │   ├── events.cljs
         │   ├── events_test.cljs
         │   ├── subs.cljs
-        │   └── index.html
+        │   ├── index.html
+        │   ├── dev/
+        │   │   ├── user.clj
+        │   │   └── scratch.cljs
+        │   └── resources/public/css/app.css
         ├── reagent/                      ; Reagent-specific
         │   ├── deps.edn
         │   ├── shadow-cljs.edn

--- a/tools/template/src/clj/new/re_frame2.clj
+++ b/tools/template/src/clj/new/re_frame2.clj
@@ -45,7 +45,9 @@
 ;; src/clj/new/re_frame2/<substrate>/ for substrate-specific files (the
 ;; views ns + the deps.edn / shadow-cljs.edn / package.json) and shares
 ;; the substrate-agnostic shell (events.cljs, subs.cljs, README.md,
-;; .gitignore, resources/public/index.html) from .../shared/.
+;; .gitignore, .editorconfig, .clj-kondo/config.edn, dev/user.clj,
+;; dev/scratch.cljs, resources/public/index.html,
+;; resources/public/css/app.css) from .../shared/.
 
 (def ^:private valid-substrates #{:reagent :uix :helix})
 
@@ -133,6 +135,14 @@
              ["package.json"    (sub-render (str substrate-name "/package.json"))]
              ["README.md"       (sub-render "shared/README.md")]
              [".gitignore"      (sub-raw    "shared/gitignore")]
+             ;; -- dev ergonomics (rf2-r2jqo) --
+             ;;
+             ;; Dotfile sources live without their leading dot on the
+             ;; classpath (clj-new's resource lookup chokes on hidden
+             ;; resources); we re-attach the dot on the output side.
+             [".editorconfig"   (sub-raw    "shared/editorconfig")]
+             [".clj-kondo/config.edn"
+              (sub-render "shared/clj-kondo/config.edn")]
              ;; -- src tree --
              ["src/{{nested-dirs}}/core.cljs"
               (sub-render (str substrate-name "/core.cljs"))]
@@ -152,6 +162,19 @@
              ;; also emits.
              ["test/{{nested-dirs}}/events_test.cljs"
               (sub-render "shared/events_test.cljs")]
-             ;; -- host HTML --
+             ;; -- dev tree (Q8 lock) --
+             ;;
+             ;; `dev/user.clj` — JVM-side `(user/refresh)` entry.
+             ;; `dev/scratch.cljs` — REPL scratch ns for firing
+             ;; (rf/dispatch …) against the running app. The `:shadow`
+             ;; alias in deps.edn puts `dev` on the classpath so both
+             ;; files are reachable from `clojure -M:shadow` and
+             ;; shadow's nREPL.
+             ["dev/user.clj"    (sub-render "shared/dev/user.clj")]
+             ["dev/scratch.cljs"
+              (sub-render "shared/dev/scratch.cljs")]
+             ;; -- host HTML + stylesheet --
              ["resources/public/index.html"
-              (sub-render "shared/index.html")])))
+              (sub-render "shared/index.html")]
+             ["resources/public/css/app.css"
+              (sub-raw    "shared/resources/public/css/app.css")])))

--- a/tools/template/src/clj/new/re_frame2/helix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/helix/deps.edn
@@ -24,6 +24,7 @@
   ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
   ;; shadow-cljs.edn is ignored when :deps is active).
   :shadow
-  {:extra-paths ["test"]
-   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+  {:extra-paths ["test" "dev"]
+   :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
    :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/helix/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/helix/shadow-cljs.edn
@@ -6,7 +6,7 @@
 ;;   :test — node-side test runner. Picks up any *_test.cljs file under
 ;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src" "test"]
+ :source-paths ["src" "test" "dev"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/src/clj/new/re_frame2/reagent/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/deps.edn
@@ -29,6 +29,7 @@
   ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
   ;; shadow-cljs.edn is ignored when :deps is active).
   :shadow
-  {:extra-paths ["test"]
-   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+  {:extra-paths ["test" "dev"]
+   :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
    :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/reagent/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/shadow-cljs.edn
@@ -6,7 +6,7 @@
 ;;   :test — node-side test runner. Picks up any *_test.cljs file under
 ;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src" "test"]
+ :source-paths ["src" "test" "dev"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/src/clj/new/re_frame2/shared/README.md
+++ b/tools/template/src/clj/new/re_frame2/shared/README.md
@@ -18,6 +18,28 @@ The first build does take a moment — shadow-cljs is downloading
 dependencies and compiling the ClojureScript. Subsequent rebuilds (on
 file save) are fast.
 
+## Hot reload
+
+`shadow-cljs watch` rebuilds on every file save and re-invokes
+`{{namespace}}.core/init` (the `:devtools/after-load` hook in
+`shadow-cljs.edn`). The entry fn is **idempotent**: re-frame2's
+`rf/init!` accepts being called repeatedly, the registrar
+re-registers in place, and `dispatch-sync [:counter/initialise]`
+re-seeds app-db.
+
+Under the hood re-frame2 guarantees a **per-frame re-init contract**:
+each call to `init!` on a frame snapshots the registrar, re-installs
+the adapter, and resets the frame's app-db to a known state — your
+handlers and subs come back wired to the new code without leaking
+state from the previous build. Add new `reg-event-db` / `reg-sub` /
+`reg-view` forms and they show up live; rename or remove a handler
+and the next reload drops the old registration.
+
+Stack traces in dev get click-to-source via the `:rf.trace/trigger-handler`
+preload (auto-wired when the re-frame-causa preload is on the
+classpath) — clicking a frame in the dev console jumps straight to
+the offending form.
+
 ## Build for release
 
 ```sh
@@ -26,6 +48,42 @@ npx shadow-cljs release app
 
 Production output lands in `resources/public/js/`. Serve `resources/public/`
 from any static host.
+
+## Production builds
+
+`shadow-cljs release` already sets `:closure-defines {goog.DEBUG false}` —
+asserts compile away, dev-only branches drop, the bundle shrinks. If
+you want to verify or override it, the explicit form is:
+
+```clojure
+;; shadow-cljs.edn :builds :app
+:release {:compiler-options {:closure-defines {goog.DEBUG false}}}
+```
+
+For production timing data, flip re-frame2's performance instrumentation
+on at compile time. Add this block alongside `:closure-defines` (it's
+off by default — turning it on costs a few cycles per dispatch):
+
+```clojure
+;; :compiler-options {:closure-defines {re-frame.performance/enabled? true}}
+```
+
+## REPL workflow
+
+Once `npx shadow-cljs watch app` is running, connect your editor to
+the shadow-cljs nREPL:
+
+- **Calva (VS Code):** `Calva: Connect to a Running REPL` →
+  `shadow-cljs` → pick the `:app` build.
+- **CIDER (Emacs):** `M-x cider-jack-in-cljs` → `shadow-cljs` →
+  `:app`.
+- **Cursive (IntelliJ):** add a `Clojure REPL → Remote` config
+  pointing at the nREPL port shadow-cljs prints on startup.
+
+shadow-cljs prints the nREPL port on its first line of output
+(default 7002 if you set `:nrepl {:port 7002}` in `shadow-cljs.edn`,
+or a randomly-assigned port otherwise). Once connected, evaluate
+forms in `dev/scratch.cljs` to drive the running app from the REPL.
 
 ## Run tests
 
@@ -51,15 +109,22 @@ alongside it as your app grows.
 ├── package.json             ; npm deps (react, react-dom, shadow-cljs runtime)
 ├── README.md                ; this file
 ├── .gitignore               ; CLJS standard
+├── .editorconfig            ; 2-space indent, LF, trim trailing whitespace
+├── .clj-kondo/
+│   └── config.edn           ; linter config (empty by default)
 ├── resources/public/
-│   └── index.html           ; host page; loads shadow-cljs's compiled output
+│   ├── index.html           ; host page; loads shadow-cljs's compiled output
+│   └── css/app.css          ; minimal plain CSS — body / button / h1
 ├── src/{{nested-dirs}}/
 │   ├── core.cljs            ; entry point — mounts the root view
 │   ├── events.cljs          ; `:counter/initialise`, `:counter/increment` handlers
 │   ├── subs.cljs            ; `:counter/value` subscription
 │   └── views.cljs           ; the counter view ({{substrate}})
-└── test/{{nested-dirs}}/
-    └── events_test.cljs     ; substrate-agnostic event-handler tests
+├── test/{{nested-dirs}}/
+│   └── events_test.cljs     ; substrate-agnostic event-handler tests
+└── dev/
+    ├── user.clj             ; JVM-side `(user/refresh)` entry
+    └── scratch.cljs         ; REPL scratch namespace for `(rf/dispatch …)` experiments
 ```
 
 ## What's in the scaffold

--- a/tools/template/src/clj/new/re_frame2/shared/clj-kondo/config.edn
+++ b/tools/template/src/clj/new/re_frame2/shared/clj-kondo/config.edn
@@ -1,0 +1,10 @@
+;; clj-kondo config for {{name}}.
+;;
+;; Empty for now — clj-kondo picks up sensible defaults and editor
+;; integrations (VS Code Calva, CIDER, IntelliJ Cursive) provide
+;; on-save linting. Add project-specific lint rules below as your
+;; app grows; the re-frame2-side macros (`reg-event-db`, `reg-sub`,
+;; `reg-view`, ...) are recognised by clj-kondo's built-in support
+;; for clojure.core-style defining forms — no hook lib required for
+;; the canonical counter shape.
+{}

--- a/tools/template/src/clj/new/re_frame2/shared/dev/scratch.cljs
+++ b/tools/template/src/clj/new/re_frame2/shared/dev/scratch.cljs
@@ -1,0 +1,26 @@
+(ns {{namespace}}.scratch
+  "Scratch namespace — REPL-driven exploration of the running app.
+
+   Connect your editor (Calva, CIDER, Cursive) to the shadow-cljs
+   nREPL after `npx shadow-cljs watch app`, then evaluate the
+   `(comment …)` forms below. Each call hits the same registrar /
+   frame the live UI is using — dispatches you fire here mutate the
+   app-db you see on screen."
+  (:require [re-frame.core :as rf]))
+
+(comment
+  ;; Fire the counter event a few times and watch the on-screen value
+  ;; tick up.
+  (rf/dispatch [:counter/increment])
+  (rf/dispatch [:counter/increment])
+
+  ;; Read the current value out of the default frame.
+  (rf/subscribe [:counter/value])
+
+  ;; Run a scratch experiment against a throw-away frame — leaves
+  ;; the live :rf/default frame untouched.
+  (rf/with-frame {:rf/id ::scratch}
+    (rf/dispatch-sync [:counter/initialise])
+    (rf/dispatch-sync [:counter/increment])
+    @(rf/subscribe [:counter/value]))
+  )

--- a/tools/template/src/clj/new/re_frame2/shared/dev/user.clj
+++ b/tools/template/src/clj/new/re_frame2/shared/dev/user.clj
@@ -1,0 +1,8 @@
+(ns user
+  "JVM-side REPL entry. `(user/refresh)` reloads changed namespaces
+   via clojure.tools.namespace; useful when iterating on event /
+   subscription handlers without restarting the shadow-cljs build."
+  (:require [clojure.tools.namespace.repl :as tn]))
+
+(defn refresh []
+  (tn/refresh))

--- a/tools/template/src/clj/new/re_frame2/shared/editorconfig
+++ b/tools/template/src/clj/new/re_frame2/shared/editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/tools/template/src/clj/new/re_frame2/shared/gitignore
+++ b/tools/template/src/clj/new/re_frame2/shared/gitignore
@@ -13,9 +13,12 @@ yarn-error.log
 /.idea/
 /.vscode/
 /.lsp/
-/.clj-kondo/
 /.cpcache/
 *.iml
+
+# clj-kondo cache (the config file itself is committed)
+/.clj-kondo/.cache/
+/.clj-kondo/.cache-version
 
 # OS
 .DS_Store

--- a/tools/template/src/clj/new/re_frame2/shared/index.html
+++ b/tools/template/src/clj/new/re_frame2/shared/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{name}} — re-frame2</title>
+    <link rel="stylesheet" href="/css/app.css">
   </head>
   <body>
     <div id="app"></div>

--- a/tools/template/src/clj/new/re_frame2/shared/resources/public/css/app.css
+++ b/tools/template/src/clj/new/re_frame2/shared/resources/public/css/app.css
@@ -1,0 +1,9 @@
+/* {{name}} — minimal stylesheet.
+ *
+ * Three rules. Plain CSS — no Tailwind, no garden, no spade. Replace
+ * or extend as your app grows; or swap to Tailwind via :css :tailwind
+ * when that template flag lands. */
+
+body { font: 16px/1.4 system-ui, sans-serif; margin: 2em; }
+button { padding: 0.4em 0.8em; }
+h1 { margin: 0 0 1em; }

--- a/tools/template/src/clj/new/re_frame2/uix/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/uix/deps.edn
@@ -26,6 +26,7 @@
   ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
   ;; shadow-cljs.edn is ignored when :deps is active).
   :shadow
-  {:extra-paths ["test"]
-   :extra-deps  {thheller/shadow-cljs {:mvn/version "{{shadow-version}}"}}
+  {:extra-paths ["test" "dev"]
+   :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
    :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/tools/template/src/clj/new/re_frame2/uix/shadow-cljs.edn
+++ b/tools/template/src/clj/new/re_frame2/uix/shadow-cljs.edn
@@ -6,7 +6,7 @@
 ;;   :test — node-side test runner. Picks up any *_test.cljs file under
 ;;           test/ and runs it via cljs.test.
 {:deps   {:aliases [:shadow]}
- :source-paths ["src" "test"]
+ :source-paths ["src" "test" "dev"]
 
  :dev-http {8280 "resources/public"}
 

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -98,7 +98,13 @@
    "package.json"
    "README.md"
    ".gitignore"
-   "resources/public/index.html"])
+   ;; Dev ergonomics bundle (rf2-r2jqo).
+   ".editorconfig"
+   ".clj-kondo/config.edn"
+   "dev/user.clj"
+   "dev/scratch.cljs"
+   "resources/public/index.html"
+   "resources/public/css/app.css"])
 
 (def ^:private per-substrate-sources
   ;; Generated under src/<nested-dirs>/ and test/<nested-dirs>/. For


### PR DESCRIPTION
## Summary

Bundles the 2026-standard dev ergonomics into every generated re-frame2 app per the template walkthrough §6 locks (2026-05-12 SHIP) and the Q8 `dev/` layout decision.

- Five new emit files: `.editorconfig`, `.clj-kondo/config.edn`, `resources/public/css/app.css`, `dev/user.clj`, `dev/scratch.cljs`.
- README adds **Hot reload** (init! idempotency + per-frame re-init contract + Causa click-to-source pointer), **Production builds** (`goog.DEBUG`/performance closure-defines), and **REPL workflow** (Calva / CIDER / Cursive + nREPL port).
- Entry fn `src/clj/new/re_frame2.clj` wires all five via `->files`; each substrate's `deps.edn` adds `dev` to the `:shadow` alias classpath and pulls in `org.clojure/tools.namespace`; `index.html` now links `/css/app.css`; `shared/gitignore` narrowed to `.clj-kondo/.cache/*` so the committed config isn't masked.
- Spec docs `000-Vision.md` and `002-Generated-Shape.md` updated; test suite `common-files` extended.

## Test plan

- [x] `clojure -M:test` — 5 tests / 83 assertions, 0 failures across Reagent / UIx / Helix
- [x] Fresh scaffold via `clj-new/create` emits all five new files at the right paths
- [x] `mkdocs build --strict` — no new warnings attributable to template-spec edits (the 5 added warnings on the branch are pre-existing `guide/08-state-machines.md` link issues unrelated to this change)
- [x] No AI attribution; pre-alpha; `ai/` + `findings/` + `decision-beads.md` untouched