### PR TITLE
docs(spec): batched back-compat cleanup — strip metadata-opt-channel promise + fix legacy-ns ref + clarify :http examples (rf2-99c3l rf2-i9gmn rf2-lvsz8)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -38,7 +38,7 @@ This Spec inherits the constraints and goals from 000 and adds two frame-specifi
 ;; Plain (non-view) APIs — frame-aware variants
 (rf/dispatch      [:foo])                          ;; defaults to :rf/default
 (rf/dispatch      [:foo] {:frame :todo             ;; opts map extends the dispatch envelope
-                          :fx-overrides {:http stub-fn}})
+                          :fx-overrides {:my-app/http stub-fn}})
 (rf/dispatch-sync [:foo] {:fx-overrides {...}})    ;; same opts-arg shape, sync variant
 (rf/subscribe     [:bar])                          ;; defaults to :rf/default
 (rf/subscribe     [:bar] {:frame :todo})           ;; opts arg targets a specific frame
@@ -98,7 +98,7 @@ This section is the **canonical grammar** for `reg-frame` metadata. Subsequent s
   {:doc          "..."                          ;; like all reg-*
    :on-create    [:todo/initialise]             ;; single event dispatched after creation
    :on-destroy   [:todo/cleanup]                ;; single event dispatched before teardown
-   :fx-overrides {:http http-stub-fn}           ;; per-frame fx replacements
+   :fx-overrides {:my-app/http http-stub-fn}    ;; per-frame fx replacements
    :interceptors [recorder validator]           ;; prepended to every event in this frame
    :drain-depth  100                            ;; depth limit for run-to-completion drain
    :on-error     :rf.error/server-projection    ;; error-handler policy per [009 §Error-handler policy](009-Instrumentation.md#error-handler-policy-on-error-per-frame); typically preset-supplied (e.g. `:ssr-server`)
@@ -163,7 +163,7 @@ The framework stamps the dispatch envelope with the frame's id automatically —
 - `:on-destroy` events do not fire (they only fire on `destroy-frame`).
 - Sub-cache, router queue, in-flight events all remain.
 
-**Absent-key semantics on re-registration:** the re-registered metadata map is the **complete replacement** of the previous map's replaceable slots, *not* a merge. A key absent from the new map clears the previous binding; a key present overwrites. So if the original `reg-frame` set `:fx-overrides {:http stub-fn}` and the re-registration omits `:fx-overrides`, the overrides map clears (no overrides apply going forward). This matches every other `reg-*` shape (re-registering a `reg-event-fx` replaces the handler entirely; metadata behaves the same way), and keeps the on-disk source the single source of truth — the runtime doesn't accumulate state the source no longer mentions. The slots that follow this rule are the same ones listed in *What gets replaced*: `:fx-overrides`, `:interceptor-overrides`, `:interceptors`, `:doc`/`:ns`/`:line`/`:file`, `:drain-depth`, `:on-create`, `:on-destroy`. Live runtime state (`app-db`, sub-cache, queue) is preserved regardless of what the metadata map says.
+**Absent-key semantics on re-registration:** the re-registered metadata map is the **complete replacement** of the previous map's replaceable slots, *not* a merge. A key absent from the new map clears the previous binding; a key present overwrites. So if the original `reg-frame` set `:fx-overrides {:my-app/http stub-fn}` and the re-registration omits `:fx-overrides`, the overrides map clears (no overrides apply going forward). This matches every other `reg-*` shape (re-registering a `reg-event-fx` replaces the handler entirely; metadata behaves the same way), and keeps the on-disk source the single source of truth — the runtime doesn't accumulate state the source no longer mentions. The slots that follow this rule are the same ones listed in *What gets replaced*: `:fx-overrides`, `:interceptor-overrides`, `:interceptors`, `:doc`/`:ns`/`:line`/`:file`, `:drain-depth`, `:on-create`, `:on-destroy`. Live runtime state (`app-db`, sub-cache, queue) is preserved regardless of what the metadata map says.
 
 **Trade-off:** there's some "config drift" between what `reg-frame` literally says and what's running. A developer who edits `:on-create` and re-saves will not see the new init event re-fire — they need to call `reset-frame` to apply it. This matches today's re-frame: `app-db` doesn't reset when you save a file, and developers expect that.
 
@@ -343,7 +343,7 @@ The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe t
 ```clojure
 {:event        [:add-todo "milk"]      ;; the user-facing vector, unchanged
  :frame        :todo                   ;; resolved frame keyword
- :fx-overrides {:http stub-fn}         ;; per-dispatch fx replacements (master's dispatch-with)
+ :fx-overrides {:my-app/http stub-fn}  ;; per-dispatch fx replacements (master's dispatch-with)
  :trace-id     "..."                   ;; tooling/agent fields
  :source       :ui                     ;; trigger kind — the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui :timer :http :machine :repl :ssr-hydration :test :other`)
  :origin       :pair                   ;; actor identity — open vocabulary, defaults to `:app`; e.g. `:pair`, `:claude`, `:story`, `:test`
@@ -356,7 +356,7 @@ The envelope is just a map. Any field can be set by:
 - **Frame-level config** — `reg-frame` keys (`:fx-overrides`, `:interceptor-overrides`, etc.) are merged into the envelope by the routing layer when an event is routed to that frame.
 - **Lexical injection** — `reg-view`-injected `dispatch` closures carry `:frame` from React context.
 
-The two-arg `dispatch` form is the single mechanism for setting envelope fields per call: `(dispatch event {:frame :todo :fx-overrides {...}})`. Per-event override variants like `dispatch-to`, `dispatch-with`, and `dispatch-sync-with` are not part of the API. (Clojure metadata on the event vector is accepted as a backwards-compat shim — see [MIGRATION.md](MIGRATION.md).)
+The two-arg `dispatch` form is the single mechanism for setting envelope fields per call: `(dispatch event {:frame :todo :fx-overrides {...}})`. Per-event override variants like `dispatch-to`, `dispatch-with`, and `dispatch-sync-with` are not part of the API. Event-vector metadata is not an opt-channel in v2; use the two-arg `(dispatch event opts)` form. (The one v1 metadata case — `^:flush-dom` — is rewritten to `:dispatch-later {:ms 0}`; see [MIGRATION.md §M-16](MIGRATION.md#m-16-flush-dom-event-vector-metadata-removed--replace-with-dispatch-later-ms-0).)
 
 The router reads the envelope's `:frame`, looks up the frame in the registry, and runs the interceptor pipeline against that frame's `app-db`/router context. Handlers receive the same shape they always have (`db`+`event-vec` for `reg-event-db`, context map for `reg-event-fx`); the envelope is not exposed to user handlers.
 
@@ -572,11 +572,11 @@ The trickiest correctness question. Consider:
 ```clojure
 (rf/reg-event-fx :load-todo
   (fn [{:keys [db event]}]
-    {:fx [[:http {:url "/todo/1"
-                  :on-success [:todo-loaded]}]]}))
+    {:fx [[:my-app/http {:url "/todo/1"
+                         :on-success [:todo-loaded]}]]}))
 ```
 
-When `:load-todo` is dispatched in frame `:todo`, the `:http` effect fires. Some time later, the HTTP machinery dispatches `[:todo-loaded ...]`. **It must dispatch into `:todo`, not `:rf/default`** — otherwise the response lands in the wrong app-db.
+When `:load-todo` is dispatched in frame `:todo`, the `:my-app/http` effect fires (`:my-app/http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md)). Some time later, the HTTP machinery dispatches `[:todo-loaded ...]`. **It must dispatch into `:todo`, not `:rf/default`** — otherwise the response lands in the wrong app-db.
 
 The mechanism is symmetric with how event handlers receive their context: **fx handlers receive the same `m` that the originating event handler received**, including `:frame`. Routing follows from explicit data, not implicit state.
 
@@ -607,7 +607,7 @@ The runtime needs to resolve fx-handlers against the frame record (for `:fx-over
 When the actual dispatching happens after the fx handler has returned (HTTP callback, websocket message, timer, deferred promise), the fx handler captures `(:frame m)` into the closure that fires later:
 
 ```clojure
-(reg-fx :http
+(reg-fx :my-app/http
   (fn [m {:keys [url on-success on-failure]}]
     (let [frame (:frame m)]
       (-> (js/fetch url)
@@ -618,7 +618,7 @@ When the actual dispatching happens after the fx handler has returned (HTTP call
 The `bound-dispatcher` helper makes this a one-liner:
 
 ```clojure
-(reg-fx :http
+(reg-fx :my-app/http
   (fn [m {:keys [url on-success on-failure]}]
     (let [d (rf/bound-dispatcher m)]                ;; closure over (:frame m)
       (-> (js/fetch url)
@@ -745,7 +745,7 @@ For async closures that fire after the body returns, capture the frame keyword e
 
 ```clojure
 (rf/dispatch-sync [:foo] {:frame :todo
-                          :fx-overrides {:http stub-fn}})
+                          :fx-overrides {:my-app/http stub-fn}})
 ```
 
 #### Calling `dispatch-sync` *inside* a handler is an error
@@ -1051,7 +1051,7 @@ This per-event drain is the canonical place every other piece of the runtime hoo
 
 > **Expected use case: testing.** Overrides are designed for tests, story fixtures, REPL exploration, and dev-time scenarios. They are *not* a production behaviour-routing mechanism — production code should use ordinary fx and interceptors registered globally. Overrides exist so tests can run without monkey-patching the global registry; they leave no trace once the test ends.
 >
-> **Pattern-level contract vs. CLJS reference (locked):** at the **pattern level**, override values are *registered ids* — `{:http :http/canned-200}` swaps one registered fx for another by id. Functions don't serialise across the wire; an SSR-capable architecture (Spec 011) requires id-valued overrides. The **CLJS reference v1** additionally supports function-valued overrides (`{:http (fn [m args] ...)}`) as a client-only convenience for tests and story fixtures where the override is a one-off lambda. Both forms accepted; id-valued is the portable shape, function-valued is CLJS-only sugar.
+> **Pattern-level contract vs. CLJS reference (locked):** at the **pattern level**, override values are *registered ids* — `{:my-app/http :my-app/http.canned-200}` swaps one registered fx for another by id. Functions don't serialise across the wire; an SSR-capable architecture (Spec 011) requires id-valued overrides. The **CLJS reference v1** additionally supports function-valued overrides (`{:my-app/http (fn [m args] ...)}`) as a client-only convenience for tests and story fixtures where the override is a one-off lambda. Both forms accepted; id-valued is the portable shape, function-valued is CLJS-only sugar.
 >
 > **Asymmetry (explicit, locked):** other-language implementations need only support **id-valued** overrides — that's the conformance contract. The CLJS reference accepting function values is a local ergonomic affordance, not a pattern-level contract. AI scaffolding (Construction-Prompts) and the conformance corpus generate id-valued overrides. The `:rf/dispatch-envelope` schema's `:fx-overrides` value is `[:map-of :keyword :any]` rather than `[:map-of :keyword :keyword]` precisely because the CLJS reference admits the function-valued form; non-CLJS implementations narrow the value type to id-only.
 
@@ -1072,24 +1072,24 @@ The pattern-level form is **id-valued** — replace one registered fx with anoth
 ```clojure
 ;; per-call — id-valued (canonical, portable)
 (rf/dispatch [:user/login {:email "..."}]
-             {:fx-overrides {:http         :http.canned-200
+             {:fx-overrides {:my-app/http  :my-app/http.canned-200
                              :localstorage nil}})                       ;; nil = noop
 
 ;; per-frame — id-valued
 (rf/reg-frame :story.auth.login-form/loading
   {:on-create    [:auth/show-loading]
-   :fx-overrides {:http :http.pending-stub}})
+   :fx-overrides {:my-app/http :my-app/http.pending-stub}})
 
 ;; per-call — function-valued (CLJS reference convenience for tests)
 (rf/dispatch [:user/login {:email "..."}]
-             {:fx-overrides {:http (fn [m args] (canned-response args))}})
+             {:fx-overrides {:my-app/http (fn [m args] (canned-response args))}})
 ```
 
 Where the id-valued form points: a separate `reg-fx` registration. The id-valued form composes with the registry — the override is itself a queryable, schema'd, source-coordinated artefact:
 
 ```clojure
-(rf/reg-fx :http.canned-200
-  {:doc       "Test stub: every :http call resolves to a canned 200 response."
+(rf/reg-fx :my-app/http.canned-200
+  {:doc       "Test stub: every :my-app/http call resolves to a canned 200 response."
    :platforms #{:client :server}}
   (fn [_m args]
     (when-let [on-success (:on-success args)]

--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -83,8 +83,10 @@ A variant is a **specific scenario** — one state of a story. Variants register
    :events    [[:auth/initialise]
                [:auth/email-changed "alice@example.com"]
                [:auth/login-pressed]]
-   :decorators [[force-fx-stub :http {:status :pending}]]})
+   :decorators [[force-fx-stub :my-app/http {:status :pending}]]})
 ```
+
+(`:my-app/http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md).)
 
 The keyword convention `:story.<path>/<variant>` keeps stories and their variants discoverable as a group, while still being a single keyword for re-frame's purposes.
 
@@ -157,7 +159,7 @@ Two registration forms are canonical, and authors choose by ergonomics:
               :loading           {:events [[:auth/initialise]
                                            [:auth/email-changed "alice@example.com"]
                                            [:auth/login-pressed]]
-                                  :decorators [[force-fx-stub :http {:status :pending}]]}}})
+                                  :decorators [[force-fx-stub :my-app/http {:status :pending}]]}}})
 ```
 
 Both forms are first-class.
@@ -260,7 +262,7 @@ Decorators wrap stories with shared infrastructure: themes, layout containers, m
 
 1. **Hiccup wrapper.** A vector that wraps the rendered view.
 2. **Frame setup.** A function that mutates the story's frame at creation — pre-populates `app-db`, registers per-frame interceptors.
-3. **Fx override.** A declaration that swaps an fx for the lifetime of the variant — `[force-fx-stub :http canned-response]`.
+3. **Fx override.** A declaration that swaps an fx for the lifetime of the variant — `[force-fx-stub :my-app/http canned-response]`.
 
 ```clojure
 ;; Hiccup wrapper — pure visual
@@ -274,7 +276,7 @@ Decorators wrap stories with shared infrastructure: themes, layout containers, m
 
 ;; Fx override — affects effects. The stub payload is data; any handler logic
 ;; lives in a registered event/fx handler that the decorator references by id.
-[force-fx-stub :http {:status 200 :body {...}}]
+[force-fx-stub :my-app/http {:status 200 :body {...}}]
 [force-fx-stub :localstorage {:value nil}]
 ```
 
@@ -360,8 +362,8 @@ Loaders run asynchronously before stories render to fetch data. **Deterministic 
 ;; The async work lives in a registered event handler; the variant references it by id.
 (rf/reg-event-fx :charts.heatmap/fetch-fixture
   (fn [_ _]
-    {:fx [[:http {:url     "/fixtures/heatmap.json"
-                  :on-success [:charts/load-fixture]}]]}))
+    {:fx [[:my-app/http {:url     "/fixtures/heatmap.json"
+                         :on-success [:charts/load-fixture]}]]}))
 
 (rf/reg-variant :story.charts.heatmap/with-real-data
   {:doc      "Renders against a fixture fetched from disk."
@@ -374,7 +376,7 @@ Loaders run asynchronously before stories render to fetch data. **Deterministic 
 
 The variant setup phases run in this fixed order:
 
-1. **Loaders.** Each event in `:loaders` is dispatched into the variant's frame. The library waits for the loader's drain to settle (run-to-completion per [002](002-Frames.md)) and any pending fx the loader emitted (e.g., `:http`) to resolve and dispatch their continuation events. A loader is *complete* when no further events are in flight against the variant's frame.
+1. **Loaders.** Each event in `:loaders` is dispatched into the variant's frame. The library waits for the loader's drain to settle (run-to-completion per [002](002-Frames.md)) and any pending fx the loader emitted (e.g., `:rf.http/managed` or a user-supplied HTTP fx) to resolve and dispatch their continuation events. A loader is *complete* when no further events are in flight against the variant's frame.
 2. **Events.** Each event in `:events` is dispatch-synced in order, after every loader has completed. By the time `:events` runs, the loaded data is already in `app-db`.
 3. **Render.** The view renders against the post-events `app-db`.
 4. **Play.** Each event in `:play` is dispatched in order against the now-rendered view (per [§Play functions](#play-functions)).
@@ -383,7 +385,7 @@ Hosts that don't have a usable async surface for waiting on loader completion (r
 
 ## Effect mocking — hook design, not policy
 
-Stubbing `:http` and similar effects for stories uses **hooks for per-variant interceptors and fx overrides** — not mocking policy baked into `reg-variant`.
+Stubbing HTTP (and similar effects) for stories uses **hooks for per-variant interceptors and fx overrides** — not mocking policy baked into `reg-variant`. The effect being stubbed may be the framework-shipped `:rf.http/managed` (see [014-HTTPRequests](014-HTTPRequests.md)) or a user-supplied fx like `:my-app/http`; the stubbing mechanism is the same.
 
 The framework hooks (at the foundation level — see [002-Frames.md](002-Frames.md)):
 

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -19,7 +19,7 @@ The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runti
 | Per-test frame fixture | `(rf/make-frame opts)` / `(rf/destroy-frame f)` |
 | Scoped REPL/test block | `(rf/with-frame :frame-id body...)` *or* `(rf/with-frame [sym expr] body...)` — see [§`with-frame` call shapes](#with-frame-call-shapes) |
 | Synchronous test trigger | `(rf/dispatch-sync event)` or `(rf/dispatch-sync event opts)` |
-| Stub fx (per-call) | `(rf/dispatch-sync ev {:fx-overrides {:http stub-fn}})` |
+| Stub fx (per-call) | `(rf/dispatch-sync ev {:fx-overrides {:my-app/http stub-fn}})` |
 | Stub fx (per-frame) | `(rf/reg-frame :test-frame {:fx-overrides {…}})` |
 | Replace interceptor | `{:interceptor-overrides {:logger nil}}` per-call or per-frame |
 | Add interceptor (recorder) | `(rf/reg-frame :test-frame {:interceptors [event-recorder]})` |
@@ -149,22 +149,24 @@ For testing state machine transitions, skip the frame entirely:
 
 ## Per-test stubbing patterns
 
-### Stubbing `:http` for an entire frame
+### Stubbing an HTTP fx for an entire frame
+
+(`:my-app/http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md). The stubbing mechanism is identical regardless of which fx-id is being overridden.)
 
 ```clojure
 (rf/reg-frame :test/auth-flow
   {:on-create   [:auth/init-idle]
-   :fx-overrides {:http (fn [_m _args] {:status 200 :body {:user/id 42}})}})
+   :fx-overrides {:my-app/http (fn [_m _args] {:status 200 :body {:user/id 42}})}})
 
-;; every event handled in :test/auth-flow uses the stub :http
+;; every event handled in :test/auth-flow uses the stub :my-app/http
 ```
 
-### Stubbing `:http` for a single dispatch
+### Stubbing an HTTP fx for a single dispatch
 
 ```clojure
 (rf/dispatch-sync [:auth/load-user]
                   {:frame :test/auth-flow
-                   :fx-overrides {:http (fn [_m _args] {:status 401 :body "unauthorised"})}})
+                   :fx-overrides {:my-app/http (fn [_m _args] {:status 401 :body "unauthorised"})}})
 ;; only this dispatch sees the 401 stub; subsequent events use the frame's default
 ```
 


### PR DESCRIPTION
## Summary

Three pre-alpha cuts from the back-compat audit (rf2-3k2w7). All doc-level / spec-level edits; safe to batch.

### rf2-99c3l — event-vector metadata as opt-channel

Spec/002-Frames.md L359 promised that Clojure metadata on the event vector was honoured as a backwards-compat opt-channel. No impl exists in the dispatch path. Per pre-alpha rule (strip promises without impl), replaced the dangling sentence with the canonical statement: event-vector metadata is not an opt-channel in v2; use the two-arg `(dispatch event opts)` form. The one v1 metadata case (`^:flush-dom`) is already handled by MIGRATION §M-16; cross-linked.

### rf2-i9gmn — re-frame.core-legacy ns mention

Already addressed by PR #482 (rf2-4lc9o, "cut re-frame.views-macros legacy import path"). The L321 sentence now reads "Plain fns are allowed indefinitely; the warning is a *quality-of-life* signal, not a deprecation." — the cleaned form the audit's pre-alpha lean recommended. Bead closes as already-done; no additional change in this PR.

### rf2-lvsz8 — `:http` example fx clarification

`:http` was used as an example fx-id across several spec files but read as if framework-shipped due to brand association. The framework actually ships `:rf.http/managed` (Spec 014); `events.cljc:69-79` rejects bare `:http` as a top-level effect-map key per M-8. Renamed example occurrences to `:my-app/http` (clearly user-namespaced) and added a clarifying note at first-use sites pointing at `:rf.http/managed` as the canonical framework surface.

Sites touched (3 files):
- `spec/002-Frames.md` — 8 :http→:my-app/http rename sites + 1 metadata-channel strip
- `spec/007-Stories.md` — 6 :http→:my-app/http rename sites + 1 prose clarification
- `spec/008-Testing.md` — 3 :http→:my-app/http rename sites + 1 prose clarification

`:source` enum mentions of `:http` (002-Frames.md L348, L401) and descriptive prose listings (L799) are unchanged — those aren't fx-id references and weren't in the audit's affected-lines list.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — clean (exit 0).
- [x] `python -m mkdocs build --strict` — warning count unchanged vs origin/main (227 → 227; all pre-existing, none introduced).
- [x] Diff of mkdocs warning sets (with-edits vs without-edits) shows zero new lines.
- [x] Sanity-checked `events.cljc:69-79` still rejects bare `:http` per M-8 (suggestion string intact).
- [x] No impl/test sources touched — strictly `spec/**/*.md`.