### PR TITLE
docs(guide): ch.06 reorder — introduce frame-provider before propagation discussion (rf2-l83q)

### DIFF
--- a/docs/guide/06-views-and-frames.md
+++ b/docs/guide/06-views-and-frames.md
@@ -225,12 +225,6 @@ The win is purely readability: `(<sub [:products/sorted])` is shorter than `@(rf
 
 These are **optional ergonomics**, not the canonical idiom in this guide; the examples here use `@(subscribe …)` and `dispatch` directly so the underlying primitive stays visible. If you're reading v1 code, or porting a v1 app, recognising the aliases is enough.
 
-### How frames propagate through the view tree
-
-The architecture above assumes a view inside a `frame-provider` subtree picks up the surrounding frame. The CLJS reference uses **React context** to carry this — when you wrap a subtree with `[rf/frame-provider {:frame :left} ...]`, every registered view rendered underneath receives the frame id through context, and the auto-injected `dispatch`/`subscribe` resolves against it.
-
-The propagation is part of `reg-view`'s contract: a registered view inside `frame-provider {:frame :left}` dispatches to `:left`. The full resolution chain is dynamic-var → React context → `:rf/default`. The split-counter example below exercises the resolution; the view fn doesn't know which frame it's been instantiated under, and the framework routes correctly.
-
 ### The Var-reference idiom
 
 `reg-view` is defn-shape: it auto-defs the symbol you supply. Reference that var like any other Reagent component:
@@ -339,6 +333,8 @@ In CLJS, the way to put a registered view inside a particular frame's subtree is
 ```
 
 Two instances of the same registered view, different frames. Each subtree's `dispatch`/`subscribe` resolves to its own frame. The view fn doesn't know it's been instantiated twice with different state.
+
+The propagation mechanism is **React context** — wrapping a subtree with `[rf/frame-provider {:frame :left} ...]` makes the frame id available to every registered view rendered underneath, and the auto-injected `dispatch`/`subscribe` resolves against it. The full resolution chain is dynamic-var → React context → `:rf/default`; this is part of `reg-view`'s contract, and the split-counter example below exercises it end-to-end.
 
 `frame-provider` is a Reagent-specific (React context-driven) construct. The pattern itself doesn't require it — what the *pattern* requires is that every dispatch/subscribe targets a specific frame, by whatever mechanism the host language provides. In TypeScript, you might use a hooks-flavoured `useFrame()`. In Python, you might pass the frame as an argument. In Clojure, React context happens to be ergonomic. The contract — every view targets a specific frame — is the part that survives across hosts.
 


### PR DESCRIPTION
## Summary

Progressive-disclosure F13 fix. The standalone §\"How frames propagate through the view tree\" in ch.06 introduced React-context internals and referenced `frame-provider` before the chapter's spine had introduced it. A reader hit \"when you wrap a subtree with `[rf/frame-provider ...]`\" with no prior context.

**Option B (merge).** Fold the propagation mechanism — React context, resolution chain dynamic-var → React context → `:rf/default` — into §`frame-provider — scoping a frame to a subtree` itself, as a one-paragraph note placed where the mechanism is most concretely grounded (right after the split-counter sketch and just before the host-portability discussion). Delete the standalone section.

Chose B over A because the propagation block was only 2 short paragraphs and content-wise belonged adjacent to frame-provider anyway. A reorder would have left the same merge-shaped result with extra churn.

## Before / after section ordering

Before, under §Views: ...The Signal Graph → `<sub`/`>evt` → **How frames propagate through the view tree** → The Var-reference idiom...

After, under §Views: ...The Signal Graph → `<sub`/`>evt` → The Var-reference idiom... (no forward-reference)

Under §Frames the §`frame-provider` section now carries the propagation mechanism note inline.

## Cross-references

No external doc anchors point at the deleted heading (`#how-frames-propagate-through-the-view-tree`); Grep confirms zero references across `docs/`, `spec/`, and skills.

## Test plan

- [x] `python scripts/check_doc_slugs.py --verbose` — \"no broken links\" across 229 markdown files
- [x] `python -m mkdocs build` — clean for this chapter; pre-existing 2 warnings in `21-stories.md` unrelated to this PR (verified by building origin/main with the same staging steps)
- [x] Chapter reads naturally on a top-to-bottom skim: §`frame-provider` now introduces the construct, shows the split-counter sketch, explains the propagation mechanism, and notes host-portability — all in one place

Net diff: -6 / +2 lines, one file (`docs/guide/06-views-and-frames.md`).