### PR TITLE
feat(causa): Time Travel scrubber panel — Phase 3 (rf2-t53ze)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -1,0 +1,366 @@
+(ns day8.re-frame2-causa.panels.time-travel
+  "Time Travel scrubber panel (Phase 3, rf2-t53ze).
+
+  Per `tools/causa/spec/002-Time-Travel.md` the panel is the scrubber-
+  shaped device for walking through epoch history without disturbing
+  the live runtime. The Phase 3 deliverable covers the timeline +
+  cursor + pin store + the two confirmed-rewind paths
+  (`reset-to-epoch` + `reset-to-pinned`).
+
+  ## Three layers
+
+    1. **The track** — a horizontal range slider over the target
+       frame's epoch history (oldest at the left). Dragging the
+       cursor fires `:rf.causa/select-epoch` (passive — per spec
+       §The passive-scrubbing rule; the runtime does not rebase).
+       `[` / `]` keyboard nav (arrow-key nudge) steps one slot
+       back / forward.
+
+    2. **The pins** — chips alongside the track. Each chip is a
+       4-tuple eagerly captured at pin time. Detached chips (epoch
+       aged out of the ring buffer) render with a dimmed marker
+       (per spec §Pins on the scrubber — 'the detached marker is
+       the visible signal that the pin out-lives the ring buffer').
+
+    3. **The buttons** — `Pin` captures the current selection with
+       a label; `Reset to current` calls `restore-epoch` against
+       the selected epoch; `Reset to pinned` calls
+       `reset-frame-db!` against the pin's `:frame-db` value
+       (per spec §Why reset-frame-db! not restore-epoch).
+
+  ## Pure hiccup
+
+  Same contract as the event-detail panel. The view never references
+  Reagent / UIx / Helix directly. The substrate adapter installed via
+  `rf/init!` handles the render. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`
+  — every `subscribe` / `dispatch` resolves to `:rf/causa`.
+
+  ## Helpers
+
+  All pure-data logic lives in `time_travel_helpers.cljc` for JVM
+  testability. This ns is the thin view-only wrapper."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.time-travel-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs) ---------------------------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- view atoms ----------------------------------------------------------
+;;
+;; The label input is local UI state — kept in a defonce atom so a
+;; hot-reload doesn't drop the user's in-progress label. The dispatch
+;; only fires on submit.
+
+(defonce ^:private label-input-atom (atom ""))
+
+(defn- read-label-input []
+  @label-input-atom)
+
+(defn- set-label-input! [v]
+  (reset! label-input-atom (or v "")))
+
+;; ---- sub-views -----------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when the target frame has no epoch history yet — usually
+  because no dispatch has run since the last reload, or because the
+  epoch artefact is not on the classpath. Per spec §Production
+  elision the panel still mounts in prod but renders this empty
+  state."
+  [target-frame]
+  [:div {:data-testid "rf-causa-time-travel-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   "No epoch history for "
+   [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+    (str target-frame)]
+   " yet. Trigger a dispatch in the host app and the scrubber will populate."])
+
+(defn- chip-view
+  "Render one pin chip. Attached chips (epoch still in history) get the
+  accent-violet marker; detached chips get a dimmed dashed marker
+  (per spec §Pins on the scrubber — the detached marker is the
+  visible signal that the pin out-lives the ring buffer).
+
+  Click → passive rebase via `:rf.causa/select-epoch`.
+  Reset button (right-click affordance lives behind the chip's action
+  menu in v1.1; Phase 3 ships the inline Reset button so the
+  end-to-end pin → reset path is testable now)."
+  [{:keys [pin attached] :as _chip-state}]
+  (let [{:keys [epoch-id label]} pin]
+    [:span {:data-testid (str "rf-causa-pin-chip-" (str epoch-id))
+            :style       {:display       "inline-flex"
+                          :align-items   "center"
+                          :gap           "6px"
+                          :padding       "2px 8px"
+                          :margin-right  "6px"
+                          :background    (:bg-3 tokens)
+                          :color         (if attached
+                                           (:text-primary tokens)
+                                           (:text-tertiary tokens))
+                          :border        (str "1px solid "
+                                              (if attached
+                                                (:border-default tokens)
+                                                (:border-subtle tokens)))
+                          :border-style  (if attached "solid" "dashed")
+                          :border-radius "10px"
+                          :font-family   sans-stack
+                          :font-size     "11px"}}
+     [:span {:style    {:color    (if attached
+                                    (:accent-violet tokens)
+                                    (:text-tertiary tokens))
+                        :cursor   "pointer"}
+             :on-click #(rf/dispatch [:rf.causa/select-epoch epoch-id])}
+      (str (if attached "●" "○") " " label)]
+     [:button {:data-testid (str "rf-causa-pin-reset-" (str epoch-id))
+               :on-click    #(rf/dispatch [:rf.causa/reset-to-pinned epoch-id])
+               :style       {:background    "transparent"
+                             :border        "none"
+                             :color         (:cyan tokens)
+                             :cursor        "pointer"
+                             :padding       "0 2px"
+                             :font-family   mono-stack
+                             :font-size     "10px"}
+               :title       "Reset frame-db to this pin"}
+      "↺"]
+     [:button {:data-testid (str "rf-causa-pin-remove-" (str epoch-id))
+               :on-click    #(rf/dispatch [:rf.causa/unpin epoch-id])
+               :style       {:background    "transparent"
+                             :border        "none"
+                             :color         (:text-tertiary tokens)
+                             :cursor        "pointer"
+                             :padding       "0 2px"
+                             :font-family   mono-stack
+                             :font-size     "10px"}
+               :title       "Remove pin"}
+      "✕"]]))
+
+(defn- chip-row
+  "Pin chips row. Hidden when no pins exist for the target frame."
+  [chip-states]
+  (when (seq chip-states)
+    (into [:div {:data-testid "rf-causa-time-travel-chips"
+                 :style       {:padding "8px 12px"
+                               :display "flex"
+                               :flex-wrap "wrap"
+                               :gap "4px"
+                               :border-bottom (str "1px solid " (:border-subtle tokens))}}]
+          (for [cs chip-states]
+            ^{:key (str (:epoch-id (:pin cs)))}
+            (chip-view cs)))))
+
+(defn- track-row
+  "The timeline + slider. The slider's position is bound to the
+  `:selected-index` of the composite — when the user drags, the
+  on-change fires `:rf.causa/select-epoch` against the stable
+  `:epoch-id` at the new slot (per Story's same rationale —
+  selection holds the id, not the index).
+
+  `[` / `]` keyboard nav routes through `on-key-down` on the slider —
+  per spec §The passive-scrubbing rule the keyboard nav is passive."
+  [{:keys [history selected-epoch-id selected-index] :as _data}]
+  (let [n        (count history)
+        max-idx  (max 0 (dec n))
+        cur-idx  (or selected-index max-idx)
+        on-step  (fn [delta]
+                   (when-let [new-id (h/step-epoch history selected-epoch-id delta)]
+                     (rf/dispatch [:rf.causa/select-epoch new-id])))]
+    [:div {:data-testid "rf-causa-time-travel-track"
+           :style       {:padding "12px"
+                         :display "flex"
+                         :align-items "center"
+                         :gap "10px"
+                         :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:button {:data-testid "rf-causa-time-travel-jump-oldest"
+               :on-click    #(when (seq history)
+                               (rf/dispatch
+                                 [:rf.causa/select-epoch
+                                  (:epoch-id (first history))]))
+               :title       "Jump to oldest"
+               :style       {:background  "transparent"
+                             :border      (str "1px solid " (:border-default tokens))
+                             :color       (:text-secondary tokens)
+                             :padding     "2px 6px"
+                             :border-radius "4px"
+                             :cursor      "pointer"
+                             :font-family mono-stack
+                             :font-size   "11px"}}
+      "◀◀"]
+     [:input {:data-testid "rf-causa-time-travel-slider"
+              :type        "range"
+              :min         0
+              :max         max-idx
+              :value       cur-idx
+              :style       {:flex 1}
+              :on-change   (fn [e]
+                             (let [idx (js/parseInt (.. e -target -value))]
+                               (when-let [eid (h/epoch-id-at-index history idx)]
+                                 (rf/dispatch [:rf.causa/select-epoch eid]))))
+              :on-key-down (fn [e]
+                             (case (.-key e)
+                               "[" (do (.preventDefault e) (on-step -1))
+                               "]" (do (.preventDefault e) (on-step  1))
+                               "ArrowLeft"  (do (.preventDefault e) (on-step -1))
+                               "ArrowRight" (do (.preventDefault e) (on-step  1))
+                               nil))}]
+     [:button {:data-testid "rf-causa-time-travel-jump-newest"
+               :on-click    #(when (seq history)
+                               (rf/dispatch
+                                 [:rf.causa/select-epoch
+                                  (:epoch-id (peek (vec history)))]))
+               :title       "Jump to newest"
+               :style       {:background  "transparent"
+                             :border      (str "1px solid " (:border-default tokens))
+                             :color       (:text-secondary tokens)
+                             :padding     "2px 6px"
+                             :border-radius "4px"
+                             :cursor      "pointer"
+                             :font-family mono-stack
+                             :font-size   "11px"}}
+      "▶▶"]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-family mono-stack
+                     :font-size "11px"
+                     :min-width "76px"
+                     :text-align "right"}}
+      (str (inc cur-idx) "/" n " epochs")]]))
+
+(defn- actions-row
+  "The pin + reset buttons. Pin uses a label input bound to a local
+  atom — submitting fires `:rf.causa/pin-current` with the resolved
+  selected-epoch-id + label. Reset to current uses restore-epoch via
+  the `:rf.causa.fx/restore-epoch` effect."
+  [{:keys [selected-epoch-id history cap-reached?] :as _data}]
+  (let [target-eid (or selected-epoch-id (h/newest-epoch-id history))
+        history-empty? (empty? history)]
+    [:div {:data-testid "rf-causa-time-travel-actions"
+           :style       {:padding "8px 12px"
+                         :display "flex"
+                         :align-items "center"
+                         :gap "8px"
+                         :border-bottom (str "1px solid " (:border-subtle tokens))
+                         :flex-wrap "wrap"}}
+     [:input {:data-testid "rf-causa-pin-label-input"
+              :type        "text"
+              :placeholder "pin label (optional)"
+              :value       (read-label-input)
+              :on-change   #(set-label-input! (.. % -target -value))
+              :style       {:flex "1 1 160px"
+                            :min-width "120px"
+                            :background  (:bg-3 tokens)
+                            :color       (:text-primary tokens)
+                            :border      (str "1px solid " (:border-default tokens))
+                            :border-radius "4px"
+                            :padding     "4px 8px"
+                            :font-family sans-stack
+                            :font-size   "12px"}}]
+     [:button {:data-testid "rf-causa-pin-current"
+               :disabled    (or history-empty? cap-reached?)
+               :on-click    #(when target-eid
+                               (rf/dispatch
+                                 [:rf.causa/pin-current target-eid
+                                  (read-label-input)])
+                               (set-label-input! ""))
+               :style       {:background  (if cap-reached?
+                                            (:bg-3 tokens)
+                                            (:accent-violet tokens))
+                             :color       (if cap-reached?
+                                            (:text-tertiary tokens)
+                                            "#fff")
+                             :border      "none"
+                             :padding     "4px 10px"
+                             :border-radius "4px"
+                             :cursor      (if cap-reached? "not-allowed" "pointer")
+                             :font-family sans-stack
+                             :font-size   "12px"
+                             :font-weight 600}}
+      "Pin"]
+     [:button {:data-testid "rf-causa-reset-to-epoch"
+               :disabled    (or history-empty? (nil? target-eid))
+               :on-click    #(rf/dispatch [:rf.causa/reset-to-epoch target-eid])
+               :style       {:background  "transparent"
+                             :color       (:text-secondary tokens)
+                             :border      (str "1px solid " (:border-default tokens))
+                             :padding     "4px 10px"
+                             :border-radius "4px"
+                             :cursor      "pointer"
+                             :font-family sans-stack
+                             :font-size   "12px"}}
+      "Reset to current"]
+     (when cap-reached?
+       [:span {:data-testid "rf-causa-pin-cap-warning"
+               :style       {:color (:yellow tokens)
+                             :font-family sans-stack
+                             :font-size "11px"}}
+        (str "Pin cap reached (" h/default-pin-cap "). Remove a pin to capture more.")])]))
+
+;; ---- public view --------------------------------------------------------
+
+(defn time-travel-view
+  "The Time Travel panel's root view. Subscribes to
+  `:rf.causa/time-travel` and renders the empty-state / track + chips
+  / actions stack."
+  []
+  (let [{:keys [target-frame history] :as data}
+        @(rf/subscribe [:rf.causa/time-travel])]
+    [:section {:data-testid "rf-causa-time-travel"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Time Travel"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "Scrub epoch history (passive). Rewind via "
+       [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+        "Reset to current"]
+       " or "
+       [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+        "Reset to pinned"]
+       ". Frame: "
+       [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+        (str target-frame)]]]
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if (empty? history)
+        (empty-state target-frame)
+        [:div
+         (track-row data)
+         (actions-row data)
+         (chip-row (:chip-states data))])]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
@@ -1,0 +1,312 @@
+(ns day8.re-frame2-causa.panels.time-travel-helpers
+  "Pure-data helpers for Causa's Time Travel scrubber panel
+  (Phase 3, rf2-t53ze).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `time_travel.cljs` touches Reagent ratoms and the
+  DOM (cursor drag, keyboard nudge, pin chip click handlers). The
+  *logic* — pin into a store, enforce cap, locate an epoch in a
+  history vector, derive cascade-ids for chips — is pure data → data.
+  Splitting that logic out into `.cljc` so it runs under the JVM unit-
+  test target (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
+
+  ## Pin shape — the 4-tuple
+
+  Per `tools/causa/spec/002-Time-Travel.md` §Pinned snapshots §What a
+  pin captures, a pin is the 4-tuple
+  `(epoch-id × frame-db-value × dispatch-id × user-label)` captured
+  eagerly at pin time:
+
+      {:epoch-id    <opaque>     ; :rf/epoch-record :epoch-id
+       :frame-db    <value>      ; :rf/epoch-record :db-after
+       :dispatch-id <int-or-nil> ; cascade root from :trace-events
+       :label       <string>}    ; user-supplied or pin-<n> default
+
+  ## Pin store shape
+
+  The store is per-frame: `{frame-id [pin-1 pin-2 ...]}`. A vector
+  preserves insertion order so chip rendering is stable. The cap is
+  per-frame (32 by default per spec §Pin store capacity); adding the
+  33rd drops the oldest with a `:pin-store-overflow` flag the view
+  reads to surface a toast.
+
+  ## Why not a set
+
+  Pins are equality-distinct on the 4-tuple (rename rewrites the
+  `:label` slot in-place, not via remove + add), so a vector with
+  ordered iteration is the right shape. Lookup by id is O(n) — fine
+  at the 32-pin cap.
+
+  ## Per spec — Lock 4
+
+  Pins are session-scoped (per spec §Session-scoped — pins do not
+  survive reload + DESIGN-RATIONALE.md Lock 4). The helpers here are
+  pure-data; the live store lives in the Causa frame's app-db, which
+  is itself memory-only (never written to localStorage / disk).
+  Refusing to persist sidesteps the corruption surface a partial
+  session-export would create."
+  (:require [clojure.string :as str]))
+
+;; ---- defaults ------------------------------------------------------------
+
+(def default-pin-cap
+  "Default per-frame pin cap. Per spec §Pin store capacity (32 chosen
+  empirically — '~10 surfaces a UI-density problem; 32 is the cliff at
+  which the user is using pins as session-export, which Lock #4 says
+  no'). Configurable via Settings → `pin-store-capacity` once Settings
+  ships (rf2-xxx); until then, callers may override via the 3-arity
+  form of `pin-snapshot`."
+  32)
+
+(def default-pin-label-prefix
+  "Default label prefix for unnamed pins (`pin-1`, `pin-2`, ...). Per
+  spec §What a pin captures — `:label` defaults to `pin-<n>`
+  (incrementing per session) if the user dismisses the label prompt."
+  "pin-")
+
+;; ---- pin construction ----------------------------------------------------
+
+(defn dispatch-id-from-epoch
+  "Walk an `:rf/epoch-record`'s `:trace-events` for the first
+  cascade-root `:dispatch-id` tag and return it; nil when no
+  dispatch-id-bearing event is present (synthetic epochs from
+  `reset-frame-db!` record `:trace-events []`).
+
+  Pure data → cascade-id-or-nil. Used both by `pin-from-epoch` (when
+  building a fresh pin) and `chip-state` (when deciding chip
+  presentation against the current history).
+
+  Mirrors `re-frame.story.ui.scrubber-xref/cascade-id-from-trace-events`
+  — same algebra, different home. Both walk `:trace-events` for
+  `:tags :dispatch-id` / `:tags :parent-dispatch-id`."
+  [epoch-record]
+  (some (fn [ev]
+          (or (get-in ev [:tags :dispatch-id])
+              (get-in ev [:tags :parent-dispatch-id])))
+        (:trace-events epoch-record)))
+
+(defn- next-default-label
+  "Return the next `pin-<n>` default label that does not collide with
+  any existing `pin-<k>` label in `pins`. Falls back to
+  `(count pins) + 1` when no existing pin matches the default pattern.
+
+  Per spec §What a pin captures — `:label` defaults to `pin-<n>`
+  (incrementing per session) if the user dismisses the label prompt."
+  [pins]
+  (let [pattern    (re-pattern (str "^" default-pin-label-prefix "(\\d+)$"))
+        used-nums  (->> pins
+                        (keep (fn [{:keys [label]}]
+                                (when (string? label)
+                                  (let [m (re-matches pattern label)]
+                                    (when m
+                                      #?(:clj  (Long/parseLong (second m))
+                                         :cljs (js/parseInt (second m) 10))))))))
+        next-n     (if (seq used-nums)
+                     (inc (apply max used-nums))
+                     (inc (count pins)))]
+    (str default-pin-label-prefix next-n)))
+
+(defn pin-from-epoch
+  "Build a fresh 4-tuple pin from an `:rf/epoch-record` + a `label`.
+  Pure data → pin map. The pin captures `:db-after` eagerly so the
+  pin survives ring-buffer age-out — Reset to pinned can still write
+  the value back via `reset-frame-db!` even after the epoch itself
+  has dropped off the scrubber.
+
+  Returns nil when `epoch-record` is nil (caller can no-op rather
+  than store a degenerate pin). A label of nil / blank-string yields
+  a `pin-<n>` default at pin-store insertion time (see `pin-snapshot`)."
+  [epoch-record label]
+  (when (some? epoch-record)
+    {:epoch-id    (:epoch-id epoch-record)
+     :frame-db    (:db-after epoch-record)
+     :dispatch-id (dispatch-id-from-epoch epoch-record)
+     :label       label}))
+
+;; ---- pin-store transitions (pure data → data) ----------------------------
+
+(defn- normalise-label
+  "If `label` is nil / blank, fall back to the next `pin-<n>` default
+  computed against `pins`. Otherwise return the original label."
+  [label pins]
+  (if (or (nil? label)
+          (and (string? label) (str/blank? label)))
+    (next-default-label pins)
+    label))
+
+(defn pin-snapshot
+  "Add `pin` to `store` under `frame-id`, enforcing the per-frame cap.
+
+  `store` shape: `{frame-id [pin-1 pin-2 ...]}`. Returns a map:
+
+      {:store        <updated-store>
+       :overflow?    <bool>            ; true when oldest pin was dropped
+       :dropped-pin  <pin-or-nil>      ; the pin removed, if any
+       :added-pin    <pin>}            ; the pin actually inserted
+
+  The :added-pin slot reflects the canonical pin shape — `:label` is
+  resolved to a `pin-<n>` default when the caller passed nil / blank.
+  Overflow drops the *oldest* pin (head of the vector) per spec §Pin
+  store capacity — 'Adding a 33rd pin drops the oldest pin with a
+  toast notification'.
+
+  Pure data → data. JVM-testable. `cap` defaults to `default-pin-cap`
+  (32); the 3-arity form lets Settings-bound overrides land without
+  rewriting every call site."
+  ([store frame-id pin]
+   (pin-snapshot store frame-id pin default-pin-cap))
+  ([store frame-id pin cap]
+   (let [existing      (vec (get store frame-id []))
+         canonical-pin (update pin :label normalise-label existing)
+         appended      (conj existing canonical-pin)
+         over?         (and (number? cap)
+                            (pos? cap)
+                            (> (count appended) cap))
+         dropped       (when over? (first appended))
+         final         (if over?
+                         (vec (rest appended))
+                         appended)]
+     {:store       (assoc store frame-id final)
+      :overflow?   (boolean over?)
+      :dropped-pin dropped
+      :added-pin   canonical-pin})))
+
+(defn unpin-snapshot
+  "Remove the pin at `epoch-id` from `store`'s entry for `frame-id`.
+  Pure data → updated-store. Returns `store` unchanged when no pin
+  matches.
+
+  Match is on `:epoch-id` — the 4-tuple's other slots are immutable
+  and the pin store rejects duplicates by id at insert time, so this
+  is the unambiguous remove key."
+  [store frame-id epoch-id]
+  (update store frame-id
+          (fn [pins]
+            (vec (remove (fn [pin] (= epoch-id (:epoch-id pin)))
+                         (or pins []))))))
+
+(defn rename-pin
+  "Rewrite the `:label` slot of the pin at `epoch-id` in `store` under
+  `frame-id`. The 4-tuple's other slots are immutable per spec
+  §Pin actions §Rename pin — rename rewrites only `:label`. Returns
+  the updated store; no-op when no pin matches."
+  [store frame-id epoch-id new-label]
+  (update store frame-id
+          (fn [pins]
+            (mapv (fn [pin]
+                    (if (= epoch-id (:epoch-id pin))
+                      (assoc pin :label new-label)
+                      pin))
+                  (or pins [])))))
+
+(defn pins-for-frame
+  "Return the pin vector for `frame-id`, or `[]` when none. Pure-data
+  accessor — useful both for tests and for the sub-projection that
+  flattens the per-frame map into the view's flat chip list."
+  [store frame-id]
+  (vec (get store frame-id [])))
+
+(defn find-pin
+  "Look up a pin in `store` by `frame-id` + `epoch-id`. nil when not
+  found. Used by the `:rf.causa/reset-to-pinned` event handler to
+  fetch the pin's `:frame-db` for `reset-frame-db!`."
+  [store frame-id epoch-id]
+  (some (fn [pin] (when (= epoch-id (:epoch-id pin)) pin))
+        (get store frame-id [])))
+
+;; ---- epoch / history navigation -----------------------------------------
+
+(defn find-epoch-in-history
+  "Return the `:rf/epoch-record` in `history` whose `:epoch-id` matches
+  `epoch-id`, or nil if absent. Pure data → record-or-nil.
+
+  Used by:
+    - the scrubber's 'click cascade → scroll-to' affordance (locate
+      the cascade's settling epoch in the history vector so the
+      scrubber cursor can rebase visually);
+    - the `:rf.causa/reset-to-epoch` event handler (assert the epoch
+      is still in the ring buffer before calling `restore-epoch`);
+    - the chip-state derivation (decide attached vs detached chip
+      rendering — a pin whose `:epoch-id` no longer appears in
+      `history` renders detached per spec §Pins on the scrubber)."
+  [history epoch-id]
+  (when (some? epoch-id)
+    (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
+          history)))
+
+(defn epoch-index-in-history
+  "Return the 0-based index of `epoch-id` in `history`, or nil when not
+  present. Used by the scrubber slider to set its position from the
+  selection without re-walking the history twice (once for the record,
+  once for the index)."
+  [history epoch-id]
+  (when (some? epoch-id)
+    (first
+      (keep-indexed
+        (fn [i r] (when (= epoch-id (:epoch-id r)) i))
+        history))))
+
+(defn epoch-id-at-index
+  "Return the `:epoch-id` at `idx` in `history`, or nil when out of
+  range. Used by the scrubber's slider on-change handler to translate
+  a slot-index to the stable :epoch-id (per the same rationale Story's
+  scrubber gives in `scrubber.cljs`: hold the stable id, not the slot
+  index, so ring-buffer eviction can't silently re-point selection)."
+  [history idx]
+  (when (and (integer? idx) (not (neg? idx)))
+    (:epoch-id (nth history idx nil))))
+
+(defn newest-epoch-id
+  "Return the `:epoch-id` of the newest record in `history`, or nil
+  when the vector is empty. The scrubber's per-frame re-bind on frame-
+  switch resets the cursor to this id (per spec §Cross-frame
+  scrubbing)."
+  [history]
+  (:epoch-id (peek (vec history))))
+
+(defn step-epoch
+  "Step `epoch-id`'s position in `history` by `delta` (an integer).
+  Returns the new `:epoch-id`, clamped to `[0 (dec (count history))]`.
+  When `epoch-id` is nil or absent from history, steps from the
+  newest epoch.
+
+  Used by the `[` / `]` keyboard nav (delta = -1 / +1) and `Shift+[`
+  / `Shift+]` (cascade-root step — out of scope for Phase 3 minimal
+  view; passthrough to per-epoch step is the safe placeholder)."
+  [history epoch-id delta]
+  (when (seq history)
+    (let [n      (count history)
+          cur    (or (epoch-index-in-history history epoch-id)
+                     (dec n))
+          target (max 0 (min (dec n) (+ cur (long delta))))]
+      (:epoch-id (nth history target nil)))))
+
+;; ---- pin chip projection -------------------------------------------------
+
+(defn chip-state
+  "Derive the per-chip presentation map for `pin` against the current
+  `history`. Pure data → data.
+
+  Returns:
+
+      {:pin      <pin>            ; full 4-tuple as stored
+       :attached <bool>           ; true iff :epoch-id is still in history
+       :index    <int-or-nil>     ; slot index in history when attached}
+
+  Per spec §Pins on the scrubber: detached chips (the pin's epoch
+  aged out of the ring buffer) still render — they keep `:frame-db`
+  so 'Reset to pinned' is still callable via `reset-frame-db!`."
+  [history pin]
+  (let [idx (epoch-index-in-history history (:epoch-id pin))]
+    {:pin      pin
+     :attached (some? idx)
+     :index    idx}))
+
+(defn chip-states
+  "Map `chip-state` over a vector of pins. Returns a vector of chip
+  presentation maps. Order preserved (insertion order matches the
+  pin-store vector)."
+  [history pins]
+  (mapv #(chip-state history %) pins))

--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -51,6 +51,14 @@
   ;; this sentinel suppresses re-registration on `:after-load`.
   (atom false))
 
+(defonce ^:private epoch-cb-registered?
+  ;; Idempotency sentinel for the epoch-callback registration. Same
+  ;; rationale as `trace-cb-registered?`. Phase 3 (rf2-t53ze) — the
+  ;; Time Travel panel needs a per-settle pump from
+  ;; `rf/register-epoch-cb!` into Causa's app-db so the scrubber's
+  ;; subscriptions re-fire when the framework appends an epoch.
+  (atom false))
+
 (defn register-trace-collector!
   "Register Causa's trace-collector callback under
   `:rf.causa/trace-collector`. Idempotent via the
@@ -63,11 +71,39 @@
                            trace-bus/collect-trace!))
   nil)
 
+(defn register-epoch-collector!
+  "Register Causa's epoch-settle pump under `:rf.causa/epoch-collector`.
+
+  On every drain-settle the framework's epoch artefact fires this
+  callback with the assembled `:rf/epoch-record`; the cb dispatches
+  `:rf.causa/epoch-recorded` into the `:rf/causa` frame so the
+  registry's event handler re-reads `rf/epoch-history` and pumps the
+  fresh snapshot into Causa's app-db. The scrubber's
+  `:rf.causa/epoch-history` sub then re-fires off the standard
+  app-db-write reactive path.
+
+  Idempotent via the `epoch-cb-registered?` sentinel. No-op when the
+  `day8/re-frame2-epoch` artefact is not on the classpath
+  (`rf/register-epoch-cb!` is itself a no-op in that case)."
+  []
+  (when (compare-and-set! epoch-cb-registered? false true)
+    (rf/register-epoch-cb! :rf.causa/epoch-collector
+      (fn [record]
+        ;; Wrap the dispatch in :rf/causa so the registry's handler
+        ;; writes to Causa's app-db, not the host's. The cb's record
+        ;; carries :frame — pass it as the dispatch arg so the
+        ;; handler can compare against its target-frame and skip
+        ;; updates for non-target frames.
+        (rf/with-frame :rf/causa
+          (rf/dispatch [:rf.causa/epoch-recorded (:frame record)])))))
+  nil)
+
 (defn reset-for-test!
-  "Reset the preload's idempotency sentinel so test fixtures can drive
+  "Reset the preload's idempotency sentinels so test fixtures can drive
   multiple load cycles. Test-only — never call from production code."
   []
   (reset! trace-cb-registered? false)
+  (reset! epoch-cb-registered? false)
   nil)
 
 ;; ---- side-effecting boot -------------------------------------------------
@@ -88,4 +124,5 @@
 (when interop/debug-enabled?
   (registry/register-causa-handlers!)
   (register-trace-collector!)
+  (register-epoch-collector!)
   (keybinding/attach!))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -37,10 +37,39 @@
     - `:rf.causa/select-dispatch-id`       event-db — set focused
     - `:rf.causa/clear-selected-dispatch-id` event-db — clear focus
 
+  ## Phase 3 scope (rf2-t53ze) — Time Travel panel
+
+  Adds the scrubber's wiring against the framework's epoch-history
+  surface. The panel's :selected-epoch-id holds the *view* selection
+  (per spec §The passive-scrubbing rule — scrubbing rebases panels;
+  rewind is opt-in). :pinned-snapshots is the per-frame pin store
+  (per spec §Pinned snapshots, Lock 4 session-scoped).
+
+    - `:rf.causa/epoch-history`            sub — :rf.causa/target-frame's history
+    - `:rf.causa/selected-epoch-id`        sub — view's selected epoch
+    - `:rf.causa/pinned-snapshots`         sub — vector of chip states
+    - `:rf.causa/time-travel`              sub — composite for the panel
+    - `:rf.causa/select-epoch`             event-db — set view selection (passive)
+    - `:rf.causa/clear-selected-epoch`     event-db — drop view selection
+    - `:rf.causa/pin-current`              event — eager-copy a pin
+    - `:rf.causa/unpin`                    event-db — drop a pin
+    - `:rf.causa/rename-pin`               event-db — rewrite a pin's :label
+    - `:rf.causa/reset-to-epoch`           event-fx — restore-epoch via fx
+    - `:rf.causa/reset-to-pinned`          event-fx — reset-frame-db! via fx
+
+  Two effects route the framework writes — `:rf.causa.fx/restore-epoch`
+  and `:rf.causa.fx/reset-frame-db!`. They are reg-fx'd thin
+  delegations to `rf/restore-epoch` / `rf/reset-frame-db!`. The
+  indirection lets test fixtures stub the writes and assert the
+  correct framework call site is reached (Reset to pinned uses
+  reset-frame-db!, not restore-epoch, per spec §Why reset-frame-db!
+  not restore-epoch).
+
   Subsequent panel beads add their own per-panel events / subs / fxs."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -49,6 +78,20 @@
   spec/007-UX-IA.md §The default landing view + §10 Lock 7. Exposed
   as a Var so the shell and tests share the source of truth."
   :event-detail)
+
+(def default-target-frame
+  "The host frame Causa's time-travel scrubber inspects by default.
+  Per spec/002-Time-Travel.md §Cross-frame scrubbing the scrubber is
+  per-frame — the frame picker (rf2-xxx, not Phase 3 scope) lets
+  the user pick a different host frame. Until that picker lands the
+  scrubber is hard-bound to :rf/default — the canonical host frame
+  per Tool-Pair §Frame naming.
+
+  Note this is the *host*'s frame, not :rf/causa — Causa's own
+  state (selection, pin store) lives in :rf/causa via the shell's
+  frame-provider; the *target* of restore-epoch / reset-frame-db! is
+  the host's :rf/default."
+  :rf/default)
 
 ;; ---- subscriptions -------------------------------------------------------
 
@@ -118,6 +161,73 @@
            :selected-dispatch-id selected-id
            :selected-cascade     by-id})))
 
+    ;; ---- Phase 3 (rf2-t53ze) — Time Travel scrubber subs ---------
+
+    ;; Target frame the scrubber inspects. Hard-bound to :rf/default
+    ;; until the frame picker (rf2-xxx) lands; the sub abstracts so
+    ;; the picker can drop in without rewiring every consumer.
+    (rf/reg-sub :rf.causa/target-frame
+      (fn [db _query]
+        (get db :target-frame default-target-frame)))
+
+    ;; Cached snapshot of the target frame's epoch history, pumped
+    ;; by `:rf.causa/epoch-recorded` (dispatched from the epoch-cb in
+    ;; preload). The cache is necessary because rf/epoch-history is a
+    ;; side-effecting read of the epoch artefact's atom — a sub fn
+    ;; can call it but the sub graph won't re-fire when the atom
+    ;; mutates. Routing history through Causa's app-db makes the sub
+    ;; reactive on its own write path.
+    (rf/reg-sub :rf.causa/epoch-history
+      (fn [db _query]
+        (get db :epoch-history [])))
+
+    ;; The view's currently-selected epoch — nil = newest (no scrub
+    ;; in flight). Per spec §The passive-scrubbing rule, scrubbing
+    ;; rebases panels but does NOT rewind app-db.
+    (rf/reg-sub :rf.causa/selected-epoch-id
+      (fn [db _query]
+        (get db :selected-epoch-id)))
+
+    ;; Per-frame pin store, keyed by target-frame. Persisted into
+    ;; Causa's app-db only — never localStorage / disk (Lock 4 per
+    ;; spec §Session-scoped — pins do not survive reload).
+    (rf/reg-sub :rf.causa/pin-store
+      (fn [db _query]
+        (get db :pin-store {})))
+
+    ;; The pin vector for the current target-frame — a flat sequence
+    ;; the view iterates. Decoupled from :rf.causa/pin-store so the
+    ;; view doesn't re-render when an unrelated frame's pins mutate.
+    (rf/reg-sub :rf.causa/pinned-snapshots
+      :<- [:rf.causa/pin-store]
+      :<- [:rf.causa/target-frame]
+      (fn [[pin-store target-frame] _query]
+        (tt-helpers/pins-for-frame pin-store target-frame)))
+
+    ;; Composite for the panel — one read produces every slot the
+    ;; view needs. Mirrors the Phase-2 `:rf.causa/event-detail`
+    ;; composite shape. The :chip-states projection runs chip-state
+    ;; over each pin against the current history so detached pins
+    ;; carry the visible signal per spec §Pins on the scrubber.
+    (rf/reg-sub :rf.causa/time-travel
+      :<- [:rf.causa/target-frame]
+      :<- [:rf.causa/epoch-history]
+      :<- [:rf.causa/selected-epoch-id]
+      :<- [:rf.causa/pinned-snapshots]
+      (fn [[target-frame history selected-id pins] _query]
+        (let [selected-record (when selected-id
+                                (tt-helpers/find-epoch-in-history
+                                  history selected-id))]
+          {:target-frame    target-frame
+           :history         history
+           :selected-epoch-id selected-id
+           :selected-record selected-record
+           :selected-index  (tt-helpers/epoch-index-in-history
+                              history selected-id)
+           :pins            pins
+           :chip-states     (tt-helpers/chip-states history pins)
+           :cap-reached?    (>= (count pins) tt-helpers/default-pin-cap)})))
+
     ;; ---- events --------------------------------------------------
     (rf/reg-event-db :rf.causa/select-panel
       (fn [db [_ panel-id]]
@@ -129,7 +239,114 @@
 
     (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
       (fn [db _event]
-        (dissoc db :selected-dispatch-id))))
+        (dissoc db :selected-dispatch-id)))
+
+    ;; ---- Phase 3 (rf2-t53ze) — Time Travel scrubber events -------
+
+    ;; Pump the latest epoch-history snapshot for the target frame
+    ;; into Causa's app-db. Dispatched from the epoch-cb registered
+    ;; in preload.cljs on every settled epoch. We don't pass the
+    ;; vector across the dispatch boundary — we re-read from the
+    ;; framework's `rf/epoch-history` so the snapshot is always
+    ;; consistent with the framework's view (the cb fires AFTER the
+    ;; record is appended; a stale arg would be off-by-one only on
+    ;; the boundary, but threading the live read keeps the contract
+    ;; simple).
+    (rf/reg-event-db :rf.causa/epoch-recorded
+      (fn [db [_ frame-id]]
+        (let [target (get db :target-frame default-target-frame)]
+          (if (= frame-id target)
+            (assoc db :epoch-history (vec (rf/epoch-history target)))
+            db))))
+
+    ;; Set the view's selected-epoch (passive scrub). Per spec §The
+    ;; passive-scrubbing rule — this DOES NOT call restore-epoch.
+    (rf/reg-event-db :rf.causa/select-epoch
+      (fn [db [_ epoch-id]]
+        (assoc db :selected-epoch-id epoch-id)))
+
+    (rf/reg-event-db :rf.causa/clear-selected-epoch
+      (fn [db _event]
+        (dissoc db :selected-epoch-id)))
+
+    ;; Pin the epoch at `epoch-id` under the current target-frame
+    ;; with `label`. The handler eagerly copies :db-after off the
+    ;; live history record (per spec §What a pin captures — eager
+    ;; capture). Enforces the 32-pin cap; surfaces `:overflow?` via
+    ;; the toast slot the view reads on next render.
+    (rf/reg-event-db :rf.causa/pin-current
+      (fn [db [_ epoch-id label]]
+        (let [target  (get db :target-frame default-target-frame)
+              history (vec (or (get db :epoch-history)
+                               (rf/epoch-history target)))
+              record  (tt-helpers/find-epoch-in-history history epoch-id)
+              pin     (tt-helpers/pin-from-epoch record label)]
+          (if (some? pin)
+            (let [{:keys [store overflow? dropped-pin]}
+                  (tt-helpers/pin-snapshot (get db :pin-store {})
+                                           target pin)]
+              (cond-> (assoc db :pin-store store)
+                overflow? (assoc :pin-overflow-toast
+                                 {:dropped-label (:label dropped-pin)
+                                  :ts            (.getTime (js/Date.))})))
+            db))))
+
+    ;; Drop a pin from the current target-frame's pin store.
+    (rf/reg-event-db :rf.causa/unpin
+      (fn [db [_ epoch-id]]
+        (let [target (get db :target-frame default-target-frame)]
+          (update db :pin-store
+                  tt-helpers/unpin-snapshot target epoch-id))))
+
+    ;; Inline-rename a pin's label. The 4-tuple's other slots are
+    ;; immutable (spec §Pin actions §Rename pin).
+    (rf/reg-event-db :rf.causa/rename-pin
+      (fn [db [_ epoch-id new-label]]
+        (let [target (get db :target-frame default-target-frame)]
+          (update db :pin-store
+                  tt-helpers/rename-pin target epoch-id new-label))))
+
+    ;; Dismiss the cap-reached toast surface.
+    (rf/reg-event-db :rf.causa/dismiss-pin-overflow-toast
+      (fn [db _] (dissoc db :pin-overflow-toast)))
+
+    ;; ---- write effects (the two confirmed-rewind paths) ----------
+
+    ;; Reset to current epoch — uses restore-epoch (the ring-buffer
+    ;; path). Per spec §The passive-scrubbing rule §rewind = explicit:
+    ;; this is the confirmed-rewind branch. Per re-frame v2's reg-fx
+    ;; contract (Spec API.md §reg-fx) the handler signature is
+    ;; (fn [ctx args] ...).
+    (rf/reg-fx :rf.causa.fx/restore-epoch
+      (fn [_ctx {:keys [frame-id epoch-id]}]
+        (rf/restore-epoch frame-id epoch-id)))
+
+    ;; Reset to pinned — uses reset-frame-db! (the value-direct path).
+    ;; Per spec §Why reset-frame-db! not restore-epoch — pins hold the
+    ;; value directly, so the rewind works even after the underlying
+    ;; epoch ages out of the ring buffer.
+    (rf/reg-fx :rf.causa.fx/reset-frame-db!
+      (fn [_ctx {:keys [frame-id frame-db]}]
+        (rf/reset-frame-db! frame-id frame-db)))
+
+    (rf/reg-event-fx :rf.causa/reset-to-epoch
+      (fn [{:keys [db]} [_ epoch-id]]
+        (let [target (get db :target-frame default-target-frame)]
+          ;; Per Spec MIGRATION §Effect map shape — re-frame2's canonical
+          ;; fx return is `{:db ... :fx [[fx-id args] ...]}`. Top-level
+          ;; effect keys other than :db / :fx are not part of the
+          ;; contract; the registered fx is invoked via the :fx vector.
+          {:fx [[:rf.causa.fx/restore-epoch
+                 {:frame-id target :epoch-id epoch-id}]]})))
+
+    (rf/reg-event-fx :rf.causa/reset-to-pinned
+      (fn [{:keys [db]} [_ epoch-id]]
+        (let [target (get db :target-frame default-target-frame)
+              pin    (tt-helpers/find-pin (get db :pin-store {})
+                                          target epoch-id)]
+          (when pin
+            {:fx [[:rf.causa.fx/reset-frame-db!
+                   {:frame-id target :frame-db (:frame-db pin)}]]})))))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -38,6 +38,7 @@
   `mount.cljs`. No per-substrate switches in view code."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
@@ -64,10 +65,11 @@
 
 (def ^:private sidebar-items
   "The sidebar's panel list. Per spec/007-UX-IA.md §Sidebar groups —
-  three groups, divider-separated. Phase 2 (rf2-op3bz) lights up
-  `:event-detail`; remaining items still render the Phase 1 stub when
-  selected (see `panel-view-for`)."
+  three groups, divider-separated. Phase 2 (rf2-op3bz) lit up
+  `:event-detail`; Phase 3 (rf2-t53ze) adds `:time-travel`. Remaining
+  items still render the Phase 1 stub when selected."
   [{:id :event-detail :label "Event detail" :bead "rf2-op3bz" :live? true}
+   {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
    {:id :app-db       :label "App-db"        :bead "rf2-xxx"}
    {:id :causality    :label "Causality"     :bead "rf2-xxx"}
    {:id :subs         :label "Subscriptions" :bead "rf2-xxx"}
@@ -109,7 +111,7 @@
     [:span {:style {:color       (:text-tertiary tokens)
                     :font-size   "12px"
                     :font-weight 400}}
-     "Phase 2 (rf2-op3bz)"]]
+     "Phase 3 (rf2-t53ze)"]]
    [:div {:style {:display "flex" :align-items "center" :gap "12px"
                   :color    (:text-secondary tokens)
                   :font-size "12px"
@@ -208,6 +210,7 @@
         item     (some #(when (= (:id %) selected) %) sidebar-items)]
     (case selected
       :event-detail [event-detail/event-detail-view]
+      :time-travel  [time-travel/time-travel-view]
       [stub-panel (or item {:label "Unknown panel"
                             :bead  "rf2-xxx"})])))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
@@ -1,0 +1,390 @@
+(ns day8.re-frame2-causa.panels.time-travel-cljs-test
+  "CLJS-side wiring tests for Causa's Time Travel scrubber panel
+  (Phase 3, rf2-t53ze).
+
+  ## Three contracts under test (in addition to the pure-data tests
+  in `time_travel_helpers_cljs_test.cljc`)
+
+  1. **Registry wires the subs / events** under the `:rf.causa/*`
+     namespace. The composite `:rf.causa/time-travel` sub returns the
+     panel's render data; the pin/unpin/select events write into
+     :rf/causa's app-db (not the host's).
+
+  2. **Reset-to-pinned uses reset-frame-db!**, NOT restore-epoch (per
+     spec/002-Time-Travel.md §Why reset-frame-db! not restore-epoch).
+     Asserted via stubbed `:rf.causa.fx/*` effects — the test fixture
+     captures the routed effect map and asserts that
+     `:rf.causa.fx/reset-frame-db!` fires (and `:rf.causa.fx/restore-
+     epoch` does NOT) when `:rf.causa/reset-to-pinned` is dispatched.
+
+  3. **Pins survive ring-buffer eviction** — the panel still renders
+     a detached chip when the pin's epoch-id is no longer in the
+     cached history, and the chip's Reset button still calls
+     reset-frame-db! with the pin's stored :frame-db.
+
+  ## Pure hiccup
+
+  Same approach as `event_detail_cljs_test.cljs` — we walk the view's
+  hiccup tree by `data-testid` rather than mounting to a DOM. Keeps
+  the suite fast + host-portable on node-test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.time-travel :as time-travel]
+            [day8.re-frame2-causa.panels.time-travel-helpers :as h]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- effect-capturing test harness --------------------------------------
+;;
+;; The two write paths route through `:rf.causa.fx/restore-epoch` and
+;; `:rf.causa.fx/reset-frame-db!`. The registry registers thin
+;; delegations to rf/restore-epoch / rf/reset-frame-db!. In tests we
+;; *replace* those reg-fx handlers with capture fns so the assertion
+;; is "the right effect map landed" — no need to wire the epoch
+;; artefact onto the test classpath.
+
+(defonce ^:private captured-effects (atom []))
+
+(defn- install-capture-fx! []
+  (reset! captured-effects [])
+  ;; Per re-frame v2's reg-fx contract the handler is (fn [ctx args] ...).
+  ;; We capture `args` (the value passed via :fx [[fx-id args]]) so the
+  ;; assertion can match against the registry's handler returns.
+  (rf/reg-fx :rf.causa.fx/restore-epoch
+    (fn [_ctx args] (swap! captured-effects conj [:rf.causa.fx/restore-epoch args])))
+  (rf/reg-fx :rf.causa.fx/reset-frame-db!
+    (fn [_ctx args] (swap! captured-effects conj [:rf.causa.fx/reset-frame-db! args]))))
+
+(defn- captured [] @captured-effects)
+
+;; ---- fixture history + register helpers ---------------------------------
+
+(defn- mk-record
+  "Build a minimal `:rf/epoch-record` map. `dispatch-id` rides on the
+  first trace event per rf2-g6ih4."
+  [epoch-id db-after dispatch-id]
+  {:epoch-id     epoch-id
+   :frame        :rf/default
+   :committed-at 0
+   :event-id     :host/dispatched
+   :trigger-event [:host/dispatched]
+   :db-before    {}
+   :db-after     db-after
+   :trace-events (if dispatch-id
+                   [{:id 1 :op-type :event :operation :event/dispatched
+                     :tags {:dispatch-id dispatch-id}}]
+                   [])})
+
+(defn- seed-history!
+  "Seed Causa's app-db's :epoch-history slot with `records`. Mirrors
+  what `:rf.causa/epoch-recorded` would do on each settle. This
+  avoids depending on the epoch artefact being on the test classpath
+  — the panel reads from the cached slot, not from rf/epoch-history
+  directly."
+  [records]
+  (registry/register-causa-handlers!)
+  (install-capture-fx!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/seed-history-for-test (vec records)])))
+
+;; The registry doesn't ship a :rf.causa/seed-history-for-test event —
+;; we register one locally for the suite so seeding goes through the
+;; normal app-db-write path.
+(defn- register-seed-event! []
+  (rf/reg-event-db :rf.causa/seed-history-for-test
+    (fn [db [_ records]]
+      (assoc db :epoch-history (vec records)))))
+
+;; ---- hiccup walker (mirrors event_detail_cljs_test.cljs) ----------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- (1) wiring ----------------------------------------------------------
+
+(deftest registry-installs-time-travel-subs
+  (testing "register-causa-handlers! installs the Phase 3 subs"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/time-travel)))
+    (is (some? (registrar/handler :sub :rf.causa/epoch-history)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-epoch-id)))
+    (is (some? (registrar/handler :sub :rf.causa/pinned-snapshots)))
+    (is (some? (registrar/handler :sub :rf.causa/target-frame)))))
+
+(deftest registry-installs-time-travel-events
+  (testing "register-causa-handlers! installs the Phase 3 events"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :event :rf.causa/select-epoch)))
+    (is (some? (registrar/handler :event :rf.causa/clear-selected-epoch)))
+    (is (some? (registrar/handler :event :rf.causa/pin-current)))
+    (is (some? (registrar/handler :event :rf.causa/unpin)))
+    (is (some? (registrar/handler :event :rf.causa/rename-pin)))
+    (is (some? (registrar/handler :event :rf.causa/reset-to-epoch)))
+    (is (some? (registrar/handler :event :rf.causa/reset-to-pinned)))
+    (is (some? (registrar/handler :event :rf.causa/epoch-recorded)))))
+
+(deftest time-travel-sub-defaults
+  (testing ":rf.causa/time-travel returns sane defaults on a fresh frame"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/time-travel])]
+        (is (= :rf/default (:target-frame data)))
+        (is (= [] (:history data)))
+        (is (= [] (:pins data)))
+        (is (= [] (:chip-states data)))
+        (is (nil? (:selected-epoch-id data)))
+        (is (false? (:cap-reached? data)))))))
+
+;; ---- (2) select epoch writes to Causa frame, not host -------------------
+
+(deftest select-epoch-writes-to-causa-frame
+  (testing ":rf.causa/select-epoch lands on :rf/causa, not :rf/default"
+    (registry/register-causa-handlers!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-epoch :e-42]))
+    (is (= :e-42 (:selected-epoch-id (frame/frame-app-db-value :rf/causa))))
+    (is (nil? (:selected-epoch-id (frame/frame-app-db-value :rf/default))))))
+
+;; ---- (3) pin captures the 4-tuple via the live event --------------------
+
+(deftest pin-current-captures-the-four-tuple-via-event
+  (testing "dispatching :rf.causa/pin-current eager-copies :db-after off
+            the cached history and stores the 4-tuple"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {:counter 1} 100)
+                    (mk-record :e-2 {:counter 2} 200)])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-current :e-2 "after-tick"])
+      (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])
+            pin  (first pins)]
+        (is (= 1 (count pins)))
+        (is (= :e-2 (:epoch-id pin)))
+        (is (= {:counter 2} (:frame-db pin)) "eager copy of :db-after")
+        (is (= 200 (:dispatch-id pin)))
+        (is (= "after-tick" (:label pin)))))))
+
+(deftest pin-cap-enforced-at-32
+  (testing "the 33rd pin drops the oldest and surfaces the overflow toast"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    ;; Seed 33 epochs and pin every one.
+    (let [records (mapv (fn [i] (mk-record (keyword (str "e-" i)) {:n i} i))
+                        (range 1 34))]
+      (seed-history! records)
+      (rf/with-frame :rf/causa
+        (doseq [i (range 1 34)]
+          (rf/dispatch-sync
+            [:rf.causa/pin-current (keyword (str "e-" i)) (str "pin-" i)]))
+        (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])
+              causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= h/default-pin-cap (count pins))
+              "pin store capped at 32")
+          (is (= :e-2 (:epoch-id (first pins)))
+              "oldest (:e-1) was dropped")
+          (is (= :e-33 (:epoch-id (last pins)))
+              "newest (:e-33) retained")
+          (is (some? (:pin-overflow-toast causa-db))
+              "overflow toast slot populated"))))))
+
+;; ---- (4) reset-to-pinned uses reset-frame-db!, NOT restore-epoch --------
+
+(deftest reset-to-pinned-calls-reset-frame-db-not-restore-epoch
+  (testing "dispatching :rf.causa/reset-to-pinned fires :rf.causa.fx/
+            reset-frame-db! against the pin's stored :frame-db, NOT
+            :rf.causa.fx/restore-epoch (per spec §Why reset-frame-db!
+            not restore-epoch)"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {:counter 7} 1)])
+    (rf/with-frame :rf/causa
+      ;; Pin :e-1 with its db-after = {:counter 7}.
+      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "checkpoint"])
+      (reset! captured-effects [])  ;; reset capture after pin
+      (rf/dispatch-sync [:rf.causa/reset-to-pinned :e-1]))
+    (let [effects (captured)]
+      (is (= 1 (count effects))
+          "exactly one effect fired")
+      (let [[fx-id fx-arg] (first effects)]
+        (is (= :rf.causa.fx/reset-frame-db! fx-id)
+            "the value-direct path is reset-frame-db!, NOT restore-epoch")
+        (is (= :rf/default (:frame-id fx-arg))
+            "fires against the target host frame")
+        (is (= {:counter 7} (:frame-db fx-arg))
+            "uses the pin's eager :frame-db, not the live one")))))
+
+(deftest reset-to-epoch-calls-restore-epoch
+  (testing "dispatching :rf.causa/reset-to-epoch fires :rf.causa.fx/
+            restore-epoch (the ring-buffer path that surfaces the six
+            restore failure modes)"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {:counter 7} 1)])
+    (rf/with-frame :rf/causa
+      (reset! captured-effects [])
+      (rf/dispatch-sync [:rf.causa/reset-to-epoch :e-1]))
+    (let [effects (captured)]
+      (is (= 1 (count effects)))
+      (let [[fx-id fx-arg] (first effects)]
+        (is (= :rf.causa.fx/restore-epoch fx-id))
+        (is (= :rf/default (:frame-id fx-arg)))
+        (is (= :e-1 (:epoch-id fx-arg)))))))
+
+;; ---- (5) pins survive ring-buffer eviction ------------------------------
+
+(deftest pinned-snapshots-survive-history-eviction
+  (testing "after the underlying epoch ages out of cached history, the
+            pin still appears in :rf.causa/pinned-snapshots (the pin
+            store is independent of history). The chip-state surfaces
+            :attached false."
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    ;; Seed history with :e-old then pin it; then re-seed history with
+    ;; a newer-only set so :e-old has aged out of the cache. The pin
+    ;; survives.
+    (seed-history! [(mk-record :e-old {:state :authed} 99)])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-current :e-old "before-login"]))
+    ;; Re-seed (simulates ring-buffer roll forward — epoch artefact
+    ;; would do this via the cb pump).
+    (seed-history! [(mk-record :e-new {:state :anon} 200)])
+    (rf/with-frame :rf/causa
+      (let [data    @(rf/subscribe [:rf.causa/time-travel])
+            pins    (:pins data)
+            chips   (:chip-states data)
+            detached (some (fn [cs] (when-not (:attached cs) cs)) chips)]
+        (is (= 1 (count pins)) "pin store unchanged by history roll-forward")
+        (is (= :e-old (:epoch-id (first pins))))
+        (is (some? detached) "chip-states surfaces a detached chip")
+        (is (= "before-login" (:label (:pin detached))))
+        ;; And reset-to-pinned still works — the pin's :frame-db is
+        ;; the value-direct handle.
+        (reset! captured-effects [])
+        (rf/dispatch-sync [:rf.causa/reset-to-pinned :e-old])
+        (let [[[fx-id fx-arg]] (captured)]
+          (is (= :rf.causa.fx/reset-frame-db! fx-id)
+              "reset-to-pinned works after eviction — pin held the value")
+          (is (= {:state :authed} (:frame-db fx-arg))))))))
+
+;; ---- (6) unpin / rename via events --------------------------------------
+
+(deftest unpin-via-event-removes-from-store
+  (testing ":rf.causa/unpin drops the pin"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {} 1) (mk-record :e-2 {} 2)])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "a"])
+      (rf/dispatch-sync [:rf.causa/pin-current :e-2 "b"])
+      (rf/dispatch-sync [:rf.causa/unpin :e-1])
+      (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])]
+        (is (= 1 (count pins)))
+        (is (= :e-2 (:epoch-id (first pins))))))))
+
+(deftest rename-pin-via-event-rewrites-only-label
+  (testing ":rf.causa/rename-pin rewrites only :label"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {:x 1} 1)])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "old"])
+      (rf/dispatch-sync [:rf.causa/rename-pin :e-1 "new"])
+      (let [pin (first @(rf/subscribe [:rf.causa/pinned-snapshots]))]
+        (is (= "new" (:label pin)))
+        (is (= :e-1  (:epoch-id pin)))
+        (is (= {:x 1} (:frame-db pin)))
+        (is (= 1     (:dispatch-id pin)))))))
+
+;; ---- (7) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-history-empty
+  (testing "with no epoch history, the panel renders the empty state"
+    (registry/register-causa-handlers!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [tree (time-travel/time-travel-view)]
+        (is (some? (find-by-testid tree "rf-causa-time-travel-empty")))
+        (is (nil?  (find-by-testid tree "rf-causa-time-travel-track")))))))
+
+(deftest track-and-actions-render-when-history-populated
+  (testing "with history populated, the panel renders the track + actions"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-1 {} 1) (mk-record :e-2 {} 2)])
+    (rf/with-frame :rf/causa
+      (let [tree (time-travel/time-travel-view)]
+        (is (some? (find-by-testid tree "rf-causa-time-travel-track")))
+        (is (some? (find-by-testid tree "rf-causa-time-travel-slider")))
+        (is (some? (find-by-testid tree "rf-causa-time-travel-actions")))
+        (is (some? (find-by-testid tree "rf-causa-pin-current")))
+        (is (some? (find-by-testid tree "rf-causa-reset-to-epoch")))
+        (is (nil?  (find-by-testid tree "rf-causa-time-travel-empty")))))))
+
+(deftest chip-renders-detached-when-epoch-aged-out
+  (testing "the view renders a detached chip when the pin's epoch is
+            no longer in the cached history"
+    (registry/register-causa-handlers!)
+    (register-seed-event!)
+    (install-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (seed-history! [(mk-record :e-old {:state :authed} 99)])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-current :e-old "before-login"]))
+    (seed-history! [(mk-record :e-new {} 200)])
+    (rf/with-frame :rf/causa
+      (let [tree (time-travel/time-travel-view)
+            chip (find-by-testid tree "rf-causa-pin-chip-:e-old")]
+        (is (some? chip)
+            "detached chip is still rendered (per spec §Pins on the scrubber)")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/time_travel_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/time_travel_helpers_cljs_test.cljc
@@ -1,0 +1,293 @@
+(ns day8.re-frame2-causa.panels.time-travel-helpers-cljs-test
+  "Pure-data tests for Causa's Time Travel scrubber panel helpers
+  (Phase 3, rf2-t53ze).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  The file ends in `_cljs_test.cljc` so:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  Same dual-target pattern as `filter_vocab_consumer_cljs_test.cljc`.
+
+  ## What's under test
+
+  Each contract is asserted against the pure-data fns in
+  `time-travel-helpers`; no Reagent, no DOM. The view-side wiring is
+  exercised in `time_travel_cljs_test.cljs` against the live Causa
+  frame.
+
+    1. **Pin captures the 4-tuple.** `pin-from-epoch` lifts the four
+       slots off an `:rf/epoch-record` (per spec §What a pin captures).
+    2. **Pin store enforces the 32-pin cap.** `pin-snapshot` drops the
+       oldest pin when count exceeds cap; surfaces `:overflow?` true
+       and `:dropped-pin` for the toast.
+    3. **Pins survive ring-buffer eviction.** `chip-state` returns
+       `:attached false` when the pin's `:epoch-id` is no longer in
+       `history`; the pin's `:frame-db` is still present so
+       `reset-frame-db!` is still callable (the detached-chip
+       affordance per spec §Pins on the scrubber).
+    4. **`find-pin` + `find-epoch-in-history` + step nav.** Lookup
+       and step-by-N navigation are total over the empty/missing
+       cases; no nil-pointer crashes."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.time-travel-helpers :as h]))
+
+;; ---- fixture data --------------------------------------------------------
+
+(defn- epoch
+  "Build a minimal `:rf/epoch-record` fixture. `dispatch-id` rides on
+  the first trace event's `:tags :dispatch-id` per rf2-g6ih4 — the
+  same projection the cascade-resolver walks."
+  ([epoch-id db-after dispatch-id]
+   {:epoch-id     epoch-id
+    :frame        :rf/default
+    :committed-at 0
+    :event-id     :user/login
+    :trigger-event [:user/login]
+    :db-before    {}
+    :db-after     db-after
+    :trace-events (if dispatch-id
+                    [{:id 1 :op-type :event :operation :event/dispatched
+                      :tags {:dispatch-id dispatch-id :event [:user/login]}}]
+                    [])}))
+
+;; ---- (1) pin captures the 4-tuple ---------------------------------------
+
+(deftest pin-from-epoch-captures-four-slots
+  (testing "pin-from-epoch lifts :epoch-id, :frame-db, :dispatch-id, :label"
+    (let [rec (epoch :e-1 {:user/name "ada"} 100)
+          pin (h/pin-from-epoch rec "before-login")]
+      (is (= :e-1                (:epoch-id pin))    ":epoch-id from record")
+      (is (= {:user/name "ada"}  (:frame-db pin))    ":frame-db from :db-after")
+      (is (= 100                 (:dispatch-id pin)) ":dispatch-id from trace-events")
+      (is (= "before-login"      (:label pin))       ":label from caller"))))
+
+(deftest pin-from-epoch-handles-synthetic-epoch
+  (testing "an epoch with empty :trace-events (synthetic from reset-frame-db!)
+            still produces a pin; :dispatch-id is nil"
+    (let [rec (epoch :e-syn {:reset? true} nil)
+          pin (h/pin-from-epoch rec "synthetic")]
+      (is (= :e-syn (:epoch-id pin)))
+      (is (= {:reset? true} (:frame-db pin)))
+      (is (nil? (:dispatch-id pin)) "no dispatch-id when trace-events is empty"))))
+
+(deftest pin-from-epoch-nil-record-returns-nil
+  (testing "pin-from-epoch is total over nil — callers no-op rather than
+            store a degenerate pin"
+    (is (nil? (h/pin-from-epoch nil "any-label")))))
+
+(deftest pin-from-epoch-eager-frame-db-capture
+  (testing "the pin's :frame-db is the value the epoch had at pin time;
+            mutating the epoch record after the fact must not change the
+            pin's snapshot (eager capture per spec §What a pin captures)"
+    (let [db1  {:counter 0}
+          rec  (epoch :e-1 db1 1)
+          pin  (h/pin-from-epoch rec "v0")]
+      ;; Simulate a later epoch with a different db; the pin's :frame-db
+      ;; must still reference the original value.
+      (is (= db1 (:frame-db pin)) "pin captures the value, not a reference"))))
+
+;; ---- (2) pin store + cap enforcement ------------------------------------
+
+(deftest pin-snapshot-appends-when-under-cap
+  (testing "appending under cap returns no overflow and grows the per-frame
+            pin vector"
+    (let [pin1 {:epoch-id :e-1 :frame-db {} :dispatch-id 1 :label "a"}
+          {:keys [store overflow? dropped-pin]}
+          (h/pin-snapshot {} :rf/default pin1)]
+      (is (= [pin1] (get store :rf/default)))
+      (is (false? overflow?))
+      (is (nil? dropped-pin)))))
+
+(deftest pin-snapshot-default-label-when-blank
+  (testing "blank / nil :label resolves to pin-<n> at insertion time"
+    (let [p1 (h/pin-from-epoch (epoch :e-1 {} 10) nil)
+          {store-1 :store added-1 :added-pin}
+          (h/pin-snapshot {} :rf/default p1)]
+      (is (= "pin-1" (:label added-1))
+          "first unnamed pin defaults to pin-1")
+      (is (= "pin-1" (:label (first (get store-1 :rf/default)))))
+      ;; Add a second unnamed pin — next number, not collision.
+      (let [p2 (h/pin-from-epoch (epoch :e-2 {} 20) "")
+            {store-2 :store added-2 :added-pin}
+            (h/pin-snapshot store-1 :rf/default p2)]
+        (is (= "pin-2" (:label added-2)) "second unnamed pin → pin-2")
+        (is (= ["pin-1" "pin-2"]
+               (mapv :label (get store-2 :rf/default))))))))
+
+(deftest pin-snapshot-cap-default-32
+  (testing "the default cap is 32 per spec §Pin store capacity"
+    (is (= 32 h/default-pin-cap))))
+
+(deftest pin-snapshot-cap-enforced-drops-oldest
+  (testing "adding the (cap+1)th pin drops the OLDEST pin and surfaces
+            :overflow? true with :dropped-pin set"
+    (let [cap   3
+          pins  (mapv (fn [i]
+                        {:epoch-id    (keyword (str "e-" i))
+                         :frame-db    {:n i}
+                         :dispatch-id i
+                         :label       (str "pin-" i)})
+                      (range 1 5)) ; pins 1..4 — the 4th overflows cap=3
+          step  (fn [acc pin]
+                  (h/pin-snapshot (:store acc) :rf/default pin cap))
+          ;; Reduce pins through pin-snapshot. Use the same shape as the
+          ;; per-call return value for the seed.
+          out   (reduce step
+                        {:store {} :overflow? false :dropped-pin nil}
+                        pins)
+          final-pins (get-in out [:store :rf/default])]
+      (is (= 3 (count final-pins))
+          "vector stays bounded at cap")
+      (is (= [:e-2 :e-3 :e-4]
+             (mapv :epoch-id final-pins))
+          "oldest pin (:e-1) dropped; newest three retained in order")
+      (is (true? (:overflow? out))
+          ":overflow? surfaces on the cap-breaching call")
+      (is (= :e-1 (:epoch-id (:dropped-pin out)))
+          ":dropped-pin names the evicted pin"))))
+
+(deftest pin-snapshot-cap-32-end-to-end
+  (testing "with the spec's 32-pin cap, the 33rd pin evicts pin #1"
+    (let [thirty-two (mapv (fn [i] {:epoch-id    (keyword (str "e-" i))
+                                    :frame-db    {:n i}
+                                    :dispatch-id i
+                                    :label       (str "pin-" i)})
+                           (range 1 33)) ; 32 pins
+          seed       {:store {} :overflow? false :dropped-pin nil}
+          step       (fn [acc pin]
+                       (h/pin-snapshot (:store acc) :rf/default pin))
+          after-32   (reduce step seed thirty-two)]
+      (is (= 32 (count (get-in after-32 [:store :rf/default]))))
+      (is (false? (:overflow? after-32))
+          "filling to exactly 32 is not an overflow")
+      ;; Adding the 33rd:
+      (let [thirty-third {:epoch-id :e-33 :frame-db {} :dispatch-id 33
+                          :label "pin-33"}
+            after-33     (h/pin-snapshot (:store after-32)
+                                         :rf/default thirty-third)]
+        (is (= 32 (count (get-in after-33 [:store :rf/default])))
+            "still capped at 32")
+        (is (true? (:overflow? after-33)))
+        (is (= :e-1 (:epoch-id (:dropped-pin after-33)))
+            "oldest (pin-1 / :e-1) evicted")
+        (is (= :e-33 (:epoch-id (last (get-in after-33 [:store :rf/default]))))
+            ":e-33 is the newest pin after eviction")))))
+
+;; ---- (3) unpin / rename / find ------------------------------------------
+
+(deftest unpin-snapshot-removes-pin
+  (testing "unpin-snapshot drops the named pin; other frames untouched"
+    (let [store {:rf/default [{:epoch-id :e-1 :frame-db {} :dispatch-id 1 :label "a"}
+                              {:epoch-id :e-2 :frame-db {} :dispatch-id 2 :label "b"}]
+                 :rf/other   [{:epoch-id :e-1 :frame-db {} :dispatch-id 1 :label "x"}]}
+          out   (h/unpin-snapshot store :rf/default :e-1)]
+      (is (= [:e-2] (mapv :epoch-id (get out :rf/default)))
+          ":e-1 dropped from :rf/default")
+      (is (= [:e-1] (mapv :epoch-id (get out :rf/other)))
+          ":rf/other untouched"))))
+
+(deftest unpin-snapshot-noop-on-miss
+  (testing "removing a non-existent pin is a no-op"
+    (let [store {:rf/default [{:epoch-id :e-1 :frame-db {} :dispatch-id 1 :label "a"}]}]
+      (is (= store (h/unpin-snapshot store :rf/default :nope))
+          "unpinning a missing id returns the store unchanged"))))
+
+(deftest rename-pin-rewrites-only-label
+  (testing "rename rewrites :label; other 4-tuple slots immutable"
+    (let [pin   {:epoch-id :e-1 :frame-db {:x 1} :dispatch-id 42 :label "old"}
+          store {:rf/default [pin]}
+          out   (h/rename-pin store :rf/default :e-1 "new")
+          got   (first (get out :rf/default))]
+      (is (= "new"   (:label got)))
+      (is (= :e-1   (:epoch-id got)))
+      (is (= {:x 1} (:frame-db got)))
+      (is (= 42     (:dispatch-id got))))))
+
+(deftest find-pin-returns-the-pin-or-nil
+  (let [pin   {:epoch-id :e-1 :frame-db {:x 1} :dispatch-id 1 :label "a"}
+        store {:rf/default [pin]}]
+    (is (= pin (h/find-pin store :rf/default :e-1)))
+    (is (nil? (h/find-pin store :rf/default :missing)))
+    (is (nil? (h/find-pin store :rf/other   :e-1)))))
+
+;; ---- (4) pins survive ring-buffer eviction ------------------------------
+
+(deftest chip-state-attached-when-epoch-in-history
+  (testing "a pin whose :epoch-id is in the current history renders attached
+            with the slot index populated"
+    (let [history [(epoch :e-1 {} 1)
+                   (epoch :e-2 {} 2)
+                   (epoch :e-3 {} 3)]
+          pin     {:epoch-id :e-2 :frame-db {} :dispatch-id 2 :label "mid"}
+          state   (h/chip-state history pin)]
+      (is (true? (:attached state)))
+      (is (= 1 (:index state)) "0-based index in history vector"))))
+
+(deftest chip-state-detached-when-epoch-aged-out
+  (testing "a pin whose :epoch-id is no longer in history renders detached;
+            :frame-db is still present on the pin so reset-frame-db! works"
+    (let [pin     {:epoch-id    :e-aged
+                   :frame-db    {:user/name "ada" :session :authed}
+                   :dispatch-id 42
+                   :label       "before-login"}
+          history [(epoch :e-100 {} 100)
+                   (epoch :e-101 {} 101)]
+          state   (h/chip-state history pin)]
+      (is (false? (:attached state)))
+      (is (nil?   (:index state)))
+      (is (= {:user/name "ada" :session :authed} (:frame-db (:pin state)))
+          "pin retains :frame-db across history eviction — the value-direct
+           handle reset-frame-db! consumes"))))
+
+(deftest chip-states-vector-preserves-order
+  (testing "chip-states preserves insertion order (the pin-store vector order)"
+    (let [history [(epoch :e-1 {} 1) (epoch :e-2 {} 2)]
+          pins    [{:epoch-id :e-1 :frame-db {} :dispatch-id 1 :label "first"}
+                   {:epoch-id :e-2 :frame-db {} :dispatch-id 2 :label "second"}
+                   {:epoch-id :e-aged :frame-db {} :dispatch-id 99 :label "old"}]
+          states  (h/chip-states history pins)]
+      (is (= ["first" "second" "old"] (mapv (comp :label :pin) states)))
+      (is (= [true true false]        (mapv :attached states))
+          "third pin (epoch aged out) renders detached"))))
+
+;; ---- (5) history navigation --------------------------------------------
+
+(deftest find-epoch-in-history-returns-record-or-nil
+  (let [history [(epoch :e-1 {} 1) (epoch :e-2 {} 2) (epoch :e-3 {} 3)]]
+    (is (= :e-2 (:epoch-id (h/find-epoch-in-history history :e-2))))
+    (is (nil? (h/find-epoch-in-history history :missing)))
+    (is (nil? (h/find-epoch-in-history history nil)))
+    (is (nil? (h/find-epoch-in-history [] :e-1)) "empty history yields nil")))
+
+(deftest epoch-index-and-epoch-id-at-index-are-inverses
+  (let [history [(epoch :e-a {} 1) (epoch :e-b {} 2) (epoch :e-c {} 3)]]
+    (is (= 1 (h/epoch-index-in-history history :e-b)))
+    (is (= :e-b (h/epoch-id-at-index history 1)))
+    (is (nil? (h/epoch-id-at-index history 99)))
+    (is (nil? (h/epoch-id-at-index history -1)))))
+
+(deftest newest-epoch-id-on-history
+  (is (= :e-c
+         (h/newest-epoch-id [(epoch :e-a {} 1) (epoch :e-b {} 2) (epoch :e-c {} 3)])))
+  (is (nil? (h/newest-epoch-id []))))
+
+(deftest step-epoch-back-and-forward
+  (let [history [(epoch :e-a {} 1) (epoch :e-b {} 2) (epoch :e-c {} 3)]]
+    (is (= :e-a (h/step-epoch history :e-b -1)) "step back from :e-b")
+    (is (= :e-c (h/step-epoch history :e-b  1)) "step forward from :e-b")
+    (is (= :e-a (h/step-epoch history :e-a -1)) "step back from oldest clamps")
+    (is (= :e-c (h/step-epoch history :e-c  1)) "step forward from newest clamps")
+    (is (= :e-c (h/step-epoch history nil   0)) "nil selection steps from newest")
+    (is (nil? (h/step-epoch [] :e-x 1))         "empty history yields nil")))
+
+(deftest dispatch-id-from-epoch-walks-trace-events
+  (testing "dispatch-id-from-epoch picks the first :dispatch-id-bearing event"
+    (is (= 42 (h/dispatch-id-from-epoch (epoch :e-1 {} 42))))
+    (is (nil? (h/dispatch-id-from-epoch (epoch :e-1 {} nil)))
+        "synthetic epoch (empty :trace-events) yields nil")))


### PR DESCRIPTION
## Summary

- Phase 3 of rf2-5aw5v (Causa v1.0 impl epic). Implements the Time Travel scrubber panel per `tools/causa/spec/002-Time-Travel.md`.
- Pure-data helpers in `time_travel_helpers.cljc` run on both JVM + node-test (per the `feedback_jvm_interop_must_work.md` standing rule).
- Sidebar wire-in routes `:time-travel` to the panel; remaining stub sidebar entries unchanged.

## Surface

- Timeline + draggable scrubber cursor; `[` / `]` / arrow-key nudging
- Pin button + label input; pin chips alongside the timeline
- 32-pin cap per spec §Pin store capacity (configurable via the 3-arity helper form once Settings lands)
- Reset to current → `restore-epoch`; Reset to pinned → `reset-frame-db!` (the value-direct path; the only way pins survive ring-buffer eviction)
- Detached chip rendering for pins whose underlying epoch has aged out

## Registrations (all under `:rf.causa/*`)

- subs: `target-frame`, `epoch-history`, `selected-epoch-id`, `pin-store`, `pinned-snapshots`, `time-travel` (composite)
- events: `epoch-recorded`, `select-epoch`, `clear-selected-epoch`, `pin-current`, `unpin`, `rename-pin`, `dismiss-pin-overflow-toast`, `reset-to-epoch` (event-fx), `reset-to-pinned` (event-fx)
- fx: `:rf.causa.fx/restore-epoch`, `:rf.causa.fx/reset-frame-db!`

Preload registers an epoch-cb under `:rf.causa/epoch-collector` that pumps the latest `epoch-history` snapshot into Causa's app-db on every settled epoch, so the scrubber sub graph re-fires off the standard app-db write path.

## Test plan

- [x] `clojure -M:test` in `tools/causa/` — 49 tests / 138 assertions / 0 failures (was 29 / 67 / 0 on main; +20 tests for helpers)
- [x] `npm run test:cljs` — 726 tests / 1849 assertions / 0 failures
- [x] `npm run test:browser` — 726 tests / 1881 assertions / 0 failures
- [x] `npm run test:elision` — passes; epoch surfaces still elide in prod
- [x] `npm run test:examples` — all examples pass
- [x] `mkdocs build --strict` — 119 warnings (same count as `origin/main`; none introduced by this change)
- [x] `npx shadow-cljs compile examples/counter` (Causa preload included) — clean compile