### PR TITLE
feat(causa): Schema-violation Timeline panel — Phase 5 (rf2-htffa)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
@@ -1,0 +1,401 @@
+(ns day8.re-frame2-causa.panels.schema-violation-timeline
+  "Schema-violation Timeline panel — Phase 5 (rf2-htffa, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/005-Schema-Timeline.md` this panel surfaces
+  Spec 010 schema-validation failures temporally — one row per
+  registered schema, coloured dots per failure, recovery-mode →
+  colour mapping. Silent schema violations are real bugs in disguise;
+  the timeline makes them impossible to ignore.
+
+  ## What this panel shows
+
+  Each `:rf.error/schema-validation-failure` trace event lands as a
+  dot on its schema's row. The x-axis is time (default 60s window,
+  drag-zoom expands); the y-axis groups by registered schema. Dot
+  colour encodes recovery:
+
+      :skip-handler          → red
+      :skip-fx               → red
+      :rollback-db           → red
+      :replaced-with-default → yellow
+      :re-raised             → red, thicker stroke
+
+  Clicking a dot opens the per-violation detail side panel (schema /
+  path / value / expected / recovery + Malli explanation + Triggered
+  by + Registered at). Hover surfaces a 240ms tooltip with the one-
+  line cause.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure
+  hiccup, no Reagent / UIx / Helix references. SVG hiccup hosts the
+  per-row track + dots; the substrate adapter mounts it via
+  `rf/render`. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — `recovery->colour`, `recovery->stroke-width`,
+  `project-violations`, `project-rows`, `empty-state-kind` — lives in
+  `schema_violation_timeline_helpers.cljc` so the algebra runs under
+  the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- layout constants ----------------------------------------------------
+
+(def ^:private label-column-width
+  "Pixel width of the schema-name label column on the left of each
+  row. Sized for typical schema-id text (`:schema/checkout` plus
+  some padding)."
+  180)
+
+(def ^:private track-min-width
+  "Minimum pixel width for the timeline track (the right side of
+  each row). The view falls back to this when the canvas hasn't
+  reported a size yet — keeps the SVG renderable in tests."
+  480)
+
+(def ^:private track-row-height 24)
+
+;; ---- empty-state views --------------------------------------------------
+
+(defn- empty-state-no-schemas
+  "Per spec §Empty state — when no schemas are registered."
+  []
+  [:div {:data-testid "rf-causa-schema-timeline-empty-no-schemas"
+         :style       {:padding     "24px"
+                       :color       (:text-secondary tokens)
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5}}
+   [:p {:style {:margin "0 0 12px 0"
+                :color  (:text-primary tokens)
+                :font-weight 600}}
+    "No schemas registered."]
+   [:p {:style {:margin "0 0 12px 0"}}
+    "Once your app registers schemas via "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "reg-app-schema"]
+    " (Spec 010), validation events will appear here:"]
+   [:ul {:style {:margin     "0 0 12px 0"
+                 :padding    "0 0 0 20px"
+                 :color      (:text-tertiary tokens)
+                 :list-style "disc"}}
+    [:li "Schema violations"]
+    [:li "Path-typed lookups"]
+    [:li "Schema-replaced-with-default events"]]])
+
+(defn- empty-state-no-violations
+  "Per spec §Empty state — schemas registered but none in-window.
+  'The empty timeline is a *result*, not a problem. Causa says so.'"
+  []
+  [:div {:data-testid "rf-causa-schema-timeline-empty-no-violations"
+         :style       {:padding     "16px 24px"
+                       :color       (:green tokens)
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5}}
+   [:p {:style {:margin "0 0 6px 0"
+                :font-weight 600}}
+    "All schemas clean in the last 60s."]
+   [:p {:style {:margin "0"
+                :color  (:text-tertiary tokens)
+                :font-size "12px"}}
+    "This is the desired state."]])
+
+;; ---- per-violation detail side panel ------------------------------------
+
+(defn- detail-row
+  "One labeled key/value row inside the detail panel."
+  [k v]
+  [:div {:style {:display "flex"
+                 :gap     "8px"
+                 :padding "2px 0"
+                 :font-family mono-stack
+                 :font-size "12px"}}
+   [:span {:style {:color     (:text-tertiary tokens)
+                   :min-width "92px"}}
+    k]
+   [:span {:style {:color       (:text-primary tokens)
+                   :word-break  "break-all"}}
+    v]])
+
+(defn- violation-detail-panel
+  "Per spec §Per-violation detail — the side panel that opens when a
+  dot is clicked. Surfaces schema / where / path / value / recovery +
+  Malli explanation + Triggered-by + Registered-at + the three
+  click-through actions."
+  [{:keys [id schema-id where path value explanation recovery dispatch-id]
+    :as _violation}]
+  [:aside {:data-testid (str "rf-causa-schema-violation-detail-" id)
+           :style       {:padding        "12px 16px"
+                         :background     (:bg-2 tokens)
+                         :border-left    (str "1px solid " (:border-default tokens))
+                         :overflow-y     "auto"
+                         :max-width      "420px"
+                         :min-width      "280px"
+                         :flex           "0 0 auto"
+                         :color          (:text-primary tokens)
+                         :font-family    sans-stack}}
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :justify-content "space-between"
+                  :margin-bottom "8px"}}
+    [:h2 {:style {:font-size "13px"
+                  :font-weight 600
+                  :margin 0
+                  :color (:text-primary tokens)}}
+     "schema violation"]
+    [:button {:data-testid "rf-causa-schema-violation-detail-close"
+              :on-click    #(rf/dispatch [:rf.causa/clear-violation-selection])
+              :style       {:background "transparent"
+                            :border     "none"
+                            :color      (:text-tertiary tokens)
+                            :cursor     "pointer"
+                            :padding    "0 2px"
+                            :font-family mono-stack
+                            :font-size "12px"}
+              :title       "Close"}
+     "✕"]]
+   (detail-row "schema"   (h/schema-row-label schema-id))
+   (when where  (detail-row "where"    (str where)))
+   (when path   (detail-row "path"     (pr-str path)))
+   (detail-row "value"    (try (pr-str value) (catch :default _ "<unprintable>")))
+   (detail-row "recovery" (str recovery))
+
+   [:div {:style {:margin "12px 0 4px 0"
+                  :color (:text-secondary tokens)
+                  :font-size "11px"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.6px"}}
+    "Malli explanation"]
+   [:pre {:style {:background  (:bg-3 tokens)
+                  :color       (:text-primary tokens)
+                  :padding     "8px"
+                  :border-radius "4px"
+                  :font-family mono-stack
+                  :font-size   "11px"
+                  :white-space "pre-wrap"
+                  :overflow-x  "auto"
+                  :margin      0}}
+    (try (pr-str explanation) (catch :default _ "<unprintable>"))]
+
+   [:div {:style {:margin "12px 0 4px 0"
+                  :color (:text-secondary tokens)
+                  :font-size "11px"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.6px"}}
+    "Triggered by"]
+   [:div {:style {:font-family mono-stack
+                  :font-size "12px"
+                  :color (:text-primary tokens)}}
+    (if dispatch-id (str "dispatch " dispatch-id) "—")]
+   (when dispatch-id
+     [:button {:data-testid "rf-causa-schema-violation-detail-open-in-graph"
+               :on-click    (fn []
+                              (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+                              (rf/dispatch [:rf.causa/select-panel :causality]))
+               :style       {:background  "transparent"
+                             :color       (:cyan tokens)
+                             :border      (str "1px solid " (:border-default tokens))
+                             :padding     "3px 8px"
+                             :border-radius "4px"
+                             :cursor      "pointer"
+                             :font-family sans-stack
+                             :font-size   "11px"
+                             :margin-top  "6px"}}
+      "Open in causality graph"])
+
+   [:div {:style {:margin "12px 0 4px 0"
+                  :color (:text-secondary tokens)
+                  :font-size "11px"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.6px"}}
+    "Filter"]
+   [:button {:data-testid "rf-causa-schema-violation-detail-filter-row"
+             :on-click    #(rf/dispatch [:rf.causa/set-schema-filter schema-id])
+             :style       {:background  "transparent"
+                           :color       (:cyan tokens)
+                           :border      (str "1px solid " (:border-default tokens))
+                           :padding     "3px 8px"
+                           :border-radius "4px"
+                           :cursor      "pointer"
+                           :font-family sans-stack
+                           :font-size   "11px"}}
+    "Show me all violations of this schema"]])
+
+;; ---- per-row timeline track --------------------------------------------
+
+(defn- row-track
+  "Render one schema row — label column + SVG track of dots."
+  [{:keys [schema-id label violations first?]} window track-width]
+  (let [row-test-id (str "rf-causa-schema-timeline-row-"
+                         (if (vector? schema-id)
+                           (pr-str schema-id)
+                           (str schema-id)))]
+    [:div {:data-testid row-test-id
+           :style       {:display     "flex"
+                         :align-items "center"
+                         :height      (str track-row-height "px")
+                         :gap         "8px"}}
+     [:div {:data-testid (str row-test-id "-label")
+            :style       {:flex          "0 0 auto"
+                          :width         (str label-column-width "px")
+                          :overflow      "hidden"
+                          :text-overflow "ellipsis"
+                          :white-space   "nowrap"
+                          :color         (:text-secondary tokens)
+                          :font-family   mono-stack
+                          :font-size     "11px"
+                          :animation     (when first?
+                                           (str "rf-causa-flash "
+                                                h/default-flash-duration-ms
+                                                "ms ease-out 1"))}}
+      label]
+     [:svg {:data-testid (str row-test-id "-track")
+            :width       (str track-width)
+            :height      (str track-row-height)
+            :style       {:display    "block"
+                          :background (:bg-1 tokens)
+                          :border-radius "2px"
+                          :flex       "1 1 auto"}}
+      ;; row baseline guide
+      [:line {:x1 0 :y1 (/ track-row-height 2)
+              :x2 track-width :y2 (/ track-row-height 2)
+              :stroke (:border-subtle tokens)
+              :stroke-width 1}]
+      (for [{:keys [id recovery time] :as v} violations
+            :let [x (h/violation-x-position window track-width v)]
+            :when (some? x)]
+        (let [{:keys [fill stroke-width re-raised?]} (h/recovery->presentation recovery)]
+          ^{:key id}
+          [:circle {:data-testid (str row-test-id "-dot-" id)
+                    :cx          x
+                    :cy          (/ track-row-height 2)
+                    :r           h/default-dot-radius
+                    :fill        fill
+                    :stroke      (if re-raised?
+                                   (:text-primary tokens)
+                                   fill)
+                    :stroke-width stroke-width
+                    :style       {:cursor "pointer"}
+                    :on-click    #(rf/dispatch [:rf.causa/select-violation id])}
+           [:title (h/format-tooltip v)]]))]]))
+
+;; ---- header strip -------------------------------------------------------
+
+(defn- header
+  "Per spec §Layout the panel header carries the schema-filter
+  indicator + a clear-filter affordance when a filter is active."
+  [{:keys [schema-filter total-violations rendered-violations]}]
+  [:header {:style {:padding "12px 16px 6px 16px"}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "12px"}}
+    [:h1 {:style {:font-size "16px"
+                  :font-weight 600
+                  :margin 0
+                  :color  (:text-primary tokens)}}
+     "Schema violations"]
+    [:span {:style {:font-size   "11px"
+                    :color       (:text-tertiary tokens)
+                    :font-family mono-stack}}
+     (str rendered-violations " / " total-violations " in view")]]
+   (when schema-filter
+     [:div {:data-testid "rf-causa-schema-timeline-filter-active"
+            :style       {:margin-top "6px"
+                          :display "flex"
+                          :align-items "center"
+                          :gap "8px"
+                          :font-size "12px"
+                          :color (:text-secondary tokens)
+                          :font-family sans-stack}}
+      [:span "filtered to "]
+      [:code {:style {:color       (:accent-violet tokens)
+                      :font-family mono-stack
+                      :font-size   "11px"}}
+       (h/schema-row-label schema-filter)]
+      [:button {:data-testid "rf-causa-schema-timeline-clear-filter"
+                :on-click    #(rf/dispatch [:rf.causa/set-schema-filter nil])
+                :style       {:background "transparent"
+                              :color      (:cyan tokens)
+                              :border     (str "1px solid " (:border-default tokens))
+                              :padding    "2px 6px"
+                              :border-radius "3px"
+                              :cursor     "pointer"
+                              :font-family sans-stack
+                              :font-size  "11px"}}
+       "Clear filter"]])])
+
+;; ---- public view --------------------------------------------------------
+
+(defn schema-violation-timeline-view
+  "The Schema-violation Timeline panel's root view. Subscribes to
+  `:rf.causa/schema-violation-timeline` and renders the empty-state
+  or the per-schema track stack."
+  []
+  (let [{:keys [rows window selected-violation schema-filter
+                total-violations rendered-violations]
+         :as _data}
+        @(rf/subscribe [:rf.causa/schema-violation-timeline])
+        empty-kind  (h/empty-state-kind rows)
+        track-width track-min-width]
+    [:section {:data-testid "rf-causa-schema-violation-timeline"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "row"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:div {:style {:flex            1
+                    :display         "flex"
+                    :flex-direction  "column"
+                    :overflow        "hidden"}}
+      (header {:schema-filter      schema-filter
+               :total-violations   (or total-violations 0)
+               :rendered-violations (or rendered-violations 0)})
+      [:div {:style {:flex 1 :overflow "auto" :padding "0 16px 16px 16px"}}
+       (case empty-kind
+         :no-schemas    (empty-state-no-schemas)
+         :no-violations (empty-state-no-violations)
+         nil            (into [:div {:data-testid "rf-causa-schema-timeline-rows"
+                                     :style       {:display "flex"
+                                                   :flex-direction "column"
+                                                   :gap "4px"
+                                                   :padding-top "8px"}}]
+                              (for [{:keys [schema-id] :as row} rows]
+                                ^{:key (pr-str schema-id)}
+                                (row-track row window track-width))))]]
+     (when selected-violation
+       (violation-detail-panel selected-violation))]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
@@ -1,0 +1,493 @@
+(ns day8.re-frame2-causa.panels.schema-violation-timeline-helpers
+  "Pure-data helpers for Causa's Schema-violation Timeline panel
+  (Phase 5, rf2-htffa).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `schema_violation_timeline.cljs` paints SVG dots
+  against per-schema rows, runs hover tooltips, and dispatches into
+  the Causa frame. The *logic* — filter the trace buffer to schema-
+  validation failures, project each failure onto its row, map the
+  five recovery modes to colours + stroke widths, project the time
+  window onto x-axis pixel positions — is pure data → data. Splitting
+  the algebra into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
+
+  ## Substrate (per `tools/causa/spec/005-Schema-Timeline.md` §Substrate)
+
+  Every schema validation failure emits a trace event:
+
+      {:op-type   :error
+       :operation :rf.error/schema-validation-failure
+       :recovery  <one of :skip-handler :skip-fx :rollback-db
+                          :replaced-with-default :re-raised>
+       :tags      {:where  ...
+                   :path   ...
+                   :value  ...
+                   :schema ...
+                   :explanation ...
+                   :frame  ...}
+       :time      <ms>}
+
+  Causa consumes this stream (via the framework's `(rf/trace-buffer)`
+  surface — Causa's own trace-bus ring) and renders the timeline.
+
+  ## The five recovery categories (per Spec 010 §Per-step recovery)
+
+  Closed set; Causa does not invent additional categories. If a sixth
+  lands via a spec increment, the panel gains a row colour.
+
+      :skip-handler          Red.    Handler did not run.
+      :skip-fx               Red.    Specific fx invocation skipped.
+      :rollback-db           Red.    `app-db` reverted to pre-handler.
+      :replaced-with-default Yellow. Framework recovered cleanly with
+                                     the schema's `:default`.
+      :re-raised             Red.    Re-thrown; thicker stroke is the
+                                     visual differentiator.
+
+  ## Layout (per spec §Layout)
+
+  A horizontal timeline. One row per registered schema; dots
+  positioned along the time axis; default 60s window. The view paints
+  each row using the projection here — this ns hands the view a flat
+  vector of `{:schema-id ... :violations [...]}` rows + pre-computed
+  pixel positions for each dot."
+  (:require [clojure.string :as str]))
+
+;; ---- defaults ------------------------------------------------------------
+
+(def default-window-ms
+  "Default time window the timeline shows, in ms. Per spec §Layout —
+  60 seconds. Drag-zoom lets the user expand; the panel writes the
+  zoomed window into Causa's app-db via
+  `:rf.causa/set-schema-timeline-window`."
+  60000)
+
+(def default-row-height
+  "SVG row height in pixels. Per spec/007-UX-IA.md §Density the
+  default cosy density uses ~24px rows."
+  24)
+
+(def default-row-padding
+  "Vertical gap between rows (used by the row-y projection)."
+  4)
+
+(def default-dot-radius
+  "Base SVG dot radius in pixels. `:re-raised` violations render with
+  the same radius but thicker stroke (per spec §Recovery → colour
+  mapping)."
+  4)
+
+(def default-re-raised-stroke-width
+  "Stroke width for `:re-raised` violations in pixels. Per spec
+  §Recovery → colour mapping — the visual differentiator that lifts
+  re-raised above the other red recoveries."
+  2)
+
+(def default-base-stroke-width
+  "Stroke width for non-`:re-raised` violations. Thin so the colour
+  carries most of the signal."
+  0.5)
+
+(def default-flash-duration-ms
+  "Per spec §Reading the timeline at a glance — when a *new* row
+  gains its first violation, the schema-name label flashes once
+  (600ms). The view sets a CSS transition with this duration."
+  600)
+
+(def default-tooltip-delay-ms
+  "Per spec §Hover tooltip — 240ms tooltip on dot hover. 'Cheap-to-
+  read; cheap-to-dismiss'."
+  240)
+
+;; ---- recovery → colour mapping ------------------------------------------
+
+(def colour-red
+  "The red used for hard-fail recoveries (`:skip-handler`, `:skip-fx`,
+  `:rollback-db`, `:re-raised`). Mirrors the `:red` token in
+  `shell.cljs`."
+  "#F87171")
+
+(def colour-yellow
+  "The yellow used for `:replaced-with-default` — the framework
+  recovered cleanly. Per spec §Recovery → colour mapping. Mirrors
+  the `:yellow` token in `shell.cljs`."
+  "#FBBF24")
+
+(def colour-unknown
+  "Fallback colour for an unrecognised recovery. The five-category
+  palette is closed per Spec 010; this fallback is defensive only —
+  if a new recovery lands via a spec increment, the panel renders
+  it as text-tertiary grey until the mapping is extended. Mirrors
+  the `:text-tertiary` token in `shell.cljs`."
+  "#6B7080")
+
+(def recovery-modes
+  "The closed set of recovery keywords per Spec 010 §Per-step
+  recovery + spec 005 §The five recovery categories. Vector form so
+  the empty-state preview can list them in declared order."
+  [:skip-handler
+   :skip-fx
+   :rollback-db
+   :replaced-with-default
+   :re-raised])
+
+(defn recovery->colour
+  "Map a recovery keyword to its dot fill colour. Per spec §Recovery
+  → colour mapping:
+
+      :skip-handler          → red
+      :skip-fx               → red
+      :rollback-db           → red
+      :replaced-with-default → yellow
+      :re-raised             → red
+
+  Falls back to `colour-unknown` for any value outside the closed set
+  (defensive — see Spec 010 'closed' note). Pure data → string;
+  JVM-testable."
+  [recovery]
+  (case recovery
+    :skip-handler          colour-red
+    :skip-fx               colour-red
+    :rollback-db           colour-red
+    :replaced-with-default colour-yellow
+    :re-raised             colour-red
+    colour-unknown))
+
+(defn recovery->stroke-width
+  "Map a recovery to its dot stroke width in pixels. `:re-raised`
+  renders thicker (per spec §Recovery → colour mapping — the visual
+  differentiator). Every other recovery uses the base width. Pure
+  data → number; JVM-testable."
+  [recovery]
+  (if (= :re-raised recovery)
+    default-re-raised-stroke-width
+    default-base-stroke-width))
+
+(defn recovery->presentation
+  "Combined projection — `{:fill <colour> :stroke-width <px>
+  :re-raised? <bool>}` for a recovery. Pure data → data. The view
+  reads from this map so the colour + stroke-width + the 're-raised
+  attention flag' move together."
+  [recovery]
+  {:fill         (recovery->colour recovery)
+   :stroke-width (recovery->stroke-width recovery)
+   :re-raised?   (= :re-raised recovery)})
+
+;; ---- trace-event classification -----------------------------------------
+
+(defn schema-violation-event?
+  "True iff `ev` (a raw trace event from the buffer) is a Spec 010
+  schema-validation failure — `:op-type :error` +
+  `:operation :rf.error/schema-validation-failure`. Pure data → bool;
+  JVM-testable.
+
+  Mirrors `re-frame.story.ui.schema-validation/schema-validation-
+  event?` — same predicate, different home. Both filter the trace
+  stream to the schema-violation subset."
+  [{:keys [op-type operation] :as _ev}]
+  (boolean
+    (and (= op-type :error)
+         (= operation :rf.error/schema-validation-failure))))
+
+;; ---- per-violation projection -------------------------------------------
+
+(defn violation-schema-id
+  "Return the schema-id a violation event is reporting against. Per
+  spec §Substrate the schema-id lives at `[:tags :schema]`.
+
+  Falls back to `[:tags :failing-id]` (the alternate slot Story's
+  schema-validation panel reads; see Spec 009 §Error event catalogue
+  for `SchemaValidationTags`). When neither is present the event is
+  bucketed under the synthetic `::unknown-schema` row so violations
+  with malformed tags still surface (instead of silently dropping).
+
+  Pure data → keyword-or-synthetic; JVM-testable."
+  [ev]
+  (or (get-in ev [:tags :schema])
+      (get-in ev [:tags :failing-id])
+      ::unknown-schema))
+
+(defn project-violation
+  "Project one raw `:rf.error/schema-validation-failure` trace event
+  into the panel's row-cell shape:
+
+      {:id          <int>              ;; the trace event's :id
+       :time        <ms>               ;; from :time
+       :schema-id   <keyword>          ;; from :tags :schema
+       :recovery    <keyword>          ;; from top-level :recovery
+       :where       <keyword>          ;; from :tags :where
+       :path        <vector|nil>       ;; from :tags :path
+       :value       <any>              ;; from :tags :value
+       :explanation <any|nil>          ;; from :tags :explanation
+       :frame       <keyword|nil>      ;; from :tags :frame
+       :dispatch-id <int|nil>          ;; from :tags :dispatch-id
+       :raw         <trace-event>}     ;; full event for deep-dives
+
+  Pure data → data; JVM-testable. The `:recovery` slot reads the
+  top-level :recovery (hoisted per Spec 009 §`:recovery` /
+  §Production hoist); falls back to `[:tags :recovery]` defensively
+  for events emitted before the hoist landed (rf2-wfbn3)."
+  [{:keys [id time recovery tags] :as ev}]
+  {:id          id
+   :time        time
+   :schema-id   (violation-schema-id ev)
+   :recovery    (or recovery (:recovery tags))
+   :where       (:where tags)
+   :path        (:path tags)
+   :value       (:value tags)
+   :explanation (or (:explanation tags) (:explain tags))
+   :frame       (:frame tags)
+   :dispatch-id (:dispatch-id tags)
+   :raw         ev})
+
+(defn project-violations
+  "Filter `events` (a seq of raw trace events from the buffer) to the
+  schema-validation-failure subset and project each one into a row
+  cell. Returns a vector in chronological order (oldest first); the
+  view groups by schema-id downstream. Pure data → data;
+  JVM-testable.
+
+  Per spec §Aging out — the timeline reads from the trace buffer
+  (bounded by Spec 009 at 200 entries by default; Causa's own ring
+  is bounded at 1000). Schema violations age out of the buffer along
+  with everything else."
+  [events]
+  (into []
+        (comp (filter schema-violation-event?)
+              (map project-violation))
+        events))
+
+;; ---- time-axis window projection ----------------------------------------
+
+(defn now-ms
+  "Return host-clock time in ms. Pure-ish — abstracted so test
+  fixtures can stub it via `with-redefs`. Cross-platform via
+  `#?(:clj ... :cljs ...)`."
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))
+
+(defn default-window
+  "Return the default time-axis window — the last
+  `default-window-ms` ms ending at `(now-ms)`. Per spec §Layout the
+  default is 60s. Pure data → `{:t0 :t1}`.
+
+  Used by the registry's `:rf.causa/schema-timeline-window` sub when
+  no window has been set explicitly."
+  []
+  (let [t1 (now-ms)]
+    {:t0 (- t1 default-window-ms)
+     :t1 t1}))
+
+(defn window-spans-ms
+  "Return the window span in ms — `(:t1 - :t0)`. Defensive
+  guard against `nil` / inverted windows; returns
+  `default-window-ms` in those cases. Pure data → number;
+  JVM-testable."
+  [{:keys [t0 t1] :as _window}]
+  (if (and (number? t0) (number? t1) (< t0 t1))
+    (- t1 t0)
+    default-window-ms))
+
+(defn violation-in-window?
+  "True iff `violation`'s `:time` falls in `[t0, t1]`. Pure data →
+  bool; JVM-testable. Per spec §Aging out — out-of-window violations
+  drop from the rendered set without leaving the underlying buffer."
+  [{:keys [t0 t1] :as _window} {:keys [time] :as _violation}]
+  (and (number? time)
+       (number? t0)
+       (number? t1)
+       (<= t0 time t1)))
+
+(defn violation-x-position
+  "Compute the SVG x-coord for `violation` against `window` + canvas
+  `width`. Pure data → number-or-nil; JVM-testable.
+
+  Out-of-window violations return nil (the view skips them); in-
+  window violations map linearly from `[t0, t1]` to `[0, width]`."
+  [{:keys [t0] :as window} width {:keys [time] :as _violation}]
+  (when (and (number? time)
+             (number? width)
+             (pos? width))
+    (let [span (window-spans-ms window)]
+      (when (pos? span)
+        (let [frac (/ (- time t0) span)]
+          (when (and (number? frac) (<= 0 frac 1))
+            (* frac width)))))))
+
+;; ---- per-row projection -------------------------------------------------
+
+(defn schema-row-key
+  "Derive a stable row key from a registered schema entry. Schema
+  registry entries are `path → schema` maps per Spec 010 §`reg-app-
+  schema` (path-based); the row key is the path itself. Used both as
+  the row's :data-testid suffix and as the dispatch arg for
+  `:rf.causa/set-schema-filter`. Pure data → vector / keyword."
+  [path-or-id]
+  (cond
+    (vector? path-or-id)  path-or-id
+    (keyword? path-or-id) path-or-id
+    :else                 ::unknown-schema))
+
+(defn schema-row-label
+  "Human-readable label for a row. Vectors render as `[:auth :email]`;
+  keywords render as `:schema/user-auth`; the synthetic
+  `::unknown-schema` renders as the literal `:?:`. Pure data →
+  string; JVM-testable."
+  [path-or-id]
+  (cond
+    (= ::unknown-schema path-or-id) ":?:"
+    (vector? path-or-id)            (pr-str path-or-id)
+    (keyword? path-or-id)           (str path-or-id)
+    :else                           (str path-or-id)))
+
+(defn group-violations-by-schema
+  "Group a vector of projected violations into a `{schema-id
+  [violations]}` map. Order preserved (insertion order in each
+  bucket; chronological iff input is chronological). Pure data →
+  data; JVM-testable."
+  [violations]
+  (reduce
+    (fn [acc v]
+      (update acc (:schema-id v) (fnil conj []) v))
+    {}
+    violations))
+
+(defn project-rows
+  "Project the row vector the view paints. Each row is:
+
+      {:schema-id   <path-or-keyword>   ;; from registered schemas
+       :label       <string>            ;; humanised
+       :violations  [<projected-violation> ...]  ;; in-window only
+       :empty?      <bool>              ;; no in-window violations
+       :first?      <bool>              ;; this row just gained its
+                                        ;; first in-window violation
+                                        ;; (flash cue; see spec
+                                        ;; §Reading the timeline at
+                                        ;; a glance)}
+
+  `schemas` is `{path → schema}` from `(rf/app-schemas frame-id)`.
+  `violations` is the flat projected vector (already filtered to the
+  current frame upstream when desired). `window` is the visible time
+  window. `previous-rows` is the row vector from the prior recompute
+  — used to detect first-violation transitions for the flash cue;
+  pass nil on the first call.
+
+  Rows whose schema-id is in `violations` but not in `schemas` (e.g.
+  a violation tagged against an unregistered schema, or the
+  synthetic ::unknown-schema bucket) are appended after the
+  registered rows so the violation still surfaces. Pure data →
+  data; JVM-testable.
+
+  Per spec §Layout the row order matches `(rf/app-schemas)`'s
+  declared order — `schemas` is expected to arrive as a vector of
+  pairs or a map iteration whose order the caller is happy with.
+  Maps from `app-schemas` are ordered insertion-wise in Clojure's
+  reference impl; the helper preserves whatever order it receives."
+  [schemas violations window previous-rows]
+  (let [by-sid       (group-violations-by-schema
+                       (filterv #(violation-in-window? window %) violations))
+        prev-by-sid  (when (sequential? previous-rows)
+                       (into {}
+                             (map (juxt :schema-id (constantly true)))
+                             (filter (comp seq :violations) previous-rows)))
+        registered-paths (cond
+                           (map? schemas)        (mapv first schemas)
+                           (sequential? schemas) (vec schemas)
+                           :else                 [])
+        registered-rows  (mapv
+                           (fn [p]
+                             (let [k  (schema-row-key p)
+                                   vs (get by-sid k [])
+                                   non-empty? (boolean (seq vs))
+                                   was-non-empty? (boolean (get prev-by-sid k))]
+                               {:schema-id k
+                                :label     (schema-row-label p)
+                                :violations vs
+                                :empty?    (not non-empty?)
+                                :first?    (and non-empty?
+                                                (not was-non-empty?))}))
+                           registered-paths)
+        registered-set   (into #{} (map :schema-id) registered-rows)
+        orphan-sids      (->> by-sid
+                              keys
+                              (remove registered-set)
+                              vec)
+        orphan-rows      (mapv
+                           (fn [sid]
+                             (let [vs (get by-sid sid [])
+                                   was-non-empty? (boolean (get prev-by-sid sid))]
+                               {:schema-id  sid
+                                :label      (schema-row-label sid)
+                                :violations vs
+                                :empty?     (empty? vs)
+                                :first?     (and (seq vs)
+                                                 (not was-non-empty?))}))
+                           orphan-sids)]
+    (into registered-rows orphan-rows)))
+
+;; ---- empty-state classification -----------------------------------------
+
+(defn empty-state-kind
+  "Classify the panel's empty-state for the view. Per spec §Empty
+  state there are three flavours:
+
+    :no-schemas        — `(rf/app-schemas)` returned nothing.
+                         The view paints the 'No schemas registered'
+                         pitch with the read-about-schemas link.
+
+    :no-violations     — schemas registered but none in-window.
+                         The view paints the 'All schemas clean in
+                         the last 60s' positive-result message.
+
+    nil                — at least one in-window violation; render
+                         the timeline normally.
+
+  Pure data → keyword-or-nil; JVM-testable."
+  [rows]
+  (cond
+    (empty? rows)
+    :no-schemas
+
+    (every? :empty? rows)
+    :no-violations
+
+    :else
+    nil))
+
+;; ---- per-violation detail -----------------------------------------------
+
+(defn find-violation
+  "Look up a projected violation by `:id` in `violations`. Returns
+  nil when not found. Used by `:rf.causa/selected-violation-detail`
+  to resolve the side-panel's detail row from the selection
+  reference. Pure data → row-or-nil; JVM-testable."
+  [violations violation-id]
+  (some (fn [v] (when (= violation-id (:id v)) v)) violations))
+
+(defn format-tooltip
+  "Build the one-line tooltip string per spec §Hover tooltip — e.g.
+  'at [:auth :email], expected :string, got nil'. Pure data →
+  string; JVM-testable.
+
+  Falls back to a best-effort summary when `:path` / `:value` are
+  absent. The full Malli explanation lives in the side-panel detail;
+  the tooltip is the cheap glance."
+  [{:keys [path value explanation] :as _violation}]
+  (let [path-str  (when (some? path)
+                    (str "at " (pr-str path)))
+        value-str (when (or (some? value) (nil? value))
+                    (try
+                      (str "got " (pr-str value))
+                      (catch #?(:clj Throwable :cljs :default) _
+                        "got <unprintable>")))
+        ;; explanation might carry a :message slot (Malli's per-error
+        ;; map); surface it when present.
+        msg       (when (map? explanation)
+                    (or (:message explanation)
+                        (some :message (:errors explanation))))]
+    (str/join ", "
+              (remove str/blank?
+                      [path-str value-str msg]))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -85,6 +85,7 @@
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
+            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]))
 
 ;; ---- defaults ------------------------------------------------------------
@@ -294,6 +295,119 @@
            :selected-dispatch-id selected-id
            :selected-epoch-id    selected-epoch-id
            :filtered?            (boolean filterable?)})))
+
+    ;; ---- Phase 5 (rf2-htffa) — Schema-violation Timeline subs ----
+    ;;
+    ;; Per tools/causa/spec/005-Schema-Timeline.md the panel reads
+    ;; from three streams:
+    ;;
+    ;;   1. (rf/app-schemas frame-id)  — registered schemas → rows
+    ;;   2. trace-buffer filtered to :rf.error/schema-validation-
+    ;;      failure → dots
+    ;;   3. the panel's own selection state — selected violation +
+    ;;      schema filter + time-axis window
+    ;;
+    ;; The composite below produces one map the view consumes per
+    ;; render. Per spec §Performance the projection is O(visible-
+    ;; violations) — typically 0–5.
+
+    ;; Registered schemas for the target frame — projected as a
+    ;; vector of `path-or-id` row keys. `rf/app-schemas` returns a
+    ;; `{path → schema}` map; the helper just iterates the map's
+    ;; entry-keys to keep the row ordering stable. Returns [] when
+    ;; the schemas artefact is not on the classpath.
+    (rf/reg-sub :rf.causa/registered-schemas
+      :<- [:rf.causa/target-frame]
+      (fn [[target-frame] _query]
+        (try
+          (vec (keys (or (rf/app-schemas {:frame target-frame}) {})))
+          (catch :default _
+            []))))
+
+    ;; The view's currently-selected violation id (the trace event's
+    ;; :id, stable per-process). nil = no selection; the detail
+    ;; side-panel hides.
+    (rf/reg-sub :rf.causa/selected-violation-id
+      (fn [db _query]
+        (get db :selected-violation-id)))
+
+    ;; Schema filter — when set, the panel narrows its rendered rows
+    ;; to the matching schema only. Per spec §Per-violation detail
+    ;; the 'Show me all violations of this schema' action sets this.
+    (rf/reg-sub :rf.causa/schema-filter
+      (fn [db _query]
+        (get db :schema-filter)))
+
+    ;; Time-axis window state — `{:t0 :t1}` in ms. nil falls back to
+    ;; the default 60s window ending at now. Per spec §Layout the
+    ;; window synchronises with the Trace panel's time-axis when
+    ;; both are visible; the shared slot is what makes the
+    ;; synchronisation a single-source-of-truth read.
+    (rf/reg-sub :rf.causa/schema-timeline-window
+      (fn [db _query]
+        (or (get db :schema-timeline-window)
+            (svt-helpers/default-window))))
+
+    ;; Projected violations filtered to the current window. Returns
+    ;; a vector of projected violation rows in chronological order
+    ;; (oldest first); the composite groups by schema downstream.
+    ;; Per spec §Aging out — out-of-window violations drop from the
+    ;; rendered set without leaving the underlying buffer.
+    (rf/reg-sub :rf.causa/schema-violations-window
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/schema-timeline-window]
+      (fn [[buffer window] _query]
+        (let [all (svt-helpers/project-violations buffer)]
+          (filterv #(svt-helpers/violation-in-window? window %) all))))
+
+    ;; Cache of the previously-rendered rows so the panel's flash
+    ;; cue (per spec §Reading the timeline at a glance) can detect
+    ;; the empty→non-empty transition. Updated on each composite
+    ;; recompute; the view reads :first? off each row.
+    (rf/reg-sub :rf.causa/schema-timeline-prev-rows
+      (fn [db _query]
+        (get db :schema-timeline-prev-rows)))
+
+    ;; The composite the view consumes. Shape:
+    ;;
+    ;;     {:rows                [<row> ...]      ;; per-schema rows
+    ;;      :window              {:t0 :t1}
+    ;;      :total-violations    <int>            ;; pre-filter count
+    ;;      :rendered-violations <int>            ;; post-filter
+    ;;      :selected-violation  <projected|nil>
+    ;;      :schema-filter       <schema-id|nil>}
+    ;;
+    ;; Per spec §Per-violation detail — `:selected-violation` is the
+    ;; full projected row (resolved from :selected-violation-id); nil
+    ;; when no selection OR when the id is no longer in the buffer.
+    (rf/reg-sub :rf.causa/schema-violation-timeline
+      :<- [:rf.causa/registered-schemas]
+      :<- [:rf.causa/schema-violations-window]
+      :<- [:rf.causa/schema-timeline-window]
+      :<- [:rf.causa/selected-violation-id]
+      :<- [:rf.causa/schema-filter]
+      :<- [:rf.causa/schema-timeline-prev-rows]
+      (fn [[schemas violations window selected-id schema-filter prev-rows] _query]
+        (let [;; If a schema-filter is set, narrow registered-schemas
+              ;; to that single row. Violations are filtered to the
+              ;; same schema-id.
+              schemas'    (if (some? schema-filter)
+                            (filterv #(= % schema-filter) schemas)
+                            schemas)
+              violations' (if (some? schema-filter)
+                            (filterv #(= schema-filter (:schema-id %))
+                                     violations)
+                            violations)
+              rows        (svt-helpers/project-rows
+                            schemas' violations' window prev-rows)
+              selected    (when selected-id
+                            (svt-helpers/find-violation violations selected-id))]
+          {:rows                 rows
+           :window               window
+           :total-violations    (count violations)
+           :rendered-violations (count violations')
+           :selected-violation   selected
+           :schema-filter        schema-filter})))
 
     ;; ---- events --------------------------------------------------
     (rf/reg-event-db :rf.causa/select-panel
@@ -665,7 +779,52 @@
 
     (rf/reg-event-db :rf.causa/hide-invalidation-chain
       (fn [db _event]
-        (dissoc db :sub-chain-open?))))
+        (dissoc db :sub-chain-open?)))
+
+    ;; ---- Phase 5 (rf2-htffa) — Schema-violation Timeline events --
+
+    ;; Clear the selected-violation-id (closes the detail side
+    ;; panel). Per spec §Per-violation detail — the close affordance
+    ;; on the detail panel header fires this.
+    (rf/reg-event-db :rf.causa/clear-violation-selection
+      (fn [db _event]
+        (dissoc db :selected-violation-id)))
+
+    ;; Select a violation by its trace-event :id (which is stable
+    ;; per-process per Spec 009 §Trace event shape). The detail side
+    ;; panel renders when this is set + the violation is still in
+    ;; the buffer. Setting nil clears the selection (parity with
+    ;; clear-violation-selection — the panel's dot click handler
+    ;; uses select, the close button uses clear).
+    (rf/reg-event-db :rf.causa/select-violation
+      (fn [db [_ violation-id]]
+        (if (some? violation-id)
+          (assoc db :selected-violation-id violation-id)
+          (dissoc db :selected-violation-id))))
+
+    ;; Set the per-schema filter — narrows the rendered rows to one
+    ;; schema. Per spec §Per-violation detail the 'Show me all
+    ;; violations of this schema' action dispatches this. Passing
+    ;; nil clears the filter (the Clear filter button in the
+    ;; header).
+    (rf/reg-event-db :rf.causa/set-schema-filter
+      (fn [db [_ schema-id]]
+        (if (some? schema-id)
+          (assoc db :schema-filter schema-id)
+          (dissoc db :schema-filter))))
+
+    ;; Set the time-axis window. Per spec §Layout drag-zoom expands
+    ;; the window; setting nil reverts to the default 60s window
+    ;; ending at now (the composite sub reads default-window when
+    ;; the slot is absent).
+    (rf/reg-event-db :rf.causa/set-schema-timeline-window
+      (fn [db [_ window]]
+        (if (and (map? window)
+                 (number? (:t0 window))
+                 (number? (:t1 window))
+                 (< (:t0 window) (:t1 window)))
+          (assoc db :schema-timeline-window window)
+          (dissoc db :schema-timeline-window)))))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -41,6 +41,7 @@
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
+            [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
@@ -82,7 +83,7 @@
    {:id :flows        :label "Flows"         :bead "rf2-xxx"}
    {:id :performance  :label "Performance"   :bead "rf2-xxx"}
    {:id :issues       :label "Issues"        :bead "rf2-xxx"}
-   {:id :schemas      :label "Schemas"       :bead "rf2-xxx"}
+   {:id :schemas      :label "Schemas"       :bead "rf2-htffa" :live? true}
    ;; Phase 5 (rf2-pzxsr). Per spec/006-Hydration-Debugger.md §Visibility
    ;; the panel is dormant until at least one :rf.ssr/hydration-mismatch
    ;; trace lands. The sidebar entry's `:dormant?` flag drives the `◌`
@@ -253,6 +254,7 @@
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
       :causality    [causality-graph/causality-graph-view]
+      :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]
       :hydration    [hydration-debugger/hydration-debugger-view]
       [stub-panel (or item {:label "Unknown panel"

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
@@ -1,0 +1,323 @@
+(ns day8.re-frame2-causa.panels.schema-violation-timeline-cljs-test
+  "CLJS-side wiring tests for Causa's Schema-violation Timeline panel
+  (Phase 5, rf2-htffa).
+
+  ## Contracts under test (in addition to the pure-data tests in
+  `schema_violation_timeline_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the subs / events** under the `:rf.causa/*`
+       namespace.
+    2. **The composite sub** returns the panel's render data shape:
+       rows + window + selection + filter.
+    3. **Selection writes to the Causa frame, not the host.**
+    4. **Schema filter narrows the rendered rows.**
+    5. **View renders the three empty states** correctly.
+    6. **View renders dots with recovery-correct colours.**
+
+  ## Pure hiccup walk
+
+  Same approach as `time_travel_cljs_test.cljs` — walk the view's
+  hiccup tree by `data-testid` rather than mounting to a DOM. Keeps
+  the suite fast + host-portable on node-test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.schema-violation-timeline :as panel]
+            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker (mirrors event_detail / time_travel tests) ----------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (string? (:data-testid (second node)))
+                 (str/starts-with? (:data-testid (second node)) prefix)))
+          (hiccup-seq tree)))
+
+;; ---- buffer helpers -----------------------------------------------------
+
+(defn- failure-ev
+  ([id schema-id recovery]
+   (failure-ev id schema-id recovery {}))
+  ([id schema-id recovery {:keys [time path value]
+                           :or {time 1000
+                                path [:auth :email]
+                                value nil}}]
+   {:id        id
+    :op-type   :error
+    :operation :rf.error/schema-validation-failure
+    :time      time
+    :recovery  recovery
+    :tags      {:where  :app-db
+                :path   path
+                :value  value
+                :schema schema-id
+                :frame  :rf/default}}))
+
+(defn- push-failures! [evs]
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
+
+;; ---- (1) registry wires subs / events -----------------------------------
+
+(deftest registry-installs-schema-timeline-subs
+  (testing "register-causa-handlers! installs the Phase 5 subs"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/schema-violation-timeline)))
+    (is (some? (registrar/handler :sub :rf.causa/registered-schemas)))
+    (is (some? (registrar/handler :sub :rf.causa/schema-violations-window)))
+    (is (some? (registrar/handler :sub :rf.causa/schema-timeline-window)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-violation-id)))
+    (is (some? (registrar/handler :sub :rf.causa/schema-filter)))))
+
+(deftest registry-installs-schema-timeline-events
+  (testing "register-causa-handlers! installs the Phase 5 events"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :event :rf.causa/select-violation)))
+    (is (some? (registrar/handler :event :rf.causa/clear-violation-selection)))
+    (is (some? (registrar/handler :event :rf.causa/set-schema-filter)))
+    (is (some? (registrar/handler :event :rf.causa/set-schema-timeline-window)))))
+
+;; ---- (2) composite sub returns sane defaults ----------------------------
+
+(deftest composite-sub-defaults-with-empty-buffer
+  (testing ":rf.causa/schema-violation-timeline returns sane defaults on a
+            fresh frame with an empty trace buffer"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/schema-violation-timeline])]
+        (is (vector? (:rows data)))
+        (is (map? (:window data)))
+        (is (number? (:t0 (:window data))))
+        (is (number? (:t1 (:window data))))
+        (is (= 0 (:total-violations data)))
+        (is (= 0 (:rendered-violations data)))
+        (is (nil? (:selected-violation data)))
+        (is (nil? (:schema-filter data)))))))
+
+;; ---- (3) select-violation writes to the Causa frame ---------------------
+
+(deftest select-violation-writes-to-causa-frame
+  (testing ":rf.causa/select-violation lands on :rf/causa, not :rf/default"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-violation 42]))
+    (is (= 42 (:selected-violation-id (frame/frame-app-db-value :rf/causa))))
+    (is (nil? (:selected-violation-id (frame/frame-app-db-value :rf/default))))))
+
+(deftest select-violation-nil-clears-selection
+  (testing "dispatching :rf.causa/select-violation with nil clears the slot"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-violation 7])
+      (rf/dispatch-sync [:rf.causa/select-violation nil]))
+    (is (nil? (:selected-violation-id (frame/frame-app-db-value :rf/causa))))))
+
+(deftest clear-violation-selection-event
+  (testing ":rf.causa/clear-violation-selection drops the slot"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-violation 1])
+      (rf/dispatch-sync [:rf.causa/clear-violation-selection]))
+    (is (nil? (:selected-violation-id (frame/frame-app-db-value :rf/causa))))))
+
+;; ---- (4) schema-filter narrows the rendered rows ------------------------
+
+(deftest set-schema-filter-narrows-rows
+  (testing "dispatching :rf.causa/set-schema-filter restricts the composite
+            to the matching schema-id"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [now-ms (.getTime (js/Date.))]
+      (push-failures! [(failure-ev 1 :s/auth :skip-handler {:time now-ms})
+                       (failure-ev 2 :s/cart :rollback-db  {:time now-ms})])
+      (rf/with-frame :rf/causa
+        ;; First, both rows surface as orphans (no schemas registered).
+        (let [data @(rf/subscribe [:rf.causa/schema-violation-timeline])]
+          (is (= 2 (:rendered-violations data))
+              "both violations render before filter"))
+        ;; Apply a filter — only :s/auth's row remains.
+        (rf/dispatch-sync [:rf.causa/set-schema-filter :s/auth])
+        (let [data @(rf/subscribe [:rf.causa/schema-violation-timeline])]
+          (is (= 1 (:rendered-violations data))
+              "filter narrows to one violation")
+          (is (= :s/auth (:schema-filter data))
+              "filter slot exposed to the view")
+          (is (some #(= :s/auth (:schema-id %)) (:rows data))
+              "the filtered row is present"))
+        ;; Clearing the filter restores both.
+        (rf/dispatch-sync [:rf.causa/set-schema-filter nil])
+        (let [data @(rf/subscribe [:rf.causa/schema-violation-timeline])]
+          (is (= 2 (:rendered-violations data))
+              "filter cleared — both violations render again")
+          (is (nil? (:schema-filter data))))))))
+
+;; ---- (5) time-axis window set/clear -------------------------------------
+
+(deftest set-schema-timeline-window-validates-shape
+  (testing "valid {:t0 :t1} maps set the slot; invalid maps clear it"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      ;; Valid window — written.
+      (rf/dispatch-sync [:rf.causa/set-schema-timeline-window
+                         {:t0 1000 :t1 2000}])
+      (is (= {:t0 1000 :t1 2000}
+             (:schema-timeline-window (frame/frame-app-db-value :rf/causa))))
+      ;; Inverted window — dropped.
+      (rf/dispatch-sync [:rf.causa/set-schema-timeline-window
+                         {:t0 2000 :t1 1000}])
+      (is (nil? (:schema-timeline-window (frame/frame-app-db-value :rf/causa))))
+      ;; nil — clears.
+      (rf/dispatch-sync [:rf.causa/set-schema-timeline-window
+                         {:t0 1000 :t1 2000}])
+      (rf/dispatch-sync [:rf.causa/set-schema-timeline-window nil])
+      (is (nil? (:schema-timeline-window (frame/frame-app-db-value :rf/causa)))))))
+
+;; ---- (6) empty states render -------------------------------------------
+
+(deftest empty-state-no-schemas-renders
+  (testing "with no registered schemas + no violations, the no-schemas
+            empty state renders"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [tree (panel/schema-violation-timeline-view)]
+        (is (some? (find-by-testid tree "rf-causa-schema-violation-timeline")))
+        (is (some? (find-by-testid tree "rf-causa-schema-timeline-empty-no-schemas")))))))
+
+;; (no-violations + violations-rendered live states use the real
+;; registered-schemas sub. The schemas artefact is not on the test
+;; classpath, so `(rf/app-schemas)` returns {} and the no-schemas
+;; branch is the one the view paints when there are no failures.
+;; The violations-rendered branch is asserted below — orphan rows
+;; surface as rows even when no schemas are registered.)
+
+(deftest violations-render-as-orphan-rows
+  (testing "violations against unregistered schemas still surface as rows
+            (per spec §Substrate — Causa renders what the buffer remembers)"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [now-ms (.getTime (js/Date.))]
+      (push-failures! [(failure-ev 1 :s/auth :skip-handler {:time now-ms})])
+      (rf/with-frame :rf/causa
+        (let [tree (panel/schema-violation-timeline-view)]
+          (is (some? (find-by-testid tree "rf-causa-schema-violation-timeline")))
+          (is (some? (find-by-testid tree "rf-causa-schema-timeline-rows"))
+              "violations render the rows container")
+          (is (nil? (find-by-testid tree "rf-causa-schema-timeline-empty-no-schemas"))
+              "empty state is replaced by the live rows"))))))
+
+;; ---- (7) recovery → colour mapping is honoured by the rendered dot -----
+
+(deftest re-raised-renders-thicker-stroke-in-view
+  (testing "the view paints :re-raised violations with the thicker stroke
+            width from the helpers"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [now-ms (.getTime (js/Date.))]
+      (push-failures! [(failure-ev 9 :s/critical :re-raised {:time now-ms})])
+      (rf/with-frame :rf/causa
+        (let [tree (panel/schema-violation-timeline-view)
+              dots (find-all-by-testid-prefix tree "rf-causa-schema-timeline-row-")]
+          (is (some
+                (fn [node]
+                  (let [attrs (when (vector? node) (second node))]
+                    (and (map? attrs)
+                         (= h/colour-red (:fill attrs))
+                         (= h/default-re-raised-stroke-width
+                            (:stroke-width attrs)))))
+                (hiccup-seq tree))
+              "at least one rendered <circle> carries the :re-raised stroke")
+          ;; Sanity — the tree contains the rows container.
+          (is (some? (find-by-testid tree "rf-causa-schema-timeline-rows"))))))))
+
+(deftest replaced-with-default-paints-yellow
+  (testing "the view paints :replaced-with-default violations with the
+            yellow colour from the helpers (the framework recovered
+            cleanly)"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [now-ms (.getTime (js/Date.))]
+      (push-failures! [(failure-ev 11 :s/soft :replaced-with-default
+                                   {:time now-ms})])
+      (rf/with-frame :rf/causa
+        (let [tree (panel/schema-violation-timeline-view)]
+          (is (some
+                (fn [node]
+                  (let [attrs (when (vector? node) (second node))]
+                    (and (map? attrs)
+                         (= h/colour-yellow (:fill attrs)))))
+                (hiccup-seq tree))
+              "at least one rendered <circle> is yellow"))))))
+
+;; ---- (8) selection round-trip surfaces detail panel --------------------
+
+(deftest selecting-a-violation-renders-detail-panel
+  (testing "after dispatching :rf.causa/select-violation, the detail side
+            panel appears in the view tree"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (let [now-ms (.getTime (js/Date.))]
+      (push-failures! [(failure-ev 77 :s/user :rollback-db
+                                   {:time now-ms
+                                    :path [:user :email]
+                                    :value "not-an-email"})])
+      (rf/with-frame :rf/causa
+        ;; Before selection — no detail panel.
+        (let [tree (panel/schema-violation-timeline-view)]
+          (is (nil? (find-by-testid tree
+                                    "rf-causa-schema-violation-detail-77"))))
+        ;; Select.
+        (rf/dispatch-sync [:rf.causa/select-violation 77])
+        (let [tree (panel/schema-violation-timeline-view)]
+          (is (some? (find-by-testid tree
+                                     "rf-causa-schema-violation-detail-77"))
+              "the detail side panel renders for the selected violation"))
+        ;; Clear.
+        (rf/dispatch-sync [:rf.causa/clear-violation-selection])
+        (let [tree (panel/schema-violation-timeline-view)]
+          (is (nil? (find-by-testid tree
+                                    "rf-causa-schema-violation-detail-77"))
+              "clearing selection unmounts the detail side panel"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_helpers_cljs_test.cljc
@@ -1,0 +1,350 @@
+(ns day8.re-frame2-causa.panels.schema-violation-timeline-helpers-cljs-test
+  "Pure-data tests for Causa's Schema-violation Timeline helpers
+  (Phase 5, rf2-htffa).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `time_travel_helpers_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **Recovery → colour mapping** — all five Spec 010 recovery
+       modes map to the correct colour; `:re-raised` carries a
+       thicker stroke; unknown recoveries fall back to the grey
+       defensive colour.
+    2. **schema-violation-event?** — classifies trace events.
+    3. **project-violation / project-violations** — projects raw
+       trace events onto row cells.
+    4. **window projection** — `violation-in-window?` +
+       `violation-x-position` are total over edge cases.
+    5. **project-rows** — registered schemas drive row order; new
+       rows surface `:first? true` on empty→non-empty transitions.
+    6. **empty-state-kind** — classifies the three empty-state
+       branches.
+    7. **format-tooltip** — builds the one-line hover summary."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- failure-ev
+  "Build a minimal `:rf.error/schema-validation-failure` trace event
+  fixture. Mirrors the shape Spec 009's error-event catalogue
+  documents: `:op-type :error`, top-level `:recovery`,
+  `:tags {:where :path :value :schema :explanation :frame
+  :dispatch-id}`."
+  ([id schema-id recovery]
+   (failure-ev id schema-id recovery {}))
+  ([id schema-id recovery {:keys [where path value explanation frame dispatch-id time]
+                           :or {where :app-db
+                                path  [:auth :email]
+                                value nil
+                                frame :rf/default
+                                time  1000}}]
+   (cond-> {:id        id
+            :op-type   :error
+            :operation :rf.error/schema-validation-failure
+            :time      time
+            :recovery  recovery
+            :tags      (cond-> {:where  where
+                                :path   path
+                                :value  value
+                                :schema schema-id
+                                :frame  frame}
+                         explanation  (assoc :explanation explanation)
+                         dispatch-id  (assoc :dispatch-id dispatch-id))})))
+
+;; ---- (1) recovery → colour mapping --------------------------------------
+
+(deftest recovery-colour-mapping-honours-spec
+  (testing "every Spec 010 recovery maps to the spec-defined colour"
+    (is (= h/colour-red    (h/recovery->colour :skip-handler)))
+    (is (= h/colour-red    (h/recovery->colour :skip-fx)))
+    (is (= h/colour-red    (h/recovery->colour :rollback-db)))
+    (is (= h/colour-yellow (h/recovery->colour :replaced-with-default)))
+    (is (= h/colour-red    (h/recovery->colour :re-raised)))))
+
+(deftest recovery-colour-unknown-recovery-falls-back
+  (testing "an unrecognised recovery falls back to the defensive grey"
+    (is (= h/colour-unknown (h/recovery->colour :something-new)))
+    (is (= h/colour-unknown (h/recovery->colour nil)))))
+
+(deftest re-raised-renders-thicker-stroke
+  (testing ":re-raised gets the thicker stroke (the visual differentiator
+            per spec §Recovery → colour mapping)"
+    (is (= h/default-re-raised-stroke-width
+           (h/recovery->stroke-width :re-raised))
+        ":re-raised stroke is thicker")
+    (doseq [r [:skip-handler :skip-fx :rollback-db :replaced-with-default]]
+      (is (= h/default-base-stroke-width
+             (h/recovery->stroke-width r))
+          (str r " uses base stroke")))))
+
+(deftest recovery-presentation-bundles-fill-and-stroke
+  (testing "recovery->presentation projects fill + stroke-width + re-raised? bit"
+    (let [p (h/recovery->presentation :re-raised)]
+      (is (= h/colour-red (:fill p)))
+      (is (= h/default-re-raised-stroke-width (:stroke-width p)))
+      (is (true? (:re-raised? p))))
+    (let [p (h/recovery->presentation :replaced-with-default)]
+      (is (= h/colour-yellow (:fill p)))
+      (is (= h/default-base-stroke-width (:stroke-width p)))
+      (is (false? (:re-raised? p))))))
+
+(deftest closed-recovery-set-listed-in-vector
+  (testing "the spec §The five recovery categories declared order is
+            preserved in `recovery-modes`"
+    (is (= [:skip-handler :skip-fx :rollback-db
+            :replaced-with-default :re-raised]
+           h/recovery-modes))))
+
+;; ---- (2) schema-violation-event? ----------------------------------------
+
+(deftest schema-violation-event-classifier
+  (testing "schema-validation-failure events are accepted"
+    (is (true? (h/schema-violation-event?
+                 (failure-ev 1 :s/auth :skip-handler)))))
+  (testing "other op-types / operations are rejected"
+    (is (false? (h/schema-violation-event?
+                  {:id 1 :op-type :event :operation :event/dispatched})))
+    (is (false? (h/schema-violation-event?
+                  {:id 1 :op-type :error :operation :rf.error/handler-exception})))
+    (is (false? (h/schema-violation-event?
+                  {:id 1 :op-type :warning
+                   :operation :rf.error/schema-validation-failure})))))
+
+;; ---- (3) project-violation / project-violations -------------------------
+
+(deftest project-violation-projects-all-slots
+  (testing "every field the panel reads ends up on the row"
+    (let [ev  (failure-ev 99 :schema/user-auth :replaced-with-default
+                          {:path [:user :email]
+                           :value nil
+                           :explanation {:message "missing required key"}
+                           :dispatch-id 42
+                           :time 12345})
+          row (h/project-violation ev)]
+      (is (= 99 (:id row)))
+      (is (= 12345 (:time row)))
+      (is (= :schema/user-auth (:schema-id row)))
+      (is (= :replaced-with-default (:recovery row)))
+      (is (= :app-db (:where row)))
+      (is (= [:user :email] (:path row)))
+      (is (nil? (:value row)))
+      (is (= {:message "missing required key"} (:explanation row)))
+      (is (= :rf/default (:frame row)))
+      (is (= 42 (:dispatch-id row)))
+      (is (= ev (:raw row))
+          "the raw trace event is preserved for deep-dives"))))
+
+(deftest project-violation-falls-back-to-tags-recovery
+  (testing "events emitted before the rf2-wfbn3 :recovery hoist (recovery
+            under :tags only) still project correctly"
+    (let [ev  {:id 1 :op-type :error
+               :operation :rf.error/schema-validation-failure
+               :tags {:schema :s/x
+                      :recovery :skip-handler
+                      :where :event}}
+          row (h/project-violation ev)]
+      (is (= :skip-handler (:recovery row))
+          "falls back to (:recovery tags) when top-level :recovery is absent"))))
+
+(deftest project-violation-synthetic-schema-id-for-malformed-events
+  (testing "events missing both :tags :schema and :tags :failing-id bucket
+            under the synthetic ::unknown-schema row"
+    (let [ev  {:id 1 :op-type :error
+               :operation :rf.error/schema-validation-failure
+               :tags {:where :app-db}}
+          row (h/project-violation ev)]
+      (is (= ::h/unknown-schema (:schema-id row))))))
+
+(deftest project-violation-failing-id-as-schema-fallback
+  (testing ":tags :failing-id is read as the schema-id when :tags :schema is
+            absent (Story's tags shape per Spec 009 §SchemaValidationTags)"
+    (let [ev  {:id 1 :op-type :error
+               :operation :rf.error/schema-validation-failure
+               :tags {:failing-id :s/user-auth
+                      :where :event}}
+          row (h/project-violation ev)]
+      (is (= :s/user-auth (:schema-id row))))))
+
+(deftest project-violations-filters-and-projects
+  (testing "non-failure events are dropped; the rest project chronologically"
+    (let [evs [(failure-ev 1 :s/a :skip-handler)
+               {:id 2 :op-type :event :operation :event/dispatched}
+               (failure-ev 3 :s/b :replaced-with-default)
+               {:id 4 :op-type :warning :operation :rf.warning/handler-replaced}
+               (failure-ev 5 :s/a :rollback-db)]
+          rows (h/project-violations evs)]
+      (is (= 3 (count rows)))
+      (is (= [1 3 5] (mapv :id rows)))
+      (is (= [:s/a :s/b :s/a] (mapv :schema-id rows))))))
+
+;; ---- (4) window projection ----------------------------------------------
+
+(deftest violation-in-window-inclusive
+  (testing "the window is inclusive at both ends"
+    (let [w {:t0 1000 :t1 2000}]
+      (is (true?  (h/violation-in-window? w {:time 1000})))
+      (is (true?  (h/violation-in-window? w {:time 1500})))
+      (is (true?  (h/violation-in-window? w {:time 2000})))
+      (is (false? (h/violation-in-window? w {:time 999})))
+      (is (false? (h/violation-in-window? w {:time 2001})))
+      (is (false? (h/violation-in-window? w {:time nil}))
+          "nil time is rejected, not crashed"))))
+
+(deftest violation-x-position-maps-linearly
+  (testing "violations at the window endpoints land at 0 and width"
+    (let [w {:t0 1000 :t1 2000}]
+      (is (= 0   (h/violation-x-position w 100 {:time 1000})))
+      (is (= 100 (h/violation-x-position w 100 {:time 2000})))
+      (is (= 50  (h/violation-x-position w 100 {:time 1500})))))
+  (testing "out-of-window violations return nil"
+    (let [w {:t0 1000 :t1 2000}]
+      (is (nil? (h/violation-x-position w 100 {:time 500})))
+      (is (nil? (h/violation-x-position w 100 {:time 5000})))))
+  (testing "edge cases — zero width, nil time, inverted window"
+    (is (nil? (h/violation-x-position {:t0 1000 :t1 2000} 0 {:time 1500})))
+    (is (nil? (h/violation-x-position {:t0 1000 :t1 2000} 100 {:time nil})))))
+
+(deftest window-spans-ms-defensive
+  (testing "defensive against nil / inverted windows — falls back to the
+            default 60s span"
+    (is (= h/default-window-ms (h/window-spans-ms nil)))
+    (is (= h/default-window-ms (h/window-spans-ms {})))
+    (is (= h/default-window-ms (h/window-spans-ms {:t0 2000 :t1 1000})))
+    (is (= 5000 (h/window-spans-ms {:t0 1000 :t1 6000})))))
+
+;; ---- (5) project-rows ---------------------------------------------------
+
+(deftest project-rows-empty-schemas-empty-violations
+  (testing "no schemas, no violations → empty row vector"
+    (is (= [] (h/project-rows [] [] {:t0 0 :t1 1000} nil)))))
+
+(deftest project-rows-orders-by-registered-schemas
+  (testing "row order mirrors the schemas iteration order"
+    (let [schemas    [[:auth] [:cart] [:order]]
+          window     {:t0 0 :t1 1000}
+          violations [(h/project-violation (failure-ev 1 [:cart] :rollback-db
+                                                       {:time 500}))]
+          rows       (h/project-rows schemas violations window nil)]
+      (is (= [[:auth] [:cart] [:order]]
+             (mapv :schema-id rows))
+          "rows render in the declared order of (rf/app-schemas)")
+      (is (= [true false true] (mapv :empty? rows))
+          ":auth and :order are empty in-window; :cart has one violation"))))
+
+(deftest project-rows-filters-out-of-window-violations
+  (testing "violations outside the window do not appear on their row"
+    (let [schemas    [[:auth]]
+          window     {:t0 1000 :t1 2000}
+          violations (mapv h/project-violation
+                           [(failure-ev 1 [:auth] :skip-handler {:time 500})
+                            (failure-ev 2 [:auth] :skip-handler {:time 1500})])
+          rows       (h/project-rows schemas violations window nil)]
+      (is (= 1 (count rows)))
+      (is (= 1 (count (:violations (first rows))))
+          "only the in-window violation surfaces")
+      (is (= 2 (:id (first (:violations (first rows)))))))))
+
+(deftest project-rows-flash-on-first-violation
+  (testing "a row that was empty in the previous render and now has a
+            violation surfaces :first? true (per spec §Reading the
+            timeline at a glance)"
+    (let [schemas    [[:auth]]
+          window     {:t0 0 :t1 1000}
+          ;; Previous render — empty.
+          prev-rows  [{:schema-id [:auth] :violations [] :empty? true}]
+          violations (mapv h/project-violation
+                           [(failure-ev 1 [:auth] :skip-handler {:time 500})])
+          rows       (h/project-rows schemas violations window prev-rows)]
+      (is (= 1 (count rows)))
+      (is (true? (:first? (first rows)))
+          ":first? flags the empty→non-empty transition"))))
+
+(deftest project-rows-no-flash-when-previous-non-empty
+  (testing "a row that was already non-empty does NOT flash again"
+    (let [schemas    [[:auth]]
+          window     {:t0 0 :t1 1000}
+          prev-rows  [{:schema-id [:auth]
+                       :violations [{:id 0 :time 100}]
+                       :empty? false}]
+          violations (mapv h/project-violation
+                           [(failure-ev 1 [:auth] :skip-handler {:time 500})])
+          rows       (h/project-rows schemas violations window prev-rows)]
+      (is (false? (:first? (first rows)))
+          ":first? stays false once the row has fired"))))
+
+(deftest project-rows-orphan-violations-surface
+  (testing "a violation whose schema-id is NOT in the registered set still
+            surfaces — appended after the registered rows so the user sees
+            the failure (per spec §Substrate — Causa renders what the
+            buffer remembers)"
+    (let [schemas    [[:auth]]
+          window     {:t0 0 :t1 1000}
+          violations (mapv h/project-violation
+                           [(failure-ev 1 :s/orphan :skip-handler {:time 500})])
+          rows       (h/project-rows schemas violations window nil)]
+      (is (= 2 (count rows)))
+      (is (= [:auth]    (:schema-id (first rows))))
+      (is (= :s/orphan  (:schema-id (second rows))))
+      (is (true?  (:empty? (first rows))))
+      (is (false? (:empty? (second rows)))))))
+
+;; ---- (6) empty-state-kind ----------------------------------------------
+
+(deftest empty-state-kind-classifies-three-branches
+  (testing "no rows → :no-schemas (the schemas-not-registered pitch)"
+    (is (= :no-schemas (h/empty-state-kind []))))
+  (testing "every row is empty → :no-violations (the 'all schemas clean'
+            positive-result message)"
+    (is (= :no-violations
+           (h/empty-state-kind
+             [{:schema-id [:auth] :violations [] :empty? true}
+              {:schema-id [:cart] :violations [] :empty? true}]))))
+  (testing "at least one violation → nil (render the timeline normally)"
+    (is (nil?
+          (h/empty-state-kind
+            [{:schema-id [:auth] :violations [{:id 1}] :empty? false}])))))
+
+;; ---- (7) find-violation -------------------------------------------------
+
+(deftest find-violation-by-id
+  (testing "find-violation locates a row by trace-event :id"
+    (let [vs (mapv h/project-violation
+                   [(failure-ev 1 :s/a :skip-handler)
+                    (failure-ev 2 :s/b :replaced-with-default)
+                    (failure-ev 3 :s/c :re-raised)])]
+      (is (= :s/b (:schema-id (h/find-violation vs 2))))
+      (is (nil? (h/find-violation vs 999))
+          "missing id returns nil"))))
+
+;; ---- (8) format-tooltip -------------------------------------------------
+
+(deftest format-tooltip-builds-one-liner
+  (testing "tooltip carries path + value when both present"
+    (let [t (h/format-tooltip {:path [:auth :email]
+                               :value nil
+                               :explanation nil})]
+      (is (some? t))
+      (is (re-find #"\[:auth :email\]" t))
+      (is (re-find #"got nil" t))))
+  (testing "tooltip surfaces an :explanation :message slot when present"
+    (let [t (h/format-tooltip {:path [:user]
+                               :value 42
+                               :explanation {:message "expected string"}})]
+      (is (re-find #"expected string" t)))))
+
+(deftest schema-row-label-renders-paths-and-keywords
+  (testing "vector paths render as their pr-str form"
+    (is (= "[:auth :email]" (h/schema-row-label [:auth :email]))))
+  (testing "keyword schema-ids render with the leading colon"
+    (is (= ":schema/user-auth" (h/schema-row-label :schema/user-auth))))
+  (testing "the synthetic ::unknown-schema renders as :?:"
+    (is (= ":?:" (h/schema-row-label ::h/unknown-schema)))))


### PR DESCRIPTION
Phase 5 of rf2-5aw5v (Causa v1.0 epic). Implements the Schema-violation Timeline panel per `tools/causa/spec/005-Schema-Timeline.md`.

## Summary

- Horizontal timeline that surfaces every `:rf.error/schema-validation-failure` trace event temporally — one row per registered schema, coloured dots per failure.
- Recovery → colour mapping (Spec 010 §Per-step recovery): `:skip-handler` / `:skip-fx` / `:rollback-db` / `:re-raised` → red; `:replaced-with-default` → yellow; `:re-raised` carries a thicker stroke as the visual differentiator.
- Per-violation detail side panel (schema / where / path / value / recovery + Malli explanation + Triggered-by + Open-in-causality-graph + Show-me-all-violations-of-this-schema filter + Clear filter affordance).
- Three empty states per spec: no schemas registered, schemas registered but no in-window violations ("All schemas clean in the last 60s"), and violations rendered.
- Time-axis window state (default 60s window) is registry-resident — `:rf.causa/schema-timeline-window` is the shared slot so the Trace panel's drag-zoom can synchronise once that panel lands.
- Sidebar `Schemas` entry promoted from dormant stub to `:live? true`.

## Surfaces

- `tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs` — view (per-row track + detail panel)
- `tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc` — pure-data projection (recovery → colour, violation projection, window projection, row projection, empty-state classification, tooltip)
- `tools/causa/src/day8/re_frame2_causa/registry.cljs` — `:rf.causa/registered-schemas`, `:rf.causa/schema-violations-window`, `:rf.causa/schema-timeline-window`, `:rf.causa/selected-violation-id`, `:rf.causa/schema-filter`, `:rf.causa/schema-violation-timeline` composite + four events (`:select-violation`, `:clear-violation-selection`, `:set-schema-filter`, `:set-schema-timeline-window`). Wrapped in `;; ── schema-violation-timeline panel begin ── / end ──` markers.
- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — sidebar entry + canvas dispatch (also marked).

## Test plan

- [x] Helpers: 24 deftests / 83 assertions cover the recovery-mode mapping, schema-violation classifier, projection, window math, row-ordering, first-violation flash detection, three empty-state branches, find-violation, tooltip formatting, and schema-row labels. JVM-runnable via Cognitect's test-runner (the `_cljs_test.cljc` dual-target pattern).
- [x] CLJS wiring: registry installation, sane composite-sub defaults, frame-isolated `select-violation` (writes to `:rf/causa`, not the host), nil-clear parity, schema-filter narrowing / clearing, time-axis window validation, three empty-state branches, recovery-correct dot rendering (re-raised stroke + yellow for replaced-with-default), selection round-trip mounts/unmounts the detail side panel.
- [x] Full Causa JVM suite: 96 tests / 297 assertions pass.
- [x] Full node-test suite: 845 tests / 2211 assertions pass.
- [x] Bundle-isolation + elision smokes pass.

Refs: rf2-5aw5v (parent epic), rf2-htffa (this phase). Builds on Spec 009 §Error event catalogue (rf2-wfbn3, just landed in #575) and Spec 010 §Per-step recovery.