### PR TITLE
feat(pair2): streaming subscription channel for trace + epoch events (rf2-hq49)

### DIFF
--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -9,13 +9,18 @@
 ;;;;
 ;;;; Design invariants (see docs/initial-spec.md):
 ;;;;   - All trace and epoch reads consume re-frame2's public Tool-Pair
-;;;;     surfaces (`re-frame.core/register-trace-cb`, `trace-buffer`,
+;;;;     surfaces (`re-frame.core/register-trace-cb!`, `trace-buffer`,
 ;;;;     `register-epoch-cb!`, `epoch-history`, `restore-epoch`). No
 ;;;;     reaching into private namespaces.
 ;;;;   - Exactly one trace listener (`:re-frame-pair2`) and one epoch
 ;;;;     listener (`:re-frame-pair2-epoch`) are registered. Multi-tool
 ;;;;     coexistence is the expected default; per Spec 009 §Listener
 ;;;;     ordering, listener ordering is not contract.
+;;;;   - Streaming subscriptions (rf2-hq49) ride those same single
+;;;;     listener slots — the listener fans matching events into per-
+;;;;     subscription queues. `subscribe!` / `drain-subscription!` /
+;;;;     `unsubscribe!` are the public surface the MCP server's
+;;;;     `subscribe` op consumes.
 ;;;;   - The `session-id` sentinel below is read by the MCP server's
 ;;;;     preload probe. A mirror is also set on
 ;;;;     `js/globalThis.__re_frame_pair2_runtime` at load time so the
@@ -313,20 +318,23 @@
   ;; last-pair-epoch). Populated by the dispatch helpers below.
   (atom #{}))
 
-(defn- on-epoch [record]
-  (swap! observed-epochs
-         (fn [m]
-           (let [frame-id (:frame record)
-                 v        (or (get m frame-id) [])
-                 v+       (conj v record)
-                 n        (count v+)]
-             (assoc m frame-id (if (> n 500) (subvec v+ (- n 500)) v+))))))
+;; The per-frame `observed-epochs` stash and the streaming dispatch both
+;; ride the same `register-epoch-cb!` slot — combined into
+;; `on-epoch-streaming` below to keep listener ordering deterministic
+;; (rf2-hq49). The legacy single-purpose `on-epoch` was inlined into the
+;; streaming listener.
+
+(declare on-epoch-streaming)
 
 (defn- ensure-epoch-listener!
   "Register the assembled-epoch listener if it isn't already. Idempotent —
-   passing the same id twice replaces (per `register-epoch-cb!` contract)."
+   passing the same id twice replaces (per `register-epoch-cb!` contract).
+
+   Installs the streaming-aware listener (rf2-hq49). The streaming
+   dispatch is a no-op when no subscriptions are active, so this is
+   safe to install unconditionally."
   []
-  (rf/register-epoch-cb! :re-frame-pair2-epoch on-epoch))
+  (rf/register-epoch-cb! :re-frame-pair2-epoch on-epoch-streaming))
 
 (defn epoch-history
   "Pass-through to (rf/epoch-history frame-id) — the framework's
@@ -444,20 +452,281 @@
 
 (defonce ^:private last-trace-id (atom 0))
 
-(defn- on-trace [event]
-  (when-let [id (:id event)]
-    (when (number? id) (reset! last-trace-id id))))
+;; The legacy `last-trace-id` cursor and the streaming dispatch both
+;; ride the same `register-trace-cb!` slot — combined into
+;; `on-trace-streaming` below (rf2-hq49). The legacy `on-trace` was
+;; inlined into the streaming listener.
+
+(declare on-trace-streaming)
 
 (defn- ensure-trace-listener!
-  "Register the raw-trace listener if it isn't already."
+  "Register the raw-trace listener if it isn't already.
+
+   Installs the streaming-aware listener (rf2-hq49). The streaming
+   dispatch is a no-op when no subscriptions are active, so this is
+   safe to install unconditionally — `last-trace-event-id` keeps
+   working through it."
   []
-  (rf/register-trace-cb :re-frame-pair2 on-trace))
+  (rf/register-trace-cb! :re-frame-pair2 on-trace-streaming))
 
 (defn last-trace-event-id
   "Last trace event id observed by the skill's listener. Useful as a
    `:since` cursor for `(rf/trace-buffer {:since N})`."
   []
   @last-trace-id)
+
+;; ---------------------------------------------------------------------------
+;; Streaming subscriptions (rf2-hq49)
+;; ---------------------------------------------------------------------------
+;;
+;; A subscription is a server-side filtered tap on the trace bus or the
+;; epoch bus. The MCP server registers a subscription via `subscribe!`,
+;; then polls `drain-subscription!` in a tight loop to retrieve queued
+;; events between polls; each batch is pushed back to the MCP client as
+;; a `notifications/progress` notification.
+;;
+;; Why poll-from-server rather than push-from-runtime? The runtime lives
+;; in the browser tab; the only side-channel back to the MCP server is
+;; the nREPL socket (controlled by the server). Polling at ~100ms is
+;; well below the perceptual threshold for the agent loop, costs one
+;; bencode round-trip per tick, and stays correct across page reloads
+;; (a reload wipes the runtime's subscription registry along with
+;; everything else; the server's poll loop sees an empty drain + the
+;; sub-id absent from `subscription-info`, and exits cleanly).
+;;
+;; Per-subscription state:
+;;   {:id <uuid>
+;;    :topic    :trace | :epoch | :fx | :error
+;;    :filter   <filter-map>         ;; vocab depends on topic
+;;    :queue    <vector of events>   ;; appended-to by the cb, drained by the server
+;;    :overflow <integer>            ;; events dropped because queue exceeded :max-buffered
+;;    :created-at <ms>
+;;    :max-buffered <integer>}       ;; queue cap; default 500
+;;
+;; Topic semantics:
+;;   :trace  — every event in the raw trace stream matching `:filter`
+;;             (filter map mirrors `(rf/trace-buffer)` filter vocab —
+;;             see rf2-97ah0). One event per delivered trace event.
+;;   :epoch  — every assembled `:rf/epoch-record` matching `:filter`
+;;             (filter map mirrors `epoch-matches?` — see watch-epochs).
+;;             One event per committed epoch.
+;;   :fx     — sugar for `:topic :trace :filter {:op-type :fx}` with
+;;             optional `:fx-id` and `:event-id` axes from the trace
+;;             filter vocabulary.
+;;   :error  — sugar for `:topic :trace :filter {:op-type :error}`,
+;;             with `:event-id`/`:handler-id`/`:source` available.
+;;
+;; The :fx and :error topics compose with axes from the trace filter
+;; vocabulary verbatim — they just default `:op-type` to `:fx` /
+;; `:error` and let callers override the rest.
+
+(defonce ^:private subscriptions
+  ;; sub-id -> subscription map (see above)
+  (atom {}))
+
+(def ^:private default-max-buffered 500)
+
+(defn- topic->base-filter
+  "Map a topic keyword to its base trace-filter constraints. `:fx` and
+   `:error` are sugar over `:op-type`; `:trace` and `:epoch` add no
+   base constraint here (the user-supplied filter is the only constraint)."
+  [topic]
+  (case topic
+    :fx    {:op-type :fx}
+    :error {:op-type :error}
+    {}))
+
+(defn- compose-trace-filter
+  "Compose the topic's base trace-filter with the user-supplied filter.
+   User keys win on conflict — the topic is a default, not a lock."
+  [topic user-filter]
+  (merge (topic->base-filter topic) (or user-filter {})))
+
+(declare epoch-matches?) ;; resolved below
+
+(defn- trace-matches?
+  "Test a raw trace event against a filter map. Mirrors the filter
+   vocabulary of `(rf/trace-buffer opts)` (rf2-97ah0) — composes
+   AND-wise, absent key means no constraint on that axis."
+  [filter-map ev]
+  (let [{:keys [operation op-type frame severity
+                event-id handler-id source origin
+                dispatch-id since-ms between]}
+        filter-map
+        [t0 t1] (when (and (sequential? between) (= 2 (count between)))
+                  between)]
+    (boolean
+      (and (or (nil? operation)  (= operation (:operation ev)))
+           (or (nil? op-type)    (= op-type   (:op-type ev)))
+           (or (nil? severity)   (= severity  (:op-type ev)))
+           (or (nil? frame)      (= frame
+                                    (or (:frame ev)
+                                        (get-in ev [:tags :frame]))))
+           (or (nil? event-id)   (= event-id
+                                    (get-in ev [:tags :event-id])))
+           (or (nil? handler-id) (= handler-id
+                                    (get-in ev [:tags :handler-id])))
+           (or (nil? source)     (= source
+                                    (or (:source ev)
+                                        (get-in ev [:tags :source]))))
+           (or (nil? origin)     (= origin
+                                    (get-in ev [:tags :origin])))
+           (or (nil? dispatch-id)(= dispatch-id
+                                    (get-in ev [:tags :dispatch-id])))
+           (or (nil? since-ms)   (and (number? (:time ev))
+                                      (> (:time ev) since-ms)))
+           (or (nil? t0)         (and (number? (:time ev))
+                                      (<= t0 (:time ev) t1)))))))
+
+(defn- enqueue!
+  "Append an event to a subscription's queue, honouring max-buffered.
+   When the queue is full we drop the new event and increment overflow —
+   keeping the oldest events lets the agent reconstruct the start of a
+   storm rather than seeing only the tail."
+  [sub-state sub-id event]
+  (update sub-state sub-id
+          (fn [sub]
+            (when sub
+              (let [q  (:queue sub)
+                    n  (count q)
+                    cap (:max-buffered sub default-max-buffered)]
+                (if (>= n cap)
+                  (update sub :overflow (fnil inc 0))
+                  (update sub :queue conj event)))))))
+
+(defn- dispatch-trace-to-subs!
+  "Called from the raw-trace listener — iterates active subscriptions of
+   trace-like topics, matches, enqueues. Cheap when no subs exist (the
+   common path)."
+  [ev]
+  (swap! subscriptions
+         (fn [m]
+           (reduce-kv
+             (fn [acc sub-id sub]
+               (if (and (contains? #{:trace :fx :error} (:topic sub))
+                        (trace-matches? (:compiled-filter sub) ev))
+                 (enqueue! acc sub-id ev)
+                 acc))
+             m m))))
+
+(defn- dispatch-epoch-to-subs!
+  "Called from the assembled-epoch listener — iterates active epoch
+   subscriptions, matches, enqueues."
+  [record]
+  (swap! subscriptions
+         (fn [m]
+           (reduce-kv
+             (fn [acc sub-id sub]
+               (if (and (= :epoch (:topic sub))
+                        (epoch-matches? (or (:filter sub) {}) record))
+                 (enqueue! acc sub-id record)
+                 acc))
+             m m))))
+
+(defn- on-trace-streaming
+  "Replacement raw-trace listener that drives both the last-trace-id
+   cursor (legacy) and the streaming subs dispatch."
+  [ev]
+  (when-let [id (:id ev)]
+    (when (number? id) (reset! last-trace-id id)))
+  (dispatch-trace-to-subs! ev))
+
+(defn- on-epoch-streaming
+  "Replacement assembled-epoch listener that drives both the observed
+   stash (legacy) and the streaming subs dispatch."
+  [record]
+  (swap! observed-epochs
+         (fn [m]
+           (let [frame-id (:frame record)
+                 v        (or (get m frame-id) [])
+                 v+       (conj v record)
+                 n        (count v+)]
+             (assoc m frame-id (if (> n 500) (subvec v+ (- n 500)) v+)))))
+  (dispatch-epoch-to-subs! record))
+
+(defn subscribe!
+  "Open a streaming subscription on the trace or epoch bus. Returns
+   `{:ok? true :sub-id <uuid>}`. Subsequent calls to
+   `drain-subscription!` return queued events matching `:filter`.
+
+   Opts:
+     :topic   :trace | :epoch | :fx | :error  (required)
+     :filter  filter map — vocab depends on topic. See namespace docs.
+     :max-buffered  cap on the in-runtime queue. Default 500. Once
+                    the cap is reached, new events are dropped and
+                    counted in `:overflow`.
+
+   Idempotency: each call returns a fresh sub-id — repeated `subscribe!`
+   calls do not share state. Use `unsubscribe!` to release."
+  [{:keys [topic filter max-buffered] :as opts}]
+  (cond
+    (not (contains? #{:trace :epoch :fx :error} topic))
+    {:ok? false :reason :unknown-topic
+     :hint "Recognised topics: :trace :epoch :fx :error"
+     :given topic}
+
+    :else
+    (let [sub-id (str (random-uuid))
+          compiled (when (#{:trace :fx :error} topic)
+                     (compose-trace-filter topic filter))
+          sub {:id            sub-id
+               :topic         topic
+               :filter        (or filter {})
+               :compiled-filter compiled
+               :queue         []
+               :overflow      0
+               :created-at    (js/Date.now)
+               :max-buffered  (or max-buffered default-max-buffered)}]
+      ;; Make sure the upgraded listeners are wired (idempotent — same
+      ;; id, replaces the basic listeners installed by `health`).
+      (rf/register-trace-cb! :re-frame-pair2 on-trace-streaming)
+      (rf/register-epoch-cb! :re-frame-pair2-epoch on-epoch-streaming)
+      (swap! subscriptions assoc sub-id sub)
+      {:ok? true :sub-id sub-id :topic topic :filter (:filter sub)})))
+
+(defn unsubscribe!
+  "Drop subscription `sub-id`. Returns `{:ok? true :sub-id ...}` even
+   if the id was unknown — callers (the MCP server's poll loop) want
+   idempotent close."
+  [sub-id]
+  (let [existed? (contains? @subscriptions sub-id)]
+    (swap! subscriptions dissoc sub-id)
+    {:ok? true :sub-id sub-id :existed? existed?}))
+
+(defn drain-subscription!
+  "Pop every queued event for `sub-id` and return them in order.
+   Returns `{:ok? true :sub-id ... :events [...] :overflow <n> :gone? bool}`.
+   If the subscription doesn't exist (already unsubscribed or runtime
+   was reloaded), `:gone? true`."
+  [sub-id]
+  (let [snap (atom nil)]
+    (swap! subscriptions
+           (fn [m]
+             (if-let [sub (get m sub-id)]
+               (do (reset! snap {:events (:queue sub)
+                                 :overflow (:overflow sub)})
+                   (assoc m sub-id (-> sub
+                                       (assoc :queue [])
+                                       (assoc :overflow 0))))
+               (do (reset! snap nil) m))))
+    (if-let [{:keys [events overflow]} @snap]
+      {:ok? true :sub-id sub-id :events events :overflow (or overflow 0) :gone? false}
+      {:ok? true :sub-id sub-id :events [] :overflow 0 :gone? true})))
+
+(defn subscription-info
+  "Return active subscription metadata — handy for diagnostics. Returns
+   `{:ok? true :subs [{:id :topic :filter :queue-depth :overflow :created-at}]}`.
+   Does not drain."
+  []
+  {:ok? true
+   :subs (mapv (fn [[sub-id sub]]
+                 {:id        sub-id
+                  :topic     (:topic sub)
+                  :filter    (:filter sub)
+                  :queue-depth (count (:queue sub))
+                  :overflow  (:overflow sub)
+                  :created-at (:created-at sub)})
+               @subscriptions)})
 
 ;; ---------------------------------------------------------------------------
 ;; Dispatch correlation (Spec 009 §Dispatch correlation)

--- a/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
@@ -1,0 +1,300 @@
+;;;; tests/runtime/streaming_subscriptions_test.clj
+;;;;
+;;;; Babashka-runnable verification of the streaming subscription
+;;;; substrate in `preload/re_frame_pair2/runtime.cljs` (rf2-hq49) —
+;;;; `subscribe!`, `drain-subscription!`, `unsubscribe!`, and the
+;;;; trace + epoch dispatchers.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `preload/re_frame_pair2/runtime.cljs` is a CLJS-only file loaded
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
+;;;;   depends on the live re-frame2 trace bus + epoch bus + reagent
+;;;;   atom — none of which run under bb. This file mirrors the
+;;;;   subscription registry, the filter compiler, the per-topic
+;;;;   dispatcher routing, and the drain semantics, and asserts the
+;;;;   behaviour against pure-data inputs.
+;;;;
+;;;;   KEEP IN SYNC WITH preload/re_frame_pair2/runtime.cljs §Streaming
+;;;;   subscriptions.
+;;;;
+;;;; Run:    bb tests/runtime/streaming_subscriptions_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns streaming-subscriptions-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of the subscription registry + helpers.
+;; ---------------------------------------------------------------------------
+
+(def default-max-buffered 500)
+
+(defn topic->base-filter
+  [topic]
+  (case topic
+    :fx    {:op-type :fx}
+    :error {:op-type :error}
+    {}))
+
+(defn compose-trace-filter
+  [topic user-filter]
+  (merge (topic->base-filter topic) (or user-filter {})))
+
+(defn trace-matches?
+  [filter-map ev]
+  (let [{:keys [operation op-type frame severity
+                event-id handler-id source origin
+                dispatch-id since-ms between]}
+        filter-map
+        [t0 t1] (when (and (sequential? between) (= 2 (count between)))
+                  between)]
+    (boolean
+      (and (or (nil? operation)  (= operation (:operation ev)))
+           (or (nil? op-type)    (= op-type   (:op-type ev)))
+           (or (nil? severity)   (= severity  (:op-type ev)))
+           (or (nil? frame)      (= frame
+                                    (or (:frame ev)
+                                        (get-in ev [:tags :frame]))))
+           (or (nil? event-id)   (= event-id
+                                    (get-in ev [:tags :event-id])))
+           (or (nil? handler-id) (= handler-id
+                                    (get-in ev [:tags :handler-id])))
+           (or (nil? source)     (= source
+                                    (or (:source ev)
+                                        (get-in ev [:tags :source]))))
+           (or (nil? origin)     (= origin
+                                    (get-in ev [:tags :origin])))
+           (or (nil? dispatch-id)(= dispatch-id
+                                    (get-in ev [:tags :dispatch-id])))
+           (or (nil? since-ms)   (and (number? (:time ev))
+                                      (> (:time ev) since-ms)))
+           (or (nil? t0)         (and (number? (:time ev))
+                                      (<= t0 (:time ev) t1)))))))
+
+;; Mirror of epoch-matches? (subset of the keys the runtime exposes —
+;; enough to exercise the dispatch routing).
+(defn epoch-matches?
+  [pred {:keys [event-id effects frame]}]
+  (let [{p-eid    :event-id
+         p-fx     :effects
+         p-frame  :frame} pred]
+    (boolean
+      (and
+        (if p-eid    (= p-eid event-id) true)
+        (if p-fx     (some #(= p-fx (:fx-id %)) effects) true)
+        (if p-frame  (= p-frame frame) true)))))
+
+(defn enqueue!
+  [sub event]
+  (let [q   (:queue sub)
+        n   (count q)
+        cap (:max-buffered sub default-max-buffered)]
+    (if (>= n cap)
+      (update sub :overflow (fnil inc 0))
+      (update sub :queue conj event))))
+
+(defn dispatch-trace-to-subs!
+  [subs ev]
+  (reduce-kv
+    (fn [acc sub-id sub]
+      (if (and (contains? #{:trace :fx :error} (:topic sub))
+               (trace-matches? (:compiled-filter sub) ev))
+        (update acc sub-id enqueue! ev)
+        acc))
+    subs subs))
+
+(defn dispatch-epoch-to-subs!
+  [subs record]
+  (reduce-kv
+    (fn [acc sub-id sub]
+      (if (and (= :epoch (:topic sub))
+               (epoch-matches? (or (:filter sub) {}) record))
+        (update acc sub-id enqueue! record)
+        acc))
+    subs subs))
+
+(defn subscribe!
+  [subs sub-id {:keys [topic filter max-buffered]}]
+  (let [compiled (when (#{:trace :fx :error} topic)
+                   (compose-trace-filter topic filter))
+        sub {:id sub-id
+             :topic topic
+             :filter (or filter {})
+             :compiled-filter compiled
+             :queue []
+             :overflow 0
+             :created-at 0
+             :max-buffered (or max-buffered default-max-buffered)}]
+    (assoc subs sub-id sub)))
+
+(defn drain-subscription!
+  [subs sub-id]
+  (if-let [sub (get subs sub-id)]
+    [{:events (:queue sub) :overflow (:overflow sub) :gone? false}
+     (assoc subs sub-id (-> sub (assoc :queue []) (assoc :overflow 0)))]
+    [{:events [] :overflow 0 :gone? true}
+     subs]))
+
+(defn unsubscribe!
+  [subs sub-id]
+  (let [existed? (contains? subs sub-id)]
+    [{:existed? existed?} (dissoc subs sub-id)]))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest topic-sugar-base-filters
+  (testing ":fx topic adds :op-type :fx as a base filter"
+    (is (= {:op-type :fx} (compose-trace-filter :fx nil))))
+  (testing ":error topic adds :op-type :error"
+    (is (= {:op-type :error} (compose-trace-filter :error nil))))
+  (testing ":trace topic adds no base — user filter is the only constraint"
+    (is (= {} (compose-trace-filter :trace nil))))
+  (testing "user filter overrides the topic's base on conflict"
+    (is (= {:op-type :error :event-id :user/login}
+           (compose-trace-filter :fx {:op-type :error :event-id :user/login})))))
+
+(deftest trace-filter-matches-by-event-id
+  (let [filter-map {:event-id :user/login}
+        match     {:operation :event/dispatched :tags {:event-id :user/login}}
+        no-match  {:operation :event/dispatched :tags {:event-id :user/logout}}]
+    (is (trace-matches? filter-map match))
+    (is (not (trace-matches? filter-map no-match)))))
+
+(deftest trace-filter-matches-by-severity
+  (let [filter-map {:severity :error}
+        match     {:op-type :error}
+        no-match  {:op-type :info}]
+    (is (trace-matches? filter-map match))
+    (is (not (trace-matches? filter-map no-match)))))
+
+(deftest trace-filter-matches-between
+  (let [filter-map {:between [100 200]}]
+    (is (trace-matches? filter-map {:time 150}))
+    (is (trace-matches? filter-map {:time 100}))
+    (is (trace-matches? filter-map {:time 200}))
+    (is (not (trace-matches? filter-map {:time 99})))
+    (is (not (trace-matches? filter-map {:time 201})))))
+
+(deftest trace-filter-frame-falls-back-to-tags
+  (let [filter-map {:frame :stories}]
+    (is (trace-matches? filter-map {:tags {:frame :stories}}))
+    (is (trace-matches? filter-map {:frame :stories}))
+    (is (not (trace-matches? filter-map {:tags {:frame :rf/default}})))))
+
+(deftest epoch-filter-matches-by-event-id
+  (is (epoch-matches? {:event-id :cart/add} {:event-id :cart/add}))
+  (is (not (epoch-matches? {:event-id :cart/add} {:event-id :cart/remove}))))
+
+(deftest epoch-filter-matches-by-effects
+  (is (epoch-matches? {:effects :http} {:effects [{:fx-id :http} {:fx-id :db}]}))
+  (is (not (epoch-matches? {:effects :http} {:effects [{:fx-id :db}]}))))
+
+(deftest subscribe-and-drain-roundtrips
+  (let [subs (-> {} (subscribe! "s1" {:topic :trace :filter {:op-type :error}}))]
+    (is (contains? subs "s1"))
+    (is (= :trace (get-in subs ["s1" :topic])))
+    (let [;; Three events, only one matches.
+          ev1 {:op-type :error :tags {:event-id :user/login}}
+          ev2 {:op-type :info  :tags {:event-id :user/login}}
+          ev3 {:op-type :error :tags {:event-id :user/logout}}
+          subs (-> subs
+                   (dispatch-trace-to-subs! ev1)
+                   (dispatch-trace-to-subs! ev2)
+                   (dispatch-trace-to-subs! ev3))]
+      (let [[drain1 subs] (drain-subscription! subs "s1")]
+        (is (= 2 (count (:events drain1))))
+        (is (= ev1 (first (:events drain1))))
+        (is (= ev3 (second (:events drain1))))
+        (is (false? (:gone? drain1)))
+        ;; A second drain (immediately after) returns empty — the
+        ;; queue is reset.
+        (let [[drain2 _] (drain-subscription! subs "s1")]
+          (is (empty? (:events drain2))))))))
+
+(deftest unsubscribe-deletes-and-future-drains-mark-gone
+  (let [subs (-> {} (subscribe! "s1" {:topic :trace}))
+        ;; Confirm the sub is live.
+        _ (is (contains? subs "s1"))
+        [unsub-resp subs] (unsubscribe! subs "s1")]
+    (is (true? (:existed? unsub-resp)))
+    (is (not (contains? subs "s1")))
+    (let [[drain-resp _] (drain-subscription! subs "s1")]
+      (is (true? (:gone? drain-resp)))
+      (is (empty? (:events drain-resp))))))
+
+(deftest unsubscribe-unknown-is-idempotent
+  (let [subs {}
+        [resp subs] (unsubscribe! subs "phantom")]
+    (is (false? (:existed? resp)))
+    (is (= {} subs))))
+
+(deftest epoch-subscription-only-receives-epoch-events
+  ;; An :epoch sub should NOT be fed trace events; a :trace sub should
+  ;; NOT be fed epoch records. Verifies the topic gating in the
+  ;; dispatchers.
+  (let [subs (-> {}
+                 (subscribe! "epoch-sub" {:topic :epoch :filter {:event-id :cart/add}})
+                 (subscribe! "trace-sub" {:topic :trace}))
+        ;; A trace event flows only to the trace sub.
+        subs (dispatch-trace-to-subs! subs {:op-type :info :tags {}})
+        ;; An epoch record flows only to the epoch sub (matching filter).
+        subs (dispatch-epoch-to-subs! subs {:event-id :cart/add :effects []})]
+    (is (= 1 (count (get-in subs ["trace-sub" :queue]))))
+    (is (= 1 (count (get-in subs ["epoch-sub" :queue]))))))
+
+(deftest fx-topic-defaults-op-type-but-respects-overrides
+  (let [;; :fx sub with no extra filter matches any trace event with
+        ;; :op-type :fx.
+        subs (-> {} (subscribe! "fx-sub" {:topic :fx}))
+        ev   {:op-type :fx :tags {:fx-id :http}}
+        ev2  {:op-type :info :tags {}}
+        subs (-> subs
+                 (dispatch-trace-to-subs! ev)
+                 (dispatch-trace-to-subs! ev2))]
+    (is (= [ev] (get-in subs ["fx-sub" :queue]))))
+  (testing "user filter can override the topic's base op-type"
+    (let [subs (-> {} (subscribe! "fx-sub" {:topic :fx :filter {:op-type :info}}))
+          ev   {:op-type :fx :tags {}}
+          ev2  {:op-type :info :tags {}}
+          subs (-> subs
+                   (dispatch-trace-to-subs! ev)
+                   (dispatch-trace-to-subs! ev2))]
+      (is (= [ev2] (get-in subs ["fx-sub" :queue]))))))
+
+(deftest error-topic-matches-error-traces
+  (let [subs (-> {} (subscribe! "err-sub" {:topic :error}))
+        err  {:op-type :error :tags {:handler-id :user/login}}
+        ok   {:op-type :info :tags {}}
+        subs (-> subs
+                 (dispatch-trace-to-subs! err)
+                 (dispatch-trace-to-subs! ok))]
+    (is (= [err] (get-in subs ["err-sub" :queue])))))
+
+(deftest queue-cap-counts-overflow-keeps-oldest
+  (let [subs (-> {} (subscribe! "s" {:topic :trace :max-buffered 2}))
+        e1 {:op-type :info :id 1}
+        e2 {:op-type :info :id 2}
+        e3 {:op-type :info :id 3}
+        e4 {:op-type :info :id 4}
+        subs (-> subs
+                 (dispatch-trace-to-subs! e1)
+                 (dispatch-trace-to-subs! e2)
+                 (dispatch-trace-to-subs! e3)
+                 (dispatch-trace-to-subs! e4))]
+    (is (= 2 (count (get-in subs ["s" :queue]))))
+    (is (= [e1 e2] (get-in subs ["s" :queue])))
+    (is (= 2 (get-in subs ["s" :overflow])))))
+
+(deftest unknown-topic-rejected-at-subscribe-level
+  ;; The runtime's `subscribe!` returns {:ok? false :reason :unknown-topic}
+  ;; — mirrored here as the dispatcher refusing to fan to an unknown topic.
+  (let [recognised #{:trace :epoch :fx :error}]
+    (is (not (contains? recognised :other)))
+    (is (every? recognised [:trace :epoch :fx :error]))))
+
+(let [{:keys [fail error]} (run-tests 'streaming-subscriptions-test)]
+  (when (or (pos? fail) (pos? error))
+    (System/exit 1)))

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -1,6 +1,6 @@
 # 003-Tool-Catalogue
 
-The seven MCP tools.
+The nine MCP tools.
 
 ## discover-app
 
@@ -130,3 +130,155 @@ know yet which slice carries the answer.
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :snapshot-failed` (with `:message`) on any other failure.
+
+## subscribe
+
+Streaming subscription on the trace or epoch bus (rf2-hq49). Push-mode
+replacement for the polling-shaped `watch-epochs` op. The MCP
+`tools/call` request stays open for the lifetime of the subscription;
+each batch of matching events is emitted as a
+`notifications/progress` notification correlated to the original call
+via `extra._meta.progressToken`. The final `tools/call` result is a
+summary `{:ok? true :sub-id :delivered N :overflow N :ticks K :reason
+<terminated-reason>}`.
+
+### Topics
+
+| Topic    | What gets pushed                                                  |
+|----------|-------------------------------------------------------------------|
+| `trace`  | Every raw trace event matching `filter`.                          |
+| `epoch`  | Every assembled `:rf/epoch-record` matching `filter`.             |
+| `fx`     | Sugar — `topic :trace` with base filter `{:op-type :fx}`.         |
+| `error`  | Sugar — `topic :trace` with base filter `{:op-type :error}`.      |
+
+User-supplied filter keys win over the topic's base filter on conflict
+— the topic is a default, not a lock. So `subscribe {:topic :fx
+:filter {:op-type :info}}` actually streams `:info` traces (the user
+filter wins). Don't do this — but the substrate doesn't refuse it.
+
+### Filter vocabulary
+
+For `topic` of `:trace`, `:fx`, or `:error`, the filter map mirrors the
+`(re-frame.core/trace-buffer opts)` filter vocabulary (rf2-97ah0).
+Recognised keys (all AND-compose; absent key means "no constraint on
+that axis"):
+
+| Key              | Match against (`ev` is the event)                                 |
+|------------------|-------------------------------------------------------------------|
+| `:operation`     | `(= operation (:operation ev))`                                   |
+| `:op-type`       | `(= op-type (:op-type ev))`                                       |
+| `:severity`      | Alias for `:op-type`, restricted to `:error` / `:warning` / `:info`. |
+| `:frame`         | `(:frame ev)` or `(get-in ev [:tags :frame])`                     |
+| `:event-id`      | `(get-in ev [:tags :event-id])`                                   |
+| `:handler-id`    | `(get-in ev [:tags :handler-id])`                                 |
+| `:source`        | `(:source ev)` or `(get-in ev [:tags :source])` — one of `:ui` / `:timer` / `:http` / `:repl` / `:machine` / `:ssr-hydration`. |
+| `:origin`        | `(get-in ev [:tags :origin])` — `:app` / `:pair` / `:story` / `:test`. |
+| `:dispatch-id`   | `(get-in ev [:tags :dispatch-id])`                                |
+| `:since-ms`      | `(> (:time ev) since-ms)` — strict-greater-than host-clock ms.    |
+| `:between`       | `[t0 t1]` — `(<= t0 (:time ev) t1)` host-clock ms.                |
+
+For `topic :epoch`, the filter map mirrors `epoch-matches?` (same
+vocab `watch-epochs` already accepts):
+
+| Key                  | Match against (`e` is the `:rf/epoch-record`)                 |
+|----------------------|---------------------------------------------------------------|
+| `:event-id`          | `(:event-id e)`                                               |
+| `:event-id-prefix`   | `(str/starts-with? (str event-id) (str prefix))`              |
+| `:effects`           | `(some #(= effects (:fx-id %)) (:effects e))`                 |
+| `:touches-path`      | `(:db-before e)` or `(:db-after e)` carries something at path |
+| `:sub-ran`           | `(some #(or (= sub-ran (:sub-id %)) (= sub-ran (first (:query-v %)))) (:sub-runs e))` |
+| `:render`            | `(some #(= render (str (:render-key %))) (:renders e))`       |
+| `:origin`            | One of the `:event/dispatched` traces has `(:tags :origin)` = `origin`. |
+| `:frame`             | `(= frame (:frame e))`                                        |
+
+### Args
+
+- `topic` (string, **required**) — one of `"trace"`, `"epoch"`, `"fx"`,
+  `"error"`.
+- `filter` (object **or** string, optional) — filter map. Accepted as
+  a JSON object or an EDN-encoded string. EDN is preferred when the
+  filter carries keywords or namespaced ids (a JSON object can't
+  carry `:cart/add` natively).
+- `max-buffered` (integer, default `500`) — runtime-side queue cap.
+  When full, new events are dropped and the count is reported in
+  `:overflow`. The dropped events are the *newest* — keeping the
+  oldest lets you reconstruct the start of a storm.
+- `poll-ms` (integer, default `100`) — server-side poll cadence. The
+  MCP server polls the runtime's drain at this interval and emits a
+  progress notification per non-empty batch.
+- `max-ms` (integer, default `0` = unbounded) — hard upper-bound on
+  how long the subscription stays open. `0` = stay open until the
+  client cancels.
+- `max-events` (integer, default `0` = unbounded) — terminate after
+  this many events have been delivered.
+- `build` (string, default `"app"`) — shadow-cljs build id.
+
+### Returns
+
+While the subscription is open, each non-empty batch tick emits
+
+```jsonc
+{
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "<token>",  // echoed from the call's _meta
+    "progress": <tick-number>,   // monotonic, 1-based
+    "message": "{:sub-id \"...\" :events [...] :overflow 0}",
+    "data": { "overflow": 0 }
+  }
+}
+```
+
+`message` is an EDN-printed string carrying the event batch — the
+same shape the runtime's `drain-subscription!` returns. Capable MCP
+clients can also inspect `data.overflow` for the count of dropped
+events on this tick.
+
+On termination, the `tools/call` result is
+
+```clojure
+{:ok? true
+ :sub-id <uuid>
+ :topic  <keyword>
+ :delivered <integer>
+ :overflow  <integer>
+ :ticks     <integer>
+ :reason    :aborted | :sub-gone | :max-ms-reached | :max-events-reached}
+```
+
+`:reason` is `:aborted` when the client cancelled the call,
+`:sub-gone` when the runtime's subscription disappeared (typically a
+full page reload, or an `unsubscribe` op fired separately),
+`:max-ms-reached` / `:max-events-reached` when the caller's
+upper-bounds fire.
+
+### Termination paths
+
+1. **Client cancel** — the MCP client cancels the `tools/call`. The
+   server's `extra.signal` AbortSignal fires; the poll loop notices
+   on its next tick, evaluates `unsubscribe!` against the runtime,
+   and resolves with `:reason :aborted`.
+2. **Out-of-band `unsubscribe`** — a separate MCP call to the
+   `unsubscribe` tool removes the sub from the runtime registry.
+   The next drain returns `:gone? true`; the poll loop resolves
+   with `:reason :sub-gone`.
+3. **Cap reached** — `max-ms` or `max-events` is exceeded.
+
+### Failure modes
+
+- `:reason :unknown-topic` if `topic` is missing or not one of the
+  four. Surfaced as `isError: true`.
+- `:reason :runtime-not-preloaded` if the preload hasn't run.
+- `:reason :subscribe-failed` on any other failure during subscribe.
+
+## unsubscribe
+
+Close a streaming subscription out-of-band. Idempotent — closing an
+unknown sub-id returns `{:ok? true :sub-id <id> :existed? false}`
+rather than an error. Useful when an MCP client wants to stop a
+stream without cancelling the `tools/call` directly (e.g. when the
+agent host can't propagate cancellation cleanly).
+
+**Args**: `sub-id` (string, **required**), `build` (string).
+
+**Returns**: `{:ok? true :sub-id <id> :existed? <bool>}`.

--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -110,7 +110,7 @@ node out/server.js
 
 ## Tool surface
 
-The seven tools, in the order a typical session uses them. Argument
+The nine tools, in the order a typical session uses them. Argument
 schemas and result shapes are specified in
 [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md).
 
@@ -123,6 +123,8 @@ schemas and result shapes are specified in
 | `watch-epochs` | Pull-mode poll for matching epochs since a given id. |
 | `tail-build` | Wait for a hot-reload to land by polling a probe form. |
 | `snapshot`   | Coarse-grained per-frame state read in one round-trip. Returns `:app-db` + `:sub-cache` + `:machines` + `:epochs` + `:traces` slices for every (or a subset of) frame(s). Mega-op for investigate-X workflows. |
+| `subscribe` | Streaming subscription on the trace / epoch bus (rf2-hq49). Push-mode replacement for `watch-epochs`; each matching event arrives as a `notifications/progress` notification. Topics: `trace`, `epoch`, `fx`, `error`. |
+| `unsubscribe` | Close a streaming subscription out-of-band. Idempotent. |
 
 (Pre-rf2-7dvg drops also exposed `inject-runtime`. That tool is gone:
 the runtime ships into consumer apps via shadow-cljs `:devtools
@@ -204,6 +206,7 @@ analogues. Listed here for reference:
 | `re-frame-pair2.runtime/watch-epochs` | preload/re_frame_pair2/runtime.cljs | Poll for epochs after id. |
 | `re-frame-pair2.runtime/probe` | preload/re_frame_pair2/runtime.cljs | Hot-reload landed signal. |
 | `re-frame-pair2.runtime/snapshot-state` | preload/re_frame_pair2/runtime.cljs | Per-frame slice composer fed by `:include` / `:frames` opts; backs the `snapshot` MCP tool. |
+| `re-frame-pair2.runtime/subscribe!` / `drain-subscription!` / `unsubscribe!` | preload/re_frame_pair2/runtime.cljs | Per-subscription filtered queue on the trace + epoch bus; backs the `subscribe` MCP tool (rf2-hq49). |
 | `shadow.cljs.devtools.api/cljs-eval` | shadow-cljs | The CLJS bridge over the JVM-side nREPL socket. |
 | `:rf/epoch-record` | framework | The epoch record shape returned by trace mode. |
 | `:origin :pair` (in event tags) | framework | Pair2's dispatches surface in the trace stream distinguishably. |
@@ -223,6 +226,7 @@ identical between the two surfaces.
 | `watch-epochs.sh` | `watch-epochs` |
 | `tail-build.sh` | `tail-build` |
 | _(none — MCP-only)_ | `snapshot` |
+| _(none — MCP-only)_ | `subscribe` / `unsubscribe` |
 
 The `snapshot` mega-op has no bash equivalent — it's a coarse-grained
 composition of the existing per-slice runtime readers, shipped as
@@ -250,7 +254,7 @@ vocabulary changes.
 ## What this doesn't expose
 
 - **No new framework primitives.** No new registries, no new
-  dispatch types, no new effect substrates. The seven ops route
+  dispatch types, no new effect substrates. The nine ops route
   through existing `re-frame-pair2.runtime` surfaces. See
   [`Principles.md`](./Principles.md) § Tool consumes the framework.
 - **No remote-attach protocol.** pair2-mcp is stdio-only; the agent
@@ -260,6 +264,11 @@ vocabulary changes.
 - **No "private" surfaces.** All public ops are listed in
   [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md); there are no
   hidden tools, no internal-only endpoints.
-- **No long-running streaming.** MCP isn't a streaming protocol;
-  `watch-epochs` is pull-mode, called repeatedly with the same
-  `since-id` rather than maintaining a server-pushed feed.
+- **No raw streaming transport.** MCP isn't a streaming protocol per
+  se. The streaming-shaped tools (`subscribe`, `unsubscribe`, rf2-hq49)
+  layer over MCP's `notifications/progress` mechanism: the server polls
+  the runtime's drain at `poll-ms` and emits one progress notification
+  per non-empty batch. The poll cadence is well below the agent loop's
+  perceptual threshold; the `tools/call` stays open for the lifetime
+  of the subscription and resolves on cancel / `unsubscribe` /
+  caller-supplied caps.

--- a/tools/pair2-mcp/spec/README.md
+++ b/tools/pair2-mcp/spec/README.md
@@ -5,7 +5,7 @@
 - **[000-Vision.md](000-Vision.md)** — Why an MCP server beats the bash-shim chain: pay cold-connect cost once per session, not per op (~700ms → ~5–50ms).
 - **[001-Wire-Protocol.md](001-Wire-Protocol.md)** — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec; framed by `@modelcontextprotocol/sdk`.
 - **[002-nREPL-Transport.md](002-nREPL-Transport.md)** — Persistent TCP socket to `127.0.0.1:<nrepl-port>`; multiplexed by UUID `id`; held for session lifetime.
-- **[003-Tool-Catalogue.md](003-Tool-Catalogue.md)** — The seven MCP tools mirroring the bash-shim catalogue: `discover-app`, plus six more.
+- **[003-Tool-Catalogue.md](003-Tool-Catalogue.md)** — The nine MCP tools: `discover-app`, `eval-cljs`, `dispatch`, `trace-window`, `watch-epochs`, `tail-build`, `snapshot`, plus the streaming pair `subscribe` / `unsubscribe` (rf2-hq49).
 - **[API.md](API.md)** — Consolidated user-facing reference for installing, configuring, launching, and calling pair2-mcp.
 - **[Principles.md](Principles.md)** — pair2-mcp-specific load-bearing principles, downstream of framework `Principles.md`.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Direction-setting decisions: question, options, pick, why, date locked.

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
@@ -64,11 +64,11 @@
 (defn- handle-list [_req]
   (js/Promise.resolve #js {:tools (tools/tool-descriptors-js)}))
 
-(defn- handle-call [conn req]
+(defn- handle-call [conn req extra]
   (let [params (j/get req :params)
         name   (j/get params :name)
         args   (or (j/get params :arguments) #js {})]
-    (-> (tools/invoke conn name args)
+    (-> (tools/invoke conn name args extra)
         (.catch (fn [err]
                   (log! "handler threw for" name "—" (.-message err))
                   #js {:isError true
@@ -91,7 +91,8 @@
                  #js {:name server-name :version server-version}
                  #js {:capabilities #js {:tools #js {}}})]
     (j/call server :setRequestHandler ListToolsSchema handle-list)
-    (j/call server :setRequestHandler CallToolSchema (fn [req] (handle-call conn req)))
+    (j/call server :setRequestHandler CallToolSchema
+            (fn [req extra] (handle-call conn req extra)))
     server))
 
 (defn main [& _args]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -14,6 +14,9 @@
   | watch-epochs  | Pull-mode live epoch streaming                            |
   | tail-build    | Wait for a hot-reload to land                             |
   | snapshot      | Coarse-grained per-frame state read (mega-op)             |
+  | subscribe     | Streaming trace/epoch channel — push-mode replacement for |
+  |               | watch-epochs (rf2-hq49)                                   |
+  | unsubscribe   | Close a streaming subscription                            |
 
   ## Preload probe (no per-session inject)
 
@@ -34,6 +37,7 @@
   Each MCP tool returns `{:content [{:type \"text\" :text <edn-string>}]}`
   on success, or `{:isError true :content [...]}` on failure."
   (:require [applied-science.js-interop :as j]
+            [cljs.reader]
             [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]))
 
@@ -394,6 +398,211 @@
         (.catch (fn [err] (err->result :snapshot-failed err))))))
 
 ;; ---------------------------------------------------------------------------
+;; Tool: subscribe — streaming trace + epoch channel (rf2-hq49).
+;;
+;; The MCP `tools/call` request runs until either:
+;;   (a) the client aborts (cancellation arrives via the MCP `extra.signal`
+;;       AbortSignal), or
+;;   (b) an `unsubscribe` op clears the sub-id from the runtime.
+;;
+;; While running, each batch of newly-queued runtime events is shipped to
+;; the client as a `notifications/progress` notification correlated to the
+;; original tools/call via `extra._meta.progressToken`. The final
+;; `tools/call` result is a summary `{:ok? true :sub-id :delivered N
+;; :overflow N :reason <terminated-reason>}`.
+;;
+;; The runtime queue is bounded (default 500); overflow events get
+;; counted in a per-sub `:overflow` slot and surfaced verbatim. The
+;; server's poll cadence (`:poll-ms`, default 100) is well below the
+;; agent-loop perceptual threshold and costs one bencode round-trip
+;; per tick.
+;;
+;; Filter vocabulary (server-side normalisation happens on the runtime).
+;;
+;; Topics:
+;;   :trace  — every entry of the raw trace stream matching `:filter`.
+;;             `:filter` keys: :operation :op-type :frame :severity
+;;                            :event-id :handler-id :source :origin
+;;                            :dispatch-id :since-ms :between
+;;             (mirrors `(rf/trace-buffer)` per rf2-97ah0).
+;;   :epoch  — every assembled `:rf/epoch-record` matching `:filter`.
+;;             `:filter` keys: :event-id :event-id-prefix :effects
+;;                            :touches-path :sub-ran :render :origin
+;;                            :frame  (mirrors `epoch-matches?`).
+;;   :fx     — sugar for :topic :trace :filter {:op-type :fx ...}.
+;;   :error  — sugar for :topic :trace :filter {:op-type :error ...}.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-poll-ms 100)
+
+(defn- progress-payload
+  "Build the JSON params payload for one `notifications/progress` tick.
+  `events` is the EDN-printed string of the batch (kept as a string so
+  the agent host sees the same shape as `tools/call` results)."
+  [progress-token tick events overflow]
+  #js {:progressToken progress-token
+       :progress      tick
+       ;; `message` is the human-readable slot. We stash an EDN form
+       ;; here so an MCP client that surfaces progress messages to
+       ;; the agent shows the events directly. A capable client can
+       ;; additionally inspect the `data` slot for the structured
+       ;; counts.
+       :message       events
+       :data          #js {:overflow overflow}})
+
+(defn- parse-filter-arg
+  "MCP-side filter arg can be either a JS object or an EDN string. We
+  accept both for ergonomic parity with the bash-shim chain (`pred`
+  has been a JSON object there). Returns an EDN-printable map or nil
+  when missing."
+  [raw]
+  (cond
+    (nil? raw)        nil
+    (string? raw)     (try (cljs.reader/read-string raw)
+                           (catch :default _
+                             {:invalid-filter-edn raw}))
+    (map? raw)        raw
+    :else             (js->clj raw :keywordize-keys true)))
+
+(defn- subscribe-tool [conn args extra]
+  (let [build-id    (arg-build args)
+        topic       (some-> (arg args :topic) keyword)
+        filter-map  (parse-filter-arg (arg args :filter))
+        max-buf     (or (arg args :max-buffered) 500)
+        poll-ms     (or (arg args :poll-ms) default-poll-ms)
+        max-ms      (or (arg args :max-ms) 0)    ;; 0 = no upper bound
+        max-events  (or (arg args :max-events) 0) ;; 0 = no upper bound
+        progress-tk (some-> extra
+                            (j/get :_meta)
+                            (j/get :progressToken))
+        send-note   (some-> extra (j/get :sendNotification))
+        signal      (some-> extra (j/get :signal))]
+    (cond
+      (or (nil? topic)
+          (not (#{:trace :epoch :fx :error} topic)))
+      (js/Promise.resolve
+        (err-text {:ok? false :reason :unknown-topic
+                   :given (arg args :topic)
+                   :hint "Recognised topics: trace, epoch, fx, error."}))
+
+      :else
+      (let [subscribe-form
+            (str "(re-frame-pair2.runtime/subscribe! "
+                 (pr-str (cond-> {:topic topic
+                                  :max-buffered max-buf}
+                           filter-map (assoc :filter filter-map)))
+                 ")")]
+        (-> (ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id subscribe-form)))
+            (.then
+              (fn [subscribe-resp]
+                (if-not (:ok? subscribe-resp)
+                  ;; Runtime refused (unknown topic, etc.) — surface verbatim.
+                  (ok-text subscribe-resp)
+                  (let [sub-id (:sub-id subscribe-resp)]
+                    (js/Promise.
+                      (fn [resolve _reject]
+                        (let [tick      (atom 0)
+                              delivered (atom 0)
+                              overflow* (atom 0)
+                              terminate
+                              (fn [reason]
+                                ;; Drop the runtime subscription and
+                                ;; resolve. Idempotent — unsubscribe!
+                                ;; returns :existed? false the second
+                                ;; time.
+                                (-> (nrepl/cljs-eval-value
+                                      conn build-id
+                                      (str "(re-frame-pair2.runtime/unsubscribe! "
+                                           (pr-str sub-id) ")"))
+                                    (.catch (fn [_] nil))
+                                    (.then
+                                      (fn [_]
+                                        (resolve
+                                          (ok-text
+                                            {:ok?        true
+                                             :sub-id     sub-id
+                                             :topic      topic
+                                             :delivered  @delivered
+                                             :overflow   @overflow*
+                                             :ticks      @tick
+                                             :reason     reason}))))))
+                              poll
+                              (fn poll []
+                                (cond
+                                  ;; Client cancelled the tools/call.
+                                  (and signal (.-aborted signal))
+                                  (terminate :aborted)
+
+                                  ;; Caller-supplied upper bounds.
+                                  (and (pos? max-events)
+                                       (>= @delivered max-events))
+                                  (terminate :max-events-reached)
+
+                                  :else
+                                  (-> (nrepl/cljs-eval-value
+                                        conn build-id
+                                        (str "(re-frame-pair2.runtime/drain-subscription! "
+                                             (pr-str sub-id) ")"))
+                                      (.then
+                                        (fn [drain-resp]
+                                          (cond
+                                            (:gone? drain-resp)
+                                            (terminate :sub-gone)
+
+                                            :else
+                                            (let [evts (:events drain-resp)
+                                                  ov   (:overflow drain-resp 0)
+                                                  n    (count evts)]
+                                              (swap! overflow* + ov)
+                                              (when (or (pos? n) (pos? ov))
+                                                (swap! tick inc)
+                                                (swap! delivered + n)
+                                                (when (and send-note progress-tk)
+                                                  (try
+                                                    (send-note
+                                                      #js {:method "notifications/progress"
+                                                           :params (progress-payload
+                                                                     progress-tk
+                                                                     @tick
+                                                                     (pr-str
+                                                                       {:sub-id sub-id
+                                                                        :events evts
+                                                                        :overflow ov})
+                                                                     ov)})
+                                                    (catch :default _ nil))))
+                                              (js/setTimeout poll poll-ms)))))
+                                      (.catch
+                                        (fn [_err]
+                                          ;; nREPL hiccup — back off
+                                          ;; and try again rather than
+                                          ;; collapsing the stream.
+                                          (js/setTimeout poll (* 2 poll-ms)))))))]
+                          ;; Optional max-ms hard cap.
+                          (when (pos? max-ms)
+                            (js/setTimeout #(terminate :max-ms-reached) max-ms))
+                          (poll))))))))
+            (.catch (fn [err] (err->result :subscribe-failed err))))))))
+
+(defn- unsubscribe-tool [conn args]
+  (let [build-id (arg-build args)
+        sub-id   (arg args :sub-id)]
+    (cond
+      (or (nil? sub-id) (str/blank? sub-id))
+      (js/Promise.resolve
+        (err-text {:ok? false :reason :missing-sub-id
+                   :hint "usage: unsubscribe {sub-id '<uuid>'}"}))
+
+      :else
+      (let [form (str "(re-frame-pair2.runtime/unsubscribe! "
+                      (pr-str sub-id) ")")]
+        (-> (ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [v] (ok-text (merge {:ok? true :sub-id sub-id}
+                                           (when (map? v) v)))))
+            (.catch (fn [err] (err->result :unsubscribe-failed err))))))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool descriptors — exposed via tools/list.
 ;; ---------------------------------------------------------------------------
 
@@ -460,6 +669,42 @@
                                          :items {:type "string"
                                                  :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
                                :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
+                  :additionalProperties false}}
+   {:name "subscribe"
+    :description (str "Open a streaming subscription on the trace or epoch bus. Push-mode replacement for watch-epochs. "
+                      "Long-running tools/call — emits each batch of matching events as a notifications/progress notification "
+                      "(correlated via the call's progressToken), and resolves with a summary when the client cancels or an "
+                      "unsubscribe op fires. Topics: 'trace' (raw trace stream), 'epoch' (assembled :rf/epoch-records), "
+                      "'fx' (trace stream filtered to :op-type :fx), 'error' (trace stream filtered to :op-type :error). "
+                      "Filter vocab depends on topic — :trace/:fx/:error accept the (rf/trace-buffer) filter map "
+                      "(:operation :op-type :frame :severity :event-id :handler-id :source :origin :dispatch-id :since-ms :between); "
+                      ":epoch accepts the epoch-matches? predicate map (:event-id :event-id-prefix :effects :touches-path "
+                      ":sub-ran :render :origin :frame). Pass `filter` either as a JSON object or as an EDN-encoded string.")
+    :inputSchema {:type "object"
+                  :properties {:topic   {:type "string"
+                                         :description "Topic name. Required."
+                                         :enum ["trace" "epoch" "fx" "error"]}
+                               :filter  {:description "Filter map (JSON object) or EDN string. Vocab depends on topic."
+                                         :oneOf [{:type "object"}
+                                                 {:type "string"}]}
+                               :max-buffered {:type "integer"
+                                              :description "Runtime-side queue cap. Default 500. Overflow is counted, not blocked."}
+                               :poll-ms {:type "integer"
+                                         :description "Server poll cadence in ms. Default 100."}
+                               :max-ms  {:type "integer"
+                                         :description "Hard upper-bound on how long the subscription stays open, ms. 0 = unbounded (close on cancel only). Default 0."}
+                               :max-events {:type "integer"
+                                            :description "Terminate after this many events have been delivered. 0 = unbounded. Default 0."}
+                               :build   {:type "string"}}
+                  :required ["topic"]
+                  :additionalProperties false}}
+   {:name "unsubscribe"
+    :description "Close the subscription with the given sub-id. Idempotent — closing an unknown sub-id returns :existed? false."
+    :inputSchema {:type "object"
+                  :properties {:sub-id {:type "string"
+                                        :description "The uuid returned by `subscribe`."}
+                               :build  {:type "string"}}
+                  :required ["sub-id"]
                   :additionalProperties false}}])
 
 (defn tool-descriptors-js []
@@ -469,8 +714,12 @@
   "Dispatch a `tools/call` invocation to the right tool implementation.
   Returns a Promise resolving to the MCP result object. Unknown tools
   resolve to an isError result rather than throwing — keeps the server
-  loop simple."
-  [conn name args]
+  loop simple.
+
+  `extra` carries the MCP `extra` payload (signal + sendNotification +
+  _meta.progressToken) for streaming tools. Non-streaming tools
+  ignore it."
+  [conn name args extra]
   (case name
     "discover-app"     (discover-app   conn args)
     "eval-cljs"        (eval-cljs-tool conn args)
@@ -479,5 +728,7 @@
     "watch-epochs"     (watch-epochs-tool conn args)
     "tail-build"       (tail-build-tool conn args)
     "snapshot"         (snapshot-tool  conn args)
+    "subscribe"        (subscribe-tool conn args extra)
+    "unsubscribe"      (unsubscribe-tool conn args)
     (js/Promise.resolve
       (err-text {:ok? false :reason :unknown-tool :tool name}))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -1,0 +1,132 @@
+(ns re-frame-pair2-mcp.subscribe-test
+  "Unit tests for the streaming subscribe / unsubscribe tools (rf2-hq49).
+
+  These tests cover the MCP-arg → runtime-form translation (the EDN
+  shape we send over nREPL), the filter-arg parser (JSON object vs
+  EDN string), and the descriptor wiring. The live end-to-end coverage
+  (notifications/progress emission, abort-signal termination) lives
+  in `test/stdio-roundtrip.js` and the live-nREPL integration test
+  against a real shadow-cljs build."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]
+            [clojure.string :as str]
+            [applied-science.js-interop :as j]))
+
+;; Mirror of `parse-filter-arg` from tools.cljs (private). Keeping a
+;; parallel test fixture documents the contract and pins the semantics —
+;; a rename in the source surfaces as a failing test rather than a
+;; silent contract drift.
+
+(defn- parse-filter [raw]
+  (cond
+    (nil? raw)    nil
+    (string? raw) (try (cljs.reader/read-string raw)
+                       (catch :default _
+                         {:invalid-filter-edn raw}))
+    (map? raw)    raw
+    :else         (js->clj raw :keywordize-keys true)))
+
+(deftest filter-arg-nil-passes-through
+  (is (nil? (parse-filter nil))))
+
+(deftest filter-arg-edn-string-reads
+  (is (= {:op-type :error}
+         (parse-filter "{:op-type :error}"))))
+
+(deftest filter-arg-edn-string-with-touches-path
+  (is (= {:touches-path [:cart :items]}
+         (parse-filter "{:touches-path [:cart :items]}"))))
+
+(deftest filter-arg-malformed-edn-surfaces-marker
+  (is (= {:invalid-filter-edn "((("}
+         (parse-filter "(((")))) ;; unbalanced delimiters
+
+(deftest filter-arg-js-object-keywordises
+  (let [obj #js {:op-type "error" :event-id "user/login"}
+        out (parse-filter obj)]
+    (is (map? out))
+    (is (= "error" (:op-type out)))
+    (is (= "user/login" (:event-id out)))))
+
+(deftest filter-arg-clj-map-passes-through
+  (is (= {:op-type :error}
+         (parse-filter {:op-type :error}))))
+
+;; The subscribe-form constructor is private. Re-implement here to
+;; pin the exact CLJS form we send to the runtime.
+
+(defn- subscribe-form
+  [topic filter-map max-buf]
+  (str "(re-frame-pair2.runtime/subscribe! "
+       (pr-str (cond-> {:topic topic :max-buffered max-buf}
+                 filter-map (assoc :filter filter-map)))
+       ")"))
+
+(deftest subscribe-form-with-trace-and-filter
+  (let [form (subscribe-form :trace {:op-type :error :event-id :user/login} 500)]
+    (is (re-find #":topic :trace" form))
+    (is (re-find #":max-buffered 500" form))
+    (is (re-find #":op-type :error" form))
+    (is (re-find #":event-id :user/login" form))))
+
+(deftest subscribe-form-without-filter-omits-key
+  (let [form (subscribe-form :epoch nil 250)]
+    (is (re-find #":topic :epoch" form))
+    (is (re-find #":max-buffered 250" form))
+    (is (not (re-find #":filter" form)))))
+
+(deftest subscribe-form-fx-topic
+  (let [form (subscribe-form :fx {:event-id :http/get} 100)]
+    (is (re-find #":topic :fx" form))
+    (is (re-find #":event-id :http/get" form))))
+
+;; Recognised topics — keep this set in lockstep with the runtime's
+;; subscribe! whitelist.
+
+(deftest recognised-topics
+  (let [recognised #{:trace :epoch :fx :error}]
+    (is (contains? recognised :trace))
+    (is (contains? recognised :epoch))
+    (is (contains? recognised :fx))
+    (is (contains? recognised :error))
+    (is (not (contains? recognised :unknown)))))
+
+;; The progress payload shape — the MCP notifications/progress
+;; notification we emit on each batch tick.
+
+(defn- progress-payload
+  [progress-token tick events-edn overflow]
+  #js {:progressToken progress-token
+       :progress      tick
+       :message       events-edn
+       :data          #js {:overflow overflow}})
+
+(deftest progress-payload-carries-token-and-counters
+  (let [p (progress-payload "tok-1" 3 "{:events [...]}" 0)]
+    (is (= "tok-1" (j/get p :progressToken)))
+    (is (= 3 (j/get p :progress)))
+    (is (= "{:events [...]}" (j/get p :message)))
+    (is (= 0 (j/get-in p [:data :overflow])))))
+
+(deftest progress-payload-with-overflow
+  (let [p (progress-payload 42 1 "{...}" 7)]
+    (is (= 42 (j/get p :progressToken)))
+    (is (= 7 (j/get-in p [:data :overflow])))))
+
+;; Unsubscribe-form pinning — the CLJS form sent over nREPL.
+
+(defn- unsubscribe-form [sub-id]
+  (str "(re-frame-pair2.runtime/unsubscribe! "
+       (pr-str sub-id) ")"))
+
+(deftest unsubscribe-form-roundtrips
+  (let [form (unsubscribe-form "abc-123-uuid")]
+    (is (= "(re-frame-pair2.runtime/unsubscribe! \"abc-123-uuid\")" form))))
+
+(defn- drain-form [sub-id]
+  (str "(re-frame-pair2.runtime/drain-subscription! "
+       (pr-str sub-id) ")"))
+
+(deftest drain-form-roundtrips
+  (is (= "(re-frame-pair2.runtime/drain-subscription! \"sub-xyz\")"
+         (drain-form "sub-xyz"))))

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -80,9 +80,10 @@ function run() {
 
       notify('notifications/initialized', {});
 
-      // 2. tools/list — expect all seven tools (six per-op + snapshot
-      // mega-op shipped in rf2-x70e). rf2-7dvg cut inject-runtime in
-      // favour of a shadow-cljs :preloads entry; see SKILL.md §Setup.
+      // 2. tools/list — expect all nine tools (six original + snapshot
+      // mega-op from rf2-x70e + subscribe/unsubscribe streaming pair
+      // from rf2-hq49). rf2-7dvg cut inject-runtime in favour of a
+      // shadow-cljs :preloads entry; see SKILL.md §Setup.
       const list = await call('tools/list', {});
       const names = (list.result?.tools || []).map((t) => t.name).sort();
       const expected = [
@@ -90,14 +91,45 @@ function run() {
         'dispatch',
         'eval-cljs',
         'snapshot',
+        'subscribe',
         'tail-build',
         'trace-window',
+        'unsubscribe',
         'watch-epochs',
       ];
       if (JSON.stringify(names) !== JSON.stringify(expected)) {
         throw new Error('tools/list mismatch:\n  expected ' + expected + '\n  got ' + names);
       }
       console.log('OK   tools/list ->', names.join(', '));
+
+      // 2c. Verify the subscribe descriptor carries the documented
+      // input schema (topic + filter + max-buffered + poll-ms +
+      // max-ms + max-events + build) and the enum of recognised
+      // topics. Pinning the exact set so accidental renames break
+      // the test instead of silently shipping a broken contract.
+      const subDesc = (list.result?.tools || []).find((t) => t.name === 'subscribe');
+      if (!subDesc) throw new Error('subscribe descriptor missing from tools/list');
+      const subProps = subDesc.inputSchema?.properties || {};
+      for (const k of ['topic', 'filter', 'max-buffered', 'poll-ms', 'max-ms', 'max-events', 'build']) {
+        if (!(k in subProps)) {
+          throw new Error('subscribe inputSchema missing property: ' + k);
+        }
+      }
+      const topicEnum = subProps.topic?.enum || [];
+      const expectedTopics = ['trace', 'epoch', 'fx', 'error'];
+      for (const t of expectedTopics) {
+        if (!topicEnum.includes(t)) {
+          throw new Error('subscribe.topic.enum missing: ' + t);
+        }
+      }
+      console.log('OK   subscribe descriptor -> topic/filter/max-buffered/poll-ms/max-ms/max-events/build');
+
+      const unsubDesc = (list.result?.tools || []).find((t) => t.name === 'unsubscribe');
+      if (!unsubDesc) throw new Error('unsubscribe descriptor missing from tools/list');
+      if (!unsubDesc.inputSchema?.required?.includes('sub-id')) {
+        throw new Error('unsubscribe.inputSchema missing required: sub-id');
+      }
+      console.log('OK   unsubscribe descriptor -> sub-id required');
 
       // 2b. Verify the snapshot descriptor carries the documented input
       // schema (frames + include + build), so accidental future renames
@@ -135,6 +167,31 @@ function run() {
         throw new Error('snapshot degraded mode expected, got: ' + JSON.stringify(snapResp));
       }
       console.log('OK   tools/call snapshot (no nREPL) -> degraded isError');
+
+      // 3c. tools/call subscribe (no nREPL) — degraded path. Proves
+      // the streaming-shaped tool is wired into the dispatch table
+      // and routes through the same degraded-mode response as the
+      // pull-mode tools.
+      const subResp = await call('tools/call', {
+        name: 'subscribe',
+        arguments: { topic: 'trace' },
+      });
+      const subTxt = subResp.result?.content?.[0]?.text || '';
+      if (!subResp.result?.isError || !subTxt.includes('nrepl-port-not-found')) {
+        throw new Error('subscribe degraded mode expected, got: ' + JSON.stringify(subResp));
+      }
+      console.log('OK   tools/call subscribe (no nREPL) -> degraded isError');
+
+      // 3d. tools/call unsubscribe (no nREPL) — same.
+      const unsubResp = await call('tools/call', {
+        name: 'unsubscribe',
+        arguments: { 'sub-id': 'fake-uuid' },
+      });
+      const unsubTxt = unsubResp.result?.content?.[0]?.text || '';
+      if (!unsubResp.result?.isError || !unsubTxt.includes('nrepl-port-not-found')) {
+        throw new Error('unsubscribe degraded mode expected, got: ' + JSON.stringify(unsubResp));
+      }
+      console.log('OK   tools/call unsubscribe (no nREPL) -> degraded isError');
 
       // 4. tools/call unknown — expect isError with :unknown-tool
       const unk = await call('tools/call', { name: 'no-such-tool', arguments: {} });


### PR DESCRIPTION
## Summary

- Adds `subscribe` / `unsubscribe` MCP tools to pair2-mcp — push-mode replacement for the polling-shaped `watch-epochs` op. The streaming shape layers over MCP `notifications/progress`: each batch of matching events is emitted as a progress notification correlated to the original `tools/call` via `_meta.progressToken`. The call resolves with a summary when cancelled, when the runtime sub disappears, or when caller-supplied caps (`max-ms` / `max-events`) fire.
- Topics: `trace`, `epoch`, `fx` (sugar over `trace` + `:op-type :fx`), `error` (sugar over `trace` + `:op-type :error`). Filter vocab mirrors `(rf/trace-buffer)` (rf2-97ah0) for trace/fx/error and `epoch-matches?` for epoch — no new vocabulary.
- Runtime substrate (`subscribe!` / `drain-subscription!` / `unsubscribe!` / `subscription-info`) rides the single existing `register-trace-cb!` + `register-epoch-cb!` slots; one shared listener fans matching events into per-sub bounded queues. Default queue cap 500; overflow is counted, not blocked.
- Parent epic: rf2-qj8e. Bead: rf2-hq49.

## Test plan

- [x] `npm test` in tools/pair2-mcp — 25 CLJS tests / 55 assertions, 0 failures.
- [x] `npm run stdio-roundtrip` — degraded-mode integration test verifies all nine tools wired into the dispatch table, descriptor schemas pinned.
- [x] All seven bb-runnable runtime tests under skills/re-frame-pair2/tests/runtime/ green, including 15 new tests / 44 assertions covering the streaming substrate (filter compose, dispatcher routing, drain semantics, queue cap + overflow, unsubscribe idempotency).
- [x] `shadow-cljs compile server` clean — 0 warnings.
- [ ] Live end-to-end against a real shadow-cljs build (the same path the existing live-nREPL test covers — to be exercised when the consumer-side workflow runs).

## Spec

- `tools/pair2-mcp/spec/003-Tool-Catalogue.md` — new `subscribe` + `unsubscribe` sections with full per-topic filter vocab table, args, return shape, termination paths, failure modes.
- `tools/pair2-mcp/spec/API.md` + `README.md` — nine-tool surface; runtime/bash mapping extended; "no streaming" caveat reframed.