### PR TITLE
docs(conformance): cross-link capability-tag README example to actual fixtures (rf2-gm0o8)

### DIFF
--- a/spec/Implementor-Checklist.md
+++ b/spec/Implementor-Checklist.md
@@ -472,6 +472,8 @@ The harness (per [conformance/README §How an implementation runs the corpus](co
 - `:ssr/*` — run if Q3 yes.
 - `:schemas/*` — run if Q4 yes (regardless of mechanism).
 
+See [conformance/README §Capability tagging worked example](conformance/README.md#capability-tagging-worked-example) for a five-fixture cross-section showing the tag conventions in practice on real corpus entries — useful as a copy-from reference when authoring the implementation's harness manifest.
+
 The corpus is the **acceptance test** for [Goal 2 — AI-implementable from the spec alone](000-Vision.md#ai-implementable-from-the-spec-alone). A fixture an AI cannot reproduce without consulting outside sources is a **spec gap**, not an implementation gap; remediation is to fix the spec corpus, not the implementation.
 
 ---

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -42,7 +42,7 @@ The classic shape: a starting state (frame configuration plus initial `app-db`),
 ```clojure
 {:fixture/id           :counter/inc-once
  :fixture/doc          "Single increment of the counter."
- :fixture/capabilities #{:core/event-handler :core/sub :core/trace}     ;; per §Capability tagging below
+ :fixture/capabilities #{:core/event-handler :core/sub}                ;; per §Capability tagging below — see also §Capability tagging worked example
  :fixture/registry    {:event {:counter/initialise {:doc "Seed."}
                                :counter/inc        {:doc "Increment."}}
                        :sub   {:count             {:doc "Current count."}}
@@ -150,7 +150,21 @@ Capability tag conventions:
 
 A flat-FSM-only port declares `:capabilities #{:core/event-handler ... :fsm/flat :actor/own-state :actor/spawn-destroy ...}` in its harness manifest; the corpus runs every fixture whose capabilities are a subset and skips the rest. The aggregate score is `passed / claimed-applicable` — an accounting of what works for the claimed list.
 
-The `:fixture/handlers` entries in both modes are written in the handler-body DSL described next: pure data the host realises into native closures. No host-specific code ships in the fixtures.
+See [§Capability tagging worked example](#capability-tagging-worked-example) immediately below for the actual tags carried by representative fixtures in the corpus today.
+
+### Capability tagging worked example
+
+The conventions above describe the schema; the corpus itself shows what those tags look like in practice. The following five fixtures are pulled verbatim from `fixtures/` — together they span the main capability axes (core, FSM hierarchy, actor model, flow tracing, managed HTTP). An AI port author landing fresh can use these as a tag-vocabulary reference rather than inventing names.
+
+| Fixture | `:fixture/capabilities` | What the tag set means |
+|---|---|---|
+| `counter-inc-once.edn` | `#{:core/event-handler :core/sub}` | The simplest pattern-required-only fixture: a single event handler, one sub. Every conformant port runs this. |
+| `after-hierarchy.edn` | `#{:fsm/hierarchical :fsm/delayed-after}` | A parent compound state with an `:after` timer. Only ports that claim both hierarchical FSM and `:after` will run it. |
+| `spawn-from-action.edn` | `#{:fsm/flat :actor/spawn}` | Imperative spawn of a child actor from inside a transition action. Requires the actor-model spawn capability on top of flat FSMs. |
+| `flow-lifecycle-emits-traces.edn` | `#{:core/event-handler :flow/basic :flow/trace}` | The flow primitive emits its five lifecycle trace events. Requires the flow substrate and the flow-trace stream. |
+| `http-managed-get-success.edn` | `#{:core/event-handler :core/sub :core/fx :rf.http/managed}` | The managed-HTTP fx happy path. Builds on the core triad and adds the managed-HTTP capability from [Spec 014](../014-HTTPRequests.md). |
+
+Read the chosen tag namespaces from the [conventions list above](#capability-tagging) and refer back to this table when authoring a new fixture or a port's harness manifest: copy the tag from the closest existing fixture rather than coining a new one.
 
 ### Handler bodies as data
 


### PR DESCRIPTION
## Summary

- The conformance README's capability-tagging explainer described `:fixture/capabilities` in the abstract but had no concrete cross-section of real fixtures. The worked Mode-A code example also carried an aspirational `:core/trace` tag that no fixture in the corpus actually uses, so a reader copying it would produce a manifest claim matching nothing.
- Add a "Capability tagging worked example" subsection right after the existing explainer, tabulating five representative fixtures pulled verbatim from `fixtures/` — `counter-inc-once.edn`, `after-hierarchy.edn`, `spawn-from-action.edn`, `flow-lifecycle-emits-traces.edn`, `http-managed-get-success.edn` — each with its actual `:fixture/capabilities` set and a one-line gloss of what the tag combination means. Together they span the main axes: core, hierarchical FSM + `:after`, actor spawn, flow tracing, managed HTTP.
- Drop the bogus `:core/trace` tag from the Mode-A code example so the inline sample matches the real `counter-inc-once.edn`, and add forward-references both from the explainer and from `Implementor-Checklist.md` Part 3 so readers reach the new worked example from either entry point.

Surface: `spec/conformance/README.md` + a one-paragraph cross-link from `spec/Implementor-Checklist.md` Part 3. No fixture EDN changed.

Tracks: `rf2-gm0o8`.

## Test plan

- [x] `python -m mkdocs build --strict` — no new warnings vs. `origin/main` baseline (both fail at 122 pre-existing guide/skills warnings unrelated to this change).
- [x] `python scripts/check_doc_slugs.py` — clean (the new `[Spec 014](../014-HTTPRequests.md)` link resolves; one initial typo was caught and fixed).
- [x] Anchors `#capability-tagging` (back-link) and `#capability-tagging-worked-example` (forward-link from explainer + Implementor-Checklist) both resolve in the rendered README.
- [x] All five cited fixtures verified to carry the listed `:fixture/capabilities` set verbatim — no aspirational tags introduced.