### PR TITLE
feat(source-coords): add :windsurf + :zed editor URI builders (rf2-achw1)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -9,6 +9,8 @@
 
       vscode://file/<path>:<line>:<column>
       cursor://file/<path>:<line>:<column>
+      windsurf://file/<path>:<line>:<column>
+      zed://file/<path>:<line>:<column>
       idea://open?file=<path>&line=<line>&column=<column>
 
   No single scheme covers every editor; the user picks one at boot via a
@@ -20,6 +22,11 @@
 
   - `:vscode` (default) — VS Code, the most-installed editor.
   - `:cursor` — Cursor (the VS Code fork).
+  - `:windsurf` — Windsurf (a VS Code fork; registers its own
+                `windsurf://` handler distinct from VS Code's).
+  - `:zed`    — Zed (the `zed://` handler is registered via the
+                editor's 'Register Zed Scheme' action; accepts the
+                same `file/<path>:<line>:<column>` grammar).
   - `:idea`   — IntelliJ family (IDEA, WebStorm, PyCharm). The single
                 `idea://` handler dispatches across all JetBrains IDEs.
   - `{:custom <uri-template>}` — user-supplied template with the
@@ -78,7 +85,7 @@
 (def ^:const known-editors
   "The keyword set of built-in editor schemes. The `:custom` form is
   not a member — `editor-uri` matches it via map-shape detection."
-  #{:vscode :cursor :idea})
+  #{:vscode :cursor :windsurf :zed :idea})
 
 (def ^:private default-editor
   "Default editor when no `:editor` config key is set. VS Code is the
@@ -124,6 +131,20 @@
   [path line column]
   (str "cursor://file/" path ":" line ":" column))
 
+(defn- windsurf-uri
+  "Build a `windsurf://file/<path>:<line>:<column>` URI. Windsurf is a
+  VS Code fork that registers its own URI handler — same colon-suffix
+  grammar, distinct scheme."
+  [path line column]
+  (str "windsurf://file/" path ":" line ":" column))
+
+(defn- zed-uri
+  "Build a `zed://file/<path>:<line>:<column>` URI. Zed's `zed://`
+  handler accepts the VS Code colon-suffix grammar (registered via
+  Zed's 'Register Zed Scheme' action)."
+  [path line column]
+  (str "zed://file/" path ":" line ":" column))
+
 (defn- idea-uri
   "Build an `idea://open?file=<path>&line=<line>&column=<column>` URI.
   The JetBrains scheme uses query parameters rather than the
@@ -160,6 +181,8 @@
   `editor` accepts:
     - `:vscode` (default when nil) — `vscode://file/<path>:<line>:<column>`
     - `:cursor`                    — `cursor://file/<path>:<line>:<column>`
+    - `:windsurf`                  — `windsurf://file/<path>:<line>:<column>`
+    - `:zed`                       — `zed://file/<path>:<line>:<column>`
     - `:idea`                      — `idea://open?file=<path>&line=<line>&column=<column>`
     - `{:custom <template>}`       — user template with `{path}` / `{file}`
                                      / `{line}` / `{column}` placeholders.
@@ -186,6 +209,12 @@
 
         (= :cursor editor)
         (cursor-uri path line column)
+
+        (= :windsurf editor)
+        (windsurf-uri path line column)
+
+        (= :zed editor)
+        (zed-uri path line column)
 
         (= :idea editor)
         (idea-uri path line column)

--- a/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
@@ -19,6 +19,13 @@
     (is (= "idea://open?file=src/app/views.cljs&line=42&column=7"
            (eu/editor-uri :idea coord)))))
 
+(deftest windsurf-zed-portable-shape
+  (testing ":windsurf / :zed produce the documented URIs under CLJS"
+    (is (= "windsurf://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :windsurf coord)))
+    (is (= "zed://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :zed coord)))))
+
 (deftest custom-template-on-cljs
   (testing ":custom template substitutes placeholders identically on CLJS"
     (is (= "x://file/src/app/views.cljs?line=42"

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -22,6 +22,26 @@
     (is (= "cursor://file/src/app/views.cljs:42:7"
            (eu/editor-uri :cursor sample-coord)))))
 
+(deftest windsurf-scheme
+  (testing ":windsurf produces windsurf://file/<path>:<line>:<column>"
+    (is (= "windsurf://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :windsurf sample-coord))))
+  (testing ":windsurf with missing :line / :column defaults to 1:1"
+    (is (= "windsurf://file/src/x.cljs:1:1"
+           (eu/editor-uri :windsurf {:file "src/x.cljs"}))))
+  (testing ":windsurf with missing :file → nil URI"
+    (is (nil? (eu/editor-uri :windsurf {:line 10 :column 1})))))
+
+(deftest zed-scheme
+  (testing ":zed produces zed://file/<path>:<line>:<column>"
+    (is (= "zed://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :zed sample-coord))))
+  (testing ":zed with missing :line / :column defaults to 1:1"
+    (is (= "zed://file/src/x.cljs:1:1"
+           (eu/editor-uri :zed {:file "src/x.cljs"}))))
+  (testing ":zed with missing :file → nil URI"
+    (is (nil? (eu/editor-uri :zed {:line 10 :column 1})))))
+
 (deftest idea-scheme
   (testing ":idea produces idea://open?file=&line=&column="
     (is (= "idea://open?file=src/app/views.cljs&line=42&column=7"
@@ -99,6 +119,8 @@
   (testing "known-editors enumerates the built-in scheme keywords"
     (is (contains? eu/known-editors :vscode))
     (is (contains? eu/known-editors :cursor))
+    (is (contains? eu/known-editors :windsurf))
+    (is (contains? eu/known-editors :zed))
     (is (contains? eu/known-editors :idea))
     ;; :custom is a map-shape, not a member of the keyword set.
     (is (not (contains? eu/known-editors :custom)))))


### PR DESCRIPTION
## Summary

Implementation follow-on to **rf2-mqm2d / #593** — that PR added the `:windsurf` and `:zed` rows to the editor-protocol matrix in `tools/causa/spec/007-UX-IA.md`; this PR teaches the helper at `implementation/core/src/re_frame/source_coords/editor_uri.cljc` how to emit URIs for those two editors so a user who sets `:rf.causa/editor :windsurf` (or `:zed`) actually gets the right scheme instead of falling through to the `:vscode` default.

Per the spec, both editors mirror the VS Code colon-suffix grammar:

```
windsurf://file/<path>:<line>:<column>
zed://file/<path>:<line>:<column>
```

Windsurf is a VS Code fork that registers its own `windsurf://` URI handler distinct from VS Code's. Zed accepts the same shape via its 'Register Zed Scheme' action.

### Changes

- `editor_uri.cljc`:
  - Extend `known-editors` from `#{:vscode :cursor :idea}` to `#{:vscode :cursor :windsurf :zed :idea}`.
  - Add private `windsurf-uri` and `zed-uri` builders mirroring `cursor-uri`.
  - Add the two cond branches in `editor-uri`.
  - Update the namespace docstring and the `editor` arg's vocabulary section.
- `source_coords_editor_uri_test.clj` (JVM): new `windsurf-scheme` + `zed-scheme` deftests covering full-coord URIs, `:line` / `:column` defaults of `1:1`, and missing-`:file` -> `nil`. Extended the `known-editors-set` deftest to assert membership of both new keywords.
- `source_coords_editor_uri_cljs_test.cljs` (CLJS): new `windsurf-zed-portable-shape` deftest proving the same URIs resolve under the CLJS build path.

## Out of scope

- Settings-modal UI changes (Causa's editor dropdown reads `known-editors` and will pick up the new keywords organically — handled in a separate bead).

## Cross-refs

- Parent (spec): rf2-mqm2d / #593.
- Original chip implementation: rf2-evgf5.

## Test plan

- [x] JVM: `clojure -M:test -n re-frame.source-coords-editor-uri-test` — 16 tests / 36 assertions, 0 failures.
- [x] CLJS: `npx shadow-cljs compile :node-test && node out/node-test.js` — full suite, 1066 tests / 2771 assertions, 0 failures (includes `re-frame.source-coords-editor-uri-cljs-test`).