### PR TITLE
feat(story): Test Codegen — record canvas interactions as :play body (rf2-5fc15)

### DIFF
--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -106,6 +106,105 @@ hides. The Causa artefact owns the actual view; Story owns the
 *integration*. See [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)
 §10x-embed.
 
+### Test Codegen — record-as-`:play` (rf2-5fc15)
+
+Storybook 9's killer feature is the record-and-save workflow: the
+user interacts with the canvas, the tool watches the event bus, and
+on 'stop' the user gets a code snippet they paste into the variant.
+Story's `:play` body is **already** a vector of EDN event vectors
+(per [`004-Assertions.md`](004-Assertions.md) §Play sequence
+execution), so the captured trace IS the codegen output — no
+Testing-Library/page-object translation layer needed.
+
+The recorder is a chrome-wide toolbar affordance. A REC chip sits at
+the right of the [toolbar](010-Toolbar.md), just before `[reset]`:
+
+```
+[chip] [chip]   ●dark ●mobile         [● REC 7]  [reset]
+```
+
+Click toggles. With a variant selected and no recording in flight,
+clicking starts capture against that variant's frame. With a recording
+in flight, clicking stops + opens a save-as-variant modal carrying the
+generated `(reg-variant ...)` form:
+
+```clojure
+(story/reg-variant :story.counter/recorded-739221
+  {:extends :story.counter/happy-path
+   :play [[:counter/inc]
+          [:counter/inc]
+          [:counter/by 7]]})
+```
+
+#### Capture boundary
+
+The recorder consumes Story's existing trace-bus listener primitive
+(per [`003-Render-Shell.md`](003-Render-Shell.md) §Trace bus + the
+`re-frame.trace/register-trace-cb!` API per Spec 009 §Listener
+contract). One process-wide callback installed at shell mount; per
+emit it short-circuits when no recording is in flight, so leaving it
+installed is free.
+
+Three filter layers:
+
+1. **Op-type** — only `:event/dispatched` emissions qualify (skip
+   `:fx` / `:sub` / `:view` / `:cofx` traffic).
+2. **Frame scope** — the emission's `:frame` tag must match the
+   recording's target variant. Cross-frame dispatches (typing in
+   another canvas while a recording is active) are dropped.
+3. **Event vocabulary** — `:rf.assert/*` events and Story-internal
+   helpers (`:rf.story/*`, `:re-frame.story.*`) are filtered. Authored
+   assertions are deliberate; recorded `:play` bodies capture user
+   intent, and assertions get added by hand.
+
+#### Public API
+
+```clojure
+;; In re-frame.story
+(start-recording!  variant-id)        ; returns recorder state
+(stop-recording!)                     ; returns captured state map
+(recording?)                          ; boolean
+(recorder-state)                      ; current state — read-only view
+(clear-recording!)                    ; drop captured trace, return to idle
+(gen-play-snippet events opts)        ; render `(reg-variant ... :play [...])`
+```
+
+`opts` for `gen-play-snippet`:
+
+- `:variant-id` (required) — keyword id for the new variant.
+- `:doc`        (optional) — docstring.
+- `:extends`    (optional) — variant id to `:extends` from (carries
+                              `:component`, `:args`, `:decorators`).
+- `:alias`      (optional) — short alias for the form (default `story`).
+
+Pure data → string; the emitted form is `read-string`-able and
+round-trips through re-frame's registrar machinery.
+
+#### Why this is structurally simpler than Storybook's recorder
+
+Storybook 9 records DOM events (`click`, `fill`, `select`) and emits
+Testing Library calls (`fireEvent.click(...)`, `await userEvent.fill(...)`),
+which then have to translate back through React's reconciliation. Story
+records re-frame events directly: every user interaction in a Story
+canvas eventually lands as a `dispatch` on the variant's router, and
+the trace bus already projects those dispatches with `:event/dispatched`
+emissions per Spec 009. Capturing the right value is one filter on the
+existing emit; the output shape is the exact vector the runtime will
+re-dispatch under `:play`. The recorder is one screenful of code.
+
+#### MCP wiring (adjacent bead)
+
+The story-mcp `record-as-variant` tool consumes the same recorder
+state through the cross-process Tool-Pair bridge (per
+[`006-MCP-Surface.md`](006-MCP-Surface.md)): the agent calls
+`start-recording!`, drives interactions via the existing MCP write
+surface (or asks the user to interact with the canvas), calls
+`stop-recording!`, and the snippet emitted by `gen-play-snippet` is
+returned as the tool's structured output for the agent to write
+back to the user's stories namespace. That bead is filed separately
+as a P2 follow-up; this spec locks the recorder's runtime contract
+so the MCP side can build against a stable surface.
+
 ## v1.1 deferrals
 
 ### Live performance ribbon
@@ -255,6 +354,7 @@ phase-2 SOTA adds that are cheap.
 | Per-variant QR code in share menu | Stage 6 |
 | Multi-substrate side-by-side pane (substrate-failures inline) | Stage 6 |
 | 10x epoch panel embed (stub + contract) | Stage 6 |
+| Test Codegen — record canvas dispatches as `:play` (rf2-5fc15) | Stage 6 |
 
 ## v1.1 ship list (first follow-up)
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -57,6 +57,10 @@
             [re-frame.story.assertions :as assertions]
             [re-frame.story.fx-stubs  :as fx-stubs]
             [re-frame.story.play      :as play]
+            ;; rf2-5fc15 — Test Codegen recorder. Pure-data state +
+            ;; snippet generator; the CLJS-only UI surface
+            ;; (`re-frame.story.ui.recorder`) wires the trace listener.
+            [re-frame.story.recorder  :as recorder]
             ;; Stage 6 (rf2-zhwd) — SOTA features. layout-debug + share
             ;; live in .cljc; multi-substrate / a11y / panels are
             ;; CLJS-only so the JVM classpath stays lean.
@@ -770,3 +774,60 @@
      v2 may return a collection when multi-shell mounts ship."
      []
      (ui-shell/active-shell)))
+
+;; ---- rf2-5fc15 — Test Codegen recorder public surface --------------------
+;;
+;; Per bead rf2-5fc15 the recorder captures canvas-dispatched events as
+;; a `:play` body. Exposing the entry points here lets tests, MCP
+;; tooling, and headless integrations drive recording programmatically
+;; without going through the toolbar UI.
+
+(defn start-recording!
+  "Begin recording events dispatched against `variant-id`'s frame. Any
+  in-flight recording is stopped first. Returns the new recorder
+  state.
+
+  Use `stop-recording!` to capture the snapshot. The captured events
+  vector is `[:events ...]` on the returned state map; pass it to
+  `gen-play-snippet` to render the `(reg-variant ...)` form."
+  [variant-id]
+  (recorder/start-recording! variant-id))
+
+(defn stop-recording!
+  "Stop the in-flight recording. Returns the recorder state map with
+  `:recording?` false, `:events` carrying the captured event vectors in
+  declared order, and `:variant-id` naming the source variant."
+  []
+  (recorder/stop-recording!))
+
+(defn recording?
+  "Boolean predicate — is a recording in flight?"
+  []
+  (recorder/recording?))
+
+(defn recorder-state
+  "Return the current recorder state map. Read-only view; transitions
+  go through `start-recording!` / `stop-recording!` / `clear-recording!`."
+  []
+  (recorder/current-state))
+
+(defn clear-recording!
+  "Drop any captured events + return the recorder to idle."
+  []
+  (recorder/clear!))
+
+(defn gen-play-snippet
+  "Render an EDN snippet `(reg-variant <id> {... :play [...]})` for
+  `events`. Pure data → string; round-trips through `read-string` and
+  re-frame's registrar machinery.
+
+  `opts` accepts:
+    :variant-id  required — keyword id for the new variant.
+    :doc         optional — short docstring.
+    :extends     optional — keyword id of a variant to `:extends`.
+    :alias       optional — short ns alias for the form (default `story`).
+
+  Empty `events` still produces a valid form (with `:play []`) so the
+  user sees the shape to fill in."
+  [events opts]
+  (recorder/gen-play-snippet events opts))

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -1,0 +1,315 @@
+(ns re-frame.story.recorder
+  "Test Codegen — record canvas-dispatched events as a `:play` body.
+
+  Per bead rf2-5fc15: Storybook 9's killer feature is the record-and-save
+  workflow — the user interacts with the canvas, the tool watches the
+  event bus, and on 'stop' it emits a code snippet the user appends to
+  a new variant. Story's `:play` body is a vector of event vectors, so
+  the captured trace is the codegen output verbatim — no Testing
+  Library / page-object translation layer is needed.
+
+  ## What this namespace does
+
+  1. Holds a per-process recorder state map (`{:recording? bool
+     :variant-id <kw> :events [<event-vec> ...] :started-ms <ms>}`).
+  2. Exposes pure helpers for the toolbar UI to consume:
+     - `start-recording!` / `stop-recording!` / `toggle!`
+     - `recording?` / `current-state` — read accessors.
+     - `record-event!` — called from the trace listener with the
+       captured event vector.
+  3. Provides a pure `gen-play-snippet` fn that emits the
+     `(reg-variant ...)` EDN form for the captured sequence — this is
+     what the user copies into source AND what the MCP layer exposes
+     downstream (story-mcp's `record-as-variant` tool, filed as a
+     separate adjacent bead).
+
+  ## Recording boundary
+
+  - Only `:event/dispatched` trace events whose `:frame` matches the
+    active recording target qualify.
+  - `:rf.assert/*` events are skipped — assertions are authored
+    deliberately, not recorded.
+  - `:rf.story/*` / `:rf.story.*` internal events (the runtime's
+    helper events like `::append-assertion`) are skipped.
+  - The listener consults `recording?` per emit — toggling off STOPS
+    recording without tearing down anything else.
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` so the snippet-generation logic and the
+  predicate fn (`recordable-event?`) are exercisable by the JVM test
+  corpus. The trace-listener wiring (`install-trace-listener!`) and the
+  Reagent / toolbar UI surface live in `re-frame.story.ui.recorder`
+  (CLJS-only).
+
+  ## Public surface
+
+  - `recordable-event?`       — pure predicate (JVM + CLJS).
+  - `gen-play-snippet`        — pure code-gen (JVM + CLJS).
+  - `state` / `current-state` — recorder state accessors.
+  - `recording?`              — boolean state accessor.
+  - `start-recording!` / `stop-recording!` / `toggle!` / `clear!`
+  - `record-event!`           — called by the listener / tests."
+  (:require [clojure.string :as str]
+            [re-frame.story.config :as config]
+            [re-frame.trace :as trace]))
+
+;; ---------------------------------------------------------------------------
+;; Pure: recordable event predicate
+;;
+;; The recorder skips assertion events (`:rf.assert/*`) and Story's
+;; own internal helpers (`:rf.story/*` / `:re-frame.story.*`) so the
+;; emitted `:play` body is exactly the user-facing dispatches that
+;; reproduce the canvas state.
+;; ---------------------------------------------------------------------------
+
+(defn- internal-namespace?
+  "True iff `ns-str` is a Story-internal namespace whose events should
+  not appear in a recorded `:play` body."
+  [ns-str]
+  (or (= "rf.assert" ns-str)
+      (= "rf.story" ns-str)
+      (and (string? ns-str)
+           (or (str/starts-with? ns-str "re-frame.story")
+               (str/starts-with? ns-str "rf.story.")))))
+
+(defn recordable-event?
+  "True iff `event` (a re-frame event vector) is one the recorder should
+  capture into a `:play` body. Filters out assertion events and
+  Story's own internal helper events. Pure data → boolean; JVM-
+  testable."
+  [event]
+  (and (vector? event)
+       (seq event)
+       (let [id (first event)]
+         (and (keyword? id)
+              (not (internal-namespace? (namespace id)))))))
+
+;; ---------------------------------------------------------------------------
+;; Pure: code-gen — `(reg-variant ... :play [...])` snippet
+;; ---------------------------------------------------------------------------
+
+(defn gen-play-snippet
+  "Build the EDN snippet for the captured events. Pure data → string.
+
+  Returns a `(re-frame.story/reg-variant <id> {... :play [...]})` form
+  the user can paste into source. The variant id and any extra body
+  keys come from `opts`:
+
+      :variant-id  required — keyword id of the new variant
+                              (e.g. `:story.counter/recorded-flow`)
+      :doc         optional — short docstring
+      :extends     optional — keyword id to `:extends` from (preserves
+                              `:component`, `:args`, `:decorators`)
+      :alias       optional — short alias to use in the form
+                              (default `\"story\"`)
+
+  When `events` is empty the snippet still renders (with an empty
+  `:play` vector) so the user sees the shape they're about to fill.
+
+  The output is human-readable EDN — each event renders on its own
+  line, indented under `:play [`. The form is `read-string`-able and
+  round-trips through re-frame's registrar machinery."
+  [events {:keys [variant-id doc extends alias]
+           :or   {alias "story"}}]
+  (let [body-keys (cond-> []
+                    doc     (conj [:doc (pr-str doc)])
+                    extends (conj [:extends (pr-str extends)])
+                    true    (conj [:play
+                                   (if (seq events)
+                                     (str "["
+                                          (str/join "\n           "
+                                                    (map pr-str events))
+                                          "]")
+                                     "[]")]))
+        body-str  (->> body-keys
+                       (map (fn [[k v]] (str k " " v)))
+                       (str/join "\n   "))]
+    (str "(" alias "/reg-variant "
+         (pr-str (or variant-id :story.recorded/example))
+         "\n  {" body-str "})")))
+
+;; ---------------------------------------------------------------------------
+;; Recorder state
+;;
+;; A single per-process atom carries the active recording. v1 supports
+;; one active recording at a time — the toolbar's REC chip is a
+;; chrome-wide affordance, paralleling the chrome-wide `:active-modes`.
+;; ---------------------------------------------------------------------------
+
+(def initial-state
+  "The recorder's idle state shape. `:recording?` flips true while a
+  capture is in flight; `:events` accumulates the captured vectors in
+  declared order (oldest first, ready to drop straight into `:play`);
+  `:variant-id` records which frame the capture targets; `:started-ms`
+  is the wall-clock start time for elapsed-time display."
+  {:recording? false
+   :variant-id nil
+   :events     []
+   :started-ms nil})
+
+(defonce
+  ^{:doc "Recorder state atom. Per-process singleton; the toolbar
+         affordance and trace listener consult this."}
+  state
+  (atom initial-state))
+
+(defn current-state
+  "Return the recorder's current state map."
+  []
+  @state)
+
+(defn recording?
+  "Boolean predicate — is a recording in progress?"
+  []
+  (:recording? @state))
+
+(defn recording-variant
+  "Return the variant id the current recording targets, or nil."
+  []
+  (:variant-id @state))
+
+(defn recorded-events
+  "Return the vector of captured event vectors (oldest first)."
+  []
+  (:events @state))
+
+;; ---------------------------------------------------------------------------
+;; Pure transition fns — make the state machine JVM-testable.
+;; ---------------------------------------------------------------------------
+
+(defn start
+  "Pure: return the recorder state for a new recording targeting
+  `variant-id`. `now-ms` is the wall-clock start time."
+  [_state variant-id now-ms]
+  {:recording? true
+   :variant-id variant-id
+   :events     []
+   :started-ms now-ms})
+
+(defn append
+  "Pure: append `event` to the recorder state's `:events` slot iff the
+  state is recording and the event is recordable. Returns the new
+  state. Idempotent against bad inputs."
+  [state event]
+  (cond-> state
+    (and (:recording? state)
+         (recordable-event? event))
+    (update :events (fnil conj []) (vec event))))
+
+(defn stop
+  "Pure: return the recorder state for a stopped recording. Preserves
+  `:events` and `:variant-id` so the UI can render the captured trace
+  in the save-as-variant dialog."
+  [state]
+  (assoc state :recording? false))
+
+(defn reset
+  "Pure: return the idle state — both `:recording?` and `:events`
+  cleared."
+  [_state]
+  initial-state)
+
+;; ---------------------------------------------------------------------------
+;; Impure: write the state atom. Gated under config/enabled? so the
+;; production CLJS build's call sites elide cleanly.
+;; ---------------------------------------------------------------------------
+
+(defn start-recording!
+  "Begin recording events dispatched against `variant-id`'s frame.
+  Returns the new state. Stops any in-flight recording first."
+  ([variant-id]
+   (start-recording! variant-id #?(:clj (System/currentTimeMillis)
+                                   :cljs (.now js/Date))))
+  ([variant-id now-ms]
+   (when config/enabled?
+     (swap! state start variant-id now-ms))
+   @state))
+
+(defn stop-recording!
+  "Stop the in-flight recording, preserving the captured events for
+  the UI's save-as-variant dialog. Returns the new state."
+  []
+  (when config/enabled?
+    (swap! state stop))
+  @state)
+
+(defn clear!
+  "Drop the captured events and return to idle."
+  []
+  (when config/enabled?
+    (reset! state initial-state))
+  @state)
+
+(defn toggle!
+  "Start or stop recording. If currently recording, stop. Otherwise
+  start a fresh recording against `variant-id`. Returns the new state."
+  [variant-id]
+  (if (recording?)
+    (stop-recording!)
+    (start-recording! variant-id)))
+
+(defn record-event!
+  "Append `event` to the recorder's captured trace iff a recording is
+  in flight. Called by the trace-bus listener for every
+  `:event/dispatched` event whose `:frame` matches the recording
+  target. Idempotent against non-recordable events (assertion events,
+  internal helpers) — the predicate filter is in `append`."
+  [event]
+  (when config/enabled?
+    (swap! state append event))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Trace-bus listener
+;;
+;; One listener per process — registered by the shell at mount, torn
+;; down at unmount. Filters every emit down to `:event/dispatched`
+;; events targeting the recorder's `:variant-id` slot. The listener
+;; is idempotent (re-registering replaces).
+;;
+;; Lives in `.cljc` so JVM tests can exercise the full record-from-
+;; trace path end-to-end against a real frame (the CLJS UI surface
+;; just delegates here).
+;; ---------------------------------------------------------------------------
+
+(def ^:const listener-id ::recorder-listener)
+
+(defn- trace-listener
+  "Trace-bus callback. Routes a single trace event through the
+  recorder's filter chain:
+
+    1. Must be a `:event/dispatched` emission.
+    2. Must target the recorder's `:variant-id` (skip cross-frame
+       traffic — interactions in another canvas shouldn't show up).
+    3. Must carry an event vector on `:tags :event`.
+
+  `record-event!` applies the `recordable-event?` filter (assertion
+  events, internal helpers) before appending."
+  [ev]
+  (when (recording?)
+    (let [{:keys [op-type operation tags]} ev]
+      (when (and (= op-type :event)
+                 (= operation :event/dispatched)
+                 (= (:frame tags) (recording-variant))
+                 (vector? (:event tags)))
+        (record-event! (:event tags))))))
+
+(defn install-trace-listener!
+  "Install the recorder's trace-bus listener. Idempotent — re-installing
+  replaces. The listener short-circuits on every emit when no recording
+  is in flight, so leaving it installed is free.
+
+  Called from the shell at mount on CLJS and from JVM integration
+  tests directly."
+  []
+  (when config/enabled?
+    (trace/register-trace-cb! listener-id trace-listener)
+    nil))
+
+(defn remove-trace-listener!
+  "Tear down the recorder's trace-bus listener. Idempotent."
+  []
+  (when config/enabled?
+    (trace/remove-trace-cb! listener-id)
+    nil))

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -1,0 +1,456 @@
+(ns re-frame.story.ui.recorder
+  "Test Codegen UI surface — toolbar REC chip + recording overlay.
+
+  Per bead rf2-5fc15. Wires the pure recorder
+  (`re-frame.story.recorder`) to:
+
+  - The chrome-level toolbar — a REC chip lives at the right of the
+    toolbar (just left of the `[reset]` button) so the affordance is
+    chrome-wide and visually unmistakable.
+  - The trace bus — installs a per-process listener that filters
+    `:event/dispatched` events targeting the currently-focused variant
+    frame and feeds them into `recorder/record-event!`.
+  - A save-as-variant dialog — when the user stops recording, a modal
+    surfaces the captured EDN snippet (the `(reg-variant ...)` form
+    they paste into source).
+
+  ## State source
+
+  The recorder UI reads `re-frame.story.recorder/state` directly — it's
+  a `clojure.core/atom` (NOT a `r/atom`), so component re-renders are
+  driven via `r/track!`-style polling against the recorder state
+  combined with the shell's existing `:hot-reload-tick` poll. v1 keeps
+  it simple: the toolbar's REC chip and the recording overlay both
+  consume the recorder state through Reagent's auto-tracking by
+  reading the recorder's CLJS-side mirror ratom (`ui-state`) — a thin
+  `r/atom` we keep in sync with the pure atom via `add-watch`. Tests
+  drive the pure atom directly without going through the mirror.
+
+  ## Listener integration
+
+  The listener lives behind a single `install-trace-listener!` call
+  the shell makes once at mount. Events with `:op-type :event` +
+  `:operation :event/dispatched` whose `:frame` tag matches the
+  recorder's `:variant-id` slot pipe through `record-event!`. The
+  pure predicate (`recordable-event?`) drops `:rf.assert/*` and
+  internal Story events.
+
+  ## UX
+
+  Toolbar REC chip:
+
+      [● REC]   while recording — red dot, white text on `#b91c1c`
+      [REC]     idle — neutral chip styling
+
+  Click toggles. When idle, clicking starts a recording targeting the
+  currently-focused variant; when active, clicking stops + opens the
+  snippet dialog.
+
+  Recording overlay — a fixed-position banner at the top-right of the
+  shell, visible while recording, naming the target variant and the
+  current event count.
+
+  Save-as-variant dialog — full-screen modal with:
+    - editable text field for the new variant id;
+    - the generated EDN snippet, copy-to-clipboard affordance;
+    - 'discard' / 'close' buttons.
+
+  ## Elision
+
+  Every public fn opens with `(when config/enabled? ...)` so production
+  CLJS builds short-circuit before any DOM call. The listener install
+  is also gated."
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [re-frame.story.config :as config]
+            [re-frame.story.recorder :as recorder]
+            [re-frame.story.ui.state :as state]))
+
+;; ---------------------------------------------------------------------------
+;; Reagent mirror of the recorder state
+;;
+;; `recorder/state` is a plain `atom` so JVM tests can exercise the state
+;; machine. CLJS-side we mirror it into a `r/atom` so the toolbar chip /
+;; overlay auto-re-render on every transition. A `add-watch` on the
+;; pure atom keeps the mirror in sync.
+;; ---------------------------------------------------------------------------
+
+(defonce ui-state
+  (r/atom (recorder/current-state)))
+
+(defonce ^:private mirror-installed?
+  (atom false))
+
+(defn- install-mirror! []
+  (when (and config/enabled? (not @mirror-installed?))
+    (reset! mirror-installed? true)
+    (add-watch recorder/state ::ui-mirror
+               (fn [_ _ _ new-state]
+                 (reset! ui-state new-state)))
+    ;; Seed once at install time so the mirror starts in sync.
+    (reset! ui-state (recorder/current-state))))
+
+;; ---------------------------------------------------------------------------
+;; Trace-bus listener wiring
+;;
+;; The actual listener lives in `re-frame.story.recorder` (cljc) so JVM
+;; integration tests can exercise the full record-from-trace path. The
+;; UI surface just delegates here and seeds the Reagent mirror so chip
+;; / overlay re-render on every transition.
+;; ---------------------------------------------------------------------------
+
+(defn install-trace-listener!
+  "Install the recorder's trace-bus listener + seed the Reagent state
+  mirror. Idempotent."
+  []
+  (when config/enabled?
+    (install-mirror!)
+    (recorder/install-trace-listener!)
+    nil))
+
+(defn remove-trace-listener!
+  "Tear down the recorder's trace-bus listener. Idempotent."
+  []
+  (when config/enabled?
+    (recorder/remove-trace-listener!)
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Toolbar REC chip
+;; ---------------------------------------------------------------------------
+
+(def ^:private styles
+  {:chip-idle   {:display         "inline-flex"
+                 :align-items     "center"
+                 :gap             "5px"
+                 :padding         "3px 10px"
+                 :background      "#37373d"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :user-select     "none"
+                 :letter-spacing  "0.4px"}
+   :chip-active {:display         "inline-flex"
+                 :align-items     "center"
+                 :gap             "5px"
+                 :padding         "3px 10px"
+                 :background      "#b91c1c"
+                 :color           "white"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :user-select     "none"
+                 :font-weight     "bold"
+                 :letter-spacing  "0.4px"
+                 :animation       "rf-story-rec-pulse 1.4s ease-in-out infinite"}
+   :chip-disabled {:display       "inline-flex"
+                 :align-items     "center"
+                 :gap             "5px"
+                 :padding         "3px 10px"
+                 :background      "#2d2d30"
+                 :color           "#777"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "not-allowed"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :user-select     "none"
+                 :letter-spacing  "0.4px"}
+   :dot         {:width        "8px"
+                 :height       "8px"
+                 :border-radius "50%"
+                 :background    "#ef4444"
+                 :box-shadow    "0 0 6px #ef4444"}
+   :overlay     {:position     "fixed"
+                 :top          "44px"
+                 :right        "12px"
+                 :z-index      1600
+                 :background   "#1f1f1f"
+                 :border       "1px solid #b91c1c"
+                 :color        "#fdd"
+                 :padding      "6px 10px"
+                 :border-radius "4px"
+                 :font-family  "monospace"
+                 :font-size    "11px"
+                 :box-shadow   "0 4px 10px rgba(0,0,0,0.6)"
+                 :display      "flex"
+                 :align-items  "center"
+                 :gap          "8px"}
+   :modal-back  {:position "fixed"
+                 :top "0" :left "0" :right "0" :bottom "0"
+                 :background "rgba(0,0,0,0.55)"
+                 :z-index 1700
+                 :display "flex"
+                 :align-items "center"
+                 :justify-content "center"}
+   :modal       {:width        "640px"
+                 :max-width    "90vw"
+                 :max-height   "80vh"
+                 :background   "#1e1e1e"
+                 :color        "#ddd"
+                 :border       "1px solid #444"
+                 :border-radius "6px"
+                 :padding      "16px"
+                 :font-family  "monospace"
+                 :font-size    "12px"
+                 :display      "flex"
+                 :flex-direction "column"
+                 :gap          "12px"
+                 :box-shadow   "0 12px 32px rgba(0,0,0,0.7)"
+                 :overflow     "hidden"}
+   :modal-title {:font-weight "bold"
+                 :color "#9cdcfe"
+                 :font-size "13px"}
+   :id-input    {:padding "6px 8px"
+                 :background "#252526"
+                 :color "white"
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :font-family "monospace"
+                 :font-size "12px"
+                 :width "100%"
+                 :box-sizing "border-box"}
+   :snippet     {:background "#0e0e10"
+                 :color "#dcdcaa"
+                 :padding "10px"
+                 :border "1px solid #333"
+                 :border-radius "4px"
+                 :white-space "pre"
+                 :overflow "auto"
+                 :max-height "44vh"
+                 :font-family "monospace"
+                 :font-size "11px"
+                 :line-height "1.45"
+                 :flex "1 1 auto"}
+   :btn-row     {:display "flex"
+                 :gap "8px"
+                 :justify-content "flex-end"}
+   :btn         {:padding "5px 12px"
+                 :background "#0e639c"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-family "monospace"
+                 :font-size "11px"}
+   :btn-muted   {:padding "5px 12px"
+                 :background "transparent"
+                 :color "#cccccc"
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-family "monospace"
+                 :font-size "11px"}
+   :hint        {:color "#9a9a9a"
+                 :font-style "italic"
+                 :font-size "10px"}})
+
+;; ---------------------------------------------------------------------------
+;; Modal state — a single flag for whether the save-as-variant dialog
+;; is open + a draft variant id the user types into.
+;;
+;; The dialog opens automatically when the user STOPS recording and
+;; there are captured events; it can also be reopened from the toolbar
+;; chip's secondary "snippet" affordance (v1 ships the auto-open path
+;; only — re-open is a v1.1 polish).
+;; ---------------------------------------------------------------------------
+
+(defonce ui-dialog
+  (r/atom {:open? false
+           :draft-id nil}))
+
+(defn- default-variant-id
+  "Derive a sensible default id for the new variant. Uses the recorded
+  variant's namespace + '/recorded-N' where N is a wall-clock-derived
+  short suffix so multiple recordings against the same variant don't
+  clobber each other."
+  [source-variant-id]
+  (when (and source-variant-id (qualified-keyword? source-variant-id))
+    (let [suffix (-> (.now js/Date)
+                     (mod 1000000)
+                     str)]
+      (keyword (namespace source-variant-id)
+               (str "recorded-" suffix)))))
+
+(defn- open-dialog! [source-variant-id]
+  (swap! ui-dialog assoc
+         :open? true
+         :draft-id (default-variant-id source-variant-id)))
+
+(defn- close-dialog! []
+  (swap! ui-dialog assoc :open? false))
+
+(defn- set-draft-id! [s]
+  (let [k (try
+            (let [stripped (cond-> s
+                             (and (string? s)
+                                  (re-find #"^:" s))
+                             (subs 1))]
+              (when (and (string? stripped) (seq stripped))
+                (if (re-find #"/" stripped)
+                  (let [[ns nm] (str/split stripped #"/" 2)]
+                    (keyword ns nm))
+                  (keyword stripped))))
+            (catch :default _ nil))]
+    (swap! ui-dialog assoc :draft-id (or k s))))
+
+;; ---------------------------------------------------------------------------
+;; Toolbar chip + overlay components
+;; ---------------------------------------------------------------------------
+
+(defn- can-record?
+  "True iff a recording can be started. Requires a selected variant —
+  the recorder targets exactly one frame."
+  [shell]
+  (some? (:selected-variant shell)))
+
+(defn rec-chip
+  "Toolbar chip rendered by the toolbar strip. Click toggles recording.
+
+  States:
+    - no variant selected → disabled (the recorder needs a target).
+    - idle               → [REC]   click to start.
+    - recording          → [● REC] click to stop + open snippet
+                            dialog.
+
+  Public so tests can introspect the chip-level hiccup without
+  driving the full toolbar."
+  []
+  (let [shell      @state/shell-state-atom
+        rec        @ui-state
+        rec?       (:recording? rec)
+        target     (:selected-variant shell)
+        enabled?   (or rec? (can-record? shell))
+        on-click   (fn [_]
+                     (cond
+                       (and (not rec?) target)
+                       (recorder/start-recording! target)
+
+                       rec?
+                       (let [{:keys [variant-id events]} (recorder/stop-recording!)]
+                         (when (seq events)
+                           (open-dialog! variant-id)))))]
+    [:button
+     {:style        (cond
+                      (not enabled?) (:chip-disabled styles)
+                      rec?           (:chip-active styles)
+                      :else          (:chip-idle styles))
+      :disabled     (not enabled?)
+      :data-test    "story-toolbar-rec"
+      :data-recording (if rec? "true" "false")
+      :aria-pressed (if rec? "true" "false")
+      :title        (cond
+                      (not enabled?)
+                      "Select a variant to record canvas interactions"
+                      rec?
+                      (str "Recording " (count (:events rec))
+                           " events — click to stop and save as variant")
+                      :else
+                      "Record canvas dispatches as a :play body (Test Codegen)")
+      :on-click     on-click}
+     (when rec? [:span {:style (:dot styles)}])
+     "REC"
+     (when rec?
+       [:span {:style {:opacity "0.85"}}
+        (str "  " (count (:events rec)))])]))
+
+(defn recording-overlay
+  "Fixed-position banner that floats at the top-right of the shell
+  while a recording is in flight. Surfaces the target variant + the
+  running event count."
+  []
+  (let [{:keys [recording? variant-id events]} @ui-state]
+    (when recording?
+      [:div
+       {:style       (:overlay styles)
+        :role        "status"
+        :aria-live   "polite"
+        :data-test   "story-recorder-overlay"}
+       [:span {:style (:dot styles)}]
+       [:span "REC"]
+       [:span {:style {:color "#fff"}}
+        (pr-str variant-id)]
+       [:span {:style {:color "#9a9a9a"}}
+        (str (count events) " event" (when (not= 1 (count events)) "s"))]
+       [:button
+        {:style    (:btn-muted styles)
+         :data-test "story-recorder-stop"
+         :on-click (fn [_]
+                     (let [{:keys [variant-id events]} (recorder/stop-recording!)]
+                       (when (seq events)
+                         (open-dialog! variant-id))))}
+        "stop"]])))
+
+;; ---------------------------------------------------------------------------
+;; Save-as-variant dialog
+;; ---------------------------------------------------------------------------
+
+(defn- copy-to-clipboard! [snippet]
+  (try
+    (when (and (exists? js/navigator) (.-clipboard js/navigator))
+      (.writeText (.-clipboard js/navigator) snippet))
+    (catch :default _ nil)))
+
+(defn save-dialog
+  "Modal dialog rendered after the user stops a non-empty recording.
+  Shows the EDN snippet — `(reg-variant <id> {... :play [...]})` —
+  and a 'copy to clipboard' affordance.
+
+  The user edits the variant id inline; the snippet re-generates on
+  every keystroke. Discard / close drop the captured events."
+  []
+  (let [{:keys [open? draft-id]}      @ui-dialog
+        {:keys [variant-id events]}   @ui-state]
+    (when open?
+      (let [snippet (recorder/gen-play-snippet
+                      events
+                      {:variant-id (or draft-id :story.recorded/example)
+                       :extends    variant-id})]
+        [:div {:style (:modal-back styles)
+               :data-test "story-recorder-dialog"
+               :on-click  (fn [e]
+                            (when (= (.-target e) (.-currentTarget e))
+                              (close-dialog!)))}
+         [:div {:style (:modal styles)
+                :on-click (fn [e] (.stopPropagation e))}
+          [:div {:style (:modal-title styles)}
+           "Test Codegen — save recording as variant"]
+          [:div {:style (:hint styles)}
+           "EDN snippet generated from "
+           (count events) " captured event"
+           (when (not= 1 (count events)) "s")
+           " against " (pr-str variant-id) ". Edit the variant id then "
+           "copy + paste into your stories namespace."]
+          [:input
+           {:type       "text"
+            :style      (:id-input styles)
+            :data-test  "story-recorder-id-input"
+            :default-value (pr-str (or draft-id :story.recorded/example))
+            :on-change  (fn [e] (set-draft-id! (.. e -target -value)))
+            :placeholder ":story.your-story/recorded-flow"}]
+          [:pre {:style (:snippet styles)
+                 :data-test "story-recorder-snippet"}
+           snippet]
+          [:div {:style (:btn-row styles)}
+           [:button
+            {:style    (:btn-muted styles)
+             :data-test "story-recorder-discard"
+             :on-click (fn [_]
+                         (recorder/clear!)
+                         (close-dialog!))}
+            "discard"]
+           [:button
+            {:style     (:btn styles)
+             :data-test "story-recorder-copy"
+             :on-click  (fn [_] (copy-to-clipboard! snippet))}
+            "copy to clipboard"]
+           [:button
+            {:style    (:btn-muted styles)
+             :data-test "story-recorder-close"
+             :on-click (fn [_] (close-dialog!))}
+            "close"]]]]))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -49,6 +49,7 @@
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
+            [re-frame.story.ui.recorder :as recorder-ui]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -354,12 +355,19 @@
          (toolbar/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
+         ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
+         ;; listener once at shell mount. The listener short-circuits
+         ;; on every emit when no recording is in flight, so leaving
+         ;; it installed is free; we only need to make sure it
+         ;; exists before the user clicks REC.
+         (recorder-ui/install-trace-listener!)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
            (ensure-listeners-for-variant! vid))))
      :component-will-unmount
      (fn [_]
        (stop-hot-reload-poll!)
        (remove-selection-watcher!)
+       (recorder-ui/remove-trace-listener!)
        (teardown-all-listeners!))
      :reagent-render
      (fn []
@@ -377,7 +385,13 @@
         ;; right inspector pane regardless of which panels are visible.
         [:div {:style (:help-slot styles)}
          [help/help-button]]
-        [help/help-host]])}))
+        [help/help-host]
+        ;; rf2-5fc15: Test Codegen recording overlay (top-right banner
+        ;; while a recording is in flight) + save-as-variant dialog
+        ;; (opens after stop). Both are fixed-position so they float
+        ;; above the three-pane layout.
+        [recorder-ui/recording-overlay]
+        [recorder-ui/save-dialog]])}))
 
 ;; ---- mount / unmount surface ---------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -49,6 +49,7 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.recorder :as ui-recorder]
             [re-frame.story.ui.state :as state]))
 
 ;; ---- localStorage --------------------------------------------------------
@@ -320,6 +321,10 @@
                ^{:key mid}
                [chip mid (get modes mid) (contains? active mid)])]])))
      [:span {:style (:spacer styles)}]
+     ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
+     ;; affordance so the chrome-wide recorder is reachable regardless of
+     ;; which variant the user has focused.
+     [ui-recorder/rec-chip]
      (when (seq (:active-modes shell))
        [:button
         {:style     (:reset styles)

--- a/tools/story/test/re_frame/story_recorder_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_recorder_cljs_test.cljs
@@ -1,0 +1,111 @@
+(ns re-frame.story-recorder-cljs-test
+  "CLJS-side tests for the Test Codegen recorder (rf2-5fc15).
+
+  Runs under shadow's `:node-test` build (ns-regexp `cljs-test$`).
+  The pure-data corpus is identical to the JVM
+  `re-frame.story-recorder-test` arm — same predicates and same
+  snippet generator — so the cljs build proves the namespace compiles
+  under CLJS as well as the JVM.
+
+  Browser-only behaviour (Reagent mirror, modal dialog) lives in the
+  CLJS-only `re-frame.story.ui.recorder` ns and is exercised under
+  the `:browser-test` target via a separate Playwright spec when that
+  layer ships."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [cljs.reader :as edn]
+            [clojure.string :as str]
+            [re-frame.story.recorder :as recorder]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-recorder! [f]
+  (recorder/clear!)
+  (f))
+
+(use-fixtures :each reset-recorder!)
+
+;; ---- recordable-event? ---------------------------------------------------
+
+(deftest recordable-event?-accepts-user-events
+  (is (recorder/recordable-event? [:counter/inc]))
+  (is (recorder/recordable-event? [:auth/login {:email "a@b"}])))
+
+(deftest recordable-event?-skips-assertions
+  (is (not (recorder/recordable-event? [:rf.assert/path-equals [:a] 1])))
+  (is (not (recorder/recordable-event? [:rf.assert/no-warnings]))))
+
+(deftest recordable-event?-skips-internal-story-events
+  (is (not (recorder/recordable-event? [:rf.story/lifecycle-tick])))
+  (is (not (recorder/recordable-event?
+             [:re-frame.story.runtime/append-assertion {}]))))
+
+;; ---- pure state machine --------------------------------------------------
+
+(deftest start-replaces-state
+  (let [s (recorder/start recorder/initial-state :story.x/y 1000)]
+    (is (:recording? s))
+    (is (= :story.x/y (:variant-id s)))
+    (is (= [] (:events s)))))
+
+(deftest append-captures-recordable-events
+  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+        s1 (-> s0
+               (recorder/append [:counter/inc])
+               (recorder/append [:rf.assert/path-equals [:a] 1])
+               (recorder/append [:counter/dec]))]
+    (is (= [[:counter/inc] [:counter/dec]] (:events s1)))))
+
+(deftest stop-preserves-events
+  (let [s (-> recorder/initial-state
+              (recorder/start :story.x/y 0)
+              (recorder/append [:counter/inc])
+              (recorder/stop))]
+    (is (not (:recording? s)))
+    (is (= [[:counter/inc]] (:events s)))))
+
+;; ---- impure entrypoints --------------------------------------------------
+
+(deftest start-and-stop-cycle
+  (recorder/start-recording! :story.x/y 0)
+  (is (recorder/recording?))
+  (recorder/record-event! [:counter/inc])
+  (recorder/record-event! [:counter/dec])
+  (recorder/stop-recording!)
+  (is (not (recorder/recording?)))
+  (is (= [[:counter/inc] [:counter/dec]]
+         (recorder/recorded-events))))
+
+(deftest toggle!-flips
+  (recorder/toggle! :story.x/y)
+  (is (recorder/recording?))
+  (recorder/toggle! :story.x/y)
+  (is (not (recorder/recording?))))
+
+;; ---- gen-play-snippet ----------------------------------------------------
+
+(deftest gen-play-snippet-renders-reg-variant
+  (let [snippet (recorder/gen-play-snippet
+                  [[:counter/inc] [:counter/dec]]
+                  {:variant-id :story.x/y})]
+    (is (str/includes? snippet "reg-variant"))
+    (is (str/includes? snippet ":story.x/y"))
+    (is (str/includes? snippet "[:counter/inc]"))
+    (is (str/includes? snippet "[:counter/dec]"))))
+
+(deftest gen-play-snippet-roundtrips
+  (let [events [[:counter/inc] [:auth/login {:id 1}]]
+        snip   (recorder/gen-play-snippet events {:variant-id :story.x/y})
+        start  (str/index-of snip ":play")
+        after  (subs snip start)
+        open   (str/index-of after "[")
+        end    (loop [i (inc open) depth 1]
+                 (cond
+                   (>= i (count after)) nil
+                   (zero? depth) i
+                   :else (let [c (.charAt after i)]
+                           (case c
+                             "[" (recur (inc i) (inc depth))
+                             "]" (recur (inc i) (dec depth))
+                             (recur (inc i) depth)))))
+        play-str (subs after open end)]
+    (is (= events (edn/read-string play-str)))))

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -1,0 +1,360 @@
+(ns re-frame.story-recorder-test
+  "JVM tests for the Test Codegen recorder (rf2-5fc15).
+
+  Pure-data coverage: the recordable-event? predicate, the state
+  machine (start / append / stop / reset), the impure entrypoints
+  driving the per-process atom, and the gen-play-snippet codegen.
+  Mirrors the cljc node-test arm in `recorder_cljs_test.cljs`.
+
+  ## Coverage layers
+
+  - `recordable-event?` — filters assertion events + Story-internal
+    helpers without dropping legitimate user dispatches.
+  - State machine (`start` / `append` / `stop` / `reset`) — pure
+    transitions; one place to lock the contract before wiring the
+    impure side.
+  - Impure entrypoints (`start-recording!`, `stop-recording!`,
+    `record-event!`, `clear!`, `toggle!`) — exercise the per-process
+    atom alongside the predicate filter.
+  - `gen-play-snippet` — the codegen output is `read-string`-able
+    EDN; the assertion is shape-level (round-trips back to the same
+    `:play` vector) so future cosmetic changes to formatting don't
+    churn the test."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.async :as async]
+            [re-frame.story.recorder :as recorder]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-recorder! [f]
+  (recorder/clear!)
+  (f))
+
+(use-fixtures :each reset-recorder!)
+
+;; ---- recordable-event? ---------------------------------------------------
+
+(deftest recordable-event?-accepts-user-events
+  (testing "ordinary user dispatches are recordable"
+    (is (recorder/recordable-event? [:counter/inc]))
+    (is (recorder/recordable-event? [:auth/login {:email "a@b"}]))
+    (is (recorder/recordable-event? [:cart/add-item :widget-x 3]))))
+
+(deftest recordable-event?-skips-assertions
+  (testing ":rf.assert/* events are filtered (assertions are authored, not recorded)"
+    (is (not (recorder/recordable-event? [:rf.assert/path-equals [:auth :status] :ok])))
+    (is (not (recorder/recordable-event? [:rf.assert/sub-equals [:count] 3])))
+    (is (not (recorder/recordable-event? [:rf.assert/no-warnings])))
+    (is (not (recorder/recordable-event? [:rf.assert/dispatched? [:counter/inc]])))))
+
+(deftest recordable-event?-skips-internal-story-events
+  (testing ":rf.story/* + re-frame.story.* internal helpers are filtered"
+    (is (not (recorder/recordable-event? [:rf.story/lifecycle-tick])))
+    (is (not (recorder/recordable-event?
+               [:re-frame.story.runtime/append-assertion {:a 1}])))
+    (is (not (recorder/recordable-event?
+               [:re-frame.story.assertions/append {:r 1}])))))
+
+(deftest recordable-event?-handles-malformed-input
+  (testing "non-event shapes are rejected"
+    (is (not (recorder/recordable-event? nil)))
+    (is (not (recorder/recordable-event? [])))
+    (is (not (recorder/recordable-event? "not-a-vector")))
+    (is (not (recorder/recordable-event? [{} "no-keyword-id"])))))
+
+;; ---- pure state machine --------------------------------------------------
+
+(deftest start-replaces-state
+  (testing "start! resets events + flips :recording? true"
+    (let [s0 recorder/initial-state
+          s1 (recorder/start s0 :story.counter/happy-path 1000)]
+      (is (true? (:recording? s1)))
+      (is (= :story.counter/happy-path (:variant-id s1)))
+      (is (= [] (:events s1)))
+      (is (= 1000 (:started-ms s1))))))
+
+(deftest start-clobbers-previous-recording
+  (testing "starting a fresh recording drops any captured events"
+    (let [s0 (-> recorder/initial-state
+                 (recorder/start :story.a/x 1000)
+                 (recorder/append [:a 1])
+                 (recorder/append [:b 2]))
+          s1 (recorder/start s0 :story.b/y 2000)]
+      (is (= [] (:events s1)))
+      (is (= :story.b/y (:variant-id s1))))))
+
+(deftest append-while-recording
+  (testing "append captures recordable events while recording"
+    (let [s0 (recorder/start recorder/initial-state :story.counter/x 0)
+          s1 (recorder/append s0 [:counter/inc])
+          s2 (recorder/append s1 [:counter/inc])
+          s3 (recorder/append s2 [:counter/dec])]
+      (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
+             (:events s3))))))
+
+(deftest append-skips-assertions-and-internals
+  (testing "append filters non-recordable events"
+    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+          s1 (-> s0
+                 (recorder/append [:rf.assert/path-equals [:a] 1])
+                 (recorder/append [:counter/inc])
+                 (recorder/append [:re-frame.story.runtime/append-assertion {}])
+                 (recorder/append [:counter/dec]))]
+      (is (= [[:counter/inc] [:counter/dec]]
+             (:events s1))))))
+
+(deftest append-noop-when-not-recording
+  (testing "append drops events when :recording? is false"
+    (let [s0 recorder/initial-state
+          s1 (recorder/append s0 [:counter/inc])]
+      (is (= [] (:events s1))))))
+
+(deftest stop-preserves-events
+  (testing "stop flips :recording? false but keeps the captured trace"
+    (let [s0 (-> recorder/initial-state
+                 (recorder/start :story.x/y 0)
+                 (recorder/append [:counter/inc]))
+          s1 (recorder/stop s0)]
+      (is (false? (:recording? s1)))
+      (is (= [[:counter/inc]] (:events s1)))
+      (is (= :story.x/y (:variant-id s1))))))
+
+(deftest reset-returns-idle
+  (testing "reset drops everything"
+    (let [s0 (-> recorder/initial-state
+                 (recorder/start :story.x/y 0)
+                 (recorder/append [:counter/inc]))
+          s1 (recorder/reset s0)]
+      (is (= recorder/initial-state s1)))))
+
+;; ---- impure entrypoints --------------------------------------------------
+
+(deftest start-recording!-mutates-state
+  (recorder/start-recording! :story.counter/x 5000)
+  (is (recorder/recording?))
+  (is (= :story.counter/x (recorder/recording-variant)))
+  (is (= [] (recorder/recorded-events))))
+
+(deftest record-event!-captures-recordable
+  (recorder/start-recording! :story.counter/x 0)
+  (recorder/record-event! [:counter/inc])
+  (recorder/record-event! [:rf.assert/path-equals [:a] 1])
+  (recorder/record-event! [:counter/dec])
+  (is (= [[:counter/inc] [:counter/dec]]
+         (recorder/recorded-events))))
+
+(deftest stop-recording!-flips-state
+  (recorder/start-recording! :story.x/y 0)
+  (recorder/record-event! [:counter/inc])
+  (recorder/stop-recording!)
+  (is (false? (recorder/recording?)))
+  (is (= [[:counter/inc]] (recorder/recorded-events))))
+
+(deftest toggle!-flips
+  (testing "toggle! starts when idle and stops when recording"
+    (recorder/toggle! :story.x/y)
+    (is (recorder/recording?))
+    (recorder/record-event! [:foo/bar])
+    (recorder/toggle! :story.x/y)
+    (is (not (recorder/recording?)))
+    (is (= [[:foo/bar]] (recorder/recorded-events)))))
+
+(deftest clear!-resets-everything
+  (recorder/start-recording! :story.x/y 0)
+  (recorder/record-event! [:counter/inc])
+  (recorder/clear!)
+  (is (= recorder/initial-state (recorder/current-state))))
+
+;; ---- gen-play-snippet ----------------------------------------------------
+
+(deftest gen-play-snippet-empty
+  (testing "gen-play-snippet with no events renders an empty :play vector"
+    (let [snip (recorder/gen-play-snippet [] {:variant-id :story.x/y})]
+      (is (string? snip))
+      (is (str/includes? snip ":story.x/y"))
+      (is (str/includes? snip ":play"))
+      (is (str/includes? snip "[]")))))
+
+(deftest gen-play-snippet-renders-reg-variant
+  (testing "snippet renders the (reg-variant ...) form with the captured trace"
+    (let [snip (recorder/gen-play-snippet
+                 [[:counter/inc] [:counter/dec]]
+                 {:variant-id :story.counter/recorded})]
+      (is (str/includes? snip "reg-variant"))
+      (is (str/includes? snip ":story.counter/recorded"))
+      (is (str/includes? snip "[:counter/inc]"))
+      (is (str/includes? snip "[:counter/dec]")))))
+
+(deftest gen-play-snippet-includes-doc
+  (let [snip (recorder/gen-play-snippet
+               [[:counter/inc]]
+               {:variant-id :story.counter/x :doc "user inc once"})]
+    (is (str/includes? snip ":doc"))
+    (is (str/includes? snip "user inc once"))))
+
+(deftest gen-play-snippet-includes-extends
+  (let [snip (recorder/gen-play-snippet
+               [[:counter/inc]]
+               {:variant-id :story.counter/recorded
+                :extends    :story.counter/happy-path})]
+    (is (str/includes? snip ":extends"))
+    (is (str/includes? snip ":story.counter/happy-path"))))
+
+(deftest gen-play-snippet-uses-custom-alias
+  (let [snip (recorder/gen-play-snippet
+               []
+               {:variant-id :story.x/y :alias "rf"})]
+    (is (str/includes? snip "rf/reg-variant"))))
+
+(defn- extract-play-vector
+  "Pull the `:play` vector substring out of the rendered snippet by
+  walking balanced brackets after the `:play` token."
+  [snippet]
+  (let [start  (str/index-of snippet ":play")
+        after  (subs snippet start)
+        open   (str/index-of after "[")]
+    (loop [i (inc open) depth 1]
+      (cond
+        (or (nil? i) (>= i (count after)))
+        nil
+
+        (zero? depth)
+        (subs after open i)
+
+        :else
+        (let [c (.charAt ^String after i)]
+          (case c
+            \[ (recur (inc i) (inc depth))
+            \] (recur (inc i) (dec depth))
+            (recur (inc i) depth)))))))
+
+(deftest gen-play-snippet-roundtrips-events
+  (testing "the rendered :play vector reads back as the original events"
+    (let [events   [[:counter/inc]
+                    [:auth/login {:email "alice@example.com" :remember? true}]
+                    [:cart/add-item :widget-x 3]]
+          snippet  (recorder/gen-play-snippet
+                     events
+                     {:variant-id :story.x/y})
+          play-str (extract-play-vector snippet)]
+      (is (some? play-str) "extractor found a :play vector substring")
+      (is (= events (edn/read-string play-str))))))
+
+;; ---- end-to-end: trace-bus integration -----------------------------------
+
+(defn- reset-rf-state! []
+  (recorder/remove-trace-listener!)
+  (recorder/clear!)
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(deftest trace-listener-captures-dispatch-into-recording
+  (testing "with a recording in flight, a dispatch against the target frame is captured"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event-db :counter/dec
+      (fn [db _] (update db :n (fnil dec 0))))
+    (story/reg-variant :story.recorder/v {:events []})
+    ;; Allocate the variant frame + install the listener.
+    (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.recorder/v)
+    ;; Drive a few dispatches against the target frame.
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
+    (rf/dispatch-sync [:counter/dec] {:frame :story.recorder/v})
+    (recorder/stop-recording!)
+    (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
+           (recorder/recorded-events)))
+    (story/destroy-variant! :story.recorder/v)
+    (recorder/remove-trace-listener!)))
+
+(deftest trace-listener-ignores-cross-frame-traffic
+  (testing "dispatches to a non-target frame don't appear in the recording"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.recorder/target {:events []})
+    (story/reg-variant :story.recorder/other  {:events []})
+    (async/deref-blocking (story/run-variant :story.recorder/target) 5000)
+    (async/deref-blocking (story/run-variant :story.recorder/other)  5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.recorder/target)
+    ;; This one lands on the recording target.
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/target})
+    ;; This one lands on a different frame and MUST be ignored.
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/other})
+    ;; This one lands on the target again.
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/target})
+    (recorder/stop-recording!)
+    (is (= [[:counter/inc] [:counter/inc]]
+           (recorder/recorded-events))
+        "only the target-frame dispatches are captured")
+    (story/destroy-variant! :story.recorder/target)
+    (story/destroy-variant! :story.recorder/other)
+    (recorder/remove-trace-listener!)))
+
+(deftest trace-listener-skips-assertion-events
+  (testing "with a recording active, :rf.assert/* dispatches don't leak into the captured :play body"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.recorder/v {:events []})
+    (async/deref-blocking (story/run-variant :story.recorder/v) 5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.recorder/v)
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
+    ;; Assertions ARE dispatchable but the recorder skips them.
+    (rf/dispatch-sync [:rf.assert/path-equals [:n] 1]
+                      {:frame :story.recorder/v})
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/v})
+    (recorder/stop-recording!)
+    (is (= [[:counter/inc] [:counter/inc]]
+           (recorder/recorded-events))
+        "only the user dispatches are captured — assertions filtered")
+    (story/destroy-variant! :story.recorder/v)
+    (recorder/remove-trace-listener!)))
+
+(deftest end-to-end-recording-to-snippet
+  (testing "the full record→stop→gen-play-snippet cycle produces a valid :play body"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-event-db :counter/by
+      (fn [db [_ n]] (update db :n (fnil + 0) n)))
+    (story/reg-variant :story.recorder/source {:events []})
+    (async/deref-blocking (story/run-variant :story.recorder/source) 5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.recorder/source)
+    (rf/dispatch-sync [:counter/inc]        {:frame :story.recorder/source})
+    (rf/dispatch-sync [:counter/inc]        {:frame :story.recorder/source})
+    (rf/dispatch-sync [:counter/by 7]       {:frame :story.recorder/source})
+    (let [{:keys [events variant-id]} (recorder/stop-recording!)
+          snippet (recorder/gen-play-snippet
+                    events
+                    {:variant-id :story.recorder/captured
+                     :extends    variant-id
+                     :doc        "recorded via Test Codegen"})
+          play-str (extract-play-vector snippet)]
+      (is (= 3 (count events)))
+      (is (str/includes? snippet "reg-variant"))
+      (is (str/includes? snippet ":story.recorder/captured"))
+      (is (str/includes? snippet ":story.recorder/source")
+          "the recorder-target id rides into the :extends slot")
+      (is (= events (edn/read-string play-str))
+          "the rendered :play vector round-trips back through read-string"))
+    (story/destroy-variant! :story.recorder/source)
+    (recorder/remove-trace-listener!)))


### PR DESCRIPTION
## Summary

Storybook 9's killer feature is the record-and-save workflow: the user interacts with the canvas, the tool watches the event bus, and on 'stop' the user gets a code snippet to paste into the variant. Story's `:play` body is **already** a vector of EDN event vectors, so the captured trace IS the codegen output — no Testing Library / page-object translation layer needed.

This PR lands `re-frame.story.recorder` + a chrome-wide REC toolbar chip + a save-as-variant modal dialog. Click REC, drive the canvas, click STOP, paste the rendered `(reg-variant ... :play [...])` form into your stories namespace.

- **Recorder core (`recorder.cljc`)** — pure-data state machine + `recordable-event?` filter (drops `:rf.assert/*` + Story-internal helpers) + `gen-play-snippet` codegen that round-trips through `read-string`. Trace-bus listener lives here so the full record-from-trace path is JVM-testable end-to-end.
- **UI surface (`ui/recorder.cljs`)** — toolbar REC chip + recording overlay + save-as-variant modal dialog (editable id field, copy-to-clipboard, discard).
- **Shell + toolbar wiring** — listener install/teardown at mount/unmount; REC chip at the right edge of the toolbar strip.
- **Public API on `re-frame.story`** — `start-recording!` / `stop-recording!` / `recording?` / `recorder-state` / `clear-recording!` / `gen-play-snippet`. The MCP `record-as-variant` tool (adjacent bead) will consume this same surface across the Tool-Pair bridge.
- **Spec** — `spec/005-SOTA-Features.md` gains a Test Codegen subsection documenting the capture boundary, the public API, the rationale vs Storybook's Testing-Library codegen, and the MCP cross-bead handoff. Test Codegen added to the v1 ship-list.

## Test plan

- [x] 26 JVM tests, 60 assertions covering the predicate, the pure state machine, the impure entrypoints, the codegen output, and **end-to-end recording via a real `dispatch-sync` against a variant frame with the listener installed**.
- [x] 10 CLJS tests under shadow's `:node-test` target — same pure surface; proves the namespace compiles + runs under CLJS.
- [x] Full Story JVM suite: 259/259 pass (up from 233).
- [x] Full re-frame2 CLJS node-test suite: 1136/1136 pass.
- [x] `counter-with-stories` example CLJS build compiles clean.
- [ ] Manual canvas-recording smoke (Mike to drive in the next dev session — push a `counter` variant, click REC, fire a few `[:counter/inc]` dispatches, click STOP, verify the snippet matches).

## Surface map

| Surface | File | Role |
|---|---|---|
| State + codegen + trace listener | `tools/story/src/re_frame/story/recorder.cljc` | Pure-data core + JVM-testable listener wiring |
| Toolbar REC chip + overlay + dialog | `tools/story/src/re_frame/story/ui/recorder.cljs` | Reagent UI surface |
| Shell mount/unmount + render | `tools/story/src/re_frame/story/ui/shell.cljs` | Listener lifecycle + overlay/dialog placement |
| Toolbar strip chip slot | `tools/story/src/re_frame/story/ui/toolbar.cljs` | REC chip lands left of `[reset]` |
| Public API re-exports | `tools/story/src/re_frame/story.cljc` | `start-recording!` / `stop-recording!` / `gen-play-snippet` / ... |
| Contract spec | `tools/story/spec/005-SOTA-Features.md` | New Test Codegen subsection |
| JVM tests | `tools/story/test/re_frame/story_recorder_test.clj` | 26 tests / 60 assertions |
| CLJS tests | `tools/story/test/re_frame/story_recorder_cljs_test.cljs` | 10 tests (node-test) |

Bead: rf2-5fc15.