### PR TITLE
docs(skills): trim SKILL.md corpus to router-SKILL budget (rf2-ve7px)

### DIFF
--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -5,162 +5,100 @@ description: >
   Swaps the artefact coord (re-frame/re-frame → day8/re-frame2 + a substrate
   adapter), applies the mechanical (Type A) rewrites from MIGRATION.md
   automatically, and flags the judgment-call (Type B) call sites for human
-  review before touching them. Use this skill whenever the user is migrating,
-  upgrading, or porting a re-frame v1 project to re-frame2 — phrases like
-  "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under
-  re-frame2", or any prompt referencing a v1 surface (re-frame.db, dispatch-with,
-  reg-global-interceptor, reg-sub-raw, ^:flush-dom, re-frame.alpha, re-frame-test,
-  old top-level :dispatch/:dispatch-n effect-map keys). For greenfield
-  bootstrap, use re-frame2-setup; for writing v2 application code, use the
-  main re-frame2 skill; for live v2-app inspection, use re-frame-pair2.
+  review before touching them. Trigger on phrasing like "migrate to
+  re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2",
+  or any prompt referencing a v1 surface (re-frame.db, dispatch-with,
+  reg-global-interceptor, reg-sub-raw, ^:flush-dom, re-frame.alpha,
+  re-frame-test, old top-level :dispatch / :dispatch-n effect-map keys).
+  Do not use for: greenfield bootstrap (use `re-frame2-setup`), writing v2
+  application code (use `re-frame2`), live v2-app inspection
+  (use `re-frame-pair2`), or porting re-frame2 itself
+  (use `re-frame2-implementor`).
 ---
 
 # re-frame-migration
 
-You are helping an author **migrate a ClojureScript codebase from re-frame v1.x to re-frame2**. The author has a project that depends on `re-frame/re-frame` today. When you are done, the project depends on `day8/re-frame2` + a substrate adapter, the mechanical (Type A) rewrites have been applied, and every judgment-call (Type B) call site has been surfaced to the author with the relevant rule cited.
+Helps an author migrate a ClojureScript codebase from re-frame v1.x to re-frame2. When done, the project depends on `day8/re-frame2` + a substrate adapter, Type A rewrites have been applied, and every Type B call site has been surfaced with the relevant rule cited.
 
-This skill teaches the **migration workflow**. The authoritative list of what changes — the M-rules (required) and O-rules (opt-in modernisations) — lives in [`MIGRATION.md`](../../spec/MIGRATION.md) in this repo. **Do not duplicate that content here.** Load [`MIGRATION.md`](../../spec/MIGRATION.md) when you start the migration and treat it as the source of truth.
+The authoritative rule corpus — M-rules (required) and O-rules (opt-in modernisations) — lives in [`MIGRATION.md`](../../spec/MIGRATION.md). **Do not duplicate that content here.** Load `MIGRATION.md` when you start the migration and treat it as the source of truth.
 
----
-
-## When to use this skill
-
-Use this skill when **any** of these are true:
-
-- The author has an existing re-frame v1.x project and wants to move to re-frame2.
-- The author mentions migrating, upgrading, porting, or v1→v2 in a re-frame context.
-- The build fails after a dep bump and the cause looks v1-shaped (missing private namespaces, removed interceptors, `dispatch-with`, the alpha namespace, the old effect-map keys).
-- The author asks "what breaks?" / "what changes?" / "is my v1 code compatible?" with re-frame2.
-
-## When NOT to use this skill
-
-Route elsewhere when:
+## When NOT to use
 
 | Author intent | Route to |
 |---|---|
-| Start a brand new re-frame2 project from scratch | `skills/re-frame2-setup/` |
-| Write event handlers, subs, machines, schemas, views in a project that is already on v2 | `skills/re-frame2/` |
-| Inspect / dispatch / debug / time-travel a *running* v2 app from the REPL | `skills/re-frame-pair2/` |
-| Build a NEW re-frame2 implementation in a different host language or substrate | `skills/re-frame2-implementor/` |
-| Understand re-frame2's design rationale (EPs, principles, conventions) | `SKILL-REDIRECT.md` at repo root |
+| Start a new re-frame2 project from scratch | `skills/re-frame2-setup/` |
+| Write new code on a project already on v2 | `skills/re-frame2/` |
+| Inspect / debug / time-travel a running v2 app | `skills/re-frame-pair2/` |
+| Build a new re-frame2 implementation in another host/substrate | `skills/re-frame2-implementor/` |
+| Read re-frame2's design rationale | `SKILL-REDIRECT.md` |
 
-If the author has already finished migrating and is now writing new code, hand off to `re-frame2`. This skill exits when the project compiles, tests pass, and Type B items have been resolved.
-
----
+Exit this skill when the project compiles, tests pass, and Type B items have been resolved.
 
 ## Cardinal rules
 
-These hold across every step of the migration.
-
 1. **[`MIGRATION.md`](../../spec/MIGRATION.md) is the source of truth.** Every rewrite cites a rule id (`M-N` or `O-N`). If a call site doesn't match any rule, **stop and ask** — do not invent a rule.
-2. **Type A is automatic, Type B is asked-first.** Type A rewrites are mechanical, unambiguous, and observably identical. Apply them without prompting. Type B rewrites depend on intent (timing-sensitive code, dynamic call sites, behaviour-changes-at-the-edge); identify every call site, explain the risk, and **wait for the author's decision** before rewriting.
-3. **Smallest correct diff.** Do not refactor for style. Do not rename things the author didn't ask to rename. Do not add new features (frames, schemas, machines, `reg-view`) unless the author asked for the opt-in modernisations (the `O-N` rules).
-4. **Apply rules in order.** Later rules sometimes depend on earlier ones (e.g. M-0 — the coord swap — is the precondition for everything else). Walk the rules top-to-bottom as listed in [`MIGRATION.md`](../../spec/MIGRATION.md); don't jump.
-5. **JVM interop is in scope.** re-frame2 preserves `re-frame.interop` and JVM-side test runs. If the project has `.clj` test runners or JVM-side fixtures, migrate them alongside the CLJS code. Do not silently CLJS-only the project.
-6. **Single-import contract for new code.** Application namespaces use `(:require [re-frame.core :as rf])`. Direct requires of `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` are out-of-contract and get rewritten or flagged per M-1 / M-23.
-7. **If a rule looks ambiguous, file a bead — don't edit [`MIGRATION.md`](../../spec/MIGRATION.md) inline.** This skill consumes that doc; it doesn't author it. Surface drift back to the maintainer.
-8. **Do not invent migration rules.** The 40+ M- and O-rules in [`MIGRATION.md`](../../spec/MIGRATION.md) were the result of cross-spec review. If something in the codebase doesn't trip a rule, leave it alone and flag for human review.
-
----
+2. **Type A is automatic; Type B is asked-first.** Type A is mechanical, unambiguous, observably identical — apply without prompting. Type B depends on intent — identify, explain the risk, wait for the author's decision.
+3. **Smallest correct diff.** Do not refactor for style; do not rename what the author didn't ask to rename; do not add features (frames, schemas, machines, `reg-view`) unless the author asked for the O-rules.
+4. **Apply rules in order.** Walk the rules top-to-bottom as listed in `MIGRATION.md`; M-0 (coord swap) is precondition for the rest.
+5. **JVM interop is in scope.** Migrate `.clj` test runners and JVM-side fixtures alongside the CLJS code.
+6. **Single-import contract for new code.** Application namespaces require `[re-frame.core :as rf]`. Direct requires of `re-frame.db`, `.router`, `.subs`, `.events`, `.registrar`, or `.alpha` get rewritten or flagged per M-1 / M-23.
+7. **Ambiguous rule? File a bead — don't edit `MIGRATION.md` inline.** This skill consumes that doc.
+8. **Do not invent migration rules.** Leave the unmatched alone and flag for human review.
 
 ## The migration workflow
 
-A six-phase walk. Each phase links to a leaf for the detail; the SKILL.md only carries the workflow shape.
+Six phases. Each links to a leaf for the detail; the SKILL.md carries only the workflow shape.
 
-### Phase 1 — Orient
+**Phase 1 — Orient.** Read the project's dep file (`deps.edn` / `project.clj` / `shadow-cljs.edn` / `bb.edn`), then [`MIGRATION.md`](../../spec/MIGRATION.md) Part 1, then the project's test-suite shape. → [`reference/setup.md`](reference/setup.md) for the M-0 dep swap.
 
-Before touching anything, gather context. Read in this order:
+**Phase 2 — Bump the dep (M-0).** Swap `re-frame/re-frame` → `day8/re-frame2` + a substrate-adapter artefact (`day8/re-frame2-reagent` unless told otherwise). Compile **before** applying any other rules — most codebases need no further changes. → [`reference/setup.md`](reference/setup.md) for per-build-tool shapes and adapter picker.
 
-1. **The codebase's dep file** — `deps.edn`, `project.clj`, `shadow-cljs.edn`, or `bb.edn` — to confirm the project is actually on `re-frame/re-frame` and identify the substrate (Reagent unless told otherwise).
-2. **[`MIGRATION.md`](../../spec/MIGRATION.md)** in the re-frame2 repo — the rule table. Skim Part 1 to know which rules exist; you'll reach for them by id during the migration.
-3. **The project's test suite shape** — is it `re-frame-test`-based, `cljs.test`-based, JVM-side, or absent? This tells you what "verified" looks like at the end.
+**Phase 3 — Sweep for breakage.** If Phase 2's compile/test surfaced failures, walk the rules in order.
+- [`reference/sequencing.md`](reference/sequencing.md) — recommended order, restated so an interrupted migration can resume.
+- [`reference/automated-transforms.md`](reference/automated-transforms.md) — Type A patterns (mechanical rewrites applied without asking).
+- [`reference/guided-checklist.md`](reference/guided-checklist.md) — Type B walkthroughs (M-3, M-5 dynamic half, M-11, M-17, M-22, etc.).
+- [`reference/breaking-changes.md`](reference/breaking-changes.md) — one-page index of every M-/O-rule by trigger surface; grep here to find the rule id.
 
-→ `reference/setup.md` covers the deps-coord swap (M-0) and the adapter-artefact addition (`day8/re-frame2-reagent` for a Reagent app); these are the precondition for everything else.
+**Phase 4 — Verify.** Recompile, re-run unit tests, smoke-test boot / dispatch / sub / hot-reload. If a step fails, find the rule, apply it, re-verify. The skill does not run tests for the author.
 
-### Phase 2 — Bump the dep (M-0)
+**Phase 5 — Opt-in modernisations (only if asked).** Walk the `O-N` rules in `MIGRATION.md` (O-1 rich metadata, O-2 `reg-view`, O-3 Malli, O-4 frames, O-5 binary fx, O-8/O-9 machines, O-13/O-14 substrate moves, O-15 `:invoke-all`, etc.). Never auto-applied as part of a routine migration.
 
-Apply M-0 from [`MIGRATION.md`](../../spec/MIGRATION.md): swap the coord from `re-frame/re-frame` to `day8/re-frame2`, **and** add a substrate-adapter artefact (`day8/re-frame2-reagent` for Reagent, `-uix` / `-helix` if the project has already moved off Reagent). Bump and **stop** — try a compile before applying any other rules. The headline expectation in MIGRATION.md is that *most codebases require no further changes*. Verify that against this project before doing more work.
+**Phase 6 — Report.** Produce the migration report per `MIGRATION.md` Part 2 §"Output format for your report". → [`reference/output-format.md`](reference/output-format.md) — the format restated with one filled-in example.
 
-→ `reference/setup.md` for the per-build-tool shape (`deps.edn` vs `project.clj` vs `shadow-cljs.edn` vs `bb.edn`), the substrate-adapter picker, and what to do if no v2 version has shipped yet.
+## Kickoff (paste-ready)
 
-### Phase 3 — Sweep for breakage
-
-If Phase 2's compile / test run surfaced failures, sweep the codebase for each M-rule in order. Use the **automated-transforms leaf** for the mechanical (Type A) rewrites and the **guided checklist** for the judgment-call (Type B) ones.
-
-→ `reference/sequencing.md` for the recommended order of rules (matches [`MIGRATION.md`](../../spec/MIGRATION.md)'s ordering; restated here so an interrupted migration can pick up).
-
-→ `reference/automated-transforms.md` for the Type A patterns — find-and-replace shapes, ns-import rewrites, effect-map key folds — that can be applied without asking.
-
-→ `reference/guided-checklist.md` for the Type B walkthroughs — `:dispatch` run-to-completion (M-3), `apply`/Var-aliased registration (M-5 dynamic half), `reg-global-interceptor` in a multi-frame context (M-17), `^:flush-dom` (M-16), the `reg-view` macro rewrite (M-22), and the rest.
-
-→ `reference/breaking-changes.md` for a one-page lookup of *every* M- and O-rule keyed to the v1 symbol or pattern that triggers it — useful when the author asks "is this thing I just hit covered by a rule?"
-
-### Phase 4 — Verify
-
-Run the project's own verification. This skill does not run the tests for the author — that's general software practice, not migration-specific. The standard sequence is: re-compile, re-run unit tests, smoke-test the running app for boot / dispatch / sub / hot-reload. If any step fails, identify which rule applies, apply it, and re-verify. Repeat.
-
-### Phase 5 — Optional opt-in modernisations (only if the author asked)
-
-If — and only if — the author explicitly asked to *modernise* the codebase (not just migrate it), walk the `O-N` rules in [`MIGRATION.md`](../../spec/MIGRATION.md): rich registration metadata (O-1), `reg-view` adoption (O-2), Malli schemas (O-3), frames (O-4), binary fx (O-5), the canonical event-vector shape (M-19 framed as opt-in), state machines (O-8 / O-9), substrate moves (O-13 / O-14), `:invoke-all` (O-15). These are **never** auto-applied as part of a routine migration — they are stylistic / structural upgrades the author opts into.
-
-### Phase 6 — Report
-
-Produce the migration report per [`MIGRATION.md`](../../spec/MIGRATION.md) Part 2 §"Output format for your report" — coord before/after, files modified, M-rules applied, items flagged for human review, anything unexpected. Keep it under 300 words unless the migration was unusually complex.
-
-→ `reference/output-format.md` restates the format with one filled-in example, so the report stays consistent across migrations.
-
----
-
-## Kickoff prompt (paste-ready)
-
-If the author wants to *delegate* the migration to a fresh Claude session — running this skill against their codebase — there is a paste-ready prompt at `reference/kickoff-prompt.md`. The author copies it into a new Claude Code session opened in the root of their v1 project; the session loads this skill and walks the six phases above autonomously, surfacing decisions back to the author at the Type B checkpoints.
-
-This is the most common shape: the migration is non-trivial enough to want a focused agent context, and the project author wants to keep their own primary session free for the rest of their work.
-
----
+For delegating the migration to a fresh Claude session: [`reference/kickoff-prompt.md`](reference/kickoff-prompt.md). The author drops it into a session opened in the root of their v1 project; the session loads this skill and walks the six phases, surfacing Type B checkpoints.
 
 ## Done checklist
 
-Tell the author the migration is complete when **all** of these are true:
+- [ ] `re-frame/re-frame` removed from every dep file; `day8/re-frame2` + adapter at a matching VERSION.
+- [ ] Project compiles cleanly with re-frame2 on the classpath.
+- [ ] Every tripped M-rule has been applied (Type A) or resolved by the author (Type B).
+- [ ] Existing test suite passes (or fails identically to pre-migration — no new failures introduced).
+- [ ] Migration report (per `MIGRATION.md` Part 2 / `reference/output-format.md`) produced and shared.
+- [ ] Items flagged for human review are explicitly listed in the report.
 
-- [ ] `re-frame/re-frame` is removed from every dep file; `day8/re-frame2` + a substrate-adapter artefact have replaced it at a matching VERSION.
-- [ ] The project compiles cleanly with re-frame2 on the classpath.
-- [ ] All M-rules that tripped in this codebase have been applied (Type A) or had their flagged-for-human-review items resolved by the author (Type B).
-- [ ] The project's existing test suite passes (or, if a test failed pre-migration, it fails identically post-migration — no new test failures introduced).
-- [ ] The migration report (per [`MIGRATION.md`](../../spec/MIGRATION.md) Part 2 / `reference/output-format.md`) has been produced and shared with the author.
-- [ ] Items flagged for human review are explicitly listed in the report — none are left as "todo" without the author's awareness.
+Hand off: *"Migration complete. Switch to **`re-frame2`** for new application code, or **`re-frame-pair2`** for live inspection. The opt-in modernisations (`O-N` rules) are available whenever you want them — not required to be on v2."*
 
-When the checklist passes, hand off: *"Migration complete. From here, switch to the **`re-frame2`** skill to write new application code, or **`re-frame-pair2`** to inspect the running app from the REPL. The opt-in modernisations (the `O-N` rules in [`MIGRATION.md`](../../spec/MIGRATION.md)) are available whenever you want to adopt them — they are not required to be on v2."*
+## Reference files (all one level deep)
 
----
+- [`reference/kickoff-prompt.md`](reference/kickoff-prompt.md) — fresh-session kickoff prompt.
+- [`reference/setup.md`](reference/setup.md) — M-0 operational detail: dep-file shapes, substrate-adapter picker, VERSION discovery, artefact-split implications.
+- [`reference/breaking-changes.md`](reference/breaking-changes.md) — compressed index of every M-/O-rule by trigger surface.
+- [`reference/sequencing.md`](reference/sequencing.md) — recommended walk order.
+- [`reference/automated-transforms.md`](reference/automated-transforms.md) — Type A patterns (mechanical, unambiguous).
+- [`reference/guided-checklist.md`](reference/guided-checklist.md) — Type B walkthroughs (judgment-call rewrites).
+- [`reference/output-format.md`](reference/output-format.md) — migration-report shape with worked examples.
 
-## Deep dives — reference files
+## Anti-patterns
 
-For depth on each phase, read the matching leaf — every leaf is one level deep so you can read it in full:
-
-- **`reference/kickoff-prompt.md`** — A paste-ready prompt the author drops into a fresh Claude Code session to kick the migration off. ~80 lines.
-- **`reference/setup.md`** — M-0 in operational detail: the dep-file shapes (`deps.edn`, `project.clj`, `shadow-cljs.edn`, `bb.edn`), the substrate-adapter picker, the VERSION discovery procedure, and the artefact-split implications (`day8/re-frame2-http` / `-machines` / `-routing` etc. are pay-as-you-go). ~120 lines.
-- **`reference/breaking-changes.md`** — A compressed one-page index of every M-rule and O-rule by trigger surface: when the author asks "is `X` covered?" you grep here, find the rule id, then load that rule's full text from [`MIGRATION.md`](../../spec/MIGRATION.md). ~180 lines.
-- **`reference/sequencing.md`** — The recommended order to walk the rules. Restated so a partial migration can resume cleanly. ~70 lines.
-- **`reference/automated-transforms.md`** — Type A patterns: the unambiguous mechanical rewrites the agent applies without asking. Shape-by-shape — ns rewrites, effect-map key consolidation, dispatch-with rewrites, framework-keyword consolidation. ~150 lines.
-- **`reference/guided-checklist.md`** — Type B walkthroughs: the judgment-call rewrites. One sub-section per Type B rule (M-3, M-5 dynamic half, M-11, M-17, M-22, ...). Each walks the author through identification, risk explanation, and the decision they need to make. ~140 lines.
-- **`reference/output-format.md`** — The migration-summary shape (the final report the agent produces), with two fully-filled-in worked examples. ~120 lines.
-
----
-
-## Anti-patterns to avoid
-
-A few traps that come up often enough to flag at the top level.
-
-- **Don't apply Type B rewrites silently.** The Type A / Type B distinction exists precisely because Type B changes can break working code in non-obvious ways. If you find yourself wanting to "just" rewrite a `:dispatch`-inside-a-handler call that depended on the v1 intermediate-render behaviour, stop — that's M-3 (Type B). Identify the call site, explain the run-to-completion change, wait for the author's decision.
-- **Don't bump every dep at once.** Bump *only* the re-frame coord (M-0). Don't update Reagent, React, shadow-cljs, or anything else as part of the migration. If those need updating, they're a separate task with separate failure modes.
-- **Don't add `day8/re-frame2-schemas` (or `-machines`, `-routing`, ...) "to be safe".** The artefact split is pay-as-you-go (per M-27 through M-32). Only add a per-feature artefact when the codebase actually uses that feature; otherwise you're inflating the classpath for no win.
-- **Don't migrate plain-Reagent fns to `reg-view` as part of the v1→v2 migration.** That is O-2 — an opt-in modernisation, never part of the required path. Plain Reagent fns continue to work in v2 (with a runtime warning only if rendered under a non-default frame, per M-11).
-- **Don't touch the `re-frame-test` namespaces eagerly.** They've been renamed to `re-frame.test-support` (M-25); apply the rename as a mechanical pass. Do not rewrite the test bodies themselves unless they trip a separate rule.
-- **Don't claim "migrated" before the report is written.** The report is the contract — it's how the author knows what changed, what's flagged, and what they still own.
-
-If you hit anything else surprising, surface it to the author rather than guessing. The migration agent's job is to do the mechanical work cleanly and ask sharp questions about the rest — not to make the project owner's decisions for them.
+- **Don't apply Type B rewrites silently** — the Type A / Type B distinction exists precisely because Type B changes can break working code (e.g. M-3 run-to-completion semantics).
+- **Don't bump every dep at once** — only the re-frame coord (M-0). Other updates are separate tasks with separate failure modes.
+- **Don't add `-schemas` / `-machines` / `-routing` "to be safe"** — the artefact split is pay-as-you-go (M-27 through M-32).
+- **Don't migrate plain-Reagent fns to `reg-view`** — that's O-2 (opt-in), never required. Plain Reagent fns work in v2 with a runtime warning only under non-default frames (M-11).
+- **Don't touch `re-frame-test` namespaces eagerly** — renamed to `re-frame.test-support` (M-25); apply as a mechanical pass. Don't rewrite test bodies unless they trip a separate rule.
+- **Don't claim "migrated" before the report is written** — the report is the contract.
 
 ---
 
-*Authoritative breaking-change list: [`MIGRATION.md`](../../spec/MIGRATION.md) (in this repo). For the v1 line: [re-frame](https://github.com/day8/re-frame). For greenfield bootstrap: `skills/re-frame2-setup/`. For application authoring on v2: `skills/re-frame2/`. For live-app inspection: `skills/re-frame-pair2/`. For building a new re-frame2 implementation in a different host language or substrate: `skills/re-frame2-implementor/`.*
+*Authoritative breaking-change list: [`MIGRATION.md`](../../spec/MIGRATION.md). v1 line: [re-frame](https://github.com/day8/re-frame). Greenfield: `skills/re-frame2-setup/`. v2 authoring: `skills/re-frame2/`. Live inspection: `skills/re-frame-pair2/`. New re-frame2 implementation in another host/substrate: `skills/re-frame2-implementor/`.*

--- a/skills/re-frame-pair-improver2/SKILL.md
+++ b/skills/re-frame-pair-improver2/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: re-frame-pair-improver2
-description: Analyze a user's recent work with re-frame-pair2 to identify friction, wasted effort, missing observability, workflow mismatches, and high-leverage improvement opportunities. Use when the user asks how re-frame-pair2 could better support their workflow, wants a retrospective on a debugging or pairing session, or wants concrete improvement ideas or bead drafts for re-frame-pair2.
+description: Analyzes a user's recent work with re-frame-pair2 to surface friction, wasted effort, missing observability, workflow mismatches, and high-leverage improvement opportunities. Use when the user asks how re-frame-pair2 could better support their workflow, wants a retrospective on a debugging or pairing session, or wants concrete improvement ideas or bead drafts for re-frame-pair2. Do not use for: ordinary re-frame-pair2 use (use re-frame-pair2 itself), authoring re-frame2 app code (use re-frame2), or general framework feedback unrelated to the pair tool.
 ---
 
 # re-frame-pair-improver2
 
-Study the current or just-finished session and turn it into a product retrospective for `re-frame-pair2`.
-
-This is a conversation, not an automated report. Surface findings, let the user steer which ones matter, and only then converge on improvements.
+Turns the current or just-finished session into a product retrospective for `re-frame-pair2`. This is a conversation, not an automated report: surface findings, let the user steer which ones matter, then converge on improvements.
 
 ## Core job
 
@@ -20,152 +18,68 @@ Deliver:
 
 ## Guard rails
 
-- Always start with session analysis. Do not jump straight to fixes.
-- Present friction points before root causes. Let the user choose which ones to dig into.
-- Default to diagnosis, not contribution. Do not assume the user wants to file a bead or propose a patch.
-- Never file a bead or edit another repo without explicit user approval.
-- If the user invoked the skill with a specific complaint, focus there first but still notice other background friction.
+- **Always start with session analysis.** Do not jump to fixes.
+- **Friction points before root causes.** Let the user pick which ones to dig into.
+- **Default to diagnosis, not contribution.** Do not assume the user wants to file a bead or propose a patch.
+- **Never file a bead or edit another repo without explicit user approval.**
+- **Stay focused on improving `re-frame-pair2`.** If the right fix is upstream in `re-frame2` (Tool-Pair surfaces, trace stream, epoch-history, schema reflection, source-coord annotation), say so and route the proposal to a `bd` bead against the `re-frame2` repo, not `re-frame-pair2`.
+- **Do not propose fixes via `re-frame-10x`.** v2's pair tooling does not depend on it. Time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces (`register-trace-cb!`, `register-epoch-cb!`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation).
 
-## Working style
+## Working style (short form)
 
-- Prefer evidence over vibes. Cite concrete moments from the session: retries, clarifications, fallbacks, stale outputs, empty outputs, mismatched docs, waits, or manual workarounds.
-- Separate symptom from cause. "We had to retry the attach three times" is the symptom; "discovery was brittle on this platform" is the likely cause.
-- Notice both direct and indirect friction.
-  - Direct: the user says something was frustrating, confusing, slow, brittle, or surprising.
-  - Indirect: repeated commands, repeated explanations, fallback to lower-level tools, manual reconstruction, hidden prerequisites, brittle environment assumptions, partial results, confusing contracts, or missing trust signals.
-- Notice positive gaps too.
-  - What almost worked?
-  - What required too much expert knowledge?
-  - What capability existed but was undiscoverable?
-  - What should have been the default?
-- Be creatively ambitious after the diagnosis is clear.
-  - Start with grounded fixes supported directly by the session.
-  - Then ask what would make this workflow feel nearly automatic, self-explaining, or hard to misuse.
-  - Include 1-2 higher-upside ideas when warranted, even if they require reshaping the workflow rather than patching a local symptom.
-  - Label speculative ideas clearly; creative does not mean vague.
-- Stay focused on improving `re-frame-pair2`. If the best fix belongs upstream in `re-frame2` itself (its Tool-Pair surfaces, trace stream, epoch-history, schema reflection, or source-coordinate annotation), say so explicitly and route the proposal there as a `bd` bead against the `re-frame2` repo, not against `re-frame-pair2`.
-- Read [references/analysis-lenses.md](references/analysis-lenses.md) when the session has multiple plausible causes or you need a sharper taxonomy.
-- Read [references/known-frictions.md](references/known-frictions.md) when the session resembles a recurring class of `re-frame-pair2` pain and you want to sanity-check whether it is a one-off or a pattern.
+- **Evidence over vibes.** Cite concrete moments: retries, clarifications, fallbacks, stale outputs, empty outputs, waits, manual workarounds.
+- **Symptom vs cause.** *"We had to retry the attach three times"* is the symptom; *"discovery was brittle on this platform"* is the likely cause.
+- **Direct and indirect friction.** The user says something was frustrating *or* you see repeated commands, repeated explanations, fallback to lower-level tools, manual reconstruction, hidden prerequisites, partial results, confusing contracts.
+- **Positive gaps too.** What almost worked? What required too much expert knowledge? What capability existed but was undiscoverable? What should have been the default?
+- **Be creatively ambitious after diagnosis.** Start with grounded fixes; then ask what would make this workflow feel nearly automatic or hard to misuse. Include 1-2 higher-upside ideas when warranted, even if they reshape the workflow rather than patching a local symptom. Label speculative ideas clearly.
 
 ## Analysis workflow
 
-1. Reconstruct the session goal.
-   - Identify the user's intended outcome, not just the last command.
-   - Capture the important environment facts: platform, target repo, live runtime state (which frame, which epoch depth), and tooling constraints.
+1. **Reconstruct the session goal.** The user's intended outcome, plus environment facts (platform, target repo, live runtime state, tooling constraints).
+2. **Build a short timeline.** Turns where progress stalled, restarted, detoured, required a workaround. Tool errors, empty/stale outputs, retries, clarification loops.
+3. **Extract friction.** Numbered list first. For each: what happened, where it appeared, initial category guess. Ask which to dig into and what was missed.
+4. **Classify the root cause** using the lens table in [`references/analysis-lenses.md`](references/analysis-lenses.md). Prefer one primary cause per finding; allow multiple contributing causes when needed.
+5. **Generate improvements at the right layer** — skill wording, structured op, runtime surface, cross-platform behavior, validation/fixture, instrumentation, or an upstream `re-frame2` bead. Prefer proposals that remove repeated effort, not just this session's exact symptom. Offer options: no action / docs / tool change / pair2 bead / upstream re-frame2 bead.
+6. **Prioritize.** Favor high-impact, specific, evidence-supported, trust-improving ideas. Return 2-5; default mix is 1-3 grounded + 0-2 bolder.
 
-2. Build a short timeline.
-   - List the turns or actions where progress stalled, restarted, detoured, or required a workaround.
-   - Include tool errors, empty outputs, stale outputs, retries, and clarification loops.
-
-3. Extract friction.
-   - Present a numbered list of friction points first.
-   - For each point, note:
-     - what happened
-     - where it showed up in the session
-     - the initial category guess
-   - Ask:
-     - which of these should we dig into?
-     - did I miss anything important?
-
-4. Classify the root cause.
-   - Work through these lenses briefly:
-
-     | Lens | Question | Typical improvement |
-     |------|----------|---------------------|
-     | Skill structure | Was the right guidance present but buried or too low-signal? | Promote to guard rail, shorten, reorder, add examples |
-     | Skill gap | Was key guidance missing entirely? | Add a new recipe, anti-pattern, or decision rule |
-     | Misleading docs | Did the docs suggest the wrong action or wrong trust model? | Correct wording, add warnings, align contracts |
-     | Missing structured op | Did the workflow need a first-class command or result shape? | Add a script/runtime op or a structured field |
-     | Unreliable op | Did an existing op behave too ambiguously or too brittlely? | Fix behavior, add warnings, strengthen validation |
-     | Default or fallback | Was the default path wrong, silent, or unsafe? | Change defaults or automate the safer fallback |
-     | Platform bug | Did the workflow break on a specific shell, OS, or browser setup? | Add platform-aware handling or explicit detection |
-     | Validation gap | Did this ship because the right fixture, smoke test, or regression test is missing? | Add test coverage or fixture support |
-     | Upstream limitation | Is `re-frame-pair2` working around the wrong abstraction in `re-frame2` itself? | File a `bd` bead against the `re-frame2` repo |
-     | Context-window issue | Did long context or low-salience guidance cause forgetfulness? | Make the guard rail shorter, earlier, and stronger |
-
-   - Prefer one primary cause per finding, but allow multiple contributing causes when needed.
-
-5. Generate improvements at the right layer.
-   - Consider several layers before choosing one:
-     - tighten `SKILL.md` instructions or recipes
-     - add or reshape a shell, script, or runtime op
-     - enrich structured results, warnings, or failure modes
-     - improve cross-platform behavior
-     - add validation, fixture coverage, or smoke tests
-     - expose new runtime instrumentation
-     - file a `bd` bead against `re-frame2` when the right fix is in the framework's Tool-Pair contract rather than the pair tool
-   - Prefer proposals that remove repeated effort, not just this session's exact symptom.
-   - Ask a broader design question before finalizing ideas:
-     - what should the tool have noticed automatically?
-     - what manual decision or reconstruction step should disappear?
-     - what would make this workflow feel obvious to a first-time user?
-     - what would prevent this class of failure earlier?
-   - Offer options when there is more than one credible path:
-     - no action
-     - docs or skill edit
-     - tool/runtime change
-     - bead draft against `re-frame-pair2`
-     - upstream escalation as a `bd` bead against `re-frame2`
-   - If the workflow itself seems wrong, include a redesign option instead of only polishing the current path.
-
-6. Prioritize.
-   - Favor ideas that are:
-     - high impact on common workflows
-     - specific enough to implement
-     - supported by session evidence
-     - likely to improve trust, speed, or debuggability
-   - Usually return 2-5 improvements, not a long brainstorm.
-   - A good default mix is 1-3 grounded improvements plus 0-2 bolder ideas.
+Load [`references/analysis-lenses.md`](references/analysis-lenses.md) when the session has multiple plausible causes or you want a sharper taxonomy. Load [`references/known-frictions.md`](references/known-frictions.md) when the session resembles a recurring class of pain and you want to sanity-check one-off vs pattern.
 
 ## Output format
 
-Use a compact retrospective with these sections when the session has enough evidence:
+Compact retrospective sections (when the session has enough evidence):
+
 - `Goal`
 - `Observed friction`
 - `Likely root causes`
 - `Improvement ideas`
-- `Bolder ideas` if there are credible higher-upside options worth separating from the grounded fixes
-- `Bead candidates` if the user wants them
-- `Other possibilities` if there were good lower-priority ideas
+- `Bolder ideas` — for credible higher-upside options worth separating from grounded fixes
+- `Bead candidates` — only if the user wants them
+- `Other possibilities` — good lower-priority ideas
 
-For each improvement idea, include:
-- the friction it addresses
-- why `re-frame-pair2` was not enough
-- the proposed change
-- the likely layer of change: skill, script/runtime, tests/docs, or upstream `re-frame2`
-- a short impact statement
+For each improvement idea: the friction it addresses; why `re-frame-pair2` wasn't enough; the proposed change; the likely layer (skill / script-runtime / tests-docs / upstream `re-frame2`); a short impact statement.
 
-If the session is too thin, say so plainly and ask for either a recap or permission to use a longer conversation as input.
+If the session is too thin, say so plainly and ask for a recap or permission to use a longer conversation as input.
 
 ## Filing improvements
 
-Never file a bead without explicit user approval.
+Never file a bead without explicit user approval. After presenting the retrospective, offer filing work only if useful: draft bead text, file via `bd create` against the appropriate repo, or split into multiple focused beads.
 
-After presenting the retrospective, only offer filing work if it is useful:
-- draft bead text
-- file the bead directly via `bd create` against the appropriate repo (`re-frame-pair2` for tool changes, `re-frame2` for upstream contract changes), if the user asks
-- split the ideas into multiple focused beads, if that would be cleaner
+**Routing.** `re-frame-pair2` — friction in the pair tool (SKILL.md, scripts, recipes, structured results, attach/discovery, cross-platform). `re-frame2` — friction caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings).
 
-Default routing:
-- `re-frame-pair2` — friction inside the pair tool: SKILL.md, scripts, recipes, structured results, attach/discovery brittleness, cross-platform handling.
-- `re-frame2` — friction caused by the framework's Tool-Pair contract: missing trace events, gaps in `epoch-history` or `restore-epoch` failure modes, missing registrar query surfaces, source-coordinate annotation gaps, schema-reflection shortcomings.
+**Before filing.** Redact secrets, tokens, internal URLs, unnecessary local paths. Don't dump the raw transcript; summarize the evidence. Search for an existing bead first (`bd list` / `bd ready` / `bd show <id>`). Prefer one bead per materially distinct improvement. Use [`references/issue-template.md`](references/issue-template.md) for structure.
 
-Before filing:
-- redact secrets, tokens, internal URLs, and unnecessary local file paths
-- avoid dumping the raw transcript; summarize the evidence instead
-- search for an existing bead with `bd list` / `bd ready` or `bd show <id>` before creating a new one
-- prefer one bead per materially distinct improvement
-- use [references/issue-template.md](references/issue-template.md) for structure
+If `bd` is not configured in the target repo, produce a ready-to-paste body and say it's a draft, not a filed bead. The same template works as a GitHub Issue.
 
-If filing is not possible (e.g. `bd` is not configured in the target repo), produce a ready-to-paste bead body and say that it is a draft, not a filed bead. If the user prefers a GitHub Issue, the same template works — just paste it there.
+## Anti-patterns
 
-## What to avoid
+- Don't reduce every problem to "write more docs". Consider product behavior, tooling, defaults, instrumentation first.
+- Don't confuse a transient local outage with a product gap unless the workflow made recovery harder than it should have.
+- Don't propose vague improvements like "better UX" without naming the concrete missing behavior.
+- Don't force every retro into a code contribution or bead, or pressure the user to file anything.
+- Don't file speculative beads unsupported by the session.
 
-- Do not reduce every problem to "write more docs". Consider product behavior, tooling, defaults, and instrumentation first.
-- Do not confuse a transient local outage with a product gap unless the workflow made recovery harder than it should have.
-- Do not propose vague improvements like "better UX" without naming the concrete missing behavior.
-- Do not confuse creativity with hand-waving. Bold ideas still need a concrete change and a believable path to value.
-- Do not force every retro into a code contribution or bead.
-- Do not file speculative beads unsupported by the session.
-- Do not pressure the user to file anything.
-- Do not propose fixes that route through `re-frame-10x` — re-frame2's pair tooling does not depend on it. Time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces (`register-trace-cb!`, `register-epoch-cb!`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation).
+## Reference files
+
+- [`references/analysis-lenses.md`](references/analysis-lenses.md) — friction signals (generic + re-frame2-specific), root-cause categories, improvement patterns, routing decisions, prioritization.
+- [`references/known-frictions.md`](references/known-frictions.md) — recurring classes of `re-frame-pair2` pain; sanity-check one-off vs pattern.
+- [`references/issue-template.md`](references/issue-template.md) — bead/issue body template.

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -4,182 +4,98 @@ description: >
   Guides an engineer building a NEW re-frame2 implementation in a different
   host language or substrate — TypeScript, F# (Fable), Kotlin/JS, Squint,
   Scala.js, PureScript, ReScript, Python, Rust, native UI, terminal, or any
-  host where re-frame2's pattern can be realised. Drives a two-phase workflow:
-  Phase 1 locks the load-bearing decisions (target language, substrate,
-  scope, identity primitive, persistent data structures, concurrency model,
-  schema mechanism, hot-reload story), and Phase 2 walks the spec corpus in
-  dependency order (001 Registration → 002 Frames → 006 Reactive substrate →
-  004 Views → optional EPs) with the conformance corpus as the acceptance
-  test. Use this skill whenever the user mentions "porting re-frame2",
-  "implementing re-frame2 in <language>", "writing a re-frame2 runtime",
-  "second re-frame2 implementation", "TypeScript port of re-frame2",
-  "implementor checklist", "conformance corpus", or any phrasing about
-  building re-frame2 itself rather than using it. For building applications
-  ON TOP OF the CLJS reference, use the re-frame2 skill instead; for
-  migrating a v1 codebase, use re-frame-migration.
+  host where re-frame2's pattern can be realised. Drives a two-phase
+  workflow (Phase 1: lock decisions; Phase 2: walk the spec corpus in
+  dependency order with the conformance corpus as the acceptance test).
+  Trigger on phrasing like "port re-frame2", "implement re-frame2 in
+  <language>", "second re-frame2 implementation", "implementor checklist",
+  "conformance corpus", or any prompt about building re-frame2 itself.
+  Do not use for: writing apps on the CLJS reference (use `re-frame2`),
+  greenfield bootstrap (use `re-frame2-setup`), v1→v2 migration
+  (use `re-frame-migration`), or live-app inspection (use `re-frame-pair2`).
 ---
 
 # re-frame2-implementor
 
-You are helping an engineer **build a new implementation of the re-frame2 pattern** — not a re-frame2 application, but a runtime that other people will then write applications against. The CLJS reference implementation in this repo is a working example of one realisation; this skill walks the engineer through realising another.
+This skill is **workflow + guidance** layered on the spec corpus at [`spec/`](../../spec/). The spec is the contract; the reference impl under `implementation/` is one worked example, not normative.
 
-The skill is **guidance + workflow** layered on top of the spec corpus at [`spec/`](../../spec/). The spec is the contract. The reference impl is one worked example, not normative.
+The job is to walk the engineer through two phases:
 
----
-
-## When to use this skill
-
-Use this skill when **any** of these are true:
-
-- The engineer is starting a port of re-frame2 to a new host language (TypeScript, Fable F#, Kotlin/JS, Squint, Scala.js, PureScript, Reason / ReScript / Melange, or any of the other hosts named in [`spec/000-Vision.md`](../../spec/000-Vision.md) — or a host outside that list).
-- The engineer is implementing re-frame2 against a non-React substrate, a native UI toolkit, a terminal UI, or any rendering surface that isn't React-on-the-browser.
-- The engineer wants to claim "this is a re-frame2 implementation" and needs to know what the claim requires.
-- The engineer is consuming [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md) and the [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) corpus to verify their work.
+1. **Phase 1** — lock the load-bearing decisions (target language, substrate, scope, identity primitive, persistent data, concurrency, schema mechanism, hot-reload).
+2. **Phase 2** — implement EPs in dependency order (001 → 002 → 006 → 004 → 009, then optional EPs per Phase 1 scope), validated by the conformance corpus.
 
 ## When NOT to use this skill
 
-Route elsewhere when:
-
 | Engineer intent | Route to |
 |---|---|
-| Write event handlers, subs, machines, views in a project using the CLJS reference | `skills/re-frame2/` |
+| Write events / subs / machines / views on the CLJS reference | `skills/re-frame2/` |
 | Bootstrap a fresh greenfield app on the CLJS reference | `skills/re-frame2-setup/` |
 | Migrate a re-frame v1 codebase to the CLJS reference | `skills/re-frame-migration/` |
 | Inspect / dispatch / debug a running v2 app | `skills/re-frame-pair2/` |
-| Understand the pattern's rationale (EP narrative, principles) | [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) at repo root |
+| Understand pattern rationale (EP narrative, principles) | [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) |
 
-If the engineer is building **applications** on the reference, hand off to `re-frame2`. This skill is exclusively for engineers building the runtime itself.
+## Cardinal rules (one-liners; full text in [`reference/cardinal-rules.md`](reference/cardinal-rules.md))
 
----
+1. **Spec is the contract.** When `implementation/` and [`spec/`](../../spec/) disagree, the spec wins.
+2. **Phase 1 before Phase 2.** Lock decisions in writing before writing code.
+3. **Dependency order.** EP 001 → 002 → 006 → 004 → 009 are the foundation; optional EPs sit downstream.
+4. **Substrate-agnostic phrasing.** Write to "the identity primitive", "the render-tree", "the reactive container" — not to hiccup / Reagent / keywords.
+5. **No core.async equivalents.** Async effects ride host primitives; cross-frame work is run-to-completion-drained.
+6. **JVM-runnability for testing.** Pure transitions and pure sub computations must be callable from a non-substrate harness.
+7. **Conformance corpus is the acceptance test.** Score is `passed / claimed-applicable`; a fixture you can't make pass without outside sources is a *spec gap*.
+8. **Spec gap → file a bead.** Don't paper, don't invent, don't extrapolate from the reference.
 
-## Cardinal rules
+## Phase 1 — lock the decisions
 
-These hold across every phase of the implementation.
+Walk [`reference/phase-1-decisions.md`](reference/phase-1-decisions.md) and produce a locked-decision record using the [`reference/decision-record.md`](reference/decision-record.md) template. The seven decision blocks (D1 target language, D2 substrate, D3 scope, D4 foundation choices, D5 schema mechanism, D6 integration story, D7 capability tag set) are detailed there; the canonical option matrices live in [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md).
 
-1. **The spec is the contract.** [`spec/`](../../spec/) is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; file a `bd create` bead against the spec or the reference impl as appropriate.
-2. **Phase 1 before Phase 2.** Decisions made under Phase 1 (host language, substrate, scope, identity primitive, concurrency model) are load-bearing for every line of code written in Phase 2. Lock them in writing before opening an editor. If a Phase 2 step forces a Phase 1 decision to change, *stop*, revise the decision record, and restart that Phase 2 step.
-3. **Implement in dependency order.** EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) are the foundation. The optional EPs (005, 007–014) sit downstream and can be deferred or skipped per Phase 1 scope.
-4. **Substrate-agnostic phrasing in code and docs.** The reference impl is a CLJS+Reagent realisation — keywords as ids, hiccup as render-tree, Reagent ratoms as the reactive container. These are *choices the reference made*. Your port chooses differently and re-frame2 is still re-frame2. Do not write code that assumes "hiccup" or "Reagent" or "keyword" universally; write code that assumes "the identity primitive", "the render-tree", "the reactive container".
-5. **No core.async equivalents.** The CLJS reference does not use core.async, and ports inherit this directive. Async effects schedule via host primitives (Promise / setTimeout / setImmediate / asyncio / tokio); cross-frame work is serialised per frame via the run-to-completion drain. If your host's idiomatic concurrency model is channel-shaped, you may use channels *internally* — but the public dispatch contract is still the run-to-completion drain.
-6. **JVM-runnability for the testing surface.** Where the CLJS reference makes `compute-sub` and `machine-transition` pure-function-callable from JVM, your port's analogue must be callable from a non-substrate test harness. Pure transitions and pure sub computations are the bedrock of the test story.
-7. **Conformance corpus is the acceptance test.** [`spec/conformance/`](https://github.com/day8/re-frame2/tree/main/spec/conformance) is the verification mechanism. Your port runs the fixtures whose capabilities are a subset of what you've claimed; the score is `passed / claimed-applicable`. A fixture you cannot make pass without consulting outside sources is a **spec gap**, not an implementation gap — file a `bd create` bead against the spec corpus.
-8. **If you find a spec gap, file a bead. Do not paper.** When implementing surfaces a missing surface, an inconsistency, or an undocumented decision, that's a spec finding. Surface it. Do not silently invent an answer; do not extrapolate from "what the reference impl does" if the spec is silent.
+Output of Phase 1: a single dated decision record committed to the port's own repo.
 
----
+## Phase 2 — walk the spec corpus
 
-## The two-phase workflow
+With Phase 1 locked, walk [`reference/phase-2-impl-order.md`](reference/phase-2-impl-order.md) EP-by-EP. The leaf carries, for each EP: what to read first, the contract to expose, how the CLJS reference realised it (as **one** example, not normative), what the conformance fixtures check, common spec-gap traps.
 
-### Phase 1 — Lock the decisions
-
-Before any code is written, the engineer walks the **decision walkthrough** at `reference/phase-1-decisions.md` and produces a **decision record** (template: `reference/decision-record.md`). The decisions are:
-
-1. **Target host language** — which language and runtime. The spec scope under [`spec/000-Vision.md`](../../spec/000-Vision.md) names eight first-class JS-cross-compile hosts; the [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) covers more (Python, Rust, Kotlin/native, Swift) — but only the in-scope eight target React+VDOM substrates by default. Any other host language picks its own substrate (Q2).
-2. **Substrate / view layer** — React+VDOM (the spec's default), a native UI toolkit, raw DOM, terminal UI, server-render only, no UI at all.
-3. **Scope — which EPs ship now** — the core EPs (001 / 002 / 006 / 004) are mandatory for any conformance claim. The optional EPs (005 state machines, 007 stories, 008 testing, 009 instrumentation, 010 schemas, 011 SSR, 012 routing, 013 flows, 014 HTTP) are declared yes/no individually per [Implementor-Checklist Part 1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-1--how-complete).
-4. **Foundation choices** — identity primitive, persistent data structures, reactive substrate, effect-handling primitive, concurrency model, hot-reload primitive ([Implementor-Checklist Part 2 §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required)).
-5. **Schema mechanism** — runtime schema layer (Malli / Zod / Pydantic / dry-rb), host-type-system, or none ([Implementor-Checklist §Schemas](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#schemas-if-q4-is-yes)).
-6. **Integration story** — standalone library, framework integration (React Native, SwiftUI, …), or embedded inside a larger runtime.
-7. **Conformance capability tag set** — the union of `:core/*` (mandatory) plus the `:fsm/*` / `:actor/*` / `:routing/*` / `:ssr/*` / `:schemas/*` capability families that match Phase 1 scope.
-
-The output of Phase 1 is a single locked-decision record. It is referenced from every Phase 2 step. The leaf `reference/phase-1-decisions.md` walks the engineer through each decision; `reference/decision-record.md` is the fill-in template.
-
-### Phase 2 — Walk the spec corpus
-
-With Phase 1 locked, the engineer implements in dependency order. Leaf: `reference/phase-2-impl-order.md`.
-
-The walking order:
-
-1. **EP 001 — Registration** ([spec](https://day8.github.io/re-frame2/spec/001-Registration/)). The registrar; closed-kinds discipline; the `reg-*` surface; metadata propagation; hot-reload semantics.
-2. **EP 002 — Frames + events + effects + subscriptions** ([spec](https://day8.github.io/re-frame2/spec/002-Frames/)). Frame as runtime boundary `{state, queue, sub-cache, id}`; per-frame app-db; dispatch envelope; the six-step pipeline; run-to-completion drain; `:db` and `:fx` semantics; sub-cache invalidation.
-3. **EP 006 — Reactive substrate** ([spec](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/)). The adapter contract: six required + two optional + one lifecycle function. Single-adapter-per-process. Revertibility constraints on adapters.
-4. **EP 004 — Views** ([spec](https://day8.github.io/re-frame2/spec/004-Views/)). `reg-view`; render-tree shape (host-chosen, serialisable); frame-provider; source-coord stamping.
-5. **EP 009 — Instrumentation** ([spec](https://day8.github.io/re-frame2/spec/009-Instrumentation/)). Trace event stream; error contract; retain-N ring buffer; production elision. Pattern-required.
-6. **Conformance corpus pass #1** — at this point a port that's claimed `{Q1=no, Q2=no, Q3=no, Q4=via-types-or-no, Q5=no, Q6=no, Q7=no}` can pass the `:core/*` fixtures. This is the first acceptance gate.
-7. **Optional EPs in the order Phase 1 declared yes for** — for each declared-yes capability, implement the matching EP and re-run the matching capability-tagged fixtures. Suggested order if multiple are in scope: 010 Schemas → 008 Testing → 005 State machines → 012 Routing → 011 SSR → 013 Flows → 014 HTTP → 007 Stories.
-
-The leaf `reference/phase-2-impl-order.md` walks each EP with: what to read first, the contract to expose, how the CLJS reference realised it (as **one** example, not normative), what the conformance fixtures check, common spec-gap traps.
-
----
+Dependency order is fixed: **EP 001 Registration → 002 Frames → 006 Reactive substrate → 004 Views → 009 Instrumentation**, then a first conformance pass against the `:core/*` fixtures. Optional EPs (010 Schemas, 008 Testing, 005 State machines, 012 Routing, 011 SSR, 013 Flows, 014 HTTP, 007 Stories) follow in the order Phase 1 declared `yes` for them.
 
 ## Source discipline
 
-Three tiers of input, in this priority:
+Three tiers, in priority order:
 
-1. **[`spec/`](../../spec/)** — the contract. Read in numeric order. Every implementation decision must trace to a normative claim here.
-2. **[`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md)** — the decision-ordered companion. Part 1 (which capabilities ship), Part 2 (per-capability mechanism choices), Part 3 (how to consume the conformance corpus). Site-published version: <https://day8.github.io/re-frame2/spec/Implementor-Checklist/>.
-3. **`implementation/`** (the CLJS reference) — a worked example. Useful for "how did *someone* solve X?" Never useful as a contract claim. The reference's specific bindings (keywords, hiccup, Reagent ratoms, Closure dead-code elimination for production elision) are **choices**, not requirements.
+1. **[`spec/`](../../spec/)** — the contract. Read in numeric order.
+2. **[`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md)** — the decision-ordered companion.
+3. **`implementation/`** — a worked example. Useful for "how did *someone* solve X?" Never useful as a contract claim.
 
-If `implementation/` and [`spec/`](../../spec/) disagree, the spec wins. File a `bd create` bead so the inconsistency is tracked.
+If `implementation/` and `spec/` disagree, the spec wins.
 
----
+## Conformance
 
-## Conformance — the acceptance test
+The corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic data. Harness shape, the EDN-handler-body DSL, capability tagging, scoring, and the spec-gap-vs-implementation-bug distinction are all in [`reference/conformance.md`](reference/conformance.md). The corpus is the acceptance test for [Goal 2 — AI-implementable from the spec alone](https://day8.github.io/re-frame2/spec/000-Vision/#ai-implementable-from-the-spec-alone).
 
-The conformance corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic data. The harness is ~300 lines per host (per [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus)):
+## Kickoff and output
 
-1. Read all `.edn` fixtures in `fixtures/`.
-2. For each fixture, check whether `:fixture/capabilities` is a subset of the port's claimed list.
-3. If yes, bootstrap the runtime, realise handler bodies via the small EDN-handler-body DSL, create a frame, run the dispatches, capture observables, compare.
-4. If no, report as "not exercised."
-5. Aggregate score: `passed / claimed-applicable`.
+- [`reference/kickoff-prompt.md`](reference/kickoff-prompt.md) — paste-ready prompt for the engineer to drop into a fresh Claude session opened in the root of their port repo.
+- [`reference/output-format.md`](reference/output-format.md) — the standard agent-output shape: implementation summary, capability tags claimed, conformance score, decisions made, spec gaps filed.
 
-Hosts without EDN parsing either ship a small reader (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap. The leaf `reference/conformance.md` walks the harness shape and the EDN-handler-body DSL.
+## Done — "v1-complete against `<capability tag set>`"
 
-The corpus is the **acceptance test for [Goal 2 — AI-implementable from the spec alone](https://day8.github.io/re-frame2/spec/000-Vision/#ai-implementable-from-the-spec-alone)**. A fixture that an implementation cannot reproduce without consulting outside sources is a **spec gap**, not an implementation gap; remediation is to fix the spec corpus, not the implementation.
+- [ ] Phase 1 decision record committed to the port's repo.
+- [ ] All in-scope EPs have a working implementation.
+- [ ] The port exposes [`spec/API.md`](../../spec/API.md), adapted to host idiom.
+- [ ] Conformance score is `(claimed-applicable) / (claimed-applicable)`.
+- [ ] Non-spec-gap failures fixed in the port; spec-gap failures filed as beads against the spec.
+- [ ] Port's README states claimed capability tags and conformance score.
 
----
+## Reference files (all one level deep)
 
-## Kickoff prompt
-
-If the engineer wants to *delegate* the implementation walkthrough to a fresh Claude Code session, there's a paste-ready prompt at `reference/kickoff-prompt.md`. The engineer copies it into a new Claude Code session opened in the root of a fresh repo for their port; the session loads this skill and walks Phase 1 + Phase 2 with the engineer.
-
-This is the typical shape: the implementor wants a focused session to drive the work, asks decisions as they arise, references the spec for every contract claim.
-
----
-
-## Done checklist
-
-Tell the engineer the implementation is "v1-complete" against the claimed scope when **all** of these are true:
-
-- [ ] Phase 1 decision record is written down, dated, and committed to the port's own repo (as a `DECISIONS.md` or equivalent).
-- [ ] All EPs in scope (per Phase 1) have a working implementation in the port's source tree.
-- [ ] The port's runtime exposes the API contract at [`spec/API.md`](../../spec/API.md), adapted to the host's idiom.
-- [ ] The conformance corpus has been run against the port; the score is `(claimed-applicable) / (claimed-applicable)` — all fixtures whose capabilities are a subset of the port's claim pass.
-- [ ] Any conformance failures that were *not* spec gaps have been fixed in the port.
-- [ ] Any conformance failures that *were* spec gaps have been filed as beads against the spec corpus (`bd create` against the re-frame2 repo).
-- [ ] The port's own README states which capability tags it claims and the conformance score against those tags.
-
-When the checklist passes, the port can claim "re-frame2 implementation, v1-complete against `<capability tag set>`."
+- [`reference/cardinal-rules.md`](reference/cardinal-rules.md) — the eight rules in prose + anti-pattern corollaries.
+- [`reference/phase-1-decisions.md`](reference/phase-1-decisions.md) — Phase 1 walkthrough, seven decision blocks.
+- [`reference/decision-record.md`](reference/decision-record.md) — fill-in template for the locked-decision record.
+- [`reference/phase-2-impl-order.md`](reference/phase-2-impl-order.md) — EP-by-EP implementation order.
+- [`reference/reference-impl-tour.md`](reference/reference-impl-tour.md) — guided tour of the CLJS reference; what's substrate-specific vs pattern-required.
+- [`reference/conformance.md`](reference/conformance.md) — corpus harness, DSL, capability tagging, scoring.
+- [`reference/kickoff-prompt.md`](reference/kickoff-prompt.md) — fresh-session kickoff prompt.
+- [`reference/output-format.md`](reference/output-format.md) — agent-output shape.
 
 ---
 
-## Deep dives — reference files
-
-For depth on each step, read the matching leaf — every leaf is one level deep from this SKILL.md:
-
-- **`reference/kickoff-prompt.md`** — A paste-ready prompt to drop into a fresh Claude Code session in the root of the engineer's port repo. ~80 lines.
-- **`reference/phase-1-decisions.md`** — The Phase 1 walkthrough: seven decision blocks, options per host, trade-offs, links into [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md) for the canonical option matrices. ~200 lines.
-- **`reference/decision-record.md`** — The fill-in template for the locked-decision record. Reproducible across ports — the engineer copies the template into their own repo, fills in each block. ~120 lines.
-- **`reference/phase-2-impl-order.md`** — EP-by-EP implementation order. For each EP: what to read, the contract to expose, what the CLJS reference did (as an example), what the conformance fixtures check, common spec-gap traps. ~250 lines.
-- **`reference/reference-impl-tour.md`** — A guided tour of the CLJS reference under `implementation/` — what's where, what was a substrate-specific choice, what's pattern-required. Read this when you want to see how *someone* solved a problem, not to find out what re-frame2 requires. ~150 lines.
-- **`reference/conformance.md`** — How to consume the conformance corpus. The harness shape, the EDN-handler-body DSL, capability tagging, how to score, when a failure is a spec gap vs an implementation bug. ~140 lines.
-- **`reference/output-format.md`** — The standard agent-output shape: implementation summary, capability tags claimed, conformance score, decisions made, spec gaps filed. ~120 lines.
-
----
-
-## Anti-patterns to avoid
-
-A few traps that come up often enough to flag at the top level.
-
-- **Don't copy the reference impl line-by-line and translate.** The reference uses macros for source-coord capture; your host may not have macros. The reference uses Reagent's automatic dependency tracking; your host may need explicit subscriptions. The reference uses keywords; your host may use branded strings. *Copy the contract, not the realisation.*
-- **Don't skip Phase 1.** The decisions made under Phase 1 (especially F2 persistent data structures and F5 concurrency model) propagate through every line of Phase 2 code. Engineers who skip Phase 1 to "just start coding" end up rewriting the foundation halfway through. The decision walkthrough takes one focused session; the rewrite takes weeks.
-- **Don't declare Q1 (state machines) `yes` unless the FSM substrate is genuinely required.** EP 005 is substantial work and gates a large block of code. Smaller ports ship `Q1=no` and add the FSM substrate later — the events/subs/fx/views triad is self-sufficient for many use cases.
-- **Don't ship without conformance.** The corpus is the only objective measure of "is this re-frame2?" Without the corpus passing, the port is "inspired by re-frame2" but not a re-frame2 implementation. Run the harness early; the corpus is also useful as your test suite during development.
-- **Don't invent surfaces the spec is silent on.** If the spec says nothing about hierarchical FSM exit-order semantics in a specific edge case, *file a bead* — don't extrapolate from the CLJS reference. The reference's choice is one realisation; the spec's silence is a gap.
-- **Don't promise the engineer "this skill will write the port for you".** The skill walks the workflow and surfaces the decisions; the engineer (or their Claude session) writes the code. Phase 2 is multi-week work in any host; the skill is the map, not the vehicle.
-
-If you hit anything else surprising, surface it to the engineer rather than guessing. The implementor's agent's job is to walk the spec corpus cleanly and surface every decision back to the engineer — not to make the engineering choices for them.
-
----
-
-*Authoritative contract: [`spec/`](../../spec/) corpus (in this repo). Decision-ordered companion: [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md). Conformance corpus: [`spec/conformance/`](../../spec/conformance/). CLJS reference (worked example): `implementation/`. For application authoring on the reference: `skills/re-frame2/`. For greenfield bootstrap: `skills/re-frame2-setup/`. For v1→v2 migration: `skills/re-frame-migration/`. For live-app inspection: `skills/re-frame-pair2/`.*
+*Authoritative contract: [`spec/`](../../spec/). Decision companion: [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md). Conformance: [`spec/conformance/`](../../spec/conformance/). CLJS reference (worked example): `implementation/`. For app authoring on the reference: `skills/re-frame2/`. Greenfield bootstrap: `skills/re-frame2-setup/`. v1→v2 migration: `skills/re-frame-migration/`. Live-app inspection: `skills/re-frame-pair2/`.*

--- a/skills/re-frame2-implementor/reference/cardinal-rules.md
+++ b/skills/re-frame2-implementor/reference/cardinal-rules.md
@@ -1,0 +1,48 @@
+# Cardinal rules — re-frame2 implementor
+
+These hold across every phase of building a new re-frame2 implementation. Each rule expands the one-line form carried in `SKILL.md`.
+
+---
+
+## 1. The spec is the contract
+
+[`spec/`](../../../spec/) is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; file a `bd create` bead against the spec or the reference impl as appropriate.
+
+## 2. Phase 1 before Phase 2
+
+Decisions made under Phase 1 (host language, substrate, scope, identity primitive, concurrency model) are load-bearing for every line of code written in Phase 2. Lock them in writing before opening an editor. If a Phase 2 step forces a Phase 1 decision to change, **stop**, revise the decision record, and restart that Phase 2 step.
+
+## 3. Implement in dependency order
+
+EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) are the foundation. The optional EPs (005, 007–014) sit downstream and can be deferred or skipped per Phase 1 scope.
+
+## 4. Substrate-agnostic phrasing in code and docs
+
+The reference impl is a CLJS+Reagent realisation — keywords as ids, hiccup as render-tree, Reagent ratoms as the reactive container. These are *choices the reference made*. Your port chooses differently and re-frame2 is still re-frame2. Do not write code that assumes "hiccup" or "Reagent" or "keyword" universally; write code that assumes "the identity primitive", "the render-tree", "the reactive container".
+
+## 5. No core.async equivalents
+
+The CLJS reference does not use core.async, and ports inherit this directive. Async effects schedule via host primitives (Promise / setTimeout / setImmediate / asyncio / tokio); cross-frame work is serialised per frame via the run-to-completion drain. If your host's idiomatic concurrency model is channel-shaped, you may use channels *internally* — but the public dispatch contract is still the run-to-completion drain.
+
+## 6. JVM-runnability for the testing surface
+
+Where the CLJS reference makes `compute-sub` and `machine-transition` pure-function-callable from JVM, your port's analogue must be callable from a non-substrate test harness. Pure transitions and pure sub computations are the bedrock of the test story.
+
+## 7. Conformance corpus is the acceptance test
+
+[`spec/conformance/`](../../../spec/conformance/) is the verification mechanism. Your port runs the fixtures whose capabilities are a subset of what you've claimed; the score is `passed / claimed-applicable`. A fixture you cannot make pass without consulting outside sources is a **spec gap**, not an implementation gap — file a `bd create` bead against the spec corpus.
+
+## 8. If you find a spec gap, file a bead. Do not paper.
+
+When implementing surfaces a missing surface, an inconsistency, or an undocumented decision, that's a spec finding. Surface it. Do not silently invent an answer; do not extrapolate from "what the reference impl does" if the spec is silent.
+
+---
+
+## Anti-patterns (rule corollaries)
+
+- **Don't copy the reference impl line-by-line and translate.** The reference uses macros for source-coord capture; your host may not have macros. The reference uses Reagent's automatic dependency tracking; your host may need explicit subscriptions. The reference uses keywords; your host may use branded strings. *Copy the contract, not the realisation.*
+- **Don't skip Phase 1.** Decisions made under Phase 1 (especially F2 persistent data structures and F5 concurrency model) propagate through every line of Phase 2 code. Engineers who skip Phase 1 to "just start coding" end up rewriting the foundation halfway through.
+- **Don't declare Q1 (state machines) `yes` unless the FSM substrate is genuinely required.** EP 005 is substantial work and gates a large block of code. Smaller ports ship `Q1=no` and add the FSM substrate later — the events/subs/fx/views triad is self-sufficient for many use cases.
+- **Don't ship without conformance.** The corpus is the only objective measure of "is this re-frame2?" Without the corpus passing, the port is "inspired by re-frame2" but not a re-frame2 implementation. Run the harness early; the corpus is also useful as your test suite during development.
+- **Don't invent surfaces the spec is silent on.** If the spec says nothing about hierarchical FSM exit-order semantics in a specific edge case, *file a bead* — don't extrapolate from the CLJS reference. The reference's choice is one realisation; the spec's silence is a gap.
+- **Don't promise the engineer "this skill will write the port for you".** The skill walks the workflow and surfaces the decisions; the engineer (or their Claude session) writes the code. Phase 2 is multi-week work in any host; the skill is the map, not the vehicle.

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -2,172 +2,79 @@
 name: re-frame2-setup
 description: >
   Scaffolds a fresh re-frame2 ClojureScript project from nothing — adds
-  the artefact dependencies to deps.edn / package.json, writes a minimal
-  shadow-cljs.edn build for a Reagent single-page app, lays down the
-  canonical entry namespace shape (with `rf/init!` + the Reagent adapter),
-  and walks the author through their first mounted counter. Use this skill
-  whenever the user is starting a new re-frame2 project, bootstrapping
-  a greenfield CLJS app from scratch, asking how to add re-frame2 to an
-  empty repo, or wants to scaffold the smallest working re-frame2 setup
-  before writing application code. Once the counter mounts, the user
-  switches to the main `re-frame2` skill for code-writing inside the
-  project, or `re-frame-pair2` for live-runtime pair-programming.
+  the artefact dependencies, writes a minimal shadow-cljs.edn for a Reagent
+  single-page app, lays down the canonical entry namespace (with
+  `rf/init!` + the Reagent adapter), and walks the author through their
+  first mounted counter. Trigger on phrasing like "start a re-frame2
+  project", "scaffold re-frame2", "add re-frame2 to my repo",
+  "hello-world re-frame2 app", or a build failure that traces to missing
+  `re-frame.core` / `re-frame.adapter.reagent` wiring. Do not use for:
+  writing application code on a working project (use `re-frame2`),
+  live-app inspection (use `re-frame-pair2`), v1→v2 migration
+  (use `re-frame-migration`), or porting re-frame2 itself
+  (use `re-frame2-implementor`). Exits once the counter mounts.
 ---
 
 # re-frame2-setup
 
-You are helping an author **bootstrap a fresh re-frame2 ClojureScript project**. The author starts with nothing (or close to nothing — a `deps.edn` they intend to fill in, an empty `package.json`, no source). When you are done, the author has a project that compiles under `shadow-cljs watch`, mounts a working counter in the browser, and is ready for them to switch to the **main `re-frame2` skill** for writing application code.
+Bootstraps a fresh re-frame2 ClojureScript project. When done: the project compiles under `shadow-cljs watch`, a counter mounts in the browser, and the author can switch to **`re-frame2`** for code-writing.
 
-This skill teaches **only** the re-frame2-specific wiring. It does not teach what `deps.edn`, `npm`, or `shadow-cljs` are — assume the author already knows. It does not teach re-frame2's API (events, subs, machines, schemas, frames, fx, flows, routing, SSR) — that's the main `re-frame2` skill's job.
+This skill teaches **only re-frame2-specific wiring**. Assume the author knows `deps.edn`, `npm`, `shadow-cljs`. It does not teach re-frame2's API — that's `re-frame2`'s job.
 
----
+## When NOT to use
 
-## When to use this skill
+| Author intent | Route to |
+|---|---|
+| Write application code on a working project | `skills/re-frame2/` |
+| Inspect / debug / pair with a running app | `skills/re-frame-pair2/` |
+| Migrate from re-frame v1 to v2 | `skills/re-frame-migration/` |
+| Implement re-frame2 itself in another host/substrate | `skills/re-frame2-implementor/` |
 
-Use this skill when **any** of these are true:
-
-- The author has just created a new directory and wants re-frame2 set up in it.
-- The author has an existing CLJS project (Reagent or otherwise) but no re-frame2 wiring yet.
-- The author says any of: *"start a re-frame2 project"*, *"scaffold re-frame2"*, *"how do I set up re-frame2"*, *"add re-frame2 to my repo"*, *"give me a hello-world re-frame2 app"*.
-- A counter / event / sub fails to compile because the build doesn't yet know what `re-frame.core` or `re-frame.adapter.reagent` is.
-
-## When NOT to use this skill
-
-Switch to a different skill when:
-
-- The author has a working re-frame2 project and wants to **write application code** — events, subs, machines, schemas, views, fx. → Use the **`re-frame2`** skill.
-- The author has a running re-frame2 app and wants to **inspect / debug / pair with it live** — dispatch from the REPL, walk app-db, trace events, time-travel. → Use the **`re-frame-pair2`** skill.
-- The author is **migrating from re-frame v1 to v2**. → Use the [`re-frame-migration`](../re-frame-migration/) skill.
-- The author is **implementing re-frame2 itself** in a different host language or substrate (TypeScript, F#, Kotlin, Python, a non-React renderer). → Use the [`re-frame2-implementor`](../re-frame2-implementor/) skill — that one walks the EP corpus and the conformance contract; this skill assumes the CLJS reference is the target.
-
-If the author asks anything beyond greenfield setup (any re-frame2 API question, any design question, any migration question), say so and point them at the right skill.
-
----
+Any non-setup question → route to the right skill; don't improvise here.
 
 ## Cardinal rules
 
-1. **Never hardcode artefact versions in suggestions you write to disk.** re-frame2 ships ten artefacts in lockstep; versions change. Look them up first (see `reference/deps-versions.md`).
-2. **All ten artefacts ship at the same VERSION.** The author picks the version once; every `day8/re-frame2-*` dep gets that same version. Mixing versions across artefacts is unsupported.
-3. **Only add the per-feature artefacts the author actually uses.** Core + adapter are mandatory; schemas / machines / routing / flows / http / ssr / epoch are optional. Defer their inclusion until the author asks for the feature.
-4. **The Reagent adapter is the default reference substrate.** Unless the author explicitly says UIx or Helix, scaffold against Reagent.
-5. **Don't write tests for the author.** This skill stops at "the counter mounts". Anything after that is the main `re-frame2` skill (which itself defers test-writing to the author).
+1. **Never hardcode artefact versions in suggestions written to disk.** Ten artefacts ship in lockstep; look up the current VERSION first (see [`reference/deps-versions.md`](reference/deps-versions.md)).
+2. **All ten artefacts ship at the same VERSION.** Mixing versions across `day8/re-frame2-*` artefacts is unsupported.
+3. **Only add per-feature artefacts the author actually uses.** Core + adapter are mandatory; `-schemas` / `-machines` / `-routing` / `-flows` / `-http` / `-ssr` / `-epoch` are pay-as-you-go.
+4. **Reagent adapter is the default reference substrate.** Unless the author explicitly says UIx or Helix, scaffold against Reagent.
+5. **Don't write tests for the author.** This skill stops at "the counter mounts."
 
----
+## Canonical greenfield path (seven steps)
 
-## Canonical greenfield path
-
-The author wants a working re-frame2 app from nothing. Walk these steps in order. Each step links to a leaf when depth is useful; otherwise it's self-contained.
-
-### Step 1 — Discover the current artefact versions
-
-re-frame2 ships ten Maven artefacts in lockstep at a single VERSION. Find that VERSION before writing any deps. → See `reference/deps-versions.md` for where to look it up and which artefacts the author needs.
-
-A typical greenfield project needs **only two artefacts on day one**:
-
-- `day8/re-frame2` (the core)
-- `day8/re-frame2-reagent` (the Reagent adapter)
-
-Per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) come in **only when the author starts using that feature**.
-
-### Step 2 — Add the deps to `deps.edn`
-
-Drop the two artefacts into `:deps` under their canonical Maven coordinates. The shape is identical to any other tools.deps project — the only re-frame2-specific bit is the artefact names and the lockstep VERSION discipline. → See `reference/deps-versions.md` §`deps.edn`.
-
-### Step 3 — Add the npm deps to `package.json`
-
-The Reagent adapter requires `react` and `react-dom`. shadow-cljs is the build tool. → See `reference/deps-versions.md` §`package.json`.
-
-Run `npm install`.
-
-### Step 4 — Write the `shadow-cljs.edn` build
-
-A re-frame2 single-page app needs **one browser build entry** — a `:target :browser`, an `:init-fn` pointing at `your-app.core/run`, and a `:source-paths` that includes your `src/` tree. No special compiler options for the basic case. → See `reference/shadow-cljs.md` for the exact shape, the optional `:devtools` block for hot-reload, and the index.html that loads the bundle.
-
-### Step 5 — Write the entry namespace
-
-`your-app/core.cljs` needs three re-frame2-specific moves:
-
-1. `:require [re-frame.core :as rf]` — the core API.
-2. `:require [re-frame.adapter.reagent :as reagent-adapter]` — the substrate adapter ships its adapter map as a var.
-3. Call `(rf/init! reagent-adapter/adapter)` **before any dispatch or render**.
-
-→ See `reference/entry-namespace.md` for the canonical shape, including how `rf/init!` interacts with `rdc/create-root` / `rdc/render`, why `defonce` matters for the React root, and how `(rf/init!)` differs from re-frame v1's implicit boot.
-
-### Step 6 — Write the first counter
-
-A registered event, a registered sub, a registered view (via the `reg-view` macro), and a mount. End-to-end in one file. → See `reference/first-counter.md` for the worked example with explanatory comments. This is the smallest piece of code that exercises every layer (event → handler → app-db change → sub recompute → view re-render).
-
-### Step 7 — Run it and verify
-
-```
-npm install            # if you haven't already
-npx shadow-cljs watch app
-```
-
-Open `http://localhost:<port>/` in a browser (port comes from the `:devtools` block in `shadow-cljs.edn` — typically `:8020`). The counter is visible. Clicking `+` / `-` flips the number. **You're done with setup.**
-
-If the build fails, see *Troubleshooting* below.
-
----
+1. **Discover the current artefact VERSION.** → [`reference/deps-versions.md`](reference/deps-versions.md). Day-one deps: `day8/re-frame2` + `day8/re-frame2-reagent` only.
+2. **Add the two artefacts to `deps.edn`.** → `reference/deps-versions.md` §`deps.edn`.
+3. **Add `react`, `react-dom`, `shadow-cljs` to `package.json`; run `npm install`.** → `reference/deps-versions.md` §`package.json`.
+4. **Write `shadow-cljs.edn`.** One `:target :browser` build, `:init-fn your-app.core/run`, `:source-paths` including `src/`. → [`reference/shadow-cljs.md`](reference/shadow-cljs.md) for the exact shape, the `:devtools` block, and the `index.html`.
+5. **Write the entry namespace.** `your-app/core.cljs` requires `[re-frame.core :as rf]` and `[re-frame.adapter.reagent :as reagent-adapter]`, then calls `(rf/init! reagent-adapter/adapter)` **before any dispatch or render**. → [`reference/entry-namespace.md`](reference/entry-namespace.md) for the canonical shape, the React-root `defonce` pattern, and the order-of-operations contract.
+6. **Write the first counter.** A registered event, sub, view (`reg-view`), and mount — end-to-end in one file. → [`reference/first-counter.md`](reference/first-counter.md).
+7. **Run and verify.** `npx shadow-cljs watch app` → open `http://localhost:<port>/`. Counter visible, `+`/`-` flips the number. **Done.**
 
 ## Done checklist
 
-Tell the author you're done when **all** of these are true:
-
 - [ ] `deps.edn` lists `day8/re-frame2` and `day8/re-frame2-reagent` at the same VERSION.
-- [ ] `package.json` lists `react`, `react-dom`, and `shadow-cljs` (correct versions, see leaf).
-- [ ] `npm install` has completed without errors.
-- [ ] `shadow-cljs.edn` has exactly one `:builds` entry for the app, with an `:init-fn` pointing at the entry ns.
-- [ ] The entry ns calls `(rf/init! reagent-adapter/adapter)` before any render.
+- [ ] `package.json` lists `react`, `react-dom`, `shadow-cljs`.
+- [ ] `npm install` completes without errors.
+- [ ] `shadow-cljs.edn` has one `:builds` entry for the app, `:init-fn` pointing at the entry ns.
+- [ ] Entry ns calls `(rf/init! reagent-adapter/adapter)` before any render.
 - [ ] `shadow-cljs watch <build-id>` compiles cleanly.
-- [ ] The browser shows the counter and clicking `+` / `-` updates it.
+- [ ] Browser shows the counter and `+`/`-` updates it.
 
-Then tell the author: *"Setup is done. From here, switch to the **`re-frame2`** skill — it'll teach you re-frame2's API (events, subs, machines, schemas, frames, fx). If you also want to inspect the running app live from the REPL, install **`re-frame-pair2`**."*
+Hand off: *"Setup is done. Switch to **`re-frame2`** for events/subs/machines/schemas/frames/fx. For live REPL inspection, install **`re-frame-pair2`**."*
 
----
+## Troubleshooting (common build failures)
 
-## Troubleshooting
+- **`Could not locate re-frame/core.cljs`** — artefact not on classpath. Check `deps.edn` and that `shadow-cljs.edn` reads it (`clj -Stree | grep re-frame2`).
+- **`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` not installed. `npm install react react-dom`. Reagent 2.x needs React 18+.
+- **Counter doesn't update, no errors** — `(rf/init! reagent-adapter/adapter)` not called, or called after `rdc/render`. Move it to the top of `run`.
+- **Blank page, no console errors** — `index.html` missing `<div id="app">`, or entry ns looking up a different id.
+- **`Uncaught ReferenceError: re_frame is not defined`** — `:init-fn` in `shadow-cljs.edn` doesn't match the entry-ns `run` symbol. Check `(defn ^:export run [] ...)` matches `:init-fn your-app.core/run`.
 
-A few build failures are specific enough to flag here. Everything else, defer to standard CLJS / shadow-cljs / npm guidance — assume the author already knows those tools.
+Anything else: point at `re-frame2` or `SKILL-REDIRECT.md`.
 
-**`Could not locate re-frame/core.cljs`** — the artefact isn't on the classpath. Re-check `deps.edn` (correct artefact name and version) and that `shadow-cljs.edn` reads from `deps.edn` automatically (it does by default; if the author set `:deps {:aliases [...]}` they may have shadowed the default). Run `clj -Stree | grep re-frame2` to confirm the JAR resolved.
+## Reference files (all one level deep)
 
-**`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` aren't installed (or the wrong major). `npm install react react-dom`. Reagent 2.x requires React 18+.
-
-**Counter doesn't update on click, no errors** — `(rf/init! reagent-adapter/adapter)` wasn't called, or was called after `rdc/render`. The adapter spec map must be installed before any subscription or render runs. Move `rf/init!` to the top of `run`.
-
-**Browser shows a blank page, no errors in console** — `index.html` is missing `<div id="app">`, or the entry ns is looking up a different id. Mismatch between `(js/document.getElementById "app")` and the actual DOM id is by far the most common cause.
-
-**Build compiles but browser console says `Uncaught ReferenceError: re_frame is not defined`** — the `:init-fn` in `shadow-cljs.edn` doesn't match the entry ns / `run` symbol. shadow-cljs needs to find the export; check it's `(defn ^:export run [] ...)` and that `:init-fn your-app.core/run` matches.
-
-If the author hits anything else, point them at the `re-frame2` skill or `SKILL-REDIRECT.md` (the latter has links to the full spec corpus and guide).
-
----
-
-## Deep dives — reference files
-
-For depth on any step, read the matching leaf — they're all one level deep so you can read them in full:
-
-- **`reference/deps-versions.md`** — How to discover the current re-frame2 VERSION; the lockstep contract; deciding which per-feature artefacts to pull in on day one; the `deps.edn` and `package.json` shape.
-- **`reference/shadow-cljs.md`** — The minimal `shadow-cljs.edn` for a single-page Reagent app; the `index.html` that loads the bundle; `:asset-path` and `:devtools` notes.
-- **`reference/entry-namespace.md`** — The canonical `core.cljs` shape; why `rf/init!` must run before any render; the Reagent root pattern (`defonce` + `rdc/create-root`); the order-of-operations contract.
-- **`reference/first-counter.md`** — End-to-end worked example: a registered event, a registered sub, a `reg-view`-defined view, and the mount. Mirrors `examples/reagent/counter/core.cljs` in the re-frame2 repo, trimmed for greenfield.
-
----
-
-## When the author asks anything beyond setup
-
-Setup-out-of-scope questions to re-route:
-
-| Author asks... | Route to... |
-|---|---|
-| "How do I write a sub that depends on another sub?" | **`re-frame2`** skill |
-| "How do I add a state machine?" | **`re-frame2`** skill |
-| "How do I structure my events folder?" | **`re-frame2`** skill |
-| "I'm migrating from re-frame v1." | **`re-frame-migration`** skill |
-| "Can I inspect app-db from the REPL?" | **`re-frame-pair2`** skill |
-| "Help me debug why my view isn't re-rendering." | **`re-frame-pair2`** skill |
-| "Are there worked examples I can study?" | `SKILL-REDIRECT.md` → Examples directory |
-| "Where's the API reference?" | `SKILL-REDIRECT.md` → API |
-
-Don't try to answer these here; this skill is greenfield setup only. Pointing the author at the right next skill is more useful than improvising.
+- [`reference/deps-versions.md`](reference/deps-versions.md) — discover the current re-frame2 VERSION; lockstep contract; per-feature artefact decisions; `deps.edn` + `package.json` shapes.
+- [`reference/shadow-cljs.md`](reference/shadow-cljs.md) — minimal `shadow-cljs.edn`; `index.html`; `:asset-path` + `:devtools`.
+- [`reference/entry-namespace.md`](reference/entry-namespace.md) — canonical `core.cljs`; `rf/init!` before render; the React-root `defonce` pattern.
+- [`reference/first-counter.md`](reference/first-counter.md) — end-to-end worked example mirroring `examples/reagent/counter/core.cljs`.

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -1,176 +1,104 @@
 ---
 name: re-frame2
-description: Writes re-frame2 ClojureScript application code — events, subscriptions, effects, frames, state machines (reg-machine, parallel regions, tags, invoke), schemas, stories, routing, tests, and the canonical patterns (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection). Use this skill whenever the user mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx, reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema, dispatch, subscribe, app-db, frames, regions, tags, the nine UI states, managed HTTP, RemoteData lifecycles, writing tests for a re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2 is not named explicitly. Authoring only (writing new code). For live-app inspection use re-frame-pair2; for greenfield project bootstrap use re-frame2-setup.
+description: Writes re-frame2 ClojureScript application code — events, subscriptions, effects, frames, state machines (reg-machine, parallel regions, tags, invoke), schemas, stories, routing, tests, and the canonical patterns (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx, reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema, dispatch, subscribe, app-db, frames, regions, tags, the nine UI states, managed HTTP, RemoteData lifecycles, writing tests for a re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2 is not named explicitly. Authoring only (writing new code). Do not use for: live-app inspection (use re-frame-pair2), greenfield project bootstrap (use re-frame2-setup), v1→v2 migration (use re-frame-migration), or porting re-frame2 itself (use re-frame2-implementor).
 ---
 
 # re-frame2
 
-Authors re-frame2 ClojureScript application code: events, subscriptions, effects, frames, state machines, schemas, stories, routing, and the canonical patterns. This is a router skill — it carries the cardinal rules and decision shortcuts, and points at one-level-deep reference and pattern leaves for depth.
+Authors re-frame2 ClojureScript application code. Router skill: this file carries decision shortcuts; depth lives one level deep in `reference/`, `patterns/`, and `decision-trees/`.
 
-## When to load this skill
+## When to load
 
-Load when the task is **writing or editing re-frame2 application source** (`.cljs` / `.cljc`): a new event handler, a subscription graph, a state machine, a view, a schema, a route, a story, or any of the canonical patterns. The user does not have to name re-frame2 — references to `reg-event-*`, `reg-sub`, `reg-fx`, `reg-machine`, `dispatch`, `subscribe`, `app-db`, frames, regions, tags, or pattern names are sufficient triggers.
+`.cljs` / `.cljc` authoring of: event handlers, subscriptions, state machines, views, schemas, routes, stories, or the canonical patterns. References to `reg-event-*`, `reg-sub`, `reg-fx`, `reg-machine`, `dispatch`, `subscribe`, `app-db`, frames, regions, tags, or pattern names are sufficient triggers — re-frame2 need not be named.
 
-## When NOT to use this skill
+## When NOT to use
 
 | Prompt shape | Route to |
 |---|---|
 | Inspect, debug, or modify a running re-frame2 app | `skills/re-frame-pair2/` |
-| Set up a new re-frame2 project from scratch (deps.edn, shadow-cljs, boot scaffolding) | `skills/re-frame2-setup/` |
+| Set up a new re-frame2 project from scratch | `skills/re-frame2-setup/` |
 | Migrate an existing re-frame v1 app to v2 | `skills/re-frame-migration/` |
 | Build a NEW re-frame2 implementation in a different host language or substrate | `skills/re-frame2-implementor/` |
-| Understand how the registrar / machine compiler / reactive substrate is implemented | `SKILL-REDIRECT.md` → EP design entries |
-| Read the full API reference, EP rationale, or pattern spec | `SKILL-REDIRECT.md` |
-
-Migration and deep-dive content are deliberately outside this skill — they live behind one redirect file (`SKILL-REDIRECT.md` at repo root), so leaves stay focused on the canonical authoring recipes.
+| Read the full API reference, EP rationale, or spec | `SKILL-REDIRECT.md` |
 
 ## Cardinal rules
 
-These hold across every leaf in this skill.
+1. **Implementation is ground truth.** When spec and `implementation/**` disagree, the implementation wins. Recipes here are verified against `implementation/**` and `examples/reagent/**`.
+2. **Recipes over explanations.** Use the canonical shape; do not re-derive from first principles.
+3. **Distinguish orchestration from state.** State machines for *modes* (legal-transitions-depend-on-current-state); slices for *fields*. See [`decision-trees/slice-or-machine.md`](decision-trees/slice-or-machine.md).
+4. **Schemas at boundaries.** `reg-app-schema` for paths that cross trust boundaries (HTTP payloads, persisted state, snapshot restores). Do not schema-fence every internal key.
+5. **`examples/reagent/<x>/` is canonical.** When a pattern has a worked example, match its shape.
+6. **Frames before globals.** Talk to a frame via `dispatch` / `subscribe`. Do not import frame internals or bypass to mutate state.
+7. **`:rf/*` is reserved.** Application keywords pick their own feature prefix (`:cart/...`, `:auth/...`).
+8. **`reg-*` macros over `register-*` functions.** Macros capture source coordinates that tools rely on; functional registrations are for advanced cases only.
+9. **Pillar 4 — assume training knowledge.** Teach the re-frame2-specific binding, not FSM theory / HTTP retry / React rendering.
 
-1. **Implementation is ground truth.** When the spec and `implementation/**` disagree, the implementation wins. Recipes here are verified against `implementation/**` and `examples/reagent/**`, not against [`spec/`](../../spec/). Spec is *why*; impl is *what*.
-2. **Recipes over explanations.** Reach for a canonical shape; do not derive from first principles. If a pattern leaf exists, use the shape it gives; do not invent a parallel one.
-3. **Distinguish orchestration from state.** Use **state machines** (`reg-machine`) when the answer to "what can the system do next" depends on the current mode (connecting / connected / disconnected; idle / submitting / submitted; loading / loaded / error). Use **slices** (a key in `app-db` driven by `reg-event-db`) when state is a field, not a mode. See `decision-trees/slice-or-machine.md`.
-4. **Schemas at boundaries, not everywhere.** Register `reg-app-schema` for the paths that cross trust boundaries (incoming HTTP payloads, persisted state on restore, machine snapshot restores). Do not schema-fence every internal key.
-5. **Examples in `examples/reagent/<x>/` are canonical.** When a pattern has a worked example, prefer the example's shape over a synthesised one. The example reflects the implementation as currently shipped.
-6. **Frames before globals.** Code talks to a frame (`(rf/dispatch [:foo])` against the default frame; or `(rf/dispatch {:frame :stories} [:foo])` to target one). Do not import frame internals; do not bypass `dispatch` / `subscribe` to mutate state.
-7. **Reserved namespaces are reserved.** The `:rf/*` keyword namespace (including `:rf.machine/*`, `:rf.epoch/*`, `:rf.http/*`, `:rf.error/*`) belongs to the framework. Application keywords pick their own feature prefix.
-8. **`reg-*` macros over `register-*` functions.** The macros capture source coordinates that tools (and `re-frame-pair2`) rely on. The functional registrations exist for advanced cases (programmatic registration, generated registrations) — reach for them only when the macro shape cannot express what you need.
-9. **Pillar 4 — assume training knowledge.** This skill teaches the *re-frame2-specific binding*: which feature implements which idea, the shape of the canonical declaration, the gotcha unique to this framework. It does not re-teach FSM theory, HTTP retry, optimistic updates, or React rendering — that knowledge is assumed.
+## Decision shortcuts
 
-## Decision: state machine, slice, or region?
+**Slice vs machine vs region** — `decision-trees/slice-or-machine.md`. Tell: if the prompt names *transitions* or *modes*, machine. If it names *fields*, *flags*, or *counters*, slice. A sub-concern of a larger feature's lifecycle is a *region* inside that feature's machine, not its own top-level machine.
 
-Quick rule (see `decision-trees/slice-or-machine.md` for the worked rules):
+**Which pattern fits** — `decision-trees/pick-a-pattern.md`. Quick map:
 
-- **Slice** — a single key in `app-db` updated by `reg-event-db`. Use for fields, lists, flags whose value evolves but whose *legal transitions* do not need enforcement.
-- **State machine** (`reg-machine`) — a top-level orchestrator. Use when the legal next transitions depend on the current state; when a feature has more than two interesting modes; when concurrent independent sub-modes exist (use `:fsm/parallel-regions`); when a step needs cancellation semantics (use `:fsm/tags` + cascade).
-- **Region** (a region inside an existing machine, not a top-level `reg-machine`) — Use when the sub-concern is *part of* a larger feature's lifecycle (e.g. a form's submission status inside a screen's load-then-edit lifecycle). The form is a region of the screen; not its own top-level machine.
-
-If unsure between slice and machine, the dominant tell is: *does the prompt mention transitions or modes?* If yes, machine. If it mentions field values or filters or a counter, slice.
-
-## Decision: which pattern fits?
-
-(See `decision-trees/pick-a-pattern.md` for the matrix.)
-
-- **HTTP request with a request/response lifecycle** → Pattern-RemoteData (`patterns/remote-data.md`).
-- **HTTP request that needs status-aware retries, error projection, or batching** → Pattern-ManagedHTTP (`patterns/managed-http.md`) — choose the fx form by default; choose the invokable-machine form when the HTTP call participates in a larger machine's `:invoke` contract.
-- **Form input with validation and submit lifecycle** → Pattern-Forms (`patterns/forms.md`).
-- **Long-running browser-side work (file processing, large reduction)** → Pattern-LongRunningWork (`patterns/long-running-work.md`).
-- **Background-fire-and-forget side effect, no response** → Pattern-AsyncEffect (`patterns/async-effect.md`).
-- **App boot sequence (configure, hydrate, navigate)** → Pattern-Boot (`patterns/boot.md`).
-- **Real-time bidirectional connection lifecycle** → Pattern-WebSocket (`patterns/websocket.md`).
-- **A view that needs to render every legal lifecycle state distinctly** → Pattern-NineStates (`patterns/nine-states.md`).
-- **Long-cached resource whose freshness may need to be checked** → Pattern-StaleDetection (`patterns/stale-detection.md`).
-
-If two patterns apply, prefer the one whose worked example most closely matches the prompt. Patterns compose: a screen can drive Pattern-Forms on submit, fire a Pattern-RemoteData request, and consume a Pattern-WebSocket push, all at once.
-
-## Where the depth lives — loading map
-
-Read the leaf that matches the task. Each leaf is ≤250 lines, target ~150. Read no more than two leaves to start a task; if a task seems to need three or more leaves, the request probably spans patterns and should be broken up.
-
-### Fundamentals — `reference/fundamentals/`
-
-| Task shape | Leaf |
+| Need | Pattern leaf |
 |---|---|
-| Author an event handler (`reg-event-db` / `reg-event-fx` / `reg-event-ctx`) | `reference/fundamentals/events.md` |
-| Author a custom effect (`reg-fx`), shape the `:fx` vector | `reference/fundamentals/fx.md` |
-| Author a coeffect (`reg-cofx`), attach via `inject-cofx` | `reference/fundamentals/cofx.md` |
-| Author a subscription, layered subs, dynamic args, machine subs | `reference/fundamentals/subs.md` |
-| Register an app-db schema; validate at the boundary | `reference/fundamentals/schemas.md` |
-| Understand frames, frame ids, default frame, per-frame config | `reference/fundamentals/frames.md` |
-| Walk the event-state cycle end to end (mental model anchor) | `reference/fundamentals/event-state-cycle.md` |
-| Lay out the source tree — where each kind of file goes | `reference/fundamentals/project-structure.md` |
+| HTTP request with request/response lifecycle | `patterns/remote-data.md` |
+| HTTP with status-aware retries / error projection / batching | `patterns/managed-http.md` |
+| Form input with validation and submit | `patterns/forms.md` |
+| Long-running browser-side work | `patterns/long-running-work.md` |
+| Fire-and-forget side effect, no response | `patterns/async-effect.md` |
+| App boot (configure, hydrate, navigate) | `patterns/boot.md` |
+| Real-time bidirectional connection | `patterns/websocket.md` |
+| View rendering every legal lifecycle state | `patterns/nine-states.md` |
+| Cached resource with freshness checks | `patterns/stale-detection.md` |
 
-### State machines — `reference/state-machines/`
+Patterns compose; a screen can use Forms on submit, RemoteData for the request, and WebSocket for a push.
 
-| Task shape | Leaf |
-|---|---|
-| Author a `reg-machine` with `:states`, `:initial`, `:guards`, `:actions` | `reference/state-machines/reg-machine.md` |
-| Compose parallel regions (single-region + `:type :parallel`) | `reference/state-machines/regions.md` |
-| Declare `:tags` on states, query with `has-tag?` | `reference/state-machines/tags.md` |
-| Use `:invoke` to spawn a child machine; consume its result; `:invoke-all` | `reference/state-machines/invoke.md` |
-| Understand the cancellation cascade — what fires on actor destroy | `reference/state-machines/cancellation.md` |
+## Where the depth lives
 
-For the slice / region / top-level-machine decision, see `decision-trees/slice-or-machine.md`.
+Load at most two leaves per task. If a task seems to need three, it likely spans patterns and should be broken up.
 
-### Tooling — `reference/tooling/`
+**Fundamentals — `reference/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
 
-| Task shape | Leaf |
-|---|---|
-| Author a story (`reg-story` / variants); use stories as a unit-test substrate | `reference/tooling/stories.md` |
-| Register a route, navigate, gate with `:can-leave?` | `reference/tooling/routing.md` |
+**State machines — `reference/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `invoke.md` (child machines), `cancellation.md`.
 
-### Cross-cutting — `reference/cross-cutting/`
+**Tooling — `reference/tooling/`**: `stories.md`, `routing.md`.
 
-| Task shape | Leaf |
-|---|---|
-| Write a test (`with-frame`, `dispatch-sync`, `compute-sub`, schema-aware fixtures) | `reference/cross-cutting/testing.md` |
-| Look up a `reg-*` family signature without loading a fundamentals leaf | `reference/cross-cutting/api-cheatsheet.md` |
+**Cross-cutting — `reference/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`.
 
-### Patterns — `patterns/`
+**Patterns — `patterns/`**: one leaf per canonical pattern (see table above). Each leaf opens with load triggers, the canonical mini-declaration, the re-frame2 features it uses, trade-offs, and the worked-example link. Cross-reference of pattern → example app: `examples-map.md`.
 
-One leaf per canonical pattern. Each leaf opens with load triggers, gives the canonical mini-declaration (verified against `implementation/**` + `examples/reagent/**`), names the re-frame2 features the pattern uses, lists trade-offs, and links to the worked example.
-
-| Pattern | Leaf | Worked example |
-|---|---|---|
-| RemoteData | `patterns/remote-data.md` | (mini-example inline; example app pending) |
-| Forms | `patterns/forms.md` | `examples/reagent/login/` |
-| Boot | `patterns/boot.md` | `examples/reagent/boot/` |
-| WebSocket | `patterns/websocket.md` | `examples/reagent/websocket/` (pending) |
-| NineStates | `patterns/nine-states.md` | `examples/reagent/nine_states/` |
-| ManagedHTTP | `patterns/managed-http.md` | `examples/reagent/managed_http_counter/` |
-| AsyncEffect | `patterns/async-effect.md` | (mini-example inline) |
-| LongRunningWork | `patterns/long-running-work.md` | `examples/reagent/long_running_work/` (pending) |
-| StaleDetection | `patterns/stale-detection.md` | (mini-example inline) |
-
-For the cross-reference of pattern → example app, see `examples-map.md`.
-
-### Decision trees — `decision-trees/`
-
-| Question | File |
-|---|---|
-| "I want to build X — which pattern?" | `decision-trees/pick-a-pattern.md` |
-| "Should this be a slice, a region, or a top-level machine?" | `decision-trees/slice-or-machine.md` |
+**Decision trees — `decision-trees/`**: `pick-a-pattern.md`, `slice-or-machine.md`.
 
 ## Authoring workflow (every task)
 
-A short checklist that applies regardless of which leaf you load.
-
-1. **Identify the surface.** What is being registered: event? sub? fx? cofx? view? machine? route? story? schema? More than one?
-2. **Load at most two leaves.** The relevant fundamentals or pattern leaf, plus a second leaf only if the task spans two surfaces (e.g. a sub plus its machine).
-3. **Read the canonical declaration in the leaf.** Match its shape — do not re-derive.
-4. **Pick the feature prefix.** Application keywords use the app's own namespace (e.g. `:cart/...`, `:auth/...`). Never start an application keyword with `:rf/` or any `:rf.*` namespace — those are reserved.
-5. **Cross-check `examples/reagent/<x>/`.** If the pattern has a worked example, scan it for the shape this leaf describes. The example reflects the implementation as shipped.
-6. **Add a schema only when crossing a boundary.** Incoming HTTP payloads, persisted state on restore, machine snapshot restores — schema these. Do not schema-fence every internal key.
-7. **Write the code.** Use the `reg-*` macros (not `register-*` functions) unless the macro shape cannot express what you need.
-8. **Apply the cut-test (Pillar 4).** Every comment line: would I write this same comment in a React, Vue, or Elm app? If yes, cut it. Comments earn their tokens by saying something specific to re-frame2.
-
-## How re-frame2 differs from re-frame v1
-
-A one-line redirect for v1-trained context: the migration workflow + breaking-change rule index lives in `skills/re-frame-migration/`; the authoritative rule corpus is [`MIGRATION.md`](../../spec/MIGRATION.md) (linked from `SKILL-REDIRECT.md` → *Migration from re-frame v1*). Do not re-derive v1 mappings from training memory — the v1→v2 surface drift is large enough that confident recall is unreliable.
-
-## Background reading (optional)
-
-These do not need to be loaded for routine authoring tasks. Reach for them when the user asks "why does it work this way?" or when designing a feature whose shape isn't obvious from a single leaf.
-
-- `SKILL-REDIRECT.md` → *Principles* — the AI-first principles the framework was designed around.
-- `SKILL-REDIRECT.md` → *Conventions* — naming, keyword namespaces, source-coord conventions.
-- `SKILL-REDIRECT.md` → *Construction prompts* — the AI-shaped templates used during framework authoring.
-- `SKILL-REDIRECT.md` → *EP design rationale* — the per-feature design documents.
+1. Identify the surface — event? sub? fx? cofx? view? machine? route? story? schema?
+2. Load at most two leaves (the relevant fundamentals or pattern; a second only if the task spans two surfaces).
+3. Match the canonical declaration in the leaf; do not re-derive.
+4. Pick the feature prefix (`:cart/...`, `:auth/...`) — never `:rf/*`.
+5. Cross-check the worked example in `examples/reagent/<x>/` when one exists.
+6. Schema only at boundaries.
+7. Use `reg-*` macros unless the macro shape can't express the need.
+8. Cut-test comments: would I write this same comment in a React / Vue / Elm app? If yes, cut it.
 
 ## Done checklist
 
-Before considering an authoring task complete:
+- [ ] Ids do not collide (`grep` the codebase for the chosen id).
+- [ ] Schema registered for any new boundary.
+- [ ] No `:rf.*` application keywords.
+- [ ] Cut-test passed on comments.
+- [ ] Shape matches the canonical declaration in the leaf.
+- [ ] If a worked example exists, the new code's shape matches it.
 
-- [ ] The registered ids do not collide with existing ones (`grep` the codebase for the chosen id).
-- [ ] Schema is registered for any boundary the new code crosses.
-- [ ] No `:rf.*` application keywords leaked in.
-- [ ] The cut-test passed on comments (no React/Vue-shaped explanations).
-- [ ] The shape matches the canonical declaration in the leaf (no re-derived shape).
-- [ ] If a worked example exists for this pattern, the new code's shape matches it.
+The user runs tests / compiler / app; this skill does not.
 
-The user runs the test suite, the compiler, and the app. This skill does not run them; that is outside its scope.
+## How re-frame2 differs from re-frame v1
+
+For v1-trained context: migration workflow + breaking-change rule index lives in `skills/re-frame-migration/`; the authoritative rule corpus is [`MIGRATION.md`](../../spec/MIGRATION.md). Do not re-derive v1 mappings from training memory.
+
+## Background reading (optional)
+
+Reach for these when the user asks "why does it work this way?" or designs a feature whose shape isn't obvious. All route via `SKILL-REDIRECT.md` at the repo root: *Principles*, *Conventions*, *Construction prompts*, *EP design rationale*.
 
 ---
 
-*This skill targets re-frame2 (the v2 line). For the v1 line, see [re-frame](https://github.com/day8/re-frame). For live-app inspection, see `skills/re-frame-pair2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For migrating a v1 codebase to v2, see `skills/re-frame-migration/`. For building a new re-frame2 implementation in a different host language or substrate, see `skills/re-frame2-implementor/`. All deep-dive links route through `SKILL-REDIRECT.md` at the repo root.*
+*re-frame2 (v2 line). v1: [re-frame](https://github.com/day8/re-frame). Live-app inspection: `skills/re-frame-pair2/`. Greenfield bootstrap: `skills/re-frame2-setup/`. v1→v2 migration: `skills/re-frame-migration/`. New re-frame2 implementation in another host/substrate: `skills/re-frame2-implementor/`. Deep-dive links route through `SKILL-REDIRECT.md`.*


### PR DESCRIPTION
## Summary

Anthropic's recommended router-SKILL size is ~3-5KB; every SKILL.md in the corpus was 2-4x over budget. This pass trims router files to one TRIGGER + DECISION + LOAD-LEAF screen and pushes long-form content to `reference/` leaves.

Per-skill before/after:

| Skill | Before | After | Delta | Notes |
|---|---:|---:|---:|---|
| `re-frame2-implementor` | 19,518 B / 185 L | 7,674 B / 101 L | -61% | Cardinal rules detail + anti-patterns moved to new `reference/cardinal-rules.md`. Phase 1 / Phase 2 enumerations compressed to one-liner pointers at the already-existing `phase-{1-decisions,2-impl-order}.md` leaves. |
| `re-frame-migration` | 15,765 B / 166 L | 8,720 B / 104 L | -45% | Phase narratives that re-explained `reference/setup.md` / `sequencing.md` compressed to one-liners; cardinal rules / anti-patterns tightened. |
| `re-frame2` | 15,317 B / 176 L | 7,565 B / 104 L | -51% | Loading-map table cut to one paragraph per area; per-pattern paragraphs compressed to a single decision table; authoring workflow tightened. |
| `re-frame2-setup` | 11,929 B / 173 L | 6,070 B / 80 L | -49% | Seven-step path compressed to one line per step; troubleshooting kept top-level but tightened; duplicate routing table removed (description frontmatter + "When NOT to use" already cover it). |
| `re-frame-pair-improver2` | 11,035 B / 171 L | 7,623 B / 85 L | -31% | 13-row lens table delegated to existing `references/analysis-lenses.md`; analysis workflow / working style / filing improvements blocks tightened. |
| `re-frame-pair2` | 11,430 B / 160 L | unchanged | — | Just trimmed in #550; bead judges it lean and best-in-corpus. |
| **Total** | **84,994 B / 1,031 L** | **49,082 B / 634 L** | **-42% / -35,912 B** | |

Description frontmatter also tightened on each touched skill — added "Do not use for..." sentences where missing, sharpened activation triggers.

## Test plan

- [ ] Read each trimmed `SKILL.md` end-to-end and confirm the trigger story still resolves: someone scanning to decide "do I use this skill?" / "which leaf do I load?" reaches the answer in one screen.
- [ ] Verify all `reference/*` and `references/*` links resolve (spot-check done; every leaf the SKILL.md points at exists in the corresponding dir).
- [ ] Confirm new `skills/re-frame2-implementor/reference/cardinal-rules.md` carries the full prose of rules 1-8 plus the anti-pattern corollaries.
- [ ] For each trimmed SKILL.md, walk one common task ("write a `reg-event-fx`", "migrate `re-frame.db` reach-through", "scaffold a counter", "diagnose a stuck attach") and verify the router routes it to the right leaf without help.

Bead: `rf2-ve7px` (do not close on merge — author wants a follow-on pass to keep `re-frame2-implementor` and `re-frame2` closer to the 3KB stretch goal).