### PR TITLE
docs(skills): migration README — fix broken guide chapter link 08→18 (rf2-vbesr)

### DIFF
--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -43,7 +43,7 @@ It does **not** duplicate `spec/MIGRATION.md` content. Each rule reference in th
 
 ## Status
 
-Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real v1 codebase migration. The structure mirrors the `re-frame2-setup` skill in this same repo. The content is grounded against `spec/MIGRATION.md`, `docs/guide/08-from-re-frame-v1.md`, and `docs/the-mayor-method.md`'s paste-prompt pattern.
+Pre-alpha. The skill is authored; it has not yet been exercised end-to-end against a real v1 codebase migration. The structure mirrors the `re-frame2-setup` skill in this same repo. The content is grounded against `spec/MIGRATION.md`, `docs/guide/18-from-re-frame-v1.md`, and `docs/the-mayor-method.md`'s paste-prompt pattern.
 
 ## Layout
 


### PR DESCRIPTION
@
## Summary

- `skills/re-frame-migration/README.md` §Status referenced `docs/guide/08-from-re-frame-v1.md`; the actual chapter is `18-from-re-frame-v1.md` (slot 08 is now `08-state-machines.md`). Likely regressed during an earlier guide reorder.
- One-line fix: update the path to `docs/guide/18-from-re-frame-v1.md`.

## Test plan

- [x] Manual link audit of `skills/re-frame-migration/README.md` — every relative path (`../`, sibling skills, `LICENSE`, `spec/MIGRATION.md`, `docs/the-mayor-method.md`, and the now-fixed guide chapter) resolves. No other stale links found.
- [x] Verified `docs/guide/18-from-re-frame-v1.md` exists and `docs/guide/08-from-re-frame-v1.md` does not.
- [x] Verified the "six re-frame2 skills" framing in the header still holds (six entries under `skills/`).
@