### PR TITLE
feat(trace): trigger-handler rides success-path :rf.fx/handled + :rf.machine/transition (rf2-lf84g)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -146,7 +146,18 @@
   §`:rf/epoch-record` `:effects` projection: every dispatched fx surfaces
   one entry, with `:outcome :ok` for the success path. The epoch projection
   consumes this trace; pair tools route off it without re-folding the raw
-  trace stream."
+  trace stream.
+
+  Per rf2-lf84g: when called inside the fx-handler's
+  `*current-trigger-handler*` binding (the user-registered fx branch),
+  `emit!` hoists the fx handler's registration coord onto the emitted
+  event's `:rf.trace/trigger-handler` slot — so consumers can jump to
+  the fx's `reg-fx` site from the success trace. Reserved fx-id calls
+  (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`)
+  emit outside any fx-handler binding; the outer event handler's
+  binding (if any) stamps the event handler's coord instead, which is
+  the right attribution for those — they don't have their own
+  registration site."
   [fx-id args frame-id]
   (trace/emit! :fx :rf.fx/handled
                {:fx-id   fx-id
@@ -228,15 +239,22 @@
     ;; a second lookup.
     (if-let [meta resolved-meta]
       (if (fx-runs-on-platform? meta active-platform)
-        (let [;; Per rf2-3nn8: bind `*current-trigger-handler*` for the
-              ;; duration of the fx handler's invocation (including the
-              ;; exception path) so error traces emitted from inside
-              ;; the fx body — `:rf.error/fx-handler-exception` here and
-              ;; anything the body itself surfaces — carry the fx
-              ;; handler's source-coord.
-              ok? (binding [trace/*current-trigger-handler*
-                            (trace/trigger-handler-from-meta :fx fx-id meta)]
-                    (try
+        ;; Per rf2-3nn8 (error path) and rf2-lf84g (success path): bind
+        ;; `*current-trigger-handler*` for the duration of the fx
+        ;; handler's invocation AND for the success-path `:rf.fx/handled`
+        ;; emit that follows. Error traces emitted from inside the fx
+        ;; body (`:rf.error/fx-handler-exception` here and anything the
+        ;; body itself surfaces) carry the fx handler's source-coord;
+        ;; the success-path `:rf.fx/handled` emit picks up the same
+        ;; coord through `emit!`'s hoist of `*current-trigger-handler*`
+        ;; (the outer event handler's binding would otherwise stamp the
+        ;; event handler's coord onto the `:rf.fx/handled` event, which
+        ;; is not what consumers want — Story/Causa want jump-to-source
+        ;; to land on the fx handler's `reg-fx` site, not the event
+        ;; handler that produced the fx vector).
+        (binding [trace/*current-trigger-handler*
+                  (trace/trigger-handler-from-meta :fx fx-id meta)]
+          (let [ok? (try
                       ((:handler-fn meta) (cond-> {:frame frame-id}
                                             origin-event (assoc :event origin-event))
                                           args)
@@ -252,9 +270,9 @@
                                               :exception-message msg
                                               :reason            (str "Effect handler `" fx-id "` threw: " msg ".")
                                               :recovery          :no-recovery}))
-                        false)))]
-          (when ok?
-            (emit-handled! fx-id args frame-id)))
+                        false))]
+            (when ok?
+              (emit-handled! fx-id args frame-id))))
         (trace/emit! :warning :rf.fx/skipped-on-platform
                      {:fx-id                fx-id
                       :frame                frame-id

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -61,23 +61,26 @@
 (defn- next-event-id []
   (swap! event-counter inc))
 
-;; ---- trigger-handler (rf2-3nn8) -------------------------------------------
+;; ---- trigger-handler (rf2-3nn8 / rf2-lf84g) -------------------------------
 ;;
-;; Per Spec 009 §Error contract: every `:rf.error/*` trace event MAY carry a
+;; Per Spec 009 §Trace correlation: a trace event MAY carry a
 ;; `:rf.trace/trigger-handler` field naming the handler whose execution
-;; produced the error. The field is OPTIONAL — it is present when an
-;; in-scope handler can be identified (event handler running, sub
-;; recomputing, fx handler dispatching, cofx injecting, view rendering)
-;; and absent when no handler is in scope (e.g. outermost-dispatch
-;; `:rf.error/no-such-handler`).
+;; produced the event. Originally introduced (rf2-3nn8) for the error
+;; path; widened (rf2-lf84g) to ride success-path traces too — every
+;; event emitted inside a handler's execution scope carries the slot.
+;; The field is OPTIONAL — it is present when an in-scope handler can
+;; be identified (event handler running, sub recomputing, fx handler
+;; dispatching, cofx injecting, view rendering) and absent when no
+;; handler is in scope (e.g. outermost-dispatch
+;; `:rf.error/no-such-handler`, registration-time emits).
 ;;
 ;; The runtime carries the in-scope handler through the dynamic Var
 ;; `*current-trigger-handler*`. Runtime boundaries (the router's
 ;; `process-event!`, the sub recompute path, the fx dispatcher, the
 ;; cofx injector, the view render wrapper) bind the Var around the
-;; user code they run; `emit-error!` reads the Var and hoists its
-;; value to the top-level `:rf.trace/trigger-handler` slot on the
-;; emitted event when bound.
+;; user code they run; `emit!` and `emit-error!` read the Var and
+;; hoist its value to the top-level `:rf.trace/trigger-handler` slot
+;; on the emitted event when bound.
 ;;
 ;; Shape (locked, per rf2-3nn8):
 ;;
@@ -97,13 +100,14 @@
 
 (def ^:dynamic *current-trigger-handler*
   "The handler currently in scope for trace emission. Bound by each
-  runtime boundary (router, subs, fx, cofx, views). When bound and an
-  error trace fires, `emit-error!` attaches the value to the event as
-  `:rf.trace/trigger-handler`. nil outside any handler's scope.
+  runtime boundary (router, subs, fx, cofx, views). When bound, both
+  `emit!` (success path) and `emit-error!` (error path) attach the
+  value to the emitted event under the top-level
+  `:rf.trace/trigger-handler` slot. nil outside any handler's scope.
 
   Shape: `{:kind <kw> :id <kw> :source-coord {:ns :file :line :column}?}`.
 
-  Per rf2-3nn8."
+  Per rf2-3nn8 (error path) and rf2-lf84g (success path)."
   nil)
 
 ;; ---- *current-dispatch-id* (rf2-g6ih4) ------------------------------------
@@ -361,7 +365,17 @@
   inside a drain processing a dispatch), the in-flight cascade's id is
   merged into `:tags :dispatch-id`. Callers that supply their own
   `:dispatch-id` in tags win (the only such caller in the framework is
-  `:event/dispatched`, which stamps its own freshly-allocated id)."
+  `:event/dispatched`, which stamps its own freshly-allocated id).
+
+  Per rf2-lf84g: when `*current-trigger-handler*` is bound (the emit
+  fires inside a handler's execution scope — event / sub / fx / cofx /
+  view), the handler's registration coord rides on the emitted event
+  under the top-level `:rf.trace/trigger-handler` slot. Mirrors the
+  error path (`emit-error!`) — same field, same shape, same elision
+  behaviour. Success-path traces emitted inside a handler's scope
+  (`:rf.fx/handled`, `:rf.machine/transition`, `:event/db-changed`,
+  `:event/do-fx`, ...) carry the registration coord so tools can
+  jump-to-source from any trace event in a cascade, not just errors."
   [op operation tags]
   (when interop/debug-enabled?
     (let [source       (:source tags)
@@ -370,6 +384,7 @@
           ;; :recovery (when present) live at the top level of the
           ;; trace event, NOT inside :tags. Hoist them here.
           cascade-id   *current-dispatch-id*
+          trigger      *current-trigger-handler*
           base-tags    (dissoc tags :source :recovery)
           ;; Per rf2-g6ih4: stamp the cascade's :dispatch-id on every
           ;; event emitted inside the drain so consumers can group raw
@@ -385,7 +400,12 @@
                             :time      (interop/now-ms)
                             :tags      tags+}
                      source   (assoc :source source)
-                     recovery (assoc :recovery recovery))]
+                     recovery (assoc :recovery recovery)
+                     ;; Per rf2-lf84g: hoist the in-scope handler's
+                     ;; registration coord onto every trace event
+                     ;; emitted inside a handler's scope. Symmetric
+                     ;; with `emit-error!` per rf2-3nn8.
+                     trigger  (assoc :rf.trace/trigger-handler trigger))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -1,0 +1,200 @@
+(ns re-frame.success-path-trigger-handler-test
+  "Per rf2-lf84g — `:rf.trace/trigger-handler` rides success-path trace events.
+
+  Spec 009 §Trace correlation widens the trigger-handler coverage post
+  rf2-lf84g: every trace event emitted inside a handler's execution
+  scope (event handler chain, fx handler body, sub recompute, cofx
+  injector, view render) carries the in-scope handler's registration
+  coord under the top-level `:rf.trace/trigger-handler` slot. Originally
+  introduced (rf2-3nn8) for error events only; widened (rf2-lf84g) so
+  success-path traces — `:rf.fx/handled`, `:rf.machine/transition`,
+  `:event/db-changed`, `:event/do-fx`, ... — also carry the coord, so
+  consumer tools (Story, Causa, re-frame-pair) can render
+  jump-to-source links from every event in a cascade, not just errors.
+
+  Locked shape (per rf2-3nn8 / rf2-lf84g):
+
+    {:kind         :event / :sub / :fx / :cofx / :view
+     :id           <registered-id>
+     :source-coord {:ns <sym> :file <string> :line <int> :column <int>}}
+
+  Slot placement: top-level on the trace event, NOT under `:tags` —
+  mirrors the error path exactly. Production elision: rides the same
+  `interop/debug-enabled?` gate as the rest of the trace surface; no
+  separate elision contract.
+
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic.
+  Mirror tests for the machine emit site live in
+  `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- events-of [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+(defn- assert-trigger-shape
+  "Assert the value at top-level `:rf.trace/trigger-handler` on `ev`
+  carries the locked shape — `:kind`, `:id`, and a `:source-coord` map
+  with at least `:ns` / `:file` / `:line`."
+  [ev expected-kind expected-id]
+  (let [t (:rf.trace/trigger-handler ev)]
+    (is (some? t)
+        (str "expected :rf.trace/trigger-handler on " (:operation ev)))
+    (is (= expected-kind (:kind t)) "kind matches")
+    (is (= expected-id   (:id t))   "id matches")
+    (let [c (:source-coord t)]
+      (is (map? c) ":source-coord present")
+      (is (symbol? (:ns c))    ":ns is a symbol")
+      (is (string? (:file c))  ":file is a string")
+      (is (integer? (:line c)) ":line is an integer"))))
+
+;; ---- :rf.fx/handled carries the fx-handler's registration coord -----------
+
+(deftest fx-handled-carries-fx-handler-trigger
+  (testing ":rf.fx/handled rides the FX handler's registration coord
+   (not the enclosing event handler's) — Story/Causa want jump-to-source
+   to land on the fx's reg-fx site, not the event-handler that produced
+   the fx vector"
+    (rf/reg-fx :rf2-lf84g/my-fx
+               (fn [_ctx _args] :ok))
+    (rf/reg-event-fx :rf2-lf84g/uses-my-fx
+                     (fn [_cofx _event]
+                       {:fx [[:rf2-lf84g/my-fx {:k 1}]]}))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-my-fx]))
+          [handled] (events-of evs :rf.fx/handled)]
+      (is (some? handled) ":rf.fx/handled trace fired")
+      (assert-trigger-shape handled :fx :rf2-lf84g/my-fx))))
+
+(deftest fx-handled-trigger-rides-at-top-level
+  (testing ":rf.trace/trigger-handler is a top-level field on success
+   traces, NOT nested under :tags — mirrors the error path shape"
+    (rf/reg-fx :rf2-lf84g/top-level-fx (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-lf84g/use-top-level
+                     (fn [_ _] {:fx [[:rf2-lf84g/top-level-fx {}]]}))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-top-level]))
+          [handled] (events-of evs :rf.fx/handled)]
+      (is (contains? handled :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives at top level")
+      (is (not (contains? (:tags handled) :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler does NOT live under :tags"))))
+
+(deftest fx-handled-trigger-matches-registrar-coord
+  (testing "the :source-coord under :rf.trace/trigger-handler on
+   :rf.fx/handled equals what the fx registrar holds"
+    (rf/reg-fx :rf2-lf84g/coord-fx (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-lf84g/use-coord
+                     (fn [_ _] {:fx [[:rf2-lf84g/coord-fx {}]]}))
+    (let [fx-meta (rf/handler-meta :fx :rf2-lf84g/coord-fx)
+          evs     (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-coord]))
+          [hdl]   (events-of evs :rf.fx/handled)
+          coord   (-> hdl :rf.trace/trigger-handler :source-coord)]
+      (is (= (:ns     fx-meta) (:ns coord)))
+      (is (= (:file   fx-meta) (:file coord)))
+      (is (= (:line   fx-meta) (:line coord)))
+      (is (= (:column fx-meta) (:column coord))))))
+
+;; ---- the reserved-fx-id path stamps the enclosing event handler -----------
+
+(deftest dispatch-fx-success-trigger-is-event-handler
+  (testing "the reserved fx-id `:dispatch` has no registration of its
+   own — the trigger-handler is the enclosing event handler. Reserved
+   fx-id success traces stamp the outermost in-scope handler."
+    (rf/reg-event-fx :rf2-lf84g/parent
+                     (fn [_ _] {:fx [[:dispatch [:rf2-lf84g/child]]]}))
+    (rf/reg-event-db :rf2-lf84g/child (fn [db _] (assoc db :child? true)))
+    (let [evs       (record-traces #(rf/dispatch-sync [:rf2-lf84g/parent]))
+          handled   (events-of evs :rf.fx/handled)
+          parent-fx (first (filter #(= :dispatch (get-in % [:tags :fx-id])) handled))]
+      (is (some? parent-fx) ":dispatch :rf.fx/handled fired")
+      ;; The reserved-fx-id path runs inside the parent event's
+      ;; *current-trigger-handler* binding (no inner fx binding kicks in
+      ;; for reserved fx-ids since there's no registered handler).
+      (assert-trigger-shape parent-fx :event :rf2-lf84g/parent))))
+
+;; ---- programmatic registration → no coord -> no trigger-handler -----------
+
+(deftest fx-handled-omits-trigger-when-no-coord
+  (testing "an fx registered without the macro path (no source-coord
+   stamp on the registrar slot) emits :rf.fx/handled with no
+   :rf.trace/trigger-handler field — better no-data than poison-data
+   (mirrors the error-path contract)"
+    (let [reg-fn (requiring-resolve 're-frame.fx/reg-fx)]
+      (reg-fn :rf2-lf84g/programmatic-fx (fn [_ _] :ok)))
+    ;; Register the event handler programmatically too so the cascade
+    ;; carries no coord at any layer — otherwise the outer event
+    ;; handler's coord would ride on `:rf.fx/handled` for reserved-fx-id
+    ;; emits. Here we exercise the user-fx path: the binding is the fx
+    ;; handler's, which has no coord, so the field is omitted.
+    (let [reg-ev (requiring-resolve 're-frame.events/reg-event-fx)]
+      (reg-ev :rf2-lf84g/uses-prog-fx
+              (fn [_ _] {:fx [[:rf2-lf84g/programmatic-fx {}]]})))
+    (let [evs       (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-prog-fx]))
+          [handled] (events-of evs :rf.fx/handled)]
+      (is (some? handled) ":rf.fx/handled fired")
+      (is (not (contains? handled :rf.trace/trigger-handler))
+          "programmatic fx-registration → no coord → field omitted"))))
+
+;; ---- the field rides on every event in the cascade -----------------------
+
+(deftest event-db-changed-and-do-fx-carry-event-handler-trigger
+  (testing "`:event/db-changed` and `:event/do-fx` fire inside the event
+   handler's *current-trigger-handler* binding — they carry the event
+   handler's registration coord under :rf.trace/trigger-handler"
+    (rf/reg-event-fx :rf2-lf84g/changes-db
+                     (fn [_ _] {:db {:n 1} :fx []}))
+    (let [evs   (record-traces #(rf/dispatch-sync [:rf2-lf84g/changes-db]))
+          [dbc] (events-of evs :event/db-changed)
+          [dof] (events-of evs :event/do-fx)]
+      (is (some? dbc) ":event/db-changed fired")
+      (is (some? dof) ":event/do-fx fired")
+      (assert-trigger-shape dbc :event :rf2-lf84g/changes-db)
+      (assert-trigger-shape dof :event :rf2-lf84g/changes-db))))
+
+;; ---- out-of-band emits omit trigger-handler -------------------------------
+
+(deftest registration-traces-omit-trigger-handler
+  (testing "trace events emitted OUTSIDE any handler's scope (registration
+   time, frame creation) carry no :rf.trace/trigger-handler"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-lf84g/reg-time-event (fn [db _] db))
+        (let [reg-traces (filter #(= :rf.registry/handler-registered (:operation %))
+                                 @seen)]
+          (is (seq reg-traces) "we saw at least one registration trace")
+          (doseq [ev reg-traces]
+            (is (not (contains? ev :rf.trace/trigger-handler))
+                (str "out-of-band " (:operation ev)
+                     " must omit :rf.trace/trigger-handler"))))
+        (finally
+          (rf/remove-trace-cb! ::rec))))))

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -1,0 +1,117 @@
+(ns re-frame.machine-transition-trigger-handler-test
+  "Per rf2-lf84g — `:rf.trace/trigger-handler` rides `:rf.machine/transition`.
+
+  Spec 009 §Trace correlation: every trace event emitted inside a
+  handler's execution scope carries the in-scope handler's registration
+  coord under the top-level `:rf.trace/trigger-handler` slot. Machines
+  register as event handlers via `reg-event-fx` (per
+  `reg-machine*` in `lifecycle_fx.cljc`), so when a machine transition
+  trace fires inside the machine's event-handler scope it picks up the
+  machine's own registration coord via `emit!`'s hoist of
+  `*current-trigger-handler*`.
+
+  Causa's machine-inspector wants 'jump to the action that just ran'
+  from a transition trace. With this widening, the registration coord
+  rides on every `:rf.machine/transition` event — tools render the
+  click-to-jump link from the same slot they already read on error
+  events.
+
+  Locked shape (per rf2-3nn8 / rf2-lf84g):
+
+    {:kind         :event           ;; machines register under :event kind
+     :id           <machine-id>
+     :source-coord {:ns <sym> :file <string> :line <int> :column <int>}}
+
+  JVM-only — the dynamic-var binding is platform-agnostic."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.machines :as machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-counters!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- transitions-of [evs]
+  (filterv #(= :rf.machine/transition (:operation %)) evs))
+
+;; ---- :rf.machine/transition carries the machine's registration coord ------
+
+(deftest machine-transition-carries-trigger-handler
+  (testing ":rf.machine/transition fires inside the machine's event-handler
+   scope, so :rf.trace/trigger-handler rides the trace with the machine's
+   registration coord — Causa's machine-inspector renders jump-to-source
+   from this field"
+    (rf/reg-machine :rf2-lf84g/tl
+      {:initial :red
+       :states  {:red    {:on {:tick {:target :green}}}
+                 :green  {:on {:tick {:target :yellow}}}
+                 :yellow {:on {:tick {:target :red}}}}})
+    (let [evs    (record-traces
+                   (fn [] (rf/dispatch-sync [:rf2-lf84g/tl [:tick]])))
+          trans  (transitions-of evs)
+          [first-trans] trans]
+      (is (some? first-trans) ":rf.machine/transition fired")
+      (let [t (:rf.trace/trigger-handler first-trans)]
+        (is (some? t) ":rf.trace/trigger-handler present on transition trace")
+        (is (= :event (:kind t)) "kind is :event (machines register as event handlers)")
+        (is (= :rf2-lf84g/tl (:id t)) "id is the machine-id")
+        (let [c (:source-coord t)]
+          (is (map? c) ":source-coord present")
+          (is (symbol? (:ns c))    ":ns is a symbol")
+          (is (string? (:file c))  ":file is a string")
+          (is (integer? (:line c)) ":line is an integer"))))))
+
+(deftest machine-transition-trigger-rides-at-top-level
+  (testing ":rf.trace/trigger-handler is a top-level field on the
+   :rf.machine/transition event, NOT nested under :tags — mirrors the
+   error-path shape"
+    (rf/reg-machine :rf2-lf84g/top-level
+      {:initial :a
+       :states  {:a {:on {:go {:target :b}}}
+                 :b {}}})
+    (let [evs    (record-traces
+                   (fn [] (rf/dispatch-sync [:rf2-lf84g/top-level [:go]])))
+          [tr]   (transitions-of evs)]
+      (is (some? tr))
+      (is (contains? tr :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives at top level")
+      (is (not (contains? (:tags tr) :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler does NOT live under :tags"))))
+
+(deftest machine-transition-coord-matches-registrar
+  (testing "the :source-coord under :rf.trace/trigger-handler equals what
+   the registrar holds on the machine's slot — same comparison the
+   trigger-handler-coord-test does for the error path"
+    (rf/reg-machine :rf2-lf84g/coord
+      {:initial :a
+       :states  {:a {:on {:go {:target :b}}}
+                 :b {}}})
+    (let [reg-meta (rf/handler-meta :event :rf2-lf84g/coord)
+          evs      (record-traces
+                     (fn [] (rf/dispatch-sync [:rf2-lf84g/coord [:go]])))
+          [tr]     (transitions-of evs)
+          coord    (-> tr :rf.trace/trigger-handler :source-coord)]
+      (is (some? tr))
+      (is (= (:ns     reg-meta) (:ns coord)))
+      (is (= (:file   reg-meta) (:file coord)))
+      (is (= (:line   reg-meta) (:line coord)))
+      (is (= (:column reg-meta) (:column coord))))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -679,7 +679,9 @@ All error trace events are open maps with these required keys:
 
 #### `:rf.trace/trigger-handler` — naming the in-scope handler
 
-The optional top-level `:rf.trace/trigger-handler` slot names the handler whose execution produced the error and carries its registration-site source-coord. Tools (10x, pair, IDE jump-to-source) render click-to-jump links from this field — given an error event, the user lands on the line of code that defined the offending handler.
+The optional top-level `:rf.trace/trigger-handler` slot names the handler whose execution produced the trace event and carries its registration-site source-coord. Tools (10x, pair, IDE jump-to-source) render click-to-jump links from this field — given a trace event, the user lands on the line of code that defined the responsible handler.
+
+The slot rides on **every** trace event emitted while a handler is in scope, not just errors. Success-path traces — `:rf.fx/handled`, `:rf.machine/transition`, `:event/db-changed`, `:event/do-fx`, ... — carry the in-scope handler's registration coord too. Originally introduced (rf2-3nn8) for `:rf.error/*` only; widened (rf2-lf84g) so consumer tools can render jump-to-source links from any trace event in a cascade, not just errors. The error-path emit shape is unchanged — same field name, same nested map, same top-level placement.
 
 Coverage is keyed off "is a handler currently in scope at emit time?":
 
@@ -690,15 +692,18 @@ Coverage is keyed off "is a handler currently in scope at emit time?":
 | Inside an fx handler body | Yes | The fx handler's coord |
 | Inside a sub recompute (body fn) | Yes | The sub's coord |
 | Inside a view render | Yes | The view's coord |
+| Inside a machine transition (machines register as event handlers) | Yes | The machine's coord |
 | At outermost dispatch with no handler resolved (`:rf.error/no-such-handler`) | No | — |
 | At depth-exceeded drain rollback (`:rf.error/drain-depth-exceeded`) | No | — |
-| At registration-time failures emitted outside any handler | No | — |
+| At registration-time emits outside any handler (`:rf.registry/handler-registered`, `:frame/created`) | No | — |
+
+For `:rf.fx/handled` specifically: the slot carries the **fx handler's** own registration coord (not the enclosing event handler that produced the `:fx` vector). The runtime rebinds `*current-trigger-handler*` to the fx handler's meta around the fx body's invocation and the success-path emit that follows, so consumer tools jump to the `reg-fx` site — where the fx's logic actually lives — not the event handler upstream. Reserved fx-ids (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) have no registration site of their own; their `:rf.fx/handled` traces carry the enclosing event handler's coord (the outer binding).
 
 The `:source-coord` payload is whatever the registrar slot's metadata holds. Macro-driven registration (`reg-event-*`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-flow`, `reg-route`, `reg-app-schema`, `reg-error-projector`) stamps `:ns` / `:file` / `:line` / `:column` flat onto the meta map at compile time; the trigger-handler builder picks those keys off and re-nests them under `:source-coord`. Programmatic / REPL registrations bypass the macro path and carry no coord — in that case the entire `:rf.trace/trigger-handler` slot is omitted rather than populated with placeholder data (better no field than poison-data).
 
-Production elision: the slot is **NOT separately elided**. The trace surface as a whole is gated by `re-frame.interop/debug-enabled?` per [§Production builds](#production-builds-zero-overhead-zero-code) — when an error trace is emitted at all, the trigger-handler field rides along on it. There is no second gate that selectively drops the field while keeping the rest of the event. Apps that keep the trace surface in production (rare; opt in by setting `goog.DEBUG=true` on the `:advanced` build) get the trigger-handler coord along with every error event. Apps using the default `goog.DEBUG=false` `:advanced` build get neither the field nor the surrounding trace surface — the entire `(when interop/debug-enabled? ...)` branch DCEs.
+Production elision: the slot is **NOT separately elided**. The trace surface as a whole is gated by `re-frame.interop/debug-enabled?` per [§Production builds](#production-builds-zero-overhead-zero-code) — when a trace event is emitted at all, the trigger-handler field rides along on it when bound. There is no second gate that selectively drops the field while keeping the rest of the event. Apps that keep the trace surface in production (rare; opt in by setting `goog.DEBUG=true` on the `:advanced` build) get the trigger-handler coord along with every emitted event. Apps using the default `goog.DEBUG=false` `:advanced` build get neither the field nor the surrounding trace surface — the entire `(when interop/debug-enabled? ...)` branch DCEs.
 
-Consumer access: read `(:rf.trace/trigger-handler error-event)` for the map, `(get-in error-event [:rf.trace/trigger-handler :source-coord])` for the coord, `(get-in error-event [:rf.trace/trigger-handler :id])` for the handler's id. No new namespace is required to read the slot.
+Consumer access: read `(:rf.trace/trigger-handler event)` for the map, `(get-in event [:rf.trace/trigger-handler :source-coord])` for the coord, `(get-in event [:rf.trace/trigger-handler :id])` for the handler's id. No new namespace is required to read the slot.
 
 ### Error namespace convention — five prefix shapes
 
@@ -1060,7 +1065,13 @@ Multiple listeners may register concurrently. **Listener-invocation order is not
 
 ### Trace correlation across the cascade
 
-Use the `:dispatch-id` field under `:tags` on **every** trace event emitted inside a cascade (per [§Dispatch correlation](#dispatch-correlation-dispatch-id--parent-dispatch-id)). Grouping raw trace events by cascade is a single-key filter — `(filter #(= cascade-id (get-in % [:tags :dispatch-id])) events)`. Tools that need cascade *trees* walk `:parent-dispatch-id` upward across `:event/dispatched` events (the inter-cascade lineage channel). Per-cascade structured projection lives in the assembled `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) — the raw `:dispatch-id` channel is the lower-level primitive.
+Two cascade-wide channels ride on **every** trace event emitted inside a cascade — neither is scoped to errors:
+
+1. **`:dispatch-id`** under `:tags` (per [§Dispatch correlation](#dispatch-correlation-dispatch-id--parent-dispatch-id)). Grouping raw trace events by cascade is a single-key filter — `(filter #(= cascade-id (get-in % [:tags :dispatch-id])) events)`. Tools that need cascade *trees* walk `:parent-dispatch-id` upward across `:event/dispatched` events (the inter-cascade lineage channel).
+
+2. **`:rf.trace/trigger-handler`** at the top level (per [§`:rf.trace/trigger-handler` — naming the in-scope handler](#rftracetrigger-handler--naming-the-in-scope-handler)). Names the handler whose code produced the event and carries its registration coord — so jump-to-source links work from every trace event in a cascade, not just errors. Rides on `:rf.fx/handled`, `:rf.machine/transition`, `:event/db-changed`, `:event/do-fx`, `:sub/run`, `:view/render`, and all `:rf.error/*` events whenever a handler is in scope at emit time. Omitted outside any handler scope (registration-time emits, outermost-dispatch lookup failures).
+
+Per-cascade structured projection lives in the assembled `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) — the raw `:dispatch-id` / `:rf.trace/trigger-handler` channels are the lower-level primitives.
 
 ### Trace event for app-db changes
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -225,10 +225,19 @@ Universal trace event shape, including error events.
    [:time      :any]                                                       ;; emit timestamp (host clock)
    [:tags      {:optional true} [:map-of :keyword :any]]                   ;; op-type-specific payload
    [:source    {:optional true} :keyword]                                  ;; (when present) the trigger source
-   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]])
+   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]
+   [:rf.trace/trigger-handler {:optional true}                              ;; (when present) the in-scope handler at emit time
+                              [:map
+                               [:kind         [:enum :event :sub :fx :cofx :view]]
+                               [:id           :keyword]
+                               [:source-coord [:map
+                                               [:ns     {:optional true} :symbol]
+                                               [:file   {:optional true} :string]
+                                               [:line   {:optional true} :int]
+                                               [:column {:optional true} :int]]]]]])
 ```
 
-The runtime emits event-at-a-time, not span-shaped: there is no `:start`/`:end`/`:duration` pair and no `:child-of` parent-id. Cascade correlation rides on `:dispatch-id` under `:tags` of **every** trace event emitted inside a cascade; `:parent-dispatch-id` rides under `:tags` of `:event/dispatched` events only (it documents inter-cascade lineage). Per [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id). Per-event frame attribution rides under `[:tags :frame]`.
+The runtime emits event-at-a-time, not span-shaped: there is no `:start`/`:end`/`:duration` pair and no `:child-of` parent-id. Cascade correlation rides on `:dispatch-id` under `:tags` of **every** trace event emitted inside a cascade; `:parent-dispatch-id` rides under `:tags` of `:event/dispatched` events only (it documents inter-cascade lineage). Per [009 §Dispatch correlation](009-Instrumentation.md#dispatch-correlation-dispatch-id--parent-dispatch-id). Per-event frame attribution rides under `[:tags :frame]`. Per-event handler attribution rides under the top-level `:rf.trace/trigger-handler` slot when a handler is in scope at emit time — `:rf.fx/handled` carries the fx handler's coord, `:rf.machine/transition` carries the machine's coord, every `:rf.error/*` carries the responsible handler's coord, every emit inside an event handler's chain carries the event handler's coord. Per [009 §`:rf.trace/trigger-handler` — naming the in-scope handler](009-Instrumentation.md#rftracetrigger-handler--naming-the-in-scope-handler).
 
 The `:op-type` vocabulary is **open** — implementations and tools may add new values additively per [Spec-ulation](Principles.md#spec-ulation). The reserved values used by the framework (in alphabetical order):
 
@@ -303,7 +312,7 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
 
 The `:op-type` discriminates severity: `:error` halts or recovers a specific operation; `:warning` is an advisory the runtime emitted alongside continuing default behaviour. Consumers branch on `:op-type` for severity routing and on `:operation` for category-specific handling.
 
-The optional `:rf.trace/trigger-handler` slot (top-level, NOT under `:tags`) names the handler whose execution produced the error and carries its registration-site source-coord. Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent when no handler is in scope (e.g. outermost-dispatch `:rf.error/no-such-handler`, depth-exceeded drain rollback). Source-coord values come from the registrar slot stamped by the kind-specific `reg-*` macro at registration time; programmatic registration paths (the underlying registration fns called without the macro wrapping) carry no coord, in which case the slot is omitted rather than populated with placeholder data. Tools render click-to-jump-to-handler links by reading `[:rf.trace/trigger-handler :source-coord]`. Not elided in production — `:rf.error/*` traces are not elided (unlike `:rf.assert/*`) and this slot rides along with them.
+The optional `:rf.trace/trigger-handler` slot (top-level, NOT under `:tags`) names the handler whose execution produced the error and carries its registration-site source-coord. Inherited from the universal `TraceEvent` shape — the slot rides on every trace event emitted while a handler is in scope, not just errors (per rf2-lf84g — success-path traces like `:rf.fx/handled` and `:rf.machine/transition` carry it too). Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent when no handler is in scope (e.g. outermost-dispatch `:rf.error/no-such-handler`, depth-exceeded drain rollback). Source-coord values come from the registrar slot stamped by the kind-specific `reg-*` macro at registration time; programmatic registration paths (the underlying registration fns called without the macro wrapping) carry no coord, in which case the slot is omitted rather than populated with placeholder data. Tools render click-to-jump-to-handler links by reading `[:rf.trace/trigger-handler :source-coord]`. Not elided in production — `:rf.error/*` traces are not elided (unlike `:rf.assert/*`) and this slot rides along with them.
 
 The canonical category vocabulary is fixed-and-additive (Spec-ulation): existing categories cannot be renamed or removed; new categories are added by extending the operation namespace. The current set is enumerated in [009 §Error categories](009-Instrumentation.md#error-categories-initial-set) and reproduced in [API.md §Error contract](API.md#error-contract). Reserved operation namespaces:
 


### PR DESCRIPTION
## Summary

Per rf2-lf84g (audit Finding 4 of `ai/findings/trace-surface-consumer-audit-2026-05-13.md`): widen `:rf.trace/trigger-handler` to ride success-path trace events so Story / Causa / re-frame-pair can render jump-to-source links from every event in a cascade, not just errors.

- `:rf.fx/handled` — picks up the fx handler's `reg-fx` site (not the enclosing event handler's). Reserved fx-ids (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) carry the enclosing event handler's coord — they have no registration site of their own.
- `:rf.machine/transition` — picks up the machine's coord (machines register as event handlers via `reg-event-fx`, so `*current-trigger-handler*` is already bound to the machine's meta at emit time).

Symmetric with the error path: same field name, same nested shape `{:kind :id :source-coord}`, same top-level placement, same `interop/debug-enabled?` elision gate. No new fields wired through tools.

## Implementation

- `re-frame.trace/emit!` reads `*current-trigger-handler*` and hoists it onto every emitted event when bound. Mirrors `emit-error!` exactly.
- `re-frame.fx/handle-one-fx` for user-registered fx: extend the existing `*current-trigger-handler*` binding to wrap the `:rf.fx/handled` success emit (not just the handler-fn invocation). Without this, the outer event handler's binding would stamp the wrong coord on success traces.
- `re-frame.machines.lifecycle-fx`: no changes — the transition emit fires inside the machine's event-handler scope, so `emit!`'s hoist picks up the machine's coord automatically.

## Spec

- 009 §`:rf.trace/trigger-handler` — widened to declare success-path coverage. Coverage table adds the machine-transition row. New paragraph pins the fx-handler-vs-event-handler attribution rule for `:rf.fx/handled`.
- 009 §Trace correlation across the cascade — enumerates both cascade-wide channels (`:dispatch-id` and `:rf.trace/trigger-handler`).
- Spec-Schemas §`:rf/trace-event` — `TraceEvent` schema adds the optional top-level slot; the cross-reference on the §`:rf/error-event` paragraph points at the widening.

## Test plan

- [x] `clojure -M:test` (core): 284 tests, 1272 assertions, 0 failures
- [x] `clojure -M:test` (machines): 119 tests, 332 assertions, 0 failures
- [x] `npm run test:cljs`: 591 tests, 1401 assertions, 0 failures
- [x] `npm run test:browser`: 591 tests, 1428 assertions, 0 failures
- [x] `npm run test:elision`: all sentinels PRESENT
- [x] `npm run test:examples`: only pre-existing `counter-with-stories` flake (verified by `git stash` baseline)
- [x] `scripts/check_doc_slugs.py`: clean
- [x] `mkdocs build --strict`: pre-existing 226 warnings on origin/main (unchanged)

7 new core tests + 3 new machine tests added.