### PR TITLE
spec(causa): co-pilot redaction defaults — privacy-by-default per Sentry precedent (rf2-uvmvl)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -420,8 +420,10 @@ Three modal surfaces float over the chrome:
 2. **Keyboard cheat-sheet** (`?`) — 480px modal listing every
    shortcut.
 3. **Settings** (`,`) — 640×480px modal: Theme · Density ·
-   Keybindings · AI provider · Buffer depths · Frame defaults ·
-   Telemetry (always off; statement of why we don't ship any).
+   Keybindings · AI provider (includes co-pilot redaction toggles per
+   [`009-AI-CoPilot.md`](./009-AI-CoPilot.md) §Redaction defaults) ·
+   Buffer depths · Frame defaults · Telemetry (always off; statement
+   of why we don't ship any).
 
 ## Discoverability
 

--- a/tools/causa/spec/009-AI-CoPilot.md
+++ b/tools/causa/spec/009-AI-CoPilot.md
@@ -217,6 +217,44 @@ In-session affordances:
 - `Ctrl+P` / `Ctrl+N` walk previous / next questions.
 - `Ctrl+R` searches within the conversation.
 
+## Redaction defaults
+
+By default, Causa's co-pilot sees only metadata, not values. This is a
+privacy-by-default stance — opt in to unmask.
+
+### Defaults
+
+| Category | Sent to LLM by default | Opt-in toggle |
+|---|---|---|
+| Event-vector args | `<redacted>` | `:rf.causa.copilot/unmask-event-args` |
+| App-db slice values | `<redacted>` | `:rf.causa.copilot/unmask-app-db` |
+| Source coords | full | (always sent) |
+| Handler IDs | full | (always sent) |
+| Trace metadata (`:dispatch-id`, `:operation`, severity) | full | (always sent) |
+
+### Settings UI
+
+Settings panel exposes per-category toggles (see
+[`007-UX-IA.md`](./007-UX-IA.md) §Modal layers — Settings, under "AI
+provider"). Defaults preserve Lock 12's privacy bet without changing
+the persistence decision (still ephemeral).
+
+### Rationale
+
+Source coords + handler IDs + trace metadata are sufficient for the
+canonical "why did this re-render?" questions. Values are needed only
+for "what's wrong with this specific app-db slice?" — opt-in surfaces
+that when the user explicitly wants it.
+
+### Cross-references
+
+- §Ephemeral conversation above (Lock #12 — conversation persistence
+  is ephemeral).
+- Sentry Session Replay's privacy-by-default precedent (all text
+  masked unless `sentry-unmask`).
+- [`007-UX-IA.md`](./007-UX-IA.md) §Modal layers — Settings panel
+  surfaces the per-category toggles.
+
 ## Voice / STT
 
 **Not at v1.0** (lock #13 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)).


### PR DESCRIPTION
## Summary

Causa §10 Lock 12 keeps conversation ephemeral but the spec didn't define which fields the LLM sees by default. This PR adds a privacy-by-default redaction policy (borrowed from Sentry Session Replay) to `009-AI-CoPilot.md`:

- **Event-vector args** → `<redacted>` by default (opt-in toggle `:rf.causa.copilot/unmask-event-args`)
- **App-db slice values** → `<redacted>` by default (opt-in toggle `:rf.causa.copilot/unmask-app-db`)
- **Source coords / handler IDs / trace metadata** → always sent

Source coords + handler IDs + trace metadata are sufficient for the canonical "why did this re-render?" questions. Values are needed only for "what's wrong with this app-db slice?" — opt-in surfaces that when the user explicitly wants it. Strengthens Lock 12's privacy bet without changing the persistence decision (still ephemeral).

`007-UX-IA.md` §Modal layers — Settings gets a cross-link to the new section so the toggles' location is discoverable from the IA spec.

Discovered from rf2-76qxg (SOTA audit).

## Test plan

- [x] `python scripts/check_doc_slugs.py --verbose` — no broken links
- [x] `python -m mkdocs build --strict` — same warning count as `main` (2 pre-existing warnings about `tools/story/spec/`, unrelated)
- [x] New `#redaction-defaults` anchor resolves
- [x] Cross-link from `007-UX-IA.md` resolves to the new section