### PR TITLE
spec(mcp): token-budget posture across pair2-mcp + story-mcp + causa-mcp (rf2-ll0yq)

### DIFF
--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -214,6 +214,76 @@ historical context is in
 [`tools/pair2-mcp/spec/DESIGN-RATIONALE.md`](../../pair2-mcp/spec/DESIGN-RATIONALE.md)
 Lock #6.
 
+## Tight token budget per response
+
+Each MCP tool response is bounded at **≤ 5,000 tokens** by
+default. The cap is normative, not aspirational: a tool that
+cannot answer inside the budget MUST trim, summarise, or
+paginate rather than over-spend.
+
+The motivation is the 2026 trend axis. Microsoft's April 2026
+recommendation (Playwright CLI **over** Playwright MCP for
+coding agents) was driven by MCP responses being roughly 4×
+larger in tokens than the equivalent CLI output. Anthropic's
+own router-SKILL guidance lands at the same ~5k ceiling. An
+agent host with a 200k context window can absorb a handful of
+20k tool returns, but the realistic working session fires
+dozens of tool calls — Causa-MCP is the most exposed of the
+triplet because its catalogue includes
+`get-trace-buffer`, `get-epoch-history`, `app-db-diff`, and
+the `subscribe` stream, all of which return payloads whose
+size scales with runtime state.
+
+The discipline applies across three axes:
+
+- **Pagination / cursor for unbounded surfaces.**
+  `get-trace-buffer`, `get-epoch-history`,
+  `list-subscriptions`, `get-causality-graph`, and any read
+  tool whose return size is a function of trace-bus depth
+  MUST accept a `:limit` argument and return a `:cursor` for
+  continuation. The default `:limit` MUST keep the response
+  under the cap. No unbounded list responses; no
+  "best-effort" omission of pagination. The `:since-ms` and
+  `:filter` arguments are not substitutes for pagination —
+  an active app can still blow the budget inside a 5-second
+  window.
+- **Summarisation modes for rich payloads.** Ops with rich
+  per-item shape (`app-db-diff`, `get-causality-graph`,
+  `get-epoch`, `get-machine-snapshot`) MUST expose a `:mode`
+  argument with at least `:count` (return totals only),
+  `:sample` (return a bounded prefix or stratified sample
+  with sizes attached), and `:full` (return everything,
+  paginated). The default MUST be `:sample` for any op whose
+  `:full` payload can exceed the cap. `app-db-diff` in
+  particular MUST default to a path-summary mode (changed
+  paths + cardinalities) rather than the full nested diff.
+- **Streaming over batch where appropriate.** The
+  `subscribe` stream returns one event per JSON-RPC
+  notification, not a buffered batch. The cap applies per
+  notification; the agent host meters consumption. A
+  `subscribe` topic whose individual events can exceed the
+  cap (e.g., a trace event with a large coeffect payload)
+  MUST attach a server-side trimmer (drop the heavy fields,
+  attach a `:elided [:cofx :db]` marker, surface a follow-up
+  `get-trace-buffer` cursor).
+
+The cap is enforced at the runtime boundary, not just
+documented. Each tool's reference entry in the catalogue
+carries a **typical-token** hint (e.g., `~1.5k`,
+`~3k under :sample`) and a **cap-reached** behaviour note
+(truncate-with-cursor, return `:ok? false :reason
+:budget-exceeded` with a hint to narrow the filter, switch
+mode, or paginate). The hints surface in `list-tools` so the
+agent can plan ahead.
+
+This is the load-bearing budget posture for Causa-MCP's
+agent-host workflow: keep the per-op cost predictable, push
+the agent to ask for what it actually needs, and never let a
+single op blow the session. Causa-MCP's value over a
+generalist surface (Chrome DevTools MCP's
+`evaluate_script`) collapses if the agent can't afford to
+call the tools.
+
 ## Backed by Causa's and the framework's principles
 
 When in doubt, defer to the principles upstream:

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -124,6 +124,63 @@ and arg shapes — only the transport differs. The MCP-only additions
 no shim equivalent. This is what makes the back-compat tractable: the
 overlap is contract-identical; the plumbing underneath is different.
 
+## Tight token budget per response
+
+Each MCP tool response is bounded at **≤ 5,000 tokens** by
+default. The cap is normative, not aspirational: a tool that
+cannot answer inside the budget MUST trim, summarise, or
+paginate rather than over-spend.
+
+The motivation is the 2026 trend axis. Microsoft's April 2026
+recommendation (Playwright CLI **over** Playwright MCP for
+coding agents) was driven by MCP responses being roughly 4×
+larger in tokens than the equivalent CLI output. Anthropic's
+own router-SKILL guidance lands at the same ~5k ceiling. An
+agent host with a 200k context window can absorb a handful of
+20k tool returns, but the realistic working session fires
+dozens of tool calls — pair2-mcp's `snapshot` mega-op and the
+`subscribe` streaming pair are the exposed surfaces here. A
+single oversized response burns the budget the agent needs
+for the next ten ops.
+
+The discipline applies across three axes:
+
+- **Pagination / cursor for unbounded surfaces.** Any op that
+  returns a list whose size is a function of runtime state
+  (`trace-window`, `subscribe` epoch batches, `handlers`
+  listings under `discover-app`) MUST accept a `:limit`
+  argument and return a `:cursor` for continuation. The
+  default `:limit` MUST keep the response under the cap. No
+  unbounded list responses; no "best-effort" omission of
+  pagination.
+- **Summarisation modes for rich payloads.** Ops with rich
+  per-item shape (`snapshot`, `trace-window`, `discover-app`)
+  MUST expose a `:mode` (or equivalent) argument with at
+  least `:count` (return totals only), `:sample` (return a
+  bounded prefix or stratified sample with sizes attached),
+  and `:full` (return everything, paginated). The default
+  MUST be `:sample` for any op whose `:full` payload can
+  exceed the cap. Agents opt into `:full` when they actually
+  need it.
+- **Streaming over batch where appropriate.** `subscribe`
+  returns one event per JSON-RPC notification, not a buffered
+  batch. The cap applies per notification; the agent host
+  meters consumption. Batching is reserved for ops whose
+  payload is naturally bounded and small.
+
+The cap is enforced at the runtime boundary, not just
+documented. Each op's reference entry in
+[`003-Tool-Catalogue.md`](003-Tool-Catalogue.md) carries a
+**typical-token** hint (e.g., `~1.2k`, `~3k under :sample`)
+and a **cap-reached** behaviour note (truncate-with-cursor,
+return `:reason :budget-exceeded` with a hint, etc.). The
+hints surface in `list-tools` so the agent can plan ahead.
+
+This is the load-bearing budget posture for pair2-mcp's
+agent-host workflow: keep the per-op cost predictable, push
+the agent to ask for what it actually needs, and never let a
+single op blow the session.
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):

--- a/tools/story-mcp/spec/Principles.md
+++ b/tools/story-mcp/spec/Principles.md
@@ -163,6 +163,66 @@ deterministically from its own jar plus the launch-time
 configuration. No surprise file reads, no environment-dependent
 discovery dance.
 
+## Tight token budget per response
+
+Each MCP tool response is bounded at **≤ 5,000 tokens** by
+default. The cap is normative, not aspirational: a tool that
+cannot answer inside the budget MUST trim, summarise, or
+paginate rather than over-spend.
+
+The motivation is the 2026 trend axis. Microsoft's April 2026
+recommendation (Playwright CLI **over** Playwright MCP for
+coding agents) was driven by MCP responses being roughly 4×
+larger in tokens than the equivalent CLI output. Anthropic's
+own router-SKILL guidance lands at the same ~5k ceiling. An
+agent host with a 200k context window can absorb a handful of
+20k tool returns, but the realistic working session fires
+dozens of tool calls — story-mcp's `run-variant` (whose
+output is the variant's rendered identity plus assertion
+results) and `list-variants` on a populous library are the
+exposed surfaces here. A single oversized response burns the
+budget the agent needs for the next ten ops.
+
+The discipline applies across three axes:
+
+- **Pagination / cursor for unbounded surfaces.**
+  `list-variants`, `list-modes`, `list-assertions`, and any
+  read tool whose return size is a function of registry size
+  MUST accept a `:limit` argument and return a `:cursor` for
+  continuation. The default `:limit` MUST keep the response
+  under the cap. No unbounded list responses; no "best-effort"
+  omission of pagination.
+- **Summarisation modes for rich payloads.** Ops with rich
+  per-item shape (`run-variant`, `snapshot-identity`,
+  `variant->edn`) MUST expose a `:mode` argument with at
+  least `:count` (return totals / pass-fail counts only),
+  `:sample` (return a bounded prefix or stratified sample
+  with sizes attached), and `:full` (return everything,
+  paginated). The default MUST be `:sample` for any op whose
+  `:full` payload can exceed the cap. The self-healing loop
+  (run → read-failures → fix) naturally biases towards
+  failure-only payloads, which is the `:sample` mode under a
+  failure filter.
+- **Streaming over batch where appropriate.** If story-mcp
+  later grows a streaming tool (e.g., a long-running batch
+  variant run), each notification MUST stay under the cap;
+  the agent host meters consumption. Batching is reserved
+  for ops whose payload is naturally bounded and small.
+
+The cap is enforced at the runtime boundary, not just
+documented. Each tool's reference entry in
+[`002-Tool-Registry.md`](002-Tool-Registry.md) carries a
+**typical-token** hint (e.g., `~0.8k`, `~3k under :sample`)
+and a **cap-reached** behaviour note (truncate-with-cursor,
+return `isError: true` with `:reason :budget-exceeded` and a
+hint to narrow the filter or switch mode). The hints surface
+in `list-tools` so the agent can plan ahead.
+
+This is the load-bearing budget posture for story-mcp's
+agent-host workflow: keep the per-op cost predictable, push
+the agent to ask for what it actually needs, and never let a
+single op blow the session.
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md)


### PR DESCRIPTION
## Summary

Adds a normative **"Tight token budget per response"** section to the `Principles.md` of all three MCP spec trees (`pair2-mcp`, `story-mcp`, `causa-mcp`). Each tool response is capped at **5,000 tokens** by default — matching Anthropic's router-SKILL guidance and the same axis driving Microsoft's April 2026 shift to Playwright CLI over Playwright MCP (~4x token reduction).

Tracks `rf2-ll0yq`. Source: `ai/findings/sweep-tools-vs-sota-2026-05-13.md` (cross-cutting finding #2).

## The posture (three concrete disciplines)

- **Pagination / cursor for unbounded surfaces** — `trace-window`, `get-epoch-history`, `list-variants`, `get-trace-buffer`, etc. MUST accept a `:limit` and return a `:cursor`. Default `:limit` MUST keep responses under the cap. No unbounded list responses; no "best-effort" omission of pagination.
- **Summarisation modes (`:count` / `:sample` / `:full`)** for rich payloads — `snapshot`, `app-db-diff`, `get-causality-graph`, `run-variant` MUST expose a `:mode` argument. Default MUST be `:sample` whenever `:full` can exceed the cap; agents opt into `:full` only when needed. `app-db-diff` defaults to a path-summary mode.
- **Streaming over batch** where appropriate — `subscribe`-style notifications apply the cap per event, with server-side trimming + cursor follow-up for heavy individual events (e.g. a trace event carrying a large coeffect db).

Each tool's catalogue entry will later carry a **typical-token hint** (e.g. `~1.2k`, `~3k under :sample`) and a **cap-reached behaviour note**, surfaced via `list-tools` so the agent can plan ahead.

## Files touched

- `tools/pair2-mcp/spec/Principles.md` — new section before "Backed by the framework's principles". Calls out `snapshot` mega-op and `subscribe` batches as the exposed surfaces.
- `tools/story-mcp/spec/Principles.md` — new section before "Backed by the framework's principles". Calls out `run-variant` output and `list-variants` on populous libraries; notes the self-healing loop naturally biases towards `:sample` under a failure filter.
- `tools/causa-mcp/spec/Principles.md` — **new file** on this branch (PR #576's scaffold is still in CI). Includes the same posture section, framed against Causa-MCP's especially-exposed catalogue: `get-trace-buffer`, `get-epoch-history`, `app-db-diff`, `get-causality-graph`, plus the `subscribe` stream.

## Coordination with PR #576

PR #576 (`rf2-006p0` causa-mcp spec scaffold) is still open. This PR creates `tools/causa-mcp/spec/Principles.md` from scratch with the token-budget posture; #576 creates the same file with the rest of the principles. Whichever merges last resolves the file-level conflict mechanically — the token-budget section folds in alongside the rest of the principles.

Lock #N cross-references that #576 introduces (Lock #2 / #3 / #4 / #5 / #6 in `DESIGN-RATIONALE.md`) were stripped from this PR's copy because the target file does not exist on `origin/main`; those references should be restored at conflict-resolution time.

## Validation

- `python scripts/check_doc_slugs.py` — passes (exit 0).
- `python -m mkdocs build` — no new warnings vs. `origin/main` baseline (122 pre-existing warnings, unchanged).

## Test plan

- [ ] Reviewer eyes the cap (5k) — does it match the project's chosen ceiling, or should it be 3k / 8k?
- [ ] Reviewer eyes the per-tool surfaces flagged in each section — anything missed?
- [ ] On merge order vs. PR #576: confirm the conflict-resolution path is the right one.