### PR TITLE
spec(machines-viz): scaffold per-tool spec/ — Vision + Principles + DESIGN-RATIONALE + API (rf2-x50eu)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -185,11 +185,14 @@ not created up-front.
   graduated). Lands as Stage 7 of the Story epic (`rf2-tgci`); same
   human-tool / agent-surface separation as causa-mcp.
 
-- **`tools/machines-viz/`** — `day8/re-frame2-machines-viz`. XState-style
-  state-chart visualisation for machines registered via `reg-machine`.
-  Consumes the trace bus and per-frame machine snapshots. Causa embeds
-  this surface; whether it also ships as a standalone jar is pending
-  the first cut.
+- **`tools/machines-viz/`** — `day8/re-frame2-machines-viz`. The
+  state-chart component for re-frame2 machines. Ships one component
+  (`MachineChart`) plus a static read-only viewer page (decodes a
+  `#machine=<base64-edn>` URL fragment). Causa's Machine Inspector
+  embeds the component; Story's per-variant machine panel embeds it
+  the same way. Explicitly **not** a visualiser-as-product (Stately's
+  Visualizer + Studio occupy that lane). Per-tool spec scaffolded via
+  rf2-x50eu; see [`tools/machines-viz/spec/`](./machines-viz/spec/).
 
 - **`tools/machines-viz-mcp/`** — `day8/re-frame2-machines-viz-mcp`.
   A likely separate MCP surface for machine viz, mirroring the

--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -1,0 +1,90 @@
+# tools/machines-viz/
+
+`day8/re-frame2-machines-viz` — **Machines-Viz**, the state-chart
+component for re-frame2 machines. *Stately-quality charts; live; embedded.*
+
+Status: **spec only; no code yet.** This directory holds the
+normative contract; implementation work begins after the spec
+ratifies. The same posture
+[`tools/causa-mcp/`](../causa-mcp/) takes (when scaffolded).
+
+## What it is
+
+A standalone CLJS jar that ships a single React-flavoured component —
+`MachineChart` — and a static read-only viewer page. The chart renders
+any re-frame2 machine registered via `reg-machine` (Spec 005), live-
+highlights the active state on transitions, and surfaces the
+microstep / `:after` / `:invoke-all` granularity that re-frame2's
+trace bus emits.
+
+`tools/machines-viz/` owns the chart. Causa (via
+[`tools/causa/spec/003-Machine-Inspector.md`](../causa/spec/003-Machine-Inspector.md))
+embeds it as the Machine Inspector panel's content; Story's machine
+panel embeds it the same way. The chart itself depends only on
+`implementation/core` + `implementation/machines` — never on Causa
+or Story. The dependency arrow flows:
+
+```
+tools/causa/   ─requires→  tools/machines-viz/  ─requires→  implementation/machines/
+tools/story/   ─requires→  tools/machines-viz/  ─requires→  implementation/core/
+```
+
+The inverse is forbidden, per [`tools/README.md`](../README.md) §the
+bundle-isolation contract. A consumer who wants a chart without the
+rest of Causa pulls `machines-viz` alone.
+
+A separate **read-only viewer page** lives in this same jar and
+renders charts decoded from a `#machine=<base64-edn>` URL fragment.
+The viewer is statically hostable, ships under the same coord, and
+is the receiving end of the Causa "Copy machine as → Share URL"
+affordance.
+
+## What it isn't
+
+- **Not** a visualiser-as-product. Stately's commercial
+  Visualizer / Studio occupy that lane (and are even an officially
+  deprecated surface within Stately's own docs — see
+  [DESIGN-RATIONALE Lock #1](./spec/DESIGN-RATIONALE.md)). Machines-Viz
+  is a component the framework's own tools embed, plus a static
+  read-only viewer for shared URLs. It does **not** ship a paste-and-
+  render editor, a registry, a multiplayer canvas, or
+  collaboration features.
+- **Not** a registrar, dispatch, effect, or component layer.
+  Machines-Viz is a downstream consumer of the framework's
+  instrumentation surface (Spec 009 trace bus + `[:rf/machines <id>]`
+  snapshots).
+- **Not** a session export. The share-URL serialises **only** the
+  machine topology + a single current-state snapshot — no trace
+  stream, no epoch buffer, no app-db slices, no conversation. Per
+  Causa Lock #4 (no session export), lifted into Machines-Viz as a
+  load-bearing principle.
+- **Not** reachable from production CLJS bundles. Per
+  [`tools/README.md`](../README.md) the dependency arrow flows
+  tool → implementation; this jar is on a separate classpath root.
+
+## Where the depth lives
+
+Per the per-tool spec-folder convention in
+[`tools/README.md`](../README.md), the substantive contract for this
+jar is decomposed into [`spec/`](./spec/):
+
+| File | Covers |
+|---|---|
+| [`spec/000-Vision.md`](./spec/000-Vision.md) | What `MachineChart` is, what the read-only viewer guarantees, share-URL encoding format; relationship to Stately Visualizer (out-of-scope). |
+| [`spec/Principles.md`](./spec/Principles.md) | Bundle-isolation, EDN-first, observation-only, embedding-host-agnostic, no session data in shares. |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The locks: scope (component-not-product), share-URL encoding, current-state-only snapshot, source migrated from Causa 003. |
+| [`spec/API.md`](./spec/API.md) | `MachineChart` component contract (`:machine-id`, `:frame-id`, `:on-state-click`, `:on-transition-click`); read-only viewer URL fragment; PNG / SVG / share-URL export functions. |
+
+## Status
+
+In design. Spec scaffolded via rf2-x50eu (2026-05-13). Decisions
+extracted from `tools/causa/spec/003-Machine-Inspector.md`; cross-
+references back to Causa for the embedding-side contract.
+Implementation work begins after the spec ratifies.
+
+## See also
+
+- [`tools/causa/spec/003-Machine-Inspector.md`](../causa/spec/003-Machine-Inspector.md) — the embedding host's side of the contract.
+- [`spec/005-StateMachines.md`](../../spec/005-StateMachines.md) — the registry the chart visualises.
+- [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md) — the trace events the live-highlight consumes.
+- [`tools/README.md`](../README.md) — per-tool jar convention + bundle isolation.

--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -1,0 +1,238 @@
+# 000-Vision: Machines-Viz — the re-frame2 state-chart component
+
+## Why it exists
+
+re-frame2 ships state machines (Spec 005) as a first-class registry.
+A registered machine's transition table is data; its runtime
+snapshot lives at `[:rf/machines <id>]`; its lifecycle, transitions,
+microsteps, `:after` timers, and `:invoke-all` joins all emit
+structured trace events (Spec 009). Visualising a machine is a
+direct projection of those substrates — no new runtime surface
+required.
+
+`tools/machines-viz/` ships the projection as **one component**
+(`MachineChart`) plus a **read-only viewer page** that renders a
+chart from a URL fragment. Causa's Machine Inspector panel
+([`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md))
+embeds it as content; Story's per-variant machine panel embeds it
+the same way. The component is the single source of charting truth;
+the hosts add transition-history ribbons, source-coord jumps, and
+panel chrome around it.
+
+The read-only viewer is the receiving end of the "Copy machine as →
+Share URL" affordance — a chart pasted into a PR description, a
+design doc, a Slack thread, or a whiteboard.
+
+## What it is
+
+A standalone CLJS jar — `day8/re-frame2-machines-viz` — that
+exports:
+
+1. **The `MachineChart` component.** A React-flavoured CLJS
+   component (substrate-agnostic via the v2 `:view` registration
+   surface; substrates' adapters re-export) that renders a
+   directional state-chart for one registered machine. It reads
+   `[:rf/machines <id>]` for live-highlight and subscribes to the
+   Spec 009 trace stream for transition / microstep / timer /
+   invoke-all granularity.
+2. **The read-only viewer page.** A statically hostable single-file
+   page (`tools/machines-viz/public/viewer.html`) that decodes a
+   `#machine=<base64-edn>` URL fragment and renders the encoded
+   chart in a no-runtime `MachineChart` (the same component with
+   click handlers no-op'd and live-trace subscription disabled).
+3. **The share-URL encoding rules.** EDN → transit-write →
+   base64url, with a `:rf.machines-viz.share/v1` envelope keying the
+   encoding version. Roundtrips: `(encode-share-url chart-state)`
+   and `(decode-share-url url)`.
+4. **PNG and SVG exporters.** Client-side rasterisers that emit a
+   chart image at 2x DPR (PNG) or as `image/svg+xml` (SVG) with
+   embedded fonts. Both include `<title>` / `<desc>` (SVG) or alt-
+   text sidecar (PNG) summarising the machine id, current state,
+   and node / transition counts.
+
+## What it isn't
+
+- **Not** a visualiser-as-product. The Stately Visualizer +
+  Stately Studio occupy that lane — paste-and-render editors,
+  saved-machine registries, multiplayer canvases, commercial
+  SaaS shells. Per [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/),
+  Stately's own Visualizer is officially deprecated within their
+  docs (replaced by the commercial Stately Editor); investing in
+  the visualiser-as-product lane chases a sunsetted product.
+  Machines-Viz is the **component the framework's own tools
+  embed**, plus a read-only viewer for shared URLs. See
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #1.
+- **Not** a session recorder. The share-URL serialises **only**
+  machine topology + a single current-state snapshot. No trace
+  stream, no epoch buffer, no app-db slices, no conversation
+  buffer. Per Causa Lock #4 (session export forbidden), lifted
+  into Machines-Viz as load-bearing.
+- **Not** a Markdown-embed (mermaid-style) renderer at v1.
+  Mermaid's killer feature is "paste this into a GitHub README
+  and it renders." The framework's post-v1 `(machine->mermaid)`
+  exporter (per [Spec 005 §Future](../../../spec/005-StateMachines.md))
+  fills that niche; Machines-Viz's share-URL viewer is the
+  interactive complement. Both live alongside; neither
+  duplicates the other. See [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)
+  §Lock #4.
+- **Not** an editor. Machines are authored in code via
+  `reg-machine`; Machines-Viz visualises what's already
+  registered. There is no canvas-driven authoring affordance, no
+  edit-the-machine-and-export-EDN flow. Post-v1 candidates
+  exist (a "paste a machine definition" web playground) but
+  v1.0 ships read-only.
+- **Not** a registrar, dispatch, effect, or component layer.
+  Machines-Viz is a downstream consumer of the framework's
+  instrumentation surface. If a chart needs data the framework
+  doesn't emit, the answer is to file a `bd` bead against
+  `spec/009-Instrumentation.md` — not to bolt a parallel
+  surface onto Machines-Viz. Same posture Causa takes (per
+  [Causa Principles §Observation only](../../causa/spec/Principles.md)).
+- **Not** part of any production bundle. The bundle-isolation
+  contract in [`tools/README.md`](../../README.md) holds: nothing
+  under `implementation/` may `:require` from `machines-viz`.
+
+## What re-frame2 unlocks for Machines-Viz
+
+Each row is "new in re-frame2 → new charting story Machines-Viz
+must tell."
+
+| re-frame2 capability | Machines-Viz surface |
+|---|---|
+| **`[:rf/machines <id>]` snapshot location** (Spec 005) | Live-highlight reads the snapshot directly; deref drives node-pulse on the active state. |
+| **`:rf.machine/transition` trace events** (Spec 009) | Edges glow on the matching event; the chart animates the from→to transition. |
+| **`:rf.machine.microstep/transition`** | Microstep-granular replay within an `:always`-driven cascade; intermediate states render with a "microstep" badge. |
+| **`:rf.machine.timer/*` events** | `:after`-bearing states render a countdown ring; the ring fills at 60Hz when the panel is visible. |
+| **`:rf.machine.invoke-all/*` events** | Parallel-child rows render with per-child state plus the join-condition label (`:all` / `:any` / `{:n N}` / `{:fn ...}`). |
+| **`:rf.machine/spawned` + `-destroyed`** | Dynamic actors appear / disappear in the parent chart's "spawned" tray; gensym'd ids surface with `:system-id` aliases parenthesised. |
+| **State-tags** (Spec 005 §State tags) | Tag-membership coloured rings on state nodes; tags listed in the node tooltip. |
+| **Source-coord stamping** (Spec 001) | Every state, transition, guard, and action carries a source-coord chip — click jumps to the registration. |
+| **`reg-machine` definition as data** | The whole chart layout is a function of the transition table; no reflection, no instrumented build. |
+| **Compound states + parallel regions** | Nested compound states render with recursive active-child highlighting; parallel regions render as side-by-side panes. |
+| **Final states with `:on-done`** | `:final?` nodes render with a doubled border; entering one fires the `:on-done` edge highlight before the auto-destroy. |
+
+## Where it lives in the stack
+
+```
+              ┌────────────────────────────────┐
+              │  Causa (Machine Inspector)     │   ─  embeds  ─┐
+              │   • transition-history ribbon  │               │
+              │   • source-coord chips         │               │
+              │   • frame picker               │               │
+              └────────────────────────────────┘               │
+                                                               ▼
+              ┌────────────────────────────────┐
+              │  Story (per-variant machine    │   ─  embeds  ─┐
+              │  panel)                        │               │
+              │   • per-variant scope          │               │
+              │   • compact chrome             │               │
+              └────────────────────────────────┘               │
+                                                               ▼
+                              ┌─────────────────────────────────────┐
+                              │  tools/machines-viz/                │
+                              │   • MachineChart component          │
+                              │   • read-only viewer page           │
+                              │   • share-URL encoder / decoder     │
+                              │   • PNG / SVG export                │
+                              └─────────────────────────────────────┘
+                                                               │
+                                                               ▼
+                              ┌─────────────────────────────────────┐
+                              │  implementation/machines + core     │
+                              │   • reg-machine + transition tables │
+                              │   • [:rf/machines <id>] snapshots   │
+                              │   • Spec 009 trace bus events       │
+                              └─────────────────────────────────────┘
+```
+
+`tools/causa/` and `tools/story/` both depend on
+`tools/machines-viz/`. The arrow does not invert. Machines-Viz
+does not know about Causa's chrome or Story's variant runtime —
+it only knows it has a `:machine-id`, a `:frame-id`, and two
+callbacks the host wired.
+
+## Scope and roadmap
+
+### v1.0 (the foundation)
+
+The component + the read-only viewer + the encoding rules — the
+surface Causa and Story require to ship their panels.
+
+- `MachineChart` component (per [`API.md`](./API.md) §MachineChart).
+- Read-only viewer page (per [`API.md`](./API.md) §Read-only viewer).
+- Share-URL encoding (per [`API.md`](./API.md) §Share-URL encoding).
+- PNG + SVG exporters.
+- Compound / parallel / `:after` / `:invoke-all` / `:final?`
+  rendering as specified in
+  [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+  §What the panel shows + §`:invoke-all` viz + §Performance.
+- Source-coord chips on every clickable element (the host wires
+  the editor URL handler via `:on-state-click` /
+  `:on-transition-click`).
+- Accessibility: SVG `<title>` / `<desc>` + machine summary text
+  alternative. **Full chart alt-view defers to v1.1** (same
+  posture Causa 003 §Accessibility takes — the transition-history
+  ribbon + machine picker on the host side carry the accessible
+  surface in v1.0).
+
+### v1.1 candidates (not committed)
+
+- Chart alt-view for screen readers (the v1 commitment deferred
+  from accessibility).
+- Mermaid emit as an export format — for cases where the topology
+  fits Mermaid's vocabulary and the user wants a Markdown-paste-
+  able artefact.
+- "Paste a machine definition" web playground hosted under the
+  viewer page (Stately-Visualizer-style onboarding flow).
+
+### Out of scope (any version)
+
+- A canvas-driven machine editor.
+- A multi-user / multiplayer canvas.
+- A saved-machine registry (the share-URL is the only persistence
+  affordance; long-term storage is the user's problem).
+- Statechart-from-non-machine-code visualisation (Stately Studio
+  2026 visualises Redux without XState; not Machines-Viz's lane).
+- SCXML import / export.
+- A Day8-hosted SaaS shell.
+
+## The bar Machines-Viz sets
+
+The v1 ship-list above is calibrated against three peer products:
+
+- **Stately Visualizer** — the gorilla. Pastable EDN-equivalent
+  rendering, animation, zoom/pan. Officially deprecated within
+  Stately's docs; their commercial Editor is the recommended
+  replacement.
+- **XState Inspector (`@xstate/inspect`)** — runtime attach;
+  live highlights; transition log; send-event surface.
+- **Mermaid statechart** (`stateDiagram-v2`) — static rendering
+  from text-as-code; the Markdown-embed workhorse.
+
+Where Machines-Viz **wins** against the peer set (per
+`ai/findings/sweep-tools-vs-sota-2026-05-13.md` §machines-viz):
+
+- `:after` countdown rings + microstep replay (no peer has both).
+- `:invoke-all` join visualisation with the join-condition label
+  (`:all` / `:any` / `{:n N}` / `{:fn ...}`).
+- Live trace integration tied to the Spec 009 bus.
+- Source-coord per node — every state, transition, guard, action
+  jumps to source.
+- Bundle isolation by classpath, not by tree-shaking discipline.
+
+Where Machines-Viz **defers** to peers:
+
+- Markdown-embed posture — Spec 005's post-v1 `(machine->mermaid)`
+  fills the niche.
+- Paste-and-render onboarding — v1.1 candidate; the v1 share-URL
+  viewer is the closest thing.
+- Statechart-from-non-machine code — Stately Studio's lane.
+
+## See also
+
+- [`Principles.md`](./Principles.md) — the load-bearing principles.
+- [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) — the locks; questions, options, picks.
+- [`API.md`](./API.md) — the consolidated public surface (`MachineChart` contract, viewer page URL, share-URL encoding).
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — Causa's embedding-side spec; the source of truth for transition-history ribbon, source-coord integration, `:invoke-all` viz, share-affordance UX.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the registry Machines-Viz visualises.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) — the trace bus the live-highlight consumes.

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1,0 +1,380 @@
+# API
+
+The consolidated user-facing surface. Implementer-readable: every
+symbol a consumer of Machines-Viz might reach for.
+
+This doc is a **reference**. The normative descriptions for the
+embedding-host side of these surfaces live in
+[`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md);
+where the two drift, this doc owns the **component contract** and
+the **share-URL encoding**, and Causa 003 owns the **panel chrome**.
+
+## Installation
+
+```clojure
+;; consumer deps.edn — typically transitive through Causa or Story
+{:deps {day8/re-frame2-machines-viz {:mvn/version "..."}}}
+```
+
+For Causa users: pulled transitively via `day8/re-frame2-causa`.
+For Story users with a machine panel: pulled transitively via
+`day8/re-frame2-story`. Direct dependents (a custom dev shell that
+wants a chart without the rest of Causa) declare it themselves.
+
+## `MachineChart` component
+
+The single chart-rendering surface. Substrate-agnostic — exported
+by every substrate adapter Machines-Viz ships against (Reagent /
+UIx / Helix).
+
+### Namespace
+
+```clojure
+(:require [day8.re-frame2-machines-viz.chart :as viz])
+```
+
+### Signature
+
+```clojure
+[viz/MachineChart props]
+```
+
+`props` is a map; the schema below is closed (the chart rejects
+unrecognised keys at registration time).
+
+### Props
+
+| Prop | Required | Default | Meaning |
+|---|---|---|---|
+| `:machine-id` | yes | n/a | The id of the registered machine to render. The chart resolves the definition via `(rf/machine-meta machine-id)` and the snapshot via `[:rf/machines machine-id]`. |
+| `:frame-id` | yes | n/a | The frame within which to resolve the registration and the snapshot. Hosts that observe only one frame can hard-code it; multi-frame hosts (Causa, Story) pass the user-selected frame here. |
+| `:on-state-click` | no | `nil` | `(fn [state-id state-meta] ...)`. Fires when the user clicks a state node. Hosts wire this to their click semantics (Causa: jump to source; Story: highlight in chrome; viewer: no-op). |
+| `:on-transition-click` | no | `nil` | `(fn [from-state event-id to-state transition-meta] ...)`. Fires on a transition edge click. |
+| `:on-guard-click` | no | `nil` | `(fn [guard-name source-meta] ...)`. Fires when the user clicks a guard label inside a transition's tooltip. |
+| `:on-action-click` | no | `nil` | `(fn [action-name source-meta] ...)`. Fires when the user clicks an action label inside a state's entry/exit tooltip. |
+| `:read-only?` | no | `false` | If `true`, all `:on-*` callbacks are no-op'd regardless of what the host passes. The viewer page sets this. |
+| `:show-microsteps?` | no | `true` | Whether intermediate `:always` microstep nodes are rendered. |
+| `:show-after-rings?` | no | `true` | Whether `:after` countdown rings render on the source states. |
+| `:show-invoke-all?` | no | `true` | Whether `:invoke-all` children render as a row of mini-machines (vs. a collapsed single icon). |
+| `:show-spawned?` | no | `true` | Whether dynamically `:rf.machine/spawn`-ed children appear in the parent's spawn-tray. |
+| `:height` | no | `nil` (flex) | Fixed height in pixels. Useful for uniform-ribbon layouts. |
+| `:width` | no | `nil` (flex) | Fixed width in pixels. |
+| `:initial-zoom` | no | `1.0` | Starting zoom factor. The user can zoom/pan after mount; the prop only sets the initial value. |
+| `:auto-pan?` | no | `false` | Whether the chart auto-pans on every transition to keep the active state visible. Causa's panel sets this from its localStorage toggle; the viewer page leaves it off. |
+| `:current-state-override` | no | `nil` | A `{:state ... :data ...}` map that overrides the live snapshot. Used by the read-only viewer page to render the shared snapshot. Out-of-scope for live charts. |
+
+The four `:on-*` callback shapes are mirrored from
+[Causa 003 §Source-coord integration](../../causa/spec/003-Machine-Inspector.md#source-coord-integration);
+the `*-meta` argument carries the registered source-coord map for the
+clicked element.
+
+### What renders
+
+For the selected machine, the chart shows:
+
+- **A directional state-chart.** Nodes are states (compound states
+  nested visually). Edges are transitions, labelled with their
+  triggering event id.
+- **The current state pulses.** Compound states' active child is
+  highlighted recursively. The pulse is the only continuous
+  animation; backgrounded charts pause it.
+- **Tooltips.** Hover a state for its tags + entry/exit actions;
+  hover an edge for its guard + action functions.
+- **`:invoke` / `:invoke-all` spawned children.** Per
+  `:show-invoke-all?`, render as a horizontal row of mini-machines
+  with the join-condition label below. Per
+  [Causa 003 §`:invoke-all` viz](../../causa/spec/003-Machine-Inspector.md#invoke-all-viz).
+- **`:after` countdown rings.** A filling arc on the source state
+  while a timer is scheduled; updates at 60Hz when the chart is
+  visible (per [DESIGN-RATIONALE Lock #8](./DESIGN-RATIONALE.md)).
+- **`:final?` states.** Rendered with a doubled border + checkmark
+  glyph.
+- **State-tag badges.** Each state node carries a coloured ring
+  per active tag union member (per Spec 005 §State tags).
+- **Microstep flashes.** Per `:show-microsteps?`, intermediate
+  states in an `:always` cascade flash briefly before the cascade
+  resolves.
+
+What does **not** render (the chart fires the callback and the
+host decides):
+
+- Transition history ribbon (Causa's chrome; lives in
+  `tools/causa/`).
+- Source-coord chips with editor-URL handler wiring (the chart
+  fires `:on-*-click`; the host opens the file).
+- A machine picker dropdown (the host owns frame + machine
+  selection).
+
+### Data sources
+
+The chart reads from the framework's public surfaces; it does not
+introduce new registries.
+
+| Surface | Used for |
+|---|---|
+| `(rf/machine-meta machine-id)` | Resolves the registered definition (states, transitions, guards, actions, source coords). |
+| `[:rf/machines <id>]` slot in frame `app-db` | Live current-state + data snapshot; deref drives the pulse. |
+| `:rf.machine/transition` trace events | Edge glow on the matching transition. |
+| `:rf.machine.microstep/transition` events | Microstep flashes. |
+| `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | `:after` countdown ring scheduling. |
+| `:rf.machine.invoke-all/started` / `-all-completed` / `-some-completed` / `-any-failed` | `:invoke-all` row updates. |
+| `:rf.machine/spawned` / `-destroyed` | Spawn-tray contents on the parent. |
+| `:rf.machine/done` | `:final?` entry highlight before auto-destroy. |
+| `:rf.machine/system-id-bound` / `-released` | Aliased addressing in the spawn-tray (gensym shows `:gensym-42 (:auth/main)`). |
+
+Source: lifted from
+[Causa 003 §Data sources](../../causa/spec/003-Machine-Inspector.md#data-sources).
+
+## Read-only viewer
+
+A static page at the canonical hosted URL (or self-hosted by the
+consumer) that renders a chart decoded from a URL fragment.
+
+### URL shape
+
+```
+https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=<base64-edn>
+```
+
+Or, when self-hosted:
+
+```
+https://acme.example.com/path/to/viewer.html#machine=<base64-edn>
+```
+
+### Behaviour
+
+- On page load, the viewer reads `location.hash`, strips the
+  leading `#machine=`, base64url-decodes, transit-reads, and
+  validates the envelope (per [§Share-URL payload schema](#share-url-payload-schema)
+  below).
+- Validation failure → a banner: "This share-URL is malformed or
+  was produced by a newer Machines-Viz." No chart renders.
+- Validation success → the viewer mounts `MachineChart` with:
+  - `:machine-id` and `:frame-id` from the payload's
+    `:chart-state` (per [§Share-URL payload schema](#share-url-payload-schema)).
+  - `:read-only?` set to `true`.
+  - `:current-state-override` from the payload's snapshot.
+  - All `:show-*` flags default to `true`.
+  - `:auto-pan?` off.
+- A single banner at the top of the page reads: **"This is a
+  static machine chart, not a Causa session — interactions are
+  disabled."**
+- A "show idle" toggle below the banner clears
+  `:current-state-override` so the chart renders the machine at
+  rest. Per [DESIGN-RATIONALE Lock #5](./DESIGN-RATIONALE.md).
+- The page is statically hostable. Per
+  [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md), the
+  canonical hosted instance at `day8.github.io` is a convenience,
+  not a contract; consumers can self-host.
+
+### What the viewer never does
+
+- It never transmits the URL fragment to a server. The fragment is
+  read client-side via `location.hash`; nothing sends it.
+- It never loads transit events, app-db slices, or any data
+  outside the validated payload schema.
+- It never enables `:on-*` callbacks. Hosts requesting a "click in
+  the viewer goes to my docs site" would have to fork the page;
+  the canonical viewer is read-only end-to-end.
+
+Source: lifted from
+[Causa 003 §Read-only viewer](../../causa/spec/003-Machine-Inspector.md#read-only-viewer).
+
+## Share-URL encoding
+
+### Encoder
+
+```clojure
+(:require [day8.re-frame2-machines-viz.share :as share])
+
+(share/encode-share-url chart-state)
+;; => "https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=..."
+
+(share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html"})
+;; => "https://acme.example.com/viewer.html#machine=..."
+```
+
+`chart-state` is a map with the schema in
+[§Share-URL payload schema](#share-url-payload-schema) below. The
+encoder:
+
+1. Validates `chart-state` against the schema. Anything outside the
+   allowlist is silently dropped (per [Principles §No session data
+   in shares](./Principles.md)).
+2. Canonicalises map / set ordering (per
+   [Principles §Reproducible from the registry alone](./Principles.md)).
+3. Wraps in the versioned envelope.
+4. EDN-prints → transit-writes → base64url-encodes.
+5. Wraps the fragment into the `:host` URL.
+
+### Decoder
+
+```clojure
+(share/decode-share-url url)
+;; => {:rf.machines-viz.share/v "1"
+;;     :rf.machines-viz.share/chart {:machine-id :auth/login-flow ...}
+;;     :rf.machines-viz.share/created 1736000000000}
+;; or throws :rf.machines-viz.share/decode-failed with :reason
+```
+
+Failure modes:
+
+| `:reason` | Meaning |
+|---|---|
+| `:malformed-fragment` | The `#machine=` fragment isn't valid base64url. |
+| `:malformed-payload` | Decoded bytes aren't valid transit. |
+| `:missing-envelope` | The payload is missing `:rf.machines-viz.share/v` or `:rf.machines-viz.share/chart`. |
+| `:unknown-version` | `:rf.machines-viz.share/v` is newer than the decoder knows. |
+| `:invalid-chart-state` | `:rf.machines-viz.share/chart` doesn't validate. |
+
+### Pipeline
+
+```
+chart-state  →  validate + canonicalise  →  envelope wrap
+             →  EDN-print  →  transit-write  →  base64url  →  URL fragment
+```
+
+Per [DESIGN-RATIONALE Lock #3](./DESIGN-RATIONALE.md).
+
+### Share-URL payload schema
+
+```clojure
+(def ShareEnvelope
+  [:map
+   [:rf.machines-viz.share/v      :string]   ;; encoding version, "1" at v1.0
+   [:rf.machines-viz.share/chart  ChartState]
+   [:rf.machines-viz.share/created :int]])   ;; wall-clock ms at encode time
+
+(def ChartState
+  [:map
+   [:machine-id  keyword?]              ;; the registered machine's id
+   [:frame-id    keyword?]              ;; the registered machine's frame
+   [:definition  MachineDefinition]     ;; the topology (states, transitions, guards, actions, :invoke, :invoke-all, :after)
+   [:snapshot   {:optional true}        ;; the current-state snapshot at share time
+    [:map
+     [:state    keyword?]
+     [:data     :any]
+     [:meta?   {:optional true} :any]]]
+   [:source-coords {:optional true}     ;; topology source-coords (per Spec 001) — only included if present in definition meta
+    [:map-of :any :any]]])
+```
+
+The `MachineDefinition` shape matches the `reg-machine` registered
+definition (per Spec 005 §Snapshot shape + §Transition table grammar)
+with **only** the topology slots included — `:guards` and `:actions`
+maps are encoded as **names only** (their fn bodies are not
+serialised; consumers re-resolve against their own registry if they
+want to run the machine). The viewer page never resolves them; it
+only renders.
+
+Anything not in the schema is silently dropped by the encoder. New
+top-level keys require an explicit `:rf.machines-viz.share/allow?`
+opt-in (per [Principles §No session data in shares](./Principles.md));
+CI enforces.
+
+### URL length
+
+For typical machines (~20 states, ~30 transitions) the encoded URL
+is under 4KB. Common URL limits sit around 8KB; we have headroom
+for moderately-sized charts.
+
+Charts large enough to exceed 8KB surface a fallback affordance
+(in the host that called `encode-share-url` — typically Causa's
+share menu): **"Copy as EDN fragment instead"** which puts the
+EDN on the clipboard instead of the URL. Per
+[Causa 003 §Share affordance §Performance](../../causa/spec/003-Machine-Inspector.md#performance_1).
+
+## Exporters
+
+### PNG
+
+```clojure
+(:require [day8.re-frame2-machines-viz.export :as export])
+
+(export/chart-as-png! chart-element)
+;; => Promise resolving to a Blob (image/png at 2x DPR)
+
+(export/copy-png-to-clipboard! chart-element)
+;; => Promise; clipboard contains the PNG + a text/plain alt-text sidecar
+```
+
+The PNG is rasterised at 2x DPR on a transparent background; the
+current-state highlight is included. An alt-text sidecar (a
+`text/plain` clipboard payload) summarises the machine: id, current
+state, node count, transition count.
+
+### SVG
+
+```clojure
+(export/chart-as-svg chart-element)
+;; => String — image/svg+xml with embedded fonts
+
+(export/copy-svg-to-clipboard! chart-element)
+;; => Promise; clipboard contains the SVG as image/svg+xml
+```
+
+The SVG includes `<title>` and `<desc>` elements summarising the
+machine (same content as the PNG sidecar). Fonts are embedded so the
+SVG renders identically when pasted into a doc or a Figma frame.
+
+### Share URL
+
+```clojure
+(export/share-url chart-element)
+;; => URL string
+
+(export/copy-share-url-to-clipboard! chart-element)
+;; => Promise; clipboard contains the URL as text/plain
+```
+
+`chart-element` is the in-DOM element rendered by `MachineChart`
+(or a hiccup-equivalent reference). The export functions derive the
+payload from the element's bound props + the live snapshot.
+
+### Accessibility
+
+Per [Causa 003 §Accessibility](../../causa/spec/003-Machine-Inspector.md#accessibility)
+(the share-affordance subsection; not the panel-level one — that's
+the second `#accessibility_1`) and
+[Lock #10 above](./DESIGN-RATIONALE.md):
+
+- **SVG**: `<title>` + `<desc>` summarise the machine textually.
+- **PNG**: a `text/plain` alt-text payload rides on the clipboard
+  alongside the image, with the same summary.
+- **Both**: a screen reader pasting the artefact into a document
+  has the same overview the sighted user has.
+
+The chart's in-place alt-view (for screen-reader navigation of the
+live chart itself, not the export) is a **v1.1 commitment**, per
+[`000-Vision.md` §v1.1 candidates](./000-Vision.md#v11-candidates-not-committed)
+and Causa 003 §Accessibility. v1.0 ships without it; the embedding
+host's transition-history ribbon + machine picker carry the
+accessible surface in the meantime.
+
+## Public CLJS API surface — summary
+
+```clojure
+day8.re-frame2-machines-viz.chart/MachineChart    ; component
+day8.re-frame2-machines-viz.share/encode-share-url
+day8.re-frame2-machines-viz.share/decode-share-url
+day8.re-frame2-machines-viz.export/chart-as-png!
+day8.re-frame2-machines-viz.export/chart-as-svg
+day8.re-frame2-machines-viz.export/share-url
+day8.re-frame2-machines-viz.export/copy-png-to-clipboard!
+day8.re-frame2-machines-viz.export/copy-svg-to-clipboard!
+day8.re-frame2-machines-viz.export/copy-share-url-to-clipboard!
+```
+
+No global state, no init function. The component is referentially
+transparent over its props; the share / export functions are pure
+(modulo the clipboard).
+
+## See also
+
+- [`000-Vision.md`](./000-Vision.md) — scope + non-goals + roadmap.
+- [`Principles.md`](./Principles.md) — load-bearing principles.
+- [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) — locks; cites Causa 003 lift-points.
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — embedding-host contract; the source spec these surfaces lifted from.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the registry the chart visualises.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) — the trace bus the live-highlight consumes.

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,570 @@
+# DESIGN-RATIONALE
+
+The direction-setting decisions that shape Machines-Viz. Each entry
+captures:
+
+- **The question** that was being decided.
+- **Options considered** that were walked through.
+- **The pick** that was locked.
+- **The why** — the reasoning trail.
+- **Date locked** + the locker.
+
+This doc is the load-bearing artefact of the per-tool spec
+convention. It exists so that a future contributor (human or AI) can
+read it and not re-ask the same questions. Where the spec text reads
+"per lock #N in DESIGN-RATIONALE.md", this is where to come.
+
+A subset of these locks are **lifted from
+[`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)**.
+Causa Spec 003 specified `MachineChart`'s prop surface, share-URL
+encoding, transition-history ribbon, and `:invoke-all` viz before
+this tool had its own spec folder. The scaffold (rf2-x50eu)
+migrates those decisions into Machines-Viz's home; Causa's 003
+remains the authoritative source for the **embedding-side**
+contract (transition history ribbon UX, source-coord jumps,
+Causa's panel chrome). Where the two could drift, this doc cites
+back to 003.
+
+---
+
+## Lock #1 — Scope: component-not-product
+
+**Locked 2026-05-13 (Mike).** **Ship as one embeddable component
+plus a read-only viewer page.** No paste-and-render editor, no
+saved-chart registry, no multiplayer canvas.
+
+### Question
+
+What surface does Machines-Viz ship at v1.0?
+
+### Options considered
+
+- **A Stately-Visualizer equivalent.** A web app where the user
+  pastes a `reg-machine` body and watches it render. Rejected as
+  product-shaped.
+- **A registry SaaS shell.** Save charts, share via URL or iframe,
+  Day8-hosted. Rejected as product-shaped and on the privacy axis.
+- **A multi-user canvas.** Multiplayer editing à la Stately Studio.
+  Rejected — out of lane.
+- **One embeddable component + a static read-only viewer page.**
+  Causa and Story embed the component; the viewer page renders a
+  shared URL. The framework owns the registry (via `reg-machine`);
+  Machines-Viz owns the rendering.
+
+### Pick
+
+**One embeddable component + a static read-only viewer page.**
+
+### Why
+
+- **Stately's own Visualizer is officially deprecated** within
+  their docs (per
+  [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/)).
+  The commercial Stately Editor is the recommended replacement.
+  Investing in the deprecated-product lane is chasing a sunset.
+- **Restraint principle** — a chart component the framework's own
+  tools embed has clear scope. A visualiser product accretes
+  features (registry, sharing UX, collaboration, billing, auth).
+  Each feature is "easy to add, hard to remove."
+- **Privacy by surface** — a Day8-hosted registry means Day8 sees
+  customers' machines. A static viewer + a client-side share-URL
+  means we see nothing. The privacy bet beats the utility bet.
+- **Bundle isolation holds trivially** — the component is the
+  only artefact; the viewer is a separate page. No conditional
+  compilation, no per-host build tricks.
+- **Mermaid covers the static-paste lane** — Spec 005's post-v1
+  `(machine->mermaid)` exporter handles Markdown-embed cases; the
+  share-URL viewer handles interactive cases. Both lanes are
+  served without growing this jar.
+
+---
+
+## Lock #2 — `MachineChart` prop contract
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).**
+**Props: `:machine-id`, `:frame-id`, `:on-state-click`,
+`:on-transition-click` (plus read-only flags).**
+
+### Question
+
+What does the host pass to `MachineChart` to render a chart?
+
+### Options considered
+
+- **Pass the machine definition directly.** The host pulls the
+  registration via `(rf/machine-meta id)` and passes the
+  transition table to the chart. Rejected — couples hosts to the
+  framework's internal definition shape and makes hot-reload
+  fragile (the chart wouldn't re-pick-up edits without explicit
+  host plumbing).
+- **Pass the snapshot directly.** The host derefs
+  `[:rf/machines <id>]` and passes the snapshot to the chart.
+  Rejected — the chart loses access to history (transition
+  events, microstep replay, `:after` rings); it would have to
+  re-derive snapshot transitions from frame deltas.
+- **Pass an id + a frame.** The chart resolves the registration
+  via `(rf/machine-meta machine-id)` and subscribes to
+  `[:rf/machines machine-id]` within `frame-id`. The host stays
+  thin; the chart owns its data plane.
+
+### Pick
+
+**Pass an id + a frame, plus two callbacks.**
+
+```clojure
+[viz/MachineChart {:machine-id          :auth/login-flow
+                   :frame-id            :app/main
+                   :on-state-click      (fn [state-id state-meta] ...)
+                   :on-transition-click (fn [from event-id to] ...)
+                   :read-only?          false      ;; viewer page sets true
+                   :show-microsteps?    true       ;; per-chart preference
+                   :show-after-rings?   true
+                   :show-invoke-all?    true}]
+```
+
+### Why
+
+- **Thin host interface** — the host doesn't need to thread the
+  definition or the snapshot. Causa's panel is a one-liner;
+  Story's per-variant panel is the same.
+- **Hot-reload safe** — the chart re-reads `(rf/machine-meta id)`
+  on every mount and on registry-change traces; the host doesn't
+  have to plumb hot-reload through.
+- **Callback shape locks the host's freedom** — Causa wires
+  `:on-state-click` to "jump to source"; Story wires it to
+  "highlight in the per-variant chrome"; the viewer page no-ops
+  both. Each host chooses, the component stays neutral.
+- **Per-chart visibility toggles ride on props** — `:show-microsteps?`
+  etc. let the host (or the chart's own settings menu) toggle
+  granularity without re-mounting. Defaults are conservative;
+  hosts opt in.
+- **Read-only flag opts out of clicks** — the viewer page sets
+  `:read-only? true` so neither callback fires regardless of
+  what the host passes.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Embedding posture. The prop names matched there are reproduced
+here verbatim.
+
+---
+
+## Lock #3 — Share-URL encoding: EDN → transit → base64url
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **Pipeline
+is `chart-state → EDN-print → transit-write → base64url → URL
+fragment`. Versioned envelope; topology + current-state snapshot
+only.**
+
+### Question
+
+How does Machines-Viz encode a chart for sharing?
+
+### Options considered
+
+- **JSON.** Lossy for keywords, sets, namespaced keys. Rejected
+  on the EDN-first principle.
+- **EDN raw + URL-encode.** Verbose; large machines blow past the
+  URL length limit fast.
+- **Transit-write + base64url, unversioned.** Compact; URL-safe.
+  Rejected on the format-evolution axis — without a version
+  envelope, future encoding changes are breaking.
+- **EDN → transit-write → base64url + versioned envelope.** The
+  envelope keys (`:rf.machines-viz.share/v`,
+  `:rf.machines-viz.share/chart`,
+  `:rf.machines-viz.share/created`) ride at the outermost level;
+  decoders dispatch on `:rf.machines-viz.share/v`.
+
+### Pick
+
+**EDN → transit-write → base64url + versioned envelope.**
+
+### Why
+
+- **EDN preserves the registered shape** — keywords, sets, nested
+  maps, namespaced keys all round-trip. JSON would force re-
+  coercion.
+- **Transit is compact** — typical machines (~20 states, ~30
+  transitions) encode to a sub-4KB URL after base64url. Common
+  URL limits sit around 8KB; we have headroom for moderate-sized
+  charts.
+- **Base64url is URL-safe** — no `+` or `/` in the alphabet; no
+  percent-encoding contention.
+- **Fragment, not query** — URL fragments are never sent in HTTP
+  requests; the share-URL is invisible to servers and to
+  browsers' navigation logs. The chart never traverses a server
+  by accident.
+- **Versioned envelope is the cheapest evolution insurance** —
+  any future change to the payload schema bumps `:rf.machines-viz.share/v`;
+  old decoders refuse old payloads with a clear message rather
+  than rendering garbage.
+- **Charts exceeding URL limits** — the `Copy as edn fragment
+  instead` fallback puts the EDN on the clipboard for paste-into-
+  a-doc. Per Causa 003 §Share affordance §Performance.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share affordance §Share URL + §Performance.
+
+---
+
+## Lock #4 — Markdown-embed: Mermaid covers it, not us
+
+**Locked 2026-05-13 (Mike).** **Machines-Viz does not emit
+Mermaid at v1.** Spec 005's post-v1 `(machine->mermaid)` exporter
+fills the Markdown-embed lane.
+
+### Question
+
+Should Machines-Viz emit Mermaid `stateDiagram-v2` as one of its
+export formats?
+
+### Options considered
+
+- **Ship Mermaid emit at v1.0.** Differentiator vs Stately
+  Visualizer (which has no Markdown-embed posture). Easy code
+  (the topology round-trips cleanly).
+- **Defer to v1.1.** The static topology fits Mermaid; `:after`
+  rings, microstep replay, `:invoke-all` joins do not. The output
+  is a partial chart; users may not realise.
+- **Don't ship at all.** Spec 005's
+  `(rf/machine->mermaid definition)` is already enumerated as a
+  post-v1 framework deliverable. Machines-Viz duplicates it.
+
+### Pick
+
+**Don't ship at all in Machines-Viz; defer to the framework's
+`(machine->mermaid)`.**
+
+### Why
+
+- **The framework's exporter lives upstream.** A consumer who
+  wants a Markdown chart can call `(rf/machine->mermaid)` directly
+  on the registered definition; no need to drag Machines-Viz
+  into the toolchain.
+- **No duplication of partial-output semantics.** If we ship
+  Mermaid emit here, we have to explain "the rings are lost," "the
+  microsteps are flattened," "the join-condition becomes a
+  comment." The framework-level exporter explains it once.
+- **Live wins for interactive cases.** The share-URL viewer
+  renders the full topology including rings and joins; Mermaid
+  doesn't. The two are complementary, not competitive.
+- **Cheaper to walk away.** If usage data later shows demand for
+  Mermaid emit inside Machines-Viz (say, because users want a
+  one-click "share as Mermaid block" affordance), it can be added
+  in v1.1 as a thin wrapper around the framework's exporter.
+
+The share-URL viewer is the "paste this into a doc and have it
+render interactively" affordance; `(machine->mermaid)` is the
+"paste this into a Markdown file" affordance. Both lanes are
+covered by complementary surfaces.
+
+---
+
+## Lock #5 — Current-state in share-URL: snapshot, not history
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **The
+share-URL payload carries the topology + a single current-state
+snapshot. No transition history; no event vector; no app-db
+slices.**
+
+### Question
+
+What state-information does the share-URL carry?
+
+### Options considered
+
+- **Topology only.** The chart renders with no active state; the
+  recipient sees the machine "at rest." Rejected — the sharer's
+  intent is usually "look at the state I was in"; a topology-only
+  share loses that context.
+- **Topology + a transition history.** The chart can replay the
+  last N transitions on load. Rejected — encodes session data,
+  violates the no-session-export principle (Causa Lock #4 lifted),
+  inflates the URL beyond practical limits.
+- **Topology + a single current-state snapshot.** The chart
+  renders with the snapshot's state highlighted. The recipient
+  has a "show idle" toggle to clear it.
+
+### Pick
+
+**Topology + a single current-state snapshot.**
+
+### Why
+
+- **Visual continuity** — the recipient sees what the sharer was
+  looking at, the canonical case for sharing a chart.
+- **Reproducible-from-registry-alone** holds for the topology;
+  the snapshot is the only non-reproducible bit and is purely a
+  visual hint.
+- **Privacy holds** — no event vectors, no app-db slices, no user
+  inputs. A snapshot is the machine's `:state` keyword plus its
+  `:data` value (which the machine author controls); if the
+  machine author put sensitive data in `:data`, they should treat
+  the registered machine as code, which is the same rule that
+  applies to source. The share-URL does not leak run-time data.
+- **"Show idle" toggle** — the viewer page offers a one-click
+  "clear active state" if the recipient wants to discuss the
+  machine in the abstract. Causa 003 §Share-URL §Read-only viewer
+  specifies this affordance.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share-URL §NOT a session export + §Privacy posture.
+
+---
+
+## Lock #6 — Read-only viewer: same component, click handlers no-op'd
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **The
+viewer page mounts the same `MachineChart` component with
+`:read-only? true`. No transition-history ribbon (there's no
+history); a single banner labels it as a static snapshot.**
+
+### Question
+
+What renders inside the read-only viewer page?
+
+### Options considered
+
+- **A reduced-feature `StaticMachineChart` component.** Separate
+  artefact, narrower surface. Rejected on duplication grounds.
+- **The same `MachineChart` with click handlers no-op'd.** The
+  `:read-only? true` flag suppresses callback firing; the
+  component renders normally.
+
+### Pick
+
+**Same component, `:read-only? true`.**
+
+### Why
+
+- **One renderer, one set of bugs.** The static viewer and the
+  embedded inspector go down identical render paths; any
+  rendering bug surfaces in both.
+- **The component already encapsulates the rendering.** Hiding
+  the transition-history ribbon is the host's responsibility —
+  the viewer page's host renders no ribbon, Causa's host renders
+  one.
+- **The banner labels the surface** — "This is a static machine
+  chart, not a Causa session — interactions are disabled." Per
+  Causa 003 §Read-only viewer.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share-URL §Read-only viewer.
+
+---
+
+## Lock #7 — Hosting posture: statically hostable, client-side rendering
+
+**Locked 2026-05-13 (Mike).** **The viewer page is a single
+static HTML file + the Machines-Viz CLJS bundle; no server logic;
+no Day8-hosted infrastructure.**
+
+### Question
+
+How does the read-only viewer page get to a user?
+
+### Options considered
+
+- **Day8-hosted SaaS shell** with a backing database for saved
+  charts. Rejected on Lock #1 (component-not-product) plus
+  privacy (no Day8 sees customer machines).
+- **Day8-hosted static page** with no backend; client-side
+  decoding. Cleanest of the hosted options.
+- **Statically hostable; consumer hosts the page themselves**
+  alongside their app. No Day8 dependency.
+
+### Pick
+
+**Statically hostable; the canonical hosted instance lives at
+`day8.github.io/re-frame2-machines-viz/` (or equivalent docs URL)
+but is **not load-bearing** — every consumer can self-host.**
+
+### Why
+
+- **No Day8-side service to operate.** The page is a static
+  asset; if `day8.github.io` goes down, every self-hoster keeps
+  working.
+- **Privacy holds maximally.** Even the canonical hosted page
+  decodes client-side; the URL fragment is never transmitted.
+- **Embed in docs without iframe gymnastics.** The viewer page
+  can be loaded by a `<script>` tag in the consumer's own docs
+  site; the consumer chooses where it lives.
+- **The canonical instance is a convenience, not a contract.**
+  Users sharing a URL with the canonical viewer get one-click
+  rendering; users who don't trust day8.github.io can self-host
+  the page and point share-URLs at their own instance.
+
+---
+
+## Lock #8 — `:after` countdown rings: 60Hz when visible, paused when not
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **`:after`
+countdown rings render at 60Hz while the chart is on-screen;
+backgrounded charts pause the ring render but the underlying
+timer keeps running.**
+
+### Question
+
+How do `:after` countdown rings update?
+
+### Options considered
+
+- **Continuous 60Hz.** Smooth; uses more CPU than necessary when
+  the chart isn't visible.
+- **Event-driven via trace stream.** The ring updates only on
+  `:rf.machine.timer/scheduled` / `-fired` events. Choppy.
+- **60Hz when visible, paused when backgrounded.** The
+  `IntersectionObserver` / `document.visibilityState` gates the
+  render loop; the framework's clock (per Spec 005) keeps
+  running, so the timer fires correctly whether or not the ring
+  is rendering.
+
+### Pick
+
+**60Hz when visible, paused when backgrounded.**
+
+### Why
+
+- **The timer is the source of truth, not the ring.** The ring
+  is a visualisation of the timer; pausing the ring does not pause
+  the timer.
+- **Backgrounded panels burn no CPU.** A Story page with 50
+  variants, each with a chart, each with a ring, would consume
+  significant CPU if every ring rendered at 60Hz. Visibility-
+  gating reduces it to "only the visible charts pay the cost."
+- **`prefers-reduced-motion` clamps the ring to a step
+  animation** — not a smooth fill. The user controls.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Performance + §Animation (the broader UX baseline lives in
+[Causa 007-UX-IA](../../causa/spec/007-UX-IA.md)).
+
+---
+
+## Lock #9 — Layout: recompute on registry change, not on transition
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **Chart
+layout runs only on registry change (machine re-registered) or
+compound-state expand/collapse. Live transitions update node
+highlights without re-layout.**
+
+### Question
+
+When does Machines-Viz recompute chart layout?
+
+### Options considered
+
+- **On every transition.** Smooth animation; flickers on large
+  charts as the layout shifts.
+- **Never** — fixed layout from first registration. Compound-
+  state expand/collapse is broken.
+- **On registry change + on compound expand/collapse only.**
+  The layout is stable across transitions; the highlight moves
+  through a stable graph.
+
+### Pick
+
+**On registry change + on compound expand/collapse only.**
+
+### Why
+
+- **Stable graphs are easier to read.** A chart that re-layouts
+  on every transition makes the user re-orient on every event;
+  cognitive cost wins over visual flourish.
+- **Performance** — re-layout is O(nodes × edges) at minimum;
+  60Hz re-layout on a 50-state chart is expensive.
+- **Hot-reload** triggers a registry-change event, which triggers
+  a layout pass — so editing a machine and saving causes the
+  chart to redraw correctly without manual intervention.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Performance.
+
+---
+
+## Lock #10 — Source migration from Causa 003
+
+**Locked 2026-05-13 (Mike).** **The following content migrates
+from Causa 003 to this jar's spec when implementation work
+begins. Until then, Causa 003 remains the read-the-spec source of
+truth.**
+
+### Migrating content
+
+| Topic | Causa 003 section | Lands in Machines-Viz spec at |
+|---|---|---|
+| `MachineChart` prop contract | §Embedding posture | [`API.md`](./API.md) §MachineChart (already lifted) |
+| Share-URL encoding pipeline | §Share affordance §Share URL + §Performance | [`API.md`](./API.md) §Share-URL encoding (already lifted) |
+| Read-only viewer behaviour | §Share-URL §Read-only viewer | [`API.md`](./API.md) §Read-only viewer (already lifted) |
+| `:after` countdown rings — render rules | §Performance | [`API.md`](./API.md) §Countdown rings + Lock #8 above |
+| Layout-recompute rules | §Performance | Lock #9 above |
+| `:invoke-all` viz — row of mini-machines | §`:invoke-all` viz | future 001-Rendering.md (post-scaffold; not in this PR) |
+| PNG / SVG export — accessibility | §Accessibility | [`API.md`](./API.md) §Exporters |
+| Privacy posture for share-URL | §Privacy posture | [Principles §No session data in shares](./Principles.md) (already lifted) |
+| Auto-pan on transition | §Auto-pan | future 001-Rendering.md |
+
+### What stays in Causa 003 (the embedding-host side)
+
+- **Transition-history ribbon UX** — Causa's chrome around the
+  chart; not part of `MachineChart` itself.
+- **Source-coord jumps via Causa's editor-URL handler** — the
+  framework registry exposes coords; Causa wires the URL handler;
+  Machines-Viz fires `:on-state-click` and stops there.
+- **Causa's machine picker dropdown.**
+- **Causa's panel header + auto-pan toggle persistence.**
+
+### Why
+
+The split is **chart-component-concerns vs embedding-host-
+concerns**. Everything that's about rendering / encoding /
+export lives here; everything that's about Causa's panel chrome
+or Story's per-variant ribbon lives in those tools' spec.
+
+The migration is staged: this scaffold PR (rf2-x50eu) covers
+[`API.md`](./API.md) + this rationale + Principles + Vision. The
+detailed rendering / layout / export specs (a future
+`001-Rendering.md`, possibly more) land as separate beads once
+implementation work picks up.
+
+Until those land, **Causa 003 is the source of truth for
+unmigrated content**, and this DESIGN-RATIONALE cites back to it.
+
+---
+
+## Open questions
+
+The locks above cover the v1.0 surface. Open questions deferred
+to implementation:
+
+- **Layout algorithm** — Dagre? ELK? Custom? (Causa 003 doesn't
+  pick; defer until first cut.)
+- **SVG primitive vs Canvas vs HTML/CSS** — Causa 003 hints
+  "SVG primitive" (per §Share affordance §Performance) but
+  doesn't lock; defer to a `001-Rendering.md` bead.
+- **Component substrate** — `MachineChart` is registered via
+  `reg-view` (Spec 004) so it works across Reagent / UIx /
+  Helix; the registration spec lives in a future capability doc.
+- **Test corpus shape** — a snapshot-tested fixture per
+  rendering case (compound, parallel, `:after`, `:invoke-all`,
+  `:final?`); shape mirrors the framework's conformance corpus.
+  Defer to implementation.
+- **Edge labels on dense graphs** — Causa 003 doesn't address
+  label collision; defer.
+
+Each of these will land as a Locked entry above when picked, or
+as a bead against this jar.
+
+---
+
+## See also
+
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — the source spec these locks migrated from; embedding-host contract.
+- [`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md) — Causa's locks; #4 (no session export) is lifted into Lock #5 above.
+- [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/) — visualizer-as-product deprecation rationale.
+- [`ai/findings/sweep-tools-vs-sota-2026-05-13.md`](../../../ai/findings/) §machines-viz — peer-comparison + gap analysis.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) §Future — `(machine->mermaid)` exporter forward-pointer.

--- a/tools/machines-viz/spec/Principles.md
+++ b/tools/machines-viz/spec/Principles.md
@@ -1,0 +1,273 @@
+# Principles
+
+The load-bearing principles. When a design call has two reasonable
+options, these are the tie-breakers. Implementers and contributors
+should be able to read this doc and reach the same answers
+Machines-Viz already reached.
+
+These are downstream of the framework's
+[Principles](../../../spec/Principles.md) and Causa's
+[Principles](../../causa/spec/Principles.md); they are
+*Machines-Viz-specific*. Where they overlap, this doc cites instead
+of repeating.
+
+## Observation only — no new runtime surfaces
+
+Machines-Viz is a **downstream consumer** of re-frame2's
+instrumentation surface. It must not add:
+
+- New registries.
+- New dispatch types.
+- New effect substrates.
+- New component substrates.
+
+If a chart needs data the framework doesn't emit, the answer is to
+**add to the framework's instrumentation** (via a spec amendment in
+`spec/009-Instrumentation.md` or `spec/005-StateMachines.md`) — not
+to bolt a parallel surface onto Machines-Viz.
+
+This is the same posture Causa takes
+([Causa Principles §Observation only](../../causa/spec/Principles.md)).
+The rule applies twice in this jar: once because the framework
+should not grow tooling-only surfaces, once because every host that
+embeds `MachineChart` must be able to count on identical behaviour.
+
+## Embedding-host-agnostic — one component, many hosts
+
+`MachineChart` does not know its host. Causa wraps it in the
+Machine Inspector panel; Story wraps it in a per-variant ribbon;
+the read-only viewer page wraps it in plain HTML. The component's
+contract is the same in every case:
+
+- Inputs: `:machine-id`, `:frame-id`, `:on-state-click`,
+  `:on-transition-click`, plus the read-only/no-op flags the
+  viewer uses.
+- Outputs: rendered SVG + the four callback events fired on user
+  interaction.
+- No assumptions: the component does **not** assume the host
+  surfaces a frame picker, a transition-history ribbon, an editor
+  URL handler, or any other Causa-shaped affordance. Hosts add
+  those.
+
+When two hosts disagree on a behaviour, the resolution lives in
+this jar — not in either host. Hosts that need different behaviour
+pass it via props or via the (small) configuration surface in
+[`API.md`](./API.md).
+
+## Bundle isolation by classpath
+
+Per [`tools/README.md`](../../README.md), tools are kept off
+consumer apps' production classpaths **structurally**. Machines-Viz
+inherits the contract: nothing in `implementation/` may `:require`
+from this jar. Causa requires this jar; Story requires this jar;
+the framework runtime does not.
+
+This is non-negotiable. A consumer who deploys a re-frame2 app to
+production must not ship a single byte of charting code. The
+mechanism is the same as the substrate-adapter split: the wrong
+artefact is absent from the classpath.
+
+## EDN-first on the wire
+
+Share-URLs encode the chart payload as EDN, not JSON. EDN preserves
+the keywords, sets, vectors, and nested maps that
+`reg-machine` definitions carry; JSON would lose the type
+information and force a re-coercion layer.
+
+The encoding pipeline:
+
+```
+chart-state  →  EDN-print  →  transit-write  →  base64url  →  URL fragment
+```
+
+Transit handles the binary-compactness; base64url is URL-safe; the
+fragment is invisible to servers and browsers' navigation logs (the
+hash component is never sent in the HTTP request). The decoding
+pipeline runs the inverse. Same EDN-first posture the MCP triplet
+takes (per `ai/findings/sweep-tools-vs-sota-2026-05-13.md` §EDN-
+first wire vocabulary).
+
+A versioned envelope keys the encoding so future format evolution
+is non-breaking:
+
+```clojure
+{:rf.machines-viz.share/v "1"           ;; encoding version
+ :rf.machines-viz.share/chart   { ... } ;; the payload
+ :rf.machines-viz.share/created <ms>}   ;; encode-time wall-clock
+```
+
+A decoder that reads a newer-than-known version refuses to render
+and surfaces "this chart was shared from a newer Machines-Viz; try
+upgrading."
+
+## No session data in shares
+
+The share-URL serialises **only** machine topology + a single
+current-state snapshot.
+
+Forbidden in a share payload:
+
+- Trace events (no event vectors; no dispatch ids; no causal walk).
+- Epoch history (no app-db slices outside `[:rf/machines <id>]`).
+- User-input data (no form values, no inputs the user typed).
+- Conversation buffers (no AI-co-pilot history).
+- Cross-machine state unless the sharer's chart explicitly includes
+  it via `:invoke-all`.
+- Any data from any panel other than the machine chart.
+
+The principle exists because the framework's runtime carries
+sensitive data by default (per
+[Spec 009 §Privacy](../../../spec/009-Instrumentation.md)). A share-
+URL that exfiltrates trace events is a privacy hole; we close it
+structurally. Per Causa Lock #4 — Session export, lifted here.
+
+The encoder is the gatekeeper: it accepts a `chart-state` value and
+silently drops anything outside the allowlist before serialising.
+The allowlist lives in [`API.md`](./API.md) §Share-URL payload
+schema; CI tests enforce that any new top-level key requires an
+explicit `:rf.machines-viz.share/allow?` opt-in.
+
+## Reproducible from the registry alone
+
+A shared chart's topology must be reproducible byte-for-byte from
+the same `reg-machine` call. Two consumers with the same re-frame2
+build and the same machine definition should encode to the same
+EDN regardless of when they encoded.
+
+This means:
+
+- **Map keys sort deterministically** (alphabetical by name, then
+  namespace) before EDN serialisation.
+- **Set members sort the same way.**
+- **Source coords** are encoded only when present in the
+  definition's metadata — never synthesised at encode time.
+- **No timestamps** other than the explicit `:rf.machines-viz.share/created`
+  envelope key; the payload itself is timeless.
+
+Reproducibility lets two consumers diff their charts when they
+disagree about a machine's behaviour. The diff is meaningful only
+if the encoding is canonical.
+
+The only non-reproducible bit is the **current-state snapshot** —
+which is purely a visual-highlight hint. The viewer has a "show
+idle" toggle that clears it.
+
+## Read-only is the default
+
+The default `MachineChart` is a viewer. Interactions are limited
+to:
+
+- Click a state node → fire `:on-state-click` (host decides what to
+  do: Causa jumps to source; the viewer page no-ops).
+- Click an edge → fire `:on-transition-click` (host decides).
+- Hover an edge / state → reveal a tooltip (this is the
+  component's own affordance; no host wiring).
+
+Machines-Viz **never** dispatches into the framework runtime. It
+**never** calls `restore-epoch`. It **never** writes to `app-db`.
+Same posture Causa takes
+([Causa Principles §Read-only by default](../../causa/spec/Principles.md))
+— the difference is that Causa's posture has a "mutate by
+confirmation" escape (re-dispatch via right-click etc.); Machines-
+Viz has no escape. The component is observation, full stop.
+
+If a host needs to drive the runtime from a chart click (Causa's
+"jump to source", say), the host wires that through its own
+machinery — Machines-Viz fires the callback and stops there.
+
+## Charts pulse only the active state
+
+The only continuous animation in a chart is the active state's
+1.2s heartbeat pulse (lifted from Causa 007-UX-IA §Animation —
+only the active machine's node pulses). Everything else is
+event-driven:
+
+- Transition: one ~250ms edge-glow on the matching event.
+- Microstep: one 150ms intermediate node flash.
+- `:after` countdown: a fill ring that updates at 60Hz **only**
+  when the chart is visible; backgrounded charts pause the fill.
+- `:invoke-all` join completes: one ~400ms row-collapse animation.
+
+No looping animations except the heartbeat. No "look at me I'm
+running" continuous strobes. Every animation respects
+`prefers-reduced-motion`; reduced motion clamps durations to 0
+except a 1-frame opacity tween where layout needs to settle.
+
+This is the framework's animation-communicates-not-decorates
+principle, applied to charts.
+
+## Colour is never alone
+
+Every coloured marker pairs with a shape, icon, or text:
+
+- Active state: green fill + a filled-glyph badge + the state-name
+  label.
+- `:after` countdown ring: amber arc + the countdown-clock icon +
+  the remaining-ms text.
+- `:final?` state: doubled border + a "✓" glyph.
+- `:invoke-all` failed child: red fill + an "!" badge + "failed"
+  label.
+- Stale microstep node: grey + dashed border + "(microstep)" text.
+
+The colour-blind path is reachable without hue. Same posture
+Causa takes
+([Causa 007-UX-IA §Colour is never alone](../../causa/spec/007-UX-IA.md)).
+
+## Restraint over completeness
+
+The temptation to grow a chart component into a full editor is
+real. The component is striking; the editor is striking-er;
+visualisation-as-product is a peer-set norm.
+
+We resist:
+
+- No drag-to-reposition (the layout is computed; the user does not
+  edit it).
+- No state-rename inside the chart (the user edits source; the
+  chart re-layouts).
+- No transition-add gesture (the user edits source).
+- No saved-chart registry (the share-URL is the only persistence
+  affordance; bookmark it, drop it in a doc).
+- No multi-user / multiplayer canvas.
+
+If a chart feature is in the v1 ship list (per
+[`000-Vision.md`](./000-Vision.md) §Scope and roadmap), it lands.
+Otherwise: defer to v1.1, or let Stately Studio own the lane. The
+machine inspector's job is to **show the cascade**, not to
+**author the machine**.
+
+## Production elision is non-negotiable
+
+The chart depends on the framework's trace bus + the
+`[:rf/machines <id>]` snapshot, both of which are gated on
+`re-frame.interop/debug-enabled?` in production (per
+[Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
+Machines-Viz contributes its own sentinels to the elision verifier
+(`npm run test:elision`); CI blocks any leak.
+
+Production builds (`:advanced` + `goog.DEBUG=false`) elide every
+surface this jar consumes. The chart is invisible in production —
+not "renders with a warning," not "degrades gracefully," **absent
+from the classpath**.
+
+## Backed by the framework's principles
+
+When in doubt, defer to the framework's
+[Principles](../../../spec/Principles.md):
+
+- **Regularity over cleverness** — one obvious way to render a
+  state, an edge, a microstep.
+- **Named things over anonymous things** — every state has a
+  stable id; every transition has a stable selector; every callback
+  prop has a stable name.
+- **Public query surfaces** — Machines-Viz reads only what the
+  framework's public registrar / trace bus / `[:rf/machines]`
+  surface exposes.
+- **Deterministic execution** — Machines-Viz's rendering is a
+  function of `(reg-machine def, snapshot, trace-history)`; no
+  hidden side-effects.
+
+Machines-Viz is a downstream artefact of the framework's
+AI-first discipline. The principles above are what *Machines-Viz
+adds* over the framework's baseline; everything below is
+inherited.

--- a/tools/machines-viz/spec/README.md
+++ b/tools/machines-viz/spec/README.md
@@ -1,0 +1,31 @@
+# Machines-Viz (`day8/re-frame2-machines-viz`) — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — What `MachineChart` is, what the read-only viewer guarantees, the share-URL encoding format; relationship to Stately Visualizer (visualizer-as-product is out of scope).
+- **[Principles.md](Principles.md)** — Bundle isolation, EDN-first wire, observation-only, embedding-host-agnostic, no session data in shares, read-only by default.
+- **[API.md](API.md)** — Consolidated public surface: `MachineChart` component contract, read-only viewer URL, share-URL encoding pipeline + payload schema, PNG / SVG exporters.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — The locks. Question, options, pick, why, locker. Several locks lift content from [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md); cross-references retained.
+
+## How to use
+
+This folder is scaffolded for the v1.0 surface. Read
+[`000-Vision.md`](000-Vision.md) first to anchor scope (one
+embeddable component + a read-only viewer page; no
+visualizer-as-product), then [`Principles.md`](Principles.md) for
+the tie-breakers, then [`API.md`](API.md) for the consolidated
+contract. [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) records the
+locks; it cites [Causa 003](../../causa/spec/003-Machine-Inspector.md)
+where decisions were originally specced on the embedding side.
+
+Numbered capability docs (`001-Rendering.md`, etc.) land as
+implementation work picks up; this scaffold is intentionally
+**API + locks first, capability detail later**. Until the
+capability docs land, [Causa 003](../../causa/spec/003-Machine-Inspector.md)
+is the source of truth for unmigrated content (transition-history
+ribbon UX, source-coord wiring, `:invoke-all` row layout details).
+
+## Status
+
+Scaffolded by [rf2-x50eu](../../../.beads/) — 2026-05-13. No code
+yet; the spec covers the contract the implementation will satisfy.


### PR DESCRIPTION
## Summary

- `tools/machines-viz/` was forward-referenced from Causa Spec 003 (Machine Inspector embeds it), Story's machine panel, and Spec 005 §Future, but had no directory on disk — the per-tool spec convention in `tools/README.md` requires every tool ship its own `spec/` folder.
- This scaffold creates `tools/machines-viz/spec/` with `000-Vision.md` + `Principles.md` + `DESIGN-RATIONALE.md` + `API.md` (plus a `spec/README.md` index), and a top-level `tools/machines-viz/README.md`. Spec only; no code lands.
- Decisions are **lifted** from `tools/causa/spec/003-Machine-Inspector.md` (the `MachineChart` prop contract, the share-URL encoding pipeline, the read-only viewer behaviour, the `:after` countdown + layout-recompute rules). Causa 003 remains the source of truth for the embedding-host side (transition-history ribbon, source-coord wiring, Causa's panel chrome); cross-references retained in both directions.
- Scope locked to **component-not-product** (Lock #1): one embeddable `MachineChart` + a static read-only viewer page that decodes `#machine=<base64-edn>` URL fragments. Stately Visualizer + Studio occupy the visualizer-as-product lane (and Stately's own Visualizer is officially deprecated per the xstate findings sweep). No paste-and-render editor, no Day8-hosted registry, no multiplayer canvas.
- Updates the `machines-viz` entry in `tools/README.md` §In design / planned to reflect the new scope and link to the spec folder.

## Decisions extracted from Causa 003

1. **`MachineChart` prop contract** (Lock #2) — `{:machine-id, :frame-id, :on-state-click, :on-transition-click, :on-guard-click, :on-action-click, :read-only?, plus :show-* visibility flags}`. Component resolves the registration via `(rf/machine-meta machine-id)`; hosts stay thin.
2. **Share-URL encoding** (Lock #3) — `chart-state → canonicalise → version-envelope → EDN-print → transit-write → base64url → URL fragment`. Versioned `:rf.machines-viz.share/v` envelope; allowlist enforces no session data; reproducible byte-for-byte from registry alone.
3. **Current-state-only in shares** (Lock #5) — share-URL carries topology + a single snapshot; no transition history, no event vectors, no app-db slices.
4. **Read-only viewer** (Lock #6) — same `MachineChart` with `:read-only? true`; click handlers no-op'd; banner labels as static snapshot; "show idle" toggle clears the snapshot.
5. **`:after` countdown rings** (Lock #8) — 60Hz while chart is visible, paused when backgrounded; timer keeps running.
6. **Layout recompute** (Lock #9) — only on registry change or compound expand/collapse, never on transition.

Additional locks captured here (not lifted):

- **Markdown-embed deferred** (Lock #4) — Spec 005's post-v1 `(machine->mermaid)` exporter covers the lane; we don't duplicate.
- **Statically hostable viewer** (Lock #7) — canonical hosted instance at `day8.github.io` is a convenience, not a contract; self-hosting works identically.
- **Source-migration plan** (Lock #10) — staged migration table from Causa 003 to forthcoming `001-Rendering.md` and follow-on capability docs.

## Files created

- `tools/machines-viz/README.md`
- `tools/machines-viz/spec/000-Vision.md`
- `tools/machines-viz/spec/Principles.md`
- `tools/machines-viz/spec/DESIGN-RATIONALE.md`
- `tools/machines-viz/spec/API.md`
- `tools/machines-viz/spec/README.md`

## Files updated

- `tools/README.md` — `machines-viz` entry under §In design / planned rewritten to reflect component-not-product scope.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — passes (every anchor link resolves, including disambiguated `#performance_1` for the Causa 003 share-affordance §Performance subsection).
- [x] `mkdocs build --strict` — passes with the 2 pre-existing warnings unrelated to this PR (`guide/21-stories.md` → `tools/story/spec/005-SOTA-Features.md` / `002-Runtime.md`; both exist on origin/main).
- [ ] Reviewer sanity-check on the lifted-vs-owned split (Causa 003 still owns the embedding-host side; machines-viz owns the component contract + encoding + viewer).

## Notes

- No code lands; this is spec scaffolding only.
- Bead `rf2-x50eu` (P2). Filed from `ai/findings/sweep-tools-vs-sota-2026-05-13.md` §machines-viz (P2 SOTA reading).