### PR TITLE
refactor(late-bind): move hook directory to data file + add drift-detection test (rf2-n2j0)

### DIFF
--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -37,96 +37,20 @@
   commits. Callers MUST register the `:on-create` event's handler
   BEFORE calling `make-frame` / `reg-frame`. (When the JVM/CLJS host
   loads `re-frame.core`, the canonical re-frame.router namespace is
-  loaded — and registers its hooks — before any user code runs.)")
+  loaded — and registers its hooks — before any user code runs.)
+
+  The authoritative inventory of every published key lives in
+  `re-frame.late-bind.directory` — plain CLJC data, one entry per
+  hook key, with the producer ns, design bead, and one-line
+  description. The drift test
+  `implementation/core/test/re_frame/late_bind_drift_test.clj`
+  asserts the directory and the `set-fn!` call sites stay in sync.")
 
 (defonce
   ^{:doc "Map of hook-key → fn. Populated by the producing namespace at
-  load time. The set of keys is documented at each call site; v1 keys:
-
-    :router/dispatch!         re-frame.router/dispatch!
-    :router/dispatch-sync!    re-frame.router/dispatch-sync!
-    :flows/reg-flow            re-frame.flows/reg-flow
-    :flows/clear-flow          re-frame.flows/clear-flow
-    :flows/reg-flow-fx!        re-frame.flows/reg-flow-fx!
-    :flows/clear-flow-fx!      re-frame.flows/clear-flow-fx!
-    :flows/run-flows!          re-frame.flows/run-flows!
-    :flows/reset-last-inputs!  re-frame.flows/reset-last-inputs!
-    :flows/reset-flows!        re-frame.flows/reset-flows!
-    :schemas/validate-event!      re-frame.schemas/validate-event!
-    :schemas/validate-app-db!     re-frame.schemas/validate-app-db!
-    :schemas/validate-cofx!       re-frame.schemas/validate-cofx!
-    :schemas/validate-sub-return! re-frame.schemas/validate-sub-return!
-    :schemas/frame-schema-entries re-frame.schemas/frame-schema-entries
-    :schemas/reg-app-schema       re-frame.schemas/reg-app-schema
-    :schemas/app-schema-at        re-frame.schemas/app-schema-at
-    :schemas/app-schemas          re-frame.schemas/app-schemas
-    :schemas/app-schemas-digest   re-frame.schemas/app-schemas-digest
-    :schemas/snapshot-by-frame    re-frame.schemas/snapshot-schemas-by-frame
-    :schemas/restore-by-frame!    re-frame.schemas/restore-schemas-by-frame!
-    :schemas/clear-by-frame!      re-frame.schemas/clear-schemas-by-frame!
-    :schemas/set-schema-validator!         re-frame.schemas/set-schema-validator! ;; rf2-froe — pluggable validator
-    :schemas/set-schema-explainer!         re-frame.schemas/set-schema-explainer! ;; rf2-froe — companion explainer
-    :schemas/validate-with-registered-fn   re-frame.schemas/validate-with-registered-fn ;; rf2-r2uh boundary seam
-    :schemas/explain-with-registered-fn    re-frame.schemas/explain-with-registered-fn  ;; rf2-r2uh boundary seam
-    :schemas/malli-validate                malli.core/validate                          ;; rf2-t0hq — published by re-frame.schemas.malli adapter ns
-    :schemas/malli-explain                 malli.core/explain                           ;; rf2-t0hq — published by re-frame.schemas.malli adapter ns
-    :machines/reg-machine             re-frame.machines/reg-machine* ;; rf2-8bp3 — plain-fn surface
-    :machines/create-machine-handler  re-frame.machines/create-machine-handler
-    :machines/machine-transition      re-frame.machines/machine-transition
-    :machines/machines                re-frame.machines/machines
-    :machines/machine-meta            re-frame.machines/machine-meta
-    :machines/machine-by-system-id    re-frame.machines/machine-by-system-id
-    :machines/reset-counters!         re-frame.machines/reset-counters!
-    :machines/spawn-fx                re-frame.machines/spawn-fx
-    :machines/destroy-machine-fx      re-frame.machines/destroy-machine-fx
-    :routing/reg-route                re-frame.routing/reg-route
-    :routing/match-url                re-frame.routing/match-url
-    :routing/route-url                re-frame.routing/route-url
-    :routing/reset-counters!          re-frame.routing/reset-counters!
-    :routing/route-sub-fn             re-frame.routing/route-sub-fn
-    :http/install-managed-request-stubs!   re-frame.http-managed/install-managed-request-stubs!
-    :http/uninstall-managed-request-stubs! re-frame.http-managed/uninstall-managed-request-stubs!
-    :http/with-managed-request-stubs*      re-frame.http-managed/with-managed-request-stubs*
-    :http/clear-all-in-flight!             re-frame.http-managed/clear-all-in-flight!
-    :http/reg-http-interceptor             re-frame.http-managed/reg-http-interceptor       ;; rf2-6y3q
-    :http/clear-http-interceptor           re-frame.http-managed/clear-http-interceptor     ;; rf2-6y3q
-    :http/clear-all-http-interceptors!     re-frame.http-managed/clear-all-http-interceptors! ;; rf2-6y3q
-    :http/abort-on-actor-destroy           re-frame.http-managed/abort-on-actor-destroy     ;; rf2-wvkn — :invoke cancellation cascade
-    :subs/subscribe-value     re-frame.subs/subscribe-value
-    :ssr/render-tree-hash        re-frame.ssr/render-tree-hash
-    :ssr/render-to-string        re-frame.ssr/render-to-string
-    :ssr/reg-error-projector     re-frame.ssr/reg-error-projector
-    :ssr/project-error           re-frame.ssr/project-error
-    :reagent/set-hiccup-emitter! re-frame.adapter.reagent/set-hiccup-emitter!
-    :views/maybe-warn-plain-fn-under-non-default-frame!  re-frame.views/maybe-warn-plain-fn-under-non-default-frame!
-    :views/clear-plain-fn-warned-pairs!                  re-frame.views/clear-plain-fn-warned-pairs!
-    :adapter/clear-warn-once-caches!  chained no-arg hook — each adapter that holds a `warned-non-dom-roots` defonce contributes a clear-step (re-frame.views/clear-warned-non-dom-roots!, re-frame.adapter.helix/clear-warned-non-dom-roots!, re-frame.adapter.uix/clear-warned-non-dom-roots!). Unlike most `:adapter/...` keys, this hook is NOT routed through the currently-installed adapter — every loaded adapter's cache must clear because test bundles can mount different adapters across tests and each adapter's defonce persists independently. `reset-runtime-fixture` invokes the top of the chain so every registered clear-step runs. Per rf2-4edk.
-    :adapter/current-frame    re-frame.views/current-frame                                       ;; rf2-d4sf — Reagent path; class-component (.-context cmp)
-                              re-frame.adapter.context/function-component-current-frame          ;;          — UIx / Helix path; function-component _currentValue read
-                                                                                                  ;; Published by each adapter ns at load time so subscribe / dispatch consult the React-context tier of the resolution chain. Signature: (fn []) -> frame-id keyword. Per rf2-0d35: each adapter wraps its reader in a routing closure that runs the impl ONLY when (substrate-adapter/current-adapter) is identical to that adapter — otherwise chains to the previously-installed reader, falling back to frame/current-frame at the chain's end. This fixes a regression where, in test bundles that load multiple adapter ns's (e.g. reagent + reagent-slim + uix + helix), the LAST-LOADED adapter's reader silently won — and an app installed via `(rf/init! reagent/adapter)` could end up reading frames via UIx's `function-component-current-frame` path (which reads `_currentValue` directly), breaking the plain-fn-under-non-default-frame-once warning's narrowness contract for plain Reagent fns.
-    :adapter/current-component reagent.core/current-component                                    ;; rf2-wbnl — classic-bridge path; stock Reagent's in-flight component
-                               reagent2.core/current-component                                   ;;          — slim adapter path; reagent2.core's in-flight component
-                                                                                                  ;; Published by each adapter ns at load time so re-frame.views can resolve the current Reagent component without hard-binding to one Reagent build. Signature: (fn []) -> Reagent component or nil. Per rf2-0d35: each adapter ns wraps its reader in a routing closure that runs the impl ONLY when (substrate-adapter/current-adapter) is identical to that adapter — otherwise chains to the previously-installed reader. This fixes a regression where, in test bundles that load multiple adapter ns's, the LAST-LOADED adapter's reader silently won at the hook regardless of which adapter was actually `(rf/init!)`-installed; under that condition warnings like plain-fn-under-non-default-frame would silently drop because the hook was reading the wrong substrate's `*current-component*` (always nil during the OTHER substrate's renders). nil when no adapter is installed; views.cljs treats nil cleanly (skips React-context tier, falls through to :rf/default).
-    :adapter/ratom            (fn [v]) -> ratom                                                  ;; rf2-s36l — `re-frame.interop/ratom`; classic-bridge → reagent.core/atom, slim → reagent2.core/atom, uix/helix → reagent.core/atom.
-    :adapter/ratom?           (fn [x]) -> boolean                                                ;; rf2-s36l — `re-frame.interop/ratom?`; classic-bridge → (satisfies? reagent.ratom/IReactiveAtom x), slim → (satisfies? reagent2.ratom/IReactiveAtom x), uix/helix → (satisfies? reagent.ratom/IReactiveAtom x).
-    :adapter/make-reaction    (fn [f]) -> reaction                                               ;; rf2-s36l — `re-frame.interop/make-reaction`; classic-bridge → reagent.ratom/make-reaction, slim → reagent2.ratom/make-reaction, uix/helix → reagent.ratom/make-reaction.
-    :adapter/add-on-dispose!  (fn [a-ratom f]) -> nil                                            ;; rf2-s36l — `re-frame.interop/add-on-dispose!`; classic-bridge → reagent.ratom/add-on-dispose!, slim → reagent2.ratom/add-on-dispose!, uix/helix → reagent.ratom/add-on-dispose! (UIx + Helix derived values reify stock Reagent's IDisposable directly).
-    :adapter/dispose!         (fn [a-ratom]) -> nil                                              ;; rf2-s36l — `re-frame.interop/dispose!`; classic-bridge → reagent.ratom/dispose!, slim → reagent2.ratom/dispose!, uix/helix → reagent.ratom/dispose!.
-    :adapter/reactive?        (fn []) -> boolean                                                 ;; rf2-s36l — `re-frame.interop/reactive?`; classic-bridge → reagent.ratom/reactive?, slim → reagent2.ratom/reactive?, uix/helix → reagent.ratom/reactive?.
-    :adapter/after-render     (fn [f]) -> nil                                                    ;; rf2-s36l — `re-frame.interop/after-render`; classic-bridge → reagent.core/after-render, slim → reagent2.core/after-render, uix/helix → reagent.core/after-render. Each adapter routes through (substrate-adapter/current-adapter) per rf2-0d35 so the installed adapter's substrate is the one whose IDisposable / IReactiveAtom dispatch handles `re-frame.subs` slot-teardown wiring; this is the seam that frees the slim Maven artefact to drop its stock-Reagent dep.
-    :adapter/wrap-view        (fn [id metadata user-fn]) -> wrapped-user-fn                      ;; rf2-00li — substrate-side source-coord injection. UIx + Helix register a wrapper that uses `React.cloneElement` to add `data-rf2-source-coord` to the rendered React element's root; the Reagent adapter does the equivalent hiccup-walk inline inside `views/reg-view*` so it does NOT register this hook. `views/reg-view*` consults the hook before its inline walk: when present, the substrate-supplied wrap-view replaces both the user-fn-supplied render and the inline hiccup walk (so a substrate that returns React elements gets React-side injection rather than mis-classified-as-non-DOM hiccup-walk output). Each adapter routes its impl through (substrate-adapter/current-adapter) per rf2-0d35 so the installed adapter's wrap-view is the one that runs. Production-elision (per Spec 009 §Production builds): each adapter's wrap-view body sits inside `(when interop/debug-enabled? ...)` so closure-folds under :advanced + goog.DEBUG=false.
-    :epoch/settle!            re-frame.epoch/settle!
-    :epoch/discard-buffer!    re-frame.epoch/discard-buffer!
-    :epoch/in-flight-buffer   re-frame.epoch/in-flight-buffer
-    :epoch/capture-event      re-frame.epoch/capture-event!
-    :epoch/epoch-history      re-frame.epoch/epoch-history
-    :epoch/restore-epoch      re-frame.epoch/restore-epoch
-    :epoch/register-epoch-cb  re-frame.epoch/register-epoch-cb!
-    :epoch/remove-epoch-cb    re-frame.epoch/remove-epoch-cb!
-    :epoch/configure!         re-frame.epoch/configure!
-    :epoch/clear-history!     re-frame.epoch/clear-history!
-    :epoch/clear-epoch-cbs!   re-frame.epoch/clear-epoch-cbs!
-    :epoch/on-frame-destroyed re-frame.epoch/on-frame-destroyed!"}
+   load time. The authoritative key inventory is
+   `re-frame.late-bind.directory/hooks`; the drift test enforces it
+   matches the in-tree `set-fn!` call sites."}
   hooks
   (atom {}))
 

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1,0 +1,407 @@
+(ns re-frame.late-bind.directory
+  "Authoritative inventory of every key published through the
+  `re-frame.late-bind` hook registry.
+
+  Plain CLJC data — one entry per published key — so the inventory is:
+
+    - editor-friendly (jump-to-definition, no docstring scrolling),
+    - diff-friendly (each row is its own line),
+    - machine-readable (the drift test in
+      `implementation/core/test/re_frame/late_bind_drift_test.clj`
+      walks this var and compares it against `set-fn!` call sites
+      across every artefact).
+
+  Each entry is a map:
+
+    {:key          fully-qualified late-bind hook key (keyword, REQUIRED)
+     :producer-ns  symbol naming the namespace that publishes the key
+                   (REQUIRED — may be a vector when an adapter routing
+                   chain has multiple publishers, see rf2-0d35)
+     :design-bead  decision-bead id that introduced or shaped the key
+                   (string, optional)
+     :description  one-line summary of what the hook does
+                   (string, REQUIRED)
+     :chained?     true when the hook is registered cumulatively rather
+                   than once-per-key (see `:adapter/clear-warn-once-caches!`
+                   and the routed `:adapter/*` hooks — chained / routed
+                   hooks publish from multiple namespaces and the drift
+                   test treats `:producer-ns` as a vector covering them
+                   all)}
+
+  Adding a new hook? Add the entry HERE and call
+  `(re-frame.late-bind/set-fn! ...)` in the producing ns — the drift
+  test fails on either omission. Do NOT update both the producer ns
+  and a free-floating prose comment; the drift check is the only
+  source of truth.")
+
+(def hooks
+  "Vector of hook-directory entries — see the ns docstring for shape.
+
+  Ordering: grouped by namespace prefix (router → flows → schemas →
+  machines → routing → http → subs → ssr → reagent → views →
+  adapter → epoch → trace) so additions land near their siblings."
+  [;; ---- re-frame.router (rf2-d4sf foundational dispatch seam) ----------------
+   {:key         :router/dispatch!
+    :producer-ns 're-frame.router
+    :description "Enqueue an event for processing by the drain loop."}
+   {:key         :router/dispatch-sync!
+    :producer-ns 're-frame.router
+    :description "Process an event synchronously, bypassing the drain queue."}
+
+   ;; ---- re-frame.flows -------------------------------------------------------
+   {:key         :flows/reg-flow
+    :producer-ns 're-frame.flows
+    :description "Register a flow definition with the runtime."}
+   {:key         :flows/clear-flow
+    :producer-ns 're-frame.flows
+    :description "Remove a previously-registered flow definition."}
+   {:key         :flows/reg-flow-fx!
+    :producer-ns 're-frame.flows
+    :description "Install the :rf.flow/reg-flow effect handler."}
+   {:key         :flows/clear-flow-fx!
+    :producer-ns 're-frame.flows
+    :description "Install the :rf.flow/clear-flow effect handler."}
+   {:key         :flows/run-flows!
+    :producer-ns 're-frame.flows
+    :description "Re-evaluate every registered flow for the current frame."}
+   {:key         :flows/reset-last-inputs!
+    :producer-ns 're-frame.flows
+    :description "Reset memoised last-input snapshots (test isolation)."}
+   {:key         :flows/reset-flows!
+    :producer-ns 're-frame.flows
+    :description "Clear the per-frame flow registry (test isolation)."}
+
+   ;; ---- re-frame.schemas (rf2-p7va boundary; rf2-r2uh / rf2-froe / rf2-t0hq) -
+   {:key         :schemas/validate-event!
+    :producer-ns 're-frame.schemas
+    :description "Validate an event vector against the registered event schema."}
+   {:key         :schemas/validate-app-db!
+    :producer-ns 're-frame.schemas
+    :description "Validate the app-db snapshot against the registered app-db schema."}
+   {:key         :schemas/validate-cofx!
+    :producer-ns 're-frame.schemas
+    :description "Validate a cofx map against the registered cofx schema."}
+   {:key         :schemas/validate-sub-return!
+    :producer-ns 're-frame.schemas
+    :description "Validate a subscription's return value against its schema."}
+   {:key         :schemas/frame-schema-entries
+    :producer-ns 're-frame.schemas
+    :description "Return the per-frame schema-registration entries (for snapshotting)."}
+   {:key         :schemas/reg-app-schema
+    :producer-ns 're-frame.schemas
+    :description "Register a path-scoped schema for app-db values."}
+   {:key         :schemas/reg-app-schemas
+    :producer-ns 're-frame.schemas
+    :description "Bulk-register multiple path-scoped app-db schemas."}
+   {:key         :schemas/app-schema-at
+    :producer-ns 're-frame.schemas
+    :description "Look up the schema registered at a path (introspection)."}
+   {:key         :schemas/app-schemas
+    :producer-ns 're-frame.schemas
+    :description "Return all path → schema registrations (introspection)."}
+   {:key         :schemas/app-schemas-digest
+    :producer-ns 're-frame.schemas
+    :description "Cheap digest of the registered-schema set (cache-key surface)."}
+   {:key         :schemas/snapshot-by-frame
+    :producer-ns 're-frame.schemas
+    :description "Snapshot the per-frame schema registry for restore."}
+   {:key         :schemas/restore-by-frame!
+    :producer-ns 're-frame.schemas
+    :description "Restore a previously-snapshotted per-frame schema registry."}
+   {:key         :schemas/clear-by-frame!
+    :producer-ns 're-frame.schemas
+    :description "Clear the schema registry entries for a frame (test isolation)."}
+   {:key         :schemas/set-schema-validator!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-froe"
+    :description "Install a pluggable schema-validator fn (overrides default)."}
+   {:key         :schemas/set-schema-explainer!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-froe"
+    :description "Install a pluggable schema-explainer fn paired with the validator."}
+   {:key         :schemas/validate-with-registered-fn
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-r2uh"
+    :description "Boundary seam: validate using the registered validator fn."}
+   {:key         :schemas/explain-with-registered-fn
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-r2uh"
+    :description "Boundary seam: explain using the registered explainer fn."}
+   {:key         :schemas/malli-validate
+    :producer-ns 're-frame.schemas.malli
+    :design-bead "rf2-t0hq"
+    :description "Default-installed Malli validator (malli.core/validate)."}
+   {:key         :schemas/malli-explain
+    :producer-ns 're-frame.schemas.malli
+    :design-bead "rf2-t0hq"
+    :description "Default-installed Malli explainer (malli.core/explain)."}
+
+   ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
+   {:key         :machines/reg-machine
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-8bp3"
+    :description "Register a state machine definition (plain-fn surface)."}
+   {:key         :machines/create-machine-handler
+    :producer-ns 're-frame.machines
+    :description "Create the event-handler that drives a machine instance."}
+   {:key         :machines/machine-transition
+    :producer-ns 're-frame.machines
+    :description "Apply a transition to a machine instance."}
+   {:key         :machines/machines
+    :producer-ns 're-frame.machines
+    :description "Return all registered machine definitions (introspection)."}
+   {:key         :machines/machine-meta
+    :producer-ns 're-frame.machines
+    :description "Return registration metadata for a named machine."}
+   {:key         :machines/machine-by-system-id
+    :producer-ns 're-frame.machines
+    :description "Look up a live machine instance by its system id."}
+   {:key         :machines/reset-counters!
+    :producer-ns 're-frame.machines
+    :description "Reset the machine spawn-counter (test isolation)."}
+   {:key         :machines/spawn-fx
+    :producer-ns 're-frame.machines
+    :description "Effect handler for :rf.machine/spawn."}
+   {:key         :machines/destroy-machine-fx
+    :producer-ns 're-frame.machines
+    :description "Effect handler for :rf.machine/destroy."}
+   {:key         :machines/invoke-all-init-fx
+    :producer-ns 're-frame.machines
+    :description "Effect handler invoking machine :init transitions during spawn."}
+   {:key         :machines/after-schedule-fx
+    :producer-ns 're-frame.machines
+    :description "Effect handler scheduling a delayed machine transition."}
+   {:key         :machines/after-cancel-fx
+    :producer-ns 're-frame.machines
+    :description "Effect handler cancelling a previously-scheduled transition."}
+
+   ;; ---- re-frame.routing (rf2-k682) -----------------------------------------
+   {:key         :routing/reg-route
+    :producer-ns 're-frame.routing
+    :description "Register a route pattern and handler."}
+   {:key         :routing/match-url
+    :producer-ns 're-frame.routing
+    :description "Match a URL against the registered routes."}
+   {:key         :routing/route-url
+    :producer-ns 're-frame.routing
+    :description "Build a URL for a route by id + params."}
+   {:key         :routing/reset-counters!
+    :producer-ns 're-frame.routing
+    :description "Reset the route-registration counter (test isolation)."}
+   {:key         :routing/route-sub-fn
+    :producer-ns 're-frame.routing
+    :description "Subscription fn returning the currently-matched route."}
+   {:key         :routing/route-link
+    :producer-ns 're-frame.routing
+    :description "Reagent / SSR `[rf/route-link ...]` view component renderer."}
+
+   ;; ---- re-frame.http-managed (rf2-5kpd / rf2-6y3q / rf2-wvkn / rf2-ijm7) ----
+   {:key         :http/install-managed-request-stubs!
+    :producer-ns 're-frame.http-managed
+    :description "Install request stubs for managed HTTP testing."}
+   {:key         :http/uninstall-managed-request-stubs!
+    :producer-ns 're-frame.http-managed
+    :description "Uninstall previously-installed managed-request stubs."}
+   {:key         :http/with-managed-request-stubs*
+    :producer-ns 're-frame.http-managed
+    :description "Function form of the with-managed-request-stubs macro."}
+   {:key         :http/clear-all-in-flight!
+    :producer-ns 're-frame.http-managed
+    :description "Abort every in-flight managed request (test isolation)."}
+   {:key         :http/reg-http-interceptor
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-6y3q"
+    :description "Register a per-frame request-side HTTP interceptor."}
+   {:key         :http/clear-http-interceptor
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-6y3q"
+    :description "Clear a single registered HTTP interceptor."}
+   {:key         :http/clear-all-http-interceptors!
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-6y3q"
+    :description "Clear every registered HTTP interceptor (test isolation)."}
+   {:key         :http/abort-on-actor-destroy
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-wvkn"
+    :description ":invoke cancellation cascade tied to actor destruction."}
+   {:key         :http/register-managed-machine!
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-ijm7"
+    :description "Register the machine-shape wrapper for managed HTTP requests."}
+
+   ;; ---- re-frame.subs --------------------------------------------------------
+   {:key         :subs/subscribe-value
+    :producer-ns 're-frame.subs
+    :description "Subscribe and immediately deref (snapshot value, no reaction)."}
+
+   ;; ---- re-frame.ssr (rf2-uo7v) ---------------------------------------------
+   {:key         :ssr/render-tree-hash
+    :producer-ns 're-frame.ssr
+    :description "Compute the stable hash of a rendered tree (SSR cache key)."}
+   {:key         :ssr/render-to-string
+    :producer-ns 're-frame.ssr
+    :description "Render a view tree to an HTML string for SSR."}
+   {:key         :ssr/reg-error-projector
+    :producer-ns 're-frame.ssr
+    :description "Register a fn projecting SSR render errors to user-facing markup."}
+   {:key         :ssr/project-error
+    :producer-ns 're-frame.ssr
+    :description "Apply the registered error-projector to an SSR render error."}
+
+   ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
+   {:key         :reagent/set-hiccup-emitter!
+    :producer-ns '[re-frame.adapter.reagent re-frame.adapter.reagent-slim]
+    :chained?    true
+    :description "Install the substrate-specific hiccup emitter for SSR."}
+
+   ;; ---- re-frame.views (CLJS, rf2-4edk warn-once chain) ---------------------
+   {:key         :views/maybe-warn-plain-fn-under-non-default-frame!
+    :producer-ns 're-frame.views.warn-once
+    :description "Emit the once-per-pair warning when a plain fn renders under a non-default frame."}
+   {:key         :views/clear-plain-fn-warned-pairs!
+    :producer-ns 're-frame.views.warn-once
+    :description "Clear the warned-pairs cache (test isolation)."}
+
+   ;; ---- :adapter/* — chained / routed across every CLJS adapter (rf2-0d35) --
+   {:key         :adapter/clear-warn-once-caches!
+    :producer-ns '[re-frame.views.warn-once
+                   re-frame.adapter.helix
+                   re-frame.adapter.uix]
+    :chained?    true
+    :design-bead "rf2-4edk"
+    :description "Chained reset of every adapter's warn-once defonce caches."}
+   {:key         :adapter/current-frame
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-d4sf"
+    :description "React-context-tier frame-id reader (each adapter routes via current-adapter)."}
+   {:key         :adapter/current-component
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim]
+    :chained?    true
+    :design-bead "rf2-wbnl"
+    :description "Resolve the in-flight Reagent component (routed via current-adapter)."}
+   {:key         :adapter/ratom
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific ratom constructor (re-frame.interop/ratom)."}
+   {:key         :adapter/ratom?
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific ratom predicate (re-frame.interop/ratom?)."}
+   {:key         :adapter/make-reaction
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific make-reaction (re-frame.interop/make-reaction)."}
+   {:key         :adapter/add-on-dispose!
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific add-on-dispose! (re-frame.interop/add-on-dispose!)."}
+   {:key         :adapter/dispose!
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific dispose! (re-frame.interop/dispose!)."}
+   {:key         :adapter/reactive?
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific reactive? predicate (re-frame.interop/reactive?)."}
+   {:key         :adapter/after-render
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-s36l"
+    :description "Substrate-specific after-render hook (re-frame.interop/after-render)."}
+   {:key         :adapter/wrap-view
+    :producer-ns '[re-frame.adapter.uix
+                   re-frame.adapter.helix]
+    :chained?    true
+    :design-bead "rf2-00li"
+    :description "Substrate-side source-coord injection on rendered React elements."}
+
+   ;; ---- re-frame.epoch (rf2-lt4e Tool-Pair surface) -------------------------
+   {:key         :epoch/settle!
+    :producer-ns 're-frame.epoch
+    :description "Settle the current in-flight epoch (commit to history)."}
+   {:key         :epoch/discard-buffer!
+    :producer-ns 're-frame.epoch
+    :description "Discard the in-flight epoch buffer without committing."}
+   {:key         :epoch/in-flight-buffer
+    :producer-ns 're-frame.epoch
+    :description "Return the in-flight epoch buffer (introspection)."}
+   {:key         :epoch/capture-event
+    :producer-ns 're-frame.epoch
+    :description "Capture an event into the in-flight epoch buffer."}
+   {:key         :epoch/epoch-history
+    :producer-ns 're-frame.epoch
+    :description "Return the committed-epoch ring buffer (introspection)."}
+   {:key         :epoch/restore-epoch
+    :producer-ns 're-frame.epoch
+    :description "Restore app-db / schemas to a previously-captured epoch."}
+   {:key         :epoch/reset-frame-db!
+    :producer-ns 're-frame.epoch
+    :description "Reset a frame's app-db to the epoch-recorded snapshot."}
+   {:key         :epoch/register-epoch-cb
+    :producer-ns 're-frame.epoch
+    :description "Register an epoch-settled callback."}
+   {:key         :epoch/remove-epoch-cb
+    :producer-ns 're-frame.epoch
+    :description "Unregister a previously-registered epoch-settled callback."}
+   {:key         :epoch/configure!
+    :producer-ns 're-frame.epoch
+    :description "Configure epoch buffer size / capture policy."}
+   {:key         :epoch/clear-history!
+    :producer-ns 're-frame.epoch
+    :description "Clear the committed-epoch ring buffer (test isolation)."}
+   {:key         :epoch/clear-epoch-cbs!
+    :producer-ns 're-frame.epoch
+    :description "Clear every registered epoch-settled callback (test isolation)."}
+   {:key         :epoch/on-frame-destroyed
+    :producer-ns 're-frame.epoch
+    :description "Tear down a frame's epoch state when the frame is destroyed."}
+
+   ;; ---- re-frame.trace (re-frame.registrar replace-warning seam) ------------
+   {:key         :trace/emit!
+    :producer-ns 're-frame.trace
+    :description "Emit a trace event (registrar replace-warning seam)."}
+   {:key         :trace/emit-error!
+    :producer-ns 're-frame.trace
+    :description "Emit a trace error event (registrar replace-warning seam)."}])
+
+(defn hook-keys
+  "Set of every late-bind hook key documented in the directory."
+  []
+  (into #{} (map :key) hooks))
+
+(defn entry
+  "Look up the directory entry for `hook-key`, or nil."
+  [hook-key]
+  (some (fn [e] (when (= hook-key (:key e)) e)) hooks))

--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -1,0 +1,169 @@
+(ns re-frame.late-bind-drift-test
+  "Per rf2-n2j0 — drift detection between the late-bind hook
+  directory (`re-frame.late-bind.directory/hooks`) and the actual
+  `(late-bind/set-fn! ...)` call sites scattered across every artefact
+  under `implementation/`.
+
+  Pre-rf2-n2j0 the directory lived in an 85-line `^:doc` metadata
+  string on the `hooks` atom in `re-frame.late_bind.cljc`. The
+  metadata silently drifted: keys were published with no entry
+  (`:trace/emit!`, `:routing/route-link`, `:machines/invoke-all-init-fx`,
+  `:epoch/reset-frame-db!`, `:schemas/reg-app-schemas`,
+  `:http/register-managed-machine!`, and several `:machines/after-*`
+  effect handlers), and entries claimed producers that never landed
+  in tree. This test pins both directions:
+
+    1. Every key the directory mentions is published by at least one
+       in-tree call site.
+    2. Every published key has a directory entry.
+
+  Mechanism: walk every `.clj{c,s}` file under `implementation/` and
+  match `(late-bind/set-fn! <keyword> ...)`. Filter to source files
+  (skip `test/` paths — test files temporarily flip hooks for
+  isolation but don't publish new keys).
+
+  Failure messages name the missing entries / orphaned publications
+  explicitly so the fix is obvious.")
+
+(require '[clojure.java.io :as io]
+         '[clojure.set :as set]
+         '[clojure.string :as str]
+         '[clojure.test :refer [deftest is testing]]
+         '[re-frame.late-bind.directory :as directory])
+
+(def ^:private repo-implementation-root
+  "Absolute path to the `implementation/` directory at the repo root.
+  Resolved relative to this file's classpath location: tests run from
+  `implementation/core/`, so `..` reaches `implementation/`."
+  (-> (io/file "..")
+      .getCanonicalFile))
+
+(defn- source-files
+  "Every `.clj`, `.cljc`, `.cljs` file under `implementation/<art>/src/`.
+  Skips `test/` directories — late-bind hook publication must live in
+  source, not test fixtures."
+  []
+  (let [root repo-implementation-root]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (filter (fn [^java.io.File f]
+                   (let [name (.getName f)]
+                     (or (str/ends-with? name ".clj")
+                         (str/ends-with? name ".cljc")
+                         (str/ends-with? name ".cljs")))))
+         (filter (fn [^java.io.File f]
+                   (let [path (.getPath f)
+                         ;; normalise separators for matching across Win/POSIX.
+                         norm (str/replace path "\\" "/")]
+                     (and (str/includes? norm "/src/")
+                          (not (str/includes? norm "/test/")))))))))
+
+(def ^:private set-fn-call-re
+  "Match `(late-bind/set-fn! :namespace/key ...`.
+
+  The keyword grammar follows the late-bind convention of namespaced
+  keywords with `/` separator. The regex is intentionally loose on
+  whitespace so multi-line forms match."
+  #"\(late-bind/set-fn!\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+
+(def ^:private route-hook-call-re
+  "Match `(substrate-adapter/route-hook! adapter :namespace/key ...`.
+
+  Per rf2-0d35 every CLJS adapter publishes its substrate-specific
+  `:adapter/*` hooks through `route-hook!` (which wraps the impl in a
+  current-adapter routing closure and chains to the previously-
+  registered handler). The wrapper invokes `late-bind/set-fn!`
+  internally — the drift scan must treat both call shapes as
+  equivalent publications."
+  #"\(substrate-adapter/route-hook!\s+\S+\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+
+(defn- match-keys
+  [re content]
+  (->> (re-seq re content)
+       (map (comp keyword #(subs % 1) second))
+       set))
+
+(defn- published-keys-in-file
+  [^java.io.File f]
+  (let [content (slurp f)]
+    (into (match-keys set-fn-call-re content)
+          (match-keys route-hook-call-re content))))
+
+(defn- published-keys
+  "Set of every late-bind key published from in-tree source files."
+  []
+  (reduce (fn [acc f]
+            (into acc (published-keys-in-file f)))
+          #{}
+          (source-files)))
+
+(defn- producer-publishes-key?
+  "Return true when one of the entry's producer-ns symbols (single or
+  vector) appears in the source for the given file. Used to spot-check
+  that an entry's claimed producer exists in tree."
+  [producer-ns]
+  (let [producers (if (sequential? producer-ns) producer-ns [producer-ns])
+        all-source (mapv slurp (source-files))]
+    (every? (fn [ns-sym]
+              (let [ns-decl (str "(ns " ns-sym)]
+                (some #(str/includes? % ns-decl) all-source)))
+            producers)))
+
+;; ---- assertions ----------------------------------------------------------
+
+(deftest every-directory-entry-has-required-fields
+  (testing "Each entry in re-frame.late-bind.directory/hooks declares :key, :producer-ns, :description"
+    (doseq [entry directory/hooks]
+      (is (keyword? (:key entry))
+          (str "entry must have a keyword :key — saw " (pr-str entry)))
+      (is (or (symbol? (:producer-ns entry))
+              (and (sequential? (:producer-ns entry))
+                   (every? symbol? (:producer-ns entry))))
+          (str "entry " (:key entry)
+               " :producer-ns must be a symbol or vector of symbols — saw "
+               (pr-str (:producer-ns entry))))
+      (is (string? (:description entry))
+          (str "entry " (:key entry) " missing :description")))))
+
+(deftest directory-keys-are-unique
+  (testing "No duplicate :key entries in the directory"
+    (let [ks   (map :key directory/hooks)
+          dups (->> (frequencies ks)
+                    (filter (fn [[_ n]] (> n 1)))
+                    (map first))]
+      (is (empty? dups)
+          (str "duplicate directory entries: " (pr-str dups))))))
+
+(deftest every-published-key-has-a-directory-entry
+  (testing "Every (late-bind/set-fn! :key ...) site in implementation/**/src is documented"
+    (let [published (published-keys)
+          documented (directory/hook-keys)
+          orphans (sort (set/difference published documented))]
+      (is (empty? orphans)
+          (str "These keys are published via (late-bind/set-fn! ...) but missing from "
+               "re-frame.late-bind.directory/hooks — add a directory entry:\n  "
+               (str/join "\n  " orphans))))))
+
+(deftest every-directory-entry-has-a-real-producer
+  (testing "Every directory entry's :producer-ns appears as a `(ns ...)` declaration in tree"
+    (let [stale (->> directory/hooks
+                     (remove (fn [e] (producer-publishes-key? (:producer-ns e))))
+                     (map :key)
+                     sort)]
+      (is (empty? stale)
+          (str "These directory entries claim a producer ns that doesn't exist in "
+               "implementation/**/src — fix :producer-ns or delete the entry:\n  "
+               (str/join "\n  " stale))))))
+
+(deftest every-directory-entry-is-actually-published
+  (testing "Every directory entry's :key has at least one (late-bind/set-fn! :key ...) call site"
+    (let [published (published-keys)
+          missing-publish (->> directory/hooks
+                               (map :key)
+                               (remove published)
+                               sort)]
+      (is (empty? missing-publish)
+          (str "These directory entries have no corresponding "
+               "(late-bind/set-fn! ...) call site in implementation/**/src "
+               "— add a publication or remove the entry:\n  "
+               (str/join "\n  " missing-publish))))))


### PR DESCRIPTION
## Summary
- Replace the 85-line `^:doc` metadata string on `re-frame.late-bind/hooks` with a structured CLJC data file `re-frame.late-bind.directory` — one map per published hook key (`:key` / `:producer-ns` / `:design-bead` / `:description` / `:chained?`). Pure data; comment-friendly; readable from both JVM and CLJS without extra resource plumbing.
- Add a drift-detection test (`implementation/core/test/re_frame/late_bind_drift_test.clj`, 5 deftests / 271 assertions) that walks every `.clj{c,s}` source file under `implementation/**/src` for both `(late-bind/set-fn! :k ...)` and `(substrate-adapter/route-hook! adapter :k ...)` publication shapes and asserts: every published key is in the directory, every directory entry has a matching publication + a real producer ns.
- Capture the directory entries the old metadata had silently missed: `:trace/emit!`, `:trace/emit-error!`, `:routing/route-link`, `:machines/invoke-all-init-fx`, `:machines/after-schedule-fx`, `:machines/after-cancel-fx`, `:epoch/reset-frame-db!`, `:schemas/reg-app-schemas`, `:http/register-managed-machine!`, and the `reagent-slim` adapter's `:adapter/current-component` publication.
- Slim `late_bind.cljc`'s metadata: the `hooks` atom now carries a one-line `:doc` pointing at the directory ns as the authoritative inventory.

## Test plan
- [x] `clojure -M:test` per artefact: core (338/1727), schemas (53/187), machines (119/332), routing (28/110), flows (26/98), http (72/230), ssr (31/118), epoch (59/233) — all pass
- [x] `npm run test:cljs` — 691 tests / 1728 assertions, 0 failures
- [x] `npm run test:browser` — 691 / 1760, 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:examples` — every example PASS
- [x] `mkdocs build --strict` — warning count unchanged vs origin/main (119 pre-existing, none added by this PR)
- [x] Drift test fails informatively on a deliberately-broken orphan publication (`:rf-n2j0/canary` injected into `router.cljc`)
- [x] Drift test fails informatively on a deliberately-broken orphan directory entry (`:rf-n2j0/orphan-directory-entry` injected into `directory.cljc`)