### PR TITLE
chore: add causa LICENSE + fill CLAUDE.md sections + fix story Reagent version drift (rf2-w46id)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,18 +73,39 @@ Per `docs/the-mayor-method.md`, the `ai/` directory at repo root holds all AI wo
 
 ## Build & Test
 
-_Add your build and test commands here_
+The CLJS reference implementation builds and tests run from `implementation/`. shadow-cljs is the build tool; npm scripts in `implementation/package.json` are the canonical entry points.
 
 ```bash
-# Example:
-# npm install
-# npm test
+# From implementation/:
+npm install                          # one-time, installs shadow-cljs + react
+npm run test:cljs                    # node-runtime CLJS tests (fast, default gate)
+npm run test:browser                 # browser tests via Playwright
+npm run test:elision                 # production elision probe
+npm run test:perf-bundle             # perf-budget bundle check
+npm run test:bundle-isolation        # tools must not leak into production bundles
+npm run test:examples                # examples test runner
+npm run story:build                  # build the story artefact
 ```
+
+Per-artefact tests run from each artefact directory via `clojure -M:test` (see e.g. `tools/story/deps.edn` `:test` alias). Workflow gates live in `.github/workflows/`.
+
+Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 
 ## Architecture Overview
 
-_Add a brief overview of your project architecture_
+**The spec is the artefact; the code is downstream.** The normative description of re-frame2 lives in [`spec/`](spec/) (~22K lines across 35+ documents); [`implementation/`](implementation/) is a CLJS reference that validates the spec end-to-end. See the repo-root [`README.md`](README.md) for the marketing-voice introduction and the project-layout map, and [`spec/README.md`](spec/README.md) for the spec index.
+
+Top-level layout:
+
+- `spec/` — the specification (primary artefact; AI-targeted)
+- `implementation/` — CLJS reference: `core/` + per-substrate `adapters/` (Reagent, UIx, Helix) + per-feature artefacts (machines, schemas, …). The top-level `implementation/shadow-cljs.edn` + `implementation/deps.edn` coordinate the cross-artefact classpath.
+- `tools/` — dev/inspection tools that consume the Spec 009 instrumentation API and Tool-Pair contract (`story/`, `story-mcp/`, `pair2-mcp/`, `causa/`, `template/`). Bundle-isolated from production builds; nothing in `implementation/` may `:require` from `tools/`.
+- `examples/` — worked examples per substrate.
+- `docs/` — human-facing guide (`docs/guide/`) and operational docs.
+- `skills/` — Claude Code skills for re-frame2 workflows.
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+Normative conventions are catalogued in [`spec/Conventions.md`](spec/Conventions.md) — reserved namespaces (the `:rf/*` single-root scheme), reserved fx-ids, reserved app-db keys, the feature-modularity id-prefix convention, and packaging conventions. [`spec/Principles.md`](spec/Principles.md) carries the nine AI-first practical principles. [`spec/Ownership.md`](spec/Ownership.md) maps every contract surface to its owning spec — the "where does X live?" reference.
+
+Hot-zone files (sequential, never parallel — see the Workflow section above for the list) and isolated surfaces (safe to parallel) are documented in the dispatch rules above; new beads should respect that split to minimise merge conflicts.

--- a/tools/causa/LICENSE
+++ b/tools/causa/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2026 Michael Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -22,7 +22,7 @@
          ;; explicit because Story's UI shell directly :require's reagent.
          ;; If implementation/core's coupling to Reagent ever loosens, this
          ;; dep stays.
-         reagent/reagent         {:mvn/version "1.2.0"}
+         reagent/reagent         {:mvn/version "2.0.1"}
 
          ;; Stage 3 (rf2-von3) — the loader four-phase lifecycle is
          ;; implemented as a state machine via `re-frame.machines` per


### PR DESCRIPTION
## Summary

Three small repo-hygiene fixes from the repo-best-practice sweep (`ai/findings/sweep-repo-best-practice-2026-05-13.md` §2 / §10; bead `rf2-w46id`).

### 1. `tools/causa/LICENSE` — added

`tools/causa/` was the lone outlier among artefact directories. Every other `tools/*` (`story`, `story-mcp`, `pair2-mcp`, `template`) and every `implementation/*/` ships an MIT LICENSE. Added the canonical MIT text (identical to the other four `tools/*/LICENSE` files, verified via `diff`) so Causa presents the same licence on Clojars as its siblings.

### 2. `CLAUDE.md` — filled placeholder sections

Three placeholder sections were left as scaffold prompts (`_Add your build and test commands here_`, etc.). Filled them with concrete content rooted in the actual repo:

- **Build & Test** — the shadow-cljs entry points and npm scripts from `implementation/package.json` (`test:cljs`, `test:browser`, `test:elision`, `test:perf-bundle`, `test:bundle-isolation`, `test:examples`, `story:build`), the per-artefact `clojure -M:test` pattern, and `mkdocs build --strict`.
- **Architecture Overview** — the "spec is the artefact" framing with a top-level layout pointing at `spec/`, `implementation/`, `tools/`, `examples/`, `docs/`, `skills/`; cross-links to `README.md` and `spec/README.md` for the deeper reads.
- **Conventions & Patterns** — pointers to `spec/Conventions.md` (reserved namespaces, fx-ids, app-db keys), `spec/Principles.md`, and `spec/Ownership.md`; restates the hot-zone-vs-isolated-surfaces dispatch rule already in the Workflow section.

The Beads Integration block, Git Conventions, the `ai/` tree section, and the Workflow section are untouched.

### 3. `tools/story/deps.edn` — Reagent 1.2.0 → 2.0.1

`tools/story/deps.edn:25` was pinned at `reagent/reagent {:mvn/version "1.2.0"}` while the rest of the repo pins `2.0.1`:

- `implementation/core/deps.edn:41`
- `tools/causa/deps.edn:42`
- `implementation/shadow-cljs.edn:87`
- `tools/template/src/clj/new/re_frame2/reagent/deps.edn:20`

Only affected `clojure -M:test` from `tools/story/` — the consolidated shadow build already resolved to 2.0.1 because `implementation/shadow-cljs.edn` wins. Now consistent everywhere.

## Validation

- `mkdocs build --strict` warning count unchanged: 122 before, 122 after. The pre-existing strict failures are in `docs/guide/20-where-next.md`, `docs/guide/21-stories.md`, and `docs/skills/re-frame2-implementor.md` — none touched here.
- No new files added to `mkdocs.yml`; LICENSE + CLAUDE.md sit outside the docs nav.
- `tools/story/deps.edn` change is a single version literal; the file still parses as EDN.

## Test plan

- [x] `mkdocs build --strict` — baseline (122 warnings) preserved
- [x] `diff tools/template/LICENSE tools/causa/LICENSE` — files identical
- [x] No remaining `1.2.0` references under `tools/story/`