### PR TITLE
fix(story/test-mode): gate createRoot to prevent counter-with-stories Playwright flake (rf2-jymd4)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -880,18 +880,36 @@ module.exports = {
     }
 
     // ====================================================================
-    // 16. Switch back to the live app — counter survives
+    // 16. Switch back to the live app — counter reappears + inc still wired
     // ====================================================================
     //
-    // Hash-change back to the live app; counter should reappear.
-    // The live app re-creates its React root inside `mount-app!` and
-    // re-renders against the surviving app-db (which still says
-    // :count 6 after the click at step 1).
+    // Hash-change back to the live app; counter should reappear. The
+    // live app re-creates its React root inside `mount-app!` and
+    // re-renders against the current app-db.
+    //
+    // Note on the expected starting value: step 3b-ii calls
+    // `page.reload()` to verify the mode-tabs primitive re-hydrates its
+    // selection from localStorage. That reload throws away the live-app
+    // JS context, so the +1 click at step 1 (which bumped :count to 6)
+    // does NOT survive into this final section — `core.cljs` re-runs
+    // `(rf/dispatch-sync [:counter/initialise 5])` on the reloaded page
+    // and the count is back at 5. The trace-panel click at step 10
+    // operates on the Story shell's variant frame, not the live app's
+    // frame, so it doesn't move the live app's :count either.
+    //
+    // We therefore assert the post-reload starting value (5), then click
+    // +1 to confirm the inc handler is still wired in the re-mounted
+    // live app and the canvas re-renders against the bumped app-db
+    // (the original Stage-8 invariant — the SPA round-trip preserves
+    // event wiring + render path).
     await page.evaluate(() => {
       window.location.hash = '#/';
     });
 
     const countAfter = page.locator('[data-test="count"]').first();
-    await expectTextEquals(countAfter, '6', 10000);
+    await expectTextEquals(countAfter, '5', 10000);
+
+    await page.locator('[data-test="inc"]').first().click();
+    await expectTextEquals(countAfter, '6');
   },
 };


### PR DESCRIPTION
## Summary

Repairs the long-standing CI flake `FAIL counter-with-stories: expected text "6" but got "5" within 10000ms`. Every PR this session has hit it; we've been admin-merging through it.

## Root cause

Not a `createRoot()` race in `tools/story/src/re_frame/story/ui/test_mode.cljc` (that file uses Reagent's `r/atom` / `r/create-class`, never reaches for `react-dom/client.createRoot`). The real cause is an authoring mismatch in the Playwright spec itself, introduced by rf2-qmjo's `:test` mode-tab rehydration assertion:

- Step 3b-ii calls `page.reload()` to verify the mode-tabs primitive re-hydrates its localStorage selection.
- That reload tears down the live-app JS context.
- After reload, `core.cljs` re-runs `(rf/dispatch-sync [:counter/initialise 5])` — `:count` is 5 again.
- The +1 click in step 1 (which bumped `:count` to 6) is gone.
- The trace-panel click in step 10 operates on the Story shell's variant frame, not the live app's frame, so it doesn't restore the live app's count.

The final step 16 hash-changed back to `#/` and asserted `count=6`. That expectation was wrong by 1 (the post-reload state is `5`). Locally this reproduces 100%; on CI it flakes because the 10000ms `expectTextEquals` retry window sometimes elapses just as Chromium settles into rendering `5`, producing a timeout error rather than a clean mismatch.

## Fix

In `examples/reagent/counter_with_stories/counter_with_stories.spec.cjs` step 16:
- assert the deterministic post-reload starting value (`5`)
- click `+1` once
- assert `6`

This preserves the original Stage-8 invariant — that the SPA round-trip preserves the live app's event wiring and render path — without depending on a state-survival property that the reload at step 3b-ii broke.

## Test plan
- [x] Reproduced the flake locally on `origin/main` (100% reproduction rate, not 1-in-N as on CI)
- [x] Applied fix; ran `npm run test:examples` (filter=counter-with-stories) 10 times — 9 clean passes, 1 unrelated port-8030 server-collision from a prior run not tearing down
- [x] `clojure -M:test` from `implementation/core` (254 tests / 1155 assertions, 0 failures)
- [x] `npm run test:cljs` (591 tests / 1401 assertions, 0 failures)