### PR TITLE
docs(guide): add "if you're skipping" upshot callouts to optional chapters (rf2-po8h)

### DIFF
--- a/docs/guide/09-forms.md
+++ b/docs/guide/09-forms.md
@@ -1,5 +1,7 @@
 # 09 — Forms
 
+> **If you're skipping this chapter, the upshot:** re-frame2 doesn't ship a forms library — it ships a *convention*. Every form lives at a slice with seven standard keys (`:draft`, `:submitted`, `:submit-attempted?`, `:status`, `:errors`, `:touched`, `:submit-error`), is driven by seven standard events (initialise / edit-field / blur-field / submit / submit-success / submit-error / reset), and follows one error-visibility rule: a per-field error is visible when the field is in `:touched` **OR** when `:submit-attempted?` is `true`. Pick the chapter up the first time you have to build a non-trivial form; the full normative spec lives in `spec/Pattern-Forms.md`.
+
 Most apps have at least one form, and most apps' forms are quietly identical underneath. A user types into a field. They tab away. They click submit. The server responds — accepts, rejects with field-level complaints, or fails for a reason that isn't any one field's fault. The user fixes something. The cycle repeats.
 
 The shape recurs everywhere: a login form, a signup form, a profile-edit form, a comment-post form, a settings panel. Each one has a *draft* (what the user is currently typing), a *submission* attempt with success / failure outcomes, a set of fields the user has *touched* so far, and a bag of *errors* — some per-field, some form-level.

--- a/docs/guide/12-the-dynamic-model.md
+++ b/docs/guide/12-the-dynamic-model.md
@@ -1,5 +1,7 @@
 # 12 — The dynamic-model story
 
+> **If you're skipping this chapter, the upshot:** the *dynamic model* — the story you tell yourself about what happens when something changes — is the load-bearing property of any system, more than syntax or types or performance. Some dynamic models (FSMs, pure functions) are fundamentally easier to reason about than others (Turing-complete free-form code). re-frame2 deliberately chose to be **less powerful** than the host language: pure handlers, data-shaped effects, run-to-completion drain, pure views. The constraint is the source of everything else the framework offers — testability, time-travel, replay, SSR, AI-amenability. If you're convinced and just want to write code, you can safely skip; pick this up the day you want the full argument with citations.
+
 > *Our intellectual powers are rather geared to master static relations and our powers to visualise processes evolving in time are relatively poorly developed.*
 > — E. W. Dijkstra
 

--- a/docs/guide/21-stories.md
+++ b/docs/guide/21-stories.md
@@ -1,6 +1,6 @@
 # 21 — Stories
 
-> **Optional deep-dive.** This chapter assumes you've absorbed the [events](04-events-state-cycle.md), [views](06-views-and-frames.md), [testing](13-testing.md), and [devtools](15-devtools-and-pair-tools.md) chapters. If you haven't yet, come back later — Stories is a layered surface on top of those, not the next link in the linear sequence.
+> **If you're skipping this chapter, the upshot:** [`re-frame2-story`](https://github.com/day8/re-frame2/tree/main/tools/story) is a frame-aware Storybook-flavoured playground built on re-frame2's own primitives — each variant runs in its own dedicated frame, variant bodies are plain EDN data (not functions), and assertions ride the same `dispatch` pipeline as production events (recording results, not throwing). Pick this up when you want a catalogue of every state of a component on one page, or when you want an agent-facing MCP surface to drive component scaffolding. The chapter assumes you've absorbed the [events](04-events-state-cycle.md), [views](06-views-and-frames.md), [testing](13-testing.md), and [devtools](15-devtools-and-pair-tools.md) chapters first.
 
 You've seen the runtime in the [events chapter](04-events-state-cycle.md), the views in the [views chapter](06-views-and-frames.md), the test machinery in the [testing chapter](13-testing.md), and the tooling pitch in the [devtools chapter](15-devtools-and-pair-tools.md). This chapter is where they converge.
 


### PR DESCRIPTION
## Summary

- Adds top-of-page "If you're skipping this chapter, the upshot:" callouts to three optional guide chapters that lacked them — 09-forms, 12-the-dynamic-model, 21-stories — matching the existing pattern landed in chapters 18 and 19.
- Each upshot is a one-paragraph synthesis of the chapter's own key takeaway, so a reader who skips picks up the load-bearing concept without acquiring orphan terminology references.
- Chapter 18 (`from-re-frame-v1`) already had the callout (rf2-15fz); chapter 21 (`stories`) had a prerequisites-only callout which is replaced by a unified skip-upshot that folds the prereq guidance in (per rf2-ayzj's intent).

## Per-chapter upshot

- **09 — Forms.** Convention not library: seven-key slice, seven-event lifecycle, one error-visibility rule (`touched` OR `submit-attempted?`).
- **12 — The dynamic-model story.** The dynamic model is the load-bearing property; some are easier than others; re-frame2 chose to be less powerful than the host language, and the constraint is the source of every other property.
- **21 — Stories.** Frame-aware Storybook-flavoured playground built on re-frame2 primitives — variant-per-frame, variant bodies are data, assertions record-don't-throw.

## Test plan

- [x] `python -m mkdocs build --strict` warning count unchanged from baseline (119).
- [x] `scripts/check_doc_slugs.py` clean.
- [x] All four optional chapters (09, 12, 18, 21) now lead with a skip-upshot callout in the same blockquote form.