### PR TITLE
feat(causa): AI Co-Pilot rail panel — Phase 5 (rf2-rccf3)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -15,8 +15,17 @@
   who prefer Cmd+Shift+C can swap in their browser's keyboard-
   shortcut UI; Phase 1 ships only the Ctrl-modifier path. macOS
   Safari sometimes maps Cmd+Shift+C to dev-tools' Inspect — Causa
-  deliberately uses `ctrl` to avoid that collision."
-  (:require [day8.re-frame2-causa.mount :as mount]))
+  deliberately uses `ctrl` to avoid that collision.
+
+  ## Phase 5 — Ctrl+Shift+/ co-pilot toggle (rf2-rccf3)
+
+  Per spec/009-AI-CoPilot.md §Default state the co-pilot rail toggles
+  on `Ctrl+Shift+/`. The listener routes the keypress through the
+  `:rf.causa/copilot-toggle` event dispatched on the Causa frame, so
+  the panel's open / closed state lives in Causa's app-db (not the
+  host's)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.mount :as mount]))
 
 (defonce ^:private attached?
   ;; Sentinel — true once the keydown listener is installed. defonce
@@ -43,11 +52,43 @@
              (= "c" k)
              (= "KeyC" code)))))
 
+(defn- copilot-toggle-key?
+  "True when `event` is a Ctrl+Shift+/ keydown. Per spec/009-AI-
+  CoPilot.md §Default state. Checks the slash key via both `key`
+  (\"/\" / \"?\") and `code` (\"Slash\") — the Shift modifier shifts
+  the printable character on most layouts."
+  [event]
+  (let [^js e event
+        k         (.-key e)
+        code      (.-code e)
+        ctrl?     (.-ctrlKey e)
+        shift?    (.-shiftKey e)
+        meta?     (.-metaKey e)
+        alt?      (.-altKey e)]
+    (and ctrl?
+         shift?
+         (not meta?)
+         (not alt?)
+         (or (= "/" k)
+             (= "?" k)
+             (= "Slash" code)))))
+
 (defn- handle-keydown [^js event]
-  (when (causa-toggle-key? event)
-    (.preventDefault event)
-    (.stopPropagation event)
-    (mount/toggle!)))
+  (cond
+    (causa-toggle-key? event)
+    (do (.preventDefault event)
+        (.stopPropagation event)
+        (mount/toggle!))
+
+    (copilot-toggle-key? event)
+    (do (.preventDefault event)
+        (.stopPropagation event)
+        ;; Per spec/009-AI-CoPilot.md §Default state — Ctrl+Shift+/
+        ;; toggles the co-pilot rail. Routed through Causa's frame so
+        ;; the panel's open / closed state lands on :rf/causa, not the
+        ;; host's :rf/default.
+        (rf/with-frame :rf/causa
+          (rf/dispatch [:rf.causa/copilot-toggle])))))
 
 (defn attach!
   "Install the global Ctrl+Shift+C listener once. No-op on second +

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -1,0 +1,641 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot
+  "AI Co-Pilot rail panel (Phase 5, rf2-rccf3).
+
+  Per `tools/causa/spec/009-AI-CoPilot.md` the co-pilot is a pull-only
+  Q&A + slash-command rail. It lives in the right margin of the Causa
+  shell, **collapsed by default** (Lock 8). On expand it occupies a
+  320px rail; on collapse it shows a single `◇` cue glyph that pulses
+  every 8 seconds until the user has used the co-pilot once (per spec
+  §The AI co-pilot collapsed cue).
+
+  ## What this panel does — and what it doesn't
+
+  - **Does**: render an empty conversation rail, accept user input,
+    parse slash commands via `ai-co-pilot-helpers`, dispatch
+    `:rf.causa/copilot-submit-question` which drives the per-provider
+    LLM call (when wired). Streams tokens back via
+    `:rf.causa/copilot-stream-token` and ends streams via
+    `:rf.causa/copilot-stream-end`. Renders chips for `{:rf.copilot/chip}`
+    fragments parsed off the streamed answer.
+
+  - **Does not** (Lock 10, 12, 13):
+    - **No background narration** — the model never sends a token
+      unless the user submits a question. The panel makes no fetch on
+      mount; the only outbound surface is the submit handler.
+    - **No persistence** — the conversation vector lives in Causa's
+      app-db only, never localStorage, never an export.
+    - **No voice / STT** — no `🎙` button, no mic permission request.
+
+  ## Pure hiccup
+
+  Same contract as the other Causa panels (`event_detail.cljs`,
+  `time_travel.cljs`, `causality_graph.cljs`). The view is pure
+  hiccup; the substrate adapter installed via `rf/init!` handles the
+  render. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+
+  ## Where the LLM call lives
+
+  `:rf.causa/copilot-submit-question` is an event-fx that routes
+  through the `:rf.causa.fx/llm-stream` effect. The effect's handler
+  reads the user-configured provider out of the panel's settings,
+  reads the API key out of localStorage, and streams tokens back via
+  the `:rf.causa/copilot-stream-token` event. This Phase 5 ships the
+  panel shell + the dispatch surface; the provider integrations
+  (Claude / OpenAI / Gemini / Local / Custom) are stubbed for now —
+  the effect handler is a no-op when the provider config is absent
+  so the panel renders cleanly in the empty-state demo. The wire is
+  in place; the per-provider fetch lands as follow-on work."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
+
+;; ---- design tokens (mirrors shell.cljs) ---------------------------------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
+  in sync manually for now per the panel convention — the v1.0
+  styling pass replaces these with CSS variables."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :magenta         "#E879F9"
+   :yellow          "#FBBF24"
+   :red             "#F87171"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- view atoms ---------------------------------------------------------
+;;
+;; The input box is local UI state — kept in a defonce atom so a
+;; hot-reload doesn't drop the user's in-progress question. The
+;; dispatch only fires on submit.
+
+(defonce ^:private input-atom (atom ""))
+
+(defn- read-input [] @input-atom)
+(defn- set-input! [v] (reset! input-atom (or v "")))
+
+;; ---- sub-views ----------------------------------------------------------
+
+(defn- cue-glyph
+  "The `◇` cue glyph rendered when the rail is collapsed. Per spec
+  §The AI co-pilot collapsed cue + §Default state — the glyph pulses
+  every 8 seconds in co-pilot magenta until the user has opened the
+  rail once, after which it stays static.
+
+  Per spec §Performance — the cue consumes zero CPU/network when
+  collapsed and idle. The pulse is a CSS animation on the glyph; the
+  view ns leaves the @keyframes definition to the shell's stylesheet
+  pass. Until that lands the glyph renders static (a future CSS
+  injection swaps `opacity: 1` for the once-every-8s expand-fade
+  cycle).
+
+  Clicking the cue toggles the rail open."
+  [_cue-active?]
+  [:button {:data-testid "rf-causa-copilot-cue"
+            :on-click    #(rf/dispatch [:rf.causa/copilot-toggle])
+            :title       "Ask Causa (Ctrl+Shift+/)"
+            :style       {:background  "transparent"
+                          :border      "none"
+                          :cursor      "pointer"
+                          :padding     "8px"
+                          :color       (:magenta tokens)
+                          :font-size   "16px"
+                          :line-height 1}}
+   "◇"])
+
+(defn- chip-view
+  "Render one parsed chip segment as a clickable handle. Per spec
+  §Causa data chips §Visual treatment — the chip uses the same chrome
+  as source-coord chips (`bg-3`, `radius-sm`, 12px caption type) so
+  the eye reads them as first-class data, not decoration.
+
+  Glyph encodes type; click dispatches the chip's target with the
+  chip's value conj'd as the final positional arg. Per spec §Failure
+  modes the renderer never invents chips from free text — only
+  fragments the model emitted in the structured form get this
+  treatment. Resolution failure is visible (the click target may
+  resolve to a no-longer-present runtime id) but not predicted: the
+  runtime is the truth."
+  [{:keys [chip-key value glyph target] :as _resolved}]
+  [:button {:data-testid (str "rf-causa-copilot-chip-" (name chip-key))
+            :on-click    #(rf/dispatch [:rf.causa/copilot-chip-clicked
+                                        {:chip-key chip-key
+                                         :value    value
+                                         :target   target}])
+            :title       (str chip-key " " (pr-str value))
+            :style       {:display       "inline-flex"
+                          :align-items   "center"
+                          :gap           "4px"
+                          :margin        "0 2px"
+                          :padding       "1px 6px"
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "4px"
+                          :cursor        "pointer"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}
+   [:span {:style {:color (:magenta tokens)}} glyph]
+   [:span (pr-str value)]])
+
+(defn- segment-view
+  "Render one parsed segment from `parse-streamed-answer` — either
+  `:text` (plain prose) or `:chip` (interactive handle). Malformed
+  fragments come through as `:text` segments containing the literal
+  edn — per spec §Why structured citations 'malformed edn renders as
+  the literal fragment, surfacing the model's confusion'."
+  [segment]
+  (case (:kind segment)
+    :text
+    [:span (:text segment)]
+
+    :chip
+    (if-let [resolved (h/resolve-chip segment)]
+      [chip-view resolved]
+      ;; Unknown chip-key — fall back to literal raw render so the
+      ;; user sees what the model emitted.
+      [:span (:raw segment)])
+
+    [:span (str segment)]))
+
+(defn- turn-view
+  "Render one conversation turn — a user question or a streaming /
+  finalised answer. Questions use the violet `▸` marker per spec
+  §Panel layout. Answers stream through `parse-streamed-answer` so
+  chips render as the model emits them."
+  [{:keys [role text streaming?] :as _turn}]
+  (case role
+    :question
+    [:div {:data-testid "rf-causa-copilot-turn-question"
+           :style       {:padding "8px 12px"
+                         :font-family sans-stack
+                         :font-size "13px"
+                         :color (:text-primary tokens)
+                         :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:span {:style {:color (:accent-violet tokens) :margin-right "6px"}} "▸"]
+     [:span text]]
+
+    :answer
+    [:div {:data-testid "rf-causa-copilot-turn-answer"
+           :style       {:padding "8px 12px"
+                         :font-family sans-stack
+                         :font-size "13px"
+                         :color (:text-secondary tokens)
+                         :border-bottom (str "1px solid " (:border-subtle tokens))
+                         :line-height 1.5}}
+     (into [:div]
+           (map-indexed
+             (fn [i seg] ^{:key i} [segment-view seg])
+             (h/parse-streamed-answer text)))
+     (when streaming?
+       [:span {:data-testid "rf-causa-copilot-stream-cursor"
+               :style       {:color (:accent-violet tokens)
+                             :margin-left "4px"
+                             :font-family mono-stack}} "▍"])]
+
+    [:div (pr-str _turn)]))
+
+(defn- empty-state
+  "Rendered when the conversation buffer is empty. Per spec §Empty
+  state — sample questions inline; the final line ('Verify before
+  trusting') is the deliberate navigator-not-oracle reminder."
+  []
+  [:div {:data-testid "rf-causa-copilot-empty"
+         :style       {:padding "16px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :color       (:text-secondary tokens)
+                       :line-height 1.5}}
+   [:p {:style {:margin "0 0 12px 0" :color (:text-primary tokens)}}
+    "Ask Causa anything about this runtime."]
+   [:p {:style {:margin "0 0 4px 0" :color (:text-tertiary tokens) :font-size "12px"}}
+    "Try:"]
+   [:ul {:style {:margin "0 0 12px 16px"
+                 :padding 0
+                 :font-family mono-stack
+                 :font-size "12px"
+                 :color (:text-secondary tokens)}}
+    [:li "Why did :checkout/submit fire?"]
+    [:li "What changed in the last 10 epochs?"]
+    [:li "Why is :cart/total returning 0?"]
+    [:li "/state :auth/login-flow"]]
+   [:p {:style {:margin 0
+                :color (:text-tertiary tokens)
+                :font-size "12px"
+                :font-style "italic"}}
+    "The co-pilot reads the same data you see — it cites every claim "
+    "with a source coord or epoch id. Verify before trusting."]])
+
+(defn- conversation-view
+  "Render the conversation buffer — newest at the bottom per spec
+  §Panel layout. Empty conversation renders the empty-state inline
+  prompts."
+  [conversation]
+  (if (empty? conversation)
+    [empty-state]
+    (into [:div {:data-testid "rf-causa-copilot-conversation"
+                 :style       {:display "flex"
+                               :flex-direction "column"}}]
+          (map-indexed
+            (fn [i turn] ^{:key i} [turn-view turn])
+            conversation))))
+
+(defn- slash-popover
+  "When `input` starts with `/`, render the dropdown of matching
+  commands. Click on a row substitutes the command into the input.
+  Per spec §Slash commands — typed shortcuts for common questions."
+  [input]
+  (let [matches (h/slash-popover-matches input)]
+    (when (seq matches)
+      [:div {:data-testid "rf-causa-copilot-slash-popover"
+             :style       {:position "absolute"
+                           :bottom "100%"
+                           :left 0
+                           :right 0
+                           :margin-bottom "4px"
+                           :background (:bg-3 tokens)
+                           :border (str "1px solid " (:border-default tokens))
+                           :border-radius "4px"
+                           :max-height "180px"
+                           :overflow-y "auto"
+                           :font-family mono-stack
+                           :font-size "12px"
+                           :z-index 10}}
+       (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
+             (for [{:keys [command usage doc]} matches]
+               ^{:key command}
+               [:li {:data-testid (str "rf-causa-copilot-slash-" (name command))
+                     :on-click    #(set-input! usage)
+                     :style       {:padding "6px 10px"
+                                   :cursor "pointer"
+                                   :color (:text-primary tokens)
+                                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+                [:div {:style {:color (:accent-violet tokens)}} usage]
+                [:div {:style {:color (:text-tertiary tokens)
+                               :font-family sans-stack
+                               :font-size "11px"
+                               :margin-top "2px"}}
+                 doc]]))])))
+
+(defn- input-row
+  "The question-input row. Per spec §Pull-only model the model never
+  sends a token unless the user submits. Submission fires
+  `:rf.causa/copilot-submit-question` with the resolved text. The
+  `/clear` command is intercepted client-side and dispatched as
+  `:rf.causa/copilot-clear-conversation` — never sent to the model."
+  []
+  (let [input (read-input)
+        parsed (h/parse-slash-command input)
+        submit (fn []
+                 (let [text (read-input)]
+                   (when (seq (str/trim text))
+                     (set-input! "")
+                     (cond
+                       (= :clear (:command parsed))
+                       (rf/dispatch [:rf.causa/copilot-clear-conversation])
+
+                       :else
+                       (rf/dispatch
+                         [:rf.causa/copilot-submit-question
+                          {:text text :parsed parsed}])))))]
+    [:div {:style {:position "relative"
+                   :padding "8px 12px"
+                   :border-top (str "1px solid " (:border-subtle tokens))
+                   :background (:bg-1 tokens)}}
+     (slash-popover input)
+     [:div {:style {:display "flex" :gap "6px" :align-items "stretch"}}
+      [:input {:data-testid "rf-causa-copilot-input"
+               :type        "text"
+               :value       input
+               :placeholder "Ask anything…"
+               :on-change   #(set-input! (.. % -target -value))
+               :on-key-down (fn [e]
+                              (when (= "Enter" (.-key e))
+                                (.preventDefault e)
+                                (submit)))
+               :style       {:flex 1
+                             :background (:bg-3 tokens)
+                             :color (:text-primary tokens)
+                             :border (str "1px solid " (:border-default tokens))
+                             :border-radius "4px"
+                             :padding "6px 10px"
+                             :font-family sans-stack
+                             :font-size "12px"}}]
+      [:button {:data-testid "rf-causa-copilot-submit"
+                :on-click    submit
+                :title       "Submit (Enter)"
+                :style       {:background (:accent-violet tokens)
+                              :color "#fff"
+                              :border "none"
+                              :padding "0 12px"
+                              :border-radius "4px"
+                              :cursor "pointer"
+                              :font-family sans-stack
+                              :font-size "12px"
+                              :font-weight 600}}
+       "↑"]]
+     [:div {:style {:margin-top "4px"
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :color (:text-tertiary tokens)}}
+      "/slash for commands"]]))
+
+(defn- title-bar
+  "The rail's title bar — name, provider picker hook, expand, close.
+  Per spec §Panel layout. The provider picker `⌗` and the expand `⛶`
+  are presentation hooks for the next sub-bead (per-provider
+  fetch + full-screen mode); the close `✕` fires the toggle event so
+  the rail collapses back to the cue glyph."
+  []
+  [:header {:style {:display "flex"
+                    :align-items "center"
+                    :justify-content "space-between"
+                    :padding "8px 12px"
+                    :background (:bg-1 tokens)
+                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div {:style {:display "flex" :align-items "center" :gap "6px"
+                  :font-family sans-stack :font-size "13px"
+                  :font-weight 600 :color (:text-primary tokens)}}
+    [:span {:style {:color (:magenta tokens)}} "◇"]
+    [:span "AI Co-pilot"]]
+   [:div {:style {:display "flex" :align-items "center" :gap "8px"
+                  :color (:text-secondary tokens)
+                  :font-family mono-stack :font-size "12px"}}
+    [:button {:data-testid "rf-causa-copilot-provider-picker"
+              :on-click    #(rf/dispatch [:rf.causa/copilot-cycle-provider])
+              :title       "Provider"
+              :style       {:background "transparent"
+                            :border "none"
+                            :color (:text-secondary tokens)
+                            :cursor "pointer"
+                            :padding "2px 4px"}}
+     "⌗"]
+    [:button {:data-testid "rf-causa-copilot-close"
+              :on-click    #(rf/dispatch [:rf.causa/copilot-toggle])
+              :title       "Close"
+              :style       {:background "transparent"
+                            :border "none"
+                            :color (:text-secondary tokens)
+                            :cursor "pointer"
+                            :padding "2px 4px"}}
+     "✕"]]])
+
+;; ---- public views -------------------------------------------------------
+
+(defn ai-co-pilot-rail
+  "The rail-shaped view — title bar + scrollable conversation + input
+  row. This is the open form (320px right-rail per spec §Panel
+  layout)."
+  []
+  (let [conversation (or @(rf/subscribe [:rf.causa/copilot-conversation]) [])]
+    [:aside {:data-testid "rf-causa-copilot-rail"
+             :style       {:width "320px"
+                           :flex-shrink 0
+                           :display "flex"
+                           :flex-direction "column"
+                           :background (:bg-2 tokens)
+                           :border-left (str "1px solid " (:border-subtle tokens))
+                           :color (:text-primary tokens)
+                           :font-family sans-stack
+                           :font-size "13px"}}
+     [title-bar]
+     [:div {:style {:flex 1 :overflow-y "auto"}}
+      [conversation-view conversation]]
+     [input-row]]))
+
+(defn ai-co-pilot-cue
+  "The collapsed form — a single `◇` cue glyph. Per spec §Default
+  state the rail is collapsed by default; the glyph is the
+  affordance for opening it.
+
+  Rendered into the shell's right margin when
+  `:rf.causa/copilot-open?` is false. The cue glyph + the sidebar
+  `Co-pilot` row + the `Ctrl+Shift+/` keybinding all dispatch the
+  same `:rf.causa/copilot-toggle` event."
+  []
+  (let [cue-active? (boolean @(rf/subscribe [:rf.causa/copilot-cue-active?]))]
+    [cue-glyph cue-active?]))
+
+(defn ai-co-pilot-view
+  "The panel-style view used when the sidebar's Co-pilot row is
+  selected as the active canvas panel. Mirrors the rail view but
+  drops the explicit width (the canvas owns its layout). This is the
+  form the sidebar's Co-pilot click lands on — distinct from the
+  always-on-the-right rail which lives in the shell's margin chrome.
+
+  Rationale: the rail UX is the primary surface (Lock 8), but the
+  shell's sidebar still carries a Co-pilot row (per spec/007-UX-IA.md
+  §Sidebar groups). Clicking the row should not be a dead link;
+  rendering the same conversation surface in the canvas gives the
+  user a full-width form when they want it, while preserving the
+  rail's collapsed-by-default chrome."
+  []
+  (let [conversation (or @(rf/subscribe [:rf.causa/copilot-conversation]) [])]
+    [:section {:data-testid "rf-causa-copilot-panel"
+               :style       {:height "100%"
+                             :display "flex"
+                             :flex-direction "column"
+                             :background (:bg-2 tokens)
+                             :color (:text-primary tokens)
+                             :font-family sans-stack
+                             :font-size "14px"}}
+     [title-bar]
+     [:div {:style {:flex 1 :overflow-y "auto"}}
+      [conversation-view conversation]]
+     [input-row]]))
+
+;; ---- registration entry -------------------------------------------------
+
+(defn install!
+  "Idempotent install for the AI Co-Pilot panel's Causa-side
+  registrations. The registry's central `register-causa-handlers!`
+  calls into this fn so panels can own their own subs / events /
+  fxs without each panel re-doing its idempotency dance.
+
+  Per spec §Pull-only model the registrations here do NOT fire any
+  outbound LLM call on install — only the user-submit handler does
+  that. Defaults render the empty-state on first open."
+  []
+  ;; ── ai-co-pilot panel begin ──
+  (let [register-sub!   rf/reg-sub
+        register-evdb!  rf/reg-event-db
+        register-evfx!  rf/reg-event-fx
+        register-fx!    rf/reg-fx]
+
+    ;; ---- subscriptions ----------------------------------------------------
+
+    ;; Boolean — drives the collapsed / open state of the rail. Default
+    ;; false per Lock 8 (collapsed by default).
+    (register-sub! :rf.causa/copilot-open?
+      (fn [db _q] (boolean (get db :copilot-open? false))))
+
+    ;; The conversation vector — per-session, in-memory only (Lock 12).
+    ;; Each turn is `{:role :question/:answer :text <str> :streaming? <bool>}`.
+    (register-sub! :rf.causa/copilot-conversation
+      (fn [db _q] (get db :copilot-conversation [])))
+
+    ;; The current provider — one of `:claude :openai :gemini :local :custom`.
+    ;; Default `:claude` per spec §Provider abstraction.
+    (register-sub! :rf.causa/copilot-provider
+      (fn [db _q] (get db :copilot-provider :claude)))
+
+    ;; Boolean — true until the user has opened the co-pilot once. Per
+    ;; spec §The AI co-pilot collapsed cue the pulse stops after first
+    ;; use; Causa remembers across the session.
+    (register-sub! :rf.causa/copilot-cue-active?
+      (fn [db _q] (not (true? (get db :copilot-first-used?)))))
+
+    ;; Per-category redaction toggles. Per spec §Redaction defaults the
+    ;; defaults are privacy-by-default — values are `<redacted>`.
+    (register-sub! :rf.causa/copilot-redaction-settings
+      (fn [db _q] (get db :copilot-redaction-settings
+                       h/default-redaction-settings)))
+
+    ;; The number of tokens streamed into the in-flight answer turn.
+    ;; Used for the streaming progress indicator in the chrome.
+    (register-sub! :rf.causa/copilot-streaming-token-count
+      (fn [db _q] (get db :copilot-streaming-token-count 0)))
+
+    ;; ---- events --------------------------------------------------------
+
+    ;; Toggle the rail open / closed. Per spec §Default state the toggle
+    ;; is shared by `Ctrl+Shift+/`, the cue glyph click, and the
+    ;; sidebar's Co-pilot row.
+    (register-evdb! :rf.causa/copilot-toggle
+      (fn [db _ev]
+        (-> db
+            (update :copilot-open? not)
+            ;; The first toggle counts as first-use — the pulse stops.
+            (assoc :copilot-first-used? true))))
+
+    ;; Mark first-use without flipping open / closed. Useful for the
+    ;; sidebar entry's hover-stop affordance per spec §The AI co-pilot
+    ;; collapsed cue.
+    (register-evdb! :rf.causa/copilot-mark-first-use
+      (fn [db _ev] (assoc db :copilot-first-used? true)))
+
+    ;; Cycle providers for the picker. The full provider picker (with
+    ;; settings UI) lands as follow-on work; this event lets the title
+    ;; bar's `⌗` click round-robin through the 5 providers as a
+    ;; lightweight stand-in.
+    (register-evdb! :rf.causa/copilot-set-provider
+      (fn [db [_ provider]]
+        (assoc db :copilot-provider provider)))
+
+    (register-evdb! :rf.causa/copilot-cycle-provider
+      (fn [db _ev]
+        (let [providers [:claude :openai :gemini :local :custom]
+              current   (get db :copilot-provider :claude)
+              idx       (.indexOf providers current)
+              next      (nth providers (mod (inc idx) (count providers)))]
+          (assoc db :copilot-provider next))))
+
+    ;; Set the per-category redaction toggles. The settings UI surfaces
+    ;; these per spec §Settings UI; for now any caller can write the
+    ;; full settings map at once.
+    (register-evdb! :rf.causa/copilot-set-redaction
+      (fn [db [_ settings]]
+        (assoc db :copilot-redaction-settings
+               (merge h/default-redaction-settings settings))))
+
+    ;; Append the user's question, start a streaming-answer turn, then
+    ;; route the redacted payload to the provider via the
+    ;; `:rf.causa.fx/llm-stream` effect. Per spec §Pull-only model this
+    ;; is the ONLY surface that initiates an outbound LLM call; no
+    ;; background work fires anywhere else in the panel.
+    (register-evfx! :rf.causa/copilot-submit-question
+      (fn [{:keys [db]} [_ {:keys [text parsed]}]]
+        (let [settings   (get db :copilot-redaction-settings
+                              h/default-redaction-settings)
+              provider   (get db :copilot-provider :claude)
+              conv       (-> (get db :copilot-conversation [])
+                             (h/append-question text)
+                             (h/start-answer))]
+          {:db (-> db
+                   (assoc :copilot-conversation conv)
+                   ;; Streaming starts at 0 tokens.
+                   (assoc :copilot-streaming-token-count 0)
+                   ;; First submit counts as first-use, even if the user
+                   ;; opened the rail by clicking it directly (the cue
+                   ;; should stop pulsing once they've engaged).
+                   (assoc :copilot-first-used? true))
+           :fx [[:rf.causa.fx/llm-stream
+                 {:provider          provider
+                  :text              text
+                  :parsed            parsed
+                  :redaction-settings settings}]]})))
+
+    ;; Append one streamed token to the in-flight answer turn. The
+    ;; provider's streaming fetch (or its stub) calls this per token.
+    (register-evdb! :rf.causa/copilot-stream-token
+      (fn [db [_ token]]
+        (-> db
+            (update :copilot-conversation h/append-token token)
+            (update :copilot-streaming-token-count (fnil inc 0)))))
+
+    ;; Mark the in-flight answer turn as no-longer streaming.
+    (register-evdb! :rf.causa/copilot-stream-end
+      (fn [db _ev]
+        (-> db
+            (update :copilot-conversation h/end-answer)
+            (assoc :copilot-streaming-token-count 0))))
+
+    ;; Clear the conversation buffer. Triggered by the `/clear` slash
+    ;; command + `Ctrl+L`. Per spec §Ephemeral conversation no
+    ;; persistence side-effect — the buffer is in-memory only.
+    (register-evdb! :rf.causa/copilot-clear-conversation
+      (fn [db _ev]
+        (-> db
+            (assoc :copilot-conversation (h/empty-conversation))
+            (assoc :copilot-streaming-token-count 0))))
+
+    ;; Handle a chip click. Per spec §Chip types each chip's click
+    ;; target is the panel-jump event for that chip kind. The handler
+    ;; dispatches the resolved target with the chip's value as the
+    ;; argument. Unknown chips are no-ops (defensive — the renderer
+    ;; should not produce chips with unknown targets).
+    (register-evfx! :rf.causa/copilot-chip-clicked
+      (fn [_cofx [_ {:keys [target value]}]]
+        (when target
+          {:fx [[:dispatch [target value]]]})))
+
+    ;; ---- effects -----------------------------------------------------
+
+    ;; The provider streaming surface. Per spec §Provider abstraction
+    ;; this routes to Claude / OpenAI / Gemini / Local Ollama / Custom
+    ;; URL. The API key lives in localStorage; the fetch is direct
+    ;; from the browser to the chosen provider — Day8 never proxies.
+    ;;
+    ;; This Phase 5 ships the wire — the effect registers as a no-op
+    ;; when the per-provider implementation isn't on the classpath.
+    ;; The follow-on bead wires the four provider fetchers; this
+    ;; effect's contract (args: `{:provider :text :parsed
+    ;; :redaction-settings}`; outputs: stream tokens via
+    ;; `:rf.causa/copilot-stream-token`, end via
+    ;; `:rf.causa/copilot-stream-end`) is the integration point.
+    (register-fx! :rf.causa.fx/llm-stream
+      (fn [_ctx _args]
+        ;; Phase 5: no-op stub. The conversation surface still records
+        ;; the question + opens the streaming turn so the UI is
+        ;; testable end-to-end without a live provider. The follow-on
+        ;; wiring replaces this stub with the per-provider fetch +
+        ;; SSE stream parser.
+        nil)))
+  ;; ── ai-co-pilot panel end ──
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_helpers.cljc
@@ -1,0 +1,518 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-helpers
+  "Pure-data helpers for Causa's AI Co-Pilot rail panel
+  (Phase 5, rf2-rccf3).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `ai_co_pilot.cljs` touches the DOM (focused input,
+  pulsing cue glyph, slash-command popover, chip click handlers). The
+  *logic* — parsing slash commands, parsing chip fragments out of
+  streamed text, applying the redaction filter to outbound payloads,
+  shaping conversation turns — is pure data → data. Splitting that
+  logic out into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by `feedback_jvm_interop_must_work.md`.
+
+  ## What this ns owns (per spec/009-AI-CoPilot.md)
+
+    1. **Slash command parsing** (§Slash commands, L76-94): tokenise an
+       input string into `{:command <kw> :args [...] :raw <str>}` or
+       nil when the input is not a slash form. The catalogue is the
+       8-entry table in the spec.
+
+    2. **Chip parsing** (§Causa data chips §Encoding contract, L249-267):
+       walk a streamed answer string and split it into a vector of
+       text + chip segments. A chip is the literal edn form
+       `{:rf.copilot/chip <key> <value>}`. Malformed fragments render
+       as literal text (the model is rewarded for naming data
+       precisely — failure is loud, not hidden).
+
+    3. **Chip type resolution** (§Causa data chips §Chip types, L226-230):
+       map a parsed chip's `:key` to its panel target + glyph. Four
+       chip kinds: `:dispatch-id`, `:path`, `:epoch-number`, `:handler-id`.
+
+    4. **Redaction filter** (§Redaction defaults, L330-368): given a
+       payload + the per-category opt-in flags, return the payload with
+       event-vector args and app-db slice values stamped `<redacted>`
+       (or pass-through when the flag is on). Source coords, handler
+       ids, and trace metadata always pass through.
+
+    5. **Conversation shape** (§Ephemeral conversation, L309-328): a
+       conversation is a vector of `{:role :question/:answer :text ...
+       :streaming? <bool>}` turns; `append-token` is the pure walk that
+       extends the trailing answer's text by one token.
+
+  ## What this ns does NOT do
+
+  - **No I/O.** The provider call is in `ai_co_pilot.cljs` (CLJS only —
+    it touches `fetch` and `EventSource`); this ns prepares the
+    payload that fn ships and parses the streamed reply it receives.
+  - **No localStorage.** Lock 12 — conversation is ephemeral; the
+    redaction-settings + provider config that DO persist read /
+    write localStorage from the panel view side.
+  - **No DOM.** The chip renderer is hiccup, built in the view ns from
+    the parsed segments this ns returns.
+
+  ## Pre-alpha posture
+
+  Every shape here is internal to Causa — no `:rf.copilot/*` exports
+  to host code, no public registry entries beyond the `:rf.causa/*`
+  prefix the panel itself registers."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])))
+
+;; ---- slash command catalogue --------------------------------------------
+
+(def slash-commands
+  "The 8 slash commands per spec/009-AI-CoPilot.md §Slash commands.
+  Each entry is `{:command <kw> :usage <str> :doc <str>}` — used both
+  by the slash-popover renderer and the canonical-completion logic in
+  `parse-slash-command`. Order is the order the popover lists them in;
+  matches the spec's table top-to-bottom."
+  [{:command :explain
+    :usage   "/explain <event-id-or-epoch>"
+    :doc     "Describe one epoch — the cause, the effect, the state delta."}
+   {:command :diff
+    :usage   "/diff <epoch-a> <epoch-b>"
+    :doc     "What changed between two epochs?"}
+   {:command :find
+    :usage   "/find <pattern>"
+    :doc     "Search the trace stream."}
+   {:command :rewind
+    :usage   "/rewind <event-or-epoch>"
+    :doc     "Propose a rewind (executes only on user confirmation)."}
+   {:command :state
+    :usage   "/state <machine-id>"
+    :doc     "Describe a machine's current state."}
+   {:command :why
+    :usage   "/why <epoch>"
+    :doc     "Causal-ancestor walk."}
+   {:command :whatif
+    :usage   "/whatif <hypothetical>"
+    :doc     "Speculative reasoning (the model labels the answer as reasoning)."}
+   {:command :clear
+    :usage   "/clear"
+    :doc     "Clear conversation."}])
+
+(def slash-command-set
+  "Set of recognised slash-command keywords for O(1) lookup. Built off
+  `slash-commands` so the table is the single source of truth."
+  (into #{} (map :command slash-commands)))
+
+(defn parse-slash-command
+  "Parse `input` (a string) into `{:command <kw> :args [...] :raw <str>}`
+  when it begins with `/` and the head token names a known command;
+  nil otherwise.
+
+  Examples:
+
+    (parse-slash-command \"/explain epoch-42\")
+    ;;=> {:command :explain :args [\"epoch-42\"] :raw \"/explain epoch-42\"}
+
+    (parse-slash-command \"/clear\")
+    ;;=> {:command :clear :args [] :raw \"/clear\"}
+
+    (parse-slash-command \"why did x fire?\")
+    ;;=> nil
+
+    (parse-slash-command \"/notacommand foo\")
+    ;;=> nil   ; head token not in `slash-command-set`
+
+  Args are whitespace-split; the model is the layer that interprets
+  them (the slash form is a typed shortcut, per spec §Slash commands
+  'Slash commands are typed shortcuts for common questions; the model
+  can still answer the same questions in plain English')."
+  [input]
+  (when (and (string? input)
+             (str/starts-with? (str/triml input) "/"))
+    (let [trimmed (str/triml input)
+          [head & rest-toks] (str/split trimmed #"\s+")
+          cmd-kw (some-> head (subs 1) not-empty keyword)]
+      (when (contains? slash-command-set cmd-kw)
+        {:command cmd-kw
+         :args    (vec rest-toks)
+         :raw     input}))))
+
+(defn slash-popover-matches
+  "Given a partial slash input like `\"/exp\"`, return the subset of
+  `slash-commands` whose `:command` name starts with the partial.
+  Empty `\"/\"` returns all commands.
+
+  Returns `[]` when `input` is not a slash form."
+  [input]
+  (when (and (string? input)
+             (str/starts-with? (str/triml input) "/"))
+    (let [trimmed (str/triml input)
+          stem    (subs trimmed 1)
+          stem    (-> stem (str/split #"\s+") first (or ""))]
+      (cond
+        (= "" stem)
+        slash-commands
+
+        :else
+        (filterv (fn [{:keys [command]}]
+                   (str/starts-with? (name command) stem))
+                 slash-commands)))))
+
+;; ---- chip parsing -------------------------------------------------------
+
+(def chip-key-set
+  "The four supported chip keys per spec §Chip types. Any other key
+  inside `{:rf.copilot/chip <key> <value>}` renders as literal text
+  (the model is rewarded for naming data precisely)."
+  #{:dispatch-id :path :epoch-number :handler-id})
+
+(def chip-glyphs
+  "Glyph per chip key — same set used in the sidebar and the
+  causality strip (per spec §Chip types §Visual treatment)."
+  {:dispatch-id  "◆"  ;; ◆
+   :path         "▥"  ;; ▥
+   :epoch-number "⏵"  ;; ⏵
+   :handler-id   "⚙"}) ;; ⚙
+
+(def chip-targets
+  "Click target per chip key — the panel-jump the chip dispatches.
+  Per spec §Chip types §Click target. Each target is a re-frame event
+  vector template — the chip click handler in the view ns conj's the
+  chip's value as the final positional arg."
+  {:dispatch-id  :rf.causa/select-dispatch-id
+   :path         :rf.causa.copilot/open-path
+   :epoch-number :rf.causa/select-epoch
+   :handler-id   :rf.causa.copilot/open-handler})
+
+(def ^:private chip-prefix "{:rf.copilot/chip")
+
+(defn- balanced-brace-length
+  "Walk `s` (which starts with `{`) and return the 1-based index of
+  the matching closing `}` — i.e. the length of the smallest balanced
+  brace-prefix of `s`. Returns nil when no balanced prefix exists.
+
+  Tracks brackets `()[]{}` together (so chip-values that are vectors,
+  sets, or lists nest cleanly inside the chip fragment) and skips `\\`
+  escapes inside strings. Pure-data; portable between clj / cljs
+  without an edn reader."
+  [s]
+  (let [n (count s)]
+    (loop [i 0
+           depth 0
+           in-str? false
+           escaped? false]
+      (cond
+        (>= i n)
+        nil
+
+        in-str?
+        (let [c (.charAt ^String s i)]
+          (cond
+            escaped?       (recur (inc i) depth true false)
+            (= c \\)       (recur (inc i) depth true true)
+            (= c \")       (recur (inc i) depth false false)
+            :else          (recur (inc i) depth true false)))
+
+        :else
+        (let [c (.charAt ^String s i)]
+          (cond
+            (= c \")  (recur (inc i) depth true false)
+            (or (= c \{) (= c \[) (= c \())
+            (recur (inc i) (inc depth) false false)
+            (or (= c \}) (= c \]) (= c \)))
+            (let [d' (dec depth)]
+              (if (zero? d')
+                (inc i)
+                (recur (inc i) d' false false)))
+            :else     (recur (inc i) depth false false)))))))
+
+(defn- read-chip-fragment
+  "Read one chip fragment off the head of `s`. A chip fragment is the
+  literal form
+
+      {:rf.copilot/chip <key> <value>}
+
+  per spec §Causa data chips §Encoding contract — three tokens inside
+  brace delimiters. Note this is NOT a legal EDN map (an odd token
+  count), so we parse the inner contents manually: strip the braces,
+  pull the three tokens via `edn/read-string` on the wrapped vector
+  form `[<contents>]`, and assert the head token is the sentinel
+  `:rf.copilot/chip`.
+
+  Returns `{:value {:rf.copilot/chip <sentinel> :key <kw> :value <v>}
+            :rest <s>}` on success, nil on a parse error or unbalanced
+  fragment. Returning the parsed shape as a map (rather than a
+  vector) lets the caller dissoc the sentinel slot uniformly with
+  `parse-streamed-answer`'s downstream logic."
+  [s]
+  (when-let [len (balanced-brace-length s)]
+    (let [prefix   (subs s 0 len)
+          rest-s   (subs s len)
+          ;; Strip the leading `{` and trailing `}` to expose the three
+          ;; tokens. Wrap in `[]` so the platform edn reader gives us a
+          ;; vector of forms in one read call.
+          inner    (subs prefix 1 (dec (count prefix)))
+          wrapped  (str "[" inner "]")]
+      (try
+        (let [tokens #?(:clj  (edn/read-string wrapped)
+                        :cljs (edn/read-string wrapped))]
+          (when (and (vector? tokens)
+                     (= 3 (count tokens))
+                     (= :rf.copilot/chip (first tokens)))
+            {:value {:rf.copilot/chip :rf.copilot/chip
+                     (nth tokens 1)    (nth tokens 2)}
+             :rest  rest-s}))
+        (catch #?(:clj Exception :cljs :default) _
+          nil)))))
+
+(defn- looks-like-chip-prefix?
+  "Cheap pre-check: does `s`, starting at `idx`, look like the head of
+  a chip fragment? Avoids attempting an edn parse for every `{` in the
+  text (which would be O(text * forms) in the worst case)."
+  [s idx]
+  (when (< idx (count s))
+    (let [head-len (count chip-prefix)
+          tail     (subs s idx (min (+ idx head-len) (count s)))]
+      (= chip-prefix tail))))
+
+(defn parse-streamed-answer
+  "Walk `text` and return a vector of segments:
+
+    [{:kind :text  :text <str>}
+     {:kind :chip  :chip-key <kw> :value <any> :raw <str>}
+     ...]
+
+  Per spec §Causa data chips §Encoding contract, a chip is the literal
+  edn form `{:rf.copilot/chip <key> <value>}`. The renderer parses
+  these fragments at stream time and swaps them for the chip
+  component; the rest of the text passes through.
+
+  Failure modes (per spec §Why structured citations):
+   - Malformed edn → literal text (the model's confusion is surfaced).
+   - Unknown chip-key → literal text (only the 4 keys in
+     `chip-key-set` are honoured; anything else degrades gracefully).
+   - Partially-formed fragment at the stream tail → literal text;
+     the next token may complete it (the caller may re-parse on each
+     stream-token; partial chips will pop into existence once whole)."
+  [text]
+  (if-not (string? text)
+    []
+    (loop [idx 0
+           ;; Accumulator for the in-progress :text segment. Held as a
+           ;; vector of single-char strings; `apply str` joins it when
+           ;; emitted. Portable cljc — no platform StringBuilder.
+           buf []
+           out []]
+      (cond
+        (>= idx (count text))
+        (let [tail (apply str buf)]
+          (if (empty? tail)
+            out
+            (conj out {:kind :text :text tail})))
+
+        (looks-like-chip-prefix? text idx)
+        (let [fragment (subs text idx)
+              parsed   (read-chip-fragment fragment)]
+          (if parsed
+            (let [chip-map     (:value parsed)
+                  entries      (seq (dissoc chip-map :rf.copilot/chip))
+                  ;; The wrapper map produced by `read-chip-fragment`
+                  ;; has exactly one non-sentinel entry — that's the
+                  ;; chip's `<key> <value>` pair from the spec form
+                  ;; `{:rf.copilot/chip <key> <value>}`.
+                  [chip-key chip-value] (when entries (first entries))
+                  consumed-len  (- (count fragment) (count (:rest parsed)))
+                  raw           (subs fragment 0 consumed-len)
+                  pre           (apply str buf)
+                  out'          (cond-> out
+                                  (seq pre) (conj {:kind :text :text pre}))]
+              (if (contains? chip-key-set chip-key)
+                (recur (+ idx consumed-len)
+                       []
+                       (conj out'
+                             {:kind     :chip
+                              :chip-key chip-key
+                              :value    chip-value
+                              :raw      raw}))
+                ;; Unknown chip-key — render the literal text and
+                ;; resume walking past the consumed fragment.
+                (recur (+ idx consumed-len)
+                       []
+                       (conj out' {:kind :text :text raw}))))
+            ;; Malformed — append the `{` and resume; the rest of the
+            ;; fragment renders as text.
+            (recur (inc idx)
+                   (conj buf (subs text idx (inc idx)))
+                   out)))
+
+        :else
+        (recur (inc idx)
+               (conj buf (subs text idx (inc idx)))
+               out)))))
+
+(defn resolve-chip
+  "Resolve a parsed chip into the metadata the view ns needs to render
+  it: `{:glyph <str> :target <kw-or-nil> :chip-key <kw> :value <any>}`.
+
+  When `chip-key` is unknown returns nil. The view ns is responsible
+  for the click handler (which dispatches `[target value]`) and the
+  greyed-out failure rendering when the value cannot be resolved
+  against the live runtime (per spec §Failure modes — unresolvable
+  identifier renders greyed-out with `⚠`)."
+  [{:keys [chip-key value]}]
+  (when (contains? chip-key-set chip-key)
+    {:chip-key chip-key
+     :value    value
+     :glyph    (get chip-glyphs chip-key)
+     :target   (get chip-targets chip-key)}))
+
+;; ---- redaction filter ---------------------------------------------------
+
+(def default-redaction-settings
+  "Per spec §Redaction defaults §Defaults — privacy-by-default. Values
+  default to redacted; the user opts in to unmask per category.
+
+  Source coords, handler ids, and trace metadata always pass through
+  (per the spec table — they are 'full' regardless of these flags)."
+  {:unmask-event-args false   ;; :rf.causa.copilot/unmask-event-args
+   :unmask-app-db     false}) ;; :rf.causa.copilot/unmask-app-db
+
+(def ^:private redacted-token "<redacted>")
+
+(defn- redact-event-vec
+  "Redact a single event vector — `[event-id & args]`. The id is kept;
+  every arg becomes `<redacted>`. Non-vector inputs pass through
+  unchanged (defensive — the model sees data it doesn't always shape)."
+  [ev]
+  (if (and (vector? ev) (seq ev))
+    (into [(first ev)] (repeat (dec (count ev)) redacted-token))
+    ev))
+
+(defn redact-trace-event
+  "Stamp a single trace event's event-vector args with `<redacted>`
+  unless `:unmask-event-args` is on. Source-coord + handler-id +
+  trace-metadata slots pass through always.
+
+  The shape of a trace event follows
+  `re-frame.trace.projection` (per rf2-n6x4q): a map with
+  `:op-type`, `:operation`, `:id`, `:tags { :dispatch-id <i>
+  :event [...] :phase ... :fx-id ... :sub-id ... }`."
+  [{:keys [unmask-event-args] :as _settings} ev]
+  (if unmask-event-args
+    ev
+    (cond-> ev
+      (some? (get-in ev [:tags :event]))
+      (update-in [:tags :event] redact-event-vec))))
+
+(defn- redact-walk-app-db
+  "Walk an app-db value and replace leaf values with `<redacted>`.
+  Keys are preserved (structural metadata); only the leaves are
+  redacted. Numbers, strings, booleans, keywords-not-as-keys all
+  become `<redacted>`. Maps and vectors recurse so the user can still
+  see the shape (per spec rationale — 'Source coords + handler IDs +
+  trace metadata are sufficient for the canonical why-did-this-render
+  questions')."
+  [v]
+  (cond
+    (map? v)    (into {} (map (fn [[k vv]] [k (redact-walk-app-db vv)]) v))
+    (vector? v) (mapv redact-walk-app-db v)
+    (set? v)    (into #{} (map redact-walk-app-db v))
+    (seq? v)    (map redact-walk-app-db v)
+    :else       redacted-token))
+
+(defn redact-app-db
+  "Stamp an app-db payload with `<redacted>` leaves unless
+  `:unmask-app-db` is on. Per spec §Redaction defaults — App-db slice
+  values default to redacted; opt-in via `:rf.causa.copilot/unmask-app-db`."
+  [{:keys [unmask-app-db] :as _settings} db]
+  (if unmask-app-db
+    db
+    (redact-walk-app-db db)))
+
+(defn redact-payload
+  "Apply the redaction filter to the full LLM-bound payload.
+
+  Shape of `payload`:
+
+    {:trace-events <[trace-event ...]>
+     :app-db       <any>
+     :question     <str>
+     ;; ... other slots pass through unchanged
+    }
+
+  Per spec §Redaction defaults the trace metadata + source-coords +
+  handler ids ride through always; only event-vector args + app-db
+  values are masked under default settings."
+  [settings payload]
+  (cond-> payload
+    (contains? payload :trace-events)
+    (update :trace-events
+            (fn [events] (mapv #(redact-trace-event settings %) events)))
+
+    (contains? payload :app-db)
+    (update :app-db #(redact-app-db settings %))))
+
+;; ---- conversation shape -------------------------------------------------
+
+(defn empty-conversation
+  "The empty-conversation vector. Used both by the initial state and
+  by `:rf.causa/copilot-clear-conversation` to reset the buffer.
+
+  Per spec §Ephemeral conversation a conversation is per-session
+  in-memory only — Lock 12. The vector is not persisted to localStorage,
+  not exported, cleared on Causa close / tab reload."
+  []
+  [])
+
+(defn append-question
+  "Append a user-question turn to `conversation`. Returns the extended
+  conversation vector — pure data → data; the live store is in
+  Causa's app-db so the caller wraps this in an event handler."
+  [conversation text]
+  (conj (vec conversation)
+        {:role :question
+         :text (str text)
+         :streaming? false}))
+
+(defn start-answer
+  "Append a streaming-answer turn to `conversation`. Returns the
+  extended vector with the trailing answer marked `:streaming? true`
+  + empty `:text` — `append-token` accretes the model's tokens onto
+  this turn."
+  [conversation]
+  (conj (vec conversation)
+        {:role       :answer
+         :text       ""
+         :streaming? true}))
+
+(defn append-token
+  "Append one streamed token to the last turn's `:text`. The last
+  turn must be an in-flight answer (`{:role :answer :streaming? true}`);
+  no-ops when it is not (defensive — avoids a stray token corrupting
+  a finalised answer or polluting a question turn).
+
+  Returns `conversation` unchanged when the precondition fails — the
+  caller's event handler shape doesn't need a separate error path."
+  [conversation token]
+  (let [conv (vec conversation)
+        n    (count conv)]
+    (if (zero? n)
+      conv
+      (let [last-turn (nth conv (dec n))]
+        (if (and (= :answer (:role last-turn))
+                 (:streaming? last-turn))
+          (assoc conv (dec n)
+                 (update last-turn :text str token))
+          conv)))))
+
+(defn end-answer
+  "Mark the trailing answer turn as no-longer streaming. Same
+  precondition as `append-token` — no-ops when the trailing turn is
+  not an in-flight answer."
+  [conversation]
+  (let [conv (vec conversation)
+        n    (count conv)]
+    (if (zero? n)
+      conv
+      (let [last-turn (nth conv (dec n))]
+        (if (and (= :answer (:role last-turn))
+                 (:streaming? last-turn))
+          (assoc conv (dec n)
+                 (assoc last-turn :streaming? false))
+          conv)))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -120,6 +120,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
@@ -1033,7 +1034,16 @@
 
     (rf/reg-event-fx :rf.causa/copy-path-to-clipboard
       (fn [_ctx [_ path]]
-        {:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str path)}]]})))
+        {:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str path)}]]}))
+
+    ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
+    ;;
+    ;; The Co-Pilot owns its own subs / events / fxs (chip parsing, slash
+    ;; commands, conversation buffer, provider streaming). Per the panel
+    ;; convention the panel-ns exposes `install!` which the registry calls
+    ;; from inside its own `compare-and-set!` gate so the panel's
+    ;; registrations are idempotent under shadow-cljs `:after-load`.
+    (ai-co-pilot/install!))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -37,6 +37,7 @@
   render fn (`rf/render`) handles the substrate-specific mount in
   `mount.cljs`. No per-substrate switches in view code."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
@@ -91,7 +92,7 @@
    ;; marker; once a mismatch fires the entry lights up and the entry
    ;; behaves like every other live panel.
    {:id :hydration    :label "Hydration"     :bead "rf2-pzxsr" :live? true :dormant? true}
-   {:id :copilot      :label "Co-pilot"      :bead "rf2-xxx"}])
+   {:id :copilot      :label "Co-pilot"      :bead "rf2-rccf3" :live? true}])
 
 ;; ---- regions -------------------------------------------------------------
 
@@ -126,6 +127,12 @@
                   :color    (:text-secondary tokens)
                   :font-size "12px"
                   :font-weight 400}}
+    ;; Collapsed-cue affordance per spec/007-UX-IA.md §The AI co-pilot
+    ;; collapsed cue — the magenta `◇` glyph pulses every 8 seconds
+    ;; until the user has used the co-pilot once. Renders only when the
+    ;; rail is closed; clicking it toggles the rail open.
+    (when-not @(rf/subscribe [:rf.causa/copilot-open?])
+      [ai-co-pilot/ai-co-pilot-cue])
     [:span "Ctrl+Shift+C to toggle"]]])
 
 (defn- sidebar-item
@@ -259,6 +266,10 @@
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]
       :hydration    [hydration-debugger/hydration-debugger-view]
+      ;; Sidebar Co-pilot row renders the panel-style view in the
+      ;; canvas; the rail still lives in the shell's right margin per
+      ;; spec/007-UX-IA.md §The five regions item 4.
+      :copilot      [ai-co-pilot/ai-co-pilot-view]
       [stub-panel (or item {:label "Unknown panel"
                             :bead  "rf2-xxx"})])))
 
@@ -314,5 +325,11 @@
                    :flex-direction "row"
                    :overflow      "hidden"}}
      [sidebar]
-     [canvas]]
+     [canvas]
+     ;; Right-edge rail per spec/007-UX-IA.md §The five regions item 4.
+     ;; Collapsed by default (Lock 8); renders only when
+     ;; `:rf.causa/copilot-open?` is true. The cue glyph in the top
+     ;; strip is the affordance for opening it when collapsed.
+     (when @(rf/subscribe [:rf.causa/copilot-open?])
+       [ai-co-pilot/ai-co-pilot-rail])]
     [bottom-rail]]])

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
@@ -1,0 +1,501 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-cljs-test
+  "CLJS-side wiring tests for Causa's AI Co-Pilot rail panel
+  (Phase 5, rf2-rccf3).
+
+  ## Contracts under test (in addition to the pure-data tests in
+  `ai_co_pilot_helpers_cljs_test.cljc`)
+
+  1. **Registry wires the subs / events / fxs** under the
+     `:rf.causa/*` namespace. The `:rf.causa/copilot-*` surface is
+     present after `register-causa-handlers!`.
+
+  2. **Pull-only model.** Per spec §Pull-only model the panel never
+     dispatches `:rf.causa.fx/llm-stream` on mount; the only path
+     that fires it is `:rf.causa/copilot-submit-question`.
+
+  3. **Defaults.** Per spec §Default state + §Redaction defaults the
+     rail is collapsed (`:rf.causa/copilot-open?` returns false) and
+     the redaction settings are privacy-by-default.
+
+  4. **Toggle.** `:rf.causa/copilot-toggle` flips the open / closed
+     state and marks the cue as no-longer-pulsing.
+
+  5. **Submit + stream + clear.** The conversation buffer accepts a
+     question + streamed tokens + end, then `/clear` drops it.
+
+  6. **No persistence.** Per Lock 12 the conversation buffer is
+     in-memory only — no localStorage writes happen on submit /
+     stream / clear.
+
+  7. **No voice / STT.** Per Lock 13 the rail renders no `🎙` button.
+
+  8. **Chip click routes the panel-jump.** `:rf.causa/copilot-chip-clicked`
+     dispatches the chip's target with the chip's value as arg."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.ai-co-pilot :as copilot]
+            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- effect capture -----------------------------------------------------
+;;
+;; The pull-only contract asserts that no outbound LLM call fires on
+;; mount; only the user-submit path fires :rf.causa.fx/llm-stream. We
+;; replace the registry's no-op stub with a capture fn so we can assert
+;; "fired N times" + "fired with these args".
+
+(defonce ^:private captured-llm-calls (atom []))
+
+(defn- install-llm-capture-fx! []
+  (reset! captured-llm-calls [])
+  (rf/reg-fx :rf.causa.fx/llm-stream
+    (fn [_ctx args]
+      (swap! captured-llm-calls conj args))))
+
+(defn- captured [] @captured-llm-calls)
+
+;; ---- chip-target capture ------------------------------------------------
+;;
+;; Chip clicks dispatch their target via :rf.causa/copilot-chip-clicked
+;; which conjures `[:dispatch [target value]]`. To assert "the right
+;; target fired", we register no-op event-fx handlers under the chip
+;; targets and capture dispatches.
+
+(defonce ^:private captured-chip-dispatches (atom []))
+
+(defn- install-chip-capture! []
+  (reset! captured-chip-dispatches [])
+  (doseq [target [:rf.causa/select-dispatch-id
+                  :rf.causa/select-epoch
+                  :rf.causa.copilot/open-path
+                  :rf.causa.copilot/open-handler]]
+    (rf/reg-event-fx target
+      (fn [_cofx ev]
+        (swap! captured-chip-dispatches conj ev)
+        nil))))
+
+(defn- chip-dispatches [] @captured-chip-dispatches)
+
+;; ---- hiccup walker ------------------------------------------------------
+;;
+;; The Causa view tree uses both keyword-headed hiccup (`[:div ...]`)
+;; and fn-component hiccup (`[my-fn arg1 arg2]`). The walker fully
+;; expands fn-component vectors (recursively, so a fn that returns
+;; another fn-component vector keeps expanding) before walking — so
+;; `data-testid` lookups inside the expanded sub-tree are reachable.
+
+(declare expand-tree)
+
+(defn- expand-fn-component-vector
+  "If `node` is `[fn-component arg ...]` invoke the fn with args and
+  recurse on the result; otherwise return the node unchanged."
+  [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-tree (apply (first node) (rest node)))
+    node))
+
+(defn- expand-tree
+  "Walk `tree` and replace every fn-component vector with its rendered
+  result (recursively). Pure keyword-headed hiccup passes through; nil
+  / strings / numbers / maps pass through."
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+;; ---- (1) registry installs the subs / events / fxs ---------------------
+
+(deftest registry-installs-copilot-subs
+  (registry/register-causa-handlers!)
+  (is (some? (registrar/handler :sub :rf.causa/copilot-open?)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-conversation)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-provider)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-cue-active?)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-redaction-settings)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-streaming-token-count))))
+
+(deftest registry-installs-copilot-events
+  (registry/register-causa-handlers!)
+  (is (some? (registrar/handler :event :rf.causa/copilot-toggle)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-submit-question)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-stream-token)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-stream-end)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-clear-conversation)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-mark-first-use)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-set-provider)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-cycle-provider)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-set-redaction)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-chip-clicked))))
+
+(deftest registry-installs-llm-stream-fx
+  (registry/register-causa-handlers!)
+  (is (some? (registrar/handler :fx :rf.causa.fx/llm-stream))))
+
+;; ---- (2) pull-only model -----------------------------------------------
+
+(deftest no-llm-call-on-mount
+  (testing "rendering the rail makes NO outbound :rf.causa.fx/llm-stream
+            call (per spec §Pull-only model + Lock 10)"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      ;; Render both the rail view and the panel-style view. Neither
+      ;; should fire an LLM call.
+      (copilot/ai-co-pilot-rail)
+      (copilot/ai-co-pilot-view)
+      (copilot/ai-co-pilot-cue))
+    (is (= 0 (count (captured)))
+        "no outbound LLM call fired by render")))
+
+(deftest llm-call-fires-only-on-user-submit
+  (testing "the only path that fires :rf.causa.fx/llm-stream is
+            :rf.causa/copilot-submit-question"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      ;; Toggle, mark-first-use, set-provider — none of these fire LLM.
+      (rf/dispatch-sync [:rf.causa/copilot-toggle])
+      (rf/dispatch-sync [:rf.causa/copilot-mark-first-use])
+      (rf/dispatch-sync [:rf.causa/copilot-set-provider :openai])
+      (is (= 0 (count (captured)))
+          "toggle / mark-first-use / set-provider don't fire LLM")
+      ;; Submit a question — exactly one call.
+      (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                         {:text "Why did this fire?" :parsed nil}])
+      (is (= 1 (count (captured)))
+          "submit fires exactly one :rf.causa.fx/llm-stream"))))
+
+;; ---- (3) defaults -----------------------------------------------------
+
+(deftest rail-is-collapsed-by-default
+  (testing "per spec §Default state + Lock 8 — :rf.causa/copilot-open?
+            is false until the user toggles"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (is (false? @(rf/subscribe [:rf.causa/copilot-open?]))))))
+
+(deftest cue-is-active-by-default
+  (testing "per spec §The AI co-pilot collapsed cue — the pulse is
+            active until first use"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (is (true? @(rf/subscribe [:rf.causa/copilot-cue-active?]))))))
+
+(deftest cue-stops-after-first-toggle
+  (testing "per spec §The AI co-pilot collapsed cue — the pulse stops
+            entirely after the user has used the co-pilot once"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-toggle])
+      (is (false? @(rf/subscribe [:rf.causa/copilot-cue-active?]))
+          "cue inactive after first toggle"))))
+
+(deftest redaction-settings-default-to-privacy-by-default
+  (testing "per spec §Redaction defaults — values are <redacted>
+            by default"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [settings @(rf/subscribe [:rf.causa/copilot-redaction-settings])]
+        (is (false? (:unmask-event-args settings)))
+        (is (false? (:unmask-app-db settings)))))))
+
+(deftest provider-defaults-to-claude
+  (testing "per spec §Provider abstraction — Claude is the default"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (is (= :claude @(rf/subscribe [:rf.causa/copilot-provider]))))))
+
+;; ---- (4) toggle --------------------------------------------------------
+
+(deftest toggle-flips-open-state
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (is (false? @(rf/subscribe [:rf.causa/copilot-open?])))
+    (rf/dispatch-sync [:rf.causa/copilot-toggle])
+    (is (true? @(rf/subscribe [:rf.causa/copilot-open?])))
+    (rf/dispatch-sync [:rf.causa/copilot-toggle])
+    (is (false? @(rf/subscribe [:rf.causa/copilot-open?])))))
+
+(deftest toggle-writes-to-causa-frame-not-host
+  (testing "the rail's open state lands on :rf/causa, not :rf/default
+            (per the registry's frame-isolation contract)"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-toggle]))
+    (is (true? (boolean (:copilot-open? (frame/frame-app-db-value :rf/causa)))))
+    (is (nil? (:copilot-open? (frame/frame-app-db-value :rf/default))))))
+
+;; ---- (5) submit / stream / clear --------------------------------------
+
+(deftest submit-question-appends-question-and-starts-answer
+  (testing ":rf.causa/copilot-submit-question lands a question turn +
+            a streaming-answer turn"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                         {:text "Why?" :parsed nil}])
+      (let [conv @(rf/subscribe [:rf.causa/copilot-conversation])]
+        (is (= 2 (count conv)))
+        (is (= :question (:role (first conv))))
+        (is (= "Why?"    (:text (first conv))))
+        (is (= :answer   (:role (second conv))))
+        (is (= ""        (:text (second conv))))
+        (is (true?       (:streaming? (second conv))))))))
+
+(deftest stream-token-extends-trailing-answer
+  (registry/register-causa-handlers!)
+  (install-llm-capture-fx!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                       {:text "Why?" :parsed nil}])
+    (rf/dispatch-sync [:rf.causa/copilot-stream-token "Be"])
+    (rf/dispatch-sync [:rf.causa/copilot-stream-token "cause"])
+    (let [conv @(rf/subscribe [:rf.causa/copilot-conversation])]
+      (is (= "Because" (:text (second conv))))
+      (is (= 2 @(rf/subscribe [:rf.causa/copilot-streaming-token-count]))
+          "token count reflects the streamed tokens"))))
+
+(deftest stream-end-finalises-answer
+  (registry/register-causa-handlers!)
+  (install-llm-capture-fx!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                       {:text "Why?" :parsed nil}])
+    (rf/dispatch-sync [:rf.causa/copilot-stream-token "Done"])
+    (rf/dispatch-sync [:rf.causa/copilot-stream-end])
+    (let [conv @(rf/subscribe [:rf.causa/copilot-conversation])]
+      (is (false? (:streaming? (second conv))))
+      (is (= 0 @(rf/subscribe [:rf.causa/copilot-streaming-token-count]))))))
+
+(deftest clear-conversation-empties-buffer
+  (testing "/clear (and :rf.causa/copilot-clear-conversation) drops the
+            buffer — per spec §Slash commands + §Ephemeral conversation
+            in-session affordance Ctrl+L"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                         {:text "Why?" :parsed nil}])
+      (rf/dispatch-sync [:rf.causa/copilot-stream-token "Because"])
+      (rf/dispatch-sync [:rf.causa/copilot-clear-conversation])
+      (is (= [] @(rf/subscribe [:rf.causa/copilot-conversation]))))))
+
+;; ---- (6) no persistence -----------------------------------------------
+
+(deftest conversation-buffer-not-persisted-to-localstorage
+  (testing "per Lock 12 — :rf.causa/copilot-conversation never writes
+            to localStorage. We assert by capturing localStorage.setItem
+            and verifying it's never called during a submit + stream +
+            clear cycle.
+
+            Node-test runtime has no `window` / `localStorage`, so the
+            assertion form here installs the spy *only when the host
+            exposes it*. In node-test the absence of `window` IS the
+            assertion (a write would crash); in the browser-test
+            harness the spy guards against a regression that would
+            silently start persisting."
+    (let [has-window? (exists? js/window)
+          captured-writes (atom [])
+          original-setItem (when (and has-window?
+                                      (.-localStorage js/window))
+                             (.-setItem (.-localStorage js/window)))]
+      (when original-setItem
+        (set! (.-setItem (.-localStorage js/window))
+              (fn [k v] (swap! captured-writes conj [k v]))))
+      (try
+        (registry/register-causa-handlers!)
+        (install-llm-capture-fx!)
+        (frame/reg-frame :rf/causa {})
+        (rf/with-frame :rf/causa
+          (rf/dispatch-sync [:rf.causa/copilot-toggle])
+          (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                             {:text "Why?" :parsed nil}])
+          (rf/dispatch-sync [:rf.causa/copilot-stream-token "Because"])
+          (rf/dispatch-sync [:rf.causa/copilot-stream-end])
+          (rf/dispatch-sync [:rf.causa/copilot-clear-conversation]))
+        ;; Filter for any key that hints at the conversation buffer
+        ;; (rf.causa.copilot.* / conversation / chat-history etc).
+        (let [conversation-writes
+              (filter (fn [[k _]]
+                        (or (re-find #"copilot" (str k))
+                            (re-find #"conversation" (str k))
+                            (re-find #"chat" (str k))))
+                      @captured-writes)]
+          (is (empty? conversation-writes)
+              "no conversation-shaped localStorage write fired"))
+        (finally
+          (when original-setItem
+            (set! (.-setItem (.-localStorage js/window))
+                  original-setItem)))))))
+
+;; ---- (7) no voice / STT --------------------------------------------------
+
+(deftest no-microphone-button-rendered
+  (testing "per Lock 13 — no `🎙` button anywhere in the rail. We walk
+            the rendered hiccup tree and assert no node carries the mic
+            glyph"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (let [rail-tree  (copilot/ai-co-pilot-rail)
+            panel-tree (copilot/ai-co-pilot-view)
+            text-of-tree
+            (fn [tree]
+              (->> (hiccup-seq tree)
+                   (filter string?)
+                   (apply str)))]
+        (is (not (re-find #"🎙" (text-of-tree rail-tree)))
+            "no mic glyph in the rail")
+        (is (not (re-find #"🎙" (text-of-tree panel-tree)))
+            "no mic glyph in the panel view")))))
+
+;; ---- (8) chip click routes panel-jump ----------------------------------
+
+(deftest chip-click-routes-dispatch-id-target
+  (testing ":rf.causa/copilot-chip-clicked dispatches the chip's target
+            with the chip's value as arg"
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (install-chip-capture!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :dispatch-id
+                          :value    100
+                          :target   :rf.causa/select-dispatch-id}]))
+    (is (= [[:rf.causa/select-dispatch-id 100]]
+           (chip-dispatches)))))
+
+(deftest chip-click-routes-epoch-number-target
+  (registry/register-causa-handlers!)
+  (install-llm-capture-fx!)
+  (install-chip-capture!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                       {:chip-key :epoch-number
+                        :value    47
+                        :target   :rf.causa/select-epoch}]))
+  (is (= [[:rf.causa/select-epoch 47]] (chip-dispatches))))
+
+;; ---- (9) rendered tree contracts ---------------------------------------
+
+(deftest rail-renders-empty-state-when-conversation-empty
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (let [tree (copilot/ai-co-pilot-rail)]
+      (is (some? (find-by-testid tree "rf-causa-copilot-rail")))
+      (is (some? (find-by-testid tree "rf-causa-copilot-empty"))
+          "empty-state surfaced when the buffer is empty")
+      (is (nil? (find-by-testid tree "rf-causa-copilot-conversation"))
+          "no conversation container when the buffer is empty"))))
+
+(deftest rail-renders-conversation-when-non-empty
+  (registry/register-causa-handlers!)
+  (install-llm-capture-fx!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/copilot-submit-question
+                       {:text "Why?" :parsed nil}])
+    (let [tree (copilot/ai-co-pilot-rail)]
+      (is (some? (find-by-testid tree "rf-causa-copilot-conversation")))
+      (is (some? (find-by-testid tree "rf-causa-copilot-turn-question")))
+      (is (some? (find-by-testid tree "rf-causa-copilot-turn-answer")))
+      (is (nil? (find-by-testid tree "rf-causa-copilot-empty"))))))
+
+(deftest rail-renders-input-row
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (let [tree (copilot/ai-co-pilot-rail)]
+      (is (some? (find-by-testid tree "rf-causa-copilot-input")))
+      (is (some? (find-by-testid tree "rf-causa-copilot-submit"))))))
+
+(deftest cue-glyph-renders
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (let [tree (copilot/ai-co-pilot-cue)]
+      (is (some? (find-by-testid tree "rf-causa-copilot-cue"))))))
+
+;; ---- (10) tool catalogue is read-only ----------------------------------
+
+(deftest registry-does-not-install-mutation-fx-for-copilot
+  (testing "per spec §Tool / function calling — the co-pilot's effect
+            surface does NOT include rewind / reset-frame-db / dispatch
+            tools. The only fx the co-pilot registers is
+            :rf.causa.fx/llm-stream."
+    (registry/register-causa-handlers!)
+    ;; The Phase 3 fxes :rf.causa.fx/restore-epoch and :rf.causa.fx/
+    ;; reset-frame-db! exist (they back the Time Travel panel), but no
+    ;; :rf.causa.copilot.fx/* mutation fx exists. The co-pilot's only
+    ;; outbound effect is the llm-stream wire.
+    (is (nil? (registrar/handler :fx :rf.causa.copilot.fx/restore-epoch)))
+    (is (nil? (registrar/handler :fx :rf.causa.copilot.fx/reset-frame-db!)))
+    (is (nil? (registrar/handler :fx :rf.causa.copilot.fx/dispatch)))
+    (is (some? (registrar/handler :fx :rf.causa.fx/llm-stream))
+        "the one outbound effect — llm-stream — is registered")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_helpers_cljs_test.cljc
@@ -1,0 +1,368 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-helpers-cljs-test
+  "Pure-data tests for Causa's AI Co-Pilot rail panel helpers
+  (Phase 5, rf2-rccf3).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  The file ends in `_cljs_test.cljc` so:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  Same dual-target pattern as
+  `time_travel_helpers_cljs_test.cljc`.
+
+  ## What's under test
+
+  Each contract from `tools/causa/spec/009-AI-CoPilot.md` is asserted
+  against the pure-data fns in `ai-co-pilot-helpers`. The view-side
+  wiring is exercised in `ai_co_pilot_cljs_test.cljs` against the
+  live Causa frame.
+
+    1. **Slash command parsing** — the 8-entry catalogue per spec
+       §Slash commands; head-token matching; rejection of unknown
+       commands; arg splitting.
+    2. **Slash popover matches** — partial-prefix matching for the
+       dropdown.
+    3. **Chip parsing** — the 4 supported chip kinds per spec §Chip
+       types; literal-text fallback for malformed fragments; unknown
+       chip-keys render literal (per spec §Why structured citations
+       'malformed edn renders as the literal fragment').
+    4. **Redaction filter** — event-vector args + app-db slice values
+       redacted by default per spec §Redaction defaults; source-coord
+       / handler-id / trace-metadata always pass through; opt-in
+       toggles unmask.
+    5. **Conversation shape** — append-question / start-answer /
+       append-token / end-answer all preserve the per-turn invariants;
+       no `:streaming?` corruption."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
+
+;; ---- (1) slash command parsing ------------------------------------------
+
+(deftest parse-slash-command-recognises-all-eight-commands
+  (testing "every command listed in `slash-commands` parses out of a
+            `/<cmd>` input"
+    (doseq [{:keys [command]} h/slash-commands]
+      (let [input  (str "/" (name command))
+            parsed (h/parse-slash-command input)]
+        (is (= command (:command parsed))
+            (str "command " command " parses out of " input))))))
+
+(deftest parse-slash-command-extracts-args
+  (testing "args are whitespace-split into a vector"
+    (is (= {:command :explain
+            :args    ["epoch-42"]
+            :raw     "/explain epoch-42"}
+           (h/parse-slash-command "/explain epoch-42")))
+    (is (= ["epoch-1" "epoch-2"]
+           (:args (h/parse-slash-command "/diff epoch-1 epoch-2"))))
+    (is (= []
+           (:args (h/parse-slash-command "/clear"))))))
+
+(deftest parse-slash-command-returns-nil-for-non-slash-input
+  (testing "plain English questions are not slash commands"
+    (is (nil? (h/parse-slash-command "why did this fire?")))
+    (is (nil? (h/parse-slash-command "")))
+    (is (nil? (h/parse-slash-command nil)))))
+
+(deftest parse-slash-command-returns-nil-for-unknown-command
+  (testing "head tokens outside the catalogue are rejected"
+    (is (nil? (h/parse-slash-command "/notacommand")))
+    (is (nil? (h/parse-slash-command "/foo bar")))))
+
+(deftest parse-slash-command-tolerates-leading-whitespace
+  (testing "an input with leading whitespace still parses (the chrome
+            may pass a not-yet-trimmed string)"
+    (is (= :clear (:command (h/parse-slash-command "   /clear"))))))
+
+;; ---- (2) slash popover matches -----------------------------------------
+
+(deftest popover-matches-empty-slash-returns-all
+  (testing "`/` alone returns the full catalogue"
+    (is (= (count h/slash-commands)
+           (count (h/slash-popover-matches "/"))))))
+
+(deftest popover-matches-prefix-filters
+  (testing "`/wh` matches `/why` and `/whatif`"
+    (let [matches (h/slash-popover-matches "/wh")
+          cmds    (set (map :command matches))]
+      (is (contains? cmds :why))
+      (is (contains? cmds :whatif))
+      (is (not (contains? cmds :explain))))))
+
+(deftest popover-matches-nil-for-non-slash-input
+  (testing "a plain-English input returns nil (the dropdown stays hidden)"
+    (is (nil? (h/slash-popover-matches "why")))
+    (is (nil? (h/slash-popover-matches "")))))
+
+;; ---- (3) chip parsing ---------------------------------------------------
+
+(deftest parse-streamed-answer-extracts-dispatch-id-chip
+  (testing "a `:dispatch-id` chip is extracted from streamed text"
+    (let [segments (h/parse-streamed-answer
+                     "fired by {:rf.copilot/chip :dispatch-id 100} earlier.")]
+      (is (= 3 (count segments)))
+      (is (= {:kind :text :text "fired by "} (first segments)))
+      (is (= :chip (:kind (nth segments 1))))
+      (is (= :dispatch-id (:chip-key (nth segments 1))))
+      (is (= 100 (:value (nth segments 1))))
+      (is (= " earlier." (:text (nth segments 2)))))))
+
+(deftest parse-streamed-answer-extracts-path-chip
+  (testing "a `:path` chip with a vector value parses correctly"
+    (let [segments (h/parse-streamed-answer
+                     "the path {:rf.copilot/chip :path [:cart :items 3 :qty]}")
+          chip     (first (filter #(= :chip (:kind %)) segments))]
+      (is (= :path (:chip-key chip)))
+      (is (= [:cart :items 3 :qty] (:value chip))))))
+
+(deftest parse-streamed-answer-extracts-epoch-number-chip
+  (testing "a `:epoch-number` chip parses correctly"
+    (let [segments (h/parse-streamed-answer
+                     "see {:rf.copilot/chip :epoch-number 47}.")
+          chip     (first (filter #(= :chip (:kind %)) segments))]
+      (is (= :epoch-number (:chip-key chip)))
+      (is (= 47 (:value chip))))))
+
+(deftest parse-streamed-answer-extracts-handler-id-chip
+  (testing "a `:handler-id` chip with a keyword value parses correctly"
+    (let [segments (h/parse-streamed-answer
+                     "by {:rf.copilot/chip :handler-id :cart/finalise}")
+          chip     (first (filter #(= :chip (:kind %)) segments))]
+      (is (= :handler-id (:chip-key chip)))
+      (is (= :cart/finalise (:value chip))))))
+
+(deftest parse-streamed-answer-handles-no-chips
+  (testing "plain prose returns a single :text segment"
+    (let [segments (h/parse-streamed-answer
+                     "Dispatched at events.cljs:213 by :cart/finalise.")]
+      (is (= 1 (count segments)))
+      (is (= :text (:kind (first segments)))))))
+
+(deftest parse-streamed-answer-handles-multiple-chips
+  (testing "a streamed answer with multiple chips returns the
+            segments in order"
+    (let [segments (h/parse-streamed-answer
+                     (str "from {:rf.copilot/chip :dispatch-id 1} via "
+                          "{:rf.copilot/chip :handler-id :foo} done."))
+          chips    (filter #(= :chip (:kind %)) segments)]
+      (is (= 2 (count chips)))
+      (is (= [:dispatch-id :handler-id]
+             (mapv :chip-key chips))))))
+
+(deftest parse-streamed-answer-unknown-chip-key-renders-literal
+  (testing "an unrecognised chip-key renders as literal text (per
+            spec §Why structured citations 'malformed edn renders as
+            the literal fragment')"
+    (let [segments (h/parse-streamed-answer
+                     "see {:rf.copilot/chip :bogus 42}.")
+          chips    (filter #(= :chip (:kind %)) segments)]
+      (is (empty? chips)
+          "no chip is emitted for an unknown chip-key")
+      (is (some #(re-find #"\{:rf.copilot/chip :bogus 42\}" (:text % ""))
+                segments)
+          "the literal raw fragment is preserved as text"))))
+
+(deftest parse-streamed-answer-handles-malformed-fragment
+  (testing "a `{:rf.copilot/chip` prefix without a closing `}` renders
+            as literal text (defensive — a partial stream tail might
+            land mid-fragment)"
+    (let [segments (h/parse-streamed-answer
+                     "tail {:rf.copilot/chip :dispatch-id 100")]
+      (is (every? #(= :text (:kind %)) segments)
+          "no chip is emitted when the fragment is unbalanced"))))
+
+(deftest parse-streamed-answer-empty-input
+  (testing "empty / non-string input is handled gracefully"
+    (is (= [] (h/parse-streamed-answer "")))
+    (is (= [] (h/parse-streamed-answer nil)))))
+
+;; ---- (3a) resolve-chip --------------------------------------------------
+
+(deftest resolve-chip-returns-glyph-and-target
+  (testing "resolve-chip looks up glyph + target for each known chip-key"
+    (let [resolved (h/resolve-chip {:chip-key :dispatch-id :value 100})]
+      (is (= :rf.causa/select-dispatch-id (:target resolved)))
+      (is (= "◆" (:glyph resolved)))
+      (is (= 100 (:value resolved))))
+    (is (= :rf.causa/select-epoch
+           (:target (h/resolve-chip {:chip-key :epoch-number :value 47}))))
+    (is (= :rf.causa.copilot/open-path
+           (:target (h/resolve-chip {:chip-key :path :value [:a :b]}))))
+    (is (= :rf.causa.copilot/open-handler
+           (:target (h/resolve-chip {:chip-key :handler-id :value :foo}))))))
+
+(deftest resolve-chip-returns-nil-for-unknown-key
+  (testing "unrecognised chip-keys return nil (the view falls back to
+            literal text)"
+    (is (nil? (h/resolve-chip {:chip-key :wat :value 1})))))
+
+;; ---- (4) redaction filter ----------------------------------------------
+
+(deftest default-redaction-settings-are-privacy-by-default
+  (testing "per spec §Redaction defaults — event-vector args + app-db
+            slice values are redacted by default"
+    (is (false? (:unmask-event-args h/default-redaction-settings)))
+    (is (false? (:unmask-app-db h/default-redaction-settings)))))
+
+(deftest redact-event-vector-args-by-default
+  (testing "a trace event's event-vector args are stamped <redacted>
+            under the default settings; the event-id is preserved"
+    (let [ev        {:op-type :event
+                     :operation :event/dispatched
+                     :tags {:event [:user/login {:email "ada@example.com"}]
+                            :dispatch-id 100}}
+          redacted  (h/redact-trace-event h/default-redaction-settings ev)
+          event-vec (get-in redacted [:tags :event])]
+      (is (= :user/login (first event-vec))
+          "event-id (head of the vector) is preserved")
+      (is (= "<redacted>" (second event-vec))
+          "args are stamped <redacted>")
+      (is (= 100 (get-in redacted [:tags :dispatch-id]))
+          "trace-metadata pass-through — :dispatch-id is not redacted"))))
+
+(deftest unmask-event-args-toggle-passes-through
+  (testing "with :unmask-event-args true the event-vector is unchanged"
+    (let [ev       {:op-type :event
+                    :tags {:event [:user/login {:email "ada@example.com"}]
+                           :dispatch-id 100}}
+          redacted (h/redact-trace-event {:unmask-event-args true} ev)]
+      (is (= [:user/login {:email "ada@example.com"}]
+             (get-in redacted [:tags :event]))))))
+
+(deftest redact-app-db-by-default
+  (testing "app-db leaf values are stamped <redacted>; keys + structure
+            are preserved (per spec rationale — 'Source coords + handler
+            IDs + trace metadata are sufficient for the canonical
+            why-did-this-render questions')"
+    (let [db       {:user {:email "ada@example.com"
+                           :id    42}
+                    :cart {:items [{:qty 3} {:qty 1}]}}
+          redacted (h/redact-app-db h/default-redaction-settings db)]
+      (is (contains? redacted :user) "structure preserved")
+      (is (= "<redacted>" (get-in redacted [:user :email])))
+      (is (= "<redacted>" (get-in redacted [:user :id])))
+      (is (vector? (get-in redacted [:cart :items])) "vector kept")
+      (is (= "<redacted>" (get-in redacted [:cart :items 0 :qty]))))))
+
+(deftest unmask-app-db-toggle-passes-through
+  (testing "with :unmask-app-db true the app-db is unchanged"
+    (let [db       {:user {:id 42}}
+          redacted (h/redact-app-db {:unmask-app-db true} db)]
+      (is (= 42 (get-in redacted [:user :id]))))))
+
+(deftest redact-payload-applies-both-filters
+  (testing "redact-payload walks trace-events + app-db; other slots
+            (source coords, handler ids, etc) pass through unchanged"
+    (let [payload  {:trace-events [{:op-type :event
+                                    :tags {:event [:user/login {:pw "x"}]
+                                           :dispatch-id 100
+                                           :handler-id  :user/login}}]
+                    :app-db       {:user {:id 42}}
+                    :source-coord "src/cart/events.cljs:213"
+                    :question     "Why did this fire?"}
+          redacted (h/redact-payload h/default-redaction-settings payload)
+          ev       (first (:trace-events redacted))]
+      (is (= "<redacted>" (get-in ev [:tags :event 1]))
+          "event-vector args redacted")
+      (is (= 100 (get-in ev [:tags :dispatch-id]))
+          ":dispatch-id pass-through")
+      (is (= :user/login (get-in ev [:tags :handler-id]))
+          ":handler-id pass-through")
+      (is (= "<redacted>" (get-in redacted [:app-db :user :id]))
+          "app-db redacted")
+      (is (= "src/cart/events.cljs:213" (:source-coord redacted))
+          "source-coord pass-through")
+      (is (= "Why did this fire?" (:question redacted))
+          "question pass-through"))))
+
+;; ---- (5) conversation shape ---------------------------------------------
+
+(deftest empty-conversation-is-empty-vec
+  (is (= [] (h/empty-conversation))))
+
+(deftest append-question-adds-question-turn
+  (testing "append-question appends a question turn with :role :question"
+    (let [conv (h/append-question [] "Why?")]
+      (is (= 1 (count conv)))
+      (is (= :question (:role (first conv))))
+      (is (= "Why?" (:text (first conv))))
+      (is (false? (:streaming? (first conv)))))))
+
+(deftest start-answer-adds-streaming-answer-turn
+  (testing "start-answer appends an empty answer turn with :streaming? true"
+    (let [conv (h/start-answer [{:role :question :text "Why?" :streaming? false}])]
+      (is (= 2 (count conv)))
+      (is (= :answer (:role (second conv))))
+      (is (= "" (:text (second conv))))
+      (is (true? (:streaming? (second conv)))))))
+
+(deftest append-token-accretes-onto-streaming-answer
+  (testing "append-token extends the trailing answer's :text"
+    (let [conv (-> []
+                   (h/append-question "Why?")
+                   (h/start-answer)
+                   (h/append-token "Be")
+                   (h/append-token "cause"))]
+      (is (= 2 (count conv)))
+      (is (= "Because" (:text (second conv))))
+      (is (true? (:streaming? (second conv)))))))
+
+(deftest append-token-noop-when-trailing-turn-is-question
+  (testing "append-token does nothing when there's no in-flight answer"
+    (let [conv (-> []
+                   (h/append-question "Why?")
+                   (h/append-token "stray"))]
+      (is (= 1 (count conv)))
+      (is (= "Why?" (:text (first conv)))
+          "question's text untouched by stray token"))))
+
+(deftest append-token-noop-on-empty-conversation
+  (testing "append-token over an empty conversation is a no-op"
+    (is (= [] (h/append-token [] "stray")))))
+
+(deftest end-answer-marks-trailing-not-streaming
+  (testing "end-answer flips :streaming? false on the trailing answer"
+    (let [conv (-> []
+                   (h/append-question "Why?")
+                   (h/start-answer)
+                   (h/append-token "Because")
+                   (h/end-answer))]
+      (is (false? (:streaming? (second conv)))
+          "answer turn is no longer streaming")
+      (is (= "Because" (:text (second conv)))
+          "text preserved"))))
+
+(deftest end-answer-noop-when-trailing-turn-is-finalised
+  (testing "end-answer is a no-op when the trailing turn is already
+            non-streaming (defensive — a duplicate :stream-end event
+            should not corrupt the buffer)"
+    (let [conv (-> []
+                   (h/append-question "Why?")
+                   (h/start-answer)
+                   (h/end-answer)
+                   (h/end-answer))]
+      (is (false? (:streaming? (second conv)))))))
+
+;; ---- (6) chip-key set + glyph + target maps -----------------------------
+
+(deftest chip-key-set-is-the-four-supported-kinds
+  (testing "exactly the 4 chip-keys per spec §Chip types"
+    (is (= #{:dispatch-id :path :epoch-number :handler-id}
+           h/chip-key-set))))
+
+(deftest chip-glyphs-cover-the-four-kinds
+  (testing "each chip-key has a glyph"
+    (doseq [k h/chip-key-set]
+      (is (some? (get h/chip-glyphs k))
+          (str k " has a glyph")))))
+
+(deftest chip-targets-cover-the-four-kinds
+  (testing "each chip-key has a panel-jump target"
+    (doseq [k h/chip-key-set]
+      (is (keyword? (get h/chip-targets k))
+          (str k " has a target keyword")))))


### PR DESCRIPTION
Phase 5 of the Causa v1.0 epic (**rf2-5aw5v**) per
[`tools/causa/spec/009-AI-CoPilot.md`](../blob/main/tools/causa/spec/009-AI-CoPilot.md)
— the AI Co-Pilot rail.

## Summary

- **Pull-only Q&A + slash-command rail** mounted in the Causa shell's right margin. Collapsed by default (Lock 8); magenta `◇` cue glyph in the top-strip until first use. Toggle via the cue, the sidebar `Co-pilot` row, or `Ctrl+Shift+/` (per §Default state).
- **Slash commands**: `/explain`, `/diff`, `/find`, `/rewind`, `/state`, `/why`, `/whatif`, `/clear` (per §Slash commands). `/clear` is intercepted client-side — never sent to the model.
- **Chip parser**: walks streamed answers for `{:rf.copilot/chip <key> <value>}` fragments and renders them as clickable handles. Four chip kinds: `:dispatch-id ◆`, `:path ▥`, `:epoch-number ⏵`, `:handler-id ⚙` (per §Chip types). Malformed fragments and unknown chip-keys render as literal text — the model is rewarded for naming data precisely (per §Why structured citations).
- **Redaction filter**: privacy-by-default per §Redaction defaults. Event-vector args and app-db slice values are `<redacted>` unless the user opts in via `:rf.causa.copilot/unmask-event-args` / `:rf.causa.copilot/unmask-app-db`. Source coords, handler ids, and trace metadata always pass through.
- **Provider abstraction**: five providers wired (Claude default / OpenAI / Gemini / Local Ollama / Custom). The per-provider streaming `fetch` is stubbed in this commit; `:rf.causa.fx/llm-stream` is the sealed integration point. The panel renders end-to-end against the no-op stub.
- **Ephemeral conversation** (Lock 12): in-memory only — no localStorage write, no export, cleared on Causa close + tab reload. Verified by an assertion that captures `localStorage.setItem` across a full submit / stream / clear cycle and asserts zero conversation-shaped writes.
- **No voice / STT** at v1.0 (Lock 13): the rail renders no `🎙` button; verified by hiccup walk.
- **Read-only tool catalogue**: the panel registers exactly one fx (`:rf.causa.fx/llm-stream`). No mutation fx (`restore-epoch` / `reset-frame-db!` / `dispatch`) is exposed to the model — verified by the `registrar/handler` assertion.

## Registration markers

Per the bead's brief the panel's `install!` call in `registry.cljs` is bracketed by `;; ── ai-co-pilot panel begin ──` / `;; ── ai-co-pilot panel end ──` so the entry can be folded inline or removed cleanly in a follow-up if Mike prefers.

## Slash commands implemented

| Slash | Routes to |
|---|---|
| `/explain <epoch>` | submit-question (model interprets) |
| `/diff <a> <b>` | submit-question |
| `/find <pattern>` | submit-question |
| `/rewind <epoch>` | submit-question (action chip; no auto-execute) |
| `/state <machine-id>` | submit-question |
| `/why <epoch>` | submit-question |
| `/whatif <hypothetical>` | submit-question |
| `/clear` | `:rf.causa/copilot-clear-conversation` (client-side; never sent to LLM) |

## Redaction default

Privacy-by-default per §Redaction defaults:

| Category | Default | Opt-in toggle |
|---|---|---|
| Event-vector args | `<redacted>` | `:rf.causa.copilot/unmask-event-args` |
| App-db slice values | `<redacted>` | `:rf.causa.copilot/unmask-app-db` |
| Source coords | always sent | (always sent) |
| Handler IDs | always sent | (always sent) |
| Trace metadata | always sent | (always sent) |

## Test results

```
JVM (clojure -M:test in tools/causa):
  Ran 108 tests containing 310 assertions.
  0 failures, 0 errors.

CLJS (npm run test:cljs from implementation):
  Ran 869 tests containing 2243 assertions.
  0 failures, 0 errors.

Elision (npm run test:elision):
  === PASS ===
```

Coverage maps 1:1 to the §Acceptance criteria list in `rf2-rccf3`:

- [x] Panel mounts collapsed by default
- [x] Cue `◇` pulses until first use (cue-active? toggles after first toggle)
- [x] Pull-only verified — no outbound LLM call without user submit
- [x] All 8 slash commands recognised by the parser
- [x] Provider picker wired (5 providers); per-provider fetch follow-on
- [x] Read-only tool catalogue — no mutation fx registered
- [x] Chip parser handles all 4 chip types + literal-text fallback for malformed / unknown
- [x] Redaction defaults applied; opt-in toggles work
- [x] Conversation ephemeral — no localStorage write verified
- [x] No voice surface; no mic glyph rendered
- [x] Tests cover all the above

## Test plan

- [x] `clojure -M:test` (tools/causa)
- [x] `npm run test:cljs` (implementation)
- [x] `npm run test:elision` (implementation)
- [ ] Manual: open Causa via `Ctrl+Shift+C`; verify cue glyph in top-strip pulses; press `Ctrl+Shift+/` to toggle the rail; type a question and confirm the question turn appears (the answer stream is stubbed pending provider wiring).