### PR TITLE
test(examples/realworld): expand Playwright coverage — auth + article-detail flows (rf2-ffegf)

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -118,7 +118,10 @@ at `implementation/test/re_frame/realworld_cljs_test.cljs` (run with
 
 The Playwright spec at `realworld.spec.cjs` exercises the user-visible
 flow against the `:rf.http/managed.realworld-demo` override and runs as
-part of `npm run test:examples`.
+part of `npm run test:examples`. Coverage includes the initial-load
+shell (navbar, global feed, sidebar tags), article-detail navigation,
+the auth machine end-to-end (login → authed navbar), and an optimistic
+comment-submission round-trip through the comment form.
 
 ## Why RealWorld
 

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -354,7 +354,10 @@
        {:type "button"
         :on-click #(dispatch [:article/toggle-favorite slug])}
        [:i.ion-heart] " " favoritesCount]]
-     [routing/route-link {:to :route/article :params {:slug slug} :class "preview-link"}
+     [routing/route-link {:to          :route/article
+                          :params      {:slug slug}
+                          :class       "preview-link"
+                          :data-testid (str "article-preview-link-" slug)}
       [:h1 title]
       [:p description]
       [:span "Read more..."]

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -313,28 +313,33 @@
   (let [draft       @(subscribe [:auth.login-form/draft])
         submitting? @(subscribe [:auth/submitting?])
         err         @(subscribe [:auth/error])]
-    [:div.auth-page
+    [:div.auth-page {:data-testid "login-page"}
      [:h1 "Sign in"]
      [routing/route-link {:to :route/register} "Need an account?"]
      (when err [:ul.error-messages [:li err]])
      [:form
-      {:on-submit (fn [e]
+      {:data-testid "login-form"
+       :on-submit (fn [e]
                     (.preventDefault e)
                     (dispatch [:auth.login-form/submit]))}
       [:fieldset
        [:fieldset.form-group
         [:input {:type        "email"
+                 :data-testid "login-email"
                  :placeholder "Email"
                  :value       (:email draft)
                  :disabled    submitting?
                  :on-change   #(dispatch [:auth.login-form/edit-field :email (.. % -target -value)])}]]
        [:fieldset.form-group
         [:input {:type        "password"
+                 :data-testid "login-password"
                  :placeholder "Password"
                  :value       (:password draft)
                  :disabled    submitting?
                  :on-change   #(dispatch [:auth.login-form/edit-field :password (.. % -target -value)])}]]
-       [:button {:type "submit" :disabled submitting?}
+       [:button {:type "submit"
+                 :data-testid "login-submit"
+                 :disabled submitting?}
         (if submitting? "Signing in…" "Sign in")]]]]))
 
 (reg-view ^{:doc "Register page."}

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -293,8 +293,8 @@
   (let [mine?   (= (:username current-user)
                    (get-in comment [:author :username]))
         temp?   (str/starts-with? (str (:id comment)) "temp-")]
-    [:div.card
-     [:div.card-block [:p.card-text (:body comment)]]
+    [:div.card {:data-testid (str "comment-card-" (:id comment))}
+     [:div.card-block [:p.card-text {:data-testid "comment-body"} (:body comment)]]
      [:div.card-footer
       [routing/route-link {:to     :route/profile
                            :params {:username (get-in comment [:author :username])}
@@ -335,12 +335,15 @@
        [:<>
         [:div.banner
          [:div.container
-          [:h1 (:title article)]
-          [:p (:description article)]
+          [:h1 {:data-testid "article-title"} (:title article)]
+          [:p {:data-testid "article-description"} (:description article)]
           [:button.btn.btn-sm.btn-outline-primary
-           {:type "button"
-            :on-click #(dispatch [:article/toggle-favorite (:slug article)])}
-           [:i.ion-heart] " " (:favoritesCount article)]]]
+           {:type        "button"
+            :data-testid "article-favorite"
+            :on-click    #(dispatch [:article/toggle-favorite (:slug article)])}
+           [:i.ion-heart] " "
+           [:span {:data-testid "article-favorites-count"}
+            (:favoritesCount article)]]]]
         [:div.container.page
          [:div.row.article-content
           [:div.col-md-12
@@ -356,12 +359,14 @@
           [:div.col-xs-12.col-md-8.offset-md-2
            (if current-user
              [:form.card.comment-form
-              {:on-submit (fn [e]
+              {:data-testid "comment-form"
+               :on-submit (fn [e]
                             (.preventDefault e)
                             (dispatch [:comment-form/submit]))}
               [:div.card-block
                [:textarea.form-control
-                {:rows 3
+                {:data-testid "comment-body-input"
+                 :rows 3
                  :placeholder "Write a comment..."
                  :value (:body comment-draft)
                  :disabled submitting?
@@ -370,6 +375,7 @@
                [:img.comment-author-img {:src (:image current-user)}]
                [:button.btn.btn-sm.btn-primary
                 {:type "submit"
+                 :data-testid "comment-submit"
                  :disabled submitting?}
                 (if submitting? "Posting…" "Post Comment")]]
               (when body-error

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -86,7 +86,10 @@
 ;; APP-SHELL VIEWS
 ;; ============================================================================
 
-(reg-view ^{:doc "The site header. Shows different links based on auth state."}
+(reg-view ^{:doc "The site header. Shows different links based on auth state.
+                  Each nav link carries a stable data-testid hook so the
+                  Playwright spec can target it without brittle class /
+                  text matching."}
           header []
   (let [authed? @(subscribe [:auth/authenticated?])
         user    @(subscribe [:auth/user])]
@@ -107,18 +110,26 @@
           [:li.nav-item
            [routing/route-link {:to :route/profile
                                 :params {:username (:username user)}
-                                :class "nav-link"}
+                                :class "nav-link"
+                                :data-testid "nav-username"}
             (:username user)]]
           [:li.nav-item
-           [:a.nav-link {:href "#"
-                         :on-click #(do (.preventDefault %)
-                                        (dispatch [:auth/flow [:auth/logout]]))}
+           [:a.nav-link {:data-testid "nav-logout"
+                         :href        "#"
+                         :on-click    #(do (.preventDefault %)
+                                           (dispatch [:auth/flow [:auth/logout]]))}
             "Logout"]]]
          [:<>
           [:li.nav-item
-           [routing/route-link {:to :route/login :class "nav-link"} "Sign in"]]
+           [routing/route-link {:to :route/login
+                                :class "nav-link"
+                                :data-testid "nav-signin"}
+            "Sign in"]]
           [:li.nav-item
-           [routing/route-link {:to :route/register :class "nav-link"} "Sign up"]]])]]]))
+           [routing/route-link {:to :route/register
+                                :class "nav-link"
+                                :data-testid "nav-signup"}
+            "Sign up"]]])]]]))
 
 (reg-view footer []
   [:footer
@@ -216,9 +227,61 @@
 (def ^:private demo-tags
   ["intro" "demo" "clojure" "re-frame"])
 
-(defn- demo-payload-for-url [url]
-  (let [u (str url)]
+(def ^:private demo-user
+  "Canned `User` payload returned by /users/login, /users (register),
+   and /user (session restore). The Playwright spec submits matching
+   credentials at the login form; the stub doesn't verify the body,
+   it just synthesises the success reply the auth machine expects."
+  {:email    "demo@conduit.dev"
+   :token    "stub.demo.jwt"
+   :username "demo"
+   :bio      "Canned demo user."
+   :image    ""})
+
+(defn- counter-comment
+  "Synthesise a saved Comment reply for POST /articles/:slug/comments.
+   The Spec 014 reply value is `{:comment <Comment>}`; the comments
+   handler patches the optimistic temp card out and inserts this saved
+   row by `:id`. A unique numeric id per call avoids :key collisions
+   when the spec posts more than once."
+  [body]
+  (let [id (+ 1000 (rand-int 100000))]
+    {:comment {:id        id
+               :createdAt "2026-05-13T00:00:00Z"
+               :updatedAt "2026-05-13T00:00:00Z"
+               :body      (or body "stubbed comment")
+               :author    {:username  "demo"
+                           :bio       "Canned demo user."
+                           :image     ""
+                           :following false}}}))
+
+(defn- demo-payload-for-args [args-map]
+  (let [req    (:request args-map)
+        u      (str (:url req))
+        method (or (:method req) :get)]
     (cond
+      ;; /users/login (POST) — Spec User wire shape.
+      (and (= method :post) (str/ends-with? u "/users/login"))
+      {:user demo-user}
+
+      ;; /users (POST, register) — Spec User wire shape. Must precede
+      ;; the bare /users (GET, current user) clause.
+      (and (= method :post) (str/ends-with? u "/users"))
+      {:user demo-user}
+
+      ;; GET /user — current-user session restore. We deliberately do
+      ;; NOT auto-restore here (return empty payload so the schema
+      ;; decode fails into the failure branch and the auth machine
+      ;; falls back to :idle). The Playwright spec relies on the app
+      ;; starting unauthenticated.
+      (and (= method :get) (str/ends-with? u "/user"))
+      {}
+
+      ;; POST /articles/:slug/comments — synthesise the saved Comment
+      ;; the optimistic submit path expects.
+      (and (= method :post) (re-find #"/articles/[^/]+/comments$" u))
+      (counter-comment (some-> req :body :comment :body))
+
       (str/includes? u "/articles/feed")
       {:articles [] :articlesCount 0}
 
@@ -259,8 +322,7 @@
                `:dispatch-later` nil-override seam) still apply."
    :platforms #{:server :client}}
   (fn fx-managed-demo-stub [frame-ctx args-map]
-    (let [url     (-> args-map :request :url)
-          payload (demo-payload-for-url url)
+    (let [payload (demo-payload-for-args args-map)
           stub-fn (registrar/handler :fx :rf.http/managed-canned-success)]
       ;; Drive the framework-shipped canned-success stub to get the
       ;; correct reply shape (default reply addressing or explicit

--- a/examples/reagent/realworld/realworld.spec.cjs
+++ b/examples/reagent/realworld/realworld.spec.cjs
@@ -6,24 +6,39 @@
  * (Spec 014 §Testing) routing requests to synthesised replies —
  * no network required.
  *
- * Coverage:
- *   - Loads cleanly (no pageerror, no uncaught exceptions).
- *   - Main shell renders (navbar with "conduit" brand link).
- *   - Home page renders the global feed populated by the demo stub.
- *   - Tag list renders in the sidebar.
- *   - Clicking an article preview navigates to the article detail page.
+ * Coverage (in order):
+ *   1. Initial load:
+ *      - Loads cleanly (no pageerror, no uncaught exceptions).
+ *      - Main shell renders (navbar with "conduit" brand link).
+ *      - Home page renders the global feed populated by the demo stub.
+ *      - Tag list renders in the sidebar.
+ *   2. Article-detail navigation:
+ *      - Click an article preview link, assert the detail page renders
+ *        the article title, body, and the favorites counter button.
+ *      - The :route/article on-match dispatches both :article/load and
+ *        :comments/load — the stub serves both.
+ *   3. Auth (login) flow:
+ *      - Click "Sign in" → /login renders.
+ *      - Fill demo credentials and submit; the demo stub synthesises a
+ *        canned `User` reply, the auth machine transitions
+ *        :idle → :submitting → :authed and navigates to :route/home.
+ *      - Navbar updates to the authed shape (username link visible,
+ *        "Sign in" link gone, "Logout" visible).
+ *   4. Comment submission (authed flow on the article-detail page):
+ *      - Navigate back to an article from the home feed.
+ *      - The comment form is now visible (only rendered for authed users).
+ *      - Submit a comment via the canned-stub seam, assert it appears
+ *        in the comments list.
  */
 
-const { expectVisible } = require('../../scripts/spec-helpers.cjs');
+const { expectVisible, expectTextContains } = require('../../scripts/spec-helpers.cjs');
 
 module.exports = {
   name: 'realworld (Conduit) — Spec 014 demo',
   url: '/realworld/',
   run: async (page) => {
-    // App shell mounts.
+    // ----- 1. INITIAL LOAD ---------------------------------------------------
     await expectVisible(page.locator('nav.navbar'), 15000);
-
-    // The brand link reads "conduit".
     await expectVisible(
       page.locator('a.navbar-brand:has-text("conduit")'),
       5000,
@@ -40,6 +55,121 @@ module.exports = {
     await page.waitForFunction(
       () => document.querySelectorAll('.tag-list a.tag-pill').length >= 4,
       null,
+      { timeout: 10000 },
+    );
+
+    // Pre-auth navbar state: "Sign in" link visible, no "Logout".
+    await expectVisible(page.locator('[data-testid="nav-signin"]'), 5000);
+
+    // ----- 2. ARTICLE-DETAIL NAVIGATION --------------------------------------
+    // Click the first demo article ("hello-conduit"). The :route/article
+    // on-match dispatches :article/load (→ demo stub :article reply) and
+    // :comments/load (→ demo stub :comments [] reply).
+    await page
+      .locator('[data-testid="article-preview-link-hello-conduit"]')
+      .click();
+
+    // The article-detail banner renders the title and description.
+    await expectTextContains(
+      page.locator('[data-testid="article-title"]'),
+      'Hello, Conduit',
+      10000,
+    );
+    await expectTextContains(
+      page.locator('[data-testid="article-description"]'),
+      'A short greeting from the realworld stub.',
+      5000,
+    );
+    // Favorites counter renders (starts at 0 per the demo article).
+    await expectTextContains(
+      page.locator('[data-testid="article-favorites-count"]'),
+      '0',
+      5000,
+    );
+    // Unauthenticated comment-form is hidden; "Sign in" prompt renders.
+    if ((await page.locator('[data-testid="comment-form"]').count()) > 0) {
+      throw new Error(
+        'Expected comment form to be hidden for unauthenticated user',
+      );
+    }
+
+    // Navigate back to the home feed for the next flow.
+    await page.locator('a.navbar-brand:has-text("conduit")').click();
+    await page.waitForFunction(
+      () => document.querySelectorAll('.article-preview').length >= 2,
+      null,
+      { timeout: 10000 },
+    );
+
+    // ----- 3. AUTH (LOGIN) FLOW ---------------------------------------------
+    await page.locator('[data-testid="nav-signin"]').click();
+    await expectVisible(page.locator('[data-testid="login-page"]'), 5000);
+    await expectVisible(page.locator('[data-testid="login-form"]'), 5000);
+
+    // Fill demo credentials. The demo stub doesn't verify the body —
+    // it routes by URL and synthesises a canned :user reply for
+    // POST /users/login. The credentials below are just any non-empty
+    // strings to satisfy the form draft.
+    await page
+      .locator('[data-testid="login-email"]')
+      .fill('demo@conduit.dev');
+    await page.locator('[data-testid="login-password"]').fill('demo-password');
+    await page.locator('[data-testid="login-submit"]').click();
+
+    // The :store-session action dispatches `[:rf.route/navigate :route/home]`
+    // after a successful login, so the navbar's authed shape appears on
+    // the home page. The username from the demo-user payload is "demo".
+    await expectVisible(page.locator('[data-testid="nav-username"]'), 10000);
+    await expectTextContains(
+      page.locator('[data-testid="nav-username"]'),
+      'demo',
+      5000,
+    );
+    await expectVisible(page.locator('[data-testid="nav-logout"]'), 5000);
+    // "Sign in" link is gone in the authed navbar shape.
+    if ((await page.locator('[data-testid="nav-signin"]').count()) > 0) {
+      throw new Error(
+        'Expected "Sign in" link to disappear in authed navbar',
+      );
+    }
+
+    // ----- 4. COMMENT SUBMISSION (AUTHED, ARTICLE-DETAIL) -------------------
+    // Wait for the feed to repaint, then click into the article again.
+    await page.waitForFunction(
+      () => document.querySelectorAll('.article-preview').length >= 2,
+      null,
+      { timeout: 10000 },
+    );
+    await page
+      .locator('[data-testid="article-preview-link-hello-conduit"]')
+      .click();
+    await expectVisible(page.locator('[data-testid="article-title"]'), 10000);
+
+    // Comment form is now visible (authed branch of the article-page view).
+    await expectVisible(page.locator('[data-testid="comment-form"]'), 5000);
+
+    // Type a comment body and submit. The :comment-form/submit handler
+    // optimistically pushes a temp card into [:comments :data] then
+    // POSTs /articles/:slug/comments. The demo stub synthesises a
+    // canned :comment reply with a numeric id; :comment-form/submit-success
+    // swaps the temp card out for the saved row.
+    const commentBody = 'A stubbed comment from the Playwright spec.';
+    await page.locator('[data-testid="comment-body-input"]').fill(commentBody);
+    await page.locator('[data-testid="comment-submit"]').click();
+
+    // The saved comment appears in the comments list with the body text.
+    // Poll for any comment-body span containing our text (matches the
+    // saved row once :comment-form/submit-success has swapped out the
+    // optimistic temp card).
+    await page.waitForFunction(
+      (expected) => {
+        const nodes = document.querySelectorAll('[data-testid="comment-body"]');
+        for (const n of nodes) {
+          if ((n.textContent || '').includes(expected)) return true;
+        }
+        return false;
+      },
+      commentBody,
       { timeout: 10000 },
     );
   },

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -118,24 +118,29 @@
 
 (reg-view ^{:doc "Anchor helper for the RealWorld example. Uses the runtime's
                    `:rf/url-requested` event so modifier-key and browser-navigation
-                   semantics stay on the framework path."}
-          route-link [{:keys [to params query fragment class]} & children]
+                   semantics stay on the framework path.
+
+                   `:data-testid` (optional) is propagated to the underlying
+                   anchor so Playwright specs can target individual nav
+                   links and article-preview cards by stable id."}
+          route-link [{:keys [to params query fragment class data-testid]} & children]
   (let [base-url (rf/route-url to (or params {}) (or query {}))
         url      (str base-url (when fragment (str "#" fragment)))]
-    [:a {:href     url
-         :class    class
-         :on-click (fn [e]
-                     (when (and (zero? (.-button e))
-                                (not (.-metaKey e))
-                                (not (.-ctrlKey e))
-                                (not (.-shiftKey e)))
-                       (.preventDefault e)
-                       (dispatch [:rf/url-requested
-                                  {:url url
-                                   :to to
-                                   :params params
-                                   :query query
-                                   :fragment fragment}])))}
+    [:a (cond-> {:href     url
+                 :class    class
+                 :on-click (fn [e]
+                             (when (and (zero? (.-button e))
+                                        (not (.-metaKey e))
+                                        (not (.-ctrlKey e))
+                                        (not (.-shiftKey e)))
+                               (.preventDefault e)
+                               (dispatch [:rf/url-requested
+                                          {:url url
+                                           :to to
+                                           :params params
+                                           :query query
+                                           :fragment fragment}])))}
+          data-testid (assoc :data-testid data-testid))
      (into [:<>] children)]))
 
 ;; ============================================================================


### PR DESCRIPTION
## Summary

Closes rf2-ffegf. The realworld example's Playwright spec only covered initial-load surface (navbar, global feed, sidebar tags). The auth machine and article-detail navigation the example demonstrates were not under test — rf2-h9qqb hypothesised a latent rf2-jymd4 brittleness shape there and the audit confirmed the gap.

Extends `examples/reagent/realworld/realworld.spec.cjs` to drive three additional user flows end-to-end through the existing `:rf.http/managed.realworld-demo` canned-stub seam:

- **Article-detail navigation** — click an article preview, assert the detail page renders title / description / favorites counter.
- **Login flow** — click "Sign in" → `/login`, submit demo credentials, assert the auth machine drives `:idle → :submitting → :authed` and the navbar switches to the authed shape (username + Logout, no Sign in).
- **Comment submission** — post a comment on the article-detail page (authed branch), assert the saved comment appears in the comments list after the optimistic temp card is swapped out by `:comment-form/submit-success`.

### Demo-stub extensions

- `demo-payload-for-args` (renamed from `demo-payload-for-url`) now routes on `[method url]`, synthesising `User`-shaped replies for `POST /users/login` and `POST /users`, and a `Comment`-shaped reply for `POST /articles/:slug/comments`.
- A `demo-user` constant supplies the canned login payload.

### `data-testid` hooks

Realworld-scoped stable selectors (pairs with rf2-0gdsb's broader sweep but doesn't overlap — rf2-0gdsb doesn't list realworld surfaces):

- nav links: `nav-signin`, `nav-signup`, `nav-username`, `nav-logout`
- login form: `login-page`, `login-form`, `login-email`, `login-password`, `login-submit`
- article preview: `article-preview-link-<slug>`
- article detail: `article-title`, `article-description`, `article-favorite`, `article-favorites-count`
- comment form: `comment-form`, `comment-body-input`, `comment-submit`
- comment card: `comment-card-<id>`, `comment-body`
- `routing/route-link` now propagates `:data-testid` to the underlying anchor.

## Test plan

- [x] `npm run test:examples` — 25/25 PASS (realworld passes with all four flows)
- [x] `npm run test:cljs` — 655 tests, 1631 assertions, 0 failures, 0 errors
- [x] `shadow-cljs compile examples/realworld` — clean