### PR TITLE
docs(MIGRATION): drop 'maximum back-compat' framing — pre-alpha stance (rf2-hblle)

### DIFF
--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1989,10 +1989,10 @@ Sections below are written in second person to an AI agent performing the migrat
 
 ### Your task
 
-You are migrating a ClojureScript codebase from re-frame v1.x to **re-frame2**. The headline expectation is that **most codebases require no changes at all** — re-frame2 is designed for maximum backwards compatibility. Your job is to:
+You are migrating a ClojureScript codebase from re-frame v1.x to **re-frame2**. re-frame2 is a **small, well-defined breaking-change set** on top of the v1 `re-frame.core` API — most call sites compile unchanged, but the breakages are real (40+ M- and O-rules in Part 1) and you are the mechanism that applies them. The median migration is M-0 plus a handful of compile errors; the worst case touches a dozen surfaces. Your job is to:
 
-1. **Apply [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — bump the dep coord to `day8/re-frame2`. Then verify the codebase compiles and runs with nothing else changed.** This is the success path for the majority of projects.
-2. **If compilation or runtime failures occur, identify which migration rule (`M-N` in Part 1) applies, apply it, and re-verify.**
+1. **Apply [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — bump the dep coord to `day8/re-frame2` (plus the substrate adapter).** Then attempt to compile and run. M-0 is mandatory; nothing else can be verified without it.
+2. **Sweep the codebase against the M-rules in Part 1.** Apply Type A rewrites mechanically; flag Type B sites and wait for the user's decision. Re-verify after each pass.
 3. **Optionally, if the user has asked you to also modernise the codebase, apply the opt-in upgrades (the `O-N` rules in Part 1).** Do not do this unless asked.
 4. **Report back** — succinctly summarise what changed, why, and what still needs attention.
 


### PR DESCRIPTION
## Summary

Closes the headline contradiction in `spec/MIGRATION.md` §Your task (bead rf2-hblle).

The §Your task section (line 1992) previously claimed:

> "The headline expectation is that **most codebases require no changes at all** — re-frame2 is designed for maximum backwards compatibility."

This directly contradicts:

- The 40+ M-/O-rules in the same document, including Type-A mandatory rewrites for namespace renames, effect-map shape changes, removed interceptors, removed surfaces.
- The CHANGELOG entry "Removed: The `re-frame/re-frame` 1.x compatibility shim. v1 and v2 cannot coexist on a single classpath".
- The pre-alpha "back-compat is not a concern" stance.

## What changes

Reframes step 1 + intro of §Your task to match the honest voice already used in `docs/guide/18-from-re-frame-v1.md`:

> "re-frame2 is a small, well-defined breaking-change set on top of the v1 `re-frame.core` API — most call sites compile unchanged, but the breakages are real (40+ M- and O-rules in Part 1) and you are the mechanism that applies them. The median migration is M-0 plus a handful of compile errors; the worst case touches a dozen surfaces."

Also tightens step 1 + 2 to describe the actual workflow (bump-then-sweep) rather than "bump and hope nothing breaks". The "What stays the same" non-breakage list, M-rules, classification, and procedure are untouched.

## Scope

`spec/MIGRATION.md` only — 3 insertions, 3 deletions. Intro paragraph (line 23) already reads "vast majority of code, with migration cost held to a small, well-defined set of breakages" which is already aligned; left unchanged.

## Test plan

- [x] No code touched; doc-only.
- [x] `grep -i -E "drop-in|preserve v1|backwards compat|backward-compat"` on MIGRATION.md returns nothing.