### PR TITLE
feat(causa): Subscriptions panel with freshness badges — Phase 5 (rf2-x0f5v)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -1,0 +1,467 @@
+(ns day8.re-frame2-causa.panels.subscriptions
+  "Subscriptions panel — Phase 5 (rf2-x0f5v, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/012-Subscriptions.md` the Subscriptions panel
+  answers the five-canonical-questions framing's #3 and #4:
+
+    3. **Why is this subscription returning the wrong value?**
+    4. **Why is this view re-rendering?**
+
+  The panel ships two affordances that did not exist in re-frame-10x:
+
+    - A **five-status badge taxonomy** — `:fresh`, `:re-running`,
+      `:invalidated`, `:cached-no-watcher`, `:error` — paired with
+      a shape glyph + tooltip per spec §\"Colour is never alone\".
+    - An **invalidation-chain affordance** — for any sub that
+      re-ran this epoch, a one-click walk **up** the input chain
+      to the originating `app-db` slice change.
+
+  ## TanStack-Query peer landscape
+
+  The badge taxonomy intentionally mirrors TanStack Query DevTools'
+  vocabulary (fresh / fetching / inactive / paused / stale) but
+  prunes to re-frame's value-equality-driven cache: there is no
+  `:stale` (per spec §\"Stale vs invalidated\") because the runtime
+  has no wall-clock aging. The shape-paired colour discipline + the
+  filter-chip header + the in-place re-running animation are the
+  TanStack hallmarks Causa adopts.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+  Every `subscribe` / `dispatch` here resolves to `:rf/causa`.
+
+  ## Helpers
+
+  All pure-data logic — `project-rows`, `compute-status`, `compute-
+  chain`, `status-counts` — lives in `subscriptions_helpers.cljc` so
+  the algebra runs under the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) --------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel.
+  Kept in sync manually for now — the v1.0 styling pass replaces
+  these with CSS variables across all panels."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn- status-colour
+  "Resolve a status's colour token to its hex via the panel's
+  `tokens` map. Single point of indirection so the test suite can
+  assert against the token without touching the hex."
+  [status]
+  (let [tok (get h/status->token status :text-tertiary)]
+    (get tokens tok (:text-tertiary tokens))))
+
+;; ---- status badge --------------------------------------------------------
+
+(defn- status-badge
+  "Per spec §\"Colour is never alone\" — the canonical badge surface.
+  Colour + shape + tooltip-label, 14px on cosy density, sitting at
+  the left margin of every sub row. `status` is one of
+  `#{:fresh :re-running :invalidated :cached-no-watcher :error}`."
+  [status]
+  (let [glyph   (get h/status->glyph status "?")
+        colour  (status-colour status)
+        tooltip (get h/status->tooltip status "Unknown")]
+    [:span {:data-testid     (str "rf-causa-sub-badge-" (name status))
+            :title           tooltip
+            :aria-label      tooltip
+            :style           {:display        "inline-block"
+                              :width          "14px"
+                              :height         "14px"
+                              :line-height    "14px"
+                              :text-align     "center"
+                              :color          colour
+                              :font-family    mono-stack
+                              :font-size      "14px"
+                              :font-weight    700
+                              :margin-right   "8px"
+                              :flex-shrink    0}}
+     glyph]))
+
+;; ---- filter chips --------------------------------------------------------
+
+(defn- filter-chip
+  "One status filter chip in the header row. Per spec §Filtering and
+  grouping — clicking toggles the chip's status in the filter set.
+  Active chips render with the status colour + a filled background;
+  inactive chips render with the status colour outline only."
+  [status active? count]
+  (let [colour  (status-colour status)
+        glyph   (get h/status->glyph status)
+        tooltip (get h/status->tooltip status)]
+    [:button {:data-testid (str "rf-causa-sub-filter-" (name status))
+              :on-click    #(rf/dispatch [:rf.causa/toggle-sub-filter status])
+              :title       tooltip
+              :style       {:display        "inline-flex"
+                            :align-items    "center"
+                            :gap            "4px"
+                            :padding        "2px 8px"
+                            :margin-right   "6px"
+                            :border-radius  "10px"
+                            :background     (if active?
+                                              "rgba(124, 92, 255, 0.18)"
+                                              "transparent")
+                            :border         (str "1px solid "
+                                                 (if active?
+                                                   colour
+                                                   (:border-default tokens)))
+                            :color          (if active?
+                                              (:text-primary tokens)
+                                              (:text-secondary tokens))
+                            :cursor         "pointer"
+                            :font-family    sans-stack
+                            :font-size      "11px"
+                            :font-weight    (if active? 600 400)}}
+     [:span {:style {:color colour :font-family mono-stack :font-weight 700}}
+      glyph]
+     [:span tooltip]
+     (when count
+       [:span {:style {:color    (:text-tertiary tokens)
+                       :font-family mono-stack
+                       :font-size "10px"}}
+        (str "(" count ")")])]))
+
+(defn- filter-header
+  "Header row carrying the five filter chips + the result count.
+  Per spec §Filtering and grouping."
+  [active-filters status-counts total]
+  [:div {:data-testid "rf-causa-subscriptions-filters"
+         :style       {:padding "8px 12px"
+                       :display "flex"
+                       :align-items "center"
+                       :flex-wrap "wrap"
+                       :gap "4px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   (into [:div {:style {:flex 1 :display "flex" :flex-wrap "wrap"}}]
+         (for [s h/statuses]
+           ^{:key s}
+           (filter-chip s (contains? active-filters s) (get status-counts s 0))))
+   [:span {:style {:color     (:text-tertiary tokens)
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :margin-left "8px"}}
+    (str total " sub" (if (= 1 total) "" "s"))]])
+
+;; ---- sub row -------------------------------------------------------------
+
+(defn- layer-pill
+  "Compact layer indicator — `L1`, `L2`, `L3+`. nil-safe."
+  [layer]
+  (let [label (cond
+                (nil? layer)  "?"
+                (<= layer 1)  "L1"
+                (= layer 2)   "L2"
+                :else         "L3+")]
+    [:span {:style {:display       "inline-block"
+                    :padding       "1px 6px"
+                    :margin-right  "8px"
+                    :border-radius "3px"
+                    :background    (:bg-3 tokens)
+                    :color         (:text-secondary tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"}}
+     label]))
+
+(defn- sub-row
+  "One row in the sub list. Clicking the row fires
+  `:rf.causa/select-sub` so the chain affordance can open against
+  this sub. Right-click would route through a context menu; v1
+  exposes the chain via the keyboard shortcut `i` + a small button
+  on the row."
+  [{:keys [query-v sub-id status layer ref-count recomputed?] :as _row}
+   selected?]
+  [:li {:data-testid (str "rf-causa-sub-row-"
+                          (h/format-sub-id sub-id))
+        :on-click   #(rf/dispatch [:rf.causa/select-sub query-v])
+        :style      {:display       "flex"
+                     :align-items   "center"
+                     :padding       "6px 12px"
+                     :background    (if selected?
+                                      (:bg-active tokens)
+                                      "transparent")
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :cursor        "pointer"
+                     :font-family   mono-stack
+                     :font-size     "13px"
+                     :color         (:text-primary tokens)}}
+   (status-badge status)
+   (layer-pill layer)
+   [:span {:style {:flex 1
+                   :min-width 0
+                   :overflow "hidden"
+                   :text-overflow "ellipsis"
+                   :white-space "nowrap"}}
+    (h/format-query-v query-v)]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-size "11px"
+                   :margin-left "8px"}}
+    (str "refs " ref-count)]
+   (when recomputed?
+     [:span {:data-testid "rf-causa-sub-row-recomputed"
+             :style {:color (:cyan tokens)
+                     :font-size "10px"
+                     :margin-left "8px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"}}
+      "ran"])
+   [:button {:data-testid (str "rf-causa-sub-row-chain-"
+                               (h/format-sub-id sub-id))
+             :on-click (fn [e]
+                         (.stopPropagation e)
+                         (rf/dispatch [:rf.causa/select-sub query-v])
+                         (rf/dispatch [:rf.causa/show-invalidation-chain query-v]))
+             :title    "Show invalidation chain"
+             :style    {:margin-left "8px"
+                        :background "transparent"
+                        :border (str "1px solid " (:border-default tokens))
+                        :color (:text-secondary tokens)
+                        :padding "1px 6px"
+                        :border-radius "3px"
+                        :cursor "pointer"
+                        :font-family sans-stack
+                        :font-size "10px"}}
+    "chain"]])
+
+;; ---- sub list ------------------------------------------------------------
+
+(defn- sub-list
+  "The default list view per spec §Where badges appear. Renders one
+  row per sub, badge at the left margin, in the canonical sort
+  order (errors first, then re-running, etc.)."
+  [rows selected-query-v]
+  (if (empty? rows)
+    [:div {:data-testid "rf-causa-subscriptions-empty-rows"
+           :style       {:padding "16px"
+                         :color   (:text-tertiary tokens)
+                         :font-family sans-stack
+                         :font-size "13px"}}
+     "No subscriptions match the current filter."]
+    (into [:ul {:data-testid "rf-causa-subscriptions-list"
+                :style {:list-style "none"
+                        :margin     0
+                        :padding    0
+                        :background (:bg-2 tokens)}}]
+          (for [row rows]
+            ^{:key (h/format-query-v (:query-v row))}
+            (sub-row row (= (:query-v row) selected-query-v))))))
+
+;; ---- invalidation-chain view --------------------------------------------
+
+(defn- chain-link
+  "One link in the invalidation chain — one of the focused sub's
+  inputs that re-ran this cascade. Per spec §What the affordance
+  renders the link carries the input's query-v + its layer + the
+  link-reason (`input changed` between sub layers; `slice changed`
+  from layer-1 down to the `app-db` path)."
+  [{:keys [query-v status layer link-reason]}]
+  [:li {:data-testid (str "rf-causa-chain-link-"
+                          (h/format-sub-id (first query-v)))
+        :style       {:padding "6px 12px"
+                      :display "flex"
+                      :align-items "center"
+                      :border-bottom (str "1px solid " (:border-subtle tokens))
+                      :font-family mono-stack
+                      :font-size "12px"
+                      :color (:text-primary tokens)}}
+   (status-badge status)
+   (layer-pill layer)
+   [:span {:style {:flex 1}} (h/format-query-v query-v)]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-size "10px"
+                   :font-family sans-stack
+                   :text-transform "uppercase"
+                   :letter-spacing "0.5px"
+                   :margin-left "8px"}}
+    (case link-reason
+      :slice-changed "slice changed"
+      :input-changed "input changed"
+      "")]])
+
+(defn- chain-view
+  "The invalidation-chain affordance — surfaces 'why did this sub
+  re-run?' as a top-down list per spec §What the affordance renders.
+  Renders the focused sub at the top + one level of inputs that
+  re-ran this cascade + the originating `app-db` path(s) when the
+  attribution lands at layer 1."
+  [{:keys [focused inputs app-db-paths missing?] :as _chain}]
+  [:section {:data-testid "rf-causa-subscriptions-chain"
+             :style       {:border-top (str "1px solid " (:border-default tokens))
+                           :background (:bg-1 tokens)}}
+   [:header {:style {:padding "8px 12px"
+                     :display "flex"
+                     :align-items "center"
+                     :justify-content "space-between"
+                     :background (:bg-3 tokens)
+                     :border-bottom (str "1px solid " (:border-subtle tokens))}}
+    [:span {:style {:font-family sans-stack
+                    :font-size   "12px"
+                    :font-weight 600
+                    :color       (:text-primary tokens)}}
+     "Invalidation chain"]
+    [:button {:data-testid "rf-causa-subscriptions-chain-close"
+              :on-click    #(rf/dispatch [:rf.causa/hide-invalidation-chain])
+              :style       {:background "transparent"
+                            :border (str "1px solid " (:border-default tokens))
+                            :color (:text-secondary tokens)
+                            :padding "1px 8px"
+                            :border-radius "4px"
+                            :cursor "pointer"
+                            :font-family sans-stack
+                            :font-size "11px"}}
+     "Close"]]
+   (cond
+     missing?
+     [:div {:data-testid "rf-causa-subscriptions-chain-missing"
+            :style       {:padding "12px"
+                          :color (:text-tertiary tokens)
+                          :font-family sans-stack
+                          :font-size "12px"}}
+      "Sub is not in the cache — nothing to chain. The cache may have
+       evicted the entry, or the sub has never been subscribed."]
+
+     :else
+     [:div
+      ;; Focused sub at the top — read 'this is the sub under
+      ;; inspection'.
+      [:ul {:data-testid "rf-causa-subscriptions-chain-focused"
+            :style {:list-style "none" :margin 0 :padding 0}}
+       (chain-link {:query-v (:query-v focused)
+                    :status  (:status focused)
+                    :layer   (:layer focused)
+                    :link-reason (cond
+                                   (or (nil? (:layer focused))
+                                       (<= (:layer focused) 1))
+                                   :slice-changed
+                                   :else
+                                   :input-changed)})]
+      ;; Inputs that re-ran this cascade — one level down.
+      (if (empty? inputs)
+        [:div {:data-testid "rf-causa-subscriptions-chain-no-inputs"
+               :style {:padding "8px 12px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "11px"}}
+         "No inputs re-ran this cascade. The sub may be layer-1 — "
+         "see the originating slice(s) below."]
+        (into [:ul {:data-testid "rf-causa-subscriptions-chain-inputs"
+                    :style {:list-style "none"
+                            :margin 0
+                            :padding 0
+                            :border-top (str "1px dashed " (:border-default tokens))}}]
+              (for [in inputs]
+                ^{:key (h/format-query-v (:query-v in))}
+                (chain-link in))))
+      ;; Originating slice(s) — layer-1 attribution.
+      (when (seq app-db-paths)
+        [:div {:data-testid "rf-causa-subscriptions-chain-app-db"
+               :style {:padding "8px 12px"
+                       :border-top (str "1px solid " (:border-subtle tokens))
+                       :font-family mono-stack
+                       :font-size "12px"
+                       :color (:text-primary tokens)}}
+         [:div {:style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :margin-bottom "4px"}}
+          "Originating slice(s)"]
+         (into [:ul {:style {:list-style "none"
+                             :margin 0
+                             :padding 0}}]
+               (for [path app-db-paths]
+                 ^{:key (pr-str path)}
+                 [:li {:style {:padding "2px 0"
+                               :color (:accent-violet tokens)}}
+                  (pr-str path)]))])])])
+
+;; ---- empty state ---------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when the sub-cache is empty (no subs have been
+  materialised in the target frame yet). Per spec §JVM behaviour —
+  the panel is CLJS-only; on JVM the cache is empty by construction
+  and the same empty-state surfaces."
+  []
+  [:div {:data-testid "rf-causa-subscriptions-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"}}
+    "No subscriptions yet."]
+   [:p {:style {:margin 0
+                :font-size "12px"
+                :color (:text-tertiary tokens)}}
+    "Subscribe to a sub in the host app — the cache populates as views render."]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn subscriptions-view
+  "The Subscriptions panel's root view. Subscribes to
+  `:rf.causa/subscriptions-data` and renders the filter chips +
+  sub list + (when a sub is selected and the chain is open) the
+  invalidation-chain affordance."
+  []
+  (let [{:keys [rows status-counts selected-query-v active-filters
+                chain-open? chain]}
+        @(rf/subscribe [:rf.causa/subscriptions-data])
+        filtered-rows (h/filter-by-status rows active-filters)
+        total         (count rows)]
+    [:section {:data-testid "rf-causa-subscriptions"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Subscriptions"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "Cache state for every materialised sub in the target frame. "
+       "Hover a badge for the status tooltip; click "
+       [:em "chain"] " for the invalidation walk."]]
+     (filter-header (or active-filters #{}) status-counts total)
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if (zero? total)
+        (empty-state)
+        (sub-list filtered-rows selected-query-v))]
+     (when chain-open?
+       (chain-view chain))]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions_helpers.cljc
@@ -1,0 +1,376 @@
+(ns day8.re-frame2-causa.panels.subscriptions-helpers
+  "Pure-data helpers for Causa's Subscriptions panel
+  (Phase 5, rf2-x0f5v, parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `subscriptions.cljs` builds the table + chip
+  hiccup; the *logic* — folding the live sub-cache + the just-settled
+  epoch's `:sub-runs` projection into a per-sub status badge — is
+  pure data → data. Splitting that algebra into `.cljc` so it runs
+  under the JVM unit-test target (`clojure -M:test`) is required by
+  `feedback_jvm_interop_must_work.md` and mirrors the
+  `causality_graph_helpers.cljc` / `time_travel_helpers.cljc` shape.
+
+  ## The five-status taxonomy (per spec/012-Subscriptions.md §The
+  five statuses)
+
+  Every sub the panel renders carries **exactly one** status badge.
+  The taxonomy is small by design — five statuses, each paired with
+  a colour + a shape + a tooltip label so colour-blind users get the
+  same signal:
+
+  | Status              | Glyph | Colour token   | Tooltip               |
+  |---------------------|-------|----------------|-----------------------|
+  | `:fresh`            | `●`   | `:green`       | Fresh                 |
+  | `:re-running`       | `◐`   | `:cyan`        | Re-running            |
+  | `:invalidated`      | `◌`   | `:yellow`      | Invalidated           |
+  | `:cached-no-watcher`| `○`   | `:text-tertiary` | Cached, no watcher  |
+  | `:error`            | `▲`   | `:red`         | Error                 |
+
+  Note the deliberate **absence** of a `:stale` status (per spec
+  §\"Stale vs invalidated\") — re-frame's sub-cache is equality-driven,
+  not wall-clock-driven; there is no middle ground.
+
+  ## Inputs to the projection
+
+  The composite sub `:rf.causa/subscriptions-data` feeds three
+  sources into `project-rows`:
+
+    1. **`sub-cache`** — the live `{query-v {:value :ref-count}}`
+       map (`(rf/sub-cache frame-id)`). CLJS-only; nil on JVM.
+
+    2. **`epoch-record`** — the just-settled epoch's record (per
+       Spec-Schemas `:rf/epoch-record`). The `:sub-runs` slot is the
+       per-cascade `:sub-id` / `:query-v` / `:recomputed?` projection
+       Causa needs to mark a sub as `:fresh` for this epoch.
+
+    3. **`error-cache`** — Causa-internal map of `query-v → throwable`
+       collected on framework `:error` trace events that carry a
+       `:sub-id`. Causa stores it on its own app-db; the helpers here
+       treat the cache as an opaque lookup.
+
+  ## What this doesn't do
+
+  This ns is **pure data**. No subscription, no atom, no `js/`
+  interop — the same fn runs under CLJ and CLJS. The CLJS-only
+  surfaces (`(rf/sub-cache ...)`) are read by the composite sub in
+  `registry.cljs`; the result is handed to this ns as a plain map.
+
+  ## Invalidation-chain (per spec §Invalidation-chain affordance)
+
+  v1 ships the badge taxonomy + a one-level chain walk. The
+  `compute-chain` fn surfaces:
+
+  - the focused sub's `query-v`
+  - its inputs (lifted off the sub-cache entry's `:input-subs` slot)
+  - which inputs **re-ran** this cascade (from `:sub-runs`)
+  - the originating `app-db` paths when an input is layer-1
+
+  Deeper walks (recursive inputs-of-inputs) are out of v1 scope —
+  the spec caps the chain at 8 layers but the v1 helper renders the
+  top layer + one level of inputs and links into the App-DB Diff
+  panel for the slice-level walk. This is the minimum surface that
+  validates the data plane; the deeper recursion lands in a
+  follow-on bead once the panel is wired to a real cascade."
+  (:require [clojure.string :as str]))
+
+;; ---- design tokens (mirrors view tokens — kept here for tests) -----------
+;;
+;; The view consumes these via this ns so the status → token mapping
+;; has one source of truth. The pure-data side stays JVM-portable.
+
+(def status->token
+  "Per spec/012-Subscriptions.md §Colour is never alone — the
+  status → colour-token mapping. Each token resolves to a hex on
+  the view side. Source of truth for the panel + every other
+  Causa surface that renders a sub badge."
+  {:fresh             :green
+   :re-running        :cyan
+   :invalidated       :yellow
+   :cached-no-watcher :text-tertiary
+   :error             :red})
+
+(def status->glyph
+  "Per spec §Colour is never alone — the shape pair. The glyph
+  carries the taxonomy without any colour signal, so the panel is
+  legible to colour-blind users."
+  {:fresh             "●"
+   :re-running        "◐"
+   :invalidated       "◌"
+   :cached-no-watcher "○"
+   :error             "▲"})
+
+(def status->tooltip
+  "Per spec §Colour is never alone — the tooltip label. Hover over
+  a badge surfaces this string after 250ms."
+  {:fresh             "Fresh"
+   :re-running        "Re-running"
+   :invalidated       "Invalidated"
+   :cached-no-watcher "Cached, no watcher"
+   :error             "Error"})
+
+(def statuses
+  "Canonical ordering — errors first, then re-running, then
+  invalidated, then fresh, then cached-no-watcher. Per spec
+  §Filtering and grouping — the default sort. Tests assert against
+  this order so a panel-wide change is one edit."
+  [:error :re-running :invalidated :fresh :cached-no-watcher])
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- sub-runs-by-query-v
+  "Index a `:sub-runs` vector by `:query-v` → the sub-run record.
+  Used by `compute-status` to ask 'did this sub re-run this epoch?'
+  in O(1). The vector is small (per-cascade) so a fresh re-index on
+  every projection call is fine."
+  [sub-runs]
+  (into {}
+        (map (juxt :query-v identity))
+        (or sub-runs [])))
+
+(defn compute-status
+  "Project one cache entry's status. Pure fn — takes the cache entry
+  (the sub-cache value for a `query-v`), the just-settled cascade's
+  sub-run record for the same `query-v` (or nil), and a flag
+  indicating the sub threw on its most recent compute. Returns one
+  of `#{:fresh :re-running :invalidated :cached-no-watcher :error}`.
+
+  Decision order (per spec §The five statuses):
+
+    1. `:error`            — most recent compute threw (explicit flag).
+    2. `:re-running`       — `:rerunning?` is true on the cache entry.
+       (The runtime sets the flag during a layer-2+ recompute inside
+       the drain; Causa observes it via the sub-cache.)
+    3. `:fresh`            — the sub re-ran this cascade and produced
+       its current cached value (`:sub-runs` carries a record with
+       `:recomputed? true`).
+    4. `:invalidated`      — `:invalidated?` is true on the cache entry,
+       but the sub has no watcher; a future deref would recompute.
+    5. `:cached-no-watcher` — fallback when ref-count is zero.
+    6. `:fresh`             — fallback when the sub has a watcher but
+       no signal of invalidation (a stable cached value the panel
+       displays as current).
+
+  Note this fn does **not** consult `:ref-count` directly for the
+  fresh / invalidated split — that distinction is the runtime's
+  call (the `:invalidated?` flag) per spec/006 §Invalidation
+  algorithm. The fn falls back on `:ref-count` only to choose
+  between `:fresh` and `:cached-no-watcher` for stably-cached subs."
+  [{:keys [ref-count rerunning? invalidated?] :as _cache-entry}
+   sub-run
+   error?]
+  (cond
+    error?                                 :error
+    rerunning?                             :re-running
+    (and sub-run (:recomputed? sub-run))   :fresh
+    invalidated?                           :invalidated
+    (or (nil? ref-count) (zero? ref-count)) :cached-no-watcher
+    :else                                  :fresh))
+
+(defn- query-v-of-cache-entry
+  "Read the canonical `query-v` off a cache entry. The runtime
+  carries `:query-v` on every entry per Spec 006 §Subscription
+  cache. Tests + the helper fall back on the entry's map-key when
+  the slot is missing (e.g. a test fixture that uses the map key
+  directly)."
+  [[k v]]
+  (or (:query-v v) k))
+
+(defn project-rows
+  "Project the live sub-cache + the just-settled epoch's `:sub-runs`
+  + the Causa error-cache into a vector of row maps the view
+  consumes. Pure fn — JVM-runnable.
+
+  Row shape:
+
+      {:query-v      [<sub-id> & args]
+       :sub-id       <sub-id>
+       :status       :fresh | :re-running | :invalidated
+                     | :cached-no-watcher | :error
+       :layer        1 | 2 | 3 | nil      ;; nil when unknown
+       :ref-count    <int>
+       :input-subs   [<query-v> ...]      ;; from cache entry
+       :recomputed?  <bool>               ;; this epoch
+       :error        <throwable or nil>}
+
+  Inputs:
+
+    `sub-cache`   — `{query-v {:value :ref-count :input-subs
+                                :layer :invalidated? :rerunning?}}`.
+                    May be nil (JVM) or empty (no subs materialised);
+                    the projection returns `[]` in either case.
+
+    `sub-runs`    — vector of `:sub-runs` records from the just-
+                    settled `:rf/epoch-record`. May be nil.
+
+    `error-cache` — `{query-v <throwable>}`. May be nil.
+
+  The returned vector is sorted into the spec's default order —
+  errors first, then re-running, then invalidated, then fresh,
+  then cached-no-watcher (per spec §Filtering and grouping). Within
+  a status, rows are sorted by `query-v` for deterministic test
+  output."
+  [sub-cache sub-runs error-cache]
+  (let [by-q-v   (sub-runs-by-query-v sub-runs)
+        err      (or error-cache {})
+        rows     (for [[k entry] (or sub-cache {})
+                       :let [q-v       (query-v-of-cache-entry [k entry])
+                             sub-run   (get by-q-v q-v)
+                             error     (get err q-v)
+                             status    (compute-status entry sub-run
+                                                       (some? error))]]
+                   {:query-v      q-v
+                    :sub-id       (first q-v)
+                    :status       status
+                    :layer        (:layer entry)
+                    :ref-count    (or (:ref-count entry) 0)
+                    :input-subs   (vec (or (:input-subs entry) []))
+                    :recomputed?  (boolean (some-> sub-run :recomputed?))
+                    :error        error})
+        sorter   (zipmap statuses (range))]
+    (vec
+      (sort-by (fn [{:keys [status query-v]}]
+                 [(get sorter status (count statuses))
+                  (pr-str query-v)])
+               rows))))
+
+(defn status-counts
+  "Per spec §Filtering and grouping + §Activity badges — the
+  sidebar's `●N` chip reads the `:error` + `:invalidated` counts to
+  decide whether to surface. Returns `{status count}` over the
+  projected rows. Pure fn."
+  [rows]
+  (frequencies (map :status rows)))
+
+(defn filter-by-status
+  "Return only the rows whose status is in `keep-statuses` (a set).
+  Pure fn. The view's filter chips toggle membership of the set
+  via `:rf.causa/toggle-sub-filter` — see registry.cljs. Passing
+  `nil` or an empty set returns all rows (the empty filter shows
+  all per spec §Filtering and grouping)."
+  [rows keep-statuses]
+  (if (or (nil? keep-statuses) (empty? keep-statuses))
+    rows
+    (filterv #(contains? keep-statuses (:status %)) rows)))
+
+;; ---- invalidation-chain affordance --------------------------------------
+
+(defn- input-row
+  "Project one input sub of the focused sub into a chain-link row.
+  `input-q-v` is the input's `query-v`; `sub-cache` / `by-q-v` /
+  `error-cache` are the same inputs `project-rows` consumes.
+
+  The link-reason (`:input-changed` between sub layers; `:slice-changed`
+  for layer-1) is derived from whether the input itself has inputs:
+  a layer-1 sub reads `app-db` directly, so its 're-ran because' is
+  the slice; a layer-2+ sub re-ran because *its* input re-ran."
+  [input-q-v sub-cache by-q-v error-cache]
+  (let [entry  (get sub-cache input-q-v)
+        layer  (:layer entry)
+        run    (get by-q-v input-q-v)
+        error  (get error-cache input-q-v)
+        status (compute-status (or entry {}) run (some? error))]
+    {:query-v     input-q-v
+     :sub-id      (first input-q-v)
+     :layer       layer
+     :status      status
+     :recomputed? (boolean (some-> run :recomputed?))
+     :link-reason (if (or (nil? layer) (<= layer 1))
+                    :slice-changed
+                    :input-changed)}))
+
+(defn compute-chain
+  "Project the invalidation chain for a focused sub. Pure fn —
+  walks **one level** of the input chain in v1. Returns:
+
+      {:focused      <row>                   ;; the focused sub
+       :inputs       [<input-row> ...]       ;; one entry per input
+                                              ;; that re-ran this
+                                              ;; cascade
+       :app-db-paths [<path> ...]             ;; layer-1 attribution
+       :missing?     <bool>}                  ;; true when the sub
+                                              ;; isn't in the cache
+
+  `app-db-paths` is the set of `app-db` paths the focused sub or
+  any of its layer-1 inputs read this cascade — surfaced for the
+  'Open in App-DB Diff' affordance per spec §How the chain is
+  computed step 3.
+
+  `changed-paths` is the cascade's set of `app-db` paths that
+  changed this epoch (per spec/004-App-DB-Diff §Changed-paths
+  derivation). The intersection of layer-1 input paths with
+  changed-paths is the *originating slice*; v1 returns the
+  intersection unfiltered so the view can render both 'paths read'
+  + 'paths changed'."
+  [focused-q-v sub-cache sub-runs error-cache changed-paths]
+  (let [by-q-v   (sub-runs-by-query-v sub-runs)
+        entry    (get sub-cache focused-q-v)
+        run      (get by-q-v focused-q-v)
+        error    (get error-cache focused-q-v)]
+    (if (nil? entry)
+      {:focused      nil
+       :inputs       []
+       :app-db-paths []
+       :missing?     true}
+      (let [status   (compute-status entry run (some? error))
+            inputs   (->> (or (:input-subs entry) [])
+                          (map #(input-row % sub-cache by-q-v error-cache))
+                          ;; Drop inputs that did not re-run this
+                          ;; cascade — per spec §How the chain is
+                          ;; computed step 2.
+                          (filter (some-fn :recomputed?
+                                           #(= :error (:status %))))
+                          vec)
+            ;; Layer-1 attribution: the focused sub's :paths slot
+            ;; (when it's a layer-1 sub) plus every layer-1 input's
+            ;; :paths slot. Intersect with changed-paths to surface
+            ;; the originating slice(s).
+            own-paths (when (and (some? (:layer entry))
+                                 (<= (:layer entry) 1))
+                        (or (:paths entry) []))
+            input-paths (->> (or (:input-subs entry) [])
+                             (mapcat (fn [iq]
+                                       (let [ie (get sub-cache iq)]
+                                         (when (and (some? (:layer ie))
+                                                    (<= (:layer ie) 1))
+                                           (or (:paths ie) [])))))
+                             vec)
+            all-paths (vec (distinct (concat own-paths input-paths)))
+            attributed (if (seq changed-paths)
+                         (filterv (set changed-paths) all-paths)
+                         all-paths)]
+        {:focused      {:query-v      focused-q-v
+                        :sub-id       (first focused-q-v)
+                        :status       status
+                        :layer        (:layer entry)
+                        :ref-count    (or (:ref-count entry) 0)
+                        :input-subs   (vec (or (:input-subs entry) []))
+                        :recomputed?  (boolean (some-> run :recomputed?))
+                        :error        error}
+         :inputs       inputs
+         :app-db-paths attributed
+         :missing?     false}))))
+
+;; ---- formatting helpers (consumed by the view) --------------------------
+
+(defn format-query-v
+  "Pretty-print a `query-v` for display. Falls back to `str` if
+  `pr-str` throws (e.g. on a JS-native value that can't be EDN-
+  printed). Mirrors the format-edn helper in event_detail.cljs but
+  lives here so the test suite can assert against the formatted
+  output without booting the view."
+  [q-v]
+  (try
+    (pr-str q-v)
+    (catch #?(:clj Throwable :cljs :default) _
+      (str q-v))))
+
+(defn format-sub-id
+  "Format a sub-id for compact display in the row's mono column.
+  Keywords keep their `:` prefix; symbols / strings render plain."
+  [sub-id]
+  (cond
+    (keyword? sub-id) (str sub-id)
+    (symbol?  sub-id) (str sub-id)
+    :else             (str/trim (str sub-id))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -83,7 +83,11 @@
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
-            [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]))
+            [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
+            ;; ── subscriptions panel begin ──
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]
+            ;; ── subscriptions panel end ──
+            ))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -411,7 +415,146 @@
                                           target epoch-id)]
           (when pin
             {:fx [[:rf.causa.fx/reset-frame-db!
-                   {:frame-id target :frame-db (:frame-db pin)}]]})))))
+                   {:frame-id target :frame-db (:frame-db pin)}]]}))))
+
+    ;; ── subscriptions panel begin ──
+    ;; Phase 5 (rf2-x0f5v, parent rf2-5aw5v) — Subscriptions panel.
+    ;;
+    ;; The panel reads three surfaces — the target frame's live
+    ;; sub-cache (`(rf/sub-cache target-frame)` — CLJS-only), the
+    ;; just-settled epoch's :sub-runs projection (lifted off the
+    ;; newest record in :rf.causa/epoch-history), and Causa's own
+    ;; per-sub error cache (populated from `:op-type :error` trace
+    ;; events that carry a :sub-id) — and folds them via
+    ;; `subs-helpers/project-rows` into one row per cached sub.
+    ;;
+    ;; Per spec/012-Subscriptions.md §JVM behaviour the panel is
+    ;; CLJS-only; on JVM the sub-cache read returns nil and the
+    ;; panel renders its empty state.
+    ;;
+    ;; Shape of `:rf.causa/subscriptions-data`:
+    ;;
+    ;;     {:rows             [<row> ...]
+    ;;      :status-counts    {status count}
+    ;;      :total            <int>
+    ;;      :selected-query-v <query-v-or-nil>
+    ;;      :active-filters   #{:fresh :re-running ...}
+    ;;      :chain-open?      <bool>
+    ;;      :chain            {<chain projection> or nil}}
+
+    ;; Read the target frame's live sub-cache. CLJS-only — on JVM
+    ;; `rf/sub-cache` returns nil; the panel's empty state surfaces
+    ;; in that case. Tests stub the sub-cache by writing to
+    ;; `:sub-cache-override` on Causa's app-db (via
+    ;; `:rf.causa/set-sub-cache-override-for-test`) so the suite can
+    ;; assert against a deterministic cache shape without booting a
+    ;; substrate's reactive cache.
+    (rf/reg-sub :rf.causa/sub-cache
+      (fn [db _query]
+        (let [target (get db :target-frame default-target-frame)
+              ov     (get db :sub-cache-override)]
+          (or ov (rf/sub-cache target)))))
+
+    ;; Test-only override hook for the sub-cache reader. Production
+    ;; code paths never dispatch this — the override slot exists
+    ;; only so JVM + node-test suites can drive the projection
+    ;; without a live substrate.
+    (rf/reg-event-db :rf.causa/set-sub-cache-override-for-test
+      (fn [db [_ ov]]
+        (if (nil? ov)
+          (dissoc db :sub-cache-override)
+          (assoc db :sub-cache-override ov))))
+
+    ;; The Causa-internal per-sub error cache. Populated on every
+    ;; :op-type :error trace event that carries a :sub-id. The shape
+    ;; is {query-v <error-info>} — the helper treats any non-nil
+    ;; value as 'this sub threw'. v1 wiring keeps the cache empty
+    ;; until a downstream bead lands the error-collector plumbing;
+    ;; the panel is read-ready today.
+    (rf/reg-sub :rf.causa/sub-error-cache
+      (fn [db _query]
+        (get db :sub-error-cache {})))
+
+    ;; The user's per-panel sub selection (drives the chain affordance).
+    (rf/reg-sub :rf.causa/selected-sub
+      (fn [db _query]
+        (get db :selected-sub)))
+
+    ;; The active filter chip set (per spec §Filtering and grouping).
+    (rf/reg-sub :rf.causa/sub-filters
+      (fn [db _query]
+        (get db :sub-filters #{})))
+
+    ;; Whether the chain affordance is open in the panel.
+    (rf/reg-sub :rf.causa/sub-chain-open?
+      (fn [db _query]
+        (boolean (get db :sub-chain-open?))))
+
+    ;; The composite — one read produces every slot the panel
+    ;; consumes. Per spec §Performance the projection is O(rows) +
+    ;; O(depth-1) for the chain; the cache shape is small (per-frame
+    ;; materialised subs cap at the substrate's own reactive graph
+    ;; size) so the fold runs cheaply on every recompute.
+    (rf/reg-sub :rf.causa/subscriptions-data
+      :<- [:rf.causa/sub-cache]
+      :<- [:rf.causa/epoch-history]
+      :<- [:rf.causa/sub-error-cache]
+      :<- [:rf.causa/selected-sub]
+      :<- [:rf.causa/sub-filters]
+      :<- [:rf.causa/sub-chain-open?]
+      (fn [[sub-cache history error-cache selected-q-v filters chain-open?]
+           _query]
+        (let [latest-epoch    (peek (vec history))
+              sub-runs        (:sub-runs latest-epoch)
+              ;; v1 has no first-class :changed-paths slot on the
+              ;; epoch-record yet (rf2-xxx will surface it); fall
+              ;; back to nil so the chain shows every layer-1 input
+              ;; path it knows about.
+              changed-paths   (:changed-paths latest-epoch)
+              rows            (subs-helpers/project-rows
+                                sub-cache sub-runs error-cache)
+              counts          (subs-helpers/status-counts rows)
+              chain           (when (and chain-open? selected-q-v)
+                                (subs-helpers/compute-chain
+                                  selected-q-v sub-cache sub-runs
+                                  error-cache changed-paths))]
+          {:rows             rows
+           :status-counts    counts
+           :total            (count rows)
+           :selected-query-v selected-q-v
+           :active-filters   (or filters #{})
+           :chain-open?      (boolean chain-open?)
+           :chain            chain})))
+
+    ;; ---- events ------------------------------------------------------
+
+    (rf/reg-event-db :rf.causa/select-sub
+      (fn [db [_ query-v]]
+        (assoc db :selected-sub query-v)))
+
+    (rf/reg-event-db :rf.causa/clear-selected-sub
+      (fn [db _event]
+        (-> db
+            (dissoc :selected-sub)
+            (dissoc :sub-chain-open?))))
+
+    (rf/reg-event-db :rf.causa/toggle-sub-filter
+      (fn [db [_ status]]
+        (let [current (get db :sub-filters #{})]
+          (assoc db :sub-filters
+                 (if (contains? current status)
+                   (disj current status)
+                   (conj current status))))))
+
+    (rf/reg-event-db :rf.causa/show-invalidation-chain
+      (fn [db [_ query-v]]
+        (cond-> (assoc db :sub-chain-open? true)
+          query-v (assoc :selected-sub query-v))))
+
+    (rf/reg-event-db :rf.causa/hide-invalidation-chain
+      (fn [db _event]
+        (dissoc db :sub-chain-open?))))
+    ;; ── subscriptions panel end ──
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -40,6 +40,9 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
+            ;; ── subscriptions panel begin ──
+            [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
+            ;; ── subscriptions panel end ──
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
@@ -73,7 +76,9 @@
    {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
    {:id :app-db       :label "App-db"        :bead "rf2-xxx"}
    {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
-   {:id :subs         :label "Subscriptions" :bead "rf2-xxx"}
+   ;; ── subscriptions panel begin ──
+   {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
+   ;; ── subscriptions panel end ──
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
    {:id :trace        :label "Trace"         :bead "rf2-xxx"}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
@@ -213,6 +218,9 @@
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
       :causality    [causality-graph/causality-graph-view]
+      ;; ── subscriptions panel begin ──
+      :subs         [subscriptions/subscriptions-view]
+      ;; ── subscriptions panel end ──
       [stub-panel (or item {:label "Unknown panel"
                             :bead  "rf2-xxx"})])))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_helpers_cljs_test.cljc
@@ -1,0 +1,283 @@
+(ns day8.re-frame2-causa.panels.subscriptions-helpers-cljs-test
+  "Pure-data tests for Causa's Subscriptions panel helpers
+  (Phase 5, rf2-x0f5v).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `causality_graph_cljs_test.cljc` and
+  `time_travel_helpers_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **compute-status** — the five-status state machine that
+       classifies one cache entry against the just-settled cascade's
+       sub-run record. Tests cover every branch + the precedence rules
+       (errors win over re-running; re-running wins over fresh).
+    2. **project-rows** — the fold over sub-cache + sub-runs + error
+       cache. Asserts row shape, ordering (errors first), counts.
+    3. **filter-by-status** — the chip-toggle filter; empty set =
+       identity, non-empty = restriction.
+    4. **compute-chain** — the invalidation-chain walk. Asserts
+       focused-sub row, inputs filtering (drops inputs that did not
+       re-run), missing-sub branch, app-db-path attribution.
+    5. **status-counts** — the sidebar-badge feed."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as h]))
+
+;; ---- (1) compute-status -------------------------------------------------
+
+(deftest compute-status-error-wins-over-everything
+  (testing "an error on a sub overrides every other signal"
+    (is (= :error (h/compute-status {:ref-count 1 :rerunning? true
+                                     :invalidated? true}
+                                    {:recomputed? true}
+                                    true)))))
+
+(deftest compute-status-re-running-wins-over-recomputed
+  (testing ":re-running takes precedence over a fresh recompute — the
+            cache flag is the runtime's mid-recompute signal"
+    (is (= :re-running (h/compute-status {:ref-count 1 :rerunning? true}
+                                         {:recomputed? true}
+                                         false)))))
+
+(deftest compute-status-recomputed-this-epoch-is-fresh
+  (testing "a sub that re-ran this cascade and produced a value is :fresh"
+    (is (= :fresh (h/compute-status {:ref-count 1}
+                                    {:recomputed? true}
+                                    false)))))
+
+(deftest compute-status-invalidated-but-no-recompute
+  (testing "an :invalidated? cache entry whose sub didn't re-run is
+            :invalidated — inputs changed but no watcher drove the recompute"
+    (is (= :invalidated (h/compute-status {:ref-count 0 :invalidated? true}
+                                          nil
+                                          false)))))
+
+(deftest compute-status-cached-no-watcher
+  (testing "ref-count zero + no invalidation surfaces :cached-no-watcher"
+    (is (= :cached-no-watcher (h/compute-status {:ref-count 0}
+                                                nil
+                                                false)))))
+
+(deftest compute-status-default-fresh
+  (testing "a stably cached entry with a watcher and no signal of
+            invalidation is :fresh (the panel displays the cached
+            value as current)"
+    (is (= :fresh (h/compute-status {:ref-count 2}
+                                    nil
+                                    false)))))
+
+(deftest compute-status-nil-ref-count-is-cached-no-watcher
+  (testing "an entry without a :ref-count slot defaults to
+            :cached-no-watcher rather than throwing"
+    (is (= :cached-no-watcher (h/compute-status {} nil false)))))
+
+;; ---- (2) project-rows ---------------------------------------------------
+
+(deftest project-rows-empty-cache-is-empty
+  (testing "no sub-cache => empty rows"
+    (is (= [] (h/project-rows nil nil nil)))
+    (is (= [] (h/project-rows {} nil nil)))))
+
+(deftest project-rows-emits-row-per-cache-entry
+  (testing "one row per cache entry, status filled from compute-status"
+    (let [cache    {[:cart/total]   {:value 42 :ref-count 1 :layer 3
+                                     :input-subs [[:cart/items]]}
+                    [:cart/items]   {:value [] :ref-count 1 :layer 2
+                                     :input-subs [[:cart/items-raw]]}
+                    [:cart/items-raw] {:value [] :ref-count 1 :layer 1}}
+          rows     (h/project-rows cache nil nil)
+          ids      (set (map :sub-id rows))]
+      (is (= 3 (count rows)))
+      (is (= #{:cart/total :cart/items :cart/items-raw} ids)))))
+
+(deftest project-rows-marks-recomputed-from-sub-runs
+  (testing "a query-v present in :sub-runs with :recomputed? true gets
+            :fresh + :recomputed? true on the row"
+    (let [cache    {[:cart/total] {:ref-count 1 :layer 3}}
+          sub-runs [{:sub-id :cart/total :query-v [:cart/total]
+                     :recomputed? true}]
+          row      (first (h/project-rows cache sub-runs nil))]
+      (is (= :fresh (:status row)))
+      (is (true? (:recomputed? row))))))
+
+(deftest project-rows-marks-errors
+  (testing "an entry whose query-v lands in error-cache gets :error
+            regardless of other signals"
+    (let [cache    {[:cart/total] {:ref-count 1 :rerunning? true}}
+          err      {[:cart/total] (ex-info "boom" {})}
+          row      (first (h/project-rows cache nil err))]
+      (is (= :error (:status row)))
+      (is (some? (:error row))))))
+
+(deftest project-rows-sorts-errors-first
+  (testing "the canonical sort order — errors first, then re-running,
+            invalidated, fresh, cached-no-watcher — per spec
+            §Filtering and grouping"
+    (let [cache    {[:a/fresh]    {:ref-count 1}
+                    [:b/cached]   {:ref-count 0}
+                    [:c/error]    {:ref-count 1}
+                    [:d/invalid]  {:invalidated? true :ref-count 0}
+                    [:e/running]  {:rerunning? true :ref-count 1}}
+          err      {[:c/error] (ex-info "boom" {})}
+          rows     (h/project-rows cache nil err)
+          statuses (map :status rows)]
+      (is (= [:error :re-running :invalidated :fresh :cached-no-watcher]
+             statuses)))))
+
+(deftest project-rows-includes-layer-and-input-subs
+  (testing "layer + input-subs are propagated onto the row so the view
+            can render the L1/L2/L3 pill and the chain affordance"
+    (let [cache {[:cart/total] {:ref-count 1 :layer 3
+                                :input-subs [[:cart/items]]}}
+          row   (first (h/project-rows cache nil nil))]
+      (is (= 3 (:layer row)))
+      (is (= [[:cart/items]] (:input-subs row))))))
+
+;; ---- (3) filter-by-status -----------------------------------------------
+
+(deftest filter-by-status-empty-set-returns-all
+  (testing "the empty filter shows all rows (per spec)"
+    (let [rows [{:status :fresh}
+                {:status :error}
+                {:status :invalidated}]]
+      (is (= rows (h/filter-by-status rows nil)))
+      (is (= rows (h/filter-by-status rows #{}))))))
+
+(deftest filter-by-status-restricts-to-set
+  (testing "a non-empty filter keeps only matching rows"
+    (let [rows [{:status :fresh}
+                {:status :error}
+                {:status :invalidated}
+                {:status :fresh}]]
+      (is (= [{:status :error}]
+             (h/filter-by-status rows #{:error})))
+      (is (= [{:status :fresh} {:status :fresh}]
+             (h/filter-by-status rows #{:fresh}))))))
+
+;; ---- (4) compute-chain --------------------------------------------------
+
+(deftest compute-chain-missing-sub-marks-missing
+  (testing "computing a chain for a sub not in the cache returns
+            :missing? true with empty inputs"
+    (let [chain (h/compute-chain [:cart/total] {} nil nil nil)]
+      (is (true? (:missing? chain)))
+      (is (= [] (:inputs chain))))))
+
+(deftest compute-chain-includes-focused-row
+  (testing "compute-chain emits the focused sub's projected row at :focused"
+    (let [cache  {[:cart/total] {:ref-count 1 :layer 3
+                                  :input-subs [[:cart/items]]}
+                  [:cart/items] {:ref-count 1 :layer 2}}
+          chain  (h/compute-chain [:cart/total] cache nil nil nil)
+          f      (:focused chain)]
+      (is (false? (:missing? chain)))
+      (is (= [:cart/total] (:query-v f)))
+      (is (= 3 (:layer f)))
+      (is (= [[:cart/items]] (:input-subs f))))))
+
+(deftest compute-chain-drops-inputs-that-did-not-rerun
+  (testing "inputs that did not re-run this cascade are not part of the
+            chain (per spec §How the chain is computed step 2)"
+    (let [cache    {[:cart/total]  {:ref-count 1 :layer 3
+                                     :input-subs [[:a] [:b]]}
+                    [:a]           {:ref-count 1 :layer 2}
+                    [:b]           {:ref-count 1 :layer 2}}
+          ;; Only :a re-ran this cascade.
+          sub-runs [{:sub-id :cart/total :query-v [:cart/total]
+                     :recomputed? true}
+                    {:sub-id :a :query-v [:a] :recomputed? true}]
+          chain    (h/compute-chain [:cart/total] cache sub-runs nil nil)
+          input-qs (set (map :query-v (:inputs chain)))]
+      (is (= #{[:a]} input-qs)
+          "only :a appears as an input — :b did not re-run, so it's dropped"))))
+
+(deftest compute-chain-keeps-errored-inputs
+  (testing "an input that errored is part of the chain even if it didn't
+            re-run — the panel surfaces the error link"
+    (let [cache    {[:cart/total]  {:ref-count 1 :layer 3
+                                     :input-subs [[:a]]}
+                    [:a]           {:ref-count 1 :layer 2}}
+          err      {[:a] (ex-info "boom" {})}
+          chain    (h/compute-chain [:cart/total] cache nil err nil)
+          input    (first (:inputs chain))]
+      (is (some? input))
+      (is (= :error (:status input))))))
+
+(deftest compute-chain-attributes-layer-1-paths
+  (testing "layer-1 inputs' :paths land in :app-db-paths, intersected
+            with the cascade's changed-paths when present"
+    (let [cache    {[:cart/total]    {:ref-count 1 :layer 3
+                                       :input-subs [[:cart/items]]}
+                    [:cart/items]    {:ref-count 1 :layer 1
+                                       :paths [[:cart :items]
+                                               [:cart :coupon]]}}
+          sub-runs [{:sub-id :cart/total :query-v [:cart/total] :recomputed? true}
+                    {:sub-id :cart/items :query-v [:cart/items] :recomputed? true}]
+          chain    (h/compute-chain [:cart/total] cache sub-runs nil
+                                    #{[:cart :items]})]
+      (is (= [[:cart :items]] (:app-db-paths chain))
+          "only the changed path appears in :app-db-paths"))))
+
+(deftest compute-chain-no-changed-paths-returns-all-layer-1-paths
+  (testing "when changed-paths is nil/empty, every layer-1 input path
+            surfaces in :app-db-paths"
+    (let [cache    {[:cart/total]    {:ref-count 1 :layer 3
+                                       :input-subs [[:cart/items]]}
+                    [:cart/items]    {:ref-count 1 :layer 1
+                                       :paths [[:cart :items]
+                                               [:cart :coupon]]}}
+          chain    (h/compute-chain [:cart/total] cache nil nil nil)]
+      (is (= #{[:cart :items] [:cart :coupon]}
+             (set (:app-db-paths chain)))))))
+
+;; ---- (5) status-counts --------------------------------------------------
+
+(deftest status-counts-tallies-by-status
+  (testing "status-counts returns a frequency map keyed by status"
+    (let [rows [{:status :fresh}
+                {:status :fresh}
+                {:status :error}
+                {:status :invalidated}]]
+      (is (= {:fresh 2 :error 1 :invalidated 1}
+             (h/status-counts rows))))))
+
+;; ---- (6) taxonomy invariants --------------------------------------------
+
+(deftest every-status-has-glyph-colour-tooltip
+  (testing "every status in the canonical vocabulary has a glyph,
+            colour token, and tooltip — per spec §Colour is never alone"
+    (doseq [s h/statuses]
+      (is (some? (get h/status->glyph s))   (str "glyph for " s))
+      (is (some? (get h/status->token s))   (str "token for " s))
+      (is (some? (get h/status->tooltip s)) (str "tooltip for " s)))))
+
+(deftest statuses-canonical-order
+  (testing "the spec's default sort order — errors first, then
+            re-running, invalidated, fresh, cached-no-watcher"
+    (is (= [:error :re-running :invalidated :fresh :cached-no-watcher]
+           h/statuses))))
+
+(deftest taxonomy-has-exactly-five
+  (testing "spec §The five statuses — exactly five; not four, not six"
+    (is (= 5 (count h/statuses)))
+    (is (= 5 (count h/status->glyph)))
+    (is (= 5 (count h/status->token)))
+    (is (= 5 (count h/status->tooltip)))))
+
+;; ---- (7) formatters -----------------------------------------------------
+
+(deftest format-query-v-prints-edn
+  (testing "format-query-v pr-strs the vector"
+    (is (= "[:cart/total]" (h/format-query-v [:cart/total])))
+    (is (= "[:cart/sub 42]" (h/format-query-v [:cart/sub 42])))))
+
+(deftest format-sub-id-keyword-keeps-colon
+  (testing "format-sub-id renders a keyword with its colon prefix"
+    (is (= ":cart/total" (h/format-sub-id :cart/total)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
@@ -1,0 +1,292 @@
+(ns day8.re-frame2-causa.panels.subscriptions-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Subscriptions panel
+  (Phase 5, rf2-x0f5v).
+
+  ## What's under test (in addition to the pure-data tests in
+  `subscriptions_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/subscriptions-data`. The composite returns rows +
+       counts + selection in the shape the view consumes.
+
+    2. **Filter chip toggles** mutate `:rf.causa/sub-filters` on the
+       Causa frame's db; the panel renders the toggled state.
+
+    3. **Sub selection + chain open** wire through
+       `:rf.causa/select-sub` and `:rf.causa/show-invalidation-chain`,
+       and the panel surfaces the chain affordance.
+
+    4. **Empty state** — when the sub-cache override is unset and
+       `(rf/sub-cache target-frame)` returns nil (no host), the panel
+       renders its empty state.
+
+  ## Pure hiccup
+
+  Same approach as `causality_graph_view_cljs_test.cljs` — walk the
+  view's hiccup tree by `data-testid` rather than mounting to the
+  DOM. Keeps the suite fast + host-portable on node-test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.subscriptions :as subscriptions]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror event_detail_cljs_test) ---------------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-cache! [cache]
+  (rf/dispatch-sync [:rf.causa/set-sub-cache-override-for-test cache]))
+
+;; ---- (1) registry wires the composite sub -------------------------------
+
+(deftest registry-installs-subscriptions-sub
+  (testing "register-causa-handlers! installs the Phase 5 composite sub +
+            every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/subscriptions-data)))
+    (is (some? (registrar/handler :sub :rf.causa/sub-cache)))
+    (is (some? (registrar/handler :sub :rf.causa/sub-error-cache)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-sub)))
+    (is (some? (registrar/handler :sub :rf.causa/sub-filters)))
+    (is (some? (registrar/handler :sub :rf.causa/sub-chain-open?)))
+    (is (some? (registrar/handler :event :rf.causa/select-sub)))
+    (is (some? (registrar/handler :event :rf.causa/clear-selected-sub)))
+    (is (some? (registrar/handler :event :rf.causa/toggle-sub-filter)))
+    (is (some? (registrar/handler :event :rf.causa/show-invalidation-chain)))
+    (is (some? (registrar/handler :event :rf.causa/hide-invalidation-chain)))))
+
+(deftest subscriptions-sub-defaults-empty
+  (testing "with no sub-cache override and no live substrate the
+            composite returns an empty rows vector + empty filters"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/subscriptions-data])]
+        (is (= [] (:rows data)))
+        (is (= 0 (:total data)))
+        (is (= #{} (:active-filters data)))
+        (is (false? (:chain-open? data)))))))
+
+(deftest subscriptions-sub-projects-cache-into-rows
+  (testing "with a sub-cache override the composite returns one row
+            per entry — projected via the helpers"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache!
+        {[:cart/total]     {:ref-count 1 :layer 3
+                            :input-subs [[:cart/items]]}
+         [:cart/items]     {:ref-count 1 :layer 2
+                            :input-subs [[:cart/items-raw]]}
+         [:cart/items-raw] {:ref-count 1 :layer 1}})
+      (let [data @(rf/subscribe [:rf.causa/subscriptions-data])
+            ids  (set (map :sub-id (:rows data)))]
+        (is (= 3 (:total data)))
+        (is (= #{:cart/total :cart/items :cart/items-raw} ids))))))
+
+;; ---- (2) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-cache-empty
+  (testing "with no override and no substrate the panel renders the
+            empty state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-subscriptions"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-subscriptions-list"))
+            "no list when there are zero rows")))))
+
+(deftest list-renders-when-cache-populated
+  (testing "with a populated sub-cache the panel renders one row per
+            sub plus the filter header"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache!
+        {[:cart/total] {:ref-count 1 :layer 3}
+         [:user/auth]  {:ref-count 2 :layer 1}})
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-list"))
+            "list container present")
+        (is (some? (find-by-testid tree "rf-causa-sub-row-:cart/total"))
+            "row for :cart/total present")
+        (is (some? (find-by-testid tree "rf-causa-sub-row-:user/auth"))
+            "row for :user/auth present")
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-filters"))
+            "filter chip header present")))))
+
+(deftest all-five-filter-chips-render
+  (testing "the filter header renders one chip per status (5 total)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache! {[:a] {:ref-count 1}}) ; need >0 total to render filters
+      (let [tree  (subscriptions/subscriptions-view)
+            chips (find-all-by-testid-prefix tree "rf-causa-sub-filter-")]
+        (is (= 5 (count chips))
+            "5 chips — one per status in the taxonomy")))))
+
+;; ---- (3) filter-toggle event --------------------------------------------
+
+(deftest toggle-filter-writes-to-causa-frame
+  (testing "dispatching :rf.causa/toggle-sub-filter toggles set membership
+            on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-sub-filter :error])
+      (is (= #{:error} @(rf/subscribe [:rf.causa/sub-filters])))
+      (rf/dispatch-sync [:rf.causa/toggle-sub-filter :invalidated])
+      (is (= #{:error :invalidated} @(rf/subscribe [:rf.causa/sub-filters])))
+      (rf/dispatch-sync [:rf.causa/toggle-sub-filter :error])
+      (is (= #{:invalidated} @(rf/subscribe [:rf.causa/sub-filters]))
+          "second toggle removes the status from the filter set"))))
+
+(deftest filter-restricts-rendered-rows
+  (testing "an active filter cuts the row list down to matching rows"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache!
+        {[:fresh-sub]    {:ref-count 1}
+         [:cached-sub]   {:ref-count 0}})
+      (rf/dispatch-sync [:rf.causa/toggle-sub-filter :fresh])
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-sub-row-:fresh-sub"))
+            "fresh sub passes the filter")
+        (is (nil? (find-by-testid tree "rf-causa-sub-row-:cached-sub"))
+            "cached-no-watcher sub is filtered out")))))
+
+;; ---- (4) sub selection + chain affordance -------------------------------
+
+(deftest select-sub-event-writes-to-causa-frame
+  (testing ":rf.causa/select-sub stores the query-v on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-sub [:cart/total]])
+      (is (= [:cart/total] @(rf/subscribe [:rf.causa/selected-sub]))))))
+
+(deftest show-invalidation-chain-opens-the-affordance
+  (testing "show-invalidation-chain sets sub-chain-open? + selects the sub"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:cart/total]])
+      (is (true? @(rf/subscribe [:rf.causa/sub-chain-open?])))
+      (is (= [:cart/total] @(rf/subscribe [:rf.causa/selected-sub]))))))
+
+(deftest hide-invalidation-chain-closes-the-affordance
+  (testing "hide-invalidation-chain clears sub-chain-open?"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:cart/total]])
+      (rf/dispatch-sync [:rf.causa/hide-invalidation-chain])
+      (is (false? @(rf/subscribe [:rf.causa/sub-chain-open?]))))))
+
+(deftest chain-renders-when-open
+  (testing "the chain affordance renders below the list when sub-chain-open?
+            is true and the focused sub exists in the cache"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache!
+        {[:cart/total] {:ref-count 1 :layer 3
+                        :input-subs [[:cart/items]]}
+         [:cart/items] {:ref-count 1 :layer 2}})
+      (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:cart/total]])
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-chain"))
+            "chain container present when chain-open? is true")
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-chain-focused"))
+            "focused sub row present in chain")))))
+
+(deftest chain-not-rendered-when-closed
+  (testing "with sub-chain-open? false the chain affordance is absent"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache! {[:cart/total] {:ref-count 1 :layer 3}})
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (nil? (find-by-testid tree "rf-causa-subscriptions-chain"))
+            "no chain container when chain-open? is false")))))
+
+(deftest chain-missing-sub-renders-missing-state
+  (testing "if the focused sub isn't in the cache the chain shows the
+            'missing' branch"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; No override — cache is nil; chain on any sub is :missing?
+      (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:nonexistent]])
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-subscriptions-chain-missing"))
+            "missing branch surfaces")))))
+
+;; ---- (5) badges per status ----------------------------------------------
+
+(deftest each-status-has-its-badge-in-row
+  (testing "every status in the taxonomy gets its glyph + colour on the row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-cache!
+        {[:fresh-sub]    {:ref-count 1}
+         [:invalid-sub]  {:invalidated? true :ref-count 0}
+         [:running-sub]  {:rerunning? true :ref-count 1}
+         [:cached-sub]   {:ref-count 0}})
+      (let [tree (subscriptions/subscriptions-view)]
+        (is (some? (find-by-testid tree "rf-causa-sub-badge-fresh")))
+        (is (some? (find-by-testid tree "rf-causa-sub-badge-invalidated")))
+        (is (some? (find-by-testid tree "rf-causa-sub-badge-re-running")))
+        (is (some? (find-by-testid tree "rf-causa-sub-badge-cached-no-watcher")))))))
+
+;; ---- (6) frame isolation ------------------------------------------------
+
+(deftest sub-filter-state-does-not-leak-into-default-frame
+  (testing "the panel's filter state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-sub-filter :error]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= #{:error} (:sub-filters causa-db))
+          "filter set lands on Causa")
+      (is (nil? (:sub-filters default-db))
+          "filter set did NOT leak into :rf/default"))))


### PR DESCRIPTION
## Summary

Phase 5 of the Causa epic (parent **rf2-5aw5v**) — adds the Subscriptions panel, the answer to the five-canonical-questions framing's #3 ("why is this subscription returning the wrong value?") and #4 ("why is this view re-rendering?"). Fully specced in `tools/causa/spec/012-Subscriptions.md`.

Two affordances that did not exist in re-frame-10x v1:

- **Five-status badge taxonomy** — `:fresh` · `:re-running` · `:invalidated` · `:cached-no-watcher` · `:error`. Mirrors TanStack Query DevTools' vocabulary, pruned to re-frame's value-equality-driven cache (no `:stale` — see spec §"Stale vs invalidated"). Each status pairs colour + shape glyph + tooltip per spec §"Colour is never alone" so colour-blind users read the same signal without hue.

- **Invalidation-chain affordance** — one-click walk *up* the input chain to the originating `app-db` slice change, for any sub that re-ran this cascade. v1 ships the focused-sub row + one level of recomputed inputs + layer-1 path attribution; deeper recursion + diamond branching are spec'd but out of v1 scope.

## Freshness state machine

`compute-status` (pure fn in `subscriptions_helpers.cljc`) classifies one cache entry against the just-settled cascade's `:sub-runs` projection + the Causa error cache. Precedence:

1. `:error` — most recent compute threw (explicit error-cache flag) — wins over everything.
2. `:re-running` — `:rerunning?` cache flag is true (mid-recompute inside the drain).
3. `:fresh` — sub re-ran this cascade (`:sub-runs` record carries `:recomputed? true`).
4. `:invalidated` — `:invalidated?` cache flag is true (inputs changed; no watcher drove the recompute).
5. `:cached-no-watcher` — `:ref-count` is zero with no invalidation signal.
6. `:fresh` (fallback) — stably cached entry with a watcher.

Five statuses · five glyphs · five tooltips · five colour tokens — exact `n=5` is asserted in tests so the taxonomy stays small (per spec: "every additional category is one more thing the programmer has to learn to read the panel fluently").

## Surface

- `tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs` — pure-hiccup view (filter chips, sub list, chain affordance).
- `tools/causa/src/day8/re_frame2_causa/panels/subscriptions_helpers.cljc` — pure-data status state-machine, row projection, chain walk; JVM-runnable for the unit-test target.
- `registry.cljs` — composite sub `:rf.causa/subscriptions-data` plus supporting subs/events (wrapped in `;; ── subscriptions panel begin/end ──` markers per the prompt for clean rebase under concurrent dispatch).
- `shell.cljs` — `:subs` sidebar slot now `:live? true` and the canvas mounts the panel.

## Test plan

- [x] JVM `clojure -M:test` — 99 tests / 271 assertions / 0 failures (includes 28 new pure-data helper tests).
- [x] CLJS `:node-test` build — 851 tests / 2187 assertions / 0 failures (includes the two new test namespaces: `subscriptions-helpers-cljs-test`, `subscriptions-view-cljs-test`).
- [x] Manual: confirm panel mounts in `shell.cljs`, filter chips toggle membership, chain affordance opens on `chain` button click.