### PR TITLE
docs(guide): consolidate flows discussion to ch.18; ch.06 keeps pointer (rf2-bvgq)

### DIFF
--- a/docs/guide/06-views-and-frames.md
+++ b/docs/guide/06-views-and-frames.md
@@ -389,7 +389,7 @@ A useful test: if two instances might want to share state under any circumstance
 
 Two adjacent topics deserve a pointer before you leave views and frames, but neither is needed up front:
 
-- **Flows — computed values stored in `app-db`** (rather than the per-frame sub-cache). A niche convenience for derived values that need to be visible to other handlers, survive SSR/hydration, or carry a schema. Reach for it only when a sub won't do.
+- **Flows — computed values stored in `app-db`** (rather than the per-frame sub-cache). A niche convenience for derived values that need to be visible to other handlers, survive SSR/hydration, or carry a schema. Reach for it only when a sub won't do. The canonical introduction lives at [18 — From re-frame v1 §Flows](18-from-re-frame-v1.md#flows--the-replacement-for-on-changes) (flows are the migration target for v1's `on-changes`); the full contract is [Spec 013](../../spec/013-Flows.md).
 - **Nine-states UI checklist** — `Nothing` / `Loading` / `Empty` / `One` / `Some` / `Too Many` / `Incorrect` / `Correct` / `Done`. Modelled as one parallel state machine with three regions; introduced once you've met parallel regions in [08 — State machines §Parallel regions](08-state-machines.md#parallel-regions).
 
 ## What we covered

--- a/docs/guide/18-from-re-frame-v1.md
+++ b/docs/guide/18-from-re-frame-v1.md
@@ -63,6 +63,28 @@ A concrete instance of "problems you might run into": v1 codebases that register
 
 The skill applies steps 1–4 unprompted and stops at step 5 for review.
 
+### Flows — the replacement for `on-changes`
+
+Another concrete instance of "removed interceptors": v1's `on-changes` ("when these in-paths change, compute and write to that out-path") migrates to **flows**. A flow is the same compute-on-input-change semantics, lifted out of the per-event interceptor chain and into the runtime — registered once, evaluated automatically after each event drain, toggleable at runtime via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`.
+
+```clojure
+(rf/reg-flow
+  {:id     :rectangle/area
+   :inputs [[:width] [:height]]            ;; vector of app-db paths
+   :output (fn [w h] (* w h))               ;; pure: (in-1, in-2, ...) → output
+   :path   [:area]                          ;; where the result is written
+   :doc    "Rectangle area computed from :width and :height."})
+```
+
+Two things to know up front:
+
+- **Flows are a niche convenience, not a sub replacement.** They're for derived values that are part of the application's *state* — visible to other event handlers, surviving SSR hydration, covered by registered schemas, queryable from the app-db inspector. If the derived value is consumed only by views, the right tool is a subscription (lighter, sub-cache-native, no `app-db` write). A typical re-frame2 app has dozens of subs and a handful of flows; tens of flows is a smell.
+- **What `on-changes` couldn't reach, flows can.** Wizard steps where a derivation only runs while a feature is engaged, feature gates, advanced-mode-only computations — `on-changes` is statically wired into specific events at registration time, so a derivation that should be conditional has no clean shape. Flows are runtime-registered and runtime-clearable; toggling is a normal fx.
+
+The migration rewrite is Type B (see [`MIGRATION.md` §M-21](../../spec/MIGRATION.md#m-21-drop-debug-trim-v-on-changes-enrich-after-interceptors)) — mechanically straightforward (`(rf/on-changes f out-path & in-paths)` → `(rf/reg-flow {:id ... :inputs in-paths :output f :path out-path})`), but the agent stops to ask about the `:id` (it suggests `:legacy/<event-id>` as a default) and whether the flow should be conditionally toggled rather than always-on. Apps without `on-changes` see no migration here at all.
+
+The full contract — frame-scoping, topological evaluation order, schema validation, the toggle fx — is in [Spec 013](../../spec/013-Flows.md).
+
 ## A note on the tooling
 
 `re-frame-10x` — the v1 devtools panel — has been renamed and reimplemented as **`re-frame-causa`** for v2. It is **not** the v1 10x ported to v2; it's a from-scratch reimplementation against re-frame2's own trace bus and epoch-history surfaces (see [15 — Tooling](15-devtools-and-pair-tools.md)). If your v1 project depended on the 10x panel during development, the v2 equivalent is causa, not 10x. The mental model — events, subs, app-db diff, time-travel — carries over; the wiring underneath does not.


### PR DESCRIPTION
## Summary

Per guide-progressive-disclosure audit F11. Earlier work (rf2-vz2n + rf2-aswf / rf2-t462) trimmed the flows treatment out of both ch.06 (views and frames) and the from-re-frame-v1 chapter in independent sweeps; neither commit landed a canonical home, so the pointer in ch.06 had no narrative target.

This change picks **ch.18 as the canonical home** — flows are the migration target for v1's `on-changes` interceptor, which makes the migration chapter the natural narrative anchor.

- **ch.18** — adds a `### Flows` section paralleling the existing `### Migrating an HTTP layer` sub-section under "Problems you might run into". Covers both framings the audit flagged: the niche-convenience framing (flows are an `app-db` escape hatch, not a sub replacement) and the `on-changes` migration framing (what `on-changes` did, what it couldn't reach, the mechanical rewrite). Points at [Spec 013](../../spec/013-Flows.md) for the full contract and `MIGRATION.md` §M-21 for the rewrite rule.
- **ch.06** — extends the existing "Beyond this chapter" pointer with a link into ch.18 §Flows (canonical introduction) plus Spec 013 (full contract). No new substantive content in ch.06; the pointer is still one line.

## Test plan

- [x] `scripts/check_doc_slugs.py` passes (the canonical doc-link gate)
- [x] `mkdocs build --strict` with `spec/` staged into `docs/spec/` (as CI does) produces only the two pre-existing `tools/story/spec/` warnings, neither related to this change
- [x] New anchor `#flows--the-replacement-for-on-changes` resolves under pymdownx's double-dash slugifier (verified via the slug-check script)
- [x] No other guide chapter holds a stale cross-reference to the old ch.06 flows section (grepped `computed-values`, `flow-escape-hatch`, the old anchor)

## Line counts

| File | Before | After | Delta |
|---|---|---|---|
| `docs/guide/06-views-and-frames.md` flows pointer | 1 line | 1 line (extended) | +0 lines |
| `docs/guide/18-from-re-frame-v1.md` §Flows | 0 lines | 22 lines | +22 lines |