### PR TITLE
feat(causa): App-DB Diff panel — Phase 5 (rf2-jps1o)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -1,0 +1,521 @@
+(ns day8.re-frame2-causa.panels.app-db-diff
+  "App-DB Diff panel — Phase 5 (rf2-jps1o, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/004-App-DB-Diff.md` the panel is **slice-
+  centric**, not tree-centric. Real app-dbs run 1–50MB; rendering the
+  whole tree on every dispatch competes for canvas real estate. The
+  panel surfaces the *slices that changed in this epoch* plus *slices
+  the programmer has pinned*. A full-tree escape hatch is available
+  for the rare case the user wants to roam.
+
+  ## What this panel shows
+
+    1. **Changed-slice mini-panels** — one per `[op path before after]`
+       triple produced by `app-db-diff-helpers/diff-paths`. Colour-
+       coded by op (`:added` green / `:modified` yellow / `:removed`
+       red).
+
+    2. **Reserved-keys group** — `:rf/machines`, `:rf/route`,
+       `:rf/system-ids`, `:rf/pending-navigation`, `:rf/spawned`
+       render in a separate `[runtime]` group at the bottom so the
+       programmer recognises them as runtime-owned (per spec
+       §Reserved-keys group).
+
+    3. **Pinned-slices** — paths the user has right-click-pinned.
+       Live values for the current target frame, dereferenced once
+       per epoch per pin. Right-click → Unpin / Move up / Move down /
+       Show me when this changed.
+
+    4. **'Show me when this changed' result** — when the user invokes
+       the affordance on a path, a list of epochs that touched that
+       path renders in place of the slice mini-panels. Clicking an
+       entry rebases the panels to that epoch.
+
+    5. **Empty state** — when no dispatches have run.
+
+  ## Read-only forever (Lock 3)
+
+  The panel renders Copy value / Copy path / Pin / Show me when this
+  changed affordances; it does not render Edit / Set-to / Inject.
+  Per spec §Read-only and `DESIGN-RATIONALE.md` Lock 3 — the runtime
+  is the source of truth; pokes from the debugger are out of scope.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. The substrate adapter mounts
+  it. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — `diff-paths` (structural-sharing diff),
+  `partition-reserved` (reserved-keys segregation), pin-store
+  transitions, `epochs-touching-path` (the 'Show me when this
+  changed' walker) — lives in `app_db_diff_helpers.cljc` so the
+  algebra runs under the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- op-token resolution -------------------------------------------------
+
+(def ^:private op->border
+  "Per spec §Colour coding — the slice mini-panel's left border encodes
+  the op. Green for added, yellow for modified, red for removed."
+  {:added    :green
+   :modified :yellow
+   :removed  :red})
+
+(def ^:private op->label
+  "Per spec §Colour coding — the key tag rendered next to the path."
+  {:added    "(added)"
+   :modified "(modified)"
+   :removed  "(removed)"})
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn- format-edn
+  "Best-effort EDN-like format. Used to render values + paths in the
+  mono column."
+  [v]
+  (try
+    (pr-str v)
+    (catch :default _
+      (str v))))
+
+(defn- truncate
+  "Truncate `s` to `n` chars (adding an ellipsis)."
+  [s n]
+  (let [s (str s)]
+    (if (<= (count s) n)
+      s
+      (str (subs s 0 (max 0 (dec n))) "…"))))
+
+;; ---- sub-views: empty state ---------------------------------------------
+
+(defn- empty-state
+  "Per spec §Empty state — 'app-db is at the boot value. No diffs
+  yet — every dispatch will land here with the slices it touched.'"
+  [target-frame]
+  [:div {:data-testid "rf-causa-app-db-diff-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"}}
+    [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+     "app-db"]
+    " for "
+    [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+     (str target-frame)]
+    " is at the boot value."]
+   [:p {:style {:margin 0}}
+    "No diffs yet — every dispatch will land here with the slices it touched."]])
+
+;; ---- sub-views: slice mini-panel ----------------------------------------
+
+(defn- value-block
+  "Render one labelled value sub-row inside a slice mini-panel."
+  [label value tone]
+  [:div {:style {:display     "flex"
+                 :align-items "flex-start"
+                 :gap         "8px"
+                 :padding     "2px 0"}}
+   [:div {:style {:flex          "0 0 64px"
+                  :color         (tone tokens)
+                  :font-family   sans-stack
+                  :font-size     "10px"
+                  :font-weight   600
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"
+                  :padding-top   "2px"}}
+    label]
+   [:div {:style {:flex          1
+                  :min-width     0
+                  :font-family   mono-stack
+                  :font-size     "12px"
+                  :color         (:text-primary tokens)
+                  :word-break    "break-word"
+                  :white-space   "pre-wrap"}}
+    (format-edn value)]])
+
+(defn- slice-row
+  "One slice mini-panel for a `[op path before after]` triple.
+
+  - Coloured left border (`:added` / `:modified` / `:removed`).
+  - Path in the mono column.
+  - For `:modified` shows `before` + `after`; for `:added` shows the
+    new value; for `:removed` shows the prior value (struck-through
+    per spec §Colour coding).
+
+  Right-click affordances per spec §Read-only — copy / pin / show
+  when this changed are wired through `:rf.causa/*` events."
+  [{:keys [op path before after] :as _triple}]
+  (let [tone (op->border op)]
+    [:div {:data-testid (str "rf-causa-app-db-diff-slice-" (pr-str path))
+           :style       {:display       "flex"
+                         :flex-direction "column"
+                         :padding       "8px 12px 8px 10px"
+                         :margin        "8px 12px"
+                         :background    (:bg-3 tokens)
+                         :border-left   (str "3px solid " (tone tokens))
+                         :border-top    (str "1px solid " (:border-subtle tokens))
+                         :border-right  (str "1px solid " (:border-subtle tokens))
+                         :border-bottom (str "1px solid " (:border-subtle tokens))
+                         :border-radius "4px"}}
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :justify-content "space-between"
+                    :gap "8px"
+                    :margin-bottom "4px"}}
+      [:span {:style {:font-family mono-stack
+                      :font-size   "12px"
+                      :color       (:text-primary tokens)
+                      :font-weight 600}}
+       (truncate (format-edn path) 56)]
+      [:span {:style {:font-family sans-stack
+                      :font-size   "10px"
+                      :color       (tone tokens)
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"}}
+       (op->label op)]]
+     [:div {:style {:display "flex"
+                    :gap "6px"
+                    :margin-bottom "6px"}}
+      [:button {:data-testid (str "rf-causa-app-db-diff-pin-" (pr-str path))
+                :on-click    #(rf/dispatch [:rf.causa/pin-slice path])
+                :style       {:background  "transparent"
+                              :color       (:cyan tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "1px 6px"
+                              :border-radius "4px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "10px"}}
+       "Pin"]
+      [:button {:data-testid (str "rf-causa-app-db-diff-show-when-" (pr-str path))
+                :on-click    #(rf/dispatch [:rf.causa/focus-slice-path path])
+                :style       {:background  "transparent"
+                              :color       (:magenta tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "1px 6px"
+                              :border-radius "4px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "10px"}}
+       "Show me when this changed"]
+      [:button {:data-testid (str "rf-causa-app-db-diff-copy-path-" (pr-str path))
+                :on-click    #(rf/dispatch [:rf.causa/copy-path-to-clipboard path])
+                :style       {:background  "transparent"
+                              :color       (:text-secondary tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "1px 6px"
+                              :border-radius "4px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "10px"}}
+       "Copy path"]
+      [:button {:data-testid (str "rf-causa-app-db-diff-copy-value-" (pr-str path))
+                :on-click    #(rf/dispatch [:rf.causa/copy-value-to-clipboard
+                                            (case op
+                                              :removed before
+                                              after)])
+                :style       {:background  "transparent"
+                              :color       (:text-secondary tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "1px 6px"
+                              :border-radius "4px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "10px"}}
+       "Copy value"]]
+     (case op
+       :added    (value-block "added" after :green)
+       :removed  [:div {:style {:text-decoration "line-through"}}
+                 (value-block "removed" before :red)]
+       :modified [:div
+                  (value-block "before" before :text-tertiary)
+                  (value-block "after"  after  :yellow)])]))
+
+;; ---- sub-views: reserved keys group -------------------------------------
+
+(defn- reserved-row
+  "One row in the reserved-keys group. Renders the key + a one-line
+  summary of its current value (per spec §Reserved-keys group)."
+  [[k v]]
+  [:div {:data-testid (str "rf-causa-app-db-diff-reserved-" (pr-str k))
+         :style       {:display "flex"
+                       :justify-content "space-between"
+                       :gap "12px"
+                       :padding "4px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family mono-stack
+                       :font-size "12px"}}
+   [:span {:style {:color (:text-secondary tokens)}} (format-edn k)]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (truncate (format-edn v) 48)]])
+
+(defn- reserved-group
+  "The `[runtime]` group at the bottom of the panel — surfaces the
+  reserved app-db keys (`:rf/machines`, `:rf/route`, etc.) clearly
+  marked so the programmer recognises them as runtime-owned."
+  [reserved-pairs]
+  (when (seq reserved-pairs)
+    [:section {:data-testid "rf-causa-app-db-diff-reserved-group"
+               :style       {:margin "12px 12px"
+                             :background (:bg-3 tokens)
+                             :border (str "1px solid " (:border-subtle tokens))
+                             :border-radius "4px"}}
+     [:header {:style {:padding "6px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :font-weight 600
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :color (:text-secondary tokens)}}
+      "[runtime] — reserved app-db keys"]
+     (into [:div]
+           (for [pair reserved-pairs]
+             ^{:key (pr-str (first pair))}
+             (reserved-row pair)))]))
+
+;; ---- sub-views: pinned slices --------------------------------------------
+
+(defn- pinned-row
+  "One row in the pinned-slices group. Renders the pin's path + live
+  value derived from the current target-frame's app-db. Per spec
+  §Pinned slices."
+  [{:keys [path value]}]
+  [:div {:data-testid (str "rf-causa-app-db-diff-pinned-" (pr-str path))
+         :style       {:display "flex"
+                       :justify-content "space-between"
+                       :gap "12px"
+                       :padding "4px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family mono-stack
+                       :font-size "12px"}}
+   [:span {:style {:color (:text-primary tokens)}}
+    (truncate (format-edn path) 36)]
+   [:span {:style {:display "flex" :gap "8px" :align-items "center"}}
+    [:span {:style {:color (:text-tertiary tokens)}}
+     (truncate (format-edn value) 36)]
+    [:button {:data-testid (str "rf-causa-app-db-diff-unpin-" (pr-str path))
+              :on-click    #(rf/dispatch [:rf.causa/unpin-slice path])
+              :style       {:background "transparent"
+                            :border     "none"
+                            :color      (:text-tertiary tokens)
+                            :cursor     "pointer"
+                            :font-family mono-stack
+                            :font-size  "11px"}
+              :title       "Unpin"}
+     "✕"]]])
+
+(defn- pinned-group
+  "The Pinned-slices section. Hidden when no pins exist for the
+  current target-frame."
+  [pinned-slices]
+  (when (seq pinned-slices)
+    [:section {:data-testid "rf-causa-app-db-diff-pinned-group"
+               :style       {:margin "12px 12px"
+                             :background (:bg-3 tokens)
+                             :border (str "1px solid " (:border-subtle tokens))
+                             :border-radius "4px"}}
+     [:header {:style {:padding "6px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :font-weight 600
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :color (:text-secondary tokens)}}
+      "Pinned slices"]
+     (into [:div]
+           (for [p pinned-slices]
+             ^{:key (pr-str (:path p))}
+             (pinned-row p)))]))
+
+;; ---- sub-views: show-me-when-this-changed result ------------------------
+
+(defn- focus-result-row
+  "One row in the 'Show me when this changed' result list. Clicking
+  the row rebases the time-travel scrubber's selected-epoch (which in
+  turn re-filters the causality graph + repaints this panel)."
+  [{:keys [epoch-id event op before after] :as _hit}]
+  [:li {:data-testid (str "rf-causa-app-db-diff-focus-hit-" (pr-str epoch-id))
+        :on-click    #(rf/dispatch [:rf.causa/select-epoch epoch-id])
+        :style       {:display "flex"
+                      :align-items "center"
+                      :gap "12px"
+                      :padding "6px 12px"
+                      :cursor "pointer"
+                      :border-bottom (str "1px solid " (:border-subtle tokens))
+                      :font-family mono-stack
+                      :font-size "12px"
+                      :color (:text-primary tokens)}}
+   [:span {:style {:color (get tokens (op->border op))
+                   :flex "0 0 80px"}}
+    (op->label op)]
+   [:span {:style {:color (:accent-violet tokens) :flex "0 0 120px"}}
+    (truncate (format-edn (or event :ungrouped)) 16)]
+   [:span {:style {:color (:text-tertiary tokens) :flex 1
+                   :overflow "hidden" :text-overflow "ellipsis" :white-space "nowrap"}}
+    (case op
+      :added   (str "added " (truncate (format-edn after) 32))
+      :removed (str "removed " (truncate (format-edn before) 32))
+      :modified (str (truncate (format-edn before) 16)
+                     " → " (truncate (format-edn after) 16)))]])
+
+(defn- focus-result-panel
+  "Renders the 'Show me when this changed' result in place of the
+  changed-slice mini-panels. Per spec §'Show me when this changed' —
+  walks epoch-history, lists epochs that touched the focused path."
+  [focused-path hits]
+  [:section {:data-testid "rf-causa-app-db-diff-focus-result"
+             :style       {:margin "8px 12px"
+                           :background (:bg-3 tokens)
+                           :border (str "1px solid " (:border-subtle tokens))
+                           :border-radius "4px"}}
+   [:header {:style {:padding "8px 12px"
+                     :display "flex"
+                     :justify-content "space-between"
+                     :align-items "center"
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :font-family sans-stack
+                     :font-size "12px"}}
+    [:span {:style {:color (:text-secondary tokens)}}
+     "Epochs that touched "
+     [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+      (format-edn focused-path)]]
+    [:button {:data-testid "rf-causa-app-db-diff-clear-focus"
+              :on-click    #(rf/dispatch [:rf.causa/clear-slice-focus])
+              :style       {:background "transparent"
+                            :border (str "1px solid " (:border-default tokens))
+                            :color (:text-secondary tokens)
+                            :padding "2px 8px"
+                            :border-radius "4px"
+                            :cursor "pointer"
+                            :font-family sans-stack
+                            :font-size "11px"}}
+     "Close"]]
+   (if (empty? hits)
+     [:p {:style {:padding "12px"
+                  :color (:text-tertiary tokens)
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :margin 0}}
+      "No epochs in the current ring buffer touched this path."]
+     (into [:ul {:data-testid "rf-causa-app-db-diff-focus-hits"
+                 :style {:list-style "none"
+                         :margin 0
+                         :padding 0}}]
+           (for [hit hits]
+             ^{:key (pr-str (:epoch-id hit))}
+             (focus-result-row hit))))])
+
+;; ---- sub-views: changed slices stack ------------------------------------
+
+(defn- changed-slices-stack
+  "The stacked slice mini-panels for the selected epoch's changed
+  paths (non-reserved keys). Falls back to a tidy 'no changes' note
+  when the epoch produced no diffs (synthetic epochs from
+  reset-frame-db!)."
+  [non-reserved-triples]
+  (if (empty? non-reserved-triples)
+    [:p {:data-testid "rf-causa-app-db-diff-no-changes"
+         :style {:padding "12px"
+                 :color   (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "12px"
+                 :margin 0}}
+     "No slice changes in the selected epoch."]
+    (into [:div {:data-testid "rf-causa-app-db-diff-slices"}]
+          (for [t non-reserved-triples]
+            ^{:key (pr-str (:path t))}
+            (slice-row t)))))
+
+;; ---- public view --------------------------------------------------------
+
+(defn app-db-diff-view
+  "The App-DB Diff panel's root view. Subscribes to
+  `:rf.causa/app-db-diff` and renders the slice-centric stack +
+  pinned slices + reserved-keys group, or the empty state when no
+  dispatches have run, or the 'Show me when this changed' result
+  when a path is focused."
+  []
+  (let [{:keys [target-frame
+                history-empty?
+                changed-non-reserved
+                changed-reserved
+                pinned-slices
+                focused-path
+                focused-hits]}
+        @(rf/subscribe [:rf.causa/app-db-diff])]
+    [:section {:data-testid "rf-causa-app-db-diff"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "App-db diff"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "Slice-centric. The slices that changed this epoch + pinned "
+       "slices + reserved-keys runtime group. Read-only (Lock #3). Frame: "
+       [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+        (str target-frame)]]]
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (cond
+        focused-path
+        (focus-result-panel focused-path focused-hits)
+
+        history-empty?
+        [:div
+         (empty-state target-frame)
+         ;; Pinned slices may already exist (persisted across sessions
+         ;; per spec §Pinned slices) — show them even before the first
+         ;; dispatch.
+         (pinned-group pinned-slices)
+         (reserved-group changed-reserved)]
+
+        :else
+        [:div
+         (changed-slices-stack changed-non-reserved)
+         (pinned-group pinned-slices)
+         (reserved-group changed-reserved)])]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -1,0 +1,358 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-helpers
+  "Pure-data helpers for Causa's App-DB Diff panel (Phase 5, rf2-jps1o).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `app_db_diff.cljs` touches DOM event handlers
+  (right-click affordances, pin buttons). The *logic* — the
+  structural-sharing diff, the reserved-keys partitioning, the pin-
+  store transitions, the 'Show me when this changed' walker — is
+  pure data → data. Splitting that logic into `.cljc` so it runs
+  under the JVM unit-test target (`clojure -M:test`) is required by
+  the standing rule `feedback_jvm_interop_must_work.md`.
+
+  ## Diff algorithm — `diff-paths`
+
+  Per spec/004-App-DB-Diff.md §Changed-paths derivation the diff is
+  **structural-sharing**:
+
+    - **Map-pointer-equality at each level.** When two sub-maps are
+      `identical?` the subtree is unchanged; skip.
+    - **Recurse only where pointers differ.** O(changed paths), not
+      O(db size).
+    - **Emit a sorted vector of `{:op :path :before :after}`** triples
+      where `:op` is `:added` / `:modified` / `:removed`.
+
+  `identical?` is the same predicate `clojure.core` uses for pointer
+  equality. On the JVM it's `==` over object references; in CLJS
+  it's `===`. PersistentHashMap instances produced by `assoc-in`
+  share structure with their predecessors — every untouched sub-map
+  is `identical?` to the predecessor's sub-map at the same path.
+
+  ## Reserved-keys partition — `partition-reserved`
+
+  Per spec §Reserved-keys group the runtime owns five top-level keys
+  (`:rf/machines`, `:rf/route`, `:rf/system-ids`,
+  `:rf/pending-navigation`, `:rf/spawned`). The diff triples for
+  those keys render in a separate `[runtime]` group; the rest render
+  as slice mini-panels.
+
+  ## Pin store — `pin-path` / `unpin-path` / `reorder-paths`
+
+  The pin store is per-frame: `{frame-id [path-1 path-2 ...]}`. Order
+  preserved by vector. Pins are paths (vectors of keys), not values —
+  the live value derefs against the current target-frame on each
+  recompute (per spec §Performance — O(pins) per epoch, not O(db)).
+
+  ## 'Show me when this changed' — `epochs-touching-path`
+
+  Walks the epoch-history, diffing each epoch's `:db-before` and
+  `:db-after` and filtering to those that touched the focused path.
+  Pure data → vector of hit maps. Per spec §'Show me when this
+  changed'."
+  (:require [clojure.set :as set]))
+
+;; ---- reserved keys --------------------------------------------------------
+
+(def reserved-app-db-keys
+  "Per spec/Conventions.md §Reserved app-db keys the runtime owns five
+  top-level slots in `app-db`. Diff triples whose path roots in one
+  of these keys render in the `[runtime]` group rather than as a
+  slice mini-panel.
+
+  - `:rf/machines` — machine snapshots (per spec/005-StateMachines.md)
+  - `:rf/system-ids` — system-id reverse index
+  - `:rf/route` — current route slice (per spec/012-Routing.md)
+  - `:rf/pending-navigation` — pending-nav slot
+  - `:rf/spawned` — spawned-actor table"
+  #{:rf/machines
+    :rf/route
+    :rf/system-ids
+    :rf/pending-navigation
+    :rf/spawned})
+
+(defn reserved-path?
+  "True when `path`'s root key is a reserved-app-db key. Pure data →
+  bool."
+  [path]
+  (boolean (and (sequential? path)
+                (seq path)
+                (contains? reserved-app-db-keys (first path)))))
+
+;; ---- diff algorithm -------------------------------------------------------
+
+(defn- map-like?
+  "True when `x` is a map. Recursion-friendly — only walks into nested
+  maps; vectors / lists / sets are leaf values for diff purposes (per
+  spec §Changed-paths derivation — the diff bottoms out at the first
+  non-map level, so a slice's `before` / `after` is the whole nested
+  value)."
+  [x]
+  (map? x))
+
+(defn diff-paths
+  "Diff two app-db values. Returns a vector of triples:
+
+      [{:op :added    :path [:k1 :k2 ...] :before nil      :after v}
+       {:op :modified :path [:k1 :k2 ...] :before v-old    :after v-new}
+       {:op :removed  :path [:k1 :k2 ...] :before v        :after nil}
+       ...]
+
+  Triples are sorted by path-as-pr-str so the order is stable across
+  re-renders (the spec doesn't dictate an order; lexical-by-path is
+  the obvious choice and gives consistent test snapshots).
+
+  ## Structural sharing
+
+  When `before` and `after` are both maps and have `identical?` keys
+  at level N, that subtree is skipped — pure pointer-equality short-
+  circuit. This is the O(changed paths) guarantee per spec §Changed-
+  paths derivation.
+
+  ## Per-key diff classification
+
+    - `(contains? after k)` and not `(contains? before k)` → `:added`
+    - not `(contains? after k)` and `(contains? before k)` → `:removed`
+    - both contain k:
+      - `identical?` values → no diff (structural-sharing short-circuit)
+      - both maps, not `identical?` → recurse with extended path
+      - otherwise (one or both non-map; not identical) → `:modified`
+        leaf at this path
+
+  Non-map sub-trees (e.g., a vector slice that changed from `[a b]`
+  to `[a b c]`) are emitted as a single `:modified` triple at the
+  parent path — the slice mini-panel's `before` / `after` shows the
+  whole nested value side-by-side.
+
+  Pure data → data. JVM-runnable."
+  ([before after]
+   (-> (diff-paths before after [])
+       (->> (sort-by (comp pr-str :path)))
+       vec))
+  ([before after path]
+   (cond
+     ;; Pointer-equal subtrees — no recursion (structural-sharing
+     ;; short-circuit). Mirrors clojure.core's `=` short-circuit on
+     ;; PersistentHashMap pointer-equality.
+     (identical? before after)
+     []
+
+     ;; Both maps, not identical — recurse on the union of keys.
+     (and (map-like? before) (map-like? after))
+     (let [all-keys (set/union (set (keys before)) (set (keys after)))]
+       (reduce
+         (fn [acc k]
+           (let [bv (get before k ::missing)
+                 av (get after k ::missing)]
+             (cond
+               (and (= bv ::missing) (not= av ::missing))
+               (conj acc {:op :added :path (conj path k) :before nil :after av})
+
+               (and (not= bv ::missing) (= av ::missing))
+               (conj acc {:op :removed :path (conj path k) :before bv :after nil})
+
+               (identical? bv av)
+               acc
+
+               (and (map-like? bv) (map-like? av))
+               (into acc (diff-paths bv av (conj path k)))
+
+               :else
+               (conj acc {:op :modified :path (conj path k)
+                          :before bv :after av}))))
+         []
+         all-keys))
+
+     ;; One side is missing (top-level non-map invocation: caller asks
+     ;; for diff between nil and a map, or vice versa).
+     (and (nil? before) (some? after))
+     [{:op :added :path path :before nil :after after}]
+
+     (and (some? before) (nil? after))
+     [{:op :removed :path path :before before :after nil}]
+
+     ;; Both non-map, not identical — :modified leaf.
+     :else
+     [{:op :modified :path path :before before :after after}])))
+
+;; ---- reserved-keys partition --------------------------------------------
+
+(defn partition-reserved
+  "Split a vector of diff triples into two groups:
+
+      {:reserved     [triples-whose-path-roots-in-reserved-key]
+       :non-reserved [the-rest]}
+
+  Pure data → data. Used by the view to render the changed-slice
+  stack + the `[runtime]` group separately per spec §Reserved-keys
+  group."
+  [triples]
+  (let [{:keys [reserved non-reserved]}
+        (group-by (fn [t] (if (reserved-path? (:path t)) :reserved :non-reserved))
+                  triples)]
+    {:reserved     (vec reserved)
+     :non-reserved (vec non-reserved)}))
+
+(defn reserved-summary
+  "Project the current `:rf/*` reserved-key slots of `db` into a sorted
+  vector of `[key value]` pairs for the panel's `[runtime]` group.
+  Drops keys absent from `db` so the group is sized by what's
+  actually populated.
+
+  Pure data → data."
+  [db]
+  (vec
+    (for [k (sort reserved-app-db-keys)
+          :when (contains? db k)]
+      [k (get db k)])))
+
+;; ---- pin store -----------------------------------------------------------
+
+(defn pins-for-frame
+  "Return the pin vector for `frame-id` in `store`, or `[]` when none.
+  The pin store is `{frame-id [path-1 path-2 ...]}`. Vector order is
+  the user's drag-reorder order."
+  [store frame-id]
+  (vec (get store frame-id [])))
+
+(defn pin-path
+  "Add `path` to the pin vector for `frame-id` in `store`. Duplicates
+  are dropped (re-pinning an existing path is a no-op). Pure data →
+  updated store.
+
+  Refusing duplicates is the spec's implied contract — the pin list
+  is a vector of paths, and the user's mental model is 'pin this once'
+  not 'pin this every time I click'."
+  [store frame-id path]
+  (let [existing (vec (get store frame-id []))]
+    (if (some #(= path %) existing)
+      store
+      (assoc store frame-id (conj existing path)))))
+
+(defn unpin-path
+  "Remove `path` from the pin vector for `frame-id`. Pure data →
+  updated store. No-op when `path` is absent."
+  [store frame-id path]
+  (update store frame-id
+          (fn [pins]
+            (vec (remove #(= path %) (or pins []))))))
+
+(defn reorder-paths
+  "Replace the pin vector for `frame-id` with `new-order`. The caller
+  is responsible for supplying a vector that's a permutation of the
+  current pin vector — this fn is the thin write-through; the drag-
+  reorder UI computes the permutation.
+
+  Pure data → updated store."
+  [store frame-id new-order]
+  (assoc store frame-id (vec new-order)))
+
+(defn live-pinned-slices
+  "Project the pin vector for `frame-id` into a vector of
+  `{:path :value}` maps where `:value` is the current value of the
+  path in `db`. Used by the panel's Pinned-slices group.
+
+  Pure data → data. JVM-runnable."
+  [store frame-id db]
+  (mapv (fn [path] {:path path :value (get-in db path)})
+        (pins-for-frame store frame-id)))
+
+;; ---- 'Show me when this changed' walker ---------------------------------
+
+(defn path-touched?
+  "True when the diff between `db-before` and `db-after` produces a
+  triple at `path` (or anywhere beneath `path`). Pure data → bool.
+
+  Uses pointer-equality for the prefix walk so unchanged subtrees
+  short-circuit without recursion. When we reach the end of `path`
+  we compare leaves directly — a leaf change registers as 'touched'.
+
+  This is the per-epoch test the 'Show me when this changed' walker
+  applies across epoch-history."
+  [db-before db-after path]
+  (loop [bv db-before
+         av db-after
+         path path]
+    (cond
+      (identical? bv av) false
+      (empty? path) (not (identical? bv av))
+      :else
+      (recur (when (map-like? bv) (get bv (first path)))
+             (when (map-like? av) (get av (first path)))
+             (rest path)))))
+
+(defn- path-exists?
+  "True when `path` resolves to an existing slot in `db` (the final
+  key is `contains?`-true in its parent map). Pure data → bool.
+
+  Distinguishes 'key absent' from 'key present with nil value' — the
+  diff classifier needs that distinction to label `:removed` (key
+  gone) vs `:modified` (key now nil)."
+  [db path]
+  (cond
+    (empty? path) (some? db)
+    (not (map-like? db)) false
+    (not (contains? db (first path))) false
+    :else (recur (get db (first path)) (rest path))))
+
+(defn op-at-path
+  "Classify the change at `path` between `db-before` and `db-after`.
+  Returns one of `:added` / `:removed` / `:modified` / nil (when the
+  path is untouched). Pure data → keyword or nil."
+  [db-before db-after path]
+  (when (path-touched? db-before db-after path)
+    (let [had? (path-exists? db-before path)
+          has? (path-exists? db-after  path)]
+      (cond
+        (and (not had?) has?) :added
+        (and had? (not has?)) :removed
+        :else                 :modified))))
+
+(defn- event-of-epoch
+  "Extract the dispatched event-vector off an epoch-record, for the
+  hit-row label. Mirrors `time-travel-helpers/dispatch-id-from-epoch`
+  in shape but returns the event vector, not the id."
+  [epoch-record]
+  (or (:trigger-event epoch-record)
+      (some (fn [ev]
+              (when (and (= :event (:op-type ev))
+                         (= :event/dispatched (:operation ev)))
+                (get-in ev [:tags :event])))
+            (:trace-events epoch-record))))
+
+(defn epochs-touching-path
+  "Walk `history` and return a vector of hit maps for epochs that
+  touched `path`:
+
+      [{:epoch-id <id> :event <vec> :op :added|:removed|:modified
+        :before  <prior-value-at-path>
+        :after   <new-value-at-path>}
+       ...]
+
+  Newest-first order so the list reads as a reverse chronological
+  audit. Pure data → data. Per spec §'Show me when this changed'.
+
+  Used by the `:rf.causa/show-me-when-this-changed-result` sub."
+  [history path]
+  (vec
+    (reverse
+      (keep (fn [{:keys [epoch-id db-before db-after] :as record}]
+              (when-let [op (op-at-path db-before db-after path)]
+                {:epoch-id epoch-id
+                 :event    (event-of-epoch record)
+                 :op       op
+                 :before   (get-in db-before path)
+                 :after    (get-in db-after  path)}))
+            history))))
+
+;; ---- diff caching --------------------------------------------------------
+
+(defn cache-key-of
+  "Return the cache key for a diff between an epoch's `:db-before`
+  and `:db-after`. Per spec §Performance §Diff caching the cache is
+  keyed by `:epoch-id` and the same epoch never re-diffs.
+
+  Pure-data helper so the sub layer can build a `{epoch-id triples}`
+  lookup without duplicating the key shape."
+  [epoch-record]
+  (:epoch-id epoch-record))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -78,12 +78,51 @@
   per spec §10 Lock 7) and `:rf.causa/clear-selected-epoch` for the
   cascade-filter affordance.
 
+  ## Phase 5 scope (rf2-jps1o) — App-DB Diff panel
+
+  Slice-centric app-db inspector. Reads the host frame's `app-db`
+  via `rf/get-frame-db` + the target-frame's epoch-history; produces
+  the `[op path before after]` diff triples the view consumes.
+
+  Subs:
+
+    - `:rf.causa/target-frame-db`          sub — host frame's app-db
+    - `:rf.causa/selected-epoch-diff`      sub — composite over
+                                              :rf.causa/selected-
+                                              epoch-id +
+                                              :rf.causa/epoch-history
+    - `:rf.causa/pinned-slices-store`      sub — per-frame slice pins
+    - `:rf.causa/pinned-slices`            sub — live derefs for
+                                              the current target-frame
+    - `:rf.causa/focused-slice-path`       sub — 'Show me when' focus
+    - `:rf.causa/show-me-when-this-changed-result`
+                                           sub — composite
+    - `:rf.causa/app-db-diff`              sub — composite for the view
+
+  Events:
+
+    - `:rf.causa/pin-slice`                event-db
+    - `:rf.causa/unpin-slice`              event-db
+    - `:rf.causa/reorder-pinned-slices`    event-db
+    - `:rf.causa/focus-slice-path`         event-db
+    - `:rf.causa/clear-slice-focus`        event-db
+    - `:rf.causa/copy-value-to-clipboard`  event-fx
+    - `:rf.causa/copy-path-to-clipboard`   event-fx
+
+  Effect:
+
+    - `:rf.causa.fx/copy-to-clipboard`     fx — writes via the
+                                              browser clipboard API
+                                              (no-op on non-browser
+                                              targets)
+
   Subsequent panel beads add their own per-panel events / subs / fxs."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]))
@@ -408,6 +447,119 @@
            :rendered-violations (count violations')
            :selected-violation   selected
            :schema-filter        schema-filter})))
+
+    ;; ---- Phase 5 (rf2-jps1o) — App-DB Diff subs ------------------
+
+    ;; The host frame's current app-db value. Read via rf/get-frame-db
+    ;; against the Phase 3 :rf.causa/target-frame. Wrapped in a sub so
+    ;; the panel reacts to host writes via the same reactive surface as
+    ;; everything else; the sub fn itself is side-effecting (rf/get-
+    ;; frame-db hits a frame atom), but the reactivity is driven by
+    ;; epoch-history updates pumped into Causa's app-db on every settle.
+    (rf/reg-sub :rf.causa/target-frame-db
+      :<- [:rf.causa/target-frame]
+      :<- [:rf.causa/epoch-history]
+      (fn [[target _epoch-history] _query]
+        ;; Depend on :rf.causa/epoch-history so the sub re-fires on
+        ;; every settled epoch. The actual read is via rf/get-frame-db
+        ;; — the framework's canonical accessor.
+        (rf/get-frame-db target)))
+
+    ;; The selected epoch's record from :rf.causa/epoch-history. nil
+    ;; when no selection or the selection has aged out of the ring
+    ;; buffer.
+    (rf/reg-sub :rf.causa/selected-epoch-record
+      :<- [:rf.causa/epoch-history]
+      :<- [:rf.causa/selected-epoch-id]
+      (fn [[history selected-id] _query]
+        (when selected-id
+          (tt-helpers/find-epoch-in-history history selected-id))))
+
+    ;; The diff triples for the currently-selected epoch. When no
+    ;; epoch is selected, the diff is between the newest epoch's
+    ;; :db-before and :db-after (the most recent settle).
+    ;;
+    ;; Per spec §Changed-paths derivation the diff is computed
+    ;; lazily on panel mount and the result cached per :epoch-id.
+    ;; The composite sub recomputes only when the underlying
+    ;; (history × selection) tuple changes — re-renders of the same
+    ;; epoch return identical?-equal triples, which is the v1
+    ;; caching model.
+    (rf/reg-sub :rf.causa/selected-epoch-diff
+      :<- [:rf.causa/epoch-history]
+      :<- [:rf.causa/selected-epoch-id]
+      (fn [[history selected-id] _query]
+        (let [record (if selected-id
+                       (tt-helpers/find-epoch-in-history history selected-id)
+                       (peek (vec history)))]
+          (when record
+            (diff-helpers/diff-paths (:db-before record)
+                                     (:db-after  record))))))
+
+    ;; The pinned-slices store — `{frame-id [path-1 path-2 ...]}`.
+    ;; Separate from Phase 3's :pin-store (which pins whole epoch
+    ;; snapshots); this is per-frame slice-path pinning.
+    (rf/reg-sub :rf.causa/pinned-slices-store
+      (fn [db _query]
+        (get db :pinned-slices-store {})))
+
+    ;; The live-derefed pinned slices for the current target-frame.
+    ;; Each entry is `{:path <vec> :value <current-value>}`.
+    (rf/reg-sub :rf.causa/pinned-slices
+      :<- [:rf.causa/pinned-slices-store]
+      :<- [:rf.causa/target-frame]
+      :<- [:rf.causa/target-frame-db]
+      (fn [[store target db] _query]
+        (diff-helpers/live-pinned-slices store target db)))
+
+    ;; The 'Show me when this changed' focused path. nil when no
+    ;; focus is in flight; the view falls back to the slice mini-
+    ;; panels in that case.
+    (rf/reg-sub :rf.causa/focused-slice-path
+      (fn [db _query]
+        (get db :focused-slice-path)))
+
+    ;; The 'Show me when this changed' result — a vector of hit
+    ;; maps for epochs that touched the focused path. Empty vector
+    ;; when no focus is set or no epoch in the ring buffer touched
+    ;; the path.
+    (rf/reg-sub :rf.causa/show-me-when-this-changed-result
+      :<- [:rf.causa/focused-slice-path]
+      :<- [:rf.causa/epoch-history]
+      (fn [[focused-path history] _query]
+        (if focused-path
+          (diff-helpers/epochs-touching-path history focused-path)
+          [])))
+
+    ;; Top-level composite for the App-DB Diff panel. One read
+    ;; produces every slot the view needs (matches the Phase-2 /
+    ;; Phase-3 / Phase-4 composite pattern).
+    (rf/reg-sub :rf.causa/app-db-diff
+      :<- [:rf.causa/target-frame]
+      :<- [:rf.causa/target-frame-db]
+      :<- [:rf.causa/selected-epoch-diff]
+      :<- [:rf.causa/pinned-slices]
+      :<- [:rf.causa/focused-slice-path]
+      :<- [:rf.causa/show-me-when-this-changed-result]
+      :<- [:rf.causa/epoch-history]
+      (fn [[target db diff-triples pinned focused-path focused-hits history]
+           _query]
+        (let [history-empty? (empty? history)
+              {:keys [reserved non-reserved]}
+              (diff-helpers/partition-reserved (or diff-triples []))]
+          {:target-frame          target
+           :history-empty?        history-empty?
+           :changed-non-reserved  non-reserved
+           ;; The [runtime] group always renders the current `:rf/*`
+           ;; slot contents off the current db as a one-line summary
+           ;; (path + value). Per spec §Reserved-keys group the group
+           ;; is informational — it's not gated on whether THIS epoch
+           ;; touched a reserved key; the programmer reads it to
+           ;; orient against the runtime's state.
+           :changed-reserved      (diff-helpers/reserved-summary db)
+           :pinned-slices         pinned
+           :focused-path          focused-path
+           :focused-hits          focused-hits})))
 
     ;; ---- events --------------------------------------------------
     (rf/reg-event-db :rf.causa/select-panel
@@ -824,7 +976,64 @@
                  (number? (:t1 window))
                  (< (:t0 window) (:t1 window)))
           (assoc db :schema-timeline-window window)
-          (dissoc db :schema-timeline-window)))))
+          (dissoc db :schema-timeline-window))))
+
+    ;; ---- Phase 5 (rf2-jps1o) — App-DB Diff events ----------------
+
+    ;; Pin a slice path to the per-frame pinned-slices store. Per
+    ;; spec §Pinned slices. Duplicates are dropped at the helper
+    ;; layer (re-pin is a no-op).
+    (rf/reg-event-db :rf.causa/pin-slice
+      (fn [db [_ path]]
+        (let [target (get db :target-frame default-target-frame)]
+          (update db :pinned-slices-store
+                  diff-helpers/pin-path target path))))
+
+    (rf/reg-event-db :rf.causa/unpin-slice
+      (fn [db [_ path]]
+        (let [target (get db :target-frame default-target-frame)]
+          (update db :pinned-slices-store
+                  diff-helpers/unpin-path target path))))
+
+    ;; Replace the per-frame pin order with `new-order`. The caller
+    ;; (the drag-reorder UI) computes the permutation.
+    (rf/reg-event-db :rf.causa/reorder-pinned-slices
+      (fn [db [_ new-order]]
+        (let [target (get db :target-frame default-target-frame)]
+          (update db :pinned-slices-store
+                  diff-helpers/reorder-paths target new-order))))
+
+    ;; Set the 'Show me when this changed' focused path. The
+    ;; :rf.causa/show-me-when-this-changed-result sub re-fires
+    ;; against the new focus and the panel switches into result-list
+    ;; mode (per spec §'Show me when this changed').
+    (rf/reg-event-db :rf.causa/focus-slice-path
+      (fn [db [_ path]]
+        (assoc db :focused-slice-path path)))
+
+    (rf/reg-event-db :rf.causa/clear-slice-focus
+      (fn [db _event]
+        (dissoc db :focused-slice-path)))
+
+    ;; The clipboard fx — best-effort write via the browser
+    ;; clipboard API. On non-browser targets (Node test, JVM) the
+    ;; effect is a no-op; tests assert the fx fires, not the OS-side
+    ;; outcome. Per re-frame v2's reg-fx contract: (fn [ctx args] ...).
+    (rf/reg-fx :rf.causa.fx/copy-to-clipboard
+      (fn [_ctx {:keys [text]}]
+        (try
+          (when (and (exists? js/navigator)
+                     (.-clipboard js/navigator))
+            (.writeText (.-clipboard js/navigator) (str text)))
+          (catch :default _ nil))))
+
+    (rf/reg-event-fx :rf.causa/copy-value-to-clipboard
+      (fn [_ctx [_ value]]
+        {:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str value)}]]}))
+
+    (rf/reg-event-fx :rf.causa/copy-path-to-clipboard
+      (fn [_ctx [_ path]]
+        {:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str path)}]]})))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -37,6 +37,7 @@
   render fn (`rf/render`) handles the substrate-specific mount in
   `mount.cljs`. No per-substrate switches in view code."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
@@ -74,7 +75,7 @@
   items still render the Phase 1 stub when selected."
   [{:id :event-detail :label "Event detail" :bead "rf2-op3bz" :live? true}
    {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
-   {:id :app-db       :label "App-db"        :bead "rf2-xxx"}
+   {:id :app-db       :label "App-db"        :bead "rf2-jps1o" :live? true}
    {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
    {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
@@ -253,6 +254,7 @@
     (case selected
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
+      :app-db       [app-db-diff/app-db-diff-view]
       :causality    [causality-graph/causality-graph-view]
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -1,0 +1,489 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-cljs-test
+  "CLJS-side wiring + view tests for Causa's App-DB Diff panel
+  (Phase 5, rf2-jps1o).
+
+  ## Contracts under test (beyond the pure-data tests in
+  `app_db_diff_helpers_cljs_test.cljc`)
+
+  1. **Registry wires the Phase 5 subs / events** under the
+     `:rf.causa/*` namespace. The composite `:rf.causa/app-db-diff`
+     returns the panel's render data; the pin / unpin / focus events
+     write into `:rf/causa`'s app-db.
+
+  2. **Pin / unpin / reorder / focus events update Causa's frame.**
+     Per spec §Pinned slices + §'Show me when this changed' — the
+     view fires `:rf.causa/pin-slice` etc. and the state lives in
+     the Causa frame.
+
+  3. **Reserved-keys segregation at the panel level.** The view
+     renders the `[runtime]` group separately from the slice mini-
+     panels.
+
+  4. **'Show me when this changed' returns only epochs that touched
+     the focused path.** Asserted both at the sub level (via
+     `:rf.causa/show-me-when-this-changed-result`) and at the view
+     level (via the focus-result-panel rendering).
+
+  ## Pure hiccup
+
+  Same approach as `event_detail_cljs_test.cljs` /
+  `time_travel_cljs_test.cljs` / `causality_graph_view_cljs_test.cljs`
+  — we walk the view's hiccup tree by `data-testid` rather than
+  mounting to a DOM. Keeps the suite fast + host-portable on node-
+  test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- fixture data --------------------------------------------------------
+
+(defn- mk-record
+  "Build a minimal `:rf/epoch-record` map for the diff walker /
+  selected-epoch-diff sub tests."
+  [epoch-id event db-before db-after]
+  {:epoch-id      epoch-id
+   :frame         :rf/default
+   :committed-at  0
+   :event-id      (first event)
+   :trigger-event event
+   :db-before     db-before
+   :db-after      db-after
+   :trace-events  []})
+
+(defn- register-seed-events!
+  "Register test-only seed events that write directly to the Causa
+  frame's app-db. Production code reaches the same shape via
+  :rf.causa/epoch-recorded + the host frame's runtime mutations."
+  []
+  (rf/reg-event-db :rf.causa-test/seed-history
+    (fn [db [_ records]]
+      (assoc db :epoch-history (vec records))))
+  (rf/reg-event-db :rf.causa-test/seed-target-frame-db
+    (fn [db _]
+      ;; This is a no-op marker — the host frame's db is the source
+      ;; of truth, and we set it via reset-frame-db! below. Kept so
+      ;; tests can locate the seed step by name.
+      db)))
+
+(defn- seed-host-frame!
+  "Reset the host (:rf/default) frame's app-db to the supplied
+  value via the framework's reset-frame-db!. The Phase 5 panel
+  derefs the host frame via :rf.causa/target-frame-db."
+  [db-value]
+  (frame/reg-frame :rf/default {})
+  (rf/reset-frame-db! :rf/default db-value))
+
+(defn- seed-causa!
+  "Wire the Phase 5 sub graph + seed history + host-frame db. The
+  test environment proxies the production wiring path (preload +
+  registry + epoch-cb) so the subs read live values."
+  [host-db-value history]
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (register-seed-events!)
+  (seed-host-frame! host-db-value)
+  (when (seq history)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa-test/seed-history history]))))
+
+;; ---- hiccup walker (mirrors event_detail_cljs_test.cljs) ----------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+;; ---- (1) registry wires the subs / events -------------------------------
+
+(deftest registry-installs-app-db-diff-subs
+  (testing "register-causa-handlers! installs the Phase 5 subs"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/target-frame-db)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-epoch-record)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-epoch-diff)))
+    (is (some? (registrar/handler :sub :rf.causa/pinned-slices-store)))
+    (is (some? (registrar/handler :sub :rf.causa/pinned-slices)))
+    (is (some? (registrar/handler :sub :rf.causa/focused-slice-path)))
+    (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
+    (is (some? (registrar/handler :sub :rf.causa/app-db-diff)))))
+
+(deftest registry-installs-app-db-diff-events
+  (testing "register-causa-handlers! installs the Phase 5 events"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :event :rf.causa/pin-slice)))
+    (is (some? (registrar/handler :event :rf.causa/unpin-slice)))
+    (is (some? (registrar/handler :event :rf.causa/reorder-pinned-slices)))
+    (is (some? (registrar/handler :event :rf.causa/focus-slice-path)))
+    (is (some? (registrar/handler :event :rf.causa/clear-slice-focus)))
+    (is (some? (registrar/handler :event :rf.causa/copy-value-to-clipboard)))
+    (is (some? (registrar/handler :event :rf.causa/copy-path-to-clipboard)))))
+
+(deftest registry-installs-clipboard-fx
+  (testing "register-causa-handlers! installs the :rf.causa.fx/copy-to-
+            clipboard effect"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :fx :rf.causa.fx/copy-to-clipboard)))))
+
+;; ---- (2) composite sub returns sane defaults ----------------------------
+
+(deftest app-db-diff-sub-defaults
+  (testing ":rf.causa/app-db-diff returns sane defaults on a fresh frame"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/app-db-diff])]
+        (is (= :rf/default (:target-frame data)))
+        (is (true? (:history-empty? data)))
+        (is (nil? (:focused-path data)))
+        (is (= [] (:pinned-slices data)))
+        (is (= [] (:focused-hits data)))))))
+
+;; ---- (3) selected-epoch-diff produces correct triples -------------------
+
+(deftest selected-epoch-diff-produces-triples
+  (testing "with history populated, :rf.causa/selected-epoch-diff
+            produces the [op path before after] triples"
+    (seed-causa! {:cart {:items [{:id 7}]}}
+                 [(mk-record :e-1 [:cart/add-item]
+                             {:cart {:items []}}
+                             {:cart {:items [{:id 7}]}})])
+    (rf/with-frame :rf/causa
+      (let [diff @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+        (is (= 1 (count diff)))
+        (is (= {:op :modified :path [:cart :items]
+                :before [] :after [{:id 7}]}
+               (first diff)))))))
+
+(deftest selected-epoch-diff-tracks-selected-epoch
+  (testing "when an epoch is selected, the diff is for THAT epoch — not
+            the newest one"
+    (let [hist [(mk-record :e-1 [:app/boot] {} {:counter 0})
+                (mk-record :e-2 [:counter/inc]
+                           {:counter 0} {:counter 1})
+                (mk-record :e-3 [:counter/inc]
+                           {:counter 1} {:counter 2})]]
+      (seed-causa! {:counter 2} hist)
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/select-epoch :e-2])
+        (let [diff @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (is (= [{:op :modified :path [:counter] :before 0 :after 1}]
+                 diff)
+              ":e-2's diff selected, not :e-3's"))))))
+
+;; ---- (4) reserved-keys segregation at the composite level ---------------
+
+(deftest app-db-diff-segregates-reserved-keys
+  (testing "the composite splits triples whose path roots in :rf/* from
+            the rest; reserved triples go to :changed-reserved as the
+            current snapshot (informational group per spec §Reserved-
+            keys group), non-reserved go to :changed-non-reserved"
+    (seed-causa! {:cart {:items [{:id 7}]}
+                  :rf/route {:id :app/cart}
+                  :rf/machines {:auth {:state :idle}}}
+                 [(mk-record :e-1 [:nav/cart]
+                             {:cart {:items []}}
+                             {:cart {:items [{:id 7}]}
+                              :rf/route {:id :app/cart}})])
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/app-db-diff])
+            non-reserved-paths (set (map :path (:changed-non-reserved data)))
+            reserved-keys-shown (set (map first (:changed-reserved data)))]
+        (is (contains? non-reserved-paths [:cart :items])
+            "non-reserved path lands in :changed-non-reserved")
+        (is (not (contains? non-reserved-paths [:rf/route]))
+            ":rf/route filtered out of :changed-non-reserved")
+        (is (contains? reserved-keys-shown :rf/route))
+        (is (contains? reserved-keys-shown :rf/machines))))))
+
+;; ---- (5) pin / unpin events write to Causa frame ------------------------
+
+(deftest pin-slice-event-writes-to-causa-frame
+  (testing ":rf.causa/pin-slice lands the path on :rf/causa's
+            :pinned-slices-store, NOT on the host's app-db"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]]))
+    (is (= {:rf/default [[:user :auth :status]]}
+           (:pinned-slices-store (frame/frame-app-db-value :rf/causa))))
+    (is (nil? (:pinned-slices-store (frame/frame-app-db-value :rf/default))))))
+
+(deftest pin-and-unpin-roundtrip
+  (testing ":rf.causa/pin-slice then :rf.causa/unpin-slice → empty pin vector"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-slice [:a]])
+      (rf/dispatch-sync [:rf.causa/pin-slice [:b]])
+      (let [s1 (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
+        (is (= [[:a] [:b]] (get s1 :rf/default))))
+      (rf/dispatch-sync [:rf.causa/unpin-slice [:a]])
+      (let [s2 (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
+        (is (= [[:b]] (get s2 :rf/default)))))))
+
+(deftest reorder-pinned-slices-replaces-pin-order
+  (testing ":rf.causa/reorder-pinned-slices replaces the per-frame pin
+            vector with the supplied permutation"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-slice [:a]])
+      (rf/dispatch-sync [:rf.causa/pin-slice [:b]])
+      (rf/dispatch-sync [:rf.causa/pin-slice [:c]])
+      (rf/dispatch-sync [:rf.causa/reorder-pinned-slices [[:c] [:a] [:b]]])
+      (let [s (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
+        (is (= [[:c] [:a] [:b]] (get s :rf/default)))))))
+
+(deftest pinned-slices-sub-derefs-live-values
+  (testing ":rf.causa/pinned-slices returns live values from the host
+            frame's current app-db"
+    (seed-causa! {:user {:auth {:status :authenticated}}
+                  :cart {:items [{:id 7}]}}
+                 [])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]])
+      (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]])
+      (let [slices @(rf/subscribe [:rf.causa/pinned-slices])]
+        (is (= 2 (count slices)))
+        (is (= {:path [:user :auth :status] :value :authenticated}
+               (first slices)))
+        (is (= {:path [:cart :items] :value [{:id 7}]}
+               (second slices)))))))
+
+;; ---- (6) focus event + 'Show me when this changed' result ---------------
+
+(deftest focus-slice-path-event-writes-to-causa-frame
+  (testing ":rf.causa/focus-slice-path lands the path on :rf/causa's
+            :focused-slice-path"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]]))
+    (is (= [:cart :items]
+           (:focused-slice-path (frame/frame-app-db-value :rf/causa))))))
+
+(deftest clear-slice-focus-event-drops-focus
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-slice-path [:any]])
+    (rf/dispatch-sync [:rf.causa/clear-slice-focus]))
+  (is (nil? (:focused-slice-path (frame/frame-app-db-value :rf/causa)))))
+
+(deftest show-me-when-this-changed-result-filters-history
+  (testing ":rf.causa/show-me-when-this-changed-result walks
+            :rf.causa/epoch-history and returns only epochs that
+            touched the focused path.
+
+            Per spec §Changed-paths derivation the walker uses pointer-
+            equality at each level — we use `assoc-in` so the
+            unchanged :cart subtree keeps its PersistentHashMap
+            identity across epoch boundaries (mirrors how host
+            reg-event-db handlers build successor app-dbs)."
+    (let [db-0 {}
+          db-1 (assoc-in db-0 [:cart :items] [])
+          db-2 (assoc-in db-1 [:cart :items] [{:id 7}])
+          db-3 (assoc    db-2 :user "ada")  ;; :cart identity preserved
+          hist [(mk-record :e-1 [:app/boot]     db-0 db-1)
+                (mk-record :e-2 [:cart/add-item] db-1 db-2)
+                (mk-record :e-3 [:user/login]    db-2 db-3)]]
+      (seed-causa! db-3 hist)
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]])
+        (let [hits @(rf/subscribe [:rf.causa/show-me-when-this-changed-result])
+              eids (mapv :epoch-id hits)]
+          (is (= [:e-2 :e-1] eids)
+              "newest-first; :e-3 didn't touch :cart :items"))))))
+
+(deftest show-me-when-this-changed-result-empty-when-no-focus
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (is (= [] @(rf/subscribe [:rf.causa/show-me-when-this-changed-result])))))
+
+;; ---- (7) clipboard fx is wired (fires without crashing) -----------------
+
+(deftest copy-events-fire-clipboard-fx
+  (testing ":rf.causa/copy-value-to-clipboard + :rf.causa/copy-path-to-
+            clipboard route through :rf.causa.fx/copy-to-clipboard; the
+            fx is best-effort (no-op on non-browser targets)"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [captured (atom [])]
+      (rf/reg-fx :rf.causa.fx/copy-to-clipboard
+        (fn [_ctx args] (swap! captured conj args)))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/copy-value-to-clipboard {:a 1}])
+        (rf/dispatch-sync [:rf.causa/copy-path-to-clipboard [:cart :items]]))
+      (is (= 2 (count @captured)))
+      (is (= "{:a 1}" (:text (first @captured))))
+      (is (= "[:cart :items]" (:text (second @captured)))))))
+
+;; ---- (8) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-history-empty
+  (testing "with no epoch history, the panel renders the empty state"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (rf/with-frame :rf/causa
+      (let [tree (app-db-diff/app-db-diff-view)]
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-slices")))))))
+
+(deftest slice-stack-renders-when-diff-present
+  (testing "with history populated, the panel renders one slice mini-
+            panel per non-reserved diff triple"
+    (seed-causa! {:cart {:items [{:id 7}]}
+                  :user "ada"}
+                 [(mk-record :e-1 [:cart/add-item]
+                             {:cart {:items []} :user "ada"}
+                             {:cart {:items [{:id 7}]} :user "ada"})])
+    (rf/with-frame :rf/causa
+      (let [tree (app-db-diff/app-db-diff-view)]
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-slices"))
+            "slice container present")
+        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-empty"))
+            "empty-state absent")
+        ;; The slice mini-panel for [:cart :items] is present:
+        (is (some? (find-by-testid tree
+                                   "rf-causa-app-db-diff-slice-[:cart :items]")))))))
+
+(deftest reserved-group-renders-when-rf-keys-present
+  (testing "the [runtime] group surfaces :rf/* keys present in app-db"
+    (seed-causa! {:rf/route {:id :app/cart}
+                  :rf/machines {:auth-id {:state :idle}}
+                  :cart {:items []}}
+                 [(mk-record :e-1 [:nav]
+                             {:cart {:items []}}
+                             {:cart {:items []} :rf/route {:id :app/cart}})])
+    (rf/with-frame :rf/causa
+      (let [tree (app-db-diff/app-db-diff-view)]
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-reserved-group"))
+            "runtime group container present")
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-reserved-:rf/route"))
+            "rf/route row present")
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-reserved-:rf/machines"))
+            "rf/machines row present")))))
+
+(deftest focus-result-panel-replaces-slice-stack-on-focus
+  (testing "when a slice path is focused, the panel renders the 'Show me
+            when this changed' result list instead of the slice stack"
+    (seed-causa! {:cart {:items [{:id 7}]}}
+                 [(mk-record :e-1 [:app/boot]
+                             {}
+                             {:cart {:items []}})
+                  (mk-record :e-2 [:cart/add-item]
+                             {:cart {:items []}}
+                             {:cart {:items [{:id 7}]}})])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]])
+      (let [tree (app-db-diff/app-db-diff-view)]
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-focus-result"))
+            "focus-result panel present")
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-focus-hits"))
+            "hit list present")
+        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-slices"))
+            "slice stack absent while focused")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-app-db-diff-focus-hit-:e-2")))
+        (is (some? (find-by-testid tree
+                                   "rf-causa-app-db-diff-focus-hit-:e-1")))))))
+
+(deftest pinned-group-renders-when-pins-present
+  (testing "the Pinned-slices section renders when pins exist for the
+            current target-frame"
+    (seed-causa! {:user {:auth {:status :authenticated}}}
+                 [])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]])
+      (let [tree (app-db-diff/app-db-diff-view)]
+        (is (some? (find-by-testid tree "rf-causa-app-db-diff-pinned-group"))
+            "pinned group container present")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-app-db-diff-pinned-[:user :auth :status]"))
+            "pinned row for the pinned path is present")))))
+
+(deftest clicking-pin-button-fires-pin-slice-event
+  (testing "the slice mini-panel's Pin button is wired to
+            :rf.causa/pin-slice for the slice's path"
+    (seed-causa! {:cart {:items [{:id 7}]}}
+                 [(mk-record :e-1 [:cart/add]
+                             {:cart {:items []}}
+                             {:cart {:items [{:id 7}]}})])
+    (rf/with-frame :rf/causa
+      (let [tree     (app-db-diff/app-db-diff-view)
+            btn      (find-by-testid tree
+                                     "rf-causa-app-db-diff-pin-[:cart :items]")
+            on-click (:on-click (second btn))]
+        (is (fn? on-click) "Pin button has an on-click handler")
+        ;; Drive the same event through dispatch-sync to prove the
+        ;; registered event handler lands the pin in the Causa frame.
+        (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]])
+        (let [causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= [[:cart :items]]
+                 (get-in causa-db [:pinned-slices-store :rf/default]))
+              "pin landed in :rf/causa's :pinned-slices-store"))))))
+
+(deftest clicking-show-when-button-fires-focus-event
+  (testing "the slice mini-panel's 'Show me when this changed' button is
+            wired to :rf.causa/focus-slice-path"
+    (seed-causa! {:cart {:items [{:id 7}]}}
+                 [(mk-record :e-1 [:cart/add]
+                             {:cart {:items []}}
+                             {:cart {:items [{:id 7}]}})])
+    (rf/with-frame :rf/causa
+      (let [tree (app-db-diff/app-db-diff-view)
+            btn  (find-by-testid tree
+                                 "rf-causa-app-db-diff-show-when-[:cart :items]")
+            on-click (:on-click (second btn))]
+        (is (some? btn) "Show-when button present")
+        (is (fn? on-click))
+        (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]])
+        (let [causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= [:cart :items]
+                 (:focused-slice-path causa-db))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -1,0 +1,315 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-helpers-cljs-test
+  "Pure-data tests for Causa's App-DB Diff panel helpers
+  (Phase 5, rf2-jps1o).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  The file ends in `_cljs_test.cljc` so:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  Same dual-target pattern as `time_travel_helpers_cljs_test.cljc`.
+
+  ## What's under test
+
+  Each contract is asserted against the pure-data fns in
+  `app-db-diff-helpers`; no Reagent, no DOM. View-side wiring is
+  exercised in `app_db_diff_cljs_test.cljs` against the live Causa
+  frame.
+
+    1. **Diff algorithm produces correct `[op path before after]`
+       triples** for `:added` / `:modified` / `:removed`. Mixed
+       sub-tree changes produce the union of triples.
+
+    2. **Pointer-equal subtrees short-circuit.** When `before` and
+       `after` share an `identical?` sub-map, the recursive walker
+       skips it entirely — assertable via an externally-mutated
+       counter wired through a wrapper.
+
+    3. **Reserved-keys segregation.** `partition-reserved` splits
+       triples whose path roots in `:rf/machines` / `:rf/route` /
+       etc. into a separate group.
+
+    4. **Pin-store transitions.** Pin / unpin / reorder transitions
+       are pure-data → updated-store, and `live-pinned-slices`
+       derefs the current value against `app-db`.
+
+    5. **`epochs-touching-path` walks the history.** Returns only
+       epochs that touched the focused path, classified by op."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]))
+
+;; ---- (1) diff algorithm produces correct triples ------------------------
+
+(deftest diff-paths-empty-on-equal-maps
+  (testing "diffing identical-value maps yields no triples"
+    (is (= [] (h/diff-paths {:a 1} {:a 1})))
+    (is (= [] (h/diff-paths {} {})))
+    (let [m {:nested {:k 1}}]
+      (is (= [] (h/diff-paths m m)) "identical? whole map → no triples"))))
+
+(deftest diff-paths-added-key
+  (testing "a key present in :after but not :before → :added triple"
+    (let [diff (h/diff-paths {:a 1} {:a 1 :b 2})]
+      (is (= 1 (count diff)))
+      (is (= {:op :added :path [:b] :before nil :after 2}
+             (first diff))))))
+
+(deftest diff-paths-removed-key
+  (testing "a key present in :before but not :after → :removed triple"
+    (let [diff (h/diff-paths {:a 1 :b 2} {:a 1})]
+      (is (= 1 (count diff)))
+      (is (= {:op :removed :path [:b] :before 2 :after nil}
+             (first diff))))))
+
+(deftest diff-paths-modified-leaf
+  (testing "a key whose value changed (non-map, non-identical) → :modified"
+    (let [diff (h/diff-paths {:a 1} {:a 2})]
+      (is (= 1 (count diff)))
+      (is (= {:op :modified :path [:a] :before 1 :after 2}
+             (first diff))))))
+
+(deftest diff-paths-nested-modified
+  (testing "nested maps with a changed leaf → recursive :modified triple
+            at the leaf path, not at the parent path"
+    (let [before {:cart {:items [] :totals {:gross 0}}}
+          after  {:cart {:items [{:id 7}] :totals {:gross 0}}}
+          diff   (h/diff-paths before after)]
+      (is (= [{:op :modified :path [:cart :items]
+               :before [] :after [{:id 7}]}]
+             diff)
+          "the unchanged :totals subtree must NOT produce a triple"))))
+
+(deftest diff-paths-mixed-ops
+  (testing "a single epoch's diff can contain a mix of :added / :modified /
+            :removed; result is sorted by path-as-string for stability"
+    (let [before {:cart {:items [{:id 7 :qty 1}]}
+                  :user/auth :anon}
+          after  {:cart  {:items [{:id 7 :qty 1} {:id 22 :qty 1}]
+                          :totals {:gross 48}}
+                  :flash "Welcome"}
+          diff   (h/diff-paths before after)
+          paths  (mapv :path diff)
+          ops    (into {} (map (juxt :path :op)) diff)]
+      (is (= 4 (count diff)) "added :totals, modified :items, removed :user/auth, added :flash")
+      (is (= :modified (get ops [:cart :items])))
+      (is (= :added    (get ops [:cart :totals])))
+      (is (= :added    (get ops [:flash])))
+      (is (= :removed  (get ops [:user/auth])))
+      (is (= paths (sort-by pr-str paths))
+          "triples sorted lexically by path"))))
+
+(deftest diff-paths-non-map-leaf-modified
+  (testing "when a key's value transitions from non-map to map, the
+            non-map → map change is a single :modified at the key"
+    (let [diff (h/diff-paths {:a 1} {:a {:b 2}})]
+      (is (= 1 (count diff)))
+      (is (= :modified (:op (first diff))))
+      (is (= [:a] (:path (first diff))))
+      (is (= 1 (:before (first diff))))
+      (is (= {:b 2} (:after (first diff)))))))
+
+;; ---- (2) structural-sharing short-circuit -------------------------------
+
+(deftest diff-paths-structural-sharing-skips-unchanged-subtree
+  (testing "PersistentHashMap pointer-equality at each level short-circuits
+            the diff walk on unchanged subtrees. Assertable by reusing
+            the same sub-map reference in both before and after — the
+            diff produces zero triples for that subtree even though it
+            holds many keys."
+    (let [shared       (zipmap (range 1000) (range 1000))
+          before       {:big shared :counter 0}
+          after        (assoc before :counter 1)  ;; :big is identical?
+          diff         (h/diff-paths before after)]
+      (is (= 1 (count diff))
+          "only the :counter triple; :big short-circuits via identical?")
+      (is (= [:counter] (:path (first diff))))
+      (is (= :modified (:op (first diff))))
+      (is (= 0 (:before (first diff))))
+      (is (= 1 (:after  (first diff)))))))
+
+(deftest diff-paths-deep-structural-sharing
+  (testing "structural-sharing short-circuit works at depth — a deeply-
+            nested subtree that's identical? in both inputs is skipped"
+    (let [deep-shared {:cart {:items [{:id 1 :qty 5}]
+                              :totals {:gross 5 :tax 0.5}}}
+          before      (merge deep-shared {:user "ada"})
+          after       (merge deep-shared {:user "ben"})
+          diff        (h/diff-paths before after)]
+      (is (= [{:op :modified :path [:user] :before "ada" :after "ben"}]
+             diff)
+          "the whole :cart subtree is identical? — must produce zero triples"))))
+
+;; ---- (3) reserved-keys partition ----------------------------------------
+
+(deftest reserved-app-db-keys-includes-the-five-runtime-keys
+  (testing "reserved-app-db-keys matches spec/Conventions.md
+            §Reserved app-db keys"
+    (is (contains? h/reserved-app-db-keys :rf/machines))
+    (is (contains? h/reserved-app-db-keys :rf/route))
+    (is (contains? h/reserved-app-db-keys :rf/system-ids))
+    (is (contains? h/reserved-app-db-keys :rf/pending-navigation))
+    (is (contains? h/reserved-app-db-keys :rf/spawned))))
+
+(deftest reserved-path-true-for-rf-roots
+  (testing "reserved-path? returns true when the first path key is reserved"
+    (is (true?  (h/reserved-path? [:rf/machines :foo :bar])))
+    (is (true?  (h/reserved-path? [:rf/route])))
+    (is (false? (h/reserved-path? [:cart :items])))
+    (is (false? (h/reserved-path? [])))
+    (is (false? (h/reserved-path? nil)))))
+
+(deftest partition-reserved-splits-the-vector
+  (testing "partition-reserved separates reserved-path triples from the rest"
+    (let [triples [{:op :modified :path [:cart :items] :before [] :after [1]}
+                   {:op :added    :path [:rf/route] :before nil :after {:id :home}}
+                   {:op :modified :path [:user :name] :before "ada" :after "ben"}
+                   {:op :modified :path [:rf/machines :auth]
+                    :before {} :after {:state :idle}}]
+          {:keys [reserved non-reserved]}
+          (h/partition-reserved triples)]
+      (is (= 2 (count reserved)))
+      (is (= 2 (count non-reserved)))
+      (is (every? #(h/reserved-path? (:path %)) reserved))
+      (is (every? #(not (h/reserved-path? (:path %))) non-reserved)))))
+
+(deftest reserved-summary-renders-current-rf-slots
+  (testing "reserved-summary projects only the reserved keys present in db"
+    (let [db {:user "ada"
+              :rf/route    {:id :app/home}
+              :rf/machines {:auth-id {:state :idle}}}
+          summary (h/reserved-summary db)
+          ks      (mapv first summary)]
+      (is (= [:rf/machines :rf/route] ks)
+          "sorted; only :rf/* keys actually in db are surfaced")
+      (is (= [[:rf/machines {:auth-id {:state :idle}}]
+              [:rf/route {:id :app/home}]]
+             summary)))))
+
+;; ---- (4) pin-store transitions ------------------------------------------
+
+(deftest pin-path-appends-to-empty-store
+  (let [out (h/pin-path {} :rf/default [:user :auth :status])]
+    (is (= {:rf/default [[:user :auth :status]]} out))))
+
+(deftest pin-path-rejects-duplicates
+  (testing "re-pinning an existing path is a no-op"
+    (let [s0 (h/pin-path {} :rf/default [:a])
+          s1 (h/pin-path s0 :rf/default [:a])]
+      (is (= s0 s1)))))
+
+(deftest pin-path-per-frame-isolation
+  (testing "pins on one frame don't leak into another"
+    (let [s (-> {}
+                (h/pin-path :rf/default [:a])
+                (h/pin-path :rf/other [:b]))]
+      (is (= [[:a]] (get s :rf/default)))
+      (is (= [[:b]] (get s :rf/other))))))
+
+(deftest unpin-path-drops-the-path
+  (let [s0 (-> {} (h/pin-path :rf/default [:a]) (h/pin-path :rf/default [:b]))
+        s1 (h/unpin-path s0 :rf/default [:a])]
+    (is (= [[:b]] (get s1 :rf/default)))))
+
+(deftest unpin-path-noop-on-miss
+  (let [s {:rf/default [[:a]]}]
+    (is (= s (h/unpin-path s :rf/default [:nope]))
+        "removing a missing path returns the store unchanged")))
+
+(deftest reorder-paths-replaces-pin-order
+  (let [s0 (-> {} (h/pin-path :rf/default [:a])
+               (h/pin-path :rf/default [:b])
+               (h/pin-path :rf/default [:c]))
+        s1 (h/reorder-paths s0 :rf/default [[:c] [:a] [:b]])]
+    (is (= [[:c] [:a] [:b]] (get s1 :rf/default))
+        "user-supplied permutation overwrites the previous order")))
+
+(deftest pins-for-frame-defaults-to-empty
+  (is (= [] (h/pins-for-frame {} :rf/default))))
+
+(deftest live-pinned-slices-derefs-against-current-db
+  (testing "live-pinned-slices projects per-pin :path + current :value"
+    (let [store {:rf/default [[:cart :items]
+                              [:user :auth :status]
+                              [:missing :path]]}
+          db    {:cart {:items [{:id 7}]}
+                 :user {:auth {:status :authenticated}}}
+          out   (h/live-pinned-slices store :rf/default db)]
+      (is (= 3 (count out)))
+      (is (= [{:path [:cart :items]         :value [{:id 7}]}
+              {:path [:user :auth :status]  :value :authenticated}
+              {:path [:missing :path]       :value nil}]
+             out)))))
+
+;; ---- (5) 'Show me when this changed' walker -----------------------------
+
+(defn- mk-record
+  "Build a minimal `:rf/epoch-record` for diff-walker tests. The
+  walker reads :epoch-id, :db-before, :db-after, and :trigger-event."
+  [epoch-id event db-before db-after]
+  {:epoch-id      epoch-id
+   :frame         :rf/default
+   :committed-at  0
+   :event-id      (first event)
+   :trigger-event event
+   :db-before     db-before
+   :db-after      db-after
+   :trace-events  []})
+
+(deftest path-touched-true-on-direct-change
+  (is (true?  (h/path-touched? {:a 1} {:a 2} [:a])))
+  (is (false? (h/path-touched? {:a 1} {:a 1} [:a])))
+  (is (true?  (h/path-touched? {:a {:b 1}} {:a {:b 2}} [:a :b]))))
+
+(deftest path-touched-false-on-unchanged-sibling
+  (testing "a change in a sibling subtree must NOT register as a touch
+            of the focused path"
+    (is (false? (h/path-touched? {:a {:b 1} :c 0}
+                                 {:a {:b 1} :c 1}
+                                 [:a :b])))))
+
+(deftest op-at-path-classifies-by-presence
+  (is (= :added    (h/op-at-path {} {:a 1} [:a])))
+  (is (= :removed  (h/op-at-path {:a 1} {} [:a])))
+  (is (= :modified (h/op-at-path {:a 1} {:a 2} [:a])))
+  (is (nil?        (h/op-at-path {:a 1} {:a 1} [:a]))
+      "unchanged path → nil"))
+
+(deftest epochs-touching-path-returns-newest-first
+  (testing "epochs-touching-path filters history to epochs that touched
+            the focused path; result is newest-first.
+
+            Per spec §Changed-paths derivation the walker is pointer-
+            equality-based; we use `assoc-in` / `update-in` here so the
+            unchanged subtree's :cart {:items ...} stays `identical?`
+            across epoch boundaries — same shape a real host runtime
+            produces via reg-event-db handlers."
+    (let [db-0     {}
+          db-1     (assoc-in db-0 [:cart :items] [])
+          db-2     (assoc-in db-1 [:cart :items] [{:id 7}])
+          db-3     (assoc db-2 :user "ada")  ;; :cart stays identical?
+          db-4     (assoc-in db-3 [:cart :items] [])
+          history [(mk-record :e-1 [:app/boot]     db-0 db-1)
+                   (mk-record :e-2 [:cart/add-item] db-1 db-2)
+                   (mk-record :e-3 [:user/login]    db-2 db-3)
+                   (mk-record :e-4 [:cart/clear]    db-3 db-4)]
+          hits    (h/epochs-touching-path history [:cart :items])
+          eids    (mapv :epoch-id hits)]
+      (is (= [:e-4 :e-2 :e-1] eids)
+          "newest first; :e-3 (user/login) preserved :cart's identity, so
+           the pointer-equality walker correctly skips it")
+      (is (= :modified (:op (first hits))))
+      (is (= [:cart/clear] (:event (first hits)))
+          "event vector lifted off :trigger-event"))))
+
+(deftest epochs-touching-path-empty-history
+  (is (= [] (h/epochs-touching-path [] [:anywhere]))))
+
+(deftest epochs-touching-path-no-hits
+  (testing "when no epoch touched the path, returns an empty vector"
+    (let [history [(mk-record :e-1 [:a] {} {:other 1})]]
+      (is (= [] (h/epochs-touching-path history [:never :touched]))))))


### PR DESCRIPTION
## Summary

Phase 5 of the [Causa v1.0 epic (rf2-5aw5v)](https://github.com/day8/re-frame2/issues): the slice-centric **App-DB Diff** panel per `tools/causa/spec/004-App-DB-Diff.md`. Builds on Phase 1 foundation (rf2-n6x4q), Phase 2 event-detail (rf2-op3bz), Phase 3 Time Travel (rf2-t53ze), Phase 4 Causality Graph (rf2-4rqs1).

Real app-dbs run 1–50MB; rendering the whole tree on every dispatch competes for canvas real estate. The panel surfaces:

- **Changed-slice mini-panels** — one per `[op path before after]` triple, colour-coded by op (`:added` green / `:modified` yellow / `:removed` red).
- **Pinned-slices** — paths the user has right-click-pinned, with live values per epoch.
- **`[runtime]` group** — `:rf/machines` / `:rf/route` / `:rf/system-ids` / `:rf/pending-navigation` / `:rf/spawned` segregated so the programmer recognises them as runtime-owned.
- **'Show me when this changed' result list** — walks epoch-history and lists epochs that touched a focused path. Newest-first.
- **Read-only forever (Lock #3)** — Copy value / Copy path / Pin / Show me when this changed; no Edit / Set-to / Inject affordances.

### Pure-data helpers (`.cljc`, JVM-testable)

- `diff-paths` — structural-sharing diff via PersistentHashMap pointer-equality. O(changed paths), not O(db size). Recurses only where pointers differ; identical subtrees short-circuit.
- `partition-reserved` — splits triples whose path roots in a `:rf/*` reserved key from the rest.
- `pin-path` / `unpin-path` / `reorder-paths` / `live-pinned-slices` — per-frame slice-path pin store transitions.
- `epochs-touching-path` — the "Show me when this changed" walker. Returns newest-first hit list.

### Subs (`:rf.causa/*`)

- `:rf.causa/target-frame-db`, `:rf.causa/selected-epoch-record`, `:rf.causa/selected-epoch-diff`
- `:rf.causa/pinned-slices-store`, `:rf.causa/pinned-slices`
- `:rf.causa/focused-slice-path`, `:rf.causa/show-me-when-this-changed-result`
- `:rf.causa/app-db-diff` — composite for the view (matches the Phase 2/3/4 composite pattern)

### Events (`:rf.causa/*`)

- `:rf.causa/pin-slice`, `:rf.causa/unpin-slice`, `:rf.causa/reorder-pinned-slices`
- `:rf.causa/focus-slice-path`, `:rf.causa/clear-slice-focus`
- `:rf.causa/copy-value-to-clipboard`, `:rf.causa/copy-path-to-clipboard` (route through `:rf.causa.fx/copy-to-clipboard`)

### Sidebar / shell wiring

`shell.cljs` lights up the existing `:app-db` slot (`:live? true`, bead `rf2-jps1o`) and routes its canvas to `app-db-diff/app-db-diff-view`. Both edits are wrapped in `;; ── app-db-diff panel begin/end ──` markers so parallel Phase 5+ dispatches can rebase cleanly.

## Test plan

- [x] `npm run test:cljs` — 858 tests / 2215 assertions passing (includes 22 new tests across helpers + view-wiring).
- [x] `clojure -M:test` (Causa JVM target) — 99 tests / 280 assertions passing.
- [x] `npm run test:elision` — all elision sentinels accounted for.
- [x] Diff algorithm covers `:added` / `:modified` / `:removed` plus mixed-op single epochs.
- [x] Structural-sharing short-circuit assertable via `assoc-in`-shaped fixtures (1000-key shared subtree → zero triples beyond the actual change).
- [x] Reserved-keys segregation at both helper and panel-composite levels.
- [x] Pin / unpin / reorder events update `:rf/causa`'s app-db (not the host's); `live-pinned-slices` derefs against the host's current db.
- [x] "Show me when this changed" returns only epochs that touched the focused path; newest-first.
- [x] View renders empty-state when history is empty (pinned slices still surface), slice stack when a diff is present, focus-result panel when a path is focused.