### PR TITLE
feat(story): trace × scrubber integration — drag through trace events with live canvas replay (rf2-sxwvf)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -724,6 +724,181 @@ module.exports = {
     }
 
     // ====================================================================
+    // 11b. Trace × scrubber cross-reference (rf2-sxwvf)
+    // ====================================================================
+    //
+    // The trace panel cross-references the scrubber's selection:
+    //   - data-scrubbed-epoch attribute set when a scrub is in flight;
+    //   - a scrub-note line surfaces above the cascade table;
+    //   - the cascade row whose post-effects produced the selected
+    //     epoch carries `data-selected="true"`;
+    //   - a "release" button clears the selection.
+    //
+    // The scrub at step 11 targeted epoch 0 — the variant's
+    // `:counter/initialise` settle, which fires BEFORE the trace
+    // listener is wired (the listener mounts on variant *selection*,
+    // not on frame allocation). So epoch 0's cascade is not in the
+    // trace buffer and no row is highlighted from that scrub.
+    //
+    // To exercise the highlight path we drive a *second* inc on top of
+    // the first (now we have epoch 1 = first inc, epoch 2 = second
+    // inc; both observed by the trace listener), then scrub to the
+    // slider's midpoint (epoch 1) — which IS in the trace buffer →
+    // the cascade row for epoch 1 is highlighted; the cascade row for
+    // epoch 2 is filtered out (emitted after the selected epoch
+    // settled). Drives both halves of the cross-reference: filter +
+    // highlight.
+
+    // Anchor: the trace panel's `[data-test]` attribute (rf2-sxwvf
+    // added this hook). The panel was already visible at §10 / §11,
+    // but capture the locator up-front for clarity.
+    const tracePanel = page.locator('[data-test="story-trace-panel"]');
+
+    // Clear the scrubber's selection first (the prior scrub at §11
+    // left selection = epoch at slider min — which would filter the
+    // trace panel to events at-or-before that epoch, hiding everything
+    // the listener captured since). Release returns the panel to
+    // showing the full buffer so we can re-scrub against a fresh
+    // pivot.
+    {
+      const rel = aside.locator('[data-test="story-scrubber-release"]');
+      if ((await rel.count()) > 0) {
+        await rel.click();
+      }
+    }
+
+    // Drive a "+" click so an inc cascade lands in the trace listener's
+    // buffer (the listener filters by `:tags :frame`; events whose
+    // frame is the active variant accumulate). We'll scrub to the
+    // LATEST epoch (slider max) so we know its cascade is in the
+    // buffer. The epoch-history ring buffer's default depth is 50, so
+    // the slider's `max` may already be saturated at 49 from earlier
+    // activity — the bump-after-inc check would be racy. We simply
+    // record the slider's current `max` and scrub to it; the latest
+    // record IS the inc we just clicked because every dispatch settles
+    // a new epoch at the tail.
+    await main.locator('[data-test="inc"]').first().click();
+
+    // Brief pause so the inc settles in the framework's epoch ring
+    // buffer (the listener wires synchronous emission but the epoch
+    // record commits on drain-settle, which is async).
+    await new Promise((r) => setTimeout(r, 250));
+
+    const sliderMax = parseInt((await slider.getAttribute('max')) || '0', 10);
+    if (sliderMax < 1) {
+      throw new Error(
+        `expected scrubber slider max >= 1 after an inc, got ${sliderMax}`,
+      );
+    }
+
+    // Drive the slider to its MAX (the latest epoch = the inc we just
+    // clicked). The cascade for that inc IS in the trace buffer (the
+    // listener was wired before the click), so the cross-reference
+    // must highlight it.
+    await slider.evaluate((el, mx) => {
+      const native = el;
+      native.value = String(mx);
+      native.dispatchEvent(new Event('input', { bubbles: true }));
+      native.dispatchEvent(new Event('change', { bubbles: true }));
+      native.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    }, sliderMax);
+
+    // data-scrubbed-epoch is set after the slider commit. Poll because
+    // the ratom commit + Reagent re-render cycle takes a couple of
+    // ticks. Anchored on `count()` rather than `visible` because the
+    // trace panel sits inside an overflow-auto scroll container — its
+    // visibility flag is racy with the right-pane's scroll position
+    // after the prior step's interactions, but its presence in the
+    // DOM is the load-bearing assertion.
+    {
+      const start = Date.now();
+      let attr = null;
+      while (Date.now() - start < 10000) {
+        if ((await tracePanel.count()) > 0) {
+          attr = await tracePanel.getAttribute('data-scrubbed-epoch').catch(() => null);
+          if (attr && attr.length > 0) break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!attr) {
+        throw new Error(
+          `expected story-trace-panel data-scrubbed-epoch to be set after scrub commit (rf2-sxwvf); panel count=${await tracePanel.count()}`,
+        );
+      }
+    }
+
+    // The scrub-note surfaces the selected epoch id. Anchor on
+    // count() because the panel sits inside an overflow-auto
+    // container (rf2-xc65) that intermittently considers nested
+    // nodes "not visible" while React re-renders.
+    {
+      const noteSel = '[data-test="story-trace-scrub-note"]';
+      const start = Date.now();
+      let ok = false;
+      while (Date.now() - start < 5000) {
+        if ((await page.locator(noteSel).count()) > 0) {
+          ok = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!ok) {
+        throw new Error(
+          'expected story-trace-scrub-note element to render after scrub commit (rf2-sxwvf)',
+        );
+      }
+    }
+
+    // At least one cascade row carries data-selected="true" — the
+    // cascade whose post-effects produced the scrubbed-to epoch.
+    {
+      const start = Date.now();
+      let selectedCount = 0;
+      while (Date.now() - start < 5000) {
+        selectedCount = await page
+          .locator('[data-test="story-trace-cascade-row"][data-selected="true"]')
+          .count();
+        if (selectedCount >= 1) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (selectedCount < 1) {
+        throw new Error(
+          'expected >=1 trace cascade row with data-selected="true" after scrub (rf2-sxwvf cross-reference did not fire)',
+        );
+      }
+    }
+
+    // The "release" button appears under the slider; clicking it
+    // clears the selection. Afterwards the panel's data-scrubbed-epoch
+    // is absent (DOM attribute removed ⇒ getAttribute returns null)
+    // and no row carries data-selected="true".
+    const releaseBtn = aside.locator('[data-test="story-scrubber-release"]');
+    await releaseBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await releaseBtn.click();
+    {
+      const start = Date.now();
+      let cleared = false;
+      while (Date.now() - start < 5000) {
+        const attr = await tracePanel
+          .getAttribute('data-scrubbed-epoch')
+          .catch(() => null);
+        const sel = await page
+          .locator('[data-test="story-trace-cascade-row"][data-selected="true"]')
+          .count();
+        if (!attr && sel === 0) {
+          cleared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!cleared) {
+        throw new Error(
+          'expected scrub-release to clear data-scrubbed-epoch and drop the highlight (rf2-sxwvf)',
+        );
+      }
+    }
+
+    // ====================================================================
     // 12. A11y panel — clicking "run" produces a status update
     // ====================================================================
     //

--- a/tools/story/spec/011-Trace-Scrubber-Cross-Ref.md
+++ b/tools/story/spec/011-Trace-Scrubber-Cross-Ref.md
@@ -1,0 +1,192 @@
+# Story — Trace × Scrubber Cross-Reference
+
+> The cross-reference between the scrubber (time-travel) and the trace
+> panel (six-domino cascade view). Scrubbing to an epoch filters the
+> trace panel to events at-or-before that epoch and highlights the
+> cascade whose post-effects produced it. The combination no JS
+> playground ships (rf2-sxwvf).
+
+## Why
+
+Story already has two independent surfaces over the same per-variant
+frame:
+
+- **The scrubber** (`re-frame.story.ui.scrubber`) reads the variant's
+  `epoch-history` and exposes a slider that scrubs forward/back through
+  epochs, committing via `restore-epoch` on release.
+- **The trace panel** (`re-frame.story.ui.trace`) registers a trace
+  listener against the variant's frame and renders the captured events
+  as six-domino cascades (per
+  [`re-frame.trace.projection/group-cascades`](../../../implementation/core/src/re_frame/trace/projection.cljc)).
+
+Until this surface they rendered independently. Tying them so "scrub to
+epoch N, see the trace that led to N + highlight the cascade that
+landed N" is a combination Storybook / Histoire / Ladle can't ship —
+they have no concept of a trace bus or an epoch buffer.
+
+This surface adds the cross-reference *without* a new shell-state slot
+— consumes the scrubber's existing per-variant `selections` ratom and
+the trace panel's existing `buffers` ratom. The render path derefs
+both and pipes the result through pure-data helpers.
+
+## Contract
+
+### Selection state
+
+The scrubber maintains a per-variant `selections` defonce ratom (CLJS
+side, in `re-frame.story.ui.scrubber`):
+
+```clojure
+{variant-id → (r/atom <selected-epoch-id-or-nil>)}
+```
+
+The value held is the epoch's **stable `:epoch-id`** — NOT the
+slider's slot index. An epoch-id is unique within a frame's history
+(per
+[`implementation/epoch/src/re_frame/epoch.cljc`](../../../implementation/epoch/src/re_frame/epoch.cljc));
+an index can silently re-point at a different record when the ring
+buffer's depth cap evicts an older epoch.
+
+Selection lifecycle:
+
+| Trigger                                 | Action                                       |
+|-----------------------------------------|----------------------------------------------|
+| Slider release on epoch N (`on-mouse-up`) | `reset!` selection → N's `:epoch-id`       |
+| Pinned-snapshot chip click              | `reset!` selection → chip's `:epoch-id`     |
+| "release" button click                  | `reset!` selection → `nil`                  |
+| Shell unmount / variant teardown        | `drop-selection!` removes the entry        |
+| Default (no scrub in flight)            | `nil`                                       |
+
+When the selection is `nil` the trace panel renders the full buffer
+without filtering or highlighting — the existing v1 behaviour.
+
+### Filter (cascades visible)
+
+When the selection is non-nil the trace panel computes a `cap`
+event-id from the selected epoch's `:trace-events`:
+
+```clojure
+(scrubber/max-trace-event-id-for-epoch variant-id selected-epoch-id)
+```
+
+`cap` is the maximum `:id` among the trace events captured for that
+epoch. Per [`spec/009-Instrumentation`](../../../spec/009-Instrumentation.md)
+§`:id`, event ids are a process-monotonic integer counter — `:id 42`
+was definitely emitted after every event with `:id ≤ 41`.
+
+The trace panel pipes the full cascade list through
+`xref/filter-cascades-up-to`:
+
+- Cascade's max event-id `≤ cap` → visible.
+- Cascade's max event-id `> cap` → hidden (emitted after the
+  selected epoch settled).
+- Cascade whose every event carries no `:id` (degenerate) → visible.
+
+When `cap` is `nil` (no scrub, synthetic epoch with empty
+`:trace-events`) the filter is the identity.
+
+### Highlight (cascade that produced the epoch)
+
+The trace panel also computes the **cascade-id of the selected epoch**
+via `scrubber/cascade-id-for-epoch`, which delegates to
+`xref/cascade-id-for-epoch`:
+
+- Walks the selected epoch's `:trace-events` for the first available
+  `:tags :dispatch-id` (or `:parent-dispatch-id` as a fallback).
+- Per [rf2-g6ih4](../../../spec/009-Instrumentation.md) the framework
+  stamps `:dispatch-id` on every in-drain event, so the resolution
+  succeeds for any non-degenerate epoch.
+
+Each visible cascade is then rendered with a `selected?` flag —
+`true` iff the cascade's `:dispatch-id` equals the selected epoch's
+cascade-id. The selected row carries:
+
+- The `:row-selected` style (amber outline + left border + tinted
+  background).
+- A `data-selected="true"` attribute on the `<div>` so browser tests
+  can assert the cross-reference fired.
+
+### Scrub note
+
+When a scrub is active, the trace panel renders a single italic line
+above the cascade table:
+
+```
+scrubbed to epoch <id> — N later cascade(s) hidden
+```
+
+`N` is `(- (count all-cascades) (count visible-cascades))`. The note
+surfaces *why* some cascades dropped out so the user doesn't read
+'fewer cascades' as 'something blew up'.
+
+The note carries `data-test="story-trace-scrub-note"` so browser
+tests can pivot on it.
+
+## Implementation files
+
+| Purpose                                                              | File                                                          |
+|----------------------------------------------------------------------|---------------------------------------------------------------|
+| Pure-data helpers — cascade-id resolution + filter + match predicate | `tools/story/src/re_frame/story/ui/scrubber_xref.cljc`        |
+| Selection ratom + epoch-history projection wrappers                  | `tools/story/src/re_frame/story/ui/scrubber.cljs`             |
+| Trace-panel derefs + cascade-row highlight rendering                 | `tools/story/src/re_frame/story/ui/trace.cljs`                |
+| Shell teardown (drop selection on variant unmount)                   | `tools/story/src/re_frame/story/ui/shell.cljs`                |
+| JVM unit tests for the pure helpers                                  | `tools/story/test/re_frame/story_scrubber_xref_test.clj`      |
+| Browser smoke                                                        | `examples/reagent/counter_with_stories/counter_with_stories.spec.cjs` §11b |
+
+The `.cljc` split keeps the cross-reference predicates JVM-testable —
+per the standing `feedback_jvm_interop_must_work.md` rule — while the
+ratom + Reagent / DOM wiring stays in `.cljs`.
+
+## Pure-data API (JVM + CLJS)
+
+```clojure
+;; ns: re-frame.story.ui.scrubber-xref
+
+(cascade-id-from-trace-events epoch-record) ;; → cascade-id-or-nil
+
+(cascade-id-for-epoch history epoch-id)     ;; → cascade-id-or-nil
+;; history :: vector of :rf/epoch-record (oldest-first), per
+;; epoch/epoch-history.
+
+(max-trace-event-id-for-epoch history epoch-id) ;; → cap-event-id-or-nil
+
+(filter-cascades-up-to cascades cap)        ;; → visible-cascades
+;; cascades :: vector of cascade records, per group-cascades.
+;; cap nil ⇒ identity.
+
+(cascade-matches-selected-epoch? cascade selected-cascade-id) ;; → boolean
+```
+
+Both wrappers in `re-frame.story.ui.scrubber` (`cascade-id-for-epoch`,
+`max-trace-event-id-for-epoch`) accept a `variant-id` rather than a
+history vector and call `epoch/epoch-history` themselves. They exist
+so the trace panel doesn't need to know about the framework's epoch
+namespace.
+
+## Out of scope (deferred)
+
+- Per-event annotations (user notes on specific trace points).
+- Diff visualisation between two scrubber positions.
+- Persistent replay sessions (Causa Lock-12 is ephemeral; same here).
+- Click-on-cascade → scrub to its epoch (the inverse direction — the
+  bead specifies the scrubber→trace direction only; the inverse adds
+  complexity for marginal UX gain at v1).
+
+## Elision
+
+Per [`005-SOTA-Features.md`](005-SOTA-Features.md) §Elision, the entire
+Story UI is gated on `re-frame.story.config/enabled?`; the scrubber and
+trace panels are gated on `re-frame.interop/debug-enabled?` (the same
+goog-define as `epoch-history`). Production CLJS builds short-circuit
+before the cross-reference code is reachable.
+
+## Cross-references
+
+- [`003-Render-Shell.md`](003-Render-Shell.md) §Trace bus consumption —
+  parent contract.
+- [`005-SOTA-Features.md`](005-SOTA-Features.md) §Six-domino trace panel —
+  parent SOTA differentiator.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+  §Dispatch correlation — `:dispatch-id` stamping rule.
+- [`implementation/epoch/src/re_frame/epoch.cljc`](../../../implementation/epoch/src/re_frame/epoch.cljc)
+  §`:rf/epoch-record` — record shape.

--- a/tools/story/src/re_frame/story/ui/scrubber.cljs
+++ b/tools/story/src/re_frame/story/ui/scrubber.cljs
@@ -17,6 +17,17 @@
   new epochs commit. The listener is keyed by variant id and torn down
   when the shell unmounts.
 
+  ## Cross-reference to the trace panel (rf2-sxwvf)
+
+  Per `spec/011-Trace-Scrubber-Cross-Ref.md` (rf2-sxwvf), the scrubber's
+  current selection is exported as a shared per-variant ratom
+  (`selections`) keyed by variant-id. The trace panel derefs this slot
+  to filter / highlight the cascade view. The selection is held as a
+  stable `:epoch-id` (NOT the slider's index) so a history-shift that
+  evicts old epochs doesn't silently re-point the selection at the
+  wrong record. Nil selection (the default) means 'no scrub in flight'
+  — the trace panel shows the full buffer.
+
   ## Elision
 
   Epoch history itself sits inside `interop/debug-enabled?` (spec/009);
@@ -26,6 +37,7 @@
   (:require [reagent.core :as r]
             [re-frame.epoch :as epoch]
             [re-frame.story.config :as config]
+            [re-frame.story.ui.scrubber-xref :as xref]
             [re-frame.story.ui.state :as state]))
 
 ;; ---- per-variant 'live history' ratom ------------------------------------
@@ -52,6 +64,66 @@
   [variant-id]
   (swap! histories dissoc variant-id)
   nil)
+
+;; ---- per-variant scrubber 'selection' ratom (rf2-sxwvf) ------------------
+;;
+;; The trace panel derefs this slot to know which epoch the user is
+;; currently inspecting. Selection holds the epoch's stable `:epoch-id`
+;; (NOT the slider's slot index) so a history-shift evicting older
+;; epochs doesn't silently re-point the selection. nil ⇒ no scrub in
+;; flight, trace panel renders the full buffer.
+
+(defonce selections
+  ;; {variant-id → r/atom holding the current selected :epoch-id (or nil)}
+  (atom {}))
+
+(defn ensure-selection-atom!
+  "Return the per-variant `selection` ratom, creating it on first
+  access. Public so the trace panel can deref the same instance the
+  scrubber commits to (a fresh `r/atom` on each render would break
+  Reagent reactivity)."
+  [variant-id]
+  (or (get @selections variant-id)
+      (let [a (r/atom nil)]
+        (swap! selections assoc variant-id a)
+        a)))
+
+(defn selected-epoch-id
+  "Return the currently-scrubbed `:epoch-id` for `variant-id`, or nil.
+  Public read surface for the trace panel's cross-reference path."
+  [variant-id]
+  (some-> (get @selections variant-id) deref))
+
+(defn select-epoch!
+  "Set the scrubber's selection for `variant-id`. Pass nil to clear."
+  [variant-id epoch-id]
+  (let [a (ensure-selection-atom! variant-id)]
+    (reset! a epoch-id))
+  nil)
+
+(defn drop-selection!
+  "Remove the per-variant selection atom. Called from shell unmount."
+  [variant-id]
+  (swap! selections dissoc variant-id)
+  nil)
+
+(defn cascade-id-for-epoch
+  "Return the cascade `:dispatch-id` that produced `epoch-id` in
+  `variant-id`'s history, or nil if the epoch is gone or carried no
+  dispatch-id-bearing events (e.g. synthetic epochs from
+  `reset-frame-db!`). Thin wrapper around the pure-data
+  `xref/cascade-id-for-epoch` so the resolution logic is shared with
+  the JVM unit tests."
+  [variant-id epoch-id]
+  (xref/cascade-id-for-epoch (epoch/epoch-history variant-id) epoch-id))
+
+(defn max-trace-event-id-for-epoch
+  "Return the maximum trace-event `:id` recorded for `epoch-id` —
+  the pivot the trace panel uses to filter out cascades emitted AFTER
+  the selected epoch settled. Thin wrapper around the pure-data
+  `xref/max-trace-event-id-for-epoch`."
+  [variant-id epoch-id]
+  (xref/max-trace-event-id-for-epoch (epoch/epoch-history variant-id) epoch-id))
 
 ;; ---- the epoch callback --------------------------------------------------
 
@@ -111,6 +183,14 @@
                  :border-radius "3px"
                  :cursor "pointer"
                  :font-size "10px"}
+   :release     {:padding "2px 8px"
+                 :background "#5a5a5a"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size "10px"
+                 :margin-left "6px"}
    :empty       {:color "#9a9a9a" :font-style "italic"}})
 
 ;; ---- public component ----------------------------------------------------
@@ -126,20 +206,29 @@
 (defn panel
   "The scrubber component. Renders a slider over the variant frame's
   epoch history, a 'capture' button that pins the current epoch, and a
-  chip row of pinned snapshots."
+  chip row of pinned snapshots.
+
+  On commit (slider release or pinned-chip click) the selected
+  `:epoch-id` is published to the per-variant `selections` ratom so the
+  trace panel can filter+highlight against it (rf2-sxwvf). Clicking
+  'release' clears the selection (trace panel re-shows the full
+  buffer)."
   [variant-id]
-  (let [history-atom (ensure-history-atom! variant-id)
+  (let [history-atom   (ensure-history-atom! variant-id)
+        selection-atom (ensure-selection-atom! variant-id)
         ;; Local UI state for the slider position — separate from the
         ;; framework's epoch history so the user can scrub without
         ;; committing until they release.
-        slider-pos   (r/atom nil)]
+        slider-pos     (r/atom nil)]
     (fn [variant-id]
-      (let [history (or @history-atom [])
-            n       (count history)
-            shell   @state/shell-state-atom
-            pinned  (get-in shell [:pinned-snapshots variant-id] [])
-            pos     (or @slider-pos (dec n) 0)]
-        [:div {:style (:panel styles)}
+      (let [history   (or @history-atom [])
+            n         (count history)
+            shell     @state/shell-state-atom
+            pinned    (get-in shell [:pinned-snapshots variant-id] [])
+            selection @selection-atom
+            pos       (or @slider-pos (dec n) 0)]
+        [:div {:style (:panel styles)
+               :data-test "story-scrubber"}
          [:div {:style (:title styles)}
           "Time travel " (when variant-id (str (pr-str variant-id)))
           " — " n " epochs"]
@@ -154,6 +243,7 @@
                       :max       (max 0 (dec n))
                       :value     pos
                       :style     (:slider styles)
+                      :data-test "story-scrubber-slider"
                       :on-change (fn [e]
                                    (reset! slider-pos
                                            (js/parseInt
@@ -165,7 +255,12 @@
                                      (when-let [record (get history idx)]
                                        (epoch/restore-epoch
                                          variant-id
-                                         (:epoch-id record)))))}]
+                                         (:epoch-id record))
+                                       ;; rf2-sxwvf: publish the selection
+                                       ;; so the trace panel filters /
+                                       ;; highlights against it.
+                                       (reset! selection-atom
+                                               (:epoch-id record)))))}]
              [:button {:style    (:button styles)
                        :on-click (fn [_]
                                    (let [record (get history pos)
@@ -175,12 +270,27 @@
                                          state/pin-snapshot
                                          variant-id label
                                          (:epoch-id record)))))}
-              "capture"]]
+              "capture"]
+             ;; rf2-sxwvf: 'release' clears the scrub-selection so the
+             ;; trace panel reverts to showing the full buffer. Only
+             ;; rendered when there IS a selection to clear, so the
+             ;; panel's visual weight is unchanged in the default
+             ;; (no-scrub) state.
+             (when selection
+               [:button {:style    (:release styles)
+                         :data-test "story-scrubber-release"
+                         :on-click (fn [_]
+                                     (reset! selection-atom nil))}
+                "release"])]
             (when (seq pinned)
               [:div {:style (:chip-row styles)}
                (for [{:keys [label epoch-id]} pinned]
                  ^{:key (str label "-" epoch-id)}
                  [:span {:style    (:chip styles)
                          :on-click (fn [_]
-                                     (epoch/restore-epoch variant-id epoch-id))}
+                                     (epoch/restore-epoch variant-id epoch-id)
+                                     ;; rf2-sxwvf: pinned-chip restore
+                                     ;; also publishes selection so
+                                     ;; trace cross-references.
+                                     (reset! selection-atom epoch-id))}
                   label])])])]))))

--- a/tools/story/src/re_frame/story/ui/scrubber_xref.cljc
+++ b/tools/story/src/re_frame/story/ui/scrubber_xref.cljc
@@ -1,0 +1,123 @@
+(ns re-frame.story.ui.scrubber-xref
+  "Pure data helpers for the trace × scrubber cross-reference (rf2-sxwvf).
+
+  The trace panel and the scrubber both live in CLJS-land — they touch
+  Reagent ratoms and the DOM. But the cross-reference *logic* — given
+  a cascade-record vector + a `cap` event-id, what's the visible subset?
+  given an epoch record, what's the cascade-id that produced it? — is
+  pure data → data. Splitting that logic out into `.cljc` so it runs
+  under the JVM unit-test target (`clojure -M:test`) is required by
+  the standing rule `feedback_jvm_interop_must_work.md`.
+
+  The corresponding ratom-touching / DOM-touching code stays in
+  `re-frame.story.ui.scrubber` (the `selections` defonce + the `panel`
+  fn) and `re-frame.story.ui.trace` (the `panel` fn that derefs the
+  selection ratom + renders the highlighted row).
+
+  See `tools/story/spec/011-Trace-Scrubber-Cross-Ref.md` for the
+  normative contract.")
+
+;; ---- cascade-id resolution (epoch → cascade) -----------------------------
+
+(defn cascade-id-from-trace-events
+  "Walk an epoch record's `:trace-events` for the first `:dispatch-id`
+  tag and return it. Pure data: epoch record → cascade-id (or nil).
+
+  Per Spec 009 §Dispatch correlation (rf2-g6ih4) the framework stamps
+  `:tags :dispatch-id` on every in-drain event. The projection picks
+  the first one available so the cascade-id resolves even when the
+  cascade-root `:event/dispatched` event was evicted from the buffer
+  before the epoch settled."
+  [epoch-record]
+  (some (fn [ev]
+          (or (get-in ev [:tags :dispatch-id])
+              (get-in ev [:tags :parent-dispatch-id])))
+        (:trace-events epoch-record)))
+
+(defn cascade-id-for-epoch
+  "Given a `history` vector and an `epoch-id`, return the cascade
+  `:dispatch-id` that produced that epoch, or nil. Pure data: history
+  + id → cascade-id-or-nil.
+
+  Returns nil when:
+    - `epoch-id` is nil (no scrub in flight);
+    - the epoch is no longer in `history` (evicted by the ring buffer's
+      depth cap);
+    - the epoch carries no dispatch-id-bearing trace events (synthetic
+      epochs from `reset-frame-db!` have empty `:trace-events`)."
+  [history epoch-id]
+  (when epoch-id
+    (some (fn [r] (when (= epoch-id (:epoch-id r))
+                    (cascade-id-from-trace-events r)))
+          history)))
+
+(defn max-trace-event-id-for-epoch
+  "Given a `history` vector and an `epoch-id`, return the maximum `:id`
+  among the trace events captured for that epoch, or nil. Pure data:
+  history + id → cap-or-nil.
+
+  Per Spec 009 §`:id` is process-monotonic — every emit increments a
+  shared counter, so an event with `:id 42` was definitely emitted
+  after every event with `:id ≤ 41`. The trace panel uses the returned
+  cap as its filter pivot: a cascade whose max event-id ≤ cap stays
+  visible; a cascade emitted after the epoch settled (max > cap) drops
+  out.
+
+  nil-result cases:
+    - `epoch-id` is nil;
+    - the epoch is gone from `history`;
+    - the epoch's `:trace-events` carried no `:id`-bearing event (a
+      synthetic `reset-frame-db!` epoch records `:trace-events []`)."
+  [history epoch-id]
+  (when epoch-id
+    (some (fn [r]
+            (when (= epoch-id (:epoch-id r))
+              (let [ids (keep :id (:trace-events r))]
+                (when (seq ids) (apply max ids)))))
+          history)))
+
+;; ---- cascade filter + highlight (cascades → visible cascades) ------------
+
+(defn- max-id-in-cascade
+  "Maximum `:id` across every event in a cascade record. Cascades whose
+  events all carry an `:id` ≤ `cap` belong to the 'at or before the
+  selected epoch' visible set."
+  [{:keys [handler fx effects subs renders other]}]
+  ;; The cascade's `:event` slot is the event vector (not a trace-event
+  ;; map) per `re-frame.trace.projection/empty-cascade`; skip it.
+  (let [all (concat (when handler [handler])
+                    (when fx [fx])
+                    effects subs renders other)
+        ids (keep :id all)]
+    (when (seq ids) (apply max ids))))
+
+(defn filter-cascades-up-to
+  "Given a vector of cascade records (`group-cascades` output) and a
+  `cap` event-id (the maximum trace-event `:id` recorded for the
+  selected epoch), return the subset whose own max-id is `≤ cap`.
+
+  Per Spec 009 `:id` is process-monotonic; comparing cascade max-id
+  against `cap` is total. A cap of nil (no scrub in flight, or a
+  synthetic epoch with no event ids) is the identity — every cascade
+  passes. Cascades whose events carry no `:id` (degenerate, shouldn't
+  happen in practice) also pass.
+
+  Pure data → data. JVM-testable."
+  [cascades cap]
+  (if (nil? cap)
+    (vec cascades)
+    (vec
+      (filter (fn [c]
+                (let [m (max-id-in-cascade c)]
+                  (or (nil? m) (<= m cap))))
+              cascades))))
+
+(defn cascade-matches-selected-epoch?
+  "True when this cascade's `:dispatch-id` is the cascade-id stamped on
+  the currently-selected epoch (i.e. this cascade's post-effects
+  produced the selected epoch). Pure data → boolean. nil
+  `selected-cascade-id` is always false (no scrub in flight ⇒ no row
+  highlights)."
+  [cascade selected-cascade-id]
+  (and (some? selected-cascade-id)
+       (= selected-cascade-id (:dispatch-id cascade))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -158,6 +158,10 @@
     (scrubber/remove-listener! variant-id)
     (trace/drop-buffer! variant-id)
     (scrubber/drop-history! variant-id)
+    ;; rf2-sxwvf: drop the per-variant scrub selection too — the cross-
+    ;; reference ratom is keyed by variant-id and needs the same
+    ;; teardown shape as the history / buffer ratoms.
+    (scrubber/drop-selection! variant-id)
     (swap! listened-variants disj variant-id)))
 
 (defn- teardown-all-listeners! []

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -34,11 +34,30 @@
   - `remove-listener!`   — tear down the cb.
 
   Both are idempotent. The shell wires them on mount/unmount of the
-  trace panel, so trace capture only runs while the panel is visible."
+  trace panel, so trace capture only runs while the panel is visible.
+
+  ## Cross-reference with the scrubber (rf2-sxwvf)
+
+  Per `spec/011-Trace-Scrubber-Cross-Ref.md` the trace panel
+  cross-references the scrubber's current scrub. When the scrubber's
+  selection is non-nil for the focused variant:
+
+    - the buffer is filtered to events with `:id` ≤ the maximum trace
+      event id stamped on the selected epoch (cascades whose traces all
+      land at or before the epoch boundary stay; cascades emitted
+      after the epoch settled fall away);
+    - the cascade whose `:dispatch-id` matches the selected epoch's
+      cascade-id is visually marked.
+
+  The cross-reference is implemented as a pair of pure-data helpers
+  (`filter-cascades-up-to` / `cascade-row-style`) so the same predicate
+  runs under the JVM unit tests AND inside the CLJS render path."
   (:require [reagent.core :as r]
             [re-frame.trace :as trace]
             [re-frame.trace.projection :as projection]
-            [re-frame.story.config :as config]))
+            [re-frame.story.config :as config]
+            [re-frame.story.ui.scrubber :as scrubber]
+            [re-frame.story.ui.scrubber-xref :as xref]))
 
 ;; ---- the per-variant trace buffer ----------------------------------------
 
@@ -136,6 +155,18 @@
 ;; Re-export for backwards-compat for any in-tree consumer.
 (def group-cascades projection/group-cascades)
 
+;; ---- cross-reference with the scrubber (rf2-sxwvf) -----------------------
+;;
+;; The pure-data helpers live in `re-frame.story.ui.scrubber-xref` so the
+;; cross-reference predicates run under the JVM unit-test target
+;; (`clojure -M:test`) — per `feedback_jvm_interop_must_work.md`. Story's
+;; render path consults the scrubber's selection ratom (CLJS-only),
+;; pipes the result of `epoch/epoch-history` + `group-cascades` into
+;; the helpers, and lifts the visible subset into the row renderer.
+
+(def filter-cascades-up-to            xref/filter-cascades-up-to)
+(def cascade-matches-selected-epoch?  xref/cascade-matches-selected-epoch?)
+
 ;; ---- styling -------------------------------------------------------------
 
 (def ^:private styles
@@ -150,11 +181,22 @@
    :title        {:font-weight "bold"
                   :margin-bottom "6px"
                   :color "#9cdcfe"}
+   :scrub-note   {:font-size "10px"
+                  :color "#dcdcaa"
+                  :font-style "italic"
+                  :margin-bottom "4px"}
    :row          {:display "grid"
                   :grid-template-columns "auto 1fr 1fr 1fr 1fr 1fr"
                   :gap "4px"
                   :padding "2px 0"
                   :border-bottom "1px dotted #333"}
+   ;; rf2-sxwvf: the highlight ring marks the cascade whose post-effects
+   ;; produced the currently-scrubbed epoch. A solid amber outline plus
+   ;; a left border so the row pops without changing the column layout.
+   :row-selected {:background "#2d2d1a"
+                  :outline "1px solid #dcdcaa"
+                  :border-left "3px solid #dcdcaa"
+                  :padding-left "4px"}
    :cell         {:padding "2px 4px"
                   :overflow "hidden"
                   :text-overflow "ellipsis"
@@ -171,25 +213,32 @@
 ;; ---- view ----------------------------------------------------------------
 
 (defn cascade-row
-  "Render one cascade as a six-column row."
-  [{:keys [event handler fx effects subs renders]}]
-  [:div {:style (:row styles)
-         :title (when-let [src (:source handler)]
-                  (str (:file src) ":" (:line src)))}
-   [:span {:style (merge (:cell styles) (:event-cell styles))}
-    (pr-str (first event))]
-   [:span {:style (merge (:cell styles) (:handler-cell styles))}
-    (if handler
-      (str "ran in " (or (get-in handler [:tags :duration-ms]) "?") "ms")
-      "—")]
-   [:span {:style (merge (:cell styles) (:fx-cell styles))}
-    (if fx (str (count (get-in fx [:tags :fx] {})) " fx") "—")]
-   [:span {:style (merge (:cell styles) (:effect-cell styles))}
-    (str (count effects) " effects")]
-   [:span {:style (merge (:cell styles) (:sub-cell styles))}
-    (str (count subs) " subs")]
-   [:span {:style (merge (:cell styles) (:render-cell styles))}
-    (str (count renders) " renders")]])
+  "Render one cascade as a six-column row. Per rf2-sxwvf, when
+  `selected?` is true the row carries the highlight ring + a
+  `data-selected=\"true\"` attribute so the browser test can assert the
+  cross-reference fired."
+  ([cascade] (cascade-row cascade false))
+  ([{:keys [event handler fx effects subs renders] :as _cascade} selected?]
+   [:div {:style (cond-> (:row styles)
+                   selected? (merge (:row-selected styles)))
+          :data-test "story-trace-cascade-row"
+          :data-selected (if selected? "true" "false")
+          :title (when-let [src (:source handler)]
+                   (str (:file src) ":" (:line src)))}
+    [:span {:style (merge (:cell styles) (:event-cell styles))}
+     (pr-str (first event))]
+    [:span {:style (merge (:cell styles) (:handler-cell styles))}
+     (if handler
+       (str "ran in " (or (get-in handler [:tags :duration-ms]) "?") "ms")
+       "—")]
+    [:span {:style (merge (:cell styles) (:fx-cell styles))}
+     (if fx (str (count (get-in fx [:tags :fx] {})) " fx") "—")]
+    [:span {:style (merge (:cell styles) (:effect-cell styles))}
+     (str (count effects) " effects")]
+    [:span {:style (merge (:cell styles) (:sub-cell styles))}
+     (str (count subs) " subs")]
+    [:span {:style (merge (:cell styles) (:render-cell styles))}
+     (str (count renders) " renders")]]))
 
 (defn panel
   "The trace panel component. Subscribes to the variant's trace buffer
@@ -197,12 +246,28 @@
 
   Mounts a listener via `register-listener!` on first render; tears down
   via `remove-listener!` when the shell unmounts (handled by
-  `re-frame.story.ui.shell`)."
+  `re-frame.story.ui.shell`).
+
+  Per rf2-sxwvf, on each render the panel derefs the scrubber's
+  `selection` ratom for the same variant. When non-nil, the buffer is
+  filtered to events at-or-before the selected epoch and the cascade
+  whose post-effects produced that epoch is visually marked."
   [variant-id]
-  (let [buffer (ensure-buffer! variant-id)]
+  (let [buffer         (ensure-buffer! variant-id)
+        selection-atom (scrubber/ensure-selection-atom! variant-id)]
     (fn [variant-id]
-      (let [events   @buffer
-            cascades (group-cascades events)]
+      (let [events             @buffer
+            selected-epoch     @selection-atom
+            cap                (when selected-epoch
+                                 (scrubber/max-trace-event-id-for-epoch
+                                   variant-id selected-epoch))
+            selected-cascade   (when selected-epoch
+                                 (scrubber/cascade-id-for-epoch
+                                   variant-id selected-epoch))
+            all-cascades       (group-cascades events)
+            visible-cascades   (filter-cascades-up-to all-cascades cap)
+            hidden-by-scrub    (- (count all-cascades)
+                                  (count visible-cascades))]
         ;; Per rf2-xc65: the panel wrap is scrollable (`overflow auto`
         ;; + `max-height 240px`). `tab-index "0"` + an aria-label make
         ;; it keyboard-focusable and named so axe-core's
@@ -210,10 +275,21 @@
         [:div {:style      (:panel styles)
                :role       "region"
                :aria-label "Trace cascades"
-               :tab-index  "0"}
+               :tab-index  "0"
+               :data-test  "story-trace-panel"
+               :data-scrubbed-epoch (when selected-epoch (str selected-epoch))}
          [:div {:style (:title styles)}
           "Trace " (when variant-id (str (pr-str variant-id))) " — "
-          (count events) " events, " (count cascades) " cascades"]
+          (count events) " events, " (count visible-cascades) " cascades"]
+         ;; rf2-sxwvf: when a scrub is active, surface the cross-reference
+         ;; state so the user sees why some cascades dropped out.
+         (when selected-epoch
+           [:div {:style (:scrub-note styles)
+                  :data-test "story-trace-scrub-note"}
+            "scrubbed to epoch " (str selected-epoch)
+            (when (pos? hidden-by-scrub)
+              (str " — " hidden-by-scrub " later cascade"
+                   (when (> hidden-by-scrub 1) "s") " hidden"))])
          [:div {:style (merge (:row styles) (:header styles))}
           [:span {:style (:cell styles)} "event"]
           [:span {:style (:cell styles)} "handler"]
@@ -221,8 +297,11 @@
           [:span {:style (:cell styles)} "effects"]
           [:span {:style (:cell styles)} "subs"]
           [:span {:style (:cell styles)} "renders"]]
-         (if (empty? cascades)
-           [:div {:style (:empty styles)} "no cascades captured yet — dispatch an event to see the six dominos"]
-           (for [c cascades]
+         (if (empty? visible-cascades)
+           [:div {:style (:empty styles)}
+            (if selected-epoch
+              "no cascades at or before the selected epoch"
+              "no cascades captured yet — dispatch an event to see the six dominos")]
+           (for [c visible-cascades]
              ^{:key (:dispatch-id c)}
-             [cascade-row c]))]))))
+             [cascade-row c (cascade-matches-selected-epoch? c selected-cascade)]))]))))

--- a/tools/story/test/re_frame/story_scrubber_xref_test.clj
+++ b/tools/story/test/re_frame/story_scrubber_xref_test.clj
@@ -1,0 +1,244 @@
+(ns re-frame.story-scrubber-xref-test
+  "JVM unit tests for the trace × scrubber cross-reference (rf2-sxwvf).
+
+  The cross-reference logic lives in `re-frame.story.ui.scrubber-xref`
+  as pure data → data so the predicates run under the JVM target. The
+  Reagent / DOM / ratom wiring lives in
+  `re-frame.story.ui.scrubber{,.cljs}` and
+  `re-frame.story.ui.trace{,.cljs}` and is exercised by the CLJS smoke
+  + Playwright browser specs.
+
+  Coverage:
+  - cascade-id resolution from an epoch record's `:trace-events`.
+  - cascade-id resolution under history-lookup (epoch present vs evicted).
+  - max-event-id resolution under history-lookup.
+  - filter-cascades-up-to:
+      - nil cap is the identity.
+      - cap drops cascades whose max event-id exceeds it.
+      - cap retains cascades whose every event id ≤ cap.
+      - cascades with no event ids pass under any cap.
+  - cascade-matches-selected-epoch? matches on :dispatch-id."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.scrubber-xref :as xref]))
+
+;; ---- fixture data --------------------------------------------------------
+
+(def ^:private cascade-a
+  "Cascade with dispatch-id 100, max event-id 6."
+  {:dispatch-id 100
+   :event       [:foo]
+   :handler     {:id 2 :tags {:dispatch-id 100 :phase :run-end}}
+   :fx          {:id 3 :tags {:dispatch-id 100}}
+   :effects     [{:id 4 :tags {:dispatch-id 100 :fx-id :db}}]
+   :subs        [{:id 5 :tags {:dispatch-id 100 :sub-id :sub/foo}}]
+   :renders     [{:id 6 :tags {:dispatch-id 100 :render-key [:app/root nil]}}]
+   :other       []})
+
+(def ^:private cascade-b
+  "Cascade with dispatch-id 200, max event-id 12 (emitted later)."
+  {:dispatch-id 200
+   :event       [:bar]
+   :handler     {:id 8 :tags {:dispatch-id 200 :phase :run-end}}
+   :fx          {:id 9 :tags {:dispatch-id 200}}
+   :effects     [{:id 10 :tags {:dispatch-id 200 :fx-id :db}}]
+   :subs        [{:id 11 :tags {:dispatch-id 200 :sub-id :sub/foo}}]
+   :renders     [{:id 12 :tags {:dispatch-id 200 :render-key [:app/root nil]}}]
+   :other       []})
+
+(def ^:private cascade-no-ids
+  "Cascade with no event ids (degenerate). Must pass under any cap."
+  {:dispatch-id 300
+   :event       [:baz]
+   :handler     nil :fx nil :effects [] :subs [] :renders []
+   :other       [{:tags {:dispatch-id 300}}]})
+
+(def ^:private epoch-a
+  {:epoch-id     7
+   :frame        :v/a
+   :trigger-event [:foo]
+   :trace-events [{:id 2 :tags {:dispatch-id 100}}
+                  {:id 6 :tags {:dispatch-id 100}}]})
+
+(def ^:private epoch-b
+  {:epoch-id     8
+   :frame        :v/a
+   :trigger-event [:bar]
+   :trace-events [{:id 8  :tags {:dispatch-id 200}}
+                  {:id 12 :tags {:dispatch-id 200}}]})
+
+(def ^:private epoch-synthetic
+  "Synthetic epoch from reset-frame-db! — :trace-events is empty."
+  {:epoch-id     9
+   :frame        :v/a
+   :trigger-event [:rf.epoch/db-replaced]
+   :trace-events []})
+
+(def ^:private history [epoch-a epoch-b epoch-synthetic])
+
+;; ---- cascade-id-from-trace-events ----------------------------------------
+
+(deftest cascade-id-from-trace-events-extracts-dispatch-id
+  (testing "first :dispatch-id tag wins"
+    (is (= 100 (xref/cascade-id-from-trace-events epoch-a)))
+    (is (= 200 (xref/cascade-id-from-trace-events epoch-b)))))
+
+(deftest cascade-id-from-trace-events-tolerates-empty
+  (testing "synthetic epoch with no events returns nil"
+    (is (nil? (xref/cascade-id-from-trace-events epoch-synthetic)))))
+
+(deftest cascade-id-from-trace-events-falls-back-to-parent-dispatch-id
+  (testing "when no :dispatch-id, :parent-dispatch-id is used"
+    (let [ep {:trace-events [{:id 1 :tags {:parent-dispatch-id 999}}]}]
+      (is (= 999 (xref/cascade-id-from-trace-events ep))))))
+
+;; ---- cascade-id-for-epoch -----------------------------------------------
+
+(deftest cascade-id-for-epoch-finds-present-epoch
+  (testing "epoch present in history resolves to its cascade-id"
+    (is (= 100 (xref/cascade-id-for-epoch history 7)))
+    (is (= 200 (xref/cascade-id-for-epoch history 8)))))
+
+(deftest cascade-id-for-epoch-nil-for-missing
+  (testing "epoch absent from history returns nil (the epoch was evicted
+            by the ring buffer's depth cap)"
+    (is (nil? (xref/cascade-id-for-epoch history 999)))))
+
+(deftest cascade-id-for-epoch-nil-for-synthetic
+  (testing "synthetic epoch (empty :trace-events) returns nil"
+    (is (nil? (xref/cascade-id-for-epoch history 9)))))
+
+(deftest cascade-id-for-epoch-nil-for-nil-id
+  (testing "nil epoch-id (no scrub in flight) returns nil — the trace
+            panel reads this as 'no highlight'"
+    (is (nil? (xref/cascade-id-for-epoch history nil)))))
+
+;; ---- max-trace-event-id-for-epoch ---------------------------------------
+
+(deftest max-trace-event-id-for-epoch-resolves-cap
+  (testing "max trace event id is the cap for filtering"
+    (is (= 6  (xref/max-trace-event-id-for-epoch history 7)))
+    (is (= 12 (xref/max-trace-event-id-for-epoch history 8)))))
+
+(deftest max-trace-event-id-for-epoch-nil-cases
+  (testing "absent / synthetic / nil cases return nil"
+    (is (nil? (xref/max-trace-event-id-for-epoch history 999)))
+    (is (nil? (xref/max-trace-event-id-for-epoch history 9)))
+    (is (nil? (xref/max-trace-event-id-for-epoch history nil)))))
+
+;; ---- filter-cascades-up-to ----------------------------------------------
+
+(deftest filter-cascades-up-to-nil-cap-is-identity
+  (testing "nil cap returns the input vector unchanged"
+    (let [cs [cascade-a cascade-b cascade-no-ids]]
+      (is (= cs (xref/filter-cascades-up-to cs nil))))))
+
+(deftest filter-cascades-up-to-drops-later-cascades
+  (testing "cascades with max-event-id > cap drop out"
+    (let [cs [cascade-a cascade-b]
+          ;; cap 6 = end of cascade-a; cascade-b's max id is 12 > 6
+          visible (xref/filter-cascades-up-to cs 6)]
+      (is (= [cascade-a] visible))
+      (is (not-any? #(= 200 (:dispatch-id %)) visible)))))
+
+(deftest filter-cascades-up-to-retains-at-cap
+  (testing "cascade whose max id equals the cap is visible"
+    (let [cs [cascade-a cascade-b]]
+      ;; cap 12 admits both — cascade-b's max id = 12.
+      (is (= [cascade-a cascade-b]
+             (xref/filter-cascades-up-to cs 12))))))
+
+(deftest filter-cascades-up-to-retains-id-less-cascades
+  (testing "cascades whose every event carries no :id pass under any cap"
+    (let [cs [cascade-a cascade-b cascade-no-ids]
+          visible (xref/filter-cascades-up-to cs 6)]
+      ;; cascade-a (max 6) + cascade-no-ids (no ids) survive
+      (is (= 2 (count visible)))
+      (is (some #(= 100 (:dispatch-id %)) visible))
+      (is (some #(= 300 (:dispatch-id %)) visible))
+      (is (not-any? #(= 200 (:dispatch-id %)) visible)))))
+
+(deftest filter-cascades-up-to-returns-vector
+  (testing "result is a vector (consumer iterates with `for` keyed by id)"
+    (is (vector? (xref/filter-cascades-up-to [cascade-a] nil)))
+    (is (vector? (xref/filter-cascades-up-to [cascade-a cascade-b] 6)))
+    (is (vector? (xref/filter-cascades-up-to [] nil)))))
+
+;; ---- cascade-matches-selected-epoch? ------------------------------------
+
+(deftest cascade-matches-selected-epoch?-matches-on-dispatch-id
+  (testing "cascade :dispatch-id == selected-cascade-id → true"
+    (is (true?  (xref/cascade-matches-selected-epoch? cascade-a 100)))
+    (is (false? (xref/cascade-matches-selected-epoch? cascade-a 200)))))
+
+(deftest cascade-matches-selected-epoch?-nil-selected-is-false
+  (testing "nil selected-cascade-id always returns false (no scrub ⇒
+            no row highlights)"
+    (is (false? (xref/cascade-matches-selected-epoch? cascade-a nil)))
+    (is (false? (xref/cascade-matches-selected-epoch? cascade-b nil)))))
+
+(deftest cascade-matches-selected-epoch?-ungrouped-cascade
+  (testing "a cascade with :dispatch-id :ungrouped does not match a
+            numeric selected-cascade-id (the projection lifts
+            free-floating traces under :ungrouped — they never produce
+            an epoch)"
+    (let [c {:dispatch-id :ungrouped}]
+      (is (false? (xref/cascade-matches-selected-epoch? c 100))))))
+
+;; ---- end-to-end shape ---------------------------------------------------
+
+(deftest end-to-end-scrub-to-cascade-a
+  (testing "scrub to epoch-a → only cascade-a is visible, cascade-a is
+            highlighted, cascade-b is filtered out (emitted after the
+            selected epoch settled)"
+    (let [selected-epoch    7
+          cap               (xref/max-trace-event-id-for-epoch history selected-epoch)
+          selected-cascade  (xref/cascade-id-for-epoch       history selected-epoch)
+          all-cascades      [cascade-a cascade-b]
+          visible           (xref/filter-cascades-up-to all-cascades cap)]
+      (is (= 6 cap))
+      (is (= 100 selected-cascade))
+      (is (= [cascade-a] visible))
+      (is (true?  (xref/cascade-matches-selected-epoch? cascade-a selected-cascade)))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-b selected-cascade))))))
+
+(deftest end-to-end-scrub-to-cascade-b
+  (testing "scrub to epoch-b → both cascades visible, cascade-b is the
+            one that landed the selected epoch (highlighted)"
+    (let [selected-epoch    8
+          cap               (xref/max-trace-event-id-for-epoch history selected-epoch)
+          selected-cascade  (xref/cascade-id-for-epoch       history selected-epoch)
+          all-cascades      [cascade-a cascade-b]
+          visible           (xref/filter-cascades-up-to all-cascades cap)]
+      (is (= 12 cap))
+      (is (= 200 selected-cascade))
+      (is (= [cascade-a cascade-b] visible))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-a selected-cascade)))
+      (is (true?  (xref/cascade-matches-selected-epoch? cascade-b selected-cascade))))))
+
+(deftest end-to-end-no-scrub
+  (testing "no scrub in flight → no filter, no highlight"
+    (let [selected-epoch    nil
+          cap               (xref/max-trace-event-id-for-epoch history selected-epoch)
+          selected-cascade  (xref/cascade-id-for-epoch       history selected-epoch)
+          all-cascades      [cascade-a cascade-b]
+          visible           (xref/filter-cascades-up-to all-cascades cap)]
+      (is (nil? cap))
+      (is (nil? selected-cascade))
+      (is (= [cascade-a cascade-b] visible))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-a selected-cascade)))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-b selected-cascade))))))
+
+(deftest end-to-end-scrub-to-synthetic-epoch
+  (testing "scrub to a reset-frame-db! synthetic epoch → cap is nil
+            (every cascade visible) but no cascade is highlighted (the
+            synthetic epoch carried no producing cascade)"
+    (let [selected-epoch    9
+          cap               (xref/max-trace-event-id-for-epoch history selected-epoch)
+          selected-cascade  (xref/cascade-id-for-epoch       history selected-epoch)
+          all-cascades      [cascade-a cascade-b]
+          visible           (xref/filter-cascades-up-to all-cascades cap)]
+      (is (nil? cap))
+      (is (nil? selected-cascade))
+      (is (= [cascade-a cascade-b] visible))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-a selected-cascade)))
+      (is (false? (xref/cascade-matches-selected-epoch? cascade-b selected-cascade))))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -27,6 +27,8 @@
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.test-mode :as test-mode]
+            [re-frame.story.ui.scrubber :as scrubber]
+            [re-frame.story.ui.scrubber-xref :as xref]
             [re-frame.story.ui.trace :as trace]
             [re-frame.story.ui.workspace :as workspace]))
 
@@ -261,6 +263,51 @@
         (is (= 1 (count (:subs c))))
         (is (= 1 (count (:renders c))))))))
 
+;; ---- trace × scrubber cross-reference (rf2-sxwvf) -----------------------
+
+(deftest trace-scrubber-cross-ref-pure-helpers-callable-in-cljs
+  (testing "the pure-data cross-ref helpers (xref ns) are JVM+CLJS:
+            CLJS callers see the same shape under the cljc target."
+    (let [history [{:epoch-id 7 :trace-events [{:id 2 :tags {:dispatch-id 100}}
+                                               {:id 6 :tags {:dispatch-id 100}}]}
+                   {:epoch-id 8 :trace-events [{:id 12 :tags {:dispatch-id 200}}]}]]
+      (is (= 100 (xref/cascade-id-for-epoch history 7)))
+      (is (= 6   (xref/max-trace-event-id-for-epoch history 7)))
+      (is (nil?  (xref/cascade-id-for-epoch history nil)))
+      ;; filter is the identity under nil cap, drops cascades under a cap.
+      (let [cs [{:dispatch-id 100 :handler {:id 2 :tags {}} :effects [] :subs [] :renders [] :other []}
+                {:dispatch-id 200 :handler {:id 12 :tags {}} :effects [] :subs [] :renders [] :other []}]]
+        (is (= cs (xref/filter-cascades-up-to cs nil)))
+        (is (= [(first cs)] (xref/filter-cascades-up-to cs 6))))
+      (is (true? (xref/cascade-matches-selected-epoch?
+                   {:dispatch-id 100} 100)))
+      (is (false? (xref/cascade-matches-selected-epoch?
+                    {:dispatch-id 200} 100))))))
+
+(deftest scrubber-selection-ratom-roundtrips
+  (testing "selection ratom set/get/drop round-trip in CLJS — the trace
+            panel's deref against the ratom sees the value the scrubber
+            committed (the wiring the .cljs `panel` fns walk)."
+    (let [vid :story.xref/v1]
+      (try
+        ;; default: no selection (cleaned in finally below)
+        (is (nil? (scrubber/selected-epoch-id vid)))
+        ;; set, read, clear via select-epoch!
+        (scrubber/select-epoch! vid 42)
+        (is (= 42 (scrubber/selected-epoch-id vid)))
+        (scrubber/select-epoch! vid nil)
+        (is (nil? (scrubber/selected-epoch-id vid)))
+        ;; ensure-selection-atom! returns the same atom on repeated calls
+        ;; (the trace panel relies on this for stable deref signal).
+        (let [a1 (scrubber/ensure-selection-atom! vid)
+              a2 (scrubber/ensure-selection-atom! vid)]
+          (is (identical? a1 a2)))
+        ;; drop-selection! removes the entry
+        (scrubber/drop-selection! vid)
+        (is (nil? (scrubber/selected-epoch-id vid)))
+        (finally
+          (scrubber/drop-selection! vid))))))
+
 ;; ---- shell render smoke -------------------------------------------------
 ;;
 ;; We don't mount to a real DOM (the node-test target has no jsdom).
@@ -270,6 +317,7 @@
   (testing "sidebar / canvas / controls / scrubber / trace expose top-level component fns"
     (is (fn? sidebar/sidebar))
     (is (fn? trace/panel))
+    (is (fn? scrubber/panel))
     ;; The controls/panel takes a variant-id arg.
     (is (fn? controls/panel))
     ;; rf2-rodx — the :docs mode pane.


### PR DESCRIPTION
## Summary

Tie Story's time-travel scrubber and its six-domino trace panel so scrubbing to an epoch filters the trace view to events at-or-before that epoch and highlights the cascade whose post-effects produced it — the SOTA combination no JS playground ships (Storybook / Histoire / Ladle have no trace bus or epoch buffer to cross-reference).

- New normative spec `tools/story/spec/011-Trace-Scrubber-Cross-Ref.md`.
- Pure-data cross-reference helpers in `re-frame.story.ui.scrubber-xref` (`.cljc`) so the filter + highlight predicates run under the JVM unit-test target — per `feedback_jvm_interop_must_work.md`.
- Per-variant `selections` defonce ratom in `re-frame.story.ui.scrubber` keyed by stable `:epoch-id` (not slider index, so ring-buffer evictions don't silently re-point).
- Trace panel reads the selection ratom, filters cascades whose max event-id ≤ the epoch's cap, and marks the producing cascade with `data-selected="true"` plus an amber outline.
- "release" button on the scrubber clears the selection so the panel reverts to the full buffer view.
- Shell teardown drops the per-variant selection ratom alongside the existing history / buffer ratoms.
- 21 new JVM unit tests (50 assertions), 2 CLJS smoke tests for the ratom wiring, an §11b sub-section in the counter_with_stories Playwright spec that drives the cross-reference end-to-end against a live shell.

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 189 tests / 522 assertions, 0 failures
- [x] `npm run test:cljs` — 598 tests / 1427 assertions, 0 failures
- [x] `npm run test:browser` — 614 tests / 1517 assertions, 0 failures
- [x] `npm run test:elision` — every gated sentinel absent in `:advanced`, present in dev
- [x] `npm run test:examples` — counter-with-stories Playwright spec including the new §11b cross-reference path passes
- [x] `python -m mkdocs build --strict` — no new warnings (119 pre-existing on main; my new spec doc is not in mkdocs nav so it doesn't change the count)