### PR TITLE
test(adapters): port high-value reagent specs to uix + helix — parity coverage (rf2-ta4b5)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
@@ -1,0 +1,360 @@
+(ns re-frame.adapter.helix-cross-spec-cljs-test
+  "Adapter-parity port of the headless subset of
+  `re-frame.cross-spec-cljs-test` to the Helix adapter (rf2-ta4b5).
+
+  Each deftest pins a Cross-Spec interaction (spec/Cross-Spec-Interactions.md)
+  under a Helix-installed adapter. The subset ported here is the one
+  whose contract is observable WITHOUT a real React render — every
+  test runs through the runtime / registrar / trace channel only.
+
+  Browser-only cross-spec cases (interactions 8 mid-render destroy, 10
+  plain-fn warn-once, the rf2-d4sf provider-routing cases) ride through
+  the Helix Playwright smoke and are out of scope here. The shared
+  framework-level cross-spec tests in core also exercise these.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind]
+            [re-frame.routing]
+            [re-frame.ssr :as ssr]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+(defn- collect-traces [k]
+  (let [traces (atom [])]
+    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    traces))
+
+(defn- stop-traces [k]
+  (rf/remove-trace-cb! k))
+
+;; --- Interaction 1 — Frame disposal with active machine instances ---------
+
+(deftest frame-destroy-with-active-machines-helix
+  "#1 Frame disposal with active machine instances — under Helix."
+  (rf/reg-frame :tenant-x {:doc "tenant frame with two machines"})
+  (rf/reg-event-db :seed
+    (fn [db _]
+      (assoc db :rf/machines {:flow/login    {:state :authed   :data {}}
+                              :flow/checkout {:state :pending  :data {}}})))
+  (rf/dispatch-sync [:seed] {:frame :tenant-x})
+  (let [traces (collect-traces ::xspec-1)]
+    (rf/destroy-frame :tenant-x)
+    (stop-traces ::xspec-1)
+    (let [machine-traces (filter #(= :rf.machine.lifecycle/destroyed
+                                      (:operation %))
+                                 @traces)]
+      (is (= 2 (count machine-traces))
+          "one trace per active machine snapshot at frame destroy")
+      (is (every? #(= :tenant-x (:frame (:tags %))) machine-traces)
+          "each trace carries the destroyed frame's id")
+      (is (= #{:authed :pending}
+             (set (map #(:last-state (:tags %)) machine-traces)))
+          "each trace records the machine's last state")
+      (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) machine-traces)
+          "each trace carries :reason :parent-frame-destroyed")
+      (is (some #(= :frame/destroyed (:operation %)) @traces)
+          ":frame/destroyed fires after the per-machine traces"))))
+
+;; --- Interaction 2 — Sub-cache hit inside a machine microstep -------------
+
+(deftest machine-microstep-subscribe-helix
+  "#2 Sub-cache hit inside a machine microstep — under Helix."
+  (rf/reg-event-db :seed (fn [_ _] {:user/role :admin}))
+  (rf/reg-sub :user-role (fn [db _] (:user/role db)))
+  (rf/dispatch-sync [:seed])
+  (let [observed-by-action (atom nil)
+        machine
+        {:initial :idle
+         :data    {}
+         :states  {:idle    {:on {:go {:target :acting :action :record-role}}}
+                   :acting  {}}
+         :actions {:record-role
+                   (fn [_data _event]
+                     (reset! observed-by-action (rf/subscribe-value [:user-role]))
+                     nil)}}]
+    (rf/reg-machine :auth/check machine)
+    (rf/dispatch-sync [:auth/check [:go]])
+    (is (= :admin @observed-by-action)
+        "the sub returns the committed app-db value visible to the action body")))
+
+;; --- Interaction 3 — Machine spawn at boot before substrate adapter ready -
+
+(deftest boot-order-adapter-ready-helix
+  "#3 Machine spawn at boot before substrate adapter ready — under Helix."
+  (rf/reg-event-db :init-shape (fn [_ _] {:rf/machines {:flow/boot {:state :armed
+                                                                    :data  {}}}}))
+  (rf/reg-frame :booted {:on-create [:init-shape]})
+  (let [db (rf/get-frame-db :booted)]
+    (is (= :armed (get-in db [:rf/machines :flow/boot :state]))
+        ":on-create completed against an installed adapter — app-db carries the seed")))
+
+;; --- Interaction 4 — Machines under SSR (allowed-subset) ------------------
+
+(deftest after-noop-shape-under-ssr-server-preset-helix
+  "#4 Machines under SSR (allowed-subset) — under Helix."
+  (rf/reg-frame :req {:preset :ssr-server})
+  (let [meta (rf/frame-meta :req)]
+    (is (= :server (get-in meta [:config :platform]))
+        ":ssr-server preset sets :platform :server on the frame config")
+    (is (= :rf.error/server-projection (get-in meta [:config :on-error]))
+        ":ssr-server preset wires :on-error to :rf.error/server-projection"))
+  (rf/reg-machine :ssr/timed
+    {:initial :idle
+     :data    {}
+     :states  {:idle    {:on {:fetch {:target :loading}}}
+               :loading {:after {500 :awake}}
+               :awake   {}}})
+  (let [traces (collect-traces ::xspec-4-after)]
+    (rf/dispatch-sync [:ssr/timed [:fetch]] {:frame :req})
+    (stop-traces ::xspec-4-after)
+    (let [skipped   (filter #(= :rf.machine.timer/skipped-on-server
+                                (:operation %))
+                            @traces)
+          scheduled (filter #(= :rf.machine.timer/scheduled
+                                (:operation %))
+                            @traces)]
+      (is (seq skipped)
+          ":after on :ssr-server emits :rf.machine.timer/skipped-on-server")
+      (is (some #(= :server (get-in % [:tags :platform])) skipped)
+          "the skipped-on-server trace records :platform :server")
+      (is (some #(= 500 (get-in % [:tags :delay])) skipped)
+          "the trace carries the declared :after delay")
+      (is (empty? scheduled)
+          "no :rf.machine.timer/scheduled trace fires on :ssr-server"))))
+
+;; --- Interaction 7 — Route-not-found under SSR ----------------------------
+
+(deftest route-not-found-ssr-status-helix
+  "#7 Route-not-found under SSR — under Helix."
+  (rf/reg-route :user/show {:path "/users/:id"})
+  (let [m (rf/match-url "/no-such-thing")]
+    (is (nil? (:route-id m))
+        "match-url surfaces no route-id for an unmatched URL"))
+  (let [traces (collect-traces ::xspec-7)]
+    (rf/match-url "/no-such-thing")
+    (stop-traces ::xspec-7)
+    (is (empty? (filter #(= :error (:op-type %)) @traces))
+        "match-url is pure: route-not-found does not emit error traces")))
+
+;; --- Interaction 9 — Reactive substrate without React-context -------------
+
+(deftest headless-explicit-frame-resolution-chain-helix
+  "#9 Reactive substrate without React-context — under Helix."
+  (rf/reg-frame :alt {:doc "alt frame"})
+  (is (= :rf/default (rf/current-frame))
+      "no dynamic binding → resolves to :rf/default")
+  (rf/with-frame :alt
+    (is (= :alt (rf/current-frame))
+        "dynamic-var tier wins over :rf/default"))
+  (is (= :rf/default (rf/current-frame))
+      "with-frame's binding is scoped — dynamic var reverts on exit"))
+
+;; --- Interaction 11 — Machine action throws -------------------------------
+
+(deftest machine-action-throws-helix
+  "#11 Machine action throws — under Helix."
+  (rf/reg-event-db :seed-state (fn [_ _] {:val :before}))
+  (rf/dispatch-sync [:seed-state])
+  (let [machine {:initial :idle
+                 :data    {}
+                 :states  {:idle  {:on {:bang {:target :angry :action :boom}}}
+                           :angry {}}
+                 :actions {:boom (fn [_ _]
+                                   (throw (ex-info "kaboom" {})))}}]
+    (rf/reg-machine :test/m machine)
+    (let [traces (collect-traces ::xspec-11)]
+      (rf/dispatch-sync [:test/m [:bang]])
+      (stop-traces ::xspec-11)
+      (let [errs (filter #(= :rf.error/machine-action-exception (:operation %))
+                         @traces)]
+        (is (seq errs)
+            "an action throw surfaces as :rf.error/machine-action-exception")
+        (is (some #(= :test/m (get-in % [:tags :machine-id])) errs)
+            "the trace identifies the machine that threw")
+        (is (some #(= :boom (get-in % [:tags :action-id])) errs)
+            "the trace identifies the action that threw"))
+      (is (not (some #(= :rf.error/handler-exception (:operation %)) @traces))
+          "the generic :rf.error/handler-exception does NOT also fire")
+      (is (= :before (:val (rf/get-frame-db :rf/default)))
+          "a non-machine app-db slice is not touched when the cascade halts"))))
+
+;; --- Interaction 12 — Effect handler throws inside a machine action's :fx -
+
+(deftest machine-fx-handler-throws-helix
+  "#12 Effect handler throws inside a machine action's :fx — under Helix."
+  (let [seen (atom [])]
+    (rf/reg-fx :throwy (fn [_ _] (throw (ex-info "fx-bang" {}))))
+    (rf/reg-fx :record  (fn [_ args] (swap! seen conj args)))
+    (let [machine {:initial :idle
+                   :data    {}
+                   :states  {:idle {:on {:go {:target :done :action :emit-fx}}}
+                             :done {}}
+                   :actions {:emit-fx
+                             (fn [_data _event]
+                               {:fx [[:throwy :a]
+                                     [:record :b]]})}}]
+      (rf/reg-machine :test/m machine)
+      (let [traces (collect-traces ::xspec-12)]
+        (rf/dispatch-sync [:test/m [:go]])
+        (stop-traces ::xspec-12)
+        (is (some #(and (= :rf.error/fx-handler-exception (:operation %))
+                        (= :throwy (get-in % [:tags :fx-id])))
+                  @traces)
+            "the throwing fx surfaces as :rf.error/fx-handler-exception")
+        (is (= [:b] @seen)
+            ":fx walk continued past the throwing fx — :record still ran")
+        (is (= :done
+               (get-in (rf/get-frame-db :rf/default) [:rf/machines :test/m :state]))
+            "the machine snapshot committed even though a downstream :fx threw")))))
+
+;; --- Interaction 13 — Hot-reload of a machine action ----------------------
+
+(deftest hot-reload-machine-action-helix
+  "#13 Hot-reload of a machine action — under Helix."
+  (let [machine-v1 {:initial :idle
+                    :data    {}
+                    :states  {:idle    {:on {:go {:target :working
+                                                  :action :tag}}}
+                              :working {:on {:go {:target :idle
+                                                  :action :tag}}}}
+                    :actions {:tag (fn [data _]
+                                     {:data (assoc data :who :v1)})}}
+        machine-v2 (assoc-in machine-v1 [:actions :tag]
+                             (fn [data _] {:data (assoc data :who :v2)}))]
+    (rf/reg-machine :test/m machine-v1)
+    (rf/dispatch-sync [:test/m [:go]])
+    (is (= :v1 (get-in (rf/get-frame-db :rf/default)
+                       [:rf/machines :test/m :data :who]))
+        "v1 action ran on the first dispatch")
+    (rf/reg-machine :test/m machine-v2)
+    (rf/dispatch-sync [:test/m [:go]])
+    (is (= :v2 (get-in (rf/get-frame-db :rf/default)
+                       [:rf/machines :test/m :data :who]))
+        "the next dispatched event resolves to the new action body")))
+
+;; --- Interaction 14 — Re-entrant dispatch from inside a handler -----------
+
+(deftest dispatch-sync-from-handler-raises-helix
+  "#14 Re-entrant dispatch from inside a handler — under Helix."
+  (let [traces (collect-traces ::xspec-14)]
+    (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
+    (rf/reg-event-fx :nested
+      (fn [_ _]
+        (rf/dispatch-sync [:outer])
+        {}))
+    (rf/dispatch-sync [:nested])
+    (stop-traces ::xspec-14)
+    (is (some (fn [ev]
+                (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
+                     (= :error (:op-type ev))))
+              @traces)
+        "a nested dispatch-sync emits :rf.error/dispatch-sync-in-handler")))
+
+;; --- Interaction 15 — Tool-Pair revert via replace-container! -------------
+
+(deftest time-travel-revert-helix
+  "#15 Re-spawning a machine instance via Tool-Pair — under Helix."
+  (let [machine {:initial :idle
+                 :data    {}
+                 :states  {:idle    {:on {:go {:target :working}}}
+                           :working {:on {:go {:target :idle}}}}}]
+    (rf/reg-machine :test/m machine)
+    (rf/dispatch-sync [:test/m [:go]])
+    (let [post-go-db (rf/get-frame-db :rf/default)]
+      (is (= :working (get-in post-go-db [:rf/machines :test/m :state]))
+          "machine reached :working")
+      (let [container (frame/get-frame-db :rf/default)
+            reverted  (assoc-in post-go-db [:rf/machines :test/m :state] :idle)]
+        (adapter/replace-container! container reverted))
+      (is (= :idle (get-in (rf/get-frame-db :rf/default)
+                           [:rf/machines :test/m :state]))
+          "after replace-container! the snapshot reads back as :idle")
+      (rf/dispatch-sync [:test/m [:go]])
+      (is (= :working (get-in (rf/get-frame-db :rf/default)
+                              [:rf/machines :test/m :state]))
+          "re-dispatch after revert advances from the restored state"))))
+
+;; --- Interaction 16 — Error projection on the server ----------------------
+
+(deftest server-error-projection-shape-helix
+  "#16 Error projection on the server — under Helix."
+  (rf/reg-frame :req {:preset :ssr-server})
+  (rf/reg-event-fx :handler-throws
+    (fn [_ _] (throw (ex-info "boom" {}))))
+  (let [traces (collect-traces ::xspec-16)]
+    (rf/dispatch-sync [:handler-throws] {:frame :req})
+    (stop-traces ::xspec-16)
+    (let [errs (filter #(= :rf.error/handler-exception (:operation %)) @traces)]
+      (is (seq errs)
+          ":rf.error/handler-exception fires on the server frame for a thrown handler")
+      (is (some #(= :req (get-in % [:tags :frame])) errs)
+          "the trace records the request frame's id")
+      (let [err          (first errs)
+            public-error (ssr/apply-error-projection! :req err)]
+        (is (= 500 (:status public-error))
+            "default projector maps :rf.error/handler-exception → :status 500")
+        (is (= :internal-error (:code public-error))
+            "default projector's :code is :internal-error")
+        (is (false? (:retryable? public-error))
+            "default projector's :retryable? is false")
+        (is (string? (:message public-error))
+            "default projector emits a one-sentence human :message")
+        (is (= 500 (:status (ssr/get-response :req)))
+            "the projector's :status is stamped onto the [:rf/response] accumulator")))))
+
+;; --- Interaction 18 — Re-registering a sub mid-cascade --------------------
+
+(deftest hot-reload-sub-mid-cascade-helix
+  "#18 Re-registering a sub mid-cascade — under Helix."
+  (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+  (rf/reg-sub :answer (fn [db _] (:n db)))
+  (rf/dispatch-sync [:seed])
+  (is (= 7 (rf/subscribe-value [:answer]))
+      "the v1 sub computes from app-db")
+  (let [_pin (rf/subscribe [:answer])]
+    (rf/reg-sub :answer (fn [db _] (* 100 (:n db))))
+    (is (= 700 (rf/subscribe-value [:answer]))
+        "after re-registration the new sub body is in effect")
+    (rf/unsubscribe [:answer])))
+
+;; --- Interaction 19 — Story decorators that override fx -------------------
+
+(deftest portable-story-fx-override-helix
+  "#19 Story decorators that override fx — under Helix."
+  (let [seen (atom [])]
+    (rf/reg-fx :http             (fn [_ args] (swap! seen conj [:real-http args])))
+    (rf/reg-fx :rf.test/http-stub (fn [_ args] (swap! seen conj [:stub args])))
+    (rf/reg-frame :story-frame {:fx-overrides {:http :rf.test/http-stub}})
+    (rf/reg-event-fx :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
+    (rf/dispatch-sync [:go] {:frame :story-frame})
+    (is (= [[:stub {:url "/x"}]] @seen)
+        "the id-valued override redirected :http → :rf.test/http-stub")))
+
+;; --- Interaction 20 — Adapter swap mid-process is forbidden ---------------
+
+(deftest adapter-already-installed-helix
+  "#20 Adapter swap mid-process is forbidden — under Helix."
+  (let [thrown? (try
+                  (rf/install-adapter! helix-adapter/adapter)
+                  false
+                  (catch :default e
+                    (= ":rf.error/adapter-already-installed"
+                       (ex-message e))))]
+    (is thrown?
+        "second install-adapter! raises :rf.error/adapter-already-installed"))
+  (rf/dispose-adapter!)
+  (rf/install-adapter! helix-adapter/adapter)
+  (is (some? (adapter/current-adapter))
+      "after dispose, install succeeds again — clean swap path"))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
@@ -1,0 +1,209 @@
+(ns re-frame.adapter.helix-dispatch-frame-capture-cljs-test
+  "Adapter-parity port of `re-frame.dispatch-frame-capture-cljs-test`
+  (rf2-l5q3) to the Helix adapter (rf2-ta4b5).
+
+  The contract: *current-frame* propagates across direct `rf/dispatch`
+  calls. The drain loop binds `frame/*current-frame*` to the envelope's
+  `:frame` for the duration of the handler chain, so a synchronous
+  `rf/dispatch` from inside the handler body sees the in-flight event's
+  frame.
+
+  This port exists so the contract is observed under a Helix-installed
+  adapter — the dispatch-envelope's `:frame` default is built via the
+  `:adapter/current-frame` late-bind hook (registered by the Helix
+  adapter at ns-load time, reading `_currentValue` off the shared
+  React context object). The headless tests below do not mount React,
+  so the React-context tier reads the createContext default
+  (`:rf/default`); resolution falls through the dynamic-var tier as
+  expected.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.trace :as trace]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; Per cljs.test: async tests require fixtures supplied as a map
+;; (fn-form fixtures don't suspend across the async body). Wrap the
+;; snapshot/restore pattern as `{:before :after}`.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace/clear-trace-cbs!)
+  (substrate-adapter/install-adapter! helix-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- seed-frames!
+  []
+  (rf/reg-frame :rf-l5q3-helix/tenant-a {:doc "tenant-a frame"})
+  (rf/reg-frame :rf-l5q3-helix/tenant-b {:doc "tenant-b frame"})
+  (rf/reg-event-db :rf-l5q3-helix/seed
+                   (fn [_ [_ marker]] {:marker marker :received []}))
+  (rf/dispatch-sync [:rf-l5q3-helix/seed :rf/default] {:frame :rf/default})
+  (rf/dispatch-sync [:rf-l5q3-helix/seed :tenant-a] {:frame :rf-l5q3-helix/tenant-a})
+  (rf/dispatch-sync [:rf-l5q3-helix/seed :tenant-b] {:frame :rf-l5q3-helix/tenant-b}))
+
+(defn- received
+  [frame-id]
+  (let [db (frame/frame-app-db-value frame-id)]
+    (:received db)))
+
+;; ---- 1. Synchronous direct rf/dispatch ------------------------------------
+
+(deftest sync-dispatch-from-handler-body-routes-to-handlers-frame-helix
+  (testing "rf/dispatch called synchronously from inside a handler routes to that handler's frame under Helix"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-helix/parent
+                     (fn [_ _]
+                       (rf/dispatch [:rf-l5q3-helix/landed])
+                       {}))
+    (rf/reg-event-db :rf-l5q3-helix/landed
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-sync)))
+    (rf/dispatch-sync [:rf-l5q3-helix/parent] {:frame :rf-l5q3-helix/tenant-a})
+    (is (= [:landed-sync] (received :rf-l5q3-helix/tenant-a))
+        "the :landed event must land on :tenant-a, not :rf/default")
+    (is (empty? (received :rf/default))
+        ":rf/default must NOT have received :landed — the dispatch was scoped to :tenant-a")))
+
+;; ---- 2. setTimeout-deferred direct rf/dispatch ----------------------------
+
+(deftest direct-dispatch-from-set-timeout-falls-through-to-default-helix
+  (testing "raw rf/dispatch from a setTimeout callback escapes *current-frame* under Helix — documented gotcha"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-helix/defer-raw
+                       (fn [_ _]
+                         (js/setTimeout
+                           (fn [] (rf/dispatch [:rf-l5q3-helix/landed-raw]))
+                           0)
+                         {}))
+      (rf/reg-event-db :rf-l5q3-helix/landed-raw
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-raw)))
+      (rf/dispatch-sync [:rf-l5q3-helix/defer-raw] {:frame :rf-l5q3-helix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-raw] (received :rf/default))
+                  ":landed-raw lands on :rf/default (dynamic binding is dead in the setTimeout callback)")
+              (is (empty? (received :rf-l5q3-helix/tenant-a))
+                  ":tenant-a sees nothing — raw rf/dispatch can't recover the in-flight frame from a setTimeout")
+              (done))
+            10))
+        10))))
+
+;; ---- 3. :fx [[:dispatch ...]] from a setTimeout — workaround --------------
+
+(deftest fx-dispatch-from-handler-routes-to-handlers-frame-helix
+  (testing ":fx [[:dispatch ...]] routes to the handler's frame under Helix — canonical pattern"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-helix/parent-fx
+                     (fn [_ _]
+                       {:fx [[:dispatch [:rf-l5q3-helix/landed-fx]]]}))
+    (rf/reg-event-db :rf-l5q3-helix/landed-fx
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-fx)))
+    (rf/dispatch-sync [:rf-l5q3-helix/parent-fx] {:frame :rf-l5q3-helix/tenant-a})
+    (is (= [:landed-fx] (received :rf-l5q3-helix/tenant-a))
+        ":fx [[:dispatch ...]] threads the frame through fx/do-fx — lands on :tenant-a")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing")))
+
+;; ---- 4a. :dispatch-later — async with frame capture -----------------------
+
+(deftest dispatch-later-survives-the-timer-helix
+  (testing ":dispatch-later threads :frame through the closure under Helix — survives the async escape"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-helix/parent-later
+                       (fn [_ _]
+                         {:fx [[:dispatch-later
+                                {:ms    0
+                                 :event [:rf-l5q3-helix/landed-later]}]]}))
+      (rf/reg-event-db :rf-l5q3-helix/landed-later
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-later)))
+      (rf/dispatch-sync [:rf-l5q3-helix/parent-later] {:frame :rf-l5q3-helix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-later] (received :rf-l5q3-helix/tenant-a))
+                  ":dispatch-later landed on :tenant-a even though the timer fired after the binding popped")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            50))
+        50))))
+
+;; ---- 4b. (dispatcher) — async with explicit capture -----------------------
+
+(deftest dispatcher-survives-set-timeout-helix
+  (testing "(rf/dispatcher) captures the in-flight frame under Helix; the captured fn is safe to call from setTimeout"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-helix/parent-bound
+                       (fn [_ _]
+                         (let [d (rf/dispatcher)]
+                           (js/setTimeout
+                             (fn [] (d [:rf-l5q3-helix/landed-bound]))
+                             0))
+                         {}))
+      (rf/reg-event-db :rf-l5q3-helix/landed-bound
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-bound)))
+      (rf/dispatch-sync [:rf-l5q3-helix/parent-bound] {:frame :rf-l5q3-helix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-bound] (received :rf-l5q3-helix/tenant-a))
+                  "(rf/dispatcher) captured :tenant-a at call time; the setTimeout callback dispatches there")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            10))
+        10))))
+
+;; ---- 5. cross-frame isolation hardness check ------------------------------
+
+(deftest sync-dispatch-isolation-between-frames-helix
+  (testing "synchronous dispatch from :tenant-a handler stays in :tenant-a under Helix; :tenant-b is untouched"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-helix/fan
+                     (fn [_ [_ payload]]
+                       (rf/dispatch [:rf-l5q3-helix/leaf payload])
+                       {}))
+    (rf/reg-event-db :rf-l5q3-helix/leaf
+                     (fn [db [_ payload]]
+                       (update db :received (fnil conj []) payload)))
+    (rf/dispatch-sync [:rf-l5q3-helix/fan :a-payload] {:frame :rf-l5q3-helix/tenant-a})
+    (rf/dispatch-sync [:rf-l5q3-helix/fan :b-payload] {:frame :rf-l5q3-helix/tenant-b})
+    (is (= [:a-payload] (received :rf-l5q3-helix/tenant-a))
+        ":tenant-a only sees its own :a-payload")
+    (is (= [:b-payload] (received :rf-l5q3-helix/tenant-b))
+        ":tenant-b only sees its own :b-payload")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing — neither cascade leaked")))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_events_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_events_cljs_test.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.adapter.helix-events-cljs-test
+  "Adapter-parity port of `re-frame.events-cljs-test` (rf2-bbea) to the
+  Helix adapter (rf2-ta4b5).
+
+  The contract: `reg-event-*` warns when `:interceptors` is mistakenly
+  placed inside the metadata map. The warning is emitted via the trace
+  channel; the channel is wired by `install-adapter!`. This port exists
+  so the warning is observed to fire under a Helix-installed adapter —
+  it pins that the registrar + trace tier compose with the Helix
+  adapter's late-bind hook stack the same way they do with Reagent's.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+(defn- collect-warnings
+  "Attach a listener that records `:rf.warning/interceptors-in-metadata-map`
+  events and return the recording atom."
+  [k]
+  (let [a (atom [])]
+    (rf/register-trace-cb! k
+      (fn [ev]
+        (when (and (= :warning (:op-type ev))
+                   (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
+          (swap! a conj ev))))
+    a))
+
+(def ^:private noop-icpt
+  {:id :test/noop :before identity :after identity})
+
+(deftest reg-event-db-warns-on-meta-interceptors-helix
+  (testing "metadata-map :interceptors triggers :rf.warning/interceptors-in-metadata-map under the Helix adapter"
+    (let [warns (collect-warnings ::db-warn)]
+      (rf/reg-event-db :test.bbea.helix/db-bad
+        {:doc "Wrongly-shaped." :interceptors [noop-icpt]}
+        (fn [db _] db))
+      (rf/remove-trace-cb! ::db-warn)
+      (is (= 1 (count @warns)))
+      (let [t (:tags (first @warns))]
+        (is (= "reg-event-db" (:reg-fn t)))
+        (is (= :test.bbea.helix/db-bad (:id t)))))))
+
+(deftest reg-event-fx-warns-on-meta-interceptors-helix
+  (let [warns (collect-warnings ::fx-warn)]
+    (rf/reg-event-fx :test.bbea.helix/fx-bad
+      {:interceptors [noop-icpt]}
+      (fn [_ _] {:db {}}))
+    (rf/remove-trace-cb! ::fx-warn)
+    (is (= 1 (count @warns)))
+    (is (= "reg-event-fx" (:reg-fn (:tags (first @warns)))))))
+
+(deftest reg-event-ctx-warns-on-meta-interceptors-helix
+  (let [warns (collect-warnings ::ctx-warn)]
+    (rf/reg-event-ctx :test.bbea.helix/ctx-bad
+      {:interceptors [noop-icpt]}
+      (fn [ctx] ctx))
+    (rf/remove-trace-cb! ::ctx-warn)
+    (is (= 1 (count @warns)))
+    (is (= "reg-event-ctx" (:reg-fn (:tags (first @warns)))))))
+
+(deftest correct-positional-form-stays-silent-helix
+  (testing "interceptors in the positional slot do NOT warn under Helix"
+    (let [warns (collect-warnings ::quiet)]
+      (rf/reg-event-db :test.bbea.helix/quiet-1
+        [noop-icpt]
+        (fn [db _] db))
+      (rf/reg-event-db :test.bbea.helix/quiet-2
+        {:doc "metadata only"}
+        [noop-icpt]
+        (fn [db _] db))
+      (rf/reg-event-db :test.bbea.helix/quiet-3
+        {:doc "metadata only, no positional interceptors"}
+        (fn [db _] db))
+      (rf/remove-trace-cb! ::quiet)
+      (is (zero? (count @warns))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_http_managed_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_http_managed_cljs_test.cljs
@@ -1,0 +1,164 @@
+(ns re-frame.adapter.helix-http-managed-cljs-test
+  "Adapter-parity port of `re-frame.http-managed-cljs-test` to the
+  Helix adapter (rf2-ta4b5).
+
+  Smoke for Spec 014 — `:rf.http/managed` under the Helix reactive
+  substrate. The canned-stub fxs and `with-managed-request-stubs*`
+  helper resolve under the Helix adapter the same way they do under
+  Reagent — confirming that `reg-event-fx` + `:fx` orchestration +
+  fx-overrides compose with the Helix late-bind hook stack.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.schemas.malli]
+            [re-frame.core :as rf]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (fn [test-fn]
+    (http-managed/clear-all-in-flight!)
+    ((test-support/reset-runtime-fixture
+       {:adapter helix-adapter/adapter})
+      test-fn)
+    (http-managed/clear-all-in-flight!)))
+
+;; ---- 1. canned-success: default reply addressing --------------------------
+
+(deftest canned-success-default-reply-addressing-helix
+  (testing "the canned-success stub dispatches a default reply under the Helix adapter"
+    (rf/reg-event-fx :article/load
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          (case (:kind reply)
+            :success {:db {:article (:value reply)}}
+            :failure {:db {:error (:failure reply)}})
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles/hello"}
+                  :decode  :json}]]})))
+    (rf/dispatch-sync [:article/load {:slug "hello"}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= {:stubbed true} (:article db))
+          "default-reply addressing routed the synthesised reply back to :article/load"))))
+
+;; ---- 2. canned-failure: explicit on-failure -------------------------------
+
+(deftest canned-failure-explicit-on-failure-helix
+  (testing "explicit :on-failure routes the failure reply to the named handler under Helix"
+    (rf/reg-event-fx :auth/login
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request    {:method :post :url "/auth/login"}
+                :on-failure [:auth/login-error]}]]}))
+    (rf/reg-event-db :auth/login-error
+      (fn [db [_ payload]]
+        (assoc db :auth-error payload)))
+    (rf/dispatch-sync [:auth/login]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= :failure (get-in db [:auth-error :kind])))
+      (is (= :rf.http/transport (get-in db [:auth-error :failure :kind]))
+          "default canned-failure :kind classifies as :rf.http/transport"))))
+
+;; ---- 3. canned-success: explicit on-success -------------------------------
+
+(deftest canned-success-explicit-on-success-helix
+  (testing "explicit :on-success routes the success reply to the named handler under Helix"
+    (rf/reg-event-fx :article/load
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request    {:method :get :url "/articles/hello"}
+                :on-success [:article/loaded]}]]}))
+    (rf/reg-event-db :article/loaded
+      (fn [db [_ payload]]
+        (assoc db :article payload)))
+    (rf/dispatch-sync [:article/load]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= :success (get-in db [:article :kind])))
+      (is (= {:stubbed true} (get-in db [:article :value]))))))
+
+;; ---- 4. silenced reply ----------------------------------------------------
+
+(deftest silenced-reply-on-success-nil-helix
+  (testing "explicit :on-success nil swallows the reply silently under Helix"
+    (let [seen (atom 0)]
+      (rf/reg-event-fx :ping
+        (fn [_ _]
+          (swap! seen inc)
+          {:fx [[:rf.http/managed
+                 {:request    {:url "/ping"}
+                  :on-success nil}]]}))
+      (rf/dispatch-sync [:ping]
+                        {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+      (is (= 1 @seen) "no reply was dispatched when :on-success is nil"))))
+
+;; ---- 5. with-managed-request-stubs* helper --------------------------------
+
+(deftest with-managed-request-stubs-helix
+  (testing "with-managed-request-stubs* installs a per-call fx under Helix"
+    (rf/reg-event-fx :articles/list
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:result reply}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs*
+      {[:get "/articles"] {:reply {:ok [:hello :world]}}}
+      (fn []
+        (rf/dispatch-sync [:articles/list]
+                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        (let [db (rf/get-frame-db :rf/default)]
+          (is (= :success (get-in db [:result :kind])))
+          (is (= [:hello :world] (get-in db [:result :value]))))))))
+
+;; ---- 6. with-managed-request-stubs* — failure mapping --------------------
+
+(deftest with-managed-request-stubs-failure-helix
+  (testing "with-managed-request-stubs* synthesises a failure reply when {:reply {:failure ...}} under Helix"
+    (rf/reg-event-fx :articles/list
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:result reply}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs*
+      {[:get "/articles"] {:reply {:failure {:kind   :rf.http/http-4xx
+                                             :status 404}}}}
+      (fn []
+        (rf/dispatch-sync [:articles/list]
+                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        (let [db (rf/get-frame-db :rf/default)]
+          (is (= :failure (get-in db [:result :kind])))
+          (is (= :rf.http/http-4xx (get-in db [:result :failure :kind])))
+          (is (= 404 (get-in db [:result :failure :status]))))))))
+
+;; ---- 7. multi-frame reply isolation -------------------------------------
+
+(deftest multi-frame-reply-isolation-helix
+  (testing "managed requests issued from frame A reply into frame A's app-db under Helix"
+    (rf/reg-event-fx :article/load
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:article (:value reply)}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles/hello"}
+                  :decode  :json}]]})))
+    (let [left  (rf/make-frame {:doc "left"
+                                :fx-overrides
+                                {:rf.http/managed :rf.http/managed-canned-success}})
+          right (rf/make-frame {:doc "right"
+                                :fx-overrides
+                                {:rf.http/managed :rf.http/managed-canned-success}})]
+      (rf/dispatch-sync [:article/load] {:frame left})
+      (rf/dispatch-sync [:article/load] {:frame right})
+      (is (= {:stubbed true} (:article (rf/get-frame-db left))))
+      (is (= {:stubbed true} (:article (rf/get-frame-db right))))
+      (is (nil? (:article (rf/get-frame-db :rf/default)))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_routing_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_routing_cljs_test.cljs
@@ -1,0 +1,105 @@
+(ns re-frame.adapter.helix-routing-cljs-test
+  "Adapter-parity port of `re-frame.routing-cljs-test` to the Helix
+  adapter (rf2-ta4b5).
+
+  Verifies the routing pipeline runs under the Helix reactive substrate
+  and locks the multi-frame routing contract.
+
+  - routing-handle-url-change-helix       — :rf/url-changed /
+                                            handle-url-change drive the
+                                            :rf/route slice under the
+                                            Helix adapter; subscriptions
+                                            resolve.
+  - routing-frame-provider-routing-helix  — multi-frame routing: each
+                                            frame's :rf/route slice is
+                                            independent, the registry is
+                                            shared, subscriptions resolve
+                                            per-frame.
+
+  Per Spec 012 §URL changes are events, §Reading the route is a sub,
+  §Multi-frame routing. Parallel to:
+    - implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter
+     :init-fn routing/reset-counters!}))
+
+;; ---- Spec 012 §URL changes are events / §Reading the route is a sub -----
+
+(deftest routing-handle-url-change-helix
+  (testing ":rf/url-changed drives the slice on Helix"
+    (let [f (rf/make-frame {:doc "isolated frame for this test"})]
+      (rf/reg-route :route.helix/home
+                    {:path "/helix/home"})
+      (rf/reg-route :route.helix/article
+                    {:path     "/helix/articles/:id"
+                     :params   [:map [:id :string]]
+                     :on-match [[:helix/article-load]]})
+      (rf/reg-event-db :helix/article-load
+                       (fn [db _] (assoc db :article-loaded? true)))
+      (rf/reg-sub :rf.helix.route/id
+                  (fn [db _] (get-in db [:rf/route :id])))
+      (rf/reg-sub :rf.helix.route/params
+                  (fn [db _] (get-in db [:rf/route :params])))
+
+      (rf/dispatch-sync [:rf/url-changed "/helix/articles/intro"] {:frame f})
+      (is (= :route.helix/article
+             (rf/subscribe-value f [:rf.helix.route/id]))
+          ":rf.route/id sub resolves under the Helix adapter")
+      (is (= {:id "intro"}
+             (rf/subscribe-value f [:rf.helix.route/params]))
+          ":rf.route/params sub resolves under the Helix adapter")
+      (is (true? (:article-loaded? (rf/get-frame-db f)))
+          ":on-match's [:helix/article-load] dispatched and ran")
+
+      (rf/dispatch-sync [:rf/url-changed "/helix/articles/welcome"] {:frame f})
+      (is (= {:id "welcome"}
+             (rf/subscribe-value f [:rf.helix.route/params]))
+          "new params land in the slice on subsequent navigation")
+      (is (some? (get-in (rf/get-frame-db f) [:rf/route :nav-token]))
+          "fresh nav-token allocated on each full navigation"))))
+
+;; ---- Spec 012 §Multi-frame routing ---------------------------------------
+
+(deftest routing-frame-provider-routing-helix
+  (testing "two frames carry independent :rf/route slices over a shared registry under Helix"
+    (rf/reg-route :route.helix2/home          {:path "/helix2/"})
+    (rf/reg-route :route.helix2/articles      {:path "/helix2/articles"})
+    (rf/reg-route :route.helix2/article       {:path   "/helix2/articles/:id"
+                                               :params [:map [:id :string]]})
+    (rf/reg-sub :rf.helix2/route (fn [db _] (:rf/route db)))
+
+    (let [left  (rf/make-frame {:doc "left tab frame"})
+          right (rf/make-frame {:doc "right tab frame"})]
+
+      (rf/dispatch-sync [:rf/url-changed "/helix2/articles"]
+                        {:frame left})
+      (rf/dispatch-sync [:rf/url-changed "/helix2/articles/intro"]
+                        {:frame right})
+
+      (let [left-route  (rf/subscribe-value left  [:rf.helix2/route])
+            right-route (rf/subscribe-value right [:rf.helix2/route])]
+        (is (= :route.helix2/articles (:id left-route))
+            "left frame's :rf/route is :route.helix2/articles")
+        (is (= :route.helix2/article  (:id right-route))
+            "right frame's :rf/route is :route.helix2/article")
+        (is (= {} (:params left-route))
+            "left frame has no :params (collection route)")
+        (is (= {:id "intro"} (:params right-route))
+            "right frame has the article id"))
+
+      (rf/dispatch-sync [:rf/url-changed "/helix2/"] {:frame left})
+      (is (= :route.helix2/home
+             (:id (rf/subscribe-value left [:rf.helix2/route])))
+          "left re-navigated to :route.helix2/home")
+      (is (= :route.helix2/article
+             (:id (rf/subscribe-value right [:rf.helix2/route])))
+          "right is unaffected by left's navigation"))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
@@ -1,0 +1,162 @@
+(ns re-frame.adapter.helix-runtime-cljs-test
+  "Adapter-parity port of the headless slice of `re-frame.runtime-cljs-test`
+  to the Helix adapter (rf2-ta4b5).
+
+  The runtime layer (dispatch, subs, with-frame, bound-fn, multi-frame
+  isolation, sub hot-reload) is substrate-agnostic, but every assertion
+  in this file runs under the Helix-installed adapter — pinning that the
+  late-bind hooks the Helix adapter publishes (`:adapter/ratom`,
+  `:adapter/make-reaction`, `:adapter/current-frame`, `:adapter/wrap-view`)
+  compose with the runtime layer the same way they do under Reagent.
+
+  This is the headless subset only — Reagent-specific `r/atom` /
+  `r/track!` / inline-hiccup-render assertions and example-driven tests
+  are out of scope; those ride through the framework-level shared tests
+  and through the Helix Playwright smoke (`examples/helix/counter`).
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.core :refer [with-frame bound-fn]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- shared dispatch + sub --------------------------------------------------
+
+(deftest dispatch-sync-helix
+  (testing "dispatch-sync runs an event-db handler under the Helix adapter"
+    (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:counter/init])
+    (rf/dispatch-sync [:counter/inc])
+    (rf/dispatch-sync [:counter/inc])
+    (is (= 2 (:n (rf/get-frame-db :rf/default))))))
+
+(deftest sub-chain-helix
+  (testing "layer-1 + layer-2 subs return computed values under the Helix adapter"
+    (rf/reg-event-db :seed (fn [_ _] {:items [10 20 30]}))
+    (rf/reg-sub :items     (fn [db _] (:items db)))
+    (rf/reg-sub :item-sum  :<- [:items] (fn [items _] (reduce + items)))
+    (rf/dispatch-sync [:seed])
+    (is (= [10 20 30] (rf/subscribe-value [:items])))
+    (is (= 60         (rf/subscribe-value [:item-sum])))))
+
+;; ---- with-frame macro -------------------------------------------------------
+
+(deftest with-frame-binds-current-frame-helix
+  (testing "with-frame :foo binds *current-frame* in the body under the Helix adapter"
+    (with-frame :left
+      (is (= :left (rf/current-frame))))
+    (testing "and the [sym expr] form binds the symbol AND the dynamic var"
+      (with-frame [f :right]
+        (is (= :right f))
+        (is (= :right (rf/current-frame))))))
+  (testing "outside any binding the dynamic var falls back to :rf/default"
+    (is (= :rf/default (rf/current-frame)))))
+
+;; ---- bound-fn macro ---------------------------------------------------------
+
+(deftest bound-fn-captures-frame-helix
+  (testing "bound-fn captures the current frame and re-binds it inside the body"
+    (rf/reg-frame :side {:doc "side frame"})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/dispatch-sync [:seed 99] {:frame :side})
+    (let [captured (with-frame :side (bound-fn [] (rf/current-frame)))]
+      (is (= :rf/default (rf/current-frame)))
+      (is (= :side       (captured))))))
+
+;; ---- frame isolation ------------------------------------------------------
+
+(deftest multi-frame-state-isolation-helix
+  (testing "two frames carry independent app-db state, share handler registry — under Helix"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    (rf/reg-event-db :counter/init (fn [_ [_ n]] {:count n}))
+    (rf/reg-event-db :counter/inc  (fn [db _] (update db :count inc)))
+    (rf/reg-sub :count (fn [db _] (:count db)))
+    (rf/dispatch-sync [:counter/init 10] {:frame :left})
+    (rf/dispatch-sync [:counter/init 100] {:frame :right})
+    (rf/dispatch-sync [:counter/inc] {:frame :left})
+    (rf/dispatch-sync [:counter/inc] {:frame :left})
+    (is (= 12  (rf/subscribe-value :left  [:count])))
+    (is (= 100 (rf/subscribe-value :right [:count])))
+    (is (nil?  (rf/subscribe-value :rf/default [:count])))))
+
+;; ---- reactivity -----------------------------------------------------------
+;;
+;; The Helix adapter's containers are plain atoms; per Spec 006 the
+;; container's `subscribe-container` surface fires `on-change` on every
+;; replace. The subscribe layer in core wraps that with a Reagent
+;; reaction (the Helix adapter delegates `:adapter/make-reaction` to
+;; stock Reagent) so the reaction's deref reflects post-event state.
+
+(deftest reactive-sub-tracks-changes-helix
+  (testing "a subscription's deref reflects post-event state under Helix"
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+    (let [r (rf/subscribe [:n])]
+      (is (= 0 @r))
+      (rf/dispatch-sync [:inc])
+      (is (= 1 @r) "the subscription observes the new value after :inc")
+      (rf/dispatch-sync [:inc])
+      (rf/dispatch-sync [:inc])
+      (is (= 3 @r))
+      (rf/unsubscribe [:n]))))
+
+;; ---- hot-reload sub invalidation ------------------------------------------
+
+(deftest sub-hot-reload-helix
+  (testing "re-registering a sub flips the next subscribe-value to the new body under Helix"
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :answer (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+    (is (= 7 (rf/subscribe-value [:answer])))
+    (let [_pin (rf/subscribe [:answer])]
+      (rf/reg-sub :answer (fn [db _] (* 10 (:n db))))
+      (is (= 70 (rf/subscribe-value [:answer]))
+          "the new sub body is in effect after re-registration")
+      (rf/unsubscribe [:answer]))))
+
+;; ---- machines (pure machine-transition) -----------------------------------
+
+(deftest machine-transition-helix
+  (testing "pure machine-transition runs under the Helix adapter"
+    (let [m {:initial :red
+             :data    {}
+             :states
+             {:red    {:on {:tick {:target :green}}}
+              :green  {:on {:tick {:target :yellow}}}
+              :yellow {:on {:tick {:target :red}}}}}
+          [s _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+      (is (= :green (:state s))))))
+
+;; ---- error paths ----------------------------------------------------------
+
+(deftest sub-exception-recovers-to-nil-helix
+  (testing "a sub whose body throws emits :rf.error/sub-exception and resolves to nil under Helix"
+    (rf/reg-event-db :init (fn [_ _] {:items "broken"}))
+    (rf/reg-sub :items (fn [db _] (:items db)))
+    (rf/reg-sub :items-count :<- [:items]
+      (fn [items _]
+        (count (.something items))))
+    (rf/dispatch-sync [:init])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (let [v (rf/subscribe-value [:items-count])]
+        (is (nil? v)
+            "the sub returns nil under :replaced-with-default recovery"))
+      (rf/remove-trace-cb! ::sub-err)
+      (is (some (fn [ev]
+                  (= :rf.error/sub-exception (:operation ev)))
+                @traces)
+          "expected :rf.error/sub-exception trace"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
@@ -1,0 +1,360 @@
+(ns re-frame.adapter.uix-cross-spec-cljs-test
+  "Adapter-parity port of the headless subset of
+  `re-frame.cross-spec-cljs-test` to the UIx adapter (rf2-ta4b5).
+
+  Each deftest pins a Cross-Spec interaction (spec/Cross-Spec-Interactions.md)
+  under a UIx-installed adapter. The subset ported here is the one
+  whose contract is observable WITHOUT a real React render — every
+  test runs through the runtime / registrar / trace channel only.
+
+  Browser-only cross-spec cases (interactions 8 mid-render destroy, 10
+  plain-fn warn-once, the rf2-d4sf provider-routing cases) ride through
+  the UIx Playwright smoke and are out of scope here. The shared
+  framework-level cross-spec tests in core also exercise these.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind]
+            [re-frame.routing]
+            [re-frame.ssr :as ssr]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+(defn- collect-traces [k]
+  (let [traces (atom [])]
+    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    traces))
+
+(defn- stop-traces [k]
+  (rf/remove-trace-cb! k))
+
+;; --- Interaction 1 — Frame disposal with active machine instances ---------
+
+(deftest frame-destroy-with-active-machines-uix
+  "#1 Frame disposal with active machine instances — under UIx."
+  (rf/reg-frame :tenant-x {:doc "tenant frame with two machines"})
+  (rf/reg-event-db :seed
+    (fn [db _]
+      (assoc db :rf/machines {:flow/login    {:state :authed   :data {}}
+                              :flow/checkout {:state :pending  :data {}}})))
+  (rf/dispatch-sync [:seed] {:frame :tenant-x})
+  (let [traces (collect-traces ::xspec-1)]
+    (rf/destroy-frame :tenant-x)
+    (stop-traces ::xspec-1)
+    (let [machine-traces (filter #(= :rf.machine.lifecycle/destroyed
+                                      (:operation %))
+                                 @traces)]
+      (is (= 2 (count machine-traces))
+          "one trace per active machine snapshot at frame destroy")
+      (is (every? #(= :tenant-x (:frame (:tags %))) machine-traces)
+          "each trace carries the destroyed frame's id")
+      (is (= #{:authed :pending}
+             (set (map #(:last-state (:tags %)) machine-traces)))
+          "each trace records the machine's last state")
+      (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) machine-traces)
+          "each trace carries :reason :parent-frame-destroyed")
+      (is (some #(= :frame/destroyed (:operation %)) @traces)
+          ":frame/destroyed fires after the per-machine traces"))))
+
+;; --- Interaction 2 — Sub-cache hit inside a machine microstep -------------
+
+(deftest machine-microstep-subscribe-uix
+  "#2 Sub-cache hit inside a machine microstep — under UIx."
+  (rf/reg-event-db :seed (fn [_ _] {:user/role :admin}))
+  (rf/reg-sub :user-role (fn [db _] (:user/role db)))
+  (rf/dispatch-sync [:seed])
+  (let [observed-by-action (atom nil)
+        machine
+        {:initial :idle
+         :data    {}
+         :states  {:idle    {:on {:go {:target :acting :action :record-role}}}
+                   :acting  {}}
+         :actions {:record-role
+                   (fn [_data _event]
+                     (reset! observed-by-action (rf/subscribe-value [:user-role]))
+                     nil)}}]
+    (rf/reg-machine :auth/check machine)
+    (rf/dispatch-sync [:auth/check [:go]])
+    (is (= :admin @observed-by-action)
+        "the sub returns the committed app-db value visible to the action body")))
+
+;; --- Interaction 3 — Machine spawn at boot before substrate adapter ready -
+
+(deftest boot-order-adapter-ready-uix
+  "#3 Machine spawn at boot before substrate adapter ready — under UIx."
+  (rf/reg-event-db :init-shape (fn [_ _] {:rf/machines {:flow/boot {:state :armed
+                                                                    :data  {}}}}))
+  (rf/reg-frame :booted {:on-create [:init-shape]})
+  (let [db (rf/get-frame-db :booted)]
+    (is (= :armed (get-in db [:rf/machines :flow/boot :state]))
+        ":on-create completed against an installed adapter — app-db carries the seed")))
+
+;; --- Interaction 4 — Machines under SSR (allowed-subset) ------------------
+
+(deftest after-noop-shape-under-ssr-server-preset-uix
+  "#4 Machines under SSR (allowed-subset) — under UIx."
+  (rf/reg-frame :req {:preset :ssr-server})
+  (let [meta (rf/frame-meta :req)]
+    (is (= :server (get-in meta [:config :platform]))
+        ":ssr-server preset sets :platform :server on the frame config")
+    (is (= :rf.error/server-projection (get-in meta [:config :on-error]))
+        ":ssr-server preset wires :on-error to :rf.error/server-projection"))
+  (rf/reg-machine :ssr/timed
+    {:initial :idle
+     :data    {}
+     :states  {:idle    {:on {:fetch {:target :loading}}}
+               :loading {:after {500 :awake}}
+               :awake   {}}})
+  (let [traces (collect-traces ::xspec-4-after)]
+    (rf/dispatch-sync [:ssr/timed [:fetch]] {:frame :req})
+    (stop-traces ::xspec-4-after)
+    (let [skipped   (filter #(= :rf.machine.timer/skipped-on-server
+                                (:operation %))
+                            @traces)
+          scheduled (filter #(= :rf.machine.timer/scheduled
+                                (:operation %))
+                            @traces)]
+      (is (seq skipped)
+          ":after on :ssr-server emits :rf.machine.timer/skipped-on-server")
+      (is (some #(= :server (get-in % [:tags :platform])) skipped)
+          "the skipped-on-server trace records :platform :server")
+      (is (some #(= 500 (get-in % [:tags :delay])) skipped)
+          "the trace carries the declared :after delay")
+      (is (empty? scheduled)
+          "no :rf.machine.timer/scheduled trace fires on :ssr-server"))))
+
+;; --- Interaction 7 — Route-not-found under SSR ----------------------------
+
+(deftest route-not-found-ssr-status-uix
+  "#7 Route-not-found under SSR — under UIx."
+  (rf/reg-route :user/show {:path "/users/:id"})
+  (let [m (rf/match-url "/no-such-thing")]
+    (is (nil? (:route-id m))
+        "match-url surfaces no route-id for an unmatched URL"))
+  (let [traces (collect-traces ::xspec-7)]
+    (rf/match-url "/no-such-thing")
+    (stop-traces ::xspec-7)
+    (is (empty? (filter #(= :error (:op-type %)) @traces))
+        "match-url is pure: route-not-found does not emit error traces")))
+
+;; --- Interaction 9 — Reactive substrate without React-context -------------
+
+(deftest headless-explicit-frame-resolution-chain-uix
+  "#9 Reactive substrate without React-context — under UIx."
+  (rf/reg-frame :alt {:doc "alt frame"})
+  (is (= :rf/default (rf/current-frame))
+      "no dynamic binding → resolves to :rf/default")
+  (rf/with-frame :alt
+    (is (= :alt (rf/current-frame))
+        "dynamic-var tier wins over :rf/default"))
+  (is (= :rf/default (rf/current-frame))
+      "with-frame's binding is scoped — dynamic var reverts on exit"))
+
+;; --- Interaction 11 — Machine action throws -------------------------------
+
+(deftest machine-action-throws-uix
+  "#11 Machine action throws — under UIx."
+  (rf/reg-event-db :seed-state (fn [_ _] {:val :before}))
+  (rf/dispatch-sync [:seed-state])
+  (let [machine {:initial :idle
+                 :data    {}
+                 :states  {:idle  {:on {:bang {:target :angry :action :boom}}}
+                           :angry {}}
+                 :actions {:boom (fn [_ _]
+                                   (throw (ex-info "kaboom" {})))}}]
+    (rf/reg-machine :test/m machine)
+    (let [traces (collect-traces ::xspec-11)]
+      (rf/dispatch-sync [:test/m [:bang]])
+      (stop-traces ::xspec-11)
+      (let [errs (filter #(= :rf.error/machine-action-exception (:operation %))
+                         @traces)]
+        (is (seq errs)
+            "an action throw surfaces as :rf.error/machine-action-exception")
+        (is (some #(= :test/m (get-in % [:tags :machine-id])) errs)
+            "the trace identifies the machine that threw")
+        (is (some #(= :boom (get-in % [:tags :action-id])) errs)
+            "the trace identifies the action that threw"))
+      (is (not (some #(= :rf.error/handler-exception (:operation %)) @traces))
+          "the generic :rf.error/handler-exception does NOT also fire")
+      (is (= :before (:val (rf/get-frame-db :rf/default)))
+          "a non-machine app-db slice is not touched when the cascade halts"))))
+
+;; --- Interaction 12 — Effect handler throws inside a machine action's :fx -
+
+(deftest machine-fx-handler-throws-uix
+  "#12 Effect handler throws inside a machine action's :fx — under UIx."
+  (let [seen (atom [])]
+    (rf/reg-fx :throwy (fn [_ _] (throw (ex-info "fx-bang" {}))))
+    (rf/reg-fx :record  (fn [_ args] (swap! seen conj args)))
+    (let [machine {:initial :idle
+                   :data    {}
+                   :states  {:idle {:on {:go {:target :done :action :emit-fx}}}
+                             :done {}}
+                   :actions {:emit-fx
+                             (fn [_data _event]
+                               {:fx [[:throwy :a]
+                                     [:record :b]]})}}]
+      (rf/reg-machine :test/m machine)
+      (let [traces (collect-traces ::xspec-12)]
+        (rf/dispatch-sync [:test/m [:go]])
+        (stop-traces ::xspec-12)
+        (is (some #(and (= :rf.error/fx-handler-exception (:operation %))
+                        (= :throwy (get-in % [:tags :fx-id])))
+                  @traces)
+            "the throwing fx surfaces as :rf.error/fx-handler-exception")
+        (is (= [:b] @seen)
+            ":fx walk continued past the throwing fx — :record still ran")
+        (is (= :done
+               (get-in (rf/get-frame-db :rf/default) [:rf/machines :test/m :state]))
+            "the machine snapshot committed even though a downstream :fx threw")))))
+
+;; --- Interaction 13 — Hot-reload of a machine action ----------------------
+
+(deftest hot-reload-machine-action-uix
+  "#13 Hot-reload of a machine action — under UIx."
+  (let [machine-v1 {:initial :idle
+                    :data    {}
+                    :states  {:idle    {:on {:go {:target :working
+                                                  :action :tag}}}
+                              :working {:on {:go {:target :idle
+                                                  :action :tag}}}}
+                    :actions {:tag (fn [data _]
+                                     {:data (assoc data :who :v1)})}}
+        machine-v2 (assoc-in machine-v1 [:actions :tag]
+                             (fn [data _] {:data (assoc data :who :v2)}))]
+    (rf/reg-machine :test/m machine-v1)
+    (rf/dispatch-sync [:test/m [:go]])
+    (is (= :v1 (get-in (rf/get-frame-db :rf/default)
+                       [:rf/machines :test/m :data :who]))
+        "v1 action ran on the first dispatch")
+    (rf/reg-machine :test/m machine-v2)
+    (rf/dispatch-sync [:test/m [:go]])
+    (is (= :v2 (get-in (rf/get-frame-db :rf/default)
+                       [:rf/machines :test/m :data :who]))
+        "the next dispatched event resolves to the new action body")))
+
+;; --- Interaction 14 — Re-entrant dispatch from inside a handler -----------
+
+(deftest dispatch-sync-from-handler-raises-uix
+  "#14 Re-entrant dispatch from inside a handler — under UIx."
+  (let [traces (collect-traces ::xspec-14)]
+    (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
+    (rf/reg-event-fx :nested
+      (fn [_ _]
+        (rf/dispatch-sync [:outer])
+        {}))
+    (rf/dispatch-sync [:nested])
+    (stop-traces ::xspec-14)
+    (is (some (fn [ev]
+                (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
+                     (= :error (:op-type ev))))
+              @traces)
+        "a nested dispatch-sync emits :rf.error/dispatch-sync-in-handler")))
+
+;; --- Interaction 15 — Tool-Pair revert via replace-container! -------------
+
+(deftest time-travel-revert-uix
+  "#15 Re-spawning a machine instance via Tool-Pair — under UIx."
+  (let [machine {:initial :idle
+                 :data    {}
+                 :states  {:idle    {:on {:go {:target :working}}}
+                           :working {:on {:go {:target :idle}}}}}]
+    (rf/reg-machine :test/m machine)
+    (rf/dispatch-sync [:test/m [:go]])
+    (let [post-go-db (rf/get-frame-db :rf/default)]
+      (is (= :working (get-in post-go-db [:rf/machines :test/m :state]))
+          "machine reached :working")
+      (let [container (frame/get-frame-db :rf/default)
+            reverted  (assoc-in post-go-db [:rf/machines :test/m :state] :idle)]
+        (adapter/replace-container! container reverted))
+      (is (= :idle (get-in (rf/get-frame-db :rf/default)
+                           [:rf/machines :test/m :state]))
+          "after replace-container! the snapshot reads back as :idle")
+      (rf/dispatch-sync [:test/m [:go]])
+      (is (= :working (get-in (rf/get-frame-db :rf/default)
+                              [:rf/machines :test/m :state]))
+          "re-dispatch after revert advances from the restored state"))))
+
+;; --- Interaction 16 — Error projection on the server ----------------------
+
+(deftest server-error-projection-shape-uix
+  "#16 Error projection on the server — under UIx."
+  (rf/reg-frame :req {:preset :ssr-server})
+  (rf/reg-event-fx :handler-throws
+    (fn [_ _] (throw (ex-info "boom" {}))))
+  (let [traces (collect-traces ::xspec-16)]
+    (rf/dispatch-sync [:handler-throws] {:frame :req})
+    (stop-traces ::xspec-16)
+    (let [errs (filter #(= :rf.error/handler-exception (:operation %)) @traces)]
+      (is (seq errs)
+          ":rf.error/handler-exception fires on the server frame for a thrown handler")
+      (is (some #(= :req (get-in % [:tags :frame])) errs)
+          "the trace records the request frame's id")
+      (let [err          (first errs)
+            public-error (ssr/apply-error-projection! :req err)]
+        (is (= 500 (:status public-error))
+            "default projector maps :rf.error/handler-exception → :status 500")
+        (is (= :internal-error (:code public-error))
+            "default projector's :code is :internal-error")
+        (is (false? (:retryable? public-error))
+            "default projector's :retryable? is false")
+        (is (string? (:message public-error))
+            "default projector emits a one-sentence human :message")
+        (is (= 500 (:status (ssr/get-response :req)))
+            "the projector's :status is stamped onto the [:rf/response] accumulator")))))
+
+;; --- Interaction 18 — Re-registering a sub mid-cascade --------------------
+
+(deftest hot-reload-sub-mid-cascade-uix
+  "#18 Re-registering a sub mid-cascade — under UIx."
+  (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+  (rf/reg-sub :answer (fn [db _] (:n db)))
+  (rf/dispatch-sync [:seed])
+  (is (= 7 (rf/subscribe-value [:answer]))
+      "the v1 sub computes from app-db")
+  (let [_pin (rf/subscribe [:answer])]
+    (rf/reg-sub :answer (fn [db _] (* 100 (:n db))))
+    (is (= 700 (rf/subscribe-value [:answer]))
+        "after re-registration the new sub body is in effect")
+    (rf/unsubscribe [:answer])))
+
+;; --- Interaction 19 — Story decorators that override fx -------------------
+
+(deftest portable-story-fx-override-uix
+  "#19 Story decorators that override fx — under UIx."
+  (let [seen (atom [])]
+    (rf/reg-fx :http             (fn [_ args] (swap! seen conj [:real-http args])))
+    (rf/reg-fx :rf.test/http-stub (fn [_ args] (swap! seen conj [:stub args])))
+    (rf/reg-frame :story-frame {:fx-overrides {:http :rf.test/http-stub}})
+    (rf/reg-event-fx :go (fn [_ _] {:fx [[:http {:url "/x"}]]}))
+    (rf/dispatch-sync [:go] {:frame :story-frame})
+    (is (= [[:stub {:url "/x"}]] @seen)
+        "the id-valued override redirected :http → :rf.test/http-stub")))
+
+;; --- Interaction 20 — Adapter swap mid-process is forbidden ---------------
+
+(deftest adapter-already-installed-uix
+  "#20 Adapter swap mid-process is forbidden — under UIx."
+  (let [thrown? (try
+                  (rf/install-adapter! uix-adapter/adapter)
+                  false
+                  (catch :default e
+                    (= ":rf.error/adapter-already-installed"
+                       (ex-message e))))]
+    (is thrown?
+        "second install-adapter! raises :rf.error/adapter-already-installed"))
+  (rf/dispose-adapter!)
+  (rf/install-adapter! uix-adapter/adapter)
+  (is (some? (adapter/current-adapter))
+      "after dispose, install succeeds again — clean swap path"))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -1,0 +1,209 @@
+(ns re-frame.adapter.uix-dispatch-frame-capture-cljs-test
+  "Adapter-parity port of `re-frame.dispatch-frame-capture-cljs-test`
+  (rf2-l5q3) to the UIx adapter (rf2-ta4b5).
+
+  The contract: *current-frame* propagates across direct `rf/dispatch`
+  calls. The drain loop binds `frame/*current-frame*` to the envelope's
+  `:frame` for the duration of the handler chain, so a synchronous
+  `rf/dispatch` from inside the handler body sees the in-flight event's
+  frame.
+
+  This port exists so the contract is observed under a UIx-installed
+  adapter — the dispatch-envelope's `:frame` default is built via the
+  `:adapter/current-frame` late-bind hook (registered by the UIx
+  adapter at ns-load time, reading `_currentValue` off the shared
+  React context object). The headless tests below do not mount React,
+  so the React-context tier reads the createContext default
+  (`:rf/default`); resolution falls through the dynamic-var tier as
+  expected.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.trace :as trace]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; Per cljs.test: async tests require fixtures supplied as a map
+;; (fn-form fixtures don't suspend across the async body). Wrap the
+;; snapshot/restore pattern as `{:before :after}`.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace/clear-trace-cbs!)
+  (substrate-adapter/install-adapter! uix-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- seed-frames!
+  []
+  (rf/reg-frame :rf-l5q3-uix/tenant-a {:doc "tenant-a frame"})
+  (rf/reg-frame :rf-l5q3-uix/tenant-b {:doc "tenant-b frame"})
+  (rf/reg-event-db :rf-l5q3-uix/seed
+                   (fn [_ [_ marker]] {:marker marker :received []}))
+  (rf/dispatch-sync [:rf-l5q3-uix/seed :rf/default] {:frame :rf/default})
+  (rf/dispatch-sync [:rf-l5q3-uix/seed :tenant-a] {:frame :rf-l5q3-uix/tenant-a})
+  (rf/dispatch-sync [:rf-l5q3-uix/seed :tenant-b] {:frame :rf-l5q3-uix/tenant-b}))
+
+(defn- received
+  [frame-id]
+  (let [db (frame/frame-app-db-value frame-id)]
+    (:received db)))
+
+;; ---- 1. Synchronous direct rf/dispatch ------------------------------------
+
+(deftest sync-dispatch-from-handler-body-routes-to-handlers-frame-uix
+  (testing "rf/dispatch called synchronously from inside a handler routes to that handler's frame under UIx"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-uix/parent
+                     (fn [_ _]
+                       (rf/dispatch [:rf-l5q3-uix/landed])
+                       {}))
+    (rf/reg-event-db :rf-l5q3-uix/landed
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-sync)))
+    (rf/dispatch-sync [:rf-l5q3-uix/parent] {:frame :rf-l5q3-uix/tenant-a})
+    (is (= [:landed-sync] (received :rf-l5q3-uix/tenant-a))
+        "the :landed event must land on :tenant-a, not :rf/default")
+    (is (empty? (received :rf/default))
+        ":rf/default must NOT have received :landed — the dispatch was scoped to :tenant-a")))
+
+;; ---- 2. setTimeout-deferred direct rf/dispatch ----------------------------
+
+(deftest direct-dispatch-from-set-timeout-falls-through-to-default-uix
+  (testing "raw rf/dispatch from a setTimeout callback escapes *current-frame* under UIx — documented gotcha"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-uix/defer-raw
+                       (fn [_ _]
+                         (js/setTimeout
+                           (fn [] (rf/dispatch [:rf-l5q3-uix/landed-raw]))
+                           0)
+                         {}))
+      (rf/reg-event-db :rf-l5q3-uix/landed-raw
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-raw)))
+      (rf/dispatch-sync [:rf-l5q3-uix/defer-raw] {:frame :rf-l5q3-uix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-raw] (received :rf/default))
+                  ":landed-raw lands on :rf/default (dynamic binding is dead in the setTimeout callback)")
+              (is (empty? (received :rf-l5q3-uix/tenant-a))
+                  ":tenant-a sees nothing — raw rf/dispatch can't recover the in-flight frame from a setTimeout")
+              (done))
+            10))
+        10))))
+
+;; ---- 3. :fx [[:dispatch ...]] from a setTimeout — workaround --------------
+
+(deftest fx-dispatch-from-handler-routes-to-handlers-frame-uix
+  (testing ":fx [[:dispatch ...]] routes to the handler's frame under UIx — canonical pattern"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-uix/parent-fx
+                     (fn [_ _]
+                       {:fx [[:dispatch [:rf-l5q3-uix/landed-fx]]]}))
+    (rf/reg-event-db :rf-l5q3-uix/landed-fx
+                     (fn [db _]
+                       (update db :received (fnil conj []) :landed-fx)))
+    (rf/dispatch-sync [:rf-l5q3-uix/parent-fx] {:frame :rf-l5q3-uix/tenant-a})
+    (is (= [:landed-fx] (received :rf-l5q3-uix/tenant-a))
+        ":fx [[:dispatch ...]] threads the frame through fx/do-fx — lands on :tenant-a")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing")))
+
+;; ---- 4a. :dispatch-later — async with frame capture -----------------------
+
+(deftest dispatch-later-survives-the-timer-uix
+  (testing ":dispatch-later threads :frame through the closure under UIx — survives the async escape"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-uix/parent-later
+                       (fn [_ _]
+                         {:fx [[:dispatch-later
+                                {:ms    0
+                                 :event [:rf-l5q3-uix/landed-later]}]]}))
+      (rf/reg-event-db :rf-l5q3-uix/landed-later
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-later)))
+      (rf/dispatch-sync [:rf-l5q3-uix/parent-later] {:frame :rf-l5q3-uix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-later] (received :rf-l5q3-uix/tenant-a))
+                  ":dispatch-later landed on :tenant-a even though the timer fired after the binding popped")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            50))
+        50))))
+
+;; ---- 4b. (dispatcher) — async with explicit capture -----------------------
+
+(deftest dispatcher-survives-set-timeout-uix
+  (testing "(rf/dispatcher) captures the in-flight frame under UIx; the captured fn is safe to call from setTimeout"
+    (async done
+      (seed-frames!)
+      (rf/reg-event-fx :rf-l5q3-uix/parent-bound
+                       (fn [_ _]
+                         (let [d (rf/dispatcher)]
+                           (js/setTimeout
+                             (fn [] (d [:rf-l5q3-uix/landed-bound]))
+                             0))
+                         {}))
+      (rf/reg-event-db :rf-l5q3-uix/landed-bound
+                       (fn [db _]
+                         (update db :received (fnil conj []) :landed-bound)))
+      (rf/dispatch-sync [:rf-l5q3-uix/parent-bound] {:frame :rf-l5q3-uix/tenant-a})
+      (js/setTimeout
+        (fn []
+          (js/setTimeout
+            (fn []
+              (is (= [:landed-bound] (received :rf-l5q3-uix/tenant-a))
+                  "(rf/dispatcher) captured :tenant-a at call time; the setTimeout callback dispatches there")
+              (is (empty? (received :rf/default))
+                  ":rf/default sees nothing")
+              (done))
+            10))
+        10))))
+
+;; ---- 5. cross-frame isolation hardness check ------------------------------
+
+(deftest sync-dispatch-isolation-between-frames-uix
+  (testing "synchronous dispatch from :tenant-a handler stays in :tenant-a under UIx; :tenant-b is untouched"
+    (seed-frames!)
+    (rf/reg-event-fx :rf-l5q3-uix/fan
+                     (fn [_ [_ payload]]
+                       (rf/dispatch [:rf-l5q3-uix/leaf payload])
+                       {}))
+    (rf/reg-event-db :rf-l5q3-uix/leaf
+                     (fn [db [_ payload]]
+                       (update db :received (fnil conj []) payload)))
+    (rf/dispatch-sync [:rf-l5q3-uix/fan :a-payload] {:frame :rf-l5q3-uix/tenant-a})
+    (rf/dispatch-sync [:rf-l5q3-uix/fan :b-payload] {:frame :rf-l5q3-uix/tenant-b})
+    (is (= [:a-payload] (received :rf-l5q3-uix/tenant-a))
+        ":tenant-a only sees its own :a-payload")
+    (is (= [:b-payload] (received :rf-l5q3-uix/tenant-b))
+        ":tenant-b only sees its own :b-payload")
+    (is (empty? (received :rf/default))
+        ":rf/default sees nothing — neither cascade leaked")))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_events_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_events_cljs_test.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.adapter.uix-events-cljs-test
+  "Adapter-parity port of `re-frame.events-cljs-test` (rf2-bbea) to the
+  UIx adapter (rf2-ta4b5).
+
+  The contract: `reg-event-*` warns when `:interceptors` is mistakenly
+  placed inside the metadata map. The warning is emitted via the trace
+  channel; the channel is wired by `install-adapter!`. This port exists
+  so the warning is observed to fire under a UIx-installed adapter —
+  it pins that the registrar + trace tier compose with the UIx
+  adapter's late-bind hook stack the same way they do with Reagent's.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+(defn- collect-warnings
+  "Attach a listener that records `:rf.warning/interceptors-in-metadata-map`
+  events and return the recording atom."
+  [k]
+  (let [a (atom [])]
+    (rf/register-trace-cb! k
+      (fn [ev]
+        (when (and (= :warning (:op-type ev))
+                   (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
+          (swap! a conj ev))))
+    a))
+
+(def ^:private noop-icpt
+  {:id :test/noop :before identity :after identity})
+
+(deftest reg-event-db-warns-on-meta-interceptors-uix
+  (testing "metadata-map :interceptors triggers :rf.warning/interceptors-in-metadata-map under the UIx adapter"
+    (let [warns (collect-warnings ::db-warn)]
+      (rf/reg-event-db :test.bbea.uix/db-bad
+        {:doc "Wrongly-shaped." :interceptors [noop-icpt]}
+        (fn [db _] db))
+      (rf/remove-trace-cb! ::db-warn)
+      (is (= 1 (count @warns)))
+      (let [t (:tags (first @warns))]
+        (is (= "reg-event-db" (:reg-fn t)))
+        (is (= :test.bbea.uix/db-bad (:id t)))))))
+
+(deftest reg-event-fx-warns-on-meta-interceptors-uix
+  (let [warns (collect-warnings ::fx-warn)]
+    (rf/reg-event-fx :test.bbea.uix/fx-bad
+      {:interceptors [noop-icpt]}
+      (fn [_ _] {:db {}}))
+    (rf/remove-trace-cb! ::fx-warn)
+    (is (= 1 (count @warns)))
+    (is (= "reg-event-fx" (:reg-fn (:tags (first @warns)))))))
+
+(deftest reg-event-ctx-warns-on-meta-interceptors-uix
+  (let [warns (collect-warnings ::ctx-warn)]
+    (rf/reg-event-ctx :test.bbea.uix/ctx-bad
+      {:interceptors [noop-icpt]}
+      (fn [ctx] ctx))
+    (rf/remove-trace-cb! ::ctx-warn)
+    (is (= 1 (count @warns)))
+    (is (= "reg-event-ctx" (:reg-fn (:tags (first @warns)))))))
+
+(deftest correct-positional-form-stays-silent-uix
+  (testing "interceptors in the positional slot do NOT warn under UIx"
+    (let [warns (collect-warnings ::quiet)]
+      (rf/reg-event-db :test.bbea.uix/quiet-1
+        [noop-icpt]
+        (fn [db _] db))
+      (rf/reg-event-db :test.bbea.uix/quiet-2
+        {:doc "metadata only"}
+        [noop-icpt]
+        (fn [db _] db))
+      (rf/reg-event-db :test.bbea.uix/quiet-3
+        {:doc "metadata only, no positional interceptors"}
+        (fn [db _] db))
+      (rf/remove-trace-cb! ::quiet)
+      (is (zero? (count @warns))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_http_managed_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_http_managed_cljs_test.cljs
@@ -1,0 +1,164 @@
+(ns re-frame.adapter.uix-http-managed-cljs-test
+  "Adapter-parity port of `re-frame.http-managed-cljs-test` to the
+  UIx adapter (rf2-ta4b5).
+
+  Smoke for Spec 014 — `:rf.http/managed` under the UIx reactive
+  substrate. The canned-stub fxs and `with-managed-request-stubs*`
+  helper resolve under the UIx adapter the same way they do under
+  Reagent — confirming that `reg-event-fx` + `:fx` orchestration +
+  fx-overrides compose with the UIx late-bind hook stack.
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/http_managed_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.schemas.malli]
+            [re-frame.core :as rf]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (fn [test-fn]
+    (http-managed/clear-all-in-flight!)
+    ((test-support/reset-runtime-fixture
+       {:adapter uix-adapter/adapter})
+      test-fn)
+    (http-managed/clear-all-in-flight!)))
+
+;; ---- 1. canned-success: default reply addressing --------------------------
+
+(deftest canned-success-default-reply-addressing-uix
+  (testing "the canned-success stub dispatches a default reply under the UIx adapter"
+    (rf/reg-event-fx :article/load
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          (case (:kind reply)
+            :success {:db {:article (:value reply)}}
+            :failure {:db {:error (:failure reply)}})
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles/hello"}
+                  :decode  :json}]]})))
+    (rf/dispatch-sync [:article/load {:slug "hello"}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= {:stubbed true} (:article db))
+          "default-reply addressing routed the synthesised reply back to :article/load"))))
+
+;; ---- 2. canned-failure: explicit on-failure -------------------------------
+
+(deftest canned-failure-explicit-on-failure-uix
+  (testing "explicit :on-failure routes the failure reply to the named handler under UIx"
+    (rf/reg-event-fx :auth/login
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request    {:method :post :url "/auth/login"}
+                :on-failure [:auth/login-error]}]]}))
+    (rf/reg-event-db :auth/login-error
+      (fn [db [_ payload]]
+        (assoc db :auth-error payload)))
+    (rf/dispatch-sync [:auth/login]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= :failure (get-in db [:auth-error :kind])))
+      (is (= :rf.http/transport (get-in db [:auth-error :failure :kind]))
+          "default canned-failure :kind classifies as :rf.http/transport"))))
+
+;; ---- 3. canned-success: explicit on-success -------------------------------
+
+(deftest canned-success-explicit-on-success-uix
+  (testing "explicit :on-success routes the success reply to the named handler under UIx"
+    (rf/reg-event-fx :article/load
+      (fn [_ _]
+        {:fx [[:rf.http/managed
+               {:request    {:method :get :url "/articles/hello"}
+                :on-success [:article/loaded]}]]}))
+    (rf/reg-event-db :article/loaded
+      (fn [db [_ payload]]
+        (assoc db :article payload)))
+    (rf/dispatch-sync [:article/load]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= :success (get-in db [:article :kind])))
+      (is (= {:stubbed true} (get-in db [:article :value]))))))
+
+;; ---- 4. silenced reply ----------------------------------------------------
+
+(deftest silenced-reply-on-success-nil-uix
+  (testing "explicit :on-success nil swallows the reply silently under UIx"
+    (let [seen (atom 0)]
+      (rf/reg-event-fx :ping
+        (fn [_ _]
+          (swap! seen inc)
+          {:fx [[:rf.http/managed
+                 {:request    {:url "/ping"}
+                  :on-success nil}]]}))
+      (rf/dispatch-sync [:ping]
+                        {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+      (is (= 1 @seen) "no reply was dispatched when :on-success is nil"))))
+
+;; ---- 5. with-managed-request-stubs* helper --------------------------------
+
+(deftest with-managed-request-stubs-uix
+  (testing "with-managed-request-stubs* installs a per-call fx under UIx"
+    (rf/reg-event-fx :articles/list
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:result reply}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs*
+      {[:get "/articles"] {:reply {:ok [:hello :world]}}}
+      (fn []
+        (rf/dispatch-sync [:articles/list]
+                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        (let [db (rf/get-frame-db :rf/default)]
+          (is (= :success (get-in db [:result :kind])))
+          (is (= [:hello :world] (get-in db [:result :value]))))))))
+
+;; ---- 6. with-managed-request-stubs* — failure mapping --------------------
+
+(deftest with-managed-request-stubs-failure-uix
+  (testing "with-managed-request-stubs* synthesises a failure reply when {:reply {:failure ...}} under UIx"
+    (rf/reg-event-fx :articles/list
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:result reply}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs*
+      {[:get "/articles"] {:reply {:failure {:kind   :rf.http/http-4xx
+                                             :status 404}}}}
+      (fn []
+        (rf/dispatch-sync [:articles/list]
+                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        (let [db (rf/get-frame-db :rf/default)]
+          (is (= :failure (get-in db [:result :kind])))
+          (is (= :rf.http/http-4xx (get-in db [:result :failure :kind])))
+          (is (= 404 (get-in db [:result :failure :status]))))))))
+
+;; ---- 7. multi-frame reply isolation -------------------------------------
+
+(deftest multi-frame-reply-isolation-uix
+  (testing "managed requests issued from frame A reply into frame A's app-db under UIx"
+    (rf/reg-event-fx :article/load
+      (fn [_ [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db {:article (:value reply)}}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles/hello"}
+                  :decode  :json}]]})))
+    (let [left  (rf/make-frame {:doc "left"
+                                :fx-overrides
+                                {:rf.http/managed :rf.http/managed-canned-success}})
+          right (rf/make-frame {:doc "right"
+                                :fx-overrides
+                                {:rf.http/managed :rf.http/managed-canned-success}})]
+      (rf/dispatch-sync [:article/load] {:frame left})
+      (rf/dispatch-sync [:article/load] {:frame right})
+      (is (= {:stubbed true} (:article (rf/get-frame-db left))))
+      (is (= {:stubbed true} (:article (rf/get-frame-db right))))
+      (is (nil? (:article (rf/get-frame-db :rf/default)))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_routing_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_routing_cljs_test.cljs
@@ -1,0 +1,105 @@
+(ns re-frame.adapter.uix-routing-cljs-test
+  "Adapter-parity port of `re-frame.routing-cljs-test` to the UIx
+  adapter (rf2-ta4b5).
+
+  Verifies the routing pipeline runs under the UIx reactive substrate
+  and locks the multi-frame routing contract.
+
+  - routing-handle-url-change-uix       — :rf/url-changed /
+                                          handle-url-change drive the
+                                          :rf/route slice under the
+                                          UIx adapter; subscriptions
+                                          resolve.
+  - routing-frame-provider-routing-uix  — multi-frame routing: each
+                                          frame's :rf/route slice is
+                                          independent, the registry is
+                                          shared, subscriptions resolve
+                                          per-frame.
+
+  Per Spec 012 §URL changes are events, §Reading the route is a sub,
+  §Multi-frame routing. Parallel to:
+    - implementation/adapters/reagent/test/re_frame/routing_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn routing/reset-counters!}))
+
+;; ---- Spec 012 §URL changes are events / §Reading the route is a sub -----
+
+(deftest routing-handle-url-change-uix
+  (testing ":rf/url-changed drives the slice on UIx"
+    (let [f (rf/make-frame {:doc "isolated frame for this test"})]
+      (rf/reg-route :route.uix/home
+                    {:path "/uix/home"})
+      (rf/reg-route :route.uix/article
+                    {:path     "/uix/articles/:id"
+                     :params   [:map [:id :string]]
+                     :on-match [[:uix/article-load]]})
+      (rf/reg-event-db :uix/article-load
+                       (fn [db _] (assoc db :article-loaded? true)))
+      (rf/reg-sub :rf.uix.route/id
+                  (fn [db _] (get-in db [:rf/route :id])))
+      (rf/reg-sub :rf.uix.route/params
+                  (fn [db _] (get-in db [:rf/route :params])))
+
+      (rf/dispatch-sync [:rf/url-changed "/uix/articles/intro"] {:frame f})
+      (is (= :route.uix/article
+             (rf/subscribe-value f [:rf.uix.route/id]))
+          ":rf.route/id sub resolves under the UIx adapter")
+      (is (= {:id "intro"}
+             (rf/subscribe-value f [:rf.uix.route/params]))
+          ":rf.route/params sub resolves under the UIx adapter")
+      (is (true? (:article-loaded? (rf/get-frame-db f)))
+          ":on-match's [:uix/article-load] dispatched and ran")
+
+      (rf/dispatch-sync [:rf/url-changed "/uix/articles/welcome"] {:frame f})
+      (is (= {:id "welcome"}
+             (rf/subscribe-value f [:rf.uix.route/params]))
+          "new params land in the slice on subsequent navigation")
+      (is (some? (get-in (rf/get-frame-db f) [:rf/route :nav-token]))
+          "fresh nav-token allocated on each full navigation"))))
+
+;; ---- Spec 012 §Multi-frame routing ---------------------------------------
+
+(deftest routing-frame-provider-routing-uix
+  (testing "two frames carry independent :rf/route slices over a shared registry under UIx"
+    (rf/reg-route :route.uix2/home          {:path "/uix2/"})
+    (rf/reg-route :route.uix2/articles      {:path "/uix2/articles"})
+    (rf/reg-route :route.uix2/article       {:path   "/uix2/articles/:id"
+                                             :params [:map [:id :string]]})
+    (rf/reg-sub :rf.uix2/route (fn [db _] (:rf/route db)))
+
+    (let [left  (rf/make-frame {:doc "left tab frame"})
+          right (rf/make-frame {:doc "right tab frame"})]
+
+      (rf/dispatch-sync [:rf/url-changed "/uix2/articles"]
+                        {:frame left})
+      (rf/dispatch-sync [:rf/url-changed "/uix2/articles/intro"]
+                        {:frame right})
+
+      (let [left-route  (rf/subscribe-value left  [:rf.uix2/route])
+            right-route (rf/subscribe-value right [:rf.uix2/route])]
+        (is (= :route.uix2/articles (:id left-route))
+            "left frame's :rf/route is :route.uix2/articles")
+        (is (= :route.uix2/article  (:id right-route))
+            "right frame's :rf/route is :route.uix2/article")
+        (is (= {} (:params left-route))
+            "left frame has no :params (collection route)")
+        (is (= {:id "intro"} (:params right-route))
+            "right frame has the article id"))
+
+      (rf/dispatch-sync [:rf/url-changed "/uix2/"] {:frame left})
+      (is (= :route.uix2/home
+             (:id (rf/subscribe-value left [:rf.uix2/route])))
+          "left re-navigated to :route.uix2/home")
+      (is (= :route.uix2/article
+             (:id (rf/subscribe-value right [:rf.uix2/route])))
+          "right is unaffected by left's navigation"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
@@ -1,0 +1,162 @@
+(ns re-frame.adapter.uix-runtime-cljs-test
+  "Adapter-parity port of the headless slice of `re-frame.runtime-cljs-test`
+  to the UIx adapter (rf2-ta4b5).
+
+  The runtime layer (dispatch, subs, with-frame, bound-fn, multi-frame
+  isolation, sub hot-reload) is substrate-agnostic, but every assertion
+  in this file runs under the UIx-installed adapter — pinning that the
+  late-bind hooks the UIx adapter publishes (`:adapter/ratom`,
+  `:adapter/make-reaction`, `:adapter/current-frame`, `:adapter/wrap-view`)
+  compose with the runtime layer the same way they do under Reagent.
+
+  This is the headless subset only — Reagent-specific `r/atom` /
+  `r/track!` / inline-hiccup-render assertions and example-driven tests
+  are out of scope; those ride through the framework-level shared tests
+  and through the UIx Playwright smoke (`examples/uix/counter`).
+
+  Parallel to:
+    - implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.core :refer [with-frame bound-fn]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- shared dispatch + sub --------------------------------------------------
+
+(deftest dispatch-sync-uix
+  (testing "dispatch-sync runs an event-db handler under the UIx adapter"
+    (rf/reg-event-db :counter/init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :counter/inc  (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:counter/init])
+    (rf/dispatch-sync [:counter/inc])
+    (rf/dispatch-sync [:counter/inc])
+    (is (= 2 (:n (rf/get-frame-db :rf/default))))))
+
+(deftest sub-chain-uix
+  (testing "layer-1 + layer-2 subs return computed values under the UIx adapter"
+    (rf/reg-event-db :seed (fn [_ _] {:items [10 20 30]}))
+    (rf/reg-sub :items     (fn [db _] (:items db)))
+    (rf/reg-sub :item-sum  :<- [:items] (fn [items _] (reduce + items)))
+    (rf/dispatch-sync [:seed])
+    (is (= [10 20 30] (rf/subscribe-value [:items])))
+    (is (= 60         (rf/subscribe-value [:item-sum])))))
+
+;; ---- with-frame macro -------------------------------------------------------
+
+(deftest with-frame-binds-current-frame-uix
+  (testing "with-frame :foo binds *current-frame* in the body under the UIx adapter"
+    (with-frame :left
+      (is (= :left (rf/current-frame))))
+    (testing "and the [sym expr] form binds the symbol AND the dynamic var"
+      (with-frame [f :right]
+        (is (= :right f))
+        (is (= :right (rf/current-frame))))))
+  (testing "outside any binding the dynamic var falls back to :rf/default"
+    (is (= :rf/default (rf/current-frame)))))
+
+;; ---- bound-fn macro ---------------------------------------------------------
+
+(deftest bound-fn-captures-frame-uix
+  (testing "bound-fn captures the current frame and re-binds it inside the body"
+    (rf/reg-frame :side {:doc "side frame"})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/dispatch-sync [:seed 99] {:frame :side})
+    (let [captured (with-frame :side (bound-fn [] (rf/current-frame)))]
+      (is (= :rf/default (rf/current-frame)))
+      (is (= :side       (captured))))))
+
+;; ---- frame isolation ------------------------------------------------------
+
+(deftest multi-frame-state-isolation-uix
+  (testing "two frames carry independent app-db state, share handler registry — under UIx"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    (rf/reg-event-db :counter/init (fn [_ [_ n]] {:count n}))
+    (rf/reg-event-db :counter/inc  (fn [db _] (update db :count inc)))
+    (rf/reg-sub :count (fn [db _] (:count db)))
+    (rf/dispatch-sync [:counter/init 10] {:frame :left})
+    (rf/dispatch-sync [:counter/init 100] {:frame :right})
+    (rf/dispatch-sync [:counter/inc] {:frame :left})
+    (rf/dispatch-sync [:counter/inc] {:frame :left})
+    (is (= 12  (rf/subscribe-value :left  [:count])))
+    (is (= 100 (rf/subscribe-value :right [:count])))
+    (is (nil?  (rf/subscribe-value :rf/default [:count])))))
+
+;; ---- reactivity -----------------------------------------------------------
+;;
+;; The UIx adapter's containers are plain atoms; per Spec 006 the
+;; container's `subscribe-container` surface fires `on-change` on every
+;; replace. The subscribe layer in core wraps that with a Reagent
+;; reaction (the UIx adapter delegates `:adapter/make-reaction` to stock
+;; Reagent) so the reaction's deref reflects post-event state.
+
+(deftest reactive-sub-tracks-changes-uix
+  (testing "a subscription's deref reflects post-event state under UIx"
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+    (let [r (rf/subscribe [:n])]
+      (is (= 0 @r))
+      (rf/dispatch-sync [:inc])
+      (is (= 1 @r) "the subscription observes the new value after :inc")
+      (rf/dispatch-sync [:inc])
+      (rf/dispatch-sync [:inc])
+      (is (= 3 @r))
+      (rf/unsubscribe [:n]))))
+
+;; ---- hot-reload sub invalidation ------------------------------------------
+
+(deftest sub-hot-reload-uix
+  (testing "re-registering a sub flips the next subscribe-value to the new body under UIx"
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :answer (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+    (is (= 7 (rf/subscribe-value [:answer])))
+    (let [_pin (rf/subscribe [:answer])]
+      (rf/reg-sub :answer (fn [db _] (* 10 (:n db))))
+      (is (= 70 (rf/subscribe-value [:answer]))
+          "the new sub body is in effect after re-registration")
+      (rf/unsubscribe [:answer]))))
+
+;; ---- machines (pure machine-transition) -----------------------------------
+
+(deftest machine-transition-uix
+  (testing "pure machine-transition runs under the UIx adapter"
+    (let [m {:initial :red
+             :data    {}
+             :states
+             {:red    {:on {:tick {:target :green}}}
+              :green  {:on {:tick {:target :yellow}}}
+              :yellow {:on {:tick {:target :red}}}}}
+          [s _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+      (is (= :green (:state s))))))
+
+;; ---- error paths ----------------------------------------------------------
+
+(deftest sub-exception-recovers-to-nil-uix
+  (testing "a sub whose body throws emits :rf.error/sub-exception and resolves to nil under UIx"
+    (rf/reg-event-db :init (fn [_ _] {:items "broken"}))
+    (rf/reg-sub :items (fn [db _] (:items db)))
+    (rf/reg-sub :items-count :<- [:items]
+      (fn [items _]
+        (count (.something items))))
+    (rf/dispatch-sync [:init])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (let [v (rf/subscribe-value [:items-count])]
+        (is (nil? v)
+            "the sub returns nil under :replaced-with-default recovery"))
+      (rf/remove-trace-cb! ::sub-err)
+      (is (some (fn [ev]
+                  (= :rf.error/sub-exception (:operation ev)))
+                @traces)
+          "expected :rf.error/sub-exception trace"))))


### PR DESCRIPTION
## Summary

Adds 6 adapter-parity test files per substrate to the Helix and UIx adapters (12 new files total, 86 new deftests, 43 per adapter). Closes the test-coverage gap surfaced by the recent rigour sweep: Reagent had 23 test files, Helix + UIx each had only 3 (`*_parity_*`, `*_derived_value_baseline_*`, `*_source_coord_dom_elision_prod_*`).

Each port mirrors a high-value Reagent spec, scopes the test ids to the target adapter (`-helix` / `-uix`), runs under the adapter's `reset-runtime-fixture`, and pins the same runtime contract under the target substrate's late-bind hook stack — confirming that core's runtime layer (events / dispatch / subs / fx / machines) composes with each adapter's published hooks (`:adapter/current-frame`, `:adapter/ratom`, `:adapter/make-reaction`, `:adapter/wrap-view`) the same way it does under Reagent.

Specs ported (per adapter):

- `*_events_cljs_test` (4 deftests) — `reg-event-*` metadata-interceptors warning under the adapter
- `*_runtime_cljs_test` (9 deftests) — dispatch-sync / sub-chain / reactive-sub / `with-frame` / `bound-fn` / multi-frame isolation / sub hot-reload / pure machine-transition / sub-exception recovery
- `*_routing_cljs_test` (2 deftests) — `:rf/url-changed` slice + multi-frame routing
- `*_dispatch_frame_capture_cljs_test` (6 deftests) — sync dispatch frame-binding, setTimeout-escape, `:fx [:dispatch]`, `:dispatch-later`, `(rf/dispatcher)`, cross-frame isolation
- `*_http_managed_cljs_test` (7 deftests) — `:rf.http/managed` canned-stub fxs + `with-managed-request-stubs*` + multi-frame reply isolation
- `*_cross_spec_cljs_test` (15 deftests) — headless subset of Cross-Spec-Interactions: frame-destroy machine traces, sub-cache microstep, boot order, SSR `:after` no-op, route-not-found, headless frame resolution chain, machine action throws, machine `:fx` throws, machine hot-reload, dispatch-sync-in-handler, replace-container revert, server error projection, mid-cascade sub re-register, story `:fx-overrides`, `adapter-already-installed`

Browser-only scenarios (real-React mounts, mid-render destroy, plain-fn warn-once, rf2-d4sf provider-routing cases) are deliberately excluded — they ride through each substrate's Playwright smoke. This work covers the node-test unit-level gap only.

Adapter sources untouched; no spec changes; existing Reagent tests untouched.

## Test plan

- [x] `npx shadow-cljs compile node-test` — passes (366 files, 13 compiled, 22 incremental warnings)
- [x] `node out/node-test.js` — **Ran 894 tests containing 2306 assertions. 0 failures, 0 errors.**
- [x] `npx shadow-cljs compile browser-test` — passes (408 files, 11 compiled, 18 warnings)
- [x] Helix test file count: 3 → 9 (43 new deftests)
- [x] UIx test file count: 3 → 9 (43 new deftests)

Bead: `rf2-ta4b5`. Source: `ai/findings/sweep-test-coverage-rigour-2026-05-13.md` §B / Finding 5.