### PR TITLE
docs(causa): drop 1.0.0 version pin + reframe causa-mcp as planned (rf2-jqp7z)

### DIFF
--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -23,9 +23,10 @@ bus, Tool-Pair epoch history, the registrar query API) — it adds
 nothing the framework didn't already expose. The 16 panels are
 *presentation* of an already-structured runtime.
 
-A separate jar `tools/causa-mcp/` exposes Causa's surfaces as MCP tools
-for AI agents — same architecture as `tools/pair2-mcp/`, different tool
-catalogue.
+A separate jar `tools/causa-mcp/` is planned to expose Causa's surfaces
+as MCP tools for AI agents — same architecture as `tools/pair2-mcp/`,
+different tool catalogue. The artefact does not yet exist on disk; the
+contract is being designed in [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md).
 
 ## Headline experiences
 
@@ -47,10 +48,17 @@ Full panel inventory in [`spec/000-Vision.md`](./spec/000-Vision.md).
 
 ### Install
 
+Until the alpha publish lands on Clojars, use the `:local/root` route
+from a checkout of this repo:
+
 ```clojure
 ;; deps.edn (dev alias only)
-{:aliases {:dev {:extra-deps {day8/re-frame2-causa {:mvn/version "1.0.0"}}}}}
+{:aliases {:dev {:extra-deps {day8/re-frame2-causa {:local/root "tools/causa"}}}}}
 ```
+
+Once published, the dev-deps coord will be
+`day8/re-frame2-causa {:mvn/version "0.0.1.alpha"}` (tracking the repo
+`VERSION`).
 
 ### Enable
 
@@ -79,19 +87,27 @@ Remove the `:preloads` entry, or set
 `:closure-defines {day8.re-frame2-causa.config/enabled? false}` to
 force-disable in dev.
 
-### MCP (Causa as an agent surface)
+### MCP (Causa as an agent surface) — planned
+
+A separate `tools/causa-mcp/` artefact is in design — it will expose
+Causa's surfaces as MCP tools so AI agents can drive the same
+observations through a tool catalogue. Neither the jar nor the npm
+wrapper ships yet.
+
+When the artefact lands, the consumer-side wiring will look roughly
+like this (the exact coord names are not final):
 
 ```bash
+# planned — not yet published
 npm install -g @day8/re-frame2-causa-mcp
 ```
 
-Add to `~/.claude/settings.json`:
-
 ```json
+// planned — ~/.claude/settings.json
 { "mcpServers": { "causa": { "command": "re-frame2-causa-mcp" } } }
 ```
 
-Tool catalogue in [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md).
+Tool catalogue under design in [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md).
 
 ## Spec
 


### PR DESCRIPTION
@
## Summary

`tools/causa/README.md` over-claimed shipped artefacts. Brings it back
in line with on-disk reality.

- **Version pin** — Quick-start dev-deps pinned `:mvn/version "1.0.0"` while
  repo `VERSION` is `0.0.1.alpha` and Clojars has not been cut. Replaced
  with the `:local/root "tools/causa"` idiom (mirroring
  `tools/template/README.md`), with the post-publish mvn coord shown as
  `0.0.1.alpha` once the alpha publish lands.
- **MCP section** — `npm install -g @day8/re-frame2-causa-mcp` was
  presented as if shipped, but `tools/causa-mcp/` does not exist on
  disk. Section header now reads "MCP (Causa as an agent surface) —
  planned"; install + settings snippets annotated as planned wiring;
  coord names noted as not-final.
- **Opening blurb** — mention of the separate `tools/causa-mcp/` jar now
  reads as "planned" with a pointer to `spec/010-MCP-Server.md`.

Surface scope: `tools/causa/README.md` only. No spec/, no code.

Bead: rf2-jqp7z. Sourced from `ai/findings/sweep-readmes-currency-2026-05-13.md`.

## Test plan

- [x] Render reviewed locally; no broken links introduced.
- [x] Status footer ("In design. … Implementation work begins after the
      spec ratifies.") is now consistent with the body.
- [x] `:local/root` idiom matches `tools/template/README.md`.
@