### PR TITLE
ci(release): include reagent-slim in deploy-leaf matrix + pre-release gate (rf2-rjq0q)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@
 #                                         │
 #                                         ├── deploy-schemas
 #                                         ├── deploy-reagent
+#                                         ├── deploy-reagent-slim
 #                                         ├── deploy-uix
 #                                         ├── deploy-helix
 #                                         ├── deploy-machines
@@ -168,6 +169,10 @@ jobs:
         working-directory: implementation/adapters/reagent
         run: clojure -M:test || echo "no JVM-runnable tests in reagent artefact (expected)"
 
+      - name: JVM tests (reagent-slim artefact, classpath probe)
+        working-directory: implementation/adapters/reagent-slim
+        run: clojure -M:test || echo "no JVM-runnable tests in reagent-slim artefact (expected)"
+
       - name: JVM tests (uix artefact, classpath probe)
         working-directory: implementation/adapters/uix
         run: clojure -M:test || echo "no JVM-runnable tests in uix artefact (expected)"
@@ -308,6 +313,10 @@ jobs:
             artefact: day8/re-frame2-reagent
             directory: implementation/adapters/reagent
             local-root: ../../core
+          - leaf: reagent-slim
+            artefact: day8/reagent-slim
+            directory: implementation/adapters/reagent-slim
+            local-root: ../../core
           - leaf: uix
             artefact: day8/re-frame2-uix
             directory: implementation/adapters/uix
@@ -439,6 +448,7 @@ jobs:
             Artefacts published to Clojars:
             - `day8/re-frame2` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-reagent` ${{ needs.deploy-core.outputs.version }}
+            - `day8/reagent-slim` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-uix` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-helix` ${{ needs.deploy-core.outputs.version }}
             - `day8/re-frame2-schemas` ${{ needs.deploy-core.outputs.version }}


### PR DESCRIPTION
## Summary

`reagent-slim` is wired into `verify-version-lockstep.sh` (the lockstep-version contract) and `test.yml`'s `jvm-reagent-slim` matrix entry, but **`release.yml`'s `deploy-leaf` matrix and the pre-release JVM test gate both omitted it**. As a result, cutting a release tag would silently skip publishing `day8/reagent-slim` to Clojars: CI would go green and the artefact simply wouldn't ship. This blocks the v0.0.1.alpha tag.

Fix:

- Add `reagent-slim` to the `deploy-leaf` matrix using the adapter shape (`local-root: ../../core`). The `artefact:` field uses `day8/reagent-slim` — the artefact's `:clein/build :lib` (verified at `implementation/adapters/reagent-slim/deps.edn:35`), deliberately distinct from the `day8/re-frame2-*` prefix because reagent-slim is a rewrite of stock Reagent, not a re-frame2 adapter alone.
- Mirror as a `JVM tests (reagent-slim artefact, classpath probe)` step in the pre-release test gate, alongside the other ten artefacts.
- Update the topological DAG diagram comment at the top of `release.yml` to include `deploy-reagent-slim`.
- Add `day8/reagent-slim` to the github-release body's published-artefacts list.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly.
- [x] Matrix sanity: 11 entries, leaves `[reagent, reagent-slim, uix, helix, schemas, machines, routing, flows, http, ssr, epoch]`.
- [x] Pre-release gate has the new `JVM tests (reagent-slim artefact, classpath probe)` step.
- [x] github-release body lists `day8/reagent-slim`.
- [ ] Full release pipeline dry-run NOT possible — gated on Clojars credentials and tag-push trigger. The next real release tag will exercise the new matrix entry and pre-release gate step.