### PR TITLE
feat(trace): lift group-cascades to framework re-frame.trace.projection; Story consumes the shared projection (rf2-wvzgd)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -45,6 +45,7 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.interop :as interop]
             [re-frame.trace :as trace]
+            [re-frame.trace.projection :as trace-projection]
             [re-frame.substrate.adapter :as adapter]
             ;; Optional-artefact wrappers (rf2-hoiu). Each ns wraps a
             ;; per-feature Maven artefact and looks the producing fns
@@ -891,6 +892,13 @@
 (def emit-trace!         trace/emit!)
 (def trace-buffer        trace/trace-buffer)
 (def clear-trace-buffer! trace/clear-trace-buffer!)
+
+;; Per rf2-wvzgd: cascade projection. Pure-data fn lifted from Story's
+;; trace panel; consumed by Story (`tools/story/src/re_frame/story/ui/
+;; trace.cljs`), and (when impl lands) Causa (rf2-5aw5v) and pair2's
+;; `cascade-of`. CLJC for JVM-side testability.
+(def group-cascades      trace-projection/group-cascades)
+(def domino-bucket       trace-projection/domino-bucket)
 
 ;; ---- epoch history (Tool-Pair §Time-travel) ------------------------------
 

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -1,0 +1,184 @@
+(ns re-frame.trace.projection
+  "Six-domino cascade projection over the raw trace event stream.
+
+  Per Spec 009 §Subscription / consumption, the trace stream is
+  event-at-a-time. Pair-shaped tools (Story's trace panel, Causa's
+  event-detail panel and causality graph, re-frame-pair2's
+  `cascade-of`) all want the same higher-level shape — one row per
+  cascade with the six-domino slots already populated. This namespace
+  ships that projection as a pure data function so each tool can stop
+  re-implementing it.
+
+  The projection is **pure data** — no atoms, no interop, no reagent.
+  Runs on the JVM, the JVM-CLJS REPL, and in production traces lifted
+  out of a session. The function is the only correlation primitive
+  consumers need above the raw stream for the common 'render this
+  cascade as six dominoes' use case.
+
+  Per rf2-g6ih4 (cascade-wide `:dispatch-id`) the projection is robust
+  against events that the framework emits *inside* a drain even though
+  they aren't `:event/dispatched` — fx invocations, sub-runs, renders,
+  errors. Every such event now carries `:tags :dispatch-id` so the
+  group-by below assembles a complete cascade record.
+
+  ## Bucketing (per Spec 009 §`:op-type` vocabulary)
+
+  Six dominoes:
+
+    1. `:event`    — `:op-type :event` + `:operation :event/dispatched`
+                     (cascade-root marker; bucket value is the event vector)
+    2. `:handler`  — `:op-type :event` + `:operation :event`
+                     (the handler ran; tags carry `:phase :run-start` / `:run-end`)
+    3. `:fx`       — `:op-type :event` + `:operation :event/do-fx`
+                     (effects map computed and about to be walked)
+    4. `:effect`   — `:op-type :fx` (any `:operation` — `:rf.fx/handled`,
+                     `:rf.fx/override-applied`, `:rf.fx/skipped-on-platform`)
+    5. `:sub`      — `:op-type :sub/run` or `:sub/create`
+    6. `:render`   — `:op-type :view` + `:operation :view/render`
+
+  Events whose op-type/operation pair doesn't fit any bucket flow
+  through `:other` so the cascade-record shape is fully accountable to
+  the input — `(reduce + 0 (map #(+ (count (:effects %)) ...) ...))`
+  equals the input event count when every event is grouped.
+
+  ## Future hooks
+
+  - Causa (rf2-5aw5v) will consume `group-cascades` in its event-detail
+    panel and causality-graph node renderer; the `:ungrouped` slot covers
+    free-floating traces (e.g. registry events emitted at app boot).
+  - re-frame-pair2's `cascade-of` MCP op currently walks
+    `:event/dispatched` traces in a slimmer form; it migrates to this
+    projection so 'show me every fx in this cascade' becomes one slice
+    of the returned record.")
+
+;; ---- bucketing ------------------------------------------------------------
+
+(def ^:private effect-op-types
+  "Op-types that classify as the fourth domino — fx invocation. The
+  framework emits `:op-type :fx` for every fx handler invocation
+  (`:rf.fx/handled`), every override (`:rf.fx/override-applied`), and
+  every platform-skip (`:rf.fx/skipped-on-platform`)."
+  #{:fx})
+
+(def ^:private sub-op-types
+  "Op-types that classify as the fifth domino — subscription work.
+  `:sub/run` is the recompute path; `:sub/create` is the first-time
+  signal-graph build."
+  #{:sub/run :sub/create})
+
+(defn domino-bucket
+  "Classify a trace event into one of the six domino buckets.
+
+  Returns one of `#{:event :handler :fx :effect :sub :render :other}`.
+  `:other` is returned for events that don't fit a domino slot (errors,
+  warnings, machine transitions, frame lifecycle, flows — every event
+  Spec 009 documents that is **not** part of the six-domino cascade).
+
+  The classification is total: every input maps to exactly one bucket."
+  [{:keys [op-type operation]}]
+  (cond
+    (= op-type :event)
+    (case operation
+      :event/dispatched :event
+      :event            :handler
+      :event/do-fx      :fx
+      :other)
+
+    (contains? effect-op-types op-type) :effect
+    (contains? sub-op-types op-type)    :sub
+
+    (and (= op-type :view) (= operation :view/render)) :render
+
+    :else :other))
+
+;; ---- cascade record -------------------------------------------------------
+
+(def ^:private empty-cascade
+  "Slot template for a cascade record. Per-cascade reduction starts here;
+  every key the consumer can rely on lives in the template."
+  {:dispatch-id nil
+   :event       nil
+   :handler     nil
+   :fx          nil
+   :effects     []
+   :subs        []
+   :renders     []
+   :other       []})
+
+(defn- cascade-id
+  "Extract the cascade identifier from an event. Per Spec 009 §Dispatch
+  correlation, `:dispatch-id` is cascade-wide. For `:event/dispatched`
+  events, `:parent-dispatch-id` documents inter-cascade lineage; for
+  pair-shaped tools assembling 'the cascade caused by THAT dispatch',
+  the event's own `:dispatch-id` is the right key (the
+  `:event/dispatched` event rides under its own cascade's id). Events
+  outside any drain (registry-time, frame-creation) carry no
+  `:dispatch-id` — they land in the `:ungrouped` bucket."
+  [ev]
+  (or (get-in ev [:tags :dispatch-id])
+      :ungrouped))
+
+(defn- absorb
+  "Fold one trace event into the per-cascade accumulator."
+  [acc ev]
+  (case (domino-bucket ev)
+    :event   (assoc acc :event (get-in ev [:tags :event]))
+    :handler (assoc acc :handler ev)
+    :fx      (assoc acc :fx ev)
+    :effect  (update acc :effects conj ev)
+    :sub     (update acc :subs conj ev)
+    :render  (update acc :renders conj ev)
+    :other   (update acc :other conj ev)))
+
+(defn- first-id
+  "Lowest `:id` among the cascade's events, or `##Inf` when no event
+  carries an id. Used for sorting cascades into emission order."
+  [{:keys [event handler fx effects subs renders other]}]
+  (let [all (concat (when handler [handler])
+                    (when fx [fx])
+                    effects subs renders other)
+        ids (keep :id all)]
+    (if (seq ids)
+      (apply min ids)
+      ;; Sentinel for cascades with no event carrying an id — sort to
+      ;; the end. Use a number-shaped value larger than any practical
+      ;; per-process trace id; CLJS-portable (no Long/MAX_VALUE).
+      #?(:clj  Long/MAX_VALUE
+         :cljs js/Number.MAX_SAFE_INTEGER))))
+
+(defn group-cascades
+  "Project a sequence of raw trace events into one cascade record per
+  `:dispatch-id`. Pure data — JVM and CLJS.
+
+  Returns a vector of maps shaped:
+
+      {:dispatch-id <cascade-id-or-:ungrouped>
+       :event       <event-vector or nil>     ;; from :event/dispatched
+       :handler     <trace-event or nil>      ;; the :run-end emit (last wins)
+       :fx          <trace-event or nil>      ;; :event/do-fx
+       :effects     [<trace-event> ...]       ;; :op-type :fx
+       :subs        [<trace-event> ...]       ;; :sub/run + :sub/create
+       :renders     [<trace-event> ...]       ;; :view/render
+       :other       [<trace-event> ...]}      ;; everything else
+                                              ;;   (errors, warnings,
+                                              ;;   machine, frame,
+                                              ;;   flow, etc.)
+
+  Events without a `:dispatch-id` (registry-time emits, frame
+  lifecycle outside a drain, REPL evals) collect under
+  `:dispatch-id :ungrouped`. The returned vector is sorted by the
+  lowest `:id` in each cascade, so cascades render in emission order.
+
+  Stable / additive: future framework op-types that don't fit a
+  domino slot will surface under `:other` automatically. Tools that
+  want richer projections of `:other` can call `domino-bucket`
+  directly on each event."
+  [events]
+  (let [groups (group-by cascade-id events)]
+    (->> groups
+         (map (fn [[dispatch-id evs]]
+                (reduce absorb
+                        (assoc empty-cascade :dispatch-id dispatch-id)
+                        evs)))
+         (sort-by first-id)
+         vec)))

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -1,0 +1,155 @@
+(ns re-frame.trace.projection-test
+  "Tests for `re-frame.trace.projection/group-cascades` +
+  `domino-bucket`. Pure-data — no fixture, no frame, no router; JVM and
+  CLJS run the same suite.
+
+  Per rf2-wvzgd: the projection was lifted from Story's trace panel.
+  The original Story version used synthetic op-types (`:event/do-fx`,
+  `:fx`, `:view/render` as op-type rather than operation) and the
+  invented `:event/run` operation; this rewrite tracks the
+  framework's actual trace surface per Spec 009 §`:op-type`
+  vocabulary."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.trace.projection :as p]))
+
+;; ---- domino-bucket --------------------------------------------------------
+
+(deftest domino-bucket-classifies-event-ops
+  (testing ":event/dispatched buckets as :event (cascade root)"
+    (is (= :event
+           (p/domino-bucket {:op-type :event :operation :event/dispatched}))))
+  (testing ":event :event buckets as :handler (the interceptor chain ran)"
+    (is (= :handler
+           (p/domino-bucket {:op-type :event :operation :event}))))
+  (testing ":event :event/do-fx buckets as :fx (effects map computed)"
+    (is (= :fx
+           (p/domino-bucket {:op-type :event :operation :event/do-fx}))))
+  (testing ":event :event/db-changed lands in :other (not a six-domino slot)"
+    (is (= :other
+           (p/domino-bucket {:op-type :event :operation :event/db-changed})))))
+
+(deftest domino-bucket-classifies-fx-as-effects
+  (testing "every :op-type :fx event — :rf.fx/handled, override-applied, etc. — buckets as :effect"
+    (is (= :effect (p/domino-bucket {:op-type :fx :operation :rf.fx/handled})))
+    (is (= :effect (p/domino-bucket {:op-type :fx :operation :rf.fx/override-applied})))
+    (is (= :effect (p/domino-bucket {:op-type :fx :operation :rf.fx/skipped-on-platform})))))
+
+(deftest domino-bucket-classifies-sub-ops
+  (testing "both :sub/run and :sub/create bucket as :sub"
+    (is (= :sub (p/domino-bucket {:op-type :sub/run    :operation :sub/run})))
+    (is (= :sub (p/domino-bucket {:op-type :sub/create :operation :sub/create})))))
+
+(deftest domino-bucket-classifies-view-render
+  (testing ":op-type :view + :operation :view/render buckets as :render"
+    (is (= :render
+           (p/domino-bucket {:op-type :view :operation :view/render})))))
+
+(deftest domino-bucket-non-domino-events-fall-through-to-other
+  (testing "events outside the six-domino vocabulary land in :other"
+    (is (= :other (p/domino-bucket {:op-type :error :operation :rf.error/no-such-handler})))
+    (is (= :other (p/domino-bucket {:op-type :warning :operation :rf.warning/interceptors-in-metadata-map})))
+    (is (= :other (p/domino-bucket {:op-type :machine :operation :rf.machine/transition})))
+    (is (= :other (p/domino-bucket {:op-type :frame :operation :frame/created})))
+    (is (= :other (p/domino-bucket {:op-type :flow :operation :rf.flow/computed})))
+    (is (= :other (p/domino-bucket {:op-type :registry :operation :rf.registry/handler-registered})))))
+
+(deftest domino-bucket-total-on-arbitrary-shapes
+  (testing "the classification is total; an unknown op-type/operation pair returns :other"
+    (is (= :other (p/domino-bucket {:op-type :totally-made-up :operation :nope})))
+    (is (= :other (p/domino-bucket {})))))
+
+;; ---- group-cascades -------------------------------------------------------
+
+(defn- cascade-evs
+  "Produce a representative one-cascade event stream."
+  [dispatch-id event-vec]
+  [{:id 1 :op-type :event    :operation :event/dispatched
+    :tags {:dispatch-id dispatch-id :event event-vec}}
+   {:id 2 :op-type :event    :operation :event
+    :tags {:dispatch-id dispatch-id :phase :run-start}}
+   {:id 3 :op-type :event    :operation :event
+    :tags {:dispatch-id dispatch-id :phase :run-end}}
+   {:id 4 :op-type :event    :operation :event/do-fx
+    :tags {:dispatch-id dispatch-id}}
+   {:id 5 :op-type :fx       :operation :rf.fx/handled
+    :tags {:dispatch-id dispatch-id :fx-id :db}}
+   {:id 6 :op-type :fx       :operation :rf.fx/handled
+    :tags {:dispatch-id dispatch-id :fx-id :dispatch}}
+   {:id 7 :op-type :sub/run  :operation :sub/run
+    :tags {:dispatch-id dispatch-id :sub-id :sub/foo}}
+   {:id 8 :op-type :view     :operation :view/render
+    :tags {:dispatch-id dispatch-id :render-key [:app/root nil]}}])
+
+(deftest group-cascades-one-cascade-six-buckets
+  (testing "a representative cascade reduces to one record with the six
+            domino slots populated"
+    (let [evs (cascade-evs 100 [:user/login {:id 42}])
+          [c & more] (p/group-cascades evs)]
+      (is (empty? more) "single cascade yields one record")
+      (is (= 100 (:dispatch-id c)))
+      (is (= [:user/login {:id 42}] (:event c)) ":event slot is the dispatched event vector")
+      (is (some? (:handler c)) ":handler slot is populated by the :run-* emit")
+      (is (some? (:fx c))      ":fx slot is the :event/do-fx emit")
+      (is (= 2 (count (:effects c))) "both :rf.fx/handled events land in :effects")
+      (is (= 1 (count (:subs c))))
+      (is (= 1 (count (:renders c))))
+      (is (= [] (:other c))    ":other is empty for a clean cascade"))))
+
+(deftest group-cascades-multiple-cascades-sorted-by-first-id
+  (testing "with two cascades interleaved, group-cascades emits them in
+            emission order (lowest :id first)"
+    (let [a (cascade-evs 200 [:a])
+          b (mapv #(update % :id + 100) (cascade-evs 300 [:b]))
+          ;; interleave: ids in :a are 1-8; :b are 101-108
+          evs (interleave a b)
+          cs  (p/group-cascades evs)]
+      (is (= 2 (count cs)))
+      (is (= 200 (:dispatch-id (first cs))))
+      (is (= 300 (:dispatch-id (second cs)))))))
+
+(deftest group-cascades-events-without-dispatch-id-land-in-ungrouped
+  (testing "events emitted outside any drain (registry-time, frame
+            lifecycle) carry no :dispatch-id and group under :ungrouped"
+    (let [evs [{:id 1 :op-type :frame :operation :frame/created :tags {:frame :app}}
+               {:id 2 :op-type :registry :operation :rf.registry/handler-registered
+                :tags {:kind :event :id :user/login}}]
+          cs (p/group-cascades evs)]
+      (is (= 1 (count cs)))
+      (is (= :ungrouped (:dispatch-id (first cs))))
+      (is (= 2 (count (:other (first cs))))
+          "frame and registry events both flow through :other"))))
+
+(deftest group-cascades-error-and-warning-events-ride-along-in-other
+  (testing "an error fired inside a cascade lands in that cascade's
+            :other slot, not as its own cascade (per rf2-g6ih4
+            :dispatch-id rides every event)"
+    (let [evs (conj (cascade-evs 400 [:foo])
+                    {:id 100 :op-type :error :operation :rf.error/handler-exception
+                     :tags {:dispatch-id 400 :event-id :foo}})
+          [c] (p/group-cascades evs)]
+      (is (= 400 (:dispatch-id c)))
+      (is (= 1 (count (:other c)))
+          "the error event lands in :other, not a sibling :ungrouped cascade"))))
+
+(deftest group-cascades-handler-slot-takes-last-event-emit
+  (testing "when the chain emits :run-start + :run-end the :handler slot
+            ends up as the :run-end event (reduce overwrites)"
+    (let [evs (cascade-evs 500 [:foo])
+          [c] (p/group-cascades evs)]
+      (is (= :run-end (get-in c [:handler :tags :phase]))))))
+
+(deftest group-cascades-empty-input-yields-empty-output
+  (is (= [] (p/group-cascades [])))
+  (is (= [] (p/group-cascades nil))))
+
+(deftest group-cascades-shape-is-stable
+  (testing "every cascade record carries the documented keys with
+            collection-shaped defaults"
+    (let [[c] (p/group-cascades [{:id 1 :op-type :event :operation :event/dispatched
+                                  :tags {:dispatch-id 1 :event [:e]}}])]
+      (is (= #{:dispatch-id :event :handler :fx :effects :subs :renders :other}
+             (set (keys c))))
+      (is (vector? (:effects c)))
+      (is (vector? (:subs c)))
+      (is (vector? (:renders c)))
+      (is (vector? (:other c))))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -244,6 +244,32 @@ Alongside the raw trace stream, the framework exposes a parallel **assembled-epo
 
 The two listener APIs are independent: tools may register either, both, or neither. They share the production-elision gate but have separate listener registries; no listener of one kind can interfere with the other.
 
+### Cascade projection (`group-cascades` / `domino-bucket`)
+
+The raw trace stream is event-at-a-time; pair-shaped UIs (the Story trace panel, the planned Causa event-detail panel, re-frame-pair2's `cascade-of`) all want the **six-domino slice** of the stream — one record per cascade with the event vector, handler emit, fx-map emit, effects, sub-runs, and renders already split into named slots. The framework ships that projection as a pure-data function in `re-frame.trace.projection`, re-exported from `re-frame.core`:
+
+```clojure
+(rf/group-cascades trace-events)
+;; -> [{:dispatch-id <id-or-:ungrouped>
+;;      :event       <event-vector | nil>   ;; from :event/dispatched
+;;      :handler     <trace-event | nil>    ;; the :op-type :event / :operation :event emit
+;;      :fx          <trace-event | nil>    ;; :event/do-fx
+;;      :effects     [<trace-event> ...]    ;; :op-type :fx — :rf.fx/handled, override-applied, …
+;;      :subs        [<trace-event> ...]    ;; :sub/run + :sub/create
+;;      :renders     [<trace-event> ...]    ;; :op-type :view / :operation :view/render
+;;      :other       [<trace-event> ...]}   ;; errors, warnings, machines, frames, flows,
+;;                                          ;;   registry, anything outside the six dominoes
+;;     ...]
+```
+
+Events without a `:dispatch-id` (registry-time emits, frame lifecycle, REPL evals outside a drain) collect under `:dispatch-id :ungrouped`. The returned vector is sorted by the lowest `:id` in each cascade so consumers render cascades in emission order. The projection is **pure data** — JVM and CLJS run the same code; tools wiring up post-mortem renders against `(rf/trace-buffer)` get the same output shape as live consumers reading from a `register-trace-cb!` listener.
+
+`(rf/domino-bucket trace-event)` is the underlying classifier — returns one of `#{:event :handler :fx :effect :sub :render :other}`. Tools that want custom rollups can call it directly per event and skip `group-cascades`.
+
+Per rf2-g6ih4 (cascade-wide `:dispatch-id`) the projection is robust against errors, fx, sub-runs, and renders that fire *inside* a drain even though they aren't `:event/dispatched` — every such event carries `:tags :dispatch-id` so they group into the cascade record automatically.
+
+The projection is additive: new `:op-type` values that don't fit a domino slot flow through `:other` without breaking existing consumers.
+
 ### Listener invocation rules
 
 - **Synchronous, event-at-a-time.** Every registered listener is invoked once per emitted trace event, on the runtime's emit call stack. There is no batching, debounce window, or background delivery loop. Listeners SHOULD return quickly; expensive work belongs on a tool-owned timer or rAF.

--- a/spec/API.md
+++ b/spec/API.md
@@ -357,6 +357,8 @@ All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Inst
 | `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | 009 |
 | `clear-trace-buffer!` | Fn | `(clear-trace-buffer!)` → nil | v1 (dev-only) | 009 |
 | `(rf/configure :trace-buffer {:depth N})` | — | See [§Configure keys](#configure-keys). | v1 (dev-only) | 009 |
+| `group-cascades` | Fn | `(group-cascades events)` → vector of cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. Pure data; JVM-runnable. Re-exported from `re-frame.trace.projection` (see [009 §Cascade projection](009-Instrumentation.md#cascade-projection-group-cascades--domino-bucket)). | v1 (dev-only) | 009 |
+| `domino-bucket` | Fn | `(domino-bucket trace-event)` → `#{:event :handler :fx :effect :sub :render :other}`. Classifies a raw trace event into the six-domino slot used by `group-cascades`. Pure data. | v1 (dev-only) | 009 |
 
 ### Epoch history (per Tool-Pair)
 

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -37,6 +37,7 @@
   trace panel, so trace capture only runs while the panel is visible."
   (:require [reagent.core :as r]
             [re-frame.trace :as trace]
+            [re-frame.trace.projection :as projection]
             [re-frame.story.config :as config]))
 
 ;; ---- the per-variant trace buffer ----------------------------------------
@@ -123,59 +124,17 @@
     nil))
 
 ;; ---- six-domino projection -----------------------------------------------
+;;
+;; Per rf2-wvzgd the bucketing + group-by logic lives in
+;; `re-frame.trace.projection` so Story, Causa, and pair2 all consume
+;; the same pure-data projection. Story previously carried its own
+;; copy here with two latent bugs (an invented `:event/run` operation
+;; and op-type/operation confusion on the fx, sub, view emits); the
+;; framework version tracks Spec 009's actual op-type vocabulary and
+;; surfaces non-six-domino events under `:other`.
 
-(defn- domino-bucket
-  "Classify a trace event into one of the six domino buckets, or nil if
-  the event doesn't fit. Returns a keyword in
-  `#{:event :handler :fx :effect :sub :render}`."
-  [ev]
-  (case (:op-type ev)
-    :event      (case (:operation ev)
-                  :event/dispatched :event
-                  :event/run        :handler
-                  nil)
-    :event/do-fx :fx
-    :fx          :effect
-    :sub/run     :sub
-    :sub/create  :sub
-    :view/render :render
-    nil))
-
-(defn group-cascades
-  "Group `events` by `:dispatch-id` and project each cascade into a
-  `{:dispatch-id ... :event <vec> :handler <ev> :fx <ev> :effects [...]
-   :subs [...] :renders [...]}` map. Public for JVM-side unit testing —
-  the bucketing is pure data.
-
-  Events without a `:dispatch-id` (e.g. raw render events not yet tied
-  to a cascade) land in a `:ungrouped` slot."
-  [events]
-  (let [groups (group-by (fn [ev] (or (get-in ev [:tags :dispatch-id])
-                                      (get-in ev [:tags :parent-dispatch-id])
-                                      :ungrouped))
-                         events)]
-    (->> groups
-         (map (fn [[dispatch-id evs]]
-                (reduce
-                  (fn [acc ev]
-                    (case (domino-bucket ev)
-                      :event   (assoc acc :event (get-in ev [:tags :event]))
-                      :handler (assoc acc :handler ev)
-                      :fx      (assoc acc :fx ev)
-                      :effect  (update acc :effects (fnil conj []) ev)
-                      :sub     (update acc :subs (fnil conj []) ev)
-                      :render  (update acc :renders (fnil conj []) ev)
-                      acc))
-                  {:dispatch-id dispatch-id
-                   :event       nil
-                   :handler     nil
-                   :fx          nil
-                   :effects     []
-                   :subs        []
-                   :renders     []}
-                  evs)))
-         (sort-by (fn [{:keys [handler]}] (or (:id handler) 0)))
-         vec)))
+;; Re-export for backwards-compat for any in-tree consumer.
+(def group-cascades projection/group-cascades)
 
 ;; ---- styling -------------------------------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -232,19 +232,25 @@
 ;; ---- trace six-domino projection ----------------------------------------
 
 (deftest trace-group-cascades-classifies
-  (testing "group-cascades splits trace events into six-domino slots"
+  (testing "group-cascades splits trace events into six-domino slots.
+            Per rf2-wvzgd the projection now lives in
+            `re-frame.trace.projection`; Story exposes the same fn
+            under `re-frame.story.ui.trace/group-cascades` for callers
+            wired to that namespace. Event shapes here track the
+            framework's actual emit pattern per Spec 009 §`:op-type`
+            vocabulary."
     (let [evs       [{:op-type :event :operation :event/dispatched
                       :id 1 :tags {:dispatch-id 100 :event [:foo]}}
-                     {:op-type :event :operation :event/run
-                      :id 2 :tags {:dispatch-id 100 :duration-ms 3}}
-                     {:op-type :event/do-fx
-                      :id 3 :tags {:dispatch-id 100 :fx {:db {}}}}
-                     {:op-type :fx
+                     {:op-type :event :operation :event
+                      :id 2 :tags {:dispatch-id 100 :phase :run-end}}
+                     {:op-type :event :operation :event/do-fx
+                      :id 3 :tags {:dispatch-id 100}}
+                     {:op-type :fx :operation :rf.fx/handled
                       :id 4 :tags {:dispatch-id 100 :fx-id :db}}
-                     {:op-type :sub/run
-                      :id 5 :tags {:dispatch-id 100 :id :sub/foo}}
-                     {:op-type :view/render
-                      :id 6 :tags {:dispatch-id 100 :view :app/root}}]
+                     {:op-type :sub/run :operation :sub/run
+                      :id 5 :tags {:dispatch-id 100 :sub-id :sub/foo}}
+                     {:op-type :view :operation :view/render
+                      :id 6 :tags {:dispatch-id 100 :render-key [:app/root nil]}}]
           cascades  (trace/group-cascades evs)]
       (is (= 1 (count cascades)))
       (let [c (first cascades)]


### PR DESCRIPTION
## Summary

- Lift Story's six-domino cascade projection (`group-cascades` + `domino-bucket`) into a new framework namespace `re-frame.trace.projection` (CLJC, JVM-runnable). Pure-data fn — same shape three downstream consumers want: Story's trace panel, Causa's planned event-detail panel and causality-graph node renderer (rf2-5aw5v, spec-only today), and re-frame-pair2's `cascade-of` MCP op.
- Re-export `rf/group-cascades` and `rf/domino-bucket` from `re-frame.core`. Story consumes the lifted version; the local impl is replaced by a same-named re-export for compat.
- Bugfix vs the Story original: the bucket fn now tracks the framework's actual emit pattern per Spec 009 §`:op-type` vocabulary. The Story version classified on a `:operation :event/run` that the runtime never emits and mis-routed fx / sub / view events through op-type discrimination on values that are actually operations (`:event/do-fx`, `:view/render`) or op-types (`:fx`, `:sub/run`). Events outside the six-domino vocabulary now flow through a new `:other` slot so the bucket fn is total.
- Per rf2-g6ih4 (cascade-wide `:dispatch-id`, landed in #484), every trace event emitted *inside* a drain — handler, fx, sub-runs, renders, errors — carries the cascade's id, so `group-cascades` yields a complete cascade record without inference from sequence.
- Spec 009 gains a new §Cascade projection subsection; API.md documents the two new public fns.

## Test plan

- [x] New `re-frame.trace.projection-test` (13 tests / 43 assertions, CLJC) covers bucketing per op-type, cascade grouping, error-events riding along in `:other`, sort order, ungrouped slot, and shape stability.
- [x] All 267 JVM tests pass (`clojure -M:test` in `implementation/core/`).
- [x] All 591 CLJS node-tests pass (`npm run test:cljs` in `implementation/`).
- [x] Story's existing `story-ui-cljs-test` updated to use the framework's actual emit shape; passes.
- [x] No new `mkdocs build --strict` warnings vs main.

## Future hooks

- Causa (rf2-5aw5v) will consume `group-cascades` in its event-detail panel and causality-graph node renderer when impl ships.
- re-frame-pair2's `cascade-of` migrates to consume the projection when the `:dispatch-id`-cascade-wide trace surface stabilises.