### PR TITLE
docs(pair2/SKILL): tighten frontmatter trigger - live-runtime use only (rf2-60kb)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: re-frame-pair2
 description: >
-  Pair-program with a live re-frame2 application. Attach to a running
-  shadow-cljs build via nREPL, inspect any frame's app-db, dispatch
-  events, hot-swap handlers, trace the six dominoes, and read the
-  per-frame epoch history — all through re-frame2's own runtime
-  contract (Tool-Pair Spec). No re-frame-10x dependency. Use this
-  skill whenever the user asks about their running re-frame2 app or
-  uses any of: re-frame2, app-db, dispatch, subscribe, reg-event,
-  reg-sub, reg-fx, reg-machine, frame, epoch, interceptor, sub-cache,
-  trace-buffer, register-trace-cb, register-epoch-cb!, restore-epoch,
-  re-com, shadow-cljs.
+  Pair-program against a **running** re-frame2 application via its
+  Tool-Pair contract — attach to a live shadow-cljs nREPL, inspect a
+  frame's app-db, dispatch events, hot-swap handlers, read the trace
+  stream and per-frame epoch history, and time-travel with
+  `restore-epoch`. Use when the user is operating on (or wants to
+  operate on) a live runtime they have running locally. **Do not use**
+  for static spec reading, architecture questions, design discussion,
+  or ordinary source edits when no runtime is involved — those belong
+  to `skills/re-frame2/` (authoring) or direct spec reading. See
+  `references/vocabulary.md` for the surface glossary; vocabulary
+  matches alone do not justify activation.
 allowed-tools:
   # MCP transport (preferred — single persistent nREPL connection per session)
   - mcp__re-frame-pair2__discover-app

--- a/skills/re-frame-pair2/references/vocabulary.md
+++ b/skills/re-frame-pair2/references/vocabulary.md
@@ -1,0 +1,51 @@
+# Vocabulary — surfaces this skill operates on
+
+This file is a flat reference glossary. It is *not* a trigger surface for the
+skill; the routing decision is made by the frontmatter in `SKILL.md`, which
+keys off the **running-runtime** precondition, not off these terms. Words
+listed here will appear in user requests once a runtime session is already
+underway, or when a code-reading task strays close enough to the runtime that
+the skill needs to confirm whether the runtime is up.
+
+If you arrived here from a source-only / spec-only question, you are in the
+wrong skill — close this and answer from the spec corpus directly.
+
+## re-frame2 runtime surfaces
+
+- **re-frame2** — the framework the running app is built on.
+- **frame** — a registered, named cascade root (`:rf/default`, plus any extras
+  the app registers). Most apps run a single frame.
+- **epoch** — one assembled run of the six dominoes for a given dispatch; the
+  unit of `epoch-history` and `restore-epoch`.
+- **app-db** — a frame's reactive root atom; read via `app-db/snapshot`,
+  written via REPL ops (ephemeral) or source edits (permanent).
+- **dispatch** — the event-entry op (`(rf/dispatch ...)` / the `dispatch`
+  structured op).
+- **subscribe** / **reg-sub** — the read-side of the cascade and its
+  registration form. `sub-cache` is the per-frame memoisation surface.
+- **reg-event** / **reg-event-fx** — write-side handler registrations.
+- **reg-fx** — effect-handler registrations; surfaced through
+  `:effects` projections on each epoch record.
+- **reg-machine** — state-machine handler registrations (Spec 005).
+- **interceptor** — the cascade middleware contract; introspectable via
+  `handler-meta`.
+- **trace-buffer** / **register-trace-cb** — the raw trace stream and its
+  listener registration (Spec 009).
+- **register-epoch-cb!** / **epoch-history** / **restore-epoch** — the
+  assembled-stream listener, the per-frame ring of epoch records, and the
+  time-travel entry point.
+
+## Toolchain / host
+
+- **shadow-cljs** — build tool; the skill attaches to its nREPL on the dev
+  build.
+- **re-com** — UI component library whose `data-rc-src` annotation feeds
+  the `dom/source-at` op as a fallback when re-frame2's own
+  `data-rf2-source-coord` isn't enabled.
+
+## When these terms appear in a request
+
+A bare mention of any of these terms does **not** mean the skill should
+activate. Activation depends on whether the user is *operating on a running
+app* or *reading source / spec*. The former is this skill's job; the latter
+belongs to `skills/re-frame2/` (authoring) or direct spec reading.


### PR DESCRIPTION
## Summary

- Rewrites `skills/re-frame-pair2/SKILL.md` frontmatter `description` from a broad keyword bucket into a tight positive trigger (live re-frame2 runtime via the Tool-Pair contract) plus an explicit negative boundary (do not use for static spec reading, architecture questions, or source-only edits — those route to `skills/re-frame2/` or direct spec reading).
- Moves the long vocabulary list out of frontmatter into `skills/re-frame-pair2/references/vocabulary.md`, with a header note clarifying that vocabulary matches alone do not justify activation.
- No changes to body, references, or scripts; the operational catalogue under `references/` is untouched.

Closes rf2-60kb.

## Rationale

The previous frontmatter description doubled as a keyword-matching surface (`re-frame2`, `app-db`, `dispatch`, `subscribe`, `reg-event`, ...). That activated the skill for ordinary source-reading or spec-reading questions where no live runtime is involved — an expensive false-positive that loads long references and biases the agent toward runtime operations the session can't perform. The body of `SKILL.md` already states the stricter precondition (a running re-frame2 app behind `shadow-cljs watch`); this PR makes the trigger surface match the body.

## Test plan

- [ ] Frontmatter YAML parses (verified via `yaml.safe_load`).
- [ ] `mkdocs build --strict` warnings are unchanged from `origin/main` (none reference `pair2` / `vocabulary`); pre-existing warnings under `docs/guide/` and `docs/skills/re-frame2-implementor.md` are orthogonal.
- [ ] Skim the new trigger description for any remaining keyword-bait phrasing.
- [ ] Confirm `references/vocabulary.md` reads as a glossary, not a trigger surface.