### PR TITLE
docs(api): batched usability cleanup — docstrings + error messages + cross-refs (rf2-5r7ec rf2-q41sw rf2-crmmz rf2-g6o5k rf2-yicyh rf2-nsr5x rf2-6a2dj + 6× P3)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -186,17 +186,26 @@
   (helix-hooks/use-context adapter-context/frame-context))
 
 (defn frame-provider
-  "User-facing Helix component scoping `frame-kw` to its subtree.
+  "User-facing component scoping `frame-kw` to its subtree. Wraps
+  children in the shared frame Context Provider — inside the subtree,
+  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
+  descendants resolve to the named frame. Per Spec 002 §What
+  `frame-provider` is.
 
-  Returns a React element wrapping `children` in the shared frame
-  Context Provider. Use:
+  Reads `:frame` from props. When missing or `nil`, falls through to
+  `:rf/default` (per rf2-sixo — defensive default that matches the
+  no-provider behaviour and avoids breaking tooling-generated trees
+  that elide the prop).
 
-      ($ frame-provider {:frame :session}
-         ($ header)
-         ($ main))
+  Helix call shape:
 
-  Per Spec 002 §What `frame-provider` is — same surface as the Reagent
-  and UIx variants, different rendering substrate."
+      ($ frame-provider {:frame :session
+                         :children [($ header) ($ main)]})
+
+  Same surface as the Reagent and UIx variants, different rendering
+  substrate. The three adapters share one React Context (per rf2-3yij
+  Decision 2) so a subtree under any frame-provider sees the right
+  frame regardless of which substrate rendered the provider."
   [{:keys [frame children]}]
   (let [frame-kw (or frame :rf/default)]
     (apply adapter-context/provider-element frame-kw

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -181,17 +181,26 @@
   (uix/use-context adapter-context/frame-context))
 
 (defn frame-provider
-  "User-facing UIx component scoping `frame-kw` to its subtree.
+  "User-facing component scoping `frame-kw` to its subtree. Wraps
+  children in the shared frame Context Provider — inside the subtree,
+  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
+  descendants resolve to the named frame. Per Spec 002 §What
+  `frame-provider` is.
 
-  Returns a React element wrapping `children` in the shared frame
-  Context Provider. Use:
+  Reads `:frame` from props. When missing or `nil`, falls through to
+  `:rf/default` (per rf2-sixo — defensive default that matches the
+  no-provider behaviour and avoids breaking tooling-generated trees
+  that elide the prop).
 
-      ($ frame-provider {:frame :session}
-         ($ header)
-         ($ main))
+  UIx call shape:
 
-  Per Spec 002 §What `frame-provider` is — same surface as the Reagent
-  variant, different rendering substrate."
+      ($ frame-provider {:frame :session
+                         :children [($ header) ($ main)]})
+
+  Same surface as the Reagent and Helix variants, different rendering
+  substrate. The three adapters share one React Context (per rf2-3yij
+  Decision 2) so a subtree under any frame-provider sees the right
+  frame regardless of which substrate rendered the provider."
   [{:keys [frame children]}]
   (let [frame-kw (or frame :rf/default)]
     (apply adapter-context/provider-element frame-kw

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -51,9 +51,44 @@
     ctx))
 
 (defn reg-cofx
-  "Register a coeffect handler.
-  cofx-handler signature: (fn [context]) → context  OR  (fn [context value]) → context.
-  Returns context with the cofx merged into :coeffects."
+  "Register a coeffect handler under `id`. A coeffect is a source of
+  input data injected into an event handler's `:coeffects` map.
+
+  Handler signatures:
+
+      (fn [context])         → context     ;; no-value form (1-arity)
+      (fn [context value])   → context     ;; value form    (2-arity)
+
+  The handler should `assoc` its result into `(:coeffects context)`
+  under a key — conventionally `id` — and return the updated context.
+  The standard cofx ids are `:db` (the frame's `app-db` value at drain
+  start) and `:event` (the dispatched event vector); both are populated
+  by the runtime before the interceptor chain runs.
+
+  Consumed by event handlers via `inject-cofx` placed in the
+  interceptor-vector slot of `reg-event-{db,fx,ctx}`:
+
+      (rf/reg-cofx :now
+        (fn [ctx]
+          (assoc-in ctx [:coeffects :now] (js/Date.))))
+
+      (rf/reg-event-fx :user/save
+        [(rf/inject-cofx :now)]                       ;; <-- inject here
+        (fn [{:keys [db now]} [_ user]]               ;; <-- read here
+          {:db (assoc db :saved-at now :user user)}))
+
+  Shapes:
+
+      (reg-cofx :id                                (fn [ctx] ...))
+      (reg-cofx :id {:doc \"...\" :spec ...}         (fn [ctx] ...))
+
+  Optional metadata keys: `:doc`, `:spec` (Malli schema for the
+  injected value — validated per Spec 010 §Validation order step 2).
+
+  Returns `id`.
+
+  See also: `inject-cofx` (consumer-side), `reg-fx` (output-side
+  counterpart), the standard `:db` / `:event` cofx registered below."
   [id metadata-or-handler & maybe-handler]
   (let [[meta handler-fn]
         (if (map? metadata-or-handler)
@@ -64,37 +99,53 @@
     id))
 
 (defn inject-cofx
-  "Build a :before-only interceptor that runs the registered cofx and
-  injects its result into the context's :coeffects.
+  "Build a `:before`-only interceptor that runs the cofx registered
+  under `cofx-id` and merges its result into the running event
+  handler's `:coeffects`.
 
-  Three arities:
-    (inject-cofx :id)                  — no value, no call-site
-    (inject-cofx :id value)            — value, no call-site
-    (inject-cofx :id value call-site)  — value + macro-stamped call-site
-                                         (use `cofx/no-value` for the
-                                         no-value path with a call-site)
+  Used in the positional interceptor-vector of `reg-event-{db,fx,ctx}`:
 
-  Per rf2-ts1a: the 3-arity form is what `re-frame.core/inject-cofx`'s
-  macro expands to — it captures `(meta &form)` at the user call site
-  and stamps it into the interceptor's closure. The `:before` body
-  binds `trace/*current-call-site*` to the captured value so error
-  events emitted from inside the body (`:rf.error/no-such-cofx`,
-  schema-validation failures, exceptions thrown by the cofx fn) carry
-  the invocation coord. Pass `nil` for the call-site to opt out of
-  stamping (the 1-/2-arity forms wrap to this with `nil`).
+      (rf/reg-cofx :now
+        (fn [ctx] (assoc-in ctx [:coeffects :now] (js/Date.))))
 
-  Per Spec 010 §Validation order step 2 (rf2-7leq) — after the cofx
-  fn returns, if the cofx's metadata carries a :spec, validate the
-  injected value. On failure, mark the context with
-  :rf/skip-handler? so subsequent handler interceptors short-circuit
-  (recovery: :no-recovery; downstream queue continues).
+      (rf/reg-event-fx :foo
+        [(rf/inject-cofx :now)]                 ;; <-- interceptor position
+        (fn [{:keys [db now]} _]                ;; <-- read injected value
+          {:db (assoc db :timestamp now)}))
 
-  Per rf2-3nn8: while the cofx fn body runs, the cofx's own
-  source-coord is the in-scope trigger-handler — errors emitted from
-  inside the cofx point at the cofx definition, not the enclosing
-  event handler. The miss path (`:rf.error/no-such-cofx`) inherits
-  the enclosing event handler's binding (set by the router) — the
-  cofx that doesn't exist has no coord to point at."
+  The handler sees the injected value under the conventional `cofx-id`
+  key in its first arg. Some cofx accept a per-call value:
+  `(inject-cofx :stub {:status 200})` — the value is passed to the
+  cofx handler's 2-arity form.
+
+  Errors:
+    `:rf.error/no-such-cofx`               — `cofx-id` is not registered;
+                                              the handler still runs but
+                                              with no injection (recovery
+                                              :no-recovery).
+    `:rf.error/schema-validation-failure`  — cofx carries a `:spec` and
+                                              the injected value fails it;
+                                              the handler is short-circuited
+                                              via `:rf/skip-handler?`.
+
+  Notes
+  -----
+  Three arities exist for plumbing reasons:
+
+      (inject-cofx :id)                   — no value, no call-site
+      (inject-cofx :id value)             — per-call value, no call-site
+      (inject-cofx :id value call-site)   — value + macro-stamped call-site
+                                            (use `cofx/no-value` for the
+                                            no-value path with a call-site)
+
+  The 3-arity form is what the `re-frame.core/inject-cofx` macro expands
+  to (per rf2-ts1a); it captures `(meta &form)` at the user call site
+  so error events emitted from the cofx body carry the invocation
+  coord. The 1-/2-arity forms wrap to the 3-arity with a `nil`
+  call-site.
+
+  See also: `reg-cofx`, `re-frame.core/inject-cofx` (macro form with
+  call-site capture)."
   ([cofx-id]
    (inject-cofx cofx-id no-value nil))
   ([cofx-id value]
@@ -128,6 +179,7 @@
 ;; ---- standard cofx --------------------------------------------------------
 
 (reg-cofx :db
+  {:doc "Inject the frame's current `app-db` value under `:coeffects :db`. Pre-populated by the drain loop before the interceptor chain runs; explicit `(inject-cofx :db)` is rarely needed and is a no-op. Exists for symmetry with `:event` and v1 idioms."}
   (fn [ctx]
     ;; The drain loop has already populated :coeffects :db with the frame's
     ;; current app-db value before invoking the chain — so this cofx is
@@ -135,6 +187,7 @@
     ctx))
 
 (reg-cofx :event
+  {:doc "Inject the dispatched event vector under `:coeffects :event`. Pre-populated by the dispatch envelope before the chain runs; explicit `(inject-cofx :event)` is a no-op."}
   (fn [ctx]
     ;; Same as :db — the dispatch envelope wires the event into :coeffects
     ;; before the chain runs.

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -129,54 +129,96 @@
 
 #?(:clj
    (defmacro reg-event-db
-     "Register a (db, event) -> new-db handler. Per Spec 001 the
-     metadata stamped onto the registry slot includes :ns / :line /
-     :file captured at this call site."
+     "Register a `(fn [db event-vec] new-db)` event handler under `id`.
+     See `re-frame.events/reg-event-db` for the full docstring (handler
+     signature, return shape, middle-slot rules, example).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `reg-event-fx`, `reg-event-ctx`, `dispatch`."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(events/reg-event-db ~id ~@args))))
 
 #?(:clj
    (defmacro reg-event-fx
-     "Register a (cofx, event) -> effects-map handler. Per Spec 001
-     the metadata stamped onto the registry slot includes :ns / :line /
-     :file captured at this call site."
+     "Register a `(fn [cofx event-vec] effect-map)` event handler under
+     `id`. The effect-map is a **closed** shape: only `:db` and `:fx`
+     are honoured at the top level (per migration M-8). See
+     `re-frame.events/reg-event-fx` for the full docstring (handler
+     signature, effect-map shape, examples).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `reg-event-db`, `reg-fx` (register a custom fx),
+     `inject-cofx` (consume a registered cofx)."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(events/reg-event-fx ~id ~@args))))
 
 #?(:clj
    (defmacro reg-event-ctx
-     "Register a context-handler. Per Spec 001 the metadata stamped
-     onto the registry slot includes :ns / :line / :file captured at
-     this call site."
+     "Register a `(fn [context] context)` full-context event handler
+     under `id`. **Advanced** — most handlers want `reg-event-db` or
+     `reg-event-fx` instead. See `re-frame.events/reg-event-ctx` for
+     the full docstring (when to reach for it, shapes, examples).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `reg-event-fx`, `->interceptor`, `assoc-coeffect`,
+     `assoc-effect`."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(events/reg-event-ctx ~id ~@args))))
 
 #?(:clj
    (defmacro reg-sub
-     "Register a subscription. Per Spec 001 the metadata stamped onto
-     the registry slot includes :ns / :line / :file captured at this
-     call site."
+     "Register a subscription under `id`. Layer-1 subs read `app-db`
+     directly; layer-2 subs chain off other subs via `:<-`. See
+     `re-frame.subs/reg-sub` for the full docstring (shapes, examples,
+     hot-reload semantics).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `subscribe`, `subscribe-value`, `compute-sub`."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(subs/reg-sub ~id ~@args))))
 
 #?(:clj
    (defmacro reg-fx
-     "Register an fx handler. Per Spec 001 the metadata stamped onto
-     the registry slot includes :ns / :line / :file captured at this
-     call site."
+     "Register an effect handler under `id`. The handler runs when a
+     `reg-event-fx` returns an effect-map carrying `[id args]` inside
+     its `:fx` vector. **Handler signature is `(fn [ctx args] ...)`**
+     — see `re-frame.fx/reg-fx` for the full docstring (ctx shape,
+     metadata keys including `:platforms`, examples).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `reg-cofx` (input-side counterpart), `clear-fx`,
+     `reg-event-fx` (the consumer)."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(fx/reg-fx ~id ~@args))))
 
 #?(:clj
    (defmacro reg-cofx
-     "Register a coeffect handler. Per Spec 001 the metadata stamped
-     onto the registry slot includes :ns / :line / :file captured at
-     this call site."
+     "Register a coeffect handler under `id`. A cofx is a source of
+     input data injected into an event handler's `:coeffects` map
+     via `inject-cofx`. See `re-frame.cofx/reg-cofx` for the full
+     docstring (handler signature, worked example, the standard
+     `:db` / `:event` cofx).
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `inject-cofx` (consumer-side), `reg-fx` (output-side
+     counterpart)."
      [id & args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(cofx/reg-cofx ~id ~@args))))
@@ -457,17 +499,48 @@
 
 #?(:clj
    (defmacro reg-route
-     "Register a route. Per Spec 001 the metadata stamped onto the
-     registry slot includes :ns / :line / :file captured at this call
-     site.
+     "Register a route under `id`. `metadata` is a map carrying at
+     minimum `:path` (the URL pattern); additional keys are documented
+     in Spec 012.
 
-     Per rf2-k682 the routing implementation lives in the
-     `day8/re-frame2-routing` artefact; the emitted form looks the
-     producing fn up via the late-bind hook table so core never
-     statically requires it. Apps that use `reg-route` MUST add
-     `day8/re-frame2-routing` to their deps and require
-     `re-frame.routing` at app boot; without it, the lookup returns
-     nil and the call throws a clear error."
+     ## Path pattern syntax
+
+     The `:path` string is parsed at registration time into a matcher.
+     Four pattern forms:
+
+       /literal      — literal segment; matches exactly.
+       /:name        — named param; captures `[^/]+` under key `:name`.
+                       Example: `/user/:id` matches `/user/42`,
+                       binding `{:id \"42\"}`.
+       /*name        — splat; captures the rest of the path greedily
+                       (including `/`). Example: `/files/*rest` matches
+                       `/files/a/b/c`, binding `{:rest \"a/b/c\"}`.
+       /{...}?       — optional group; the inner segment(s) match if
+                       present, otherwise default. Example:
+                       `/users{/:id}?` matches both `/users` and
+                       `/users/42`.
+
+     See Spec 012 §Pattern syntax for full grammar (escapes, conflict
+     resolution between literals and params).
+
+     ## Example
+
+         (rf/reg-route :user/profile
+           {:path \"/user/:id\"
+            :params {:id [:int]}})
+
+     ## Artefact split
+
+     Per rf2-k682 the routing implementation ships in
+     `day8/re-frame2-routing`; the emitted form looks the producing fn
+     up via the late-bind hook table. Apps using `reg-route` MUST add
+     `day8/re-frame2-routing` to deps and require `re-frame.routing` at
+     boot; without it, the call raises `:rf.error/routing-artefact-missing`.
+
+     Per Spec 001 the metadata stamped onto the registry slot includes
+     `:ns` / `:line` / `:file` captured at this macro call site.
+
+     See also: `match-url`, `route-url`, `route-link`."
      [id metadata]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
                        `(rf-routing/reg-route ~id ~metadata))))
@@ -655,7 +728,7 @@
 
 (def clear-event events/clear-event)
 (def clear-sub   subs/clear-sub)
-(def clear-fx    fx/unregister-fx)
+(def clear-fx    fx/clear-fx)
 (def clear-subscription-cache! subs/clear-subscription-cache!)
 
 ;; ---- dispatch and subscribe -----------------------------------------------
@@ -743,14 +816,25 @@
 
 #?(:clj
    (defmacro dispatch
-     "Enqueue `event-vec` on the target frame's router. Per Spec 002
-     §Routing. Per rf2-ts1a: macro form — captures the call site at
-     compile time and threads it through the dispatch envelope so any
-     error trace emitted while the handler chain runs carries the
-     invocation coord as `:rf.trace/call-site`.
+     "Enqueue `event-vec` on the target frame's router. The matching
+     `reg-event-*` handler runs on the next tick — `dispatch` returns
+     immediately, BEFORE the handler runs. The handler's effects
+     (`:db` update, `:fx` side-effects) happen asynchronously.
+
+     Returns nil. Use `dispatch-sync` for synchronous execution in
+     tests, REPL, and bootstrap. Inside an event handler, do NOT call
+     `dispatch` directly — return `{:fx [[:dispatch event] ...]}` so
+     the dispatch rides through the runtime's effect-map walker.
+
+     Per Spec 002 §Routing. Per rf2-ts1a: this macro captures
+     `(meta &form)` at compile time and threads it through the
+     dispatch envelope so any error trace emitted while the handler
+     chain runs carries the invocation coord as `:rf.trace/call-site`.
 
      For higher-order use (`(map dispatch* xs)`) and programmatic
-     callers, use `dispatch*` — the runtime-callable fn form."
+     callers, use `dispatch*` — the runtime-callable fn form.
+
+     See also: `dispatch-sync`, `dispatcher` (captured-frame closure)."
      ([event-vec]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         `(if re-frame.interop/debug-enabled?
@@ -765,11 +849,27 @@
 
 #?(:clj
    (defmacro dispatch-sync
-     "Run `event-vec` end-to-end synchronously, then drain. Per Spec 002
-     §dispatch-sync. Per rf2-ts1a: macro form — captures the call site
-     and threads it through the dispatch envelope.
+     "Run `event-vec` end-to-end synchronously. The handler runs before
+     this fn returns; the router drains to fixed point (any
+     `[:dispatch event]` effects cascade synchronously too).
 
-     For higher-order use and programmatic callers, use `dispatch-sync*`."
+     **Never call from inside a running event handler.** Doing so
+     raises `:rf.error/dispatch-sync-in-handler` — use
+     `{:fx [[:dispatch event]]}` from the handler instead. The runtime
+     queues the dispatch onto the current cascade rather than re-entering
+     the dispatch loop.
+
+     `dispatch-sync` is for tests, REPL sessions, and bootstrap.
+     Production application code prefers `dispatch` — synchronous
+     re-entrancy is dangerous and the framework polices it.
+
+     Per Spec 002 §dispatch-sync. Per rf2-ts1a: this macro captures
+     `(meta &form)` and threads it through the dispatch envelope.
+
+     For higher-order use and programmatic callers, use `dispatch-sync*`.
+
+     See also: `dispatch`, `:rf.error/dispatch-sync-in-handler`
+     (the in-handler error category)."
      ([event-vec]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         `(if re-frame.interop/debug-enabled?
@@ -784,13 +884,27 @@
 
 #?(:clj
    (defmacro subscribe
-     "Per Spec 006 §Lookup algorithm. Per rf2-ts1a: macro form —
-     captures the call site and binds `trace/*current-call-site*`
-     around the underlying subscribe so the synchronous miss path
-     (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`) carries
-     the invocation coord.
+     "Return a reaction whose value is the registered sub's current
+     output for `query-v`. Deref to read; under Reagent the deref
+     tracks the surrounding component for re-render on change.
 
-     For HoF / programmatic subscribe, use `subscribe*`."
+     `query-v` is `[sub-id & args]` (the sub's `handler-fn` receives
+     it as its second arg). The 2-arity form `(subscribe frame-id
+     query-v)` targets an explicit frame; otherwise the active frame
+     resolves per `current-frame` (dynamic-var → React-context → `:rf/default`).
+
+     Returns nil for an unknown sub and emits `:rf.error/no-such-sub`.
+
+     Use `subscribe-value` for a one-shot read (no reactive tracking).
+     For HoF / programmatic subscribe, use `subscribe*`.
+
+     Per Spec 006 §Lookup algorithm. Per rf2-ts1a: this macro captures
+     `(meta &form)` and binds `trace/*current-call-site*` around the
+     underlying subscribe so the synchronous miss path carries the
+     invocation coord.
+
+     See also: `subscribe-value`, `unsubscribe`, `current-frame`,
+     `reg-sub`."
      ([query-v]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         `(if re-frame.interop/debug-enabled?
@@ -806,13 +920,32 @@
 
 #?(:clj
    (defmacro inject-cofx
-     "Build a `:before`-only interceptor that runs the registered cofx.
-     Per rf2-ts1a: macro form — captures the call site and threads it
-     into the interceptor's closure so errors emitted from inside the
-     cofx body (`:rf.error/no-such-cofx`, schema-validation failures)
-     carry the invocation coord.
+     "Used as an interceptor in the positional interceptor-vector of
+     `reg-event-fx` / `reg-event-db` / `reg-event-ctx`. Builds a
+     `:before`-only interceptor that runs the cofx registered under
+     `cofx-id` and merges its result into the handler's `:coeffects`.
 
-     For HoF / programmatic interceptor construction, use `inject-cofx*`."
+         (rf/reg-cofx :now
+           (fn [ctx] (assoc-in ctx [:coeffects :now] (js/Date.))))
+
+         (rf/reg-event-fx :foo
+           [(rf/inject-cofx :now)]                  ;; <-- interceptor position
+           (fn [{:keys [now]} _] ...))
+
+     Some cofx accept a per-call value:
+     `(inject-cofx :stub {:status 200})`.
+
+     Per rf2-ts1a: this macro captures `(meta &form)` and threads the
+     call-site into the interceptor's closure so errors emitted from
+     inside the cofx body (`:rf.error/no-such-cofx`, schema-validation
+     failures) carry the invocation coord.
+
+     For HoF / programmatic interceptor construction (computed cofx
+     ids, code-gen pipelines), use `inject-cofx*` — the runtime-callable
+     fn form.
+
+     See also: `reg-cofx`, `re-frame.cofx/inject-cofx` (the underlying
+     fn — full docstring lives there)."
      ([cofx-id]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         ;; Route through the 3-arity with the `cofx/no-value` sentinel
@@ -1019,6 +1152,14 @@
 ;; and the API.md table); it lives in re-frame.views to keep React/Reagent off
 ;; the JVM load path.
 
+;; User-facing component scoping a frame keyword to its subtree. Wraps
+;; children in the shared frame Context Provider so descendants resolve
+;; to the named frame via `(rf/dispatcher)` / `(rf/subscriber)` /
+;; `reg-view`-registered components. Per Spec 002 §What `frame-provider`
+;; is; per rf2-zde3z the canonical phrasing lives on the Reagent /
+;; UIx / Helix implementations themselves — see
+;; `re-frame.views.provider/frame-provider` for the Reagent variant
+;; documented in full.
 #?(:cljs (def frame-provider views/frame-provider))
 
 ;; ---- routing helpers ------------------------------------------------------
@@ -1211,6 +1352,18 @@
 
 ;; ---- boot -----------------------------------------------------------------
 
+(defn- bad-init-arg!
+  "Raise `:rf.error/no-adapter-specified` with a consistent reason
+  string. Factored out of `init!`'s nil-check and not-map-check to
+  avoid prose drift between the two branches."
+  [received]
+  (throw (ex-info ":rf.error/no-adapter-specified"
+                  (cond-> {:where    'rf/init!
+                           :expected "adapter spec map"
+                           :recovery :no-recovery
+                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter). Per rf2-agql the default-adapter registry was removed."}
+                    (some? received) (assoc :received received)))))
+
 (defn init!
   "Idempotent boot. Installs a substrate adapter and ensures the
   `:rf/default` frame is present.
@@ -1224,7 +1377,7 @@
   Each adapter ns exports an `adapter` Var holding the spec map.
   Consumers require the ns and pass that Var:
 
-    (require '[re-frame.adapter.reagent :as reagent])
+    (require '[re-frame.adapter.reagent :as reagent])  ;; or .uix / .helix
     (rf/init! reagent/adapter)
 
   Per rf2-agql (replaces rf2-84po): rf2 ships no default-adapter
@@ -1242,23 +1395,14 @@
   look up. The error message points the consumer at the adapter-ns +
   adapter-Var pattern.
 
-  Per Spec 006 §Adapter selection at boot."
+  Per Spec 006 §Adapter selection at boot.
+
+  See also: `re-frame.adapter.reagent/adapter`,
+  `re-frame.adapter.uix/adapter`, `re-frame.adapter.helix/adapter`."
   [adapter-map]
   (cond
-    (nil? adapter-map)
-    (throw (ex-info ":rf.error/no-adapter-specified"
-                    {:where    'init!
-                     :recovery :no-recovery
-                     :reason   "rf/init! was called with nil. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter). Per rf2-agql the default-adapter registry was removed."}))
-
-    (not (map? adapter-map))
-    (throw (ex-info ":rf.error/no-adapter-specified"
-                    {:where    'init!
-                     :received adapter-map
-                     :expected "adapter spec map"
-                     :recovery :no-recovery
-                     :reason   "rf/init! takes the adapter spec map directly — there is no keyword form and no registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter). Per rf2-agql the default-adapter registry was removed."}))
-
+    (nil? adapter-map)        (bad-init-arg! nil)
+    (not (map? adapter-map))  (bad-init-arg! adapter-map)
     :else
     (do
       (when-not (adapter/current-adapter)

--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -1,28 +1,23 @@
 (ns re-frame.core-epoch
   "Public-API wrappers for the optional epoch artefact (Tool-Pair
-  §Time-travel).
+  §Time-travel). Implementation ships in `day8/re-frame2-epoch`
+  (`re-frame.epoch` ns) per rf2-lt4e.
 
-  Per rf2-lt4e the epoch implementation ships in the
-  `day8/re-frame2-epoch` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.epoch]` — that would pull the per-frame
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
+
+  Per-feature carve-out: the epoch artefact pulls the per-frame
   `:rf/epoch-record` ring buffer, the per-cascade trace-capture path,
-  the `:sub-runs` / `:renders` / `:effects` projection walker, the
-  schema-validate / machine-version / missing-reference predicates, and
-  every `:rf.epoch/*` keyword string onto every consumer's classpath
-  even when the pair-tool surface is unused.
+  the `:sub-runs` / `:renders` / `:effects` projection walker, and
+  every `:rf.epoch/*` keyword string. The entire epoch surface is also
+  gated on `interop/debug-enabled?` (Tool-Pair §Time-travel §Production
+  elision).
 
-  Per Tool-Pair §Time-travel §Production elision the entire epoch
-  surface is gated on `interop/debug-enabled?` whether or not the
-  artefact is on the classpath; the wrappers degrade silently (empty
-  vector / false / no-op) when it's absent so a release build that
-  omits the artefact does not raise. `reset-frame-db!` is the
-  exception — it records an epoch as part of its contract, so it
-  raises `:rf.error/epoch-artefact-missing` rather than degrading.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them) so `core.cljc` is not cluttered with optional-artefact glue.
-  The single-import contract is preserved: users continue to write
-  `rf/epoch-history` after `(:require [re-frame.core :as rf])`."
+  Absent-artefact behaviour: wrappers degrade silently (empty vector /
+  `false` / no-op) so a release build that omits the artefact does not
+  raise. `reset-frame-db!` is the exception — it records an epoch as
+  part of its contract and raises `:rf.error/epoch-artefact-missing`."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn epoch-history
@@ -97,6 +92,6 @@
   (if-let [f (late-bind/get-fn :epoch/reset-frame-db!)]
     (f frame-id new-db)
     (throw (ex-info ":rf.error/epoch-artefact-missing"
-                    {:where    'reset-frame-db!
+                    {:where    'rf/reset-frame-db!
                      :recovery :no-recovery
                      :reason   "rf/reset-frame-db! requires day8/re-frame2-epoch on the classpath; add it to deps and require re-frame.epoch at app boot."}))))

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -1,22 +1,16 @@
 (ns re-frame.core-flows
   "Public-API wrappers for the optional flows artefact (Spec 013).
+  Implementation ships in `day8/re-frame2-flows` (`re-frame.flows`
+  ns) per rf2-tfw3.
 
-  Per rf2-tfw3 the flows implementation ships in the
-  `day8/re-frame2-flows` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.flows]` — that would pull the per-frame
-  flow registry, the topological-sort engine, and the dirty-check
-  `last-inputs` map onto every consumer's classpath even when no flow
-  is registered.
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
 
-  The fns in this namespace look the flows API up through the late-bind
-  hook table at call time, which the flows artefact populates from its
-  own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them as `rf/reg-flow`, `rf/clear-flow`) so `core.cljc` is not
-  cluttered with optional-artefact glue. The single-import contract is
-  preserved: users continue to write `rf/reg-flow` after
-  `(:require [re-frame.core :as rf])`."
+  Per-feature carve-out: the flows artefact pulls the per-frame flow
+  registry, the topological-sort engine, and the dirty-check
+  `last-inputs` map — none of which appear on a consumer's classpath
+  when this wrapper's hooks are unregistered."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn clear-flow
@@ -27,7 +21,7 @@
    (if-let [f (late-bind/get-fn :flows/clear-flow)]
      (f id opts)
      (throw (ex-info ":rf.error/flows-artefact-missing"
-                     {:where    'clear-flow
+                     {:where    'rf/clear-flow
                       :flow-id  id
                       :recovery :no-recovery
                       :reason   "rf/clear-flow requires day8/re-frame2-flows on the classpath; add it to deps and require re-frame.flows at app boot."})))))
@@ -42,6 +36,6 @@
    (if-let [f (late-bind/get-fn :flows/reg-flow)]
      (f flow opts)
      (throw (ex-info ":rf.error/flows-artefact-missing"
-                     {:where    'reg-flow
+                     {:where    'rf/reg-flow
                       :recovery :no-recovery
                       :reason   "rf/reg-flow requires day8/re-frame2-flows on the classpath; add it to deps and require re-frame.flows at app boot."})))))

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -1,25 +1,18 @@
 (ns re-frame.core-http
   "Public-API wrappers for the optional managed-HTTP artefact (Spec 014).
+  Implementation ships in `day8/re-frame2-http`
+  (`re-frame.http-managed` ns) per rf2-5kpd.
 
-  Per rf2-5kpd the `:rf.http/managed` family is registered at
-  re-frame.http-managed ns-load time, but the namespace ships in the
-  `day8/re-frame2-http` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.http-managed]` — that would pull the
-  namespace, the in-flight request registry, the Fetch /
-  `java.net.http.HttpClient` transport adapters, the encode / decode
-  pipeline, the retry-with-backoff machinery, the eight-category
-  `:rf.http/*` failure taxonomy, and every `:rf.http/*` keyword string
-  onto every consumer's classpath even when no managed-HTTP request is
-  issued.
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
 
-  The fns in this namespace look the http API up through the late-bind
-  hook table at call time, which the http artefact populates from its
-  own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them) so `core.cljc` is not cluttered with optional-artefact glue.
-  The single-import contract is preserved: users continue to write
-  `rf/install-managed-request-stubs!` after `(:require [re-frame.core :as rf])`."
+  Per-feature carve-out: the http artefact pulls the in-flight request
+  registry, the Fetch / `java.net.http.HttpClient` transport adapters,
+  the encode/decode pipeline, the retry-with-backoff machinery, the
+  eight-category `:rf.http/*` failure taxonomy, and every `:rf.http/*`
+  keyword string — none of which appear on a consumer's classpath when
+  this wrapper's hooks are unregistered."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn install-managed-request-stubs!
@@ -30,7 +23,7 @@
   (if-let [f (late-bind/get-fn :http/install-managed-request-stubs!)]
     (f stubs)
     (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'install-managed-request-stubs!
+                    {:where    'rf/install-managed-request-stubs!
                      :recovery :no-recovery
                      :reason   "rf/install-managed-request-stubs! requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
 
@@ -42,7 +35,7 @@
   (if-let [f (late-bind/get-fn :http/uninstall-managed-request-stubs!)]
     (f)
     (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'uninstall-managed-request-stubs!
+                    {:where    'rf/uninstall-managed-request-stubs!
                      :recovery :no-recovery
                      :reason   "rf/uninstall-managed-request-stubs! requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
 
@@ -53,7 +46,7 @@
   (if-let [f (late-bind/get-fn :http/with-managed-request-stubs*)]
     (f stubs thunk)
     (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'with-managed-request-stubs*
+                    {:where    'rf/with-managed-request-stubs*
                      :recovery :no-recovery
                      :reason   "rf/with-managed-request-stubs* requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
 
@@ -76,7 +69,7 @@
   (if-let [f (late-bind/get-fn :http/reg-http-interceptor)]
     (f interceptor)
     (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'reg-http-interceptor
+                    {:where    'rf/reg-http-interceptor
                      :recovery :no-recovery
                      :reason   "rf/reg-http-interceptor requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
 
@@ -92,6 +85,6 @@
    (if-let [f (late-bind/get-fn :http/clear-http-interceptor)]
      (f frame id)
      (throw (ex-info ":rf.error/http-artefact-missing"
-                     {:where    'clear-http-interceptor
+                     {:where    'rf/clear-http-interceptor
                       :recovery :no-recovery
                       :reason   "rf/clear-http-interceptor requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."})))))

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -1,20 +1,16 @@
 (ns re-frame.core-machines
   "Public-API wrappers for the optional machines artefact (Spec 005).
+  Implementation ships in `day8/re-frame2-machines`
+  (`re-frame.machines` ns) per rf2-xbtj.
 
-  Per rf2-xbtj the machines implementation ships in the
-  `day8/re-frame2-machines` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.machines]` — that would pull the
-  machines namespace and its `:rf/machine` sub registration onto every
-  consumer's classpath even when no machine is registered.
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
 
-  The fns in this namespace look the machines API up through the
-  late-bind hook table at call time, which the machines artefact
-  populates from its own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them) so `core.cljc` is not cluttered with optional-artefact glue.
-  The single-import contract is preserved: users continue to write
-  `rf/reg-machine` after `(:require [re-frame.core :as rf])`."
+  Per-feature carve-out: the machines artefact pulls the machine
+  registry, the entry/exit cascade engine, and the `:rf/machine` /
+  `:rf/machine-has-tag?` framework subs — none of which appear on a
+  consumer's classpath when this wrapper's hooks are unregistered."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.router :as router]
             [re-frame.subs :as subs]))
@@ -26,7 +22,7 @@
   (if-let [f (late-bind/get-fn :machines/create-machine-handler)]
     (f machine)
     (throw (ex-info ":rf.error/machines-artefact-missing"
-                    {:where    'create-machine-handler
+                    {:where    'rf/create-machine-handler
                      :recovery :no-recovery
                      :reason   "rf/create-machine-handler requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
 
@@ -37,7 +33,7 @@
   (if-let [f (late-bind/get-fn :machines/machine-transition)]
     (f machine snapshot event)
     (throw (ex-info ":rf.error/machines-artefact-missing"
-                    {:where    'machine-transition
+                    {:where    'rf/machine-transition
                      :recovery :no-recovery
                      :reason   "rf/machine-transition requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
 
@@ -98,7 +94,7 @@
   spec at expansion time). Late-bound via :machines/reg-machine."
   [machine-id machine]
   (reg-machine-impl
-    'reg-machine*
+    'rf/reg-machine*
     "rf/reg-machine* requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."
     machine-id machine))
 
@@ -107,14 +103,14 @@
   when the spec form is not stamped (no per-element source-coords). The
   separation from `reg-machine*` keeps `:where` symbols faithful to the
   user-facing surface — `rf/reg-machine` raises with `:where
-  'reg-machine`, `rf/reg-machine*` raises with `:where 'reg-machine*`.
+  'rf/reg-machine`, `rf/reg-machine*` raises with `:where 'rf/reg-machine*`.
 
   Callers should NOT invoke this directly — use `rf/reg-machine`
   (macro) or `rf/reg-machine*` (plain fn). It is public only because
   the macro emits a reference to it."
   [machine-id machine]
   (reg-machine-impl
-    'reg-machine
+    'rf/reg-machine
     "rf/reg-machine requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."
     machine-id machine))
 

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -1,22 +1,17 @@
 (ns re-frame.core-routing
   "Public-API wrappers for the optional routing artefact (Spec 012).
+  Implementation ships in `day8/re-frame2-routing`
+  (`re-frame.routing` ns) per rf2-k682.
 
-  Per rf2-k682 the routing implementation ships in the
-  `day8/re-frame2-routing` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.routing]` — that would pull the
-  route-rank / pattern-compile / nav-token machinery, the `:rf/route`
-  reg-sub family, and every `:rf.route/*` / `:rf.nav/*` keyword string
-  onto every consumer's classpath even when no route is registered.
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
 
-  The fns in this namespace look the routing API up through the
-  late-bind hook table at call time, which the routing artefact
-  populates from its own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them as `rf/reg-route`, `rf/match-url`, `rf/route-url`) so `core.cljc`
-  is not cluttered with optional-artefact glue. The single-import
-  contract is preserved: users continue to write `rf/reg-route` after
-  `(:require [re-frame.core :as rf])`."
+  Per-feature carve-out (relative to the canonical convention): the
+  routing artefact pulls the route-rank / pattern-compile / nav-token
+  machinery, the `:rf/route` reg-sub family, and every `:rf.route/*` /
+  `:rf.nav/*` keyword string — none of which appear on a consumer's
+  classpath when this wrapper's hooks are unregistered."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn match-url
@@ -28,7 +23,7 @@
   (if-let [f (late-bind/get-fn :routing/match-url)]
     (f url)
     (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'match-url
+                    {:where    'rf/match-url
                      :recovery :no-recovery
                      :reason   "rf/match-url requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
 
@@ -41,7 +36,7 @@
    (if-let [f (late-bind/get-fn :routing/route-url)]
      (f route-id path-params query-params)
      (throw (ex-info ":rf.error/routing-artefact-missing"
-                     {:where    'route-url
+                     {:where    'rf/route-url
                       :route-id route-id
                       :recovery :no-recovery
                       :reason   "rf/route-url requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."})))))
@@ -55,7 +50,7 @@
   (if-let [f (late-bind/get-fn :routing/reg-route)]
     (f id metadata)
     (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'reg-route
+                    {:where    'rf/reg-route
                      :route-id id
                      :recovery :no-recovery
                      :reason   "rf/reg-route requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
@@ -84,6 +79,6 @@
   (if-let [f (late-bind/get-fn :routing/route-link)]
     (apply f args)
     (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'route-link
+                    {:where    'rf/route-link
                      :recovery :no-recovery
                      :reason   "rf/route-link requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -1,20 +1,16 @@
 (ns re-frame.core-schemas
   "Public-API wrappers for the optional schemas artefact (Spec 010).
+  Implementation ships in `day8/re-frame2-schemas`
+  (`re-frame.schemas` ns) per rf2-p7va.
 
-  Per rf2-p7va the schemas implementation ships in the
-  `day8/re-frame2-schemas` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.schemas]` — that would pull schemas
-  (and its Malli dep) onto every consumer's classpath even when no
-  schema is registered.
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
 
-  The fns in this namespace look the schemas API up through the
-  late-bind hook table at call time, which the schemas artefact
-  populates from its own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them) so `core.cljc` is not cluttered with optional-artefact glue.
-  The single-import contract is preserved: users continue to write
-  `rf/reg-app-schema` after `(:require [re-frame.core :as rf])`."
+  Per-feature carve-out: the schemas artefact pulls Malli (the default
+  validator) onto the classpath — apps that want to drop the ~24 KB
+  gzipped Malli surface omit the artefact and either use a substitute
+  validator (per rf2-froe) or skip schema validation entirely."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn app-schema-at
@@ -89,7 +85,7 @@
    (if-let [f (late-bind/get-fn :schemas/reg-app-schema)]
      (f path schema opts)
      (throw (ex-info ":rf.error/schemas-artefact-missing"
-                     {:where    'reg-app-schema
+                     {:where    'rf/reg-app-schema
                       :path     path
                       :recovery :no-recovery
                       :reason   "rf/reg-app-schema requires day8/re-frame2-schemas on the classpath; add it to deps and require re-frame.schemas at app boot."})))))
@@ -115,6 +111,6 @@
    (if-let [f (late-bind/get-fn :schemas/reg-app-schemas)]
      (f path->schema opts)
      (throw (ex-info ":rf.error/schemas-artefact-missing"
-                     {:where    'reg-app-schemas
+                     {:where    'rf/reg-app-schemas
                       :recovery :no-recovery
                       :reason   "rf/reg-app-schemas requires day8/re-frame2-schemas on the classpath; add it to deps and require re-frame.schemas at app boot."})))))

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -1,25 +1,19 @@
 (ns re-frame.core-ssr
   "Public-API wrappers for the optional SSR artefact (Spec 011).
+  Implementation ships in `day8/re-frame2-ssr` (`re-frame.ssr` ns)
+  per rf2-uo7v.
 
-  Per rf2-uo7v the SSR implementation ships in the
-  `day8/re-frame2-ssr` Maven artefact. The core artefact MUST NOT
-  statically `:require [re-frame.ssr]` — that would pull the pure
-  hiccup → HTML emitter, the FNV-1a render-tree-hash machinery, the
-  per-request `[:rf/response]` accumulator, the six `:rf.server/*`
-  server-only fxs, the `reg-error-projector` registry kind plus its
-  built-in default, the SSR error-projection trace listener, the
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
+  look the producing fns up via the late-bind hook table at call time;
+  consumers reach the surfaces through `re-frame.core` re-exports.
+
+  Per-feature carve-out: the SSR artefact pulls the hiccup → HTML
+  emitter, the FNV-1a render-tree-hash machinery, the per-request
+  `[:rf/response]` accumulator, the six `:rf.server/*` fxs, the
+  `reg-error-projector` registry kind plus its default, the
   `:rf/hydrate` event, and every `:rf.ssr/*` / `:rf.server/*` keyword
-  string onto every consumer's classpath even when no server-side
-  rendering is performed.
-
-  The fns in this namespace look the ssr API up through the late-bind
-  hook table at call time, which the ssr artefact populates from its
-  own ns-load.
-
-  Per rf2-hoiu these wrappers live here (and `re-frame.core` re-exports
-  them) so `core.cljc` is not cluttered with optional-artefact glue.
-  The single-import contract is preserved: users continue to write
-  `rf/render-to-string` after `(:require [re-frame.core :as rf])`."
+  string — none of which appear on a consumer's classpath when this
+  wrapper's hooks are unregistered."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn render-to-string
@@ -35,7 +29,7 @@
    (if-let [f (late-bind/get-fn :ssr/render-to-string)]
      (f render-tree opts)
      (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'render-to-string
+                     {:where    'rf/render-to-string
                       :recovery :no-recovery
                       :reason   "rf/render-to-string requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
 
@@ -48,7 +42,7 @@
   (if-let [f (late-bind/get-fn :ssr/render-tree-hash)]
     (f render-tree)
     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                    {:where    'render-tree-hash
+                    {:where    'rf/render-tree-hash
                      :recovery :no-recovery
                      :reason   "rf/render-tree-hash requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
 
@@ -62,7 +56,7 @@
    (if-let [f (late-bind/get-fn :ssr/reg-error-projector)]
      (f id metadata projector-fn)
      (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'reg-error-projector
+                     {:where    'rf/reg-error-projector
                       :id       id
                       :recovery :no-recovery
                       :reason   "rf/reg-error-projector requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
@@ -75,7 +69,7 @@
   (if-let [f (late-bind/get-fn :ssr/project-error)]
     (f frame-id trace-event)
     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                    {:where    'project-error
+                    {:where    'rf/project-error
                      :frame    frame-id
                      :recovery :no-recovery
                      :reason   "rf/project-error requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -197,13 +197,48 @@
         (cond
           (map? middle)        [middle [] handler]
           (vector? middle)     [{} middle handler]
-          :else                (throw (ex-info "re-frame2: bad reg-event-* args"
-                                               {:args args}))))
+          :else                (throw (ex-info
+                                        "reg-event-*: middle slot must be a metadata-map or an interceptor-vector"
+                                        {:args     args
+                                         :got      middle
+                                         :expected "metadata-map (e.g. {:doc \"...\"}) OR interceptor-vector (e.g. [(path :a)])"}))))
     3 (let [[meta interceptors handler] args]
         [meta (or interceptors []) handler])
-    (throw (ex-info "re-frame2: reg-event-* arity error" {:args args}))))
+    (throw (ex-info
+             "reg-event-* arity error — expected (id handler), (id metadata handler), (id interceptors handler), or (id metadata interceptors handler)"
+             {:args args :count (count args)}))))
 
 (defn reg-event-db
+  "Register a `(fn [db event-vec] new-db)` event handler under `id`.
+
+  The handler is **pure** — it receives the current `app-db` value and
+  the event vector that triggered the dispatch, and returns the next
+  `app-db` value. The runtime atomically swaps the frame's `app-db` to
+  the returned value before any `:fx` are walked. For side-effecting
+  handlers reach for `reg-event-fx`; for full-context manipulation reach
+  for `reg-event-ctx`.
+
+  Shapes (the middle slot is optional and may be metadata OR
+  interceptor-vector, NOT both — per Conventions §`:interceptors` is
+  positional, not metadata):
+
+      (reg-event-db :id                          (fn [db ev] new-db))
+      (reg-event-db :id {:doc \"...\" :spec ...}   (fn [db ev] new-db))
+      (reg-event-db :id [(path :counter)]        (fn [slice ev] new-slice))
+      (reg-event-db :id {:doc \"...\"} [icpt]      (fn [db ev] new-db))
+
+  Returns `id`.
+
+  Example:
+
+      (rf/reg-event-db :counter/inc
+        (fn [db _]
+          (update db :n inc)))
+
+      (rf/dispatch [:counter/inc])
+
+  See also: `reg-event-fx` (effect-map handlers), `reg-event-ctx`
+  (advanced — context manipulation), `dispatch`, `dispatch-sync`."
   [id & args]
   (let [[meta interceptors handler-fn] (normalise-args args)
         _           (warn-interceptors-in-meta! "reg-event-db" id meta)
@@ -217,6 +252,48 @@
     id))
 
 (defn reg-event-fx
+  "Register a `(fn [cofx event-vec] effect-map)` event handler under `id`.
+
+  The handler is **pure** — it receives a coeffect map (carrying `:db`,
+  `:event`, plus any cofx injected via `inject-cofx`) and the event
+  vector, and returns an effect-map. The runtime walks the effects in
+  order:
+
+  1. `:db`  — atomic swap to the frame's `app-db` (Spec 002 §`:fx`
+     ordering, rule 1).
+  2. `:fx`  — vector of `[fx-id args]` pairs, processed in source order
+     by the registered fx handlers (see `reg-fx`).
+
+  The effect-map is a **closed shape**: only `:db` and `:fx` are
+  permitted at the top level (per migration M-8). Legacy v1 top-level
+  keys (`:dispatch`, `:dispatch-later`, `:http`, ...) wrap as `:fx`
+  entries — `{:fx [[:dispatch event] ...]}`.
+
+  Shapes (the middle slot is optional and may be metadata OR
+  interceptor-vector, NOT both):
+
+      (reg-event-fx :id                       (fn [cofx ev] {...}))
+      (reg-event-fx :id {:doc \"...\"}          (fn [cofx ev] {...}))
+      (reg-event-fx :id [(inject-cofx :now)]  (fn [cofx ev] {...}))
+      (reg-event-fx :id {:doc \"...\"} [icpt]   (fn [cofx ev] {...}))
+
+  Returns `id`. Returning `nil` from the handler is a documented no-op.
+
+  Example:
+
+      (rf/reg-event-fx :user/save
+        (fn [{:keys [db]} [_ user]]
+          {:db (assoc db :user/pending? true)
+           :fx [[:dispatch [:analytics/track :user-save]]
+                [:rf.http/managed {:method :post
+                                   :url    \"/api/users\"
+                                   :body   user
+                                   :on-success [:user/saved]
+                                   :on-failure [:user/save-failed]}]]}))
+
+  See also: `reg-event-db` (pure db-only handlers), `reg-event-ctx`
+  (advanced — context manipulation), `reg-fx` (register a custom fx),
+  `inject-cofx` (consume a registered cofx)."
   [id & args]
   (let [[meta interceptors handler-fn] (normalise-args args)
         _           (warn-interceptors-in-meta! "reg-event-fx" id meta)
@@ -230,6 +307,28 @@
     id))
 
 (defn reg-event-ctx
+  "Register a `(fn [context] context)` full-context event handler under
+  `id`. **Advanced** — most handlers want `reg-event-db` or
+  `reg-event-fx` instead.
+
+  Use this when the handler needs to manipulate the interceptor context
+  directly: read or assoc multiple coeffects, build effects keyed off
+  pre-existing context state, short-circuit downstream interceptors, or
+  perform context-level work that the `{:db ... :fx [...]}` shape can't
+  express.
+
+  Returns `id`. Returning `nil` from the handler leaves the inbound
+  context unchanged (documented no-op).
+
+  Shapes (the middle slot is optional and may be metadata OR
+  interceptor-vector, NOT both):
+
+      (reg-event-ctx :id                  (fn [ctx] new-ctx))
+      (reg-event-ctx :id {:doc \"...\"}     (fn [ctx] new-ctx))
+      (reg-event-ctx :id [icpt1 icpt2]    (fn [ctx] new-ctx))
+
+  See also: `reg-event-db`, `reg-event-fx`, `->interceptor`,
+  `assoc-coeffect`, `assoc-effect`."
   [id & args]
   (let [[meta interceptors handler-fn] (normalise-args args)
         _           (warn-interceptors-in-meta! "reg-event-ctx" id meta)
@@ -243,5 +342,12 @@
     id))
 
 (defn clear-event
+  "Unregister an event handler. Zero-arity clears every registered
+  event handler in the registrar; one-arity clears the named one.
+
+  Hot-reload tools and test fixtures call this between rebuilds to
+  drop stale handlers; production code rarely needs it. Returns nil.
+
+  See also: `reg-event-db`, `reg-event-fx`, `reg-event-ctx`."
   ([] (registrar/clear-kind! :event))
   ([id] (registrar/unregister! :event id)))

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -31,12 +31,59 @@
 ;; ---- registration ---------------------------------------------------------
 
 (defn reg-fx
-  "Register an fx handler.
+  "Register an effect handler under `id`. The handler runs when a
+  `reg-event-fx` returns an effect-map carrying `[id args]` inside its
+  `:fx` vector — `{:fx [[:my-fx args] ...]}`.
 
-  metadata may contain:
-    :doc        one-sentence what-and-why
-    :spec       Malli schema for the args (per Spec 010)
-    :platforms  set of #{:client :server}; default #{:client :server}"
+  Handler signature: `(fn [ctx args] ...)` — **v2 changed from v1**.
+
+    `ctx`  is a small map carrying:
+             `:frame` — the active frame id (Spec 002 §`:fx` ordering)
+             `:event` — the originating event vector (Spec 014 §Reply
+                        addressing). The fx may capture the originating
+                        `event-id` to address replies back without a
+                        separate cofx-injection step.
+    `args` is the second element of the `[id args]` pair as emitted by
+           the event handler (any value — map, vector, scalar).
+
+  Shapes:
+
+      (reg-fx :id                                  (fn [ctx args] ...))
+      (reg-fx :id {:doc \"...\" :platforms #{:client}} (fn [ctx args] ...))
+
+  Optional metadata keys:
+
+      :doc        one-sentence what-and-why; surfaces via
+                  `(rf/handler-meta :fx id)`.
+      :spec       Malli schema for `args` (per Spec 010 §:spec on fx
+                  registrations).
+      :platforms  set of `#{:client :server}`; default
+                  `#{:client :server}`. The fx is skipped on platforms
+                  not in the set (`:rf.fx/skipped-on-platform` warning
+                  trace).
+
+  Returns `id`.
+
+  Example:
+
+      (rf/reg-fx :my/notify
+        {:doc       \"Show a toast notification.\"
+         :platforms #{:client}}
+        (fn [_ctx {:keys [message level]}]
+          (js/window.toast level message)))
+
+      ;; Consumed from an event handler:
+      (rf/reg-event-fx :user/login-failed
+        (fn [_ [_ reason]]
+          {:fx [[:my/notify {:level :error :message (str \"Login failed: \" reason)}]]}))
+
+  Framework-shipped fx (`:dispatch`, `:dispatch-later`, `:rf.http/managed`,
+  `:rf.nav/push-url`, ...) are documented in `spec/API.md §Effect-map
+  shape` and their per-feature Spec; introspect via
+  `(rf/handler-meta :fx <id>)`.
+
+  See also: `reg-cofx` (the input-side counterpart), `clear-fx`,
+  `reg-event-fx` (the consumer)."
   [id metadata-or-handler & maybe-handler]
   (let [[meta handler-fn]
         (if (map? metadata-or-handler)
@@ -46,8 +93,20 @@
                                        :handler-fn handler-fn))
     id))
 
-(defn unregister-fx [id]
-  (registrar/unregister! :fx id))
+(defn clear-fx
+  "Unregister an fx handler. Zero-arity clears every registered fx;
+  one-arity clears the named one. Hot-reload tools and test fixtures
+  call this between rebuilds.
+
+  Returns nil. See also: `reg-fx`, the user-facing surface `rf/clear-fx`
+  (this is the underlying fn — they point at the same value)."
+  ([] (registrar/clear-kind! :fx))
+  ([id] (registrar/unregister! :fx id)))
+
+;; Back-compat alias retained transiently — internal callers may still
+;; reach for `unregister-fx`. Pre-alpha: prefer `clear-fx`; the alias
+;; can be cut once internal references are migrated.
+(def unregister-fx clear-fx)
 
 ;; ---- the platform predicate -----------------------------------------------
 

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -12,9 +12,42 @@
   reverse order (the standard interceptor pattern from Pedestal / re-frame v1).")
 
 (defn ->interceptor
-  "Build an interceptor map from kwargs. The primitive — users compose
-  custom before/after work via this rather than via stdlib helpers
-  (which v2 has trimmed)."
+  "Build an interceptor map from kwargs. The primitive for custom
+  interceptors — v2 trims the v1 stdlib helpers in favour of this one
+  entry point.
+
+  Kwargs:
+    :id      keyword name (default `:unnamed`); appears in error traces.
+    :before  `(fn [context] new-context)` — runs before the handler.
+             Read inputs via `get-coeffect`; write outputs via
+             `assoc-coeffect` / `assoc-effect`.
+    :after   `(fn [context] new-context)` — runs after the handler,
+             in reverse declaration order.
+
+  The `context` map carries:
+    `:coeffects` — input data: `:db` (current app-db value), `:event`
+                   (the dispatched event vector), and any cofx injected
+                   via `inject-cofx`.
+    `:effects`   — output data the chain accumulates: `:db` (next
+                   app-db value), `:fx` (the vector of `[fx-id args]`
+                   pairs the runtime walks after the chain).
+
+  Example:
+
+      (def log-event
+        (rf/->interceptor
+          :id     :log-event
+          :before (fn [ctx]
+                    (println \"event:\" (rf/get-coeffect ctx :event))
+                    ctx)))
+
+      (rf/reg-event-db :foo
+        [log-event]
+        (fn [db _] db))
+
+  See also: `get-coeffect`, `assoc-coeffect`, `get-effect`,
+  `assoc-effect`, `inject-cofx`, `path` / `unwrap` (the std interceptors
+  v2 ships), `reg-event-ctx` (full-context handler)."
   [& {:keys [id before after]}]
   (cond-> {:id (or id :unnamed)}
     before (assoc :before before)
@@ -23,22 +56,50 @@
 ;; ---- context plumbing -----------------------------------------------------
 
 (defn get-coeffect
+  "Read from the context's `:coeffects` map.
+
+  Arities: `(get-coeffect ctx)` returns the whole coeffects map;
+  `(get-coeffect ctx k)` returns the value at key `k` (nil if absent);
+  `(get-coeffect ctx k not-found)` returns `not-found` when absent.
+
+  See also: `assoc-coeffect`, `update-coeffect`."
   ([context] (:coeffects context))
   ([context k] (get (:coeffects context) k))
   ([context k not-found] (get (:coeffects context) k not-found)))
 
-(defn assoc-coeffect [context k v]
+(defn assoc-coeffect
+  "Set the value at `k` in the context's `:coeffects` map. Returns the
+  updated context. Use from a `:before` interceptor when injecting a
+  coeffect into the chain. See also: `get-coeffect`, `update-coeffect`."
+  [context k v]
   (assoc-in context [:coeffects k] v))
 
-(defn update-coeffect [context k f & args]
+(defn update-coeffect
+  "Apply `f` (with optional trailing `args`) to the value at `k` in the
+  context's `:coeffects` map. Returns the updated context. See also:
+  `assoc-coeffect`, `get-coeffect`."
+  [context k f & args]
   (apply update-in context [:coeffects k] f args))
 
 (defn get-effect
+  "Read from the context's `:effects` map.
+
+  Arities: `(get-effect ctx)` returns the whole effects map;
+  `(get-effect ctx k)` returns the value at key `k`;
+  `(get-effect ctx k not-found)` returns `not-found` when absent.
+
+  See also: `assoc-effect`."
   ([context] (:effects context))
   ([context k] (get (:effects context) k))
   ([context k not-found] (get (:effects context) k not-found)))
 
-(defn assoc-effect [context k v]
+(defn assoc-effect
+  "Set the value at `k` in the context's `:effects` map. Returns the
+  updated context. Use from a handler-wrapper interceptor (or an
+  `:after`) to publish an effect the runtime will walk. The top-level
+  effect-map is closed: only `:db` and `:fx` are honoured per migration
+  M-8. See also: `get-effect`, `assoc-coeffect`."
+  [context k v]
   (assoc-in context [:effects k] v))
 
 ;; ---- chain execution ------------------------------------------------------

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -73,12 +73,52 @@
          :handler-fn    (first remaining)}
 
         :else
-        (throw (ex-info "re-frame2: bad reg-sub args"
-                        {:id id :remaining remaining}))))))
+        (throw (ex-info
+                 "reg-sub: bad args — expected layer-1 (handler-fn), layer-2 single (:<- [:upstream] handler-fn), or layer-2 multi (:<- [:a] :<- [:b] handler-fn)"
+                 {:id id :remaining remaining}))))))
 
 (defn reg-sub
-  "Register a subscription. The only sub-registration form in v2 (per
-  Spec 002 §Subscriptions composing — reg-sub-raw is dropped)."
+  "Register a subscription under `id`. The only sub-registration form
+  in v2 — `reg-sub-raw` is dropped (per Spec 002 §Subscriptions
+  composing).
+
+  Three shapes:
+
+      ;; Layer-1 — reads `app-db` directly.
+      (reg-sub :id
+        (fn [db query-v] ...derived-value...))
+
+      ;; Layer-2, single input — chains off one upstream sub.
+      (reg-sub :id
+        :<- [:upstream-id]
+        (fn [upstream-val query-v] ...derived-value...))
+
+      ;; Layer-2, multi input — chains off N upstream subs.
+      (reg-sub :id
+        :<- [:a-sub]
+        :<- [:b-sub]
+        (fn [[a-val b-val] query-v] ...derived-value...))
+
+  An optional metadata-map may precede the `:<-` chain / handler:
+  `(reg-sub :id {:doc \"...\" :spec ...} ...)`. The `query-v` arg the
+  handler receives is the full `[sub-id & args]` subscription vector
+  the caller passed to `subscribe`.
+
+  Returns `id`. Re-registering an existing `id` replaces the prior
+  registration; cached entries for the affected sub are invalidated
+  (hot-reload-safe).
+
+  Example:
+
+      (rf/reg-sub :user/name (fn [db _] (get-in db [:user :name])))
+
+      (rf/reg-sub :user/initials
+        :<- [:user/name]
+        (fn [name _]
+          (clojure.string/join (map first (clojure.string/split name #\"\\s+\")))))
+
+  See also: `subscribe` (reactive form), `subscribe-value` (one-shot
+  read), `compute-sub` (pure compute against a db value), `clear-sub`."
   [id & args]
   (let [{:keys [meta handler-fn input-signals]} (parse-reg-sub-args id args)]
     (registrar/register! :sub id
@@ -94,6 +134,13 @@
     id))
 
 (defn clear-sub
+  "Unregister a subscription. Zero-arity clears every registered sub
+  in the registrar; one-arity clears the named one. Hot-reload tools
+  and test fixtures call this between rebuilds; production code rarely
+  needs it.
+
+  Returns nil. See also: `reg-sub`, `clear-subscription-cache!`
+  (the runtime-cache counterpart)."
   ([] (registrar/clear-kind! :sub))
   ([id] (registrar/unregister! :sub id)))
 
@@ -415,13 +462,18 @@
            (compute-and-cache! frame-id query-v)))))))
 
 (defn subscribe-value
-  "Subscribe and immediately deref. Useful in handler bodies where a
-  reaction isn't needed — the caller wants the value now.
+  "One-shot read of a sub's current value. Subscribes, derefs, then
+  unsubscribes — does NOT retain a reference on the cache entry and
+  does NOT register the caller for reactive re-render.
 
-  subscribe-value also calls unsubscribe immediately so it does NOT
-  retain a ref on the cache entry — the caller asked a one-shot
-  question. Reactive callers (Reagent views, tools holding the
-  reaction) should use subscribe."
+  Use in tests, REPL sessions, machine-action bodies, SSR builders,
+  or any non-reactive consumer that wants the value right now. For
+  reactive consumers (Reagent views, tools holding the reaction) use
+  `subscribe`. For event handlers prefer `(inject-cofx :sub-as-cofx)`
+  so the read is part of the cofx contract rather than a side-effect
+  inside the handler body.
+
+  See also: `subscribe`, `compute-sub`, `inject-cofx`."
   ([query-v] (subscribe-value (resolve-current-frame) query-v))
   ([frame-id query-v]
    (let [reaction (subscribe frame-id query-v)
@@ -587,10 +639,18 @@
       :installed))
 
 (defn clear-subscription-cache!
-  "Dispose every cached entry and clear the cache. Test fixtures use this.
-  Cancels any pending grace-period timers before disposing — a deferred
-  disposal landing after this fn returned would close over a stale
-  reaction."
+  "Dispose every cached entry in a frame's runtime sub-cache and clear
+  the cache. Cancels any pending grace-period timers before disposing —
+  a deferred disposal landing after this fn returned would close over
+  a stale reaction.
+
+  Test fixtures and REPL-driven reloads call this between scenarios
+  to ensure the cache is empty before re-subscribing. Test code
+  generally prefers `reset-runtime-fixture` (per `test_support`) which
+  bundles cache-clearing with registrar / frame state reset.
+
+  Zero-arity targets `:rf/default`; one-arity targets the named frame.
+  Returns nil. See also: `clear-sub` (registrar-side counterpart)."
   ([] (clear-subscription-cache! :rf/default))
   ([frame-id]
    (when-let [cache (:sub-cache (frame/frame frame-id))]

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -92,27 +92,32 @@
   frame-provider-component)
 
 (defn frame-provider
-  "User-facing Reagent component that scopes a frame keyword to its
-  subtree. Inside the subtree, `(rf/dispatcher)` / `(rf/subscriber)`
-  capture the named frame; reg-view-registered descendants resolve to
-  it via React context.
+  "User-facing component scoping `frame-kw` to its subtree. Wraps
+  children in the shared frame Context Provider — inside the subtree,
+  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
+  descendants resolve to the named frame. Per Spec 002 §What
+  `frame-provider` is.
+
+  Reads `:frame` from props. When missing or `nil`, falls through to
+  `:rf/default` (per rf2-sixo — defensive default that matches the
+  no-provider behaviour and avoids breaking tooling-generated trees
+  that elide the prop).
+
+  Reagent call shape:
 
       [rf/frame-provider {:frame :session}
        [header]
        [main-area]
        [footer]]
 
-  `props` is a map carrying `:frame frame-id`. Children render under
-  that frame (variadic — zero, one, or many).
+  Children are variadic (zero, one, or many). Same surface as the UIx
+  and Helix variants, different rendering substrate. The three adapters
+  share one React Context (per rf2-3yij Decision 2) so a subtree under
+  any frame-provider sees the right frame regardless of which substrate
+  rendered the provider.
 
-  When `:frame` is missing or `nil`, falls through to `:rf/default` —
-  matches the no-provider behaviour. This is the defensive default per
-  the rf2-sixo decision; an explicit error would catch typos but would
-  also break tooling-generated trees that elide the prop.
-
-  Per Spec 002 §What `frame-provider` is. `build-frame-provider` is the
-  lower-level substrate hook; this fn is the canonical user-facing
-  surface."
+  `build-frame-provider` is the lower-level substrate hook; this fn is
+  the canonical user-facing surface."
   [props & children]
   (let [frame-kw (or (:frame props) :rf/default)]
     (into [(build-frame-provider) frame-kw] children)))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1220,8 +1220,8 @@
           (is (= ":rf.error/epoch-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'reset-frame-db! (:where data))
-                "ex-data carries :where = 'reset-frame-db!")
+            (is (= 'rf/reset-frame-db! (:where data))
+                "ex-data carries :where = 'rf/reset-frame-db!")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")
             (is (string? (:reason data))

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -50,8 +50,8 @@
           (is (= ":rf.error/flows-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'clear-flow (:where data))
-                "ex-data carries :where = 'clear-flow")
+            (is (= 'rf/clear-flow (:where data))
+                "ex-data carries :where = 'rf/clear-flow")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")
             (is (string? (:reason data))
@@ -77,9 +77,9 @@
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in `re-frame.core-flows/reg-flow`
             ;; — the sibling-namespace fn-form delegate the macro routes
-            ;; through — so `:where` is the bare unqualified symbol of the
-            ;; user-facing surface (`rf/reg-flow`).
-            (is (= 'reg-flow (:where data))
-                "ex-data carries :where = 'reg-flow")
+            ;; through. Per rf2-j8icl the `:where` symbol is namespace-
+            ;; qualified to the user-facing surface (`rf/reg-flow`).
+            (is (= 'rf/reg-flow (:where data))
+                "ex-data carries :where = 'rf/reg-flow")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -64,7 +64,7 @@
   [{:keys [frame id before] :as interceptor}]
   (when-not (valid-interceptor? interceptor)
     (throw (ex-info ":rf.error/http-bad-interceptor"
-                    {:where    'reg-http-interceptor
+                    {:where    'rf/reg-http-interceptor
                      :recovery :no-recovery
                      :received interceptor
                      :reason   "interceptor must be a map with :id (keyword) and :before (fn)"})))

--- a/implementation/http/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/http/test/re_frame/late_bind_missing_test.clj
@@ -50,8 +50,8 @@
           (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'install-managed-request-stubs! (:where data))
-                "ex-data carries :where = 'install-managed-request-stubs!")
+            (is (= 'rf/install-managed-request-stubs! (:where data))
+                "ex-data carries :where = 'rf/install-managed-request-stubs!")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")
             (is (string? (:reason data))
@@ -69,8 +69,8 @@
           (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'uninstall-managed-request-stubs! (:where data))
-                "ex-data carries :where = 'uninstall-managed-request-stubs!")
+            (is (= 'rf/uninstall-managed-request-stubs! (:where data))
+                "ex-data carries :where = 'rf/uninstall-managed-request-stubs!")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
 
@@ -86,7 +86,7 @@
           (is (= ":rf.error/http-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'with-managed-request-stubs* (:where data))
-                "ex-data carries :where = 'with-managed-request-stubs*")
+            (is (= 'rf/with-managed-request-stubs* (:where data))
+                "ex-data carries :where = 'rf/with-managed-request-stubs*")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -172,11 +172,25 @@
 ;; (`:rf.machine/spawned`, `:rf.machine/destroyed`) nor the handler
 ;; symbols on its production-elision bundle.
 
-(fx/reg-fx :rf.machine/spawn             spawn-fx)
-(fx/reg-fx :rf.machine/destroy           destroy-machine-fx)
-(fx/reg-fx :rf.machine/invoke-all-init   invoke-all-init-fx)
-(fx/reg-fx :rf.machine/after-schedule    after-schedule-fx)
-(fx/reg-fx :rf.machine/after-cancel      after-cancel-fx)
+(fx/reg-fx :rf.machine/spawn
+  {:doc "Spawn a machine instance. Per Spec 005 §Declarative :invoke (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:initial-data`."}
+  spawn-fx)
+
+(fx/reg-fx :rf.machine/destroy
+  {:doc "Destroy a spawned machine instance and clear its `[:rf/machines machine-id]` slot. Per Spec 005 §Declarative :invoke."}
+  destroy-machine-fx)
+
+(fx/reg-fx :rf.machine/invoke-all-init
+  {:doc "Machine-internal: fire `:initial-entry` cascades for every machine spawned at app boot. Per Spec 005 §Initial entry. Not for direct application use."}
+  invoke-all-init-fx)
+
+(fx/reg-fx :rf.machine/after-schedule
+  {:doc "Machine-internal: schedule an `:after` timer event for a machine state. Per Spec 005 §Timed transitions. Not for direct application use."}
+  after-schedule-fx)
+
+(fx/reg-fx :rf.machine/after-cancel
+  {:doc "Machine-internal: cancel a previously-scheduled `:after` timer. Per Spec 005 §Timed transitions. Not for direct application use."}
+  after-cancel-fx)
 
 ;; ---- framework-shipped subs -----------------------------------------------
 ;;
@@ -190,6 +204,7 @@
 ;; shallow — a sub registered inside the sub-namespace wouldn't re-fire.
 
 (subs/reg-sub :rf/machine
+  {:doc "Subscribe to a machine's current snapshot `{:state <kw> :data <map> :tags <set>}`. Returns nil for an unknown or not-yet-initialised machine. Per Spec 005 §Subscribing to machines via sub-machine."}
   (fn [db [_ machine-id]]
     (get-in db [:rf/machines machine-id])))
 
@@ -203,6 +218,7 @@
 ;; off `:rf/machine` — so a view that only cares about whether a specific
 ;; tag is present re-renders only when the containment-bit flips.
 (subs/reg-sub :rf/machine-has-tag?
+  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1)."}
   (fn [db [_ machine-id tag]]
     (contains? (get-in db [:rf/machines machine-id :tags]) tag)))
 

--- a/implementation/machines/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/machines/test/re_frame/late_bind_missing_test.clj
@@ -58,8 +58,8 @@
           (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'reg-machine* (:where data))
-                "ex-data carries :where = 'reg-machine*")
+            (is (= 'rf/reg-machine* (:where data))
+                "ex-data carries :where = 'rf/reg-machine*")
             (is (= :probe/machine (:machine-id data))
                 "ex-data carries :machine-id from the call site")
             (is (= :no-recovery (:recovery data))
@@ -83,11 +83,11 @@
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in
             ;; `re-frame.core-machines/reg-machine` — the sibling-namespace
-            ;; fn-form delegate the macro routes through — so `:where`
-            ;; is the bare unqualified symbol of the user-facing surface
-            ;; (`rf/reg-machine`).
-            (is (= 'reg-machine (:where data))
-                "ex-data carries :where = 'reg-machine")
+            ;; fn-form delegate the macro routes through. Per rf2-j8icl
+            ;; the `:where` symbol is namespace-qualified to the user-
+            ;; facing surface (`rf/reg-machine`).
+            (is (= 'rf/reg-machine (:where data))
+                "ex-data carries :where = 'rf/reg-machine")
             (is (= :probe/macro-machine (:machine-id data))
                 "ex-data carries :machine-id from the call site")
             (is (= :no-recovery (:recovery data))
@@ -106,8 +106,8 @@
           (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'create-machine-handler (:where data))
-                "ex-data carries :where = 'create-machine-handler")
+            (is (= 'rf/create-machine-handler (:where data))
+                "ex-data carries :where = 'rf/create-machine-handler")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
 
@@ -126,8 +126,8 @@
           (is (= ":rf.error/machines-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'machine-transition (:where data))
-                "ex-data carries :where = 'machine-transition")
+            (is (= 'rf/machine-transition (:where data))
+                "ex-data carries :where = 'rf/machine-transition")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
 

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -919,12 +919,24 @@ unknown strategies as :preserve (no-op)."}
   [db _query]
   (:rf/route db))
 
-(subs/reg-sub :rf/route route-sub-fn)
-(subs/reg-sub :rf.route/id         :<- [:rf/route] (fn [route _] (:id route)))
-(subs/reg-sub :rf.route/params     :<- [:rf/route] (fn [route _] (:params route)))
-(subs/reg-sub :rf.route/query      :<- [:rf/route] (fn [route _] (:query route)))
-(subs/reg-sub :rf.route/transition :<- [:rf/route] (fn [route _] (:transition route)))
-(subs/reg-sub :rf.route/error      :<- [:rf/route] (fn [route _] (:error route)))
+(subs/reg-sub :rf/route
+  {:doc "Subscribe to the current route map `{:id :params :query :transition :error}`. Layer-1 read of the `:rf/route` slice. Per Spec 012."}
+  route-sub-fn)
+(subs/reg-sub :rf.route/id
+  {:doc "Subscribe to the current route's `:id` keyword. Per Spec 012."}
+  :<- [:rf/route] (fn [route _] (:id route)))
+(subs/reg-sub :rf.route/params
+  {:doc "Subscribe to the current route's path params map. Per Spec 012."}
+  :<- [:rf/route] (fn [route _] (:params route)))
+(subs/reg-sub :rf.route/query
+  {:doc "Subscribe to the current route's query params map. Per Spec 012."}
+  :<- [:rf/route] (fn [route _] (:query route)))
+(subs/reg-sub :rf.route/transition
+  {:doc "Subscribe to the current route's `:transition` state. Per Spec 012 §Route transitions."}
+  :<- [:rf/route] (fn [route _] (:transition route)))
+(subs/reg-sub :rf.route/error
+  {:doc "Subscribe to the current route's `:error` (nil when no error). Per Spec 012."}
+  :<- [:rf/route] (fn [route _] (:error route)))
 
 ;; ---- route-link registered view ------------------------------------------
 ;;

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -50,8 +50,8 @@
           (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'match-url (:where data))
-                "ex-data carries :where = 'match-url")
+            (is (= 'rf/match-url (:where data))
+                "ex-data carries :where = 'rf/match-url")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")
             (is (string? (:reason data))
@@ -69,8 +69,8 @@
           (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'route-url (:where data))
-                "ex-data carries :where = 'route-url")
+            (is (= 'rf/route-url (:where data))
+                "ex-data carries :where = 'rf/route-url")
             (is (= :route/probe (:route-id data))
                 "ex-data carries :route-id from the call site")
             (is (= :no-recovery (:recovery data))
@@ -90,10 +90,11 @@
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in `re-frame.core-routing/reg-route`
             ;; — the sibling-namespace fn-form delegate the macro routes
-            ;; through — so `:where` is the bare unqualified symbol of the
-            ;; user-facing surface (`rf/reg-route`).
-            (is (= 'reg-route (:where data))
-                "ex-data carries :where = 'reg-route")
+            ;; through. Per rf2-j8icl the `:where` symbol is namespace-
+            ;; qualified to the user-facing surface so users greping for
+            ;; the symbol find `rf/reg-route` call sites.
+            (is (= 'rf/reg-route (:where data))
+                "ex-data carries :where = 'rf/reg-route")
             (is (= :route/probe (:route-id data))
                 "ex-data carries :route-id from the call site")
             (is (= :no-recovery (:recovery data))
@@ -116,7 +117,7 @@
           (is (= ":rf.error/routing-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'route-link (:where data))
-                "ex-data carries :where = 'route-link")
+            (is (= 'rf/route-link (:where data))
+                "ex-data carries :where = 'rf/route-link")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))

--- a/implementation/schemas/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/schemas/test/re_frame/late_bind_missing_test.clj
@@ -58,11 +58,12 @@
           (let [data (ex-data thrown)]
             ;; Per rf2-hoiu the throw lives in
             ;; `re-frame.core-schemas/reg-app-schema` — the sibling-
-            ;; namespace fn-form delegate the macro routes through — so
-            ;; `:where` is the bare unqualified symbol of the user-facing
-            ;; surface (`rf/reg-app-schema`).
-            (is (= 'reg-app-schema (:where data))
-                "ex-data carries :where = 'reg-app-schema")
+            ;; namespace fn-form delegate the macro routes through. Per
+            ;; rf2-j8icl the `:where` symbol is namespace-qualified to
+            ;; the user-facing surface (`rf/reg-app-schema`) so callers
+            ;; greping for the symbol find call sites in their codebase.
+            (is (= 'rf/reg-app-schema (:where data))
+                "ex-data carries :where = 'rf/reg-app-schema")
             (is (= [:probe] (:path data))
                 "ex-data carries :path from the call site")
             (is (= :no-recovery (:recovery data))

--- a/implementation/ssr/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/ssr/test/re_frame/late_bind_missing_test.clj
@@ -50,8 +50,8 @@
           (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'render-to-string (:where data))
-                "ex-data carries :where = 'render-to-string")
+            (is (= 'rf/render-to-string (:where data))
+                "ex-data carries :where = 'rf/render-to-string")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")
             (is (string? (:reason data))
@@ -69,8 +69,8 @@
           (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'render-tree-hash (:where data))
-                "ex-data carries :where = 'render-tree-hash")
+            (is (= 'rf/render-tree-hash (:where data))
+                "ex-data carries :where = 'rf/render-tree-hash")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
 
@@ -90,13 +90,14 @@
           (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            ;; The :where stamped here is the bare 'reg-error-projector
-            ;; symbol — the macro forwards to the plain-fn delegate
+            ;; Per rf2-j8icl the `:where` symbol is namespace-qualified
+            ;; to the user-facing surface (`rf/reg-error-projector`) so
+            ;; greping for the symbol finds call sites in the user's
+            ;; codebase. The macro forwards to the plain-fn delegate
             ;; `-reg-error-projector`, which is where the late-bind
-            ;; check (and ex-info) lives. The fn does not syntax-quote
-            ;; through a macro layer, so :where is the bare symbol.
-            (is (= 'reg-error-projector (:where data))
-                "ex-data carries :where = 'reg-error-projector")
+            ;; check (and ex-info) lives.
+            (is (= 'rf/reg-error-projector (:where data))
+                "ex-data carries :where = 'rf/reg-error-projector")
             (is (= :probe/projector (:id data))
                 "ex-data carries :id from the call site")
             (is (= :no-recovery (:recovery data))
@@ -114,8 +115,8 @@
           (is (= ":rf.error/ssr-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
-            (is (= 'project-error (:where data))
-                "ex-data carries :where = 'project-error")
+            (is (= 'rf/project-error (:where data))
+                "ex-data carries :where = 'rf/project-error")
             (is (= :rf/default (:frame data))
                 "ex-data carries :frame from the call site")
             (is (= :no-recovery (:recovery data))

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -401,6 +401,16 @@ Each per-feature artefact is **independent**. Core MUST NOT transitively `:requi
 
 The independence rule applies to the per-adapter tier too: adapters depend on core; core never depends on an adapter. The runtime's substrate-aware seams (e.g. `re-frame.ssr/install-render-to-string!`) are call-back hooks the adapter ns wires from its own load-time, not requires from core.
 
+### Optional-artefact wrapper convention
+
+Each optional-artefact wrapper lives in core under `re-frame.core-<feature>` (e.g. `re-frame.core-routing`, `re-frame.core-flows`). The wrapper publishes the public-API fns that consumers reach via `re-frame.core` re-exports, but the **implementation** of each fn lives in a separate Maven artefact (`day8/re-frame2-<feature>`).
+
+Core MUST NOT statically `:require` the producing namespace — that would pull the feature's implementation onto every consumer's classpath even when no feature surface is used. Each wrapper fn instead looks the producing fn up through the [late-bind hook table](#) at call time, which the producing artefact populates from its own ns-load.
+
+The single-import contract is preserved: users continue to write `rf/reg-flow` after `(:require [re-frame.core :as rf])` — the wrapper ns is reached via `re-frame.core`'s re-export. When the producing artefact is absent the wrapper raises a documented `:rf.error/<feature>-artefact-missing` ex-info with `:where 'rf/<surface>`, `:recovery :no-recovery`, and a `:reason` string naming the artefact and the ns to require at boot.
+
+Per [rf2-hoiu](#) the wrappers live in sibling namespaces rather than in `core.cljc` itself so `core.cljc` stays free of optional-artefact glue. Per [rf2-2vbm](#) the file naming uses `core_<feature>` rather than `core/<feature>` because CLJS goog.provide for `re-frame.core` overwrites its parent object.
+
 ### Naming convention
 
 The artefact-naming convention is `re-frame2-<thing>`, where `<thing>` is the feature-id (per Spec topic) or adapter name. The Maven group is `day8` for the CLJS reference's published artefacts.


### PR DESCRIPTION
## Summary

Batched cleanup of 13 audit findings (rf2-1itgd / `ai/findings/implementation-usability-2026-05-13.md`).

**P2 — surfaces newcomers touch first:**
- rf2-5r7ec — `reg-event-db` / `reg-event-fx` / `reg-event-ctx` rewritten with full docstrings (signature, return, middle-slot, worked example, siblings)
- rf2-q41sw — `reg-sub` rewritten (layer-1 / layer-2 / `:<-` form documented inline)
- rf2-crmmz — `reg-fx` now names handler signature `(fn [ctx args] ...)` — was invisible
- rf2-g6o5k — `reg-cofx` + `inject-cofx` rewritten as a pair with consumption worked example
- rf2-yicyh — `dispatch-sync` leads with the in-handler footgun + `:rf.error/dispatch-sync-in-handler` cross-ref
- rf2-nsr5x — `->interceptor` + `assoc-coeffect`/`assoc-effect`/`get-coeffect`/`get-effect`/`update-coeffect` now carry docstrings
- rf2-6a2dj — `:doc` metadata stamped on framework-registered fx / subs / cofx so `(rf/handler-meta KIND id)` self-documents

**P3 cleanup:**
- rf2-6bm2f — `clear-event` / `clear-sub` / `clear-fx` / `clear-subscription-cache!` docstrings; `fx/unregister-fx` → `clear-fx` rename (alias preserved)
- rf2-j8icl — `:where` symbols in the seven `:rf.error/*-artefact-missing` throws qualified to `rf/<surface>` so users greping the error trace find call sites in their codebase; six late-bind-missing test files updated
- rf2-a0abi — 20-line artefact-split boilerplate trimmed out of seven `core_*.cljc` ns-docs; canonical "Optional-artefact wrapper convention" section added to `spec/Conventions.md`
- rf2-vkrmd — "See also" cross-references added across 11 public surfaces
- rf2-7ah7c — `:path` pattern syntax (named params, splats, optional groups) hoisted into `reg-route`'s docstring
- rf2-zde3z — canonical phrasing stamped across Reagent / UIx / Helix `frame-provider`; `init!` nil-check duplication factored into `bad-init-arg!` helper

**Behaviour:** no change beyond the `:where` symbol tightening (tests updated alongside) and the cosmetic `unregister-fx` → `clear-fx` rename (alias preserved).

## Test plan
- [x] `clojure -M:test` per artefact (core, routing, flows, schemas, machines, ssr, epoch, http) — all green (330 + 28 + 26 + 53 + 119 + 31 + 59 + 72 = 718 deftests)
- [x] `npm run test:cljs` — green (646 deftests, 1612 assertions)
- [x] `npm run test:elision` — green
- [x] `npm run test:bundle-isolation` — green
- [ ] `npm run test:browser` — port collision in local env; CI will run
- [ ] `mkdocs build --strict` — 119 pre-existing warnings unchanged (link-rot in guide / skills md files unrelated to this PR; verified by stash + rebuild baseline)