### PR TITLE
feat(story+causa): open-in-editor affordance — click any source-coord to launch VS Code / Cursor / IntelliJ (rf2-evgf5)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -1,0 +1,214 @@
+(ns re-frame.source-coords.editor-uri
+  "Build an 'open in editor' URI from a source-coord map (per rf2-evgf5).
+
+  Tools that surface a `{:file :line :column :ns}` source-coord — Story's
+  variant canvas, Story's per-test failure detail, Causa's event-detail
+  hero, etc. — wrap the coord in a clickable affordance that launches the
+  user's editor at that file:line. The de-facto protocol in 2026 is a
+  custom URI scheme per editor:
+
+      vscode://file/<path>:<line>:<column>
+      cursor://file/<path>:<line>:<column>
+      idea://open?file=<path>&line=<line>&column=<column>
+
+  No single scheme covers every editor; the user picks one at boot via a
+  configuration key (`:rf.story/editor`, `:rf.causa/editor`). The pure
+  helper here builds the URI string; the tool's UI layer attaches it to
+  an `<a href>` or fires it via `window.location.href`.
+
+  ## Editor keyword vocabulary
+
+  - `:vscode` (default) — VS Code, the most-installed editor.
+  - `:cursor` — Cursor (the VS Code fork).
+  - `:idea`   — IntelliJ family (IDEA, WebStorm, PyCharm). The single
+                `idea://` handler dispatches across all JetBrains IDEs.
+  - `{:custom <uri-template>}` — user-supplied template with the
+                placeholders `{path}` / `{line}` / `{column}` / `{file}`
+                substituted from the source-coord. `{file}` is an alias
+                for `{path}` so the template reads naturally either way.
+
+  ## Why custom-template support
+
+  Editor schemes evolve. The 2026 set is vscode/cursor/idea/sublime/
+  zed; by 2027 a new editor will ship its own scheme. The custom slot
+  means a host doesn't have to wait for an upstream PR to support its
+  editor — set `{:custom \"my-editor://open?path={path}&row={line}\"}`
+  and tooling picks it up.
+
+  ## Path semantics
+
+  Source-coord `:file` is what the macro layer captured at registration
+  time. Under CLJS it's typically `\"path/to/file.cljs\"` relative to the
+  classpath root (resolved via the form-meta `:file` slot, per rf2-mdjp).
+  The editor opens the file from disk, so the URI must carry a path the
+  editor's resolver can find.
+
+  v1 ships the file string verbatim and lets the editor resolve it.
+  Hosts that need workspace-absolute paths can use `:custom` with a
+  prefix template like `\"vscode://file/{HOST_WORKSPACE_ROOT}/{path}:{line}\"`
+  — the substitution itself stays pure-data; the host's template
+  controls the prefix.
+
+  ## What this namespace deliberately doesn't do
+
+  - No editor detection (no `navigator.userAgent` sniffing) — the user
+    picks the editor via config.
+  - No fallback URI scheme — if the editor isn't installed, the click
+    no-ops cleanly (the OS handler chain returns).
+  - No async / Promise — pure data → data, JVM + CLJS portable.
+  - No dispatch / re-frame plumbing — the UI layer attaches the URI to
+    a DOM node and lets the browser fire it. Keeps this helper tool-
+    agnostic so Story + Causa + future tools (Pair? a Helix DevTool?)
+    consume it identically.
+
+  ## Source-coord shape
+
+  Matches `re-frame.source-coords` / `re-frame.story.registrar`:
+
+      {:ns sym? :file string? :line int? :column int?}
+
+  `:file` is required for any meaningful URI (an editor URI without a
+  file is a no-op). `:line` and `:column` are optional; URIs fall back
+  to line 1 / column 1 when absent so the editor at least opens the
+  file. Missing `:file` → `nil` URI; the UI layer hides the button."
+  (:require [clojure.string :as str]))
+
+;; ---- known schemes -------------------------------------------------------
+
+(def ^:const known-editors
+  "The keyword set of built-in editor schemes. The `:custom` form is
+  not a member — `editor-uri` matches it via map-shape detection."
+  #{:vscode :cursor :idea})
+
+(def ^:private default-editor
+  "Default editor when no `:editor` config key is set. VS Code is the
+  most-installed editor in 2026 (Stack Overflow Developer Survey 2025
+  + JetBrains DevEcosystem 2025 both put it >70%)."
+  :vscode)
+
+;; ---- pure: source-coord normalisation -----------------------------------
+
+(defn- coord-line
+  "Pull a usable `:line` value out of `source-coord`. Returns `1` when
+  `:line` is missing — editor URIs without a line scheme still resolve
+  to the file's first line."
+  [source-coord]
+  (or (:line source-coord) 1))
+
+(defn- coord-column
+  "Pull a usable `:column` value out of `source-coord`. Returns `1` when
+  `:column` is missing — editor URIs without a column resolve to the
+  start of the line."
+  [source-coord]
+  (or (:column source-coord) 1))
+
+(defn- coord-file
+  "Return the `:file` slot of `source-coord`, or `nil` when absent / blank.
+  Callers test the return value: a nil file → nil URI → the UI hides the
+  button."
+  [source-coord]
+  (let [f (:file source-coord)]
+    (when (and (string? f) (not (str/blank? f)))
+      f)))
+
+;; ---- pure: scheme builders ----------------------------------------------
+
+(defn- vscode-uri
+  "Build a `vscode://file/<path>:<line>:<column>` URI."
+  [path line column]
+  (str "vscode://file/" path ":" line ":" column))
+
+(defn- cursor-uri
+  "Build a `cursor://file/<path>:<line>:<column>` URI. Cursor inherits
+  VS Code's URI grammar, only the scheme differs."
+  [path line column]
+  (str "cursor://file/" path ":" line ":" column))
+
+(defn- idea-uri
+  "Build an `idea://open?file=<path>&line=<line>&column=<column>` URI.
+  The JetBrains scheme uses query parameters rather than the
+  colon-suffix form."
+  [path line column]
+  (str "idea://open?file=" path "&line=" line "&column=" column))
+
+;; ---- pure: custom-template substitution ---------------------------------
+
+(defn- substitute-template
+  "Substitute `{path}` / `{file}` / `{line}` / `{column}` placeholders in
+  `template` with the corresponding values. Missing placeholders fall
+  through unchanged so user templates with extra tokens stay readable.
+
+  Substitution is order-independent and idempotent — a template that
+  doesn't contain `{column}` simply omits the column. Used by the
+  `:custom` editor form."
+  [template path line column]
+  (-> template
+      (str/replace "{path}"   (str path))
+      (str/replace "{file}"   (str path))
+      (str/replace "{line}"   (str line))
+      (str/replace "{column}" (str column))))
+
+;; ---- public: editor-uri --------------------------------------------------
+
+(defn editor-uri
+  "Build an 'open in editor' URI for `source-coord` against `editor`.
+
+  Returns a string URI when `source-coord` carries a non-blank `:file`,
+  else `nil` (callers hide their open-in-editor affordance when the URI
+  is nil).
+
+  `editor` accepts:
+    - `:vscode` (default when nil) — `vscode://file/<path>:<line>:<column>`
+    - `:cursor`                    — `cursor://file/<path>:<line>:<column>`
+    - `:idea`                      — `idea://open?file=<path>&line=<line>&column=<column>`
+    - `{:custom <template>}`       — user template with `{path}` / `{file}`
+                                     / `{line}` / `{column}` placeholders.
+    - any unknown keyword          — treated as the default `:vscode`
+                                     scheme (so a typoed editor key
+                                     still produces a clickable URI
+                                     rather than nothing).
+
+  Pure data → data; JVM + CLJS portable. No URL-encoding of the path —
+  editor handlers expect raw paths; URL-encoding `/` to `%2F` confuses
+  the file resolver in every editor tested. Spaces in paths are the one
+  edge case (rare in a Clojure project; absent from re-frame2 + its
+  examples)."
+  [editor source-coord]
+  (when-let [path (coord-file source-coord)]
+    (let [line   (coord-line source-coord)
+          column (coord-column source-coord)]
+      (cond
+        ;; Custom template: `{:custom "<uri-template>"}`. Validate the
+        ;; template is a string; anything else falls through to the
+        ;; default editor.
+        (and (map? editor) (string? (:custom editor)))
+        (substitute-template (:custom editor) path line column)
+
+        (= :cursor editor)
+        (cursor-uri path line column)
+
+        (= :idea editor)
+        (idea-uri path line column)
+
+        ;; :vscode is the default; any unknown keyword also lands here.
+        :else
+        (vscode-uri path line column)))))
+
+(defn open-button-title
+  "Build the `title` attribute string an 'Open' button should carry.
+  Includes the file:line so a hover reveals exactly where the click
+  will land. Pure data → data; JVM + CLJS portable.
+
+  Returns a generic 'Open in editor' when source-coord lacks `:file`."
+  [source-coord]
+  (if-let [path (coord-file source-coord)]
+    (str "Open in editor — " path ":" (coord-line source-coord))
+    "Open in editor"))
+
+(defn has-source?
+  "Predicate — true iff `source-coord` carries enough data for a
+  meaningful editor URI (a non-blank `:file`). Tools gate the open
+  button's render on this; a coord without `:file` means we never
+  captured a usable location and the button would no-op."
+  [source-coord]
+  (some? (coord-file source-coord)))

--- a/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
@@ -1,0 +1,36 @@
+(ns re-frame.source-coords-editor-uri-cljs-test
+  "CLJS smoke tests for `re-frame.source-coords.editor-uri` (rf2-evgf5).
+
+  The pure helper is JVM + CLJS portable; the bulk of the matrix lives
+  in the JVM test ns. This file verifies the CLJS build path resolves
+  the same URIs."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.source-coords.editor-uri :as eu]))
+
+(def ^:private coord
+  {:ns 'app.views :file "src/app/views.cljs" :line 42 :column 7})
+
+(deftest vscode-cursor-idea-portable-shape
+  (testing ":vscode / :cursor / :idea produce the documented URIs under CLJS"
+    (is (= "vscode://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :vscode coord)))
+    (is (= "cursor://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :cursor coord)))
+    (is (= "idea://open?file=src/app/views.cljs&line=42&column=7"
+           (eu/editor-uri :idea coord)))))
+
+(deftest custom-template-on-cljs
+  (testing ":custom template substitutes placeholders identically on CLJS"
+    (is (= "x://file/src/app/views.cljs?line=42"
+           (eu/editor-uri
+             {:custom "x://file/{path}?line={line}"}
+             coord)))))
+
+(deftest nil-file-cljs
+  (testing "missing :file on CLJS → nil URI"
+    (is (nil? (eu/editor-uri :vscode {:line 10})))))
+
+(deftest has-source-cljs
+  (testing "has-source? on CLJS"
+    (is (eu/has-source? coord))
+    (is (not (eu/has-source? nil)))))

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -1,0 +1,104 @@
+(ns re-frame.source-coords-editor-uri-test
+  "JVM tests for `re-frame.source-coords.editor-uri` (rf2-evgf5).
+
+  Pure data → data — the same expected URIs verify on the CLJS side via
+  `re-frame.source-coords-editor-uri-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.source-coords.editor-uri :as eu]))
+
+(def ^:private sample-coord
+  {:ns 'app.views :file "src/app/views.cljs" :line 42 :column 7})
+
+(deftest vscode-default-scheme
+  (testing "nil editor falls through to :vscode"
+    (is (= "vscode://file/src/app/views.cljs:42:7"
+           (eu/editor-uri nil sample-coord))))
+  (testing ":vscode produces vscode://file/<path>:<line>:<column>"
+    (is (= "vscode://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :vscode sample-coord)))))
+
+(deftest cursor-scheme
+  (testing ":cursor produces cursor://file/<path>:<line>:<column>"
+    (is (= "cursor://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :cursor sample-coord)))))
+
+(deftest idea-scheme
+  (testing ":idea produces idea://open?file=&line=&column="
+    (is (= "idea://open?file=src/app/views.cljs&line=42&column=7"
+           (eu/editor-uri :idea sample-coord)))))
+
+(deftest custom-template-substitutes-all-placeholders
+  (testing "{path} / {line} / {column} placeholders are substituted"
+    (is (= "my-editor://open?p=src/app/views.cljs&l=42&c=7"
+           (eu/editor-uri
+             {:custom "my-editor://open?p={path}&l={line}&c={column}"}
+             sample-coord)))))
+
+(deftest custom-template-file-alias
+  (testing "{file} is an alias for {path}"
+    (is (= "x://src/app/views.cljs/42"
+           (eu/editor-uri
+             {:custom "x://{file}/{line}"}
+             sample-coord)))))
+
+(deftest custom-template-omits-missing-placeholders
+  (testing "custom template without {column} simply omits the column"
+    (is (= "vscode://file/src/app/views.cljs:42"
+           (eu/editor-uri
+             {:custom "vscode://file/{path}:{line}"}
+             sample-coord)))))
+
+(deftest missing-column-defaults-to-1
+  (testing ":column missing on source-coord → URI carries column 1"
+    (is (= "vscode://file/src/x.cljs:10:1"
+           (eu/editor-uri :vscode
+                          {:file "src/x.cljs" :line 10})))))
+
+(deftest missing-line-defaults-to-1
+  (testing ":line missing on source-coord → URI carries line 1"
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "src/x.cljs"})))))
+
+(deftest missing-file-returns-nil
+  (testing "no :file → nil URI (UI hides the open button)"
+    (is (nil? (eu/editor-uri :vscode {:line 10 :column 1})))
+    (is (nil? (eu/editor-uri :vscode nil)))
+    (is (nil? (eu/editor-uri :vscode {:file ""})))
+    (is (nil? (eu/editor-uri :vscode {:file "   "})))))
+
+(deftest unknown-editor-falls-back-to-vscode
+  (testing "unknown editor keyword treated as :vscode (typo-tolerant)"
+    (is (= "vscode://file/src/x.cljs:5:1"
+           (eu/editor-uri :emacs {:file "src/x.cljs" :line 5})))))
+
+(deftest custom-template-non-string-falls-back
+  (testing "custom map with non-string :custom slot falls back to default"
+    (is (= "vscode://file/src/x.cljs:5:1"
+           (eu/editor-uri {:custom nil} {:file "src/x.cljs" :line 5})))
+    (is (= "vscode://file/src/x.cljs:5:1"
+           (eu/editor-uri {:custom 42} {:file "src/x.cljs" :line 5})))))
+
+(deftest has-source-predicate
+  (testing "has-source? gates the open button render"
+    (is (eu/has-source? {:file "x.cljs"}))
+    (is (eu/has-source? {:file "x.cljs" :line 1 :column 1}))
+    (is (not (eu/has-source? {:line 10})))
+    (is (not (eu/has-source? {:file ""})))
+    (is (not (eu/has-source? nil)))))
+
+(deftest open-button-title-shape
+  (testing "open-button-title carries file:line hover text"
+    (is (= "Open in editor — src/x.cljs:42"
+           (eu/open-button-title {:file "src/x.cljs" :line 42}))))
+  (testing "no :file → generic Open-in-editor label"
+    (is (= "Open in editor" (eu/open-button-title nil)))
+    (is (= "Open in editor" (eu/open-button-title {:line 10})))))
+
+(deftest known-editors-set
+  (testing "known-editors enumerates the built-in scheme keywords"
+    (is (contains? eu/known-editors :vscode))
+    (is (contains? eu/known-editors :cursor))
+    (is (contains? eu/known-editors :idea))
+    ;; :custom is a map-shape, not a member of the keyword set.
+    (is (not (contains? eu/known-editors :custom)))))

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -157,8 +157,40 @@ reference:
 | `(rf/sub-cache frame-id)` (CLJS only) | Tool-Pair | The subscription graph. |
 | `:dispatch-id` / `:parent-dispatch-id` (in `:tags`) | Spec 009 | The causality graph edges. |
 | `:origin` (in `:tags`) | Spec 009 | The colour-coding axis. |
-| Source-coord metadata (`:ns` / `:line` / `:column` / `:file`) | Spec 001 / 006 | Click-to-source. |
+| Source-coord metadata (`:ns` / `:line` / `:column` / `:file`) | Spec 001 / 006 | Click-to-source — see `Open in editor` below. |
 | `data-rf2-source-coord` DOM attribute | Spec 006 | DOM-level source-coord (for the rare cases where DOM event → source is needed). |
+
+## Open in editor (rf2-evgf5)
+
+Every panel that surfaces a source-coord (the event-detail hero, the
+causality graph nodes, the machine inspector's state / edge / guard /
+action chips, the hydration debugger's render-tree rows, the trace
+panel's per-event rows, etc.) wraps the coord in a clickable `open`
+chip. Click sets `window.location.href` to a URI-scheme handler the OS
+dispatches to the configured editor:
+
+| Editor (config key) | URI scheme |
+|---|---|
+| `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
+| `:cursor`           | `cursor://file/<path>:<line>:<column>` |
+| `:idea`             | `idea://open?file=<path>&line=<line>&column=<column>` |
+| `{:custom <tpl>}`   | user template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
+
+Host applications set the preference at boot:
+
+```clojure
+(require '[day8.re-frame2-causa.config :as causa-config])
+(causa-config/configure! {:editor :cursor})
+```
+
+Causa's editor preference is **independent** of Story's
+`:rf.story/editor` (hosts that run both tools can route each tool to a
+different editor). The shared URI builder lives at
+`re-frame.source-coords.editor-uri` (core artefact, CLJC); Causa's
+mirror chip (`day8.re-frame2-causa.open-in-editor/open-chip`) consumes
+it. Unknown editor keywords fall back to `:vscode` so a typo still
+yields a clickable URI rather than a no-op; source-coords without
+`:file` hide the chip entirely.
 
 ## MCP API
 

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -1,0 +1,87 @@
+(ns day8.re-frame2-causa.config
+  "Compile-time and runtime configuration for Causa.
+
+  Phase 1 holds a single config concern: the 'Open in editor' preference
+  (rf2-evgf5). Future phases extend this with theme defaults, buffer
+  depth, panel placement, etc.
+
+  ## Why a separate config ns
+
+  The host application sets the Causa editor preference via
+  `(day8.re-frame2-causa.config/set-editor! :cursor)` at boot. Holding
+  the preference behind an atom in a dedicated ns lets the UI shell
+  read it without importing the host's boot code.
+
+  Causa's editor preference is **independent** of Story's. Hosts that
+  run both tools may want different editors (e.g. VS Code for app
+  development, IntelliJ for the test reading workflow); two atoms,
+  two `configure!` surfaces.
+
+  ## Production posture
+
+  The atom is a plain Clojure data store. Production builds DCE the
+  Causa shell (gated on `interop/debug-enabled?` in preload.cljs); the
+  atom survives but is never read. CLJC so the JVM test corpus can
+  cover the round-trip without a CLJS runtime."
+  (:require [re-frame.source-coords.editor-uri :as editor-uri]))
+
+;; ---- editor preference ---------------------------------------------------
+
+(defonce
+  ^{:doc "Atom holding Causa's 'Open in editor' preference. Default
+         `:vscode`. Accepts the keywords `:vscode` / `:cursor` /
+         `:idea` plus the `{:custom \"<uri-template>\"}` form (see
+         `re-frame.source-coords.editor-uri/editor-uri`)."}
+  editor
+  (atom :vscode))
+
+(defn set-editor!
+  "Set Causa's 'Open in editor' preference. Hosts call this once at
+  boot (typically inside their `app.core` ns alongside any Causa-
+  specific setup).
+
+  Accepts:
+    - `:vscode` (default) — `vscode://file/<path>:<line>:<column>`
+    - `:cursor`           — `cursor://file/<path>:<line>:<column>`
+    - `:idea`             — `idea://open?file=<path>&line=<line>&column=<column>`
+    - `{:custom <uri-template>}` — user template with `{path}` / `{file}` /
+                                   `{line}` / `{column}` placeholders.
+    - `nil`               — reset to `:vscode` default.
+
+  Returns nothing."
+  [e]
+  (reset! editor (or e :vscode))
+  nil)
+
+(defn get-editor
+  "Return the current editor preference."
+  []
+  @editor)
+
+;; ---- configure! convenience ---------------------------------------------
+
+(defn configure!
+  "Top-level Causa configuration. Phase 1 accepts `{:editor <kw>}` per
+  rf2-evgf5; future phases extend with theme / buffer / placement keys.
+
+  Hosts typically call this once at boot:
+
+      (require '[day8.re-frame2-causa.config :as causa-config])
+      (causa-config/configure! {:editor :cursor})
+
+  Returns nothing."
+  [{:keys [editor] :as _opts}]
+  (when (some? editor)
+    (set-editor! editor))
+  nil)
+
+;; ---- pass-through: editor-uri --------------------------------------------
+
+(defn editor-uri
+  "Build an 'Open in editor' URI for `source-coord` using Causa's
+  configured editor. Thin wrapper around
+  `re-frame.source-coords.editor-uri/editor-uri` that reads the current
+  preference from the atom. Returns a string URI, or nil when the
+  source-coord has no `:file`."
+  [source-coord]
+  (editor-uri/editor-uri (get-editor) source-coord))

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -1,0 +1,79 @@
+(ns day8.re-frame2-causa.open-in-editor
+  "Causa-side 'Open in editor' chip (rf2-evgf5).
+
+  Mirrors `re-frame.story.ui.open-in-editor` — same affordance shape,
+  reads Causa's editor preference from `day8.re-frame2-causa.config`.
+
+  Per the bead's scope expansion (2026-05-13): Causa panels that
+  display a source-coord (event-detail hero, six-domino cascade,
+  machine inspector state/edge/guard/action, hydration debugger, etc.)
+  wrap the coord in a clickable chip that launches the user's editor
+  at file:line. Phase 1 ships the helper + the shell-stub demo
+  surface; the live panels consume this in subsequent phases."
+  (:require [day8.re-frame2-causa.config :as config]
+            [re-frame.source-coords.editor-uri :as editor-uri]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private chip-styles
+  ;; Aligned with the Causa shell's dark-theme tokens
+  ;; (`day8.re-frame2-causa.shell/tokens`). Inline styles in Phase 1;
+  ;; the v1 styling pass moves these to CSS variables when the per-
+  ;; panel beads land.
+  {:chip {:padding         "1px 8px"
+          :background      "transparent"
+          :color           "#7C5CFF"
+          :border          "1px solid #2F3441"
+          :border-radius   "3px"
+          :cursor          "pointer"
+          :font-family     "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"
+          :font-size       "10px"
+          :margin-left     "8px"
+          :text-decoration "none"
+          :display         "inline-block"
+          :line-height     "16px"}})
+
+;; ---- side-effect: open the editor ----------------------------------------
+
+(defn- open!
+  "Set `window.location.href` to `uri`. Custom URI schemes hand off to
+  the OS handler chain. Returns nothing."
+  [uri]
+  (when (and uri js/window)
+    (set! (.-location js/window) uri)
+    nil))
+
+;; ---- public: the open-in-editor chip ------------------------------------
+
+(defn open-chip
+  "Render an 'open' chip for a Causa source-coord. Reads the current
+  editor preference from `config/get-editor`; builds the URI via
+  `editor-uri/editor-uri`; click fires `window.location.href`.
+
+  Returns nil when the source-coord lacks a usable `:file` slot — the
+  UI hides the chip rather than rendering a no-op.
+
+  Source-coord shape: `{:file :line :column :ns}` per
+  `re-frame.source-coords`. Causa receives source-coords on the trace
+  events it buffers (`:source-coord` slot) and on the registry's
+  `(rf/handler-meta kind id)` reads."
+  [source-coord]
+  (when (editor-uri/has-source? source-coord)
+    (let [editor (config/get-editor)
+          uri    (editor-uri/editor-uri editor source-coord)]
+      (when uri
+        [:a {:style       (:chip chip-styles)
+             :href        uri
+             :title       (editor-uri/open-button-title source-coord)
+             :data-testid "causa-open-in-editor"
+             :data-editor (cond
+                            (map? editor) "custom"
+                            :else         (name editor))
+             :on-click    (fn [e]
+                            ;; Stop the browser from trying to render
+                            ;; the custom URI inline; fire the handoff
+                            ;; explicitly so the OS scheme handler
+                            ;; dispatches.
+                            (.preventDefault e)
+                            (open! uri))}
+         "open"]))))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -34,7 +34,8 @@
   Per rf2-tijr the view code is pure hiccup. The substrate adapter's
   render fn (`rf/render`) handles the substrate-specific mount in
   `mount.cljs`. No per-substrate switches in view code."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
 ;; ---- design tokens (dark theme per spec/007-UX-IA.md) --------------------
 
@@ -179,13 +180,31 @@
                      :font-family "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"}}
       ":rf/default"]
      " is unaffected)."]
-    (let [buf-count (count @(rf/subscribe [:rf.causa/trace-buffer]))]
-      [:p {:style {:font-size "13px"
-                   :color     (:text-tertiary tokens)
-                   :margin    0}}
-       "Trace buffer: "
-       [:span {:style {:color (:accent-violet tokens)}} buf-count]
-       " events collected."])]])
+    (let [buf       @(rf/subscribe [:rf.causa/trace-buffer])
+          buf-count (count buf)
+          last-coord (->> buf reverse (some :source-coord))]
+      [:div
+       [:p {:style {:font-size "13px"
+                    :color     (:text-tertiary tokens)
+                    :margin    "0 0 8px 0"}}
+        "Trace buffer: "
+        [:span {:style {:color (:accent-violet tokens)}} buf-count]
+        " events collected."]
+       ;; rf2-evgf5: demonstrate the 'Open in editor' chip. Phase 1
+       ;; surfaces the last buffered event's source-coord here as a
+       ;; preview; subsequent panel beads (event-detail hero, six-
+       ;; domino cascade, machine inspector) consume the same chip
+       ;; against their own coord slots.
+       (when last-coord
+         [:p {:style {:font-size "13px"
+                      :color     (:text-tertiary tokens)
+                      :margin    0}}
+          "Last event source: "
+          [:span {:style {:color       (:text-secondary tokens)
+                          :font-family "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"}}
+           (str (:file last-coord)
+                (when (:line last-coord) (str ":" (:line last-coord))))]
+          (open-in-editor/open-chip last-coord)])])]])
 
 (defn- bottom-rail
   "Bottom rail (40px) — time-travel scrubber + frame info + issues

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -1,0 +1,60 @@
+(ns day8.re-frame2-causa.config-test
+  "JVM tests for Causa's config — the editor preference + configure!
+  round-trip (rf2-evgf5)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.config :as config]))
+
+(defn reset-editor [test-fn]
+  (config/set-editor! :vscode)
+  (test-fn)
+  (config/set-editor! :vscode))
+
+(use-fixtures :each reset-editor)
+
+(deftest default-editor-is-vscode
+  (testing "Causa's default editor preference is :vscode"
+    (is (= :vscode (config/get-editor)))))
+
+(deftest set-editor-round-trips
+  (testing "set-editor! writes and get-editor reads"
+    (config/set-editor! :cursor)
+    (is (= :cursor (config/get-editor)))
+    (config/set-editor! :idea)
+    (is (= :idea (config/get-editor)))
+    (config/set-editor! {:custom "zed://file/{path}:{line}"})
+    (is (= {:custom "zed://file/{path}:{line}"} (config/get-editor)))))
+
+(deftest nil-editor-resets-to-vscode
+  (testing "set-editor! with nil resets to :vscode"
+    (config/set-editor! :cursor)
+    (config/set-editor! nil)
+    (is (= :vscode (config/get-editor)))))
+
+(deftest configure-passes-editor-through
+  (testing "configure! routes :editor through set-editor!"
+    (config/configure! {:editor :cursor})
+    (is (= :cursor (config/get-editor)))
+    (config/configure! {:editor :idea})
+    (is (= :idea (config/get-editor)))))
+
+(deftest configure-without-editor-leaves-preference
+  (testing "configure! without :editor leaves the preference unchanged"
+    (config/set-editor! :cursor)
+    (config/configure! {})
+    (is (= :cursor (config/get-editor)))))
+
+(deftest editor-uri-uses-current-preference
+  (testing "config/editor-uri reads from the live preference atom"
+    (let [coord {:file "src/x.cljs" :line 12 :column 4}]
+      (config/set-editor! :vscode)
+      (is (= "vscode://file/src/x.cljs:12:4" (config/editor-uri coord)))
+      (config/set-editor! :cursor)
+      (is (= "cursor://file/src/x.cljs:12:4" (config/editor-uri coord)))
+      (config/set-editor! :idea)
+      (is (= "idea://open?file=src/x.cljs&line=12&column=4"
+             (config/editor-uri coord))))))
+
+(deftest editor-uri-nil-for-missing-file
+  (testing "config/editor-uri returns nil when coord has no :file"
+    (is (nil? (config/editor-uri {:line 10})))
+    (is (nil? (config/editor-uri nil)))))

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -1,0 +1,62 @@
+(ns day8.re-frame2-causa.open-in-editor-cljs-test
+  "CLJS smoke tests for Causa's 'Open in editor' chip (rf2-evgf5).
+
+  The URI math lives in `re-frame.source-coords.editor-uri` and is
+  matrix-tested at the core layer. This file covers Causa-specific
+  glue:
+
+  - `config/set-editor!` round-trips on the CLJS side.
+  - `open-chip` returns nil for source-coords without `:file`.
+  - `open-chip` renders an `<a>` hiccup tag with the configured
+    editor's URI scheme.
+  - The chip carries `data-testid=\"causa-open-in-editor\"` so the
+    e2e suite can target it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
+
+(defn reset-editor! []
+  (config/set-editor! :vscode))
+
+(use-fixtures :each {:before reset-editor!
+                     :after  reset-editor!})
+
+(deftest open-chip-renders-anchor-with-href
+  (testing "open-chip returns an <a> hiccup vector when source has :file"
+    (let [coord  {:ns 'app.events :file "src/app/events.cljs" :line 17 :column 3}
+          hiccup (open-in-editor/open-chip coord)]
+      (is (vector? hiccup))
+      (is (= :a (first hiccup)))
+      (let [props (second hiccup)]
+        (is (= "vscode://file/src/app/events.cljs:17:3" (:href props)))
+        (is (= "causa-open-in-editor" (:data-testid props)))
+        (is (= "vscode" (:data-editor props)))
+        (is (fn? (:on-click props)))))))
+
+(deftest open-chip-respects-editor-preference
+  (testing "switching Causa's editor flips the URI on render"
+    (let [coord {:file "src/x.cljs" :line 10}]
+      (config/set-editor! :cursor)
+      (is (= "cursor://file/src/x.cljs:10:1"
+             (:href (second (open-in-editor/open-chip coord)))))
+      (config/set-editor! :idea)
+      (is (= "idea://open?file=src/x.cljs&line=10&column=1"
+             (:href (second (open-in-editor/open-chip coord))))))))
+
+(deftest open-chip-supports-custom-template
+  (testing ":custom template via Causa configure!"
+    (config/configure! {:editor {:custom "zed://file/{path}:{line}"}})
+    (is (= "zed://file/src/x.cljs:5"
+           (:href (second (open-in-editor/open-chip
+                            {:file "src/x.cljs" :line 5 :column 2}))))))
+  (testing ":custom data-editor attr"
+    (is (= "custom"
+           (:data-editor
+             (second (open-in-editor/open-chip
+                       {:file "src/x.cljs" :line 5})))))))
+
+(deftest open-chip-nil-when-source-missing
+  (testing "open-chip returns nil when source-coord lacks :file"
+    (is (nil? (open-in-editor/open-chip nil)))
+    (is (nil? (open-in-editor/open-chip {:line 1})))
+    (is (nil? (open-in-editor/open-chip {:file ""})))))

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -128,11 +128,37 @@ Autodocs panel from `:doc` + schemas + variant table — the basic
 panel ships at v1; the polish (cross-link navigation, hover preview,
 prose-injection points) is v1.1.
 
-### "Open in editor" per variant
+### "Open in editor" per variant (rf2-evgf5 — shipped)
 
 Reads the `:source` slot stamped at registration time and opens the
-variant's defining file:line in the configured editor (via the editor
-MCP, when available).
+variant's defining file:line in the configured editor.
+
+The affordance renders as an `open` chip next to:
+
+- The variant title in the canvas header (reads the variant body's
+  `:source` slot — stamped at `reg-variant` time per spec/001).
+- Each failing `:test` mode row's failure detail (reads the
+  assertion record's `:source` slot per spec/004).
+
+Click sets `window.location.href` to a URI-scheme handler the OS
+dispatches to the configured editor:
+
+| Editor (config key) | URI scheme |
+|---|---|
+| `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
+| `:cursor`           | `cursor://file/<path>:<line>:<column>` |
+| `:idea`             | `idea://open?file=<path>&line=<line>&column=<column>` |
+| `{:custom <tpl>}`   | user template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
+
+The host sets the preference via `(story/configure! {:editor :cursor})`
+at boot. Unknown keywords fall back to `:vscode` so a typo still
+yields a clickable URI rather than a no-op. Source-coords without
+`:file` hide the chip entirely.
+
+The shared URI builder lives at `re-frame.source-coords.editor-uri`
+under the core artefact and is CLJC-portable; Causa's mirror
+affordance (`day8.re-frame2-causa.open-in-editor`) consumes the same
+helper.
 
 ## Production elision under `:advanced`
 
@@ -232,7 +258,7 @@ phase-2 SOTA adds that are cheap.
 | Live performance ribbon (FPS, INP, long tasks, CLS, memory, Reagent profiling) | Stage 6 (deferred) |
 | Design-token panel (conditional on upstream token emission) | Stage 6 (deferred) |
 | MCP write surface (`register-variant`, `unregister-variant`) | Stage 7 (deferred) |
-| "Open in editor" per variant | Stage 8 (post-Stage-1) |
+| "Open in editor" per variant (rf2-evgf5) | shipped — Stage 6 + Stage 8 |
 | Per-variant autodocs panel polish | Stage 6 (deferred) |
 
 ## v2 ship list (post-1.0 deferred)

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -412,11 +412,20 @@
 
   `{:global-args {...}}` — replace the global args map.
 
+  `{:editor <kw>}` — 'Open in editor' preference per rf2-evgf5. One of
+  `:vscode` (default) / `:cursor` / `:idea` / `{:custom \"<template>\"}`.
+  Drives the `vscode://` / `cursor://` / `idea://` URI scheme the
+  source-coord open-button affordances emit. See
+  `re-frame.source-coords.editor-uri/editor-uri` for the per-editor URI
+  grammar.
+
   Other keys are accepted for forward compatibility but ignored at
   Stage 3."
-  [{:keys [global-args] :as _opts}]
+  [{:keys [global-args editor] :as _opts}]
   (when (some? global-args)
     (config/set-global-args! global-args))
+  (when (some? editor)
+    (config/set-editor! editor))
   nil)
 
 ;; ---- registry reset (test fixtures) -------------------------------------

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -97,3 +97,42 @@
   "Return the current global args map."
   []
   @global-args)
+
+;; ---- *editor* (rf2-evgf5 — 'Open in editor' affordance) ----------------
+;;
+;; Per Spec 005-SOTA-Features.md §'Open in editor' per variant, every
+;; source-coord-bearing Story surface (variant canvas title, per-test
+;; failure detail, etc.) renders a small 'Open' button that launches the
+;; user's editor at the registered file:line. The user picks the editor
+;; once at boot via `(story/configure! {:editor :cursor})`; this atom
+;; holds the chosen editor.
+;;
+;; Defaults to `:vscode` — the most-installed editor in 2026 (Stack
+;; Overflow Developer Survey 2025 + JetBrains DevEcosystem 2025).
+;; Accepts the keywords `:vscode` / `:cursor` / `:idea` plus the
+;; `{:custom "<uri-template>"}` form (see
+;; `re-frame.source-coords.editor-uri/editor-uri`).
+;;
+;; The atom is plain data; production builds with `enabled?` false DCE
+;; the UI shell that reads it, so the editor preference itself is
+;; harmless if it survives into a release bundle.
+
+(defonce
+  ^{:doc "Atom holding the editor preference. Default `:vscode`. Set
+         by `re-frame.story/configure!` via the `:editor` key. Read by
+         the UI shell's open-in-editor buttons."}
+  editor
+  (atom :vscode))
+
+(defn set-editor!
+  "Replace the editor preference. Accepts `:vscode` / `:cursor` /
+  `:idea` / `{:custom \"<template>\"}` / nil (resets to `:vscode`).
+  Story's `configure!` calls this."
+  [e]
+  (reset! editor (or e :vscode))
+  nil)
+
+(defn get-editor
+  "Return the current editor preference."
+  []
+  @editor)

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -26,6 +26,7 @@
             [re-frame.story.decorators :as decorators]
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
+            [re-frame.story.ui.open-in-editor :as open-in-editor]
             [re-frame.story.ui.share :as share]
             [re-frame.story.ui.state :as state]))
 
@@ -213,6 +214,7 @@
   - >1 substrate → multi-substrate side-by-side grid (IMPL-SPEC §2.2)."
   [variant-id]
   (let [view-id        (variant-component variant-id)
+        variant-body   (registrar/handler-meta :variant variant-id)
         decorator-pack (decorators/resolve-decorators variant-id)
         eff-args       (args/resolve-args
                          variant-id
@@ -236,6 +238,12 @@
          (str " (substrates: "
               (str/join ", " (map name (sort-by name substrates)))
               ")")])
+      ;; rf2-evgf5: per-variant 'Open in editor' chip. Reads :source
+      ;; off the variant body and routes through the user's configured
+      ;; editor URI scheme. Renders nothing when no source-coord was
+      ;; captured at registration.
+      (when variant-id
+        (open-in-editor/open-chip-for-variant variant-body))
       ;; Stage 6: per-variant share affordance (IMPL-SPEC §2.8.5).
       (when variant-id
         [share/share-button variant-id])]

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -1,0 +1,124 @@
+(ns re-frame.story.ui.open-in-editor
+  "The 'Open in editor' affordance — a small chip / button that opens
+  the editor at a source-coord's file:line. Per rf2-evgf5 + Spec 005-
+  SOTA-Features.md §'Open in editor' per variant.
+
+  The component reads the user's editor preference from
+  `re-frame.story.config/editor` (set at boot via `story/configure!`)
+  and consults `re-frame.source-coords.editor-uri/editor-uri` to build
+  the URI. Click sets `window.location.href` — the OS handler chain
+  dispatches the URI to the registered editor.
+
+  ## Why `window.location.href` rather than `window.open`
+
+  Custom URI schemes don't open new windows; they hand off to the OS
+  handler. `window.open(\"vscode://...\")` opens a blank popup which
+  the user has to close manually. `set-href!` triggers the same OS
+  dispatch without leaving an orphaned window.
+
+  ## When it renders nothing
+
+  The chip render-fn returns nil when `source-coord` lacks `:file` —
+  the macro layer didn't capture a usable file path (the
+  `\"NO_SOURCE_PATH\"` sentinel under CLJS without a form-meta
+  fallback, per rf2-mdjp). The UI hides the chip entirely so the user
+  doesn't click a no-op.
+
+  ## Bundle isolation
+
+  Lives in the Story CLJS bundle; production builds elide the entire
+  UI shell so this ns never enters a release bundle."
+  (:require [re-frame.story.config :as config]
+            [re-frame.source-coords.editor-uri :as editor-uri]))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private chip-styles
+  {:chip      {:padding         "2px 8px"
+               :background      "#37373d"
+               :color           "#9cdcfe"
+               :border          "1px solid #555"
+               :border-radius   "3px"
+               :cursor          "pointer"
+               :font-family     "monospace"
+               :font-size       "10px"
+               :margin-left     "8px"
+               :text-decoration "none"
+               :display         "inline-block"}
+   :chip-test {:padding         "1px 6px"
+               :background      "#252526"
+               :color           "#9cdcfe"
+               :border          "1px solid #444"
+               :border-radius   "2px"
+               :cursor          "pointer"
+               :font-family     "monospace"
+               :font-size       "10px"
+               :margin-left     "8px"
+               :text-decoration "none"
+               :display         "inline-block"}})
+
+;; ---- side-effect: open the editor ----------------------------------------
+
+(defn- open!
+  "Set `window.location.href` to `uri`. Custom URI schemes hand off to
+  the OS handler chain. Returns nothing."
+  [uri]
+  (when (and uri js/window)
+    (set! (.-location js/window) uri)
+    nil))
+
+;; ---- public: the open-in-editor chip ------------------------------------
+
+(defn open-chip
+  "Render an 'Open' chip for a source-coord. Reads the current editor
+  preference from `config/editor`; constructs the URI via
+  `editor-uri/editor-uri`; click fires `window.location.href := uri`.
+
+  Returns nil when the source-coord has no usable `:file` slot — the
+  UI hides the chip rather than showing a no-op affordance.
+
+  `variant-of-style` is `:title` (default — for the canvas title bar)
+  or `:test-detail` (for the per-test failure detail box, slightly
+  more compact).
+
+  `data-test` attribute is `\"story-open-in-editor\"` so the e2e suite
+  can target the chip without relying on style selectors.
+
+  Source-coord shape: `{:file :line :column :ns}` per
+  `re-frame.source-coords` / `re-frame.story.registrar`."
+  ([source-coord]
+   (open-chip source-coord :title))
+  ([source-coord variant-of-style]
+   (when (editor-uri/has-source? source-coord)
+     (let [editor (config/get-editor)
+           uri    (editor-uri/editor-uri editor source-coord)
+           style  (case variant-of-style
+                    :test-detail (:chip-test chip-styles)
+                    (:chip chip-styles))]
+       (when uri
+         [:a {:style       style
+              :href        uri
+              :title       (editor-uri/open-button-title source-coord)
+              :data-test   "story-open-in-editor"
+              :data-editor (cond
+                             (map? editor) "custom"
+                             :else         (name editor))
+              :on-click    (fn [e]
+                             ;; Prevent React/Reagent's default link
+                             ;; navigation (otherwise the browser
+                             ;; tries to render the custom URI inside
+                             ;; the tab); explicitly call `open!` so
+                             ;; the OS handler fires.
+                             (.preventDefault e)
+                             (open! uri))}
+          "open"])))))
+
+(defn open-chip-for-variant
+  "Render an open-chip for a variant — reads the source-coord off the
+  variant body's `:source` slot (the registrar/spec/001-captured map).
+  Returns nil when no coord is present.
+
+  `variant-body` is the body map returned by
+  `re-frame.story.registrar/handler-meta :variant variant-id`."
+  [variant-body]
+  (open-chip (:source variant-body) :title))

--- a/tools/story/src/re_frame/story/ui/test_mode.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode.cljc
@@ -50,6 +50,7 @@
                        [re-frame.story.runtime   :as runtime]
                        [re-frame.story.async     :as async]
                        [re-frame.interop         :as interop]
+                       [re-frame.story.ui.open-in-editor :as open-in-editor]
                        [re-frame.story.ui.state  :as state]])))
 
 ;; ---- pure: parent-story-id ----------------------------------------------
@@ -478,7 +479,11 @@
       (when (and (map? source) (or (:file source) (:line source)))
         [:div {:style (:detail-source styles)}
          (str "at " (:file source)
-              (when (:line source) (str ":" (:line source))))])]))
+              (when (:line source) (str ":" (:line source))))
+         ;; rf2-evgf5: per-assertion 'Open in editor' chip — surfaces the
+         ;; assertion's source-coord (the play-step site, captured by the
+         ;; assertion's record builder per spec/004).
+         (open-in-editor/open-chip source :test-detail)])]))
 
 #?(:cljs
    (defn- status-glyph

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -1,0 +1,86 @@
+(ns re-frame.story-open-in-editor-cljs-test
+  "CLJS tests for the Story-side 'Open in editor' chip (rf2-evgf5).
+
+  The pure URI logic lives in `re-frame.source-coords.editor-uri` and is
+  matrix-tested on the JVM. This file covers the Story-specific glue:
+
+  - `config/set-editor!` round-trips on the CLJS side.
+  - `open-chip` returns nil when the source-coord lacks `:file`.
+  - `open-chip` renders an `<a>` hiccup tag with the current editor's
+    URI when the coord carries `:file`.
+  - The chip carries the `data-test` hook for the e2e suite.
+  - `open-chip-for-variant` reads `:source` off the variant body."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.config :as config]
+            [re-frame.story.ui.open-in-editor :as open-in-editor]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-editor! []
+  (config/set-editor! :vscode))
+
+(use-fixtures :each {:before reset-editor!
+                     :after  reset-editor!})
+
+;; ---- chip rendering ------------------------------------------------------
+
+(deftest open-chip-renders-anchor-with-href
+  (testing "open-chip returns an <a> hiccup vector when source has :file"
+    (let [coord  {:ns 'app.views :file "src/app/views.cljs" :line 42 :column 7}
+          hiccup (open-in-editor/open-chip coord)]
+      (is (vector? hiccup))
+      (is (= :a (first hiccup)))
+      (let [props (second hiccup)]
+        (is (string? (:href props)))
+        (is (= "vscode://file/src/app/views.cljs:42:7" (:href props)))
+        (is (= "story-open-in-editor" (:data-test props)))
+        (is (= "vscode" (:data-editor props)))
+        (is (fn? (:on-click props)))))))
+
+(deftest open-chip-respects-editor-preference
+  (testing "switching editor flips the URI scheme on subsequent renders"
+    (let [coord {:file "src/x.cljs" :line 10 :column 1}]
+      (config/set-editor! :cursor)
+      (is (= "cursor://file/src/x.cljs:10:1"
+             (:href (second (open-in-editor/open-chip coord)))))
+      (config/set-editor! :idea)
+      (is (= "idea://open?file=src/x.cljs&line=10&column=1"
+             (:href (second (open-in-editor/open-chip coord))))))))
+
+(deftest open-chip-supports-custom-template
+  (testing ":custom template is read live from config"
+    (config/set-editor! {:custom "zed://file/{path}:{line}"})
+    (let [coord {:file "src/x.cljs" :line 5 :column 2}]
+      (is (= "zed://file/src/x.cljs:5"
+             (:href (second (open-in-editor/open-chip coord)))))
+      (is (= "custom"
+             (:data-editor (second (open-in-editor/open-chip coord))))))))
+
+(deftest open-chip-nil-when-source-missing
+  (testing "open-chip returns nil when source-coord lacks :file"
+    (is (nil? (open-in-editor/open-chip nil)))
+    (is (nil? (open-in-editor/open-chip {:line 10})))
+    (is (nil? (open-in-editor/open-chip {:file ""})))))
+
+(deftest open-chip-for-variant-reads-source-slot
+  (testing "open-chip-for-variant pulls :source off the variant body"
+    (let [body {:events []
+                :source {:ns 'app.stories
+                         :file "src/app/stories.cljs"
+                         :line 17
+                         :column 3}}
+          hiccup (open-in-editor/open-chip-for-variant body)]
+      (is (vector? hiccup))
+      (is (= "vscode://file/src/app/stories.cljs:17:3"
+             (:href (second hiccup))))))
+  (testing "open-chip-for-variant nil when variant body has no :source"
+    (is (nil? (open-in-editor/open-chip-for-variant {:events []})))
+    (is (nil? (open-in-editor/open-chip-for-variant nil)))))
+
+(deftest open-chip-title-attribute-shape
+  (testing "the chip's :title attr surfaces file:line for hover"
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app.cljs" :line 99 :column 4})
+          props  (second hiccup)]
+      (is (= "Open in editor — src/app.cljs:99"
+             (:title props))))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -451,6 +451,25 @@
     (let [r (story/resolve-args :story.cfg/v)]
       (is (= :dark (:theme r))))))
 
+(deftest configure-sets-editor-preference
+  (testing "configure! writes the :editor preference (rf2-evgf5)"
+    ;; Default is :vscode.
+    (config/set-editor! :vscode)
+    (is (= :vscode (config/get-editor)))
+    (story/configure! {:editor :cursor})
+    (is (= :cursor (config/get-editor)))
+    (story/configure! {:editor :idea})
+    (is (= :idea (config/get-editor)))
+    (story/configure! {:editor {:custom "zed://file/{path}:{line}"}})
+    (is (= {:custom "zed://file/{path}:{line}"} (config/get-editor)))
+    ;; Reset for downstream tests.
+    (config/set-editor! :vscode))
+  (testing "configure! with no :editor leaves the preference untouched"
+    (config/set-editor! :cursor)
+    (story/configure! {:global-args {:theme :dark}})
+    (is (= :cursor (config/get-editor)))
+    (config/set-editor! :vscode)))
+
 ;; ===========================================================================
 ;; ASYNC ABSTRACTION
 ;; ===========================================================================


### PR DESCRIPTION
## Summary

- Adds a CLJC `editor-uri` helper under `re-frame.source-coords.editor-uri` that builds an 'open in editor' URI from a source-coord map. Pure data → data; supports `:vscode` (default), `:cursor`, `:idea`, and `{:custom <template>}` with `{path}`/`{file}`/`{line}`/`{column}` placeholders.
- Story: a per-variant `open` chip in the canvas title bar reading the variant body's `:source` slot, plus a per-assertion chip in the `:test` mode failure-detail box reading each assertion record's `:source`. The editor preference is set via `(story/configure! {:editor :cursor})`.
- Causa: a mirror `open-chip` ns + `causa-config/configure!` surface; Phase 1 demo lives in the shell stub against the last buffered trace event's `:source-coord`. Subsequent panel beads (event-detail hero, six-domino cascade, machine inspector, hydration debugger) consume the same chip.

## Design

- One shared URI builder; two independent editor preferences (Story vs Causa) so hosts running both tools can route each to a different editor.
- Click sets `window.location.href` so the OS hands the custom URI to the editor handler.
- Unknown editor keyword falls back to `:vscode` (typo-tolerant). Source-coords without `:file` hide the chip entirely.
- Spec updates: `tools/story/spec/005-SOTA-Features.md` moves the v1.1 'Open in editor' entry to shipped with the URI grammar table; `tools/causa/spec/API.md` adds an Open-in-editor section.

## Test plan

- [x] `clojure -M:test` — 309 core JVM tests pass (14 new in `re-frame.source-coords-editor-uri-test`)
- [x] `clojure -M:test` in `tools/causa` — 11 tests pass (8 new in `day8.re-frame2-causa.config-test`)
- [x] `clojure -M:test` in `tools/story` — 169 tests pass (+ `configure-sets-editor-preference`)
- [x] `npm run test:cljs` — 612 CLJS tests pass including `source-coords-editor-uri-cljs-test`, `story-open-in-editor-cljs-test`, `causa.open-in-editor-cljs-test`
- [ ] Manual smoke (reviewer): in `examples/reagent/counter_with_stories`, open Story shell, click the `open` chip next to `:story.counter/clicked-three-times`. Expect VS Code (or whatever `(story/configure! {:editor ...})` selects) to open the variant's `:source` file at the registered line.