### PR TITLE
test(trace): cover sub-recompute / view-render / cofx scopes for :rf.trace/trigger-handler (rf2-npm2p)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
@@ -1,0 +1,152 @@
+(ns re-frame.view-render-trigger-handler-cljs-test
+  "Per rf2-npm2p — `:rf.trace/trigger-handler` rides the `:view/render`
+  trace event with the view's own registration coord.
+
+  Spec 009 §:rf.trace/trigger-handler table — 'Inside a view render:
+  the view's coord'. `views.cljs`'s `reg-view*` wraps the user render-fn
+  in a frame-aware-view that rebinds `*current-trigger-handler*` to the
+  view's `trigger-handler-from-meta` value around the body, and
+  `emit-render-trace!` fires `:view/render` from inside that binding.
+  The trace event therefore carries the view's registration coord on
+  the top-level `:rf.trace/trigger-handler` slot — Causa's event-detail
+  panel and pair2's jump-to-source UX render click-to-jump links from
+  this field for every trace in a cascade, including view renders.
+
+  Locked shape (per rf2-3nn8 / rf2-lf84g):
+
+    {:kind         :view
+     :id           <registered-view-id>
+     :source-coord {:ns <sym> :file <string> :line <int> :column <int>}}
+
+  CLJS-specific — the Reagent adapter / `views.cljs` wrapper is the
+  emit site; the JVM core has no view-render machinery. Mirror tests
+  for the other handler scopes (event, fx, sub, machine, cofx) live in
+  `implementation/core/test/re_frame/success_path_trigger_handler_test.clj`
+  and `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- record-traces!
+  "Attach a listener that captures every `:view/render` trace into an
+  atom. Returns the atom; caller is responsible for `remove-trace-cb!`."
+  []
+  (let [recorded (atom [])]
+    (rf/register-trace-cb! ::recorder
+      (fn [ev]
+        (when (= :view/render (:operation ev))
+          (swap! recorded conj ev))))
+    recorded))
+
+(defn- assert-trigger-shape
+  "Assert the value at top-level `:rf.trace/trigger-handler` on `ev`
+  carries the locked shape — `:kind`, `:id`, and a `:source-coord` map
+  with at least `:ns` / `:file` / `:line`."
+  [ev expected-id]
+  (let [t (:rf.trace/trigger-handler ev)]
+    (is (some? t)
+        (str "expected :rf.trace/trigger-handler on " (:operation ev)))
+    (is (= :view (:kind t)) "kind matches :view")
+    (is (= expected-id (:id t)) "id matches the registered view-id")
+    (let [c (:source-coord t)]
+      (is (map? c) ":source-coord present")
+      (is (symbol? (:ns c))    ":ns is a symbol")
+      (is (string? (:file c))  ":file is a string")
+      (is (integer? (:line c)) ":line is an integer"))))
+
+;; ---- :view/render carries the view's registration coord -------------------
+
+(deftest view-render-carries-trigger-handler
+  (testing ":view/render rides the view's own registration coord —
+   Causa / pair2 want jump-to-source on a view render trace to land
+   on the reg-view site, the same way fx-handled / sub-run / machine-
+   transition tests already pin"
+    (let [traces (record-traces!)]
+      (rf/reg-view ^{:rf/id :rf2-npm2p/sample} sample-view []
+        [:span "ok"])
+      (let [render (rf/view :rf2-npm2p/sample)]
+        (render))
+      (is (= 1 (count @traces)) "exactly one :view/render trace fired")
+      (assert-trigger-shape (first @traces) :rf2-npm2p/sample)
+      (rf/remove-trace-cb! ::recorder))))
+
+(deftest view-render-trigger-rides-at-top-level
+  (testing ":rf.trace/trigger-handler on :view/render is a top-level
+   field, NOT nested under :tags — mirrors the error / fx-handled /
+   sub-run / machine-transition shapes"
+    (let [traces (record-traces!)]
+      (rf/reg-view ^{:rf/id :rf2-npm2p/top-level-view} top-level-view []
+        [:span "hi"])
+      ((rf/view :rf2-npm2p/top-level-view))
+      (let [ev (first @traces)]
+        (is (some? ev))
+        (is (contains? ev :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives at top level")
+        (is (not (contains? (:tags ev) :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler does NOT live under :tags"))
+      (rf/remove-trace-cb! ::recorder))))
+
+(deftest view-render-trigger-matches-registrar-coord
+  (testing "the :source-coord under :rf.trace/trigger-handler on
+   :view/render equals what the registrar holds on the view's slot —
+   same comparison the other scope tests do"
+    (let [traces (record-traces!)]
+      (rf/reg-view ^{:rf/id :rf2-npm2p/coord-view} coord-view []
+        [:p "p"])
+      ((rf/view :rf2-npm2p/coord-view))
+      (let [reg-meta (rf/handler-meta :view :rf2-npm2p/coord-view)
+            ev       (first @traces)
+            coord    (-> ev :rf.trace/trigger-handler :source-coord)]
+        (is (some? ev))
+        (is (= (:ns     reg-meta) (:ns coord)))
+        (is (= (:file   reg-meta) (:file coord)))
+        (is (= (:line   reg-meta) (:line coord)))
+        (is (= (:column reg-meta) (:column coord))))
+      (rf/remove-trace-cb! ::recorder))))
+
+(deftest each-render-carries-trigger-handler
+  (testing "every :view/render invocation carries the trigger-handler
+   — not just the first render. The wrapper rebinds the dynamic var on
+   each invocation; the slot rides every emit."
+    (let [traces (record-traces!)]
+      (rf/reg-view ^{:rf/id :rf2-npm2p/multi-render} multi-render [n]
+        [:span "n-" n])
+      (let [render (rf/view :rf2-npm2p/multi-render)]
+        (render 1)
+        (render 2)
+        (render 3))
+      (is (= 3 (count @traces)) "three :view/render traces fired")
+      (doseq [ev @traces]
+        (assert-trigger-shape ev :rf2-npm2p/multi-render))
+      (rf/remove-trace-cb! ::recorder))))
+
+;; ---- programmatic registration → no coord → no trigger-handler ------------
+
+(deftest programmatic-view-omits-trigger-on-render
+  (testing "a view registered via `reg-view*` without macro-captured
+   coords emits :view/render with no :rf.trace/trigger-handler field —
+   better no-data than poison-data (mirrors the fx, sub, cofx
+   programmatic paths)"
+    (let [traces (record-traces!)]
+      ;; `reg-view*` (the plain-fn surface, not the macro) bypasses
+      ;; the source-coord capture path entirely. The trigger-handler
+      ;; builder gets an empty meta map and yields nil, so the slot
+      ;; is omitted from the emitted event.
+      (rf/reg-view* :rf2-npm2p/programmatic
+        (fn [] [:span "x"]))
+      ((rf/view :rf2-npm2p/programmatic))
+      (let [ev (first @traces)]
+        (is (some? ev) ":view/render fired")
+        (is (not (contains? ev :rf.trace/trigger-handler))
+            "programmatic view-registration → no coord → field omitted"))
+      (rf/remove-trace-cb! ::recorder))))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -185,17 +185,23 @@
      exception emit :rf.error/sub-exception and yield nil (recovery
      :replaced-with-default)."
   [body-fn in-vals query-id query-v frame-id input-signals sub-meta]
-  (trace/emit! :sub/run :sub/run
-               {:sub-id  query-id
-                :query-v query-v
-                :frame   frame-id})
-  ;; Per rf2-3nn8: bind `*current-trigger-handler*` to the sub's own
-  ;; source-coord for the body-fn invocation + the validation step so
-  ;; any error trace fired during the recompute (the `:rf.error/sub-
-  ;; exception` catch below, schema-validation failures, transitive
+  ;; Per rf2-3nn8 / rf2-lf84g (success-path widening) / rf2-npm2p
+  ;; (sub-recompute scope coverage): bind `*current-trigger-handler*` to
+  ;; the sub's own source-coord for the `:sub/run` success-trace emit,
+  ;; the body-fn invocation, and the validation step so every trace
+  ;; fired during the recompute (success path: `:sub/run`; error path:
+  ;; `:rf.error/sub-exception`, schema-validation failures, transitive
   ;; sub misses) carries the in-flight sub's coord.
+  ;;
+  ;; Per Spec 009 §:rf.trace/trigger-handler table row "Inside a sub
+  ;; recompute (body fn)": carries the sub's coord. The emit MUST sit
+  ;; inside the binding for the sub's coord to ride the success trace.
   (binding [trace/*current-trigger-handler*
             (trace/trigger-handler-from-meta :sub query-id sub-meta)]
+    (trace/emit! :sub/run :sub/run
+                 {:sub-id  query-id
+                  :query-v query-v
+                  :frame   frame-id})
     (try
       (let [computed (performance/mark-and-measure :sub query-id
                       (if (empty? input-signals)

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -198,3 +198,210 @@
                      " must omit :rf.trace/trigger-handler"))))
         (finally
           (rf/remove-trace-cb! ::rec))))))
+
+;; ---- :sub/run carries the sub's registration coord (rf2-npm2p) ------------
+;;
+;; Spec 009 §:rf.trace/trigger-handler table — "Inside a sub recompute (body
+;; fn): the sub's coord". The `:sub/run` success-trace emits inside the
+;; sub's recompute scope, so it carries the sub's own registration coord
+;; (not the enclosing event handler's, even when the recompute fires
+;; inside a dispatch's drain). Causa's event-detail panel + pair2's
+;; jump-to-source UX render click-to-jump links from this slot on every
+;; trace in a cascade, including sub recomputes.
+
+(deftest sub-run-carries-sub-trigger
+  (testing ":sub/run rides the sub's own registration coord — Causa /
+   pair2 want jump-to-source to land on the reg-sub site of the sub
+   that recomputed, not the upstream event handler whose db change
+   caused the recompute"
+    (rf/reg-sub :rf2-npm2p/n
+                (fn [db _] (:n db)))
+    (let [evs (record-traces
+                (fn [] (deref (rf/subscribe [:rf2-npm2p/n]))))
+          [run] (events-of evs :sub/run)]
+      (is (some? run) ":sub/run trace fired on recompute")
+      (assert-trigger-shape run :sub :rf2-npm2p/n))))
+
+(deftest sub-run-trigger-rides-at-top-level
+  (testing ":rf.trace/trigger-handler on :sub/run is a top-level field,
+   NOT nested under :tags — mirrors the error / fx-handled / machine-
+   transition shapes"
+    (rf/reg-sub :rf2-npm2p/top-level
+                (fn [db _] db))
+    (let [evs   (record-traces
+                  (fn [] (deref (rf/subscribe [:rf2-npm2p/top-level]))))
+          [run] (events-of evs :sub/run)]
+      (is (some? run))
+      (is (contains? run :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives at top level")
+      (is (not (contains? (:tags run) :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler does NOT live under :tags"))))
+
+(deftest sub-run-trigger-matches-registrar-coord
+  (testing "the :source-coord under :rf.trace/trigger-handler on :sub/run
+   equals what the registrar holds on the sub's slot — same comparison
+   the other scope tests do (fx, machine, event)"
+    (rf/reg-sub :rf2-npm2p/coord
+                (fn [db _] db))
+    (let [sub-meta (rf/handler-meta :sub :rf2-npm2p/coord)
+          evs      (record-traces
+                     (fn [] (deref (rf/subscribe [:rf2-npm2p/coord]))))
+          [run]    (events-of evs :sub/run)
+          coord    (-> run :rf.trace/trigger-handler :source-coord)]
+      (is (some? run))
+      (is (= (:ns     sub-meta) (:ns coord)))
+      (is (= (:file   sub-meta) (:file coord)))
+      (is (= (:line   sub-meta) (:line coord)))
+      (is (= (:column sub-meta) (:column coord))))))
+
+(deftest sub-run-trigger-is-sub-not-enclosing-event
+  (testing "when a sub fires during a dispatch (the event handler's
+   db change is observed by a subsequent deref), :sub/run still carries
+   the SUB's coord — not the enclosing event handler's. The runtime
+   rebinds `*current-trigger-handler*` around the sub recompute for
+   exactly this reason; otherwise tools would jump to the upstream
+   event handler whenever a sub fired during a cascade."
+    (rf/reg-sub :rf2-npm2p/from-cascade
+                (fn [db _] (:n db)))
+    ;; Register an event handler that dispatches the db change and
+    ;; ALSO derefs the sub inside the same handler — that way the
+    ;; recompute fires inside the in-flight event handler's binding
+    ;; scope, and the trigger-handler hoist contract is what's under
+    ;; test: does the inner sub-binding override the outer event-
+    ;; handler-binding for the `:sub/run` emit? Per Spec 009 §:rf.trace
+    ;; /trigger-handler table, yes (the inner scope wins).
+    (rf/reg-event-db :rf2-npm2p/changes-n
+                     (fn [db _]
+                       (let [new-db (assoc db :n 1)]
+                         ;; Touch the sub from inside the event body
+                         ;; so the recompute fires while the event
+                         ;; handler's binding is in scope.
+                         @(rf/subscribe [:rf2-npm2p/from-cascade])
+                         new-db)))
+    (let [evs   (record-traces
+                  (fn [] (rf/dispatch-sync [:rf2-npm2p/changes-n])))
+          [run] (events-of evs :sub/run)]
+      (is (some? run) ":sub/run fired inside the cascade")
+      ;; The KIND under trigger-handler is :sub, not :event. Even
+      ;; though the deref happens INSIDE the event handler's drain,
+      ;; the sub-recompute body rebinds the trigger-handler. Same
+      ;; shape as fx-handled — the inner binding wins over the outer.
+      (assert-trigger-shape run :sub :rf2-npm2p/from-cascade))))
+
+(deftest programmatic-sub-omits-trigger-on-run
+  (testing "a sub registered without the macro path (no source-coord
+   stamp on the registrar slot) emits :sub/run with no
+   :rf.trace/trigger-handler field — better no-data than poison-data
+   (mirrors the fx-handled programmatic path)"
+    (let [reg-fn (requiring-resolve 're-frame.subs/reg-sub)]
+      (reg-fn :rf2-npm2p/programmatic
+              (fn [db _] db)))
+    (let [evs   (record-traces
+                  (fn [] (deref (rf/subscribe [:rf2-npm2p/programmatic]))))
+          [run] (events-of evs :sub/run)]
+      (is (some? run) ":sub/run fired")
+      (is (not (contains? run :rf.trace/trigger-handler))
+          "programmatic sub-registration → no coord → field omitted"))))
+
+;; ---- cofx body carries the cofx's registration coord (rf2-npm2p) ----------
+;;
+;; Spec 009 §:rf.trace/trigger-handler table — "Inside a cofx fn body:
+;; the cofx's coord". `cofx.cljc` rebinds `*current-trigger-handler*`
+;; around the cofx fn invocation so traces emitted from inside the
+;; cofx body (e.g. an instrumented http cofx emitting `:rf.http/issued`)
+;; carry the cofx's own registration coord, not the enclosing event
+;; handler's.
+;;
+;; The framework's stock cofx surface emits no success-path trace of its
+;; own (`cofx.cljc` only emits `:rf.error/no-such-cofx` on the miss
+;; path). To exercise the success-path binding contract, the test
+;; registers a cofx whose body itself calls `trace/emit!` — exactly the
+;; pattern an instrumented cofx (http, persistence, websocket) would
+;; use to surface its work into the trace stream. The emitted event
+;; rides the cofx's trigger-handler binding because it fires from
+;; inside the cofx fn's invocation scope.
+
+(deftest cofx-body-trace-carries-cofx-trigger
+  (testing "a trace emitted from inside the cofx fn body rides the
+   cofx's registration coord — the cofx rebinds
+   `*current-trigger-handler*` around the body, overriding the
+   enclosing event handler's binding"
+    (rf/reg-cofx :rf2-npm2p/instrumented-cofx
+                 (fn [ctx]
+                   ;; Emit a custom trace from inside the cofx body —
+                   ;; this is exactly what an instrumented cofx
+                   ;; (http issuance, persistence read, etc.) does to
+                   ;; surface its work into the trace stream. The
+                   ;; binding established by `cofx.cljc`'s `:before`
+                   ;; phase MUST cause this emit to carry the cofx's
+                   ;; coord (not the enclosing event handler's).
+                   (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {:from :cofx})
+                   ctx))
+    (rf/reg-event-fx :rf2-npm2p/uses-cofx
+                     [(rf/inject-cofx :rf2-npm2p/instrumented-cofx)]
+                     (fn [_cofx _event] {}))
+    (let [evs     (record-traces
+                    (fn [] (rf/dispatch-sync [:rf2-npm2p/uses-cofx])))
+          [probe] (events-of evs :rf2-npm2p/probe)]
+      (is (some? probe) "custom trace fired from inside the cofx body")
+      (assert-trigger-shape probe :cofx :rf2-npm2p/instrumented-cofx))))
+
+(deftest cofx-body-trigger-rides-at-top-level
+  (testing ":rf.trace/trigger-handler on a cofx-body trace is a
+   top-level field, NOT nested under :tags"
+    (rf/reg-cofx :rf2-npm2p/top-level-cofx
+                 (fn [ctx]
+                   (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
+                   ctx))
+    (rf/reg-event-fx :rf2-npm2p/use-top-level-cofx
+                     [(rf/inject-cofx :rf2-npm2p/top-level-cofx)]
+                     (fn [_ _] {}))
+    (let [evs     (record-traces
+                    (fn [] (rf/dispatch-sync [:rf2-npm2p/use-top-level-cofx])))
+          [probe] (events-of evs :rf2-npm2p/probe)]
+      (is (some? probe))
+      (is (contains? probe :rf.trace/trigger-handler)
+          ":rf.trace/trigger-handler lives at top level")
+      (is (not (contains? (:tags probe) :rf.trace/trigger-handler))
+          ":rf.trace/trigger-handler does NOT live under :tags"))))
+
+(deftest cofx-body-trigger-matches-registrar-coord
+  (testing "the :source-coord under :rf.trace/trigger-handler on a
+   cofx-body trace equals what the registrar holds on the cofx's slot"
+    (rf/reg-cofx :rf2-npm2p/coord-cofx
+                 (fn [ctx]
+                   (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
+                   ctx))
+    (rf/reg-event-fx :rf2-npm2p/use-coord-cofx
+                     [(rf/inject-cofx :rf2-npm2p/coord-cofx)]
+                     (fn [_ _] {}))
+    (let [cofx-meta (rf/handler-meta :cofx :rf2-npm2p/coord-cofx)
+          evs       (record-traces
+                      (fn [] (rf/dispatch-sync [:rf2-npm2p/use-coord-cofx])))
+          [probe]   (events-of evs :rf2-npm2p/probe)
+          coord     (-> probe :rf.trace/trigger-handler :source-coord)]
+      (is (some? probe))
+      (is (= (:ns     cofx-meta) (:ns coord)))
+      (is (= (:file   cofx-meta) (:file coord)))
+      (is (= (:line   cofx-meta) (:line coord)))
+      (is (= (:column cofx-meta) (:column coord))))))
+
+(deftest programmatic-cofx-omits-trigger-on-body-trace
+  (testing "a cofx registered without the macro path (no source-coord
+   stamp on the registrar slot) — traces emitted from inside its body
+   carry no :rf.trace/trigger-handler field. Better no-data than
+   poison-data, mirroring the fx + sub programmatic paths."
+    (let [reg-fn (requiring-resolve 're-frame.cofx/reg-cofx)]
+      (reg-fn :rf2-npm2p/prog-cofx
+              (fn [ctx]
+                (trace/emit! :rf2-npm2p/probe :rf2-npm2p/probe {})
+                ctx)))
+    (rf/reg-event-fx :rf2-npm2p/use-prog-cofx
+                     [(rf/inject-cofx :rf2-npm2p/prog-cofx)]
+                     (fn [_ _] {}))
+    (let [evs     (record-traces
+                    (fn [] (rf/dispatch-sync [:rf2-npm2p/use-prog-cofx])))
+          [probe] (events-of evs :rf2-npm2p/probe)]
+      (is (some? probe))
+      (is (not (contains? probe :rf.trace/trigger-handler))
+          "programmatic cofx-registration → no coord → field omitted"))))


### PR DESCRIPTION
## Summary

Per rf2-npm2p — extend `:rf.trace/trigger-handler` success-path coverage to the three handler scopes left untested after rf2-lf84g (event, fx, machine) and rf2-3nn8 (error path):

- **sub recompute (JVM)** — five new tests in `success_path_trigger_handler_test.clj`: `:sub/run` carries the sub's own coord, top-level placement, registrar-coord parity, inner-binding wins over the enclosing event handler in a cascade, programmatic registration omits the slot.
- **cofx body (JVM)** — four new tests in the same file: a trace emitted from inside a cofx fn body carries the cofx's coord (the pattern instrumented cofx like http use), top-level placement, registrar-coord parity, programmatic registration omits the slot.
- **view render (CLJS)** — new file `view_render_trigger_handler_cljs_test.cljs` under `adapters/reagent/test/`: `:view/render` rides the view's coord through `views.cljs`'s `frame-aware-view` wrapper, top-level placement, registrar-coord parity, every render carries the slot, programmatic `reg-view*` omits it.

### Impl gap surfaced and fixed

`re-frame.subs/validate-and-trace` was emitting `:sub/run` **before** establishing the `*current-trigger-handler*` binding for the sub's own coord. Result: `:sub/run` carried the enclosing event handler's coord (cascade case) or nil (top-level subscribe), contradicting Spec 009 §:rf.trace/trigger-handler table row *"Inside a sub recompute (body fn): the sub's coord"*. Fixed by moving the emit inside the binding form. Filed as rf2-jffaf, closed on this commit.

Causa's event-detail panel (rf2-op3bz) and pair2's jump-to-source UX both consume `:rf.trace/trigger-handler` from these scopes; a future regression in dynvar binding around sub-recompute / view-render / cofx now fails a unit test instead of silently degrading the tools.

## Test plan

- [x] `clojure -M:test` per artefact (core, machines, schemas, routing, flows, http, ssr, epoch) — all pass
- [x] `npm run test:cljs` (node-test bundle, 622 tests) — passes, includes new `view-render-trigger-handler-cljs-test`
- [x] `npm run test:elision` — passes, prod elision intact
- [ ] `npm run test:browser` — local port conflict with another worktree; CI is the source of truth
- [x] mkdocs warnings on this branch are pre-existing (119 warnings, none touch the changed surfaces)

## Beads

- rf2-npm2p — closed by this PR
- rf2-jffaf — impl gap follow-up bead; closed (fix lives in the same commit)