### PR TITLE
docs(pair2): add agents/openai.yaml + include agents/ in package.json (rf2-o0yz)

### DIFF
--- a/skills/re-frame-pair2/agents/openai.yaml
+++ b/skills/re-frame-pair2/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "re-frame-pair2"
+  short_description: "Pair-program against a live re-frame2 app: inspect app-db, dispatch events, trace dominoes, hot-swap handlers, and restore epochs through the Tool-Pair runtime contract. Use only when a runtime is attached; do not use for static source-only work."
+  default_prompt: "Use $re-frame-pair2 to attach to my running re-frame2 app and help me investigate what's happening in the live runtime."

--- a/skills/re-frame-pair2/package.json
+++ b/skills/re-frame-pair2/package.json
@@ -29,6 +29,7 @@
     "SKILL.md",
     "README.md",
     "LICENSE",
+    "agents/",
     "scripts/",
     "preload/",
     ".claude-plugin/",


### PR DESCRIPTION
## Summary

- Adds `skills/re-frame-pair2/agents/openai.yaml` so pair2 exposes the same cross-agent metadata surface (`display_name`, `short_description`, `default_prompt`) that `re-frame-pair-improver2` already ships.
- Includes `agents/` in `skills/re-frame-pair2/package.json`'s `files` array so the new directory is part of the package payload.
- `short_description` aligns with the rf2-60kb direction: positive trigger (live runtime / introspection / dispatch / tracing / hot-swap / epoch restore) and negative boundary (not for static source-only work).

## Why

Closes rf2-o0yz. `re-frame-pair2` is the flagship runtime skill in this repo but was the only skill in `skills/` without an `agents/` surface, hurting cross-agent discoverability and creating an asymmetry with `re-frame-pair-improver2`.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [x] `skills/re-frame-pair2/package.json` still parses as JSON.
- [x] `re-frame-pair-improver2/package.json` already lists `agents/` (consistency check passes; no change needed).
- [x] `mkdocs build --strict` warnings unchanged vs origin/main (pre-existing 226 warnings, none introduced).