### PR TITLE
docs(skills): factor cross-skill routing matrix into skills/README.md — single source (rf2-rcrbr)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -85,6 +85,41 @@ re-frame2 ships **six** skills, grouped by the situation they cover:
 - **Just finished a pairing session and noticed friction?** →
   `re-frame-pair-improver2`.
 
+## Skill routing — single source
+
+Each per-skill `SKILL.md` formerly carried its own "When NOT to use this
+skill" table mapping the other five skills' triggers to a route. Those
+30+ cross-referenced cells drift in lockstep. **This section is the
+single source of truth**; per-skill `SKILL.md` files point here instead
+of duplicating.
+
+### Trigger → skill
+
+| Author / engineer intent | Trigger phrasing / surface | Route to |
+|---|---|---|
+| Bootstrap a brand-new re-frame2 ClojureScript project from nothing (or an empty CLJS project with shadow-cljs/Clojure but zero re-frame2 wiring) | "start a re-frame2 project", "scaffold re-frame2", "hello-world re-frame2 app", "new re-frame2 app", build failure on a freshly-scaffolded project tracing to missing `re-frame.core` / `re-frame.adapter.reagent` wiring | [`re-frame2-setup/`](./re-frame2-setup/) |
+| Write new application code on a working re-frame2 project | events, subs, fx, cofx, frames, state machines, schemas, stories, routing, canonical patterns; `reg-event-*`, `reg-sub`, `reg-fx`, `reg-machine`, `reg-view`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db` | [`re-frame2/`](./re-frame2/) |
+| Migrate an existing re-frame v1.x ClojureScript codebase to re-frame2 | "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2", or any v1 surface (`re-frame.db`, `dispatch-with`, `reg-global-interceptor`, `reg-sub-raw`, `^:flush-dom`, `re-frame.alpha`, `re-frame-test`, old top-level `:dispatch` / `:dispatch-n` effect-map keys) | [`re-frame-migration/`](./re-frame-migration/) |
+| Pair-program against a **running** re-frame2 application — attach to a live shadow-cljs nREPL, inspect a frame's `app-db`, dispatch events, hot-swap handlers, walk traces / epochs, time-travel with `restore-epoch` | live runtime is involved; user is operating on (or wants to operate on) a running local app | [`re-frame-pair2/`](./re-frame-pair2/) |
+| Retrospect on a **just-finished** `re-frame-pair2` session and turn it into prioritised improvement ideas for the pair-tool skill, scripts, MCP surface, or upstream `re-frame2` Tool-Pair contract | concrete recent `re-frame-pair2` session in the conversation; user explicitly asks to improve `re-frame-pair2` or wants an opt-in bead draft | [`re-frame-pair-improver2/`](./re-frame-pair-improver2/) |
+| Build a **new re-frame2 implementation** in a different host language or substrate (TypeScript, F# / Fable, Kotlin/JS, Squint, Scala.js, PureScript, ReScript, Python, Rust, native UI, terminal, …) — porting the pattern, not building an app on the CLJS reference | "port re-frame2", "implement re-frame2 in &lt;language&gt;", "second re-frame2 implementation", "implementor checklist", "conformance corpus", or any prompt about building re-frame2 itself | [`re-frame2-implementor/`](./re-frame2-implementor/) |
+| Read re-frame2's full API reference, EP design rationale, principles, conventions, or spec corpus | spec / architecture / design discussion without a running app or active authoring task | [`SKILL-REDIRECT.md`](../SKILL-REDIRECT.md) |
+
+### Disqualifiers (vocabulary alone is not enough)
+
+- Vocabulary matches without context don't justify activation. *"retro"*, *"what went wrong"*, *"improve workflow"* don't unlock `re-frame-pair-improver2` unless a real `re-frame-pair2` session has occurred in the conversation (or the user supplies a recap).
+- Spec-reading, architecture questions, design discussion belong to [`SKILL-REDIRECT.md`](../SKILL-REDIRECT.md) — not to `re-frame-pair2` (no runtime) and not to `re-frame2` (not authoring).
+- Generic debugging retrospectives, post-mortems on shell sessions, IDE workflows, or test-suite runs are out of scope for `re-frame-pair-improver2` — there is no pair-tool surface to improve.
+- Mid-session pair work stays in `re-frame-pair2`; switch to `re-frame-pair-improver2` only after the work, not during it.
+- "Adding re-frame2 to an existing app with other state management or non-trivial code" is an authoring task — route to `re-frame2/`, not `re-frame2-setup/`. Setup is greenfield-only and exits once the counter mounts.
+
+### Routing for friction found mid-pair retro
+
+`re-frame-pair-improver2` proposals route as follows:
+
+- **Pair-tool friction** (SKILL.md wording, scripts, recipes, structured-results shapes, attach/discovery, cross-platform behavior) → bead against `re-frame-pair2`.
+- **Framework / Tool-Pair contract friction** (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings) → bead against `re-frame2` (upstream).
+
 ## Layout convention
 
 Each skill subdir contains, at minimum:

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -24,13 +24,7 @@ The authoritative rule corpus — M-rules (required) and O-rules (opt-in moderni
 
 ## When NOT to use
 
-| Author intent | Route to |
-|---|---|
-| Start a new re-frame2 project from scratch | `skills/re-frame2-setup/` |
-| Write new code on a project already on v2 | `skills/re-frame2/` |
-| Inspect / debug / time-travel a running v2 app | `skills/re-frame-pair2/` |
-| Build a new re-frame2 implementation in another host/substrate | `skills/re-frame2-implementor/` |
-| Read re-frame2's design rationale | `SKILL-REDIRECT.md` |
+Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). In brief: not for greenfield bootstrap, authoring on an already-v2 project, live-runtime inspection, porting re-frame2 itself, or spec / design-rationale reading.
 
 Exit this skill when the project compiles, tests pass, and Type B items have been resolved.
 
@@ -105,4 +99,4 @@ Hand off: *"Migration complete. Switch to **`re-frame2`** for new application co
 
 ---
 
-*Authoritative breaking-change list: [`MIGRATION.md`](../../spec/MIGRATION.md). v1 line: [re-frame](https://github.com/day8/re-frame). Greenfield: `skills/re-frame2-setup/`. v2 authoring: `skills/re-frame2/`. Live inspection: `skills/re-frame-pair2/`. New re-frame2 implementation in another host/substrate: `skills/re-frame2-implementor/`.*
+*Authoritative breaking-change list: [`MIGRATION.md`](../../spec/MIGRATION.md). v1 line: [re-frame](https://github.com/day8/re-frame). Full skill-disambiguation matrix: [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source).*

--- a/skills/re-frame-pair-improver2/SKILL.md
+++ b/skills/re-frame-pair-improver2/SKILL.md
@@ -45,14 +45,9 @@ Deliver:
 
 ## When NOT to use this skill
 
-Activation precondition is strict: a concrete `re-frame-pair2` session must have already occurred (in this conversation, or as a user-supplied recap). Decline and route elsewhere when:
+**Activation precondition is strict**: a concrete `re-frame-pair2` session must have already occurred (in this conversation, or as a user-supplied recap). If no pair-tool surface was exercised, decline — there is nothing to improve.
 
-- No `re-frame-pair2` session happened. Generic debugging retrospectives, post-mortems on shell sessions, IDE workflows, or test-suite runs are out of scope — there is no pair-tool surface to improve.
-- The user is mid-session and still trying to make progress. Switch back to `re-frame-pair2`; retrospect after the work, not during it.
-- The user is authoring re-frame2 app code (handlers, subs, frames, schemas) without a live runtime involved. Route to `re-frame2`.
-- The feedback is about the `re-frame2` framework spec, architecture, or design — not the pair-tool experience. Either route to `re-frame2` directly or file a `bd` bead against the `re-frame2` repo without invoking this skill.
-- The user wants help fixing a bug in their own app (not in `re-frame-pair2`). Route to `re-frame-pair2`.
-- Vocabulary alone matches ("retro", "what went wrong", "improve workflow") but no pair-tool session is on the table. Ask the user to confirm the session before activating; if there is none, decline.
+Routing decisions (mid-session pair work, app-authoring without a live runtime, framework / spec feedback, app-bug help, vocabulary-only matches) follow the matrix at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source) and §Disqualifiers.
 
 When in doubt, ask: *"Was there a `re-frame-pair2` session you want me to retrospect on?"* Decline rather than fabricate evidence.
 

--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -157,4 +157,4 @@ Load at most two references for a single task. If you find yourself wanting thre
 
 ---
 
-*Deep-dive content (full API reference, EP design rationale, spec corpus, migration guide) routes through [`SKILL-REDIRECT.md`](../../SKILL-REDIRECT.md) at the repo root. For authoring re-frame2 code (rather than inspecting a live app), see `skills/re-frame2/`. For greenfield bootstrap, see `skills/re-frame2-setup/`. For porting re-frame2 itself to a different host language or substrate (rather than using the CLJS reference), see `skills/re-frame2-implementor/`.*
+*Deep-dive content (full API reference, EP design rationale, spec corpus, migration guide) routes through [`SKILL-REDIRECT.md`](../../SKILL-REDIRECT.md) at the repo root. Full skill-disambiguation matrix (when to use which skill) lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source).*

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -26,13 +26,7 @@ The job is to walk the engineer through two phases:
 
 ## When NOT to use this skill
 
-| Engineer intent | Route to |
-|---|---|
-| Write events / subs / machines / views on the CLJS reference | `skills/re-frame2/` |
-| Bootstrap a fresh greenfield app on the CLJS reference | `skills/re-frame2-setup/` |
-| Migrate a re-frame v1 codebase to the CLJS reference | `skills/re-frame-migration/` |
-| Inspect / dispatch / debug a running v2 app | `skills/re-frame-pair2/` |
-| Understand pattern rationale (EP narrative, principles) | [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKILL-REDIRECT.md) |
+Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). In brief: not for authoring on the CLJS reference, greenfield bootstrap, v1→v2 migration, live-app inspection, or pattern-rationale reading.
 
 ## Cardinal rules (one-liners; full text in [`reference/cardinal-rules.md`](reference/cardinal-rules.md))
 
@@ -98,4 +92,4 @@ The corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic da
 
 ---
 
-*Authoritative contract: [`spec/`](../../spec/). Decision companion: [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md). Conformance: [`spec/conformance/`](../../spec/conformance/). CLJS reference (worked example): `implementation/`. For app authoring on the reference: `skills/re-frame2/`. Greenfield bootstrap: `skills/re-frame2-setup/`. v1→v2 migration: `skills/re-frame-migration/`. Live-app inspection: `skills/re-frame-pair2/`.*
+*Authoritative contract: [`spec/`](../../spec/). Decision companion: [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md). Conformance: [`spec/conformance/`](../../spec/conformance/). CLJS reference (worked example): `implementation/`. Full skill-disambiguation matrix: [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source).*

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -29,13 +29,7 @@ This skill teaches **only re-frame2-specific wiring**. Assume the author knows `
 
 ## When NOT to use
 
-| Author intent | Route to |
-|---|---|
-| Add re-frame2 to an existing app with other state management or non-trivial code | `skills/re-frame2/` |
-| Write application code on a working re-frame2 project | `skills/re-frame2/` |
-| Inspect / debug / pair with a running app | `skills/re-frame-pair2/` |
-| Migrate an existing re-frame v1 codebase to v2 | `skills/re-frame-migration/` |
-| Spec, architecture, or porting questions about re-frame2 itself | `skills/re-frame2-implementor/` |
+Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). In brief: not for adding re-frame2 to an existing non-trivial app (that's authoring), writing application code on a working v2 project, live-app inspection, v1→v2 migration, or spec / architecture / porting questions about re-frame2 itself.
 
 Any non-setup question → route to the right skill; don't improvise here.
 

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -13,13 +13,7 @@ Authors re-frame2 ClojureScript application code. Router skill: this file carrie
 
 ## When NOT to use
 
-| Prompt shape | Route to |
-|---|---|
-| Inspect, debug, or modify a running re-frame2 app | `skills/re-frame-pair2/` |
-| Set up a new re-frame2 project from scratch | `skills/re-frame2-setup/` |
-| Migrate an existing re-frame v1 app to v2 | `skills/re-frame-migration/` |
-| Build a NEW re-frame2 implementation in a different host language or substrate | `skills/re-frame2-implementor/` |
-| Read the full API reference, EP rationale, or spec | `SKILL-REDIRECT.md` |
+Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). In brief: not for live-runtime inspection, greenfield bootstrap, v1→v2 migration, porting re-frame2 itself, or spec / API / EP rationale reading.
 
 ## Cardinal rules
 
@@ -101,4 +95,4 @@ Reach for these when the user asks "why does it work this way?" or designs a fea
 
 ---
 
-*re-frame2 (v2 line). v1: [re-frame](https://github.com/day8/re-frame). Live-app inspection: `skills/re-frame-pair2/`. Greenfield bootstrap: `skills/re-frame2-setup/`. v1→v2 migration: `skills/re-frame-migration/`. New re-frame2 implementation in another host/substrate: `skills/re-frame2-implementor/`. Deep-dive links route through `SKILL-REDIRECT.md`.*
+*re-frame2 (v2 line). v1: [re-frame](https://github.com/day8/re-frame). Full skill-disambiguation matrix: [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source). Deep-dive links route through `SKILL-REDIRECT.md`.*


### PR DESCRIPTION
## Summary

Five skills carried a 'When NOT to use' table listing the other skills' triggers; a sixth (`re-frame-pair-improver2`) carried the same content in prose. ~30 cross-referenced cells that drifted in lockstep.

Consolidates the cross-skill routing into a single canonical matrix at `skills/README.md` §Skill routing — single source. Each per-skill `SKILL.md` replaces its routing table (and redundant footer cross-refs) with a one-line pointer to the master matrix.

- Each skill's YAML `description` frontmatter is unchanged — load-bearing activation triggers stay verbatim at each skill's surface.
- Single source of truth: change a skill's scope once, in `skills/README.md`, instead of editing six files in lockstep.
- 6 SKILL.mds cross-reference the single source.

## Stats

- Net **-29 lines** across the six `SKILL.md` files.
- **+35 lines** at the single source in `skills/README.md` (new §Skill routing — single source + §Disqualifiers + §Routing for friction found mid-pair retro).

## Test plan

- [x] `python scripts/check_doc_slugs.py` passes.
- [x] `python -m mkdocs build --strict` introduces no new warnings tied to the edited files (pre-existing warnings on `guide/20-where-next.md` and `skills/re-frame2-implementor.md` are unrelated to this PR).
- [x] Each thinned `SKILL.md` retains a one-line cross-ref to `skills/README.md §Skill routing — single source`.
- [x] Each skill's frontmatter `description` (load-bearing for activation) is unchanged.

Refs: rf2-rcrbr