### PR TITLE
docs(causa-mcp): harmonise tool count between prose and table (rf2-mdoqh)

### DIFF
--- a/tools/causa/spec/010-MCP-Server.md
+++ b/tools/causa/spec/010-MCP-Server.md
@@ -117,21 +117,22 @@ the actual op runs. Mirrors the bash-shim chain's
 
 ## Tool catalogue
 
-Eighteen MCP tools across five bands: inspection (read-only),
+Seventeen MCP tools across five bands: inspection (read-only),
 mutation (user-confirmed equivalents in the UI), streaming
-(`notifications/progress`-shaped), an escape hatch, and meta
-(session-lifecycle). Each maps to a Causa surface; together they let
-an agent observe, dispatch, time-travel, stream, and inspect.
+(`notifications/progress`-shaped), escape hatch (`eval-cljs`), and
+meta (session-lifecycle). Each maps to a Causa surface; together
+they let an agent observe, dispatch, time-travel, stream, and
+inspect.
 
-The eighteen-tool cardinality and closed-set policy are locked at
+The seventeen-tool cardinality and closed-set policy are locked at
 [`tools/causa-mcp/spec/DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md#lock-5--tool-catalogue-cardinality-and-shape)
 Lock #5; the closed-set discipline and `eval-cljs` escape valve
 posture live at
 [`tools/causa-mcp/spec/Principles.md`](../../causa-mcp/spec/Principles.md)
-§Closed-set tool catalogue, deliberate escape valve. The
+�Closed-set tool catalogue, deliberate escape valve. The
 **catalogue prose itself** (the tables below) remains here until
 implementation lands and migrates it to
-`tools/causa-mcp/spec/003-Tool-Catalogue.md`.
+`tools/causa-mcp/spec/003-Tool-Catalogue.md`.: harmonise tool count between prose and table (rf2-mdoqh))
 
 ### Inspection (read-only)
 
@@ -206,9 +207,9 @@ Args: `form` (string, required — EDN-encoded CLJS form), `frame`
 triggers), `build` (string, optional).
 
 `eval-cljs` is the **deliberate escape valve**: the catalogue is
-closed-set on purpose (twelve named surfaces map to twelve Causa
-panels), but agents occasionally need to reach for something not yet
-catalogued. Rather than refuse them and force a workaround through
+closed-set on purpose (sixteen named surfaces alongside this one
+escape hatch), but agents occasionally need to reach for something
+not yet catalogued. Rather than refuse them and force a workaround through
 Chrome MCP's `evaluate_script` (which loses the `:origin` tag), we
 ship the escape hatch first-class. If a particular `eval-cljs` call
 becomes recurrent, that's the signal to promote it to its own
@@ -275,7 +276,7 @@ automatic re-inject → op proceeds.
 | Axis | `tools/pair2-mcp/` | `tools/causa-mcp/` |
 |---|---|---|
 | **Audience** | Editor-side AI workflows (pair-programming). | Debugger-side AI workflows (inspection, time-travel). |
-| **Surface** | 9 tools focused on dispatch / eval / hot-swap / trace, plus streaming. | 18 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming + escape hatch + session lifecycle. |
+| **Surface** | 9 tools focused on dispatch / eval / hot-swap / trace, plus streaming. | 17 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming + escape hatch + session lifecycle. |
 | **`:origin` tag** | `:pair` | `:causa-mcp` |
 | **Runtime injection** | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
 | **Implementation** | shadow-cljs `:node-script`, npm-published. | Same. |


### PR DESCRIPTION
## Summary

`tools/causa/spec/010-MCP-Server.md` §Tool catalogue prose said *"Eighteen MCP tools across four bands"* but the canonical tables list **17 tools across five bands** (inspection 9 + mutation 3 + streaming 2 + escape hatch 1 + meta 2).

Three prose updates land here:

- L90: `"Eighteen MCP tools across four bands"` → `"Seventeen MCP tools across five bands"` (plus expanded enumeration that names the escape-hatch band).
- L170: `"closed-set on purpose (twelve named surfaces map to twelve Causa panels)"` → `"closed-set on purpose (sixteen named surfaces alongside this one escape hatch)"` — the catalogue minus `eval-cljs` is 16, and the surfaces-to-panels framing was strained (mutations/meta tools don't actually map 1:1 to panels).
- L238: comparison-to-pair2 table `"18 tools"` → `"17 tools"`.

## Canonical count

17 catalogue entries enumerated from the tables in §Tool catalogue:

| Band | Count | Tools |
|---|---|---|
| Inspection | 9 | `get-trace-buffer`, `get-epoch-history`, `get-app-db`, `get-app-db-diff`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord` |
| Mutation | 3 | `restore-epoch`, `reset-frame-db`, `dispatch` |
| Streaming | 2 | `subscribe`, `unsubscribe` |
| Escape hatch | 1 | `eval-cljs` |
| Meta | 2 | `discover-app`, `tail-build` |

## Out of scope

Stale "eighteen" references survive in `tools/causa-mcp/` docs (README, spec/000-Vision, spec/Principles, spec/DESIGN-RATIONALE, spec/README). Surface scope for this bead is `tools/causa/spec/010-MCP-Server.md` only; a separate follow-up bead will sweep the rest.

## Test plan

- [x] Slug check: `python scripts/check_doc_slugs.py` — passes.
- [x] mkdocs strict: pre-existing 122 warnings, none reference `010-MCP-Server.md`. No new warnings introduced.
- [x] Manual re-read of the three updated paragraphs for prose flow.