### PR TITLE
feat(causa): Causality Graph panel — Phase 4 (rf2-4rqs1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
@@ -1,0 +1,332 @@
+(ns day8.re-frame2-causa.panels.causality-graph
+  "Causality Graph panel — Phase 4 (rf2-4rqs1, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/001-Causality-Graph.md` this is a *peer*
+  panel — first-class, sidebar entry, but not the front door. The
+  hero is event-detail; the graph is the deeper-walk view when the
+  cascade is more than two hops, spans frames, or when triaging a
+  session with 30+ events. No other JS devtool renders this view —
+  it is the unique-to-Causa differentiator (rf2-76qxg audit).
+
+  ## What this panel shows
+
+  Each dispatch cascade in the trace buffer renders as a node;
+  parent→child dispatches connect via arrows. Non-dispatch trace
+  events (fx, sub, render, machine transitions, errors) surface as
+  flags on the parent dispatch's node rather than spawning their own
+  outbound edges (per spec §Edges — 'those traces attach inside their
+  dispatch's node').
+
+  Clicking a node fires `:rf.causa/select-dispatch-id` — the same
+  event the event-detail hero consumes (Phase 2, rf2-op3bz). The two
+  panels share selection so the user can switch between them without
+  re-selecting.
+
+  When the Time Travel scrubber has a selected-epoch (Phase 3,
+  rf2-t53ze) and that epoch's settling cascade-id is in the graph,
+  the graph filters to that cascade family (`filter-to-cascade` in
+  the helpers ns).
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure
+  hiccup, no Reagent / UIx / Helix references. SVG hiccup hosts the
+  graph; the substrate adapter mounts it via `rf/render`. Frame
+  isolation comes from the enclosing `[rf/frame-provider {:frame
+  :rf/causa}]` in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — `project-cascades-to-graph`, `compute-layout`,
+  `filter-to-cascade` — lives in `causality_graph_helpers.cljc` so
+  the algebra runs under the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.causality-graph-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn- format-edn
+  "Best-effort EDN-like format. Used to render the event vector
+  inside each node's label."
+  [v]
+  (try
+    (pr-str v)
+    (catch :default _
+      (str v))))
+
+(defn- truncate
+  "Truncate `s` to `n` chars (adding an ellipsis). Pure-data so the
+  node label always fits inside `default-node-width`."
+  [s n]
+  (let [s (str s)]
+    (if (<= (count s) n)
+      s
+      (str (subs s 0 (max 0 (dec n))) "…"))))
+
+(defn- node-label
+  "One-line label for a node. Shows the event vector (or a
+  placeholder when the cascade has no event)."
+  [{:keys [event] :as _node}]
+  (truncate (format-edn (or event :ungrouped)) 22))
+
+;; ---- empty state ---------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when the buffer holds no dispatch cascades yet. Per
+  spec/001-Causality-Graph.md §Empty state — 'No cascades yet. Click
+  around your app — every dispatch lands here as a node.'"
+  []
+  [:div {:data-testid "rf-causa-causality-graph-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"}}
+    "No cascades yet."]
+   [:p {:style {:margin 0
+                :font-size "12px"
+                :color (:text-tertiary tokens)}}
+    "Click around your app — every dispatch lands here as a node."]])
+
+;; ---- SVG primitives ------------------------------------------------------
+
+(defn- node-rect
+  "One dispatch node — a rounded rect with a glyph + event label.
+  Clicking the rect fires `:rf.causa/select-dispatch-id`."
+  [{:keys [dispatch-id origin] :as node}
+   {:keys [x y]}
+   selected?]
+  (let [fill   (or (get h/origin->fill origin)
+                   (get h/origin->fill :app))
+        stroke (get h/status->stroke (h/node-border-token node))
+        stroke-w (if selected? 2 1)
+        cursor "pointer"
+        w h/default-node-width
+        hgt h/default-node-height
+        label (node-label node)
+        glyph (h/node-glyph node selected?)]
+    [:g {:data-testid (str "rf-causa-graph-node-" dispatch-id)
+         :on-click    #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+         :style       {:cursor cursor}}
+     [:rect {:x            x
+             :y            y
+             :width        w
+             :height       hgt
+             :rx           8
+             :ry           8
+             :fill         fill
+             :fill-opacity (if selected? 1.0 0.85)
+             :stroke       stroke
+             :stroke-width stroke-w}]
+     ;; Glyph (◆ / ○ / ◉) on the left.
+     [:text {:x            (+ x 10)
+             :y            (+ y 26)
+             :fill         "#fff"
+             :font-family  mono-stack
+             :font-size    14
+             :font-weight  700
+             :pointer-events "none"}
+      glyph]
+     ;; Event-vector label (mono).
+     [:text {:x            (+ x 28)
+             :y            (+ y 19)
+             :fill         "#fff"
+             :font-family  mono-stack
+             :font-size    11
+             :pointer-events "none"}
+      label]
+     ;; Sub-label: dispatch-id + status counts.
+     [:text {:x            (+ x 28)
+             :y            (+ y 34)
+             :fill         "rgba(255,255,255,0.7)"
+             :font-family  mono-stack
+             :font-size    9
+             :pointer-events "none"}
+      (str "#" dispatch-id
+           " · fx " (:effect-count node)
+           " · v " (:render-count node))]]))
+
+(defn- arrow-path
+  "Build an SVG path string from the parent's bottom-centre to the
+  child's top-centre. Straight line — per spec §Edge style 'straight
+  lines for in-frame parent → child; curved lines for cross-frame
+  jumps'. Cross-frame swimlanes ride a follow-on bead; v1 ships the
+  in-frame straight-line case."
+  [parent-pos child-pos]
+  (let [w  h/default-node-width
+        hgt h/default-node-height
+        px (+ (:x parent-pos) (/ w 2))
+        py (+ (:y parent-pos) hgt)
+        cx (+ (:x child-pos) (/ w 2))
+        cy (:y child-pos)]
+    (str "M " px " " py " L " cx " " cy)))
+
+(defn- arrow-line
+  "Render one arrow — a path + an arrowhead at the child end. The
+  arrowhead is a tiny triangle, drawn separately so it sits flush
+  against the child node's top border."
+  [arrow positions]
+  (let [[parent-id child-id] arrow
+        ppos (get positions parent-id)
+        cpos (get positions child-id)]
+    (when (and ppos cpos)
+      [:g {:data-testid (str "rf-causa-graph-arrow-" parent-id "-" child-id)}
+       [:path {:d            (arrow-path ppos cpos)
+               :stroke       (:text-tertiary tokens)
+               :stroke-width 1.5
+               :fill         "none"
+               :marker-end   "url(#rf-causa-arrowhead)"}]])))
+
+(defn- defs
+  "SVG `<defs>` element — declares the arrowhead marker every arrow
+  reuses via `marker-end=\"url(#rf-causa-arrowhead)\"`."
+  []
+  [:defs
+   [:marker {:id           "rf-causa-arrowhead"
+             :viewBox      "0 0 10 10"
+             :refX         9
+             :refY         5
+             :markerWidth  6
+             :markerHeight 6
+             :orient       "auto-start-reverse"}
+    [:path {:d    "M 0 0 L 10 5 L 0 10 z"
+            :fill (:text-tertiary tokens)}]]])
+
+;; ---- legend --------------------------------------------------------------
+
+(defn- legend
+  "Compact key explaining the visual encoding. Per spec §Visual
+  encoding the colour-only signal is always paired with a glyph or
+  icon."
+  []
+  [:div {:data-testid "rf-causa-causality-graph-legend"
+         :style       {:padding "6px 12px"
+                       :display "flex"
+                       :flex-wrap "wrap"
+                       :gap "12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :color (:text-tertiary tokens)}}
+   (for [[label sym]
+         [["◆ root" :accent-violet]
+          ["○ child" :text-secondary]
+          ["◉ selected" :magenta]
+          [":app violet" :accent-violet]
+          [":pair indigo" :accent-violet]
+          [":story cyan" :cyan]
+          ["err border" :red]
+          ["warn border" :yellow]]]
+     ^{:key label}
+     [:span {:style {:color (sym tokens)}} label])])
+
+;; ---- graph canvas --------------------------------------------------------
+
+(defn- graph-svg
+  "The SVG canvas — defs + arrows + nodes, sized to the layout's
+  bounding box."
+  [{:keys [nodes arrows] :as _graph}
+   {:keys [positions width height] :as _layout}
+   selected-id]
+  [:svg {:data-testid "rf-causa-causality-graph-svg"
+         :width   width
+         :height  height
+         :viewBox (str "0 0 " width " " height)
+         :style   {:display "block"
+                   :background (:bg-2 tokens)}}
+   (defs)
+   ;; Arrows first so nodes paint over the arrow line ends.
+   (into [:g {:data-testid "rf-causa-causality-graph-arrows"}]
+         (for [a arrows]
+           ^{:key (str (first a) "->" (second a))}
+           (arrow-line a positions)))
+   ;; Nodes on top.
+   (into [:g {:data-testid "rf-causa-causality-graph-nodes"}]
+         (for [n nodes
+               :let [pos (get positions (:dispatch-id n))]
+               :when pos]
+           ^{:key (:dispatch-id n)}
+           (node-rect n pos (= selected-id (:dispatch-id n)))))])
+
+;; ---- public view --------------------------------------------------------
+
+(defn causality-graph-view
+  "The Causality Graph panel's root view. Subscribes to
+  `:rf.causa/causality-graph-data` and renders either the empty
+  state (no cascades) or the SVG canvas (one or more cascades)."
+  []
+  (let [{:keys [graph layout selected-dispatch-id selected-epoch-id filtered?]}
+        @(rf/subscribe [:rf.causa/causality-graph-data])
+        nodes (:nodes graph)]
+    [:section {:data-testid "rf-causa-causality-graph"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Causality"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       (str (count nodes) " cascade" (if (= 1 (count nodes)) "" "s")
+            ". Click a node to drill in.")
+       (when filtered?
+         [:span {:data-testid "rf-causa-causality-graph-filtered"
+                 :style       {:margin-left "8px"
+                               :color (:magenta tokens)}}
+          "(filtered to selected epoch's cascade — "
+          [:code {:style {:color (:magenta tokens) :font-family mono-stack}}
+           (str selected-epoch-id)]
+          [:button {:data-testid "rf-causa-causality-graph-clear-filter"
+                    :on-click    #(rf/dispatch [:rf.causa/clear-selected-epoch])
+                    :style       {:margin-left "6px"
+                                  :background "transparent"
+                                  :border (str "1px solid " (:border-default tokens))
+                                  :color (:text-secondary tokens)
+                                  :padding "1px 6px"
+                                  :border-radius "4px"
+                                  :cursor "pointer"
+                                  :font-family sans-stack
+                                  :font-size "10px"}}
+           "clear"]
+          ")"])]]
+     (legend)
+     [:div {:style {:flex 1 :overflow "auto" :padding "0 12px 12px 12px"}}
+      (if (empty? nodes)
+        (empty-state)
+        (graph-svg graph layout selected-dispatch-id))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph_helpers.cljc
@@ -1,0 +1,498 @@
+(ns day8.re-frame2-causa.panels.causality-graph-helpers
+  "Pure-data helpers for Causa's Causality Graph panel
+  (Phase 4, rf2-4rqs1).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `causality_graph.cljs` builds an SVG hiccup tree;
+  the *logic* — projecting a cascade vector into nodes + arrows, and
+  computing layout positions — is pure data → data. Splitting the
+  algebra into `.cljc` so it runs under the JVM test target
+  (`clojure -M:test`) is required by `feedback_jvm_interop_must_work.md`.
+
+  ## Data model (per spec/001-Causality-Graph.md §Data model)
+
+  The graph reads cascade records produced by
+  `re-frame.trace.projection/group-cascades` (rf2-wvzgd) plus the raw
+  trace events the cascade was assembled from. Each cascade produces:
+
+    - **One dispatch node** keyed by `:dispatch-id`. The node carries
+      the event vector, the `:origin` axis (`:app` / `:pair` /
+      `:story` / `:test` / `:causa`), an `:error?` / `:warning?` flag
+      derived from the cascade's `:other` bucket, and the `:root?`
+      bit (true when the cascade's parent-dispatch-id is nil).
+
+    - **Zero or one arrow** from `:parent-dispatch-id` → `:dispatch-id`
+      when the cascade is a child. The parent edge is only emitted
+      when the parent cascade is also present in the input — orphan
+      child cascades render as roots (per spec §What this doesn't do:
+      'No retroactive correlation. If a dispatch was emitted before
+      the trace surface knew about it … it appears as a root in the
+      graph').
+
+  Non-dispatch trace events (`:op-type :fx`, `:sub/run`, `:view/render`,
+  `:rf.machine/transition`, errors) are surfaced as flags on the
+  parent dispatch's node rather than spawning their own nodes — per
+  spec §Edges 'Dispatch contains significant trace … those traces
+  attach inside their dispatch's node rather than spawning their own
+  outbound edge'.
+
+  ## Layout (per spec/001-Causality-Graph.md §Layout)
+
+  Top-down DAG layout. Roots live at the top; children stack
+  vertically beneath their parent. Horizontal axis groups siblings
+  side-by-side; vertical axis is time (older at the top).
+
+  The layout is intentionally simple — a level-based BFS from each
+  root, assigning column slots in encounter order. Cross-cascade edges
+  (parent in one branch, child in another) take the column they land
+  on; the v1 layout does not run a force-directed pass. Per the spec
+  §Performance — re-layout runs incrementally — but the v1 helper is
+  a stable O(n) pass over the cascade vector. The full incremental-
+  layout pass lands in rf2-xxx once the panel's perf budget is
+  measured against a real cascade stream."
+  (:require [clojure.set :as set]))
+
+;; ---- layout constants ----------------------------------------------------
+
+(def default-node-width
+  "SVG width of a dispatch node, in pixels. Per spec/007-UX-IA.md
+  §The causality strip the strip uses 24×24px pills on cosy density;
+  the full graph uses ~120×40px tiles so the event vector fits inside
+  the node on one line."
+  140)
+
+(def default-node-height
+  "SVG height of a dispatch node, in pixels. Matches the strip's
+  cosy-density vertical rhythm."
+  44)
+
+(def default-column-gap
+  "Horizontal gap between sibling node columns, in pixels. Sized so a
+  parent's children fit beneath it without overlap at the default
+  node width."
+  24)
+
+(def default-row-gap
+  "Vertical gap between cascade levels, in pixels. Tuned so the arrow
+  between a parent and child is long enough to be read at a glance
+  but short enough that 6+ levels fit in a 600px-tall panel."
+  28)
+
+(def default-margin
+  "Outer SVG margin around the layout's bounding box, in pixels.
+  Prevents edge-clipping at the panel edges."
+  16)
+
+;; ---- node / arrow projection --------------------------------------------
+
+(defn- dispatched-event-of
+  "Walk a cascade's `:other` + `:handler` + `:fx` buckets for the
+  `:event/dispatched` emit and return it (the trace event itself, not
+  the event vector). nil when no such emit landed in the cascade —
+  which can happen for the `:ungrouped` bucket (registry-time events
+  without a `:dispatch-id`) and for cascades whose root event predates
+  the trace surface."
+  [cascade]
+  ;; group-cascades does NOT keep the `:event/dispatched` trace event
+  ;; verbatim — it only retains the event *vector* under :event. To
+  ;; surface :origin / :parent-dispatch-id we need access to the raw
+  ;; trace event. We accept the cascade may not carry it; callers fall
+  ;; back to nil when the slot is missing.
+  (or (:event-trace cascade)            ; supplied by enrich step below
+      (some (fn [ev]
+              (when (and (= :event (:op-type ev))
+                         (= :event/dispatched (:operation ev)))
+                ev))
+            (concat [(:handler cascade) (:fx cascade)]
+                    (:effects cascade)
+                    (:other cascade)))))
+
+(defn enrich-cascades
+  "Augment each cascade record with the `:event/dispatched` trace
+  event lifted off the raw trace stream. `group-cascades` retains
+  the event *vector* under `:event` but drops the original trace
+  event; the graph needs `:tags :origin` + `:tags :parent-dispatch-id`
+  off that event, so we re-walk the raw stream once and stitch the
+  dispatched-trace back onto each cascade record under
+  `:event-trace`.
+
+  Pure data → cascades-with-event-trace. JVM-runnable."
+  [cascades trace-events]
+  (let [by-id (->> trace-events
+                   (filter (fn [ev]
+                             (and (= :event (:op-type ev))
+                                  (= :event/dispatched (:operation ev)))))
+                   (reduce (fn [m ev]
+                             (let [did (get-in ev [:tags :dispatch-id])]
+                               (cond-> m
+                                 did (assoc did ev))))
+                           {}))]
+    (mapv (fn [c]
+            (if-let [t (get by-id (:dispatch-id c))]
+              (assoc c :event-trace t)
+              c))
+          cascades)))
+
+(defn- origin-of
+  "Read `:origin` off the cascade's dispatched-event trace. Returns
+  one of `:app` / `:pair` / `:story` / `:test` / `:causa`; defaults
+  to `:app` when the cascade carries no :event/dispatched trace
+  event (e.g. the `:ungrouped` bucket). Spec/002 §Dispatch origin
+  tagging."
+  [cascade]
+  (or (some-> cascade dispatched-event-of :tags :origin)
+      :app))
+
+(defn- parent-of
+  "Read `:parent-dispatch-id` off the cascade's dispatched-event
+  trace. nil for root cascades; nil for the `:ungrouped` bucket."
+  [cascade]
+  (some-> cascade dispatched-event-of :tags :parent-dispatch-id))
+
+(defn- has-error?
+  "True when the cascade contains an `:op-type :error` event. Drives
+  the red border treatment per spec §Visual encoding §Border colour."
+  [cascade]
+  (boolean
+    (some (fn [ev] (= :error (:op-type ev)))
+          (:other cascade))))
+
+(defn- has-warning?
+  "True when the cascade contains a `:op-type :warning` event. Drives
+  the amber border treatment per spec §Visual encoding §Border
+  colour."
+  [cascade]
+  (boolean
+    (some (fn [ev] (= :warning (:op-type ev)))
+          (:other cascade))))
+
+(defn- node-of
+  "Project one cascade record into the graph's node shape:
+
+      {:dispatch-id  <id>
+       :event        <event vector>
+       :origin       :app | :pair | :story | :test | :causa
+       :root?        bool
+       :error?       bool
+       :warning?     bool
+       :parent       <dispatch-id or nil>
+       :effect-count <int>     ; for badge / hover summary
+       :sub-count    <int>
+       :render-count <int>
+       :other-count  <int>}"
+  [cascade root?]
+  {:dispatch-id  (:dispatch-id cascade)
+   :event        (:event cascade)
+   :origin       (origin-of cascade)
+   :root?        root?
+   :error?       (has-error? cascade)
+   :warning?     (has-warning? cascade)
+   :parent       (parent-of cascade)
+   :effect-count (count (:effects cascade))
+   :sub-count    (count (:subs cascade))
+   :render-count (count (:renders cascade))
+   :other-count  (count (:other cascade))})
+
+(defn project-cascades-to-graph
+  "Project a vector of enriched cascades (from `enrich-cascades`) into
+  a `{:nodes [...] :arrows [...]}` map.
+
+  Each cascade becomes one node; each cascade whose parent is *also*
+  in the cascade set produces an arrow `[parent-id child-id]`. Orphan
+  children (parent missing from the buffer) render as roots per spec
+  §What this doesn't do — 'no retroactive correlation'.
+
+  The `:ungrouped` cascade is filtered out — it has no `:dispatch-id`
+  and no causal lineage; rendering it would clutter the graph with a
+  bucket that consumers should inspect via the event-detail panel's
+  `:other` row.
+
+  Returns:
+
+      {:nodes  [<node> ...]    ; one per dispatch cascade
+       :arrows [[parent-id child-id] ...]
+       :roots  #{<id> ...}     ; ids with no in-graph parent
+       :index  {<id> <node>}}  ; convenience lookup
+
+  Pure data → data. JVM-runnable."
+  [cascades]
+  (let [dispatch-cascades (filter (fn [c]
+                                    (and (some? (:dispatch-id c))
+                                         (not= :ungrouped (:dispatch-id c))))
+                                  cascades)
+        ids               (set (map :dispatch-id dispatch-cascades))
+        ;; A cascade is a root if its parent isn't in the cascade
+        ;; set (either truly root, or orphan whose parent aged out).
+        nodes             (mapv (fn [c]
+                                  (let [parent (parent-of c)
+                                        root?  (or (nil? parent)
+                                                   (not (contains? ids parent)))]
+                                    (node-of c root?)))
+                                dispatch-cascades)
+        arrows            (->> nodes
+                               (keep (fn [{:keys [dispatch-id parent]}]
+                                       (when (and parent (contains? ids parent))
+                                         [parent dispatch-id])))
+                               vec)
+        roots             (->> nodes
+                               (filter :root?)
+                               (map :dispatch-id)
+                               set)
+        index             (into {} (map (juxt :dispatch-id identity)) nodes)]
+    {:nodes  nodes
+     :arrows arrows
+     :roots  roots
+     :index  index}))
+
+;; ---- layout --------------------------------------------------------------
+
+(defn- children-by-parent
+  "Index `arrows` by parent-id → vector of child-ids. Used by the
+  layout walker to descend the DAG breadth-first."
+  [arrows]
+  (reduce (fn [m [p c]]
+            (update m p (fnil conj []) c))
+          {}
+          arrows))
+
+(defn- assign-levels
+  "Walk the graph from `roots` outward, recording the level (distance
+  from a root) for each node. Roots are level 0; their children are
+  level 1; etc. Returns a map `{dispatch-id level}`.
+
+  Cycles cannot occur in practice (parent-dispatch-id is allocated
+  monotonically before the child is enqueued), but the walker is
+  defensive: a node never re-enters the queue once it has a level."
+  [roots children]
+  (loop [acc      {}
+         frontier (vec (for [r roots] [r 0]))]
+    (if (empty? frontier)
+      acc
+      (let [[[id lvl] & more] frontier
+            seen?  (contains? acc id)
+            acc'   (if seen? acc (assoc acc id lvl))
+            kids   (when-not seen? (get children id))
+            next   (into (vec more)
+                         (for [k kids] [k (inc lvl)]))]
+        (recur acc' next)))))
+
+(defn- assign-columns
+  "Assign each node a 0-based column index. The encounter order is a
+  stable BFS from roots, so siblings cluster horizontally and the
+  layout is deterministic over a fixed input.
+
+  Per spec §Layout the v1 horizontal axis is *frame swimlanes*. The
+  v1 helper collapses every cascade onto the same swimlane (rf2-4rqs1
+  scope); the cross-frame swimlane assignment lands when the frame
+  picker / Spec 002 §Cross-frame fx surface is wired into the
+  buffer (rf2-xxx — out of Phase 4 scope)."
+  [roots children level-of all-ids]
+  (let [;; Walk in BFS order from the roots; pure-data so the encounter
+        ;; index is stable.
+        walk-order (loop [order    []
+                          seen     #{}
+                          frontier (vec roots)]
+                     (if (empty? frontier)
+                       order
+                       (let [[id & more] frontier
+                             new?  (not (contains? seen id))]
+                         (if new?
+                           (recur (conj order id)
+                                  (conj seen id)
+                                  (into (vec more) (get children id)))
+                           (recur order seen (vec more))))))
+        ;; Append any nodes the BFS missed (defensive — shouldn't
+        ;; happen given enrich-cascades' invariants, but keeps the
+        ;; helper total over arbitrary input).
+        missed     (remove (set walk-order) all-ids)
+        full-order (into walk-order missed)
+        ;; Per-level column counter. Each new id at level `lvl` gets
+        ;; the next unused column within its level.
+        per-level  (atom {})]
+    (into {}
+          (for [id full-order
+                :let [lvl (get level-of id 0)
+                      col (get @per-level lvl 0)]]
+            (do
+              (swap! per-level update lvl (fnil inc 0))
+              [id col])))))
+
+(defn compute-layout
+  "Compute pixel positions for every node in the graph.
+
+  Returns `{:positions {dispatch-id {:x px :y px}} :width W :height H}`.
+
+  - Roots live at the top (y = `default-margin`).
+  - Levels stack downward by `default-node-height + default-row-gap`.
+  - Within a level, siblings stack left-to-right by
+    `default-node-width + default-column-gap`.
+  - Width / height are the SVG canvas size that bounds every node
+    plus the outer margin.
+
+  Pure data → data. Deterministic given the same input — callers can
+  diff two layouts for animation hooks (rf2-xxx)."
+  [{:keys [nodes arrows roots] :as _graph}]
+  (let [children  (children-by-parent arrows)
+        all-ids   (map :dispatch-id nodes)
+        level-of  (assign-levels roots children)
+        ;; Nodes the level walker missed (orphans without an in-graph
+        ;; parent that weren't in :roots) default to level 0.
+        level-of  (reduce (fn [m id]
+                            (if (contains? m id) m (assoc m id 0)))
+                          level-of
+                          all-ids)
+        column-of (assign-columns roots children level-of all-ids)
+        positions (into {}
+                        (for [id all-ids
+                              :let [lvl (get level-of id 0)
+                                    col (get column-of id 0)]]
+                          [id {:x (+ default-margin
+                                     (* col (+ default-node-width
+                                               default-column-gap)))
+                               :y (+ default-margin
+                                     (* lvl (+ default-node-height
+                                               default-row-gap)))}]))
+        max-col   (apply max 0 (vals column-of))
+        max-lvl   (apply max 0 (vals level-of))
+        width     (+ default-margin
+                     (* (inc max-col) (+ default-node-width
+                                         default-column-gap)))
+        height    (+ default-margin
+                     (* (inc max-lvl) (+ default-node-height
+                                         default-row-gap)))]
+    {:positions positions
+     :width     width
+     :height    height
+     :level-of  level-of
+     :column-of column-of}))
+
+;; ---- cascade filtering ---------------------------------------------------
+
+(defn- ancestors-of
+  "Walk `parent-of`'s chain from `id` upward until a root is hit.
+  Returns a set including `id` itself."
+  [id parent-by-id]
+  (loop [acc #{id}
+         cur (get parent-by-id id)]
+    (if (or (nil? cur) (contains? acc cur))
+      acc
+      (recur (conj acc cur) (get parent-by-id cur)))))
+
+(defn- descendants-of
+  "Walk `children-by-parent` from `id` downward. Returns a set
+  including `id` itself."
+  [id children-by-parent]
+  (loop [acc      #{id}
+         frontier [id]]
+    (if (empty? frontier)
+      acc
+      (let [[cur & more] frontier
+            kids         (remove acc (get children-by-parent cur))]
+        (recur (into acc kids) (into (vec more) kids))))))
+
+(defn cascade-of
+  "Return the set of dispatch-ids that belong to the same cascade
+  family as `dispatch-id` — every ancestor walked up through
+  `:parent`, plus every descendant walked down through `:children`.
+
+  Pure data → id-set. Used by `filter-to-cascade` and by the
+  spec §Find root cause affordance (rf2-xxx)."
+  [{:keys [nodes arrows] :as _graph} dispatch-id]
+  (when dispatch-id
+    (let [parent-by-id (into {} (map (juxt :dispatch-id :parent)) nodes)
+          children     (children-by-parent arrows)]
+      (set/union (ancestors-of dispatch-id parent-by-id)
+                 (descendants-of dispatch-id children)))))
+
+(defn filter-to-cascade
+  "Return a new graph containing only the cascade family of
+  `dispatch-id`. Used when Time Travel's selected-epoch carries a
+  cascade-id — the graph filters to that one cascade family per spec
+  §Filter graph to this cascade.
+
+  Pass nil for `dispatch-id` to return the graph unchanged. Pure
+  data → data."
+  [graph dispatch-id]
+  (if (nil? dispatch-id)
+    graph
+    (let [keep-ids (cascade-of graph dispatch-id)
+          nodes'   (filterv #(contains? keep-ids (:dispatch-id %))
+                            (:nodes graph))
+          arrows'  (filterv (fn [[p c]]
+                              (and (contains? keep-ids p)
+                                   (contains? keep-ids c)))
+                            (:arrows graph))
+          roots'   (into #{} (filter keep-ids) (:roots graph))
+          ;; Recompute roots: any node whose parent is now missing
+          ;; from the filtered set becomes a root in the filtered
+          ;; sub-graph.
+          roots''  (into roots'
+                         (for [{:keys [dispatch-id parent]} nodes'
+                               :when (or (nil? parent)
+                                         (not (contains? keep-ids parent)))]
+                           dispatch-id))
+          index'   (into {} (map (juxt :dispatch-id identity)) nodes')]
+      {:nodes  (mapv (fn [n]
+                       (if (contains? roots'' (:dispatch-id n))
+                         (assoc n :root? true)
+                         n))
+                     nodes')
+       :arrows arrows'
+       :roots  roots''
+       :index  index'})))
+
+;; ---- node selection from an epoch-id ------------------------------------
+
+(defn dispatch-id-of-epoch
+  "Resolve an `:rf/epoch-record`'s settling cascade-id by walking its
+  `:trace-events` for the first `:dispatch-id`-bearing event. Mirrors
+  `time-travel-helpers/dispatch-id-from-epoch` so the panel can route
+  a selected-epoch → 'filter to this cascade' without depending on
+  the time-travel namespace.
+
+  Pure data → id-or-nil."
+  [epoch-record]
+  (some (fn [ev]
+          (or (get-in ev [:tags :dispatch-id])
+              (get-in ev [:tags :parent-dispatch-id])))
+        (:trace-events epoch-record)))
+
+;; ---- node visual tokens (pure-data — view consumes via index) -----------
+
+(def origin->fill
+  "Per spec §Visual encoding §Fill colour. Mirrors the dark-theme
+  tokens in `spec/007-UX-IA.md` §Dark theme tokens — keeping this
+  table here keeps the test surface JVM-runnable (the panel imports
+  the same map and consumes it during render)."
+  {:app    "#7C5CFF"   ; violet (brand / app origin)
+   :pair   "#5570FF"   ; indigo
+   :story  "#43C3D0"   ; cyan
+   :test   "#43C3D0"   ; cyan (test rides the story accent)
+   :causa  "#6B7080"}) ; grey-tertiary (Causa's own re-dispatches)
+
+(def status->stroke
+  "Per spec §Visual encoding §Border colour. Errors > warnings >
+  default — surfaced on the node by `node-border-token`."
+  {:error   "#F87171"   ; red
+   :warning "#FBBF24"   ; amber
+   :default "#2F3441"}) ; border-default token
+
+(defn node-border-token
+  "Resolve a node's border token. Errors win over warnings; default
+  otherwise."
+  [{:keys [error? warning?] :as _node}]
+  (cond
+    error?   :error
+    warning? :warning
+    :else    :default))
+
+(defn node-glyph
+  "Per spec §Visual encoding §Glyph. ◆ root · ○ child · ◉ selected.
+  Pure-data so tests can assert the glyph choice without rendering
+  SVG."
+  [{:keys [root?] :as _node} selected?]
+  (cond
+    selected? "◉"
+    root?     "◆"
+    :else     "○"))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -65,11 +65,25 @@
   reset-frame-db!, not restore-epoch, per spec §Why reset-frame-db!
   not restore-epoch).
 
+  ## Phase 4 scope (rf2-4rqs1) — Causality Graph panel
+
+  Reuses the Phase 2 / Phase 3 surface (trace-buffer, selected-
+  dispatch-id, selected-epoch-id) and adds one composite sub that
+  projects + lays out the graph data the panel consumes:
+
+    - `:rf.causa/causality-graph-data` sub — composite
+
+  No new events are required: the graph reuses
+  `:rf.causa/select-dispatch-id` (shared with the event-detail hero
+  per spec §10 Lock 7) and `:rf.causa/clear-selected-epoch` for the
+  cascade-filter affordance.
+
   Subsequent panel beads add their own per-panel events / subs / fxs."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
-            [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]))
+            [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
+            [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -227,6 +241,57 @@
            :pins            pins
            :chip-states     (tt-helpers/chip-states history pins)
            :cap-reached?    (>= (count pins) tt-helpers/default-pin-cap)})))
+
+    ;; ---- Phase 4 (rf2-4rqs1) — Causality Graph composite sub -----
+    ;;
+    ;; The graph reads from the same trace-buffer as the event-detail
+    ;; panel. It projects the buffer via group-cascades, enriches each
+    ;; cascade with its :event/dispatched trace event (so :origin /
+    ;; :parent-dispatch-id are available), then folds into nodes +
+    ;; arrows and computes a top-down layout. When the Time Travel
+    ;; scrubber has a selected-epoch whose settling cascade-id is in
+    ;; the graph, the graph filters to that cascade family.
+    ;;
+    ;; Shape:
+    ;;
+    ;;     {:graph                {:nodes [...] :arrows [...] ...}
+    ;;      :layout               {:positions {...} :width :height ...}
+    ;;      :selected-dispatch-id <id-or-nil>
+    ;;      :selected-epoch-id    <id-or-nil>
+    ;;      :filtered?            <bool>}
+    ;;
+    ;; Per spec §Performance the v1 helper runs O(n) over the buffer.
+    ;; The composite recomputes when any of its signals change — the
+    ;; reactive surface is the same as the event-detail composite.
+    (rf/reg-sub :rf.causa/causality-graph-data
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/selected-dispatch-id]
+      :<- [:rf.causa/selected-epoch-id]
+      :<- [:rf.causa/epoch-history]
+      (fn [[buffer selected-id selected-epoch-id history] _query]
+        (let [cascades         (projection/group-cascades buffer)
+              enriched         (cg-helpers/enrich-cascades cascades buffer)
+              graph            (cg-helpers/project-cascades-to-graph enriched)
+              ;; When Time Travel's selected-epoch resolves to a
+              ;; cascade-id, filter the graph to that cascade family.
+              epoch-record     (when selected-epoch-id
+                                 (tt-helpers/find-epoch-in-history
+                                   history selected-epoch-id))
+              cascade-id-filter (some-> epoch-record
+                                        cg-helpers/dispatch-id-of-epoch)
+              filterable?      (and cascade-id-filter
+                                    (some #(= cascade-id-filter (:dispatch-id %))
+                                          (:nodes graph)))
+              graph'           (if filterable?
+                                 (cg-helpers/filter-to-cascade
+                                   graph cascade-id-filter)
+                                 graph)
+              layout           (cg-helpers/compute-layout graph')]
+          {:graph                graph'
+           :layout               layout
+           :selected-dispatch-id selected-id
+           :selected-epoch-id    selected-epoch-id
+           :filtered?            (boolean filterable?)})))
 
     ;; ---- events --------------------------------------------------
     (rf/reg-event-db :rf.causa/select-panel

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -39,6 +39,7 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
+            [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
@@ -71,7 +72,7 @@
   [{:id :event-detail :label "Event detail" :bead "rf2-op3bz" :live? true}
    {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
    {:id :app-db       :label "App-db"        :bead "rf2-xxx"}
-   {:id :causality    :label "Causality"     :bead "rf2-xxx"}
+   {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
    {:id :subs         :label "Subscriptions" :bead "rf2-xxx"}
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
    {:id :trace        :label "Trace"         :bead "rf2-xxx"}
@@ -111,7 +112,7 @@
     [:span {:style {:color       (:text-tertiary tokens)
                     :font-size   "12px"
                     :font-weight 400}}
-     "Phase 3 (rf2-t53ze)"]]
+     "Phase 4 (rf2-4rqs1)"]]
    [:div {:style {:display "flex" :align-items "center" :gap "12px"
                   :color    (:text-secondary tokens)
                   :font-size "12px"
@@ -211,6 +212,7 @@
     (case selected
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
+      :causality    [causality-graph/causality-graph-view]
       [stub-panel (or item {:label "Unknown panel"
                             :bead  "rf2-xxx"})])))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_cljs_test.cljc
@@ -1,0 +1,362 @@
+(ns day8.re-frame2-causa.panels.causality-graph-cljs-test
+  "Pure-data tests for Causa's Causality Graph helpers
+  (Phase 4, rf2-4rqs1).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  The file ends in `_cljs_test.cljc` so:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  Same dual-target pattern as `time_travel_helpers_cljs_test.cljc`.
+
+  ## What's under test
+
+    1. **project-cascades-to-graph** — turns cascade records into a
+       `{:nodes :arrows :roots}` map. Roots, child edges, orphan
+       handling are all asserted.
+    2. **compute-layout** — produces deterministic pixel positions
+       for every node; the bounding-box width / height accommodate
+       every node.
+    3. **filter-to-cascade** — slices the graph down to one cascade
+       family; passing nil returns the graph unchanged.
+    4. **enrich-cascades** — stitches the dispatched-event trace back
+       onto each cascade record so :origin / :parent-dispatch-id are
+       reachable from a cascade map alone."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.panels.causality-graph-helpers :as h]))
+
+;; ---- fixture builders ----------------------------------------------------
+
+(defn- dispatched-ev
+  "Build a `:event/dispatched` trace event for `dispatch-id`."
+  ([id dispatch-id event-vec]
+   (dispatched-ev id dispatch-id event-vec nil :app))
+  ([id dispatch-id event-vec parent-dispatch-id]
+   (dispatched-ev id dispatch-id event-vec parent-dispatch-id :app))
+  ([id dispatch-id event-vec parent-dispatch-id origin]
+   {:id        id
+    :op-type   :event
+    :operation :event/dispatched
+    :tags      (cond-> {:dispatch-id dispatch-id
+                        :event       event-vec
+                        :origin      origin}
+                 parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id))}))
+
+(defn- handler-ev
+  [id dispatch-id]
+  {:id id :op-type :event :operation :event
+   :tags {:dispatch-id dispatch-id :phase :run-end}})
+
+(defn- fx-ev
+  [id dispatch-id fx-id]
+  {:id id :op-type :fx :operation :rf.fx/handled
+   :tags {:dispatch-id dispatch-id :fx-id fx-id}})
+
+(defn- render-ev
+  [id dispatch-id render-key]
+  {:id id :op-type :view :operation :view/render
+   :tags {:dispatch-id dispatch-id :render-key render-key}})
+
+(defn- error-ev
+  [id dispatch-id]
+  {:id id :op-type :error :operation :rf.error/schema-validation-failure
+   :tags {:dispatch-id dispatch-id}})
+
+(defn- warning-ev
+  [id dispatch-id]
+  {:id id :op-type :warning :operation :rf.warning/handler-replaced
+   :tags {:dispatch-id dispatch-id}})
+
+(defn- cascade-events
+  "Produce a representative one-cascade trace stream. `parent` is the
+  parent-dispatch-id (nil for a root)."
+  ([id-base dispatch-id event-vec]
+   (cascade-events id-base dispatch-id event-vec nil :app))
+  ([id-base dispatch-id event-vec parent]
+   (cascade-events id-base dispatch-id event-vec parent :app))
+  ([id-base dispatch-id event-vec parent origin]
+   [(dispatched-ev (+ id-base 1) dispatch-id event-vec parent origin)
+    (handler-ev    (+ id-base 2) dispatch-id)
+    (fx-ev         (+ id-base 3) dispatch-id :db)
+    (render-ev     (+ id-base 4) dispatch-id [:app/root nil])]))
+
+(defn- pipeline
+  "Run trace events through group-cascades + enrich-cascades + project-
+  cascades-to-graph so each test asserts against the same shape the
+  panel's composite sub produces."
+  [trace-events]
+  (-> (projection/group-cascades trace-events)
+      (h/enrich-cascades trace-events)
+      h/project-cascades-to-graph))
+
+;; ---- (1) project-cascades-to-graph --------------------------------------
+
+(deftest single-root-cascade-projects-to-one-node
+  (testing "one root cascade → one node, no arrows, dispatch-id is the root"
+    (let [graph (pipeline (cascade-events 0 100 [:user/login]))]
+      (is (= 1 (count (:nodes graph))))
+      (is (= [] (:arrows graph)))
+      (is (= #{100} (:roots graph)))
+      (let [node (first (:nodes graph))]
+        (is (= 100 (:dispatch-id node)))
+        (is (= [:user/login] (:event node)))
+        (is (true? (:root? node)))
+        (is (= :app (:origin node)))
+        (is (false? (:error? node)))
+        (is (false? (:warning? node)))
+        (is (= 1 (:effect-count node)) "one :rf.fx/handled in fixture")
+        (is (= 1 (:render-count node)))))))
+
+(deftest parent-child-cascade-produces-arrow
+  (testing "two cascades with parent→child :parent-dispatch-id produce one arrow"
+    (let [trace  (concat (cascade-events 0   100 [:user/login])
+                         (cascade-events 100 200 [:user/redirect] 100))
+          graph  (pipeline trace)
+          arrows (:arrows graph)]
+      (is (= 2 (count (:nodes graph))))
+      (is (= [[100 200]] arrows))
+      (is (= #{100} (:roots graph)))
+      (let [parent (some #(when (= 100 (:dispatch-id %)) %) (:nodes graph))
+            child  (some #(when (= 200 (:dispatch-id %)) %) (:nodes graph))]
+        (is (true?  (:root? parent)))
+        (is (false? (:root? child)))
+        (is (= 100  (:parent child)))))))
+
+(deftest orphan-child-renders-as-root
+  (testing "a child cascade whose parent isn't in the buffer (aged out)
+            renders as a root; no arrow into it (per spec §What this doesn't
+            do — 'no retroactive correlation')"
+    (let [trace (cascade-events 0 200 [:user/redirect] 999)  ; parent 999 absent
+          graph (pipeline trace)]
+      (is (= 1 (count (:nodes graph))))
+      (is (= [] (:arrows graph)) "no arrow when parent isn't in the graph")
+      (is (= #{200} (:roots graph)))
+      (is (true? (:root? (first (:nodes graph))))))))
+
+(deftest three-level-cascade-arrows-form-chain
+  (testing "root → child → grandchild produces two arrows in chain order"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100)
+                         (cascade-events 200 300 [:c] 200))
+          graph  (pipeline trace)]
+      (is (= 3 (count (:nodes graph))))
+      (is (= #{[100 200] [200 300]} (set (:arrows graph))))
+      (is (= #{100} (:roots graph))))))
+
+(deftest fan-out-multiple-children
+  (testing "one parent with two children produces two arrows from the same id"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100)
+                         (cascade-events 200 300 [:c] 100))
+          graph  (pipeline trace)]
+      (is (= 3 (count (:nodes graph))))
+      (is (= #{[100 200] [100 300]} (set (:arrows graph))))
+      (is (= #{100} (:roots graph))))))
+
+(deftest ungrouped-cascade-is-skipped
+  (testing "events without a :dispatch-id collect under :ungrouped in
+            group-cascades; the graph drops that bucket (no nil node)"
+    (let [trace  [{:id 1 :op-type :event :operation :event/dispatched
+                   :tags {:event [:boot] :origin :app}}] ; no :dispatch-id
+          graph  (pipeline trace)]
+      (is (= 0 (count (:nodes graph)))
+          ":ungrouped cascade does not produce a graph node")
+      (is (= [] (:arrows graph))))))
+
+(deftest origin-axis-reflected-on-node
+  (testing ":origin per-cascade lands on the node — drives the fill colour"
+    (let [trace [(dispatched-ev 1 100 [:foo] nil :app)
+                 (dispatched-ev 2 200 [:bar] nil :pair)
+                 (dispatched-ev 3 300 [:baz] nil :story)
+                 (dispatched-ev 4 400 [:qux] nil :causa)]
+          graph (pipeline trace)
+          by-id (into {} (map (juxt :dispatch-id :origin)) (:nodes graph))]
+      (is (= :app   (get by-id 100)))
+      (is (= :pair  (get by-id 200)))
+      (is (= :story (get by-id 300)))
+      (is (= :causa (get by-id 400))))))
+
+(deftest error-and-warning-flags-set-on-node
+  (testing "errors / warnings in the cascade's :other bucket set :error?
+            / :warning? on the node (drives the red / amber border treatment)"
+    (let [trace (concat (cascade-events 0 100 [:bad])
+                        [(error-ev 99 100)]
+                        (cascade-events 100 200 [:ok])
+                        [(warning-ev 199 200)])
+          graph  (pipeline trace)
+          by-id  (into {} (map (juxt :dispatch-id identity)) (:nodes graph))]
+      (is (true?  (:error?   (get by-id 100))))
+      (is (false? (:warning? (get by-id 100))))
+      (is (false? (:error?   (get by-id 200))))
+      (is (true?  (:warning? (get by-id 200)))))))
+
+;; ---- (2) compute-layout -------------------------------------------------
+
+(deftest layout-produces-position-for-every-node
+  (testing "compute-layout returns one {:x :y} entry per node"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100)
+                         (cascade-events 200 300 [:c] 100))
+          graph  (pipeline trace)
+          layout (h/compute-layout graph)]
+      (is (= 3 (count (:positions layout))))
+      (doseq [id [100 200 300]]
+        (is (some? (get-in layout [:positions id]))
+            (str "position present for " id))))))
+
+(deftest layout-stacks-children-below-parent
+  (testing "child y > parent y (top-down) — vertical axis is time per spec"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100))
+          graph  (pipeline trace)
+          layout (h/compute-layout graph)
+          py     (get-in layout [:positions 100 :y])
+          cy     (get-in layout [:positions 200 :y])]
+      (is (< py cy) "child sits below parent in pixel space"))))
+
+(deftest layout-spreads-siblings-horizontally
+  (testing "two siblings of the same parent get distinct x coordinates"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100)
+                         (cascade-events 200 300 [:c] 100))
+          graph  (pipeline trace)
+          layout (h/compute-layout graph)
+          x2     (get-in layout [:positions 200 :x])
+          x3     (get-in layout [:positions 300 :x])]
+      (is (not= x2 x3) "siblings occupy distinct columns"))))
+
+(deftest layout-deterministic-over-the-same-input
+  (testing "two runs of compute-layout over identical input yield identical
+            positions — required so the panel can diff layouts for the
+            animation hook (rf2-xxx)"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100)
+                         (cascade-events 200 300 [:c] 200))
+          graph  (pipeline trace)
+          l1     (h/compute-layout graph)
+          l2     (h/compute-layout graph)]
+      (is (= (:positions l1) (:positions l2)))
+      (is (= (:width l1) (:width l2)))
+      (is (= (:height l1) (:height l2))))))
+
+(deftest layout-width-and-height-bound-every-node
+  (testing "the layout's :width / :height are at least node-width /
+            node-height past the rightmost / bottommost node"
+    (let [trace  (concat (cascade-events 0   100 [:a])
+                         (cascade-events 100 200 [:b] 100))
+          graph  (pipeline trace)
+          layout (h/compute-layout graph)
+          max-x  (apply max (map :x (vals (:positions layout))))
+          max-y  (apply max (map :y (vals (:positions layout))))]
+      (is (>= (:width  layout) (+ max-x h/default-node-width))
+          "width spans every node's right edge")
+      (is (>= (:height layout) (+ max-y h/default-node-height))
+          "height spans every node's bottom edge"))))
+
+(deftest layout-empty-graph-degenerate
+  (testing "compute-layout on an empty graph returns sensible defaults"
+    (let [layout (h/compute-layout {:nodes [] :arrows [] :roots #{} :index {}})]
+      (is (= {} (:positions layout)))
+      (is (pos? (:width  layout))  "non-zero canvas even when empty")
+      (is (pos? (:height layout))))))
+
+;; ---- (3) filter-to-cascade ----------------------------------------------
+
+(deftest filter-to-cascade-keeps-family-only
+  (testing "filter-to-cascade keeps the cascade family (ancestors + self
+            + descendants) and drops the rest"
+    (let [trace  (concat
+                   ;; family A: 100 → 200 → 300
+                   (cascade-events 0   100 [:a])
+                   (cascade-events 100 200 [:b] 100)
+                   (cascade-events 200 300 [:c] 200)
+                   ;; unrelated root: 400
+                   (cascade-events 300 400 [:other]))
+          graph  (pipeline trace)
+          ;; Filter from the middle of family A — both ancestor (100)
+          ;; and descendant (300) must survive.
+          filt   (h/filter-to-cascade graph 200)
+          ids    (set (map :dispatch-id (:nodes filt)))]
+      (is (= #{100 200 300} ids))
+      (is (not (contains? ids 400)))
+      (is (= #{[100 200] [200 300]} (set (:arrows filt)))))))
+
+(deftest filter-to-cascade-nil-returns-graph-unchanged
+  (testing "filter-to-cascade nil is the identity"
+    (let [trace (concat (cascade-events 0   100 [:a])
+                        (cascade-events 100 200 [:b]))
+          graph (pipeline trace)
+          filt  (h/filter-to-cascade graph nil)]
+      (is (= (set (map :dispatch-id (:nodes graph)))
+             (set (map :dispatch-id (:nodes filt))))))))
+
+(deftest filter-to-cascade-on-missing-id-yields-empty-graph
+  (testing "filtering on a dispatch-id not in the graph yields an empty
+            graph (no nodes, no arrows) — caller should fall back to
+            the unfiltered graph; the composite sub does so already"
+    (let [trace  (cascade-events 0 100 [:a])
+          graph  (pipeline trace)
+          filt   (h/filter-to-cascade graph 999)]
+      (is (= [] (:nodes filt)))
+      (is (= [] (:arrows filt))))))
+
+;; ---- (4) enrich-cascades ------------------------------------------------
+
+(deftest enrich-cascades-attaches-event-trace
+  (testing "enrich-cascades attaches the :event/dispatched trace event
+            onto each cascade record under :event-trace"
+    (let [trace    (cascade-events 0 100 [:user/login] nil :pair)
+          cascades (projection/group-cascades trace)
+          enriched (h/enrich-cascades cascades trace)
+          c        (first enriched)]
+      (is (some? (:event-trace c)))
+      (is (= :pair (get-in c [:event-trace :tags :origin]))))))
+
+(deftest enrich-cascades-handles-missing-dispatched
+  (testing "a cascade with no :event/dispatched trace event is left
+            unchanged — :event-trace stays nil"
+    (let [trace    [(handler-ev 1 100)] ; no :event/dispatched
+          cascades (projection/group-cascades trace)
+          enriched (h/enrich-cascades cascades trace)]
+      (is (every? #(nil? (:event-trace %)) enriched)))))
+
+;; ---- (5) dispatch-id-of-epoch -------------------------------------------
+
+(deftest dispatch-id-of-epoch-walks-trace-events
+  (testing "dispatch-id-of-epoch picks the first :dispatch-id-bearing event"
+    (let [rec1 {:trace-events [(dispatched-ev 1 42 [:foo])]}
+          rec2 {:trace-events []} ; synthetic epoch — no dispatch-id
+          rec3 {:trace-events [{:id 1 :op-type :event :operation :event
+                                :tags {:parent-dispatch-id 99}}]}]
+      (is (= 42 (h/dispatch-id-of-epoch rec1)))
+      (is (nil? (h/dispatch-id-of-epoch rec2)))
+      (is (= 99 (h/dispatch-id-of-epoch rec3))
+          "falls back to :parent-dispatch-id when :dispatch-id absent"))))
+
+;; ---- (6) visual token helpers -------------------------------------------
+
+(deftest node-border-token-precedence
+  (testing "errors win over warnings; default otherwise"
+    (is (= :error   (h/node-border-token {:error? true  :warning? false})))
+    (is (= :error   (h/node-border-token {:error? true  :warning? true})))
+    (is (= :warning (h/node-border-token {:error? false :warning? true})))
+    (is (= :default (h/node-border-token {:error? false :warning? false})))))
+
+(deftest node-glyph-selection
+  (testing "selected wins; root next; default child"
+    (is (= "◉" (h/node-glyph {:root? true}  true)))
+    (is (= "◉" (h/node-glyph {:root? false} true)))
+    (is (= "◆" (h/node-glyph {:root? true}  false)))
+    (is (= "○" (h/node-glyph {:root? false} false)))))
+
+(deftest origin-fill-covers-spec-axis
+  (testing "every :origin from spec/002 §Dispatch origin tagging has a fill"
+    (doseq [o [:app :pair :story :test :causa]]
+      (is (some? (get h/origin->fill o))
+          (str "fill present for :" (name o))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
@@ -1,0 +1,268 @@
+(ns day8.re-frame2-causa.panels.causality-graph-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Causality Graph panel
+  (Phase 4, rf2-4rqs1).
+
+  ## Three contracts under test (in addition to the pure-data tests
+  in `causality_graph_cljs_test.cljc`)
+
+  1. **Registry wires the composite sub** under `:rf.causa/causality-
+     graph-data`. The composite returns the same graph + layout the
+     view consumes.
+
+  2. **Clicking a node fires `:rf.causa/select-dispatch-id`** — the
+     shared selection event with the event-detail hero (per spec
+     §10 Lock 7).
+
+  3. **Selected-epoch filters the graph** to the cascade family
+     containing that epoch's settling dispatch (per spec §The
+     passive-scrubbing rule + spec/001-Causality-Graph.md §Filter
+     graph to this cascade).
+
+  ## Pure hiccup
+
+  Same approach as `event_detail_cljs_test.cljs` and
+  `time_travel_cljs_test.cljs` — we walk the view's hiccup tree by
+  `data-testid` rather than mounting to a DOM. Keeps the suite fast
+  + host-portable on node-test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.causality-graph :as causality-graph]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- fixture trace stream ------------------------------------------------
+
+(defn- cascade-evs
+  "Produce a one-cascade trace stream. Same shape as
+  `event_detail_cljs_test.cljs` + a `:parent-dispatch-id` slot."
+  ([dispatch-id event-vec id-base]
+   (cascade-evs dispatch-id event-vec id-base nil))
+  ([dispatch-id event-vec id-base parent]
+   [{:id (+ id-base 1) :op-type :event    :operation :event/dispatched
+     :tags (cond-> {:dispatch-id dispatch-id :event event-vec :origin :app}
+             parent (assoc :parent-dispatch-id parent))}
+    {:id (+ id-base 2) :op-type :event    :operation :event
+     :tags {:dispatch-id dispatch-id :phase :run-end}}
+    {:id (+ id-base 3) :op-type :fx       :operation :rf.fx/handled
+     :tags {:dispatch-id dispatch-id :fx-id :db}}
+    {:id (+ id-base 4) :op-type :view     :operation :view/render
+     :tags {:dispatch-id dispatch-id :render-key [:app/root nil]}}]))
+
+(defn- seed-buffer!
+  "Wire the trace collector (preload-style) and push the supplied
+  events through it so the Causa buffer matches the production
+  delivery path."
+  [evs]
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+;; ---- (1) registry wires the composite sub -------------------------------
+
+(deftest registry-installs-causality-graph-sub
+  (testing "register-causa-handlers! installs the Phase 4 composite sub"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/causality-graph-data)))))
+
+(deftest causality-graph-sub-defaults
+  (testing "the composite returns an empty graph + sensible layout when
+            the buffer is empty"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/causality-graph-data])]
+        (is (= [] (get-in data [:graph :nodes])))
+        (is (= [] (get-in data [:graph :arrows])))
+        (is (some? (:layout data)))
+        (is (false? (:filtered? data)))
+        (is (nil? (:selected-dispatch-id data)))))))
+
+(deftest causality-graph-sub-projects-cascades
+  (testing "with a buffer populated, the composite returns one node per
+            cascade and the parent → child arrow"
+    (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
+                          (cascade-evs 200 [:user/redirect] 100 100)))
+    (rf/with-frame :rf/causa
+      (let [data  @(rf/subscribe [:rf.causa/causality-graph-data])
+            ids   (set (map :dispatch-id (get-in data [:graph :nodes])))]
+        (is (= #{100 200} ids))
+        (is (= [[100 200]] (get-in data [:graph :arrows])))))))
+
+;; ---- (2) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-no-cascades
+  (testing "the panel renders the empty state when the buffer has no
+            dispatch cascades"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [tree (causality-graph/causality-graph-view)]
+        (is (some? (find-by-testid tree "rf-causa-causality-graph-empty"))
+            "empty-state container present")
+        (is (nil?  (find-by-testid tree "rf-causa-causality-graph-svg"))
+            "SVG canvas absent when empty")))))
+
+(deftest svg-renders-when-cascades-present
+  (testing "with cascades in the buffer the panel renders the SVG canvas
+            with one node per cascade"
+    (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
+                          (cascade-evs 200 [:user/redirect] 100 100)))
+    (rf/with-frame :rf/causa
+      (let [tree (causality-graph/causality-graph-view)]
+        (is (some? (find-by-testid tree "rf-causa-causality-graph-svg"))
+            "SVG container present")
+        (is (nil?  (find-by-testid tree "rf-causa-causality-graph-empty"))
+            "empty-state absent when cascades present")
+        (is (some? (find-by-testid tree "rf-causa-graph-node-100"))
+            "node for dispatch 100")
+        (is (some? (find-by-testid tree "rf-causa-graph-node-200"))
+            "node for dispatch 200")
+        (is (some? (find-by-testid tree "rf-causa-graph-arrow-100-200"))
+            "arrow 100 → 200")))))
+
+;; ---- (3) clicking a node fires select-dispatch-id -----------------------
+
+(deftest clicking-node-fires-select-dispatch-id
+  (testing "the node's on-click is wired to :rf.causa/select-dispatch-id —
+            shared with the event-detail hero panel. We assert the
+            handler is callable and that the dispatch reaches Causa's
+            frame via dispatch-sync on the same event (rf/dispatch from
+            inside the click is async — we trust the on-click is the
+            constructed dispatch call, then prove the event handler
+            writes to the right frame)."
+    (seed-buffer! (cascade-evs 100 [:user/login] 0))
+    (rf/with-frame :rf/causa
+      (let [tree     (causality-graph/causality-graph-view)
+            node     (find-by-testid tree "rf-causa-graph-node-100")
+            on-click (:on-click (second node))]
+        (is (fn? on-click)
+            "node carries an on-click handler (wired to :rf.causa/select-dispatch-id)")
+        ;; Drive the same event through dispatch-sync so the test
+        ;; doesn't race the router's drain — proves the registered
+        ;; event handler lands the selection on the Causa frame.
+        (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+        (let [causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= 100 (:selected-dispatch-id causa-db))
+              "selection lands on the Causa frame"))))))
+
+(deftest selected-node-renders-with-selected-glyph
+  (testing "after select, the composite sub surfaces :selected-dispatch-id
+            and the view's node renders with the selected glyph"
+    (seed-buffer! (cascade-evs 100 [:user/login] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [data @(rf/subscribe [:rf.causa/causality-graph-data])]
+        (is (= 100 (:selected-dispatch-id data))
+            "composite returns the selection")))))
+
+;; ---- (4) selected-epoch filters to cascade family -----------------------
+
+(deftest selected-epoch-filters-graph-to-cascade
+  (testing "when Time Travel's :selected-epoch-id resolves to a cascade-id
+            in the graph, the graph filters to that cascade family"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    ;; Seed two unrelated cascades (100 and 400) so we can prove the
+    ;; filter cuts the unrelated one out.
+    (seed-buffer! (concat (cascade-evs 100 [:family-a] 0)
+                          (cascade-evs 400 [:family-b] 100)))
+    (rf/with-frame :rf/causa
+      ;; Register a seed-event so we can write epoch-history without
+      ;; depending on the epoch artefact being on the test classpath.
+      (rf/reg-event-db :rf.causa/seed-history-for-test
+        (fn [db [_ records]]
+          (assoc db :epoch-history (vec records))))
+      ;; Seed a history with one epoch whose settling cascade-id = 100.
+      (rf/dispatch-sync
+        [:rf.causa/seed-history-for-test
+         [{:epoch-id     :e-100
+           :frame        :rf/default
+           :committed-at 0
+           :event-id     :foo
+           :trigger-event [:foo]
+           :db-before    {}
+           :db-after     {}
+           :trace-events [{:id 1 :op-type :event :operation :event/dispatched
+                           :tags {:dispatch-id 100}}]}]])
+      (rf/dispatch-sync [:rf.causa/select-epoch :e-100])
+      (let [data @(rf/subscribe [:rf.causa/causality-graph-data])
+            ids  (set (map :dispatch-id (get-in data [:graph :nodes])))]
+        (is (true? (:filtered? data)) ":filtered? flag set")
+        (is (= #{100} ids)
+            "graph contains only the cascade family of the selected epoch")
+        (is (not (contains? ids 400))
+            "unrelated cascade dropped")))))
+
+(deftest selected-epoch-not-in-graph-falls-back
+  (testing "when the selected-epoch's cascade-id is NOT in the graph
+            (aged out of the buffer), the graph falls back to the
+            unfiltered view"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (seed-buffer! (cascade-evs 100 [:in-buffer] 0))
+    (rf/with-frame :rf/causa
+      (rf/reg-event-db :rf.causa/seed-history-for-test
+        (fn [db [_ records]]
+          (assoc db :epoch-history (vec records))))
+      ;; Epoch's settling cascade-id 999 is NOT in the buffer.
+      (rf/dispatch-sync
+        [:rf.causa/seed-history-for-test
+         [{:epoch-id     :e-old
+           :frame        :rf/default
+           :committed-at 0
+           :event-id     :foo
+           :trigger-event [:foo]
+           :db-before    {}
+           :db-after     {}
+           :trace-events [{:id 1 :op-type :event :operation :event/dispatched
+                           :tags {:dispatch-id 999}}]}]])
+      (rf/dispatch-sync [:rf.causa/select-epoch :e-old])
+      (let [data @(rf/subscribe [:rf.causa/causality-graph-data])
+            ids  (set (map :dispatch-id (get-in data [:graph :nodes])))]
+        (is (false? (:filtered? data))
+            ":filtered? false when the cascade isn't in the graph")
+        (is (= #{100} ids)
+            "graph still surfaces every cascade in the buffer")))))


### PR DESCRIPTION
## Summary

Phase 4 of the **rf2-5aw5v** Causa epic — the unique-to-Causa Causality Graph panel (no peer devtool renders this view, per the rf2-76qxg audit). Implements the panel per `tools/causa/spec/001-Causality-Graph.md` against the foundation shipped in Phase 1 (rf2-n6x4q), Phase 2 (rf2-op3bz), and Phase 3 (rf2-t53ze).

- **Panel** `tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs` — pure SVG-hiccup; nodes are dispatch cascades, arrows are `:parent-dispatch-id` lineage. Colour-coded by `:origin` per Spec 007-UX-IA; glyphs `◆` root / `○` child / `◉` selected so the colour signal pairs with a shape (a11y).
- **Pure-data helpers** `tools/causa/src/day8/re_frame2_causa/panels/causality_graph_helpers.cljc` — `enrich-cascades`, `project-cascades-to-graph`, `compute-layout` (BFS top-down DAG), `cascade-of`, `filter-to-cascade`, `dispatch-id-of-epoch`. JVM-runnable per `feedback_jvm_interop_must_work.md`.
- **Registry** `:rf.causa/causality-graph-data` composite sub — projects + lays out the graph on every recompute. No new events; reuses `:rf.causa/select-dispatch-id` with the event-detail hero (§10 Lock 7). When Time Travel's `:selected-epoch-id` resolves to a cascade-id in the graph, the composite filters to that cascade family per spec §Filter graph to this cascade.
- **Shell** wires the Causality sidebar entry to mount the panel.
- **Tests** 32 new deftests across `causality_graph_cljs_test.cljc` (22 helper) and `causality_graph_view_cljs_test.cljs` (10 view + wiring).

## Test plan

- [x] `clojure -M:test` in `tools/causa` — 72 tests / 214 assertions / 0 failures
- [x] `npm run test:cljs` — 759 tests / 1950 assertions / 0 failures (+32 deftests / +99 assertions vs baseline 727 / 1851)
- [x] `npm run test:browser` — 759 tests / 1982 assertions / 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:examples` — 25 / 25 examples PASS
- [ ] Counter app + Causa preload — manual smoke pending (worktree headless)