### PR TITLE
fix(router): single-drainer invariant — prevents JVM peek+pop race under stress (rf2-ynk7)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -154,14 +154,26 @@
 ;; ---- registration ---------------------------------------------------------
 
 (defn- new-frame-record [id config]
-  {:id        id
-   :app-db    (adapter/make-state-container {})
-   :router    (atom {:queue interop/empty-queue :scheduled? false})
-   :sub-cache (atom {})
-   :lifecycle {:created-at (interop/now-ms)
-               :destroyed? false
-               :listeners  []}
-   :config    config})
+  {:id         id
+   :app-db     (adapter/make-state-container {})
+   :router     (atom {:queue interop/empty-queue :scheduled? false})
+   ;; Per rf2-ynk7 §single-drainer invariant: a separate CAS-able cell
+   ;; that admits at most one thread into `drain!` at a time. On the JVM
+   ;; the executor's `next-tick` callback can wake while the calling
+   ;; thread is mid-drain (e.g. `dispatch-sync!`); without this guard,
+   ;; both threads' peek+pop sequence on `:queue` is non-atomic and
+   ;; double-processes / drops envelopes (the rf2-lmkk #442 flake). The
+   ;; loser of the CAS no-ops; the winning drainer rechecks the queue
+   ;; before releasing the flag so envelopes queued in the gap are not
+   ;; orphaned. CLJS is single-threaded so the CAS is uncontended there,
+   ;; but the same flag preserves the contract under any future
+   ;; concurrent host.
+   :drain-lock (atom false)
+   :sub-cache  (atom {})
+   :lifecycle  {:created-at (interop/now-ms)
+                :destroyed? false
+                :listeners  []}
+   :config     config})
 
 (declare destroy-frame!)
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -437,73 +437,163 @@
       (discard! frame-id))))
 
 (defn- handle-drain-settled!
-  "Tail-path for the empty-queue branch of `drain!`. Clear `:scheduled?`
-  and, if at least one event was processed, commit the epoch record
-  per Tool-Pair §Time-travel."
-  [frame-id router db-before depth]
-  (swap! router assoc :scheduled? false)
+  "Tail-path for the empty-queue branch of `drain!`. If at least one event
+  was processed, commit the epoch record per Tool-Pair §Time-travel.
+
+  Per rf2-ynk7 §single-drainer invariant: `:scheduled?` is no longer
+  cleared here. The drain loop's outer `finally` clears `:scheduled?`
+  AND releases `:drain-lock` under a single `locking router` block so
+  any concurrent submitter's `ensure-drain-scheduled!` check serializes
+  against the release. Splitting the two would re-open the
+  enqueue-after-empty-check race that motivated this bead."
+  [frame-id _router db-before depth]
   (when (pos? depth)
     (when-let [settle! (late-bind/get-fn :epoch/settle!)]
       (let [db-after (frame/frame-app-db-value frame-id)]
         (settle! frame-id db-before db-after)))))
 
-(defn- drain!
-  "Outer drain loop for a single frame. Repeatedly dequeue and process
-  until the queue is empty. Bounded by :drain-depth (default 100; per
-  Spec 002 §Run-to-completion §Rules).
+(defn- drain-loop!
+  "The drain body proper. Assumes the caller holds `:drain-lock` (per
+  rf2-ynk7 §single-drainer invariant) so this fn has exclusive access
+  to the queue's peek+pop pair.
 
-  Sets :in-drain? on the router state for the duration of the loop so
-  reentrant dispatch-sync! detects 'we're already in a drain' and
-  refuses (regardless of whether the outer drain came from
-  dispatch-sync or async dispatch).
+  Outer loop re-enters whenever an envelope arrives between the inner
+  empty-check and the lock-protected release window. Each pass takes a
+  fresh `db-before` snapshot so the epoch settle callback (Tool-Pair
+  §Time-travel) sees the right pre-cascade state for that pass."
+  [frame-id router drain-lock drain-depth]
+  (loop []
+    (let [db-before (frame/frame-app-db-value frame-id)
+          outcome
+          (try
+            ;; Per rf2-ynk7: track which thread holds the drain so the
+            ;; dispatch-sync guard ("nested inside a handler?") can
+            ;; discriminate same-thread nesting from a concurrent caller
+            ;; on a different thread. On CLJS — single-threaded — every
+            ;; check is necessarily same-thread, so `true` works as the
+            ;; marker.
+            (swap! router assoc :in-drain? #?(:clj (Thread/currentThread)
+                                              :cljs true))
+            (loop [depth      0
+                   last-event nil]
+              (cond
+                (>= depth drain-depth)
+                (do (handle-depth-exceeded! frame-id router db-before depth last-event)
+                    ::halt)
 
-  Two tail-paths are extracted as named helpers:
+                :else
+                (let [{:keys [queue]} @router]
+                  (if (empty? queue)
+                    (do (handle-drain-settled! frame-id router db-before depth)
+                        ::settled)
+                    ;; Per rf2-ynk7: with the single-drainer invariant
+                    ;; held by drain-lock, this peek+pop pair is now
+                    ;; atomic w.r.t. any other drain attempt. The pre-
+                    ;; fix race (executor and main thread both peek the
+                    ;; same envelope) cannot occur — the loser of the
+                    ;; CAS in `drain-try!` / `drain-block!` never reaches
+                    ;; this code.
+                    (let [envelope (peek queue)]
+                      (swap! router update :queue pop)
+                      (process-event! envelope)
+                      (recur (inc depth) (:event envelope)))))))
+            (finally
+              (swap! router assoc :in-drain? nil)))]
+      (cond
+        ;; Depth-exceeded forcibly cleared the queue and set
+        ;; :scheduled? false. Just release the drain-lock — no need to
+        ;; re-check the queue (it's empty by construction).
+        (= outcome ::halt)
+        (locking router
+          (reset! drain-lock false))
 
-    `handle-depth-exceeded!` — when the depth limit is hit, restore
-    `app-db` to the pre-drain snapshot (atomic rollback per Spec 002
-    §Run-to-completion §Rules rule 3), then emit
-    :rf.error/drain-depth-exceeded, then halt (the remaining queued
-    events are discarded). Rationale: re-frame's general 'events are
-    atomic' principle extends to the drain — a depth-exceeded drain
-    composes many events whose collective effect on `:db` is a partial
-    cascade; preserving that partial cascade leaves callers observing
-    a state no single event produced. Rolling back to `db-before` is
-    the same discipline applied to the partial-drain boundary.
+        ;; Inner loop saw the queue empty. Under the same lock that
+        ;; submitters take in `ensure-drain-scheduled!`, re-check the
+        ;; queue. If a submitter enqueued between the inner empty-check
+        ;; and now, see the new envelope and recur. Otherwise clear
+        ;; `:scheduled?` AND release `:drain-lock` under one lock so a
+        ;; serialized submitter observes both flags false and schedules
+        ;; a fresh drain. This is the orphan-prevention seam.
+        :else
+        (let [more?
+              (locking router
+                (let [{:keys [queue]} @router]
+                  (if (empty? queue)
+                    (do (swap! router assoc :scheduled? false)
+                        (reset! drain-lock false)
+                        false)
+                    true)))]
+          (when more?
+            (recur)))))))
 
-    `handle-drain-settled!` — when the queue empties, clear `:scheduled?`
-    and commit the epoch record per Tool-Pair §Time-travel. The settle!
-    / discard-buffer! hooks are looked up through late-bind so this
-    namespace stays free of a require on re-frame.epoch."
+(defn- drain-emergency-release!
+  "Mid-drain panic path. An unhandled exception escaped `drain-loop!`
+  past its own `finally` cleanup. Clear the router flags and release
+  the drain-lock so the frame is not permanently stuck — then re-throw
+  so the caller observes the failure."
+  [router drain-lock]
+  (locking router
+    (swap! router assoc :scheduled? false :in-drain? nil)
+    (reset! drain-lock false)))
+
+(defn- drain-try!
+  "Async drain entry point (called from `interop/next-tick`). CAS-tries
+  the drain-lock; on lose, the active drainer holds the responsibility
+  for the queue (its release block re-checks under lock — see
+  drain-loop!). On win, runs the drain body and releases.
+
+  Per rf2-ynk7 §single-drainer invariant."
   [frame-id]
   (let [frame-record (frame/frame frame-id)]
     (when frame-record
-      (let [router       (:router frame-record)
-            drain-depth  (get-in frame-record [:config :drain-depth] drain-depth-default)
-            ;; Per Tool-Pair §Time-travel: snapshot `:db-before` at the
-            ;; instant the drain begins so the eventual `:rf/epoch-record`
-            ;; can carry the pre-cascade state regardless of how many
-            ;; intermediate handlers commit `:db`. Per Spec 002 §Run-to-
-            ;; completion §Rules rule 3, the same snapshot is the
-            ;; rollback target if the drain trips the depth limit.
-            db-before    (frame/frame-app-db-value frame-id)]
-        (swap! router assoc :in-drain? true)
-        (try
-          (loop [depth      0
-                 last-event nil]
-            (cond
-              (>= depth drain-depth)
-              (handle-depth-exceeded! frame-id router db-before depth last-event)
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        (when (compare-and-set! drain-lock false true)
+          (try
+            (drain-loop! frame-id router drain-lock drain-depth)
+            (catch #?(:clj Throwable :cljs :default) t
+              (drain-emergency-release! router drain-lock)
+              (throw t))))))))
 
-              :else
-              (let [{:keys [queue]} @router]
-                (if (empty? queue)
-                  (handle-drain-settled! frame-id router db-before depth)
-                  (let [envelope (peek queue)]
-                    (swap! router update :queue pop)
-                    (process-event! envelope)
-                    (recur (inc depth) (:event envelope)))))))
-          (finally
-            (swap! router assoc :in-drain? false)))))))
+(defn- drain-block!
+  "Synchronous drain entry point (called from `dispatch-sync!`). Unlike
+  the async path, dispatch-sync's contract requires the cascade settle
+  before return — so on CAS-loss this path BLOCKS (Thread/yield on JVM;
+  trivially uncontended on CLJS) until the active drainer releases the
+  lock, then runs `under-lock-fn` (typically the seed-push) and drains.
+
+  Per rf2-ynk7 §single-drainer invariant: dispatch-sync's seed-push at
+  the FRONT of the queue MUST happen while it holds the drain-lock —
+  otherwise the prepend interleaves with the active drainer's peek+pop
+  and produces the same race the drain-lock was introduced to fix
+  (envelope A peek'd, B prepended, A popped becomes B, B processed as
+  if it were A's pop result). The `under-lock-fn` callback shape lets
+  the caller perform the seed-push inside the lock seam.
+
+  `under-lock-fn` runs once, immediately after CAS-acquire, before the
+  drain loop. Exceptions inside it propagate through the same emergency-
+  release path as the drain loop body."
+  [frame-id under-lock-fn]
+  (let [frame-record (frame/frame frame-id)]
+    (when frame-record
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        ;; Spin-CAS until we acquire. On JVM the active drainer holds
+        ;; the lock for the duration of one drain pass — bounded by
+        ;; drain-depth events at most — so the wait is bounded. CLJS
+        ;; is single-threaded; the CAS succeeds on first attempt.
+        (loop []
+          (when-not (compare-and-set! drain-lock false true)
+            #?(:clj (Thread/yield))
+            (recur)))
+        (try
+          (under-lock-fn)
+          (drain-loop! frame-id router drain-lock drain-depth)
+          (catch #?(:clj Throwable :cljs :default) t
+            (drain-emergency-release! router drain-lock)
+            (throw t)))))))
 
 (defn- ensure-drain-scheduled!
   [frame-id router]
@@ -515,7 +605,7 @@
               (do (swap! router assoc :scheduled? true)
                   true))))]
     (when should-schedule?
-      (interop/next-tick (fn [] (drain! frame-id))))))
+      (interop/next-tick (fn [] (drain-try! frame-id))))))
 
 (defn- emit-dispatched-trace!
   "Emit the :event :event/dispatched trace event for this envelope. Per
@@ -579,8 +669,19 @@
                           {:frame (:frame envelope) :event event
                            :recovery :no-recovery})
 
-       (let [r @(:router frame-record)]
-         (or (:in-sync-drain? r) (:in-drain? r)))
+       (let [r @(:router frame-record)
+             ;; Per rf2-ynk7: `:in-drain?` now holds the drainer's
+             ;; thread (or nil). Only flag as "nested" when the current
+             ;; thread is the drainer — a different thread mid-drain is
+             ;; a concurrent caller, which `drain-block!` handles
+             ;; correctly by spin-CAS-waiting. CLJS: `:in-drain?` is
+             ;; `true` or `nil`; the equality check still discriminates
+             ;; (truthy = same-thread by construction on a single-
+             ;; threaded host).
+             same-thread-drain?
+             #?(:clj  (identical? (:in-drain? r) (Thread/currentThread))
+                :cljs (true? (:in-drain? r)))]
+         (or (:in-sync-drain? r) same-thread-drain?))
        ;; Per Spec 002 §dispatch-sync: nesting dispatch-sync inside ANY
        ;; running drain (sync or async) is an error — the event would
        ;; interleave with the outer handler's run-to-completion.
@@ -593,17 +694,28 @@
        :else
        (let [router (:router frame-record)]
          (emit-dispatched-trace! envelope true)
-         ;; Put the seed at the front and mark scheduled to suppress async.
-         ;; :in-sync-drain? lets a nested dispatch-sync detect the unsafe
-         ;; call and refuse rather than silently interleave.
-         (swap! router (fn [{:keys [queue] :as r}]
-                         (assoc r
-                                :queue (into interop/empty-queue
-                                             (cons envelope queue))
-                                :scheduled?     true
-                                :in-sync-drain? true)))
          (try
-           (drain! (:frame envelope))
+           ;; Per rf2-ynk7 §single-drainer invariant: dispatch-sync
+           ;; needs the cascade settled before return AND the seed-
+           ;; push at the FRONT of the queue must not interleave with
+           ;; an active drainer's peek+pop. drain-block! spin-CAS-
+           ;; acquires the drain-lock, THEN runs the callback below
+           ;; (the prepend now sits inside the single-drainer window —
+           ;; no other drain can be mid-peek+pop), THEN runs the drain
+           ;; loop. The :in-sync-drain? flag suppresses any concurrent
+           ;; dispatch-sync from another thread; :scheduled? true
+           ;; suppresses async drain scheduling mid-cascade.
+           ;; :in-sync-drain? is cleared in the outer finally after
+           ;; drain-block! returns.
+           (drain-block!
+             (:frame envelope)
+             (fn []
+               (swap! router (fn [{:keys [queue] :as r}]
+                               (assoc r
+                                      :queue (into interop/empty-queue
+                                                   (cons envelope queue))
+                                      :scheduled?     true
+                                      :in-sync-drain? true)))))
            (finally
              (swap! router assoc :in-sync-drain? false)))))
      nil)))

--- a/implementation/core/test/re_frame/router_drain_race_test.clj
+++ b/implementation/core/test/re_frame/router_drain_race_test.clj
@@ -1,0 +1,159 @@
+(ns re-frame.router-drain-race-test
+  "Per rf2-ynk7 §single-drainer invariant: stress-test the JVM-only
+  race between the executor thread's `next-tick` drain callback and a
+  main-thread `dispatch-sync!` drain. Before the fix, the
+  `[:sync-only :sync-only]` corruption (double-peek of one envelope,
+  drop of another) reproduced at ~4 fails / 1000 iters; after the fix
+  the property should hold across many thousands of iterations.
+
+  This file is the production-side companion to rf2-lmkk #442's test-
+  only stabilisation. The rf2-lmkk fix wrapped
+  `async-dispatch-resolves-after-current-drain` in a
+  `with-redefs [interop/next-tick ...]` that bypasses the executor; this
+  file targets the SAME failure shape without bypassing the executor —
+  exercising the actual production code path the bead's fix lives in."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; The stress iteration count is set to keep CI under ~60s on the JVM
+;; while staying well above the per-1000 failure-rate threshold the
+;; pre-fix code exhibited (~4/1000). 5000 iterations on the fixed code
+;; should land at 0/5000 with high confidence — the new lower bound on
+;; the failure-rate-after-fix is 0.
+(def ^:private stress-iters
+  (or (some-> (System/getenv "RF2_YNK7_STRESS_ITERS") Long/parseLong)
+      5000))
+
+(deftest single-drainer-invariant-stress
+  ;; rf2-ynk7 — Spec 002 §Run-to-completion §single-drainer invariant.
+  ;; Pre-fix the same scenario produced ~4 fails / 1000 iters with the
+  ;; race producing `[:sync-only :sync-only]` (the async envelope was
+  ;; peek'd twice and a different envelope was dropped by the trailing
+  ;; pop). Post-fix the CAS on `:drain-lock` admits a single drainer at
+  ;; a time; the spin-CAS-wait in `drain-block!` keeps `dispatch-sync`'s
+  ;; cascade-settled-before-return contract intact even when the
+  ;; executor is mid-drain.
+  ;;
+  ;; This test does NOT use `with-redefs [interop/next-tick ...]` — the
+  ;; real JVM executor MUST be in the picture for the race window to
+  ;; appear. rf2-lmkk #442's test variant uses the with-redefs form
+  ;; because it pins a different property (the executor's callback
+  ;; ordering); this test pins the underlying race fix.
+  (testing (str "no [:sync-only :sync-only] corruption across "
+                stress-iters " iterations")
+    (rf/reg-event-db :outside-async
+      (fn [db _] (assoc db :outside? true)))
+    (rf/reg-event-db :sync-only
+      (fn [db _] (assoc db :sync? true)))
+
+    (let [failures (atom [])
+          ;; Capture the per-iter `order` atom through a global indirection
+          ;; so we don't have to re-register handlers each iter (which
+          ;; can race with leftover envelopes from a prior iter).
+          current-order (atom (atom []))
+          done-promise  (atom (promise))]
+      (rf/reg-event-db :outside-async-stress
+        (fn [db _]
+          (swap! @current-order conj :outside-async)
+          (deliver @done-promise :ok)
+          (assoc db :outside? true)))
+      (rf/reg-event-db :sync-only-stress
+        (fn [db _]
+          (swap! @current-order conj :sync-only)
+          (assoc db :sync? true)))
+      (dotimes [i stress-iters]
+        (let [order (atom [])
+              done  (promise)]
+          (reset! current-order order)
+          (reset! done-promise done)
+          ;; Schedule the async dispatch FIRST. Its drain callback rides
+          ;; the real `interop/next-tick` → JVM single-thread executor.
+          (rf/dispatch [:outside-async-stress])
+          ;; Then run a sync drain. Pre-fix: race window between the
+          ;; executor's wake-up and main thread's drain on the SAME
+          ;; queue. Both threads could peek the same envelope.
+          (rf/dispatch-sync [:sync-only-stress])
+          ;; Wait for the async cascade to settle. If we time out, the
+          ;; async event was dropped (the original race shape).
+          (let [d (deref done 5000 :timeout)]
+            (when (= :timeout d)
+              (swap! failures conj {:iter i :reason :timeout :order @order})))
+          ;; Validate: both events ran exactly once.
+          (let [final-order @order
+                sync-count   (count (filter #{:sync-only} final-order))
+                async-count  (count (filter #{:outside-async} final-order))]
+            (when-not (and (= 1 sync-count) (= 1 async-count))
+              (swap! failures conj {:iter        i
+                                    :order       final-order
+                                    :sync-count  sync-count
+                                    :async-count async-count})))))
+      (is (zero? (count @failures))
+          (str "Expected zero failures across " stress-iters
+               " iterations; got " (count @failures)
+               (when (pos? (count @failures))
+                 (str ". First few: " (pr-str (vec (take 5 @failures))))))))))
+
+(deftest concurrent-dispatch-stress
+  ;; A second stress shape: many submitter threads concurrently
+  ;; `dispatch`-ing to one frame while another thread runs
+  ;; `dispatch-sync`. Tests that the single-drainer invariant holds
+  ;; under high contention — every dispatched event runs exactly once,
+  ;; no envelope is dropped, no envelope is double-processed.
+  ;;
+  ;; Per rf2-ynk7 this is the broader correctness property the bead
+  ;; named: at most one thread inside `drain!` at any instant; the
+  ;; orphan window (envelope queued between empty-check and lock
+  ;; release) closed by the release-under-locking-router seam.
+  (testing "N submitter threads + sync drain — no events lost or duplicated"
+    (let [n-submitters 8
+          per-thread   200
+          total        (* n-submitters per-thread)]
+      ;; Use a dedicated frame with a high :drain-depth so the cascade
+      ;; doesn't trip the default 100-event limit and roll back the
+      ;; partial cascade per Spec 002 §Run-to-completion §Rules rule 3.
+      ;; This test is about the single-drainer invariant, not depth-
+      ;; limit behaviour.
+      (rf/reg-frame :stress.race/main {:drain-depth (* 4 (+ total 2))})
+      (rf/reg-event-db :bump
+        (fn [db _] (update db :n (fnil inc 0))))
+      ;; Spin up submitter threads. They all dispatch concurrently.
+      (let [latch   (java.util.concurrent.CountDownLatch. 1)
+            futures (vec (for [_ (range n-submitters)]
+                           (future
+                             (.await latch)
+                             (dotimes [_ per-thread]
+                               (rf/dispatch [:bump] {:frame :stress.race/main})))))]
+        (.countDown latch)
+        ;; While submitters are running, the main thread fires a sync
+        ;; drain. The single-drainer invariant must keep both safe.
+        (rf/dispatch-sync [:bump] {:frame :stress.race/main})
+        ;; Wait for all submitters to finish dispatching.
+        (doseq [f futures] @f)
+        ;; Now drain anything still queued by riding one more sync
+        ;; drain. The drain-block! contract is "spin-CAS until the
+        ;; lock is free, then drain everything until empty".
+        (rf/dispatch-sync [:bump] {:frame :stress.race/main}))
+      ;; Total = N submitters * per-thread + 2 sync drains.
+      (let [expected (+ total 2)
+            actual   (:n (rf/get-frame-db :stress.race/main))]
+        (is (= expected actual)
+            (str "Expected " expected " events processed (no drops/dups); "
+                 "got " actual))))))

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -793,6 +793,12 @@ The distinction is documentary and conceptual, not technical. One dispatch pipel
    :drain-depth 100})       ;; default and runtime-overridable
 ```
 
+### Single-drainer invariant (concurrent hosts)
+
+The drain operates under a **single-drainer invariant**: only one thread executes `drain!` at a time. Concurrent dispatch attempts enqueue and wake the executor, which no-ops if a drain is already running — the active drainer picks up newly-queued envelopes before returning. Per rf2-ynk7.
+
+On single-threaded hosts (CLJS) this is trivially true. On the JVM the runtime's `interop/next-tick` executor can fire its callback concurrently with the calling thread (typically `dispatch-sync` on the main thread), so the implementation must CAS-acquire a per-frame drain-lock at every `drain!` entry; the loser of the CAS returns without touching the queue. `dispatch-sync` spin-waits for the lock and performs its seed-push under the lock so the prepend does not interleave with another drainer's `peek+pop`. The release of the drain-lock and the clearing of the per-router `:scheduled?` flag happen under the same `locking` block that the submit path uses for its scheduling check — that single seam closes the orphan-envelope window (an envelope queued between the inner empty-check and the lock release would otherwise be visible to neither the outgoing drainer's loop nor the next submitter's scheduling decision).
+
 ### What is and isn't drained
 
 - **Synchronous re-dispatches (machine-to-machine messages)** are drained.


### PR DESCRIPTION
## The race (rf2-ynk7)

Surfaced during rf2-lmkk JVM flake stabilisation (#442). The test-only `with-redefs [interop/next-tick ...]` fix is in place; this is the production fix.

`router.cljc`'s `drain!` read the queue via `peek` then mutated via `swap! ... pop`. The pair was not atomic across threads. On the JVM the `interop/next-tick` executor could wake mid `dispatch-sync!` drain, and both threads would:

1. `peek` the same envelope,
2. process it (double-process one event),
3. `pop` — dropping a different envelope.

Shape under stress: `[:sync-only :sync-only]` where `[:sync-only :outside-async]` was expected, because the async event got peek'd twice and the next event was popped without being processed.

## Fix shape (Option B — single-drainer invariant)

Mike's decision 2026-05-13. Only one thread runs `drain!` against a given frame at any instant.

- New per-frame `:drain-lock` boolean atom on the frame record.
- `drain-try!` (async-path entry from `interop/next-tick`): CAS-acquires; loser no-ops (the active drainer rechecks the queue before releasing — see below).
- `drain-block!` (sync-path entry from `dispatch-sync!`): spin-yields on CAS-loss until the lock is free, then takes drain duty. Runs an under-lock callback (the seed-prepend) before the drain loop — without that, dispatch-sync's prepend interleaves with an active drainer's peek+pop and reproduces the same race the lock was meant to fix.
- The drain's empty-check + `:scheduled? false` clear + `:drain-lock` release happen under one `locking router` block — the same lock the submit path uses for its scheduling decision. Closes the orphan-envelope window.
- `:in-drain?` now holds the drainer's `Thread` reference (or nil) so the `dispatch-sync-in-handler` guard can discriminate same-thread nesting from a concurrent caller on a different thread. Truthy semantics for downstream consumers (epoch) preserved.
- CLJS is single-threaded — the CAS is uncontended there, but the same code path runs (cheap), keeping the contract intact under any future concurrent host.

## Test plan

Stress-test the failure shape from rf2-lmkk without `with-redefs`:

- [x] `single-drainer-invariant-stress`: 5000 iters, 0 failures (vs. ~197/1000 pre-fix)
- [x] `concurrent-dispatch-stress` (8 submitter threads × 200 dispatches + 2 sync drains): all 1602 events processed exactly once (vs. 1539/1602 pre-fix)
- [x] Existing `re-frame.drain-test` (7 tests, 36 assertions, including the `with-redefs` rf2-lmkk variant) — green
- [x] Full JVM core suite (279 tests, 1232 assertions) — green
- [x] epoch / machines / flows / http / routing / ssr / schemas — all green
- [x] CLJS `test:cljs` (591 tests, 1401 assertions) — green

## Spec update

`spec/002-Frames.md` §Run-to-completion gains a `§Single-drainer invariant` paragraph documenting the contract.