### PR TITLE
feat(pair2): snapshot mega-op — coarse-grained per-frame state read in one round-trip (rf2-x70e)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -19,6 +19,7 @@ allowed-tools:
   - mcp__re-frame-pair2__trace-window
   - mcp__re-frame-pair2__watch-epochs
   - mcp__re-frame-pair2__tail-build
+  - mcp__re-frame-pair2__snapshot
   # Bash-shim transport (deprecated — kept for back-compat sessions
   # where the MCP server isn't installed yet)
   - Bash(scripts/discover-app.sh *)

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -864,6 +864,90 @@
        result))))
 
 ;; ---------------------------------------------------------------------------
+;; Coarse-grained snapshot — one round-trip per investigate-X workflow.
+;; ---------------------------------------------------------------------------
+;;
+;; Many investigate-X tasks chain 5-10 reads — each currently a fresh nREPL
+;; round-trip plus Claude-think latency. The runtime-side composer below
+;; assembles every per-frame slice (:app-db, :sub-cache, :machines, :epochs,
+;; :traces) in one CLJS eval, so the MCP `snapshot` op is a single bencode
+;; round-trip producing one map keyed by frame-id.
+;;
+;; Each slice delegates to the existing per-slice reader — no parallel
+;; reimplementation. The composer just routes by `:include` keys.
+
+(def ^:private all-snapshot-slices
+  [:app-db :sub-cache :machines :epochs :traces])
+
+(defn- snapshot-frame-slice
+  "Compute one slice for one frame-id. Delegates to the existing per-slice
+   readers."
+  [frame-id slice]
+  (case slice
+    :app-db     (rf/get-frame-db frame-id)
+    :sub-cache  (rf/sub-cache frame-id)
+    ;; The global machine-id list is registrar-level (not per-frame).
+    ;; Per Spec 005 each frame holds its own machine snapshots at
+    ;; [:rf/machines machine-id] in app-db, so the per-frame slice
+    ;; returns {:ids [...] :state {machine-id snapshot}}.
+    :machines   (let [ids (vec (rf/machines))
+                      state (or (get (rf/get-frame-db frame-id) :rf/machines)
+                                {})]
+                  {:ids ids :state state})
+    :epochs     (vec (rf/epoch-history frame-id))
+    ;; The retain-N trace ring buffer is global; filter by frame.
+    :traces     (vec (rf/trace-buffer {:frame frame-id}))
+    nil))
+
+(defn- snapshot-frame
+  "Assemble the requested slices for one frame-id."
+  [frame-id slices]
+  (reduce (fn [m slice]
+            (assoc m slice (snapshot-frame-slice frame-id slice)))
+          {}
+          slices))
+
+(defn snapshot-state
+  "Coarse-grained per-frame state read. Returns one map keyed by
+   frame-id whose values are slice maps.
+
+   Opts:
+     :frames    :all (default) or a vector of frame-ids.
+     :include   vector of slice keywords. Defaults to
+                [:app-db :sub-cache :machines :epochs :traces].
+                Pass a subset to skip slices.
+
+   Example return shape:
+
+     {:rf/default {:app-db {...}
+                   :sub-cache {[:cart/total] {:value 42 :ref-count 2}}
+                   :machines {:ids [:auth] :state {:auth {...}}}
+                   :epochs [{...}{...}]
+                   :traces [{...}{...}]}
+      :stories    {...}}
+
+   Routes through existing per-slice readers — no parallel implementation.
+   Side effects: installs the trace + epoch listeners (idempotent via
+   `health`)."
+  ([] (snapshot-state {}))
+  ([{:keys [frames include]
+     :or   {frames  :all
+            include all-snapshot-slices}}]
+   (install-last-click-capture!)
+   (ensure-trace-listener!)
+   (ensure-epoch-listener!)
+   (let [registered (vec (rf/frame-ids))
+         fids       (cond
+                      (= :all frames)  registered
+                      (sequential? frames) (vec frames)
+                      :else            registered)
+         slices     (vec include)]
+     (reduce (fn [m fid]
+               (assoc m fid (snapshot-frame fid slices)))
+             {}
+             fids))))
+
+;; ---------------------------------------------------------------------------
 ;; Health check
 ;; ---------------------------------------------------------------------------
 

--- a/skills/re-frame-pair2/references/mcp-transport.md
+++ b/skills/re-frame-pair2/references/mcp-transport.md
@@ -50,9 +50,40 @@ The server auto-discovers the nREPL port from (in order):
 | `scripts/trace-window.sh 1000`    | `trace-window` | `{ms: 1000}` |
 | `scripts/watch-epochs.sh --event-id-prefix :cart` | `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
 | `scripts/tail-build.sh --probe '<form>'` | `tail-build` | `{probe: "..."}` |
+| _(none — MCP-only)_                | `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"]}` |
 
 (`inject-runtime` is gone — the runtime ships into the app via
 shadow-cljs `:devtools :preloads`. See `SKILL.md` §Setup.)
+
+## When to use `snapshot` vs the per-op reads
+
+`snapshot` is the **coarse-grained mega-op** for investigate-X
+workflows that would otherwise chain 5-10 individual reads
+(`app-db/snapshot` + `subs/cache` + `machines/list` + `epoch/history`
++ `trace/buffer`, etc.). Each per-op read is its own bencode
+round-trip plus Claude-think latency; `snapshot` collapses the whole
+thing into one round-trip.
+
+Use `snapshot` when:
+
+- You're starting a post-mortem and don't yet know which slice
+  carries the answer.
+- You want a fixed reference point — same call, same shape, several
+  hypotheses to test against it.
+- You need cross-slice context (e.g. "what was app-db at the same
+  moment the trace ring shows this event?").
+
+Use the per-op reads when:
+
+- You know exactly which slice you want and only need that slice.
+- You want a path-scoped value (`runtime/app-db-at [:deep :path]`).
+- You want a derived projection (`runtime/find-where`, `cascade-of`,
+  `last-pair-epoch`) — `snapshot` returns raw history; projections
+  still need their dedicated forms via `eval-cljs`.
+
+`snapshot` accepts `include` to subset the slices —
+`{include: ["app-db","epochs"]}` returns just those two — and
+`frames` to pick a subset of frame-ids — `{frames: [":stories"]}`.
 
 ## Preload probe (no inject step)
 

--- a/skills/re-frame-pair2/tests/runtime/snapshot_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/snapshot_test.clj
@@ -1,0 +1,162 @@
+;;;; tests/runtime/snapshot_test.clj
+;;;;
+;;;; Babashka-runnable verification of the `snapshot-state` mega-op in
+;;;; `preload/re_frame_pair2/runtime.cljs` — the rf2-x70e coarse-grained
+;;;; per-frame state reader the pair2 MCP server exposes as the
+;;;; `snapshot` tool.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `preload/re_frame_pair2/runtime.cljs` is a CLJS-only file loaded
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
+;;;;   depends on the live re-frame2 frame registry, sub-cache, trace
+;;;;   buffer, and epoch history — none of which run under bb. The real
+;;;;   shadow-cljs test build (planned per `docs/TESTING.md` §1) will
+;;;;   exercise the `.cljs` source in place under Node; until then this
+;;;;   file mirrors the slice routing and the per-frame composer and
+;;;;   asserts behaviour against stubbed framework surfaces.
+;;;;
+;;;;   KEEP IN SYNC WITH preload/re_frame_pair2/runtime.cljs §Coarse-grained
+;;;;   snapshot.
+;;;;
+;;;; Run:    bb tests/runtime/snapshot_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns snapshot-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Stubbed framework surfaces.
+;; ---------------------------------------------------------------------------
+;;
+;; Two registered frames with predictable per-slice state. The composer
+;; under test routes by `:include` keys and assembles one map per
+;; frame-id.
+
+(def fixture-frames
+  {:rf/default {:app-db    {:cart {:items 3 :total 4200}
+                            :rf/machines {:auth {:state :authed}}}
+                :sub-cache {[:cart/total] {:value 4200 :ref-count 2}}
+                :epochs    [{:epoch-id "e1" :event-id :app/init}
+                            {:epoch-id "e2" :event-id :cart/add}]
+                :traces    [{:id 1 :operation :event/dispatched :tags {:frame :rf/default}}
+                            {:id 2 :operation :sub/run        :tags {:frame :rf/default}}]}
+   :stories     {:app-db    {:scenarios {:checkout :ready}
+                             :rf/machines {}}
+                 :sub-cache {[:stories/active] {:value :checkout :ref-count 1}}
+                 :epochs    [{:epoch-id "s1" :event-id :stories/load}]
+                 :traces    [{:id 3 :operation :event/dispatched :tags {:frame :stories}}]}})
+
+(defn stub-frame-ids [] (keys fixture-frames))
+(defn stub-get-frame-db [fid] (get-in fixture-frames [fid :app-db]))
+(defn stub-sub-cache    [fid] (get-in fixture-frames [fid :sub-cache]))
+(defn stub-epoch-history [fid] (get-in fixture-frames [fid :epochs]))
+(defn stub-machines [] [:auth :session])  ;; global registrar surface
+(defn stub-trace-buffer [opts]
+  (let [fid (:frame opts)]
+    (filter #(= fid (get-in % [:tags :frame]))
+            (mapcat (fn [[_ slices]] (:traces slices)) fixture-frames))))
+
+;; Mirror of preload/re_frame_pair2/runtime.cljs §Coarse-grained snapshot.
+;; KEEP IN SYNC.
+
+(def ^:private all-snapshot-slices
+  [:app-db :sub-cache :machines :epochs :traces])
+
+(defn- snapshot-frame-slice [frame-id slice]
+  (case slice
+    :app-db     (stub-get-frame-db frame-id)
+    :sub-cache  (stub-sub-cache frame-id)
+    :machines   {:ids   (vec (stub-machines))
+                 :state (or (get (stub-get-frame-db frame-id) :rf/machines) {})}
+    :epochs     (vec (stub-epoch-history frame-id))
+    :traces     (vec (stub-trace-buffer {:frame frame-id}))
+    nil))
+
+(defn- snapshot-frame [frame-id slices]
+  (reduce (fn [m slice]
+            (assoc m slice (snapshot-frame-slice frame-id slice)))
+          {}
+          slices))
+
+(defn snapshot-state
+  ([] (snapshot-state {}))
+  ([{:keys [frames include]
+     :or   {frames :all include all-snapshot-slices}}]
+   (let [registered (vec (stub-frame-ids))
+         fids       (cond
+                      (= :all frames)    registered
+                      (sequential? frames) (vec frames)
+                      :else               registered)
+         slices     (vec include)]
+     (reduce (fn [m fid] (assoc m fid (snapshot-frame fid slices))) {} fids))))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest defaults-include-all-frames-and-all-slices
+  (let [snap (snapshot-state)]
+    (testing "every registered frame is present"
+      (is (= #{:rf/default :stories} (set (keys snap)))))
+    (testing "every slice is present per frame"
+      (doseq [fid [:rf/default :stories]]
+        (is (= #{:app-db :sub-cache :machines :epochs :traces}
+               (set (keys (get snap fid))))
+            (str fid " missing slice keys"))))))
+
+(deftest app-db-slice-delegates-to-get-frame-db
+  (let [snap (snapshot-state {:include [:app-db]})]
+    (is (= {:cart {:items 3 :total 4200}
+            :rf/machines {:auth {:state :authed}}}
+           (get-in snap [:rf/default :app-db])))
+    (is (= {:scenarios {:checkout :ready} :rf/machines {}}
+           (get-in snap [:stories :app-db])))))
+
+(deftest sub-cache-slice-delegates-to-rf-sub-cache
+  (let [snap (snapshot-state {:include [:sub-cache]})]
+    (is (= {[:cart/total] {:value 4200 :ref-count 2}}
+           (get-in snap [:rf/default :sub-cache])))))
+
+(deftest machines-slice-combines-registrar-and-per-frame-state
+  (let [snap (snapshot-state {:include [:machines]})]
+    (is (= [:auth :session]
+           (get-in snap [:rf/default :machines :ids]))
+        "global registrar ids appear under :ids")
+    (is (= {:auth {:state :authed}}
+           (get-in snap [:rf/default :machines :state]))
+        "per-frame state appears under :state")
+    (is (= {} (get-in snap [:stories :machines :state]))
+        "frames with no machines snapshot get an empty state map")))
+
+(deftest epochs-slice-returns-history-vector
+  (let [snap (snapshot-state {:include [:epochs]})]
+    (is (vector? (get-in snap [:rf/default :epochs])))
+    (is (= 2 (count (get-in snap [:rf/default :epochs]))))
+    (is (= "e1" (-> snap :rf/default :epochs first :epoch-id)))))
+
+(deftest traces-slice-is-frame-scoped
+  (let [snap (snapshot-state {:include [:traces]})]
+    (is (every? #(= :rf/default (get-in % [:tags :frame]))
+                (get-in snap [:rf/default :traces]))
+        "trace buffer filtered by frame, no leaks across frames")
+    (is (every? #(= :stories (get-in % [:tags :frame]))
+                (get-in snap [:stories :traces])))))
+
+(deftest include-subset-honours-pick-list
+  (let [snap (snapshot-state {:include [:app-db :epochs]})]
+    (is (= #{:app-db :epochs}
+           (set (keys (get snap :rf/default))))
+        "only the requested slices appear")))
+
+(deftest frames-vector-narrows-to-listed-frames
+  (let [snap (snapshot-state {:frames [:stories]})]
+    (is (= #{:stories} (set (keys snap)))
+        "only :stories appears in the result")))
+
+(deftest frames-all-keyword-matches-registered-frames
+  (is (= (set (stub-frame-ids))
+         (set (keys (snapshot-state {:frames :all}))))))
+
+(let [{:keys [fail error]} (run-tests 'snapshot-test)]
+  (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -11,7 +11,7 @@ back-compat, but new sessions should prefer the MCP server.
 ## What it is
 
 A Node-based stdio JSON-RPC server (written in ClojureScript, compiled
-via shadow-cljs to a single `.js` file) that exposes the six pair2
+via shadow-cljs to a single `.js` file) that exposes the seven pair2
 ops as MCP tools. AI agents (Claude Code, Cursor, Copilot) launch it
 as a subprocess; one persistent nREPL socket is held for the lifetime
 of the session.
@@ -33,6 +33,7 @@ cljs-eval compile.
 | `trace-window` | `trace-window.sh`         | Return the epochs that landed in the last N ms. |
 | `watch-epochs` | `watch-epochs.sh`         | Pull-mode poll for matching epochs added after a given epoch-id. Predicate keys: `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`. |
 | `tail-build`   | `tail-build.sh`           | Wait for a hot-reload to land by polling a probe form until its value changes. |
+| `snapshot`     | _(new — no bash equivalent)_ | Coarse-grained per-frame state read in one round-trip. Returns a map keyed by frame-id with `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces` slices. Prefer for investigate-X workflows over chaining 5-10 individual reads. |
 
 ## Quick start
 
@@ -79,6 +80,34 @@ Or, with the pair2 skill loaded, just describe the task — the skill's
 SKILL.md teaches the agent which tool to call. See
 [`../../skills/re-frame-pair2/SKILL.md`](../../skills/re-frame-pair2/SKILL.md).
 
+### Snapshot — one call instead of five
+
+For investigate-X workflows (post-mortems, "what state is the app in
+right now?", "what changed between these two epochs?"):
+
+```text
+Agent: tools/call snapshot {frames: "all"}
+Server: {:ok? true
+         :frames :all
+         :include [:app-db :sub-cache :machines :epochs :traces]
+         :snapshot {:rf/default {:app-db {...}
+                                 :sub-cache {[:cart/total] {:value 42 ...}}
+                                 :machines {:ids [:auth] :state {:auth {...}}}
+                                 :epochs [{:epoch-id "..." ...} ...]
+                                 :traces [{:operation :event/dispatched ...}]}}}
+```
+
+Subset what you need with `include`:
+
+```text
+Agent: tools/call snapshot {frames: ["rf/default"], include: ["app-db", "epochs"]}
+```
+
+Per-op reads (`eval-cljs` against `runtime/app-db-at`, etc.) remain
+available — they're still the right call when you genuinely need one
+slice for one frame. `snapshot` is the right surface when you don't
+yet know which slice carries the answer.
+
 ## How preload probing works (rf2-7dvg)
 
 A full page reload in the browser destroys the CLJS runtime but
@@ -103,7 +132,7 @@ The contract lives in [`spec/`](./spec/):
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What this server is, why it replaces the bash-shim chain. |
 | [`spec/001-Wire-Protocol.md`](./spec/001-Wire-Protocol.md) | JSON-RPC 2.0 over stdio; lifecycle; tool dispatch. |
 | [`spec/002-nREPL-Transport.md`](./spec/002-nREPL-Transport.md) | Persistent socket, bencode framing, sentinel-based reconnect. |
-| [`spec/003-Tool-Catalogue.md`](./spec/003-Tool-Catalogue.md) | The seven tools, their argument schemas, EDN result shape. |
+| [`spec/003-Tool-Catalogue.md`](./spec/003-Tool-Catalogue.md) | The seven tools (six per-op + the `snapshot` mega-op), their argument schemas, EDN result shape. |
 
 ## Development
 
@@ -149,7 +178,7 @@ tools/pair2-mcp/
 ├── pilot/                                    ; pre-port toolchain pilot
 └── src/re_frame_pair2_mcp/
     ├── nrepl.cljs                            ; persistent socket + bencode
-    ├── tools.cljs                            ; the 7 MCP tools
+    ├── tools.cljs                            ; the 7 MCP tools (6 per-op + snapshot mega-op)
     └── server.cljs                           ; stdio JSON-RPC entry point
 └── test/
     ├── re_frame_pair2_mcp/nrepl_test.cljs    ; bencode framing unit tests

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -1,6 +1,6 @@
 # 003-Tool-Catalogue
 
-The six MCP tools.
+The seven MCP tools.
 
 ## discover-app
 
@@ -84,3 +84,49 @@ after the reload), `wait-ms` (integer, default 5000), `build` (string).
 **Returns**: `{:ok? true :t <ms> :soft? false}` on a real change, or
 `{:ok? false :reason :timed-out}` on timeout. If `probe` is omitted,
 falls back to a 300ms soft delay (matches the bash version).
+
+## snapshot
+
+Coarse-grained per-frame state read in **one round-trip**. The mega-op
+for investigate-X workflows that would otherwise chain 5-10 individual
+reads. Server-side composition over the existing per-slice runtime
+readers (`get-frame-db`, `sub-cache`, `machines` + frame-local
+`[:rf/machines]`, `epoch-history`, `trace-buffer`); no parallel
+implementation.
+
+**Args**: `frames` (string `"all"` or array of frame-id strings like
+`":rf/default"`, default `"all"`), `include` (array of slice names —
+subset of `["app-db" "sub-cache" "machines" "epochs" "traces"]`,
+default all five), `build` (string).
+
+**Returns**:
+
+```clojure
+{:ok? true
+ :frames :all|[<frame-id>...]
+ :include [:app-db :sub-cache :machines :epochs :traces]
+ :snapshot {<frame-id> {:app-db    {...}
+                        :sub-cache {<query-v> {:value v :ref-count n}}
+                        :machines  {:ids [<machine-id>...]
+                                    :state {<machine-id> <snapshot>}}
+                        :epochs    [<:rf/epoch-record> ...]
+                        :traces    [<trace-event> ...]}
+            ...}}
+```
+
+The `:machines` slice combines the global registrar's machine-id list
+(`rf/machines`) with the per-frame state stash at `[:rf/machines]` in
+the frame's `app-db` (per Spec 005). The `:traces` slice filters the
+retain-N trace ring buffer by `:frame`. Other slices delegate
+verbatim to the public per-slice surface.
+
+Pass a smaller `include` to subset (e.g.
+`{:frames "all" :include ["app-db" "epochs"]}` for a quick
+"state + recent history" probe). Per-op fine-grain reads (`eval-cljs`
+against `runtime/app-db-at`, `runtime/sub-cache`, etc.) stay
+available — they're the right surface when you genuinely need one
+slice for one frame. `snapshot` is the right surface when you don't
+know yet which slice carries the answer.
+
+`:reason :runtime-not-preloaded` if the preload hasn't run;
+`:reason :snapshot-failed` (with `:message`) on any other failure.

--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -123,6 +123,7 @@ schemas and result shapes are specified in
 | `trace-window` | Return epoch records from the last N ms. |
 | `watch-epochs` | Pull-mode poll for matching epochs since a given id. |
 | `tail-build` | Wait for a hot-reload to land by polling a probe form. |
+| `snapshot`   | Coarse-grained per-frame state read in one round-trip. Returns `:app-db` + `:sub-cache` + `:machines` + `:epochs` + `:traces` slices for every (or a subset of) frame(s). Mega-op for investigate-X workflows. |
 
 (Pre-rf2-7dvg drops also exposed `inject-runtime`. That tool is gone:
 the runtime ships into consumer apps via shadow-cljs `:devtools
@@ -203,6 +204,7 @@ analogues. Listed here for reference:
 | `re-frame-pair2.runtime/trace-window` | preload/re_frame_pair2/runtime.cljs | Last-N-ms epoch lookback. |
 | `re-frame-pair2.runtime/watch-epochs` | preload/re_frame_pair2/runtime.cljs | Poll for epochs after id. |
 | `re-frame-pair2.runtime/probe` | preload/re_frame_pair2/runtime.cljs | Hot-reload landed signal. |
+| `re-frame-pair2.runtime/snapshot-state` | preload/re_frame_pair2/runtime.cljs | Per-frame slice composer fed by `:include` / `:frames` opts; backs the `snapshot` MCP tool. |
 | `shadow.cljs.devtools.api/cljs-eval` | shadow-cljs | The CLJS bridge over the JVM-side nREPL socket. |
 | `:rf/epoch-record` | framework | The epoch record shape returned by trace mode. |
 | `:origin :pair` (in event tags) | framework | Pair2's dispatches surface in the trace stream distinguishably. |
@@ -221,6 +223,14 @@ identical between the two surfaces.
 | `trace-window.sh` | `trace-window` |
 | `watch-epochs.sh` | `watch-epochs` |
 | `tail-build.sh` | `tail-build` |
+| _(none — MCP-only)_ | `snapshot` |
+
+The `snapshot` mega-op has no bash equivalent — it's a coarse-grained
+composition of the existing per-slice runtime readers, shipped as
+part of the rf2-x70e drop to cut round-trips for investigate-X
+workflows. Agents that need its semantics under the bash shim chain
+the per-op reads (`app-db/snapshot` + `subs/cache` + `machines/list`
++ `epoch/history` + `trace/buffer`) in sequence.
 
 Agents may mix shim calls and MCP tool calls in the same workflow
 during the transition. New sessions should prefer the MCP server for

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -13,6 +13,7 @@
   | trace-window  | Epochs in the last N ms                                   |
   | watch-epochs  | Pull-mode live epoch streaming                            |
   | tail-build    | Wait for a hot-reload to land                             |
+  | snapshot      | Coarse-grained per-frame state read (mega-op)             |
 
   ## Preload probe (no per-session inject)
 
@@ -318,6 +319,81 @@
                           :message (.-message err)}))))))))
 
 ;; ---------------------------------------------------------------------------
+;; Tool: snapshot — coarse-grained per-frame state read in one round-trip.
+;;
+;; Many investigate-X workflows chain 5-10 reads; each is a bencode
+;; round-trip plus Claude-think latency. This op composes the existing
+;; per-slice readers server-side and returns a per-frame map.
+;; ---------------------------------------------------------------------------
+
+(def ^:private valid-slices
+  #{:app-db :sub-cache :machines :epochs :traces})
+
+(defn- ->frame-keyword
+  "Coerce a frame-id string into a keyword. Accepts both bare names
+   (`\"rf/default\"`) and EDN-shaped strings (`\":rf/default\"`) — strips
+   a leading colon when present so callers can pass either form."
+  [x]
+  (cond
+    (keyword? x) x
+    (string? x)
+    (let [s (if (str/starts-with? x ":") (subs x 1) x)]
+      (keyword s))
+    :else (keyword x)))
+
+(defn- parse-frames-arg
+  "Normalise the `frames` MCP arg into the form the runtime expects.
+   Accepts `:all`, the string \"all\", a JS array of strings, or a CLJS
+   vector. Returns `:all` or a vector of keyword frame-ids. Returns
+   `:all` for nil / empty / unrecognised input — least-surprise."
+  [raw]
+  (cond
+    (nil? raw) :all
+    (or (= raw :all) (= raw "all")) :all
+    (array? raw)
+    (->> (js->clj raw) (mapv ->frame-keyword))
+    (sequential? raw)
+    (mapv ->frame-keyword raw)
+    :else :all))
+
+(defn- parse-include-arg
+  "Normalise the `include` MCP arg into the slice vector the runtime
+   expects. Filters to known slices; returns the full set when arg
+   is nil / empty / all-unknown."
+  [raw]
+  (let [full [:app-db :sub-cache :machines :epochs :traces]
+        coerce (fn [xs]
+                 (->> xs
+                      (map keyword)
+                      (filter valid-slices)
+                      vec))]
+    (cond
+      (nil? raw) full
+      (array? raw)
+      (let [v (coerce (js->clj raw))]
+        (if (seq v) v full))
+      (sequential? raw)
+      (let [v (coerce raw)]
+        (if (seq v) v full))
+      :else full)))
+
+(defn- snapshot-tool [conn args]
+  (let [build-id (arg-build args)
+        frames   (parse-frames-arg (arg args :frames))
+        include  (parse-include-arg (arg args :include))
+        opts     {:frames frames :include include}
+        form     (str "(re-frame-pair2.runtime/snapshot-state "
+                      (pr-str opts) ")")]
+    (-> (ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+        (.then (fn [v]
+                 (ok-text {:ok?      true
+                           :frames   (if (= :all frames) :all (vec frames))
+                           :include  include
+                           :snapshot v})))
+        (.catch (fn [err] (err->result :snapshot-failed err))))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool descriptors — exposed via tools/list.
 ;; ---------------------------------------------------------------------------
 
@@ -368,6 +444,22 @@
                   :properties {:probe   {:type "string" :description "CLJS form whose value should change after the reload"}
                                :wait-ms {:type "integer" :description "Max wait in ms (default 5000)"}
                                :build   {:type "string"}}
+                  :additionalProperties false}}
+   {:name "snapshot"
+    :description (str "Coarse-grained per-frame state read in one round-trip — the mega-op for investigate-X workflows. "
+                      "Returns a map keyed by frame-id whose values carry the requested slices: "
+                      ":app-db, :sub-cache, :machines, :epochs, :traces. "
+                      "Server-side composition over the existing per-slice runtime readers. "
+                      "Prefer this over chaining 5-10 individual reads.")
+    :inputSchema {:type "object"
+                  :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
+                                         :oneOf [{:type "string"}
+                                                 {:type "array" :items {:type "string"}}]}
+                               :include {:type "array"
+                                         :description "Slices to include. Defaults to all five. Recognised: app-db, sub-cache, machines, epochs, traces."
+                                         :items {:type "string"
+                                                 :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
+                               :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
                   :additionalProperties false}}])
 
 (defn tool-descriptors-js []
@@ -386,5 +478,6 @@
     "trace-window"     (trace-window-tool conn args)
     "watch-epochs"     (watch-epochs-tool conn args)
     "tail-build"       (tail-build-tool conn args)
+    "snapshot"         (snapshot-tool  conn args)
     (js/Promise.resolve
       (err-text {:ok? false :reason :unknown-tool :tool name}))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
@@ -1,0 +1,93 @@
+(ns re-frame-pair2-mcp.snapshot-test
+  "Unit tests for the snapshot tool's argument parsing — the shape we
+  send to `re-frame-pair2.runtime/snapshot-state` over nREPL.
+
+  The live end-to-end coverage lives in `test/stdio-roundtrip.js` (the
+  degraded-mode dispatch path) and the manual live-nREPL integration
+  test against a real shadow-cljs build. The CLJS layer here just
+  pins the MCP-arg→runtime-opts translation so accidental renames or
+  case slips break the test rather than silently shipping a broken
+  contract."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [applied-science.js-interop :as j]))
+
+;; The parsers are private in tools.cljs — re-implement the contract
+;; here so we test what callers see and so the test fails if the
+;; semantics drift. Mirror of `parse-frames-arg` and `parse-include-arg`.
+
+(def ^:private valid-slices
+  #{:app-db :sub-cache :machines :epochs :traces})
+
+(defn- ->frame-keyword [x]
+  (cond
+    (keyword? x) x
+    (string? x)
+    (let [s (if (str/starts-with? x ":") (subs x 1) x)]
+      (keyword s))
+    :else (keyword x)))
+
+(defn- parse-frames [raw]
+  (cond
+    (nil? raw) :all
+    (or (= raw :all) (= raw "all")) :all
+    (array? raw) (->> (js->clj raw) (mapv ->frame-keyword))
+    (sequential? raw) (mapv ->frame-keyword raw)
+    :else :all))
+
+(defn- parse-include [raw]
+  (let [full [:app-db :sub-cache :machines :epochs :traces]
+        coerce (fn [xs]
+                 (->> xs
+                      (map keyword)
+                      (filter valid-slices)
+                      vec))]
+    (cond
+      (nil? raw) full
+      (array? raw)
+      (let [v (coerce (js->clj raw))]
+        (if (seq v) v full))
+      (sequential? raw)
+      (let [v (coerce raw)]
+        (if (seq v) v full))
+      :else full)))
+
+(deftest frames-default-is-all
+  (is (= :all (parse-frames nil)))
+  (is (= :all (parse-frames "all"))))
+
+(deftest frames-array-coerces-to-keywords
+  (let [arr #js [":rf/default" ":stories"]]
+    (is (= [:rf/default :stories] (parse-frames arr)))))
+
+(deftest frames-vector-coerces-to-keywords
+  (is (= [:rf/default :stories]
+         (parse-frames [":rf/default" ":stories"]))))
+
+(deftest include-default-is-full-slice-set
+  (is (= [:app-db :sub-cache :machines :epochs :traces]
+         (parse-include nil)))
+  (is (= [:app-db :sub-cache :machines :epochs :traces]
+         (parse-include #js []))))
+
+(deftest include-filters-unknown-slices
+  (testing "unknown slices fall away, known stay in order"
+    (is (= [:app-db :epochs]
+           (parse-include #js ["app-db" "garbage" "epochs"]))))
+  (testing "all-unknown falls back to the full list"
+    (is (= [:app-db :sub-cache :machines :epochs :traces]
+           (parse-include #js ["garbage" "more-garbage"])))))
+
+(deftest include-accepts-subset
+  (is (= [:app-db :sub-cache] (parse-include #js ["app-db" "sub-cache"]))))
+
+(deftest snapshot-state-form-is-edn-readable
+  ;; The MCP server pr-strs the opts map into a CLJS eval form like
+  ;; `(re-frame-pair2.runtime/snapshot-state {:frames :all :include [...]})`.
+  ;; Ensure the canonical default round-trips through pr-str.
+  (let [opts {:frames :all
+              :include (parse-include nil)}
+        form (str "(re-frame-pair2.runtime/snapshot-state "
+                  (pr-str opts) ")")]
+    (is (re-find #":frames :all" form))
+    (is (re-find #":include \[:app-db :sub-cache :machines :epochs :traces\]" form))))

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -3,9 +3,11 @@
 //
 // This test does NOT need a live shadow-cljs nREPL — it exercises:
 //   - initialize handshake
-//   - tools/list (expects all six tools)
+//   - tools/list (expects all seven tools, including the snapshot mega-op)
 //   - tools/call eval-cljs against an absent nREPL (expects graceful
 //     :nrepl-port-not-found degraded mode)
+//   - tools/call snapshot against an absent nREPL (same degraded mode —
+//     proves the new tool is wired into the dispatch table)
 //
 // A separate live-nrepl test (spec/INTEGRATION.md) covers the
 // connected-to-shadow-cljs case.
@@ -78,14 +80,16 @@ function run() {
 
       notify('notifications/initialized', {});
 
-      // 2. tools/list — expect all six tools (rf2-7dvg cut inject-runtime
-      // in favour of a shadow-cljs :preloads entry; see SKILL.md §Setup).
+      // 2. tools/list — expect all seven tools (six per-op + snapshot
+      // mega-op shipped in rf2-x70e). rf2-7dvg cut inject-runtime in
+      // favour of a shadow-cljs :preloads entry; see SKILL.md §Setup.
       const list = await call('tools/list', {});
       const names = (list.result?.tools || []).map((t) => t.name).sort();
       const expected = [
         'discover-app',
         'dispatch',
         'eval-cljs',
+        'snapshot',
         'tail-build',
         'trace-window',
         'watch-epochs',
@@ -94,6 +98,19 @@ function run() {
         throw new Error('tools/list mismatch:\n  expected ' + expected + '\n  got ' + names);
       }
       console.log('OK   tools/list ->', names.join(', '));
+
+      // 2b. Verify the snapshot descriptor carries the documented input
+      // schema (frames + include + build), so accidental future renames
+      // break the test instead of silently shipping a broken contract.
+      const snapDesc = (list.result?.tools || []).find((t) => t.name === 'snapshot');
+      if (!snapDesc) throw new Error('snapshot descriptor missing from tools/list');
+      const props = snapDesc.inputSchema?.properties || {};
+      for (const k of ['frames', 'include', 'build']) {
+        if (!(k in props)) {
+          throw new Error('snapshot inputSchema missing property: ' + k);
+        }
+      }
+      console.log('OK   snapshot descriptor -> frames/include/build');
 
       // 3. tools/call eval-cljs without nREPL — expect graceful degraded result
       const evalResp = await call('tools/call', {
@@ -105,6 +122,19 @@ function run() {
         throw new Error('eval-cljs degraded mode expected, got: ' + JSON.stringify(evalResp));
       }
       console.log('OK   tools/call eval-cljs (no nREPL) -> degraded isError');
+
+      // 3b. tools/call snapshot — same degraded path. Proves the new
+      // tool is wired into the dispatch table (would surface
+      // :unknown-tool otherwise).
+      const snapResp = await call('tools/call', {
+        name: 'snapshot',
+        arguments: { frames: 'all' },
+      });
+      const snapText = snapResp.result?.content?.[0]?.text || '';
+      if (!snapResp.result?.isError || !snapText.includes('nrepl-port-not-found')) {
+        throw new Error('snapshot degraded mode expected, got: ' + JSON.stringify(snapResp));
+      }
+      console.log('OK   tools/call snapshot (no nREPL) -> degraded isError');
 
       // 4. tools/call unknown — expect isError with :unknown-tool
       const unk = await call('tools/call', { name: 'no-such-tool', arguments: {} });


### PR DESCRIPTION
## Summary

- New `snapshot` MCP tool composes the existing per-slice runtime readers (`get-frame-db`, `sub-cache`, `machines` + per-frame `[:rf/machines]`, `epoch-history`, `trace-buffer`) into one bencode round-trip per investigate-X workflow.
- Op signature: `snapshot {frames: \"all\"|[\":rf/default\",...], include: [\"app-db\",\"sub-cache\",\"machines\",\"epochs\",\"traces\"]}`. Defaults to all frames + all slices; subset via `include`.
- Returns `{:ok? true :frames _ :include _ :snapshot {<frame-id> {<slice> <value>}}}`.
- Granular per-op reads stay available; `snapshot` is the right surface when you don't yet know which slice carries the answer.

## Files changed

- `skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs` — new `snapshot-state` composer.
- `tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs` — new `snapshot` tool + arg parsers + descriptor + invoke wire-in.
- `tools/pair2-mcp/spec/003-Tool-Catalogue.md`, `spec/API.md` — op signature + return shape + slice semantics.
- `tools/pair2-mcp/README.md`, `skills/re-frame-pair2/SKILL.md`, `references/mcp-transport.md` — usage example + when-to-use guidance.
- `tools/pair2-mcp/test/stdio-roundtrip.js` — assert seven tools in `tools/list`, snapshot descriptor shape, snapshot dispatch path.
- `tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs` — CLJS arg-parsing tests.
- `skills/re-frame-pair2/tests/runtime/snapshot_test.clj` — bb-runnable structural tests for slice routing + per-frame composer.

## Test plan

- [x] `npm test` (CLJS unit tests): 11 tests / 25 assertions, 0 failures.
- [x] `npm run build` + `npm run stdio-roundtrip`: SERVER STDIO ROUND-TRIP GREEN — initialize, tools/list (7 tools), snapshot descriptor shape, eval-cljs degraded path, snapshot degraded path, unknown-tool path all green.
- [x] All bb runtime tests (`tests/runtime/*.clj`) pass: snapshot (9/17), preload-sentinel (3/3), multi-frame (17/25), app-db-reset (7/11), parse-rf2-coord (12/21), watch-op-modes (12/55).
- [ ] Live-nREPL integration against a real shadow-cljs build (manual — depends on consumer-side preload landing the new `snapshot-state` helper).

Closes rf2-x70e.