### PR TITLE
fix(schemas): late-bind Malli adapter — restore CLJS validation via re-frame.schemas.malli ns (rf2-t0hq)

### DIFF
--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -11,7 +11,15 @@
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves at the call sites below.
-            [re-frame.schemas]))
+            [re-frame.schemas]
+            ;; Per rf2-t0hq the CLJS default validator routes through
+            ;; the late-bind hook `:schemas/malli-validate`, which the
+            ;; `re-frame.schemas.malli` adapter ns publishes at load
+            ;; time. The require is the canonical CLJS opt-in for
+            ;; Malli validation — without it, the default validator
+            ;; soft-passes per Spec 010 §Recommended soft-pass and
+            ;; no failure trace fires for malformed app-db slices.
+            [re-frame.schemas.malli]))
 
 ;; ============================================================================
 ;; WIRE SHAPES — what the mocked endpoints return

--- a/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
@@ -25,7 +25,14 @@
   this smoke locks that the canned-stub fxs and the public test seam
   resolve under the Reagent adapter the same way they do on the JVM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [malli.core]
+            ;; Per rf2-t0hq — the canonical CLJS opt-in for Malli
+            ;; validation. Publishes :schemas/malli-validate /
+            ;; :schemas/malli-explain into the late-bind hook table so
+            ;; the default validator delegates to Malli on CLJS. The
+            ;; http-managed CLJS smoke exercises `:rf.http/decode-
+            ;; schemas` shapes that route through the registered
+            ;; validator; without this require they'd soft-pass.
+            [re-frame.schemas.malli]
             [re-frame.core :as rf]
             [re-frame.http-managed :as http-managed]
             [re-frame.adapter.reagent :as reagent-adapter]

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -68,6 +68,8 @@
     :schemas/set-schema-explainer!         re-frame.schemas/set-schema-explainer! ;; rf2-froe — companion explainer
     :schemas/validate-with-registered-fn   re-frame.schemas/validate-with-registered-fn ;; rf2-r2uh boundary seam
     :schemas/explain-with-registered-fn    re-frame.schemas/explain-with-registered-fn  ;; rf2-r2uh boundary seam
+    :schemas/malli-validate                malli.core/validate                          ;; rf2-t0hq — published by re-frame.schemas.malli adapter ns
+    :schemas/malli-explain                 malli.core/explain                           ;; rf2-t0hq — published by re-frame.schemas.malli adapter ns
     :machines/reg-machine             re-frame.machines/reg-machine* ;; rf2-8bp3 — plain-fn surface
     :machines/create-machine-handler  re-frame.machines/create-machine-handler
     :machines/machine-transition      re-frame.machines/machine-transition

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -478,12 +478,25 @@
 ;; ---- restore failure-mode predicates --------------------------------------
 
 (defn- malli-validate-fn
-  "Return the malli validate fn (resolved at call site) or nil."
+  "Return the malli validate fn or nil.
+
+  Per rf2-t0hq the CLJS runtime `resolve` is a compile-time analyzer
+  affordance, not a runtime fn — the historical `:cljs (resolve
+  'malli.core/validate)` arm silently returned nil, so the
+  schema-mismatch failure-mode predicate at epoch-restore time treated
+  every recorded db as conforming on CLJS.
+
+  Lookup order matches `re-frame.schemas/default-malli-validate`:
+    1. Late-bind hook `:schemas/malli-validate` (published by
+       `re-frame.schemas.malli` when loaded).
+    2. JVM only — fall back to `(requiring-resolve 'malli.core/validate)`.
+    3. Return nil (soft-pass — the schema-validate-ok? caller treats
+       a nil validate fn as 'cannot disprove, treat as valid')."
   []
-  #?(:clj  (try (requiring-resolve 'malli.core/validate)
-                (catch Throwable _ nil))
-     :cljs (try (resolve 'malli.core/validate)
-                (catch :default _ nil))))
+  (or (late-bind/get-fn :schemas/malli-validate)
+      #?(:clj  (try (requiring-resolve 'malli.core/validate)
+                    (catch Throwable _ nil))
+         :cljs nil)))
 
 (defn- registered-app-schemas
   "Return the {path → schema-meta} map registered against the named

--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -12,9 +12,12 @@
 ;;   {:deps {day8/re-frame2         {:mvn/version "..."}
 ;;           day8/re-frame2-schemas {:mvn/version "..."}}}
 ;;
-;; And, on CLJS, require malli.core at app-boot so the validate fn
-;; resolves at runtime (re-frame.schemas uses `(resolve 'malli.core/validate)`
-;; which only finds vars already loaded).
+;; And, on CLJS, require `re-frame.schemas.malli` at app-boot to publish
+;; Malli's validate / explain into the late-bind hook table (rf2-t0hq).
+;; Without that require the default validator soft-passes per Spec 010
+;; §Recommended soft-pass — even if Malli is on the classpath, the
+;; framework cannot reach it through CLJS's runtime resolve (which is
+;; a compile-time analyzer affordance only, not a runtime fn).
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -59,42 +59,64 @@
 ;; A combined `(set-schema-validator! {:validate ... :explain ...})`
 ;; arity exists for callers who want to install both atomically.
 
+;; Per rf2-t0hq the CLJS default validator used to reach Malli through
+;; runtime `resolve` — but CLJS has no runtime resolve (the symbol is
+;; a compile-time analyzer affordance only). The catch silently
+;; swallowed the failure and the validator returned true for every
+;; value, so Malli was never consulted on CLJS unless the user
+;; explicitly called `(rf/set-schema-validator! malli.core/validate)`.
+;;
+;; The fix is the rf2-froe / rf2-p7va substitute-validator pattern:
+;; the `re-frame.schemas.malli` adapter namespace (this artefact)
+;; publishes Malli's `validate` and `explain` into the late-bind hook
+;; table on ns-load. The default fns below consult the table on every
+;; call. Apps opt in to Malli validation on CLJS by requiring
+;; `re-frame.schemas.malli` at app boot.
+;;
+;; On the JVM `requiring-resolve` still works as a no-require fallback
+;; so existing JVM tests / apps keep working without an explicit
+;; require of the adapter ns; the late-bind hook takes precedence when
+;; the adapter ns IS loaded.
+
 (defn- default-malli-validate
-  "The default validator — delegates to malli.core/validate. Returns
-  truthy on conform, falsey on fail. When Malli is not on the
-  classpath the resolve returns nil and we treat the value as
-  passing (we cannot disprove the shape). Apps that want
-  Malli-absent behaviour to be a hard fail register a stricter
-  validator via `set-schema-validator!`."
+  "The default validator — delegates to malli.core/validate via the
+  late-bind hook published by `re-frame.schemas.malli` (rf2-t0hq).
+
+  Lookup order:
+    1. Late-bind hook `:schemas/malli-validate` (published by
+       `re-frame.schemas.malli` when that namespace is loaded).
+    2. On the JVM only, fall back to `(requiring-resolve
+       'malli.core/validate)` so the JVM artefact tests / apps that
+       have Malli on the classpath but don't `:require
+       [re-frame.schemas.malli]` keep working.
+    3. Soft-pass — return true (per Spec 010 §Recommended soft-pass).
+
+  Apps that want Malli-absent behaviour to be a hard fail register
+  a stricter validator via `set-schema-validator!`."
   [schema value]
-  #?(:clj
-     (try
-       (if-let [v (requiring-resolve 'malli.core/validate)]
-         (v schema value)
-         true)
-       (catch Throwable _ true))
-     :cljs
-     (try
-       (if-let [v (resolve 'malli.core/validate)]
-         (v schema value)
-         true)
-       (catch :default _ true))))
+  (if-let [v (late-bind/get-fn :schemas/malli-validate)]
+    (v schema value)
+    #?(:clj  (try
+               (if-let [v (requiring-resolve 'malli.core/validate)]
+                 (v schema value)
+                 true)
+               (catch Throwable _ true))
+       :cljs true)))
 
 (defn- default-malli-explain
-  "The default explainer — delegates to malli.core/explain. Returns
-  the Malli explanation map on fail or nil on conform / when Malli
-  is not on the classpath."
+  "The default explainer — delegates to malli.core/explain via the
+  late-bind hook published by `re-frame.schemas.malli` (rf2-t0hq).
+  Same lookup order as `default-malli-validate`. Returns the Malli
+  explanation map on fail; nil on conform / when Malli is not on the
+  classpath / when the adapter ns is not loaded."
   [schema value]
-  #?(:clj
-     (try
-       (when-let [e (requiring-resolve 'malli.core/explain)]
-         (e schema value))
-       (catch Throwable _ nil))
-     :cljs
-     (try
-       (when-let [e (resolve 'malli.core/explain)]
-         (e schema value))
-       (catch :default _ nil))))
+  (if-let [e (late-bind/get-fn :schemas/malli-explain)]
+    (e schema value)
+    #?(:clj  (try
+               (when-let [e (requiring-resolve 'malli.core/explain)]
+                 (e schema value))
+               (catch Throwable _ nil))
+       :cljs nil)))
 
 (defonce
   ^{:doc "The currently-registered validator fn — `(fn [schema value]

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -1,0 +1,64 @@
+(ns re-frame.schemas.malli
+  "Malli adapter for the schemas artefact (rf2-t0hq).
+
+  Per Spec 010 §Default validator the CLJS reference's default validator
+  delegates to Malli (`malli.core/validate` / `malli.core/explain`).
+  Historically `re-frame.schemas/default-malli-validate` reached Malli
+  via runtime `resolve` on CLJS:
+
+      :cljs
+      (try
+        (if-let [v (resolve 'malli.core/validate)]
+          (v schema value)
+          true)
+        (catch :default _ true))
+
+  CLJS has no runtime `resolve` (the symbol is a compile-time analyzer
+  affordance only); the `if-let`'s `nil` branch always fired and the
+  default validator returned `true` for every value. Malli was never
+  consulted on CLJS — `(rf/reg-app-schema [:user :age] :int)` then a
+  commit of `\"twenty-three\"` produced no
+  `:rf.error/schema-validation-failure` trace.
+
+  The fix follows the rf2-froe / rf2-p7va substitute-validator
+  precedent: this namespace exists only to publish Malli's `validate`
+  and `explain` fns into the framework's late-bind hook table.
+  `re-frame.schemas/default-malli-validate` and
+  `default-malli-explain` consult the table at call time and delegate
+  to whatever's published; absent any publisher they soft-pass per the
+  Spec 010 §Recommended soft-pass rule.
+
+  CLJS users opt in by requiring this namespace at app boot:
+
+      (ns my-app.core
+        (:require [re-frame.core :as rf]
+                  [re-frame.schemas]         ;; load the schemas artefact
+                  [re-frame.schemas.malli])) ;; publish Malli into the hook table
+
+  On the JVM the schemas artefact's `default-malli-validate` already
+  works via `requiring-resolve` — but loading this namespace at boot
+  is harmless and symmetrical (CLJS + JVM bundles look identical).
+
+  Apps that want to drop the Malli surface entirely (per rf2-qnxf
+  bundle audit) do NOT require this namespace and either:
+
+    - Leave the default in place (soft-pass; no failure traces fire).
+    - Call `(rf/set-schema-validator! my-validator-fn)` at boot to
+      install a custom validator.
+    - Call `(rf/set-schema-validator! nil)` for a hard no-op."
+  (:require [malli.core]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---- publish Malli into the late-bind hook table -------------------------
+;;
+;; Per rf2-t0hq the two hooks `:schemas/malli-validate` and
+;; `:schemas/malli-explain` are read by `re-frame.schemas/default-malli-
+;; validate` / `default-malli-explain` on every validate call. Both
+;; sides of the seam are in this artefact so the contract is local;
+;; the seam is published as a hook key so future ports
+;; (`re-frame.schemas.zod` / `.pydantic` / ...) can register their own
+;; default validator pair without a code change to the schemas
+;; namespace.
+
+(late-bind/set-fn! :schemas/malli-validate malli.core/validate)
+(late-bind/set-fn! :schemas/malli-explain  malli.core/explain)

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -33,14 +33,14 @@
   prod-mode assertions would fail under `goog.DEBUG=true` because the
   boundary is a no-op in dev (per Spec 010 L145)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            ;; Pull malli into the bundle. The boundary interceptor
-            ;; routes through the registered validator via the
-            ;; :schemas/validate-with-registered-fn late-bind hook;
-            ;; without malli on the classpath the default validator is
-            ;; nil and the boundary no-ops. The conformance fixtures
-            ;; for app-db slice validation rely on user code requiring
-            ;; malli at app boot; this test does the same.
-            [malli.core]
+            ;; Per rf2-t0hq the CLJS default validator routes through
+            ;; the late-bind hook `:schemas/malli-validate`, which the
+            ;; `re-frame.schemas.malli` adapter ns publishes at load
+            ;; time. Without it the default validator soft-passes and
+            ;; the boundary interceptor never sees a failure. The
+            ;; canonical opt-in for CLJS apps that want Malli validation
+            ;; at the boundary is to require the adapter ns at boot.
+            [re-frame.schemas.malli]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -15,16 +15,16 @@
   fixtures (schema-app-db-slice-validates.edn et al.) cover the broader
   contract."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            ;; Pull malli into the bundle. re-frame.schemas/malli-validate*
-            ;; uses (resolve 'malli.core/validate) — which on CLJS only
-            ;; finds vars already loaded into the runtime. Without this
-            ;; require, the resolve returns nil and validation silently
-            ;; passes (the JVM's requiring-resolve has no CLJS analogue).
-            ;; The conformance fixtures for app-db slice validation rely
-            ;; on user code requiring malli at app boot; this test does
-            ;; the same.
-            [malli.core]
+            ;; Per rf2-t0hq the CLJS default validator routes through
+            ;; the late-bind hook `:schemas/malli-validate`, which the
+            ;; `re-frame.schemas.malli` adapter ns publishes at load
+            ;; time. The require is the canonical opt-in pattern for
+            ;; CLJS apps that want Malli validation; without it, the
+            ;; default validator soft-passes (per Spec 010
+            ;; §Recommended soft-pass) and no failure trace fires.
+            [re-frame.schemas.malli]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
@@ -90,6 +90,76 @@
                               (:operation %))
                           @traces))
           "no validation-failure traces — every commit conforms"))))
+
+;; ---- rf2-t0hq — Malli adapter late-bind seam ------------------------------
+;;
+;; Two contract tests pin the rf2-t0hq fix. The first asserts that with
+;; the canonical opt-in (`(:require [re-frame.schemas.malli])` — done at
+;; the top of this file) the default validator DOES consult Malli on
+;; CLJS, so a malformed commit fires :rf.error/schema-validation-failure.
+;; This is the contract the historical bug silently violated — the
+;; `:cljs (resolve 'malli.core/validate)` runtime resolve returned nil
+;; and every value was treated as conforming.
+;;
+;; The second test pins the soft-pass arm: with the late-bind hook
+;; cleared (simulating an app that doesn't require `re-frame.schemas.
+;; malli`), the default validator returns true for every value per
+;; Spec 010 §Recommended soft-pass and no failure trace fires. We
+;; restore the hook on the way out so downstream tests see the canonical
+;; opt-in's behaviour.
+
+(deftest rf2-t0hq-cljs-malli-adapter-enables-validation
+  (testing "Per rf2-t0hq: with `re-frame.schemas.malli` required at
+            app boot, the default validator consults Malli on CLJS and
+            a malformed commit fires :rf.error/schema-validation-failure.
+            The fix's load-bearing contract — historically the CLJS
+            runtime `resolve` returned nil and Malli was never consulted,
+            so this trace silently never fired."
+    (rf/reg-app-schema [:user :age] :int)
+    (rf/reg-event-db :user/set-age-bad
+      (fn [db _] (assoc-in db [:user :age] "twenty-three")))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::t0hq (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:user/set-age-bad])
+      (rf/remove-trace-cb! ::t0hq)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "the default Malli validator fired on CLJS via the late-bind
+             hook — this is the contract rf2-t0hq restored")
+        (let [v (first violations)]
+          (is (= :app-db (-> v :tags :where)))
+          (is (= [:user :age] (-> v :tags :path)))
+          (is (= "twenty-three" (-> v :tags :value))))))))
+
+(deftest rf2-t0hq-cljs-no-adapter-soft-passes
+  (testing "Per Spec 010 §Recommended soft-pass: when an app does NOT
+            require `re-frame.schemas.malli`, the late-bind hook
+            `:schemas/malli-validate` is absent, the default validator
+            returns true for every value, and no failure trace fires.
+            We simulate the no-adapter case by temporarily clearing the
+            hook — the implementation must take its soft-pass arm."
+    (let [prior-v (late-bind/get-fn :schemas/malli-validate)
+          prior-e (late-bind/get-fn :schemas/malli-explain)]
+      (late-bind/set-fn! :schemas/malli-validate nil)
+      (late-bind/set-fn! :schemas/malli-explain  nil)
+      (try
+        (rf/reg-app-schema [:n] :int)
+        (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
+        (let [traces (atom [])]
+          (rf/register-trace-cb! ::no-adapter (fn [ev] (swap! traces conj ev)))
+          (rf/dispatch-sync [:n/break])
+          (rf/remove-trace-cb! ::no-adapter)
+          (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                  (:operation %))
+                              @traces))
+              "soft-pass arm — no validator hook, no failure trace, the
+               malformed commit silently 'conforms' to the spec's
+               new-user-friendly default"))
+        (finally
+          (late-bind/set-fn! :schemas/malli-validate prior-v)
+          (late-bind/set-fn! :schemas/malli-explain  prior-e))))))
 
 ;; ---- rf2-jwm4 — event-payload validation under Reagent -------------------
 ;;

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -332,6 +332,23 @@ This recommendation is normative-soft: ports that ship a different default-absen
 
 What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
 
+### Opting in to Malli validation on CLJS (rf2-t0hq)
+
+CLJS apps that want the default Malli validator to run **must** require the `re-frame.schemas.malli` adapter namespace at app boot:
+
+```clojure
+(ns my-app.core
+  (:require [re-frame.core :as rf]
+            [re-frame.schemas]         ;; load the schemas artefact (rf2-p7va)
+            [re-frame.schemas.malli])) ;; publish Malli into the late-bind hook table (rf2-t0hq)
+```
+
+The adapter namespace's only job is to publish `malli.core/validate` and `malli.core/explain` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain`). The schemas artefact's default validator consults these hooks on every call; absent the hook (i.e. the adapter ns was not required) the validator soft-passes per [§Recommended soft-pass](#recommended-soft-pass-when-the-default-validators-library-is-absent).
+
+The motivation is the bug rf2-t0hq fixed: CLJS has no runtime `resolve`, so the previous implementation's `(resolve 'malli.core/validate)` always returned nil on CLJS and the default validator silently soft-passed even when Malli was on the classpath. The late-bind adapter pattern (matching the rf2-froe / rf2-p7va substitute-validator precedent) preserves Malli's optional-dep status while making the opt-in explicit and runtime-correct.
+
+On the **JVM** loading the adapter namespace is optional but harmless — the schemas artefact's `default-malli-validate` falls back to `requiring-resolve` so JVM apps that have Malli on the classpath get Malli validation without an explicit require. Apps that want their bundle to be runtime-identical on JVM and CLJS require `re-frame.schemas.malli` on both sides.
+
 ### Worked example — installing a no-op validator at boot (CLJS reference)
 
 The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cost-audit.md` §3.7 / §4): an app that doesn't need runtime schema validation can install a no-op at boot and avoid pulling the default validator's schema-language library (Malli on the CLJS reference) into its production bundle.
@@ -340,10 +357,14 @@ The motivating use-case is bundle-cost reduction (per `findings/malli-bundle-cos
 (ns my-app.core
   (:require [re-frame.core :as rf]
             [re-frame.schemas]   ;; load the schemas artefact (rf2-p7va)
-            ;; NOTE: we do NOT (:require [malli.core]) here — the
-            ;; CLJS reference's default validator does
-            ;; (resolve 'malli.core/validate); that returns nil when
-            ;; Malli is absent and the no-op below replaces it entirely.
+            ;; NOTE: we do NOT require [re-frame.schemas.malli] here —
+            ;; the late-bind adapter pattern (rf2-t0hq) gates Malli
+            ;; on an explicit require. Skipping the require means
+            ;; Malli is never pulled into the bundle, and the
+            ;; default validator soft-passes per §Recommended
+            ;; soft-pass. The (rf/set-schema-validator! nil) below
+            ;; tightens the soft-pass arm to an active no-op so the
+            ;; intent is explicit.
             ))
 
 ;; Install the no-op BEFORE the first reg-app-schema / :spec metadata.

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1062,7 +1062,7 @@ Per [rf2-p7va](#) (the first per-feature artefact split per [rf2-5vjj](#) Strate
         day8/re-frame2-schemas {:mvn/version "<latest>"}}}  ;; ← new in v2
 ```
 
-CLJS apps additionally require `malli.core` somewhere in their boot path — `re-frame.schemas`'s validate fn is found via `(resolve 'malli.core/validate)` and only resolves a var that has already been loaded into the runtime. The schemas artefact carries Malli as a `:deps` entry so the namespace is available; the app's `:require [malli.core]` is what loads it.
+CLJS apps additionally require `re-frame.schemas.malli` somewhere in their boot path so the default validator delegates to Malli (rf2-t0hq). The adapter namespace publishes `malli.core/validate` and `malli.core/explain` into the framework's late-bind hook table on ns-load; the schemas artefact's default validator consults the hook on every call. Absent the require, the default validator soft-passes per Spec 010 §Recommended soft-pass (CLJS has no runtime `resolve`, so a previous-generation `(resolve 'malli.core/validate)` approach silently no-op'd even when Malli was on the classpath). The schemas artefact carries Malli as a `:deps` entry so the namespace is available without an explicit `:require`; the app's `:require [re-frame.schemas.malli]` is what wires the runtime fns into the framework.
 
 **Public API** (in `re-frame.core`) is unchanged — `(rf/reg-app-schema ...)`, `(rf/app-schema-at ...)`, `(rf/app-schemas ...)` still work, the wrappers in core late-bind through the hook table to the schemas artefact's implementations. An app that calls `rf/reg-app-schema` *without* the schemas artefact on the classpath gets a clear `:rf.error/schemas-artefact-missing` error at the call site.
 


### PR DESCRIPTION
## Summary

- `re-frame.schemas`'s CLJS default validator reached Malli via runtime `(resolve ''malli.core/validate)` — but CLJS has no runtime resolve (the symbol is a compile-time analyzer affordance only). The catch silently swallowed the failure and the validator returned `true` for every value, so Malli was never consulted on CLJS unless an app explicitly called `(rf/set-schema-validator! malli.core/validate)`. `(rf/reg-app-schema [:user :age] :int)` followed by a commit of `"twenty-three"` produced no `:rf.error/schema-validation-failure` trace — the Spec 010 §Validation timing contract silently failed on the CLJS reference''s primary target. JVM was unaffected because it uses `requiring-resolve` (a genuine runtime fn).
- The fix matches the rf2-froe / rf2-p7va substitute-validator precedent. A new `re-frame.schemas.malli` adapter namespace publishes `malli.core/validate` / `malli.core/explain` into the framework''s late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain`). The schemas artefact''s default validator consults the hook on every call; absent the hook (i.e. the adapter ns was not required) the validator soft-passes per Spec 010 §Recommended soft-pass. CLJS apps opt in by adding `(:require [re-frame.schemas.malli])` to their boot ns — one line. The JVM path keeps its `requiring-resolve` fallback so JVM apps remain unchanged.
- `re-frame.epoch/malli-validate-fn` had the same CLJS bug at the schema-mismatch failure-mode predicate and now consults the same late-bind hook with the same JVM fallback. Spec 010 §Opting in to Malli validation on CLJS documents the opt-in pattern; spec/MIGRATION.md replaces the obsolete `[malli.core]` boot-time require advice with `[re-frame.schemas.malli]`. The boot example schema.cljs demonstrates the require.

## Test plan

- [x] JVM `clojure -M:test` (schemas): 49 tests / 176 assertions, 0 failures
- [x] JVM `clojure -M:test` (epoch): 59 tests / 233 assertions, 0 failures
- [x] JVM `clojure -M:test` (core): 277 tests / 1230 assertions, 0 failures
- [x] CLJS `npm run test:cljs` (node-test): 593 tests / 1406 assertions, 0 failures
- [x] CLJS `npm run test:browser`: 591 tests / 1428 assertions, 0 failures
- [x] CLJS `npm run test:browser-schemas-boundary-prod` (release `:advanced`): 5 tests / 7 assertions, 0 failures
- [x] CLJS `npm run test:browser-prod-elision` (release `:advanced`): 11 tests / 33 assertions, 0 failures
- [x] CLJS `npm run test:elision`: PASS
- [x] CLJS `npm run test:examples`: pre-existing flake on `counter-with-stories` (reproduces on unmodified `origin/main` — unrelated)
- [x] New contract test `rf2-t0hq-cljs-malli-adapter-enables-validation` asserts the bug''s reverse — a malformed CLJS commit fires `:rf.error/schema-validation-failure` (the contract the bug silently violated)
- [x] New companion test `rf2-t0hq-cljs-no-adapter-soft-passes` pins the soft-pass arm by clearing the late-bind hook