### PR TITLE
cut(fx): drop unary-fx-handler back-compat path; promote O-5 to M-rule (rf2-j9cm2)

### DIFF
--- a/implementation/core/test/re_frame/source_coords_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_cljs_test.cljs
@@ -86,7 +86,7 @@
 
 (deftest reg-fx-file-is-not-no-source-path
   (testing "rf2-mdjp: reg-fx emits a real :file under CLJS"
-    (rf/reg-fx :rf2-mdjp/reg-fx-sample (fn [_] nil))
+    (rf/reg-fx :rf2-mdjp/reg-fx-sample (fn [_ _] nil))
     (let [f (:file (rf/handler-meta :fx :rf2-mdjp/reg-fx-sample))]
       (is (not= "NO_SOURCE_PATH" f)))))
 

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -57,7 +57,7 @@ Six phases. Each links to a leaf for the detail; the SKILL.md carries only the w
 
 **Phase 4 — Verify.** Recompile, re-run unit tests, smoke-test boot / dispatch / sub / hot-reload. If a step fails, find the rule, apply it, re-verify. The skill does not run tests for the author.
 
-**Phase 5 — Opt-in modernisations (only if asked).** Walk the `O-N` rules in `MIGRATION.md` (O-1 rich metadata, O-2 `reg-view`, O-3 Malli, O-4 frames, O-5 binary fx, O-8/O-9 machines, O-13/O-14 substrate moves, O-15 `:invoke-all`, etc.). Never auto-applied as part of a routine migration.
+**Phase 5 — Opt-in modernisations (only if asked).** Walk the `O-N` rules in `MIGRATION.md` (O-1 rich metadata, O-2 `reg-view`, O-3 Malli, O-4 frames, O-8/O-9 machines, O-13/O-14 substrate moves, O-15 `:invoke-all`, etc.). Never auto-applied as part of a routine migration. (O-5 was promoted to M-51 under rf2-j9cm2 — binary fx is now required, not opt-in.)
 
 **Phase 6 — Report.** Produce the migration report per `MIGRATION.md` Part 2 §"Output format for your report". → [`reference/output-format.md`](reference/output-format.md) — the format restated with one filled-in example.
 

--- a/skills/re-frame-migration/reference/breaking-changes.md
+++ b/skills/re-frame-migration/reference/breaking-changes.md
@@ -67,6 +67,7 @@ A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered 
 | Machine `:tags` slot and `:rf/machine-has-tag?` sub | M-47 | — | Additive. No user-side action. |
 | `:type :parallel` machines with map-shaped `:state` | M-48 | — | Additive. No user-side action. |
 | Snapshot `:state` reader pattern-matching against the third arm (map) | M-49 | — | Additive; widens to a third arm. Readers that pattern-match exhaustively on `:state` may need to widen the dispatch. |
+| Unary `reg-fx` handler `(fn [args] ...)` | **M-51** | A | Mechanical: `(fn [args] body)` → `(fn [_ args] body)`. The unary back-compat path is cut; the runtime invokes every fx with two args. Async handlers should additionally capture `(rf/dispatcher)` for frame-aware callbacks. |
 
 The M-numbered slots that are "informational only" / "additive" / "—" still appear so an agent walking the rule list doesn't get confused by gaps. There is no user-side action required for those rules.
 
@@ -80,7 +81,7 @@ The author **must** ask for these. They are never auto-applied as part of a rout
 | Adopt `reg-view` for plain Reagent fns | **O-2** | Drop `defn`; replace with `(rf/reg-view view-name [args] body)`. Frame-aware. |
 | Add Malli schemas on `app-db` paths and on event payloads | **O-3** | Pull `day8/re-frame2-schemas`; register via `reg-app-schema`. Boundary-only — don't schema-fence every internal key. |
 | Lift a namespaced sub-tree of `app-db` into its own frame | **O-4** | Use `reg-frame :feature-name`; existing `:rf/default`-targeted events stay where they are. Multi-instance enabler. |
-| Update fx handlers to binary form `(fn [m _] ...)` | **O-5** | Future-proofs fx for full multi-frame support; both forms work today. |
+| Update fx handlers to binary form `(fn [m _] ...)` | O-5 | Promoted to M-51; now a required mechanical rewrite, not opt-in. |
 | Future-proof code that introspected Reagent-reaction subscription return types | **O-6** | Drop type checks; use `(rf/subscribe-value [...])` if you need the value outside a reactive context. |
 | `:dispatch-n` to `:fx` | O-7 | Absorbed into M-8 (no longer opt-in). |
 | Adopt the Spec 012 routing surface | **O-8** | If you have a third-party router (reitit/secretary/bidi), this is the move-to-`reg-route` rewrite. Pairs with M-14. |
@@ -96,7 +97,7 @@ The author **must** ask for these. They are never auto-applied as part of a rout
 
 ## Type A vs Type B — at a glance
 
-**Type A — apply automatically.** The pattern is unambiguous, the rewrite is structural, the result is observably identical (or strictly better). M-0, M-1, M-4, M-5 (direct half), M-6, M-7, M-8, M-9, M-16, M-17 (single-frame half), M-20, M-21 (`debug` / `trim-v` half), M-22, M-23 (the find-and-replace half), M-24, M-25, M-26 (most), M-27 through M-40 (mostly dep-only adds), M-42.
+**Type A — apply automatically.** The pattern is unambiguous, the rewrite is structural, the result is observably identical (or strictly better). M-0, M-1, M-4, M-5 (direct half), M-6, M-7, M-8, M-9, M-16, M-17 (single-frame half), M-20, M-21 (`debug` / `trim-v` half), M-22, M-23 (the find-and-replace half), M-24, M-25, M-26 (most), M-27 through M-40 (mostly dep-only adds), M-42, M-50, M-51.
 
 **Type B — ask before applying.** The rewrite depends on intent the agent cannot recover statically. M-3, M-5 (Var-aliasing half), M-10, M-11, M-12, M-13, M-14, M-15, M-17 (multi-frame half), M-18, M-19, M-21 (`on-changes` / `enrich` / `after` half), M-23 (lifecycle policy half), M-26 (`add-post-event-callback` / error-handler half).
 

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -146,7 +146,7 @@ Per Spec 002 §Per-frame and per-call overrides, dispatches can carry `:fx-overr
 scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http
 ```
 
-The stub must already be registered via `(rf/reg-fx :stub-http (fn [v] ...))`. The override applies for this dispatch only; subsequent dispatches use the canonical `:http` again.
+The stub must already be registered via `(rf/reg-fx :stub-http (fn [_ v] ...))`. The override applies for this dispatch only; subsequent dispatches use the canonical `:http` again.
 
 For `:rf.http/managed` failure-category experiments (Spec 014 §Failure categories), stub `:http` to fire one of the canonical failure traces directly.
 

--- a/skills/re-frame2/reference/cross-cutting/testing.md
+++ b/skills/re-frame2/reference/cross-cutting/testing.md
@@ -168,7 +168,7 @@ For arbitrary fx, override the registered handler from inside the test — the f
 
 ```clojure
 (let [calls (atom [])]
-  (rf/reg-fx :app/persist (fn [v] (swap! calls conj v)))
+  (rf/reg-fx :app/persist (fn [_ v] (swap! calls conj v)))
   (rf/dispatch-sync [:cart/save])
   (is (= [{:items [...]}] @calls)))
 ```

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -12,7 +12,7 @@ A **frame** is an **isolated runtime boundary**, identified by keyword, that own
 
 All frames share **one global handler registrar**. Multi-frame means "multiple instances of the same app's handlers" — devcards, isolated widgets, story variants, test fixtures — not "multiple different apps with different handler sets on one page." The latter use case (micro-frontends, embedded white-label widgets) is out of scope; iframes already serve it.
 
-**Backwards compatibility:** existing single-frame apps need no migration. A pre-registered `:rf/default` catches every dispatch and subscription that doesn't specify a frame; today's re-frame is structurally re-frame2 with only the default frame in play.
+**Single-frame is one shape of multi-frame.** A pre-registered `:rf/default` catches every dispatch and subscription that doesn't specify a frame. An app that only ever uses `:rf/default` is a multi-frame app with one frame in play — same runtime, same routing, same drain loop. The default isn't a migration shim; it's the no-ceremony case of the canonical addressing model.
 
 ## Goals
 
@@ -328,15 +328,15 @@ Tests use this pattern as their fixture lifecycle:
 
 The mechanism that gets a dispatch to the right frame is **frame identity carried on the in-flight event**.
 
-User-facing event shape stays a vector — `[:add-todo "milk"]` — for backwards compat. The **canonical call shapes** are:
+User-facing event shape is a vector — `[:add-todo "milk"]` — id-first, polymorphic on the head keyword. The **canonical call shapes** are:
 
 | Arity | Canonical | Tolerated (discouraged) |
 |---|---|---|
 | Trivial — id only | `[:counter/inc]` | (same) |
 | Single argument | `[:user-by-id 42]` | (same) |
-| Multi-argument | `[:user/login {:email e :password p}]` (single map payload) | `[:user/login e p]` (multi-positional; linter nudges; existing v1 codebases unaffected) |
+| Multi-argument | `[:user/login {:email e :password p}]` (single map payload) | `[:user/login e p]` (multi-positional; linter nudges) |
 
-The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe takes the same shape (`[:items-filtered {:status :pending :limit 20}]`). The full rationale is in [Principles §Name over place](Principles.md#name-over-place); the migration rule for legacy multi-positional code is [MIGRATION §M-19](MIGRATION.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in). The v1 `unwrap` interceptor (which required this exact `[event-id payload-map]` shape) ships unchanged in v2 as opt-in handler-side sugar; v1 `trim-v` is dropped because its purpose was the multi-positional form v2 leaves behind.
+The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe takes the same shape (`[:items-filtered {:status :pending :limit 20}]`). The full rationale is in [Principles §Name over place](Principles.md#name-over-place); the migration rule for v1 multi-positional code is [MIGRATION §M-19](MIGRATION.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in). The v1 `unwrap` interceptor (which required this exact `[event-id payload-map]` shape) ships in v2 as opt-in handler-side sugar; v1 `trim-v` is dropped because its purpose was the multi-positional form v2 leaves behind.
 
 *Internally*, every dispatch becomes a **dispatch envelope**:
 
@@ -537,7 +537,7 @@ Sometimes a function created during render isn't a hiccup callback but is invoke
 
 `bound-fn` produces a `(fn ...)` that, when called, runs in a `binding [*current-frame* <captured-frame>]` block — `*current-frame*` is the dynamic-binding tier of the resolution chain (above), so plain `dispatch`/`subscribe` inside the closure pick up the right frame.
 
-The dynamic var (`*current-frame*`) plays two roles, which can read as contradictory if not separated. For `bound-fn` and `with-frame`, it is the **primary mechanism**: these constructs deliberately use the dynamic-binding tier as their definition. For the unary-fx fallback path (per [§Async effects — backwards compatibility](#backwards-compatibility--legacy-unary-fx-handlers) below), it is a **compatibility shim** — `do-fx` wraps unary handlers in a binding so legacy `(rf/dispatch ev)` calls inside them remain frame-aware. Same Clojure construct, used at different layers; the primary-mechanism vs. shim distinction is about *intent*, not implementation.
+The dynamic var (`*current-frame*`) is the primary mechanism for `bound-fn`, `with-frame`, and the router's per-handler binding: these constructs deliberately use the dynamic-binding tier as their definition, so synchronous dispatches inside their bodies pick up the right frame without an explicit `:frame` opt at the call site. Async callbacks that escape the binding (timers, promises, websocket messages) need an explicit hand-off — capture `(rf/dispatcher)` inside the body or thread `{:frame frame}` into the callback.
 
 ### Subscriptions composing across the signal graph
 
@@ -626,21 +626,6 @@ A closure over `(:frame m)` keeps each call site terse:
           (.then  #(d on-success))
           (.catch #(d on-failure))))))
 ```
-
-#### Backwards compatibility — legacy unary fx handlers
-
-Existing fx libraries shipping unary handlers `(fn [args] (rf/dispatch ...))` continue to work without update:
-
-```clojure
-;; legacy unary, no update needed for re-frame2 to compile or run
-(reg-fx :dispatch
-  (fn [event]
-    (rf/dispatch event)))
-```
-
-`do-fx` detects arity at registration. When invoking a unary handler, it wraps the call in `(binding [*current-frame* (:frame m)] ...)`, so any internal `(rf/dispatch event)` is frame-aware via the dynamic-var fallback. **The dynamic var is a compatibility shim, not the primary mechanism** — new fx code uses the binary form.
-
-The async case is the one place where unary legacy handlers can still get multi-frame routing wrong: if the library captures a callback that fires after the handler returns, the dynamic-var binding has unwound. Library authors targeting re-frame2's multi-frame use cases should update to binary; swap `(rf/dispatch ev)` for `(rf/dispatch ev {:frame frame})` or capture `(rf/dispatcher)` inside the binary handler's body where `*current-frame*` is bound.
 
 #### What library authors of async fx have to know
 
@@ -1211,7 +1196,7 @@ Library authors **do not need to know about frames** if they only register handl
 - **re-frame-async-flow** schedules events via the standard `:dispatch` effect; frame propagation is automatic per the rule above.
 - **re-pressed**, **re-frame-http-fx**, etc. — same story, provided their fx implementations use the standard dispatch effect or capture a frame-bound dispatch fn via `(rf/dispatcher)`.
 
-Authors of fx that escape into async land *do* have to forward the frame — either by capturing `(rf/dispatcher)` inside the binary handler body or by threading `{:frame frame}` through every callback's dispatch. This is a small, well-defined obligation; documented in [§Async effects and frame propagation](#async-effects-and-frame-propagation) and as opt-in rule O-5 in [MIGRATION.md](MIGRATION.md).
+Authors of fx that escape into async land *do* have to forward the frame — either by capturing `(rf/dispatcher)` inside the binary handler body or by threading `{:frame frame}` through every callback's dispatch. This is a small, well-defined obligation; documented in [§Async effects and frame propagation](#async-effects-and-frame-propagation) and as required rule M-51 in [MIGRATION.md](MIGRATION.md#m-51-reg-fx-handlers-are-binary--rewrite-unary-handlers-to-take-an-unused-first-arg).
 
 ## Tooling and agent-amenability
 

--- a/spec/MIGRATION.md
+++ b/spec/MIGRATION.md
@@ -1685,6 +1685,64 @@ Body, override-map shape, precedence rules, and composition with `with-frame` ar
 
 **Cross-references.** [API.md §Testing](API.md#testing) for the row; [Spec 002 §`:fx-overrides`](002-Frames.md#fx-overrides--replace-fx-handlers) for the override-value shapes the macro honours.
 
+### M-51. `reg-fx` handlers are binary — rewrite unary handlers to take an unused first arg
+
+**Type A — pre-1.0 spec lock; mechanical rewrite.** The v1 spec is pre-release; no back-compat constraint applies. Codebases that registered unary fx handlers under v1 (`(fn [args] body)`) rewrite mechanically to the binary form (`(fn [_ args] body)`).
+
+Per [rf2-j9cm2](#), the canonical `reg-fx` signature is binary: `(fn [m args] body)` where `m` carries `:frame`, `:event`, and (per [Spec 014 §Reply addressing](014-HTTPRequests.md#reply-addressing)) any cofx the handler needs to address replies. The v1 unary signature `(fn [args] body)` and the runtime arity-detect / `*current-frame*`-wrapping shim that supported it are dropped. The runtime invokes every registered fx handler with two args; a unary handler raises a language-level arity error at the call site (`ArityException` on JVM, `TypeError` / "Cannot read … of undefined" or similar on CLJS depending on shape).
+
+**Why.** Pre-alpha cuts the v1 compat tax: one signature, no arity branch in `do-fx`, no `*current-frame*` dynamic-var binding to maintain just for the unary path. The dynamic-var was only ever a shim for sync paths — it could not cover async callbacks (the binding has unwound by then), so library authors targeting multi-frame had to update to binary anyway. Cutting the shim shortens the path and removes a footgun (unary handler that *appears* to work in sync tests but silently routes to `:rf/default` from async callbacks).
+
+**Migration recipe.** For every `reg-fx` call site whose handler is unary, prepend an unused first parameter:
+
+Before:
+
+```clojure
+(rf/reg-fx :http-xhrio
+  (fn [request]                                       ;; unary v1
+    (let [{:keys [on-success on-failure]} request]
+      (ajax/ajax-request
+        {:handler (fn [[ok? response]]
+                    (rf/dispatch (conj (if ok? on-success on-failure) response)))}))))
+```
+
+After (mechanical):
+
+```clojure
+(rf/reg-fx :http-xhrio
+  (fn [_ request]                                     ;; binary; `m` ignored
+    (let [{:keys [on-success on-failure]} request]
+      (ajax/ajax-request
+        {:handler (fn [[ok? response]]
+                    (rf/dispatch (conj (if ok? on-success on-failure) response)))}))))
+```
+
+The simple ignore-`m` rewrite preserves v1 sync semantics — the handler runs and any dispatches it issues default to `:rf/default`. For multi-frame correctness in async callbacks, follow up with the frame-bound dispatcher pattern:
+
+```clojure
+(rf/reg-fx :http-xhrio
+  (fn [m request]                                     ;; binary; frame-aware
+    (let [d (rf/dispatcher)                           ;; *current-frame* bound to (:frame m)
+          {:keys [on-success on-failure]} request]
+      (ajax/ajax-request
+        {:handler (fn [[ok? response]]
+                    (d (conj (if ok? on-success on-failure) response)))}))))
+```
+
+The dispatcher-capture step is needed only for async-dispatching fx that target multi-frame use; sync-only handlers are correct after the mechanical `_`-prepend.
+
+**What to look for.** Greps for `reg-fx` followed by a one-arg `fn` literal:
+
+```
+rg -U 'reg-fx[^\n]*\n[^\n]*\(fn \[[a-zA-Z_-]+\]'
+```
+
+Library packages (`re-frame-http-fx`, `re-frame-async-flow-fx`, etc.) and apps that defined their own fx handlers are the typical hits. Single-frame apps that only used the reserved `:dispatch` / `:dispatch-later` / `:db` / `:fx` effects have no `reg-fx` call sites and need no change.
+
+**Apply to:** every unary `reg-fx` handler in the codebase. The runtime no longer accepts the unary shape.
+
+**Cross-references.** [Spec 002 §Async effects and frame propagation](002-Frames.md#async-effects-and-frame-propagation) for the binary signature's contract; [Spec 002 §What library authors of async fx have to know](002-Frames.md#what-library-authors-of-async-fx-have-to-know) for the async-correctness checklist.
+
 ---
 
 ## Opt-in modernisation (only if asked)
@@ -1750,52 +1808,9 @@ Apply only with explicit user direction; this is a real authoring exercise, not 
 
 If the codebase has a self-contained subsystem under a single `app-db` path (e.g. all `:auth/*` keys, with corresponding events/subs all namespaced `:auth/...`), it can be reorganised as a separate frame for cleaner isolation. This is a meaningful architectural change, not a mechanical migration. **Do not apply unless explicitly asked.**
 
-### O-5. Update fx handlers to binary form for full multi-frame support
+### O-5. ~~Update fx handlers to binary form for full multi-frame support~~ — *promoted to [M-51](#m-51-reg-fx-handlers-are-binary--rewrite-unary-handlers-to-take-an-unused-first-arg).*
 
-re-frame2's primary `reg-fx` signature is binary: `(fn [m fx-arg] ...)`, where `m` is the same context the originating event handler received (with `:db`, `:event`, `:frame`, `:trace-id`, `:source`, and any cofx). Legacy unary handlers `(fn [fx-arg] ...)` continue to work — `do-fx` detects arity and wraps unary handlers in a `*current-frame*` binding so internal `rf/dispatch` calls still route correctly in single-frame contexts and most sync multi-frame cases.
-
-The case where unary fx handlers go wrong is **async dispatch**: if the handler captures a callback that fires after it returns (HTTP response, timer fire, websocket message), the dynamic-var binding has unwound and the callback's `rf/dispatch` defaults to `:rf/default`. Libraries that dispatch asynchronously (re-frame-http-fx, re-frame-async-flow-fx, etc.) need updating to be fully multi-frame-correct.
-
-**What to look for** in the codebase (this rule mostly applies to library authors and to apps that registered their own async fx):
-
-```clojure
-;; legacy unary fx with async dispatch — works in single-frame, leaks to default in multi-frame
-(rf/reg-fx :http-xhrio
-  (fn [request]
-    (let [{:keys [on-success on-failure]} request]
-      (ajax/ajax-request 
-        {:handler (fn [[ok? response]]
-                    (rf/dispatch (conj (if ok? on-success on-failure) response)))}))))
-```
-
-**What to do:**
-
-```clojure
-;; binary, frame-aware
-(rf/reg-fx :http-xhrio
-  (fn [m request]
-    (let [d (rf/dispatcher)                               ;; *current-frame* bound to (:frame m)
-          {:keys [on-success on-failure]} request]
-      (ajax/ajax-request 
-        {:handler (fn [[ok? response]]
-                    (d (conj (if ok? on-success on-failure) response)))}))))
-```
-
-The change is mechanical:
-
-1. Add `m` as the first arg.
-2. At handler entry, capture a frame-bound dispatch fn: `(let [d (rf/dispatcher)] ...)` — the binary handler's body runs with `*current-frame*` bound to `(:frame m)`, so `(rf/dispatcher)` captures that frame.
-3. In every async callback, replace `rf/dispatch` with `d`.
-
-**Apply only if:**
-
-- The codebase ships an fx that dispatches asynchronously, AND
-- It is intended to support re-frame2 multi-frame use, AND
-- The user has asked for this change explicitly.
-
-For sync-only fx (most user-defined fx) and for apps that don't use multi-frame, no change is required.
-
-**Why:** see [002-Frames.md §Async effects and frame propagation](002-Frames.md). The binary signature gives explicit data flow for the frame; the dynamic-var fallback covers legacy unary handlers in sync paths but cannot cover async ones.
+Per [rf2-j9cm2](#) the unary-fx-handler back-compat path was cut from the runtime; the binary signature is the only signature `do-fx` accepts. What was an opt-in modernisation under v1 compat is now a required mechanical rewrite — see M-51 above.
 
 ### O-6. Future-proof against Reagent-specific subscription return types
 


### PR DESCRIPTION
## Summary

- The runtime arity-detect + `*current-frame*` wrapping shim for unary v1 fx handlers is already gone from `do-fx`; this PR catches the spec and migration surfaces up to that state. Pre-alpha cut, no AI attribution.
- `spec/002-Frames.md`: drop the "Backwards compatibility — legacy unary fx handlers" sub-section; reframe the three "for backwards compat" lead-ins (default-frame, vector event shape, multi-positional toleration) as canonical designs rather than v1 carryover; collapse the primary-mechanism-vs-shim paragraph on `*current-frame*` now that the shim is gone.
- `spec/MIGRATION.md`: add **M-50** promoting the binary-fx-handler rewrite from opt-in (O-5) to required (Type A mechanical: `(fn [args] body)` → `(fn [_ args] body)`). O-5 becomes a strike-through pointer to M-50.
- Sweep trailing references in `002-Frames.md`, `re-frame-migration` SKILL.md / breaking-changes leaf, and the three skill / test code samples (`source_coords_cljs_test.cljs`, `testing.md`, `recipes.md`).

Runtime behaviour for a registered unary handler: language-level arity error at the call site — `ArityException` on JVM, `TypeError` on CLJS — because `do-fx` always invokes with two args. No dedicated re-frame error category needed.

## Test plan

- [x] `clojure -M:test` from `implementation/core/`, `http/`, `machines/`, `routing/`, `flows/`, `ssr/`, `epoch/`, `schemas/` — all green (353 / 72 / 119 / 28 / 26 / 31 / 59 / 53 tests).
- [x] `npm run test:cljs` from `implementation/` — 937 tests, 2407 assertions, 0 failures, 0 errors.
- [x] `python scripts/check_doc_slugs.py` — no broken anchors.