### PR TITLE
fix(subs): decrement input ref-counts on parent disposal — restores balanced subscribe/unsubscribe invariant (rf2-f3rd)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -139,7 +139,7 @@
   []
   (or (:grace-period-ms @config) 0))
 
-(declare subscribe)
+(declare subscribe unsubscribe)
 
 (defn- maybe-validate-sub-return!
   "Per Spec 010 §Validation order step 6 (rf2-wcam) — after a sub
@@ -306,6 +306,19 @@
                             :pending-dispose nil})
       (interop/add-on-dispose! reaction
         (fn []
+          ;; Per rf2-f3rd: a layer-2+ sub's construction called `subscribe`
+          ;; once per `:<-` input (line 290 above), each incrementing the
+          ;; input's `:ref-count`. The disposal of this parent slot must
+          ;; release those refs symmetrically — without this, input
+          ;; ref-counts leak after Reagent auto-disposes the parent. We
+          ;; decrement inputs BEFORE clearing the parent slot so the cache
+          ;; introspection invariant ("ref-count reflects live refs")
+          ;; holds at every observable moment; the recursive disposal
+          ;; cascade is driven by the same ref-count → 0 path
+          ;; `unsubscribe` already takes.
+          (doseq [input-q input-signals]
+            (try (unsubscribe frame-id input-q)
+                 (catch #?(:clj Throwable :cljs :default) _ nil)))
           (swap! cache (fn [m]
                          (if (identical? reaction (get-in m [k :reaction]))
                            (dissoc m k)
@@ -387,8 +400,6 @@
                           (assoc :pending-dispose nil))))
              (:reaction entry))
            (compute-and-cache! frame-id query-v)))))))
-
-(declare unsubscribe)
 
 (defn subscribe-value
   "Subscribe and immediately deref. Useful in handler bodies where a

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -452,3 +452,177 @@
           (is (= count-after-dispose @recompute-count)
               "subsequent state changes still do not recompute"))))))
 
+;; ---- rf2-f3rd: layer-2+ disposal decrements input ref-counts --------------
+;;
+;; Per Spec 006 §Reference counting and disposal — disposal cascades clause:
+;; "When a layer-2 sub disposes, its layer-1 inputs lose one reader each;
+;; if they were held only by that layer-2 sub, they enter their own
+;; grace-period." Pre-fix, `compute-and-cache!`'s `add-on-dispose!`
+;; callback only dissoc'd the parent slot and never decremented the
+;; input ref-counts that `subscribe` incremented during construction —
+;; so input ref-counts leaked. The fix walks `:input-signals` and calls
+;; `unsubscribe` on each input symmetrically with the construction-time
+;; `subscribe` calls. These tests pin the symmetric invariant.
+
+(deftest layer-2-disposal-decrements-input-ref-counts
+  (testing "disposing a layer-2 sub decrements ref-counts on every :<- input"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :sum
+      :<- [:a]
+      :<- [:b]
+      (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+
+    ;; Subscribe to the parent layer-2 sub. This recursively subscribes
+    ;; to both inputs, bumping each to ref-count 1.
+    (let [r (rf/subscribe [:sum])]
+      (is (= 5 @r))
+      (is (= 1 (entry-ref-count [:sum])) "parent ref-count = 1")
+      (is (= 1 (entry-ref-count [:a])) "input :a ref-count = 1 after layer-2 build")
+      (is (= 1 (entry-ref-count [:b])) "input :b ref-count = 1 after layer-2 build"))
+
+    ;; Dispose the parent (sole subscriber drops → grace=0 sync dispose).
+    (rf/unsubscribe [:sum])
+
+    ;; Parent slot is gone; inputs cascaded to ref-count 0 and were
+    ;; themselves disposed (no other holders).
+    (is (not (contains? (cache-keys) [:sum])) "parent disposed")
+    (is (not (contains? (cache-keys) [:a]))
+        "input :a disposed via cascade (ref-count → 0)")
+    (is (not (contains? (cache-keys) [:b]))
+        "input :b disposed via cascade (ref-count → 0)")))
+
+(deftest layer-2-disposal-respects-shared-inputs
+  (testing "disposing one layer-2 sub decrements shared input only by one"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3 :c 4}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :c (fn [db _] (:c db)))
+    ;; Two layer-2 subs that share input :a.
+    (rf/reg-sub :ab :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/reg-sub :ac :<- [:a] :<- [:c] (fn [[a c] _] (+ a c)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:ab])
+    (rf/subscribe [:ac])
+
+    ;; :a is held by both layer-2 subs → ref-count 2.
+    (is (= 2 (entry-ref-count [:a])) "shared input :a has ref-count 2")
+    (is (= 1 (entry-ref-count [:b])))
+    (is (= 1 (entry-ref-count [:c])))
+
+    ;; Dispose one layer-2 sub.
+    (rf/unsubscribe [:ab])
+
+    ;; :a's ref-count drops to 1 (not 0) — the other layer-2 still holds it.
+    (is (not (contains? (cache-keys) [:ab])) ":ab disposed")
+    (is (contains? (cache-keys) [:a])
+        ":a survives — still referenced by :ac")
+    (is (= 1 (entry-ref-count [:a]))
+        "shared input ref-count dropped by exactly 1 (now 1, not 0, not 2)")
+    (is (not (contains? (cache-keys) [:b]))
+        ":b was held only by :ab — disposed via cascade")
+    (is (contains? (cache-keys) [:c])
+        ":c untouched — still held by :ac")
+    (is (= 1 (entry-ref-count [:c])))
+
+    ;; Dispose the other layer-2 sub. Now :a's ref-count hits 0.
+    (rf/unsubscribe [:ac])
+    (is (not (contains? (cache-keys) [:ac])))
+    (is (not (contains? (cache-keys) [:a]))
+        ":a finally disposed after the last layer-2 holder dropped")
+    (is (not (contains? (cache-keys) [:c]))
+        ":c disposed via cascade")))
+
+(deftest layer-2-disposal-respects-externally-held-input
+  (testing "an input also held by a direct subscribe is not over-disposed"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+
+    ;; External subscriber to :a, parallel to the layer-2 sub that also uses :a.
+    (rf/subscribe [:a])
+    (rf/subscribe [:sum])
+
+    ;; :a has TWO holders: the direct subscribe AND :sum's construction.
+    (is (= 2 (entry-ref-count [:a]))
+        ":a ref-count is 2 — one direct subscribe, one layer-2 dependency")
+    (is (= 1 (entry-ref-count [:b])))
+    (is (= 1 (entry-ref-count [:sum])))
+
+    ;; Dispose the layer-2 sub. :a's count drops from 2 → 1 (NOT 0).
+    (rf/unsubscribe [:sum])
+    (is (not (contains? (cache-keys) [:sum])))
+    (is (contains? (cache-keys) [:a]) ":a NOT disposed — external holder remains")
+    (is (= 1 (entry-ref-count [:a]))
+        "decrement was exactly one — external subscribe still holds :a")
+    (is (not (contains? (cache-keys) [:b]))
+        ":b had only the layer-2 holder — disposed via cascade")
+
+    ;; External unsubscribe finishes the job.
+    (rf/unsubscribe [:a])
+    (is (not (contains? (cache-keys) [:a]))
+        ":a disposed when external holder drops")))
+
+(deftest layer-3-disposal-cascades-through-chain
+  (testing "disposal cascades recursively through a layer-3 chain"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :a*2 :<- [:a]   (fn [a _] (* 2 a)))
+    (rf/reg-sub :a*4 :<- [:a*2] (fn [a2 _] (* 2 a2)))
+    (rf/dispatch-sync [:init])
+
+    (let [r (rf/subscribe [:a*4])]
+      (is (= 8 @r))
+      (is (= 1 (entry-ref-count [:a*4])))
+      (is (= 1 (entry-ref-count [:a*2])))
+      (is (= 1 (entry-ref-count [:a]))))
+
+    (rf/unsubscribe [:a*4])
+
+    ;; Whole chain cascaded to disposal.
+    (is (not (contains? (cache-keys) [:a*4])))
+    (is (not (contains? (cache-keys) [:a*2])))
+    (is (not (contains? (cache-keys) [:a])))))
+
+(deftest layer-2-multi-subscriber-disposal-keeps-inputs-alive
+  (testing "with two parent subscribers, dropping one keeps inputs at ref-count 1"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :sum :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+
+    ;; Two subscribers to the same parent — parent ref-count goes to 2,
+    ;; inputs are constructed once (only the FIRST subscribe runs the
+    ;; cache-miss path that subscribes to inputs).
+    (rf/subscribe [:sum])
+    (rf/subscribe [:sum])
+    (is (= 2 (entry-ref-count [:sum])))
+    (is (= 1 (entry-ref-count [:a]))
+        "inputs only acquired on the cache-miss path — ref-count 1")
+    (is (= 1 (entry-ref-count [:b])))
+
+    ;; First unsubscribe: parent drops to 1, inputs untouched
+    ;; (the parent slot didn't dispose, so its on-dispose didn't fire).
+    (rf/unsubscribe [:sum])
+    (is (= 1 (entry-ref-count [:sum])))
+    (is (= 1 (entry-ref-count [:a]))
+        "inputs untouched — parent slot still live")
+    (is (= 1 (entry-ref-count [:b])))
+
+    ;; Second unsubscribe: parent disposes, cascade fires.
+    (rf/unsubscribe [:sum])
+    (is (not (contains? (cache-keys) [:sum])))
+    (is (not (contains? (cache-keys) [:a])))
+    (is (not (contains? (cache-keys) [:b])))))
+


### PR DESCRIPTION
## Summary

A layer-2+ sub's `compute-and-cache!` recursively calls `subscribe` on each `:<-` input, each call incrementing the input's `:ref-count`. The parent reaction's `add-on-dispose!` callback only dissoc'd the parent's cache slot — it never decremented the input ref-counts it had bumped at construction time. Result: input subs leaked ref-count.

Mike chose **Option B (decrement on dispose)** for `rf2-f3rd` on 2026-05-13 — "what the integer says, reality reflects" invariant.

## Fix

Walk `:input-signals` in the parent's on-dispose callback and call `unsubscribe` symmetrically on each input before clearing the parent slot. Forward-declares `unsubscribe` so it's reachable from `compute-and-cache!`.

This brings the disposal cascade clause from Spec 006 §Reference counting and disposal into actual behaviour:

> When a layer-2 sub disposes, its layer-1 inputs lose one reader each; if they were held only by that layer-2 sub, they enter their own grace-period.

The fix is mechanical — the recursive cascade falls out because `unsubscribe` already triggers `dispose-entry-now!` (or schedules `pending-dispose`) at ref-count → 0, which fires the same on-dispose path again on the input. Chain depth is bounded by the static sub-topology.

### Edge case verified

A layer-2+ sub with an input also held externally (direct `subscribe` from another view) is **not over-disposed**: the input's ref-count tracks both holders independently, so the layer-2 disposal merely decrements (e.g. 2 → 1) and the external holder keeps the input alive.

## Tests (new in `sub_cache_test.clj`, all grace=0)

- `layer-2-disposal-decrements-input-ref-counts` — solo parent → inputs cascade to disposal.
- `layer-2-disposal-respects-shared-inputs` — two parents share an input; first dispose drops shared count from 2 → 1, second from 1 → 0.
- `layer-2-disposal-respects-externally-held-input` — input also held by a direct `subscribe` is decremented but not disposed.
- `layer-3-disposal-cascades-through-chain` — three-layer chain cascades end-to-end.
- `layer-2-multi-subscriber-disposal-keeps-inputs-alive` — two parent subscribers keep inputs alive until both drop.

No existing tests required adjustment — prior tests of post-dispose `:ref-count` on a single layer-1 sub were already balanced under `subscribe`/`unsubscribe` pairing; the bug was specific to layer-2+ inputs that were never directly `unsubscribe`d.

## Test plan

- [x] `clojure -M:test` in `implementation/core`: 282 tests / 1273 assertions / 0 failures.
- [x] `clojure -M:test` in `implementation/epoch`: 59 tests / 233 assertions / 0 failures.
- [x] `npm run test:cljs`: 591 tests / 1401 assertions / 0 failures.
- [x] `npm run test:elision`: PASS.
- [x] `npm run test:examples`: all 25 examples PASS.