### PR TITLE
feat(story): live schema-validation panel — surface Spec 010 boundary failures per variant (rf2-dvue)

### DIFF
--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -52,7 +52,8 @@
             [re-frame.story.layout-debug :as layout-debug]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.a11y :as a11y]
-            [re-frame.story.ui.canvas :as canvas]))
+            [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.schema-validation :as schema-validation]))
 
 ;; ---- styling -------------------------------------------------------------
 
@@ -250,7 +251,10 @@
        :placement :right
        :render    layout-debug-render-id})
     ;; A11y panel — registers in its own ns.
-    (a11y/install-canonical-a11y!)))
+    (a11y/install-canonical-a11y!)
+    ;; Schema-validation panel (rf2-dvue) — registers in its own ns
+    ;; so the late-bind validator lookup stays isolated.
+    (schema-validation/install!)))
 
 ;; ---- panel host ---------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -1,0 +1,574 @@
+(ns re-frame.story.ui.schema-validation
+  "Schema-validation panel — live Spec 010 boundary-failure surface per
+  variant. Per Story SOTA audit F-N / rf2-dvue.
+
+  ## What it is
+
+  When a variant's `:component` (a registered `:view`) carries a Spec
+  010 schema (Malli or whatever validator is installed), this panel
+  surfaces two streams in one place:
+
+    1. **Args violations** — given the variant's resolved args + the
+       component's registered schema, walks every `:map` entry and
+       reports per-key conformance. The user gets an at-a-glance
+       'these args don't match the schema' view that complements the
+       Controls panel's widget-derivation.
+
+    2. **Trace violations** — every `:rf.error/schema-validation-failure`
+       trace event scoped to the variant's frame (per Spec 010
+       §Validation timing — events at boundary, sub returns, cofx
+       injections, app-db post-handler slices). Boundary validation
+       runs even in production, so the panel is the one place a
+       developer reading a Story sees 'this variant is silently
+       violating its schema right now'.
+
+  ## Differentiator vs Storybook 8
+
+  Storybook 8 has no schema-introspection equivalent. JSON Schema /
+  PropTypes are descriptive metadata, not runtime conformance — Story
+  consumes the same `:spec` slot the framework's dev-mode validator
+  consumes and renders failures from the live trace bus. The reader
+  sees 'the args you're rendering this variant with violate the
+  component's contract' immediately.
+
+  ## Schema lookup
+
+  The panel looks for the component schema in this order (first match
+  wins):
+
+    1. The variant body's `:schema` slot — explicit per-variant
+       override (forward-compatible with the `:rf/schema` Spec 010
+       slot per IMPL-SPEC §9.4).
+    2. The parent story body's `:schema` slot — story-wide schema.
+    3. The framework registrar's `:view` metadata for the variant's
+       `:component`, looking at `:spec` (Spec 010 canonical) then
+       `:schema` (legacy / Story-only alias).
+
+  When no schema is on file, the args section reports 'no schema
+  registered' and the trace section still surfaces any
+  `:rf.error/schema-validation-failure` events emitted against the
+  frame (e.g. from `reg-app-schema` registrations the variant set up,
+  or from event / cofx specs on dispatched events).
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` so the pure projection helpers
+  (`schema-validation-event?`, `project-failure`, `project-failures`,
+  `args-violations`, `format-explain`) run under both the JVM unit-
+  test target and the CLJS node-test build. The Reagent rendering,
+  the panel registration, and the validator lookup-via-late-bind live
+  under `:cljs`.
+
+  ## Elision
+
+  Production builds with `re-frame.story.config/enabled?` false skip
+  the `install!` call (per `re-frame.story.ui.panels/install-
+  canonical-panels!`'s `(when enabled? ...)` gate); the require graph
+  from the disabled shell is DCE-pruned so the panel never reaches
+  prod bundles. The pure helpers stay in the bundle but never run.
+
+  ## Panel registry slot
+
+  Registers as `:rf.story.panel/schema-validation` via
+  `reg-story-panel*`, placement `:right`. The render view is
+  `:rf.story.panel/schema-validation-view`, registered against the
+  framework view registry."
+  (:require [clojure.string :as str]
+            #?@(:cljs [[reagent.core              :as r]
+                       [re-frame.core             :as rf]
+                       [re-frame.late-bind        :as late-bind]
+                       [re-frame.story.args       :as args]
+                       [re-frame.story.config     :as config]
+                       [re-frame.story.registrar  :as story-registrar]
+                       [re-frame.story.ui.trace   :as trace]
+                       [re-frame.registrar        :as framework-registrar]])))
+
+;; ---- pure: classify a trace event ---------------------------------------
+
+(defn schema-validation-event?
+  "True iff `ev` (a raw trace event from the buffer) is a Spec 010
+  schema-validation failure — `:op-type :error` +
+  `:operation :rf.error/schema-validation-failure`. Pure data → bool;
+  JVM-testable."
+  [{:keys [op-type operation] :as _ev}]
+  (boolean
+    (and (= op-type :error)
+         (= operation :rf.error/schema-validation-failure))))
+
+;; ---- pure: project a failure into a row --------------------------------
+
+(defn project-failure
+  "Project one raw `:rf.error/schema-validation-failure` trace event
+  into a row the panel renders. Per Spec 010 §Per-step recovery the
+  failing event's `:tags` carries:
+
+    - `:where` — `:event` / `:sub-return` / `:cofx` / `:app-db` /
+                 `:fx-args` (per Spec 010 §Validation order).
+    - `:failing-id` / `:event-id` / `:sub-id` / `:cofx-id` / `:fx-id`
+                 — the id of the artefact whose `:spec` failed.
+    - `:received` — the actual value that failed (event vector / value /
+                    coeffect map / slice).
+    - `:explain` — the validator's explanation (Malli explain map on
+                   the CLJS reference; other shapes on other ports).
+    - `:path` (when present, for app-db failures) — the registered
+                schema path.
+    - `:frame` — the frame id the failure fired in.
+    - `:recovery` — the spec-defined recovery posture.
+
+  Output row shape:
+
+      {:id          <int>              ;; the trace event's :id (stable per-process key)
+       :time        <ms-since-epoch>   ;; from the trace event's :time
+       :where       <kw>               ;; :event / :sub-return / :cofx / :app-db / :fx-args
+       :failing-id  <kw|nil>           ;; the artefact id whose :spec failed
+       :path        <vector|nil>       ;; only for app-db failures
+       :received    <any>              ;; the rejected value
+       :explain     <any|nil>          ;; the validator's explanation
+       :recovery    <kw|nil>           ;; the spec-defined recovery
+       :raw         <trace-event>}     ;; the full event for trace deep-dives
+
+  Pure data → data; JVM-testable."
+  [{:keys [tags id time recovery] :as ev}]
+  {:id         id
+   :time       time
+   :where      (:where tags)
+   :failing-id (or (:failing-id tags)
+                   (:event-id   tags)
+                   (:sub-id     tags)
+                   (:cofx-id    tags)
+                   (:fx-id      tags))
+   :path       (:path     tags)
+   :received   (:received tags)
+   :explain    (:explain  tags)
+   :recovery   (or recovery (:recovery tags))
+   :raw        ev})
+
+(defn project-failures
+  "Filter `events` (a seq of raw trace events from the buffer) to the
+  schema-validation-failure subset and project each one into a row.
+  Returns a vector in chronological order (oldest first). Pure data
+  → data; JVM-testable."
+  [events]
+  (into []
+        (comp (filter schema-validation-event?)
+              (map project-failure))
+        events))
+
+;; ---- pure: Malli walk over `:map` schemas ------------------------------
+;;
+;; Mirrors the helpers in `re-frame.story.ui.controls` — but kept
+;; in-namespace so this file stands on its own under the JVM test
+;; target.
+
+(defn- properties? [x] (map? x))
+
+(defn- schema-op [s] (when (vector? s) (first s)))
+
+(defn- schema-children
+  "Return the child schemas of a vector schema, skipping the optional
+  properties map."
+  [s]
+  (when (vector? s)
+    (let [r (rest s)]
+      (if (properties? (first r)) (rest r) r))))
+
+(defn- map-entry-key   [entry] (first entry))
+
+(defn- map-entry-schema
+  [entry]
+  (let [r (rest entry)]
+    (if (properties? (first r))
+      (second r)
+      (first r))))
+
+(defn map-schema?
+  "True iff `schema` is a Malli `[:map ...]` vector form. The arg-
+  walker only descends into top-level maps — every other shape is
+  surfaced as a whole-value violation under the synthetic `::root`
+  arg-key."
+  [schema]
+  (and (vector? schema)
+       (= :map (schema-op schema))))
+
+(defn map-entries
+  "Return the `[k child-schema]` pairs of a `[:map ...]` schema, in
+  declared order. Skips the optional properties map at index 1. Pure
+  data → seq; JVM-testable."
+  [schema]
+  (when (map-schema? schema)
+    (mapv (fn [e] [(map-entry-key e) (map-entry-schema e)])
+          (schema-children schema))))
+
+;; ---- pure: args-violation projection ------------------------------------
+
+(defn args-violations
+  "Given a resolved args map, a component schema, and a validator fn
+  pair (`{:validate (fn [schema value] truthy?) :explain (fn [schema
+  value] explanation-or-nil)}`), return a vector of per-key violation
+  maps for the args that fail their entry schema.
+
+  When the schema is a `[:map ...]` form the walker checks every
+  registered entry against the matching value in `args` and collects
+  the failures. When the schema is anything else (top-level
+  non-`:map` shape) the walker validates the whole `args` map against
+  the schema and returns a single `::root` violation when it fails.
+
+  Per Spec 010 §Recommended soft-pass when the validator is absent
+  (`nil`), every value passes — the panel reports 'no violations'.
+
+  Output: vector of
+
+      {:key      <arg-key|::root>
+       :value    <any>
+       :schema   <schema-fragment>
+       :explain  <any|nil>}
+
+  Pure data → data; JVM-testable.
+
+  Validator-fn shape:
+
+      validator-fns = {:validate <fn> :explain <fn-or-nil>}
+
+  Both fns are pure (per Spec 010 §Locked rules). When `:validate`
+  is nil/absent the walker treats every value as conforming."
+  [args schema validator-fns]
+  (let [validate (:validate validator-fns)
+        explain  (:explain  validator-fns)]
+    (cond
+      ;; No validator registered — soft-pass per Spec 010.
+      (nil? validate)
+      []
+
+      ;; No schema on file — nothing to validate.
+      (nil? schema)
+      []
+
+      ;; Top-level :map — walk entries.
+      (map-schema? schema)
+      (into []
+            (keep (fn [[k child-schema]]
+                    (let [v (get args k)]
+                      (when-not (validate child-schema v)
+                        {:key     k
+                         :value   v
+                         :schema  child-schema
+                         :explain (when explain (explain child-schema v))}))))
+            (map-entries schema))
+
+      ;; Top-level non-:map — validate whole args against the schema.
+      :else
+      (if (validate schema args)
+        []
+        [{:key     ::root
+          :value   args
+          :schema  schema
+          :explain (when explain (explain schema args))}]))))
+
+;; ---- pure: format-explain ------------------------------------------------
+
+(defn format-explain
+  "Render a validator explanation as a short, human-readable string
+  the panel can stick into a row tooltip / inline note. Malli's
+  explanations are nested maps with `:errors` carrying per-path
+  detail; we pr-str the whole shape when we can't introspect.
+
+  Pure; JVM-testable.
+
+  - `nil` → empty string.
+  - Malli explanation map (has `:errors`) → joined error paths.
+  - Anything else → `pr-str`."
+  [explanation]
+  (cond
+    (nil? explanation)
+    ""
+
+    (and (map? explanation) (vector? (:errors explanation)))
+    (->> (:errors explanation)
+         (map (fn [{:keys [path message] :as _err}]
+                (let [path-str (if (seq path)
+                                 (str/join "->" (map pr-str path))
+                                 "(root)")]
+                  (str path-str ": " (or message "schema violation")))))
+         (str/join "; "))
+
+    :else
+    (pr-str explanation)))
+
+;; ---- CLJS: schema lookup ------------------------------------------------
+
+#?(:cljs
+   (defn resolve-component-schema
+     "Resolve the component schema for `variant-id`, looking in:
+
+       1. The variant body's `:schema` slot.
+       2. The parent story body's `:schema` slot.
+       3. The framework registrar's `:view` metadata for the
+          `:component` id, looking at `:spec` first (Spec 010
+          canonical) then `:schema`.
+
+     Returns the schema value, or nil when none is registered.
+
+     The panel's CLJS-only render path calls this; the pure
+     helpers (`args-violations`) take a pre-resolved schema and
+     are JVM-friendly."
+     [variant-id]
+     (let [vb         (story-registrar/handler-meta :variant variant-id)
+           story-id   (args/parent-story-id variant-id)
+           sb         (when story-id (story-registrar/handler-meta :story story-id))
+           comp-id    (or (:component vb) (:component sb))
+           view-meta  (when comp-id (framework-registrar/handler-meta :view comp-id))]
+       (or (:schema vb)
+           (:schema sb)
+           (:spec   view-meta)
+           (:schema view-meta)))))
+
+;; ---- CLJS: validator lookup via late-bind -------------------------------
+
+#?(:cljs
+   (defn validator-fns
+     "Resolve the registered validator + explainer through the late-bind
+     hook table. Returns `{:validate <fn> :explain <fn-or-nil>}`. Both
+     entries default to nil when the schemas artefact is not on the
+     classpath — `args-violations` then soft-passes per Spec 010
+     §Recommended soft-pass.
+
+     The validator hook (`:schemas/validate-with-registered-fn`) is
+     published by `re-frame.schemas` on ns-load; the boundary surface
+     it fronts is identical to the framework's dev-mode hot path, so
+     a panel using these fns sees exactly the same conformance
+     decisions the framework's `validate-app-db!` / `validate-event!`
+     emit."
+     []
+     {:validate (late-bind/get-fn :schemas/validate-with-registered-fn)
+      :explain  (late-bind/get-fn :schemas/explain-with-registered-fn)}))
+
+;; ---- CLJS: styling ------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:wrap         {:padding "8px"
+                     :background "#252526"
+                     :color "#cccccc"
+                     :font-family "monospace"
+                     :font-size "11px"
+                     :border-top "1px solid #444"
+                     :overflow "auto"
+                     :max-height "320px"}
+      :section      {:margin-bottom "10px"}
+      :section-h    {:font-weight "bold"
+                     :color "#b0b0b0"
+                     :text-transform "uppercase"
+                     :font-size "10px"
+                     :letter-spacing "0.5px"
+                     :margin-bottom "4px"}
+      :hint         {:color "#9a9a9a"
+                     :font-style "italic"
+                     :font-size "10px"
+                     :margin-bottom "4px"}
+      :empty        {:color "#9a9a9a"
+                     :font-style "italic"
+                     :padding "2px 0"}
+      :violation    {:padding "4px 6px"
+                     :margin "2px 0"
+                     :background "#332"
+                     :border-left "3px solid #ff4040"
+                     :color "#fdd"}
+      :v-key        {:color "#dcdcaa"
+                     :font-weight "bold"}
+      :v-value      {:color "#9cdcfe"}
+      :v-schema     {:color "#ce9178"
+                     :font-size "10px"}
+      :v-explain    {:color "#aaa"
+                     :font-size "10px"
+                     :margin-top "2px"}
+      :row          {:display "grid"
+                     :grid-template-columns "92px 80px 1fr"
+                     :gap "6px"
+                     :padding "2px 0"
+                     :border-bottom "1px dotted #2a2a2a"
+                     :align-items "baseline"}
+      :cell         {:overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space "nowrap"}
+      :cell-time    {:color "#9a9a9a"}
+      :cell-where   {:color "#9cdcfe"
+                     :font-style "italic"}
+      :cell-detail  {:color "#dcdcaa"}}))
+
+;; ---- CLJS: render helpers -----------------------------------------------
+
+#?(:cljs
+   (defn- format-timestamp-ms [ms]
+     (when (and ms (number? ms))
+       (let [d (js/Date. ms)
+             pad (fn [n w] (let [s (str n)]
+                             (if (< (count s) w)
+                               (str (apply str (repeat (- w (count s)) "0")) s)
+                               s)))]
+         (str (pad (.getHours d)   2) ":"
+              (pad (.getMinutes d) 2) ":"
+              (pad (.getSeconds d) 2) "."
+              (pad (mod ms 1000)   3))))))
+
+#?(:cljs
+   (defn- args-violation-row
+     [{:keys [key value schema explain] :as _violation}]
+     (let [key-label (if (= key ::root)
+                       "(whole args map)"
+                       (pr-str key))]
+       [:div {:style                     (:violation styles)
+              :data-test                 "story-schema-args-violation"
+              :data-arg-key              (str key)}
+        [:div
+         [:span {:style (:v-key styles)} key-label]
+         " = "
+         [:span {:style (:v-value styles)} (pr-str value)]]
+        [:div {:style (:v-schema styles)}
+         (str "schema: " (pr-str schema))]
+        (when explain
+          [:div {:style (:v-explain styles)}
+           (format-explain explain)])])))
+
+#?(:cljs
+   (defn- trace-failure-row
+     [{:keys [id time where failing-id path received explain recovery] :as _row}]
+     [:div {:style                  (:row styles)
+            :data-test              "story-schema-trace-row"
+            :data-where             (when where (name where))
+            :data-failing-id        (when failing-id (str failing-id))
+            :title                  (when explain (format-explain explain))
+            :key                    id}
+      [:span {:style (merge (:cell styles) (:cell-time styles))}
+       (or (format-timestamp-ms time) "")]
+      [:span {:style (merge (:cell styles) (:cell-where styles))}
+       (if where (pr-str where) "—")]
+      [:span {:style (merge (:cell styles) (:cell-detail styles))}
+       (cond-> (str (if failing-id (pr-str failing-id) "—"))
+         path     (str " @ " (pr-str path))
+         recovery (str " (" (pr-str recovery) ")"))]]))
+
+;; ---- CLJS: the panel ----------------------------------------------------
+
+#?(:cljs
+   (defn panel
+     "The schema-validation panel. Per rf2-dvue Form-2 — the inner
+     render fn derefs the trace buffer so Reagent's reaction
+     tracking sees every change.
+
+     The panel surfaces two streams:
+
+       1. **Args violations** — computed on every render from the
+          variant's resolved args + the component's schema +
+          the registered validator. Cheap to recompute (one Malli
+          validate per top-level entry); no caching needed at v1.
+       2. **Trace failures** — filtered + projected from the variant's
+          per-variant trace buffer (the same buffer the trace + actions
+          panels read).
+
+     Renders a scrollable region tagged with `data-test=\"story-
+     schema-panel\"` and `role=\"region\"` + `aria-label` so axe-core's
+     scrollable-region-focusable rule passes and the browser-test
+     spec can anchor on it."
+     [variant-id]
+     ;; Form-2 — capture the trace buffer atom on the outer closure
+     ;; so the per-render fn observes the same source-of-truth across
+     ;; the component's lifecycle.
+     (let [_buf (trace/ensure-buffer! variant-id)]
+       (fn [variant-id]
+         (let [buf            (trace/ensure-buffer! variant-id)
+               events         @buf
+               trace-rows     (project-failures events)
+               schema         (resolve-component-schema variant-id)
+               vfns           (validator-fns)
+               eff-args       (args/resolve-args variant-id)
+               args-viols     (args-violations eff-args schema vfns)
+               schema-known?  (some? schema)
+               validator-on?  (some? (:validate vfns))]
+           [:div {:style      (:wrap styles)
+                  :role       "region"
+                  :aria-label "Schema validation"
+                  :tab-index  "0"
+                  :data-test  "story-schema-panel"}
+            ;; Args section.
+            [:div {:style (:section styles)}
+             [:div {:style (:section-h styles)}
+              "Args vs schema"
+              (when variant-id (str " — " (pr-str variant-id)))]
+             [:div {:style (:hint styles)}
+              (cond
+                (not schema-known?)
+                "no schema registered for the variant's :component — see Spec 010."
+
+                (not validator-on?)
+                "no validator registered (require [re-frame.schemas.malli] at boot to enable Malli)."
+
+                :else
+                "every arg checked against the component's Spec 010 schema on each render.")]
+             (cond
+               (or (not schema-known?) (not validator-on?))
+               nil
+
+               (zero? (count args-viols))
+               [:div {:style (:empty styles)
+                      :data-test "story-schema-args-empty"}
+                "no args violations"]
+
+               :else
+               [:div {:data-test "story-schema-args-violations"}
+                (for [v args-viols]
+                  ^{:key (str (:key v))}
+                  [args-violation-row v])])]
+            ;; Trace section.
+            [:div {:style (:section styles)}
+             [:div {:style (:section-h styles)}
+              "Trace failures — :rf.error/schema-validation-failure"]
+             [:div {:style (:hint styles)}
+              "every dev-mode or boundary-mode schema check that failed in this variant's frame."]
+             (if (zero? (count trace-rows))
+               [:div {:style (:empty styles)
+                      :data-test "story-schema-trace-empty"}
+                "no schema-validation-failure trace events captured yet"]
+               [:div {:data-test "story-schema-trace-rows"}
+                [:div {:style (merge (:row styles)
+                                     {:font-weight "bold"
+                                      :color       "#b0b0b0"})}
+                 [:span {:style (:cell styles)} "time"]
+                 [:span {:style (:cell styles)} "where"]
+                 [:span {:style (:cell styles)} "detail"]]
+                (for [row trace-rows]
+                  ^{:key (:id row)}
+                  [trace-failure-row row])])]])))))
+
+;; ---- CLJS: panel registration -------------------------------------------
+
+#?(:cljs
+   (def ^:const panel-id
+     "Story-panel id for the schema-validation panel. Per Story SOTA
+     audit F-N / rf2-dvue."
+     :rf.story.panel/schema-validation))
+
+#?(:cljs
+   (def ^:const panel-render-id
+     "View id the panel registration points at. Registered against the
+     framework view registry so the late-bind lookup in
+     `re-frame.core/view` finds it."
+     :rf.story.panel/schema-validation-view))
+
+#?(:cljs
+   (defn install!
+     "Register the schema-validation panel via `reg-story-panel*` and
+     the panel-render view via `reg-view*`. Idempotent. Skipped when
+     `re-frame.story.config/enabled?` is false (the production-elision
+     contract).
+
+     Called from `re-frame.story.ui.panels/install-canonical-panels!`
+     during `re-frame.story/install-canonical-vocabulary!`."
+     []
+     (when config/enabled?
+       (rf/reg-view* panel-render-id (fn [variant-id] [panel variant-id]))
+       (story-registrar/reg-story-panel*
+         panel-id
+         {:doc       "Live Spec 010 schema-validation panel — args vs schema + boundary trace failures."
+          :title     "Schema validation"
+          :placement :right
+          :render    panel-render-id}))))

--- a/tools/story/test/re_frame/story/ui/schema_validation_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/schema_validation_cljs_test.cljc
@@ -1,0 +1,405 @@
+(ns re-frame.story.ui.schema-validation-cljs-test
+  "Tests for the Schema-validation panel (rf2-dvue).
+
+  Runs on both the JVM (cognitect.test-runner under
+  `clojure -M:test`) and the CLJS node-test build (shadow's
+  `:node-test` target; ns-regexp `cljs-test$` picks up this ns
+  because its name ends in `cljs-test`).
+
+  ## Coverage layers
+
+  - **Pure data** (JVM + CLJS): `schema-validation-event?`
+    classification, `project-failure` / `project-failures`
+    projection, `map-schema?` + `map-entries` Malli walk,
+    `args-violations` with synthetic validator/explainer pairs, and
+    `format-explain` rendering.
+  - **CLJS-only side-effects**: panel registration shape (the panel
+    is registered with `:placement :right` against the canonical
+    `:rf.story.panel/schema-validation` id), panel-render view is
+    registered against the framework view registry, and the Reagent
+    `panel` component returns hiccup when called against a
+    registered variant."
+  (:require [clojure.test :refer [deftest is testing]]
+            #?@(:cljs [[re-frame.core             :as rf]
+                       [re-frame.frame            :as frame]
+                       [re-frame.registrar        :as registrar]
+                       [re-frame.substrate.plain-atom :as plain-atom]
+                       [re-frame.story            :as story]
+                       [re-frame.story.ui.panels  :as panels]])
+            [re-frame.story.ui.schema-validation :as sv]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn failure-event
+  "Build a `:rf.error/schema-validation-failure` trace event with
+  sensible defaults. `tags` is merged over the canonical base tags so
+  per-test overrides land cleanly. When `tags` carries `:recovery`,
+  that value is also hoisted to the top-level `:recovery` slot —
+  matching the framework's emit shape (`re-frame.trace/emit-error!`
+  hoists `(:recovery tags :no-recovery)` onto the event itself)."
+  ([id where]
+   (failure-event id where {}))
+  ([id where tags]
+   {:op-type   :error
+    :operation :rf.error/schema-validation-failure
+    :id        id
+    :time      (+ 1700000000000 (* id 10))
+    :recovery  (:recovery tags :no-recovery)
+    :tags      (merge {:category :rf.error/schema-validation-failure
+                       :where    where
+                       :frame    :story.x/y}
+                      tags)}))
+
+(defn unrelated-trace-event
+  "Build a non-schema-failure trace event (something that should be
+  filtered out — a regular dispatch, a handler exception, etc.)."
+  [id op-type operation]
+  {:op-type   op-type
+   :operation operation
+   :id        id
+   :time      (+ 1700000000000 (* id 10))
+   :tags      {:dispatch-id (+ 1000 id)}})
+
+;; ---- pure: schema-validation-event? classification ----------------------
+
+(deftest schema-validation-event?-classifies-failures
+  (testing ":rf.error/schema-validation-failure trace events qualify"
+    (is (sv/schema-validation-event? (failure-event 1 :event)))
+    (is (sv/schema-validation-event? (failure-event 2 :sub-return)))
+    (is (sv/schema-validation-event? (failure-event 3 :app-db)))
+    (is (sv/schema-validation-event? (failure-event 4 :cofx)))
+    (is (sv/schema-validation-event? (failure-event 5 :fx-args)))))
+
+(deftest schema-validation-event?-rejects-unrelated
+  (testing "non-error trace events and unrelated error categories are filtered out"
+    (is (not (sv/schema-validation-event?
+               (unrelated-trace-event 10 :event :event/dispatched))))
+    (is (not (sv/schema-validation-event?
+               (unrelated-trace-event 11 :error :rf.error/handler-exception))))
+    (is (not (sv/schema-validation-event?
+               (unrelated-trace-event 12 :error :rf.error/no-such-sub))))
+    (is (not (sv/schema-validation-event?
+               (unrelated-trace-event 13 :warning :rf.fx/skipped-on-platform))))))
+
+(deftest schema-validation-event?-rejects-malformed
+  (testing "empty / partial trace events do not classify"
+    (is (not (sv/schema-validation-event? {})))
+    (is (not (sv/schema-validation-event? {:op-type :error})))
+    (is (not (sv/schema-validation-event?
+               {:op-type :error :operation :rf.error/something-else})))))
+
+;; ---- pure: project-failure ----------------------------------------------
+
+(deftest project-failure-event-row
+  (testing "a :where :event failure projects the event-id under :failing-id"
+    (let [ev  (failure-event 1 :event {:event-id  :auth/login
+                                       :received  [:auth/login {}]
+                                       :explain   {:errors [{:path [:email] :message "missing"}]}})
+          row (sv/project-failure ev)]
+      (is (= 1                       (:id row)))
+      (is (= :event                  (:where row)))
+      (is (= :auth/login             (:failing-id row)))
+      (is (= [:auth/login {}]        (:received row)))
+      (is (some? (:explain row)))
+      (is (= :no-recovery            (:recovery row)))
+      (is (= ev                      (:raw row))))))
+
+(deftest project-failure-sub-return-row
+  (testing "a :where :sub-return failure projects the sub-id under :failing-id"
+    (let [ev  (failure-event 2 :sub-return {:sub-id   :pending-todos
+                                            :received [{:bad "shape"}]
+                                            :recovery :replaced-with-default})
+          row (sv/project-failure ev)]
+      (is (= :sub-return             (:where row)))
+      (is (= :pending-todos          (:failing-id row)))
+      (is (= :replaced-with-default  (:recovery row))))))
+
+(deftest project-failure-app-db-row
+  (testing "a :where :app-db failure projects the path and the failing-id is nil"
+    (let [ev  (failure-event 3 :app-db {:path     [:user :credentials]
+                                        :received {:no-id true}})
+          row (sv/project-failure ev)]
+      (is (= :app-db                 (:where row)))
+      (is (= [:user :credentials]    (:path row)))
+      (is (nil? (:failing-id row))))))
+
+(deftest project-failure-cofx-row
+  (testing "a :where :cofx failure carries an explicit :failing-id (the
+            event-id whose handler was about to run — per Spec 010
+            §Validation order step 2's emit shape); the projector
+            surfaces that under :failing-id"
+    (let [ev  (failure-event 4 :cofx {:cofx-id    :now
+                                      :event-id   :foo/bar
+                                      :failing-id :foo/bar})
+          row (sv/project-failure ev)]
+      (is (= :cofx                   (:where row)))
+      (is (= :foo/bar                (:failing-id row))))))
+
+(deftest project-failure-falls-back-to-id-when-no-explicit-failing-id
+  (testing "when an emission shape omits :failing-id, the projector
+            falls back through event-id → sub-id → cofx-id → fx-id"
+    (let [row (sv/project-failure (failure-event 50 :cofx {:cofx-id :now}))]
+      (is (= :now (:failing-id row))))))
+
+(deftest project-failure-fx-args-row
+  (testing "a :where :fx-args failure projects the fx-id under :failing-id"
+    (let [ev  (failure-event 5 :fx-args {:fx-id :http-xhrio
+                                         :received {:url 7}})
+          row (sv/project-failure ev)]
+      (is (= :fx-args                (:where row)))
+      (is (= :http-xhrio             (:failing-id row))))))
+
+;; ---- pure: project-failures filter+project ------------------------------
+
+(deftest project-failures-filters-and-projects
+  (testing "a mixed buffer returns only schema-failure rows, projected,
+            in input order"
+    (let [buf  [(failure-event 1 :event {:event-id :foo/bar})
+                (unrelated-trace-event 2 :event :event/dispatched)
+                (unrelated-trace-event 3 :sub/run :sub/run)
+                (failure-event 4 :app-db {:path [:user]})
+                (unrelated-trace-event 5 :view :view/render)
+                (failure-event 6 :sub-return {:sub-id :pending-todos})]
+          rows (sv/project-failures buf)]
+      (is (= 3 (count rows)))
+      (is (= [1 4 6]              (map :id rows)))
+      (is (= [:event :app-db :sub-return] (map :where rows)))
+      (is (= [:foo/bar nil :pending-todos] (map :failing-id rows))))))
+
+(deftest project-failures-empty
+  (testing "empty / all-unrelated buffers project to empty vector"
+    (is (= [] (sv/project-failures [])))
+    (is (= [] (sv/project-failures
+                [(unrelated-trace-event 1 :event :event/dispatched)
+                 (unrelated-trace-event 2 :error :rf.error/handler-exception)])))))
+
+;; ---- pure: map-schema? + map-entries ------------------------------------
+
+(deftest map-schema?-classifies-map-shapes
+  (testing "[:map ...] vectors are recognised; everything else is not"
+    (is (sv/map-schema? [:map [:a :string]]))
+    (is (sv/map-schema? [:map {:closed true} [:a :string]]))
+    (is (not (sv/map-schema? [:vector :string])))
+    (is (not (sv/map-schema? :string)))
+    (is (not (sv/map-schema? nil)))
+    (is (not (sv/map-schema? {})))
+    (is (not (sv/map-schema? [:enum :a :b])))))
+
+(deftest map-entries-projects-pairs
+  (testing "map-entries returns [k child-schema] pairs in declared order,
+            skipping the optional properties map at index 1"
+    (is (= [[:a :string] [:b :int]]
+           (sv/map-entries [:map [:a :string] [:b :int]])))
+    (is (= [[:a :string] [:b :int]]
+           (sv/map-entries [:map {:closed true} [:a :string] [:b :int]])))
+    (is (nil? (sv/map-entries [:vector :string]))))
+  (testing "Malli map-entry with per-entry properties — `[k {:optional true} schema]`
+            — projects to the child schema (the third element)"
+    (is (= [[:a :string]]
+           (sv/map-entries [:map [:a {:optional true} :string]])))))
+
+;; ---- pure: args-violations ----------------------------------------------
+
+(defn- truthy-validator
+  "A validator fn that returns true on every (schema, value) pair —
+  the test stand-in for 'every value conforms'."
+  [_schema _value]
+  true)
+
+(defn- string-validator
+  "A validator fn that mimics Malli's `:string` predicate: passes
+  strings, rejects everything else."
+  [schema value]
+  (cond
+    (= :string schema)            (string? value)
+    (= :int    schema)            (integer? value)
+    (= :boolean schema)           (boolean? (or value false))
+    (and (vector? schema)
+         (= :map (first schema))) (map? value)
+    :else                         true))
+
+(defn- string-explainer
+  "Companion explainer for `string-validator` — returns a Malli-shaped
+  explain map with one `:errors` entry per failure."
+  [schema value]
+  {:errors [{:path    []
+             :message (str "expected " (pr-str schema)
+                           " got "    (pr-str value))}]})
+
+(deftest args-violations-no-validator-soft-passes
+  (testing "no validator registered (nil) → every value passes; empty
+            vector returned (per Spec 010 §Recommended soft-pass)"
+    (is (= [] (sv/args-violations {:a 7 :b "x"}
+                                  [:map [:a :string] [:b :int]]
+                                  {:validate nil :explain nil})))))
+
+(deftest args-violations-no-schema-passes
+  (testing "no schema on file → nothing to validate; empty vector"
+    (is (= [] (sv/args-violations {:a 7}
+                                  nil
+                                  {:validate truthy-validator :explain nil})))))
+
+(deftest args-violations-walks-map-entries
+  (testing "every :map entry's value is checked against its child schema;
+            failures collect with {:key :value :schema :explain}"
+    (let [args   {:name 42 :age "old" :active "yes"}
+          schema [:map
+                  [:name   :string]
+                  [:age    :int]
+                  [:active :boolean]]
+          viols  (sv/args-violations args schema
+                                     {:validate string-validator
+                                      :explain  string-explainer})
+          by-key (into {} (map (juxt :key identity)) viols)]
+      (is (= 3 (count viols)))
+      (is (contains? by-key :name))
+      (is (contains? by-key :age))
+      (is (contains? by-key :active))
+      ;; The value carried under each violation matches the supplied arg.
+      (is (= 42    (get-in by-key [:name :value])))
+      (is (= "old" (get-in by-key [:age :value])))
+      ;; The child schema rides on each violation.
+      (is (= :string  (get-in by-key [:name :schema])))
+      (is (= :int     (get-in by-key [:age :schema])))
+      (is (= :boolean (get-in by-key [:active :schema])))
+      ;; The explainer's output is captured.
+      (is (some? (get-in by-key [:name :explain]))))))
+
+(deftest args-violations-conforming-args-empty
+  (testing "when every arg conforms, the violation vector is empty"
+    (is (= [] (sv/args-violations {:name "alice" :age 30}
+                                  [:map [:name :string] [:age :int]]
+                                  {:validate string-validator
+                                   :explain  string-explainer})))))
+
+(deftest args-violations-skips-missing-keys-when-validator-accepts
+  (testing "a missing arg key passes through to the validator as nil;
+            a validator that accepts nil records no violation, one
+            that rejects nil records a violation. The walker doesn't
+            short-circuit on missing keys — it routes through the
+            registered validator like the framework does"
+    (let [args   {:name "alice"}    ;; :age missing
+          schema [:map [:name :string] [:age :int]]
+          viols  (sv/args-violations args schema
+                                     {:validate string-validator
+                                      :explain  string-explainer})]
+      (is (= 1 (count viols)))
+      (is (= :age (-> viols first :key)))
+      (is (nil?   (-> viols first :value))))))
+
+(deftest args-violations-non-map-schema-root-violation
+  (testing "a non-:map top-level schema validates the whole args
+            against the schema; failure surfaces under ::root"
+    ;; string-validator treats `:string` as 'must be a string'; the
+    ;; whole args map is not a string → violation.
+    (let [viols (sv/args-violations {:name "x"} :string
+                                    {:validate string-validator
+                                     :explain  string-explainer})]
+      (is (= 1 (count viols)))
+      (is (= ::sv/root (-> viols first :key)))
+      (is (= {:name "x"} (-> viols first :value))))))
+
+(deftest args-violations-non-map-schema-passing
+  (testing "a non-:map top-level schema that conforms emits no violation"
+    ;; A truthy validator accepts every value, so the whole-args check
+    ;; passes.
+    (is (= [] (sv/args-violations {:any "x"} :something
+                                  {:validate truthy-validator
+                                   :explain  string-explainer})))))
+
+;; ---- pure: format-explain -----------------------------------------------
+
+(deftest format-explain-nil
+  (testing "nil renders as the empty string so the renderer can
+            interpolate it safely"
+    (is (= "" (sv/format-explain nil)))))
+
+(deftest format-explain-malli-shape
+  (testing "a Malli explain map (`{:errors [...]}`) flattens to a
+            joined path-and-message string"
+    (let [explanation {:errors [{:path [:email] :message "missing"}
+                                {:path []       :message "bad"}]}
+          out         (sv/format-explain explanation)]
+      (is (string? out))
+      (is (re-find #":email" out))
+      (is (re-find #"missing" out))
+      (is (re-find #"\(root\)" out))
+      (is (re-find #"bad" out)))))
+
+(deftest format-explain-falls-back-to-pr-str
+  (testing "explanations that aren't Malli-shaped fall back to pr-str"
+    (is (= "\"a plain string\"" (sv/format-explain "a plain string")))
+    (is (= ":a-keyword"         (sv/format-explain :a-keyword)))))
+
+;; ---- CLJS-only: panel registration --------------------------------------
+
+#?(:cljs
+   (defn- reset-all! []
+     (story/clear-all!)
+     (registrar/clear-all!)
+     (reset! frame/frames {})
+     (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+     (story/install-canonical-vocabulary!)
+     (frame/ensure-default-frame!)))
+
+#?(:cljs
+   (deftest ^:cljs panel-id-stable
+     (testing "panel-id is :rf.story.panel/schema-validation per the
+              SOTA audit's reservation"
+       (is (= :rf.story.panel/schema-validation sv/panel-id)))))
+
+#?(:cljs
+   (deftest ^:cljs panel-renders-against-canonical-bootstrap
+     (testing "after install-canonical-vocabulary! the schema-validation
+              panel is registered against the story side-table"
+       (reset-all!)
+       (let [ps (story/handlers :story-panel)]
+         (is (contains? ps sv/panel-id))
+         (let [body (story/handler-meta :story-panel sv/panel-id)]
+           (is (= :right                  (:placement body)))
+           (is (= sv/panel-render-id      (:render body)))
+           (is (re-find #"(?i)schema"     (or (:title body) ""))))))))
+
+#?(:cljs
+   (deftest ^:cljs panel-render-view-registered
+     (testing "the panel-render view is registered against the framework
+              view registry so the late-bind lookup in re-frame.core/view
+              finds it"
+       (reset-all!)
+       (is (some? (rf/view sv/panel-render-id))))))
+
+#?(:cljs
+   (deftest ^:cljs panel-renders-hiccup
+     (testing "the panel render fn returns a hiccup vector for an
+              unregistered variant id (graceful empty state)"
+       (reset-all!)
+       (let [out ((sv/panel :story.unknown/y) :story.unknown/y)]
+         (is (vector? out))
+         (is (= :div (first out)))))))
+
+#?(:cljs
+   (deftest ^:cljs panel-shows-up-in-right-placement
+     (testing "render-panels-at-placement :right picks up the schema
+              validation panel"
+       (reset-all!)
+       (let [out (panels/render-panels-at-placement
+                   :right :story.x/y {})]
+         ;; The host returns a hiccup vector with one entry per visible
+         ;; panel; assert the schema-validation slot is among the entries
+         ;; by serialising and looking for the panel id.
+         (is (vector? out))
+         (is (re-find (re-pattern (str sv/panel-id))
+                      (pr-str out)))))))
+
+#?(:cljs
+   (deftest ^:cljs validator-fns-defaults-to-nil-without-schemas-artefact
+     (testing "when re-frame.schemas hasn't published its hooks, the
+              validator-fns lookup returns {:validate nil :explain nil}
+              and args-violations soft-passes. When the artefact IS on
+              the classpath (the common case in this repo's tests), the
+              validator publishes truthy hooks — both shapes are
+              acceptable, the panel adapts to either"
+       (let [{:keys [validate explain]} (sv/validator-fns)]
+         ;; Both fns are either nil (soft-pass) or callable.
+         (is (or (nil? validate) (fn? validate)))
+         (is (or (nil? explain)  (fn? explain)))))))


### PR DESCRIPTION
## Summary

- Adds `:rf.story.panel/schema-validation` (placement `:right`) — the Story SOTA audit F-N differentiator vs Storybook 8, which has no schema-introspection equivalent.
- The panel surfaces two streams for the active variant in one place: **args violations** (the variant's resolved args walked against the component's registered `:spec` via the `:schemas/validate-with-registered-fn` + `:schemas/explain-with-registered-fn` late-bind hooks) and **trace failures** (`:rf.error/schema-validation-failure` events from the per-variant trace buffer, projected across `:event` / `:sub-return` / `:cofx` / `:app-db` / `:fx-args` boundaries per Spec 010 §Validation order).
- Schema lookup walks variant body `:schema` → parent story body `:schema` → framework `:view` registry `:spec` → `:view` registry `:schema`. Soft-passes when no validator or no schema is on file, per Spec 010 §Recommended soft-pass. Production elision: `install!` is gated on `re-frame.story.config/enabled?`, so the require graph DCE-prunes the panel from release bundles.

Cross-reference: `ai/findings/story-sota-audit-2026-05-13.md` F-N.

## Test plan

- [x] `npm run test:cljs` (top-level) — 807 tests / 2085 assertions / 0 failures / 0 errors, including the new `re-frame.story.ui.schema-validation-cljs-test` ns.
- [x] `clojure -M:test -n re-frame.story.ui.schema-validation-cljs-test` under `tools/story/` — 23 tests / 75 assertions / 0 failures (pure JVM-side helpers).
- [ ] Manual: open Story, register a variant with a `:component` carrying a `:spec` and broken args; confirm the right-placement panel shows the args violation rows + any boundary trace failures.