### PR TITLE
feat(story): build-time static docs site — 'story build' produces a publishable HTML playground (rf2-8wgpm)

### DIFF
--- a/examples/reagent/counter_with_stories/story_static.cljs
+++ b/examples/reagent/counter_with_stories/story_static.cljs
@@ -1,0 +1,56 @@
+(ns counter-with-stories.story-static
+  "Static-export entry point — per tools/story/spec/013-Static-Build.md
+  (rf2-8wgpm).
+
+  The canonical counter-with-stories example ships with two entry
+  points:
+
+  - `core.cljs` (build `:examples/counter-with-stories`) — the
+    development-flavoured hash-routed SPA. `#/` renders the live counter;
+    `#/stories` mounts the Story shell. This is what `shadow-cljs watch`
+    serves and what the Playwright spec drives.
+
+  - `story-static.cljs` (this ns; build `:story-static/counter-with-
+    stories`) — the **static-export entry point**. Mounts the Story
+    shell directly (no hash routing, no live-counter view). The build
+    runs under `:advanced` + `:closure-defines
+    {re-frame.story.config/static-mode? true}` so the shell drops its
+    dev-time affordances (registrar-fingerprint poll, first-visit help
+    auto-open) and the bundle is suitable for publishing to GitHub
+    Pages / Netlify / S3.
+
+  Per the rf2-8wgpm bead this entry-point is the sanity-test rig for the
+  `story:build` invocation; the published bundle for the canonical
+  counter-with-stories example is the artefact a downstream consumer
+  can clone, point at their own stories ns, and re-run."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Source the stories ns so all `reg-*` calls fire on namespace
+            ;; load. The variant bodies reference views / events / subs by
+            ;; id; the stories ns transitively requires them.
+            [counter-with-stories.stories]))
+
+(defn ^:export run
+  "Mount the Story shell at `#app`. Idempotent on hot-reload (which
+  doesn't happen under `release` builds, but the path is correct under
+  `compile` too)."
+  []
+  (rf/init! reagent-adapter/adapter)
+  ;; Install the seven canonical tags + lifecycle machine + assertions
+  ;; + force-fx-stub decorator + layout-debug trio + canonical cofx +
+  ;; Reagent multi-substrate + v1.0 panel set. Idempotent.
+  (story/install-canonical-vocabulary!)
+  ;; Story global configuration — pinned defaults a published docs site
+  ;; can ship with. Locale defaults to :en; the editor preference
+  ;; doesn't matter because the open-in-editor affordance is dev-only
+  ;; (file:// hrefs in a published site are not actionable).
+  (story/configure! {:global-args {:locale :en}})
+  ;; Seed the live-app's :count slot so any embedded `counter-card`
+  ;; view that renders under the variant canvas starts from a
+  ;; deterministic value rather than `nil`.
+  (rf/dispatch-sync [:counter/initialise 5])
+  ;; Mount the Story shell directly onto `#app`. No hash routing — this
+  ;; ns is the static-export entry only, the SPA lives in core.cljs.
+  (story/mount-shell! (js/document.getElementById "app")))

--- a/examples/reagent/counter_with_stories/story_static.index.html
+++ b/examples/reagent/counter_with_stories/story_static.index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>counter-with-stories — re-frame2 Story (static)</title>
+  <meta name="description" content="Static export of the re-frame2-story playground for the canonical counter-with-stories example. Published via `npm run story:build` (rf2-8wgpm).">
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: #1e1e1e; }
+    #app { height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -21,6 +21,8 @@
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:bundle-isolation": "shadow-cljs release examples/counter && node scripts/check-bundle-isolation.cjs",
     "test:bundle-comparison": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-counter-slim-and-fast.cjs",
-    "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs"
+    "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
+    "story:build": "node scripts/story-build.cjs",
+    "test:story-static": "node scripts/check-story-static.cjs"
   }
 }

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/*
+ * Story static-export sanity check (rf2-8wgpm).
+ *
+ * 1. Runs `story-build.cjs` to produce the static export at
+ *    `implementation/out/story-static/counter-with-stories/`.
+ * 2. Serves the output directory via http-server on port 8040.
+ * 3. Drives a headless Chromium against http://127.0.0.1:8040/ and
+ *    verifies the Story shell mounted (the canonical "Select a variant
+ *    or workspace" placeholder is rendered, and the chrome landmarks
+ *    are present).
+ * 4. Verifies the first-visit help overlay is suppressed (per
+ *    spec/013 §Static-mode runtime semantics — visitors arriving at a
+ *    published docs site don't get the dev-time onboarding modal).
+ * 5. Tears the server down.
+ *
+ * Mirrors the shape of `serve-and-run-browser-tests.cjs` so the
+ * orchestration is familiar to anyone who's wired a per-build
+ * smoke spec.
+ */
+
+'use strict';
+
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const PORT = 8040;
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+const OUT_DIR = path.join(
+  IMPL_ROOT,
+  'out',
+  'story-static',
+  'counter-with-stories',
+);
+const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+  paths: [IMPL_ROOT],
+});
+const READY_TIMEOUT_MS = 30000;
+const POLL_MS = 200;
+
+function runBuild() {
+  // Use process.execPath directly without shell:true — on Windows the
+  // installed node.exe path commonly contains spaces ("Program Files"),
+  // which the shell wrapper splits on. Skipping `shell` keeps the
+  // argv pass-through verbatim.
+  const script = path.join(__dirname, 'story-build.cjs');
+  const result = spawnSync(process.execPath, [script], {
+    cwd: IMPL_ROOT,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error(`story-build.cjs failed (exit ${result.status})`);
+  }
+}
+
+function probe(port) {
+  return new Promise((resolve) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
+      (res) => {
+        res.resume();
+        resolve(res.statusCode != null);
+      },
+    );
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForReady(port, deadline) {
+  while (Date.now() < deadline) {
+    if (await probe(port)) return true;
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  return false;
+}
+
+async function smokeTest(baseUrl) {
+  let playwright;
+  try {
+    playwright = require('playwright');
+  } catch (e) {
+    throw new Error(
+      'playwright not installed — run `npm install --prefix implementation` first.',
+    );
+  }
+
+  const browser = await playwright.chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(`console.error: ${msg.text()}`);
+  });
+
+  try {
+    await page.goto(baseUrl, { waitUntil: 'load', timeout: 30000 });
+
+    // The shell renders the "Select a variant or workspace" placeholder
+    // when no variant / workspace is selected. The Story chrome lands
+    // around it: the sidebar lists the four counter variants + two
+    // workspaces.
+    await page
+      .getByText(/Select a variant or workspace from the sidebar/i, { exact: false })
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    // Three landmarks (nav / main / aside) — same shape as the dev-mode
+    // shell. Static-mode flips the dev-time affordances OFF; the chrome
+    // structure is identical.
+    await page.getByRole('navigation').waitFor({ state: 'visible', timeout: 5000 });
+    await page.getByRole('main').waitFor({ state: 'visible', timeout: 5000 });
+    await page
+      .getByRole('complementary')
+      .waitFor({ state: 'visible', timeout: 5000 });
+
+    // The chrome-level toolbar renders. Per spec/010 the strip emits
+    // `data-test="story-toolbar"`.
+    await page
+      .locator('[data-test="story-toolbar"]')
+      .waitFor({ state: 'visible', timeout: 5000 });
+
+    // First-visit help overlay must be SUPPRESSED in static mode (per
+    // spec/013 §Static-mode runtime semantics). The dev-mode shell pops
+    // a `role="dialog" aria-modal="true"` overlay on first paint; the
+    // static-mode shell does not. We assert the overlay is absent ~1s
+    // after first paint (enough for any `component-did-mount` race).
+    await new Promise((r) => setTimeout(r, 1000));
+    const dialogCount = await page.getByRole('dialog').count();
+    if (dialogCount > 0) {
+      throw new Error(
+        `expected the first-visit help overlay to be suppressed in static mode, found ${dialogCount} dialog(s)`,
+      );
+    }
+
+    // Click a variant from the sidebar — the canvas re-renders with
+    // that variant's title, proving the registry survived `:advanced`
+    // compilation and the dispatch / subscription path is wired.
+    const navRow = page
+      .getByRole('navigation')
+      .getByText('/empty', { exact: false })
+      .first();
+    await navRow.waitFor({ state: 'visible', timeout: 10000 });
+    await navRow.click();
+    await page
+      .getByText(':story.counter/empty', { exact: false })
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
+
+    if (consoleErrors.length > 0) {
+      console.warn('console errors observed (non-fatal):');
+      for (const e of consoleErrors) console.warn('  ' + e);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+(async () => {
+  // 1. Build.
+  runBuild();
+
+  // 2. Sanity-check the on-disk shape — the build script writes
+  //    index.html + main.js + manifest.json next to a `cljs-runtime/`
+  //    directory.
+  for (const required of ['index.html', 'main.js', 'manifest.json']) {
+    const p = path.join(OUT_DIR, required);
+    if (!fs.existsSync(p)) {
+      console.error(`Build output missing ${required} at ${p}`);
+      process.exit(1);
+    }
+  }
+
+  // 3. Serve.
+  const server = spawn(
+    process.execPath,
+    [HTTP_SERVER_BIN, OUT_DIR, '-p', String(PORT), '-s', '-c-1'],
+    { cwd: IMPL_ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
+  );
+
+  let serverDown = false;
+  server.on('exit', (code, signal) => {
+    serverDown = true;
+    if (code !== 0 && code !== null) {
+      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  if (!ready || serverDown) {
+    console.error(
+      `http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`,
+    );
+    if (!serverDown) server.kill();
+    process.exit(1);
+  }
+
+  // 4. Smoke.
+  let smokeError = null;
+  try {
+    await smokeTest(`http://127.0.0.1:${PORT}/`);
+    console.log('story-static smoke passed.');
+  } catch (err) {
+    smokeError = err;
+    console.error('story-static smoke failed:', err.message || err);
+  }
+
+  // 5. Tear down.
+  if (!serverDown) {
+    server.kill();
+  }
+  process.exit(smokeError ? 1 : 0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/implementation/scripts/story-build.cjs
+++ b/implementation/scripts/story-build.cjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/*
+ * `story:build` — the Story static-export driver (rf2-8wgpm).
+ *
+ * Per tools/story/spec/013-Static-Build.md the invocation:
+ *
+ *   1. Releases the `:story-static/counter-with-stories` shadow-cljs
+ *      build (`:advanced` compile, `:closure-defines` with
+ *      `re-frame.story.config/static-mode?` true).
+ *
+ *   2. Stages
+ *      examples/reagent/counter_with_stories/story_static.index.html as
+ *      `index.html` next to the bundled `main.js` so the output
+ *      directory is publishable as-is (the `:asset-path "."` means
+ *      every cljs_base / cljs-runtime sibling resolves relative to the
+ *      page, so the bundle works under any prefix).
+ *
+ *   3. Writes a `manifest.json` next to the bundle declaring the build
+ *      target, the source ns, and the bundle's intent so consumers /
+ *      downstream tooling can introspect without re-parsing the shadow
+ *      output.
+ *
+ * This is the canonical sanity-test rig for the static-export
+ * surface — the counter_with_stories example is the worked example
+ * the rest of the docs site points at. Downstream consumers point
+ * the same invocation at their own stories ns by:
+ *
+ *   - Adding a `:story-static/<their-app>` build to their shadow-cljs.edn
+ *     (mirroring the entry below).
+ *   - Adding their `<app>.story-static/run` ns that requires their
+ *     stories ns + calls `(story/install-canonical-vocabulary!)` +
+ *     `(story/mount-shell! (js/document.getElementById "app"))`.
+ *   - Re-running this script with `STORY_BUILD_TARGET=<their-target>`.
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// __dirname is <repo>/implementation/scripts. IMPL_ROOT is
+// <repo>/implementation; REPO_ROOT is <repo>.
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+
+// The build target the driver compiles. Override via STORY_BUILD_TARGET
+// if the consumer has their own static-export build.
+const BUILD_TARGET =
+  process.env.STORY_BUILD_TARGET || 'story-static/counter-with-stories';
+
+// Match shadow-cljs's output-dir convention — `out/<build-target>/`
+// (note: shadow strips the leading `:` from the keyword and keeps the
+// slash). The driver computes this from the build target so a custom
+// target maps to a custom output directory automatically.
+const OUTPUT_DIR =
+  process.env.STORY_BUILD_OUTPUT_DIR ||
+  path.join(IMPL_ROOT, 'out', BUILD_TARGET);
+
+// The HTML source to stage as index.html. The canonical example is
+// the counter_with_stories story_static.index.html; override for
+// downstream apps.
+const HTML_SRC =
+  process.env.STORY_BUILD_INDEX_HTML ||
+  path.join(
+    REPO_ROOT,
+    'examples',
+    'reagent',
+    'counter_with_stories',
+    'story_static.index.html',
+  );
+
+function release() {
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'npx.cmd' : 'npx';
+  const args = ['shadow-cljs', 'release', BUILD_TARGET];
+  console.log(`> ${cmd} ${args.join(' ')}`);
+  const result = spawnSync(cmd, args, {
+    cwd: IMPL_ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+  });
+  if (result.status !== 0) {
+    throw new Error(`shadow-cljs release ${BUILD_TARGET} failed (exit ${result.status})`);
+  }
+}
+
+function stageIndexHtml() {
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    throw new Error(`Build output dir missing: ${OUTPUT_DIR}`);
+  }
+  if (!fs.existsSync(HTML_SRC)) {
+    throw new Error(`HTML source missing: ${HTML_SRC}`);
+  }
+  const dest = path.join(OUTPUT_DIR, 'index.html');
+  fs.copyFileSync(HTML_SRC, dest);
+  console.log(`Staged ${HTML_SRC} -> ${dest}`);
+}
+
+function writeManifest() {
+  const manifest = {
+    name: 're-frame2-story static export',
+    target: BUILD_TARGET,
+    bead: 'rf2-8wgpm',
+    spec: 'tools/story/spec/013-Static-Build.md',
+    sourceHtml: path.relative(REPO_ROOT, HTML_SRC).split(path.sep).join('/'),
+    builtAt: new Date().toISOString(),
+    closureDefines: {
+      're-frame.story.config/static-mode?': true,
+    },
+    publishable: true,
+  };
+  const dest = path.join(OUTPUT_DIR, 'manifest.json');
+  fs.writeFileSync(dest, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`Wrote manifest ${dest}`);
+}
+
+function summarise() {
+  const entries = fs.readdirSync(OUTPUT_DIR);
+  const sizes = entries.map((e) => {
+    const p = path.join(OUTPUT_DIR, e);
+    let size = 0;
+    try {
+      const stat = fs.statSync(p);
+      if (stat.isFile()) size = stat.size;
+    } catch (_) {
+      /* ignore */
+    }
+    return { name: e, size };
+  });
+  console.log('');
+  console.log(`Static-export output at ${OUTPUT_DIR}:`);
+  for (const { name, size } of sizes) {
+    console.log(`  ${name}${size ? ` (${size} bytes)` : ''}`);
+  }
+  console.log('');
+  console.log('Serve locally to verify:');
+  console.log(
+    `  npx http-server "${OUTPUT_DIR.split(path.sep).join('/')}" -p 8040 -c-1 -s`,
+  );
+  console.log('  Then visit http://127.0.0.1:8040/');
+}
+
+function main() {
+  release();
+  stageIndexHtml();
+  writeManifest();
+  summarise();
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err.message || err);
+  process.exit(1);
+}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -477,6 +477,28 @@
    :asset-path "."
    :modules    {:main {:init-fn counter-with-stories.core/run}}}
 
+  ;; Story static-export build (rf2-8wgpm) — see
+  ;; tools/story/spec/013-Static-Build.md. Same source tree as
+  ;; :examples/counter-with-stories, but the entry-point is
+  ;; counter-with-stories.story-static/run (no hash routing, mounts the
+  ;; Story shell directly) and the bundle compiles with
+  ;; :closure-defines {re-frame.story.config/static-mode? true} so the
+  ;; shell drops its dev-time affordances (registrar-fingerprint poll,
+  ;; first-visit help auto-open).
+  ;;
+  ;; The `story:build` npm script (per
+  ;; tools/story/spec/013-Static-Build.md §Invocation) drives this build
+  ;; via `shadow-cljs release`, then stages
+  ;; examples/reagent/counter_with_stories/story_static.index.html as
+  ;; index.html so the output directory is publishable as-is to GitHub
+  ;; Pages / Netlify / S3.
+  :story-static/counter-with-stories
+  {:target           :browser
+   :output-dir       "out/story-static/counter-with-stories"
+   :asset-path       "."
+   :compiler-options {:closure-defines {re-frame.story.config/static-mode? true}}
+   :modules          {:main {:init-fn counter-with-stories.story-static/run}}}
+
   ;; Pattern-WebSocket worked example (rf2-yf97). Canonical worked
   ;; example for spec/Pattern-WebSocket.md — connection machine with
   ;; hierarchical :active parent, :invoke'd socket actor, :after

--- a/tools/story/spec/013-Static-Build.md
+++ b/tools/story/spec/013-Static-Build.md
@@ -1,0 +1,261 @@
+# Story — Build-Time Static Export
+
+> `story:build` — Story's equivalent of Storybook 8's `storybook build` /
+> Histoire's `histoire build` / Ladle's `ladle build`. Compiles the
+> playground to a static HTML directory the user publishes to GitHub
+> Pages, Netlify, Vercel, or raw S3. Implements rf2-8wgpm.
+
+## Why
+
+The dev-mode story shell mounts under `shadow-cljs watch` and expects a
+live JVM-backed compiler on the other end of the websocket — fine for
+development, useless for sharing the playground with a non-CLJS
+audience. SOTA peers (Storybook 8, Histoire, Ladle) all ship a
+build-time invocation that produces a self-contained, deployable
+HTML directory:
+
+- Bundled JS (advanced compile, gzip-friendly).
+- A static `index.html` that loads the bundle.
+- Optional per-story HTML deep-links / sitemap.
+
+`story:build` is the re-frame2 equivalent. It does **not** invent a new
+chrome — the published bundle renders the same shell `mount-shell!`
+already produces, minus the dev-time affordances that would either
+break or feel out of place on a static site.
+
+## Scope (v1.0)
+
+- **Single-page application.** The published bundle is an SPA — one
+  `index.html`, one `main.js`, one set of cljs-runtime siblings. The
+  story shell's existing in-memory selection state (sidebar, tag
+  filter, mode toolbar) drives navigation; visitors deep-link via the
+  share URL (per [`005-SOTA-Features.md`](005-SOTA-Features.md) §QR
+  code in share menu) rather than per-variant routes.
+- **Per-story HTML files deferred.** A future iteration may emit one
+  HTML file per variant for SEO / link-preview embedding (Storybook's
+  `--docs` mode equivalent). v1 keeps the surface narrow — the SPA
+  works under any static host without server-side rewrite rules.
+
+## Static-mode runtime semantics
+
+The shell honours a second compile-time flag —
+`re-frame.story.config/static-mode?` — alongside the existing
+`enabled?` gate from [`000-Vision.md`](000-Vision.md). When
+`static-mode?` is `true`:
+
+- **No registrar-fingerprint poll.** The shell's 500ms `setInterval`
+  that watches for `reg-*` mutations (per
+  [`003-Render-Shell.md`](003-Render-Shell.md) §Hot-reload trigger)
+  short-circuits at `start-hot-reload-poll!`. Under `:advanced` the
+  whole branch DCEs; the bundle never schedules the interval.
+- **First-visit help overlay suppressed.** The dev-time onboarding
+  modal that auto-opens for first-time visitors (per rf2-381i)
+  short-circuits its `component-did-mount` auto-open path. The
+  manual `?` chip still renders so on-demand help is reachable; the
+  modal just doesn't pop unprompted. Visitors arriving at a
+  published docs site already arrived with intent.
+- **Causa preload omitted.** The Causa devtools preload
+  (`day8.re-frame2-causa.preload`) is wired via shadow-cljs's
+  `:devtools/preloads` slot — which the documentation specifies
+  applies to `watch`/`compile` only, NOT `release`. The static-export
+  build is a `release`, so Causa rides out of the bundle by
+  construction; no flag-side gate is required.
+- **Shadow-cljs hot-reload connection elided.** `release` builds
+  don't include the websocket bridge to the dev server, so the bundle
+  is self-contained the moment it leaves the compiler. The
+  `static-mode?` flag is orthogonal — it gates Story-specific
+  dev-time behaviour, not shadow-cljs's infrastructure.
+
+The flag defaults to `false`; only the `story:build` invocation (or a
+custom downstream build mirroring its `:closure-defines`) sets it to
+`true`. On the JVM the flag is a plain `const` def of `false` so JVM
+tests always operate against the dev-flavoured branch.
+
+## Build target
+
+A new shadow-cljs build, mirroring the per-example pattern under
+[`implementation/shadow-cljs.edn`](../../../implementation/shadow-cljs.edn):
+
+```edn
+:story-static/counter-with-stories
+{:target           :browser
+ :output-dir       "out/story-static/counter-with-stories"
+ :asset-path       "."
+ :compiler-options {:closure-defines {re-frame.story.config/static-mode? true}}
+ :modules          {:main {:init-fn counter-with-stories.story-static/run}}}
+```
+
+The build target name uses the `story-static/<app-name>` prefix so
+shadow's output-dir convention nests the bundle under
+`out/story-static/<app-name>/`, separated from `out/examples/` where
+the dev-flavoured per-example builds land. Downstream consumers
+mirror the same shape for their own apps.
+
+The entry-point ns
+(`counter-with-stories.story-static`) is a small static-export
+companion to the example's `core.cljs` — it requires the same
+`stories.cljs` registrations, installs the canonical vocabulary, and
+mounts the shell directly via `(story/mount-shell! ...)`. No hash
+routing, no live-counter view; the published bundle exists to render
+the Story playground.
+
+## Invocation
+
+```bash
+# From implementation/
+npm run story:build
+```
+
+Driven by [`implementation/scripts/story-build.cjs`](../../../implementation/scripts/story-build.cjs).
+The script:
+
+1. Runs `shadow-cljs release story-static/counter-with-stories`.
+2. Stages
+   `examples/reagent/counter_with_stories/story_static.index.html` as
+   `index.html` next to the compiled `main.js`.
+3. Writes a small `manifest.json` next to the bundle declaring the
+   build target, the source HTML, the active closure-defines, and the
+   build timestamp — so downstream tooling can introspect the
+   artefact without re-parsing shadow's output.
+
+Overridable via environment variables for downstream apps with their
+own static-export build:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `STORY_BUILD_TARGET` | `story-static/counter-with-stories` | shadow-cljs build id |
+| `STORY_BUILD_OUTPUT_DIR` | `implementation/out/<target>/` | output directory |
+| `STORY_BUILD_INDEX_HTML` | `examples/reagent/counter_with_stories/story_static.index.html` | HTML to stage |
+
+## Output shape
+
+After `npm run story:build`:
+
+```
+implementation/out/story-static/counter-with-stories/
+├── index.html               # the host page (staged from story_static.index.html)
+├── main.js                  # the advanced-compiled bundle
+├── manifest.json            # build metadata
+├── cljs-runtime/            # shadow-cljs runtime siblings (advanced compile only)
+│   └── ...
+└── (assets staged by the shadow build, if any)
+```
+
+The directory is deployable as-is. Every relative `<script>` / asset
+reference resolves correctly under any URL prefix because the build
+sets `:asset-path "."` — the bundle's Closure runtime resolves siblings
+relative to the page, not the document root.
+
+## Sanity test
+
+```bash
+# From implementation/
+npm run test:story-static
+```
+
+Driven by [`implementation/scripts/check-story-static.cjs`](../../../implementation/scripts/check-story-static.cjs).
+The script:
+
+1. Runs `story-build.cjs` (compile + stage + manifest).
+2. Asserts `index.html`, `main.js`, `manifest.json` are all present.
+3. Spawns `http-server` over the output directory on port 8040.
+4. Drives headless Chromium against `http://127.0.0.1:8040/` and
+   verifies:
+   - The Story shell mounted (the placeholder "Select a variant or
+     workspace from the sidebar" text is rendered).
+   - The three landmarks (`<nav>` / `<main>` / `<aside>`) are present
+     and reachable by role.
+   - The chrome-level toolbar (`[data-test="story-toolbar"]`) is
+     rendered.
+   - The first-visit help overlay is **suppressed** (no
+     `role="dialog"` element appears within 1s of first paint).
+   - Clicking a variant in the sidebar updates the canvas with the
+     selected variant's title — proves the registry survived
+     `:advanced` compilation and dispatch / subscription paths work.
+5. Tears the server down.
+
+A single PASS / FAIL line is logged; non-zero exit on smoke failure.
+
+## Deploy targets
+
+The output directory is a vanilla static-asset bundle, so any
+host that serves arbitrary directories will do:
+
+- **GitHub Pages** — push the directory to a `gh-pages` branch (or
+  point Pages at `/docs/`). The `index.html` is the entry; everything
+  else resolves relative.
+- **Netlify / Vercel** — point at the output directory as the publish
+  root. No build command needed; the directory is already built.
+- **Cloudflare Pages** / **AWS Amplify** — same shape.
+- **Raw S3 + CloudFront** — `aws s3 sync out/story-static/<app>/
+  s3://<bucket>/ --delete`; set the default root object to
+  `index.html` on CloudFront so deep-links resolve.
+- **Local preview** — `npx http-server <output-dir> -p 8040 -c-1 -s`.
+
+No HTML preview hardening (no `<meta name="robots">` tweak, no
+CSP header injection, no asset versioning rewrite) is performed by
+`story:build`; the static export is the raw playground bundle and
+deploys verbatim. Consumers who want CSP / robots / cache rules layer
+those at the hosting layer (their `_headers` file under Netlify,
+their `staticwebapp.config.json` under Azure, etc.).
+
+## What gets bundled
+
+| Surface | Status |
+|---|---|
+| Story registrations (the four counter variants, two workspaces, three modes, one decorator, one panel) | bundled |
+| The seven canonical `:rf.assert/*` event handlers | bundled |
+| The canonical force-fx-stub decorator | bundled |
+| The layout-debug overlay trio | bundled |
+| The chrome-level toolbar + mode-tabs strip | bundled |
+| The a11y panel (axe-core lazy-load endpoint stays the same) | bundled |
+| The six-domino trace panel | bundled |
+| The scrubber + time-travel cross-reference | bundled |
+
+## What gets stripped
+
+| Surface | Why |
+|---|---|
+| `:devtools/preloads` (Causa preload) | `release` builds ignore the slot — Causa rides out by construction |
+| `shadow-cljs` websocket bridge | `release` builds don't include the dev-server connection |
+| Registrar-fingerprint poll (the 500ms `setInterval`) | gated on `(not static-mode?)`; DCEs under `:advanced` |
+| First-visit help overlay auto-open | gated on `(not static-mode?)` |
+| `goog.DEBUG`-keyed branches (trace listener emit, source-coord DOM stamp) | the rest of the framework's standard release-build elision still applies |
+
+## Downstream pattern
+
+A consumer publishing their own app's playground:
+
+1. Add a `<app>.story-static` ns mirroring
+   `counter_with_stories/story_static.cljs`. The body installs the
+   canonical vocabulary, applies any `configure!` defaults, and calls
+   `(story/mount-shell! (js/document.getElementById "app"))`.
+2. Add a `:story-static/<app>` shadow-cljs build mirroring
+   `:story-static/counter-with-stories`, pointing
+   `:init-fn` at `<app>.story-static/run` and setting
+   `:closure-defines {re-frame.story.config/static-mode? true}`.
+3. Add an `<app>.story_static.index.html` host page (a 12-line shim
+   mirroring `counter_with_stories/story_static.index.html`).
+4. Run `STORY_BUILD_TARGET=story-static/<app>
+   STORY_BUILD_INDEX_HTML=<path-to-shim>.html npm run story:build`.
+5. Publish `implementation/out/story-static/<app>/` to the host of
+   choice.
+
+## Cross-references
+
+- [`000-Vision.md`](000-Vision.md) §What re-frame2-story is — the
+  scope-setting read.
+- [`003-Render-Shell.md`](003-Render-Shell.md) §Hot-reload trigger —
+  the registrar-fingerprint poll the static-mode flag suppresses.
+- [`005-SOTA-Features.md`](005-SOTA-Features.md) §Production elision
+  — the `enabled?` flag (production-mode strip) this flag stacks
+  alongside.
+- [`010-Toolbar.md`](010-Toolbar.md) §URL deep-link — the
+  share-URL mechanism `:story-static` consumers rely on for
+  deep-linking variants without a per-variant HTML file.
+- [`examples/reagent/counter_with_stories/`](../../../examples/reagent/counter_with_stories/)
+  — the canonical worked example.
+- [`implementation/scripts/story-build.cjs`](../../../implementation/scripts/story-build.cjs)
+  — the build driver.
+- [`implementation/scripts/check-story-static.cjs`](../../../implementation/scripts/check-story-static.cjs)
+  — the sanity-test rig.

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -690,6 +690,22 @@
   ([variant-id]       (decorators/resolve-decorators variant-id))
   ([variant-id opts]  (decorators/resolve-decorators variant-id opts)))
 
+;; ---- rf2-8wgpm: static-mode? probe --------------------------------------
+
+(defn static-mode?
+  "Per tools/story/spec/013-Static-Build.md — return true iff Story is
+  running in static-export mode (the bundle was built via the
+  `story:build` invocation with `:closure-defines
+  {re-frame.story.config/static-mode? true}`).
+
+  Consumers don't normally need to consult this directly; the shell
+  itself flips its dev-time affordances (hot-reload poll, first-visit
+  help overlay auto-open) off when the flag is true. Surfaced here as
+  a public probe for tooling / examples that want to render a
+  'this is a published static site' badge or hide a dev-only link."
+  []
+  config/static-mode?)
+
 (def stage
   "Sentinel that names which Stage's surface is loaded.
 

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -45,6 +45,43 @@
            `:advanced`."
            true))
 
+;; ---- the static-export flag (rf2-8wgpm) ---------------------------------
+;;
+;; A second goog-define that flips Story's chrome into "static export"
+;; mode — the bundle is intended to be served as a publishable HTML
+;; playground (Storybook 8 / Histoire / Ladle's `story build` equivalent)
+;; rather than mounted under a live `shadow-cljs watch` dev session.
+;;
+;; In static mode the shell:
+;;   - Does NOT start the registrar-fingerprint hot-reload poll (no
+;;     dev-time registrations will land, so the 500ms setInterval is
+;;     wasted work and emits a periodic ratom-write that thrashes the
+;;     React tree).
+;;   - Suppresses the first-visit help overlay by default (visitors
+;;     arriving at a published docs site already know what they're
+;;     looking at; the overlay is a dev-time onboarding affordance).
+;;
+;; Causa preloads are already absent from `shadow-cljs release` builds
+;; (per shadow-cljs's docs on the :devtools key, `:preloads` is
+;; honoured by `watch`/`compile` but NOT by `release`), so no flag-side
+;; gate is required there.
+;;
+;; The flag is a CLJS-side `goog-define` defaulting to false; on the
+;; JVM it's a plain `def` because the JVM has no notion of a static
+;; export — JVM tests always see `static-mode?` as false.
+
+#?(:cljs (goog-define ^boolean static-mode?
+           ;; @define {boolean}
+           ;; Defaults to `false`. The `story:build` invocation (per
+           ;; tools/story/spec/013-Static-Build.md) sets this to true
+           ;; via :closure-defines so the shell drops its dev-time
+           ;; affordances.
+           false)
+   :clj  (def ^:const static-mode?
+           "JVM-side: never in static mode. JVM consumers always operate
+           in the development-flavoured branch."
+           false))
+
 ;; ---- macro-side access ---------------------------------------------------
 ;;
 ;; Macros emit code that checks the flag *at compile time* so the

--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -33,7 +33,8 @@
 
   Production builds with `re-frame.story.config/enabled?` false never
   reach this ns; Closure DCE drops the lot."
-  (:require [reagent.core :as r]))
+  (:require [reagent.core :as r]
+            [re-frame.story.config :as config]))
 
 ;; ---- localStorage flag --------------------------------------------------
 
@@ -308,7 +309,14 @@
        ;; Auto-open on first visit. Guarded so reseting / re-mounting
        ;; the shell mid-session (e.g. via hot-reload) doesn't pop the
        ;; modal again — only fires when no flag is persisted.
-       (when-not (seen?)
+       ;;
+       ;; Per rf2-8wgpm (static-build): suppress the auto-open in
+       ;; static-export mode. A visitor landing on a published docs
+       ;; site already arrived with intent; the dev-time onboarding
+       ;; overlay just gets in their way. The manual ? chip is still
+       ;; rendered so on-demand help remains reachable.
+       (when (and (not config/static-mode?)
+                  (not (seen?)))
          (reset! open? true)))
      :reagent-render
      (fn []

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -131,9 +131,16 @@
 (defonce ^:private hot-reload-poll-handle (atom nil))
 
 (defn- start-hot-reload-poll!
-  "Begin polling for fingerprint changes. v1 mechanism per Stage 4."
+  "Begin polling for fingerprint changes. v1 mechanism per Stage 4.
+
+  Per rf2-8wgpm (tools/story/spec/013-Static-Build.md): under
+  `re-frame.story.config/static-mode?` the registrar is frozen — no
+  dev-time `reg-*` mutations will land, so the 500ms poll is wasted
+  work that thrashes the React tree on every tick. Skip the poll
+  entirely; the shell renders against a stable registry."
   []
   (when (and config/enabled?
+             (not config/static-mode?)
              (nil? @hot-reload-poll-handle))
     (let [h (js/setInterval detect-and-tick! 500)]
       (reset! hot-reload-poll-handle h))))

--- a/tools/story/test/re_frame/story_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_cljs_test.cljs
@@ -29,6 +29,19 @@
   (testing "Story is enabled in this CLJS test build"
     (is (true? config/enabled?))))
 
+;; ---- static-mode? (rf2-8wgpm) -------------------------------------------
+
+(deftest static-mode-flag-defaults-false-in-cljs-test-build
+  (testing "re-frame.story.config/static-mode? defaults to false in the CLJS test build"
+    ;; Per tools/story/spec/013-Static-Build.md the goog-define defaults
+    ;; to false; only the `story:build` invocation (or a custom
+    ;; downstream build mirroring its :closure-defines) flips it true.
+    ;; The node-test build under shadow-cljs runs without overriding
+    ;; the define, so we expect the default-false branch here.
+    (is (false? config/static-mode?)))
+  (testing "the public probe (re-frame.story/static-mode?) reflects the flag"
+    (is (false? (story/static-mode?)))))
+
 ;; ---- macros emit working code -------------------------------------------
 
 (deftest cljs-smoke-reg-story-and-variant

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -377,6 +377,17 @@
   (testing "re-frame.story.config/enabled? is true at JVM-test time"
     (is (true? story-config/enabled?))))
 
+;; ---- static-mode? (rf2-8wgpm) ----------------------------------------
+
+(deftest static-mode-defaults-false-on-jvm
+  (testing "re-frame.story.config/static-mode? defaults to false on the JVM"
+    ;; Per tools/story/spec/013-Static-Build.md the JVM-side def is a
+    ;; plain const false — JVM consumers never operate in static mode
+    ;; (the flag exists for CLJS :advanced builds via :closure-defines).
+    (is (false? story-config/static-mode?)))
+  (testing "the public probe (re-frame.story/static-mode?) reflects the flag"
+    (is (false? (re-frame.story/static-mode?)))))
+
 ;; ---- Stage 6 contract check -----------------------------------------
 
 (deftest stage-marker


### PR DESCRIPTION
## Summary

- Adds Story's equivalent of Storybook 8's `storybook build` (also Histoire / Ladle's `build` invocation): `npm run story:build` compiles the Story playground to a static HTML directory deployable as-is to GitHub Pages, Netlify, Vercel, Cloudflare Pages, AWS Amplify, or raw S3.
- New compile-time flag `re-frame.story.config/static-mode?` (CLJS goog-define, default false) flips the shell into static-export mode — skips the 500ms registrar-fingerprint poll and suppresses the first-visit help overlay's auto-open. The manual `?` help chip still renders.
- New shadow-cljs build `:story-static/counter-with-stories` mirrors the per-example pattern; the canonical worked example doubles as the sanity-test rig. Downstream consumers point the same invocation at their own stories ns via `STORY_BUILD_TARGET=` / `STORY_BUILD_OUTPUT_DIR=` / `STORY_BUILD_INDEX_HTML=` env vars.
- `tools/story/spec/013-Static-Build.md` documents the build target, the static-mode runtime semantics, the output shape (`index.html` + `main.js` + `manifest.json` + `cljs-runtime/`), the deploy-target options, and the downstream consumer pattern.

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 203 tests / 584 assertions pass (adds JVM coverage for the `static-mode?` default-false invariant).
- [x] `npm run test:cljs` — 692 tests / 1730 assertions pass (adds CLJS coverage mirror).
- [x] `npm run test:browser` — 692 tests / 1762 assertions pass.
- [x] `npm run test:elision` — pre-existing sentinel-presence + sentinel-absent contracts continue to hold; the new flag does not perturb the bundle-isolation surface.
- [x] `npm run test:examples` — every example (counter-with-stories + 24 others) still passes its Playwright smoke.
- [x] `npm run story:build` — produces a deployable `out/story-static/counter-with-stories/` artefact (599 B index.html + 758 KB main.js + manifest.json + cljs-runtime siblings).
- [x] `npm run test:story-static` — the new sanity-test rig builds + serves + Playwright-smokes the published bundle; verifies the shell mounted, the three landmarks render, the toolbar appears, sidebar variant click updates the canvas, and the help overlay is suppressed.
- [ ] `mkdocs build --strict` — fails on two pre-existing warnings in `guide/21-stories.md` (broken links to `../../tools/story/spec/005-SOTA-Features.md` and `../../tools/story/spec/002-Runtime.md`); verified identical on bare `origin/main`, unrelated to this PR.