### PR TITLE
test(conformance): drop :actor/timeout from claim set — retired per rf2-3y3y (rf2-iro3h)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -107,7 +107,13 @@
     :actor/invoke
     :actor/spawn-and-join
     :actor/system-id
-    :actor/timeout
+    ;; :actor/timeout retired per rf2-3y3y — :fsm/delayed-after subsumes
+    ;; it. The state-level :after primitive covers wall-clock-timeout
+    ;; semantics for both pure timed-transition states and :invoke-bearing
+    ;; states; the after-*.edn fixtures (after-single-delay, after-hierarchy,
+    ;; after-stale-detection, parallel-after-scoped-to-region) exercise the
+    ;; canonical primitive. See [spec/005-StateMachines.md §Capability matrix]
+    ;; and [spec/MIGRATION.md §M-44].
     :flow/basic
     :flow/topo
     :flow/dirty-check

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -66,7 +66,13 @@
     :actor/invoke
     :actor/spawn-and-join                              ;; rf2-6vmw / rf2-er0t
     :actor/system-id                                   ;; rf2-suue / rf2-ecv4
-    :actor/timeout                                     ;; rf2-1lop
+    ;; :actor/timeout retired per rf2-3y3y — :fsm/delayed-after subsumes
+    ;; it. The state-level :after primitive covers wall-clock-timeout
+    ;; semantics for both pure timed-transition states and :invoke-bearing
+    ;; states; the after-*.edn fixtures (after-single-delay, after-hierarchy,
+    ;; after-stale-detection, parallel-after-scoped-to-region) exercise the
+    ;; canonical primitive. See [spec/005-StateMachines.md §Capability matrix]
+    ;; and [spec/MIGRATION.md §M-44].
     ;; Flow capabilities — per Spec 013. The flow-*.edn fixtures
     ;; (recompute-on-input-change, multi-input-topo, noop-on-value-equal-
     ;; input, toggle-via-fx, hot-reload-preserves-output) declare these.


### PR DESCRIPTION
## Summary

- `:actor/timeout` was claimed by both the JVM and CLJS conformance runners but no fixture in `spec/conformance/fixtures/` referenced it, making the claim unverifiable (per the test-coverage sweep, finding B-3).
- Per [Spec 005 §Capability matrix](../blob/main/spec/005-StateMachines.md) and [MIGRATION §M-44](../blob/main/spec/MIGRATION.md) (rf2-3y3y), the capability axis is **retired** — `:fsm/delayed-after` subsumes it. The state-level `:after` primitive covers wall-clock-timeout semantics for both pure timed-transition states and `:invoke`-bearing states.
- The bead (rf2-iro3h) offered two options: ship a fixture, or drop the capability. Ship-a-fixture is not viable because the contract no longer exists in the spec; drop is the only correct action. Retirement note in both files cross-references the spec + MIGRATION entries so the next reader doesn't have to retrace this.

The canonical primitive is already exercised by the after-*.edn fixtures: `after-single-delay`, `after-hierarchy`, `after-stale-detection`, `parallel-after-scoped-to-region`.

## Test plan

- [x] JVM conformance corpus: 110 passed, 0 failed (`clojure -M:test -n re-frame.conformance-test`)
- [x] CLJS conformance corpus: 110 passed, 0 failed (`npx shadow-cljs compile node-test && node out/node-test.js`)
- [x] No fixture references `:actor/timeout` (`grep -r "actor/timeout" spec/conformance/`)
- [x] No fixture is newly skipped or newly claimed by this change (skipped list unchanged: only `:flow/lifecycle-emits-traces` due to pending `:flow/trace`; PR #579)

Bead: [rf2-iro3h](https://github.com/day8/re-frame2/issues?q=rf2-iro3h)