### PR TITLE
docs(skills+guide): document cofx-wrapping pattern — canonical idiom for reading sub values in handlers (rf2-wurbi)

### DIFF
--- a/docs/guide/05-coeffects.md
+++ b/docs/guide/05-coeffects.md
@@ -215,6 +215,58 @@ Read a value out of `localStorage` by key. TodoMVC's `:todo.storage/todos` cofx 
 
 `examples/reagent/todomvc/db.cljs` and its sibling `events.cljs` exercise the pattern end-to-end. The `:initialise` handler stays pure; the only place `localStorage.getItem` appears in the codebase is inside `reg-cofx`. SSR — where there's no `localStorage` — gets a `nil` for the cofx value because the `some->` short-circuits; the handler degrades gracefully without branching on platform.
 
+## Reading a sub from a handler
+
+Sooner or later you'll write a handler that needs a sub's current value. An order-placement event wants to stamp the order with the currently-logged-in user; an "apply discount" event wants to read the cart total computed by `[:cart/total]`. The wrong move — and the one the reflex reaches for — is to call `rf/subscribe` (or its one-shot sibling `rf/subscribe-value`) directly from inside the handler body:
+
+```clojure
+;; Don't do this
+(rf/reg-event-fx :order/place
+  (fn [{:keys [db]} [_ order]]
+    (let [current (rf/subscribe-value [:user/current])]   ;; ← implicit read
+      {:db (assoc-in db [:orders (:id order)]
+                     (assoc order :placed-by current))})))
+```
+
+This breaks the same per-handler purity property cofx exist to protect, for the same reasons calling `(js/Date.)` from a handler does. The handler's output is no longer a function of its `[coeffects event]` pair — it now also depends on whatever `:user/current` happens to compute against the registry at drain time. The test framework can't fix `:user/current` for one handler without globally re-registering the sub. Replaying an epoch becomes brittle because the recorded event won't carry the sub's value, only its id. Subs are part of the view-stream's reactivity story (chapter 06); reading one from a handler crosses streams.
+
+The fix is the same one we used for `:now` and `:new-id` — wrap the impure read as a cofx and inject it:
+
+```clojure
+(rf/reg-cofx :user/current
+  {:doc "Inject the value of the [:user/current] sub into coeffects."}
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :user/current]
+              (rf/subscribe-value [:user/current]))))
+
+(rf/reg-event-fx :order/place
+  [(rf/inject-cofx :user/current)]
+  (fn [{:keys [db user/current]} [_ order]]
+    {:db (assoc-in db [:orders (:id order)]
+                   (assoc order :placed-by current))}))
+```
+
+Now the handler is back to being a pure function of `db`, `user/current`, and the event. The single impure operation — materialising a reaction, derefing it, unsubscribing — is quarantined inside the cofx handler. `rf/subscribe-value` is the right primitive here: it does that whole three-step dance in one call, so the cofx leaves no live reaction behind. (Using `@(rf/subscribe ...)` would also produce the right value but leak the reaction until GC; for one-shot reads at injection time, prefer `subscribe-value`.)
+
+When the sub takes arguments, parameterise the cofx with the binary form from earlier in the chapter:
+
+```clojure
+(rf/reg-cofx :sub/value
+  (fn [ctx query-v]
+    (assoc-in ctx [:coeffects :sub/value]
+              (rf/subscribe-value query-v))))
+
+;; One generic cofx; the call site picks the sub:
+(rf/reg-event-fx :order/cancel
+  [(rf/inject-cofx :sub/value [:order/by-id 42])]
+  (fn [{:keys [db sub/value]} _]
+    {:db (assoc-in db [:orders 42 :status] :cancelled)}))
+```
+
+You will reach for this often enough that "wrap as cofx" becomes muscle memory. It's worth flagging — and you may have noticed its absence — that re-frame2 deliberately does not ship a `cofx-from-sub` shortcut that collapses the five-line `reg-cofx` form into a single helper. The shortcut was considered (rf2-gw8j) and rejected. The five lines aren't friction to be papered over; they're the surface area that says "this is a coeffect, register it like one." A helper would imply subscribing-inside-handlers is the rule and the cofx is the workaround. It isn't — the cofx is the rule, and the wrap is the cost of admission for any handler that reads anything beyond `:db` and `:event`. The same five-line shape is what `:now`, `:new-id`, and `:local-store` use; sub-values aren't special.
+
+The same pattern, in agent-skill form (terser, with the gotchas pinned for AI authors): [`skills/re-frame2/`](../../skills/re-frame2/) → `reference/fundamentals/cofx.md` §*Reading a sub from a handler — wrap as cofx*.
+
 ## Testing via cofx stubs
 
 This is the payoff. A handler that uses `(inject-cofx :now)` is testable without faking `js/Date`, mocking the clock, or threading a `Clock` argument through every call site. The test re-registers `:now` with a stub before the handler-under-test runs, and the framework's id-redirect picks up the new binding:
@@ -272,6 +324,7 @@ The forward link from [chapter 07's table](07-interceptors.md#the-context-map) p
 - `reg-cofx` registers a cofx handler that takes the context (and optionally a value) and returns the context with the cofx value injected under `[:coeffects <id>]`.
 - Multiple cofxes compose by listing multiple `inject-cofx` interceptors in source order.
 - `reg-event-db` doesn't see injected cofx values; use `reg-event-fx` for any handler that needs them.
+- A handler that needs a sub's current value wraps the read as a cofx and injects it — never `rf/subscribe` from inside a handler body.
 - Testing is by re-registration — stub `:now` to return a fixed instant, scope it with `with-fresh-registrar`, and the handler-under-test becomes deterministic.
 
 ## Next

--- a/skills/re-frame2/reference/fundamentals/cofx.md
+++ b/skills/re-frame2/reference/fundamentals/cofx.md
@@ -63,6 +63,48 @@ The cofx writes under `[:coeffects :todo.storage/todos]`; the handler destructur
 
 Pure handlers are testable, replayable (for re-frame-pair2 epoch restore), and serialisable (for SSR snapshots). A handler that reads `Date.now()` directly is non-deterministic; the same handler that destructures `now` from coeffects is a pure function of its inputs.
 
+## Reading a sub from a handler — wrap as cofx
+
+A handler that needs a sub's current value **must not** call `(rf/subscribe ...)` (or `rf/subscribe-value`) from inside its body. Subscriptions are a view-layer concern; reading one implicitly from a handler breaks per-handler purity — the same `[coeffects event]` pair would no longer fully determine the handler's output, and `subscribe` would silently establish a reaction in whatever evaluation context the drain loop happened to be in.
+
+The canonical shape is to wrap the sub read as a cofx and inject it. The cofx handler is the one place the impure read lives; the event handler stays a function of its coeffects map.
+
+```clojure
+;; Register a cofx that materialises the sub at injection time.
+(rf/reg-cofx :user/current
+  {:doc "Inject the value of the [:user/current] sub into coeffects."}
+  (fn [ctx]
+    (assoc-in ctx [:coeffects :user/current]
+              (rf/subscribe-value [:user/current]))))
+
+;; Inject and destructure like any other cofx.
+(rf/reg-event-fx :order/place
+  [(rf/inject-cofx :user/current)]
+  (fn [{:keys [db user/current]} [_ order]]
+    {:db (assoc-in db [:orders (:id order)]
+                   (assoc order :placed-by current))}))
+```
+
+Two notes on the cofx body:
+
+- **`rf/subscribe-value` is the right primitive** — it materialises, derefs, and unsubscribes in one call, so the cofx leaves no reaction behind. `@(rf/subscribe ...)` inside the cofx would also work but leaks the reaction until GC.
+- **Parameterise with the 2-arg form.** If the sub takes args (`[:order/by-id 42]`), register the cofx binary and pass the args through `inject-cofx`:
+
+```clojure
+(rf/reg-cofx :sub/value
+  (fn [ctx query-v]
+    (assoc-in ctx [:coeffects :sub/value] (rf/subscribe-value query-v))))
+
+;; Used:
+(rf/reg-event-fx :order/cancel
+  [(rf/inject-cofx :sub/value [:order/by-id 42])]
+  (fn [{:keys [db sub/value]} _] ...))
+```
+
+There is deliberately **no `cofx-from-sub` shortcut helper** in `re-frame.core` (rf2-gw8j closed as won't-ship, 2026-05-13). The five-line `reg-cofx` wrapper above is the canonical shape; collapsing it into a one-liner would imply that subscribing-inside-handlers is the rule and the wrap is the workaround, when it is the other way around.
+
+Narrative treatment of the same pattern (for humans): `SKILL-REDIRECT.md` → **Guide ch.05 §Reading a sub from a handler**.
+
 ## Common gotchas
 
 - **`inject-cofx` returns an interceptor, not the value.** It must go in the positional interceptors vector, not the metadata-map (the metadata-map's `:interceptors` key is silently dropped — see [events.md](events.md)).

--- a/spec/API.md
+++ b/spec/API.md
@@ -28,7 +28,7 @@
 | `reg-event-ctx` | M | `(reg-event-ctx id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | 002 | |
 | `reg-sub` | M | `(reg-sub id ?metadata signal-fn? computation-fn)` | v1 (preserved + extended) | 002 | `:<-` sugar preserved. The only sub-registration form in v2. |
 | `reg-fx` | M | `(reg-fx id ?metadata handler)` | v1 (preserved + extended) | 002 | Unary or binary handler. |
-| `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | 002 | |
+| `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | 002 | Reading a sub's value from a handler is by cofx-wrapping — see [Guide ch.05 §Reading a sub from a handler](../docs/guide/05-coeffects.md#reading-a-sub-from-a-handler). |
 | `reg-frame` | M | `(reg-frame id metadata)` | v1 | 002 | Atomic create + register. |
 | `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | 002 | Anonymous frame; gensym'd id. |
 | `reg-view` | M | `(reg-view sym [args] body+)` / `(reg-view sym docstring [args] body+)` / `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | 004 | Defn-shape; auto-defs the symbol; auto-derives id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. |


### PR DESCRIPTION
## Summary

Documents the canonical idiom for reading a subscription value from inside an event handler: **wrap the sub read as a cofx, inject it**. Adds the pattern to three entry points so it's discoverable from skill, guide, and API row.

- **Skill** (`skills/re-frame2/reference/fundamentals/cofx.md`) — new section "Reading a sub from a handler — wrap as cofx". Five-line `reg-cofx` over `rf/subscribe-value`, plus the binary `:sub/value` form for parameterised subs. Notes that `rf/cofx-from-sub` was explicitly rejected (rf2-gw8j won't-ship, 2026-05-13).
- **Guide ch.05** (`docs/guide/05-coeffects.md`) — new subsection between "Common cofxes" and "Testing via cofx stubs". Opens with the anti-pattern (`rf/subscribe-value` inside a handler), then the wrap with a worked `:order/place` example, then the binary form. Closes with the won't-ship rationale.
- **`spec/API.md`** — `reg-cofx` Notes column now cross-links to the guide subsection.

Replaces rf2-gw8j (closed as won't-ship per rf2-hyh5w pre-alpha audit). The ergonomic complaint that motivated `cofx-from-sub` is real; the fix is docs, not new surface.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exit 0, clean
- [x] `python -m mkdocs build --strict` — warning count unchanged from origin/main baseline (227); no new warnings introduced
- [x] Pattern reachable from three entry points: skill leaf, guide chapter, API row Notes
- [x] No AI attribution; no `ai/` / `findings/` / `decision-beads.md` staged