### PR TITLE
docs(skills): re-frame-pair-improver2 — declare allowed-tools (rf2-rrn8s)

### DIFF
--- a/skills/re-frame-pair-improver2/SKILL.md
+++ b/skills/re-frame-pair-improver2/SKILL.md
@@ -19,6 +19,13 @@ description: >
   ("retro", "what went wrong", "how could this be better") do not
   justify activation — a real `re-frame-pair2` session must have
   occurred in this conversation or be summarised by the user.
+allowed-tools:
+  - Bash(bd *)
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
 ---
 
 # re-frame-pair-improver2


### PR DESCRIPTION
## Summary

`skills/re-frame-pair-improver2/SKILL.md` had no `allowed-tools:` block in frontmatter — the implicit full surface worked but the contract was unstated. The skill's core job is to file `bd` improvement-proposal beads, so it needs `Bash(bd *)` plus the standard Read/Edit/Write/Grep/Glob.

Declared block (matches indent style of `re-frame-pair2/SKILL.md`):

```yaml
allowed-tools:
  - Bash(bd *)
  - Read
  - Edit
  - Write
  - Grep
  - Glob
```

Per the skills best-practice sweep (`ai/findings/sweep-skills-best-practice-2026-05-13.md` §B-skill-improver2-allowed-tools), this brings the improver2 skill in line with the rest of the corpus — `re-frame-pair2` was the only sibling that already declared `allowed-tools` explicitly.

## Surface scope

`skills/re-frame-pair-improver2/SKILL.md` only — 7 insertions, 0 deletions.

## Test plan

- [x] Frontmatter parses (YAML is well-formed; indent matches sibling skill)
- [x] Diff is exactly the 7-line `allowed-tools:` block, nothing else
- [x] No body / prose changes
