### PR TITLE
fix(api): -reg-error-projector private at re-export per leading-dash convention (rf2-ubeyt)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -692,8 +692,14 @@
 ;; ships in day8/re-frame2-ssr; the producing fn is looked up through
 ;; the late-bind hook table so core never statically requires
 ;; re-frame.ssr. The fn-form delegate is `rf-ssr/-reg-error-projector`.
+;;
+;; The local `-reg-error-projector` def below is `^:private` (per the
+;; leading-dash convention — rf2-ubeyt). The JVM macro emits
+;; `rf-ssr/-reg-error-projector` directly so it never depends on the
+;; local alias being visible at the user's compile site. The CLJS branch
+;; (line below) reuses the private alias within this namespace.
 
-(def -reg-error-projector rf-ssr/-reg-error-projector)
+(def ^:private -reg-error-projector rf-ssr/-reg-error-projector)
 
 #?(:clj
    (defmacro reg-error-projector
@@ -709,7 +715,7 @@
      call site."
      [& args]
      (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
-                       `(-reg-error-projector ~@args))))
+                       `(rf-ssr/-reg-error-projector ~@args))))
 
 #?(:cljs
    (def reg-error-projector -reg-error-projector))


### PR DESCRIPTION
## Summary

- Mark the `re-frame.core/-reg-error-projector` re-export `^:private` so the dash form is not reachable as `rf/-reg-error-projector` from user namespaces. Per the leading-dash convention (`-foo` = private impl), users should reach the surface only via the `reg-error-projector` macro (JVM) or the public alias (CLJS).
- Update the JVM macro to emit `rf-ssr/-reg-error-projector` directly (the public fn in `re-frame.core-ssr`) so user-site compilation does not depend on the private local alias being visible — a `^:private` local cannot be referenced by name from the macro expansion at the user's compile site, so the macro now syntax-quotes the public ssr-wrapper symbol.
- The CLJS branch (`(def reg-error-projector -reg-error-projector)`) keeps using the private local alias within the namespace (private members are accessible within the same namespace).

## Notes

- Zero external callers of `rf/-reg-error-projector` existed prior to this change (verified via repo-wide search).
- `spec/API.md` only documents the public `reg-error-projector` macro form (row at API.md:43); no edit needed.

## Test plan

- [x] `clojure -M:test` (JVM core) — 357 tests, 0 failures.
- [x] `clojure -M:test` (JVM ssr) — 31 tests, 0 failures.
- [x] `npm run test:cljs` (node-runtime CLJS) — 1127 tests, 0 failures.
- [x] Confirmed that without the macro change, the `^:private` alone produces `IllegalStateException: var: #'re-frame.core/-reg-error-projector is not public` at user-site compile (caught by `source_coords_test.clj`).

Bead: rf2-ubeyt.