### PR TITLE
test(conformance): add :flow/trace to claimed-capabilities — flow-lifecycle fixture now runs (rf2-efjs6)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -113,6 +113,10 @@
     :flow/dirty-check
     :flow/toggle
     :flow/hot-reload
+    ;; Spec 009 §Flow trace events / Spec 013 §Flow tracing (rf2-2s1o) —
+    ;; the runtime emits the :rf.flow/* lifecycle events. Claimed so
+    ;; `flow-lifecycle-emits-traces.edn` runs on CLJS too (rf2-efjs6).
+    :flow/trace
     :rf.http/managed})
 
 (def claimed-spec-versions

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -75,6 +75,11 @@
     :flow/dirty-check
     :flow/toggle
     :flow/hot-reload
+    ;; Spec 009 §Flow trace events / Spec 013 §Flow tracing (rf2-2s1o) —
+    ;; the runtime emits :rf.flow/registered, :rf.flow/computed,
+    ;; :rf.flow/skip, :rf.flow/cleared, :rf.flow/failed under :op-type
+    ;; :flow. Claimed so `flow-lifecycle-emits-traces.edn` runs (rf2-efjs6).
+    :flow/trace
     ;; Spec 014 — :rf.http/managed (rf2-z1mw)
     :rf.http/managed})
 


### PR DESCRIPTION
## Summary

- Add `:flow/trace` to the `claimed-capabilities` set in both the JVM (`conformance_test.clj`) and CLJS (`conformance_corpus_cljs_test.cljs`) corpus runners.
- Without it, `flow-lifecycle-emits-traces.edn` (which declares `#{:core/event-handler :flow/basic :flow/trace}`) silently skipped — the runner reported the skip but the suite stayed green, leaving re-frame-10x v2's flow-trace contract (rf2-2s1o) with zero conformance coverage.

## Why

Per the test-coverage rigour sweep (`ai/findings/sweep-test-coverage-rigour-2026-05-13.md` §Finding 2 — B-2), a claim-set typo left the most load-bearing flow-trace fixture out of the runnable set. The fixture itself was already passing under `flows_trace_test.clj` — only the cross-corpus claim was missing.

## Verification

- JVM (`clojure -M:test --var re-frame.conformance-test/run-conformance-corpus`): `total: 111, runnable: 111, passed: 111, failed: 0, skipped: 0`. `:flow/lifecycle-emits-traces` now appears in the Passing list.
- CLJS (`shadow-cljs compile node-test` + `node out/node-test.js`): `Conformance corpus (CLJS): total fixtures 111, runnable 111, passed 111, failed 0, skipped 0`. Same fixture now in Passing.

## Test plan

- [x] JVM conformance suite runs the fixture and passes
- [x] CLJS conformance suite runs the fixture and passes
- [x] No other claimed-capability changes — diff is two adds (one per runner)