### PR TITLE
test(conformance): runner fails on silent fixture skips (rf2-a3q1r)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -129,6 +129,31 @@
   "Fixture spec versions this CLJS build claims to conform against."
   #{"1.0"})
 
+;; ---- known-skipped capabilities (rf2-a3q1r) ------------------------------
+;;
+;; A fixture declaring `:fixture/capabilities` that name a capability not in
+;; `claimed-capabilities` AND not in `known-skipped-capabilities` is treated
+;; as a typo / claim-set drift and FAILS the suite. The pre-rf2-a3q1r runner
+;; silently skipped any out-of-claim fixture, which masked at least one bug
+;; (`:flow/trace` missing from the claim-set hid `flow-lifecycle-emits-traces.edn`
+;; from the suite — see the sweep-test-coverage-rigour finding).
+;;
+;; Adding a capability here is an explicit declaration that this build
+;; INTENTIONALLY does not claim it; the corresponding fixtures are reported
+;; as out-of-claim skips and do not block the suite. A capability appearing
+;; in both sets is a configuration error (resolve by removing from one).
+;;
+;; Today this set is empty: every capability referenced by a fixture is
+;; also in `claimed-capabilities`. The allowlist exists so future divergence
+;; between corpus and host requires an explicit decision rather than silent
+;; rot.
+
+(def known-skipped-capabilities
+  "Capabilities this build INTENTIONALLY does not claim. Fixtures whose
+  capabilities fall here are reported as out-of-claim skips but do not
+  block the suite."
+  #{})
+
 ;; ---- fixture loading (compile-time inlined) -------------------------------
 
 (def fixtures
@@ -229,6 +254,29 @@
   [fixture]
   (let [caps (or (:fixture/capabilities fixture) #{})]
     (every? claimed-capabilities caps)))
+
+(defn- classify-capabilities
+  "Per rf2-a3q1r, partition a fixture's :fixture/capabilities into
+  {:claimed   #{...}    ;; in `claimed-capabilities`
+   :allowed   #{...}    ;; in `known-skipped-capabilities` but not claimed
+   :unknown   #{...}}   ;; in neither — typo or claim-set drift
+
+  A fixture is RUNNABLE iff `:unknown` and `:allowed` are both empty.
+  A fixture is SKIPPED (out-of-claim) iff `:unknown` is empty and
+  `:allowed` is non-empty.
+  A fixture is a FAILURE iff `:unknown` is non-empty — the suite must
+  fail rather than silently mask the typo."
+  [fixture]
+  (let [caps (or (:fixture/capabilities fixture) #{})]
+    {:claimed (into #{} (filter claimed-capabilities) caps)
+     :allowed (into #{} (filter (fn [c]
+                                  (and (contains? known-skipped-capabilities c)
+                                       (not (contains? claimed-capabilities c))))
+                                caps))
+     :unknown (into #{} (remove (fn [c]
+                                  (or (contains? claimed-capabilities c)
+                                      (contains? known-skipped-capabilities c)))
+                                caps))}))
 
 (defn- spec-version-claimed?
   "True if the fixture targets a spec version this build claims.
@@ -829,15 +877,38 @@
                              :reason       "spec-version not in claimed set"
                              :spec-version (:fixture/spec-version fixture)})
 
-        (not (runnable? fixture))
-        (swap! results conj {:fixture-id   (:fixture/id fixture)
-                             :skipped?     true
-                             :reason       "capabilities not in claimed set"
-                             :capabilities (:fixture/capabilities fixture)})
-
+        ;; Per rf2-a3q1r: three-way classification of fixture capabilities.
+        ;; A fixture whose caps include any capability that is neither
+        ;; CLAIMED nor explicitly KNOWN-SKIPPED is a typo / claim-set drift
+        ;; — it FAILS the suite rather than being silently skipped.
         :else
-        (swap! results conj (assoc (run-fixture fixture)
-                              :fname fname))))
+        (let [{:keys [allowed unknown]} (classify-capabilities fixture)]
+          (cond
+            (seq unknown)
+            (swap! results conj
+                   {:fixture-id   (:fixture/id fixture)
+                    :passed?      false
+                    :unknown-caps unknown
+                    :error        (str "unknown capabilities: " unknown
+                                       " — capability is neither in "
+                                       "claimed-capabilities nor in "
+                                       "known-skipped-capabilities. "
+                                       "Either claim it (and ensure the host "
+                                       "implements it) or add to the "
+                                       "known-skipped-capabilities allowlist "
+                                       "to document an intentional gap.")})
+
+            (seq allowed)
+            (swap! results conj
+                   {:fixture-id   (:fixture/id fixture)
+                    :skipped?     true
+                    :reason       "capabilities intentionally not claimed (allowlisted)"
+                    :capabilities (:fixture/capabilities fixture)
+                    :allowed      allowed})
+
+            :else
+            (swap! results conj (assoc (run-fixture fixture)
+                                  :fname fname))))))
     (let [all     @results
           run     (filter (complement :skipped?) all)
           passed  (filter :passed? run)
@@ -866,6 +937,8 @@
         (println "Failures:")
         (doseq [f failed]
           (println "  " (:fixture-id f))
+          (when (:unknown-caps f)
+            (println "    unknown capabilities (rf2-a3q1r):" (:unknown-caps f)))
           (when (:error f)
             (println "    error:" (:error f)))
           (when-let [td (:expected-db f)]

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -105,6 +105,31 @@
   "Fixture spec versions this implementation claims to conform against."
   #{"1.0"})
 
+;; ---- known-skipped capabilities (rf2-a3q1r) ------------------------------
+;;
+;; A fixture declaring `:fixture/capabilities` that name a capability not in
+;; `claimed-capabilities` AND not in `known-skipped-capabilities` is treated
+;; as a typo / claim-set drift and FAILS the suite. The pre-rf2-a3q1r runner
+;; silently skipped any out-of-claim fixture, which masked at least one bug
+;; (`:flow/trace` missing from the claim-set hid `flow-lifecycle-emits-traces.edn`
+;; from the suite — see the sweep-test-coverage-rigour finding).
+;;
+;; Adding a capability here is an explicit declaration that this build
+;; INTENTIONALLY does not claim it; the corresponding fixtures are reported
+;; as out-of-claim skips and do not block the suite. A capability appearing
+;; in both sets is a configuration error (resolve by removing from one).
+;;
+;; Today this set is empty: every capability referenced by a fixture is
+;; also in `claimed-capabilities`. The allowlist exists so future divergence
+;; between corpus and host requires an explicit decision rather than silent
+;; rot.
+
+(def known-skipped-capabilities
+  "Capabilities this build INTENTIONALLY does not claim. Fixtures whose
+  capabilities fall here are reported as out-of-claim skips but do not
+  block the suite."
+  #{})
+
 ;; ---- fixture loader -------------------------------------------------------
 
 (def fixtures-dir
@@ -181,6 +206,29 @@
   [fixture]
   (let [caps (or (:fixture/capabilities fixture) #{})]
     (every? claimed-capabilities caps)))
+
+(defn- classify-capabilities
+  "Per rf2-a3q1r, partition a fixture's :fixture/capabilities into
+  {:claimed   #{...}    ;; in `claimed-capabilities`
+   :allowed   #{...}    ;; in `known-skipped-capabilities` but not claimed
+   :unknown   #{...}}   ;; in neither — typo or claim-set drift
+
+  A fixture is RUNNABLE iff `:unknown` and `:allowed` are both empty.
+  A fixture is SKIPPED (out-of-claim) iff `:unknown` is empty and
+  `:allowed` is non-empty.
+  A fixture is a FAILURE iff `:unknown` is non-empty — the suite must
+  fail rather than silently mask the typo."
+  [fixture]
+  (let [caps (or (:fixture/capabilities fixture) #{})]
+    {:claimed (into #{} (filter claimed-capabilities) caps)
+     :allowed (into #{} (filter (fn [c]
+                                  (and (contains? known-skipped-capabilities c)
+                                       (not (contains? claimed-capabilities c))))
+                                caps))
+     :unknown (into #{} (remove (fn [c]
+                                  (or (contains? claimed-capabilities c)
+                                      (contains? known-skipped-capabilities c)))
+                                caps))}))
 
 (defn- spec-version-claimed?
   "True if the fixture targets a spec version this build claims.
@@ -916,15 +964,38 @@
                              :reason       "spec-version not in claimed set"
                              :spec-version (:fixture/spec-version fixture)})
 
-        (not (runnable? fixture))
-        (swap! results conj {:fixture-id (:fixture/id fixture)
-                             :skipped?   true
-                             :reason     "capabilities not in claimed set"
-                             :capabilities (:fixture/capabilities fixture)})
-
+        ;; Per rf2-a3q1r: three-way classification of fixture capabilities.
+        ;; A fixture whose caps include any capability that is neither
+        ;; CLAIMED nor explicitly KNOWN-SKIPPED is a typo / claim-set drift
+        ;; — it FAILS the suite rather than being silently skipped.
         :else
-        (swap! results conj (assoc (run-fixture fixture)
-                              :fname fname))))
+        (let [{:keys [allowed unknown]} (classify-capabilities fixture)]
+          (cond
+            (seq unknown)
+            (swap! results conj
+                   {:fixture-id   (:fixture/id fixture)
+                    :passed?      false
+                    :unknown-caps unknown
+                    :error        (str "unknown capabilities: " unknown
+                                       " — capability is neither in "
+                                       "claimed-capabilities nor in "
+                                       "known-skipped-capabilities. "
+                                       "Either claim it (and ensure the host "
+                                       "implements it) or add to the "
+                                       "known-skipped-capabilities allowlist "
+                                       "to document an intentional gap.")})
+
+            (seq allowed)
+            (swap! results conj
+                   {:fixture-id   (:fixture/id fixture)
+                    :skipped?     true
+                    :reason       "capabilities intentionally not claimed (allowlisted)"
+                    :capabilities (:fixture/capabilities fixture)
+                    :allowed      allowed})
+
+            :else
+            (swap! results conj (assoc (run-fixture fixture)
+                                  :fname fname))))))
     (let [all       @results
           run       (filter (complement :skipped?) all)
           passed    (filter :passed? run)
@@ -953,6 +1024,8 @@
         (println "Failures:")
         (doseq [f failed]
           (println "  " (:fixture-id f))
+          (when (:unknown-caps f)
+            (println "    unknown capabilities (rf2-a3q1r):" (:unknown-caps f)))
           (when (:error f)
             (println "    error:" (:error f)))
           (when-let [td (:expected-db f)]

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -150,6 +150,13 @@ Capability tag conventions:
 
 A flat-FSM-only port declares `:capabilities #{:core/event-handler ... :fsm/flat :actor/own-state :actor/spawn-destroy ...}` in its harness manifest; the corpus runs every fixture whose capabilities are a subset and skips the rest. The aggregate score is `passed / claimed-applicable` — an accounting of what works for the claimed list.
 
+A port's harness MUST distinguish two flavours of out-of-claim capability so silent rot can't mask coverage gaps (per `rf2-a3q1r`):
+
+- **Intentional out-of-claim** — the port's `claimed-capabilities` deliberately excludes the capability (e.g. a flat-FSM-only port skipping `:fsm/hierarchical`). The harness MAINTAINS an explicit `known-skipped-capabilities` allowlist; capabilities in this set produce "skipped (out-of-claim)" reports without failing the suite.
+- **Typo / claim-set drift** — a fixture's capability appears in neither the claimed set nor the allowlist. The pre-rf2-a3q1r harness silently skipped these; the post-rf2-a3q1r contract is that the suite FAILS with a diagnostic naming the unknown capability. The remedy is either to add the capability to `claimed-capabilities` (with the runtime backing to match) or to add it to `known-skipped-capabilities` (an explicit decision not to claim it).
+
+The reference harness (`implementation/core/test/re_frame/conformance_test.clj` and `implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs`) keeps `known-skipped-capabilities` as an empty set today: every capability referenced by a corpus fixture is also claimed. The allowlist exists so that any future divergence requires an explicit decision rather than silent drift.
+
 See [§Capability tagging worked example](#capability-tagging-worked-example) immediately below for the actual tags carried by representative fixtures in the corpus today.
 
 ### Capability tagging worked example


### PR DESCRIPTION
## Summary

- Conformance runners now FAIL the suite when a fixture declares a capability that's in neither `claimed-capabilities` nor `known-skipped-capabilities` — closing the silent-skip hole that previously masked `:flow/trace` missing from the claim-set.
- Three-way classification: claimed → run · allowlisted → skip-with-info · unknown → FAIL with diagnostic.
- `known-skipped-capabilities` allowlist starts empty on both JVM and CLJS runners (every capability used by the 111-fixture corpus is currently claimed).
- `spec/conformance/README.md` §Capability tagging documents the contract for port-authors implementing their own harness.

## Background

Per `rf2-a3q1r` and the sweep-test-coverage-rigour finding: the pre-rf2-a3q1r runner reported out-of-claim fixtures via `println` but the assertion `(is (zero? (count failed)))` ignored skipped fixtures. A claim-set typo (capability dropped from `claimed-capabilities` while a fixture still declares it) was indistinguishable from an intentional out-of-claim gap. The new mechanism forces an explicit decision for every divergence.

## Verification

Tested the failure path with a synthetic typo (removed `:flow/trace` from `claimed-capabilities` on both hosts):

- JVM: `flow-lifecycle-emits-traces.edn` fails with `unknown capabilities (rf2-a3q1r): #{:flow/trace}` and the suite assertion fails.
- CLJS: identical diagnostic; suite fails.

Reverted the typo. Both hosts return to 111/111 passed, 0 failed, 0 skipped.

## Test plan

- [x] JVM conformance: 111/111 passed, 0 failed, 0 skipped
- [x] CLJS conformance: 111/111 passed, 0 failed, 0 skipped
- [x] Full CLJS test suite: 937 tests, 0 failures, 0 errors
- [x] Synthetic typo path verified on both hosts (then reverted)