### PR TITLE
docs(skills): declare allowed-tools on remaining 4 SKILL.mds (rf2-5t1n2)

### DIFF
--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -14,6 +14,14 @@ description: >
   application code (use `re-frame2`), live v2-app inspection
   (use `re-frame-pair2`), or porting re-frame2 itself
   (use `re-frame2-implementor`).
+allowed-tools:
+  - Bash(rg *)
+  - Bash(rg -l *)
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
 ---
 
 # re-frame-migration

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -13,6 +13,13 @@ description: >
   Do not use for: writing apps on the CLJS reference (use `re-frame2`),
   greenfield bootstrap (use `re-frame2-setup`), v1→v2 migration
   (use `re-frame-migration`), or live-app inspection (use `re-frame-pair2`).
+allowed-tools:
+  - Bash(bd *)
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
 ---
 
 # re-frame2-implementor

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -19,6 +19,16 @@ description: >
   (use `re-frame-migration`); spec, architecture, or porting questions
   about re-frame2 itself (use `re-frame2-implementor`). Exits once the
   counter mounts.
+allowed-tools:
+  - Bash(clojure *)
+  - Bash(npm *)
+  - Bash(npx *)
+  - Bash(shadow-cljs *)
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
 ---
 
 # re-frame2-setup

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: re-frame2
 description: Writes re-frame2 ClojureScript application code — events, subscriptions, effects, frames, state machines (reg-machine, parallel regions, tags, invoke), schemas, stories, routing, tests, and the canonical patterns (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx, reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema, dispatch, subscribe, app-db, frames, regions, tags, the nine UI states, managed HTTP, RemoteData lifecycles, writing tests for a re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2 is not named explicitly. Authoring only (writing new code). Do not use for: live-app inspection (use re-frame-pair2), greenfield project bootstrap (use re-frame2-setup), v1→v2 migration (use re-frame-migration), or porting re-frame2 itself (use re-frame2-implementor).
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
 ---
 
 # re-frame2


### PR DESCRIPTION
## Summary

Adds `allowed-tools:` frontmatter to the four remaining SKILL.mds that
implicitly accepted Claude Code's full tool surface. After PR #600
(rf2-rrn8s) closed the gap on `re-frame-pair-improver2`, these four were
the last skills still leaving the contract surface unstated.

Each list reflects the skill's actual workflow (verified by reading the
SKILL body and its `reference/` leaves):

- **`re-frame2`** (authoring): `Read`, `Edit`, `Write`, `Grep`, `Glob` —
  no shelling out; the user runs tests / compiler / app.
- **`re-frame-migration`** (v1->v2 mechanical agent): adds `Bash(rg *)` /
  `Bash(rg -l *)` for grepping the user's codebase to discover ids
  (`reference/auto-call-site-rewrites.md` step 1 calls `grep` over `src/`).
- **`re-frame2-implementor`** (host porting): adds `Bash(bd *)` for
  filing spec-gap beads per Cardinal Rule 8 and the conformance leaves.
- **`re-frame2-setup`** (greenfield bootstrap): adds `Bash(clojure *)`,
  `Bash(npm *)`, `Bash(npx *)`, `Bash(shadow-cljs *)` for the seven-step
  canonical path (deps lookup via `clj -Stree`, `npm install`,
  `npx shadow-cljs watch app`).

Shape matches the YAML list used by `re-frame-pair2` and
`re-frame-pair-improver2`. No SKILL bodies, reference files, or
workflow semantics change.

## Test plan

- [x] Each skill's `allowed-tools:` list verified against its body /
      `reference/` leaves.
- [x] Frontmatter parses (2-space indent, `- Tool` list shape).
- [ ] Re-runs of each skill against typical prompts continue to
      function (will surface naturally once exercised).