### PR TITLE
feat(http): rf.http/get / post / put / delete helpers — reduce :rf.http/managed boilerplate (rf2-pf4k)

### DIFF
--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -33,6 +33,10 @@
             ;; it, dispatching `:rf.http/managed` would fail with
             ;; :rf.error/no-such-fx.
             [re-frame.http-managed]
+            ;; rf2-pf4k — call-site helpers (rf.http/get / post / put /
+            ;; delete / patch / head / options) that synthesise the
+            ;; canonical [:rf.http/managed args-map] envelope.
+            [re-frame.http :as rf.http]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -69,12 +73,13 @@
                (assoc :status :error
                       :error  (:failure (:rf/reply msg))))}
 
-      ;; Initial branch — issue the request.
+      ;; Initial branch — issue the request. rf2-pf4k: the
+      ;; `rf.http/get` helper synthesises the same `[:rf.http/managed
+      ;; args-map]` envelope a hand-written `:method :get` entry
+      ;; would; the call-site reads as one line of intent.
       :else
       {:db (assoc db :status :loading :error nil)
-       :fx [[:rf.http/managed
-             {:request {:method :get :url "api/inc.json"}
-              :decode  :json}]]})))
+       :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
 
 ;; -- Fail (real 404 from http-server) ----------------------------------------
 
@@ -88,17 +93,16 @@
       ;; Should not happen — the URL is intentionally 404.
       {:db (assoc db :status :idle :error nil)}
 
+      ;; rf2-pf4k — same `rf.http/get` helper as above. Per Spec 014
+      ;; §Classification order, status-check fires before decode — so
+      ;; even with `:decode :json`, a 404 with an HTML or plain-text
+      ;; body classifies as :rf.http/http-4xx (the raw body lands at
+      ;; :body), not :rf.http/decode-failure. Leaving :decode at the
+      ;; default `:auto` here exercises the common case: a JSON
+      ;; endpoint that 404s with a load-balancer HTML page.
       :else
       {:db (assoc db :status :loading :error nil)
-       :fx [[:rf.http/managed
-             ;; Per Spec 014 §Classification order, status-check fires
-             ;; before decode — so even with `:decode :json`, a 404 with
-             ;; an HTML or plain-text body classifies as :rf.http/http-4xx
-             ;; (the raw body lands at :body), not :rf.http/decode-failure.
-             ;; Leaving :decode at the default `:auto` here exercises the
-             ;; common case: a JSON endpoint that 404s with a load-balancer
-             ;; HTML page.
-             {:request {:method :get :url "api/does-not-exist"}}]]})))
+       :fx [(rf.http/get "api/does-not-exist")]})))
 
 ;; -- Retry-recover (canned-stub at app level) --------------------------------
 ;;
@@ -145,12 +149,13 @@
       (some-> msg :rf/reply :kind some?)
       {:db (assoc db :status :idle)}
 
+      ;; rf2-pf4k — `rf.http/get` with `:request-id` for the abort
+      ;; surface; reads the same as the hand-written form.
       :else
       {:db (assoc db :status :loading :error nil)
-       :fx [[:rf.http/managed
-             {:request    {:method :get :url "api/long"}
-              :request-id :counter/long
-              :decode     :json}]]})))
+       :fx [(rf.http/get "api/long"
+                         {:request-id :counter/long
+                          :decode     :json})]})))
 
 (rf/reg-event-fx :counter/cancel
   (fn [{:keys [db]} _]

--- a/implementation/http/src/re_frame/http.cljc
+++ b/implementation/http/src/re_frame/http.cljc
@@ -1,0 +1,162 @@
+(ns re-frame.http
+  "Spec 014 — call-site ergonomics for `:rf.http/managed` (rf2-pf4k).
+
+  Pure helpers that synthesise the canonical `[:rf.http/managed args-map]`
+  fx-vector for the common HTTP verbs. They take a URL + an optional map
+  of additional args (per [Spec 014 §The args map]) and return a vector
+  ready to drop into `:fx`. Result:
+
+  ```clojure
+  {:fx [(rf.http/get \"/api/items\"
+         {:on-success [:items/loaded]})]}
+  ```
+
+  Reduces every call site by 4-6 lines vs spelling out the
+  `[:rf.http/managed {:request {:method :get :url ...} ...}]` envelope
+  directly.
+
+  ## Surface
+
+  - `(get url)` / `(get url args-map)`
+  - `(post url)` / `(post url args-map)`
+  - `(put url)` / `(put url args-map)`
+  - `(delete url)` / `(delete url args-map)`
+  - `(patch url)` / `(patch url args-map)`
+  - `(head url)` / `(head url args-map)`
+  - `(options url)` / `(options url args-map)`
+
+  Each helper sets `(:method (:request args-map))` to the verb's
+  keyword. Caller-supplied `:request` keys take precedence over the
+  defaults except `:method`, which the helper always pins. The
+  caller-supplied `:url` (if any) is overwritten with the helper's
+  `url` argument so the call-site contract reads cleanly.
+
+  All other top-level keys (`:decode`, `:accept`, `:retry`,
+  `:timeout-ms`, `:on-success`, `:on-failure`, `:request-id`,
+  `:abort-signal`, etc.) pass through to the canonical args map
+  unchanged. See Spec 014 §The args map for the closed key set.
+
+  ## Why ship in `day8/re-frame2-http`
+
+  The helpers build `[:rf.http/managed ...]` fx vectors — calling them
+  only makes sense when the http artefact is on the classpath. Shipping
+  here couples the helpers to the artefact that supplies the fx they
+  reference; an app that drops the http dep loses the helpers along
+  with the fx, instead of failing at dispatch time with a stale
+  `:rf.error/no-such-fx`.
+
+  ## Naming
+
+  `get` collides with `clojure.core/get`; we `:refer-clojure :exclude
+  [get]`. Users alias the namespace (`[re-frame.http :as rf.http]`) and
+  write `(rf.http/get ...)` — the bare symbol form is rare since the
+  helpers are typically inside `:fx [...]` already-namespaced. The
+  other verbs (`post`, `put`, `delete`, `patch`, `head`, `options`)
+  don't collide with `clojure.core`.
+
+  ## Args-map merging
+
+  The helpers compose by `merge`:
+
+  ```
+  (rf.http/post \"/api/items\"
+                {:request {:body item}
+                 :on-success [:item/saved]})
+  ;; →
+  [:rf.http/managed
+   {:request {:method :post :url \"/api/items\" :body item}
+    :on-success [:item/saved]}]
+  ```
+
+  Top-level `merge` (caller wins) for every key except `:request`,
+  which is itself merged with the helper's `{:method <verb> :url url}`
+  pair (helper's `:method` and `:url` win). This lets callers supply
+  the request envelope's other slots (`:headers`, `:body`, `:params`,
+  `:credentials`, etc.) without losing the helper's verb-pinning.
+
+  See Spec 014 for the canonical args-map shape."
+  (:refer-clojure :exclude [get]))
+
+(defn- build
+  "Build a `[:rf.http/managed args-map]` fx vector for the given verb,
+  URL, and caller args. Internal — the public helpers are thin wrappers."
+  [method url args]
+  (let [req (assoc (clojure.core/get args :request {})
+                   :method method
+                   :url    url)]
+    [:rf.http/managed (assoc args :request req)]))
+
+(defn get
+  "Spec 014 helper — build a GET `[:rf.http/managed args-map]` fx vector.
+
+  Single-arity form is the minimal call: just the URL.
+
+  Multi-arity form merges `args` into the canonical args map (top-level
+  merge; `:request` itself is merged with `{:method :get :url url}`).
+  Caller-supplied `:method` and `:url` under `:request` are overwritten
+  by the helper.
+
+  Example:
+    {:fx [(rf.http/get \"/api/items\")
+          (rf.http/get \"/api/items\" {:on-success [:items/loaded]})
+          (rf.http/get \"/api/items\"
+                       {:on-success [:items/loaded]
+                        :retry      retry-policy
+                        :decode     ItemListSchema})]}"
+  ([url]      (build :get url {}))
+  ([url args] (build :get url args)))
+
+(defn post
+  "Spec 014 helper — build a POST `[:rf.http/managed args-map]` fx vector.
+
+  Pass `:body` under `:request` (and optionally `:request-content-type
+  :json` to JSON-encode a clj coll, per Spec 014 §Body encoding):
+
+    (rf.http/post \"/api/items\"
+                  {:request    {:body new-item
+                                :request-content-type :json}
+                   :on-success [:items/created]})"
+  ([url]      (build :post url {}))
+  ([url args] (build :post url args)))
+
+(defn put
+  "Spec 014 helper — build a PUT `[:rf.http/managed args-map]` fx vector.
+
+  Same shape as `post`; PUT semantics. See Spec 014 §The args map."
+  ([url]      (build :put url {}))
+  ([url args] (build :put url args)))
+
+(defn delete
+  "Spec 014 helper — build a DELETE `[:rf.http/managed args-map]` fx vector.
+
+  Single-arity: just the URL. Multi-arity: merge `args` into the
+  canonical envelope. Example:
+
+    (rf.http/delete \"/api/items/42\"
+                    {:on-success [:items/removed 42]})"
+  ([url]      (build :delete url {}))
+  ([url args] (build :delete url args)))
+
+(defn patch
+  "Spec 014 helper — build a PATCH `[:rf.http/managed args-map]` fx vector.
+
+  Same shape as `post` / `put`; PATCH semantics."
+  ([url]      (build :patch url {}))
+  ([url args] (build :patch url args)))
+
+(defn head
+  "Spec 014 helper — build a HEAD `[:rf.http/managed args-map]` fx vector.
+
+  HEAD requests typically don't carry `:decode` since the response has
+  no body; the caller can still set `:on-success` / `:on-failure` to
+  branch on status."
+  ([url]      (build :head url {}))
+  ([url args] (build :head url args)))
+
+(defn options
+  "Spec 014 helper — build an OPTIONS `[:rf.http/managed args-map]` fx
+  vector. Rarely needed from user code (browsers issue OPTIONS as CORS
+  preflight automatically), but provided for symmetry with the other
+  verbs and the rare case of explicit capability discovery."
+  ([url]      (build :options url {}))
+  ([url args] (build :options url args)))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -1,0 +1,58 @@
+(ns re-frame.http-cljs-test
+  "CLJS-side smoke for the `re-frame.http` call-site helpers (rf2-pf4k).
+
+  The JVM `re-frame.http-test` covers the full shape contract. This
+  smoke just confirms the helpers compile clean under CLJS (the file
+  is `.cljc` with no host-specific bits, but a CLJS-side load is the
+  fastest way to catch a regression that would otherwise only surface
+  in shadow-cljs builds)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.http :as rf.http]))
+
+(deftest get-helper-shape
+  (testing "(rf.http/get url) produces [:rf.http/managed {:request {:method :get :url url}}]"
+    (is (= [:rf.http/managed
+            {:request {:method :get :url "/api/items"}}]
+           (rf.http/get "/api/items")))))
+
+(deftest post-helper-shape
+  (testing "(rf.http/post url args) merges :request body with helper's verb + url"
+    (is (= [:rf.http/managed
+            {:request    {:method :post
+                          :url    "/api/items"
+                          :body   {:title "new"}
+                          :request-content-type :json}
+             :on-success [:item/created]}]
+           (rf.http/post "/api/items"
+                         {:request    {:body {:title "new"}
+                                       :request-content-type :json}
+                          :on-success [:item/created]})))))
+
+(deftest put-delete-patch-head-options-shapes
+  (testing "every verb pins the right :method"
+    (is (= :put     (-> (rf.http/put     "/x") second :request :method)))
+    (is (= :delete  (-> (rf.http/delete  "/x") second :request :method)))
+    (is (= :patch   (-> (rf.http/patch   "/x") second :request :method)))
+    (is (= :head    (-> (rf.http/head    "/x") second :request :method)))
+    (is (= :options (-> (rf.http/options "/x") second :request :method)))))
+
+(deftest top-level-keys-pass-through
+  (testing ":decode, :accept, :retry, :timeout-ms, :request-id, :abort-signal pass through"
+    (let [accept (fn [v] {:ok v})
+          retry  {:on #{:rf.http/transport} :max-attempts 2}
+          out    (rf.http/get "/x"
+                              {:decode       :json
+                               :accept       accept
+                               :retry        retry
+                               :timeout-ms   5000
+                               :on-success   [:loaded]
+                               :on-failure   [:errored]
+                               :request-id   :search})
+          args   (second out)]
+      (is (= :json (:decode args)))
+      (is (identical? accept (:accept args)))
+      (is (= retry (:retry args)))
+      (is (= 5000 (:timeout-ms args)))
+      (is (= [:loaded] (:on-success args)))
+      (is (= [:errored] (:on-failure args)))
+      (is (= :search (:request-id args))))))

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -1,0 +1,147 @@
+(ns re-frame.http-helpers-integration-test
+  "Integration tests for the `re-frame.http` call-site helpers (rf2-pf4k).
+
+  These exercise the helpers through the actual dispatch path —
+  `(rf.http/get ...)` inside an `:fx` vector returned by an
+  event-fx handler, dispatched through `rf/dispatch-sync` with a
+  canned-stub `:fx-overrides`, and assert the reply lands as
+  expected. Companion to `re-frame.http-test` (pure-fn shape tests)
+  and `re-frame.http-managed-test` (fx contract end-to-end)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.registrar :as registrar]
+            [re-frame.http :as rf.http]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- per-test reset (mirrors http-managed-test) ---------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (require 're-frame.http-managed :reload)
+  ((requiring-resolve 're-frame.machines/reset-counters!))
+  (http-managed/clear-all-in-flight!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- await-reply!
+  "Wait up to timeout-ms for `pred` to be true on the default frame's db."
+  ([pred] (await-reply! pred 5000))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [db (rf/get-frame-db :rf/default)]
+         (cond
+           (pred db) db
+           (> (System/currentTimeMillis) deadline)
+           (throw (ex-info "timed out awaiting reply" {:final-db db}))
+           :else (do (Thread/sleep 25) (recur))))))))
+
+;; ---- 1. (rf.http/get url args) dispatches through canned-success ----------
+
+(deftest helper-get-routes-through-managed
+  (testing "(rf.http/get ...) in :fx is indistinguishable from a hand-written :rf.http/managed entry"
+    (rf/reg-event-fx :items/load
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          (case (:kind reply)
+            :success {:db (assoc db :items (:value reply))}
+            :failure {:db (assoc db :error (:failure reply))})
+          {:fx [(rf.http/get "/api/items" {:decode :json})]})))
+    (rf/dispatch-sync [:items/load {}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (await-reply! #(some? (:items %)))]
+      (is (= {:stubbed true} (:items db))))))
+
+;; ---- 2. (rf.http/post url args) with explicit :on-success -----------------
+
+(deftest helper-post-routes-with-explicit-on-success
+  (testing "(rf.http/post ...) with explicit :on-success dispatches there"
+    (rf/reg-event-fx :item/create
+      (fn [_ _]
+        {:fx [(rf.http/post "/api/items"
+                            {:request    {:body {:title "new"}
+                                          :request-content-type :json}
+                             :on-success [:item/created]})]}))
+    (rf/reg-event-db :item/created
+      (fn [db [_ payload]]
+        (assoc db :created payload)))
+    (rf/dispatch-sync [:item/create]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (await-reply! #(some? (:created %)))]
+      (is (= :success (get-in db [:created :kind]))))))
+
+;; ---- 3. (rf.http/delete url args) with explicit :on-failure ---------------
+
+(deftest helper-delete-routes-with-explicit-on-failure
+  (testing "(rf.http/delete ...) with explicit :on-failure dispatches there on failure"
+    (rf/reg-event-fx :item/delete
+      (fn [_ _]
+        {:fx [(rf.http/delete "/api/items/42"
+                              {:on-failure [:item/delete-failed]})]}))
+    (rf/reg-event-db :item/delete-failed
+      (fn [db [_ payload]]
+        (assoc db :delete-error payload)))
+    (rf/dispatch-sync [:item/delete]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+    (let [db (await-reply! #(some? (:delete-error %)))]
+      (is (= :failure (get-in db [:delete-error :kind])))
+      (is (= :rf.http/transport (get-in db [:delete-error :failure :kind]))))))
+
+;; ---- 4. (rf.http/put url args) with :request-id (abort surface) -----------
+
+(deftest helper-put-carries-request-id
+  (testing "(rf.http/put ...) with :request-id flows it through to the args map"
+    ;; Hand-write the expected fx vector, then assert the helper produces it.
+    ;; This is a pure-fn assertion that supplements the integration tests above
+    ;; (the request-id end-to-end behaviour is covered by http-managed-test).
+    (is (= [:rf.http/managed
+            {:request    {:method :put
+                          :url    "/api/items/42"
+                          :body   {:title "updated"}
+                          :request-content-type :json}
+             :request-id [:item :update 42]}]
+           (rf.http/put "/api/items/42"
+                        {:request    {:body {:title "updated"}
+                                      :request-content-type :json}
+                         :request-id [:item :update 42]})))))
+
+;; ---- 5. (rf.http/get url) — minimal form, default reply addressing --------
+
+(deftest helper-get-minimal-default-reply-addressing
+  (testing "(rf.http/get url) — no extra args; reply lands back at originating handler"
+    (rf/reg-event-fx :ping
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :pong (:value reply))}
+          {:fx [(rf.http/get "/api/ping")]})))
+    (rf/dispatch-sync [:ping]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (await-reply! #(some? (:pong %)))]
+      (is (= {:stubbed true} (:pong db))))))
+
+;; ---- 6. helper + retry policy passes through ------------------------------
+
+(deftest helper-with-retry-policy
+  (testing "(rf.http/get ...) carries :retry config through to the args map"
+    (let [retry {:on           #{:rf.http/transport :rf.http/http-5xx}
+                 :max-attempts 4
+                 :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}}]
+      (is (= [:rf.http/managed
+              {:request {:method :get :url "/api/items"}
+               :retry   retry
+               :decode  :json}]
+             (rf.http/get "/api/items" {:retry retry :decode :json}))))))

--- a/implementation/http/test/re_frame/http_test.clj
+++ b/implementation/http/test/re_frame/http_test.clj
@@ -1,0 +1,228 @@
+(ns re-frame.http-test
+  "Unit tests for the `re-frame.http` call-site helpers (rf2-pf4k).
+
+  These are pure-fn tests — they assert the helpers synthesise the
+  canonical `[:rf.http/managed args-map]` fx-vector with the right
+  shape. The `re-frame.http-managed-test` suite exercises the
+  fx-side contract (transport, decode, retry, abort) end-to-end."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.http :as rf.http]))
+
+;; ---- 1. minimal form -------------------------------------------------------
+
+(deftest minimal-get
+  (testing "(get url) — just the URL, no extra args"
+    (is (= [:rf.http/managed
+            {:request {:method :get :url "/api/items"}}]
+           (rf.http/get "/api/items")))))
+
+(deftest minimal-post
+  (testing "(post url) — just the URL, no extra args"
+    (is (= [:rf.http/managed
+            {:request {:method :post :url "/api/items"}}]
+           (rf.http/post "/api/items")))))
+
+(deftest minimal-put
+  (testing "(put url) — just the URL"
+    (is (= [:rf.http/managed
+            {:request {:method :put :url "/api/items/1"}}]
+           (rf.http/put "/api/items/1")))))
+
+(deftest minimal-delete
+  (testing "(delete url) — just the URL"
+    (is (= [:rf.http/managed
+            {:request {:method :delete :url "/api/items/1"}}]
+           (rf.http/delete "/api/items/1")))))
+
+(deftest minimal-patch
+  (testing "(patch url) — just the URL"
+    (is (= [:rf.http/managed
+            {:request {:method :patch :url "/api/items/1"}}]
+           (rf.http/patch "/api/items/1")))))
+
+(deftest minimal-head
+  (testing "(head url) — just the URL"
+    (is (= [:rf.http/managed
+            {:request {:method :head :url "/api/items"}}]
+           (rf.http/head "/api/items")))))
+
+(deftest minimal-options
+  (testing "(options url) — just the URL"
+    (is (= [:rf.http/managed
+            {:request {:method :options :url "/api/items"}}]
+           (rf.http/options "/api/items")))))
+
+;; ---- 2. on-success / on-failure pass through ------------------------------
+
+(deftest on-success-passes-through
+  (testing ":on-success at the top level passes through unchanged"
+    (is (= [:rf.http/managed
+            {:request    {:method :get :url "/api/items"}
+             :on-success [:items/loaded]}]
+           (rf.http/get "/api/items" {:on-success [:items/loaded]})))))
+
+(deftest on-failure-passes-through
+  (testing ":on-failure at the top level passes through unchanged"
+    (is (= [:rf.http/managed
+            {:request    {:method :post :url "/api/items"}
+             :on-failure [:items/create-failed]}]
+           (rf.http/post "/api/items" {:on-failure [:items/create-failed]})))))
+
+(deftest both-on-success-and-on-failure
+  (testing "both reply handlers, plus a request-id"
+    (is (= [:rf.http/managed
+            {:request    {:method :get :url "/api/items"}
+             :on-success [:items/loaded]
+             :on-failure [:items/load-failed]
+             :request-id [:items :load]}]
+           (rf.http/get "/api/items"
+                        {:on-success [:items/loaded]
+                         :on-failure [:items/load-failed]
+                         :request-id [:items :load]})))))
+
+;; ---- 3. request-envelope merging ------------------------------------------
+
+(deftest request-body-merges-under-request
+  (testing "caller-supplied :request keys merge with helper's :method + :url"
+    (is (= [:rf.http/managed
+            {:request {:method :post
+                       :url    "/api/items"
+                       :body   {:title "new"}
+                       :request-content-type :json}}]
+           (rf.http/post "/api/items"
+                         {:request {:body {:title "new"}
+                                    :request-content-type :json}})))))
+
+(deftest request-headers-merge
+  (testing "caller-supplied :headers under :request pass through"
+    (is (= [:rf.http/managed
+            {:request {:method :get
+                       :url    "/api/items"
+                       :headers {"X-Trace" "abc"}}}]
+           (rf.http/get "/api/items"
+                        {:request {:headers {"X-Trace" "abc"}}})))))
+
+(deftest request-params-merge
+  (testing "caller-supplied :params under :request pass through"
+    (is (= [:rf.http/managed
+            {:request {:method :get
+                       :url    "/api/search"
+                       :params {:q "foo" :page 2}}}]
+           (rf.http/get "/api/search"
+                        {:request {:params {:q "foo" :page 2}}})))))
+
+;; ---- 4. helper pins :method and :url --------------------------------------
+
+(deftest helper-overrides-caller-method
+  (testing "caller's :request :method is overwritten by the helper's verb"
+    ;; A user accidentally passes :method :get to (rf.http/post ...).
+    ;; The helper's verb wins — POST it is.
+    (is (= :post
+           (-> (rf.http/post "/api/items"
+                             {:request {:method :get :body "x"}})
+               second :request :method)))))
+
+(deftest helper-overrides-caller-url
+  (testing "caller's :request :url is overwritten by the helper's URL arg"
+    (is (= "/api/items"
+           (-> (rf.http/get "/api/items"
+                            {:request {:url "/somewhere-else"}})
+               second :request :url)))))
+
+;; ---- 5. top-level keys (decode, accept, retry, timeout-ms, abort-signal) --
+
+(deftest decode-passes-through
+  (testing ":decode at top level"
+    (is (= :json
+           (-> (rf.http/get "/api/items" {:decode :json})
+               second :decode)))))
+
+(deftest accept-passes-through
+  (testing ":accept at top level (fn)"
+    (let [my-accept (fn [v] {:ok v})]
+      (is (= my-accept
+             (-> (rf.http/get "/api/items" {:accept my-accept})
+                 second :accept))))))
+
+(deftest retry-passes-through
+  (testing ":retry at top level"
+    (let [retry {:on           #{:rf.http/transport :rf.http/http-5xx}
+                 :max-attempts 3
+                 :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}}]
+      (is (= retry
+             (-> (rf.http/get "/api/items" {:retry retry})
+                 second :retry))))))
+
+(deftest timeout-ms-passes-through
+  (testing ":timeout-ms at top level"
+    (is (= 5000
+           (-> (rf.http/get "/api/items" {:timeout-ms 5000})
+               second :timeout-ms)))))
+
+(deftest request-id-passes-through
+  (testing ":request-id at top level"
+    (is (= :search
+           (-> (rf.http/get "/api/search" {:request-id :search})
+               second :request-id)))))
+
+(deftest abort-signal-passes-through
+  (testing ":abort-signal at top level"
+    (let [signal (Object.)]
+      (is (identical? signal
+                      (-> (rf.http/get "/api/items" {:abort-signal signal})
+                          second :abort-signal))))))
+
+;; ---- 6. full-fat example (every common slot at once) ----------------------
+
+(deftest full-fat-shape
+  (testing "every common top-level slot, plus :request body, simultaneously"
+    (let [retry  {:on #{:rf.http/transport} :max-attempts 2
+                  :backoff {:base-ms 100 :factor 2 :max-ms 500 :jitter false}}
+          accept (fn [v] {:ok v})]
+      (is (= [:rf.http/managed
+              {:request    {:method  :post
+                            :url     "/api/items"
+                            :body    {:title "new"}
+                            :headers {"X-Trace" "abc"}
+                            :request-content-type :json}
+               :decode     :json
+               :accept     accept
+               :retry      retry
+               :timeout-ms 5000
+               :on-success [:items/created]
+               :on-failure [:items/create-failed]
+               :request-id [:items :create]}]
+             (rf.http/post "/api/items"
+                           {:request    {:body    {:title "new"}
+                                         :headers {"X-Trace" "abc"}
+                                         :request-content-type :json}
+                            :decode     :json
+                            :accept     accept
+                            :retry      retry
+                            :timeout-ms 5000
+                            :on-success [:items/created]
+                            :on-failure [:items/create-failed]
+                            :request-id [:items :create]}))))))
+
+;; ---- 7. shape contract — every helper yields the canonical envelope -------
+
+(deftest every-helper-yields-canonical-shape
+  (testing "the fx vector is always [:rf.http/managed <args-map>]"
+    (doseq [helper [rf.http/get rf.http/post rf.http/put rf.http/delete
+                    rf.http/patch rf.http/head rf.http/options]]
+      (let [fx (helper "/x")]
+        (is (vector? fx))
+        (is (= 2 (count fx)))
+        (is (= :rf.http/managed (first fx)))
+        (is (map? (second fx)))
+        (is (= "/x" (-> fx second :request :url)))))))
+
+(deftest verb-to-method-mapping
+  (testing "each helper pins its verb keyword onto :request :method"
+    (is (= :get     (-> (rf.http/get     "/x") second :request :method)))
+    (is (= :post    (-> (rf.http/post    "/x") second :request :method)))
+    (is (= :put     (-> (rf.http/put     "/x") second :request :method)))
+    (is (= :delete  (-> (rf.http/delete  "/x") second :request :method)))
+    (is (= :patch   (-> (rf.http/patch   "/x") second :request :method)))
+    (is (= :head    (-> (rf.http/head    "/x") second :request :method)))
+    (is (= :options (-> (rf.http/options "/x") second :request :method)))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -572,6 +572,72 @@ Hot-reload tools that re-evaluate registration call sites get the right behaviou
 
 Both are re-exported from `re-frame.core`. Both ship in `day8/re-frame2-http`; an app that omits the artefact gets `:rf.error/http-artefact-missing` from the core re-exports per the standard pattern.
 
+## Call-site helpers
+
+The canonical `[:rf.http/managed args-map]` envelope is correct and complete, but the args map carries 12+ keys and every call site repeats `{:request {:method <verb> :url <url>} ...}` boilerplate. The `re-frame.http` namespace ships pure synthesis fns — one per HTTP verb — that build the canonical fx vector from a URL + an optional args map. Result:
+
+```clojure
+;; Without helpers — the canonical form, always supported:
+{:fx [[:rf.http/managed {:request {:method :get :url "/api/items"}
+                         :on-success [:items/loaded]}]]}
+
+;; With helpers — same envelope, fewer keys at the call site:
+{:fx [(rf.http/get "/api/items" {:on-success [:items/loaded]})]}
+```
+
+### Surface
+
+```clojure
+(:require [re-frame.http :as rf.http])
+
+(rf.http/get     url)  (rf.http/get     url args)
+(rf.http/post    url)  (rf.http/post    url args)
+(rf.http/put     url)  (rf.http/put     url args)
+(rf.http/delete  url)  (rf.http/delete  url args)
+(rf.http/patch   url)  (rf.http/patch   url args)
+(rf.http/head    url)  (rf.http/head    url args)
+(rf.http/options url)  (rf.http/options url args)
+```
+
+Each helper returns a `[:rf.http/managed args-map]` vector ready to drop into `:fx`. The helper pins `(:method (:request args-map))` to its verb's keyword and `(:url (:request args-map))` to the URL argument; caller-supplied `:method` / `:url` under `:request` are overwritten so the call-site contract reads cleanly.
+
+| Helper | `(:request (:method ...))` pinned to |
+|---|---|
+| `rf.http/get`     | `:get`     |
+| `rf.http/post`    | `:post`    |
+| `rf.http/put`     | `:put`     |
+| `rf.http/delete`  | `:delete`  |
+| `rf.http/patch`   | `:patch`   |
+| `rf.http/head`    | `:head`    |
+| `rf.http/options` | `:options` |
+
+### Args-map merging
+
+Top-level keys (`:decode`, `:accept`, `:retry`, `:timeout-ms`, `:on-success`, `:on-failure`, `:request-id`, `:abort-signal`, etc.) pass through to the args map unchanged. The `:request` map is itself merged with the helper's `{:method <verb> :url url}` pair (helper wins on `:method` and `:url`; caller supplies `:headers`, `:body`, `:params`, `:credentials`, etc.).
+
+```clojure
+(rf.http/post "/api/items"
+              {:request    {:body new-item :request-content-type :json}
+               :on-success [:items/created]
+               :on-failure [:items/create-failed]})
+;; ↓ expands to ↓
+[:rf.http/managed
+ {:request    {:method :post :url "/api/items"
+               :body   new-item :request-content-type :json}
+  :on-success [:items/created]
+  :on-failure [:items/create-failed]}]
+```
+
+### Naming
+
+`get` collides with `clojure.core/get`; the namespace does `(:refer-clojure :exclude [get])` internally. Users alias the namespace (`[re-frame.http :as rf.http]`) and write `(rf.http/get ...)` — the alias is what makes the bare verb names readable. The other verbs (`post`, `put`, `delete`, `patch`, `head`, `options`) don't collide with `clojure.core`.
+
+### Artefact
+
+Ships in `day8/re-frame2-http` alongside the `:rf.http/managed` fx the helpers reference. Loading the helpers and the fx are a single dep decision; an app that omits the http artefact can't call the helpers in the first place (compile-time `ns` failure) rather than discovering at dispatch time that `:rf.http/managed` isn't registered.
+
+The helpers are NOT re-exported from `re-frame.core` — users explicitly `(:require [re-frame.http :as rf.http])`. Re-exporting under the `rf/` segment would lose the `rf.http/` namespace prefix that makes the call site read as "an HTTP GET" rather than "some framework get".
+
 ## Examples
 
 ### A — Simplest possible (sugar all the way down)
@@ -649,6 +715,53 @@ The auth flow has separate success/error handlers (often a state machine), so th
 ```
 
 The `:rf.http/managed-abort` fx cancels any in-flight `:request-id :search`, then a fresh request fires.
+
+### F — Same flows, with the call-site helpers
+
+```clojure
+(:require [re-frame.http :as rf.http])
+
+;; A — minimal GET, default reply addressing:
+(rf/reg-event-fx :ping
+  (fn [{:keys [db]} [_ msg]]
+    (if-let [reply (:rf/reply msg)]
+      {:db (assoc db :pinged-at (:elapsed-at reply))}
+      {:fx [(rf.http/get "/ping")]})))                       ;; ← 1 line vs 1 envelope
+
+;; B — schema-driven GET with retry:
+(rf/reg-event-fx :articles/list
+  (fn [{:keys [db]} [_ {:keys [page] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ...
+      {:fx [(rf.http/get "/articles"
+                         {:request {:params {:page page :page-size 20}}
+                          :decode  ArticleListResponse
+                          :retry   {:on           #{:rf.http/transport :rf.http/http-5xx}
+                                    :max-attempts 3
+                                    :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}}})]})))
+
+;; C — POST with body and explicit reply targets:
+(rf/reg-event-fx :auth/login
+  (fn [{:keys [db]} [_ creds]]
+    {:fx [(rf.http/post "/auth/login"
+                        {:request    {:body creds :request-content-type :json}
+                         :decode     AuthResponse
+                         :on-success [:auth/login-success]
+                         :on-failure [:auth/login-error]})]}))
+
+;; E — aborting a stale search:
+(rf/reg-event-fx :search/query
+  (fn [{:keys [db]} [_ {:keys [q] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      ...
+      {:fx [[:rf.http/managed-abort :search]
+            (rf.http/get "/search"
+                         {:request    {:params {:q q}}
+                          :request-id :search
+                          :decode     SearchResponse})]})))
+```
+
+The fx vectors the helpers synthesise are exactly the same shape as the hand-written versions in §A–§E above; `:fx-overrides`, `with-managed-request-stubs`, the trace stream, and pair tools see no difference. The helpers are call-site sugar over the same canonical envelope.
 
 ## Testing
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -246,8 +246,17 @@ Standard cofx (server-only):
 | `uninstall-managed-request-stubs!` | Fn | `(uninstall-managed-request-stubs!)` — drop any installed stubs and restore real-request routing. Idempotent. Per [014 §Testing](014-HTTPRequests.md#testing). | v1 (optional capability, dev/test) | 014 |
 | `reg-http-interceptor` | Fn | `(reg-http-interceptor {:frame ... :id ... :before (fn [ctx] ctx')})` — register a request-side interceptor on a frame's `:rf.http/managed` middleware chain (per [014 §Middleware](014-HTTPRequests.md#middleware), rf2-6y3q). `:before` receives a ctx `{:request :args :frame :event}` and returns a (possibly-modified) ctx. | v1 (optional capability) | 014 |
 | `clear-http-interceptor` | Fn | `(clear-http-interceptor id)` / `(clear-http-interceptor frame id)` — unregister an interceptor by id (per [014 §Middleware](014-HTTPRequests.md#middleware), rf2-6y3q). Single-arity targets `:rf/default`. | v1 (optional capability) | 014 |
+| `re-frame.http/get`     | Fn | `(rf.http/get url)` / `(rf.http/get url args)` — build a `[:rf.http/managed {:request {:method :get :url url} ...}]` fx vector (per [014 §Call-site helpers](014-HTTPRequests.md#call-site-helpers), rf2-pf4k). | v1 (optional capability) | 014 |
+| `re-frame.http/post`    | Fn | `(rf.http/post url)` / `(rf.http/post url args)` — POST helper; same shape as `get`. | v1 (optional capability) | 014 |
+| `re-frame.http/put`     | Fn | `(rf.http/put url)` / `(rf.http/put url args)` — PUT helper. | v1 (optional capability) | 014 |
+| `re-frame.http/delete`  | Fn | `(rf.http/delete url)` / `(rf.http/delete url args)` — DELETE helper. | v1 (optional capability) | 014 |
+| `re-frame.http/patch`   | Fn | `(rf.http/patch url)` / `(rf.http/patch url args)` — PATCH helper. | v1 (optional capability) | 014 |
+| `re-frame.http/head`    | Fn | `(rf.http/head url)` / `(rf.http/head url args)` — HEAD helper. | v1 (optional capability) | 014 |
+| `re-frame.http/options` | Fn | `(rf.http/options url)` / `(rf.http/options url args)` — OPTIONS helper. | v1 (optional capability) | 014 |
 
 Public API surface in `re-frame.core` for ports that ship Spec 014. Ports that omit it MUST NOT register `:rf.http/*` for any other purpose (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)).
+
+The verb helpers (`get` / `post` / `put` / `delete` / `patch` / `head` / `options`) live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. They're pure synthesis fns that produce the canonical `[:rf.http/managed args-map]` fx vector; the namespace ships in `day8/re-frame2-http` (same artefact as the fx they reference) so loading the helpers and the fx are a single dep decision.
 
 ### Reply-payload shape
 


### PR DESCRIPTION
## Summary

The `:rf.http/managed` args map carries 12+ keys. Even the common case (GET this URL, dispatch this event on success) requires several keys; apps issuing many requests carry boilerplate at every call site.

Ship `re-frame.http` — a tiny new namespace in `day8/re-frame2-http` that provides pure synthesis fns, one per HTTP verb, that build the canonical `[:rf.http/managed args-map]` fx vector:

```clojure
(:require [re-frame.http :as rf.http])

(rf.http/get     url [args])    ;; → [:rf.http/managed {:request {:method :get :url url ...} ...}]
(rf.http/post    url [args])
(rf.http/put     url [args])
(rf.http/delete  url [args])
(rf.http/patch   url [args])
(rf.http/head    url [args])
(rf.http/options url [args])
```

Top-level keys (`:decode` / `:accept` / `:retry` / `:timeout-ms` / `:on-success` / `:on-failure` / `:request-id` / `:abort-signal`) pass through unchanged. The `:request` map is merged with the helper's `{:method <verb> :url url}` pair (helper wins on `:method` and `:url`; caller supplies `:headers`, `:body`, `:params`, etc.).

```clojure
;; Before:
{:fx [[:rf.http/managed {:request {:method :get :url "/api/items"}
                          :decode :json
                          :on-success [:items/loaded]}]]}

;; After:
{:fx [(rf.http/get "/api/items"
                   {:decode :json :on-success [:items/loaded]})]}
```

Reduces every call site by 4-6 lines.

## Design decisions

- **Naming.** `get` collides with `clojure.core/get`; the ns does `(:refer-clojure :exclude [get])`. Users alias the ns (`[re-frame.http :as rf.http]`) and write `(rf.http/get ...)` — the alias is what makes the bare verb names readable. The other verbs don't collide.
- **Artefact.** Ships in `day8/re-frame2-http` alongside the `:rf.http/managed` fx the helpers reference — loading the helpers and the fx are a single dep decision; an app that omits the http artefact can't call the helpers in the first place (compile-time `ns` failure) rather than discovering at dispatch time that the fx isn't registered.
- **Not re-exported from `re-frame.core`.** Users explicitly `(:require [re-frame.http :as rf.http])`. Re-exporting under the `rf/` segment would lose the `rf.http/` namespace prefix that makes the call site read as "an HTTP GET" rather than "some framework get".
- **Pure synthesis.** Helpers don't dispatch, don't touch the in-flight registry, don't call into the http artefact's runtime. They build a data structure; the fx-side contract is unchanged.

## Files changed

| File | Lines | What |
|---|---|---|
| `implementation/http/src/re_frame/http.cljc` | +155 | New ns; 7 verb helpers + internal `build` synthesiser |
| `implementation/http/test/re_frame/http_test.clj` | +204 | 23 unit tests (shape, merging, passthrough, verb mapping) |
| `implementation/http/test/re_frame/http_helpers_integration_test.clj` | +138 | 6 integration tests through `dispatch-sync` + canned stubs |
| `implementation/http/test/re_frame/http_cljs_test.cljs` | +50 | 4 CLJS smoke tests |
| `examples/reagent/managed_http_counter/core.cljs` | +/-15 | Three call sites refactored to use `rf.http/get` |
| `spec/014-HTTPRequests.md` | +118 | New §Call-site helpers + Example F |
| `spec/API.md` | +9 | Seven new rows in the HTTP requests table |

## Test plan

- [x] `clojure -M:test` (implementation/http): 72 tests / 230 assertions pass (was 42 / 159 — **+30 tests / +71 assertions**)
- [x] `npm run test:cljs`: 616 tests / 1472 assertions pass (was 612 / 1458 — **+4 tests / +14 assertions**)
- [x] `npm run test:elision`: all sentinels PRESENT per the prod-elision contract
- [x] `npm run test:examples`: 24 / 24 PASS, including `managed-http-counter` (refactored) and `realworld` (unchanged surface)
- [x] `mkdocs build --strict`: 119 warnings identical to baseline; no new warnings from the spec edits
- [x] `npm run test:bundle-isolation`: pre-existing baseline failure on `main`, unrelated to this PR

**Total test delta: +34 tests / +85 assertions.**