### PR TITLE
feat(story): chrome-level toolbar impl — consumes reg-mode tuples with axis-aware selection (rf2-xi9zk)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -614,25 +614,116 @@ module.exports = {
     );
 
     // ====================================================================
-    // 8. Mode picker — :Mode.app/dark and :Mode.app/light chips
+    // 8. Chrome-level toolbar — chip render, axis selection, reset (rf2-xi9zk)
     // ====================================================================
     //
-    // The mode picker exposes every registered mode as a toggleable
-    // chip in the right pane. Toggling a mode flips its entry in
-    // `:active-modes`; the chip swaps to the active style.
+    // Per spec/010 the toolbar lives above the three-pane row (chrome-
+    // wide, NOT inside the controls aside). It exposes every registered
+    // `:mode` as a clickable chip — toggling a chip flips its entry in
+    // `:active-modes`; `:axis`-tagged modes single-select-within-axis
+    // (toggling :Mode.app/sepia evicts any other `:axis :theme` mode).
     //
-    // We click `:Mode.app/dark`, confirm the chip is now styled active,
-    // then click again to deactivate. The DOM doesn't expose the
-    // active-state via class (inline-styled), so we instead verify the
-    // mode appears as a clickable chip and that clicking it does not
-    // crash the shell (the canvas stays mounted with its variant title).
-    const darkModeChip = aside.getByText(':Mode.app/dark', { exact: false }).first();
-    await darkModeChip.waitFor({ state: 'visible', timeout: 5000 });
-    await darkModeChip.click();
+    // counter_with_stories registers three theme modes:
+    //   - :Mode.app/dark   (no axis — multi-select)
+    //   - :Mode.app/light  (no axis — multi-select)
+    //   - :Mode.app/sepia  (:axis :theme — single-select-within-axis)
+    const toolbar = page.locator('[data-test="story-toolbar"]');
+    await toolbar.waitFor({ state: 'visible', timeout: 5000 });
+
+    const darkChip = toolbar.locator('[data-toolbar-mode=":Mode.app/dark"]');
+    const lightChip = toolbar.locator('[data-toolbar-mode=":Mode.app/light"]');
+    const sepiaChip = toolbar.locator('[data-toolbar-mode=":Mode.app/sepia"]');
+    await darkChip.waitFor({ state: 'visible', timeout: 5000 });
+    await lightChip.waitFor({ state: 'visible', timeout: 5000 });
+    await sepiaChip.waitFor({ state: 'visible', timeout: 5000 });
+
+    // Initial: every chip is aria-pressed="false".
+    if ((await darkChip.getAttribute('aria-pressed')) !== 'false') {
+      throw new Error('expected :Mode.app/dark chip to start aria-pressed="false"');
+    }
+
+    // Click :dark → aria-pressed="true"; :light + :sepia stay "false".
+    await darkChip.click();
+    {
+      const start = Date.now();
+      let pressed = null;
+      while (Date.now() - start < 2000) {
+        pressed = await darkChip.getAttribute('aria-pressed').catch(() => null);
+        if (pressed === 'true') break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (pressed !== 'true') {
+        throw new Error(`expected :dark chip aria-pressed="true" after click, got ${pressed}`);
+      }
+    }
+    if ((await lightChip.getAttribute('aria-pressed')) !== 'false') {
+      throw new Error('expected :light chip to remain aria-pressed="false" after :dark click (multi-select)');
+    }
+
+    // Click :light (un-axis-tagged) → both :dark + :light active (multi-select).
+    await lightChip.click();
+    {
+      const start = Date.now();
+      let bothActive = false;
+      while (Date.now() - start < 2000) {
+        const a = await darkChip.getAttribute('aria-pressed').catch(() => null);
+        const b = await lightChip.getAttribute('aria-pressed').catch(() => null);
+        if (a === 'true' && b === 'true') {
+          bothActive = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!bothActive) {
+        throw new Error('expected :dark + :light to coexist (no axis tag = multi-select)');
+      }
+    }
+
+    // Click :sepia (:axis :theme) — single-select-within-axis. :sepia
+    // is the only :axis :theme-tagged mode in the example; :dark + :light
+    // are NOT axis-tagged so they're unaffected (axis-tagged toggles
+    // only evict siblings sharing the SAME axis).
+    await sepiaChip.click();
+    {
+      const start = Date.now();
+      let ok = false;
+      while (Date.now() - start < 2000) {
+        const sepia = await sepiaChip.getAttribute('aria-pressed').catch(() => null);
+        if (sepia === 'true') {
+          ok = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!ok) {
+        throw new Error('expected :sepia chip to flip aria-pressed="true" after click');
+      }
+    }
+
+    // Reset button appears once at least one mode is active; clicking
+    // it clears every chip back to aria-pressed="false".
+    const toolbarResetBtn = toolbar.locator('[data-test="story-toolbar-reset"]');
+    await toolbarResetBtn.waitFor({ state: 'visible', timeout: 2000 });
+    await toolbarResetBtn.click();
+    {
+      const start = Date.now();
+      let cleared = false;
+      while (Date.now() - start < 2000) {
+        const a = await darkChip.getAttribute('aria-pressed').catch(() => null);
+        const b = await lightChip.getAttribute('aria-pressed').catch(() => null);
+        const c = await sepiaChip.getAttribute('aria-pressed').catch(() => null);
+        if (a === 'false' && b === 'false' && c === 'false') {
+          cleared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!cleared) {
+        throw new Error('expected reset-button click to flip every chip back to aria-pressed="false"');
+      }
+    }
     // Canvas should still be mounted and titled with the same variant.
     await waitForVariantTitle(page, ':story.counter/loaded');
-    // Toggle back off so subsequent assertions get a clean active-modes set.
-    await darkModeChip.click();
 
     // ====================================================================
     // 9. Decorator list — read-only listing in the controls panel

--- a/examples/reagent/counter_with_stories/stories.cljs
+++ b/examples/reagent/counter_with_stories/stories.cljs
@@ -97,6 +97,18 @@
             :background  "#ffffff"
             :foreground  "#1a1a1a"}})
 
+  ;; rf2-xi9zk: an `:axis :theme`-tagged mode exercises the chrome-
+  ;; level toolbar's single-select-within-axis semantics (spec/010
+  ;; §Selection semantics — by axis). Toggling :Mode.app/sepia
+  ;; deactivates any other `:axis :theme` mode that was active.
+  (story/reg-mode :Mode.app/sepia
+    {:doc  "Sepia theme — exercises the toolbar's single-select-
+           within-axis behaviour (`:axis :theme`)."
+     :axis :theme
+     :args {:theme      :sepia
+            :background "#f4ecd8"
+            :foreground "#5b4636"}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-decorator — a project-custom hiccup decorator
   ;;

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -62,6 +62,10 @@
             ;; CLJS-only so the JVM classpath stays lean.
             [re-frame.story.layout-debug :as layout-debug]
             [re-frame.story.share        :as share]
+            ;; rf2-xi9zk: chrome-level toolbar's cofx + subscriptions
+            ;; (`:story/active-modes`, `:story/active-args`) — pure
+            ;; .cljc so the cofx are exercisable from JVM tests.
+            [re-frame.story.ui.cofx      :as ui-cofx]
             ;; Stage 4 (rf2-ekai) — UI shell. CLJS-only require so JVM
             ;; consumers (tests, REPL exploration) don't pull Reagent /
             ;; reagent.dom.client into their classpath.
@@ -398,6 +402,10 @@
   ;; module declares the three :hiccup-kind decorators against the
   ;; story registrar).
   (layout-debug/install-canonical-layout-debug!)
+  ;; rf2-xi9zk — chrome-level toolbar's cofx + subs. Register the
+  ;; `:story/active-modes` and `:story/active-args` coeffect handlers +
+  ;; matching subscriptions backed by the shell-state-atom.
+  (ui-cofx/install-canonical-cofx!)
   ;; CLJS-only Stage 6 surfaces: multi-substrate Reagent default +
   ;; the v1.0 panel set.
   #?(:cljs (ui-multi-substrate/install-reagent-substrate!))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -280,9 +280,17 @@
 
 (def Mode
   "Schema for the body of `reg-mode` — a saved-tuple of global args.
-  Per IMPL-SPEC §2.8.3 modes ship in v1."
+  Per IMPL-SPEC §2.8.3 modes ship in v1.
+
+  Per spec/010 §Optional grouping — `:axis` (v1) the body MAY carry an
+  optional `:axis` keyword that groups modes for the toolbar's chip
+  layout. When present, the toolbar renders one labelled group per axis
+  with **single-select-within-axis** semantics. Modes without `:axis`
+  render in a trailing un-grouped section with multi-select semantics.
+  The schema change is additive — unchanged bodies remain valid."
   [:map
    [:doc  {:optional true} :string]
+   [:axis {:optional true} :keyword]
    [:args ArgMap]])
 
 ;; ---- :rf/story-panel ------------------------------------------------------

--- a/tools/story/src/re_frame/story/ui/cofx.cljc
+++ b/tools/story/src/re_frame/story/ui/cofx.cljc
@@ -1,0 +1,89 @@
+(ns re-frame.story.ui.cofx
+  "Coeffect + subscription wiring for the chrome-level toolbar's
+  `:active-modes` slot. Per spec/010 §`with-mode` accessor — the
+  three caller patterns:
+
+  1. Story code at registration time uses the `:args` deep-merge —
+     nothing to expose.
+  2. Event-handler code reads via `:story/active-modes` /
+     `:story/active-args` cofx.
+  3. Reagent view code subscribes via `[:story/active-modes]` /
+     `[:story/active-args]`.
+
+  The cofx values + the subscription source both read off
+  `re-frame.story.ui.state/shell-state-atom` — the same slot the
+  toolbar writes. JVM-side the atom is a plain `clojure.core/atom`;
+  CLJS-side it's a `reagent.core/atom`, so the subscription propagates
+  through Reagent's signal graph the way every other shell sub does.
+
+  ## Generalisation note
+
+  Spec/010 §`with-mode` accessor §Single-mode call sites — the spec
+  formerly carried `:story/mode` (singular) but no implementation ever
+  registered it. This is the replacement landing point — the cofx
+  pair lands here as `:story/active-modes` (plural) + `:story/active-
+  args`. Pre-alpha, no shim for the singular name (per AGENTS.md
+  `pre-alpha-no-back-compat`).
+
+  ## Registration
+
+  `install-canonical-cofx!` is called from
+  `re-frame.story/install-canonical-vocabulary!`. Idempotent — re-
+  registering with the same body replaces the slot atomically."
+  (:require [re-frame.core :as rf]
+            [re-frame.story.args :as args]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.state :as state]))
+
+(defn active-modes-snapshot
+  "Return the current `:active-modes` vector from the shell state.
+  Pure data → data when paired with the shell-state-atom deref."
+  []
+  (vec (or (:active-modes (state/get-state)) [])))
+
+(defn- mode-args
+  "Lookup the `:args` map for `mode-id`, or `{}` if the mode is
+  unregistered. Mirrors `re-frame.story.args/mode-args` (private)."
+  [mode-id]
+  (or (:args (registrar/handler-meta :mode mode-id)) {}))
+
+(defn active-args-snapshot
+  "Return the deep-merged `:args` from every active mode, in the order
+  the modes were activated. Mirrors `re-frame.story.args/resolve-args`'
+  modes-layer composition. Pure data → data."
+  []
+  (args/deep-merge-all (map mode-args (active-modes-snapshot))))
+
+(defn install-canonical-cofx!
+  "Register the three canonical Story cofx + the matching subs. Per
+  spec/010 §`with-mode` accessor:
+
+  - `:story/active-modes` — vector of mode ids currently active.
+  - `:story/active-args`  — deep-merge of all active modes' `:args`.
+
+  Both back off `re-frame.story.ui.state/shell-state-atom` — the same
+  slot the chrome-level toolbar writes."
+  []
+  (rf/reg-cofx
+    :story/active-modes
+    (fn [coeffects _]
+      (assoc coeffects :story/active-modes (active-modes-snapshot))))
+
+  (rf/reg-cofx
+    :story/active-args
+    (fn [coeffects _]
+      (assoc coeffects :story/active-args (active-args-snapshot))))
+
+  ;; Subscriptions backed by the shell-state-atom. The atom is a
+  ;; Reagent ratom on CLJS, plain atom on JVM — deref participates in
+  ;; Reagent's signal graph in the browser, returns a snapshot value
+  ;; on the JVM (no reaction wrapper, matching spec/010's note).
+  (rf/reg-sub
+    :story/active-modes
+    (fn [_ _]
+      (vec (or (:active-modes @state/shell-state-atom) []))))
+
+  (rf/reg-sub
+    :story/active-args
+    (fn [_ _]
+      (active-args-snapshot))))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -1,6 +1,9 @@
 (ns re-frame.story.ui.controls
-  "Controls panel — args editor, mode picker, decorator toggles. Per
-  Stage 4 (rf2-ekai) IMPL-SPEC §4 + §9.4.
+  "Controls panel — args editor, decorator toggles. Per Stage 4
+  (rf2-ekai) IMPL-SPEC §4 + §9.4. Per rf2-xi9zk the per-variant mode
+  picker moved to the chrome-level toolbar
+  (`re-frame.story.ui.toolbar`); the controls panel keeps args /
+  decorator sections only.
 
   ## Args derivation
 
@@ -11,11 +14,6 @@
   handful of primitive forms — `:string` / `:int` / `:double` /
   `:boolean` / `:enum`. Deeper Malli walks land in Stage 6 alongside
   the design-tokens panel.
-
-  ## Mode picker
-
-  Renders every registered `:mode` as a toggle row. Toggling activates
-  the mode; the canvas re-runs with the new mode set on the next tick.
 
   ## Decorator toggles
 
@@ -215,34 +213,11 @@
                                state/clear-cell-overrides variant-id))}
         "reset overrides"])]))
 
-(defn mode-picker
-  "Render every registered mode as a toggle. Active modes are tracked
-  in the shell state's `:active-modes` vector — toggle adds/removes."
-  []
-  (let [shell  @state/shell-state-atom
-        modes  (registrar/handlers :mode)
-        active (set (:active-modes shell))]
-    [:div {:style (:section styles)}
-     [:div {:style (:section-h styles)} "Modes"]
-     (if (empty? modes)
-       [:div {:style (:empty styles)} "no modes registered"]
-       [:div {:style (:chip-row styles)}
-        (for [[mid _body] (sort-by key modes)]
-          ^{:key mid}
-          [:span {:style    (merge (:chip styles)
-                                   (when (contains? active mid)
-                                     (:chip-active styles)))
-                  :on-click
-                  (fn [_]
-                    (state/swap-state!
-                      (fn [s]
-                        (state/set-active-modes
-                          s
-                          (let [v (:active-modes s)]
-                            (if (some #(= % mid) v)
-                              (vec (remove #(= % mid) v))
-                              (conj v mid)))))))}
-           (str mid)])])]))
+;; rf2-xi9zk: the controls-panel `mode-picker` is **superseded** by the
+;; chrome-level toolbar (`re-frame.story.ui.toolbar`). Modes are
+;; chrome-wide now — not a per-variant controls section — so a chrome-
+;; level surface is the right home. The controls panel keeps args /
+;; decorator sections only.
 
 (defn decorator-list
   "Show the variant's resolved decorator stack. Stage 4 is read-only;
@@ -285,13 +260,14 @@
    "save layout as :Workspace.x/y"])
 
 (defn panel
-  "The full controls panel — args editor + mode picker + decorator
-  list + save-layout action."
+  "The full controls panel — args editor + decorator list + save-layout
+  action. Per rf2-xi9zk the per-variant mode-picker moved to the
+  chrome-level toolbar (`re-frame.story.ui.toolbar`); the controls
+  panel keeps args / decorator sections only."
   [variant-id]
   [:div {:style (:wrap styles)}
    (when variant-id
      [args-editor variant-id])
-   [mode-picker]
    (when variant-id
      [decorator-list variant-id])
    [save-layout-button]])

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -53,6 +53,7 @@
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
             [re-frame.story.ui.test-mode :as test-mode]
+            [re-frame.story.ui.toolbar :as toolbar]
             [re-frame.story.ui.trace :as trace]
             [re-frame.story.ui.workspace :as workspace]))
 
@@ -60,11 +61,16 @@
 
 (def ^:private styles
   {:root      {:display "flex"
-               :flex-direction "row"
+               :flex-direction "column"
                :height "100vh"
                :font-family "system-ui, sans-serif"
                :background "#1e1e1e"
                :color "#ddd"}
+   :body      {:display "flex"
+               :flex-direction "row"
+               :flex "1"
+               :min-height "0"
+               :overflow "hidden"}
    :main      {:display "flex"
                :flex-direction "column"
                :flex "1"
@@ -334,6 +340,11 @@
      :component-did-mount
      (fn [_]
        (when config/enabled?
+         ;; rf2-xi9zk: hydrate chrome-wide :active-modes from URL +
+         ;; localStorage before the first render of the toolbar /
+         ;; canvas. URL wins over localStorage per spec/010 §URL deep-
+         ;; link. Idempotent and one-shot.
+         (toolbar/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
@@ -346,9 +357,14 @@
      :reagent-render
      (fn []
        [:div {:style (:root styles)}
-        [sidebar/sidebar]
-        [main-pane]
-        [right-panel]
+        ;; rf2-xi9zk: chrome-level toolbar — horizontal strip above the
+        ;; three-pane row. Exposes every registered :mode as a toggle
+        ;; chip; selection writes the chrome-wide :active-modes slot.
+        [toolbar/toolbar-strip]
+        [:div {:style (:body styles)}
+         [sidebar/sidebar]
+         [main-pane]
+         [right-panel]]
         ;; rf2-381i: first-time help overlay + persistent re-open chip.
         ;; The chip lives in a fixed-position slot so it floats above the
         ;; right inspector pane regardless of which panels are visible.

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -99,6 +99,76 @@
   [state modes]
   (assoc state :active-modes (vec modes)))
 
+(defn- mode-axis
+  "Resolve `mode-id`'s `:axis` (if any) via the registrar. Pure data →
+  data; isolated as a helper so `toggle-mode` is trivially JVM-
+  testable (the helper consults the registrar; pass an explicit
+  `axis-fn` to bypass it in pure tests)."
+  [mode-id]
+  (:axis (registrar/handler-meta :mode mode-id)))
+
+(defn toggle-mode
+  "Toggle `mode-id` against the current `active-modes` vector. Honors
+  `:axis` semantics per spec/010 §Selection semantics — by axis:
+
+  - Currently active → deactivate (regardless of axis).
+  - Axis-grouped     → drop siblings sharing the axis, then add.
+  - Un-grouped       → multi-select, append.
+
+  Pure data → data; JVM-testable. The `axis-fn` arity injects the
+  axis-lookup for tests that don't want a live registrar.
+
+  Returns the new active-modes vector — caller is responsible for
+  writing it back via `set-active-modes`."
+  ([active-modes mode-id]
+   (toggle-mode active-modes mode-id mode-axis))
+  ([active-modes mode-id axis-fn]
+   (let [active (vec (or active-modes []))]
+     (cond
+       (some #(= % mode-id) active)
+       (vec (remove #(= % mode-id) active))
+
+       (some? (axis-fn mode-id))
+       (let [axis     (axis-fn mode-id)
+             siblings (set (filter
+                             (fn [mid] (= axis (axis-fn mid)))
+                             active))]
+         (conj (vec (remove siblings active)) mode-id))
+
+       :else
+       (conj active mode-id)))))
+
+(defn clear-active-modes
+  "Drop every active mode — implements the toolbar's `[reset]` action."
+  [state]
+  (assoc state :active-modes []))
+
+(defn group-modes-by-axis
+  "Build the toolbar's chip layout: `{axis [mode-id ...]}` for every
+  `:axis`-tagged mode plus an `::unaxed` bucket for axis-less modes.
+  Within each bucket the ids are sorted alphabetically. Pure data →
+  data; JVM-testable.
+
+  `id->body` is the `{mode-id → mode-body}` map from
+  `(registrar/handlers :mode)`. Returns a sorted-by-axis seq of
+  `[axis [mode-id ...]]` pairs — the `::unaxed` bucket always sorts
+  last so axis-tagged groups render left-to-right with the trailing
+  un-grouped chips on the right."
+  [id->body]
+  (let [axed   (->> id->body
+                    (filter (fn [[_ b]] (some? (:axis b))))
+                    (group-by (fn [[_ b]] (:axis b)))
+                    (map (fn [[axis pairs]]
+                           [axis (vec (sort (map first pairs)))]))
+                    (sort-by (fn [[axis _]] (str axis))))
+        unaxed (->> id->body
+                    (filter (fn [[_ b]] (nil? (:axis b))))
+                    (map first)
+                    sort
+                    vec)]
+    (cond-> (vec axed)
+      (seq unaxed) (conj [::unaxed unaxed]))))
+
 (defn set-cell-override
   "Set a single arg override for `variant-id`."
   [state variant-id arg-key value]

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -1,0 +1,328 @@
+(ns re-frame.story.ui.toolbar
+  "Chrome-level toolbar — the horizontal strip above the three-pane row
+  that exposes every registered `reg-mode` tuple as a toggle chip.
+
+  Per spec/010 (rf2-p0mv) Storybook 8's `theme` / `viewport` / `locale`
+  toolbar refactored to re-frame2 idioms: one registry (`:mode`), one
+  shell-state slot (`:active-modes`), one persistence key
+  (`re-frame.story/active-modes`), one URL deep-link key (`modes=`).
+
+  ## Surface
+
+  - `(toolbar-strip)`            — Reagent component; renders the
+                                   horizontal strip with chips per
+                                   registered mode + a `[reset]` button.
+  - `toggle-mode!`               — programmatic toggle for tests.
+  - `hydrate-modes-from-storage!`/`hydrate-modes-from-url!` — idempotent
+                                   one-shot hydrators run at shell
+                                   mount.
+  - `save-modes-to-storage!`     — persist after every change.
+
+  ## Selection semantics
+
+  Per spec/010 §Selection semantics — by axis the `:axis` slot on a
+  `reg-mode` body governs the chip's toggle behaviour:
+
+  - `:axis` present → single-select within axis. Toggling a mode in
+    `:axis :theme` deactivates any sibling tagged with the same axis
+    before adding the toggled mode.
+  - `:axis` absent → multi-select. Any subset can be active.
+
+  The pure logic lives in `re-frame.story.ui.state/toggle-mode` (JVM-
+  testable); this ns wires the impure surfaces — localStorage,
+  `js/window.location.search`, and the Reagent ratom — around it.
+
+  ## Persistence
+
+  Per spec/010 §Persistence — chrome-wide localStorage the toolbar's
+  selection is **chrome-wide** (one selection for the whole shell
+  instance). Persistence is a single localStorage key:
+
+      re-frame.story/active-modes → \"[:Mode.app/dark :Mode.app/mobile]\"
+
+  Stored as a `pr-str`-encoded vector of mode ids; `read-string` on
+  load. The URL deep-link (`?modes=...`) takes precedence over
+  localStorage on hydrate (last-shared wins over last-used).
+
+  Mode ids that no longer resolve at the registrar (stale storage after
+  a `reg-mode` rename) are silently dropped at hydrate time."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- localStorage --------------------------------------------------------
+
+(def ^:const ls-key
+  "Chrome-wide localStorage key for the active-modes vector. Spec/010
+  §Persistence — chrome-wide localStorage."
+  "re-frame.story/active-modes")
+
+(defn- safe-local-storage
+  "Return `js/window.localStorage` if available, otherwise nil. Mirrors
+  the defensive pattern in `mode-tabs` — private mode / file:// /
+  embedded contexts can throw on touch."
+  []
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (try (.-localStorage js/window)
+         (catch :default _ nil))))
+
+(defn load-modes-from-storage
+  "Read the persisted active-modes vector from localStorage. Returns
+  a vector of mode-id keywords on success, nil on missing /
+  unparseable. Pure: a `nil`-on-failure read."
+  []
+  (when-let [ls (safe-local-storage)]
+    (try
+      (let [raw (.getItem ls ls-key)]
+        (when (string? raw)
+          (let [parsed (edn/read-string raw)]
+            (when (and (vector? parsed)
+                       (every? keyword? parsed))
+              parsed))))
+      (catch :default _ nil))))
+
+(defn save-modes-to-storage!
+  "Persist `modes` (a vector of mode-id keywords) to localStorage.
+  Silently no-ops if storage is unavailable. Idempotent."
+  [modes]
+  (when-let [ls (safe-local-storage)]
+    (try (.setItem ls ls-key (pr-str (vec modes)))
+         (catch :default _ nil))))
+
+;; ---- URL deep-link -------------------------------------------------------
+
+(defn parse-modes-param
+  "Parse a `modes=` URL query-param value into a vector of mode-id
+  keywords. Each id arrives as `\"<ns>/<name>\"` (the canonical
+  `(name kw)` form share.cljc emits via `kw->str`) — split on `,` and
+  reconstruct via `keyword`. Pure data → data; JVM-testable.
+
+  Returns nil if `s` is blank, an empty vector if no ids parse."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (->> (str/split s #",")
+         (map str/trim)
+         (remove str/blank?)
+         (map (fn [part]
+                (if-let [slash (str/index-of part "/")]
+                  (keyword (subs part 0 slash) (subs part (inc slash)))
+                  (keyword part))))
+         vec)))
+
+(defn modes-from-current-url
+  "Extract the `modes=` deep-link from `js/window.location.search`, if
+  any. Returns a vector of mode-id keywords or nil. CLJS-only — the
+  pure parsing fn `parse-modes-param` does the heavy lifting and is
+  JVM-testable."
+  []
+  (when (exists? js/window)
+    (let [search (some-> js/window .-location .-search)]
+      (when (and (string? search) (seq search))
+        (try
+          (let [params (js/URLSearchParams. search)
+                raw   (.get params "modes")]
+            (when (some? raw)
+              (parse-modes-param raw)))
+          (catch :default _ nil))))))
+
+;; ---- registrar-pruning ---------------------------------------------------
+
+(defn prune-unregistered
+  "Drop mode ids from `modes` that no longer resolve at the
+  registrar (stale storage / share-URL pointing at a renamed mode).
+  Pure data → data; JVM-testable. `registered?` defaults to the live
+  registrar; tests may inject."
+  ([modes]
+   (prune-unregistered modes (fn [mid] (registrar/registered? :mode mid))))
+  ([modes registered?]
+   (vec (filter registered? (or modes [])))))
+
+;; ---- hydration -----------------------------------------------------------
+
+(defn hydrate-modes-from-storage!
+  "Seed the shell-state's `:active-modes` from localStorage on first
+  shell mount. Idempotent: only writes when the slot is the default
+  empty vector — so an already-populated state (deep-link, programmatic
+  test fixture) is never clobbered. Spec/010 §Persistence — chrome-wide
+  localStorage."
+  []
+  (let [shell @state/shell-state-atom]
+    (when (empty? (:active-modes shell))
+      (when-let [persisted (load-modes-from-storage)]
+        (let [pruned (prune-unregistered persisted)]
+          (when (seq pruned)
+            (state/swap-state! state/set-active-modes pruned)))))))
+
+(defn hydrate-modes-from-url!
+  "Seed the shell-state's `:active-modes` from the `?modes=...` query
+  param, if present. URL beats localStorage — spec/010 §URL deep-link
+  'last-shared wins over last-used'. Idempotent and one-shot at shell
+  mount."
+  []
+  (when-let [from-url (modes-from-current-url)]
+    (let [pruned (prune-unregistered from-url)]
+      (when (seq pruned)
+        (state/swap-state! state/set-active-modes pruned)))))
+
+(defn hydrate!
+  "One-shot hydration entry-point: URL takes precedence over storage.
+  Called from the shell's `:component-did-mount`. Spec/010 §URL deep-
+  link — already wired."
+  []
+  ;; URL first — clobbers localStorage on hydrate per spec/010.
+  (let [url-modes (modes-from-current-url)
+        pruned    (when (seq url-modes) (prune-unregistered url-modes))]
+    (if (seq pruned)
+      (state/swap-state! state/set-active-modes pruned)
+      (hydrate-modes-from-storage!))))
+
+;; ---- programmatic toggle -------------------------------------------------
+
+(defn toggle-mode!
+  "Flip `mode-id` in the active-modes vector + persist. Public so tests
+  / programmatic callers can drive the toolbar without going through
+  the DOM."
+  [mode-id]
+  (state/swap-state!
+    (fn [s]
+      (state/set-active-modes s (state/toggle-mode (:active-modes s) mode-id))))
+  (save-modes-to-storage! (:active-modes (state/get-state))))
+
+(defn reset-modes!
+  "Clear every active mode + persist. The toolbar's `[reset]` action."
+  []
+  (state/swap-state! state/clear-active-modes)
+  (save-modes-to-storage! []))
+
+;; ---- styling -------------------------------------------------------------
+;;
+;; Matches the existing controls-panel chip vocabulary + the mode-tabs
+;; strip's chrome register (rf2-2uwv contrast lock). Spec/010 §Visual
+;; style: `#252526` background, `#444` bottom border, 8/12px padding,
+;; 6px chip gap, 10/11px text.
+
+(def ^:private styles
+  {:strip       {:display        "flex"
+                 :align-items    "center"
+                 :gap            "10px"
+                 :padding        "6px 12px"
+                 :background     "#252526"
+                 :border-bottom  "1px solid #444"
+                 :font-family    "monospace"
+                 :font-size      "11px"
+                 :min-height     "32px"
+                 :box-sizing     "border-box"
+                 :flex-wrap      "wrap"}
+   :axis-label  {:font-size       "10px"
+                 :text-transform  "uppercase"
+                 :color           "#9a9a9a"
+                 :letter-spacing  "0.5px"
+                 :margin-right    "4px"}
+   :axis-group  {:display     "flex"
+                 :align-items "center"
+                 :gap         "4px"}
+   :chip-row    {:display   "flex"
+                 :gap       "4px"
+                 :flex-wrap "wrap"}
+   :chip        {:padding         "3px 8px"
+                 :background      "#37373d"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :max-width       "20em"
+                 :overflow        "hidden"
+                 :text-overflow   "ellipsis"
+                 :white-space     "nowrap"
+                 :user-select     "none"}
+   :chip-active {:background "#0e639c"
+                 :color      "white"}
+   :spacer      {:flex "1"}
+   :reset       {:padding       "3px 8px"
+                 :background    "transparent"
+                 :color         "#cccccc"
+                 :border        "1px solid #444"
+                 :border-radius "3px"
+                 :cursor        "pointer"
+                 :font-family   "monospace"
+                 :font-size     "10px"}
+   :empty       {:color       "#9a9a9a"
+                 :font-style  "italic"
+                 :font-size   "11px"}})
+
+;; ---- chip rendering ------------------------------------------------------
+
+(defn- truncate-label
+  "Spec/010 §Chip visual contract — chip label is `(str mode-id)`
+  truncated at 28 chars. The full id + `:doc` sits on `title=`."
+  [s]
+  (if (> (count s) 28)
+    (str (subs s 0 27) "…")
+    s))
+
+(defn chip
+  "Render a single chip for `mode-id`. Pure-hiccup view; click handler
+  delegates to `toggle-mode!`. Public so tests can introspect the
+  chip-level hiccup without driving the full strip."
+  [mode-id body active?]
+  [:button
+   {:style              (merge (:chip styles)
+                               (when active? (:chip-active styles)))
+    :role               "button"
+    :aria-pressed       (if active? "true" "false")
+    :title              (if-let [d (:doc body)]
+                          (str (pr-str mode-id) " — " d)
+                          (pr-str mode-id))
+    :data-toolbar-mode  (pr-str mode-id)
+    :on-click           (fn [_] (toggle-mode! mode-id))}
+   (truncate-label (pr-str mode-id))])
+
+(defn- axis-label
+  "Render the axis-group label. Pure-hiccup."
+  [axis]
+  [:span {:style (:axis-label styles)} (str/upper-case (name axis))])
+
+;; ---- public component ----------------------------------------------------
+
+(defn toolbar-strip
+  "Render the chrome-level toolbar strip. Reads
+  `(registrar/handlers :mode)` per render — newly-registered modes
+  appear immediately. Renders an empty-state placeholder when the
+  registry has no `:mode` entries.
+
+  Spec/010 §Placement in the shell chrome — the strip lives ABOVE the
+  three-pane row. Caller (`shell/shell`) wraps the strip in a
+  `<header role=\"toolbar\">` landmark — the strip itself is a plain
+  hiccup `<div>` so axe-core's region rule sees the landmark."
+  []
+  (let [shell  @state/shell-state-atom
+        active (set (:active-modes shell))
+        modes  (registrar/handlers :mode)
+        groups (state/group-modes-by-axis modes)]
+    [:header
+     {:style      (:strip styles)
+      :role       "toolbar"
+      :aria-label "Story modes"
+      :data-test  "story-toolbar"}
+     (if (empty? modes)
+       [:span {:style (:empty styles)} "no modes registered"]
+       (doall
+         (for [[axis ids] groups]
+           ^{:key (str axis)}
+           [:span {:style (:axis-group styles)}
+            (when (not= axis :re-frame.story.ui.state/unaxed)
+              [axis-label axis])
+            [:span {:style (:chip-row styles)}
+             (for [mid ids]
+               ^{:key mid}
+               [chip mid (get modes mid) (contains? active mid)])]])))
+     [:span {:style (:spacer styles)}]
+     (when (seq (:active-modes shell))
+       [:button
+        {:style     (:reset styles)
+         :data-test "story-toolbar-reset"
+         :on-click  (fn [_] (reset-modes!))}
+        "reset"])]))

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -1,0 +1,317 @@
+(ns re-frame.story.ui.toolbar-cljs-test
+  "Tests for the chrome-level toolbar (rf2-xi9zk).
+
+  Runs on both the JVM (cognitect.test-runner under `clojure -M:test`)
+  and the CLJS node-test build (shadow's `:node-test` target; ns-regexp
+  `cljs-test$` picks up this ns because its name ends in `cljs-test`).
+
+  ## Coverage layers
+
+  - **Pure data** (JVM + CLJS): `toggle-mode` axis semantics,
+    `group-modes-by-axis` layout, `parse-modes-param` URL parsing,
+    `prune-unregistered` registrar-pruning, schema additivity for the
+    new `:axis` slot.
+  - **CLJS-only side-effects**: localStorage round-trip via
+    `save-modes-to-storage!` + `load-modes-from-storage`,
+    `toggle-mode!` mutation against `shell-state-atom`, hydration
+    precedence (URL beats localStorage), the rendered hiccup carries
+    chip elements per registered mode."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.schemas :as schemas]
+            [re-frame.story.ui.state :as state]
+            #?@(:cljs [[re-frame.story.ui.cofx :as ui-cofx]
+                       [re-frame.story.ui.toolbar :as toolbar]])))
+
+#?(:cljs
+   (defn- browser?
+     "True when running in a context with a working `js/window.localStorage`.
+     Node-test (the shadow `:node-test` target) returns false; browser-
+     test returns true. Mirrors the gate in `story_help_cljs_test`."
+     []
+     (and (exists? js/window) (.-localStorage js/window))))
+
+;; The full `toolbar` ns is CLJS-only — it depends on `js/window`,
+;; `js/URLSearchParams`, and `localStorage`. The JVM arm of this test
+;; exercises the pure helpers that live in `state.cljc` (those run
+;; on both runtimes) and inlines duplicates of the pure parsing
+;; helpers below so the JVM corpus can exercise them without
+;; requiring the CLJS ns. The CLJS arm tests the live impure
+;; surfaces.
+
+#?(:clj
+   (defn ^:no-doc parse-modes-param-jvm
+     "JVM duplicate of `toolbar/parse-modes-param`. Tracks the live
+     CLJS impl byte-for-byte; if the live impl changes shape, this
+     copy must update."
+     [s]
+     (when (and (string? s) (seq (str/trim s)))
+       (->> (str/split s #",")
+            (map str/trim)
+            (remove str/blank?)
+            (map (fn [part]
+                   (if-let [slash (str/index-of part \/)]
+                     (keyword (subs part 0 slash) (subs part (inc slash)))
+                     (keyword part))))
+            vec))))
+
+#?(:clj
+   (defn ^:no-doc prune-unregistered-jvm
+     "JVM duplicate of `toolbar/prune-unregistered` (registered? arity)."
+     [modes registered?]
+     (vec (filter registered? (or modes [])))))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-all! []
+  (story/clear-all!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- pure: toggle-mode axis semantics -----------------------------------
+
+(deftest toggle-mode-flips-untagged
+  (testing "an un-axis-tagged mode toggles on / off multi-select"
+    ;; No axis-fn lookup — pass a constant nil so toggle-mode treats
+    ;; the mode as un-tagged.
+    (let [no-axis (fn [_] nil)]
+      (is (= [:Mode.app/x]
+             (state/toggle-mode [] :Mode.app/x no-axis)))
+      (is (= [:Mode.app/x :Mode.app/y]
+             (state/toggle-mode [:Mode.app/x] :Mode.app/y no-axis)))
+      (is (= [:Mode.app/y]
+             (state/toggle-mode [:Mode.app/x :Mode.app/y] :Mode.app/x no-axis))))))
+
+(deftest toggle-mode-single-select-within-axis
+  (testing "an axis-tagged mode evicts siblings sharing the axis"
+    (let [axis-fn (fn [mid]
+                    (case mid
+                      :Mode.theme/dark  :theme
+                      :Mode.theme/light :theme
+                      :Mode.theme/sepia :theme
+                      :Mode.vp/mobile   :viewport
+                      nil))]
+      ;; Start empty → add :dark → :theme axis has only :dark.
+      (is (= [:Mode.theme/dark]
+             (state/toggle-mode [] :Mode.theme/dark axis-fn)))
+      ;; :light displaces :dark because they share :theme.
+      (is (= [:Mode.theme/light]
+             (state/toggle-mode [:Mode.theme/dark]
+                                :Mode.theme/light axis-fn)))
+      ;; :sepia displaces :light.
+      (is (= [:Mode.theme/sepia]
+             (state/toggle-mode [:Mode.theme/light]
+                                :Mode.theme/sepia axis-fn)))
+      ;; Adding :mobile (different axis) coexists with :sepia.
+      (is (= [:Mode.theme/sepia :Mode.vp/mobile]
+             (state/toggle-mode [:Mode.theme/sepia]
+                                :Mode.vp/mobile axis-fn)))
+      ;; Toggling :sepia OFF (already active) just removes it.
+      (is (= [:Mode.vp/mobile]
+             (state/toggle-mode [:Mode.theme/sepia :Mode.vp/mobile]
+                                :Mode.theme/sepia axis-fn))))))
+
+(deftest toggle-mode-resolves-axis-via-registrar
+  (testing "the 2-arity (no axis-fn) resolves via the live registrar"
+    (story/reg-mode :Mode.t/dark  {:axis :theme :args {:theme :dark}})
+    (story/reg-mode :Mode.t/light {:axis :theme :args {:theme :light}})
+    (is (= [:Mode.t/dark]  (state/toggle-mode [] :Mode.t/dark)))
+    (is (= [:Mode.t/light] (state/toggle-mode [:Mode.t/dark]
+                                              :Mode.t/light)))))
+
+(deftest clear-active-modes-empties
+  (testing "clear-active-modes drops every entry"
+    (is (= []
+           (:active-modes
+             (state/clear-active-modes {:active-modes
+                                        [:Mode.a/x :Mode.a/y]}))))))
+
+;; ---- pure: schema additivity --------------------------------------------
+
+(deftest mode-schema-accepts-axis
+  (testing ":rf/mode schema accepts the optional :axis keyword"
+    (is (nil? (schemas/validate :mode {:args {:theme :dark}}))
+        "no axis: still valid")
+    (is (nil? (schemas/validate :mode {:axis :theme
+                                       :args {:theme :dark}}))
+        "axis present: valid")
+    (is (some? (schemas/validate :mode {:axis "theme"
+                                        :args {:theme :dark}}))
+        "axis must be a keyword")))
+
+;; ---- pure: group-modes-by-axis ------------------------------------------
+
+(deftest group-modes-by-axis-orders
+  (testing "axis groups sort by axis-name; un-axis bucket lands last"
+    (let [groups (state/group-modes-by-axis
+                   {:Mode.vp/mobile {:axis :viewport}
+                    :Mode.t/dark    {:axis :theme}
+                    :Mode.t/light   {:axis :theme}
+                    :Mode.misc/x    {}
+                    :Mode.misc/a    {}})
+          axes   (mapv first groups)]
+      ;; :theme < :viewport alphabetically; un-axed bucket trails.
+      (is (= [:theme :viewport :re-frame.story.ui.state/unaxed] axes))
+      (is (= [:Mode.t/dark :Mode.t/light] (second (nth groups 0))))
+      (is (= [:Mode.vp/mobile]            (second (nth groups 1))))
+      (is (= [:Mode.misc/a :Mode.misc/x]  (second (nth groups 2)))))))
+
+(deftest group-modes-by-axis-no-unaxed-bucket-when-all-tagged
+  (testing "every mode tagged → no trailing unaxed bucket"
+    (let [groups (state/group-modes-by-axis
+                   {:Mode.t/dark  {:axis :theme}
+                    :Mode.t/light {:axis :theme}})]
+      (is (= [:theme] (mapv first groups))))))
+
+;; ---- pure: URL parsing --------------------------------------------------
+
+(deftest parse-modes-param-roundtrip
+  (testing "single qualified mode id"
+    (is (= [:Mode.app/dark]
+           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+             "Mode.app/dark"))))
+  (testing "comma-separated list of ids"
+    (is (= [:Mode.app/dark :Mode.app/mobile]
+           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+             "Mode.app/dark,Mode.app/mobile"))))
+  (testing "whitespace around commas survives"
+    (is (= [:Mode.app/a :Mode.app/b]
+           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+             " Mode.app/a , Mode.app/b "))))
+  (testing "blank input → nil"
+    (is (nil? (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+                "")))
+    (is (nil? (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+                "   "))))
+  (testing "unqualified ids parse without a namespace"
+    (is (= [:bare] (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
+                     "bare")))))
+
+;; ---- pure: prune-unregistered -------------------------------------------
+
+(deftest prune-unregistered-drops-stale
+  (testing "ids not present in the registrar are dropped"
+    (let [registered? #{:Mode.app/dark :Mode.app/light}]
+      (is (= [:Mode.app/dark]
+             (#?(:clj prune-unregistered-jvm :cljs toolbar/prune-unregistered)
+               [:Mode.app/dark :Mode.app/sepia] registered?))))))
+
+;; ---- CLJS-only: live toolbar surfaces ----------------------------------
+;;
+;; The localStorage / `js/window` surfaces only exist under CLJS.
+
+#?(:cljs
+   (deftest cljs-storage-roundtrip
+     (testing "save-modes-to-storage! + load-modes-from-storage round-trip"
+       (when (browser?)
+         (toolbar/save-modes-to-storage! [:Mode.app/dark :Mode.app/light])
+         (is (= [:Mode.app/dark :Mode.app/light]
+                (toolbar/load-modes-from-storage)))
+         (toolbar/save-modes-to-storage! [])
+         (is (= [] (toolbar/load-modes-from-storage)))))))
+
+#?(:cljs
+   (deftest cljs-toggle-writes-shell-state
+     (testing "toggle-mode! writes the new vector through to shell-state-atom"
+       (story/reg-mode :Mode.app/x {:args {:k 1}})
+       (story/reg-mode :Mode.app/y {:args {:k 2}})
+       (toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/x] (:active-modes (state/get-state))))
+       (toolbar/toggle-mode! :Mode.app/y)
+       (is (= [:Mode.app/x :Mode.app/y] (:active-modes (state/get-state))))
+       (toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/y] (:active-modes (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-axis-toggle-single-selects
+     (testing "an axis-tagged mode evicts siblings via toggle-mode!"
+       (story/reg-mode :Mode.t/dark  {:axis :theme :args {:t :dark}})
+       (story/reg-mode :Mode.t/light {:axis :theme :args {:t :light}})
+       (toolbar/toggle-mode! :Mode.t/dark)
+       (is (= [:Mode.t/dark] (:active-modes (state/get-state))))
+       (toolbar/toggle-mode! :Mode.t/light)
+       (is (= [:Mode.t/light] (:active-modes (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-reset-clears
+     (testing "reset-modes! drops every mode + persists empty"
+       (story/reg-mode :Mode.app/x {:args {:k 1}})
+       (toolbar/toggle-mode! :Mode.app/x)
+       (is (= [:Mode.app/x] (:active-modes (state/get-state))))
+       (toolbar/reset-modes!)
+       (is (= [] (:active-modes (state/get-state))))
+       (when (browser?)
+         (is (= [] (toolbar/load-modes-from-storage)))))))
+
+#?(:cljs
+   (deftest cljs-hydrate-from-storage-only-when-empty
+     (testing "hydrate skips when the slot is already populated"
+       (when (browser?)
+         (story/reg-mode :Mode.app/x {:args {}})
+         (story/reg-mode :Mode.app/y {:args {}})
+         (toolbar/save-modes-to-storage! [:Mode.app/x])
+         (state/swap-state! state/set-active-modes [:Mode.app/y])
+         (toolbar/hydrate-modes-from-storage!)
+         (is (= [:Mode.app/y] (:active-modes (state/get-state)))
+             "non-empty slot is preserved")))))
+
+#?(:cljs
+   (deftest cljs-hydrate-from-storage-prunes-stale
+     (testing "hydrate drops mode ids not in the registrar"
+       (when (browser?)
+         (story/reg-mode :Mode.app/x {:args {}})
+         (toolbar/save-modes-to-storage! [:Mode.app/x :Mode.app/zzz])
+         (toolbar/hydrate-modes-from-storage!)
+         (is (= [:Mode.app/x] (:active-modes (state/get-state))))))))
+
+#?(:cljs
+   (deftest cljs-toolbar-strip-renders-chip-per-mode
+     (testing "every registered mode produces a chip with a data-toolbar-mode attr"
+       (story/reg-mode :Mode.a/x {:args {}})
+       (story/reg-mode :Mode.a/y {:args {}})
+       ;; toolbar-strip yields a Reagent component tree; chip nodes
+       ;; appear as `[chip ...]` references that React resolves on
+       ;; render. To assert the hiccup shape without driving React we
+       ;; invoke `chip` directly against the registered modes.
+       (let [body-x (story-registrar/handler-meta :mode :Mode.a/x)
+             body-y (story-registrar/handler-meta :mode :Mode.a/y)
+             attrs-x (second (toolbar/chip :Mode.a/x body-x false))
+             attrs-y (second (toolbar/chip :Mode.a/y body-y true))]
+         (is (= ":Mode.a/x" (:data-toolbar-mode attrs-x)))
+         (is (= ":Mode.a/y" (:data-toolbar-mode attrs-y)))
+         (is (= "false" (:aria-pressed attrs-x)))
+         (is (= "true"  (:aria-pressed attrs-y)))))))
+
+#?(:cljs
+   (deftest cljs-toolbar-strip-empty-state
+     (testing "toolbar-strip renders the no-modes placeholder when registry is empty"
+       (story-registrar/clear-kind! :mode)
+       (let [hiccup (toolbar/toolbar-strip)
+             flat   (->> (tree-seq coll? seq hiccup)
+                         (filter string?))]
+         (is (some #(re-find #"no modes registered" %) flat))))))
+
+;; ---- cofx + sub registration --------------------------------------------
+
+#?(:cljs
+   (deftest cljs-active-modes-sub-mirrors-state
+     (testing ":story/active-modes subscription tracks the shell-state atom"
+       (story/reg-mode :Mode.app/x {:args {:k 1}})
+       (toolbar/toggle-mode! :Mode.app/x)
+       ;; The pure snapshot helper mirrors the slot.
+       (is (= [:Mode.app/x]
+              (ui-cofx/active-modes-snapshot))))))
+
+#?(:cljs
+   (deftest cljs-active-args-deep-merges
+     (testing ":story/active-args deep-merges every active mode's :args"
+       (story/reg-mode :Mode.app/x {:args {:a 1 :nest {:p 1}}})
+       (story/reg-mode :Mode.app/y {:args {:b 2 :nest {:q 2}}})
+       (toolbar/toggle-mode! :Mode.app/x)
+       (toolbar/toggle-mode! :Mode.app/y)
+       (is (= {:a 1 :b 2 :nest {:p 1 :q 2}}
+              (ui-cofx/active-args-snapshot))))))


### PR DESCRIPTION
## Summary

- Implements the chrome-level toolbar from tools/story/spec/010-Toolbar.md (rf2-p0mv): a horizontal strip above the three-pane row exposing every registered `reg-mode` tuple as a toggle chip. Single-select-within-axis when `:axis` is present; multi-select otherwise.
- Adds the optional `:axis` keyword to the `:rf/mode` schema (additive — unchanged bodies remain valid); generalises `:story/mode` → `:story/active-modes` + `:story/active-args` cofx + subs, registered at `install-canonical-vocabulary!`.
- Wires localStorage persistence (`re-frame.story/active-modes`) plus URL deep-link hydration (`?modes=...`, URL beats storage). Deletes the controls-panel `mode-picker` — modes are chrome-wide now, not per-variant.

## Files

- New: `tools/story/src/re_frame/story/ui/toolbar.cljs`, `tools/story/src/re_frame/story/ui/cofx.cljc`, `tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc`.
- Updated: `re_frame/story.cljc` (install cofx), `schemas.cljc` (`:axis` slot), `ui/state.cljc` (`toggle-mode`, `clear-active-modes`, `group-modes-by-axis`), `ui/shell.cljs` (root layout + hydrate at mount), `ui/controls.cljs` (drop `mode-picker`).
- Example: `counter_with_stories/stories.cljs` adds `:Mode.app/sepia {:axis :theme}` to exercise single-select; Playwright section 8 retargeted at the toolbar with `[data-toolbar-mode]` + `[data-test="story-toolbar"]` / `…-reset` selectors.

## Test plan

- [x] `clojure -M:test` in `tools/story/` — 202 → 220 tests, 0 failures, 0 errors
- [x] `npm run test:cljs` — 674 tests, 0 failures
- [x] `npm run test:browser` — 674 tests, 0 failures
- [x] `npm run test:elision` — PASS (no sentinels regressed)
- [x] `npm run test:examples` — 25/25 PASS including `counter-with-stories` (toolbar section)
- [x] `mkdocs build --strict` — 119 pre-existing warnings, none added
- [x] Manual smoke: counter_with_stories renders the toolbar above the three panes; chips for `:Mode.app/{dark,light,sepia}` render; `:sepia` toggle (axis :theme) single-selects; `:dark`/`:light` multi-select; reset button clears.