### PR TITLE
spec(causa): extend editor-protocol matrix with :windsurf + :zed (rf2-mqm2d)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -378,10 +378,14 @@ build from that coord.
 
 | Editor | Config key | URI template |
 |---|---|---|
-| VS Code (and forks: Cursor, Windsurf, code-server) | `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
-| Cursor (distinct scheme) | `:cursor` | `cursor://file/<path>:<line>:<column>` |
+| VS Code (and forks that share its scheme: code-server, VSCodium) | `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
+| Cursor (distinct scheme — VS Code fork) | `:cursor` | `cursor://file/<path>:<line>:<column>` |
+| Windsurf (distinct scheme — VS Code fork, registers its own handler) | `:windsurf` | `windsurf://file/<path>:<line>:<column>` |
+| Zed | `:zed` | `zed://file/<path>:<line>:<column>` |
 | JetBrains family (IDEA, WebStorm, Cursive, PyCharm) | `:idea` | `idea://open?file=<path>&line=<line>&column=<column>` |
-| Anything else (Sublime, Zed, Emacs server-mode, Vim with a URL handler) | `{:custom <template>}` | user template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
+| Anything else (Sublime, Emacs server-mode, Vim with a URL handler, Helix) | `{:custom <template>}` | user template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
+
+The `:windsurf` and `:zed` rows mirror the VS Code colon-suffix shape — Windsurf as a VS Code fork inherits the file/line/column grammar; Zed's `zed://` handler (registered via the editor's "Register Zed Scheme" action) accepts the same URI shape per its open-listener pipeline. Editors that ship without a stable URI handler still route through `{:custom <template>}` until they standardise.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

- Adds explicit rows for `:windsurf` and `:zed` to the editor-protocol matrix in `tools/causa/spec/007-UX-IA.md` (the prior matrix from rf2-tiew3 grouped Windsurf into the VS Code fork list and shunted Zed into `{:custom}`).
- Tightens the `:vscode` row to forks that share the `vscode://` scheme verbatim (code-server, VSCodium); Cursor and Windsurf now carry their own rows with distinct schemes.
- Updates the catch-all `{:custom}` row's examples — Zed leaves the bucket; Helix joins it.

## Rows added

| Editor | Config key | URI template |
|---|---|---|
| Windsurf (distinct scheme — VS Code fork) | `:windsurf` | `windsurf://file/<path>:<line>:<column>` |
| Zed | `:zed` | `zed://file/<path>:<line>:<column>` |

Both follow the VS Code colon-suffix shape: Windsurf as a VS Code fork inherits the grammar; Zed's `zed://` handler (registered via its "Register Zed Scheme" action and the `open_listener.rs` pipeline) accepts the same URI shape.

## Scope

- Spec-only edit; the implementation helper at `implementation/core/src/re_frame/source_coords/editor_uri.cljc` still recognises only `:vscode` / `:cursor` / `:idea` / `:custom`. A follow-on bead will extend `known-editors` + add `windsurf-uri` / `zed-uri` builders — separate PR.

## Test plan

- [ ] `tools/causa/spec/007-UX-IA.md` renders the new rows correctly.
- [ ] Cross-references to rf2-evgf5 + `editor_uri.cljc` still resolve.