### PR TITLE
spec(causa-mcp): scaffold per-tool spec/ — Vision + Principles + DESIGN-RATIONALE (rf2-006p0)

### DIFF
--- a/tools/causa-mcp/README.md
+++ b/tools/causa-mcp/README.md
@@ -1,0 +1,67 @@
+# tools/causa-mcp/
+
+`day8/re-frame2-causa-mcp` — the **MCP (Model Context Protocol)
+agent surface** for [Causa](../causa/). Spec only; no
+implementation yet.
+
+## Status
+
+**Spec scaffold.** This folder contains the per-tool spec/
+contract ([`spec/`](./spec/)) and nothing else. No `deps.edn`,
+no `src/`, no `test/`. Implementation work begins after Causa's
+panel ratifies; the four pair2-mcp-shape capability files
+(`001-Wire-Protocol`, `002-nREPL-Transport`,
+`003-Tool-Catalogue`, plus an `API.md`) land at that point.
+
+The scaffold exists so that direction-setting decisions
+accumulated inside
+[`tools/causa/spec/010-MCP-Server.md`](../causa/spec/010-MCP-Server.md)
+have a permanent home. Per the per-tool spec convention in
+[`tools/README.md`](../README.md), every shipped tool has a
+local `spec/` folder; this one is the spec folder ahead of the
+tool.
+
+## What it will be
+
+A Node-based stdio JSON-RPC server, written in ClojureScript,
+compiled via shadow-cljs to a single `.js` artefact. AI agents
+(Claude Code, Cursor, Copilot) launch it as a subprocess; one
+persistent nREPL socket is held for the lifetime of the session;
+eighteen Causa-shaped MCP tools are exposed.
+
+The architecture mirrors [`tools/pair2-mcp/`](../pair2-mcp/)
+exactly — same transport, same nREPL bridge, same bencode pin,
+same runtime-injection footing. Different tool catalogue,
+different `:origin` tag.
+
+Full design contract:
+[`spec/`](./spec/).
+
+## Where the depth lives
+
+| File | Covers |
+|---|---|
+| [`spec/000-Vision.md`](./spec/000-Vision.md) | What this jar is, why it's separate from Causa, how the eighteen-tool catalogue maps to Causa's panels, the relationship to Chrome DevTools MCP. |
+| [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles: origin tagging is the convention, EDN canonical, closed-set catalogue with deliberate escape valve, same single-persistent-nREPL footing as pair2-mcp. |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The eight direction-setting decisions: question, options, pick, why, date locked. |
+
+The full tool catalogue (signatures, return shapes, example
+flows) lives in
+[`tools/causa/spec/010-MCP-Server.md`](../causa/spec/010-MCP-Server.md)
+until implementation lands and this folder grows
+`003-Tool-Catalogue.md`.
+
+## See also
+
+- [`spec/`](./spec/) — this jar's contract.
+- [`tools/causa/`](../causa/) — Causa-the-panel; the human face
+  of the same instrumentation surface.
+- [`tools/causa/spec/010-MCP-Server.md`](../causa/spec/010-MCP-Server.md) —
+  the full MCP catalogue and Chrome MCP per-tool comparison
+  (will migrate into this folder when implementation lands).
+- [`tools/pair2-mcp/`](../pair2-mcp/) — the editor-side
+  counterpart; same architecture, different catalogue.
+- [`tools/README.md`](../README.md) — per-tool jar convention +
+  bundle isolation.
+- [Spec 009 — Instrumentation](../../spec/009-Instrumentation.md) —
+  the trace-bus contract Causa-MCP consumes.

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -1,0 +1,241 @@
+# 000-Vision: Causa MCP server
+
+Causa-MCP is the **agent face of Causa**. Where
+[`tools/causa/`](../../causa/) ships Causa-the-panel for human
+debuggers, this artefact ships an MCP server so AI agents
+(Claude Code, Cursor, Copilot, and any other host that speaks
+Model Context Protocol) can drive the same surfaces — read the
+trace bus, walk the epoch history, dispatch into a frame,
+rewind to a named epoch, subscribe to live trace events — over
+stdio JSON-RPC, without opening Causa's UI.
+
+This spec folder is the per-tool normative contract for
+`tools/causa-mcp/`. It is the **load-bearing scaffold** stood up
+before implementation begins: the design decisions accumulated
+inside [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+get their permanent home here. When implementation lands, this
+folder gets fleshed out with the four `tools/pair2-mcp/spec/`-shape
+files (`001-Wire-Protocol`, `002-nREPL-Transport`,
+`003-Tool-Catalogue`) parameterised for Causa.
+
+## Why a separate jar
+
+Causa-the-panel is human-facing; Causa-MCP is agent-facing.
+Humans and agents ship as distinct jars so the MCP server can be
+loaded without dragging the entire Causa UI into the classpath;
+the two surfaces split:
+
+- **[`tools/causa/`](../../causa/)** — `day8/re-frame2-causa`. The
+  DOM-injected panel. Pulled by shadow-cljs `:preloads`.
+  Browser-side artefact.
+- **`tools/causa-mcp/`** — `day8/re-frame2-causa-mcp`. The MCP
+  server. Pulled by `npm install`. Node-side artefact, attached
+  over nREPL.
+
+Both consume the same re-frame2 instrumentation surface
+([Spec 009 trace bus](../../../spec/009-Instrumentation.md),
+[Tool-Pair epoch history](../../../spec/Tool-Pair.md), registrar
+query API). Neither depends on the other.
+
+The separation is the same shape `tools/story/` and
+`tools/story-mcp/` use: a human-facing panel and an agent-facing
+surface ship as distinct jars so the agent jar can be loaded
+without the UI dependencies.
+
+## What it is
+
+A Node-based stdio JSON-RPC server, written in ClojureScript,
+compiled via shadow-cljs to a single `.js` artefact. AI agents
+launch it as a subprocess; one persistent nREPL socket is held
+for the lifetime of the session; eighteen Causa-shaped tools are
+exposed as MCP tools.
+
+The architecture mirrors [`tools/pair2-mcp/`](../../pair2-mcp/)
+exactly:
+
+- Same `@modelcontextprotocol/sdk` `StdioServerTransport`.
+- Same bencode-pinned nREPL bridge (per
+  [`tools/pair2-mcp/spec/002-nREPL-Transport.md`](../../pair2-mcp/spec/002-nREPL-Transport.md)).
+- Same port-discovery walk (`$SHADOW_CLJS_NREPL_PORT` → standard
+  shadow paths → `.nrepl-port`).
+- Same runtime-injection footing: a small sentinel namespace
+  (`re-frame2-causa-mcp.runtime`) re-ships on browser reload.
+- Same degraded-boot policy: tools return structured
+  `{:ok? false :reason ...}` errors rather than refusing to start.
+
+Different tool catalogue. Different `:origin` tag.
+
+## What it isn't
+
+- **Not** a new re-frame2 runtime extension. Tools route through
+  the existing Causa instrumentation surfaces via `cljs-eval`;
+  nothing new is registered against the framework.
+- **Not** a Causa panel. The MCP server speaks JSON-RPC; the
+  Causa UI is a separate artefact and need not be open for the
+  MCP server to work.
+- **Not** part of any production bundle. Per
+  [`tools/README.md`](../../README.md), the dependency arrow flows
+  tool → implementation; this artefact lives on a separate npm
+  classpath and is invisible to consumer apps.
+- **Not** a generalist agent surface. The tool catalogue is
+  closed-set and shaped to Causa's panels; the deliberate escape
+  valve is `eval-cljs`, which preserves the `:origin` tag.
+
+## MCP catalogue summary
+
+Eighteen tools across five bands; the full enumeration with
+signatures, return shapes, and example flows lives in
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+until implementation lands and this folder grows its own
+`003-Tool-Catalogue.md` (the pair2-mcp-shape companion to
+`Principles.md` and `DESIGN-RATIONALE.md`). The short list:
+
+| Band | Tools |
+|---|---|
+| **Inspection** (read-only, 9 tools) | `get-trace-buffer`, `get-epoch-history`, `get-app-db`, `get-app-db-diff`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`. |
+| **Mutation** (user-confirmed equivalents, 3 tools) | `restore-epoch`, `reset-frame-db`, `dispatch`. |
+| **Streaming** (push-mode, 2 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters. |
+| **Escape hatch** (1 tool) | `eval-cljs` — arbitrary CLJS form; any side-effects inherit `:origin :causa-mcp`. |
+| **Meta** (session lifecycle, 2 tools) | `discover-app`, `tail-build`. |
+| **Compatibility** (1 tool) | (room for one more on the v1.0 ship; current catalogue is 17 + 1 placeholder for any catalogue-promotion that lands before ship.) |
+
+Each tool maps to a Causa panel; together they let an agent
+observe, dispatch, time-travel, stream, and inspect.
+
+## Every MCP-driven mutation leaves a visible footprint
+
+The defining property of Causa-MCP — and a first-class
+differentiator against generalist agent surfaces like Chrome
+DevTools MCP's `evaluate_script` — is that **every dispatch,
+every `reset-frame-db`, every `restore-epoch` issued through this
+server is tagged `:origin :causa-mcp` on the trace bus**. The
+agent driving the server leaves an audit trail; its mutations
+are filterable, separable from the user's, and distinguishable
+from `:app` / `:pair` / `:story` / `:test` mutations in the same
+session.
+
+Chrome's `evaluate_script` is untagged: an agent that hand-rolls
+`js/window.dispatch(...)` is **indistinguishable** in the trace
+from a real user click. Causa-MCP's tag inversion
+(`:origin :causa-mcp` by default; opt out at your peril) means a
+post-incident audit can ask "what did the agent do?" and get a
+complete, filterable answer via
+`get-trace-buffer {:filter {:origin :causa-mcp}}`.
+
+The origin tagging is **the convention**, not a suggestion —
+captured as a load-bearing principle in
+[`Principles.md`](./Principles.md) and locked in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Relationship to Causa
+
+Causa-MCP **consumes** Causa's runtime surfaces via the shared
+[Spec 009](../../../spec/009-Instrumentation.md) instrumentation
+contract:
+
+| Causa panel | Causa-MCP tool(s) |
+|---|---|
+| Trace timeline | `get-trace-buffer`, `subscribe :trace` |
+| Time-travel scrubber | `get-epoch-history`, `restore-epoch`, `subscribe :epoch` |
+| App-db inspector | `get-app-db`, `get-app-db-diff` |
+| Machine inspector | `get-machine-state`, `get-machine-list` |
+| Issues ribbon | `get-issues`, `subscribe :error` |
+| Settings → registry browser | `get-handlers`, `get-source-coord` |
+| Right-click → Re-dispatch | `dispatch` |
+| "Try anyway" on schema mismatch | `reset-frame-db` |
+| Bottom-rail Rewind button | `restore-epoch` |
+
+Neither artefact depends on the other at the classpath. The
+Causa panel works without the MCP server; the MCP server works
+without the panel. The two coexist in the same session — agents
+can drive Causa-MCP while a human inspects the Causa panel; both
+see the same runtime, and the `:origin` tag is what lets a human
+scrubbing the timeline see at-a-glance which mutations the agent
+authored.
+
+## Relationship to `tools/pair2-mcp/`
+
+Causa-MCP is the **debugger-side** counterpart to pair2-mcp's
+**editor-side** workflow:
+
+| Axis | [`tools/pair2-mcp/`](../../pair2-mcp/) | `tools/causa-mcp/` |
+|---|---|---|
+| Audience | Editor-side AI workflows (build/edit/test). | Debugger-side AI workflows (inspect/time-travel). |
+| Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 18 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
+| `:origin` tag | `:pair` | `:causa-mcp` |
+| Runtime ns | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
+| Implementation | shadow-cljs `:node-script`, npm-published. | Same. |
+| MCP transport | stdio JSON-RPC 2.0. | Same. |
+
+Both can coexist in the same session — the agent picks the right
+tool for the workflow (pair2-mcp for "build/edit/test";
+causa-mcp for "inspect/debug/time-travel"). They don't talk to
+each other; the agent host multiplexes.
+
+## Relationship to Chrome DevTools MCP
+
+[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+owns the **browser-substrate** (screenshots, DOM, network,
+memory, performance, 46 tools across 8 categories as of v0.26.0,
+May 2026). Causa-MCP owns the **app-domain** (re-frame2 events,
+subs, machines, app-db, epochs). They are **complementary, not
+competitive** — an agent debugging a real bug typically wants
+both, and the agent host's `mcpServers` config loads them
+side-by-side.
+
+The defining differentiator on the rows that overlap (e.g.
+`get-trace-buffer` vs Chrome's `list_console_messages`) is
+**structured trace**. Chrome's console is a flat string log;
+Causa-MCP's trace bus carries `:dispatch-id`,
+`:parent-dispatch-id`, `:source-coord`, `:origin`, `:event-id`,
+`:handler-id`, `:since-ms`, `:between`, `:pred` as filter axes.
+Every domain question is a filter, not a regex.
+
+Per-tool comparison and the co-install snippet are in
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Chrome DevTools MCP co-install. When implementation lands and
+this folder grows `003-Tool-Catalogue.md`, the comparison moves
+with the catalogue.
+
+## Why ClojureScript + shadow-cljs → Node
+
+Same answer as pair2-mcp (per
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
+Lock #1). The team runs shadow-cljs daily; one more
+`:node-script` target is trivial; the npm MCP SDK is reachable
+via js-interop; end users install Node only. JVM Clojure was
+rejected for startup cost; nbb / pure babashka for tooling
+maturity; foreign-language stacks for ecosystem mismatch.
+
+Captured as Lock #1 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Why a server, not an IDE plugin
+
+MCP is the agent-host's contract for tool integration. By
+implementing MCP over stdio, this artefact works with **every**
+MCP-capable host (Claude Code, Cursor, Copilot, etc.) without
+per-host plumbing.
+
+Captured as Lock #2 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Status
+
+**Spec scaffold.** No source yet. The implementation work begins
+after Causa's panel ratifies; the four pair2-mcp-shape capability
+files (`001-Wire-Protocol`, `002-nREPL-Transport`,
+`003-Tool-Catalogue`, plus an `API.md`) land at that point. The
+locked design decisions accumulated to date live in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md); the load-bearing
+tie-breakers live in [`Principles.md`](./Principles.md).
+
+The forward references that motivated this scaffold:
+
+- [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  describes the entire MCP contract from Causa's side. When this
+  folder grows `003-Tool-Catalogue.md`, the catalogue prose
+  migrates here and `010-MCP-Server.md` shrinks to a pointer.
+- [`tools/causa/README.md`](../../causa/README.md) §MCP
+  advertises `npm install -g @day8/re-frame2-causa-mcp` — the
+  npm coord is locked even though the package doesn't exist
+  yet. The scaffold prevents that coord becoming an orphan when
+  implementation lands.

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,550 @@
+# DESIGN-RATIONALE
+
+The direction-setting decisions that shape Causa-MCP. Each entry
+captures:
+
+- **The question** that was being decided.
+- **Options considered.**
+- **The pick** that was locked.
+- **The why** — the reasoning trail.
+- **Date locked** + the locker.
+
+This doc is the load-bearing artefact of the per-tool spec
+convention. It exists so that a future contributor (human or
+AI) can read it and not re-ask the same questions. Where the
+spec text reads "per Lock #N in DESIGN-RATIONALE.md", this is
+where to come.
+
+The locks below were accumulated inside
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+and Causa's own
+[DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)
+(specifically [Lock #6 — MCP timing](../../causa/spec/DESIGN-RATIONALE.md#lock-6--mcp-timing))
+before this folder existed. Lifting them here gives them a
+proper home and prevents them being silently rewritten when
+implementation work begins.
+
+The locks are downstream of (and reuse most of)
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md).
+Where a Causa-MCP lock is identical to a pair2-mcp lock, the
+entry below cites and points instead of duplicating.
+
+---
+
+## Lock #1 — Implementation language
+
+**Locked 2026-05-12 (Mike).** **ClojureScript compiled via
+shadow-cljs to a Node `:node-script` target.** Same as
+pair2-mcp.
+
+### Question
+
+What language and runtime hosts the Causa-MCP server's process?
+
+### Options considered
+
+Same set as pair2-mcp Lock #1:
+
+- ClojureScript + shadow-cljs → Node.
+- JVM Clojure.
+- `nbb` (Node + babashka-flavoured SCI).
+- Pure babashka.
+- JavaScript / TypeScript directly.
+
+### Pick
+
+**ClojureScript + shadow-cljs → Node.**
+
+### Why
+
+Inherited from pair2-mcp's Lock #1 (see
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
+#lock-1--implementation-language). The reasoning is identical
+— Node's install cost is zero for shadow-cljs users; cold-start
+is ~50ms vs JVM's 1–2s; the team writes ClojureScript daily; the
+npm MCP SDK works fine through shadow-cljs's CommonJS interop.
+
+Causa-MCP additionally benefits from sharing the toolchain with
+pair2-mcp: forking the project layout (`deps.edn`,
+`shadow-cljs.edn`, `pilot/` smoke harness, runtime ns
+conventions) means the implementation cost is dominated by
+writing the eighteen-tool dispatcher rather than rebuilding the
+transport plumbing.
+
+### Date locked
+
+2026-05-12 (Mike). Locked at the same time as Causa's
+[Lock #6 — MCP timing](../../causa/spec/DESIGN-RATIONALE.md#lock-6--mcp-timing)
+reversal — the v1.0 MCP-ship decision implicitly committed to
+the pair2-mcp template's language stack.
+
+### Trail-of-thought citations
+
+- pair2-mcp PR #423 (the toolchain pilot).
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Transport ("Same as `tools/pair2-mcp/spec/001-Wire-Protocol.md`").
+
+---
+
+## Lock #2 — Agent-host transport
+
+**Locked 2026-05-12 (Mike).** **MCP over stdio.** No custom
+WebSocket protocol. Same as pair2-mcp Lock #2.
+
+### Question
+
+How does Causa-MCP speak to agent hosts? MCP, a custom
+WebSocket, HTTP, or some other shape?
+
+### Pick
+
+**MCP over stdio** (newline-delimited JSON-RPC 2.0 per the
+[MCP stdio transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)).
+
+### Why
+
+Inherited from pair2-mcp's Lock #2. MCP is the contract every
+modern agent host (Claude Code, Cursor, Copilot) already speaks;
+implementing MCP once works for all of them. Stdio is the
+lowest-friction transport (no port allocation, no firewall
+negotiation, no reconnect logic).
+
+The Causa-specific reinforcement: the
+[Hybrid launch-modes lock](../../causa/spec/DESIGN-RATIONALE.md#lock-9--launch-modes)
+explicitly rejected a custom WebSocket remote-attach protocol
+for Causa. MCP-over-stdio absorbed the remote-attach concern.
+Inverting that here (a custom Causa-MCP transport) would
+re-introduce the protocol-versioning + security + reconnect-logic
+surface Lock #9 ruled out.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- pair2-mcp PR #423 description.
+- Causa
+  [`DESIGN-RATIONALE.md` Lock #9 — Launch modes](../../causa/spec/DESIGN-RATIONALE.md#lock-9--launch-modes).
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Transport.
+
+---
+
+## Lock #3 — Connection model
+
+**Locked 2026-05-12 (Mike).** **Single persistent nREPL socket**
+for the lifetime of the session. Same as pair2-mcp Lock #3.
+
+### Question
+
+Does Causa-MCP open a fresh nREPL connection per op or hold one
+persistent socket for the session?
+
+### Pick
+
+**Single persistent socket.** Multiplexed by op-id
+(`{id → resolve-fn}` pending map).
+
+### Why
+
+Inherited from pair2-mcp's Lock #3 (see
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
+#lock-3--connection-model). The latency calculus is identical;
+Causa-MCP sessions are even longer-running than pair2-mcp's (an
+agent debugging a bug walks the trace stream over many minutes,
+firing many tools), so the persistent-socket win is larger.
+
+Streaming makes the persistent socket non-optional: the
+`subscribe` / `unsubscribe` pair (per
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Streaming) holds a `tools/call` open for the lifetime of the
+subscription and emits `notifications/progress` over it.
+Reconnect-per-op is incompatible with the streaming surface.
+
+### Date locked
+
+2026-05-12 (Mike).
+
+### Trail-of-thought citations
+
+- pair2-mcp PR #423 description.
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §nREPL bridge ("Same as `tools/pair2-mcp/spec/002-nREPL-Transport.md`").
+
+---
+
+## Lock #4 — Origin tagging is the convention
+
+**Locked 2026-05-12 (Mike).** **Every Causa-MCP-driven
+side-effect is tagged `:origin :causa-mcp` on the trace bus.**
+The tag is set at the entry point of every mutating tool and at
+the boundary of `eval-cljs`; opt-out is a per-call argument that
+costs the agent a deliberate ceremony.
+
+### Question
+
+Should Causa-MCP tag its mutations on the trace bus, and if so
+with what discipline (default-on / default-off / mandatory)?
+
+### Options considered
+
+- **Default-off.** Tools have an `:origin :causa-mcp` argument
+  the agent passes when it wants the tag; absent argument means
+  untagged.
+- **Default-on, opt-out per call.** The server sets the tag
+  automatically; the agent can override per call with
+  `{:origin :app}` (e.g. when simulating a user click for
+  reproducibility).
+- **Mandatory.** No opt-out at all.
+- **Drop the tag entirely.** Match Chrome MCP's
+  `evaluate_script` — agent mutations are indistinguishable from
+  user mutations.
+
+### Pick
+
+**Default-on, opt-out per call.** The tag is set at the entry
+point of every mutating tool (`dispatch`, `reset-frame-db`,
+`restore-epoch`) and at the boundary of `eval-cljs` (any
+dispatch the eval'd form triggers inherits the tag via the
+runtime install hook's
+`re-frame2-causa-mcp.runtime/current-origin` dynamic var). An
+agent that genuinely wants to simulate a user click passes
+`:origin :app` explicitly — the override is one keyword.
+
+### Why
+
+- **Audit trail is the load-bearing differentiator.** This is
+  the single property that distinguishes Causa-MCP from
+  generalist agent surfaces (Chrome MCP's `evaluate_script`).
+  A post-incident audit asking "what did the agent do?" must
+  return a complete, filterable answer; default-off would mean
+  agents who forget to tag are silently invisible.
+- **Opt-out, not opt-in.** Default-on means the agent has to
+  *try* to be invisible. The ceremony cost (one keyword) makes
+  the opt-out a deliberate act, surfaceable in the prompt
+  history: "the agent ran `dispatch` with `:origin :app` here —
+  why?"
+- **The override is necessary, not optional.** A skill that's
+  reproducing a user-shaped bug from a session log needs to fire
+  the dispatch tagged `:origin :app` so the replay matches the
+  original trace. Mandatory tagging would force the agent
+  through `eval-cljs` (which itself tags as `:causa-mcp` — there
+  is no escape hatch). Per-call override is the correct knob.
+- **Dropping the tag would be malpractice.** Causa's whole point
+  is the structured trace bus; the `:origin` axis is part of
+  Spec 009's vocabulary. Causa-MCP is the place that vocabulary
+  earns its keep against agent surfaces.
+
+### Date locked
+
+2026-05-12 (Mike). Implicit in Causa's
+[Lock #6 — MCP timing](../../causa/spec/DESIGN-RATIONALE.md#lock-6--mcp-timing)
+on the same day, made explicit in the
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Origin tagging section. This lock lifts the orphan to its
+proper home.
+
+### Trail-of-thought citations
+
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Every MCP-driven mutation leaves a visible footprint.
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Origin tagging (the full vocabulary).
+- [Spec 009 §Filter vocabulary](../../../spec/009-Instrumentation.md)
+  — the `:origin` axis the tag plugs into.
+- pair2-mcp's `:origin :pair` tag (the precedent, less
+  load-bearing because pair2-mcp is editor-side rather than
+  debugger-side).
+
+---
+
+## Lock #5 — Tool catalogue cardinality and shape
+
+**Locked 2026-05-12 (Mike).** **Eighteen tools across five
+bands** (inspection / mutation / streaming / escape hatch / meta).
+The catalogue is closed-set; additions require a Lock entry
+here. `eval-cljs` is the deliberate escape valve.
+
+### Question
+
+How many MCP tools does Causa-MCP expose, and which ones?
+
+### Options considered
+
+- **Mirror pair2-mcp** (9 tools — `discover-app`, `eval-cljs`,
+  `dispatch`, `trace-window`, `watch-epochs`, `tail-build`,
+  `snapshot`, `subscribe`, `unsubscribe`). Smallest surface;
+  agent has to compose for Causa-shaped questions.
+- **Hand-rolled minimal set** (~6 tools — `get-trace`,
+  `get-app-db`, `dispatch`, `restore-epoch`, `eval-cljs`,
+  `discover-app`). Less surface, less to maintain.
+- **Eighteen tools mapped to Causa panels** (per
+  [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Tool catalogue). One tool per Causa-visible affordance plus
+  the streaming pair, the escape hatch, and the meta tools.
+- **Open-ended catalogue.** Add tools as new surfaces ship;
+  expand freely.
+
+### Pick
+
+**Eighteen tools across five bands.** The catalogue is
+closed-set on purpose — additions are deliberate (a Lock entry
+here, a discussion). `eval-cljs` absorbs the long tail.
+
+### Why
+
+- **One tool per Causa panel is the symmetry.** Causa's pitch
+  is "the cascade you can see"; Causa-MCP's pitch is "the
+  cascade your agent can read." Eighteen tools map cleanly to
+  eighteen Causa surfaces (9 read + 3 mutate + 2 stream + 1
+  escape hatch + 2 meta + 1 reserved). The agent reading
+  `tools/list` sees a one-to-one map.
+- **Pair2-mcp's catalogue is editor-side; Causa's is
+  debugger-side.** Mirroring pair2 wholesale would leave
+  agents writing Chrome MCP `evaluate_script` blocks for
+  Causa-shaped questions (`get-app-db-diff`,
+  `get-machine-list`, `get-issues`) — losing the `:origin` tag
+  and the structured trace's filter vocabulary.
+- **Closed-set keeps the surface comprehensible.** Eighteen
+  named tools is at the upper edge of what an agent can hold in
+  context comfortably. Beyond that, agent confusion (calling
+  the wrong tool) starts to dominate; closed-set with an
+  escape valve is the right balance.
+- **The escape valve is the steam vent.** `eval-cljs` ships
+  first-class precisely so the catalogue can stay closed-set.
+  If a particular `eval-cljs` pattern recurs, that's the
+  signal to promote it to its own catalogue entry — but the
+  promotion is a deliberate Lock entry, not a silent merge.
+
+### Date locked
+
+2026-05-12 (Mike). The eighteen-tool catalogue was assembled
+during Causa's
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+authoring on 2026-05-12; the lock entry below pins the
+cardinality and the closed-set policy.
+
+### Trail-of-thought citations
+
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Tool catalogue (the full enumeration with signatures and
+  return shapes).
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Per-tool comparison with Chrome DevTools MCP (the table
+  motivating each tool's existence).
+- pair2-mcp's
+  [Lock #4 — Tool catalogue cardinality](../../pair2-mcp/spec/DESIGN-RATIONALE.md#lock-4--tool-catalogue-cardinality)
+  (the precedent at smaller cardinality).
+
+---
+
+## Lock #6 — npm package coord
+
+**Locked 2026-05-12 (Mike).** **`@day8/re-frame2-causa-mcp`.**
+The coord matches the existing
+[`tools/causa/README.md`](../../causa/README.md) §MCP
+advertisement and the Causa
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Install snippet.
+
+### Question
+
+What's the npm package name for Causa-MCP, and does it match the
+maven coord shape?
+
+### Options considered
+
+- **`@day8/re-frame2-causa-mcp`.** Matches the maven coord
+  `day8/re-frame2-causa-mcp`. Mirrors pair2-mcp's
+  `@day8/re-frame-pair2-mcp` shape.
+- **`@day8/causa-mcp`.** Shorter; drops the `re-frame2-` prefix.
+- **`causa-mcp`.** No scope; matches Chrome DevTools MCP's
+  `chrome-devtools-mcp` shape.
+- **`@re-frame2/causa-mcp`.** Different scope.
+
+### Pick
+
+**`@day8/re-frame2-causa-mcp`.** The maven coord is
+`day8/re-frame2-causa-mcp`; the npm coord matches by convention.
+
+### Why
+
+- **Brand consistency.** Day8 ships the framework, the panel,
+  and the agent surface under the `day8/re-frame2-*` namespace.
+  Dropping the `re-frame2-` prefix on npm would suggest Causa
+  is framework-agnostic; it isn't.
+- **Pair2-mcp precedent.** pair2-mcp uses
+  `@day8/re-frame-pair2-mcp` (matching the maven
+  `day8/re-frame-pair2-mcp`); Causa-MCP mirrors the shape.
+- **Search-distinguishable.** `causa-mcp` (no scope) is at risk
+  of collision with whatever else "causa" comes to mean in the
+  npm ecosystem. The scoped name is unambiguous.
+- **The coord is already advertised.** Causa's
+  [`README.md`](../../causa/README.md) §MCP and
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Install both reference `@day8/re-frame2-causa-mcp` in
+  install snippets users may copy-paste. Inverting the lock now
+  would orphan those snippets.
+
+### Date locked
+
+2026-05-12 (Mike). The coord was used in the
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Install + configure section on 2026-05-12; this lock pins it
+so the npm coord doesn't drift when implementation lands.
+
+### Trail-of-thought citations
+
+- Causa
+  [`README.md`](../../causa/README.md) §MCP (`npm install -g @day8/re-frame2-causa-mcp`).
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Install + configure.
+- pair2-mcp's npm coord
+  ([`tools/pair2-mcp/README.md`](../../pair2-mcp/README.md)).
+
+---
+
+## Lock #7 — Chrome DevTools MCP is complementary, not competitive
+
+**Locked 2026-05-12 (Mike).** **Co-install over compete.**
+Causa-MCP and Chrome DevTools MCP load side-by-side; the agent
+host multiplexes. Causa-MCP does not reinvent Chrome's
+browser-substrate surfaces (screenshots, DOM, network, memory,
+performance).
+
+### Question
+
+When Causa-MCP overlaps with Chrome DevTools MCP (e.g.
+`get-trace-buffer` vs `list_console_messages`), what's the
+posture — compete, or co-install?
+
+### Options considered
+
+- **Compete: ship a fuller Causa-MCP catalogue.** Add
+  screenshot capture, DOM inspection, network log reading.
+  One MCP server, all the answers.
+- **Co-install: stay in lane.** Causa-MCP owns the app-domain
+  (re-frame2 events, subs, machines, app-db, epochs). Chrome
+  MCP owns the browser-substrate. The agent host loads both.
+- **Disjoint cards.** Causa-MCP only loads if Chrome MCP isn't
+  detected (single-MCP-active mode).
+
+### Pick
+
+**Co-install.** Both servers load; the agent picks the right
+tool per question. The agent host's `mcpServers` config holds
+both entries.
+
+### Why
+
+- **Stay in lane.** Causa-MCP's expertise is the structured
+  trace bus + epoch history + machine snapshots + schema
+  violations. Chrome MCP's expertise is the browser substrate.
+  Each is best-of-class in its lane; mashing them together
+  would dilute both.
+- **The structured-trace differentiator only wins by staying
+  narrow.** The whole reason `get-trace-buffer` beats
+  `list_console_messages` is that Causa-MCP knows the trace
+  bus's vocabulary (`:dispatch-id`, `:source-coord`, `:origin`).
+  Reinventing screenshots would steal effort from sharpening
+  that edge.
+- **The `:origin` tag works across servers.** A Chrome MCP
+  `evaluate_script` mutation shows up in Causa-MCP's trace bus
+  tagged `:origin :app` (it bypasses Causa-MCP's entry points);
+  Causa-MCP's own dispatches show up tagged `:origin :causa-mcp`.
+  The agent host's multiplex preserves the audit trail.
+- **The agent host already multiplexes.** Claude Code, Cursor,
+  Copilot all load multiple `mcpServers` entries. Co-install is
+  the path of least friction.
+
+### Date locked
+
+2026-05-12 (Mike). Encoded in the
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Chrome DevTools MCP co-install section on 2026-05-12.
+
+### Trail-of-thought citations
+
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Chrome DevTools MCP co-install.
+- Causa
+  [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+  §Per-tool comparison with Chrome DevTools MCP (winner-per-row
+  table).
+
+---
+
+## Lock #8 — bencode pinning
+
+**Locked 2026-05-12 (Mike).** **`bencode@~2.0.3`** pinned via
+npm. Same as pair2-mcp Lock #5.
+
+### Question
+
+Which bencode npm package handles nREPL framing for Causa-MCP?
+
+### Pick
+
+**`bencode@~2.0.3`**, pinned with the tilde to admit patch
+updates only.
+
+### Why
+
+Inherited from pair2-mcp's Lock #5 (see
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
+#lock-5--bencode-pinning). `bencode@4+` is ESM-only and fails
+under shadow-cljs's `:node-script` CommonJS interop;
+`bencode@2`'s `position`-vs-`bytes` footgun is documented in
+pair2-mcp's `002-nREPL-Transport.md`.
+
+Causa-MCP inherits the pin directly — same shadow-cljs build
+target, same CommonJS interop, same partial-frame decoding logic.
+
+### Date locked
+
+2026-05-12 (Mike). The lock is implicitly committed by the
+"same as pair2-mcp" framing in Causa's
+[`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§nREPL bridge. This lock makes the inheritance explicit so the
+pin doesn't silently drift on a future `npm audit` pass.
+
+### Trail-of-thought citations
+
+- pair2-mcp's
+  [Lock #5 — bencode pinning](../../pair2-mcp/spec/DESIGN-RATIONALE.md#lock-5--bencode-pinning).
+- [`tools/pair2-mcp/spec/002-nREPL-Transport.md`](../../pair2-mcp/spec/002-nREPL-Transport.md)
+  §Bencode framing.
+
+---
+
+## Summary table
+
+| # | Question | Pick | Date |
+|---|---|---|---|
+| 1 | Implementation language | **ClojureScript + shadow-cljs → Node** (inherited from pair2-mcp Lock #1) | 2026-05-12 |
+| 2 | Agent-host transport | **MCP over stdio** (inherited from pair2-mcp Lock #2) | 2026-05-12 |
+| 3 | Connection model | **Single persistent nREPL socket** (inherited from pair2-mcp Lock #3) | 2026-05-12 |
+| 4 | Origin tagging | **Default-on, opt-out per call — `:origin :causa-mcp`** | 2026-05-12 |
+| 5 | Tool catalogue | **Eighteen tools across five bands; closed-set + `eval-cljs` escape valve** | 2026-05-12 |
+| 6 | npm package coord | **`@day8/re-frame2-causa-mcp`** | 2026-05-12 |
+| 7 | Chrome DevTools MCP posture | **Co-install, stay in lane** | 2026-05-12 |
+| 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
+
+These eight locks define Causa-MCP's pre-implementation surface.
+They were extracted from
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)
+[Lock #6 — MCP timing](../../causa/spec/DESIGN-RATIONALE.md#lock-6--mcp-timing)
+when this spec folder was stood up. When implementation work
+begins, additional locks (e.g. specific test-runner choice,
+specific deps-vendor choice, etc.) will land here.

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -1,0 +1,235 @@
+# Principles
+
+The load-bearing principles for Causa-MCP. When a design call
+has two reasonable options, these are the tie-breakers.
+Implementers and contributors should be able to read this doc
+and reach the same answers Causa-MCP already reached.
+
+These are downstream of the framework's
+[Principles](../../../spec/Principles.md) and of Causa's
+[Principles](../../causa/spec/Principles.md) (Causa-MCP is
+Causa's agent face — the panel's principles apply transitively
+to anything Causa-MCP does). The principles below are what
+*Causa-MCP adds* on top.
+
+## Tool consumes the framework; doesn't extend it
+
+Causa-MCP is a **downstream consumer** of re-frame2's existing
+surfaces. It must not add:
+
+- New registries.
+- New dispatch types.
+- New effect substrates.
+- New component substrates.
+
+The eighteen tools route through the existing
+`re-frame2-causa-mcp.runtime` namespace via `cljs-eval`. Nothing
+new is registered against the framework; nothing new is
+introduced into a consumer app's runtime.
+
+This is the
+[downstream-EPs-consume-foundation rule](../../../spec/Principles.md)
+applied to tools: tools observe and exercise what the framework
+emits and registers; they do not invent new substrates.
+
+Concretely: when implementation surfaces a runtime gap (e.g.
+"I want to inspect cross-frame causality but the trace bus
+doesn't expose `:parent-frame`"), file a `bd` bead against
+[`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+or the relevant Causa spec. Don't bolt a parallel surface onto
+the MCP server.
+
+## Origin tagging is the convention, not a suggestion
+
+Every Causa-MCP-driven side-effect on the trace bus carries
+`:tags :origin :causa-mcp`. The tag is set at the entry point of
+each mutating tool (`dispatch`, `reset-frame-db`,
+`restore-epoch`) and at the boundary of `eval-cljs` (any
+dispatch the eval'd form triggers inherits the tag — the
+runtime install hook reads
+`re-frame2-causa-mcp.runtime/current-origin` for the dynamic
+extent of the eval call).
+
+This is the **load-bearing differentiator** against generalist
+agent surfaces (Chrome DevTools MCP's `evaluate_script` is
+untagged — an agent hand-rolling `js/window.dispatch(...)` is
+indistinguishable from a real user click). It costs nothing at
+the call site and the audit-trail payoff is substantial:
+
+| Question | Trace filter |
+|---|---|
+| What did the agent do this session? | `get-trace-buffer {:filter {:origin :causa-mcp}}` |
+| Did the agent or the user fire `:cart/checkout`? | `get-trace-buffer {:filter {:event-id :cart/checkout}}` then read `:tags :origin` on each match |
+| Stream just my own mutations as they happen | `subscribe {:topic :trace :filter {:origin :causa-mcp}}` |
+
+The full origin vocabulary (`:app` / `:pair` / `:causa-mcp` /
+`:story` / `:test`) is the
+[Spec 009 §Origin axis](../../../spec/009-Instrumentation.md);
+Causa-MCP's job is to honour it.
+
+Captured as Lock #4 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## EDN canonical; JSON the wire
+
+Causa-MCP's args and returns travel as MCP-shaped JSON but
+**the canonical form is EDN-encoded strings inside the JSON
+text payload**. The catalogue ships with EDN-encoded `filter`
+maps, EDN-encoded `path` arguments, EDN-encoded return values.
+
+Why: re-frame2's runtime speaks EDN. A `:filter` map of
+`{:operation :event :origin :causa-mcp :since-ms 5000}` cannot
+round-trip through JSON without losing keyword shapes. Encoding
+the filter as an EDN string inside the JSON payload preserves
+the runtime's vocabulary; the server parses with
+`cljs.reader/read-string` at the runtime boundary.
+
+The convention is the same shape pair2-mcp uses; see
+[`tools/pair2-mcp/spec/003-Tool-Catalogue.md`](../../pair2-mcp/spec/003-Tool-Catalogue.md)
+for the wire-format details.
+
+## MCP, not an IDE plugin
+
+The agent-host integration contract is **Model Context Protocol
+over stdio**, not a per-editor extension.
+
+By implementing MCP, this artefact works with every MCP-capable
+host (Claude Code, Cursor, Copilot, and whatever lands next)
+without per-host plumbing. The cost of one stdio JSON-RPC server
+is paid once; the alternative — N editor extensions, each
+re-implementing the same tool surface — pays the cost N times
+and ages worse.
+
+A custom WebSocket protocol was considered and rejected for the
+same reason in pair2-mcp; Causa-MCP inherits the lock.
+
+Captured as Lock #2 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Single persistent nREPL socket
+
+One TCP socket to the shadow-cljs nREPL is opened on first need
+and held for the lifetime of the session. Subsequent ops reuse
+the socket without reconnecting.
+
+Same break-even calculus as pair2-mcp: per-op latency drops from
+~700ms (bash startup + babashka startup + fresh nREPL connect
+per call) to ~5–50ms (one bencode round-trip on the open socket).
+A typical Causa-MCP session fires dozens to hundreds of ops.
+
+Captured as Lock #3 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Stage-marker-independent
+
+Causa-MCP must work against any conforming re-frame2 runtime. It
+does not depend on a specific shadow-cljs build configuration, a
+specific stage marker, or a specific re-frame2 release line.
+
+Concretely:
+
+- The `build` argument defaults to `"app"` but is configurable
+  on every op (and via the `SHADOW_CLJS_BUILD_ID` env var).
+- Port discovery walks `$SHADOW_CLJS_NREPL_PORT` → standard
+  shadow paths → `.nrepl-port`. Any of them satisfy the contract.
+- Runtime presence is marker-detected (the runtime exposes
+  `re-frame2-causa-mcp.runtime/session-id`); a missing sentinel
+  triggers automatic re-injection on the next op rather than a
+  failed boot.
+- The runtime contract is the shape of the eighteen tools, not
+  a specific framework version.
+
+A project that adopts a non-default build id, a custom nREPL
+port, or a slightly different shadow layout still gets a working
+Causa-MCP without code changes.
+
+## Degraded boot, not failed boot
+
+If the nREPL port can't be resolved at startup (no port file, no
+env var, shadow-cljs not running yet), the server still boots
+and answers `tools/list`. Every `tools/call` returns a
+structured `:ok? false :reason :nrepl-port-not-found` error so
+the agent host can surface the problem and the user can start
+shadow-cljs without restarting the server.
+
+If the runtime hasn't been preloaded, the first mutating /
+inspecting tool call returns
+`:ok? false :reason :runtime-not-preloaded` with a setup hint
+pointing at the consumer's `shadow-cljs.edn` `:preloads` block.
+
+The agent-host workflow is *don't make the user restart
+anything*. The server's job is to keep working through the gaps
+and surface a useful error when the runtime isn't ready.
+
+Same posture as pair2-mcp.
+
+## Read-mostly catalogue; mutate via the in-panel-equivalent gates
+
+The eighteen tools split 9 read / 3 mutate / 2 stream / 1 escape
+hatch / 2 meta. The mutating tools (`restore-epoch`,
+`reset-frame-db`, `dispatch`) mirror the in-panel right-click
+affordances the human user already has — Causa-MCP doesn't
+introduce a *new* mutation surface, it gives the agent the same
+surface the human has.
+
+This is the symmetry the privacy + consent model rests on: the
+user enabling the MCP server is the user *delegating their
+in-panel rights* to the agent. The audit trail (origin tagging,
+above) makes the delegation visible.
+
+The escape hatch (`eval-cljs`) is the deliberate exception — it
+lets agents reach for surfaces the catalogue doesn't yet cover.
+Any side-effect the eval'd form triggers inherits the
+`:origin :causa-mcp` tag (the runtime install hook handles the
+dynamic-extent rebind). If a particular `eval-cljs` call becomes
+recurrent, that's the signal to promote it to its own catalogue
+entry.
+
+## Closed-set tool catalogue, deliberate escape valve
+
+The catalogue is **closed-set on purpose**: eighteen named
+surfaces map to eighteen Causa panels. Adding tools is a
+deliberate act (a `bd` bead, a discussion, a Lock entry in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)). Drift is
+prevented by the discipline that every new tool maps to an
+existing Causa surface — the framework's instrumentation
+contract is the rate-limit.
+
+The `eval-cljs` escape valve absorbs the long tail (per the
+section above). Refusing to ship an escape hatch would force
+agents through Chrome MCP's `evaluate_script` (which loses the
+`:origin` tag) — a worse outcome for the audit trail.
+
+Captured as Lock #5 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
+## Bash-shim back-compat is *not* a goal
+
+Unlike pair2-mcp (which mirrors a pre-existing bash-shim
+catalogue under `skills/re-frame-pair2/scripts/`), Causa-MCP
+starts greenfield. There is no shim chain to deprecate, no
+"side-by-side cadence" lock, no transition period. The MCP
+surface *is* the agent-driven surface for Causa.
+
+This is a clean break by accident, not by design: pair2
+predated MCP and had to absorb the migration; Causa launches
+with MCP-the-pattern already established by pair2-mcp. The
+historical context is in
+[`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
+Lock #6.
+
+## Backed by Causa's and the framework's principles
+
+When in doubt, defer to the principles upstream:
+
+- **Causa's [Principles](../../causa/spec/Principles.md)** —
+  "Read-only by default, mutate by confirmation" applies to the
+  MCP surface too; the mutation tools mirror the in-panel
+  right-click affordances, and the user's consent model is the
+  same (enabling the MCP server is enabling the mutations).
+- **Framework's [Principles](../../../spec/Principles.md)** —
+  regularity over cleverness, named things over anonymous
+  things, public query surfaces, deterministic execution, no
+  core.async (the async return-shape is JavaScript Promises;
+  the Node host's native async substrate).
+
+Causa-MCP is a downstream artefact of Causa's design and the
+framework's AI-first discipline. The principles above are what
+*Causa-MCP adds* on top of both baselines; everything below is
+inherited.

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -1,0 +1,39 @@
+# Causa-MCP — Spec
+
+Spec scaffold for [`tools/causa-mcp/`](../). No implementation
+yet; the folder is the **permanent home** for design decisions
+accumulated inside
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+before this folder existed.
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; eighteen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
+- **[Principles.md](Principles.md)** — Load-bearing principles: origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Eight direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
+
+## Files that will land at implementation time
+
+Following [`tools/pair2-mcp/spec/`](../../pair2-mcp/spec/)'s
+shape, the implementation phase will add:
+
+- `001-Wire-Protocol.md` — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec.
+- `002-nREPL-Transport.md` — Persistent TCP socket; bencode framing; port discovery; runtime injection.
+- `003-Tool-Catalogue.md` — The eighteen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here.)
+- `API.md` — Consolidated user-facing reference: install, configure, launch, call.
+- `findings/` — Exploratory working substrate; audit lineage, not normative.
+
+## How to use
+
+Read [`000-Vision.md`](000-Vision.md) first to anchor *why*.
+[`Principles.md`](Principles.md) is the tie-breaker doc when
+two reasonable design choices conflict.
+[`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) captures the locks
+— decisions that survived discussion and shouldn't be re-asked.
+
+Until the implementation-phase files land, the **catalogue
+canonical** is
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+§Tool catalogue. Cross-references from this folder back into
+Causa's spec are deliberate; the orphan-lock lift will happen
+when `003-Tool-Catalogue.md` is authored.


### PR DESCRIPTION
## Summary

Stand up `tools/causa-mcp/spec/` ahead of implementation. `tools/causa-mcp/` is a forward-referenced tool with no folder on disk; design decisions for it have been accumulating as orphan locks inside `tools/causa/spec/010-MCP-Server.md`. This PR gives them a proper home (per the per-tool spec convention in `tools/README.md`).

## What lands

- `tools/causa-mcp/README.md` — stub README ("spec only; no code yet").
- `tools/causa-mcp/spec/000-Vision.md` — Causa-MCP is the agent face of Causa; eighteen MCP tools across five bands; shadow-cljs / Node / persistent-nREPL architecture mirrors pair2-mcp; relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
- `tools/causa-mcp/spec/Principles.md` — load-bearing principles: origin tagging is the convention, EDN canonical, closed-set catalogue with `eval-cljs` escape valve, single persistent nREPL socket, stage-marker-independent. Shape mirrors `tools/pair2-mcp/spec/Principles.md` and `tools/causa/spec/Principles.md`.
- `tools/causa-mcp/spec/DESIGN-RATIONALE.md` — eight direction-setting locks. Four net-new (origin tagging discipline; eighteen-tool closed-set catalogue with `eval-cljs` escape valve; npm coord `@day8/re-frame2-causa-mcp`; Chrome DevTools MCP co-install-over-compete posture); four cite pair2-mcp's DESIGN-RATIONALE rather than duplicating (language, transport, connection model, bencode pin).
- `tools/causa-mcp/spec/README.md` — folder index.

The full eighteen-tool catalogue prose stays in `tools/causa/spec/010-MCP-Server.md` for now; it migrates to a new `003-Tool-Catalogue.md` in this folder when implementation work begins.

## Source

- Sweep finding: `ai/findings/sweep-tools-spec-completeness-2026-05-13.md` §`tools/causa-mcp/spec/` (originally P3; lifted to P2 because Causa's MCP work depends on this not being a duplication trap when it lands).
- Orphan locks lifted from `tools/causa/spec/010-MCP-Server.md` (origin tagging, tool catalogue cardinality, Chrome MCP co-install posture, npm coord).

## Test plan

- [x] `scripts/check_doc_slugs.py` — exit 0 (no broken links / anchors introduced).
- [x] `mkdocs build --strict` — warning count unchanged at 122 (pre-existing baseline; no regression from this PR).
- [x] All cross-link targets verified: `spec/009-Instrumentation.md`, `spec/Principles.md`, `spec/Tool-Pair.md`, `tools/causa/spec/010-MCP-Server.md`, `tools/causa/spec/DESIGN-RATIONALE.md` (including `#lock-6--mcp-timing` anchor), `tools/causa/spec/Principles.md`, `tools/causa/README.md`, `tools/pair2-mcp/spec/DESIGN-RATIONALE.md`, `tools/pair2-mcp/spec/Principles.md`, `tools/pair2-mcp/spec/003-Tool-Catalogue.md`, `tools/README.md`.

## Bead

rf2-006p0 — not closed by this PR (the bead also proposed `API.md`; that lands with implementation when the catalogue prose migrates from `tools/causa/spec/010-MCP-Server.md`).