### PR TITLE
cut(epoch): drop legacy :rf/snapshot-version top-level slot tolerance (rf2-8tv7h)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -557,12 +557,9 @@
 (defn- snapshot-version
   "Read the recorded snapshot's `:rf/snapshot-version`. Per
   Spec-Schemas §`:rf/machine-snapshot` and Spec 005 §Snapshot shape,
-  the canonical slot is `[:meta :rf/snapshot-version]`. Tolerates
-  the legacy top-level `:rf/snapshot-version` slot for snapshots
-  written before the meta-nesting was finalised."
+  the canonical slot is `[:meta :rf/snapshot-version]`."
   [snapshot]
-  (or (get-in snapshot [:meta :rf/snapshot-version])
-      (:rf/snapshot-version snapshot)))
+  (get-in snapshot [:meta :rf/snapshot-version]))
 
 (defn- machine-definition-version
   "Read the currently-registered machine definition's
@@ -612,9 +609,7 @@
 
   Per rf2-ocg1: both versions are read through the public Spec 005
   §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`
-  and the registered machine's `[:meta :rf/snapshot-version]`. The
-  legacy top-level `:rf/snapshot-version` slot on the snapshot is
-  tolerated for back-compat."
+  and the registered machine's `[:meta :rf/snapshot-version]`."
   [db]
   (some (fn [[machine-id snapshot]]
           (let [recorded (snapshot-version snapshot)]

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -556,40 +556,6 @@
           (is (= 1 (:version-recorded (:tags ev))))
           (is (= 2 (:version-current  (:tags ev)))))))))
 
-(deftest restore-version-legacy-snapshot-slot-tolerated
-  (testing "snapshots written before :rf/snapshot-version moved into :meta
-  remain comparable. The legacy top-level slot resolves to the same recorded
-  version. Per rf2-ocg1 (back-compat tolerance)."
-    (rf/reg-frame :test/main {})
-    (rf/reg-machine :machine/tl
-      {:initial :red
-       :meta    {:rf/snapshot-version 1}
-       :states  {:red {} :green {}}})
-    ;; Commit a snapshot with the LEGACY top-level slot.
-    (rf/reg-event-db :put-snap
-      (fn [db _]
-        (assoc-in db [:rf/machines :machine/tl]
-                  {:state :red :data {} :rf/snapshot-version 1})))
-    (rf/dispatch-sync [:put-snap] {:frame :test/main})
-
-    (let [target (last (rf/epoch-history :test/main))]
-      ;; Bump definition version.
-      (rf/reg-machine :machine/tl
-        {:initial :red
-         :meta    {:rf/snapshot-version 2}
-         :states  {:red {} :green {}}})
-
-      (let [recorded (record-trace!)
-            ok?      (rf/restore-epoch :test/main (:epoch-id target))]
-        (is (false? ok?))
-        (let [ev (some (fn [ev]
-                         (when (= :rf.epoch/restore-version-mismatch (:operation ev))
-                           ev))
-                       @recorded)]
-          (is (some? ev))
-          (is (= 1 (:version-recorded (:tags ev))))
-          (is (= 2 (:version-current  (:tags ev)))))))))
-
 (deftest restore-failure-during-drain
   (testing "restore-epoch called from inside a drain fires :rf.epoch/restore-during-drain"
     (rf/reg-frame :test/main {})


### PR DESCRIPTION
## Summary

Pre-alpha cut. The epoch snapshot-version reader tolerated a legacy top-level `:rf/snapshot-version` slot for snapshots written before the meta-nesting was finalised. That was intra-v2 back-compat with no real users — cut.

- `snapshot-version` now reads only `[:meta :rf/snapshot-version]`
- Drop the tolerance clause from the docstring and from `machine-version-mismatch`
- Delete `restore-version-legacy-snapshot-slot-tolerated` test

The canonical `[:meta :rf/snapshot-version]` path remains covered by `restore-failure-version-mismatch`.

## Scope

- `implementation/epoch/src/re_frame/epoch.cljc`
- `implementation/epoch/test/re_frame/epoch_test.clj`

No spec docs referenced the legacy slot — they all already point at the canonical `[:meta :rf/snapshot-version]` path.

## Test plan

- [x] Epoch JVM suite: 58 tests, 229 assertions, 0 failures, 0 errors