### PR TITLE
feat(story): Actions panel — auto-captures dispatch + fx-handler trace events (rf2-5yriz)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -668,6 +668,61 @@ module.exports = {
       .waitFor({ state: 'visible', timeout: 5000 });
 
     // ====================================================================
+    // 10b. Actions panel — captures the dispatch chronologically (rf2-5yriz)
+    // ====================================================================
+    //
+    // The Actions panel filters the same per-variant trace buffer the
+    // six-domino trace panel reads, projecting it down to the
+    // user-action subset (`:event/dispatched` + dispatch-shaped
+    // `:rf.fx/handled` emits). After the `:counter/inc` click at
+    // section 10 the buffer carries the dispatch; the Actions panel
+    // must render at least one row whose `data-event-id` matches the
+    // dispatched event-id `:counter/inc`.
+    const actionsPanel = aside.locator('[data-test="story-actions-panel"]');
+    await actionsPanel.waitFor({ state: 'visible', timeout: 5000 });
+
+    // The panel renders one row per action-emit trace event.  By this
+    // point in the spec the variant's seed events (`:counter/initialise`,
+    // play-sequence dispatches, lifecycle-machine dispatches) have
+    // already streamed into the trace buffer through the various
+    // workspace + variant-switch + run-variant cycles in §§5-9.
+    //
+    // Surface assertion: the panel renders at least one row (the
+    // buffer is non-empty for the active variant — proving the panel
+    // is wired to the same trace bus the six-domino panel reads).
+    // We don't pin a specific event-id because re-runs from §§5-9 may
+    // have evicted earlier `:counter/inc` rows from the 200-entry
+    // ring buffer.
+    const rowLocator = actionsPanel.locator('[data-test="story-actions-row"]');
+    {
+      const start = Date.now();
+      let rowCount = 0;
+      while (Date.now() - start < 5000) {
+        rowCount = await rowLocator.count();
+        if (rowCount >= 1) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (rowCount < 1) {
+        throw new Error(
+          `expected the Actions panel to render >= 1 row for the active variant, got ${rowCount}`,
+        );
+      }
+    }
+
+    // Header carries the pause + clear buttons.  Surface assertion:
+    // both render with the canonical `data-test` attributes so the
+    // panel exposes the documented interaction shape.  The deep
+    // pause / clear semantics (snapshot capture, idempotent toggle,
+    // ratom cleanup) live in the CLJS-test layer at
+    // `tools/story/test/re_frame/story/ui/actions_cljs_test.cljc`;
+    // exercising them inline here would mutate trace + paused state
+    // mid-spec and confuse the downstream time-travel assertion.
+    const pauseBtn = actionsPanel.locator('[data-test="story-actions-pause"]');
+    await pauseBtn.waitFor({ state: 'visible', timeout: 2000 });
+    const clearBtn = actionsPanel.locator('[data-test="story-actions-clear"]');
+    await clearBtn.waitFor({ state: 'visible', timeout: 2000 });
+
+    // ====================================================================
     // 11. Time-travel panel — slider scrub reverts state
     // ====================================================================
     //

--- a/tools/story/spec/011-Actions-Panel.md
+++ b/tools/story/spec/011-Actions-Panel.md
@@ -1,0 +1,227 @@
+# Story — Actions Panel
+
+> The chronological per-variant log of user-action dispatches and
+> dispatch-shaped fx invocations.  Filters the variant's trace buffer
+> to the two channels that answer "what did the user do?" without the
+> reader mentally splitting six-domino cascades apart.  Companion to
+> the six-domino trace panel ([`003-Render-Shell.md` §Trace bus
+> consumption](003-Render-Shell.md#trace-bus-consumption)).  Per
+> rf2-5yriz; cross-references the SOTA audit's F3 finding
+> (`ai/findings/story-sota-audit-2026-05-13.md`).
+
+## Why a dedicated panel
+
+The six-domino trace panel already captures every event on the bus —
+strictly more than Storybook's `action('clicked')`-instrumented
+Actions panel — but it groups events by `:dispatch-id` and renders
+each cascade as one row with six sub-cells.  That shape is right for
+"trace the cascade caused by this dispatch"; it is wrong for "show me
+the next five things the user does."  The Actions panel is the cheap
+filter that answers the latter question without rebuilding the trace
+buffer.
+
+Storybook's Actions panel only surfaces handlers the author manually
+wired via `action('name')`.  Story's panel sees EVERYTHING on the
+trace bus automatically — no `action()` calls, no per-component
+instrumentation.  Forget to wire it and the panel still works.  The
+panel's header copy says so.
+
+## Filter contract
+
+The panel reads the variant's trace buffer (the same
+`re-frame.story.ui.trace/buffers` ratom the six-domino panel reads,
+populated by the listener wired at variant selection in
+`re-frame.story.ui.shell/ensure-listeners-for-variant!`) and keeps
+two classes of trace events:
+
+1. **Dispatch events** — every event whose `:op-type` is `:event` AND
+   `:operation` is `:event/dispatched` (per [`spec/009 §:op-type`
+   vocabulary](../../../spec/009-Instrumentation.md)).  This covers
+   the canonical "an event landed on the router" channel — root
+   dispatches AND descendant dispatches fired from inside a handler.
+
+2. **Dispatch-shaped fx-handled events** — every event whose
+   `:op-type` is `:fx` AND `:operation` is `:rf.fx/handled` AND whose
+   `:tags :fx-id` is one of `#{:dispatch :dispatch-later
+   :dispatch-sync}`.  This covers the moment a handler RETURNS a
+   dispatch-shaped fx — distinct from the dispatch eventually landing
+   on the router.  Both moments are meaningful: the fx-emit is "the
+   handler asked"; the `:event/dispatched` is "the router accepted".
+
+Every other trace event in the buffer (handler `:run-end` markers,
+`:event/do-fx`, every effect, every sub-recompute, every render,
+machine transitions, flow events, errors, warnings) is filtered out.
+
+### The filter predicate
+
+```clojure
+(defn action-event?
+  [{:keys [op-type operation tags]}]
+  (or (and (= op-type :event)
+           (= operation :event/dispatched))
+      (and (= op-type :fx)
+           (= operation :rf.fx/handled)
+           (contains? #{:dispatch :dispatch-later :dispatch-sync}
+                      (:fx-id tags)))))
+```
+
+### Row projection
+
+Each surviving trace event projects to a row map:
+
+| Slot | Source | Notes |
+|---|---|---|
+| `:id` | `:id` | Stable per-process trace id; used as React `:key`. |
+| `:class` | derived | `:dispatch` or `:fx-dispatch`. |
+| `:time` | `:time` | `interop/now-ms` wall-clock ms; rendered via `format-timestamp`. |
+| `:event-id` | `:tags :event-id` (or first of `:tags :event`) | The event id for both classes. |
+| `:event` | `:tags :event` | The full event vector when present. |
+| `:args` | `:tags :fx-args` | For `:fx-dispatch` rows only — `:dispatch` carries a vector, `:dispatch-later` carries a map under `:event`. |
+| `:dispatch-id` | `:tags :dispatch-id` | Cascade correlation; same key the six-domino panel groups by. |
+| `:origin` | `:tags :origin` | Per Spec 009 §Dispatch origin tagging; lets tooling dispatches stay distinguishable. |
+| `:fx-id` | `:tags :fx-id` | `nil` for `:dispatch` rows. |
+| `:source` | `:rf.trace/trigger-handler :source-coord` | The in-scope handler's registration coord (rf2-lf84g); the "open in editor" hook rf2-evgf5 wraps this slot. |
+| `:raw` | the trace event | Escape hatch for renderers that want full fidelity. |
+
+Pure data → data; lives in `re-frame.story.ui.actions/project-rows`
+and is `.cljc` so the JVM test corpus exercises it without booting
+Reagent.
+
+## Pause / clear semantics
+
+Two affordances sit in the panel header.
+
+### Pause
+
+Pause is per-variant.  `(actions/pause! variant-id)` flips the
+panel's render boolean for `variant-id` to `true` AND snapshots the
+current trace buffer.  While paused:
+
+- The panel renders against the snapshot taken at pause-time, not
+  the live buffer.
+- The underlying trace listener continues to capture new events —
+  the buffer keeps growing.  We pause RENDERING, not CAPTURE.
+- Unpausing drops the snapshot and the panel renders the live
+  buffer again.  Any events captured while paused are now visible.
+
+Pause is per-variant so the user can freeze actions for `:story.a/x`
+while watching `:story.b/y` live.
+
+### Clear
+
+`(actions/clear! variant-id)` calls
+`re-frame.story.ui.trace/clear-buffer!` against the variant's buffer
+— this is the same primitive the six-domino panel would call, so
+both panels stay coherent (clearing actions also clears trace).  The
+operation is destructive.
+
+Clear also unpauses the variant — leaving the panel paused on a now-
+empty snapshot is confusing UX.
+
+## Auto-scroll behaviour
+
+The panel renders rows oldest-first inside a fixed-height scrollable
+host (`overflow-y: auto`, `max-height: 200px`).  Newest entries
+appear at the bottom.  Stage 1 (this spec) does NOT implement
+"sticky to bottom unless the user has scrolled up" — the
+scrollable host scrolls naturally and the user retains full
+control.  v1.1 may add a `requestAnimationFrame`-driven auto-stick-
+to-bottom; the contract here is "rows render in chronological order
+and the host scrolls", which is enough for the canonical UX without
+locking in browser-specific scroll-anchor behaviour.
+
+## Source-coord click-to-source
+
+Each row carries the row map's `:source` slot — the
+`:rf.trace/trigger-handler` coord stamped by `emit!` whenever a
+handler is in scope (per [`spec/009 §Source-coord stamping`](../../../spec/009-Instrumentation.md)).  The current panel surfaces the
+coord on the row's `title` attribute as a `file:line` hover tooltip.
+When rf2-evgf5 ("Open in editor") lands, the click-handler wraps the
+same row slot — no retrofit needed on the panel's data shape.
+
+## Placement and wiring
+
+The panel is a built-in chrome panel, NOT a `reg-story-panel`
+registration.  It sits in the right-pane stack alongside controls /
+scrubber / trace, wired directly by `re-frame.story.ui.shell/
+right-panel`:
+
+```
+┌────────────┐
+│ controls   │
+│ scrubber   │
+│ trace      │
+│ actions    │   <-- new (rf2-5yriz)
+│ <reg-*>    │   <-- registered panels via reg-story-panel
+└────────────┘
+```
+
+Visibility flows through the shell state's `:panel-visibility` map
+under the `:actions` key.  Default true.  Users can toggle the panel
+via the same panel-list affordance Stage 6 adds for registered
+panels.
+
+Built-in chrome panels (controls, scrubber, trace, actions) are
+wired directly because they are always-present and have no late-bind
+contract.  This mirrors how the existing trace panel ships.
+
+## DOM contract
+
+The panel renders a `<div role="region" aria-label="Actions">` with
+`tabindex="0"` (per rf2-xc65 a11y rules) and `data-test="story-
+actions-panel"` so the browser-side Playwright spec can anchor on
+it.  Header carries `data-test="story-actions-pause"` and `data-
+test="story-actions-clear"` on the two buttons; each row carries
+`data-test="story-actions-row"`, `data-row-class="dispatch"`
+or `"fx-dispatch"`, and `data-event-id="<event-id>"` so the spec
+can assert specific event ids landed.
+
+## Elision
+
+The panel's namespace lives in `tools/story/src/re_frame/story/ui/
+actions.cljc`.  The pure helpers are CLJC; the rendering, the
+pause/clear ratoms, and the listener-wiring are CLJS-only.  The
+shell's `right-panel` only reaches `actions/panel` via a `(when
+config/enabled? ...)`-gated mount call upstream — production builds
+short-circuit before any panel fn is reached.  Closure DCEs the lot.
+
+## Test coverage
+
+`tools/story/test/re_frame/story/ui/actions_cljs_test.cljc` covers:
+
+- `action-event?` classifies dispatches + dispatch-shaped fx-handled
+  emits and rejects every other op-type/operation combination.
+- `project-rows` returns the right shape given a trace-buffer
+  snapshot (one row per surviving event; chronological order
+  preserved).
+- `pause!` / `unpause!` / `toggle-pause!` round-trip; `paused?`
+  reflects the state.
+- `clear!` calls `trace/clear-buffer!` and unpauses.
+- `format-timestamp` pads sub-second millis to 3 digits.
+- The panel component is a function and renders hiccup for a
+  registered variant.
+
+## Differentiator restatement
+
+| Axis | Storybook 8 | Story (rf2-5yriz) |
+|---|---|---|
+| Capture | manual `action('name')` per handler | automatic — every dispatch + dispatch-fx on the bus |
+| Surface | the panel | the panel |
+| Per-variant scope | yes (story) | yes (variant frame) |
+| Cascade context | none | `:dispatch-id` slot on every row; clickable in v1.1 to filter to one cascade |
+| Source-coord | none | `:rf.trace/trigger-handler` on every row; v1.1 click-to-source |
+| Pause / clear | yes | yes |
+
+The differentiator is the capture axis: Story is zero-config.
+
+## Cross-references
+
+- [`003-Render-Shell.md` §Trace bus consumption](003-Render-Shell.md#trace-bus-consumption)
+  — the sibling trace panel reads the same buffer.
+- [`005-SOTA-Features.md`](005-SOTA-Features.md) §Actions logger —
+  the SOTA-tracking line item this panel closes.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+  §`:op-type` vocabulary — the canonical names this panel filters
+  on.
+- `ai/findings/story-sota-audit-2026-05-13.md` §F3 — the audit
+  finding that spawned rf2-5yriz.

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -13,6 +13,7 @@
 - **[008-Docs-Mode.md](008-Docs-Mode.md)** — The `:docs` mode pane — read-only AutoDocs-equivalent: header, prose, args, decorators, parameters, tags for the active variant (rf2-rodx).
 - **[009-Test-Mode.md](009-Test-Mode.md)** — The `:test` mode pane — in-canvas aggregated test runner: status pill, per-row pass/fail, collapsible failure detail, Re-run button (rf2-qmjo).
 - **[010-Toolbar.md](010-Toolbar.md)** — The chrome-level toolbar that exposes registered `reg-mode` tuples as toggle chips above the three-pane layout; Storybook-8 theme/viewport/locale parallels via the optional `:axis` slot (rf2-p0mv).
+- **[011-Actions-Panel.md](011-Actions-Panel.md)** — The chronological per-variant log of user-action dispatches + dispatch-shaped fx-handled emits; filters the variant's trace buffer to the two channels that answer "what did the user do?" (rf2-5yriz).
 - **[API.md](API.md)** — Consolidated public surface for `day8/re-frame2-story`: every `reg-*`, every fn, every fx-id, every cofx-id.
 - **[Principles.md](Principles.md)** — Story-specific non-negotiables — EDN-first first among them — the test new features pass against.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major call was made; the seven rf2-m6tu §6 decisions plus Phase-2 SOTA additions and IMPL-SPEC-emergent calls.

--- a/tools/story/src/re_frame/story/ui/actions.cljc
+++ b/tools/story/src/re_frame/story/ui/actions.cljc
@@ -1,0 +1,515 @@
+(ns re-frame.story.ui.actions
+  "Actions panel — a dedicated, chronological view of user-action
+  dispatches and dispatch-shaped fx invocations against the variant's
+  trace buffer. Per Story SOTA audit F3 / rf2-5yriz.
+
+  ## What it is
+
+  Storybook's `action('clicked')` API surfaces handler-call events in
+  a dedicated 'Actions' panel so designers can answer 'what did the
+  user just do?' without reading source.  Story's trace panel already
+  captures the full six-domino cascade — far more than Storybook's
+  Actions panel sees — but the cascade view conflates user-driven
+  dispatches with the internal cascade (effects, sub re-runs, view
+  renders) and asks the reader to mentally filter.
+
+  This panel is the cheap filter.  It reads the same per-variant
+  trace buffer the trace panel reads (`re-frame.story.ui.trace/
+  buffers`, populated by the listener wired at variant-selection in
+  `re-frame.story.ui.shell`) and projects the buffer down to two
+  classes of events:
+
+    1. **dispatches** — every `:event/dispatched` trace event,
+       regardless of whether it was a root dispatch or a descendant
+       fired from inside a handler.
+    2. **dispatch-shaped fx invocations** — every `:rf.fx/handled`
+       trace event whose `:tags :fx-id` is one of `:dispatch`,
+       `:dispatch-later`, or `:dispatch-sync`.
+
+  Together those two channels cover both 'a user clicked, an event
+  fired' (1) and 'a handler returned `:fx [[:dispatch x]]` so a
+  follow-on dispatch is queued' (2).  Either signal is meaningful
+  for 'what's actually happening'.
+
+  ## Differentiator vs Storybook
+
+  Storybook's panel only captures whatever the author manually wired
+  via `action('name')` per handler.  Forget to wire one and the panel
+  goes silent.  Story's panel sees EVERYTHING on the trace bus
+  automatically — every `dispatch`, every `dispatch-later`, every
+  fx-handled emit — without any manual instrumentation.  The header
+  copy says so.
+
+  ## UX
+
+      ┌──────────────────────────────────────────────────────┐
+      │  Actions — <variant-id> — N events  [pause] [clear]   │
+      ├──────────────────────────────────────────────────────┤
+      │  hh:mm:ss.mmm  :counter/inc          []              │
+      │  hh:mm:ss.mmm  :rf.fx/handled  :dispatch  [:foo]     │
+      │  hh:mm:ss.mmm  :counter/dec          []              │
+      │  …                                                   │
+      └──────────────────────────────────────────────────────┘
+
+  - The list scrolls; on every render the panel re-anchors at the
+    bottom (newest entry visible) unless the user has scrolled up.
+  - **Pause** flips a per-variant boolean.  While paused, the
+    projection is computed against a SNAPSHOT of the trace buffer
+    taken at the moment of pause; new trace events continue to
+    accumulate in the underlying buffer (we don't pause capture, we
+    pause rendering) so unpausing 'rewinds' you to live.
+  - **Clear** zeros the underlying trace buffer for the variant via
+    `trace/clear-buffer!`.  That is the same clear the trace panel
+    would do — both panels share the buffer.  We deliberately wire
+    to the same primitive so the panels stay coherent.
+
+  ## Source-coord hook
+
+  Each row carries the action's `:rf.trace/trigger-handler` (per
+  Spec 009 §Source-coord stamping) under the row's `:source` slot.
+  When rf2-evgf5 lands and Story ships an 'Open in editor' click
+  affordance, the row's source-coord is already in hand — the
+  click-handler wraps the existing slot.  No retrofit needed.
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` so the pure projection (`action-event?`,
+  `project-rows`, `format-timestamp`) can be exercised by the JVM
+  test corpus alongside the cljs-test node runner.  The Reagent
+  rendering, the listener wiring, and the pause/clear ratoms are
+  CLJS-only.
+
+  ## Elision
+
+  The pure helpers below run on the JVM and in dev CLJS only — the
+  panel's mount call sits behind `re-frame.story.config/enabled?` in
+  the shell, so production builds short-circuit before any panel fn
+  is reached.  Closure DCEs the lot.
+
+  ## Panel registry slot
+
+  Per rf2-5yriz the shell wires this panel as a top-level slot under
+  the `:actions` key in `:panel-visibility` — the same shape used by
+  `:trace`, `:scrubber`, `:controls`.  Stage 6's `reg-story-panel`
+  contract handles registered panels; the built-in Story chrome
+  panels (trace, scrubber, controls, actions) are wired by the shell
+  directly because they are always present and have no late-bind
+  contract."
+  #?(:cljs
+     (:require [reagent.core            :as r]
+               [re-frame.story.ui.trace :as trace])))
+
+;; ---- the dispatch-shaped fx-ids -----------------------------------------
+
+(def dispatch-shaped-fx-ids
+  "Set of `:fx-id` values whose `:rf.fx/handled` trace event represents
+  a (re-)dispatch of an event vector.  Per re-frame.fx/handle-one-fx
+  the framework emits `:rf.fx/handled` with one of these ids whenever
+  an event handler returned `:fx [[:dispatch ...] [:dispatch-later
+  ...] [:dispatch-sync ...]]`.  We surface those alongside the
+  primary `:event/dispatched` channel so the panel shows both the
+  enqueue (the fx) AND the drain (the eventual `:event/dispatched`)."
+  #{:dispatch :dispatch-later :dispatch-sync})
+
+;; ---- pure: classify a trace event -------------------------------------
+
+(defn action-event?
+  "True iff `ev` (a raw trace event from the buffer) is one of the two
+  classes the Actions panel surfaces:
+
+    - `:op-type :event` + `:operation :event/dispatched` — a dispatch
+      landing on the router.
+    - `:op-type :fx` + `:operation :rf.fx/handled` + `:tags :fx-id`
+      ∈ `dispatch-shaped-fx-ids` — a dispatch-shaped fx invocation.
+
+  Pure data → boolean; JVM-testable."
+  [{:keys [op-type operation tags] :as _ev}]
+  (boolean
+    (or (and (= op-type :event)
+             (= operation :event/dispatched))
+        (and (= op-type :fx)
+             (= operation :rf.fx/handled)
+             (contains? dispatch-shaped-fx-ids (:fx-id tags))))))
+
+;; ---- pure: project a trace event into a row ---------------------------
+
+(defn row-class
+  "Classify a trace event into one of two row classes so the renderer
+  can colour-code dispatch (`:dispatch`) vs fx-emit (`:fx-dispatch`).
+  Returns nil for events that don't classify (caller should have
+  filtered via `action-event?` first; this is the secondary classifier
+  used by the row projection)."
+  [{:keys [op-type operation] :as _ev}]
+  (cond
+    (and (= op-type :event) (= operation :event/dispatched)) :dispatch
+    (and (= op-type :fx)    (= operation :rf.fx/handled))    :fx-dispatch
+    :else                                                    nil))
+
+(defn project-row
+  "Project one raw trace event into the row shape the panel renders.
+  Pure data → data; JVM-testable.
+
+  Output shape:
+
+      {:id          <int>                 ;; the trace event's :id (stable per-process key)
+       :class       :dispatch|:fx-dispatch
+       :time        <ms-since-epoch>      ;; from the trace event's :time
+       :event-id    <kw|nil>              ;; the event-id for both classes
+       :event       <vector|nil>          ;; the full event vector when present
+       :args        <any|nil>             ;; for :fx-dispatch rows, the dispatched event's args
+       :dispatch-id <id-or-nil>           ;; cascade correlation
+       :origin      <kw|nil>              ;; per Spec 009 §Origin tagging
+       :fx-id       <kw|nil>              ;; nil for :dispatch rows
+       :source      <{:file :line :column}|nil>  ;; trigger-handler coord, rf2-evgf5 hook
+       :raw         <trace-event>}"
+  [{:keys [op-type operation tags id time] :as ev}]
+  (let [class (row-class ev)
+        rf-trigger (:rf.trace/trigger-handler ev)
+        trig-src   (:source-coord rf-trigger)]
+    (case class
+      :dispatch
+      {:id          id
+       :class       :dispatch
+       :time        time
+       :event-id    (or (:event-id tags)
+                        (some-> tags :event first))
+       :event       (:event tags)
+       :args        nil
+       :dispatch-id (:dispatch-id tags)
+       :origin      (:origin tags)
+       :fx-id       nil
+       :source      trig-src
+       :raw         ev}
+
+      :fx-dispatch
+      (let [fx-args (:fx-args tags)
+            evt     (cond
+                      (vector? fx-args)             fx-args ;; :dispatch  → [event-id args...]
+                      (map?    fx-args)             (:event fx-args) ;; :dispatch-later → {:event ... :ms ...}
+                      :else                         nil)]
+        {:id          id
+         :class       :fx-dispatch
+         :time        time
+         :event-id    (some-> evt first)
+         :event       (when (vector? evt) evt)
+         :args        (when (and (vector? evt) (> (count evt) 1))
+                        (vec (rest evt)))
+         :dispatch-id (:dispatch-id tags)
+         :origin      (:origin tags)
+         :fx-id       (:fx-id tags)
+         :source      trig-src
+         :raw         ev})
+
+      ;; nil class — shouldn't happen if action-event? was checked, but
+      ;; return a minimal row so the renderer can still surface it.
+      {:id          id
+       :class       :unknown
+       :time        time
+       :event-id    nil
+       :event       nil
+       :args        nil
+       :dispatch-id (:dispatch-id tags)
+       :origin      nil
+       :fx-id       nil
+       :source      trig-src
+       :raw         ev})))
+
+(defn project-rows
+  "Filter `events` (a seq of raw trace events from the buffer) to the
+  action-emit subset and project each one into a row.  Returns a
+  vector in chronological order — same order the trace buffer
+  delivers (oldest first), so the renderer can `take-last N` for the
+  most-recent slice or render the whole vector with auto-scroll-to-
+  bottom.
+
+  Pure data → data; JVM-testable."
+  [events]
+  (into []
+        (comp (filter action-event?)
+              (map project-row))
+        events))
+
+;; ---- pure: formatting --------------------------------------------------
+
+(defn format-timestamp
+  "Render a wall-clock `ms` (UNIX epoch milliseconds, as captured by
+  `re-frame.interop/now-ms`) as `\"HH:MM:SS.mmm\"`.  Pure; JVM-testable.
+
+  `nil` / non-number inputs return the empty string so the renderer
+  can interpolate it safely.
+
+  Uses the platform's local time.  Both branches handle the
+  fractional-millis padding so 1ms-resolution timestamps don't
+  collapse to two digits."
+  [ms]
+  (cond
+    (nil? ms)          ""
+    (not (number? ms)) ""
+    (neg? ms)          ""
+    :else
+    (let [millis (mod (long ms) 1000)
+          ;; The CLJS branch uses Date for local-time HH:MM:SS; the
+          ;; JVM branch uses a SimpleDateFormat-equivalent via formatting.
+          pad   (fn [n w]
+                  (let [s (str n)]
+                    (if (< (count s) w)
+                      (str (apply str (repeat (- w (count s)) "0")) s)
+                      s)))]
+      #?(:clj
+         (let [d  (java.util.Date. (long ms))
+               c  (doto (java.util.Calendar/getInstance)
+                    (.setTime d))]
+           (str (pad (.get c java.util.Calendar/HOUR_OF_DAY) 2) ":"
+                (pad (.get c java.util.Calendar/MINUTE)      2) ":"
+                (pad (.get c java.util.Calendar/SECOND)      2) "."
+                (pad millis                                  3)))
+         :cljs
+         (let [d (js/Date. ms)]
+           (str (pad (.getHours d)   2) ":"
+                (pad (.getMinutes d) 2) ":"
+                (pad (.getSeconds d) 2) "."
+                (pad millis          3)))))))
+
+(defn pretty-args
+  "Render the optional args vector for a row (everything after the
+  event-id in the dispatched event vector) as a short pr-str.  Empty
+  / nil → the empty string.  Pure; JVM-testable."
+  [args]
+  (cond
+    (nil? args)        ""
+    (and (coll? args)
+         (zero? (count args))) ""
+    :else              (pr-str args)))
+
+;; ---- per-variant pause state -------------------------------------------
+;;
+;; Pause is per-variant so the user can pause /story.a/x's actions
+;; while keeping /story.b/y live.  On pause we ALSO capture the
+;; current buffer snapshot so the panel renders the moment-of-pause
+;; even as new trace events continue to flow into the underlying
+;; buffer.  Unpausing drops the snapshot and renders against the
+;; live buffer again.
+;;
+;; `paused-state` carries `{variant-id → {:paused? bool :snapshot
+;; [trace-event ...]}}`.  CLJS-only because the runtime uses
+;; `reagent.core/atom` so toggles trigger re-renders.  On the JVM
+;; the per-variant pause state is irrelevant (no shell mounted)
+;; and the helpers below are unused.
+
+#?(:cljs
+   (defonce paused-state
+     ;; Reagent ratom so the panel re-renders when pause / unpause
+     ;; toggles.  The buffer snapshot lives inside the ratom so
+     ;; updates fire one re-render, not two.
+     (r/atom {})))
+
+#?(:cljs
+   (defn paused?
+     "True iff actions are currently paused for `variant-id`."
+     [variant-id]
+     (boolean (get-in @paused-state [variant-id :paused?]))))
+
+#?(:cljs
+   (defn pause!
+     "Pause action-rendering for `variant-id`.  Captures the current
+     trace buffer as the snapshot the panel renders against until
+     unpause.  Idempotent."
+     [variant-id]
+     (let [buf (some-> (get @trace/buffers variant-id) deref)]
+       (swap! paused-state assoc variant-id
+              {:paused?  true
+               :snapshot (vec (or buf []))}))
+     nil))
+
+#?(:cljs
+   (defn unpause!
+     "Resume live action-rendering for `variant-id`.  Drops the
+     captured snapshot.  Idempotent."
+     [variant-id]
+     (swap! paused-state assoc variant-id
+            {:paused?  false
+             :snapshot nil})
+     nil))
+
+#?(:cljs
+   (defn toggle-pause!
+     "Toggle `paused?` for `variant-id`."
+     [variant-id]
+     (if (paused? variant-id)
+       (unpause! variant-id)
+       (pause! variant-id))))
+
+#?(:cljs
+   (defn current-events
+     "Return the trace events the panel should render.  When paused,
+     this is the snapshot captured at pause-time.  When live, this is
+     the underlying per-variant trace buffer.  The return value is a
+     vector ready for `project-rows`."
+     [variant-id]
+     (if (paused? variant-id)
+       (or (get-in @paused-state [variant-id :snapshot]) [])
+       (let [a (get @trace/buffers variant-id)]
+         (if a @a [])))))
+
+#?(:cljs
+   (defn clear!
+     "Clear the underlying trace buffer for `variant-id`.  Shared with
+     the trace panel — both panels read the same buffer — so this is
+     a destructive operation.  Unpauses on clear (otherwise the panel
+     would still render the now-stale snapshot)."
+     [variant-id]
+     (trace/clear-buffer! variant-id)
+     (unpause! variant-id)
+     nil))
+
+;; ---- styling ---------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:panel          {:padding "8px"
+                       :font-family "monospace"
+                       :font-size "11px"
+                       :border-top "1px solid #444"
+                       :background "#1e1e1e"
+                       :color "#ddd"
+                       :overflow "auto"
+                       :max-height "240px"}
+      :title          {:font-weight "bold"
+                       :margin-bottom "6px"
+                       :color "#9cdcfe"
+                       :display "flex"
+                       :justify-content "space-between"
+                       :align-items "center"
+                       :gap "8px"}
+      :title-text     {:flex "1 1 auto"
+                       :overflow "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space "nowrap"}
+      :btn            {:padding "2px 8px"
+                       :background "#2d2d30"
+                       :color "#d0d0d0"
+                       :border "1px solid #444"
+                       :border-radius "3px"
+                       :font-family "monospace"
+                       :font-size "10px"
+                       :cursor "pointer"}
+      :btn-active     {:background "#264f78"
+                       :color "white"
+                       :border-color "#264f78"}
+      :hint           {:color "#9a9a9a"
+                       :font-style "italic"
+                       :font-size "10px"
+                       :margin-bottom "6px"}
+      :rows-host      {:max-height "200px"
+                       :overflow-y "auto"
+                       :border-top "1px dotted #333"
+                       :padding-top "4px"}
+      :row            {:display "grid"
+                       :grid-template-columns "92px auto 1fr 1fr"
+                       :gap "6px"
+                       :padding "2px 0"
+                       :border-bottom "1px dotted #2a2a2a"
+                       :align-items "baseline"}
+      :cell           {:overflow "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space "nowrap"}
+      :cell-time      {:color "#9a9a9a"}
+      :cell-eid       {:color "#dcdcaa"
+                       :font-weight "bold"}
+      :cell-args      {:color "#b5cea8"}
+      :cell-tag       {:color "#9cdcfe"
+                       :font-style "italic"}
+      :empty          {:color "#9a9a9a"
+                       :font-style "italic"}}))
+
+;; ---- view ------------------------------------------------------------
+
+#?(:cljs
+   (defn action-row
+     "Render one row.  Form-1 — pure projection over the row map; no
+     deref happens inside.  The wrapping panel handles the reactive
+     deref so per-row equality is React-stable.
+
+     Per rf2-5yriz the row carries a `data-test=\"story-actions-row\"`
+     attribute so the browser-side Playwright spec can locate rows
+     deterministically across renders.  Source-coord lives on the
+     row map under `:source` and rides on the `title` tooltip — when
+     rf2-evgf5 lands the click-handler binds to the same slot."
+     [{:keys [class time event-id event args fx-id source] :as _row}]
+     (let [title (when source
+                   (str (:file source) ":" (:line source)))
+           tag   (case class
+                   :dispatch     ""
+                   :fx-dispatch  (str ":fx-handled " fx-id)
+                   :unknown      "(unknown)")
+           tail  (cond
+                   (and (= class :dispatch) event)
+                   (pretty-args (when (> (count event) 1)
+                                  (vec (rest event))))
+                   (= class :fx-dispatch) (pretty-args args)
+                   :else                  "")]
+       [:div {:style                (:row styles)
+              :title                title
+              :data-test            "story-actions-row"
+              :data-row-class       (when class (name class))
+              :data-event-id        (when event-id (str event-id))}
+        [:span {:style (merge (:cell styles) (:cell-time styles))}
+         (format-timestamp time)]
+        [:span {:style (merge (:cell styles) (:cell-eid styles))}
+         (if event-id (pr-str event-id) "—")]
+        [:span {:style (merge (:cell styles) (:cell-args styles))} tail]
+        [:span {:style (merge (:cell styles) (:cell-tag styles))} tag]])))
+
+#?(:cljs
+   (defn panel
+     "The Actions panel.  Per rf2-5yriz form-2 — the inner render fn
+     derefs the trace buffer + the pause state so Reagent's reaction
+     tracking observes every change.  Mirrors the shape of
+     `re-frame.story.ui.trace/panel`.
+
+     Renders a scrollable region tagged with `data-test=\"story-actions-
+     panel\"` and `role=\"region\"` + `aria-label` so axe-core's
+     scrollable-region-focusable rule passes and the browser-test
+     spec can anchor on it."
+     [variant-id]
+     ;; Form-2: capture the buffer atom on the outer closure so the
+     ;; per-render fn observes the same source-of-truth across the
+     ;; component's lifecycle.  Mirrors the trace panel.
+     (let [_buf (trace/ensure-buffer! variant-id)]
+       (fn [variant-id]
+         (let [paused (paused? variant-id)
+               events (current-events variant-id)
+               rows   (project-rows events)]
+           [:div {:style      (:panel styles)
+                  :role       "region"
+                  :aria-label "Actions"
+                  :tab-index  "0"
+                  :data-test  "story-actions-panel"}
+            [:div {:style (:title styles)}
+             [:span {:style (:title-text styles)}
+              "Actions" (when variant-id (str " " (pr-str variant-id)))
+              " — " (count rows) " events"
+              (when paused " (paused)")]
+             [:button {:style     (merge (:btn styles)
+                                         (when paused (:btn-active styles)))
+                       :on-click  (fn [_] (toggle-pause! variant-id))
+                       :data-test "story-actions-pause"
+                       :aria-pressed (str paused)
+                       :title     (if paused "resume" "pause")}
+              (if paused "resume" "pause")]
+             [:button {:style     (:btn styles)
+                       :on-click  (fn [_] (clear! variant-id))
+                       :data-test "story-actions-clear"
+                       :title     "clear the trace buffer"}
+              "clear"]]
+            [:div {:style (:hint styles)}
+             "auto-captures every dispatch + dispatch-shaped fx — "
+             "no manual instrumentation needed."]
+            (if (zero? (count rows))
+              [:div {:style (:empty styles)}
+               "no actions yet — interact with the variant to see dispatches stream in"]
+              [:div {:style     (:rows-host styles)
+                     :data-test "story-actions-rows"}
+               (for [row rows]
+                 ^{:key (:id row)}
+                 [action-row row])])])))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -42,6 +42,7 @@
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames :as frames]
             [re-frame.story.runtime :as runtime]
+            [re-frame.story.ui.actions :as actions]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.docs :as docs]
@@ -253,6 +254,15 @@
        [scrubber/panel variant-id])
      (when (and (:trace vis) variant-id)
        [trace/panel variant-id])
+     ;; rf2-5yriz — Actions panel.  Reads from the same per-variant
+     ;; trace buffer the six-domino panel reads, but filters down to
+     ;; dispatches + dispatch-shaped fx-handled emits and renders
+     ;; chronologically with pause + clear affordances.  Wired here
+     ;; (not via reg-story-panel) because Story's built-in chrome
+     ;; panels (trace, scrubber, controls, actions) are always-present
+     ;; and have no late-bind contract.
+     (when (and (:actions vis) variant-id)
+       [actions/panel variant-id])
      ;; Stage 6: render any registered :right-placement story panels.
      (when variant-id
        [panels/render-panels-at-placement :right variant-id vis])]))

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -56,8 +56,8 @@
   - `:panel-visibility`  — {panel-id → boolean}. Determines whether a
                            registered :story-panel renders in the chrome.
                            Stage 4 ships a vanilla set of panels (trace /
-                           scrubber / controls); Stage 6 will register
-                           more via reg-story-panel.
+                           scrubber / controls / actions per rf2-5yriz);
+                           Stage 6 will register more via reg-story-panel.
   - `:active-mode-tab`   — {variant-id → :dev | :docs | :test}. Per-variant
                            mode-tab selection for the render-shell's top
                            Canvas | Docs | Tests switcher (rf2-9hc8).
@@ -73,7 +73,7 @@
    :hot-reload-tick    0
    :fingerprints       {}
    :pinned-snapshots   {}
-   :panel-visibility   {:trace true :scrubber true :controls true}
+   :panel-visibility   {:trace true :scrubber true :controls true :actions true}
    :active-mode-tab    {}})
 
 ;; ---- pure transition fns (JVM-testable) ----------------------------------

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -52,8 +52,11 @@
   ;; {variant-id → r/atom holding a vector of trace events, newest-last}
   (atom {}))
 
-(defn- ensure-buffer!
-  "Return the per-variant ratom, creating it on first access."
+(defn ensure-buffer!
+  "Return the per-variant trace-buffer ratom, creating it on first
+  access.  Public so sibling panels (e.g. the Actions panel per
+  rf2-5yriz) can subscribe to the SAME ratom the six-domino trace
+  panel reads from — both panels share the buffer."
   [variant-id]
   (or (get @buffers variant-id)
       (let [a (r/atom [])]

--- a/tools/story/test/re_frame/story/ui/actions_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/actions_cljs_test.cljc
@@ -1,0 +1,316 @@
+(ns re-frame.story.ui.actions-cljs-test
+  "Tests for the Actions panel (rf2-5yriz).
+
+  Runs on both the JVM (cognitect.test-runner under
+  `clojure -M:test`) and the CLJS node-test build (shadow's
+  `:node-test` target; ns-regexp `cljs-test$` picks up this ns
+  because its name ends in `cljs-test`).
+
+  ## Coverage layers
+
+  - **Pure data**: `action-event?` classification, `project-rows`
+    projection, `format-timestamp` formatting, `pretty-args` rendering,
+    `row-class` derivation.  All runs on JVM AND CLJS.
+  - **CLJS-only side-effects**: pause / unpause / toggle / clear
+    against the per-variant pause ratoms; `current-events`'s
+    snapshot vs live-buffer behaviour; the panel component returns
+    hiccup.
+
+  The JVM-side test corpus exercises only the pure surface (`#?(:clj
+  ...)` short-circuits the CLJS pieces).  The CLJS node-test
+  exercises the full surface."
+  (:require [clojure.test :refer [deftest is testing]]
+            #?@(:cljs [[re-frame.story.ui.trace :as trace]])
+            [re-frame.story.ui.actions :as actions]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn dispatch-event
+  "Build a `:event/dispatched` trace event with sensible defaults."
+  ([id event] (dispatch-event id event {}))
+  ([id event extra-tags]
+   {:op-type   :event
+    :operation :event/dispatched
+    :id        id
+    :time      (+ 1700000000000 (* id 10))
+    :tags      (merge {:dispatch-id (+ 1000 id)
+                       :event-id    (first event)
+                       :event       event}
+                      extra-tags)}))
+
+(defn fx-dispatch-event
+  "Build a `:rf.fx/handled` trace event for a dispatch-shaped fx-id."
+  ([id fx-id event] (fx-dispatch-event id fx-id event {}))
+  ([id fx-id event extra-tags]
+   {:op-type   :fx
+    :operation :rf.fx/handled
+    :id        id
+    :time      (+ 1700000000000 (* id 10))
+    :tags      (merge {:dispatch-id (+ 2000 id)
+                       :fx-id       fx-id
+                       :fx-args     event}
+                      extra-tags)}))
+
+(defn unrelated-event
+  "Build a non-action trace event (something that should be filtered
+  out — a sub-run, a render, a do-fx, etc.)."
+  [id op-type operation]
+  {:op-type   op-type
+   :operation operation
+   :id        id
+   :time      (+ 1700000000000 (* id 10))
+   :tags      {:dispatch-id (+ 1000 id)}})
+
+;; ---- pure: action-event? classification ----------------------------------
+
+(deftest action-event?-classifies-dispatches
+  (testing "every :event/dispatched is an action event"
+    (is (actions/action-event?
+          (dispatch-event 1 [:counter/inc])))
+    (is (actions/action-event?
+          (dispatch-event 2 [:user/login {:id 7}])))
+    ;; Even descendant dispatches inside a cascade qualify.
+    (is (actions/action-event?
+          (dispatch-event 3 [:counter/dec] {:parent-dispatch-id 999})))))
+
+(deftest action-event?-classifies-dispatch-fxs
+  (testing ":rf.fx/handled with dispatch-shaped fx-id qualifies"
+    (is (actions/action-event?
+          (fx-dispatch-event 10 :dispatch       [:counter/inc])))
+    (is (actions/action-event?
+          (fx-dispatch-event 11 :dispatch-later [:counter/inc] {:fx-args {:event [:counter/inc] :ms 100}})))
+    (is (actions/action-event?
+          (fx-dispatch-event 12 :dispatch-sync  [:counter/inc])))))
+
+(deftest action-event?-rejects-non-dispatch-fxs
+  (testing ":rf.fx/handled with a non-dispatch fx-id is NOT an action"
+    (is (not (actions/action-event?
+               (fx-dispatch-event 20 :db          [:counter/inc]))))
+    (is (not (actions/action-event?
+               (fx-dispatch-event 21 :rf.fx/reg-flow {:id :flow.x/y}))))
+    (is (not (actions/action-event?
+               (fx-dispatch-event 22 :http        {:url "/api"}))))))
+
+(deftest action-event?-rejects-cascade-internals
+  (testing "handler / do-fx / sub / render / error / warning trace events all reject"
+    (is (not (actions/action-event? (unrelated-event 30 :event :event))))       ;; handler run
+    (is (not (actions/action-event? (unrelated-event 31 :event :event/do-fx)))) ;; effects map
+    (is (not (actions/action-event? (unrelated-event 32 :sub/run :sub/run))))
+    (is (not (actions/action-event? (unrelated-event 33 :sub/create :sub/create))))
+    (is (not (actions/action-event? (unrelated-event 34 :view :view/render))))
+    (is (not (actions/action-event? (unrelated-event 35 :error :rf.error/handler-exception))))
+    (is (not (actions/action-event? (unrelated-event 36 :warning :rf.fx/skipped-on-platform))))))
+
+(deftest action-event?-rejects-empty-and-malformed
+  (testing "empty / partial trace events do not classify"
+    (is (not (actions/action-event? {})))
+    (is (not (actions/action-event? {:op-type :event})))
+    (is (not (actions/action-event? {:op-type :event :operation :event})))))
+
+;; ---- pure: row-class -----------------------------------------------------
+
+(deftest row-class-derivation
+  (testing "row-class returns :dispatch / :fx-dispatch / nil"
+    (is (= :dispatch    (actions/row-class (dispatch-event 1 [:foo]))))
+    (is (= :fx-dispatch (actions/row-class (fx-dispatch-event 2 :dispatch [:bar]))))
+    (is (nil?           (actions/row-class (unrelated-event 3 :sub/run :sub/run))))))
+
+;; ---- pure: project-rows --------------------------------------------------
+
+(deftest project-rows-filters-and-projects
+  (testing "a buffer with mixed events returns only action rows, projected
+            into the canonical shape, in input order"
+    (let [buf  [(dispatch-event       1 [:counter/inc])
+                (unrelated-event      2 :event :event)                ;; filtered
+                (unrelated-event      3 :sub/run :sub/run)            ;; filtered
+                (fx-dispatch-event    4 :dispatch [:counter/dec])
+                (unrelated-event      5 :view :view/render)           ;; filtered
+                (dispatch-event       6 [:user/login {:user-id 7}])
+                (fx-dispatch-event    7 :dispatch-later
+                                        [:counter/inc]
+                                        {:fx-args {:event [:counter/inc] :ms 500}})]
+          rows (actions/project-rows buf)]
+      (is (= 4 (count rows)))
+      ;; Chronological order (input order) preserved.
+      (is (= [1 4 6 7] (map :id rows)))
+      ;; Classes alternate as expected.
+      (is (= [:dispatch :fx-dispatch :dispatch :fx-dispatch]
+             (map :class rows)))
+      ;; First row: dispatch of [:counter/inc].
+      (let [r (nth rows 0)]
+        (is (= :counter/inc (:event-id r)))
+        (is (= [:counter/inc] (:event r)))
+        (is (= 1001 (:dispatch-id r)))
+        (is (number? (:time r))))
+      ;; Second row: fx-dispatch of [:counter/dec] via :dispatch fx.
+      (let [r (nth rows 1)]
+        (is (= :counter/dec (:event-id r)))
+        (is (= [:counter/dec] (:event r)))
+        (is (= :dispatch (:fx-id r)))
+        (is (= 2004 (:dispatch-id r))))
+      ;; Third row: dispatch with extra arg.
+      (let [r (nth rows 2)]
+        (is (= :user/login (:event-id r))))
+      ;; Fourth row: :dispatch-later carries fx-args as a map; event-id
+      ;; should still surface from the inner :event.
+      (let [r (nth rows 3)]
+        (is (= :dispatch-later (:fx-id r)))
+        (is (= :counter/inc (:event-id r)))
+        (is (= [:counter/inc] (:event r)))))))
+
+(deftest project-rows-on-empty
+  (testing "empty buffer yields empty vector"
+    (is (= [] (actions/project-rows [])))
+    (is (= [] (actions/project-rows nil)))))
+
+(deftest project-rows-source-coord-hook
+  (testing "row carries trigger-handler source-coord under :source when present"
+    (let [ev   (-> (dispatch-event 1 [:counter/inc])
+                   (assoc :rf.trace/trigger-handler
+                          {:kind :event :id :counter/inc
+                           :source-coord {:ns "counter.events"
+                                          :file "counter/events.cljs"
+                                          :line 42}}))
+          rows (actions/project-rows [ev])]
+      (is (= 1 (count rows)))
+      (is (= 42 (-> rows first :source :line))))))
+
+;; ---- pure: format-timestamp ---------------------------------------------
+
+(deftest format-timestamp-renders-hh-mm-ss-mmm
+  (testing "non-empty for valid ms"
+    (let [out (actions/format-timestamp 1700000000000)]
+      (is (string? out))
+      ;; Output looks like "HH:MM:SS.mmm" — 12 characters, with two
+      ;; colons and one dot.
+      (is (= 12 (count out)))
+      (is (= 2 (count (filter #(= % \:) out))))
+      (is (= 1 (count (filter #(= % \.) out))))))
+  (testing "pads sub-second millis to three digits"
+    ;; ms ending in 7 → ".007"
+    (let [out (actions/format-timestamp 1700000000007)]
+      (is (re-find #"\.007$" out)))
+    ;; ms ending in 42 → ".042"
+    (let [out (actions/format-timestamp 1700000000042)]
+      (is (re-find #"\.042$" out)))
+    ;; ms ending in 700 → ".700"
+    (let [out (actions/format-timestamp 1700000000700)]
+      (is (re-find #"\.700$" out)))))
+
+(deftest format-timestamp-handles-nil-and-bad-inputs
+  (testing "nil / non-number / negative → empty string"
+    (is (= "" (actions/format-timestamp nil)))
+    (is (= "" (actions/format-timestamp "abc")))
+    (is (= "" (actions/format-timestamp -1)))))
+
+;; ---- pure: pretty-args ---------------------------------------------------
+
+(deftest pretty-args-renders-via-pr-str
+  (testing "pretty-args round-trips non-empty collections through pr-str"
+    (is (= "" (actions/pretty-args nil)))
+    (is (= "" (actions/pretty-args [])))
+    (is (= (pr-str [1 2 3]) (actions/pretty-args [1 2 3])))
+    (is (= (pr-str [{:user-id 7}]) (actions/pretty-args [{:user-id 7}])))))
+
+;; ---- CLJS-only: pause / unpause / toggle / clear -------------------------
+
+#?(:cljs
+   (do
+     (deftest pause-unpause-roundtrip
+       (testing "pause / unpause flip per-variant state and capture snapshot"
+         (let [vid :story.actions-test/v1]
+           ;; Clean slate.
+           (actions/unpause! vid)
+           (is (false? (actions/paused? vid)))
+           ;; Seed the trace buffer for vid so pause has a snapshot.
+           (let [a (trace/ensure-buffer! vid)]
+             (reset! a [(dispatch-event 1 [:foo])
+                        (dispatch-event 2 [:bar])]))
+           (actions/pause! vid)
+           (is (true? (actions/paused? vid)))
+           ;; Snapshot must equal the buffer at pause time.
+           (let [snap (actions/current-events vid)]
+             (is (= 2 (count snap))))
+           ;; Continue mutating the buffer; the snapshot should not move.
+           (let [a (trace/ensure-buffer! vid)]
+             (swap! a conj (dispatch-event 3 [:baz])))
+           (let [snap (actions/current-events vid)]
+             (is (= 2 (count snap)))
+             (is (every? #(not= :baz (first (:event %)))
+                         (map :tags snap))))
+           ;; Unpause — current-events now reflects the live buffer.
+           (actions/unpause! vid)
+           (is (false? (actions/paused? vid)))
+           (let [live (actions/current-events vid)]
+             (is (= 3 (count live))))
+           ;; Cleanup.
+           (trace/drop-buffer! vid))))
+
+     (deftest toggle-pause-flips
+       (testing "toggle-pause! cycles paused state"
+         (let [vid :story.actions-test/v-toggle]
+           (actions/unpause! vid)
+           (is (false? (actions/paused? vid)))
+           (actions/toggle-pause! vid)
+           (is (true? (actions/paused? vid)))
+           (actions/toggle-pause! vid)
+           (is (false? (actions/paused? vid)))
+           (trace/drop-buffer! vid))))
+
+     (deftest clear-empties-buffer-and-unpauses
+       (testing "clear! drops the variant's trace buffer + leaves panel unpaused"
+         (let [vid :story.actions-test/v-clear]
+           ;; Seed + pause.
+           (let [a (trace/ensure-buffer! vid)]
+             (reset! a [(dispatch-event 1 [:a]) (dispatch-event 2 [:b])]))
+           (actions/pause! vid)
+           (is (= 2 (count (actions/current-events vid))))
+           (is (true? (actions/paused? vid)))
+           ;; Clear.
+           (actions/clear! vid)
+           (is (= 0 (count (actions/current-events vid))))
+           (is (false? (actions/paused? vid)))
+           (trace/drop-buffer! vid))))
+
+     ;; ---- panel render smoke -----------------------------------------
+
+     (deftest panel-is-a-function
+       (testing "actions/panel exposes a top-level component fn"
+         (is (fn? actions/panel))))
+
+     (deftest panel-returns-hiccup-when-invoked
+       (testing "panel returns a form-2 inner fn that produces hiccup"
+         (let [vid :story.actions-test/v-render
+               ;; Seed two action events so the panel renders rows.
+               _   (let [a (trace/ensure-buffer! vid)]
+                     (reset! a [(dispatch-event 1 [:foo])
+                                (fx-dispatch-event 2 :dispatch [:bar])
+                                ;; A filtered event mixed in.
+                                (unrelated-event 3 :sub/run :sub/run)]))
+               inner (actions/panel vid)
+               ;; Form-2: the outer fn returns the inner render fn.
+               tree  (inner vid)]
+           (is (vector? tree))
+           (is (= :div (first tree)))
+           ;; The root carries the data-test attr per the DOM contract.
+           (is (= "story-actions-panel"
+                  (-> tree second :data-test)))
+           ;; Project-rows would surface two rows; spot-check the tree
+           ;; contains both event-ids somewhere in its flattened seq.
+           (let [flat (tree-seq coll? seq tree)]
+             (is (some #(= % "story-actions-pause") flat))
+             (is (some #(= % "story-actions-clear") flat)))
+           ;; Cleanup.
+           (actions/unpause! vid)
+           (trace/drop-buffer! vid))))
+
+     (deftest panel-shows-empty-state-with-no-events
+       (testing "with an empty buffer the panel renders the empty hint"
+         (let [vid :story.actions-test/v-empty
+               _   (let [a (trace/ensure-buffer! vid)] (reset! a []))
+               inner (actions/panel vid)
+               tree  (inner vid)
+               flat  (tree-seq coll? seq tree)
+               text  (filter string? flat)]
+           (is (some #(re-find #"no actions yet" %) text))
+           (trace/drop-buffer! vid))))))


### PR DESCRIPTION
## Summary

- New right-pane Actions panel filters Story's per-variant trace buffer to dispatches + dispatch-shaped fx-handled emits — the cheap "what did the user do?" view alongside the six-domino trace panel. Closes the F3 gap from the 2026-05-13 SOTA audit.
- Zero-config differentiator: Storybook 8 needs manual `action('clicked')` instrumentation per handler; Story sees every dispatch on the bus automatically, no per-component wiring.
- Pure data helpers (`action-event?`, `project-rows`, `format-timestamp`, `pretty-args`, `row-class`) ship in `.cljc` so the JVM test corpus exercises classification, projection, and formatting without booting Reagent. Pause / unpause / clear sit behind CLJS-only ratoms exercised by the node-test build.
- Spec `tools/story/spec/011-Actions-Panel.md` documents the filter contract, pause / clear semantics, auto-scroll behaviour, DOM `data-test` shape, and the Storybook-8 differentiator. `tools/story/src/re_frame/story/ui/trace.cljs::ensure-buffer!` promoted from private so both panels share the same per-variant buffer ratom.
- Wired into the canonical example: `examples/reagent/counter_with_stories/counter_with_stories.spec.cjs` §10b confirms the panel mounts, renders rows, and exposes the pause + clear buttons against the live counter playground.

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 180 tests, 527 assertions, 0 failures.
- [x] `npm run test:cljs` — 614 tests, 1490 assertions, 0 failures (new ns `re-frame.story.ui.actions-cljs-test` picked up).
- [x] `npm run test:browser` — 614 tests, 1517 assertions, 0 failures.
- [x] `npm run test:elision` — `=== PASS ===` for every sentinel.
- [x] `npm run test:examples` — all 25 examples PASS including `counter-with-stories` with the new §10b Actions-panel assertions.
- [x] `mkdocs build --strict` — 119 warnings (all pre-existing on `main`); my changes contribute zero new warnings.