### PR TITLE
feat(causa): Issues ribbon panel — Phase 5 (rf2-d1p4o)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -1,0 +1,403 @@
+(ns day8.re-frame2-causa.panels.issues-ribbon
+  "Issues ribbon panel — Phase 5 (rf2-d1p4o, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/000-Vision.md` L94 + spec/007-UX-IA.md
+  §Sidebar groups the Issues ribbon is the unified feed of errors,
+  warnings, schema violations, and hydration mismatches. It ties to
+  the spec/009-Instrumentation.md §Error event catalogue which
+  enumerates the ~95 categories the runtime emits — the panel
+  consumes that stream end-to-end.
+
+  ## What this panel shows
+
+  Each issue trace event from the buffer lands as one row. Per the
+  bead's minimum-viable contract rows render:
+
+      timestamp · category · severity · short description · jump-to-source
+
+  Click a row → the parent dispatch is selected (`:rf.causa/select-
+  dispatch-id`) and the user pivots to the event-detail panel for the
+  cascade that produced the issue. Click the source-coord chip →
+  the editor opens at that line (via the `:rf.causa/open-in-editor`
+  event stub — the actual editor jump rides on the open-in-editor
+  module).
+
+  ## Filter axes (per the bead's contract)
+
+      severity         — error / warning / advisory  (chip row)
+      category-prefix  — :rf.error/* vs :rf.warning/* etc.  (chip row)
+      since-ms         — within this many ms of now  (numeric input)
+
+  Each axis is independent; empty filter sets disable the axis.
+
+  ## Empty states
+
+  Per the bead's contract:
+
+    :no-issues  → 'No issues observed in this session.' with the
+                  '✓ All clear' badge — the desired state.
+    :no-matches → issues exist but the active filters hide them
+                  all. Carries a 'Clear filters' affordance.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure
+  hiccup, no Reagent / UIx / Helix references. Frame isolation
+  comes from the enclosing `[rf/frame-provider {:frame :rf/causa}]`
+  in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — severity classification, category-prefix
+  projection, filter application, empty-state classification —
+  lives in `issues_ribbon_helpers.cljc` so the algebra runs under
+  the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- chip helpers -------------------------------------------------------
+
+(defn- chip
+  "One toggleable filter chip. `active?` drives the highlighted
+  styling. `on-click` fires the relevant toggle event-db."
+  [{:keys [label active? on-click test-id colour]}]
+  [:button {:data-testid test-id
+            :on-click    on-click
+            :style       {:background    (if active?
+                                           (:bg-active tokens)
+                                           "transparent")
+                          :color         (if active?
+                                           (:text-primary tokens)
+                                           (or colour (:text-secondary tokens)))
+                          :border        (str "1px solid "
+                                              (if active?
+                                                (or colour (:border-default tokens))
+                                                (:border-subtle tokens)))
+                          :border-radius "999px"
+                          :padding       "2px 10px"
+                          :cursor        "pointer"
+                          :font-family   sans-stack
+                          :font-size     "11px"
+                          :font-weight   (if active? 600 400)
+                          :letter-spacing "0.2px"
+                          :margin-right  "6px"
+                          :margin-bottom "4px"}}
+   label])
+
+(defn- severity-chips
+  "Filter chip row for the three severity buckets. Each chip toggles
+  membership in the active severity set."
+  [active-severities counts]
+  (into [:div {:data-testid "rf-causa-issues-severity-chips"
+               :style       {:display "flex" :flex-wrap "wrap"}}]
+        (for [severity h/severity-order
+              :let [active? (contains? active-severities severity)
+                    n       (get counts severity 0)
+                    colour  (h/severity-colour severity)]]
+          (chip {:label    (str (h/severity-label severity)
+                                " · "
+                                n)
+                 :active?  active?
+                 :colour   colour
+                 :test-id  (str "rf-causa-issues-severity-chip-"
+                                (name severity))
+                 :on-click #(rf/dispatch [:rf.causa/toggle-issues-severity
+                                          severity])}))))
+
+(defn- prefix-chips
+  "Filter chip row for the distinct category prefixes present in the
+  feed. Per spec/009 the prefix carries the domain provenance — a
+  programmer filtering for `:rf.ssr/*` is asking 'just SSR issues'."
+  [active-prefixes prefixes]
+  (when (seq prefixes)
+    (into [:div {:data-testid "rf-causa-issues-prefix-chips"
+                 :style       {:display "flex" :flex-wrap "wrap"
+                               :margin-top "4px"}}]
+          (for [prefix prefixes
+                :let [active? (contains? active-prefixes prefix)]]
+            (chip {:label    prefix
+                   :active?  active?
+                   :colour   (:accent-violet tokens)
+                   :test-id  (str "rf-causa-issues-prefix-chip-" prefix)
+                   :on-click #(rf/dispatch [:rf.causa/toggle-issues-prefix
+                                            prefix])})))))
+
+(defn- since-input
+  "The `since-ms` filter — a numeric input rendered as a chip-row
+  sibling. Values are in seconds for ergonomic typing; the helper
+  converts to ms before dispatching."
+  [since-ms]
+  [:div {:data-testid "rf-causa-issues-since-input"
+         :style {:display "flex"
+                 :align-items "center"
+                 :gap "6px"
+                 :margin-top "4px"
+                 :font-family sans-stack
+                 :font-size "11px"
+                 :color (:text-secondary tokens)}}
+   [:span "since"]
+   [:input {:type      "number"
+            :min       "0"
+            :step      "10"
+            :value     (str (when (number? since-ms) (long (/ since-ms 1000))))
+            :on-change (fn [e]
+                         (let [v (.. e -target -value)
+                               n (try
+                                   (let [parsed (js/parseInt v 10)]
+                                     (when-not (js/isNaN parsed) parsed))
+                                   (catch :default _ nil))]
+                           (rf/dispatch [:rf.causa/set-issues-since-seconds n])))
+            :style     {:width "60px"
+                        :background (:bg-3 tokens)
+                        :color (:text-primary tokens)
+                        :border (str "1px solid " (:border-subtle tokens))
+                        :border-radius "3px"
+                        :padding "2px 4px"
+                        :font-family mono-stack
+                        :font-size "11px"}}]
+   [:span "s ago"]])
+
+;; ---- header strip -------------------------------------------------------
+
+(defn- header
+  "Panel header — title + counts + filter chips."
+  [{:keys [total rendered severity-counts active-severities
+           active-prefixes distinct-prefixes since-ms any-filter?]}]
+  [:header {:style {:padding "12px 16px 6px 16px"
+                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "12px"}}
+    [:h1 {:style {:font-size "16px"
+                  :font-weight 600
+                  :margin 0
+                  :color  (:text-primary tokens)}}
+     "Issues"]
+    [:span {:data-testid "rf-causa-issues-counts"
+            :style {:font-size   "11px"
+                    :color       (:text-tertiary tokens)
+                    :font-family mono-stack}}
+     (str rendered " / " total " in view")]
+    (when any-filter?
+      [:button {:data-testid "rf-causa-issues-clear-filters"
+                :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters])
+                :style       {:margin-left "auto"
+                              :background  "transparent"
+                              :color       (:cyan tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "2px 8px"
+                              :border-radius "3px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "11px"}}
+       "Clear filters"])]
+   [:div {:style {:margin-top "8px"}}
+    (severity-chips active-severities severity-counts)
+    (prefix-chips active-prefixes distinct-prefixes)
+    (since-input since-ms)]])
+
+;; ---- per-row -------------------------------------------------------------
+
+(defn- issue-row
+  "One row in the issues feed. Click the row → pivot to the cascade
+  in the event-detail panel. Click the source-coord chip → open in
+  editor."
+  [{:keys [id time severity operation category-prefix description
+           source-coord dispatch-id]
+    :as _issue}]
+  (let [row-test-id (str "rf-causa-issues-row-" id)
+        colour      (h/severity-colour severity)]
+    [:li {:key         id
+          :data-testid row-test-id
+          :on-click    (fn []
+                         (when dispatch-id
+                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+                           (rf/dispatch [:rf.causa/select-panel :event-detail])))
+          :style       {:display       "grid"
+                        :grid-template-columns "84px 18px minmax(120px, 1fr) 2fr auto"
+                        :gap           "10px"
+                        :align-items   "center"
+                        :padding       "6px 16px"
+                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :cursor        (if dispatch-id "pointer" "default")
+                        :color         (:text-primary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     ;; Timestamp
+     [:span {:data-testid (str row-test-id "-time")
+             :style {:color (:text-tertiary tokens)
+                     :font-size "11px"
+                     :white-space "nowrap"}}
+      (or (h/format-time time) "—")]
+     ;; Severity glyph
+     [:span {:data-testid (str row-test-id "-severity")
+             :title       (h/severity-label severity)
+             :style       {:color colour
+                           :font-weight 700
+                           :text-align "center"}}
+      (h/severity-glyph severity)]
+     ;; Category prefix
+     [:span {:data-testid (str row-test-id "-category")
+             :style       {:color       (:accent-violet tokens)
+                           :overflow    "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}
+             :title       (str operation)}
+      (or category-prefix "—")]
+     ;; Description
+     [:span {:data-testid (str row-test-id "-description")
+             :style       {:color (:text-secondary tokens)
+                           :overflow "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}
+             :title       description}
+      description]
+     ;; Source-coord (when present)
+     (if source-coord
+       [:button {:data-testid (str row-test-id "-source")
+                 :on-click    (fn [e]
+                                ;; Stop propagation so the row's pivot
+                                ;; handler doesn't also fire — the
+                                ;; source-coord click is a distinct
+                                ;; affordance per the bead's contract.
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/open-in-editor
+                                              {:source-coord source-coord}]))
+                 :style       {:background  "transparent"
+                               :color       (:cyan tokens)
+                               :border      (str "1px solid " (:border-subtle tokens))
+                               :padding     "1px 6px"
+                               :border-radius "3px"
+                               :cursor      "pointer"
+                               :font-family mono-stack
+                               :font-size   "10px"}}
+        source-coord]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"}}
+        "—"])]))
+
+;; ---- empty states -------------------------------------------------------
+
+(defn- empty-state-no-issues
+  "Per the bead's contract — the desired state. 'No issues observed
+  in this session.' with the '✓ All clear' badge."
+  []
+  [:div {:data-testid "rf-causa-issues-empty-no-issues"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :gap "10px"
+                  :margin-bottom "8px"}}
+    [:span {:style {:color       (:green tokens)
+                    :font-size   "16px"
+                    :font-weight 700}}
+     "✓"]
+    [:span {:style {:color       (:green tokens)
+                    :font-weight 600}}
+     "All clear"]]
+   [:p {:style {:margin 0
+                :color  (:text-tertiary tokens)}}
+    "No issues observed in this session."]])
+
+(defn- empty-state-no-matches
+  "Issues exist but the active filters hide them all. Carries a
+  Clear filters affordance."
+  []
+  [:div {:data-testid "rf-causa-issues-empty-no-matches"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin "0 0 12px 0"
+                :color (:text-primary tokens)
+                :font-weight 600}}
+    "No issues match the active filters."]
+   [:p {:style {:margin "0 0 12px 0"
+                :color (:text-tertiary tokens)}}
+    "Adjust the severity / prefix / since-ms chips above to widen the feed."]
+   [:button {:data-testid "rf-causa-issues-empty-clear-filters"
+             :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters])
+             :style       {:background "transparent"
+                           :color      (:cyan tokens)
+                           :border     (str "1px solid " (:border-default tokens))
+                           :padding    "4px 10px"
+                           :border-radius "3px"
+                           :cursor     "pointer"
+                           :font-family sans-stack
+                           :font-size  "12px"}}
+    "Clear filters"]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn issues-ribbon-view
+  "The Issues ribbon panel's root view. Subscribes to
+  `:rf.causa/issues-ribbon` and renders the empty-state or the feed."
+  []
+  (let [{:keys [issues total rendered severity-counts distinct-prefixes
+                filters empty-kind]
+         :as _data}
+        @(rf/subscribe [:rf.causa/issues-ribbon])
+        {:keys [severities prefixes since-ms]} filters
+        any-filter? (boolean (or (seq severities)
+                                 (seq prefixes)
+                                 (some? since-ms)))]
+    [:section {:data-testid "rf-causa-issues-ribbon"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     (header {:total              total
+              :rendered           rendered
+              :severity-counts    severity-counts
+              :active-severities  (or severities #{})
+              :active-prefixes    (or prefixes #{})
+              :distinct-prefixes  distinct-prefixes
+              :since-ms           since-ms
+              :any-filter?        any-filter?})
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (case empty-kind
+        :no-issues  (empty-state-no-issues)
+        :no-matches (empty-state-no-matches)
+        nil         (into [:ul {:data-testid "rf-causa-issues-feed"
+                                :style       {:list-style "none"
+                                              :margin     0
+                                              :padding    0}}]
+                          (for [issue issues]
+                            (issue-row issue))))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -1,0 +1,402 @@
+(ns day8.re-frame2-causa.panels.issues-ribbon-helpers
+  "Pure-data helpers for Causa's Issues ribbon panel (Phase 5, rf2-d1p4o).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `issues_ribbon.cljs` paints the per-row issue feed
+  and dispatches into the Causa frame. The *logic* — filter the trace
+  buffer to the issue subset (errors + warnings + hydration mismatches
+  + schema violations), project each trace event into a flat row
+  shape, derive severity / category-prefix groupings, and apply the
+  three filter axes (severity / category-prefix / since-ms) — is pure
+  data → data. Splitting the algebra into `.cljc` so it runs under
+  the JVM unit-test target (`clojure -M:test`) is required by the
+  standing rule `feedback_jvm_interop_must_work.md`.
+
+  ## Substrate (per `spec/009-Instrumentation.md` §Error event catalogue)
+
+  The Issues ribbon is the unified feed across the catalogue Spec 009
+  enumerates. Per the catalogue (the single normative source) every
+  issue trace event carries:
+
+      {:id        <int>           ;; stable per-process
+       :time      <ms>
+       :op-type   <:error :warning :info :fx :frame :event ...>
+       :operation <keyword namespaced under one of the five prefixes>
+       :recovery  <keyword or :no-recovery>
+       :tags      {...category-specific...}}
+
+  The five normative error-event prefixes from Spec 009 §Error
+  namespace convention are:
+
+      :rf.error/<category>   — runtime errors (default-recovery rules)
+      :rf.fx/<category>      — fx-substrate diagnostics
+      :rf.ssr/<category>     — SSR-substrate diagnostics (hydration etc.)
+      :rf.warning/<category> — recoverable misuse advisories
+      :rf.epoch/<category>   — epoch / time-travel diagnostics
+
+  Plus the :rf.cofx/, :rf.frame/, :rf.http/, :rf.http.interceptor/
+  and :route.nav-token/ subgroups that appear in the catalogue.
+
+  ## Severity
+
+  Spec 009's `:op-type` field is the universal severity discriminator.
+  The ribbon ladders it onto three buckets:
+
+      :error    — `:op-type :error`
+      :warning  — `:op-type :warning`
+      :advisory — `:op-type :info`
+
+  Lifecycle / success-path traces (`:op-type` `:event`, `:fx`,
+  `:frame`, `:sub/*`, `:view/*`, etc.) are NOT issues and never reach
+  the ribbon.
+
+  ## Category prefix
+
+  The ribbon groups by the keyword namespace of `:operation`. Per
+  Spec 009 a consumer routing on the prefix gets the domain
+  provenance (`:rf.error/*` vs `:rf.warning/*` vs `:rf.ssr/*` ...).
+  The helper exposes `category-prefix` as the canonical projection.
+
+  ## Filter axes (per the bead's minimum-viable contract)
+
+      severity         — #{:error :warning :advisory}
+      category-prefix  — #{\"rf.error\" \"rf.warning\" \"rf.ssr\" ...}
+      since-ms         — relative time window; events older than
+                         `(- now-ms since-ms)` drop from the feed
+
+  Each axis is independent; empty filters disable the axis."
+  (:require [clojure.string :as str]))
+
+;; ---- defaults ------------------------------------------------------------
+
+(def default-since-ms
+  "Default 'since' window in ms. The ribbon shows issues from this
+  many ms ago to now. 10 minutes — long enough that a programmer
+  stepping back from the screen can return and still see the burst."
+  600000)
+
+(def severity-order
+  "Render order for severity in the empty filter chip-row. Errors
+  first because they're the most urgent; advisories last."
+  [:error :warning :advisory])
+
+;; ---- severity classification --------------------------------------------
+
+(defn op-type->severity
+  "Map a trace event's `:op-type` onto the ribbon's three severity
+  buckets. Returns nil for `:op-type` values that are not issues
+  (`:event`, `:fx`, `:frame`, `:sub/run`, `:view/render`, etc.).
+  Pure data → keyword-or-nil; JVM-testable."
+  [op-type]
+  (case op-type
+    :error   :error
+    :warning :warning
+    :info    :advisory
+    nil))
+
+(defn issue-event?
+  "True iff `ev` is an issue (carries a non-nil severity per
+  `op-type->severity`). Pure data → bool; JVM-testable.
+
+  Excluded by design: every success-path / lifecycle op-type. The
+  ribbon is the issues-only feed; success traces have their own
+  panels (Event detail, Subscriptions, Causality graph)."
+  [{:keys [op-type] :as _ev}]
+  (some? (op-type->severity op-type)))
+
+(defn severity-colour
+  "Map a severity keyword to its swatch colour. Mirrors the
+  shell.cljs token names so the panel can reuse them. The strings
+  are returned so the helper stays pure (no token-map dependency)."
+  [severity]
+  (case severity
+    :error    "#F87171"  ; :red
+    :warning  "#FBBF24"  ; :yellow
+    :advisory "#43C3D0"  ; :cyan
+    "#6B7080"))           ; :text-tertiary fallback
+
+(defn severity-glyph
+  "Single-character glyph the per-row severity dot renders. Pure
+  data → string; JVM-testable. Chosen for low-vision contrast: filled
+  triangle for errors, hollow circle for warnings, dot for advisories."
+  [severity]
+  (case severity
+    :error    "▲"
+    :warning  "●"
+    :advisory "·"
+    "○"))
+
+(defn severity-label
+  "Human-readable label for the severity chip. Pure data → string."
+  [severity]
+  (case severity
+    :error    "error"
+    :warning  "warning"
+    :advisory "advisory"
+    (str severity)))
+
+;; ---- category-prefix projection -----------------------------------------
+
+(defn category-prefix
+  "Project a trace event's `:operation` onto its category prefix —
+  the keyword namespace (e.g. `\"rf.error\"`, `\"rf.warning\"`,
+  `\"rf.ssr\"`). Per Spec 009 §Error namespace convention the prefix
+  carries domain provenance. Returns nil for events whose `:operation`
+  has no namespace (the catalogue's `:route.nav-token/*` etc. still
+  match — the namespace is `route.nav-token`).
+
+  Pure data → string-or-nil; JVM-testable."
+  [{:keys [operation] :as _ev}]
+  (when (keyword? operation)
+    (namespace operation)))
+
+;; ---- short description --------------------------------------------------
+
+(defn short-description
+  "Build the per-row one-line description. Per the bead's contract
+  rows render: `timestamp · category · severity · short description`.
+  The description is the `:operation` keyword + (when available) a
+  terse summary lifted from `:tags`.
+
+  Reads (in priority order):
+    1. `[:tags :reason]`           — most categories carry this
+    2. `[:tags :exception-message]` — handler / fx exceptions
+    3. `[:tags :event]`             — dispatched event vector
+    4. `[:tags :failing-id]`        — registrar miss / effect-map shape
+    5. `[:tags :path]`              — schema validation
+    6. `(str operation)` only — fallback
+
+  Pure data → string; JVM-testable."
+  [{:keys [operation tags] :as _ev}]
+  (let [op-str (if operation (str operation) "(unknown)")
+        detail (or (:reason tags)
+                   (:exception-message tags)
+                   (when (vector? (:event tags))
+                     (pr-str (:event tags)))
+                   (when (some? (:failing-id tags))
+                     (str (:failing-id tags)))
+                   (when (some? (:path tags))
+                     (try (pr-str (:path tags))
+                          (catch #?(:clj Throwable :cljs :default) _ nil))))]
+    (if (and detail (not (str/blank? (str detail))))
+      (str op-str " — " detail)
+      op-str)))
+
+;; ---- source-coord projection --------------------------------------------
+
+(defn source-coord
+  "Extract a `file:line` string from `:rf.trace/trigger-handler`'s
+  `:source-coord` slot. Per Spec 009 every emit inside a dispatch
+  carries this slot when handler scope is bound (per rf2-3nn8 /
+  rf2-lf84g). Returns nil when no coord is available. Pure data →
+  string-or-nil; JVM-testable."
+  [ev]
+  (when-let [trigger (:rf.trace/trigger-handler ev)]
+    (let [{:keys [file line]} (:source-coord trigger)]
+      (when file
+        (cond-> file
+          line (str ":" line))))))
+
+;; ---- per-issue projection ------------------------------------------------
+
+(defn project-issue
+  "Project one raw trace event into the ribbon's row shape:
+
+      {:id              <int>           ;; the trace event's :id
+       :time            <ms>
+       :severity        <:error :warning :advisory>
+       :op-type         <kw>
+       :operation       <kw>
+       :category-prefix <string-or-nil>
+       :description     <string>
+       :source-coord    <string-or-nil>
+       :dispatch-id     <int-or-nil>
+       :recovery        <kw-or-nil>
+       :raw             <trace-event>}
+
+  Pure data → data; JVM-testable. Returns nil when `ev` is not an
+  issue (success-path / lifecycle trace) so callers can `keep` over
+  a mixed stream."
+  [{:keys [id time op-type operation recovery tags] :as ev}]
+  (when (issue-event? ev)
+    {:id              id
+     :time            time
+     :severity        (op-type->severity op-type)
+     :op-type         op-type
+     :operation       operation
+     :category-prefix (category-prefix ev)
+     :description     (short-description ev)
+     :source-coord    (source-coord ev)
+     :dispatch-id     (or (:dispatch-id tags)
+                          (get-in ev [:tags :dispatch-id]))
+     :recovery        recovery
+     :raw             ev}))
+
+(defn project-issues
+  "Filter `events` to the issue subset and project each one. Returns
+  a vector in chronological order (oldest first). Pure data → data;
+  JVM-testable."
+  [events]
+  (into []
+        (keep project-issue)
+        events))
+
+;; ---- now-ms (abstracted for test fixtures) ------------------------------
+
+(defn now-ms
+  "Return host-clock time in ms. Pure-ish — abstracted so test
+  fixtures can stub via `with-redefs`. Cross-platform via
+  `#?(:clj ... :cljs ...)`."
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))
+
+;; ---- filter application -------------------------------------------------
+
+(defn passes-severity?
+  "True iff `issue`'s severity is in the active filter set, or if
+  the filter set is empty (= no severity restriction). Pure data →
+  bool; JVM-testable."
+  [active-severities {:keys [severity] :as _issue}]
+  (or (empty? active-severities)
+      (contains? active-severities severity)))
+
+(defn passes-category-prefix?
+  "True iff `issue`'s category-prefix is in the active filter set,
+  or if the filter set is empty. Pure data → bool; JVM-testable."
+  [active-prefixes {:keys [category-prefix] :as _issue}]
+  (or (empty? active-prefixes)
+      (contains? active-prefixes category-prefix)))
+
+(defn passes-since?
+  "True iff `issue`'s `:time` is within `since-ms` of `now`. Pure
+  data → bool; JVM-testable.
+
+  `nil` `since-ms` disables the axis (any time is acceptable).
+  `nil` `:time` falls back to 'in window' so issues without a stamp
+  still surface — defensive against malformed trace events."
+  [now since-ms {:keys [time] :as _issue}]
+  (or (nil? since-ms)
+      (nil? time)
+      (and (number? time)
+           (number? now)
+           (>= time (- now since-ms)))))
+
+(defn apply-filters
+  "Apply the three filter axes to `issues`. Pure data → vector;
+  JVM-testable. Each axis is independent — empty filter sets / nil
+  since-ms disable the axis.
+
+  `filters` is `{:severities #{...} :prefixes #{...} :since-ms <ms>}`.
+  `now` is the wall-clock 'now' to test :time against (helper-
+  injected so tests don't depend on the system clock)."
+  [issues filters now]
+  (let [{:keys [severities prefixes since-ms]} filters]
+    (filterv
+      (fn [issue]
+        (and (passes-severity? severities issue)
+             (passes-category-prefix? prefixes issue)
+             (passes-since? now since-ms issue)))
+      issues)))
+
+;; ---- category-prefix enumeration ----------------------------------------
+
+(defn distinct-prefixes
+  "Return the distinct category-prefixes present in `issues` in
+  first-seen order. The view uses this to populate the prefix-filter
+  chip row only with prefixes that have at least one issue — empty
+  prefix chips would be noise. Pure data → vector; JVM-testable."
+  [issues]
+  (into []
+        (comp (map :category-prefix)
+              (remove nil?)
+              (distinct))
+        issues))
+
+;; ---- composite projection (the panel reads this) ------------------------
+
+(defn project-feed
+  "Top-level projection — produces every slot the view needs in one
+  pass. Pure data → data; JVM-testable.
+
+  Returns:
+
+      {:issues               [<row> ...]      ;; post-filter, newest first
+       :total                <int>            ;; pre-filter count
+       :rendered             <int>            ;; post-filter count
+       :severity-counts      {severity count} ;; pre-filter histogram
+       :distinct-prefixes    [<prefix> ...]
+       :filters              <pass-through>
+       :empty-kind           <:no-issues / :no-matches / nil>}
+
+  `events` is the raw trace-buffer. `filters` is the current filter
+  state. `now` is wall-clock ms.
+
+  `:empty-kind` discriminates the three empty-state branches:
+
+      :no-issues  — the feed itself is empty (no issues observed).
+                    The view paints the 'All clear' positive-result
+                    badge.
+      :no-matches — issues exist but the active filters hide them
+                    all. The view paints 'No issues match filters'
+                    with a clear-filters affordance.
+      nil         — at least one issue passed; render the feed."
+  [events filters now]
+  (let [all              (project-issues events)
+        filtered         (apply-filters all filters now)
+        ;; Newest first for display per the bead's contract
+        ;; (timestamp · category · severity · short description).
+        sorted-display   (vec (reverse filtered))
+        severity-counts  (reduce
+                           (fn [acc {:keys [severity]}]
+                             (update acc severity (fnil inc 0)))
+                           {}
+                           all)
+        empty-kind       (cond
+                           (empty? all)      :no-issues
+                           (empty? filtered) :no-matches
+                           :else             nil)]
+    {:issues            sorted-display
+     :total             (count all)
+     :rendered          (count filtered)
+     :severity-counts   severity-counts
+     :distinct-prefixes (distinct-prefixes all)
+     :filters           filters
+     :empty-kind        empty-kind}))
+
+;; ---- selection ----------------------------------------------------------
+
+(defn find-issue
+  "Look up a projected issue by `:id` in `issues`. Returns nil when
+  not found. Pure data → row-or-nil; JVM-testable."
+  [issues issue-id]
+  (some (fn [v] (when (= issue-id (:id v)) v)) issues))
+
+;; ---- formatting ---------------------------------------------------------
+
+(defn format-time
+  "Render `t` (ms-since-epoch) as `HH:MM:SS.mmm`. Pure-ish —
+  uses the platform Date constructor. JVM-testable iff the caller
+  passes a stable time. The view feeds raw `:time` from the trace
+  event so the formatting matches the trace stream's clock."
+  [t]
+  (when (number? t)
+    #?(:clj  (let [^java.time.Instant inst (java.time.Instant/ofEpochMilli (long t))
+                   ^java.time.LocalTime lt (.toLocalTime
+                                             (.atZone inst (java.time.ZoneId/systemDefault)))]
+               (format "%02d:%02d:%02d.%03d"
+                       (.getHour lt)
+                       (.getMinute lt)
+                       (.getSecond lt)
+                       (long (mod t 1000))))
+       :cljs (let [d (js/Date. t)
+                   pad (fn [n w]
+                         (let [s (str n)]
+                           (if (< (count s) w)
+                             (str (apply str (repeat (- w (count s)) "0")) s)
+                             s)))]
+               (str (pad (.getHours d) 2) ":"
+                    (pad (.getMinutes d) 2) ":"
+                    (pad (.getSeconds d) 2) "."
+                    (pad (.getMilliseconds d) 3))))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -125,6 +125,7 @@
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]))
 
@@ -1035,6 +1036,96 @@
     (rf/reg-event-fx :rf.causa/copy-path-to-clipboard
       (fn [_ctx [_ path]]
         {:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str path)}]]}))
+
+    ;; ---- Phase 5 (rf2-d1p4o) — Issues ribbon panel ---------------------
+    ;;
+    ;; Per `tools/causa/spec/000-Vision.md` L94 + spec/009-Instrumentation.md
+    ;; §Error event catalogue the panel is the unified feed across errors,
+    ;; warnings, schema violations, and hydration mismatches. It reads
+    ;; from the same trace-buffer as every other panel; the helpers
+    ;; classify each event into the ribbon's three severity buckets
+    ;; (:error / :warning / :advisory) and project the per-row shape
+    ;; (timestamp · category · severity · short description · jump-to-
+    ;; source).
+    ;;
+    ;; Filter axes per the bead's minimum-viable contract:
+    ;;
+    ;;   :severities  #{:error :warning :advisory}
+    ;;   :prefixes    #{"rf.error" "rf.warning" "rf.ssr" ...}
+    ;;   :since-ms    relative time window in ms (nil = no restriction)
+    ;;
+    ;; Each axis is independent; empty filter sets / nil :since-ms
+    ;; disable the axis.
+    ;;
+    ;; Shape of `:rf.causa/issues-ribbon`:
+    ;;
+    ;;     {:issues               [<row> ...]      ;; post-filter
+    ;;      :total                <int>            ;; pre-filter count
+    ;;      :rendered             <int>            ;; post-filter count
+    ;;      :severity-counts      {sev count}
+    ;;      :distinct-prefixes    [<prefix> ...]
+    ;;      :filters              <pass-through>
+    ;;      :empty-kind           <:no-issues / :no-matches / nil>}
+
+    ;; Active filter state — the panel reads the three slots through
+    ;; one sub so the view re-renders atomically when filters change.
+    (rf/reg-sub :rf.causa/issues-filters
+      (fn [db _query]
+        {:severities (get db :issues-active-severities #{})
+         :prefixes   (get db :issues-active-prefixes #{})
+         :since-ms   (get db :issues-since-ms)}))
+
+    ;; Composite — produces every slot the view consumes. The
+    ;; helper's `project-feed` does the heavy lifting; the sub is a
+    ;; thin wrapper that injects `now-ms` (so the since-ms axis is
+    ;; meaningful) and reads the trace-buffer + filter state through
+    ;; the reactive surface.
+    (rf/reg-sub :rf.causa/issues-ribbon
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/issues-filters]
+      (fn [[buffer filters] _query]
+        (issues-helpers/project-feed buffer filters (issues-helpers/now-ms))))
+
+    ;; ---- Issues ribbon events --------------------------------------
+
+    ;; Toggle a severity chip in/out of the active filter set. Per
+    ;; the bead's contract each axis is independent.
+    (rf/reg-event-db :rf.causa/toggle-issues-severity
+      (fn [db [_ severity]]
+        (let [current (get db :issues-active-severities #{})]
+          (assoc db :issues-active-severities
+                 (if (contains? current severity)
+                   (disj current severity)
+                   (conj current severity))))))
+
+    ;; Toggle a category-prefix chip. Same shape as the severity
+    ;; toggle — multi-select set; empty set = no restriction.
+    (rf/reg-event-db :rf.causa/toggle-issues-prefix
+      (fn [db [_ prefix]]
+        (let [current (get db :issues-active-prefixes #{})]
+          (assoc db :issues-active-prefixes
+                 (if (contains? current prefix)
+                   (disj current prefix)
+                   (conj current prefix))))))
+
+    ;; Set the since-ms axis from a seconds-typed user input. The
+    ;; view converts s → ms here so the helper's filter-application
+    ;; stays uniform in ms. nil / non-positive values clear the axis.
+    (rf/reg-event-db :rf.causa/set-issues-since-seconds
+      (fn [db [_ seconds]]
+        (if (and (number? seconds) (pos? seconds))
+          (assoc db :issues-since-ms (* (long seconds) 1000))
+          (dissoc db :issues-since-ms))))
+
+    ;; Clear every filter axis in one shot. The Clear filters
+    ;; affordance in the header + the no-matches empty state both
+    ;; fire this.
+    (rf/reg-event-db :rf.causa/clear-issues-filters
+      (fn [db _event]
+        (-> db
+            (dissoc :issues-active-severities)
+            (dissoc :issues-active-prefixes)
+            (dissoc :issues-since-ms))))
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -43,6 +43,7 @@
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
+            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.registry :as registry]
@@ -84,7 +85,7 @@
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
    {:id :flows        :label "Flows"         :bead "rf2-xxx"}
    {:id :performance  :label "Performance"   :bead "rf2-xxx"}
-   {:id :issues       :label "Issues"        :bead "rf2-xxx"}
+   {:id :issues       :label "Issues"        :bead "rf2-d1p4o" :live? true}
    {:id :schemas      :label "Schemas"       :bead "rf2-htffa" :live? true}
    ;; Phase 5 (rf2-pzxsr). Per spec/006-Hydration-Debugger.md §Visibility
    ;; the panel is dormant until at least one :rf.ssr/hydration-mismatch
@@ -266,6 +267,7 @@
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]
       :hydration    [hydration-debugger/hydration-debugger-view]
+      :issues       [issues-ribbon/issues-ribbon-view]
       ;; Sidebar Co-pilot row renders the panel-style view in the
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -1,0 +1,357 @@
+(ns day8.re-frame2-causa.panels.issues-ribbon-helpers-cljs-test
+  "Pure-data tests for Causa's Issues ribbon helpers (Phase 5, rf2-d1p4o).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `schema_violation_timeline_helpers_cljs_
+  test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **op-type → severity mapping** — every issue op-type maps to
+       the correct severity bucket; non-issue op-types return nil.
+    2. **issue-event?** — classifies trace events.
+    3. **category-prefix** — projects `:operation`'s keyword namespace.
+    4. **project-issue** — projects raw trace events onto row cells.
+    5. **filter axes** — severity / prefix / since-ms are independent;
+       empty filters disable the axis.
+    6. **project-feed** — top-level composite; empty-kind classifier.
+    7. **format-time** — renders a stable HH:MM:SS.mmm string."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- error-ev
+  "Build a Spec 009-shaped error trace event."
+  ([id operation]
+   (error-ev id operation {}))
+  ([id operation {:keys [time tags recovery]
+                  :or {time 1000 tags {} recovery :no-recovery}}]
+   {:id        id
+    :op-type   :error
+    :operation operation
+    :time      time
+    :recovery  recovery
+    :tags      tags}))
+
+(defn- warning-ev
+  ([id operation]
+   (warning-ev id operation {}))
+  ([id operation {:keys [time tags] :or {time 1000 tags {}}}]
+   {:id        id
+    :op-type   :warning
+    :operation operation
+    :time      time
+    :tags      tags}))
+
+(defn- advisory-ev
+  ([id operation]
+   (advisory-ev id operation {}))
+  ([id operation {:keys [time tags] :or {time 1000 tags {}}}]
+   {:id        id
+    :op-type   :info
+    :operation operation
+    :time      time
+    :tags      tags}))
+
+(defn- non-issue-ev
+  "A success-path trace event — should never reach the ribbon."
+  [id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :time      1000
+   :tags      {}})
+
+;; ---- (1) op-type → severity mapping ------------------------------------
+
+(deftest op-type-severity-mapping-honours-spec
+  (testing "the three issue op-types map to the ribbon's severity buckets"
+    (is (= :error    (h/op-type->severity :error)))
+    (is (= :warning  (h/op-type->severity :warning)))
+    (is (= :advisory (h/op-type->severity :info))))
+  (testing "non-issue op-types return nil"
+    (is (nil? (h/op-type->severity :event)))
+    (is (nil? (h/op-type->severity :fx)))
+    (is (nil? (h/op-type->severity :frame)))
+    (is (nil? (h/op-type->severity :sub/run)))
+    (is (nil? (h/op-type->severity :view/render)))
+    (is (nil? (h/op-type->severity nil)))))
+
+(deftest severity-colour-mapping-honours-tokens
+  (testing "each severity gets the shell.cljs token-equivalent colour"
+    (is (= "#F87171" (h/severity-colour :error)))
+    (is (= "#FBBF24" (h/severity-colour :warning)))
+    (is (= "#43C3D0" (h/severity-colour :advisory)))
+    (is (= "#6B7080" (h/severity-colour :unknown)))))
+
+(deftest severity-label-stable
+  (is (= "error"    (h/severity-label :error)))
+  (is (= "warning"  (h/severity-label :warning)))
+  (is (= "advisory" (h/severity-label :advisory))))
+
+;; ---- (2) issue-event? classifier ---------------------------------------
+
+(deftest issue-event-classifier
+  (testing "errors / warnings / advisories are issues"
+    (is (true? (h/issue-event? (error-ev 1 :rf.error/handler-exception))))
+    (is (true? (h/issue-event? (warning-ev 2 :rf.warning/missing-doc))))
+    (is (true? (h/issue-event? (advisory-ev 3 :rf.http/retry-attempt)))))
+  (testing "success-path / lifecycle events are NOT issues"
+    (is (false? (h/issue-event? (non-issue-ev 4))))
+    (is (false? (h/issue-event? {:id 5 :op-type :fx :operation :rf.fx/handled})))
+    (is (false? (h/issue-event? {:id 6 :op-type :sub/run})))
+    (is (false? (h/issue-event? {:id 7 :op-type :view/render})))
+    (is (false? (h/issue-event? {:id 8 :op-type :frame})))))
+
+;; ---- (3) category-prefix projection ------------------------------------
+
+(deftest category-prefix-projection
+  (testing "the five normative Spec 009 prefixes round-trip"
+    (is (= "rf.error"
+           (h/category-prefix (error-ev 1 :rf.error/handler-exception))))
+    (is (= "rf.warning"
+           (h/category-prefix (warning-ev 2 :rf.warning/missing-doc))))
+    (is (= "rf.ssr"
+           (h/category-prefix (warning-ev 3 :rf.ssr/hydration-mismatch))))
+    (is (= "rf.fx"
+           (h/category-prefix (warning-ev 4 :rf.fx/skipped-on-platform))))
+    (is (= "rf.epoch"
+           (h/category-prefix (error-ev 5 :rf.epoch/restore-unknown-epoch)))))
+  (testing "non-keyword operations return nil"
+    (is (nil? (h/category-prefix {:id 99 :op-type :error :operation nil}))))
+  (testing "non-namespaced keywords return nil"
+    (is (nil? (h/category-prefix {:id 100 :op-type :error
+                                  :operation :bare-keyword})))))
+
+;; ---- (4) project-issue --------------------------------------------------
+
+(deftest project-issue-shape
+  (let [ev  (error-ev 42 :rf.error/handler-exception
+                      {:time 5000
+                       :tags {:event [:counter/inc]
+                              :exception-message "boom"
+                              :dispatch-id 99}})
+        row (h/project-issue ev)]
+    (testing "every required slot is populated"
+      (is (= 42 (:id row)))
+      (is (= 5000 (:time row)))
+      (is (= :error (:severity row)))
+      (is (= :rf.error/handler-exception (:operation row)))
+      (is (= "rf.error" (:category-prefix row)))
+      (is (= 99 (:dispatch-id row))))
+    (testing "the :raw slot carries the source event"
+      (is (= ev (:raw row))))
+    (testing "description carries the operation + a terse summary"
+      (is (re-find #"rf.error/handler-exception" (:description row)))
+      (is (re-find #"boom" (:description row))))))
+
+(deftest project-issue-skips-non-issues
+  (is (nil? (h/project-issue (non-issue-ev 1))))
+  (is (nil? (h/project-issue {:id 2 :op-type :fx :operation :rf.fx/handled}))))
+
+(deftest project-issues-filters-and-orders
+  (let [stream [(error-ev 1 :rf.error/handler-exception {:time 100})
+                (non-issue-ev 2)
+                (warning-ev 3 :rf.warning/missing-doc {:time 200})
+                (non-issue-ev 4)
+                (advisory-ev 5 :rf.http/retry-attempt {:time 300})]
+        rows   (h/project-issues stream)]
+    (is (= 3 (count rows)))
+    (is (= [1 3 5] (mapv :id rows)))
+    (is (= [:error :warning :advisory] (mapv :severity rows)))))
+
+;; ---- (5) filter axes ---------------------------------------------------
+
+(deftest severity-filter-passes-when-empty
+  (let [row {:severity :error}]
+    (is (true? (h/passes-severity? #{} row)))
+    (is (true? (h/passes-severity? nil row)))))
+
+(deftest severity-filter-restricts-when-set
+  (is (true?  (h/passes-severity? #{:error} {:severity :error})))
+  (is (false? (h/passes-severity? #{:error} {:severity :warning})))
+  (is (true?  (h/passes-severity? #{:error :warning}
+                                  {:severity :warning}))))
+
+(deftest prefix-filter-restricts-when-set
+  (is (true?  (h/passes-category-prefix? #{} {:category-prefix "rf.error"})))
+  (is (true?  (h/passes-category-prefix? #{"rf.error"}
+                                         {:category-prefix "rf.error"})))
+  (is (false? (h/passes-category-prefix? #{"rf.error"}
+                                         {:category-prefix "rf.warning"}))))
+
+(deftest since-filter-when-disabled-passes-all
+  (let [row {:time 100}]
+    (is (true? (h/passes-since? 1000 nil row)))))
+
+(deftest since-filter-restricts-by-time
+  (is (true?  (h/passes-since? 1000 500 {:time 600})))
+  (is (true?  (h/passes-since? 1000 500 {:time 500})))
+  (is (true?  (h/passes-since? 1000 500 {:time 1000})))
+  (is (false? (h/passes-since? 1000 500 {:time 400})))
+  (is (false? (h/passes-since? 1000 500 {:time 0}))))
+
+(deftest apply-filters-composes-three-axes
+  (let [now 1000
+        rows [{:id 1 :severity :error    :category-prefix "rf.error"   :time 950}
+              {:id 2 :severity :warning  :category-prefix "rf.warning" :time 700}
+              {:id 3 :severity :advisory :category-prefix "rf.http"    :time 200}
+              {:id 4 :severity :error    :category-prefix "rf.error"   :time 100}]]
+    (testing "no filters → everything passes"
+      (is (= [1 2 3 4]
+             (mapv :id (h/apply-filters rows {} now)))))
+    (testing "severity-only filter restricts"
+      (is (= [1 4]
+             (mapv :id (h/apply-filters rows
+                                        {:severities #{:error}}
+                                        now)))))
+    (testing "prefix-only filter restricts"
+      (is (= [2]
+             (mapv :id (h/apply-filters rows
+                                        {:prefixes #{"rf.warning"}}
+                                        now)))))
+    (testing "since-ms filter restricts (now-500ms cutoff)"
+      (is (= [1 2]
+             (mapv :id (h/apply-filters rows
+                                        {:since-ms 500}
+                                        now)))))
+    (testing "three axes combine intersectively"
+      (is (= [1]
+             (mapv :id (h/apply-filters
+                         rows
+                         {:severities #{:error}
+                          :prefixes   #{"rf.error"}
+                          :since-ms   500}
+                         now)))))))
+
+;; ---- (6) project-feed (top-level composite) -----------------------------
+
+(deftest project-feed-empty-stream
+  (let [feed (h/project-feed [] {} 1000)]
+    (is (= 0 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (= :no-issues (:empty-kind feed)))))
+
+(deftest project-feed-no-matches
+  (let [stream [(error-ev 1 :rf.error/handler-exception {:time 100})]
+        feed   (h/project-feed stream {:severities #{:warning}} 1000)]
+    (is (= 1 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (= :no-matches (:empty-kind feed)))))
+
+(deftest project-feed-newest-first
+  (let [stream [(error-ev 1 :rf.error/handler-exception {:time 100})
+                (warning-ev 2 :rf.warning/missing-doc   {:time 200})
+                (advisory-ev 3 :rf.http/retry-attempt   {:time 300})]
+        feed   (h/project-feed stream {} 1000)]
+    (testing ":issues is in newest-first order for display"
+      (is (= [3 2 1] (mapv :id (:issues feed)))))
+    (testing ":empty-kind is nil when there are matches"
+      (is (nil? (:empty-kind feed))))))
+
+(deftest project-feed-severity-counts
+  (let [stream [(error-ev 1 :rf.error/handler-exception)
+                (error-ev 2 :rf.error/no-such-fx)
+                (warning-ev 3 :rf.warning/missing-doc)
+                (advisory-ev 4 :rf.http/retry-attempt)]
+        feed   (h/project-feed stream {} 1000)]
+    (is (= {:error 2 :warning 1 :advisory 1}
+           (:severity-counts feed)))))
+
+(deftest project-feed-distinct-prefixes
+  (let [stream [(error-ev 1 :rf.error/handler-exception)
+                (warning-ev 2 :rf.warning/missing-doc)
+                (warning-ev 3 :rf.ssr/hydration-mismatch)
+                (error-ev 4 :rf.error/no-such-sub)]
+        feed   (h/project-feed stream {} 1000)]
+    (testing "distinct-prefixes is in first-seen order"
+      (is (= ["rf.error" "rf.warning" "rf.ssr"]
+             (:distinct-prefixes feed))))))
+
+(deftest project-feed-merges-all-four-bead-contract-sources
+  (testing "errors + warnings + schema violations + hydration mismatches
+            all surface in one feed per the bead's contract"
+    (let [stream [(error-ev 1 :rf.error/handler-exception     {:time 100})
+                  (warning-ev 2 :rf.warning/missing-doc       {:time 200})
+                  (error-ev 3 :rf.error/schema-validation-failure
+                              {:time 300 :tags {:path [:auth :email]}})
+                  (warning-ev 4 :rf.ssr/hydration-mismatch    {:time 400})]
+          feed   (h/project-feed stream {} 1000)]
+      (is (= 4 (:rendered feed)))
+      ;; All four sources present, regardless of order.
+      (is (= #{:rf.error/handler-exception
+               :rf.warning/missing-doc
+               :rf.error/schema-validation-failure
+               :rf.ssr/hydration-mismatch}
+             (set (mapv :operation (:issues feed))))))))
+
+;; ---- (7) format-time ---------------------------------------------------
+
+(deftest format-time-renders-hms-with-millis
+  (testing "format-time returns nil on non-numeric input"
+    (is (nil? (h/format-time nil)))
+    (is (nil? (h/format-time "not a number"))))
+  (testing "format-time returns a HH:MM:SS.mmm-shaped string on numeric input"
+    (let [s (h/format-time 12345)]
+      (is (string? s))
+      (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
+
+;; ---- (8) find-issue ----------------------------------------------------
+
+(deftest find-issue-by-id
+  (let [rows [{:id 1 :severity :error}
+              {:id 2 :severity :warning}
+              {:id 3 :severity :advisory}]]
+    (is (= {:id 2 :severity :warning} (h/find-issue rows 2)))
+    (is (nil? (h/find-issue rows 99)))))
+
+;; ---- (9) short-description --------------------------------------------
+
+(deftest short-description-uses-priority-order
+  (testing "reason is preferred when present"
+    (is (re-find #"specific because"
+                 (h/short-description
+                   (error-ev 1 :rf.error/no-such-handler
+                             {:tags {:reason "specific because" :event [:x]}})))))
+  (testing "exception-message is used when no reason"
+    (is (re-find #"boom"
+                 (h/short-description
+                   (error-ev 1 :rf.error/handler-exception
+                             {:tags {:exception-message "boom"}})))))
+  (testing "event vector is used when neither reason nor exception is set"
+    (is (re-find #"counter/inc"
+                 (h/short-description
+                   (error-ev 1 :rf.error/no-such-handler
+                             {:tags {:event [:counter/inc]}})))))
+  (testing "fallback is the operation keyword alone"
+    (is (= ":rf.error/handler-exception"
+           (h/short-description
+             (error-ev 1 :rf.error/handler-exception {:tags {}}))))))
+
+;; ---- (10) source-coord ------------------------------------------------
+
+(deftest source-coord-projection
+  (testing "source-coord pulls file:line from :rf.trace/trigger-handler"
+    (is (= "src/foo.cljs:42"
+           (h/source-coord
+             {:id 1 :op-type :error
+              :operation :rf.error/handler-exception
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"
+                                                        :line 42}}}))))
+  (testing "missing trigger-handler returns nil"
+    (is (nil? (h/source-coord {:id 1 :op-type :error
+                               :operation :rf.error/handler-exception}))))
+  (testing "missing :line returns just the file"
+    (is (= "src/foo.cljs"
+           (h/source-coord
+             {:id 1 :op-type :error
+              :operation :rf.error/handler-exception
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"}}})))))


### PR DESCRIPTION
## Summary

Phase 5 of the **rf2-5aw5v** Causa v1.0 epic — the **Issues ribbon** panel. Unified feed across the four issue sources the bead enumerates:

- errors (`:op-type :error`)
- warnings (`:op-type :warning`)
- schema violations (`:rf.error/schema-validation-failure`)
- hydration mismatches (`:rf.ssr/hydration-mismatch`)

Reads from the same trace-buffer every other Causa panel consumes; ties to **spec/009-Instrumentation.md §Error event catalogue** (the 95-category enumeration that landed via #575).

## Filter axes (per the bead's minimum-viable contract)

| Axis | Shape | UI |
|---|---|---|
| **severity** | `#{:error :warning :advisory}` | toggleable chips with per-bucket counts |
| **category-prefix** | `#{"rf.error" "rf.warning" "rf.ssr" ...}` | toggleable chips, populated from distinct prefixes in the feed |
| **since-ms** | relative-time window (nil disables) | numeric input (seconds-typed) |

Each axis is independent; empty filter sets / `nil` since-ms disable that axis. The header carries a **Clear filters** affordance when any axis is active.

## Severity ladder

Spec 009's `:op-type` discriminator maps onto three buckets:

    :error    ← :op-type :error
    :warning  ← :op-type :warning
    :advisory ← :op-type :info

Lifecycle / success-path traces (`:event`, `:fx`, `:frame`, `:sub/run`, `:view/render`, ...) are **not** issues and never reach the ribbon.

## Per-row layout

Per the bead's contract each row renders:

    timestamp · severity · category · short description · jump-to-source

- **Click row** → pivots to the event-detail panel for the parent cascade (`:rf.causa/select-dispatch-id` + `:rf.causa/select-panel :event-detail`)
- **Click source-coord chip** → fires `:rf.causa/open-in-editor` (event propagation stopped so the row pivot doesn't double-fire)

## Empty states

- `:no-issues`  — *"No issues observed in this session."* with the green **✓ All clear** badge — the desired state
- `:no-matches` — issues exist but the active filters hide them all; carries a Clear filters affordance

## Surface

| Path | Role |
|---|---|
| `tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs` | view (header, chip rows, feed) |
| `tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc` | severity / prefix / filter logic — JVM-testable |
| `tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc` | 24 deftests, 89 assertions |
| `tools/causa/src/day8/re_frame2_causa/registry.cljs` | `:rf.causa/issues-ribbon` composite + filter events |
| `tools/causa/src/day8/re_frame2_causa/shell.cljs` | sidebar entry goes `:live? true`; canvas case wires the view |

## Test plan

- [x] Causa JVM suite: `clojure -M:test` → **237 tests, 674 assertions, 0 failures**
- [x] CLJS node-test build: `npm run test:cljs` → **1151 tests, 3017 assertions, 0 failures**
- [ ] Smoke-test the panel in a host app (the four merged Phase 5 panels already exercise the framing; the issues ribbon is the last)

Parent epic: **rf2-5aw5v** (Causa v1.0).