### PR TITLE
spec(causa): batched SOTA learn-from extensions — co-pilot chips + empty-state hints + machine inspector share (rf2-5zy95 rf2-spy54 rf2-tugvq)

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -161,6 +161,102 @@ state per-machine in localStorage).
 - **Transition history** virtualises past 200 entries; older entries
   scroll into view but are not retained in DOM.
 
+## Share affordance
+
+Right-click on the machine chart (or use the panel header's `⋯`
+overflow menu) surfaces a **Copy machine as…** sub-menu:
+
+| Format | Output |
+|---|---|
+| **PNG** | Rasterised chart at 2x DPR, transparent background, current-state highlight included. Copied to clipboard as an image. |
+| **SVG** | Vector chart with embedded fonts (so it renders identically when pasted into a doc or a Figma frame), current-state highlight included. Copied to clipboard as `image/svg+xml`. |
+| **Share URL** | A URL with a serialised static machine definition encoded in the fragment (`#machine=<base64-edn>`). When opened in a Causa-equipped page, Causa renders the chart in a read-only viewer; when opened elsewhere it falls back to a hosted viewer in `tools/machines-viz/`. |
+
+Inspired by Stately Visualizer's registry-style share (save chart,
+share URL, embed iframe). The use cases: dropping a chart into a
+pull-request description, into a design doc, into a Slack thread,
+or onto a whiteboard during a design discussion.
+
+### NOT a session export
+
+This is **not** a session export. Lock #4 holds: Causa never
+serialises the running trace stream, the epoch buffer, the app-db
+history, or the conversation — those are session-local by design,
+for the privacy and reproducibility reasons spelled out in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) (Lock #4 — Session
+export).
+
+What this share affordance serialises is a **static machine
+definition**:
+
+- The machine's topology (states, transitions, guards, actions,
+  `:invoke` / `:invoke-all` declarations, `:after` timer
+  specifications) — i.e. the data that was registered via
+  `reg-machine`.
+- The machine's current state at the moment of the share (the
+  `[:rf/machines <id>]` snapshot) — for visual continuity, so the
+  recipient sees what the sharer was looking at.
+- The machine-id and the source-coord metadata for jump-to-source
+  resolution.
+
+What it does **not** serialise:
+
+- Trace events, epochs, app-db slices outside `[:rf/machines <id>]`,
+  user inputs, fx outputs, conversation buffer.
+- Any data from any panel other than the machine inspector.
+- Any cross-machine state (parent / sibling machines unless the
+  sharer's chart explicitly includes them via `:invoke-all`).
+
+The serialised form is **reproducible from the registry alone**:
+anyone with the same re-frame2 build and the same `reg-machine`
+call can reconstruct the topology byte-for-byte. The current-state
+field is the only non-reproducible bit, and it is purely a
+visual-highlight hint — the recipient can clear it via the
+read-only viewer's "show idle" toggle.
+
+### Read-only viewer
+
+A page that loads with `#machine=...` in its URL fragment renders
+the chart in a read-only `MachineChart` (the same component from
+`tools/machines-viz/` but with `:on-state-click` and
+`:on-transition-click` no-op'd, and the transition-history ribbon
+hidden — there is no transition history to show; this is a
+snapshot, not a session). The page surfaces a single banner: "This
+is a static machine chart, not a Causa session — interactions are
+disabled."
+
+### Privacy posture
+
+A share URL embeds **only** machine topology + current-state. It
+contains no event vectors, no user data, no app-db slices, no
+source code. Authors of state machines must still treat the
+registered topology as code (it may reveal product structure), but
+the share affordance does not leak run-time data.
+
+The chart is generated client-side; nothing is sent to a server.
+The hosted viewer in `tools/machines-viz/` is statically hostable
+and itself stateless.
+
+### Performance
+
+- PNG / SVG rendering: client-side via the same SVG primitive the
+  inspector uses, at the chart's natural size. Sub-50ms for charts
+  up to ~80 nodes.
+- Share-URL encoding: edn → transit-write → base64; for typical
+  machines (~20 states, ~30 transitions) the URL is under 4 KB.
+  Charts large enough to exceed common URL limits (~8 KB) surface
+  a "Copy as edn fragment instead" fallback that puts the payload
+  on the clipboard.
+
+### Accessibility
+
+The PNG / SVG outputs include an `<title>` and `<desc>` element
+(SVG) or alt-text companion (PNG, as a sidecar `text/plain` payload
+on the clipboard) summarising the machine: its id, its current
+state, and the number of states / transitions. Screen readers
+pasting the SVG into a document have the same overview the
+sighted user has.
+
 ## Empty state
 
 When no machines are registered:

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -435,15 +435,99 @@ Three layers, no onboarding tour:
    (then never again).
 
 2. **Empty-state hints.** Each empty state shows a contextual
-   keyboard hint ("No events yet. Press `Ctrl+Shift+C` again to
-   close..."). On first event selection, a 4-second auto-dismiss
-   popover suggests "Press `c` for the causality graph."
+   keyboard hint and, where appropriate, a sibling co-pilot
+   slash-command nudge. The keyboard hint is the canonical surface
+   ("No events yet. Press `Ctrl+Shift+C` again to close…"); the
+   co-pilot hint is the auxiliary, opt-in surface — see
+   §Empty-state hints below for the per-panel table. On first event
+   selection, a 4-second auto-dismiss popover suggests "Press `c`
+   for the causality graph."
 
 3. **The command palette itself.** Typing `?` in the palette filters
    to commands and shows their shortcuts. The palette is the
    documentation.
 
 We do **not** ship a tour. Causa is a tool, not an experience.
+
+## Empty-state hints
+
+Each panel's empty state — when no data has landed yet, or when the
+relevant runtime feature isn't wired up — pairs the canonical
+keyboard hint with an optional sibling co-pilot slash-command hint.
+This is the discoverability nudge for the co-pilot: Lock 8 keeps the
+rail collapsed by default, so the empty-state is the first place a
+new user sees what the co-pilot can do.
+
+Inspired by Chrome DevTools' command-palette discovery surface and
+Gemini's auto-suggested prompts in empty states. The keyboard hint
+is the canonical answer for power users; the slash-command hint is
+the bridge for users who prefer natural-language interrogation.
+
+### Per-panel hints
+
+The empty-state copy lives in each panel's own spec — see the
+"Empty state" section in [`001-Causality-Graph.md`](./001-Causality-Graph.md),
+[`003-Machine-Inspector.md`](./003-Machine-Inspector.md),
+[`004-App-DB-Diff.md`](./004-App-DB-Diff.md),
+[`005-Schema-Timeline.md`](./005-Schema-Timeline.md), and
+[`006-Hydration-Debugger.md`](./006-Hydration-Debugger.md). This
+table is the canonical mapping from each empty state to its
+co-pilot sibling hint:
+
+| Panel / state | Keyboard hint | Co-pilot hint (sibling) |
+|---|---|---|
+| Events — no events yet | "Press `[c]` for the causality graph." | "…or ask the co-pilot: `/why <epoch>`." |
+| Causality — no cascades yet | "Press `[` / `]` to walk history." | "…or ask: `/explain <epoch>`." |
+| App-db — no diffs yet | "Every dispatch lands here." | "…or ask: `/diff <epoch-a> <epoch-b>`." |
+| Machines — no machines registered | "→ Read about machine integration." | "…or ask: `/state <machine-id>` once one is registered." |
+| Schemas — no schemas registered | "→ Read about schema integration." | (none — no schemas means no data to query; co-pilot would have nothing to cite) |
+| Hydration — no SSR detected | "→ See Spec 011." | (none — Lock 4 / privacy posture: don't nudge into a feature the app may not opt into) |
+| Trace — empty buffer | "Click around your app." | "…or ask: `/find <pattern>` once events land." |
+| Co-pilot — first open | (already lists example questions inline) | (this *is* the co-pilot empty state — see [`009-AI-CoPilot.md`](./009-AI-CoPilot.md) §Empty state) |
+
+The keyboard hint is always primary; the co-pilot hint is appended
+as a sibling line beneath the keyboard hint. Where the co-pilot
+column is **(none)**, no sibling renders — the keyboard hint stands
+alone. A panel may also omit the co-pilot hint when the empty state
+exists because *the underlying feature isn't wired up* (no schemas
+registered, no SSR detected) — in those cases the co-pilot has no
+data to cite and the hint would be a hollow gesture.
+
+### Visual treatment
+
+The sibling hint renders below the keyboard hint in the same
+caption type (12px, `text-tertiary`) with a leading `◇` glyph in
+co-pilot magenta so the eye reads it as a co-pilot affordance:
+
+```
+   No events yet.
+   Click around your app — every dispatch will land here.
+
+   Press [c] for the causality graph.
+   ◇ …or ask the co-pilot: /why <epoch>
+```
+
+The `◇` glyph is the same one used in the sidebar's co-pilot row
+and the top-strip's collapsed cue (see §The AI co-pilot collapsed
+cue above) — visual continuity reinforces "this is how you reach
+the co-pilot."
+
+### Discoverability budget
+
+The sibling co-pilot hint **does not** open the co-pilot rail. The
+user must press `Ctrl+Shift+/` (or click the rail entry) to invoke
+the suggested command — same Lock 8 posture. The hint is a
+discoverability nudge, not a CTA.
+
+After the user has used the co-pilot once, the sibling hint
+continues to render (it's a slash-command teach, not a once-only
+onboarding). The cue glyph in the top strip stops pulsing (per §The
+AI co-pilot collapsed cue) but the in-panel hints persist as
+contextual prompts.
+
+### `prefers-reduced-motion`
+
+No animation on these hints; they render in place at panel mount.
 
 ## Bundle splitting
 

--- a/tools/causa/spec/009-AI-CoPilot.md
+++ b/tools/causa/spec/009-AI-CoPilot.md
@@ -127,6 +127,12 @@ Context you have:
 Rules:
 - Cite source coords for every claim (e.g. "events.cljs:213").
 - Reference epoch ids so the user can verify in the panel.
+- When you cite a runtime identifier — a dispatch-id, a path, an
+  epoch-number, or a handler-id — emit the structured form
+  {:rf.copilot/chip <key> <value>} inline so the UI renders an
+  interactive chip pointing at that piece of evidence. Use the
+  plain text form only when the identifier cannot be expressed as a
+  chip (e.g. partially-redacted values).
 - Say "I cannot determine that" plainly when you cannot.
 - One action suggestion at a time.
 - Never invent data. If you do not see it in the trace, do not claim it.
@@ -183,6 +189,9 @@ Responses are markdown rendered with:
   json).
 - **Source-coord chips.** `src/cart/events.cljs:213` renders as a
   chip with a `🔗` icon; click opens source.
+- **Causa data chips.** Structured runtime identifiers in the
+  response render as interactive Causa chips, not plain text — see
+  §Causa data chips below.
 - **Action chips.** `[Open source]`, `[Show graph]`, `[Rewind here]`,
   `[Filter to this cascade]` — inline buttons in the response.
   Action chips that mutate runtime (rewind, re-dispatch) always
@@ -194,6 +203,108 @@ Responses are markdown rendered with:
 
 Responses **stream** (per token, ~25 tokens/sec). First words within
 ~600ms of Enter. Respects `prefers-reduced-motion` (instant render).
+
+## Causa data chips
+
+The model produces citations as **structured tokens**, not prose.
+When the LLM's tool-call response or streamed answer contains a known
+runtime identifier — a `:dispatch-id`, a `:path`, an
+`:epoch-number`, a `:handler-id` — Causa renders it as a clickable
+chip that opens the relevant panel pointed at that exact piece of
+evidence. The model talks; the chip points.
+
+This is Lock 2 made concrete: the co-pilot is a *navigator pointing
+at evidence*. A chip is not text-styled-as-a-link; it is a live
+handle on the runtime — the same primitive that the Causality panel
+and the Trace panel render. (Inspired by Portal's "any value can be
+inspected by clicking"; in Causa every cited value is the inspected
+handle itself.)
+
+### Chip types
+
+| Token shape | Chip | Click target |
+|---|---|---|
+| `:dispatch-id <uuid>` | `◆ :checkout/submit` | Events panel — opens that epoch in event-detail. |
+| `:path [<seg> <seg> ...]` | `▥ [:cart :items 3 :qty]` | App-db panel — opens that slice in the app-db inspector, with the path expanded and the slice highlighted. |
+| `:epoch-number <n>` | `⏵ epoch 47` | Bottom scrubber — jumps the scrubber to that epoch (passive; does not rewind). |
+| `:handler-id <id>` | `⚙ :cart/finalise` | Events panel → "Open source" — opens that handler's registration site (the `reg-event-*` call), falling back to the `:doc` if no coord is stamped. |
+
+### Visual treatment
+
+- Same chip chrome as source-coord chips (background `bg-3`,
+  `radius-sm`, 12px caption type) so the eye reads them as
+  first-class data, not decoration.
+- Glyph encodes type (the table above). Glyphs are the same set used
+  in the sidebar and causality strip (`◆`, `▥`, `⏵`, `⚙`) so the
+  chip's affordance is legible without colour.
+- Hover surfaces a tooltip with the resolved value the chip refers
+  to (e.g. an epoch-number chip's tooltip shows the epoch's event
+  vector and timestamp). The user can verify the chip points where
+  it should before clicking — the navigator-not-oracle posture
+  applies to chips too.
+- Right-click opens a small menu: **Open** (default), **Pin** (for
+  app-db paths — pins the slice in App-db's pinned-slices area),
+  **Copy** (copies the identifier as edn).
+
+### Encoding contract
+
+The model emits citations as inline edn fragments inside the
+streamed text:
+
+```
+The :checkout/submit was dispatched from
+{:rf.copilot/chip :dispatch-id #uuid "..."} by :cart/finalise
+({:rf.copilot/chip :handler-id :cart/finalise}). The :path
+{:rf.copilot/chip :path [:cart :items 3 :qty]} changed from 1 to 0
+at {:rf.copilot/chip :epoch-number 47}.
+```
+
+The renderer parses `{:rf.copilot/chip <key> <value>}` fragments at
+stream time and swaps them for the chip component. The system prompt
+(§System prompt above) instructs the model in this encoding;
+unstructured citations still render as plain text and the user reads
+them as prose. The renderer never invents chips from free text — a
+chip only ever renders where the model emitted the explicit form.
+
+### Why structured citations
+
+Free-text identifiers (`epoch 47`, `events.cljs:213`) work but are
+brittle: a model that paraphrases ("the 47th epoch") drops the
+handle. Structured fragments fail loudly: malformed edn renders as
+the literal fragment, surfacing the model's confusion rather than
+hiding it behind plausible prose. The model is rewarded for naming
+data precisely.
+
+### Failure modes
+
+- **Unresolvable identifier.** A chip whose target doesn't exist
+  (stale epoch, GC'd dispatch-id, unregistered handler) renders
+  greyed-out with a `⚠` glyph; click surfaces a "no longer in the
+  trace buffer" tooltip. The model is not asked to verify resolution
+  before emitting; the runtime is the truth.
+- **Empty path / `nil` value.** A `:path` chip pointing at a path
+  that doesn't exist in the current `app-db` opens the App-db panel
+  scrolled to the deepest existing ancestor, with a "this path is
+  absent at the active epoch" hint inline.
+- **Cross-frame identifiers.** When the model cites a `:dispatch-id`
+  from a frame other than the active one, the chip displays the
+  frame badge (`:user/main`) and clicking switches frame as part of
+  opening the epoch.
+
+### Out of scope
+
+- **No editing chip targets after render.** A chip's binding is
+  fixed at emit time; if the user wants to rebind, they ask again.
+- **No drag-and-drop.** Chips are buttons, not draggable values
+  (drag-and-drop would invite the user to compose mutations across
+  panels — out of scope for a pull-only Q&A surface).
+- **No chips in user input.** The user types text; only the model
+  emits chips. (The command palette is the user-side equivalent
+  surface for jumping to a specific epoch / handler / path.)
+
+Cross-reference: [`001-Causality-Graph.md`](./001-Causality-Graph.md)
+§Interactions — chips reuse the same panel-jump primitives the
+graph's click and right-click affordances expose.
 
 ## Ephemeral conversation
 


### PR DESCRIPTION
## Summary

Three disjoint Causa spec extensions filed by the SOTA-alternatives audit (rf2-76qxg). Batched because all three touch separate docs under `tools/causa/spec/`.

### rf2-5zy95 — Co-pilot citations as interactive Causa chips (Portal-inspired)
**File:** `tools/causa/spec/009-AI-CoPilot.md`

Adds a **Causa data chips** section. The co-pilot now emits structured tokens (`{:rf.copilot/chip <key> <value>}`) inline for `:dispatch-id`, `:path`, `:epoch-number`, `:handler-id`. The renderer swaps each for an interactive chip that opens the relevant panel pointed at the cited evidence:

- `:dispatch-id` chip → Events panel, that epoch's detail
- `:path` chip → App-db inspector, that slice highlighted
- `:epoch-number` chip → scrubber jumps (passive, doesn't rewind)
- `:handler-id` chip → handler's registration site

Inspired by Portal's "any value can be inspected by clicking" — except here every cited value *is* the inspected handle, not text-styled-as-a-link. Strengthens Lock 2's "navigator pointing at evidence" framing. The system prompt (§System prompt) is updated to teach the encoding; visual treatment, encoding contract, failure modes (unresolvable id, empty path, cross-frame), and out-of-scope (no drag-drop, no chips in user input) are all spelled out.

### rf2-spy54 — Empty-state hints reference co-pilot slash commands
**File:** `tools/causa/spec/007-UX-IA.md`

Promotes **Empty-state hints** from a sub-bullet under §Discoverability into its own top-level section with a per-panel mapping table. Each context-aware empty state pairs the canonical keyboard hint with a sibling co-pilot slash-command nudge:

- "No events yet" → Press `[c]` for causality graph, `◇ …or ask: /why <epoch>`
- "No machines registered" → keyboard hint + `◇ …or ask: /state <machine-id>`
- App-db, Causality, Trace — analogous

Inspired by Chrome DevTools (2026) command palette + Gemini's auto-suggested empty-state prompts. Lock 8 stays intact: the hint does **not** open the rail; the user still presses `Ctrl+Shift+/`. Skipped where the underlying feature isn't wired up (no schemas, no SSR) — co-pilot would have nothing to cite. The `◇` glyph in co-pilot magenta carries visual continuity with the sidebar's co-pilot row and the top-strip's collapsed cue.

### rf2-tugvq — Machine Inspector share affordance (Stately-inspired)
**File:** `tools/causa/spec/003-Machine-Inspector.md`

Adds a **Share affordance** section. Right-click on the chart (or panel header's `⋯` menu) surfaces a *Copy machine as…* sub-menu with PNG / SVG / share-URL options. Inspired by Stately Visualizer's registry-style share.

**Explicit NOT-a-session-export distinction (Lock #4 holds).** The serialised payload is the **static machine definition**: topology (states, transitions, guards, actions, `:invoke` / `:invoke-all`, `:after`) plus the current-state snapshot. Everything is reproducible from the registry alone. What's **not** serialised: trace events, epochs, app-db slices outside `[:rf/machines <id>]`, conversation, anything from other panels. Share-URLs render in a read-only viewer with interactions no-op'd; privacy posture and accessibility (SVG `<title>` / `<desc>`, alt-text companion for PNG) covered.

## Verification

- `python scripts/check_doc_slugs.py -v` → 229 files scanned, no broken links (EXIT=0)
- `python scripts/check_doc_slugs.py --self-test -v` → 7/7 PASS
- `mkdocs build --strict` → 119 pre-existing warnings unchanged on `releases/2016.md`, `EPs/re-frame2/*`, `skills/re-frame2-implementor.md` etc. **Zero new warnings** introduced by this PR (verified with `diff` against baseline build log)

## Test plan

- [ ] Read 009 §Causa data chips end-to-end; confirm chip encoding contract is implementable
- [ ] Read 007 §Empty-state hints; confirm the per-panel table aligns with each panel's spec
- [ ] Read 003 §Share affordance; confirm NOT-a-session-export language is unambiguous