### PR TITLE
docs(pair2-mcp): harmonise tool count to 9 in src + test code (rf2-erbts)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
@@ -11,8 +11,9 @@
      is running — the first tool that needs the socket gets a
      structured error).
   2. `initialize`: standard MCP handshake.
-  3. `tools/list`: returns the seven tool descriptors (mirror of the
-     bash-shim catalogue).
+  3. `tools/list`: returns the nine tool descriptors (the seven
+     bash-shim ops plus the `snapshot` mega-op from rf2-x70e and the
+     `subscribe` / `unsubscribe` streaming pair from rf2-hq49).
   4. `tools/call`: dispatch to `tools.cljs`. Each call ensures the
      in-browser runtime is injected via the sentinel probe.
   5. stdin EOF: shut down cleanly.

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -3,7 +3,8 @@
 //
 // This test does NOT need a live shadow-cljs nREPL — it exercises:
 //   - initialize handshake
-//   - tools/list (expects all seven tools, including the snapshot mega-op)
+//   - tools/list (expects all nine tools, including the snapshot mega-op
+//     and the subscribe/unsubscribe streaming pair)
 //   - tools/call eval-cljs against an absent nREPL (expects graceful
 //     :nrepl-port-not-found degraded mode)
 //   - tools/call snapshot against an absent nREPL (same degraded mode —


### PR DESCRIPTION
## Summary

Follow-on to rf2-zbtgf (PR #578), which harmonised the **spec + README**
to the canonical 9 tools. The same drift survived in code and test
comments:

- `tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs:14` — boot-lifecycle
  docstring said *"the seven tool descriptors (mirror of the bash-shim
  catalogue)"*. The catalogue diverged from the bash-shim catalogue (7
  ops) when rf2-x70e added the `snapshot` mega-op and rf2-hq49 added the
  `subscribe` / `unsubscribe` streaming pair. Updated to nine with a
  one-line note of why.
- `tools/pair2-mcp/test/stdio-roundtrip.js:6` — header comment said *"all
  seven tools"*; line 83 already said *"nine"* and the `expected[]` array
  at line 89 enumerates all nine. Header brought into line with the rest
  of the file (internally inconsistent before this change).

Comment-only — no runtime behaviour change, no `expected[]` array touched
(it was already canonical-9).

## Test plan

- [x] `rg -i "seven|nine|7 tools|9 tools" tools/pair2-mcp/src tools/pair2-mcp/test` — only the intentional historical reference *"the nine tool descriptors (the seven bash-shim ops plus...)"* survives in the new docstring; no "seven" left anywhere else in src/ or test/.
- [x] `node --check tools/pair2-mcp/test/stdio-roundtrip.js` — JS syntax OK.
- [ ] CI runs the pair2-mcp test suite end-to-end (`npm test` requires a `shadow-cljs compile` step which isn't run in this comment-only patch).