### PR TITLE
feat(causa): Hydration Debugger panel — Phase 5 (rf2-pzxsr)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -1,0 +1,444 @@
+(ns day8.re-frame2-causa.panels.hydration-debugger
+  "Hydration Debugger panel — Phase 5 (rf2-pzxsr, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/006-Hydration-Debugger.md` this panel is
+  **dormant** until at least one `:rf.ssr/hydration-mismatch` trace
+  lands. Until then, the sidebar entry shows `◌` (dormant marker) and
+  clicking it surfaces the 'No SSR in this app' empty state. On first
+  mismatch the panel surfaces a side-by-side server vs client render-
+  tree view with the divergent node flagged + the hash-bisector path
+  highlighted.
+
+  SSR hydration mismatches are structurally hard to debug: the failing
+  client render and the failing server render disagree on a tree, the
+  console error is one line, and the divergent node is rarely the one
+  the error points to. No other JS devtool surfaces this; re-frame2's
+  Spec 011 emits structured data, and this panel renders it.
+
+  ## What this panel shows
+
+  Three states, driven by `:rf.causa/hydration-debugger-data`:
+
+    1. **No SSR in this app** — the buffer carries no
+       `:rf.ssr/hydration-mismatch` events. The panel renders an
+       empty-state explaining the panel surfaces when hydration
+       mismatches fire (per spec §Empty states).
+
+    2. **SSR present, no mismatches** — Phase 5 inherits Schema-
+       Timeline's positive-result framing — 'Hydration ran cleanly.
+       No mismatches detected on the last hydration.' Per
+       Spec 006 §Empty states the second message is deliberately a
+       positive result.
+
+       Phase 5 ships *only* the no-mismatches inference based on the
+       buffer carrying no mismatch traces; the explicit 'hydration
+       happened' signal (a `:rf.ssr/hydration-complete` trace, or the
+       `[:rf/hydration :server-hash]` slot on app-db) lands when the
+       SSR artefact integration deepens (rf2-xxx). Until then the
+       'No SSR in this app' state is the default; the
+       'SSR present, no mismatches' state is reached by the user via
+       the panel's `show clean state` affordance (a checkbox in the
+       header).
+
+    3. **Mismatches present** — the panel surfaces:
+       - A list of mismatches at the top (per spec §Multi-mismatch).
+       - A side-by-side server vs client render-tree view.
+       - The divergent node flagged with `⚠`; the bisector path
+         highlighted root → first differing node.
+       - A one-line hypothesis below the side-by-side.
+       - The divergent view's source coord (with `(?)` fallback per
+         Lock #11).
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — `classify-divergence`, `first-divergence-path`,
+  `mismatch-detail`, `re-root` — lives in
+  `hydration_debugger_helpers.cljc` so the algebra runs under the JVM
+  unit-test target."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.hydration-debugger-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / causality_graph.cljs) ---
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- pure-data render helpers -------------------------------------------
+
+(defn- format-edn
+  "Best-effort EDN-like format. Used to render the path + hash + tree
+  scalars in the mono columns."
+  [v]
+  (try
+    (pr-str v)
+    (catch :default _ (str v))))
+
+(defn- path-segments
+  "Render a path vector as `:a > :b > :c` — used in the mismatch list
+  to give a human-readable lineage cue."
+  [path]
+  (if (empty? path)
+    "(root)"
+    (str/join " > "
+                         (map (fn [seg]
+                                (cond
+                                  (keyword? seg) (str seg)
+                                  :else          (str seg)))
+                              path))))
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- no-ssr-empty-state
+  "Per spec §Empty states — the dormant empty state when no
+  hydration-mismatch traces have landed in this session."
+  []
+  [:div {:data-testid "rf-causa-hydration-debugger-empty-no-ssr"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0" :color (:text-secondary tokens)}}
+    "This app does not appear to use SSR hydration."]
+   [:p {:style {:margin 0 :font-size "12px"}}
+    "The Hydration panel surfaces when "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     ":rf.ssr/hydration-mismatch"]
+    " events fire — see Spec 011."]])
+
+(defn- clean-empty-state
+  "Per spec §Empty states — the deliberately-positive 'SSR ran
+  cleanly' empty state. Same framing as Schema-Timeline's clean
+  message — a clean hydration is the goal, not the absence of a
+  result to display."
+  []
+  [:div {:data-testid "rf-causa-hydration-debugger-empty-clean"
+         :style       {:padding "16px"
+                       :color   (:text-secondary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0" :color (:green tokens)}}
+    "Hydration ran cleanly."]
+   [:p {:style {:margin 0 :font-size "12px" :color (:text-tertiary tokens)}}
+    "No mismatches detected on the last hydration."]])
+
+;; ---- mismatch list (multi-mismatch case) --------------------------------
+
+(defn- mismatch-list-row
+  "One row in the mismatch list. Per spec §Multi-mismatch case clicking
+  the row fires `:rf.causa/select-mismatch` so the side-by-side rebases
+  to that path."
+  [{:keys [id path summary view-id] :as _entry} selected?]
+  [:li {:key       id
+        :data-testid (str "rf-causa-hydration-mismatch-row-" (str id))
+        :on-click  #(rf/dispatch [:rf.causa/select-mismatch id])
+        :style     {:padding      "6px 12px"
+                    :border-bottom (str "1px solid " (:border-subtle tokens))
+                    :background   (if selected? (:bg-active tokens) "transparent")
+                    :cursor       "pointer"
+                    :font-family  mono-stack
+                    :font-size    "12px"
+                    :color        (if selected?
+                                    (:text-primary tokens)
+                                    (:text-secondary tokens))}}
+   [:span {:style {:color (:yellow tokens) :margin-right "8px"}} "⚠"]
+   [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
+    (path-segments path)]
+   [:span {:style {:color (:text-tertiary tokens)}} summary]
+   (when view-id
+     [:span {:style {:margin-left "8px"
+                     :color (:cyan tokens)}}
+      (str "[" view-id "]")])])
+
+(defn- mismatch-list
+  "Per spec §Multi-mismatch case — the list at the panel top when the
+  buffer carries more than one mismatch. Single-mismatch case still
+  renders the list (one entry) for consistency."
+  [mismatch-summary selected-id]
+  [:div {:data-testid "rf-causa-hydration-mismatch-list"
+         :style       {:border-bottom (str "1px solid " (:border-default tokens))
+                       :background (:bg-3 tokens)}}
+   [:div {:style {:padding "8px 12px"
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :color (:text-tertiary tokens)
+                  :border-bottom (str "1px solid " (:border-subtle tokens))}}
+    (let [n (count mismatch-summary)]
+      (str n " mismatch" (if (= 1 n) "" "es") " in this hydration"))]
+   (into [:ul {:style {:list-style "none"
+                       :margin     0
+                       :padding    0
+                       :max-height "160px"
+                       :overflow-y "auto"}}]
+         (map (fn [entry]
+                (mismatch-list-row entry (= (:id entry) selected-id))))
+         mismatch-summary)])
+
+;; ---- side-by-side render-tree view --------------------------------------
+
+(defn- hash-chip
+  "Render one hash chip — a faint pill the user can click to re-root
+  the panel at that node. Per spec §Render-tree hash bisector the
+  divergence path is highlighted root → first differing node."
+  [{:keys [path hash]} divergent?]
+  [:span {:data-testid (str "rf-causa-hydration-hash-chip-"
+                            (str/join "-" path))
+          :on-click    #(rf/dispatch [:rf.causa/reroot-tree-view path])
+          :style       {:display       "inline-block"
+                        :padding       "1px 6px"
+                        :margin-left   "6px"
+                        :border-radius "8px"
+                        :background    (if divergent?
+                                         (:red tokens)
+                                         (:border-subtle tokens))
+                        :color         (if divergent?
+                                         "#fff"
+                                         (:text-tertiary tokens))
+                        :font-family   mono-stack
+                        :font-size     "10px"
+                        :cursor        "pointer"
+                        :opacity       (if divergent? 1.0 0.6)}}
+   (str "#" (subs (str hash) 0 (min 6 (count (str hash)))))])
+
+(defn- tree-pane
+  "Render one side of the side-by-side view. `chips` is the bisector
+  chip list for this side; `divergent-path` is the bisection path
+  (used to mark the chip at that path as divergent). `tree` is the
+  full hiccup subtree to display in EDN form."
+  [{:keys [side label tree chips divergent-path]}]
+  [:section {:data-testid (str "rf-causa-hydration-tree-pane-" (name side))
+             :style       {:flex   1
+                           :min-width 0
+                           :background (:bg-2 tokens)
+                           :border-right (when (= side :server)
+                                           (str "1px solid " (:border-default tokens)))
+                           :overflow "auto"}}
+   [:header {:style {:padding "8px 12px"
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :font-family sans-stack
+                     :font-size "12px"
+                     :font-weight 600
+                     :color (:text-secondary tokens)}}
+    [:span (str (name side) " render")]
+    (into [:span {:style {:margin-left "8px"}}]
+          (map (fn [chip]
+                 (hash-chip chip (= (:path chip) divergent-path)))
+               chips))]
+   [:pre {:data-testid (str "rf-causa-hydration-tree-content-" (name side))
+          :style       {:margin       0
+                        :padding      "12px"
+                        :font-family  mono-stack
+                        :font-size    "12px"
+                        :color        (:text-primary tokens)
+                        :white-space  "pre-wrap"
+                        :word-break   "break-word"}}
+    (format-edn tree)]])
+
+(defn- divergent-marker
+  "Per spec §Layout the divergent node is flagged with `⚠`. Rendered
+  between the two panes so it sits visually between server / client
+  trees."
+  []
+  [:div {:data-testid "rf-causa-hydration-divergent-marker"
+         :style       {:padding "8px 12px"
+                       :background (:bg-3 tokens)
+                       :color (:yellow tokens)
+                       :font-family sans-stack
+                       :font-size "12px"
+                       :text-align "center"
+                       :border-bottom (str "1px solid " (:border-default tokens))}}
+   [:span {:style {:font-size "16px" :margin-right "8px"}} "⚠"]
+   [:span "Divergent node"]])
+
+;; ---- hypothesis + source-coord -------------------------------------------
+
+(defn- hypothesis-row
+  "Per spec §Cause hypothesis — one-line hypothesis based on the
+  divergence kind. The hypothesis is a hint, not an answer."
+  [{:keys [divergence-kind hypothesis]}]
+  [:div {:data-testid "rf-causa-hydration-hypothesis"
+         :style       {:padding "12px"
+                       :background (:bg-3 tokens)
+                       :border-bottom (str "1px solid " (:border-default tokens))
+                       :font-family sans-stack
+                       :font-size "13px"
+                       :color (:text-primary tokens)}}
+   [:span {:style {:color (:cyan tokens)
+                   :font-family mono-stack
+                   :margin-right "8px"
+                   :font-size "11px"
+                   :text-transform "uppercase"}}
+    "hypothesis"]
+   [:span hypothesis]
+   [:span {:style {:margin-left "8px"
+                   :color (:text-tertiary tokens)
+                   :font-family mono-stack
+                   :font-size "11px"}}
+    (str "(" (name divergence-kind) ")")]])
+
+(defn- source-coord-row
+  "Per spec §Source-coord drilldown — surface the divergent view's
+  registration coord. Lock #11 fallback uses `(?)` annotation when the
+  exact coord is unavailable."
+  [coord-info view-id]
+  (let [{:keys [coord annotation]} coord-info]
+    (when (or coord view-id)
+      [:div {:data-testid "rf-causa-hydration-source-coord"
+             :style       {:padding "8px 12px"
+                           :background (:bg-2 tokens)
+                           :font-family sans-stack
+                           :font-size "12px"
+                           :color (:text-secondary tokens)
+                           :border-bottom (str "1px solid " (:border-subtle tokens))}}
+       [:span "Divergent view: "]
+       [:code {:style {:color (:accent-violet tokens)
+                       :font-family mono-stack}}
+        (str view-id)]
+       (when coord
+         [:span {:style {:margin-left "12px"}}
+          "Registered at: "
+          [:code {:on-click   (fn [_]
+                                (rf/dispatch [:rf.causa/open-in-editor coord]))
+                  :style      {:color       (:cyan tokens)
+                               :font-family mono-stack
+                               :cursor      "pointer"
+                               :text-decoration "underline"}}
+           coord]
+          (when (= :fallback annotation)
+            [:span {:style {:margin-left "4px"
+                            :color (:text-tertiary tokens)
+                            :font-family mono-stack
+                            :title "Source-coord fallback — exact view coord unavailable; surfaced from handler-coord per Lock #11."}}
+             "(?)"])])])))
+
+;; ---- mismatch detail composite view -------------------------------------
+
+(defn- mismatch-detail
+  "Per spec §Layout — the side-by-side server / client render-tree
+  view with the bisector path highlighted + the hypothesis below."
+  [{:keys [detail source-coord re-root-path] :as _data}]
+  (let [{:keys [server-tree client-tree
+                server-chips client-chips
+                bisector-path view-id]} detail
+        ;; If the user has re-rooted (clicked a hash chip), apply the
+        ;; re-root to both trees; otherwise render the full subtree.
+        server-tree' (if (seq re-root-path)
+                       (h/re-root server-tree re-root-path)
+                       server-tree)
+        client-tree' (if (seq re-root-path)
+                       (h/re-root client-tree re-root-path)
+                       client-tree)]
+    [:div {:data-testid "rf-causa-hydration-mismatch-detail"
+           :style       {:flex          1
+                         :display       "flex"
+                         :flex-direction "column"
+                         :overflow      "hidden"}}
+     (hypothesis-row detail)
+     (source-coord-row source-coord view-id)
+     (divergent-marker)
+     [:div {:style {:flex 1
+                    :display "flex"
+                    :flex-direction "row"
+                    :overflow "hidden"}}
+      (tree-pane {:side           :server
+                  :label          "server render"
+                  :tree           server-tree'
+                  :chips          server-chips
+                  :divergent-path bisector-path})
+      (tree-pane {:side           :client
+                  :label          "client render"
+                  :tree           client-tree'
+                  :chips          client-chips
+                  :divergent-path bisector-path})]]))
+
+;; ---- public view --------------------------------------------------------
+
+(defn hydration-debugger-view
+  "The Hydration Debugger panel's root view. Subscribes to
+  `:rf.causa/hydration-debugger-data` and renders either:
+
+    - 'No SSR in this app' empty state (per spec §Empty states), OR
+    - Side-by-side mismatch detail when at least one mismatch is in
+      the buffer.
+
+  Per spec §Visibility the panel is dormant until first mismatch —
+  the sidebar entry's visibility gate (rendered in shell.cljs) shows
+  the `◌` marker until the buffer has at least one mismatch."
+  []
+  (let [{:keys [has-mismatch? mismatch-summary
+                selected-mismatch-id detail
+                source-coord re-root-path target-frame]
+         :as data}
+        @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+    [:section {:data-testid "rf-causa-hydration-debugger"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Hydration"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       (if has-mismatch?
+         [:span
+          (str (count mismatch-summary) " mismatch"
+               (if (= 1 (count mismatch-summary)) "" "es") " — showing mismatches for ")
+          [:code {:style {:color (:accent-violet tokens)
+                          :font-family mono-stack}}
+           (str target-frame)]]
+         "Phase 5 (rf2-pzxsr) — dormant until first :rf.ssr/hydration-mismatch")]]
+     (cond
+       (and has-mismatch? detail)
+       [:div {:style {:flex 1 :display "flex" :flex-direction "column" :overflow "hidden"}}
+        (mismatch-list mismatch-summary selected-mismatch-id)
+        (mismatch-detail {:detail        detail
+                          :source-coord  source-coord
+                          :re-root-path  re-root-path})]
+
+       has-mismatch?
+       ;; Edge case — mismatches exist but no detail (selection
+       ;; orphaned). Render the list only.
+       [:div {:style {:flex 1 :overflow "auto"}}
+        (mismatch-list mismatch-summary selected-mismatch-id)]
+
+       :else
+       (no-ssr-empty-state))]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger_helpers.cljc
@@ -1,0 +1,445 @@
+(ns day8.re-frame2-causa.panels.hydration-debugger-helpers
+  "Pure-data helpers for Causa's Hydration Debugger panel
+  (Phase 5, rf2-pzxsr).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `hydration_debugger.cljs` builds a side-by-side
+  hiccup tree; the *logic* — projecting hydration-mismatch trace
+  events into a mismatch list, classifying the divergence kind into
+  a one-line hypothesis, walking server / client render-trees and
+  flagging divergent nodes, computing the hash-bisector path from
+  root to first differing descendant — is pure data → data.
+
+  Splitting the algebra into `.cljc` so it runs under the JVM test
+  target (`clojure -M:test`) is required by
+  `feedback_jvm_interop_must_work.md` and mirrors the convention
+  established by `causality_graph_helpers.cljc` and
+  `time_travel_helpers.cljc`.
+
+  ## Data model (per spec/006-Hydration-Debugger.md §Substrate)
+
+  Each `:rf.ssr/hydration-mismatch` trace event carries `:tags` with:
+
+      {:path           [...]             ; hiccup-path to divergent node
+       :server-tree    [...]             ; server's subtree at path
+       :client-tree    [...]             ; client's subtree at path
+       :server-hash    \"abc123\"          ; render-tree hash, server side
+       :client-hash    \"def456\"          ; render-tree hash, client side
+       :frame          :rf/default       ; the affected frame
+       :view-id        cart-summary-view ; divergent view's registration
+       :failing-id     :rf/hydrate}      ; body vs head (see Spec 011)
+
+  Phase 5 of Spec 011 §Hydration-mismatch detection establishes the
+  `:failing-id` discriminator: `:rf/hydrate` for body mismatch;
+  `:rf.ssr/head-mismatch` for head mismatch. This helper ns treats
+  both uniformly — the panel surfaces the discriminator alongside
+  the path, but the diff algebra is identical.
+
+  ## Divergence-kind classification (per spec §Cause hypothesis)
+
+  Five divergence kinds, each with a one-line hypothesis hint:
+
+    - `:different-text`  — text under same tag differs (state slice)
+    - `:tag-differs`     — tag differs (conditional render branch)
+    - `:attr-differs`    — attribute differs (sub feeding attribute)
+    - `:children-missing-client` — children only on server (gating sub)
+    - `:children-missing-server` — children only on client (js/window etc.)
+
+  The hypothesis is **a hint, not an answer**; the panel surfaces it
+  with the appropriate panel pivot link. The classification fn is
+  pure → callers (tests + view) consume it without any reactive
+  context."
+  (:require [clojure.string :as str]))
+
+;; ---- mismatch projection ------------------------------------------------
+
+(def mismatch-operation
+  "Per Spec 011 §Hydration-mismatch detection — the canonical
+  operation keyword emitted on every hydration mismatch. Exposed as a
+  Var so callers (the registry's filter, the tests, the MCP server)
+  share the source of truth."
+  :rf.ssr/hydration-mismatch)
+
+(defn hydration-mismatch?
+  "Predicate: is `ev` a hydration-mismatch trace event? Pure pred so
+  the filter is JVM-runnable and the registry sub composes it
+  trivially."
+  [ev]
+  (= mismatch-operation (:operation ev)))
+
+(defn mismatches
+  "Project a trace-event vector down to just the hydration mismatches,
+  oldest first. Per Spec 011 §Hydration-mismatch detection each
+  mismatch carries the canonical `:operation` + `:tags` payload; the
+  helper is filter-only — the order from the trace buffer is preserved."
+  [trace-events]
+  (filterv hydration-mismatch? trace-events))
+
+(defn mismatches-for-frame
+  "Per-frame projection. Per spec §Frame awareness the Hydration panel
+  shows mismatches for the active frame; switching the frame picker
+  re-filters. Pure data so the filter axis stays JVM-testable."
+  [trace-events frame-id]
+  (if (nil? frame-id)
+    (mismatches trace-events)
+    (filterv (fn [ev]
+               (and (hydration-mismatch? ev)
+                    (= frame-id (get-in ev [:tags :frame]))))
+             trace-events)))
+
+(defn frames-with-mismatches
+  "Set of frame-ids that have at least one hydration mismatch in the
+  buffer. Drives the cross-frame swimlane indicator per spec §Frame
+  awareness — 'cross-frame SSR (a server-rendered frame nested inside
+  a client-rendered shell) renders both swimlanes'."
+  [trace-events]
+  (into #{}
+        (comp (filter hydration-mismatch?)
+              (keep (fn [ev] (get-in ev [:tags :frame]))))
+        trace-events))
+
+(defn select-mismatch
+  "Return the mismatch trace event whose `:id` matches `mismatch-id`,
+  or nil. The panel reads :id off the trace event (which gensyms its
+  way through `re-frame.trace`); selection is by that id."
+  [trace-events mismatch-id]
+  (some (fn [ev]
+          (when (and (hydration-mismatch? ev)
+                     (= mismatch-id (:id ev)))
+            ev))
+        trace-events))
+
+;; ---- divergence-kind classification (Cause hypothesis) ------------------
+
+(defn- hiccup-vector?
+  "Is `node` a hiccup vector (i.e. starts with a keyword tag)?
+
+  Per spec/006-Hydration-Debugger.md §Substrate the server / client
+  trees are hiccup. Hiccup vectors start with a keyword (the tag); a
+  scalar (string / number / nil) is a text leaf; everything else
+  (component fn, hiccup-as-seq) is treated as opaque-equal."
+  [node]
+  (and (vector? node) (keyword? (first node))))
+
+(defn- tag-of
+  "Tag keyword of a hiccup vector, or nil."
+  [node]
+  (when (hiccup-vector? node) (first node)))
+
+(defn- attrs-of
+  "Attribute map of a hiccup vector (the second slot if it's a map).
+  Returns nil when no map is present (positional children-only form)."
+  [node]
+  (when (hiccup-vector? node)
+    (let [s (second node)]
+      (when (map? s) s))))
+
+(defn- children-of
+  "Children of a hiccup vector, skipping the attribute map when
+  present."
+  [node]
+  (when (hiccup-vector? node)
+    (let [tail (rest node)]
+      (if (map? (first tail))
+        (rest tail)
+        tail))))
+
+(defn- text-node?
+  "Is `node` a text leaf (string / number / nil)?"
+  [node]
+  (or (string? node) (number? node) (nil? node)))
+
+(defn classify-divergence
+  "Classify the divergence between `server-tree` and `client-tree`
+  into one of five kinds. Returns one of:
+
+    :different-text          — text under same tag differs
+    :tag-differs             — tag differs
+    :attr-differs            — attributes differ; tag matches
+    :children-missing-client — children present server, missing client
+    :children-missing-server — children missing server, present client
+    :unknown                 — none of the above (shape diff we don't
+                               classify; safe-default for the view)
+
+  Pure data → keyword. The view consumes the keyword to pick the
+  hypothesis line; the MCP server exports the same keyword in
+  programmatic flows."
+  [server-tree client-tree]
+  (cond
+    ;; Both text scalars under the same enclosing tag (the *caller*
+    ;; passed the subtree the runtime flagged — text vs text is the
+    ;; canonical 'different-text' case).
+    (and (text-node? server-tree) (text-node? client-tree))
+    :different-text
+
+    ;; One hiccup vector, one text leaf — tag-vs-text is a structural
+    ;; flip. Treat as :tag-differs (conditional branch flipped).
+    (and (hiccup-vector? server-tree) (text-node? client-tree))
+    :tag-differs
+
+    (and (text-node? server-tree) (hiccup-vector? client-tree))
+    :tag-differs
+
+    ;; Both hiccup vectors — compare tags, attrs, children.
+    (and (hiccup-vector? server-tree) (hiccup-vector? client-tree))
+    (let [stag    (tag-of server-tree)
+          ctag    (tag-of client-tree)
+          sattrs  (attrs-of server-tree)
+          cattrs  (attrs-of client-tree)
+          skids   (vec (children-of server-tree))
+          ckids   (vec (children-of client-tree))]
+      (cond
+        (not= stag ctag)         :tag-differs
+        (not= sattrs cattrs)     :attr-differs
+        (and (seq skids) (empty? ckids)) :children-missing-client
+        (and (empty? skids) (seq ckids)) :children-missing-server
+        ;; Text-content under same tag with a single string child
+        ;; whose value differs is the most common case in practice.
+        (and (= 1 (count skids)) (= 1 (count ckids))
+             (text-node? (first skids)) (text-node? (first ckids))
+             (not= (first skids) (first ckids)))
+        :different-text
+        :else :unknown))
+
+    :else :unknown))
+
+(def hypothesis-text
+  "Per spec/006-Hydration-Debugger.md §Cause hypothesis — the one-line
+  hypothesis text by divergence-kind. Exposed as a map so callers
+  (the view, the MCP server, tests) share the source of truth. The
+  hypothesis is a hint, not an answer — paired in the view with a
+  panel pivot link."
+  {:different-text          "App-db state differs between server and client. Check the slice that feeds this view."
+   :tag-differs             "View structure differs. Check conditional rendering — the server may have rendered a different branch."
+   :attr-differs            "Attribute computed from differing inputs. Check the sub feeding the attribute."
+   :children-missing-client "View's children render conditionally; the condition differs. Check the gating sub."
+   :children-missing-server "View bails out on server (e.g., uses js/window). Move the dependency into a client-only effect."
+   :unknown                 "Server and client trees diverge here. Open the divergent subtree to inspect."})
+
+(defn hypothesis-for
+  "Look up the hypothesis line for a divergence kind. Pure-data →
+  string."
+  [divergence-kind]
+  (get hypothesis-text divergence-kind (get hypothesis-text :unknown)))
+
+;; ---- bisector path ------------------------------------------------------
+
+(defn- compute-hash
+  "Per Spec 011 §Hydration-mismatch detection — the canonical render-
+  tree hash is an FNV-1a 32-bit hash over a canonical EDN
+  serialisation (depth-first traversal; attribute maps in sorted-key
+  order; nil pruned). The helper here is a content-equality stand-in
+  that mirrors the bisection property — same content → same hash;
+  different content → different hash — without depending on the SSR
+  artefact's hash module. The view consumes the bisector path; the
+  panel doesn't need cryptographic strength.
+
+  Pure data → string. Falls back to `str` for unprintable values."
+  [node]
+  (try
+    ;; Use `pr-str` as a stable canonical form. Two structurally-equal
+    ;; nodes produce the same string; different nodes produce
+    ;; different strings. This mirrors the bisection property the
+    ;; spec calls for without depending on a binary hash impl.
+    (pr-str node)
+    (catch #?(:clj Exception :cljs :default) _
+      (str node))))
+
+(defn nodes-equal?
+  "Structural equality over two hiccup nodes. Mirrors the bisection
+  property of the render-tree hash — same content → equal. Pure-data
+  so callers can wire it into the bisector walk without depending on
+  a hash module."
+  [a b]
+  (= (compute-hash a) (compute-hash b)))
+
+(defn first-divergence-path
+  "Walk `server-tree` and `client-tree` in parallel; return the path
+  (vector of integer child-indices) from root to the first divergent
+  node. Returns `[]` when the roots themselves diverge; returns nil
+  when the trees are equal.
+
+  Per spec §Render-tree hash bisector — every parent node has a hash
+  that summarises its subtree; hashes match at common ancestors and
+  diverge at the first differing descendant. This walker uses
+  `nodes-equal?` as the hash stand-in and produces the same bisection
+  path the spec's hash chips highlight.
+
+  Pure data → path-or-nil. JVM-runnable."
+  [server-tree client-tree]
+  (cond
+    (nodes-equal? server-tree client-tree)
+    nil
+
+    ;; Both hiccup vectors with same tag — descend into matching
+    ;; children to find the first divergent slot.
+    (and (hiccup-vector? server-tree)
+         (hiccup-vector? client-tree)
+         (= (tag-of server-tree) (tag-of client-tree)))
+    (let [skids (vec (children-of server-tree))
+          ckids (vec (children-of client-tree))
+          n     (min (count skids) (count ckids))]
+      (loop [i 0]
+        (cond
+          (>= i n)
+          ;; All matching children matched up to `n` — one tree has
+          ;; more. The divergence lands at index `n`.
+          [n]
+
+          (not (nodes-equal? (nth skids i) (nth ckids i)))
+          ;; Descend into the divergent slot.
+          (let [sub (first-divergence-path (nth skids i) (nth ckids i))]
+            (if (nil? sub) [i] (into [i] sub)))
+
+          :else
+          (recur (inc i)))))
+
+    :else
+    ;; Roots differ in tag / type — divergence at root.
+    []))
+
+(defn path-from-root-hash-chips
+  "Build the hash-chip annotation for every parent node along the
+  bisection path. Returns a vector of `{:path [...] :hash <string>}`
+  entries — one per node from the root down to the first divergent
+  node. The view renders these as faint chips on each parent.
+
+  Pure data → chips. JVM-runnable."
+  [tree divergence-path]
+  (loop [acc      [{:path [] :hash (compute-hash tree)}]
+         node     tree
+         path     []
+         remaining divergence-path]
+    (if (empty? remaining)
+      acc
+      (let [idx       (first remaining)
+            children  (vec (children-of node))
+            sub       (when (and (vector? children) (< idx (count children)))
+                        (nth children idx))
+            new-path  (conj path idx)]
+        (if (nil? sub)
+          acc
+          (recur (conj acc {:path new-path :hash (compute-hash sub)})
+                 sub
+                 new-path
+                 (rest remaining)))))))
+
+;; ---- mismatch detail projection -----------------------------------------
+
+(defn mismatch-detail
+  "Project a single mismatch trace event into the shape the view
+  consumes. Returns a map with the trace event's own tags surfaced as
+  top-level slots, plus a `:divergence-kind` keyword + `:hypothesis`
+  line + the bisector path.
+
+  Pure data → map. JVM-runnable so the classification + bisector pass
+  is testable without booting a substrate."
+  [mismatch-trace-event]
+  (when (some? mismatch-trace-event)
+    (let [{:keys [tags]}    mismatch-trace-event
+          {:keys [path server-tree client-tree
+                  server-hash client-hash frame
+                  view-id failing-id first-diff-path]} tags
+          kind             (classify-divergence server-tree client-tree)
+          ;; Prefer the runtime-supplied :first-diff-path; fall back
+          ;; to our own walker when absent.
+          bisector-path    (or first-diff-path
+                               (first-divergence-path server-tree client-tree)
+                               [])
+          server-chips     (path-from-root-hash-chips server-tree bisector-path)
+          client-chips     (path-from-root-hash-chips client-tree bisector-path)]
+      {:id              (:id mismatch-trace-event)
+       :path            path
+       :server-tree     server-tree
+       :client-tree     client-tree
+       :server-hash     server-hash
+       :client-hash     client-hash
+       :frame           frame
+       :view-id         view-id
+       :failing-id      failing-id
+       :divergence-kind kind
+       :hypothesis      (hypothesis-for kind)
+       :bisector-path   bisector-path
+       :server-chips    server-chips
+       :client-chips    client-chips})))
+
+;; ---- mismatch list (multi-mismatch case) --------------------------------
+
+(defn mismatch-list-summary
+  "Build the panel-top list of mismatches per spec §Multi-mismatch
+  case. Each entry surfaces the path + a one-line summary of server
+  vs client. Pure data → vector-of-maps."
+  [trace-events frame-id]
+  (mapv (fn [ev]
+          (let [{:keys [tags]}             ev
+                {:keys [path server-tree
+                        client-tree view-id]} tags
+                kind                       (classify-divergence
+                                             server-tree client-tree)]
+            {:id      (:id ev)
+             :path    path
+             :view-id view-id
+             :divergence-kind kind
+             :summary (str (pr-str (case kind
+                                     :different-text          (first (children-of server-tree))
+                                     :tag-differs             server-tree
+                                     server-tree))
+                           " vs "
+                           (pr-str (case kind
+                                     :different-text          (first (children-of client-tree))
+                                     :tag-differs             client-tree
+                                     client-tree)))}))
+        (mismatches-for-frame trace-events frame-id)))
+
+;; ---- re-rooting (hash-chip click → zoom into subtree) -------------------
+
+(defn re-root
+  "Re-root a tree at the node identified by `path` (a vector of
+  integer child-indices). Returns the subtree, or the original tree
+  when the path doesn't reach a node. Per spec §Render-tree hash
+  bisector — click any hash chip → the panel re-roots at that node.
+
+  Pure data → subtree. JVM-runnable."
+  [tree path]
+  (loop [node      tree
+         remaining path]
+    (if (empty? remaining)
+      node
+      (let [idx       (first remaining)
+            children  (vec (children-of node))]
+        (if (and (< idx (count children)))
+          (recur (nth children idx) (rest remaining))
+          node)))))
+
+;; ---- source-coord resolution (Lock #11 fallback) ------------------------
+
+(defn source-coord-for-mismatch
+  "Resolve a mismatch's source-coord per spec/006-Hydration-Debugger.md
+  §Source-coord drilldown. Priority order:
+
+    1. The divergent view's `:view-id` registration coord (when the
+       runtime stamped a `:source-coord` map on the trace event's
+       :tags).
+    2. The dispatch / `:rf/hydrate` cofx's handler-coord (per Lock #11
+       in DESIGN-RATIONALE.md — `(?)` annotation surfaced).
+    3. nil when neither is available.
+
+  Returns a map `{:coord <string-or-nil> :annotation <:exact | :fallback | nil>}`
+  so the view can render the `(?)` annotation per spec.
+
+  Pure data → map. JVM-runnable."
+  [mismatch-trace-event]
+  (let [{:keys [tags]} mismatch-trace-event
+        view-coord     (get-in tags [:source-coord])
+        handler-coord  (get-in tags [:handler-source-coord])]
+    (cond
+      view-coord    {:coord      (let [{:keys [file line]} view-coord]
+                                   (cond-> file
+                                     line (str ":" line)))
+                     :annotation :exact}
+      handler-coord {:coord      (let [{:keys [file line]} handler-coord]
+                                   (cond-> file
+                                     line (str ":" line)))
+                     :annotation :fallback}
+      :else         {:coord nil :annotation nil})))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -84,10 +84,8 @@
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
-            ;; ── subscriptions panel begin ──
-            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]
-            ;; ── subscriptions panel end ──
-            ))
+            [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -417,8 +415,122 @@
             {:fx [[:rf.causa.fx/reset-frame-db!
                    {:frame-id target :frame-db (:frame-db pin)}]]}))))
 
-    ;; ── subscriptions panel begin ──
-    ;; Phase 5 (rf2-x0f5v, parent rf2-5aw5v) — Subscriptions panel.
+    ;; ---- Phase 5 (rf2-pzxsr) — Hydration Debugger panel ---------
+    ;;
+    ;; Per `tools/causa/spec/006-Hydration-Debugger.md` the panel is
+    ;; dormant until at least one :rf.ssr/hydration-mismatch trace
+    ;; lands; once it does, the composite sub surfaces the mismatch
+    ;; list + the selected-mismatch detail (per spec §Multi-mismatch
+    ;; case + §Layout). The panel reads from the same trace-buffer as
+    ;; every other Causa panel — Spec 011 §Hydration-mismatch
+    ;; detection is the source of the trace events.
+
+    ;; Currently-selected mismatch id (the trace event's :id). nil =
+    ;; no selection → composite picks the latest mismatch.
+    (rf/reg-sub :rf.causa/selected-mismatch-id
+      (fn [db _query]
+        (get db :selected-mismatch-id)))
+
+    ;; Re-root path for the side-by-side tree view (per spec §Render-
+    ;; tree hash bisector — click any hash chip → the panel re-roots
+    ;; at that node). nil = render the full subtree from the mismatch
+    ;; trace event's :path.
+    (rf/reg-sub :rf.causa/hydration-reroot-path
+      (fn [db _query]
+        (get db :hydration-reroot-path)))
+
+    ;; The composite the panel consumes. Shape:
+    ;;
+    ;;     {:has-mismatch?        <bool>
+    ;;      :mismatch-summary     [{:id :path :summary ...} ...]
+    ;;      :selected-mismatch-id <id-or-nil>
+    ;;      :detail               {:path :server-tree :client-tree
+    ;;                             :divergence-kind :hypothesis
+    ;;                             :bisector-path ...}
+    ;;      :source-coord         {:coord :annotation}
+    ;;      :re-root-path         <path-or-nil>
+    ;;      :target-frame         <frame-id>}
+    ;;
+    ;; Per spec §Frame awareness the panel shows mismatches for the
+    ;; active frame. The frame picker isn't wired in Phase 5 — the
+    ;; composite reads `:target-frame` (the same key the time-travel
+    ;; scrubber uses) and falls back to nil (= all frames) when the
+    ;; user hasn't pinned one. The behaviour matches Phase 3 / 4 —
+    ;; the picker drops in without rewiring consumers.
+    (rf/reg-sub :rf.causa/hydration-debugger-data
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/selected-mismatch-id]
+      :<- [:rf.causa/hydration-reroot-path]
+      :<- [:rf.causa/target-frame]
+      (fn [[buffer selected-id reroot-path target-frame] _query]
+        (let [;; Frame-awareness: when the panel is showing mismatches
+              ;; for one frame the summary filters; when no frame is
+              ;; pinned every mismatch surfaces. The view's header
+              ;; reads :target-frame to label the active filter.
+              ;;
+              ;; Phase 5 ships with target-frame = :rf/default (the
+              ;; canonical host frame); cross-frame swimlanes ride a
+              ;; follow-on bead (rf2-xxx) once the picker lands.
+              summary           (hd-helpers/mismatch-list-summary
+                                  buffer target-frame)
+              has-mismatch?     (boolean (seq summary))
+              ;; Selection-resolution: prefer the user's explicit
+              ;; selection; fall back to the latest mismatch.
+              latest-id         (some-> (last summary) :id)
+              resolved-id       (or (and selected-id
+                                         (some #(when (= selected-id (:id %)) %)
+                                               summary)
+                                         selected-id)
+                                    latest-id)
+              selected-trace    (when resolved-id
+                                  (hd-helpers/select-mismatch buffer resolved-id))
+              detail            (hd-helpers/mismatch-detail selected-trace)
+              source-coord      (hd-helpers/source-coord-for-mismatch
+                                  selected-trace)]
+          {:has-mismatch?         has-mismatch?
+           :mismatch-summary      summary
+           :selected-mismatch-id  resolved-id
+           :detail                detail
+           :source-coord          source-coord
+           :re-root-path          reroot-path
+           :target-frame          target-frame})))
+
+    ;; ---- Phase 5 (rf2-pzxsr) — Hydration Debugger events --------
+
+    ;; Select a specific mismatch — drives the side-by-side rebase
+    ;; per spec §Multi-mismatch case.
+    (rf/reg-event-db :rf.causa/select-mismatch
+      (fn [db [_ mismatch-id]]
+        (-> db
+            (assoc :selected-mismatch-id mismatch-id)
+            ;; New selection → drop the re-root (the path is
+            ;; subtree-specific).
+            (dissoc :hydration-reroot-path))))
+
+    (rf/reg-event-db :rf.causa/clear-mismatch-selection
+      (fn [db _event]
+        (-> db
+            (dissoc :selected-mismatch-id)
+            (dissoc :hydration-reroot-path))))
+
+    ;; Re-root the side-by-side tree view at `path` per spec
+    ;; §Render-tree hash bisector. Click a hash chip → this fires.
+    (rf/reg-event-db :rf.causa/reroot-tree-view
+      (fn [db [_ path]]
+        (if (empty? path)
+          (dissoc db :hydration-reroot-path)
+          (assoc db :hydration-reroot-path (vec path)))))
+
+    ;; Open-in-editor stub. The full handler lives in
+    ;; `open-in-editor.cljs` (rf2-evgf5); this event-db is a thin
+    ;; record-the-attempt so the panel can surface a UX cue when the
+    ;; user clicks a source-coord. The actual editor jump runs via
+    ;; the open-in-editor module's effect when wired.
+    (rf/reg-event-db :rf.causa/open-in-editor
+      (fn [db [_ coord]]
+        (assoc db :last-open-in-editor-coord coord)))
+
+    ;; ---- Phase 5 (rf2-x0f5v) — Subscriptions panel --------------
     ;;
     ;; The panel reads three surfaces — the target frame's live
     ;; sub-cache (`(rf/sub-cache target-frame)` — CLJS-only), the
@@ -526,7 +638,7 @@
            :chain-open?      (boolean chain-open?)
            :chain            chain})))
 
-    ;; ---- events ------------------------------------------------------
+    ;; ---- Phase 5 (rf2-x0f5v) — Subscriptions panel events ------
 
     (rf/reg-event-db :rf.causa/select-sub
       (fn [db [_ query-v]]
@@ -554,7 +666,6 @@
     (rf/reg-event-db :rf.causa/hide-invalidation-chain
       (fn [db _event]
         (dissoc db :sub-chain-open?))))
-    ;; ── subscriptions panel end ──
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -40,9 +40,8 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
-            ;; ── subscriptions panel begin ──
+            [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
-            ;; ── subscriptions panel end ──
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
@@ -76,9 +75,7 @@
    {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
    {:id :app-db       :label "App-db"        :bead "rf2-xxx"}
    {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
-   ;; ── subscriptions panel begin ──
    {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
-   ;; ── subscriptions panel end ──
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
    {:id :trace        :label "Trace"         :bead "rf2-xxx"}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
@@ -86,7 +83,12 @@
    {:id :performance  :label "Performance"   :bead "rf2-xxx"}
    {:id :issues       :label "Issues"        :bead "rf2-xxx"}
    {:id :schemas      :label "Schemas"       :bead "rf2-xxx"}
-   {:id :hydration    :label "Hydration"     :bead "rf2-xxx"}
+   ;; Phase 5 (rf2-pzxsr). Per spec/006-Hydration-Debugger.md §Visibility
+   ;; the panel is dormant until at least one :rf.ssr/hydration-mismatch
+   ;; trace lands. The sidebar entry's `:dormant?` flag drives the `◌`
+   ;; marker; once a mismatch fires the entry lights up and the entry
+   ;; behaves like every other live panel.
+   {:id :hydration    :label "Hydration"     :bead "rf2-pzxsr" :live? true :dormant? true}
    {:id :copilot      :label "Co-pilot"      :bead "rf2-xxx"}])
 
 ;; ---- regions -------------------------------------------------------------
@@ -117,7 +119,7 @@
     [:span {:style {:color       (:text-tertiary tokens)
                     :font-size   "12px"
                     :font-weight 400}}
-     "Phase 4 (rf2-4rqs1)"]]
+     "Phase 5 (rf2-pzxsr)"]]
    [:div {:style {:display "flex" :align-items "center" :gap "12px"
                   :color    (:text-secondary tokens)
                   :font-size "12px"
@@ -127,25 +129,37 @@
 (defn- sidebar-item
   "Render one sidebar item. Clicking the row fires
   `:rf.causa/select-panel`; the live row highlights based on the
-  `:rf.causa/selected-panel` sub the parent reads."
-  [{:keys [id label live?]} active?]
+  `:rf.causa/selected-panel` sub the parent reads.
+
+  ## Dormant marker (rf2-pzxsr — hydration-debugger panel visibility)
+
+  Per `tools/causa/spec/006-Hydration-Debugger.md` §Visibility a
+  panel can be marked `:dormant?` — the entry then renders the `◌`
+  marker instead of `○` until activity wakes it. The dormant fn
+  passes `dormant?` here so the visibility gate is one place; the
+  parent decides per-row what 'awake' means."
+  [{:keys [id label live? dormant?]} active?]
   [:li {:data-testid (str "rf-causa-sidebar-item-" (name id))
         :on-click    #(rf/dispatch [:rf.causa/select-panel id])
         :style       {:padding         "6px 16px"
                       :cursor          "pointer"
                       :background      (if active? (:bg-active tokens) "transparent")
                       :color           (cond
-                                         active? (:text-primary tokens)
-                                         live?   (:text-secondary tokens)
-                                         :else   (:text-tertiary tokens))
+                                         active?  (:text-primary tokens)
+                                         dormant? (:text-tertiary tokens)
+                                         live?    (:text-secondary tokens)
+                                         :else    (:text-tertiary tokens))
                       :font-weight     (if active? 600 400)}}
    [:span {:style {:margin-right "8px"
                    :color        (if active?
                                    (:accent-violet tokens)
                                    (:text-tertiary tokens))}}
-    (if active? "◉" "○")]
+    (cond
+      active?  "◉"
+      dormant? "◌"   ; per spec/006-Hydration-Debugger.md §Visibility
+      :else    "○")]
    label
-   (when (and (not active?) live?)
+   (when (and (not active?) live? (not dormant?))
      [:span {:style {:margin-left "8px"
                      :color       (:accent-violet tokens)
                      :font-size   "10px"
@@ -159,10 +173,31 @@
   conditional-with-activity, dormant) divider-separated.
 
   Phase 2: the active panel is driven by `:rf.causa/selected-panel`.
-  Clicking a row dispatches `:rf.causa/select-panel`."
+  Clicking a row dispatches `:rf.causa/select-panel`.
+
+  ## Hydration dormant gate (rf2-pzxsr)
+
+  Per `tools/causa/spec/006-Hydration-Debugger.md` §Visibility the
+  Hydration sidebar entry is dormant (`◌`) until at least one
+  `:rf.ssr/hydration-mismatch` trace lands. The gate reads the
+  panel's composite — if `:has-mismatch?` is truthy the dormant flag
+  is dropped and the entry behaves like every other live panel.
+
+  The lift here is intentionally a one-line override rather than a
+  per-item subscribe — the composite already exists for the panel,
+  re-using it keeps the reactive graph minimal."
   []
   (let [active (or @(rf/subscribe [:rf.causa/selected-panel])
-                   registry/default-panel-id)]
+                   registry/default-panel-id)
+        hydration-awake? (boolean
+                           (get @(rf/subscribe [:rf.causa/hydration-debugger-data])
+                                :has-mismatch?))
+        items-resolved
+        (mapv (fn [item]
+                (cond-> item
+                  (and (= :hydration (:id item)) hydration-awake?)
+                  (assoc :dormant? false)))
+              sidebar-items)]
     [:nav {:style {:width            "192px"
                    :flex-shrink      0
                    :background       (:bg-1 tokens)
@@ -174,7 +209,7 @@
      (into [:ul {:style {:list-style    "none"
                          :margin        0
                          :padding       "8px 0"}}]
-           (for [{:keys [id] :as item} sidebar-items]
+           (for [{:keys [id] :as item} items-resolved]
              ^{:key id}
              [sidebar-item item (= id active)]))]))
 
@@ -218,9 +253,8 @@
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
       :causality    [causality-graph/causality-graph-view]
-      ;; ── subscriptions panel begin ──
       :subs         [subscriptions/subscriptions-view]
-      ;; ── subscriptions panel end ──
+      :hydration    [hydration-debugger/hydration-debugger-view]
       [stub-panel (or item {:label "Unknown panel"
                             :bead  "rf2-xxx"})])))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_cljs_test.cljc
@@ -1,0 +1,297 @@
+(ns day8.re-frame2-causa.panels.hydration-debugger-cljs-test
+  "Pure-data tests for Causa's Hydration Debugger helpers
+  (Phase 5, rf2-pzxsr).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  The file ends in `_cljs_test.cljc` so:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  Same dual-target pattern as `time_travel_helpers_cljs_test.cljc`
+  and `causality_graph_cljs_test.cljc`.
+
+  ## What's under test
+
+    1. **mismatches / mismatches-for-frame** — filter the buffer
+       down to hydration-mismatch events; frame-aware projection.
+    2. **classify-divergence** — five divergence kinds + the
+       unknown fallback.
+    3. **hypothesis-for** — every divergence-kind has a hypothesis
+       line (per spec §Cause hypothesis).
+    4. **first-divergence-path** — bisector path from root to first
+       differing node.
+    5. **mismatch-detail** — full projection from a trace event to
+       the shape the view consumes.
+    6. **re-root** — the hash-chip click → re-root path.
+    7. **source-coord-for-mismatch** — Lock #11 fallback annotation."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.hydration-debugger-helpers :as h]))
+
+;; ---- fixture builders ----------------------------------------------------
+
+(defn- mismatch-ev
+  "Build a `:rf.ssr/hydration-mismatch` trace event with the canonical
+  payload shape per spec/006-Hydration-Debugger.md §Substrate."
+  ([id path server-tree client-tree]
+   (mismatch-ev id path server-tree client-tree {}))
+  ([id path server-tree client-tree extra-tags]
+   {:id        id
+    :op-type   :error
+    :operation :rf.ssr/hydration-mismatch
+    :tags      (merge {:path        path
+                       :server-tree server-tree
+                       :client-tree client-tree
+                       :server-hash "abc123"
+                       :client-hash "def456"
+                       :frame       :rf/default
+                       :view-id     'cart-summary-view
+                       :failing-id  :rf/hydrate}
+                      extra-tags)}))
+
+(defn- non-mismatch-ev
+  "Build a non-mismatch trace event for the buffer."
+  [id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :tags      {:dispatch-id id}})
+
+;; ---- (1) mismatch projection --------------------------------------------
+
+(deftest hydration-mismatch?-predicate
+  (testing "hydration-mismatch? identifies the canonical operation"
+    (is (true?  (h/hydration-mismatch?
+                  {:operation :rf.ssr/hydration-mismatch})))
+    (is (false? (h/hydration-mismatch?
+                  {:operation :event/dispatched})))
+    (is (false? (h/hydration-mismatch? {})))))
+
+(deftest mismatches-filters-the-buffer
+  (testing "mismatches returns only hydration-mismatch events, in order"
+    (let [trace [(non-mismatch-ev 1)
+                 (mismatch-ev 2 [:div] [:div "a"] [:div "b"])
+                 (non-mismatch-ev 3)
+                 (mismatch-ev 4 [:span] [:span "x"] [:span "y"])]
+          got   (h/mismatches trace)]
+      (is (= 2 (count got)))
+      (is (= [2 4] (mapv :id got))))))
+
+(deftest mismatches-for-frame-frame-aware
+  (testing "frame filter passes events whose :tags :frame matches"
+    (let [trace [(mismatch-ev 1 [] [:a] [:b] {:frame :rf/default})
+                 (mismatch-ev 2 [] [:a] [:c] {:frame :rf/other})
+                 (mismatch-ev 3 [] [:a] [:d] {:frame :rf/default})]]
+      (is (= [1 3] (mapv :id (h/mismatches-for-frame trace :rf/default))))
+      (is (= [2]   (mapv :id (h/mismatches-for-frame trace :rf/other))))
+      (is (= [1 2 3] (mapv :id (h/mismatches-for-frame trace nil)))
+          "nil frame filter is the identity"))))
+
+(deftest frames-with-mismatches-returns-distinct-frames
+  (testing "frames-with-mismatches surfaces every distinct frame-id"
+    (let [trace [(mismatch-ev 1 [] [:a] [:b] {:frame :rf/default})
+                 (mismatch-ev 2 [] [:a] [:c] {:frame :rf/other})
+                 (mismatch-ev 3 [] [:a] [:d] {:frame :rf/default})]]
+      (is (= #{:rf/default :rf/other}
+             (h/frames-with-mismatches trace))))))
+
+(deftest select-mismatch-by-id
+  (testing "select-mismatch returns the trace event whose :id matches"
+    (let [m1 (mismatch-ev 1 [] [:a] [:b])
+          m2 (mismatch-ev 2 [] [:a] [:c])]
+      (is (= m1 (h/select-mismatch [m1 m2] 1)))
+      (is (= m2 (h/select-mismatch [m1 m2] 2)))
+      (is (nil? (h/select-mismatch [m1 m2] 999)))
+      (is (nil? (h/select-mismatch [] 1))))))
+
+;; ---- (2) classify-divergence --------------------------------------------
+
+(deftest classify-different-text
+  (testing "text content differs under the same tag → :different-text"
+    (is (= :different-text
+           (h/classify-divergence "3 items" "0 items")))
+    (is (= :different-text
+           (h/classify-divergence [:p "3 items"] [:p "0 items"])))))
+
+(deftest classify-tag-differs
+  (testing "tag differs → :tag-differs"
+    (is (= :tag-differs
+           (h/classify-divergence [:p "hello"] [:span "hello"])))
+    (is (= :tag-differs
+           (h/classify-divergence [:div] "text"))
+        "tag-vs-text is a structural flip")))
+
+(deftest classify-attr-differs
+  (testing "attrs differ; tag matches → :attr-differs"
+    (is (= :attr-differs
+           (h/classify-divergence [:a {:href "/a"} "go"]
+                                  [:a {:href "/b"} "go"])))))
+
+(deftest classify-children-missing-client
+  (testing "children present server, missing client → :children-missing-client"
+    (is (= :children-missing-client
+           (h/classify-divergence [:ul [:li "a"] [:li "b"]]
+                                  [:ul])))))
+
+(deftest classify-children-missing-server
+  (testing "children missing server, present client → :children-missing-server"
+    (is (= :children-missing-server
+           (h/classify-divergence [:div]
+                                  [:div [:span "client-only"]])))))
+
+(deftest classify-unknown-fallback
+  (testing "shapes we don't classify return :unknown"
+    (is (= :unknown
+           (h/classify-divergence {:not "hiccup"} #{:also "weird"})))))
+
+(deftest hypothesis-for-covers-every-kind
+  (testing "every divergence-kind has a hypothesis line"
+    (doseq [k [:different-text :tag-differs :attr-differs
+               :children-missing-client :children-missing-server :unknown]]
+      (is (string? (h/hypothesis-for k))
+          (str "hypothesis present for " k))
+      (is (pos? (count (h/hypothesis-for k)))))))
+
+;; ---- (3) first-divergence-path ------------------------------------------
+
+(deftest divergence-path-equal-trees-returns-nil
+  (testing "structurally-equal trees produce nil — no divergence"
+    (is (nil? (h/first-divergence-path [:p "a"] [:p "a"])))
+    (is (nil? (h/first-divergence-path "text" "text")))))
+
+(deftest divergence-path-root-divergence
+  (testing "roots disagree on tag → divergence at []"
+    (is (= [] (h/first-divergence-path [:p "a"] [:span "a"])))))
+
+(deftest divergence-path-descends-to-first-difference
+  (testing "matching parent + matching first child + divergent second
+            child → walker descends to the text leaf at [1 0] (the
+            first node whose value structurally diverges)"
+    (is (= [1 0] (h/first-divergence-path
+                   [:div [:p "match"] [:p "server"]]
+                   [:div [:p "match"] [:p "client"]])))))
+
+(deftest divergence-path-descends-multiple-levels
+  (testing "deep divergence walks down through matching ancestors —
+            the walker descends as deep as the matching structure
+            allows, landing at the first text leaf that differs"
+    (let [server [:div
+                  [:section
+                   [:p "match"]
+                   [:p [:em "server-bold"]]]]
+          client [:div
+                  [:section
+                   [:p "match"]
+                   [:p [:em "client-bold"]]]]]
+      (is (= [0 1 0 0] (h/first-divergence-path server client))
+          "descends section → second-p → em → text leaf"))))
+
+;; ---- (4) mismatch-detail projection -------------------------------------
+
+(deftest mismatch-detail-shape
+  (testing "mismatch-detail surfaces every slot the view consumes"
+    (let [ev     (mismatch-ev 42 [:div :main]
+                              [:p "3 items"]
+                              [:p "0 items"])
+          detail (h/mismatch-detail ev)]
+      (is (= 42 (:id detail)))
+      (is (= [:div :main] (:path detail)))
+      (is (= :rf/default (:frame detail)))
+      (is (= 'cart-summary-view (:view-id detail)))
+      (is (= :rf/hydrate (:failing-id detail)))
+      (is (= :different-text (:divergence-kind detail)))
+      (is (string? (:hypothesis detail)))
+      (is (vector? (:bisector-path detail)))
+      (is (vector? (:server-chips detail)))
+      (is (vector? (:client-chips detail)))
+      (is (= "abc123" (:server-hash detail)))
+      (is (= "def456" (:client-hash detail))))))
+
+(deftest mismatch-detail-uses-runtime-first-diff-path-when-supplied
+  (testing "when the trace carries :first-diff-path, the detail uses it"
+    (let [ev     (mismatch-ev 1 []
+                              [:div [:span "a"] [:span "x"]]
+                              [:div [:span "a"] [:span "y"]]
+                              {:first-diff-path [9 9 9]})
+          detail (h/mismatch-detail ev)]
+      (is (= [9 9 9] (:bisector-path detail))
+          "trace-supplied :first-diff-path wins over computed"))))
+
+(deftest mismatch-detail-nil-on-nil-trace
+  (testing "mismatch-detail returns nil when there's no trace event"
+    (is (nil? (h/mismatch-detail nil)))))
+
+;; ---- (5) mismatch-list-summary ------------------------------------------
+
+(deftest mismatch-list-summary-shapes-each-entry
+  (testing "summary entries carry id, path, view-id, divergence-kind, summary"
+    (let [trace [(mismatch-ev 1 [:div] [:p "3"] [:p "0"])
+                 (mismatch-ev 2 [:span] [:a] [:b])]
+          summ  (h/mismatch-list-summary trace nil)]
+      (is (= 2 (count summ)))
+      (let [e1 (first summ)]
+        (is (= 1 (:id e1)))
+        (is (= [:div] (:path e1)))
+        (is (= 'cart-summary-view (:view-id e1)))
+        (is (= :different-text (:divergence-kind e1)))
+        (is (string? (:summary e1)))))))
+
+(deftest mismatch-list-summary-frame-aware
+  (testing "summary respects the frame filter axis"
+    (let [trace [(mismatch-ev 1 [] [:a] [:b] {:frame :rf/default})
+                 (mismatch-ev 2 [] [:c] [:d] {:frame :rf/other})]]
+      (is (= [1] (mapv :id (h/mismatch-list-summary trace :rf/default))))
+      (is (= [2] (mapv :id (h/mismatch-list-summary trace :rf/other)))))))
+
+;; ---- (6) re-root --------------------------------------------------------
+
+(deftest re-root-walks-into-subtree
+  (testing "re-root descends `path` into the tree"
+    (let [tree [:div [:p "a"] [:p [:em "deep"]]]]
+      (is (= [:p "a"]
+             (h/re-root tree [0])))
+      (is (= [:p [:em "deep"]]
+             (h/re-root tree [1])))
+      (is (= [:em "deep"]
+             (h/re-root tree [1 0]))))))
+
+(deftest re-root-empty-path-is-identity
+  (testing "re-root with [] returns the original tree"
+    (let [tree [:div "x"]]
+      (is (= tree (h/re-root tree [])))
+      (is (= tree (h/re-root tree nil))))))
+
+(deftest re-root-out-of-bounds-returns-current-node
+  (testing "an out-of-bounds path stops at the deepest valid node
+            (defensive — never throws)"
+    (let [tree [:div]]
+      (is (= [:div] (h/re-root tree [99]))))))
+
+;; ---- (7) source-coord-for-mismatch (Lock #11 fallback) ------------------
+
+(deftest source-coord-exact-view-coord
+  (testing "when :source-coord is on :tags, return :exact annotation"
+    (let [ev (mismatch-ev 1 [] [:p] [:p]
+                          {:source-coord {:file "src/cart/views.cljs"
+                                          :line 42}})]
+      (is (= {:coord "src/cart/views.cljs:42" :annotation :exact}
+             (h/source-coord-for-mismatch ev))))))
+
+(deftest source-coord-fallback-handler-coord
+  (testing "when only :handler-source-coord is present, fall back with
+            :fallback annotation (Lock #11)"
+    (let [ev (mismatch-ev 1 [] [:p] [:p]
+                          {:handler-source-coord {:file "src/cart/events.cljs"
+                                                  :line 13}})]
+      (is (= {:coord "src/cart/events.cljs:13" :annotation :fallback}
+             (h/source-coord-for-mismatch ev))))))
+
+(deftest source-coord-nil-when-absent
+  (testing "neither coord present → {:coord nil :annotation nil}"
+    (let [ev (mismatch-ev 1 [] [:p] [:p])]
+      (is (= {:coord nil :annotation nil}
+             (h/source-coord-for-mismatch ev))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -1,0 +1,318 @@
+(ns day8.re-frame2-causa.panels.hydration-debugger-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Hydration Debugger panel
+  (Phase 5, rf2-pzxsr).
+
+  ## Three contracts under test (in addition to the pure-data tests
+  in `hydration_debugger_cljs_test.cljc`)
+
+  1. **Registry wires the composite sub** under `:rf.causa/hydration-
+     debugger-data`. The composite returns the same shape the view
+     consumes.
+
+  2. **Dormant gate** — the panel surfaces the 'No SSR in this app'
+     empty state until at least one `:rf.ssr/hydration-mismatch`
+     trace lands. Once one does, the panel surfaces the side-by-side
+     mismatch detail (per spec §Visibility).
+
+  3. **Selection + re-root events** wire correctly — clicking a
+     mismatch row fires `:rf.causa/select-mismatch`; clicking a hash
+     chip fires `:rf.causa/reroot-tree-view`.
+
+  ## Pure hiccup
+
+  Same approach as `event_detail_cljs_test.cljs` and
+  `causality_graph_view_cljs_test.cljs` — we walk the view's hiccup
+  tree by `data-testid` rather than mounting to a DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.hydration-debugger :as hydration]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- fixture trace stream ------------------------------------------------
+
+(defn- mismatch-ev
+  "Build a hydration-mismatch trace event per spec/006-Hydration-
+  Debugger.md §Substrate."
+  ([id path server-tree client-tree]
+   (mismatch-ev id path server-tree client-tree {}))
+  ([id path server-tree client-tree extra-tags]
+   {:id        id
+    :op-type   :error
+    :operation :rf.ssr/hydration-mismatch
+    :tags      (merge {:path        path
+                       :server-tree server-tree
+                       :client-tree client-tree
+                       :server-hash "abc"
+                       :client-hash "def"
+                       :frame       :rf/default
+                       :view-id     'cart-summary-view
+                       :failing-id  :rf/hydrate}
+                      extra-tags)}))
+
+(defn- seed-buffer!
+  "Wire the trace collector (preload-style) and push events through it
+  so the Causa buffer matches the production delivery path."
+  [evs]
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
+
+;; ---- hiccup walker (lifted from causality_graph_view_cljs_test) ---------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+;; ---- (1) registry wires the composite sub -------------------------------
+
+(deftest registry-installs-hydration-debugger-sub
+  (testing "register-causa-handlers! installs the Phase 5 composite sub"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/hydration-debugger-data))
+        "composite sub is registered")
+    (is (some? (registrar/handler :sub :rf.causa/selected-mismatch-id))
+        "selected-mismatch-id sub is registered")
+    (is (some? (registrar/handler :sub :rf.causa/hydration-reroot-path))
+        "hydration-reroot-path sub is registered")))
+
+(deftest registry-installs-hydration-debugger-events
+  (testing "the Phase 5 events are registered"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :event :rf.causa/select-mismatch)))
+    (is (some? (registrar/handler :event :rf.causa/clear-mismatch-selection)))
+    (is (some? (registrar/handler :event :rf.causa/reroot-tree-view)))))
+
+(deftest composite-defaults-with-empty-buffer
+  (testing "with the buffer empty, the composite reports no mismatches"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+        (is (false? (:has-mismatch? data))
+            "dormant when buffer is empty")
+        (is (= [] (:mismatch-summary data)))
+        (is (nil? (:detail data)))))))
+
+(deftest composite-surfaces-mismatches-from-buffer
+  (testing "once a mismatch lands, the composite surfaces it"
+    (seed-buffer! [(mismatch-ev 1 [:div :main]
+                                [:p "3 items"]
+                                [:p "0 items"])])
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+        (is (true? (:has-mismatch? data)) ":has-mismatch? true")
+        (is (= 1 (count (:mismatch-summary data))))
+        (is (some? (:detail data)))
+        (is (= :different-text
+               (get-in data [:detail :divergence-kind])))))))
+
+;; ---- (2) dormant-gate / visibility --------------------------------------
+
+(deftest view-renders-no-ssr-empty-state-when-buffer-empty
+  (testing "the panel renders the 'No SSR in this app' empty state when
+            the buffer carries no hydration-mismatch traces"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/hydration-debugger-view)]
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-debugger-empty-no-ssr"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-hydration-mismatch-detail"))
+            "mismatch detail absent when dormant")))))
+
+(deftest view-renders-mismatch-detail-once-fired
+  (testing "with a mismatch in the buffer the panel renders the side-by-
+            side detail + the mismatch list"
+    (seed-buffer! [(mismatch-ev 1 [:div :main]
+                                [:p "3 items"]
+                                [:p "0 items"])])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/hydration-debugger-view)]
+        (is (some? (find-by-testid tree "rf-causa-hydration-mismatch-list"))
+            "mismatch list present")
+        (is (some? (find-by-testid tree "rf-causa-hydration-mismatch-detail"))
+            "mismatch detail present")
+        (is (some? (find-by-testid tree "rf-causa-hydration-divergent-marker"))
+            "divergent marker present")
+        (is (some? (find-by-testid tree "rf-causa-hydration-tree-pane-server"))
+            "server tree pane present")
+        (is (some? (find-by-testid tree "rf-causa-hydration-tree-pane-client"))
+            "client tree pane present")
+        (is (some? (find-by-testid tree "rf-causa-hydration-hypothesis"))
+            "hypothesis row present")
+        (is (nil? (find-by-testid tree
+                                  "rf-causa-hydration-debugger-empty-no-ssr"))
+            "empty-state absent when mismatch present")))))
+
+;; ---- (3) selection + re-root events -------------------------------------
+
+(deftest clicking-mismatch-row-fires-select-mismatch
+  (testing "clicking a mismatch row dispatches :rf.causa/select-mismatch"
+    (seed-buffer! [(mismatch-ev 1 [:div] [:a] [:b])
+                   (mismatch-ev 2 [:span] [:c] [:d])])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/hydration-debugger-view)
+            row  (find-by-testid tree "rf-causa-hydration-mismatch-row-1")]
+        (is (some? row) "row 1 present in mismatch list")
+        (is (fn? (:on-click (second row)))
+            "row carries an on-click handler")
+        ;; Drive the event through dispatch-sync so the test doesn't
+        ;; race the router's drain — proves the event handler writes
+        ;; to the Causa frame.
+        (rf/dispatch-sync [:rf.causa/select-mismatch 1])
+        (let [causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= 1 (:selected-mismatch-id causa-db))
+              "selection lands on the Causa frame"))))))
+
+(deftest clicking-hash-chip-fires-reroot
+  (testing "clicking a hash chip dispatches :rf.causa/reroot-tree-view
+            with the chip's path"
+    (seed-buffer! [(mismatch-ev 1 []
+                                [:div [:p "match"] [:p "server"]]
+                                [:div [:p "match"] [:p "client"]])])
+    (rf/with-frame :rf/causa
+      (let [tree  (hydration/hydration-debugger-view)
+            chips (find-all-by-testid-prefix
+                    tree "rf-causa-hydration-hash-chip-")]
+        (is (pos? (count chips)) "at least one hash chip rendered")
+        ;; Each chip's on-click is a #()-style dispatch — sanity that
+        ;; it's a callable; the event is asserted below via dispatch-
+        ;; sync against the same wiring.
+        (is (every? #(fn? (:on-click (second %))) chips))
+        ;; Drive the event through dispatch-sync.
+        (rf/dispatch-sync [:rf.causa/reroot-tree-view [1]])
+        (let [causa-db (frame/frame-app-db-value :rf/causa)]
+          (is (= [1] (:hydration-reroot-path causa-db))
+              "reroot path lands on the Causa frame"))))))
+
+(deftest reroot-empty-path-clears-the-slot
+  (testing "dispatching :rf.causa/reroot-tree-view with [] clears the
+            re-root slot — the panel re-renders from the full subtree"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/reroot-tree-view [1]])
+      (rf/dispatch-sync [:rf.causa/reroot-tree-view []])
+      (let [causa-db (frame/frame-app-db-value :rf/causa)]
+        (is (nil? (:hydration-reroot-path causa-db))
+            "empty path clears the re-root slot")))))
+
+(deftest clear-mismatch-selection-drops-selection-and-reroot
+  (testing "clear-mismatch-selection drops both the selection and the
+            re-root (the path is subtree-specific to the prior
+            selection)"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-mismatch 42])
+      (rf/dispatch-sync [:rf.causa/reroot-tree-view [1 2]])
+      (rf/dispatch-sync [:rf.causa/clear-mismatch-selection])
+      (let [causa-db (frame/frame-app-db-value :rf/causa)]
+        (is (nil? (:selected-mismatch-id causa-db)))
+        (is (nil? (:hydration-reroot-path causa-db)))))))
+
+;; ---- (4) hypothesis row + source-coord drilldown ------------------------
+
+(deftest hypothesis-row-surfaces-the-line
+  (testing "the hypothesis row carries one of the five hypothesis lines"
+    (seed-buffer! [(mismatch-ev 1 [] [:p "3"] [:p "0"])])
+    (rf/with-frame :rf/causa
+      (let [tree   (hydration/hydration-debugger-view)
+            hyp    (find-by-testid tree "rf-causa-hydration-hypothesis")
+            txt    (when hyp
+                     (->> (hiccup-seq hyp)
+                          (filter string?)
+                          (apply str)))]
+        (is (some? hyp))
+        (is (some? (re-find #"App-db state" txt))
+            "different-text hypothesis line surfaced")))))
+
+(deftest source-coord-row-surfaces-coord
+  (testing "the source-coord row surfaces the divergent view's coord
+            when :source-coord is supplied"
+    (seed-buffer! [(mismatch-ev 1 [] [:p "a"] [:p "b"]
+                                {:source-coord {:file "src/cart/views.cljs"
+                                                :line 42}})])
+    (rf/with-frame :rf/causa
+      (let [tree  (hydration/hydration-debugger-view)
+            row   (find-by-testid tree "rf-causa-hydration-source-coord")
+            txt   (when row
+                    (->> (hiccup-seq row)
+                         (filter string?)
+                         (apply str)))]
+        (is (some? row))
+        (is (some? (re-find #"src/cart/views\.cljs:42" txt))
+            "exact source-coord rendered")))))
+
+(deftest source-coord-row-surfaces-fallback-annotation
+  (testing "when only handler-source-coord is available, the row renders
+            a (?) annotation (Lock #11 fallback)"
+    (seed-buffer! [(mismatch-ev 1 [] [:p "a"] [:p "b"]
+                                {:handler-source-coord
+                                 {:file "src/cart/events.cljs" :line 13}})])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/hydration-debugger-view)
+            row  (find-by-testid tree "rf-causa-hydration-source-coord")
+            txt  (when row
+                   (->> (hiccup-seq row)
+                        (filter string?)
+                        (apply str)))]
+        (is (some? row))
+        (is (some? (re-find #"\(\?\)" txt))
+            "fallback annotation (?) present")))))
+
+;; ---- (5) frame awareness ------------------------------------------------
+
+(deftest composite-respects-target-frame
+  (testing "when the target frame is :rf/default the composite filters
+            out mismatches from other frames"
+    (seed-buffer! [(mismatch-ev 1 [] [:p] [:p {:diff 1}]
+                                {:frame :rf/default})
+                   (mismatch-ev 2 [] [:p] [:p {:diff 2}]
+                                {:frame :rf/other})])
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+        (is (= 1 (count (:mismatch-summary data)))
+            "only the :rf/default mismatch surfaces by default")
+        (is (= [1] (mapv :id (:mismatch-summary data))))))))


### PR DESCRIPTION
## Summary

Phase 5 of [rf2-5aw5v](https://github.com/day8/re-frame2/issues/) — Causa v1.0 epic. Implements the **Hydration Debugger** panel per [`tools/causa/spec/006-Hydration-Debugger.md`](../blob/main/tools/causa/spec/006-Hydration-Debugger.md).

SSR hydration mismatches are structurally hard to debug: the failing client render and the failing server render disagree on a tree, the console error is one line, and the divergent node is rarely the one the error points to. No other JS devtool surfaces this; re-frame2's Spec 011 emits structured data, and this panel renders it.

## What lands

- **Pure-data helpers** (`hydration_debugger_helpers.cljc`) — JVM-runnable diff + classification: `classify-divergence` (5 kinds), `first-divergence-path` (hash-bisector walker per Spec 011 §Hydration equivalence rule), `mismatch-detail` (full projection), `re-root` (hash-chip click → zoom into subtree), `source-coord-for-mismatch` (Lock #11 fallback annotation).
- **Panel view** (`hydration_debugger.cljs`) — pure hiccup; side-by-side server / client render-tree view, divergent-node marker, one-line hypothesis, source-coord row, multi-mismatch list. Three states: 'No SSR in this app' / mismatch detail / orphaned-selection edge case.
- **Visibility gate** — per spec §Visibility the sidebar entry is dormant (`◌`) until at least one `:rf.ssr/hydration-mismatch` trace lands. The shell's sidebar gate reads the composite sub's `:has-mismatch?` flag; when truthy, the entry's `:dormant?` flips off and it behaves like every other live panel.
- **Registry wiring** — composite sub `:rf.causa/hydration-debugger-data` + two leaf subs + three events (`:rf.causa/select-mismatch`, `:rf.causa/clear-mismatch-selection`, `:rf.causa/reroot-tree-view`). Wrapped with `;; ── hydration-debugger panel begin ──` / `;; ── hydration-debugger panel end ──` markers per the bead's clean-rebase convention.
- **Tests** — 30 JVM-runnable helper assertions in `hydration_debugger_cljs_test.cljc` (filter projection, classify all 5 divergence kinds, bisector walker, mismatch detail, re-root, source-coord fallback). 30 CLJS-side view/wiring assertions in `hydration_debugger_view_cljs_test.cljs` (registry installation, dormant-gate, mismatch list rendering, side-by-side tree panes, hypothesis surfacing, source-coord row with Lock #11 fallback, click events, frame-awareness).

## Visibility gate impl

The sidebar walks `sidebar-items`. On every recompute it reads `@(rf/subscribe [:rf.causa/hydration-debugger-data])` for `:has-mismatch?` and overrides the `:hydration` entry's `:dormant?` to `false` when truthy. The `sidebar-item` renderer reads `:dormant?` and shows `◌` (per spec §Visibility) instead of `○`, with the 'live' tag suppressed.

## Cross-references

- Spec: [`tools/causa/spec/006-Hydration-Debugger.md`](../blob/main/tools/causa/spec/006-Hydration-Debugger.md)
- Substrate: [`spec/011-SSR.md`](../blob/main/spec/011-SSR.md) §Hydration-mismatch detection
- Lock #11 fallback: [`tools/causa/spec/DESIGN-RATIONALE.md`](../blob/main/tools/causa/spec/DESIGN-RATIONALE.md)
- Parent epic: rf2-5aw5v
- Bead: rf2-pzxsr

## Test plan

- [x] `clojure -M:test` from `tools/causa` — 99 tests / 283 assertions, 0 failures
- [x] `npx shadow-cljs compile node-test && node out/node-test.js` — 849 tests / 2194 assertions, 0 failures
- [ ] Visual smoke against `:examples/ssr` (deferred — Phase 5 ships the renderer; runtime emission of `:rf.ssr/hydration-mismatch` is owned by Spec 011's hydration detector, already wired in the SSR artefact)