### PR TITLE
fix(http-managed): suppress :on-failure reply on superseded aborts — debounce-search no longer races (rf2-lxd3)

### DIFF
--- a/implementation/http/src/re_frame/http_transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http_transport_cljs.cljc
@@ -124,23 +124,31 @@
 
 #?(:cljs
    (defn- finalise-failure!
-     "Final-failure dispatch (after retries exhausted or non-retriable)."
+     "Final-failure dispatch (after retries exhausted or non-retriable).
+
+     Per rf2-lxd3: when a fresh request supersedes a prior one with the
+     same `:request-id`, the prior request's `:on-failure` reply is NOT
+     dispatched (the supersede semantic = the new request replaces the
+     old one — the original `:on-failure` would race the new request's
+     outcome and corrupt debounce-search patterns). The supersede event
+     still emits to the trace bus (`:rf.http/aborted` with
+     `:reason :request-id-superseded`); consumers wanting abort telemetry
+     subscribe via `register-trace-cb!`."
      [ctx failure]
      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
-     (when (and interop/debug-enabled?
-                (= :rf.http/aborted (:kind failure)))
-       ;; Aborted is its own category — the trace is a single error event.
-       nil)
      (when interop/debug-enabled?
        (trace/emit-error! (:kind failure)
                           (assoc failure
                                  :request-id (:request-id ctx)
                                  :url        (:url ctx)
                                  :recovery   :no-recovery)))
-     (dispatch-reply! (assoc ctx
-                             :kind          :failure
-                             :reply-payload {:kind    :failure
-                                             :failure failure}))))
+     (let [superseded? (and (= :rf.http/aborted (:kind failure))
+                            (= :request-id-superseded (:reason failure)))]
+       (when-not superseded?
+         (dispatch-reply! (assoc ctx
+                                 :kind          :failure
+                                 :reply-payload {:kind    :failure
+                                                 :failure failure}))))))
 
 #?(:cljs
    (defn- maybe-retry!

--- a/implementation/http/src/re_frame/http_transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http_transport_jvm.cljc
@@ -143,6 +143,16 @@
 
 #?(:clj
    (defn- finalise-failure!
+     "Final-failure dispatch (after retries exhausted or non-retriable).
+
+     Per rf2-lxd3: when a fresh request supersedes a prior one with the
+     same `:request-id`, the prior request's `:on-failure` reply is NOT
+     dispatched (the supersede semantic = the new request replaces the
+     old one — the original `:on-failure` would race the new request's
+     outcome and corrupt debounce-search patterns). The supersede event
+     still emits to the trace bus (`:rf.http/aborted` with
+     `:reason :request-id-superseded`); consumers wanting abort telemetry
+     subscribe via `register-trace-cb!`."
      [ctx failure]
      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
      (when interop/debug-enabled?
@@ -151,10 +161,13 @@
                                  :request-id (:request-id ctx)
                                  :url        (:url ctx)
                                  :recovery   :no-recovery)))
-     (dispatch-reply! (assoc ctx
-                             :kind          :failure
-                             :reply-payload {:kind    :failure
-                                             :failure failure}))))
+     (let [superseded? (and (= :rf.http/aborted (:kind failure))
+                            (= :request-id-superseded (:reason failure)))]
+       (when-not superseded?
+         (dispatch-reply! (assoc ctx
+                                 :kind          :failure
+                                 :reply-payload {:kind    :failure
+                                                 :failure failure}))))))
 
 #?(:clj
    (defn- maybe-retry!

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -570,3 +570,174 @@
           (is (= :rf.http/timeout (get-in db [:reply :failure :kind]))))
         (.countDown latch)
         (finally (stop-server! srv))))))
+
+;; ---- 14. supersede on same :request-id (rf2-lxd3) -------------------------
+;;
+;; Per rf2-lxd3 decision A: when a fresh request supersedes a prior one
+;; with the same `:request-id`, the prior request's `:on-failure` reply
+;; is NOT dispatched (semantic = the new request replaces the old one,
+;; debounce-search mental model). The supersede event still emits to
+;; the trace bus (`:rf.http/aborted` with `:reason :request-id-superseded`);
+;; consumers wanting abort telemetry subscribe via `register-trace-cb!`.
+
+(deftest jvm-supersede-does-not-fire-on-failure
+  (testing "rf2-lxd3 — superseding a request with the same :request-id MUST NOT
+            fire the prior request's :on-failure. The :on-success is silenced
+            (nil) on both requests so the test isolates failure-reply behaviour
+            from the JVM transport's natural-completion path."
+    (let [latch         (CountDownLatch. 1)
+          a-failed?     (atom false)
+          b-success?    (atom false)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; Block long enough for the second dispatch to supersede the
+              ;; first BEFORE the server responds.
+              (.await latch 5 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :search/run
+          (fn [_ [_ q]]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/q?" q)}
+                    :request-id :search
+                    :decode     :json
+                    ;; Silence success on the prior request — only the
+                    ;; supersede-driven :on-failure dispatch is under test.
+                    :on-success nil
+                    :on-failure [:search/a-failed]}]]}))
+        (rf/reg-event-fx :search/run-superseding
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/q?fresh")}
+                    :request-id :search
+                    :decode     :json
+                    :on-failure nil
+                    :on-success [:search/b-ok]}]]}))
+        (rf/reg-event-db :search/a-failed (fn [db _] (reset! a-failed? true) db))
+        (rf/reg-event-db :search/b-ok     (fn [db _] (reset! b-success? true) db))
+
+        (rf/dispatch-sync [:search/run "stale"])
+        ;; Let the first request reach in-flight.
+        (await-condition!
+          #(seq (http-managed/in-flight-snapshot))
+          2000)
+        ;; Fire the superseding request — same :request-id.
+        (rf/dispatch-sync [:search/run-superseding])
+        ;; Release the server so the second request can complete.
+        (.countDown latch)
+        ;; Wait for the second request's success reply.
+        (await-condition! #(true? @b-success?) 5000)
+        ;; The PRIOR request's :on-failure (:search/a-failed) MUST NOT
+        ;; have fired. Allow extra settle time to rule out a delayed
+        ;; dispatch from either the abort path or the natural-completion
+        ;; path (which is :success, silenced by :on-success nil).
+        (Thread/sleep 100)
+        (is (false? @a-failed?)
+            "the superseded request's :on-failure must NOT fire (rf2-lxd3 fix)")
+        (is (true? @b-success?)
+            "the superseding request's :on-success DOES fire")
+        (finally (stop-server! srv))))))
+
+(deftest jvm-supersede-still-emits-trace-event
+  (testing "rf2-lxd3 — supersede still emits :rf.http/aborted trace event with
+            :reason :request-id-superseded so register-trace-cb! consumers
+            keep visibility"
+    (let [latch    (CountDownLatch. 1)
+          events   (atom [])
+          cb-id    ::lxd3-trace
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (.await latch 5 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (trace/register-trace-cb! cb-id
+                                  (fn [ev]
+                                    (when (= :rf.http/aborted (:operation ev))
+                                      (swap! events conj ev))))
+        (rf/reg-event-fx :search/run
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/q1")}
+                    :request-id :search
+                    :decode     :json}]]}))
+        (rf/reg-event-fx :search/run-superseding
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/q2")}
+                    :request-id :search
+                    :decode     :json}]]}))
+
+        (rf/dispatch-sync [:search/run])
+        (await-condition!
+          #(seq (http-managed/in-flight-snapshot))
+          2000)
+        (rf/dispatch-sync [:search/run-superseding])
+        (await-condition! #(seq @events) 2000)
+
+        (let [ev (first @events)
+              tags (:tags ev)]
+          (is (= :rf.http/aborted (:operation ev))
+              "supersede emits :rf.http/aborted trace event")
+          (is (= :request-id-superseded (:reason tags))
+              ":reason :request-id-superseded distinguishes supersede from :user / :actor-destroyed")
+          (is (= :search (:request-id tags))
+              ":request-id rides on the trace event"))
+
+        (.countDown latch)
+        (finally
+          (trace/remove-trace-cb! cb-id)
+          (stop-server! srv))))))
+
+(deftest jvm-non-superseded-abort-still-fires-reply
+  (testing "rf2-lxd3 regression guard — a non-supersede abort (manual
+            :rf.http/managed-abort) STILL fires :on-failure as before.
+            Only :reason :request-id-superseded suppresses the reply."
+    (let [latch        (CountDownLatch. 1)
+          reply-fired? (atom false)
+          reply-data   (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (.await latch 5 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json" "{}")))]
+      (try
+        (rf/reg-event-fx :slow/load
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/slow")}
+                    :request-id :slow
+                    :decode     :json
+                    :on-failure [:slow/failed]}]]}))
+        (rf/reg-event-fx :slow/abort
+          (fn [_ _] {:fx [[:rf.http/managed-abort :slow]]}))
+        (rf/reg-event-db :slow/failed
+          (fn [db [_ payload]]
+            (reset! reply-fired? true)
+            (reset! reply-data payload)
+            db))
+
+        (rf/dispatch-sync [:slow/load])
+        (await-condition!
+          #(seq (http-managed/in-flight-snapshot))
+          2000)
+        ;; User-initiated abort — the abort fn passes `:user` as the reason.
+        (rf/dispatch-sync [:slow/abort])
+        (await-condition! #(true? @reply-fired?) 2000)
+
+        (is (true? @reply-fired?)
+            "non-supersede abort STILL dispatches :on-failure")
+        ;; Per build-reply-event: explicit :on-failure [:slow/failed] appends
+        ;; the reply payload as the last arg — the handler receives the
+        ;; payload directly (NOT wrapped under :rf/reply).
+        (let [reply @reply-data]
+          (is (= :failure (:kind reply))
+              "the reply is a :failure reply")
+          (is (= :rf.http/aborted (-> reply :failure :kind))
+              "failure kind is :rf.http/aborted")
+          (is (not= :request-id-superseded (-> reply :failure :reason))
+              ":reason is NOT :request-id-superseded (this is the regression guard)"))
+
+        (.countDown latch)
+        (finally (stop-server! srv))))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -317,7 +317,7 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 | `:rf.http/http-5xx` | Non-2xx 5xx response | same as `:http-4xx` |
 | `:rf.http/decode-failure` | A success-eligible (2xx) response whose body the decode pipeline rejected (schema validation error, JSON syntax error, custom decoder threw). Non-2xx responses never produce `:rf.http/decode-failure` — they classify by status. | `:body-text`, `:cause`, `:schema-validation-failure?` |
 | `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. The user's failure map sits at `:detail`; `:decoded` carries the pre-`:accept` decoded value for context. | `:detail` (user's verbatim failure map), `:decoded` |
-| `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal` | `:request-id` (if any), `:reason` (`:user` / `:request-id-superseded`) |
+| `:rf.http/aborted` | The request was aborted via `:request-id` or `:abort-signal` | `:request-id` (if any), `:reason` (`:user` on the reply; `:request-id-superseded` is trace-only — see [§`:request-id` (internal)](#request-id-internal)) |
 
 The category vocabulary is **closed for v1** — additions require a Spec change. The `:rf.http/*` namespace makes these unambiguous wherever they leak: trace events, error projector, `:retry :on` sets, epoch records.
 
@@ -404,7 +404,7 @@ A subsequent `:rf.http/managed-abort` fx with the same id (compared by `=`) canc
 {:fx [[:rf.http/managed-abort [:articles :load "hello"]]]}
 ```
 
-When two in-flight requests share an id, issuing a new one with the same id supersedes the old one (`:reason :request-id-superseded` on the aborted reply); a manual `:rf.http/managed-abort` aborts whichever request currently holds the id (`:reason :user`).
+When a fresh request supersedes a prior one with the same `:request-id`, the prior request's `:on-failure` reply is **not dispatched** — semantically the new request *replaces* the old one (the debounce-search mental model). The supersede event still emits to the trace bus (`:rf.http/aborted` with `:reason :request-id-superseded`); consumers wanting abort telemetry subscribe via `register-trace-cb!` at `:warning` or `:error` severity. A manual `:rf.http/managed-abort` aborts whichever request currently holds the id and DOES dispatch `:on-failure` with `:reason :user`.
 
 ### `:abort-signal` (external)
 
@@ -440,7 +440,7 @@ The aborted reply is the same shape as a manual-abort failure:
                       :actor-id   <destroyed-spawned-actor-id>}}}
 ```
 
-The discriminator from a user-issued abort is `:reason` — `:user` (manual `:rf.http/managed-abort`), `:request-id-superseded` (a fresh request with the same `:request-id`), or `:actor-destroyed` (this contract). Callers that branch on `:reason` recover that distinction; callers that don't see one uniform "aborted" outcome.
+The discriminator from a user-issued abort is `:reason` — `:user` (manual `:rf.http/managed-abort`) or `:actor-destroyed` (this contract). Callers that branch on `:reason` recover that distinction; callers that don't see one uniform "aborted" outcome. (The third reason value, `:request-id-superseded`, never lands on a reply dispatch — per [§`:request-id` (internal)](#request-id-internal) supersede suppresses the prior request's reply and emits only to the trace bus.)
 
 The reply lands at the originating handler exactly as any other reply does (per [§Reply addressing](#reply-addressing)). For requests issued by a spawned actor whose handler the destroy already unregistered, the dispatch is a no-op — the actor's snapshot is gone and there is no event handler to receive the reply. The trace event still fires; the abort is still observable through instrumentation.
 


### PR DESCRIPTION
## Summary

- `http-managed`'s `supersede!` was invoking the prior request's `:abort-fn`, which routed through `finalise-failure!` and dispatched the prior request's `:on-failure` event with `{:kind :rf.http/aborted :reason :request-id-superseded ...}`. In debounce-search patterns this raced the superseding request's outcome and corrupted user-visible state.
- Per the decision logged on rf2-lxd3 (option A — suppress reply), `finalise-failure!` now detects supersede-driven aborts (`:rf.http/aborted` + `:reason :request-id-superseded`) and skips `dispatch-reply!`. The trace emit (`trace/emit-error!`) still fires, so consumers using `register-trace-cb!` keep abort telemetry. Other abort reasons (`:user`, `:actor-destroyed`) preserve existing behaviour.
- Spec 014 §`:request-id`, the failure-categories table, and the abort-on-actor-destroy §Failure shape discriminator block are updated to reflect that `:request-id-superseded` is a trace-only signal.

## Test plan

- [x] `clojure -M:test` in `implementation/http` — 42 tests / 159 assertions, all green (3 new supersede tests).
- [x] `npm run test:cljs` — 591 tests / 1401 assertions, all green.
- [x] `npm run test:browser` — 591 tests / 1428 assertions, all green.
- [x] `npm run test:elision` — passes.
- [x] mkdocs strict — no NEW warnings introduced (pre-existing warnings unchanged).

## New coverage

1. `jvm-supersede-does-not-fire-on-failure` — core fix: dispatch req A with `:on-failure [:a-failed]`; dispatch req B with same `:request-id`; assert `:a-failed` does NOT fire.
2. `jvm-supersede-still-emits-trace-event` — trace bus still sees `:rf.http/aborted` with `:reason :request-id-superseded` via `register-trace-cb!`.
3. `jvm-non-superseded-abort-still-fires-reply` — regression guard: manual `:rf.http/managed-abort` STILL dispatches `:on-failure` (only supersede suppresses).