### PR TITLE
cut(fx): drop unregister-fx back-compat alias + sole call site (rf2-3epl4)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -103,11 +103,6 @@
   ([] (registrar/clear-kind! :fx))
   ([id] (registrar/unregister! :fx id)))
 
-;; Back-compat alias retained transiently — internal callers may still
-;; reach for `unregister-fx`. Pre-alpha: prefer `clear-fx`; the alias
-;; can be cut once internal references are migrated.
-(def unregister-fx clear-fx)
-
 ;; ---- the platform predicate -----------------------------------------------
 
 (defn- fx-runs-on-platform? [meta active-platform]

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -379,7 +379,7 @@
 ;; ---- clear-fx round-trip (rf2-634y) --------------------------------------
 ;;
 ;; Per Spec 002 / API.md §Lifecycle and `core.cljc:869`: `rf/clear-fx` is
-;; an alias of `fx/unregister-fx`. Used by hot-reload tooling and by
+;; an alias of `fx/clear-fx`. Used by hot-reload tooling and by
 ;; `http_managed.cljc:1606` for stub uninstall. Pre-rf2-634y no test
 ;; pinned this behaviour.
 ;;

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -137,7 +137,7 @@
 
 (defn uninstall-managed-request-stubs!
   []
-  (fx/unregister-fx stub-fx-id)
+  (fx/clear-fx stub-fx-id)
   nil)
 
 (defn with-managed-request-stubs*


### PR DESCRIPTION
## Summary

- `fx/unregister-fx` was a self-acknowledged transient back-compat alias for `fx/clear-fx`; its own comment named the end-state ("cut once internal references are migrated").
- Single internal call site lived in `http_machine_wrapper.cljc`'s `uninstall-managed-request-stubs!` — rewritten to the canonical `fx/clear-fx`.
- Test comment in `fx_test.clj` that referenced the alias by name updated to point at the canonical fn.
- Pre-alpha sweep (`ai/findings/sweep-backcompat-cuts-2026-05-13.md` §S4 / B-4, P2). No deprecation cycle warranted.

## Test plan

- [x] JVM core: `clojure -M:test` from `implementation/core/` — 353 tests, 1959 assertions, 0 failures, 0 errors.
- [x] JVM http: `clojure -M:test` from `implementation/http/` — 72 tests, 230 assertions, 0 failures, 0 errors.
- [x] CLJS node-test: `npx shadow-cljs compile node-test && node out/node-test.js` — 808 tests, 2086 assertions, 0 failures, 0 errors.
- [x] `rg unregister-fx` over the tree shows no remaining hits except the beads issue file.