### PR TITLE
docs(examples): add README for counter_slim_and_fast (rf2-zy2rk)

### DIFF
--- a/examples/reagent/counter_slim_and_fast/README.md
+++ b/examples/reagent/counter_slim_and_fast/README.md
@@ -1,0 +1,103 @@
+# counter-slim-and-fast — slim-substrate counter
+
+The canonical counter (`examples/reagent/counter/`) re-mounted on the
+[`day8/reagent-slim`](https://github.com/day8/reagent-slim) rewrite
+rather than stock `day8/re-frame2-reagent` (the thin bridge over
+stock Reagent). The user-visible behaviour is identical to the
+canonical counter; the difference is the substrate beneath.
+
+Every user-facing Reagent import points at `reagent2.*` instead of
+stock `reagent.*`, and `(rf/init!)` is called with
+`re-frame.adapter.reagent-slim/adapter`. The same six-domino
+dataflow flows through a different reactive substrate.
+
+## What this example demonstrates
+
+The S3-008 + S3-005 contract from
+[`implementation/adapters/reagent-slim/IMPL-SPEC.md`](../../../implementation/adapters/reagent-slim/IMPL-SPEC.md)
+§1.4 + §1.8 + §8 — a binding bundle-comparison claim about the
+slim substrate:
+
+1. **Stock-Reagent impl isolation.** The advanced-compiled bundle for
+   this example contains NO `reagent.impl.*` symbols. The slim
+   rewrite has its own `reagent2.impl.*` substrate; the bridge's
+   `reagent.impl.*` internals must be entirely absent.
+2. **Pure-CLJS SSR.** The bundle contains NO `react-dom/server`
+   symbols, even though `run` exercises
+   `reagent2.dom.server/render-to-static-markup` at boot. The slim's
+   SSR seam is pure-CLJS (per IMPL-SPEC §8.7), so the bundle has no
+   compiled-in path to `react-dom/server`.
+3. **Methodology control.** The stock-Reagent counter bundle
+   (`examples/counter`) MUST still contain both groups of symbols —
+   that proves the grep has signal. If a future stock-Reagent upgrade
+   DCEs them out of the stock bundle too, the test fails loudly and
+   the sentinel set gets re-derived.
+
+The grep that enforces all three invariants lives at
+[`implementation/scripts/check-counter-slim-and-fast.cjs`](../../../implementation/scripts/check-counter-slim-and-fast.cjs);
+the CI job is `cljs-bundle-comparison` in
+`.github/workflows/test.yml`.
+
+The slim adapter is also a drop-in for the bridge at the
+behavioural level: same clicks, same counts. The Playwright spec
+runs the exact assertions as the canonical counter's spec —
+initial render shows 5, `+` → 6, two `-` → 4.
+
+## Files
+
+```
+counter_slim_and_fast/
+  core.cljs                          mount + events/subs/view + SSR exercise
+  index.html                         minimal host page
+  counter_slim_and_fast.spec.cjs     Playwright smoke (drop-in parity with counter)
+  README.md                          this file
+```
+
+The bundle-comparison verifier is repo-level rather than per-example
+and lives under `implementation/scripts/`.
+
+## How to run
+
+The example is wired into the canonical examples harness. From
+`implementation/`:
+
+```bash
+npm run test:examples
+```
+
+That compiles every example (this one builds under shadow-cljs id
+`examples/counter-slim-and-fast`), stages its `index.html` into
+`out/examples/counter-slim-and-fast/`, serves the lot on port 8030,
+and runs the Playwright smoke spec.
+
+The bundle-comparison contract is exercised separately by the
+`cljs-bundle-comparison` CI job. To run it locally:
+
+```bash
+# From implementation/ — release both bundles, then grep.
+npx shadow-cljs release examples/counter examples/counter-slim-and-fast
+node scripts/check-counter-slim-and-fast.cjs
+```
+
+To iterate on the source alone, watch the build directly from
+`implementation/`:
+
+```bash
+shadow-cljs watch examples/counter-slim-and-fast
+```
+
+(Run `npm run test:examples` once first so
+`out/examples/counter-slim-and-fast/index.html` is staged; subsequent
+watch builds reuse it.)
+
+## Cross-references
+
+- [`examples/reagent/counter/`](../counter/) — the canonical counter
+  on the stock-Reagent bridge; this example's behavioural twin.
+- [`implementation/adapters/reagent-slim/IMPL-SPEC.md`](../../../implementation/adapters/reagent-slim/IMPL-SPEC.md)
+  §1.4 + §1.8 + §8 — the spec the bundle-comparison contract binds
+  to.
+- [`spec/006-ReactiveSubstrate.md`](../../../spec/006-ReactiveSubstrate.md) —
+  the substrate contract the slim adapter satisfies.
+- [`spec/Conventions.md` §Adapter test matrix policy](../../../spec/Conventions.md#adapter-test-matrix-policy) —
+  why the slim build sits alongside the bridge build in CI.


### PR DESCRIPTION
## Summary

- Adds the missing per-example `README.md` for `examples/reagent/counter_slim_and_fast/`. Every other Reagent worked example already has one — this closes the inconsistency surfaced by the README sweep that fed rf2-2hrdg.
- Documents what the example proves: the S3-008 + S3-005 bundle-comparison contract (no `reagent.impl.*`, no `react-dom/server` in the slim's advanced bundle) plus drop-in behavioural parity with the canonical counter.
- Cross-refs `IMPL-SPEC.md` §1.4 + §1.8 + §8, `spec/006-ReactiveSubstrate.md`, and the canonical counter example.

## Test plan

- [ ] Browsing `examples/reagent/counter_slim_and_fast/` now shows a README that matches the shape and depth of `boot/README.md` / `todomvc/README.md`.
- [ ] Cross-references resolve to existing paths (canonical counter, IMPL-SPEC, Spec 006, Conventions).