### PR TITLE
feat(api): call-site source-coords via dispatch/subscribe/inject-cofx macros + *-fn variants (rf2-ts1a)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -11,9 +11,17 @@
   registered cofx into the context."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
+
+(def ^{:doc "Sentinel for `inject-cofx`'s 3-arity 'no-value' branch.
+  Used by `re-frame.core/inject-cofx`'s macro form (rf2-ts1a) to thread
+  a call-site through the no-value path without inventing a private
+  sentinel at the macro layer. Equality-tested via `identical?` so
+  user values never collide."} no-value
+  ::no-value)
 
 (defn- maybe-validate-cofx!
   "Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
@@ -59,9 +67,21 @@
   "Build a :before-only interceptor that runs the registered cofx and
   injects its result into the context's :coeffects.
 
-  Two arities:
-    (inject-cofx :id)        — no value
-    (inject-cofx :id value)  — passes value as second arg to the cofx fn
+  Three arities:
+    (inject-cofx :id)                  — no value, no call-site
+    (inject-cofx :id value)            — value, no call-site
+    (inject-cofx :id value call-site)  — value + macro-stamped call-site
+                                         (use `cofx/no-value` for the
+                                         no-value path with a call-site)
+
+  Per rf2-ts1a: the 3-arity form is what `re-frame.core/inject-cofx`'s
+  macro expands to — it captures `(meta &form)` at the user call site
+  and stamps it into the interceptor's closure. The `:before` body
+  binds `trace/*current-call-site*` to the captured value so error
+  events emitted from inside the body (`:rf.error/no-such-cofx`,
+  schema-validation failures, exceptions thrown by the cofx fn) carry
+  the invocation coord. Pass `nil` for the call-site to opt out of
+  stamping (the 1-/2-arity forms wrap to this with `nil`).
 
   Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
   fn returns, if the cofx's metadata carries a :spec, validate the
@@ -76,38 +96,34 @@
   the enclosing event handler's binding (set by the router) — the
   cofx that doesn't exist has no coord to point at."
   ([cofx-id]
-   (interceptor/->interceptor
-     :id (keyword (str "cofx-" (name cofx-id)))
-     :before
-     (fn [ctx]
-       (if-let [meta (registrar/lookup :cofx cofx-id)]
-         (binding [trace/*current-trigger-handler*
-                   (trace/trigger-handler-from-meta :cofx cofx-id meta)]
-           (-> ((:handler-fn meta) ctx)
-               (maybe-validate-cofx! cofx-id meta)))
-         (let [event (interceptor/get-coeffect ctx :event)]
-           (trace/emit-error! :rf.error/no-such-cofx
-                              {:cofx-id  cofx-id
-                               :event-id (when (vector? event) (first event))
-                               :recovery :no-recovery})
-           ctx)))))
+   (inject-cofx cofx-id no-value nil))
   ([cofx-id value]
-   (interceptor/->interceptor
-     :id (keyword (str "cofx-" (name cofx-id)))
-     :before
-     (fn [ctx]
-       (if-let [meta (registrar/lookup :cofx cofx-id)]
-         (binding [trace/*current-trigger-handler*
-                   (trace/trigger-handler-from-meta :cofx cofx-id meta)]
-           (-> ((:handler-fn meta) ctx value)
-               (maybe-validate-cofx! cofx-id meta)))
-         (let [event (interceptor/get-coeffect ctx :event)]
-           (trace/emit-error! :rf.error/no-such-cofx
-                              {:cofx-id    cofx-id
-                               :cofx-value value
-                               :event-id   (when (vector? event) (first event))
-                               :recovery   :no-recovery})
-           ctx))))))
+   (inject-cofx cofx-id value nil))
+  ([cofx-id value call-site]
+   (let [valued?      (not (identical? value no-value))
+         captured-cs  (when interop/debug-enabled? call-site)]
+     (interceptor/->interceptor
+       :id (keyword (str "cofx-" (name cofx-id)))
+       :before
+       (fn [ctx]
+         (if-let [meta (registrar/lookup :cofx cofx-id)]
+           (binding [trace/*current-trigger-handler*
+                     (trace/trigger-handler-from-meta :cofx cofx-id meta)
+                     trace/*current-call-site*
+                     (or captured-cs trace/*current-call-site*)]
+             (-> (if valued?
+                   ((:handler-fn meta) ctx value)
+                   ((:handler-fn meta) ctx))
+                 (maybe-validate-cofx! cofx-id meta)))
+           (binding [trace/*current-call-site*
+                     (or captured-cs trace/*current-call-site*)]
+             (let [event (interceptor/get-coeffect ctx :event)]
+               (trace/emit-error! :rf.error/no-such-cofx
+                                  (cond-> {:cofx-id  cofx-id
+                                           :event-id (when (vector? event) (first event))
+                                           :recovery :no-recovery}
+                                    valued? (assoc :cofx-value value)))
+               ctx))))))))
 
 ;; ---- standard cofx --------------------------------------------------------
 

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -78,7 +78,9 @@
   ;; Spec 004 §reg-view, the macros live in re-frame.core; CLJS users
   ;; can write `rf/reg-view` after `(:require [re-frame.core :as rf])`
   ;; without an explicit `:require-macros` clause at the call site.
-  #?(:cljs (:require-macros [re-frame.core :refer [reg-view with-frame bound-fn]])))
+  #?(:cljs (:require-macros [re-frame.core :refer [reg-view with-frame bound-fn
+                                                   dispatch dispatch-sync
+                                                   subscribe inject-cofx]])))
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -622,13 +624,174 @@
 (def clear-subscription-cache! subs/clear-subscription-cache!)
 
 ;; ---- dispatch and subscribe -----------------------------------------------
+;;
+;; Per rf2-ts1a — call-site source-coords. Each user-facing surface ships
+;; as a macro + `*`-fn pair (Q1=C: existing-name macro, fn-form gets the
+;; `*` suffix; same convention as `reg-view` / `reg-view*` and `reg-
+;; machine` / `reg-machine*` per Conventions §`*`-suffix naming).
+;;
+;;   `dispatch`       — macro; captures `(meta &form)` and routes through
+;;                       `dispatch*` with the call-site stamped on `opts`.
+;;   `dispatch*`      — runtime-callable fn (delegates to `router/dispatch!`).
+;;                       Use this in HoF contexts (`(map dispatch* xs)`) or
+;;                       when the surface is reached programmatically.
+;;
+;; Same shape for `dispatch-sync` / `dispatch-sync*`, `subscribe` /
+;; `subscribe*`, `inject-cofx` / `inject-cofx*`.
+;;
+;; The compile-time `:rf.trace/call-site` map elides under `goog.DEBUG=
+;; false` (Q3=B dev-only elision) — the macro expansion is
+;; `(if interop/debug-enabled? <stamping-call> <plain-call>)` so the
+;; entire stamping branch (including the literal map) DCE's. emit-error!
+;; reads `trace/*current-call-site*` and attaches the value as
+;; `:rf.trace/call-site` (Q2=A flat sibling of `:rf.trace/trigger-handler`)
+;; on the emitted event.
 
-(def dispatch       router/dispatch!)
-(def dispatch-sync  router/dispatch-sync!)
-(def subscribe      subs/subscribe)
+(def dispatch*       router/dispatch!)
+(def dispatch-sync*  router/dispatch-sync!)
 (def subscribe-value subs/subscribe-value)
-(def unsubscribe    subs/unsubscribe)
-(def compute-sub    subs/compute-sub)
+(def unsubscribe     subs/unsubscribe)
+(def compute-sub     subs/compute-sub)
+
+(defn subscribe*
+  "Runtime-callable fn form of `subscribe`. Per rf2-ts1a — the macro
+  form `re-frame.core/subscribe` captures `(meta &form)` and binds
+  `trace/*current-call-site*` around a call to this fn. Direct callers
+  (HoF use, programmatic subscribe paths, view-render closures injected
+  by `reg-view`) skip the call-site stamping by calling this fn
+  directly.
+
+  Arities mirror `re-frame.subs/subscribe`."
+  ([query-v]            (subs/subscribe query-v))
+  ([frame-id query-v]   (subs/subscribe frame-id query-v)))
+
+(defn inject-cofx*
+  "Runtime-callable fn form of `inject-cofx`. Per rf2-ts1a — the macro
+  form `re-frame.core/inject-cofx` captures `(meta &form)` and routes
+  here with the call-site as the trailing arg. Direct callers skip
+  call-site stamping by omitting the trailing arg.
+
+  Arities:
+    (inject-cofx* :id)                  — no value, no call-site
+    (inject-cofx* :id value)            — value, no call-site
+    (inject-cofx* :id value call-site)  — full macro path (value + call-site)
+
+  The macro expansion uses `cofx/no-value` (a public sentinel) to thread
+  the call-site through the no-value branch without ambiguity."
+  ([cofx-id]                      (cofx/inject-cofx cofx-id))
+  ([cofx-id value]                (cofx/inject-cofx cofx-id value nil))
+  ([cofx-id value call-site]      (cofx/inject-cofx cofx-id value call-site)))
+
+;; ---- call-site capturing macros (rf2-ts1a) -------------------------------
+;;
+;; Each macro captures `(meta &form)` and `*ns*` / `*file*` at expansion
+;; time and emits an `(if interop/debug-enabled? <stamping> <plain>)`
+;; branch around the matching `*`-fn call. Under :advanced +
+;; `goog.DEBUG=false` the closure compiler constant-folds the gate to
+;; false and the entire stamping branch — including the literal
+;; `:rf.trace/call-site` map — DCE's. Per Q3=B dev-only elision.
+;;
+;; The `coords-form` helper is reused from `re-frame.source-coords` so
+;; the literal map carries the same `{:ns :file :line :column}` shape as
+;; registration-site coords (rf2-mdjp `:file` resolution rules apply
+;; identically — form-meta `:file` wins, `"NO_SOURCE_PATH"` sentinel is
+;; dropped).
+
+#?(:clj
+   (defn ^:private call-site-form
+     "Build the literal call-site cond-> map for a callable's macro form.
+     Returns the unguarded form; callers wrap in their own
+     `(if interop/debug-enabled? ... ...)` so the entire branch (binding
+     scope or opts-key assoc) DCEs under `goog.DEBUG=false`."
+     [form-meta ns-sym file]
+     (source-coords/coords-form form-meta file ns-sym)))
+
+#?(:clj
+   (defmacro dispatch
+     "Enqueue `event-vec` on the target frame's router. Per Spec 002
+     §Routing. Per rf2-ts1a: macro form — captures the call site at
+     compile time and threads it through the dispatch envelope so any
+     error trace emitted while the handler chain runs carries the
+     invocation coord as `:rf.trace/call-site`.
+
+     For higher-order use (`(map dispatch* xs)`) and programmatic
+     callers, use `dispatch*` — the runtime-callable fn form."
+     ([event-vec]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/dispatch* ~event-vec {:rf.trace/call-site ~cs-form})
+           (re-frame.core/dispatch* ~event-vec))))
+     ([event-vec opts]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/dispatch* ~event-vec
+                                    (assoc ~opts :rf.trace/call-site ~cs-form))
+           (re-frame.core/dispatch* ~event-vec ~opts))))))
+
+#?(:clj
+   (defmacro dispatch-sync
+     "Run `event-vec` end-to-end synchronously, then drain. Per Spec 002
+     §dispatch-sync. Per rf2-ts1a: macro form — captures the call site
+     and threads it through the dispatch envelope.
+
+     For higher-order use and programmatic callers, use `dispatch-sync*`."
+     ([event-vec]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/dispatch-sync* ~event-vec {:rf.trace/call-site ~cs-form})
+           (re-frame.core/dispatch-sync* ~event-vec))))
+     ([event-vec opts]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/dispatch-sync* ~event-vec
+                                         (assoc ~opts :rf.trace/call-site ~cs-form))
+           (re-frame.core/dispatch-sync* ~event-vec ~opts))))))
+
+#?(:clj
+   (defmacro subscribe
+     "Per Spec 006 §Lookup algorithm. Per rf2-ts1a: macro form —
+     captures the call site and binds `trace/*current-call-site*`
+     around the underlying subscribe so the synchronous miss path
+     (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`) carries
+     the invocation coord.
+
+     For HoF / programmatic subscribe, use `subscribe*`."
+     ([query-v]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (binding [re-frame.trace/*current-call-site* ~cs-form]
+             (re-frame.core/subscribe* ~query-v))
+           (re-frame.core/subscribe* ~query-v))))
+     ([frame-id query-v]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (binding [re-frame.trace/*current-call-site* ~cs-form]
+             (re-frame.core/subscribe* ~frame-id ~query-v))
+           (re-frame.core/subscribe* ~frame-id ~query-v))))))
+
+#?(:clj
+   (defmacro inject-cofx
+     "Build a `:before`-only interceptor that runs the registered cofx.
+     Per rf2-ts1a: macro form — captures the call site and threads it
+     into the interceptor's closure so errors emitted from inside the
+     cofx body (`:rf.error/no-such-cofx`, schema-validation failures)
+     carry the invocation coord.
+
+     For HoF / programmatic interceptor construction, use `inject-cofx*`."
+     ([cofx-id]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        ;; Route through the 3-arity with the `cofx/no-value` sentinel
+        ;; so the call-site can ride. The 3-arity branch in
+        ;; cofx/inject-cofx detects the sentinel via identical? and
+        ;; takes the no-value path through the cofx fn body.
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/inject-cofx* ~cofx-id re-frame.cofx/no-value ~cs-form)
+           (re-frame.core/inject-cofx* ~cofx-id))))
+     ([cofx-id value]
+      (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
+        `(if re-frame.interop/debug-enabled?
+           (re-frame.core/inject-cofx* ~cofx-id ~value ~cs-form)
+           (re-frame.core/inject-cofx* ~cofx-id ~value))))))
 
 ;; ---- frame-aware closures (runtime side) ---------------------------------
 ;;
@@ -665,21 +828,32 @@
   Captures the frame at call time, so closures do not need to thread it.
 
   Per Spec 004 §Affordance for plain fns:
-    (let [d (rf/dispatcher)] [:button {:on-click #(d [:inc])} ...])"
+    (let [d (rf/dispatcher)] [:button {:on-click #(d [:inc])} ...])
+
+  Per rf2-ts1a: the returned closure delegates to the fn-form
+  `dispatch*` so it does NOT bake the call-site of this very file's
+  body onto every dispatch — captured dispatchers run from user
+  callsites (timers, event listeners, etc.) where the original
+  invocation has no syntactic position to attribute to."
   []
   (let [frame (current-frame)]
     (fn dispatch-fn
-      ([event] (dispatch event {:frame frame}))
-      ([event opts] (dispatch event (assoc opts :frame frame))))))
+      ([event]      (dispatch* event {:frame frame}))
+      ([event opts] (dispatch* event (assoc opts :frame frame))))))
 
 (defn subscriber
   "Return a fn that subscribes under the current frame. Captures the
-  frame at call time. The returned fn delegates to subscribe."
+  frame at call time. The returned fn delegates to subscribe.
+
+  Per rf2-ts1a: the returned closure delegates to `subs/subscribe`
+  (the underlying fn) for the same reason `dispatcher` uses `dispatch*`
+  — captured subscribers live across the macro/call-site horizon and
+  shouldn't pin this file's line."
   []
   (let [frame (current-frame)]
     (fn subscribe-fn
       [query-v]
-      (subscribe frame query-v))))
+      (subs/subscribe frame query-v))))
 
 ;; with-frame is a macro (per Spec 002 §with-frame and spec/API.md row 74).
 ;; Two shapes:

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -60,10 +60,24 @@
     :dispatch-id        process-monotonic id allocated here per
                         Spec 009 §Dispatch correlation
     :parent-dispatch-id the in-flight dispatch's id when this dispatch is
-                        emitted from inside another event's processing"
+                        emitted from inside another event's processing
+    :call-site          compile-time-captured invocation coord stamped by
+                        the `dispatch` / `dispatch-sync` macro (rf2-ts1a).
+                        nil for the fn-form path (`dispatch*` etc.) and
+                        under `goog.DEBUG=false` advanced builds."
   [event opts]
   (let [dispatch-id        (when interop/debug-enabled? (next-dispatch-id))
         parent-dispatch-id (when interop/debug-enabled? trace/*current-dispatch-id*)
+        ;; Per rf2-ts1a: read the macro-stamped `:rf.trace/call-site`
+        ;; only when interop/debug-enabled?. Wrap the read itself in
+        ;; the gate so the closure compiler can DCE the keyword
+        ;; reference under `:advanced` + `goog.DEBUG=false`. Without
+        ;; this gate the `(:rf.trace/call-site opts)` keyword-as-fn
+        ;; call survives even when the consuming `cond->` predicate
+        ;; is dead, because the keyword's interned-string slot is
+        ;; referenced syntactically.
+        call-site          (when interop/debug-enabled?
+                             (:rf.trace/call-site opts))
         ;; Per rf2-d4sf consult the `:adapter/current-frame` late-bind
         ;; hook on CLJS so dispatch picks up the React-context tier of
         ;; the resolution chain. Adapters publish the hook at ns-load
@@ -97,6 +111,13 @@
              :source                 (:source opts :ui)
              :origin                 (:origin opts :app)
              :dispatched-at          (interop/now-ms)}
+      ;; Per rf2-ts1a: the macro form of `dispatch` / `dispatch-sync`
+      ;; stamps an `:rf.trace/call-site` on the opts map. The read in
+      ;; `call-site` above is gated on interop/debug-enabled? so this
+      ;; branch and its keyword literal DCE under :advanced +
+      ;; goog.DEBUG=false. fn-form callers (`dispatch*`) supply nil
+      ;; and the key is omitted.
+      call-site          (assoc :call-site         call-site)
       dispatch-id        (assoc :dispatch-id        dispatch-id)
       parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id)
       fallthrough?       (assoc :fell-through-to-default? true))))
@@ -403,10 +424,18 @@
       a fresh stack with no dynamic binding. Use `(rf/bound-dispatcher)`
       (capture-at-call-time), `:fx [[:dispatch ...]]` (fx-walker
       threads the frame), or `:dispatch-later` (frame captured in
-      closure) for those paths. Per rf2-l5q3."
+      closure) for those paths. Per rf2-l5q3.
+
+   3. `trace/*current-call-site*` — bound to the envelope's `:call-site`
+      (when supplied by the `dispatch` / `dispatch-sync` macro per
+      rf2-ts1a). Errors emitted while the handler chain runs (handler
+      exception, no-such-cofx, no-such-fx, schema validation failure,
+      ...) read the Var and attach the call-site to the event as
+      `:rf.trace/call-site`. nil for fn-form dispatch (`dispatch*`)."
   [envelope]
   (binding [trace/*current-dispatch-id*  (:dispatch-id envelope)
-            frame/*current-frame*        (:frame envelope)]
+            frame/*current-frame*        (:frame envelope)
+            trace/*current-call-site*    (:call-site envelope)]
     (process-event* envelope)))
 
 (def ^:private drain-depth-default 100)
@@ -628,15 +657,26 @@
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:
   FIFO at the runtime layer; no reordering, no priority lanes. The drain
-  loop picks it up in this same drain cycle (run-to-completion)."
+  loop picks it up in this same drain cycle (run-to-completion).
+
+  Per rf2-ts1a: the runtime-callable fn form (`re-frame.core/dispatch*`
+  in public API terms). The macro form `re-frame.core/dispatch` stamps
+  an `:rf.trace/call-site` onto `opts` at compile time; from there it
+  rides the envelope and gets bound around the handler chain's
+  invocation in `process-event!`."
   ([event] (dispatch! event {}))
   ([event opts]
    (let [envelope     (build-envelope event opts)
          frame-record (frame/frame (:frame envelope))]
      (cond
        (nil? frame-record)
-       (trace/emit-error! :rf.error/frame-destroyed
-                          {:frame (:frame envelope) :event event})
+       ;; The frame-destroyed emit fires synchronously — bind the
+       ;; envelope's call-site so the error event carries it. Reading
+       ;; the call-site through the envelope (already gated) avoids a
+       ;; second `(:rf.trace/call-site opts)` keyword reference here.
+       (binding [trace/*current-call-site* (:call-site envelope)]
+         (trace/emit-error! :rf.error/frame-destroyed
+                            {:frame (:frame envelope) :event event}))
 
        :else
        (let [router (:router frame-record)]
@@ -726,16 +766,24 @@
   drains to settled before the caller's drain resumes); per Spec 002
   §Rules rule 1 this is intentional (frames are independent state
   machines) but rarely the caller's intent, so the warning surfaces the
-  pattern for observability tools without refusing the call."
+  pattern for observability tools without refusing the call.
+
+  Per rf2-ts1a: runtime-callable fn form for `dispatch-sync` (the macro
+  form stamps an `:rf.trace/call-site` onto `opts` at compile time)."
   ([event] (dispatch-sync! event {}))
   ([event opts]
    (let [envelope     (build-envelope event opts)
-         frame-record (frame/frame (:frame envelope))]
+         frame-record (frame/frame (:frame envelope))
+         ;; Read the call-site from the envelope (already gated in
+         ;; build-envelope) so the synchronous error emits below can
+         ;; carry it without referencing the keyword a second time.
+         call-site    (:call-site envelope)]
      (cond
        (nil? frame-record)
-       (trace/emit-error! :rf.error/frame-destroyed
-                          {:frame (:frame envelope) :event event
-                           :recovery :no-recovery})
+       (binding [trace/*current-call-site* call-site]
+         (trace/emit-error! :rf.error/frame-destroyed
+                            {:frame (:frame envelope) :event event
+                             :recovery :no-recovery}))
 
        (let [r @(:router frame-record)
              ;; Per rf2-ynk7: `:in-drain?` now holds the drainer's
@@ -753,11 +801,12 @@
        ;; Per Spec 002 §dispatch-sync: nesting dispatch-sync inside the
        ;; SAME frame's running drain (sync or async) is an error — the
        ;; event would interleave with the outer handler's run-to-completion.
-       (trace/emit-error! :rf.error/dispatch-sync-in-handler
-                          {:frame    (:frame envelope)
-                           :event    event
-                           :reason   "dispatch-sync called from inside a running drain. Use dispatch (the queued form) instead so the event runs after the current drain settles."
-                           :recovery :no-recovery})
+       (binding [trace/*current-call-site* call-site]
+         (trace/emit-error! :rf.error/dispatch-sync-in-handler
+                            {:frame    (:frame envelope)
+                             :event    event
+                             :reason   "dispatch-sync called from inside a running drain. Use dispatch (the queued form) instead so the event runs after the current drain settles."
+                             :recovery :no-recovery}))
 
        :else
        (let [router (:router frame-record)]

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -357,7 +357,14 @@
   non-default-frame-once` fires once per (component-id, frame-id)
   pair. The check is late-bound through re-frame.views (CLJS-only) so
   the JVM build never loads it; production (`:advanced` +
-  `goog.DEBUG=false`) elides via `interop/debug-enabled?`."
+  `goog.DEBUG=false`) elides via `interop/debug-enabled?`.
+
+  Per rf2-ts1a: this is the runtime-callable fn form. The macro form
+  `re-frame.core/subscribe` captures `(meta &form)` and delegates here
+  through `re-frame.core/subscribe*`, binding `trace/*current-call-site*`
+  for the duration so any error emitted inside the synchronous miss
+  path (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`) carries
+  the invocation coord."
   ([query-v]
    #?(:cljs
       (let [frame-id (resolve-current-frame)]

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -110,6 +110,55 @@
   Per rf2-3nn8 (error path) and rf2-lf84g (success path)."
   nil)
 
+;; ---- call-site (rf2-ts1a) -------------------------------------------------
+;;
+;; Complement to `*current-trigger-handler*` (rf2-3nn8). Where the trigger-
+;; handler names the registration site of the in-scope handler, the call-site
+;; names the **invocation line** of the specific callable that's about to
+;; emit (or has just emitted) an error — e.g. the `(rf/dispatch [:bad-event])`
+;; line, the `(rf/subscribe [:bad-sub])` line, the `(rf/inject-cofx :missing)`
+;; line. With both pieces, tooling renders two clickable links per error:
+;; "handler defined at X:142" (trigger-handler) and "failed call at Y:147"
+;; (call-site).
+;;
+;; The call-site is captured at compile time by the macro form of the
+;; callable (per Q1=C: existing-name macro + `*` fn variant; `dispatch` is
+;; the macro, `dispatch*` is the runtime-callable fn). The macro binds this
+;; Var around the underlying `*`-fn call; `emit-error!` reads the Var and
+;; hoists the value to the top-level `:rf.trace/call-site` slot on the
+;; emitted event (Q2=A: flat sibling of `:rf.trace/trigger-handler`).
+;;
+;; For dispatched events the binding happens not at the macro call site but
+;; later, when the router's drain pulls the envelope out of the queue:
+;; `dispatch*` stamps the call-site onto the envelope, and `process-event!`
+;; binds this Var from the envelope before invoking the handler chain so
+;; any error emitted inside the chain carries it.
+;;
+;; For interceptors (`inject-cofx`) the call-site is captured by the
+;; macro into the interceptor's closure; the `:before` body binds the Var
+;; before calling the cofx fn.
+;;
+;; Elision (Q3=B): dev-only. The macros omit the call-site map entirely
+;; when `goog.DEBUG=false` so the compiled-out call becomes `(dispatch*
+;; event-vec)` — identical to the fn-form path. The closure compiler
+;; constant-folds the dead branch and the map literal DCE's.
+
+(def ^:dynamic *current-call-site*
+  "The compile-time-captured call site of the surface (`dispatch`,
+  `dispatch-sync`, `subscribe`, `inject-cofx`) about to emit (or just
+  emitted) an error. Bound by each surface's macro form around the
+  underlying `*`-fn invocation; `emit-error!` reads the Var and attaches
+  the value to the emitted event under `:rf.trace/call-site`. nil when
+  the surface was reached through its fn form (`dispatch*` etc.) or when
+  no surface is in scope.
+
+  Shape: `{:ns <sym> :file <string> :line <int> :column <int>}` — the
+  same shape as `:source-coord` under `:rf.trace/trigger-handler`, but
+  carries the **invocation** line rather than the registration line.
+
+  Per rf2-ts1a (Q1=C macro+fn pair, Q2=A flat key, Q3=B dev-only elision)."
+  nil)
+
 ;; ---- *current-dispatch-id* (rf2-g6ih4) ------------------------------------
 ;;
 ;; Per Spec 009 §Dispatch correlation: `:dispatch-id` is a **cascade-wide**
@@ -429,6 +478,14 @@
   emitted event. Absent when no handler is in scope (e.g. outermost-
   dispatch `:rf.error/no-such-handler`).
 
+  Per rf2-ts1a: when `*current-call-site*` is bound (the error fires
+  inside the body of a surface that was reached through its macro form
+  — `dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`), the
+  compile-time-captured call site is hoisted to the top-level
+  `:rf.trace/call-site` slot on the emitted event. Absent when the
+  surface was reached through its fn form (`dispatch*` etc.) or when
+  no surface is in scope.
+
   Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the error fires
   inside a drain), the in-flight cascade's id is merged into
   `:tags :dispatch-id` so consumers can correlate the error with the
@@ -436,6 +493,7 @@
   [error-operation tags]
   (when interop/debug-enabled?
     (let [trigger    *current-trigger-handler*
+          call-site  *current-call-site*
           cascade-id *current-dispatch-id*
           base-tags  (merge {:category error-operation} tags)
           tags+      (if (and cascade-id (not (contains? base-tags :dispatch-id)))
@@ -447,7 +505,8 @@
                               :time      (interop/now-ms)
                               :tags      tags+
                               :recovery  (:recovery tags :no-recovery)}
-                       trigger (assoc :rf.trace/trigger-handler trigger))]
+                       trigger   (assoc :rf.trace/trigger-handler trigger)
+                       call-site (assoc :rf.trace/call-site       call-site))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -279,6 +279,30 @@
      :actions {:noop   (fn [_ _] {})}
      :states  {:idle {:on {:tick {:target :idle :guard :never? :action :noop}}}}}))
 
+;; ---- rf2-ts1a: call-site source-coord macros ------------------------------
+;;
+;; The `dispatch` / `dispatch-sync` / `subscribe` / `inject-cofx` macros stamp
+;; an `:rf.trace/call-site` map at compile time (per Q3=B dev-only elision).
+;; Under `:advanced` + `goog.DEBUG=false`, the macro's
+;; `(if interop/debug-enabled? <stamp-branch> <no-stamp-branch>)` expansion
+;; folds away — the stamp branch DCE's and the literal map vanishes from
+;; the bundle. The keyword `:rf.trace/call-site`'s string fragment must
+;; NOT appear in the production bundle.
+
+(defn ^:export touch-call-site-macros! []
+  ;; Each macro form below emits a literal `:rf.trace/call-site` map
+  ;; under DEBUG=true. The stamp-branches must DCE under DEBUG=false.
+  (rf/reg-event-db :probe/cs-event (fn [db _ev] db))
+  (rf/reg-sub      :probe/cs-sub   (fn [db _q] db))
+  (rf/reg-cofx     :probe/cs-cofx  (fn [ctx] ctx))
+  ;; dispatch + dispatch-sync macros
+  (rf/dispatch [:probe/cs-event])
+  (rf/dispatch-sync [:probe/cs-event])
+  ;; subscribe macro
+  (let [_r (rf/subscribe [:probe/cs-sub])] nil)
+  ;; inject-cofx macro (interceptor construction site)
+  (let [_i (rf/inject-cofx :probe/cs-cofx)] nil))
+
 ;; ---- entry point ----------------------------------------------------------
 
 (defn ^:export run []
@@ -289,6 +313,7 @@
   (touch-epoch!)
   (touch-views!)
   (touch-machines!)
+  (touch-call-site-macros!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.
   (trace/emit! :event :rf.probe/direct-touch {:source :probe}))

--- a/implementation/core/test/re_frame/source_coord_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coord_cljs_test.cljs
@@ -1,0 +1,81 @@
+(ns re-frame.source-coord-cljs-test
+  "Per rf2-ts1a — CLJS-side smoke check for `:rf.trace/call-site` on
+  `:rf.error/*` trace events. JVM-side coverage lives in
+  `source_coord_test.cljc`; the macro-expansion path is identical
+  across both targets (the `.cljc` macros run on the Clojure side of
+  the compiler in either case), so this file primarily verifies that
+  the CLJS bundle wires up the dynamic-var read end-to-end without a
+  regression."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/reset-runtime-fixture
+                      {:adapter plain-atom/adapter}))
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- errors-of [evs op]
+  (filterv #(and (= :error (:op-type %))
+                 (= op     (:operation %)))
+           evs))
+
+(deftest cljs-dispatch-macro-stamps-call-site
+  (testing "CLJS: dispatch-sync macro stamps :rf.trace/call-site at the top level"
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/missing])))
+          [miss] (errors-of evs :rf.error/no-such-handler)]
+      (is (some? miss))
+      (let [cs (:rf.trace/call-site miss)]
+        (is (some? cs) "call-site captured")
+        (is (symbol? (:ns cs)))
+        (is (integer? (:line cs)))
+        (is (not (contains? (:tags miss) :rf.trace/call-site))
+            ":rf.trace/call-site lives at top level, not under :tags")))))
+
+(deftest cljs-dispatch-star-fn-omits-call-site
+  (testing "CLJS: dispatch-sync* fn-form does NOT stamp"
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync* [:rf2-ts1a/missing])))
+          [miss] (errors-of evs :rf.error/no-such-handler)]
+      (is (some? miss))
+      (is (not (contains? miss :rf.trace/call-site))))))
+
+(deftest cljs-subscribe-macro-stamps-call-site
+  (testing "CLJS: subscribe macro stamps :rf.trace/call-site on :rf.error/no-such-sub"
+    (let [evs (record-traces
+               (fn []
+                 (rf/subscribe [:rf2-ts1a/missing-sub])))
+          [miss] (errors-of evs :rf.error/no-such-sub)]
+      (is (some? miss))
+      (is (some? (:rf.trace/call-site miss))))))
+
+(deftest cljs-subscribe-star-fn-omits-call-site
+  (testing "CLJS: subscribe* fn-form does NOT stamp"
+    (let [evs (record-traces
+               (fn []
+                 (rf/subscribe* [:rf2-ts1a/missing-sub])))
+          [miss] (errors-of evs :rf.error/no-such-sub)]
+      (is (some? miss))
+      (is (not (contains? miss :rf.trace/call-site))))))
+
+(deftest cljs-inject-cofx-macro-stamps-call-site
+  (testing "CLJS: inject-cofx macro stamps :rf.trace/call-site on :rf.error/no-such-cofx"
+    (rf/reg-event-fx :rf2-ts1a/uses-missing-cofx-cljs
+                     [(rf/inject-cofx :rf2-ts1a/no-such-cofx-cljs)]
+                     (fn [_cofx _event] {}))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/uses-missing-cofx-cljs])))
+          [miss] (errors-of evs :rf.error/no-such-cofx)]
+      (is (some? miss))
+      (is (some? (:rf.trace/call-site miss))))))

--- a/implementation/core/test/re_frame/source_coord_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_test.cljc
@@ -1,0 +1,246 @@
+(ns re-frame.source-coord-test
+  "Per rf2-ts1a — `:rf.trace/call-site` on `:rf.error/*` trace events.
+
+  Complement to rf2-3nn8 (`:rf.trace/trigger-handler`). Where trigger-
+  handler names the registration site of the in-scope handler, call-site
+  names the **invocation line** of the user-facing surface — the
+  `(rf/dispatch ...)`, `(rf/subscribe ...)`, `(rf/inject-cofx ...)`, or
+  `(rf/dispatch-sync ...)` call that produced (or routed to) the error.
+
+  Q1=C — existing-name macro + `*` fn variant (`dispatch` is the macro;
+         `dispatch*` is the fn). The macro stamps the call-site; the
+         fn-form skips stamping.
+  Q2=A — flat `:rf.trace/call-site {:ns :file :line :column}` as a
+         top-level sibling of `:rf.trace/trigger-handler`. Not nested.
+  Q3=B — dev-only elision. Stripped from `:advanced` + `goog.DEBUG=
+         false` bundles via the same DCE path other dev-only surfaces
+         use (elision-probe sentinel covers the bundle-level assertion).
+
+  JVM-side coverage here; CLJS mirror per
+  `source_coord_cljs_test.cljs`. Macro-expansion is JVM-side for both
+  targets (the `.cljc` macros run on the Clojure side of the compiler
+  in either case), so the call-site capture path itself is the same;
+  only the runtime delivery differs."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  "Run `body-fn` with a trace listener attached and return the captured
+  events."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- errors-of
+  "Filter captured traces to those whose `:operation` matches the supplied
+  operation keyword."
+  [evs op]
+  (filterv #(and (= :error (:op-type %))
+                 (= op     (:operation %)))
+           evs))
+
+(defn- assert-call-site-shape
+  "The call-site map MUST live at the top level of the event (not
+  nested under `:tags`) and carry `:ns` / `:file` / `:line` (column
+  may be absent if the macro lost it under `:file` resolution)."
+  [ev]
+  (let [cs (:rf.trace/call-site ev)]
+    (is (some? cs)
+        (str "expected :rf.trace/call-site on " (:operation ev)))
+    (is (not (contains? (:tags ev) :rf.trace/call-site))
+        ":rf.trace/call-site lives at the top level, NOT under :tags")
+    (is (symbol? (:ns cs))   ":ns is a symbol")
+    (is (string? (:file cs)) ":file is a string")
+    (is (integer? (:line cs)) ":line is an integer")))
+
+;; ---- Q1 — dispatch-sync macro stamps; dispatch-sync* fn does NOT ----------
+
+(deftest dispatch-sync-macro-stamps-call-site-on-no-such-handler
+  (testing ":rf.error/no-such-handler from dispatch-sync macro carries the call site"
+    (let [evs (record-traces
+               (fn []
+                 ;; dispatch-sync forces synchronous drain so the
+                 ;; no-such-handler trace fires before record-traces
+                 ;; returns. Plain `dispatch` schedules the drain via
+                 ;; next-tick; the test thread would exit first.
+                 (rf/dispatch-sync [:rf2-ts1a/no-such-event])))
+          [miss] (errors-of evs :rf.error/no-such-handler)]
+      (is (some? miss) "no-such-handler trace fired")
+      (assert-call-site-shape miss))))
+
+(deftest dispatch-sync-star-fn-omits-call-site-on-no-such-handler
+  (testing "the fn-form `dispatch-sync*` does NOT carry a call site"
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync* [:rf2-ts1a/no-such-event])))
+          [miss] (errors-of evs :rf.error/no-such-handler)]
+      (is (some? miss))
+      (is (not (contains? miss :rf.trace/call-site))
+          ":rf.trace/call-site omitted on the fn-form path"))))
+
+;; ---- subscribe / subscribe* -----------------------------------------------
+
+(deftest subscribe-macro-stamps-call-site-on-no-such-sub
+  (testing ":rf.error/no-such-sub from subscribe macro carries the call site"
+    (let [evs (record-traces
+               (fn []
+                 (rf/subscribe [:rf2-ts1a/no-such-sub])))
+          [miss] (errors-of evs :rf.error/no-such-sub)]
+      (is (some? miss) "no-such-sub trace fired")
+      (assert-call-site-shape miss))))
+
+(deftest subscribe-star-fn-omits-call-site
+  (testing "the fn-form `subscribe*` does NOT carry a call site"
+    (let [evs (record-traces
+               (fn []
+                 (rf/subscribe* [:rf2-ts1a/no-such-sub])))
+          [miss] (errors-of evs :rf.error/no-such-sub)]
+      (is (some? miss))
+      (is (not (contains? miss :rf.trace/call-site))
+          ":rf.trace/call-site omitted on the fn-form path"))))
+
+;; ---- inject-cofx / inject-cofx* -------------------------------------------
+
+(deftest inject-cofx-macro-stamps-call-site
+  (testing ":rf.error/no-such-cofx carries the call site of inject-cofx (macro form)"
+    (rf/reg-event-fx :rf2-ts1a/uses-missing-cofx
+                     [(rf/inject-cofx :rf2-ts1a/no-such-cofx)]
+                     (fn [_cofx _event] {}))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/uses-missing-cofx])))
+          [miss] (errors-of evs :rf.error/no-such-cofx)]
+      (is (some? miss))
+      (assert-call-site-shape miss))))
+
+(deftest inject-cofx-star-fn-omits-its-own-call-site
+  (testing "the fn-form `inject-cofx*` does NOT stamp its own call-site;
+   when the enclosing dispatch uses the fn-form too, no call-site rides
+   on the resulting :rf.error/no-such-cofx event"
+    (rf/reg-event-fx :rf2-ts1a/uses-missing-cofx-fn
+                     [(rf/inject-cofx* :rf2-ts1a/no-such-cofx-fn)]
+                     (fn [_cofx _event] {}))
+    (let [evs (record-traces
+               (fn []
+                 ;; Both the inject-cofx and the dispatch-sync are fn-form
+                 ;; — neither stamps a call-site, so the error event
+                 ;; should carry none.
+                 (rf/dispatch-sync* [:rf2-ts1a/uses-missing-cofx-fn])))
+          [miss] (errors-of evs :rf.error/no-such-cofx)]
+      (is (some? miss))
+      (is (not (contains? miss :rf.trace/call-site))
+          ":rf.trace/call-site omitted on the all-fn-form path"))))
+
+(deftest inject-cofx-star-fn-inherits-dispatchs-call-site
+  (testing "when inject-cofx* (fn-form) is reached from a macro-form
+   dispatch-sync, the error carries the dispatch's call-site — the
+   interceptor closure didn't capture one of its own, so the
+   ambient binding wins"
+    (rf/reg-event-fx :rf2-ts1a/uses-missing-cofx-mixed
+                     [(rf/inject-cofx* :rf2-ts1a/no-such-cofx-mixed)]
+                     (fn [_cofx _event] {}))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/uses-missing-cofx-mixed])))
+          [miss] (errors-of evs :rf.error/no-such-cofx)]
+      (is (some? miss))
+      ;; The dispatch-sync macro stamped its own call-site onto the
+      ;; envelope; process-event! bound it; the no-such-cofx emit
+      ;; inside the inject-cofx*'s :before body picks it up because
+      ;; the interceptor didn't pin its own call-site.
+      (is (some? (:rf.trace/call-site miss))
+          ":rf.trace/call-site present (dispatch's call-site)"))))
+
+;; ---- dispatch-sync / dispatch-sync* --------------------------------------
+
+(deftest dispatch-sync-macro-stamps-call-site-on-handler-exception
+  (testing "dispatch-sync macro stamps the call-site through the envelope
+   to errors emitted INSIDE the handler chain"
+    (rf/reg-event-fx :rf2-ts1a/throws
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/throws])))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (is (some? exc))
+      (assert-call-site-shape exc))))
+
+(deftest dispatch-sync-star-fn-omits-call-site-on-handler-exception
+  (testing "the fn-form `dispatch-sync*` does NOT carry a call site"
+    (rf/reg-event-fx :rf2-ts1a/throws-fn
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync* [:rf2-ts1a/throws-fn])))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (is (some? exc))
+      (is (not (contains? exc :rf.trace/call-site))
+          ":rf.trace/call-site omitted on the dispatch-sync* fn-form path"))))
+
+;; ---- top-level placement (Q2=A) ------------------------------------------
+
+(deftest call-site-rides-at-top-level
+  (testing ":rf.trace/call-site lives at the top level, sibling of
+   :rf.trace/trigger-handler — NOT nested under :tags"
+    (rf/reg-event-fx :rf2-ts1a/top-level
+                     (fn [_cofx _event]
+                       (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/top-level])))
+          [exc] (errors-of evs :rf.error/handler-exception)]
+      (is (contains? exc :rf.trace/call-site)
+          ":rf.trace/call-site lives at the top level of the event")
+      (is (not (contains? (:tags exc) :rf.trace/call-site))
+          ":rf.trace/call-site does NOT live under :tags")
+      ;; Mirror trigger-handler placement so both pieces sit side-by-side
+      ;; in the event shape.
+      (is (contains? exc :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives alongside :rf.trace/call-site"))))
+
+;; ---- call-site captures the actual source line ----------------------------
+
+(deftest call-site-line-matches-call-site
+  (testing "the captured :line is the line of the dispatch macro form
+   and :file points at this test file"
+    (let [evs (record-traces
+               (fn []
+                 (rf/dispatch-sync [:rf2-ts1a/missing])))   ;; ← THIS line
+          [miss] (errors-of evs :rf.error/no-such-handler)
+          cs     (:rf.trace/call-site miss)]
+      (is (some? cs))
+      ;; We can't hardcode the line number (file edits would break the
+      ;; test); instead assert the line is plausible (positive integer)
+      ;; and the file points at this test file.
+      (is (integer? (:line cs)))
+      (is (pos? (:line cs)))
+      (is (string? (:file cs)))
+      (is (re-find #"source_coord_test" (:file cs))
+          (str ":file should point at this test file — got " (:file cs))))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -180,7 +180,16 @@ const DEV_ONLY_SENTINELS = [
   // `rf.machine/source-coords` string fragment must NOT survive in
   // production bundles.
   { source: 're-frame.core/reg-machine (rf.machine/source-coords stamping)',
-    sentinel: 'rf.machine/source-coords' }
+    sentinel: 'rf.machine/source-coords' },
+  // re-frame.core/{dispatch,dispatch-sync,subscribe,inject-cofx} —
+  // call-site source-coord stamping (rf2-ts1a, Q3=B dev-only elision).
+  // Each macro emits an `(if interop/debug-enabled? <stamp-branch>
+  // <no-stamp-branch>)` expansion; under :advanced + goog.DEBUG=false
+  // the closure compiler constant-folds the gate to false and the
+  // stamp branch DCEs. The `rf.trace/call-site` keyword's string
+  // fragment must NOT survive in production bundles.
+  { source: 're-frame.core/{dispatch,subscribe,inject-cofx} (rf.trace/call-site stamping)',
+    sentinel: 'rf.trace/call-site' }
   // Note (rf2-d3k3): re-frame.views/maybe-warn-plain-fn-under-non-
   // default-frame! emits :rf.warning/plain-fn-under-non-default-frame-
   // once gated on interop/debug-enabled?. We do NOT add a sentinel

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -723,6 +723,9 @@ All error trace events are open maps with these required keys:
    {:kind         #{:event :sub :fx :cofx :view}
     :id           keyword
     :source-coord {:ns sym? :file string? :line int? :column int?}}
+ :rf.trace/call-site                             ;; (when present) invocation coord stamped by the
+   {:ns sym? :file string?                       ;; macro form (rf2-ts1a). Dev-only — elided under
+    :line int? :column int?}                     ;; :advanced + goog.DEBUG=false.
  :tags      {:category    :rf.error/<category>   ;; same as :operation, for consumer convenience
              :failing-id  any                    ;; the registered id that failed (event id, fx id, sub id, view id, etc.)
              :reason      string                 ;; one-sentence human description
@@ -759,6 +762,44 @@ The `:source-coord` payload is whatever the registrar slot's metadata holds. Mac
 Production elision: the slot is **NOT separately elided**. The trace surface as a whole is gated by `re-frame.interop/debug-enabled?` per [§Production builds](#production-builds-zero-overhead-zero-code) — when a trace event is emitted at all, the trigger-handler field rides along on it when bound. There is no second gate that selectively drops the field while keeping the rest of the event. Apps that keep the trace surface in production (rare; opt in by setting `goog.DEBUG=true` on the `:advanced` build) get the trigger-handler coord along with every emitted event. Apps using the default `goog.DEBUG=false` `:advanced` build get neither the field nor the surrounding trace surface — the entire `(when interop/debug-enabled? ...)` branch DCEs.
 
 Consumer access: read `(:rf.trace/trigger-handler event)` for the map, `(get-in event [:rf.trace/trigger-handler :source-coord])` for the coord, `(get-in event [:rf.trace/trigger-handler :id])` for the handler's id. No new namespace is required to read the slot.
+
+#### `:rf.trace/call-site` — naming the invocation line (rf2-ts1a)
+
+The optional top-level `:rf.trace/call-site` slot is a **sibling** of `:rf.trace/trigger-handler` (not nested) and names the **invocation line** of the user-facing surface that triggered the trace event — the `(rf/dispatch [:bad-event])` line, the `(rf/subscribe [:bad-sub])` line, the `(rf/inject-cofx :missing)` line, the `(rf/dispatch-sync [:throws])` line. Where trigger-handler answers *"where is the failing handler defined?"*, call-site answers *"where is the failing handler called?"* Tools render two clickable links per error: registration-site jump (trigger-handler) and invocation-site jump (call-site).
+
+Shape (flat map, mirrors `:source-coord` under `:rf.trace/trigger-handler`):
+
+```clojure
+{:ns     <sym>     ;; the calling namespace
+ :file   <string>  ;; the source file, per rf2-mdjp `:file` resolution
+ :line   <int>     ;; the line of the macro form
+ :column <int>}    ;; optional refinement
+```
+
+The macro forms of four user-facing surfaces stamp the call-site at compile time; their `*`-suffix fn counterparts (per [Conventions §`*`-suffix naming](Conventions.md#-suffix-naming-for-fn-versions-of-macros)) do not stamp:
+
+| Surface | Macro (stamps) | Fn-form (no stamp) |
+|---|---|---|
+| Dispatch (queued) | `dispatch` | `dispatch*` |
+| Dispatch (sync)   | `dispatch-sync` | `dispatch-sync*` |
+| Subscribe         | `subscribe` | `subscribe*` |
+| Inject cofx       | `inject-cofx` | `inject-cofx*` |
+
+For `dispatch` / `dispatch-sync`, the call-site rides through the dispatch envelope and is bound around `process-event!` so errors emitted **inside the handler chain** (handler exception, no-such-cofx, no-such-fx, schema validation failures) attach the call-site of the dispatch that triggered the cascade — the user lands on the line they wrote, not somewhere deep in framework code. For `subscribe`, the macro binds the Var around the synchronous miss path so `:rf.error/no-such-sub` and `:rf.error/frame-destroyed` carry the invocation coord. For `inject-cofx`, the macro stamps into the interceptor's closure so the `:before` body's emits carry the original `(rf/inject-cofx :id)` line — the interceptor itself may run later in the cascade, but the captured coord still points at the user's code.
+
+Coverage:
+
+| Reached through                  | `:rf.trace/call-site` present? |
+|---|---|
+| Macro form (`dispatch`, `subscribe`, `inject-cofx`, `dispatch-sync`) | Yes |
+| Fn form (`dispatch*`, `subscribe*`, `inject-cofx*`, `dispatch-sync*`) | No |
+| Higher-order use (`(map dispatch* xs)`) — fn form required | No |
+| View-render injected `dispatch` / `subscribe` locals (per `reg-view`) | No — the wrapper delegates through `dispatch*` / `subs/subscribe` |
+| Captured dispatcher / subscriber (`(rf/dispatcher)`, `(rf/bound-dispatcher)`) | No — the returned closure delegates through `dispatch*` |
+
+Production elision (Q3=B): **dev-only**. Each macro expands to `(if interop/debug-enabled? <stamping-branch> <no-stamping-branch>)`; under `:advanced` + `goog.DEBUG=false` the closure compiler constant-folds the gate to false and the entire stamping branch DCE's — the literal `{:rf.trace/call-site {...}}` map vanishes from the bundle. Apps using `goog.DEBUG=true` builds (or any JVM build) get the field; the default `:advanced` + `goog.DEBUG=false` production build does not — the elision-probe (per [§Production builds](#production-builds-zero-overhead-zero-code)) asserts the `"rf.trace/call-site"` string fragment is absent from the production bundle. The trace surface itself is still gated; this is an additional compile-time gate that strips the call-site machinery even when the trace surface is kept live.
+
+The mechanism is "compile-time map + dynamic-var bind + emit-error read." The macro produces a literal map at compile time; the runtime binds `re-frame.trace/*current-call-site*` around the underlying `*`-fn call (or threads the value through the dispatch envelope so `process-event!` binds it for the handler chain); `emit-error!` reads the Var and hoists it onto the emitted event when bound. No new namespace or registry; consumer access is `(:rf.trace/call-site event)`.
 
 ### Error namespace convention — five prefix shapes
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -59,9 +59,12 @@
 
 | API | M/Fn | Signature | Status | Spec |
 |---|---|---|---|---|
-| `dispatch` | Fn | `(dispatch event)` / `(dispatch event opts)` | v1 (preserved + extended) | 002 |
-| `dispatch-sync` | Fn | `(dispatch-sync event)` / `(dispatch-sync event opts)` | v1 (preserved + extended) | 002 |
-| `subscribe` | Fn | `(subscribe query-v)` / `(subscribe query-v opts)` | v1 (preserved + extended) | 002 |
+| `dispatch` | M | `(dispatch event)` / `(dispatch event opts)` | v1 (preserved + extended); macro per rf2-ts1a — captures call-site for `:rf.trace/call-site` | 002 |
+| `dispatch*` | Fn | `(dispatch* event)` / `(dispatch* event opts)` | rf2-ts1a — fn form for HoF / programmatic dispatch (no call-site stamping) | 002 |
+| `dispatch-sync` | M | `(dispatch-sync event)` / `(dispatch-sync event opts)` | v1 (preserved + extended); macro per rf2-ts1a | 002 |
+| `dispatch-sync*` | Fn | `(dispatch-sync* event)` / `(dispatch-sync* event opts)` | rf2-ts1a — fn form for HoF / programmatic sync dispatch | 002 |
+| `subscribe` | M | `(subscribe query-v)` / `(subscribe frame-id query-v)` | v1 (preserved + extended); macro per rf2-ts1a | 002 |
+| `subscribe*` | Fn | `(subscribe* query-v)` / `(subscribe* frame-id query-v)` | rf2-ts1a — fn form for HoF / programmatic subscribe | 002 |
 | `subscribe-value` | Fn | `(subscribe-value query-v)` / `(subscribe-value frame-id query-v)` → value (subscribe + deref + immediate unsubscribe; one-shot, non-reactive read for handler bodies, machine actions, REPL) | v1 | 002 |
 | `unsubscribe` | Fn | `(unsubscribe query-v)` / `(unsubscribe frame-id query-v)` → nil (decrement the cache ref-count; ref-count→0 schedules disposal after the configured `:sub-cache` grace-period) | v1 | 002 |
 | `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot. Sugar over `(subscribe [:rf/machine machine-id])`. | v1 | 005 |
@@ -504,7 +507,8 @@ The v2 std-interceptor surface is **three specific helpers** plus the `->interce
 
 | API | M/Fn | Signature | Purpose |
 |---|---|---|---|
-| `inject-cofx` | Fn | `(inject-cofx id)` / `(inject-cofx id value)` | Inject a registered cofx into the handler's coeffect map. Specific work — `:cofx` registry lookup, not subsumable by `->interceptor`. |
+| `inject-cofx` | M | `(inject-cofx id)` / `(inject-cofx id value)` | Inject a registered cofx into the handler's coeffect map. Macro per rf2-ts1a — captures call-site for `:rf.trace/call-site` on errors emitted from inside the cofx body. Specific work — `:cofx` registry lookup, not subsumable by `->interceptor`. |
+| `inject-cofx*` | Fn | `(inject-cofx* id)` / `(inject-cofx* id value)` | Fn form (rf2-ts1a) for HoF / programmatic interceptor construction — no call-site stamping. |
 | `path` | Fn | `(path & path)` | Focus a handler on an `app-db` sub-slice. Specific work — `:before` focuses, `:after` splices the result back into parent db. |
 | `unwrap` | (val) | `unwrap` | Assert `[id payload-map]` event shape; replace `:event` coeffect with the payload map; restore on `:after`. Sugar over the M-19 canonical map-payload form. |
 | `->interceptor` | Fn | `(->interceptor & {:keys [id before after]})` | The primitive. Build a custom interceptor with `:before` and/or `:after` slots. **Use this for any work not covered by the three specific helpers above** — analytics, logging, validation, ad-hoc context manipulation. The resulting interceptor is named, addressable, and queryable like any other artefact. |

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -246,9 +246,22 @@ The four buckets are exhaustive for the surfaces in [API.md](API.md). The `regis
 
 ## `*`-suffix naming for fn-versions of macros
 
-When a macro has a fn-version (the unsweetened, runtime-callable surface), the fn gets a `*` suffix. Standard Clojure idiom — `let` / `let*`, `fn` / `fn*`. The macro is the ergonomic surface (parses extra shapes, captures source-coords from `&form`, defs Vars, injects locals); the `*`-fn is the plain-fn delegate that runtime callers invoke when they need a non-literal body, a computed id, or registration without the macro tier.
+When a macro has a fn-version (the unsweetened, runtime-callable surface), the fn gets a `*` suffix. Standard Clojure idiom — `let` / `let*`, `fn` / `fn*`. The macro is the ergonomic surface (parses extra shapes, captures source-coords from `&form`, defs Vars, injects locals, **stamps invocation call-sites** for tooling per [009 §`:rf.trace/call-site` — naming the invocation line](009-Instrumentation.md#rftracecall-site--naming-the-invocation-line-rf2-ts1a)); the `*`-fn is the plain-fn delegate that runtime callers invoke when they need a non-literal body, a computed id, registration without the macro tier, or higher-order use (`(map dispatch* xs)` — the macro can't ride a HoF position).
 
-For now the only pair is `reg-view` / `reg-view*` (per [Spec 004 §reg-view*](004-Views.md#reg-view--the-plain-fn-escape-hatch)); future macros that want fn partners follow the same convention.
+The current pairs:
+
+| Macro (ergonomic) | Fn (`*` form) | Spec |
+|---|---|---|
+| `reg-view` | `reg-view*` | [004 §reg-view*](004-Views.md#reg-view--the-plain-fn-escape-hatch) |
+| `reg-machine` | `reg-machine*` | [005 §reg-machine vs reg-machine*](005-StateMachines.md) |
+| `dispatch` | `dispatch*` | rf2-ts1a — call-site stamping |
+| `dispatch-sync` | `dispatch-sync*` | rf2-ts1a — call-site stamping |
+| `subscribe` | `subscribe*` | rf2-ts1a — call-site stamping |
+| `inject-cofx` | `inject-cofx*` | rf2-ts1a — call-site stamping |
+
+The `dispatch` / `subscribe` / `inject-cofx` macros (per rf2-ts1a) are the canonical invocation surface in user code — they pay no extra runtime cost in production (the call-site stamp DCEs under `:advanced` + `goog.DEBUG=false`) and let tooling render two click-to-jump links per error: registration-site (`:rf.trace/trigger-handler`) and invocation-site (`:rf.trace/call-site`). The `*`-fn forms exist for higher-order use and programmatic / REPL paths where there is no syntactic call site to attribute to.
+
+Future macros that want fn partners follow the same convention.
 
 The convention applies **only where there is a macro tier**. The other `reg-*` registrations (`reg-event-db`, `reg-event-fx`, `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`) are already plain fns — they need no macro tier and therefore no `*` partner. Adding `reg-event-db*` / etc. would be a pure alias and add no value; that's not done. (See [Cross-Spec-Interactions §Family asymmetry](Cross-Spec-Interactions.md#21-family-asymmetry--only-reg-view-has-a-macro-tier) for why the family is intentionally asymmetric.)
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -303,6 +303,12 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
                                                [:file   {:optional true} :string]
                                                [:line   {:optional true} :int]
                                                [:column {:optional true} :int]]]]]
+   [:rf.trace/call-site       {:optional true}    ;; rf2-ts1a — invocation coord stamped by the
+                              [:map               ;; macro form of dispatch / dispatch-sync /
+                               [:ns     {:optional true} :symbol]    ;; subscribe / inject-cofx
+                               [:file   {:optional true} :string]
+                               [:line   {:optional true} :int]
+                               [:column {:optional true} :int]]]
    [:tags      [:map
                 [:category    :keyword]         ;; same value as :operation, for consumer convenience
                 [:failing-id  {:optional true} :any]
@@ -313,6 +319,8 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
 The `:op-type` discriminates severity: `:error` halts or recovers a specific operation; `:warning` is an advisory the runtime emitted alongside continuing default behaviour. Consumers branch on `:op-type` for severity routing and on `:operation` for category-specific handling.
 
 The optional `:rf.trace/trigger-handler` slot (top-level, NOT under `:tags`) names the handler whose execution produced the error and carries its registration-site source-coord. Inherited from the universal `TraceEvent` shape — the slot rides on every trace event emitted while a handler is in scope, not just errors (per rf2-lf84g — success-path traces like `:rf.fx/handled` and `:rf.machine/transition` carry it too). Present when a handler is in scope at emit time (event handler running, sub recomputing, fx handler dispatching, cofx injecting, view rendering); absent when no handler is in scope (e.g. outermost-dispatch `:rf.error/no-such-handler`, depth-exceeded drain rollback). Source-coord values come from the registrar slot stamped by the kind-specific `reg-*` macro at registration time; programmatic registration paths (the underlying registration fns called without the macro wrapping) carry no coord, in which case the slot is omitted rather than populated with placeholder data. Tools render click-to-jump-to-handler links by reading `[:rf.trace/trigger-handler :source-coord]`. Not elided in production — `:rf.error/*` traces are not elided (unlike `:rf.assert/*`) and this slot rides along with them.
+
+The optional `:rf.trace/call-site` slot (top-level, sibling of `:rf.trace/trigger-handler`) names the **invocation** line of the user-facing surface that triggered the error — the `(rf/dispatch [:bad-event])` line, the `(rf/subscribe [:bad-sub])` line, the `(rf/inject-cofx :missing)` line. Where `:rf.trace/trigger-handler` answers "where is the failing handler **defined**?", `:rf.trace/call-site` answers "where is the failing handler **called**?". Tools that consume both render two clickable links per error: registration-site jump and invocation-site jump. Present when the surface was reached through its macro form (`dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`); absent when reached through the runtime-callable fn form (`dispatch*`, `dispatch-sync*`, `subscribe*`, `inject-cofx*`) — HoF use, programmatic / REPL paths, view-render closures captured by `(rf/dispatcher)` / `(rf/subscriber)` — and absent under `:advanced` + `goog.DEBUG=false` builds (per rf2-ts1a Q3=B: dev-only elision; the macro's stamp branch DCEs and the literal map vanishes). Per rf2-ts1a.
 
 The canonical category vocabulary is fixed-and-additive (Spec-ulation): existing categories cannot be renamed or removed; new categories are added by extending the operation namespace. The current set is enumerated in [009 §Error categories](009-Instrumentation.md#error-categories-initial-set) and reproduced in [API.md §Error contract](API.md#error-contract). Reserved operation namespaces:
 


### PR DESCRIPTION
## Summary

- Adds `:rf.trace/call-site` to `:rf.error/*` trace events — the **invocation line** of the user-facing surface that triggered the error. Complement to rf2-3nn8's `:rf.trace/trigger-handler` (registration line).
- Ships four macro+fn pairs following the existing `reg-view`/`reg-view*` convention: `dispatch`/`dispatch*`, `dispatch-sync`/`dispatch-sync*`, `subscribe`/`subscribe*`, `inject-cofx`/`inject-cofx*`. The macro stamps the call-site; the `*`-fn skips stamping (HoF / programmatic use).
- Dev-only elision: each macro expands to `(if interop/debug-enabled? <stamping> <plain>)` so the stamp branch DCEs under `:advanced` + `goog.DEBUG=false`. elision-probe sentinel asserts the `"rf.trace/call-site"` string is absent from production bundles.

## Locked decisions (2026-05-13)

- **Q1=C** — existing-name macro + `*`-fn variant (same shape as `reg-view`/`reg-view*`, `reg-machine`/`reg-machine*`).
- **Q2=A** — flat `:rf.trace/call-site {:ns :file :line :column}` as a top-level sibling of `:rf.trace/trigger-handler`. Not nested under `:tags`.
- **Q3=B** — dev-only elision via the `interop/debug-enabled?` gate.

## Implementation

- **Macros** stamp the call-site map and route to the matching `*`-fn. For `dispatch` / `dispatch-sync` the call-site rides through the dispatch envelope and `process-event!` binds `trace/*current-call-site*` around the handler chain so errors emitted inside the chain (handler exception, no-such-cofx, schema validation, ...) carry the dispatch's call-site. For `subscribe` / `inject-cofx` the macro binds the Var directly around the underlying call / inside the interceptor closure.
- **`emit-error!`** reads `*current-call-site*` and hoists the value onto the emitted event under `:rf.trace/call-site` when bound — mirrors the trigger-handler hoist (rf2-3nn8).
- **`dispatcher` / `subscriber` / view-injected `dispatch` / `subscribe`** delegate through the fn forms so captured closures don't bake the framework's source line onto every dispatch — those callbacks run from user call-sites that have no syntactic position to attribute to.
- **`cofx/no-value`** sentinel publicised so the `inject-cofx` macro's 1-arity path can thread a call-site through the no-value branch without inventing a private sentinel at the macro layer.

## Test plan

- [x] JVM core tests pass (306 tests / 1376 assertions, +11 new in `source_coord_test.cljc`)
- [x] All other JVM artefacts pass (flows / routing / schemas / machines / ssr / http / epoch)
- [x] CLJS node tests pass (601 tests / 1427 assertions, +5 new in `source_coord_cljs_test.cljs`)
- [x] CLJS browser tests pass (614 tests / 1517 assertions)
- [x] Elision probe PASS — `rf.trace/call-site` absent from `:advanced` + `goog.DEBUG=false` bundle, present in control build
- [x] `scripts/check_doc_slugs.py` clean
- [x] No HoF / programmatic regressions — sweep of `examples/` found zero `(map dispatch ...)` / `#'rf/dispatch` style uses that would require migration to the `*` forms

## Spec sections edited

- `spec/Spec-Schemas.md` — `:rf/error-event` shape adds `:rf.trace/call-site` (flat map, sibling of trigger-handler)
- `spec/009-Instrumentation.md` — new §`:rf.trace/call-site` — naming the invocation line (rf2-ts1a) with coverage matrix and elision contract
- `spec/Conventions.md` — `*`-suffix naming table extended with the four new pairs; macro responsibilities expanded to include call-site stamping
- `spec/API.md` — Dispatch / subscribe / std-interceptor rows mark the four surfaces as `M` and add the `*` companions