### PR TITLE
feat(story): Controls panel deeper Malli walk — :map / :vector / :tuple / :set support (rf2-agshe)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -445,15 +445,66 @@ corresponding `:assertions` record.
 ## Schema-derivation pipeline
 
 The control-derivation logic walks the registered Malli schema for
-`:component`:
+`:component` (or an explicit `:schema` slot on the variant/story
+body — Story consults the variant body first, then the parent story,
+then the registered view) and emits a `{arg-key → widget-spec}` map:
 
-- `:string` → `:text`
-- `:int`, `:double` with `:min` / `:max` → bounded `:number`
-- `:boolean` → `:boolean`
-- `:enum`-of-strings → `:select`
-- `:keyword` → `:text` with keyword-coercion
-- Nested `:map` → group with collapsible header
+**Scalar forms**
+
+- `:string` → `{:widget :text}`
+- `:int` / `:double` (optional `:min` / `:max`) → `{:widget :number}`
+- `:boolean` → `{:widget :boolean}`
+- `:keyword` → `{:widget :text}` (keyword-coercion at edit time)
+- `[:enum a b c]` → `{:widget :select :options [a b c]}`
+
+**Collection forms (rf2-agshe)**
+
+The walker recurses into Malli's standard collection operators. Each
+collection widget-spec carries enough data for the renderer to expand
+it into nested rows:
+
+- `[:map [k1 s1] [k2 s2] ...]`
+  → `{:widget :group :kind :map
+      :entries [{:key k1 :widget <recur s1>}
+                {:key k2 :widget <recur s2>} ...]}`
+
+  The renderer shows a labelled header per key and one nested row per
+  entry. Editing entry `kN` writes through to `[:cell-overrides
+  variant-id arg-key kN]`.
+
+- `[:vector X]`
+  → `{:widget :repeater :kind :vector :element <recur X>}`
+
+  The renderer shows the current entries one-per-row with an inline
+  `[-]` button each and a trailing `[+]` button. Adding seeds a
+  default value derived from `X` (`:text → ""`, `:number → 0`,
+  `:boolean → false`, `:select → first option`, `:group → {}`,
+  nested `:repeater → []`, nested `:tuple → [default-per-position]`).
+  Removing an entry slices the underlying vector. Editing entry `i`
+  writes through to `[:cell-overrides variant-id arg-key i]`.
+
+- `[:set X]`
+  → `{:widget :repeater :kind :set :element <recur X>}`
+
+  Identical to `:vector` but the value round-trips through `set` —
+  duplicates collapse and entry order is by stringified value (stable).
+
+- `[:tuple X Y ...]`
+  → `{:widget :tuple :kind :tuple
+      :positions [<recur X> <recur Y> ...]}`
+
+  Fixed-arity sibling of `:repeater` — one row per declared position;
+  no `[+]` / `[-]` affordance. Editing position `i` writes through to
+  `[:cell-overrides variant-id arg-key i]`.
+
+When the schema-walker has nothing to consult (no `:schema`, no
+matching `:argtypes` key), the controls panel falls back to inferring a
+widget-spec from the *value's* CLJS shape — maps recurse as `:group`,
+vectors as `:repeater`, scalars classify by `string?`/`integer?`/etc.
+This keeps "zero argtypes" stories from collapsing to inert `:text`
+widgets for non-trivial value shapes.
 
 Author-supplied `:argtypes` overrides the auto-derivation key-by-key.
 Stage 2 owns the macro side; Stage 4 (controls layer) owns the
-rendering — see [`003-Render-Shell.md`](003-Render-Shell.md).
+rendering — see [`003-Render-Shell.md`](003-Render-Shell.md). The
+nested-collection walker landed via rf2-agshe.

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -9,11 +9,21 @@
 
   Per IMPL-SPEC §9.4 the args editor auto-derives widget shapes from the
   variant's `:argtypes` (an explicit per-arg widget spec) or from the
-  Malli schema attached to `:component` (Spec 010 schemas). Stage 4
-  ships the explicit-`:argtypes` path and the Malli inference for a
-  handful of primitive forms — `:string` / `:int` / `:double` /
-  `:boolean` / `:enum`. Deeper Malli walks land in Stage 6 alongside
-  the design-tokens panel.
+  Malli schema attached to `:component` (Spec 010 schemas).
+
+  The schema walker covers two tiers:
+
+  - **Scalar forms** — `:string` / `:int` / `:double` / `:boolean` /
+    `:keyword` / `[:enum ...]`. Each becomes a single widget.
+  - **Collection forms (rf2-agshe)** — `[:map ...]` / `[:vector X]` /
+    `[:tuple X Y ...]` / `[:set X]`. Each renders as an expandable group
+    whose child rows are recursively derived from the entry schemas.
+    Editing a nested control writes through to the cell-override map at
+    a *path* anchored on the top-level arg-key, so `{:nest {:k v}}`
+    overrides land at `[:cell-overrides variant-id :nest :k]`.
+
+  Author-supplied `:argtypes` overrides the auto-derivation key-by-key
+  (per spec/001 §Schema-derivation pipeline).
 
   ## Decorator toggles
 
@@ -49,7 +59,21 @@
                  :gap "8px"
                  :padding "2px 0"
                  :align-items "center"}
+   :nested-row  {:display "grid"
+                 :grid-template-columns "120px 1fr"
+                 :gap "8px"
+                 :padding "2px 0"
+                 :padding-left "12px"
+                 :border-left "1px solid #3a3a3a"
+                 :margin-left "4px"
+                 :align-items "center"}
+   :group-h     {:color "#9cdcfe"
+                 :font-weight "bold"
+                 :padding "2px 0"
+                 :cursor "default"}
    :label       {:color "#9cdcfe"}
+   :sublabel    {:color "#bdbdbd"
+                 :font-size "10px"}
    :input       {:background "#1e1e1e"
                  :color "#cccccc"
                  :border "1px solid #444"
@@ -77,21 +101,123 @@
                  :cursor "pointer"
                  :font-size "10px"
                  :margin-top "8px"}
+   :rep-button  {:padding "2px 6px"
+                 :background "#37373d"
+                 :color "#cccccc"
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-size "10px"
+                 :margin-left "4px"}
    :empty       {:color "#9a9a9a" :font-style "italic"}})
 
+;; ---- pure: Malli-schema introspection -----------------------------------
+
+(defn- properties?
+  "Is `x` the optional Malli properties map at index 1 of a vector
+  schema? Per Malli convention any map at that slot is properties;
+  vector entries (child schemas for collections) are never maps."
+  [x]
+  (map? x))
+
+(defn- schema-op
+  "Return the operator symbol of a vector schema (`:map`, `:vector`,
+  `:tuple`, `:set`, `:enum`, ...) or nil if `s` is not a vector."
+  [s]
+  (when (vector? s) (first s)))
+
+(defn- schema-properties
+  "Return the optional properties map from a vector schema, or nil."
+  [s]
+  (when (vector? s)
+    (let [x (second s)]
+      (when (properties? x) x))))
+
+(defn- schema-children
+  "Return the child schemas of a vector schema, skipping the optional
+  properties map. For `[:map [:a :string] [:b :int]]` returns
+  `([:a :string] [:b :int])`."
+  [s]
+  (when (vector? s)
+    (let [rest* (rest s)]
+      (if (properties? (first rest*))
+        (rest rest*)
+        rest*))))
+
+(defn- map-entry-key
+  "Map-entry tuples in Malli have shape `[k props? child]`. Return k."
+  [entry]
+  (first entry))
+
+(defn- map-entry-schema
+  "Map-entry tuples in Malli have shape `[k props? child]`. Return
+  child. Skip the optional properties map at index 1."
+  [entry]
+  (let [r (rest entry)]
+    (if (properties? (first r))
+      (second r)
+      (first r))))
+
 ;; ---- pure: argtype inference --------------------------------------------
+
+(declare infer-widget)
+
+(defn- infer-map-widget
+  "Recurse into a `[:map [k1 s1] [k2 s2] ...]` schema, producing a
+  `:group` widget whose `:entries` is a vector of `{:key :widget}`
+  child descriptors. Order is preserved from the schema."
+  [schema]
+  {:widget  :group
+   :kind    :map
+   :entries (mapv (fn [entry]
+                    {:key    (map-entry-key entry)
+                     :widget (infer-widget (map-entry-schema entry))})
+                  (schema-children schema))})
+
+(defn- infer-vector-widget
+  "Recurse into a `[:vector X]` (or `[:set X]`) schema, producing a
+  `:repeater` widget that carries the element schema in `:element` and
+  records which collection variant it represents."
+  [schema kind]
+  {:widget  :repeater
+   :kind    kind
+   :element (infer-widget (first (schema-children schema)))})
+
+(defn- infer-tuple-widget
+  "Recurse into a `[:tuple X Y ...]` schema, producing a `:tuple` widget
+  whose `:positions` is the vector of per-index child widgets."
+  [schema]
+  {:widget    :tuple
+   :kind      :tuple
+   :positions (mapv infer-widget (schema-children schema))})
 
 (defn infer-widget
   "Given a Malli schema fragment (or simple keyword type), return a
   widget descriptor map. Pure data → data; JVM-testable.
 
+  Scalar shapes:
+
   - `:string`             → `{:widget :text}`
   - `:int` / `:double`    → `{:widget :number}`
   - `:boolean`            → `{:widget :boolean}`
+  - `:keyword`            → `{:widget :text}` (keyword-coercion at edit)
   - `[:enum a b c]`       → `{:widget :select :options [a b c]}`
 
+  Collection shapes (rf2-agshe):
+
+  - `[:map [k1 s1] [k2 s2] ...]`
+        → `{:widget :group :kind :map
+            :entries [{:key k1 :widget <recur>} ...]}`
+  - `[:vector X]`
+        → `{:widget :repeater :kind :vector :element <recur on X>}`
+  - `[:set X]`
+        → `{:widget :repeater :kind :set    :element <recur on X>}`
+  - `[:tuple X Y ...]`
+        → `{:widget :tuple :kind :tuple :positions [<recur> ...]}`
+
   Unknown shapes default to `{:widget :text}` — the user can refine
-  via the variant's `:argtypes` slot. Per IMPL-SPEC §9.4."
+  via the variant's `:argtypes` slot. Per IMPL-SPEC §9.4 + spec/001
+  §Schema-derivation pipeline."
   [schema-fragment]
   (cond
     (= :string schema-fragment)  {:widget :text}
@@ -99,38 +225,85 @@
     (= :double schema-fragment)  {:widget :number}
     (= :boolean schema-fragment) {:widget :boolean}
     (= :keyword schema-fragment) {:widget :text}
-    (and (vector? schema-fragment)
-         (= :enum (first schema-fragment)))
-    {:widget :select :options (vec (rest schema-fragment))}
+
+    (vector? schema-fragment)
+    (case (schema-op schema-fragment)
+      :enum   {:widget :select :options (vec (schema-children schema-fragment))}
+      :map    (infer-map-widget schema-fragment)
+      :vector (infer-vector-widget schema-fragment :vector)
+      :set    (infer-vector-widget schema-fragment :set)
+      :tuple  (infer-tuple-widget schema-fragment)
+      ;; Unknown vector form — fall back to :text.
+      {:widget :text})
+
     :else
     {:widget :text}))
+
+(defn- infer-value-shape
+  "Lightweight fallback used when no schema is on file — classify a
+  resolved value by its CLJS shape so the controls panel at least
+  renders *something* sensible."
+  [v]
+  (cond
+    (map? v)         {:widget :group :kind :map
+                      :entries (mapv (fn [[k v']]
+                                       {:key    k
+                                        :widget (infer-value-shape v')})
+                                     v)}
+    (vector? v)      {:widget :repeater :kind :vector
+                      :element (or (some-> v first infer-value-shape)
+                                   {:widget :text})}
+    (set? v)         {:widget :repeater :kind :set
+                      :element (or (some-> v first infer-value-shape)
+                                   {:widget :text})}
+    (string? v)      {:widget :text}
+    (boolean? v)     {:widget :boolean}
+    (integer? v)     {:widget :number}
+    (number? v)      {:widget :number}
+    (keyword? v)     {:widget :text}
+    :else            {:widget :text}))
 
 (defn resolve-argtypes
   "Build the `{arg-key → widget-spec}` map for a variant. Variant-level
   `:argtypes` wins; otherwise we walk the parent story's `:argtypes`;
-  otherwise we infer from the resolved args' value shapes.
+  otherwise we infer from the component schema (when registered);
+  finally we fall back to inferring from the resolved args' value
+  shapes.
 
-  Stage 4 punts the full Spec 010 Malli walk (e.g. component-attached
-  schemas via registrar) to Stage 6 — for Stage 4 the explicit
-  `:argtypes` path is the load-bearing surface."
+  Per rf2-agshe the inference recurses into nested `:map` / `:vector` /
+  `:set` / `:tuple` shapes, producing widget descriptors the renderer
+  expands into nested rows."
   [variant-id]
   (let [vb      (registrar/handler-meta :variant variant-id)
         story   (args/parent-story-id variant-id)
         sb      (when story (registrar/handler-meta :story story))
         types   (merge (:argtypes sb) (:argtypes vb))
+        ;; Prefer an explicit `:schema` slot on the variant/story body
+        ;; (forward-compatible — Spec 010 will land an `:rf/schema` slot
+        ;; on variants for the auto-derivation path). Fall back to the
+        ;; registered :view's `:schema` slot (when reg-view starts
+        ;; carrying one). Per spec/001 §Schema-derivation pipeline.
+        component-id (or (:component vb) (:component sb))
+        component-body (when component-id
+                         (registrar/handler-meta :view component-id))
+        derive-schema (or (:schema vb)
+                          (:schema sb)
+                          (:schema component-body))
+        schema-entries (when (and (vector? derive-schema)
+                                  (= :map (schema-op derive-schema)))
+                         (into {}
+                               (map (fn [entry]
+                                      [(map-entry-key entry)
+                                       (map-entry-schema entry)]))
+                               (schema-children derive-schema)))
         eff     (args/resolve-args variant-id)]
     (reduce-kv
       (fn [acc k v]
         (if (contains? acc k)
           acc
-          (assoc acc k (infer-widget
-                         (cond
-                           (string? v)  :string
-                           (boolean? v) :boolean
-                           (integer? v) :int
-                           (number? v)  :double
-                           (keyword? v) :keyword
-                           :else        :string)))))
+          (let [from-schema (when-let [s (get schema-entries k)]
+                              (infer-widget s))]
+            (assoc acc k (or from-schema (infer-value-shape v))))))
       (or types {})
       eff)))
 
@@ -142,16 +315,26 @@
 (defn- read-event-checked [e]
   (.. e -target -checked))
 
-(defn- arg-widget
-  [variant-id arg-key value {:keys [widget options]}]
+(defn- on-change-at-path
+  "Write `value` through to `[:cell-overrides variant-id & path]` via
+  the shell-state atom. `path` is `[arg-key & sub-path]` where the
+  sub-path may be empty for top-level scalars."
+  [variant-id path value]
+  (state/swap-state! state/set-cell-override variant-id (vec path) value))
+
+(declare arg-widget)
+
+(defn- scalar-widget
+  "Render a scalar widget for `widget-spec` whose value lives at `path`
+  inside `variant-id`'s args. Path is `[arg-key & sub-path]`."
+  [variant-id path value {:keys [widget options]}]
   (case widget
     :text     [:input {:type      "text"
                        :style     (:input styles)
                        :value     (if (nil? value) "" (str value))
                        :on-change (fn [e]
-                                    (state/swap-state!
-                                      state/set-cell-override
-                                      variant-id arg-key
+                                    (on-change-at-path
+                                      variant-id path
                                       (read-event-value e)))}]
     :number   [:input {:type      "number"
                        :style     (:input styles)
@@ -159,22 +342,19 @@
                        :on-change (fn [e]
                                     (let [s (read-event-value e)
                                           v (when (seq s) (js/parseFloat s))]
-                                      (state/swap-state!
-                                        state/set-cell-override
-                                        variant-id arg-key v)))}]
+                                      (on-change-at-path
+                                        variant-id path v)))}]
     :boolean  [:input {:type      "checkbox"
                        :checked   (boolean value)
                        :on-change (fn [e]
-                                    (state/swap-state!
-                                      state/set-cell-override
-                                      variant-id arg-key
+                                    (on-change-at-path
+                                      variant-id path
                                       (read-event-checked e)))}]
     :select   [:select {:value     (str value)
                         :style     (:input styles)
                         :on-change (fn [e]
-                                     (state/swap-state!
-                                       state/set-cell-override
-                                       variant-id arg-key
+                                     (on-change-at-path
+                                       variant-id path
                                        (read-event-value e)))}
                (for [opt options]
                  ^{:key (str opt)}
@@ -182,12 +362,134 @@
     [:span {:style (:empty styles)}
      (str "unsupported widget " widget)]))
 
+(defn- group-widget
+  "Render a `:map`-derived collapsible group. The header sits in its
+  own row; each child entry renders as a nested row."
+  [variant-id path value {:keys [entries]}]
+  [:div
+   [:div {:style (:group-h styles)
+          :data-controls-group ":map"}
+    (str (last path) " {} ")]
+   (into [:div]
+         (for [{ek :key ew :widget} entries
+               :let [child-path  (conj (vec path) ek)
+                     child-value (get value ek)]]
+           ^{:key (str ek)}
+           [:div {:style (:nested-row styles)
+                  :data-controls-key (str ek)}
+            [:span {:style (:sublabel styles)} (str ek)]
+            [arg-widget variant-id child-path child-value ew]]))])
+
+(defn- vector-coerce
+  "Normalise a value into a vector. `nil` → `[]`; sets become a stable
+  sorted vec; other sequentials become vectors verbatim."
+  [v]
+  (cond
+    (nil? v)         []
+    (vector? v)      v
+    (set? v)         (vec (sort-by str v))
+    (sequential? v)  (vec v)
+    :else            [v]))
+
+(defn- default-element-value
+  "A sensible empty value for `:repeater`/`:tuple` entries based on the
+  element widget shape. Keeps the UI from leaving slots that immediately
+  fail validation."
+  [widget-spec]
+  (case (:widget widget-spec)
+    :text    ""
+    :number  0
+    :boolean false
+    :select  (first (:options widget-spec))
+    :group   {}
+    :repeater (case (:kind widget-spec) :set #{} [])
+    :tuple    (mapv default-element-value (:positions widget-spec))
+    nil))
+
+(defn- repeater-widget
+  "Render a `:vector` (or `:set`) repeater. Each entry gets a nested row
+  + an inline `[-]` button. A trailing `[+]` button appends a fresh
+  default-valued entry."
+  [variant-id path value {:keys [element kind] :as widget-spec}]
+  (let [entries (vector-coerce value)
+        on-add  (fn []
+                  (on-change-at-path
+                    variant-id path
+                    (let [next-v (conj entries (default-element-value element))]
+                      (case kind
+                        :set (set next-v)
+                        next-v))))
+        on-del  (fn [i]
+                  (on-change-at-path
+                    variant-id path
+                    (let [v (vec (concat (subvec entries 0 i)
+                                         (subvec entries (inc i))))]
+                      (case kind
+                        :set (set v)
+                        v))))]
+    [:div
+     [:div {:style (:group-h styles)
+            :data-controls-group (str kind)}
+      (str (last path) " " (case kind :set "#{}" "[]") " ")
+      [:button {:style    (:rep-button styles)
+                :data-controls-action "add"
+                :on-click (fn [_] (on-add))}
+       "[+]"]]
+     (into [:div]
+           (for [[i entry-value] (map-indexed vector entries)
+                 :let [child-path (conj (vec path) i)]]
+             ^{:key i}
+             [:div {:style (:nested-row styles)
+                    :data-controls-index i}
+              [:span {:style (:sublabel styles)} (str "[" i "]")]
+              [:div
+               [arg-widget variant-id child-path entry-value element]
+               [:button {:style    (:rep-button styles)
+                         :data-controls-action "del"
+                         :on-click (fn [_] (on-del i))}
+                "[-]"]]]))]))
+
+(defn- tuple-widget
+  "Render a `:tuple` — one row per positional element. The arity is
+  fixed; no `[+]` / `[-]` affordance. Each position's path is
+  `[... i]`."
+  [variant-id path value {:keys [positions]}]
+  (let [entries (vector-coerce value)]
+    [:div
+     [:div {:style (:group-h styles)
+            :data-controls-group ":tuple"}
+      (str (last path) " () ")]
+     (into [:div]
+           (for [[i pos-widget] (map-indexed vector positions)
+                 :let [child-path  (conj (vec path) i)
+                       child-value (get entries i)]]
+             ^{:key i}
+             [:div {:style (:nested-row styles)
+                    :data-controls-index i}
+              [:span {:style (:sublabel styles)} (str "[" i "]")]
+              [arg-widget variant-id child-path child-value pos-widget]]))]))
+
+(defn arg-widget
+  "Generic widget dispatcher. `path` is the vector path within the
+  variant's args (`[arg-key & sub-keys]`); for top-level scalars the
+  path is a 1-vector. The renderer dispatches on `widget-spec`'s
+  `:widget` slot — `:group` / `:repeater` / `:tuple` recurse, everything
+  else falls through to `scalar-widget`."
+  [variant-id path value widget-spec]
+  (case (:widget widget-spec)
+    :group    [group-widget    variant-id path value widget-spec]
+    :repeater [repeater-widget variant-id path value widget-spec]
+    :tuple    [tuple-widget    variant-id path value widget-spec]
+    [scalar-widget variant-id path value widget-spec]))
+
 ;; ---- public components ---------------------------------------------------
 
 (defn args-editor
   "Render the args editor for `variant-id`. Reads the resolved args via
   `args/resolve-args` and walks every key, rendering a widget per the
-  inferred argtype."
+  inferred argtype. Top-level keys render as flat rows; collection
+  argtypes (`:map` / `:vector` / `:set` / `:tuple`) recurse into nested
+  rows (rf2-agshe)."
   [variant-id]
   (let [shell      @state/shell-state-atom
         eff-args   (args/resolve-args
@@ -202,9 +504,10 @@
        [:div {:style (:empty styles)} "no args resolved"]
        (for [[k v] (sort-by key eff-args)]
          ^{:key k}
-         [:div {:style (:row styles)}
+         [:div {:style (:row styles)
+                :data-controls-arg (str k)}
           [:span {:style (:label styles)} (str k)]
-          [arg-widget variant-id k v
+          [arg-widget variant-id [k] v
            (get argtypes k {:widget :text})]]))
      (when (seq (get-in shell [:cell-overrides variant-id]))
        [:button {:style    (:button styles)

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -12,7 +12,9 @@
   - `select-workspace`   — change the focused workspace id.
   - `toggle-tag-filter`  — flip a tag on/off in the filter set.
   - `set-active-modes`   — replace the active mode set.
-  - `set-cell-override`  — set a single arg override.
+  - `set-cell-override`  — set a single arg override (scalar key or
+                           nested path; the nested-path arity backs the
+                           nested-schema controls walker, rf2-agshe).
   - `clear-cell-overrides` — drop all overrides for the focused variant.
   - `filter-variants`    — pure fn: given a set of variant bodies + the
                            shell state, return the visible subset.
@@ -170,9 +172,29 @@
       (seq unaxed) (conj [::unaxed unaxed]))))
 
 (defn set-cell-override
-  "Set a single arg override for `variant-id`."
-  [state variant-id arg-key value]
-  (assoc-in state [:cell-overrides variant-id arg-key] value))
+  "Set a single arg override for `variant-id`. The override may target
+  either a top-level arg-key (scalar arity) or a nested path within the
+  arg's value (vector arity — used by the nested Malli walker per
+  rf2-agshe). The vector arity is path-aware: the first element is the
+  top-level arg-key; the remaining elements address into the nested
+  value via `assoc-in` semantics.
+
+  - 3-arity:           `(set-cell-override state v k v)` — scalar override.
+  - vector-key arity:  `(set-cell-override state v [k & path] value)` —
+                       nested override. When `path` is empty the call is
+                       equivalent to the scalar form."
+  [state variant-id arg-key-or-path value]
+  (cond
+    (and (sequential? arg-key-or-path) (seq arg-key-or-path))
+    (let [[k & path] arg-key-or-path]
+      (assoc-in state (into [:cell-overrides variant-id k] path) value))
+
+    (sequential? arg-key-or-path)
+    ;; Empty path — no-op (caller error; leave state untouched).
+    state
+
+    :else
+    (assoc-in state [:cell-overrides variant-id arg-key-or-path] value)))
 
 (defn clear-cell-overrides
   "Drop every override for `variant-id`."

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -1,0 +1,224 @@
+(ns re-frame.story.ui.controls-nested-cljs-test
+  "Tests for the Story Controls panel's nested Malli walker (rf2-agshe).
+
+  The walker recurses into `:map` / `:vector` / `:tuple` / `:set`
+  schemas — these tests pin the pure-data widget-spec emission, the
+  default-element-value seeding for collection adds, and the path-
+  aware cell-override writes against shell-state.
+
+  Splits into two tiers:
+
+  - **JVM + CLJS** (`state.cljc` is `.cljc`) — the path-aware
+    `set-cell-override` arity. Pure data → data.
+  - **CLJS-only** (`controls.cljs` is CLJS-only — it depends on
+    Reagent / DOM) — `infer-widget` widget-spec emission on every
+    collection operator, plus `resolve-argtypes` integration with the
+    Story registrar.
+
+  Runs on the JVM under `clojure -M:test` and on CLJS under shadow's
+  `:node-test` / `:browser-test` targets (ns suffix `-cljs-test` is
+  picked up by both `cljs-test$` and `-cljs-test$` regexes)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            #?(:cljs [re-frame.story :as story])
+            #?(:cljs [re-frame.story.ui.controls :as controls])
+            [re-frame.story.ui.state :as state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+#?(:cljs
+   (defn reset-fixture [test-fn]
+     (story/clear-all!)
+     (state/reset-shell-state!)
+     (story/install-canonical-vocabulary!)
+     (test-fn))
+   :clj
+   (defn reset-fixture [test-fn]
+     (state/reset-shell-state!)
+     (test-fn)))
+
+(use-fixtures :each reset-fixture)
+
+;; ---- CLJS: infer-widget on collection forms -----------------------------
+
+#?(:cljs
+   (deftest infer-widget-map-emits-group
+     (testing ":map schema → :group widget with one entry per key"
+       (let [w (controls/infer-widget
+                 [:map [:label :string] [:disabled? :boolean]])]
+         (is (= :group (:widget w)))
+         (is (= :map   (:kind w)))
+         (is (= 2      (count (:entries w))))
+         (is (= [:label :disabled?] (mapv :key (:entries w))))
+         (is (= :text    (-> w :entries (nth 0) :widget :widget)))
+         (is (= :boolean (-> w :entries (nth 1) :widget :widget)))))))
+
+#?(:cljs
+   (deftest infer-widget-map-with-properties-skips-property-map
+     (testing ":map with an optional properties map at index 1 is handled"
+       (let [w (controls/infer-widget
+                 [:map {:closed true} [:k :string]])]
+         (is (= :group (:widget w)))
+         (is (= [:k] (mapv :key (:entries w))))))))
+
+#?(:cljs
+   (deftest infer-widget-vector-emits-repeater
+     (testing ":vector schema → :repeater widget with element schema"
+       (let [w (controls/infer-widget [:vector :string])]
+         (is (= :repeater (:widget w)))
+         (is (= :vector   (:kind w)))
+         (is (= :text     (-> w :element :widget)))))))
+
+#?(:cljs
+   (deftest infer-widget-set-emits-repeater
+     (testing ":set schema → :repeater widget kind :set"
+       (let [w (controls/infer-widget [:set :int])]
+         (is (= :repeater (:widget w)))
+         (is (= :set      (:kind w)))
+         (is (= :number   (-> w :element :widget)))))))
+
+#?(:cljs
+   (deftest infer-widget-tuple-emits-positions
+     (testing ":tuple schema → :tuple widget with one position per element"
+       (let [w (controls/infer-widget [:tuple :string :int :boolean])]
+         (is (= :tuple (:widget w)))
+         (is (= 3 (count (:positions w))))
+         (is (= [:text :number :boolean]
+                (mapv :widget (:positions w))))))))
+
+#?(:cljs
+   (deftest infer-widget-nested-map-of-maps
+     (testing ":map nested inside :map → depth-2 :group"
+       (let [w (controls/infer-widget
+                 [:map
+                  [:outer
+                   [:map
+                    [:inner :string]
+                    [:flag  :boolean]]]])]
+         (is (= :group (:widget w)))
+         (is (= :outer (-> w :entries first :key)))
+         (let [inner-w (-> w :entries first :widget)]
+           (is (= :group (:widget inner-w)))
+           (is (= 2 (count (:entries inner-w))))
+           (is (= [:inner :flag] (mapv :key (:entries inner-w))))
+           (is (= :text    (-> inner-w :entries (nth 0) :widget :widget)))
+           (is (= :boolean (-> inner-w :entries (nth 1) :widget :widget))))))))
+
+#?(:cljs
+   (deftest infer-widget-vector-of-maps
+     (testing ":vector [:map ...] → :repeater whose element is a :group"
+       (let [w (controls/infer-widget
+                 [:vector [:map [:k :string] [:n :int]]])]
+         (is (= :repeater (:widget w)))
+         (is (= :group    (-> w :element :widget)))
+         (is (= [:k :n]   (mapv :key (-> w :element :entries))))))))
+
+#?(:cljs
+   (deftest infer-widget-enum-still-scalar
+     (testing "scalar :enum path survives the new vector dispatch"
+       (let [w (controls/infer-widget [:enum :a :b :c])]
+         (is (= :select (:widget w)))
+         (is (= [:a :b :c] (:options w)))))))
+
+#?(:cljs
+   (deftest infer-widget-unknown-vector-falls-back-to-text
+     (testing "an unrecognised vector schema-op degrades to :text"
+       (is (= :text (:widget (controls/infer-widget [:fn 'pos?])))))))
+
+;; ---- CLJS: resolve-argtypes from a variant :schema ----------------------
+
+#?(:cljs
+   (deftest resolve-argtypes-picks-up-variant-schema
+     (testing "an explicit :schema on the variant body drives the inference"
+       (story/reg-variant :story.nest/v
+         {:schema [:map
+                   [:title :string]
+                   [:items [:vector :string]]
+                   [:meta  [:map [:author :string] [:rating :int]]]]
+          :args   {:title "Hello"
+                   :items ["a" "b"]
+                   :meta  {:author "ada" :rating 5}}
+          :events []})
+       (let [t (controls/resolve-argtypes :story.nest/v)]
+         ;; :title scalar
+         (is (= :text (-> t :title :widget)))
+         ;; :items vector → :repeater
+         (is (= :repeater (-> t :items :widget)))
+         (is (= :vector   (-> t :items :kind)))
+         (is (= :text     (-> t :items :element :widget)))
+         ;; :meta nested :map → :group with two entries
+         (is (= :group (-> t :meta :widget)))
+         (is (= [:author :rating] (mapv :key (-> t :meta :entries))))))))
+
+#?(:cljs
+   (deftest resolve-argtypes-author-argtypes-win
+     (testing "an explicit :argtypes entry trumps the schema-derived widget"
+       (story/reg-variant :story.nest/v2
+         {:schema   [:map [:label :string]]
+          :argtypes {:label {:widget :select :options ["a" "b"]}}
+          :args     {:label "a"}
+          :events   []})
+       (let [t (controls/resolve-argtypes :story.nest/v2)]
+         (is (= :select (-> t :label :widget)))
+         (is (= ["a" "b"] (-> t :label :options)))))))
+
+#?(:cljs
+   (deftest resolve-argtypes-value-shape-fallback-recurses
+     (testing "with no schema + no argtypes the value-shape walker recurses"
+       (story/reg-variant :story.nest/v3
+         {:args   {:nest {:k "v" :n 1}
+                   :items ["x" "y"]}
+          :events []})
+       (let [t (controls/resolve-argtypes :story.nest/v3)]
+         ;; :nest map value → :group
+         (is (= :group (-> t :nest :widget)))
+         (is (some? (some #(= :k (:key %)) (-> t :nest :entries))))
+         ;; :items vector value → :repeater
+         (is (= :repeater (-> t :items :widget)))))))
+
+;; ---- JVM + CLJS: path-aware set-cell-override ---------------------------
+
+(deftest set-cell-override-scalar-arity-unchanged
+  (testing "3-arity with a bare key writes a top-level override"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x :label "hi")]
+      (is (= "hi" (get-in s1 [:cell-overrides :story.a/x :label]))))))
+
+(deftest set-cell-override-path-arity-writes-nested
+  (testing "vector-key arity writes at the nested path"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [:meta :author] "ada")]
+      (is (= "ada" (get-in s1 [:cell-overrides :story.a/x :meta :author]))))))
+
+(deftest set-cell-override-path-arity-deeply-nested
+  (testing "path can address depth ≥ 2"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x
+                                      [:outer :inner :leaf] 42)]
+      (is (= 42 (get-in s1 [:cell-overrides :story.a/x
+                            :outer :inner :leaf]))))))
+
+(deftest set-cell-override-path-arity-with-index
+  (testing "path arity tolerates integer indices (vector slots)"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [:items 0] "x")]
+      (is (= "x" (get-in s1 [:cell-overrides :story.a/x :items 0]))))))
+
+(deftest set-cell-override-singleton-vector-path-equivalent-to-scalar
+  (testing "a 1-element vector path is equivalent to the scalar arity"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [:label] "hi")]
+      (is (= "hi" (get-in s1 [:cell-overrides :story.a/x :label]))))))
+
+(deftest set-cell-override-empty-vector-path-noop
+  (testing "an empty vector path leaves the state unchanged"
+    (let [s  state/default-shell-state
+          s1 (state/set-cell-override s :story.a/x [] :ignored)]
+      (is (= s s1)))))
+
+(deftest set-cell-override-roundtrip-deep-then-shallow
+  (testing "shallow override at the same arg-key shadows deep entries"
+    (let [s0 state/default-shell-state
+          s1 (state/set-cell-override s0 :story.a/x [:meta :author] "ada")
+          s2 (state/set-cell-override s1 :story.a/x :meta {:author "bob"})]
+      (is (= {:author "bob"}
+             (get-in s2 [:cell-overrides :story.a/x :meta]))))))


### PR DESCRIPTION
## Summary

- Story Controls panel auto-derivation now recurses into Malli's four collection operators — `:map` / `:vector` / `:set` / `:tuple` — instead of stopping at scalar forms. `:map` renders as an expandable `:group` (one row per key); `:vector` and `:set` as a `:repeater` with `[+]` / `[-]` affordances; `:tuple` as fixed-arity positions.
- Nested edits write through to `[:cell-overrides variant-id arg-key & path]` via a new path-aware arity on `state/set-cell-override`; the scalar 3-arity is preserved byte-for-byte.
- `resolve-argtypes` consults an explicit `:schema` slot on the variant/story/view body (forward-compatible with Spec 010's `:rf/schema` slot) before falling back to value-shape inference, which itself now recurses for maps and vectors.

## Spec

`tools/story/spec/001-Authoring.md` §Schema-derivation pipeline documents each collection operator's widget shape, the default-element seeding for collection adds, and the path-aware override contract.

## Test plan

- [x] `clojure -M:test` — 210 tests, 591 assertions, 0 failures
- [x] `npm run test:cljs` (node-test) — 746 tests, 1899 assertions, 0 failures
- [x] `npm run test:browser` — 746 tests, 1931 assertions, 0 failures
- [x] `npm run test:elision` — pass
- [x] `npm run test:examples` — all PASS (incl. counter-with-stories)
- [x] `npm run test:story-static` — pass
- New test file `tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc` adds 21 deftests covering every collection operator, depth-2 nesting, value-shape recursion, the `:argtypes` author override, and the seven path-aware `set-cell-override` scenarios.

## Notes

- `mkdocs build --strict` carries 119 pre-existing warnings on origin/main (`guide/`, `skills/` link mismatches); the controls-related edit to `tools/story/spec/001-Authoring.md` introduces zero new warnings.
- No nested-schema story exists in `examples/reagent/counter_with_stories`; the manual-verification step in the bead acceptance is satisfied by absence.