### PR TITLE
docs(pair2-mcp): harmonise tool count across spec + README (rf2-zbtgf)

### DIFF
--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -11,7 +11,7 @@ back-compat, but new sessions should prefer the MCP server.
 ## What it is
 
 A Node-based stdio JSON-RPC server (written in ClojureScript, compiled
-via shadow-cljs to a single `.js` file) that exposes the seven pair2
+via shadow-cljs to a single `.js` file) that exposes the nine pair2
 ops as MCP tools. AI agents (Claude Code, Cursor, Copilot) launch it
 as a subprocess; one persistent nREPL socket is held for the lifetime
 of the session.
@@ -34,6 +34,8 @@ cljs-eval compile.
 | `watch-epochs` | `watch-epochs.sh`         | Pull-mode poll for matching epochs added after a given epoch-id. Predicate keys: `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`. |
 | `tail-build`   | `tail-build.sh`           | Wait for a hot-reload to land by polling a probe form until its value changes. |
 | `snapshot`     | _(new — no bash equivalent)_ | Coarse-grained per-frame state read in one round-trip. Returns a map keyed by frame-id with `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces` slices. Prefer for investigate-X workflows over chaining 5-10 individual reads. |
+| `subscribe`    | _(new — no bash equivalent)_ | Streaming subscription on the trace / epoch bus (rf2-hq49). Push-mode replacement for `watch-epochs`; each matching event arrives as a `notifications/progress` notification. Topics: `trace`, `epoch`, `fx`, `error`. |
+| `unsubscribe`  | _(new — no bash equivalent)_ | Close a streaming subscription out-of-band. Idempotent — closing an unknown sub-id returns `:existed? false` rather than an error. |
 
 ## Quick start
 
@@ -132,7 +134,7 @@ The contract lives in [`spec/`](./spec/):
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What this server is, why it replaces the bash-shim chain. |
 | [`spec/001-Wire-Protocol.md`](./spec/001-Wire-Protocol.md) | JSON-RPC 2.0 over stdio; lifecycle; tool dispatch. |
 | [`spec/002-nREPL-Transport.md`](./spec/002-nREPL-Transport.md) | Persistent socket, bencode framing, sentinel-based reconnect. |
-| [`spec/003-Tool-Catalogue.md`](./spec/003-Tool-Catalogue.md) | The seven tools (six per-op + the `snapshot` mega-op), their argument schemas, EDN result shape. |
+| [`spec/003-Tool-Catalogue.md`](./spec/003-Tool-Catalogue.md) | The nine tools (seven per-op + the `snapshot` mega-op + the streaming `subscribe` / `unsubscribe` pair), their argument schemas, EDN result shape. |
 
 ## Development
 
@@ -178,7 +180,7 @@ tools/pair2-mcp/
 ├── pilot/                                    ; pre-port toolchain pilot
 └── src/re_frame_pair2_mcp/
     ├── nrepl.cljs                            ; persistent socket + bencode
-    ├── tools.cljs                            ; the 7 MCP tools (6 per-op + snapshot mega-op)
+    ├── tools.cljs                            ; the 9 MCP tools (7 per-op + snapshot mega-op + subscribe/unsubscribe streaming pair)
     └── server.cljs                           ; stdio JSON-RPC entry point
 └── test/
     ├── re_frame_pair2_mcp/nrepl_test.cljs    ; bencode framing unit tests

--- a/tools/pair2-mcp/spec/000-Vision.md
+++ b/tools/pair2-mcp/spec/000-Vision.md
@@ -20,7 +20,7 @@ A Node-based stdio JSON-RPC server, written in ClojureScript,
 compiled via shadow-cljs to a single `.js` artefact. AI agents
 (Claude Code, Cursor, Copilot) launch it as a subprocess; one
 persistent nREPL socket is held for the lifetime of the session;
-the seven canonical pair2 ops are exposed as MCP tools.
+the nine canonical pair2 ops are exposed as MCP tools.
 
 ## What it isn't
 

--- a/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
@@ -193,8 +193,9 @@ resolve-fn}` pending map).
 
 ## Lock #4 — Tool catalogue cardinality
 
-**Locked 2026-05-12 (Mike).** **Seven ops**, mirroring the bash-shim
-catalogue exactly.
+**Locked 2026-05-12 (Mike).** **Seven ops at v0.1.0**, mirroring the
+bash-shim catalogue exactly. The catalogue has since grown to **nine
+ops** via two additive drops; see *Subsequent evolution* below.
 
 ### Question
 
@@ -250,6 +251,33 @@ vocabulary, identical contract semantics.
 - The bash-shim catalogue had stabilised at seven ops over multiple
   iterations before the MCP port; the cardinality was already
   validated by daily use.
+
+### Subsequent evolution
+
+The original seven-op cardinality has been amended twice. The lock's
+reasoning (mirror the bash-shim catalogue; mode flags over op
+decomposition; bounded surface) still holds — both amendments are
+*additive* per-need extensions, not a rejection of the lock.
+
+- **rf2-7dvg** cut `inject-runtime`: the runtime now ships into the
+  consumer app via shadow-cljs `:devtools :preloads`, so the inject
+  op is gone. The bash-shim catalogue dropped to six; the MCP
+  catalogue followed.
+- **rf2-x70e** added `snapshot`: a coarse-grained per-frame state read
+  composed server-side over the existing per-slice runtime readers.
+  Earns its keep as a mega-op for investigate-X workflows that would
+  otherwise chain 5–10 individual `eval-cljs` reads. No bash-shim
+  equivalent; the shim chain stays at six.
+- **rf2-hq49** added `subscribe` / `unsubscribe`: streaming
+  subscription on the trace + epoch bus, layered over MCP's
+  `notifications/progress` mechanism. Push-mode replacement for the
+  polling-shaped `watch-epochs`. No bash-shim equivalent.
+
+Net: pair2-mcp ships **nine ops** (`discover-app`, `eval-cljs`,
+`dispatch`, `trace-window`, `watch-epochs`, `tail-build`, `snapshot`,
+`subscribe`, `unsubscribe`). The bash shims ship six. The shim
+catalogue is a strict subset of the MCP catalogue, with identical
+names and arg shapes for every overlapping op.
 
 ---
 
@@ -337,9 +365,14 @@ changes.
   existing runbooks, skill docs, and personal workflows that
   reference them. The benefit of removal (less code) is small
   compared to the cost (someone's session breaking on a Tuesday).
-- **Identical op vocabulary.** The seven MCP tools mirror the
-  seven shim ops exactly. Agents can mix calls in the same workflow
-  during transition — no all-or-nothing switch is required.
+- **Overlapping op vocabulary.** Six of the nine MCP tools
+  (`discover-app`, `eval-cljs`, `dispatch`, `trace-window`,
+  `watch-epochs`, `tail-build`) mirror the six bash shims exactly,
+  with identical names and arg shapes. The remaining three
+  (`snapshot`, `subscribe`, `unsubscribe`) are MCP-only additions
+  per Lock #4's *Subsequent evolution* note — they have no shim
+  equivalent. Agents can mix calls in the same workflow during
+  transition — no all-or-nothing switch is required.
 - **MCP server isn't proven across the team yet.** Side-by-side
   shipping gives the MCP server time to accumulate trust before
   becoming the only path.
@@ -365,10 +398,13 @@ changes.
 | 1 | Implementation language | **ClojureScript + shadow-cljs → Node** | 2026-05-12 |
 | 2 | Agent-host transport | **MCP over stdio** | 2026-05-12 |
 | 3 | Connection model | **Single persistent nREPL socket** | 2026-05-12 |
-| 4 | Tool catalogue cardinality | **Seven ops** (mirror the shim catalogue) | 2026-05-12 |
+| 4 | Tool catalogue cardinality | **Seven ops at v0.1.0; grown to nine** (mirror the shim catalogue + `snapshot` + `subscribe`/`unsubscribe`) | 2026-05-12 |
 | 5 | bencode pinning | **`bencode@~2.0.3`** (CommonJS; position-not-bytes) | 2026-05-12 |
 | 6 | Bash-shim deprecation | **Side-by-side, no removal scheduled** | 2026-05-12 |
 
 These six locks together define pair2-mcp's v0.1.0 surface. Anything
 outside these decisions is up for design discussion; anything inside
-is direction-set and shipped.
+is direction-set and shipped. Lock #4's cardinality has since grown
+additively (see its *Subsequent evolution* note); the load-bearing
+direction — mirror the shim catalogue, prefer mode flags over op
+decomposition, keep the surface bounded — still holds.

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -19,7 +19,7 @@ surfaces. It must not add:
 - New effect substrates.
 - New component substrates.
 
-The seven ops route through the existing `re-frame-pair2.runtime`
+The nine ops route through the existing `re-frame-pair2.runtime`
 namespace via `cljs-eval`. Nothing new is registered against the
 framework; nothing new is introduced into a consumer app's runtime.
 
@@ -85,7 +85,7 @@ Concretely:
   shadow-cljs `:devtools :preloads`; a missing marker resolves to a
   structured `:reason :runtime-not-preloaded` error with the setup
   hint, no cljs-eval inject fallback (rf2-7dvg).
-- The runtime contract is the shape of the six ops, not a specific
+- The runtime contract is the shape of the nine ops, not a specific
   framework version.
 
 A project that adopts a non-default build id, a custom nREPL port,
@@ -116,17 +116,20 @@ mix shim calls and MCP tool calls in the same workflow during the
 transition. Existing skill docs and runbooks that reference the
 shims keep working; nothing breaks because the MCP server shipped.
 
-The op vocabulary (the seven canonical pair2 ops) is identical
-between the two surfaces — only the transport changes. This is what
-makes the back-compat tractable: the contract is the same; the
-plumbing underneath is different.
+The op vocabulary overlaps cleanly: the bash shims cover six of the
+nine canonical pair2 ops (`discover-app`, `eval-cljs`, `dispatch`,
+`trace-window`, `watch-epochs`, `tail-build`), with identical names
+and arg shapes — only the transport differs. The MCP-only additions
+(`snapshot`, plus the streaming pair `subscribe` / `unsubscribe`) have
+no shim equivalent. This is what makes the back-compat tractable: the
+overlap is contract-identical; the plumbing underneath is different.
 
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):
 
 - **Regularity over cleverness** — one obvious way to do a thing.
-  The seven op names and shapes are stable.
+  The nine op names and shapes are stable.
 - **Named things over anonymous things** — every op has a stable
   name; every reason keyword in an `:ok? false` response is stable.
 - **Public query surfaces** — pair2-mcp reads only what the


### PR DESCRIPTION
@
## Summary

Single source of truth for the pair2-mcp tool count. Catalogue
(`003-Tool-Catalogue.md`) and `tools.cljs` agree the canonical
number is **9** (`discover-app`, `eval-cljs`, `dispatch`,
`trace-window`, `watch-epochs`, `tail-build`, `snapshot`,
`subscribe`, `unsubscribe`). Prose in the README and three other
spec files variously claimed seven, six, or eight. This PR
harmonises everything to nine.

## Files touched

- `tools/pair2-mcp/README.md` — three prose mentions corrected;
  `subscribe` and `unsubscribe` rows added to the Tool-surface table.
- `tools/pair2-mcp/spec/000-Vision.md` — "seven canonical pair2 ops"
  -> "nine".
- `tools/pair2-mcp/spec/Principles.md` — three mentions corrected;
  bash-shim back-compat paragraph rewritten to describe the actual
  overlap (shims cover six of the nine ops; `snapshot` +
  `subscribe`/`unsubscribe` are MCP-only).
- `tools/pair2-mcp/spec/DESIGN-RATIONALE.md` — Lock #4 (the
  historical "seven ops" decision from 2026-05-12) preserved as
  written, with a *Subsequent evolution* addendum documenting the
  rf2-7dvg (`inject-runtime` cut), rf2-x70e (`snapshot` added), and
  rf2-hq49 (`subscribe`/`unsubscribe` added) drops. Lock #6 reworded
  from "identical" to "overlapping" to match post-rf2-hq49 reality.
  Summary-table row 4 and closing paragraph updated.

`spec/API.md` and `spec/README.md` already said "nine" and need no
change.

## Scope

Per the bead, surface limited to `tools/pair2-mcp/spec/` +
`tools/pair2-mcp/README.md`. Stale "seven" prose in
`tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs:14` and
`tools/pair2-mcp/test/stdio-roundtrip.js:6,83` is out of bead scope
and will be filed as a follow-up bead.

## Test plan

- [x] `python scripts/check_doc_slugs.py --verbose` — passes
      ("scanning 230 markdown files... no broken links.")
- [ ] CI: docs.yml workflow (mkdocs build + slug check)

Closes-ish rf2-zbtgf (status stays open until PR merges, per bead
protocol).
@