### PR TITLE
feat(causa): Trace panel — 9-axis filter (rf2-argrj)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -1,0 +1,428 @@
+(ns day8.re-frame2-causa.panels.trace
+  "Trace panel — Phase 5 (rf2-argrj, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/000-Vision.md` L89 (panel-inventory row) the
+  Trace panel is the raw-event ribbon — every trace event in the
+  buffer renders as one timestamped row, filterable along the 9-axis
+  vocabulary documented in `spec/009-Instrumentation.md` §Filter
+  vocabulary. Where the Issues ribbon collapses the stream to
+  issues only, this panel surfaces every op-type so a programmer
+  can grep across the full vocabulary.
+
+  ## What this panel shows
+
+  A scrollable, timestamped ribbon. Each row carries:
+
+      timestamp · op-type-dot · operation · description · source-coord
+
+  Clicking a row → the parent dispatch-id is selected
+  (`:rf.causa/select-dispatch-id`) and the user pivots to the
+  event-detail panel for the cascade. Empty `:dispatch-id` events
+  (registry-time / lifecycle) stay non-clickable.
+
+  Per-row chip-filter affordance: clicking any axis value in the
+  row narrows the filter on that axis to the clicked value (the
+  bead's 'per-row chip-filter UI' contract). The header's clear-all
+  affordance drops every filter at once.
+
+  ## Filter axes (Spec 009 §Filter vocabulary)
+
+  All 9 named axes the vocabulary enumerates are surfaced:
+
+      :op-type      :severity     :source      :origin       :frame
+      :operation    :event-id     :handler-id  :dispatch-id
+
+  Each axis is set via `:rf.causa/set-trace-filter` (axis, value);
+  `nil` clears the axis. The numeric `:since` / `:since-ms` /
+  `:between` and `:pred` axes are accepted by the filter algebra but
+  ride a follow-on bead for the UI (drag-zoom on the time-axis,
+  expression input).
+
+  ## Empty states
+
+  Per the bead's contract:
+
+    :no-events   → 'No events observed in this session.' Once the
+                   trace bus starts flowing this clears immediately.
+    :no-matches  → events exist but the active filters hide them
+                   all. 'No events match current filters' + Clear.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — pure hiccup, no
+  Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in shell.cljs.
+
+  ## Helpers
+
+  All pure-data logic — filter application, row projection, axis
+  enumeration, empty-state classification — lives in
+  `trace_helpers.cljc` so the algebra runs under the JVM unit-test
+  target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.trace-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
+
+(def ^:private tokens
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- axis labelling -----------------------------------------------------
+
+(def ^:private axis-labels
+  "Human-readable label for each filter axis. The view uses these
+  for the chip-row headers and for the 'active filter' badges in the
+  header strip."
+  {:op-type     "op-type"
+   :severity    "severity"
+   :source      "source"
+   :origin      "origin"
+   :frame       "frame"
+   :operation   "operation"
+   :event-id    "event-id"
+   :handler-id  "handler-id"
+   :dispatch-id "dispatch-id"})
+
+(defn- format-axis-value
+  "Render an axis value for display. Keywords render with their
+  namespace; numbers / strings render as-is; nils as '(none)'."
+  [v]
+  (cond
+    (nil? v)     "(none)"
+    (keyword? v) (str v)
+    :else        (pr-str v)))
+
+;; ---- chip helpers -------------------------------------------------------
+
+(defn- chip
+  "One filter chip. `active?` drives the highlighted styling.
+  `on-click` fires the relevant axis toggle."
+  [{:keys [label active? on-click test-id colour]}]
+  [:button {:data-testid test-id
+            :on-click    on-click
+            :style       {:background    (if active?
+                                           (:bg-active tokens)
+                                           "transparent")
+                          :color         (if active?
+                                           (:text-primary tokens)
+                                           (or colour (:text-secondary tokens)))
+                          :border        (str "1px solid "
+                                              (if active?
+                                                (or colour (:border-default tokens))
+                                                (:border-subtle tokens)))
+                          :border-radius "999px"
+                          :padding       "2px 10px"
+                          :cursor        "pointer"
+                          :font-family   sans-stack
+                          :font-size     "11px"
+                          :font-weight   (if active? 600 400)
+                          :letter-spacing "0.2px"
+                          :margin-right  "6px"
+                          :margin-bottom "4px"}}
+   label])
+
+(defn- axis-chip-row
+  "Render a chip-row for one filter axis. Each chip toggles the axis
+  to its value; the currently-active value (if any) renders highlit.
+  Only renders when there are at least two distinct values — a
+  single-value axis has nothing to filter on."
+  [{:keys [axis active-value distinct counts axis-colour]}]
+  (when (and (sequential? distinct) (>= (count distinct) 2))
+    (into [:div {:data-testid (str "rf-causa-trace-axis-row-" (name axis))
+                 :style       {:display    "flex"
+                               :flex-wrap  "wrap"
+                               :align-items "baseline"
+                               :margin-top "4px"}}
+           [:span {:style {:font-family   sans-stack
+                           :font-size     "10px"
+                           :color         (:text-tertiary tokens)
+                           :text-transform "uppercase"
+                           :letter-spacing "0.5px"
+                           :margin-right  "8px"
+                           :min-width     "70px"}}
+            (get axis-labels axis (name axis))]]
+          (for [value distinct
+                :let [active? (= active-value value)
+                      n       (get counts value 0)
+                      colour  (cond
+                                (and (= axis :op-type) (some? value))
+                                (h/op-type-colour value)
+                                (= axis :severity)
+                                (h/op-type-colour value)
+                                :else axis-colour)]]
+            (chip {:label    (str (format-axis-value value) " · " n)
+                   :active?  active?
+                   :colour   colour
+                   :test-id  (str "rf-causa-trace-axis-chip-"
+                                  (name axis) "-"
+                                  (if (keyword? value)
+                                    (str (some-> value namespace (str "_"))
+                                         (name value))
+                                    (str value)))
+                   :on-click #(rf/dispatch
+                                [:rf.causa/set-trace-filter
+                                 axis
+                                 (when-not active? value)])})))))
+
+;; ---- header strip -------------------------------------------------------
+
+(defn- header
+  "Panel header — title + counts + chip rows + clear-all."
+  [{:keys [total rendered distinct counts filters any-filter?]}]
+  [:header {:style {:padding       "12px 16px 6px 16px"
+                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "12px"}}
+    [:h1 {:style {:font-size   "16px"
+                  :font-weight 600
+                  :margin      0
+                  :color       (:text-primary tokens)}}
+     "Trace"]
+    [:span {:data-testid "rf-causa-trace-counts"
+            :style {:font-size   "11px"
+                    :color       (:text-tertiary tokens)
+                    :font-family mono-stack}}
+     (str rendered " / " total " in view")]
+    (when any-filter?
+      [:button {:data-testid "rf-causa-trace-clear-filters"
+                :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters])
+                :style       {:margin-left "auto"
+                              :background  "transparent"
+                              :color       (:cyan tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "2px 8px"
+                              :border-radius "3px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "11px"}}
+       "Clear filters"])]
+   [:div {:style {:margin-top "8px"}}
+    (for [axis h/filter-axes]
+      ^{:key axis}
+      [axis-chip-row {:axis         axis
+                      :active-value (get filters axis)
+                      :distinct     (get distinct axis)
+                      :counts       (get counts axis)
+                      :axis-colour  (:accent-violet tokens)}])]])
+
+;; ---- per-row -------------------------------------------------------------
+
+(defn- row-chip
+  "A minimal in-row chip — clicking it sets the panel's filter on
+  the named axis to the clicked value, per the bead's per-row chip-
+  filter UI contract."
+  [{:keys [axis value test-id]}]
+  (when (some? value)
+    [:button {:data-testid test-id
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch [:rf.causa/set-trace-filter
+                                           axis value]))
+              :title       (str "filter " (name axis) " = "
+                                (format-axis-value value))
+              :style       {:background    "transparent"
+                            :color         (:text-tertiary tokens)
+                            :border        (str "1px solid "
+                                                (:border-subtle tokens))
+                            :border-radius "3px"
+                            :padding       "1px 6px"
+                            :cursor        "pointer"
+                            :font-family   mono-stack
+                            :font-size     "10px"
+                            :margin-right  "4px"}}
+     (format-axis-value value)]))
+
+(defn- trace-row
+  "One row in the trace ribbon."
+  [{:keys [id time op-type operation source origin frame description
+           source-coord dispatch-id]
+    :as _row}]
+  (let [row-test-id (str "rf-causa-trace-row-" id)
+        dot-colour  (h/op-type-colour op-type)]
+    [:li {:key         id
+          :data-testid row-test-id
+          :on-click    (fn []
+                         (when dispatch-id
+                           (rf/dispatch [:rf.causa/select-dispatch-id
+                                         dispatch-id])
+                           (rf/dispatch [:rf.causa/select-panel
+                                         :event-detail])))
+          :style       {:display       "grid"
+                        :grid-template-columns
+                        "84px 14px minmax(140px, 1fr) 2fr auto auto"
+                        :gap           "10px"
+                        :align-items   "center"
+                        :padding       "6px 16px"
+                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :cursor        (if dispatch-id "pointer" "default")
+                        :color         (:text-primary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     ;; Timestamp
+     [:span {:data-testid (str row-test-id "-time")
+             :style {:color (:text-tertiary tokens)
+                     :font-size "11px"
+                     :white-space "nowrap"}}
+      (or (h/format-time time) "—")]
+     ;; op-type dot
+     [:span {:data-testid (str row-test-id "-op-type-dot")
+             :title       (str op-type)
+             :style       {:color dot-colour
+                           :font-weight 700
+                           :text-align "center"}}
+      "●"]
+     ;; Operation
+     [:span {:data-testid (str row-test-id "-operation")
+             :style       {:color         (:accent-violet tokens)
+                           :overflow      "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space   "nowrap"}
+             :title       (str operation)}
+      (or (some-> operation str) "—")]
+     ;; Description
+     [:span {:data-testid (str row-test-id "-description")
+             :style       {:color         (:text-secondary tokens)
+                           :overflow      "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space   "nowrap"}
+             :title       description}
+      description]
+     ;; Per-row chip-filters — the bead's contract. We surface the four
+     ;; commonly-grepped axes that ride on the row directly (source,
+     ;; origin, frame). The op-type / severity chips ride the dot;
+     ;; clicking the dot itself is a future affordance — for v1 the
+     ;; chip-row in the header is the op-type entry point.
+     [:span {:data-testid (str row-test-id "-row-chips")
+             :style       {:display "flex"
+                           :align-items "center"
+                           :white-space "nowrap"}}
+      (row-chip {:axis :source :value source
+                 :test-id (str row-test-id "-source-chip")})
+      (row-chip {:axis :origin :value origin
+                 :test-id (str row-test-id "-origin-chip")})
+      (row-chip {:axis :frame :value frame
+                 :test-id (str row-test-id "-frame-chip")})]
+     ;; Source-coord (when present)
+     (if source-coord
+       [:button {:data-testid (str row-test-id "-source-coord")
+                 :on-click    (fn [e]
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/open-in-editor
+                                              {:source-coord source-coord}]))
+                 :style       {:background  "transparent"
+                               :color       (:cyan tokens)
+                               :border      (str "1px solid " (:border-subtle tokens))
+                               :padding     "1px 6px"
+                               :border-radius "3px"
+                               :cursor      "pointer"
+                               :font-family mono-stack
+                               :font-size   "10px"}}
+        source-coord]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"}}
+        "—"])]))
+
+;; ---- empty states -------------------------------------------------------
+
+(defn- empty-state-no-events
+  "Per the bead's contract — the buffer is empty (no traces observed
+  yet)."
+  []
+  [:div {:data-testid "rf-causa-trace-empty-no-events"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin 0
+                :color  (:text-tertiary tokens)}}
+    "No events observed in this session. "
+    "Once the host app dispatches anything the ribbon will fill."]])
+
+(defn- empty-state-no-matches
+  "Per the bead's contract — events exist but the active filters
+  hide them all. Carries a Clear filters affordance."
+  []
+  [:div {:data-testid "rf-causa-trace-empty-no-matches"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin "0 0 12px 0"
+                :color (:text-primary tokens)
+                :font-weight 600}}
+    "No events match current filters."]
+   [:p {:style {:margin "0 0 12px 0"
+                :color (:text-tertiary tokens)}}
+    "Adjust the chip rows above — clearing any one axis widens the ribbon."]
+   [:button {:data-testid "rf-causa-trace-empty-clear-filters"
+             :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters])
+             :style       {:background "transparent"
+                           :color      (:cyan tokens)
+                           :border     (str "1px solid " (:border-default tokens))
+                           :padding    "4px 10px"
+                           :border-radius "3px"
+                           :cursor     "pointer"
+                           :font-family sans-stack
+                           :font-size  "12px"}}
+    "Clear filters"]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn trace-view
+  "The Trace panel's root view. Subscribes to `:rf.causa/trace-feed`
+  and renders either the chip-filterable ribbon or the empty-state."
+  []
+  (let [{:keys [rows total rendered distinct counts filters
+                any-filter? empty-kind]
+         :as _data}
+        @(rf/subscribe [:rf.causa/trace-feed])]
+    [:section {:data-testid "rf-causa-trace"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     (header {:total       total
+              :rendered    rendered
+              :distinct    distinct
+              :counts      counts
+              :filters     filters
+              :any-filter? any-filter?})
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (case empty-kind
+        :no-events  (empty-state-no-events)
+        :no-matches (empty-state-no-matches)
+        nil         (into [:ul {:data-testid "rf-causa-trace-feed"
+                                :style       {:list-style "none"
+                                              :margin     0
+                                              :padding    0}}]
+                          (for [row rows]
+                            (trace-row row))))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -1,0 +1,350 @@
+(ns day8.re-frame2-causa.panels.trace-helpers
+  "Pure-data helpers for Causa's Trace panel (Phase 5, rf2-argrj).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `trace.cljs` paints a scrollable, timestamped
+  ribbon of raw trace events and dispatches into the Causa frame.
+  The *logic* — applying the 9-axis filter vocabulary from Spec 009
+  §Filter vocabulary, projecting raw events into row shape,
+  enumerating per-axis distinct values for the chip rows, and
+  classifying the empty state — is pure data → data. Splitting the
+  algebra into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
+
+  ## Substrate (per `spec/009-Instrumentation.md` §Filter vocabulary)
+
+  The Trace panel is the UI consumer of the canonical 9-axis filter
+  vocabulary documented in Spec 009 §Filter vocabulary (the algebra
+  itself is implemented in `re-frame.trace/trace-buffer` and exposed
+  pure-data via `day8.re-frame2-causa.trace-bus/filter-events` per
+  rf2-qi8au). Where the Issues ribbon collapses the stream to issues
+  only, the Trace panel surfaces the *raw* stream — every op-type,
+  every operation — so a programmer can grep across the full
+  vocabulary.
+
+  ## Filter axes (per the bead's minimum-viable contract)
+
+  All 13 axes Spec 009 §Filter vocabulary enumerates are accepted:
+
+      :operation     keyword           single value
+      :op-type       keyword           single value
+      :since         number            cursor on :id
+      :frame         keyword           :tags :frame match
+      :severity      kw                :error / :warning / :info
+      :event-id      keyword           :tags :event-id
+      :handler-id    keyword           :tags :handler-id
+      :source        keyword           :ui / :timer / :http / ...
+      :origin        keyword           :app / :pair / :story / ...
+      :dispatch-id   number            cascade-wide
+      :since-ms      number            wall-clock cutoff
+      :between       [t0 t1]           wall-clock window
+      :pred          (fn [ev] truthy)  escape hatch
+
+  Empty / nil values disable an axis. Composition is AND-wise — the
+  canonical `trace-bus/filter-events` does the work; this ns adds
+  the panel's projection + per-axis chip enumeration on top."
+  (:require #?(:clj  [clojure.string :as str]
+               :cljs [clojure.string :as str])
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- the canonical 9-axis vocabulary ------------------------------------
+
+(def filter-axes
+  "The canonical filter-vocabulary axes Spec 009 §Filter vocabulary
+  enumerates. Render order for the chip rows in the panel — most-
+  commonly-used axes first. Source/Origin/Frame/Severity ride the
+  enumerable-as-chips path; everything else (:dispatch-id, :event-id,
+  :handler-id, :operation, :op-type) is per-row click-to-filter; the
+  numeric axes (:since, :since-ms, :between) and :pred ride a
+  follow-on bead."
+  [:op-type :severity :source :origin :frame
+   :operation :event-id :handler-id :dispatch-id])
+
+;; ---- short-description ---------------------------------------------------
+
+(defn short-description
+  "Build a one-line per-row description. Reads (in priority order):
+
+    1. `[:tags :event]`             — dispatched event vector
+    2. `[:tags :reason]`            — most error categories carry this
+    3. `[:tags :exception-message]` — handler / fx exceptions
+    4. `[:tags :sub-id]`            — sub-run / sub-create
+    5. `[:tags :fx-id]`             — fx invocations
+    6. `[:tags :render-key]`        — view renders
+    7. `(str operation)` only       — fallback
+
+  Pure data → string; JVM-testable."
+  [{:keys [operation tags] :as _ev}]
+  (let [op-str (if operation (str operation) "(unknown)")
+        detail (or (when (vector? (:event tags))
+                     (try (pr-str (:event tags))
+                          (catch #?(:clj Throwable :cljs :default) _ nil)))
+                   (:reason tags)
+                   (:exception-message tags)
+                   (when (some? (:sub-id tags))
+                     (str (:sub-id tags)))
+                   (when (some? (:fx-id tags))
+                     (str (:fx-id tags)))
+                   (when (some? (:render-key tags))
+                     (try (pr-str (:render-key tags))
+                          (catch #?(:clj Throwable :cljs :default) _ nil))))]
+    (if (and detail (not (str/blank? (str detail))))
+      (str op-str " — " detail)
+      op-str)))
+
+;; ---- source-coord projection --------------------------------------------
+
+(defn source-coord
+  "Extract a `file:line` string from `:rf.trace/trigger-handler`'s
+  `:source-coord` slot. Per Spec 009 §Source-coord every emit inside
+  a dispatch carries this slot when handler scope is bound (per
+  rf2-3nn8 / rf2-lf84g). Pure data → string-or-nil; JVM-testable."
+  [ev]
+  (when-let [trigger (:rf.trace/trigger-handler ev)]
+    (let [{:keys [file line]} (:source-coord trigger)]
+      (when file
+        (cond-> file
+          line (str ":" line))))))
+
+;; ---- per-row projection -------------------------------------------------
+
+(defn frame-of
+  "Project the event's frame routing key. Per Spec 009 §Canonical
+  per-frame routing key (rf2-shaa1) every trace event that names a
+  frame uses `:frame` under `:tags`; consumers also fall back to a
+  top-level `:frame` for events emitted before the canonical move
+  landed (defensive — the framework no longer emits the alias)."
+  [ev]
+  (or (get-in ev [:tags :frame])
+      (:frame ev)))
+
+(defn origin-of
+  "Project the dispatch-origin slot per Spec 009 §Origin tagging
+  (`:tags :origin`). Defensive against absence — returns nil."
+  [ev]
+  (get-in ev [:tags :origin]))
+
+(defn project-row
+  "Project one raw trace event into the panel's row shape:
+
+      {:id              <int>
+       :time            <ms>
+       :op-type         <kw>
+       :operation       <kw>
+       :severity        <:error/:warning/:info-or-nil>
+       :source          <kw-or-nil>
+       :origin          <kw-or-nil>
+       :frame           <kw-or-nil>
+       :event-id        <kw-or-nil>
+       :handler-id      <kw-or-nil>
+       :dispatch-id     <int-or-nil>
+       :description     <string>
+       :source-coord    <string-or-nil>
+       :tags            <map>                ;; full tags for the detail view
+       :raw             <trace-event>}
+
+  Pure data → data; JVM-testable."
+  [{:keys [id time op-type operation source tags] :as ev}]
+  {:id              id
+   :time            time
+   :op-type         op-type
+   :operation       operation
+   ;; :severity is the synonym axis Spec 009 documents — set when the
+   ;; op-type is one of the three severity tiers, nil otherwise.
+   :severity        (case op-type
+                      :error   :error
+                      :warning :warning
+                      :info    :info
+                      nil)
+   :source          (or source (get-in ev [:tags :source]))
+   :origin          (origin-of ev)
+   :frame           (frame-of ev)
+   :event-id        (get-in ev [:tags :event-id])
+   :handler-id      (get-in ev [:tags :handler-id])
+   :dispatch-id     (get-in ev [:tags :dispatch-id])
+   :description     (short-description ev)
+   :source-coord    (source-coord ev)
+   :tags            tags
+   :raw             ev})
+
+(defn project-rows
+  "Project every event in `events` into a row. Returns a vector in
+  chronological order (oldest first). Pure data → data."
+  [events]
+  (mapv project-row events))
+
+;; ---- filter application -------------------------------------------------
+
+(defn normalise-filters
+  "Drop axis entries whose value is nil / empty so the downstream
+  `trace-bus/filter-events` receives only meaningful axes. Pure data;
+  JVM-testable. The view sets axis = nil to clear an axis; this fn
+  is the single 'is this axis active?' arbiter."
+  [filters]
+  (into {}
+        (filter (fn [[_ v]]
+                  (cond
+                    (nil? v)                              false
+                    (and (string? v) (str/blank? v))      false
+                    (and (coll? v) (empty? v))            false
+                    :else                                 true)))
+        (or filters {})))
+
+(defn any-filter-active?
+  "True iff at least one filter axis is active. Drives the
+  'Clear filters' affordance in the header."
+  [filters]
+  (boolean (seq (normalise-filters filters))))
+
+(defn apply-filters
+  "Apply the 9-axis filter vocabulary to `events`. Pure data →
+  vector; JVM-testable. Delegates to `trace-bus/filter-events` so
+  the algebra stays in lockstep with the framework's canonical
+  filter. Returns a vector in chronological order (oldest first)."
+  [events filters]
+  (let [normalised (normalise-filters filters)]
+    (if (empty? normalised)
+      (vec events)
+      (trace-bus/filter-events events normalised))))
+
+;; ---- enumeration --------------------------------------------------------
+
+(defn distinct-values
+  "Return the distinct values of `axis` present in `rows`, in first-
+  seen order, dropping nils. The view uses this to populate the chip-
+  filter rows with only the axis values that have at least one row —
+  empty chips would be noise. Pure data → vector; JVM-testable."
+  [rows axis]
+  (into []
+        (comp (map axis)
+              (remove nil?)
+              (distinct))
+        rows))
+
+(defn axis-counts
+  "Histogram per-axis value → count. Drives chip badge counts. Pure
+  data → map; JVM-testable."
+  [rows axis]
+  (reduce
+    (fn [acc row]
+      (let [v (get row axis)]
+        (if (nil? v) acc (update acc v (fnil inc 0)))))
+    {}
+    rows))
+
+;; ---- now-ms (abstracted for tests) --------------------------------------
+
+(defn now-ms
+  "Return host-clock time in ms. Pure-ish — abstracted so test
+  fixtures can stub via `with-redefs`."
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))
+
+;; ---- composite projection (the panel reads this) ------------------------
+
+(defn project-feed
+  "Top-level projection — produces every slot the view needs in one
+  pass. Pure data → data; JVM-testable.
+
+  Returns:
+
+      {:rows              [<row> ...]    ;; post-filter, newest first
+       :total             <int>          ;; pre-filter count
+       :rendered          <int>          ;; post-filter count
+       :distinct          {<axis> [...]} ;; per-axis chip values
+       :counts            {<axis> {<value> <int>}}
+       :filters           <pass-through normalised>
+       :any-filter?       <bool>
+       :empty-kind        <:no-events / :no-matches / nil>}
+
+  `events` is the raw trace-buffer. `filters` is the 9-axis filter
+  map (per Spec 009 §Filter vocabulary).
+
+  `:empty-kind` discriminates the two empty-state branches:
+
+      :no-events  — the buffer is empty (no traces observed yet).
+      :no-matches — events exist but the active filters hide them
+                    all. The view paints 'No events match current
+                    filters' with a clear-filters affordance.
+      nil         — at least one event passes; render the ribbon."
+  [events filters]
+  (let [all-rows         (project-rows events)
+        normalised       (normalise-filters filters)
+        filtered-events  (apply-filters events normalised)
+        filtered-rows    (project-rows filtered-events)
+        ;; Newest first for display per the bead's contract
+        ;; (scrollable timestamped event ribbon).
+        sorted-display   (vec (reverse filtered-rows))
+        distinct-by      (into {}
+                               (for [axis filter-axes]
+                                 [axis (distinct-values all-rows axis)]))
+        counts-by        (into {}
+                               (for [axis filter-axes]
+                                 [axis (axis-counts all-rows axis)]))
+        empty-kind       (cond
+                           (empty? all-rows)        :no-events
+                           (empty? filtered-rows)   :no-matches
+                           :else                    nil)]
+    {:rows         sorted-display
+     :total        (count all-rows)
+     :rendered     (count filtered-rows)
+     :distinct     distinct-by
+     :counts       counts-by
+     :filters      normalised
+     :any-filter?  (boolean (seq normalised))
+     :empty-kind   empty-kind}))
+
+;; ---- selection ----------------------------------------------------------
+
+(defn find-row
+  "Look up a projected row by `:id` in `rows`. Returns nil when not
+  found. Pure data → row-or-nil; JVM-testable."
+  [rows row-id]
+  (some (fn [v] (when (= row-id (:id v)) v)) rows))
+
+;; ---- formatting ---------------------------------------------------------
+
+(defn format-time
+  "Render `t` (ms-since-epoch) as `HH:MM:SS.mmm`. Matches the
+  Issues ribbon's format so the two ribbons share a visual rhythm.
+  Pure-ish — uses the platform Date constructor."
+  [t]
+  (when (number? t)
+    #?(:clj  (let [^java.time.Instant inst (java.time.Instant/ofEpochMilli (long t))
+                   ^java.time.LocalTime lt (.toLocalTime
+                                             (.atZone inst (java.time.ZoneId/systemDefault)))]
+               (format "%02d:%02d:%02d.%03d"
+                       (.getHour lt)
+                       (.getMinute lt)
+                       (.getSecond lt)
+                       (long (mod t 1000))))
+       :cljs (let [d   (js/Date. t)
+                   pad (fn [n w]
+                         (let [s (str n)]
+                           (if (< (count s) w)
+                             (str (apply str (repeat (- w (count s)) "0")) s)
+                             s)))]
+               (str (pad (.getHours d) 2) ":"
+                    (pad (.getMinutes d) 2) ":"
+                    (pad (.getSeconds d) 2) "."
+                    (pad (.getMilliseconds d) 3))))))
+
+(defn op-type-colour
+  "Colour swatch for an op-type. Drives the per-row dot + the
+  op-type chip styling. Pure data → string; JVM-testable."
+  [op-type]
+  (case op-type
+    :error              "#F87171"  ; :red
+    :warning            "#FBBF24"  ; :yellow
+    :info               "#43C3D0"  ; :cyan
+    :event              "#7C5CFF"  ; :accent-violet
+    :event/db-changed   "#7C5CFF"
+    :fx                 "#4ADE80"  ; :green
+    :sub/run            "#43C3D0"
+    :sub/create         "#43C3D0"
+    :view/render        "#E879F9"  ; :magenta
+    :frame              "#A8AEC0"  ; :text-secondary
+    "#A8AEC0"))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -127,7 +127,8 @@
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
-            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]))
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]
+            [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -1126,6 +1127,60 @@
             (dissoc :issues-active-severities)
             (dissoc :issues-active-prefixes)
             (dissoc :issues-since-ms))))
+
+    ;; ---- Phase 5 (rf2-argrj) — Trace panel ------------------------------
+    ;;
+    ;; The Trace panel is the UI consumer of the canonical 9-axis filter
+    ;; vocabulary documented in spec/009-Instrumentation.md §Filter
+    ;; vocabulary (rf2-97ah0). Where the Issues ribbon collapses the
+    ;; stream to issues only, this panel surfaces the raw stream so a
+    ;; programmer can grep across every op-type / operation / source /
+    ;; origin / frame / etc.
+    ;;
+    ;; Shape of `:rf.causa/trace-feed`:
+    ;;
+    ;;     {:rows         [<row> ...]      ;; post-filter, newest first
+    ;;      :total        <int>            ;; pre-filter count
+    ;;      :rendered     <int>            ;; post-filter count
+    ;;      :distinct     {<axis> [...]}   ;; per-axis chip values
+    ;;      :counts       {<axis> {<value> <int>}}
+    ;;      :filters      <pass-through normalised>
+    ;;      :any-filter?  <bool>
+    ;;      :empty-kind   <:no-events / :no-matches / nil>}
+
+    ;; The current 9-axis filter map. Each axis is independent; the
+    ;; helper's `normalise-filters` drops nil / empty values before
+    ;; applying — the view sets axis = nil to clear an axis.
+    (rf/reg-sub :rf.causa/trace-filters
+      (fn [db _query]
+        (get db :trace-filters {})))
+
+    ;; Composite — produces every slot the view consumes. Reactive
+    ;; surface: trace-buffer + filter state. The helper's
+    ;; `project-feed` does the heavy lifting.
+    (rf/reg-sub :rf.causa/trace-feed
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/trace-filters]
+      (fn [[buffer filters] _query]
+        (trace-helpers/project-feed buffer filters)))
+
+    ;; Set or clear one axis. Passing nil-value clears that axis;
+    ;; setting a value replaces any existing value on that axis (the
+    ;; chip-filter UI is single-value per axis for v1; multi-value
+    ;; rides a follow-on bead).
+    (rf/reg-event-db :rf.causa/set-trace-filter
+      (fn [db [_ axis value]]
+        (let [current (get db :trace-filters {})]
+          (assoc db :trace-filters
+                 (if (nil? value)
+                   (dissoc current axis)
+                   (assoc current axis value))))))
+
+    ;; Clear every filter axis in one shot. Wired from the header's
+    ;; 'Clear filters' button + the no-matches empty state.
+    (rf/reg-event-db :rf.causa/clear-trace-filters
+      (fn [db _event]
+        (dissoc db :trace-filters)))
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -46,6 +46,7 @@
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
+            [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
 
@@ -81,7 +82,7 @@
    {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
    {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
-   {:id :trace        :label "Trace"         :bead "rf2-xxx"}
+   {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
    {:id :flows        :label "Flows"         :bead "rf2-xxx"}
    {:id :performance  :label "Performance"   :bead "rf2-xxx"}
@@ -268,6 +269,7 @@
       :subs         [subscriptions/subscriptions-view]
       :hydration    [hydration-debugger/hydration-debugger-view]
       :issues       [issues-ribbon/issues-ribbon-view]
+      :trace        [trace/trace-view]
       ;; Sidebar Co-pilot row renders the panel-style view in the
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -1,0 +1,389 @@
+(ns day8.re-frame2-causa.panels.trace-helpers-cljs-test
+  "Pure-data tests for Causa's Trace panel helpers (Phase 5, rf2-argrj).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `issues_ribbon_helpers_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **Per-row projection** — `project-row` populates every axis
+       slot from raw trace events (Spec 009 §Filter vocabulary).
+    2. **Each of the 9 filter axes** filters correctly in isolation:
+       `:operation` / `:op-type` / `:since` / `:frame` / `:severity`
+       / `:event-id` / `:handler-id` / `:source` / `:origin` /
+       `:dispatch-id` / `:since-ms` / `:between` / `:pred`.
+    3. **Composition** — axes combine AND-wise.
+    4. **`:between` and `:since-ms`** time-range axes work.
+    5. **`:pred`** arbitrary predicate axis works.
+    6. **`normalise-filters`** drops nil / empty values.
+    7. **`distinct-values` + `axis-counts`** populate the chip rows.
+    8. **`project-feed`** composite + empty-kind classification."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.trace-helpers :as h]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- ev
+  "Build a Spec 009-shaped trace event for the tests. The 9 filter
+  axes pull from both top-level slots and `:tags` — the fixture
+  surfaces every slot the vocabulary documents."
+  [{:keys [id op-type operation time source origin frame event-id
+           handler-id dispatch-id tags coord]
+    :or {time 1000 tags {}}}]
+  (cond-> {:id        id
+           :op-type   op-type
+           :operation operation
+           :time      time
+           :tags      (cond-> tags
+                       origin       (assoc :origin origin)
+                       frame        (assoc :frame frame)
+                       event-id     (assoc :event-id event-id)
+                       handler-id   (assoc :handler-id handler-id)
+                       dispatch-id  (assoc :dispatch-id dispatch-id))}
+    source (assoc :source source)
+    coord  (assoc :rf.trace/trigger-handler {:source-coord coord})))
+
+;; ---- (1) per-row projection --------------------------------------------
+
+(deftest project-row-populates-every-axis-slot
+  (let [e (ev {:id 7 :op-type :event :operation :event/dispatched
+               :time 500 :source :ui :origin :app
+               :frame :rf/default :event-id :counter/inc
+               :handler-id :counter/inc-handler
+               :dispatch-id 42
+               :tags {:event [:counter/inc]}
+               :coord {:file "src/foo.cljs" :line 12}})
+        row (h/project-row e)]
+    (is (= 7 (:id row)))
+    (is (= 500 (:time row)))
+    (is (= :event (:op-type row)))
+    (is (= :event/dispatched (:operation row)))
+    (is (= :ui (:source row)))
+    (is (= :app (:origin row)))
+    (is (= :rf/default (:frame row)))
+    (is (= :counter/inc (:event-id row)))
+    (is (= :counter/inc-handler (:handler-id row)))
+    (is (= 42 (:dispatch-id row)))
+    (is (= "src/foo.cljs:12" (:source-coord row)))
+    (is (= e (:raw row)))))
+
+(deftest project-row-severity-derived-from-op-type
+  (testing ":severity is the Spec 009 synonym axis"
+    (is (= :error   (:severity (h/project-row
+                                  (ev {:id 1 :op-type :error
+                                       :operation :rf.error/x})))))
+    (is (= :warning (:severity (h/project-row
+                                  (ev {:id 1 :op-type :warning
+                                       :operation :rf.warning/x})))))
+    (is (= :info    (:severity (h/project-row
+                                  (ev {:id 1 :op-type :info
+                                       :operation :rf.http/x})))))
+    (is (nil? (:severity (h/project-row
+                           (ev {:id 1 :op-type :event
+                                :operation :event/dispatched})))))))
+
+;; ---- (2) the 9 filter axes — each in isolation -------------------------
+
+(defn- events-fixture
+  "A small mixed-vocabulary fixture used across the axis tests. Every
+  axis the panel filters on has at least two distinct values so a
+  filter actually does work."
+  []
+  [(ev {:id 1 :op-type :event   :operation :event/dispatched
+        :time 100 :source :ui :origin :app
+        :frame :rf/default :event-id :user/login
+        :dispatch-id 10 :tags {:event [:user/login]}})
+   (ev {:id 2 :op-type :error   :operation :rf.error/handler-exception
+        :time 200 :source :ui :origin :app
+        :frame :rf/default :handler-id :user/login-handler
+        :dispatch-id 10
+        :tags {:exception-message "boom"}})
+   (ev {:id 3 :op-type :warning :operation :rf.warning/missing-doc
+        :time 300 :source :timer :origin :pair
+        :frame :rf/causa :dispatch-id 11})
+   (ev {:id 4 :op-type :sub/run :operation :sub/run
+        :time 400 :source :ui :origin :app
+        :frame :rf/default :dispatch-id 10
+        :tags {:sub-id :app/counter}})
+   (ev {:id 5 :op-type :info    :operation :rf.http/retry-attempt
+        :time 500 :source :http :origin :app
+        :frame :rf/default :dispatch-id 12})])
+
+(deftest filter-by-operation
+  (is (= [2]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:operation :rf.error/handler-exception})))))
+
+(deftest filter-by-op-type
+  (is (= [2]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:op-type :error}))))
+  (is (= [4]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:op-type :sub/run})))))
+
+(deftest filter-by-since-cursor
+  (testing ":since is a cursor on :id — strictly greater than"
+    (is (= [3 4 5]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:since 2}))))))
+
+(deftest filter-by-frame
+  (is (= [3]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:frame :rf/causa}))))
+  (is (= [1 2 4 5]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:frame :rf/default})))))
+
+(deftest filter-by-severity
+  (testing ":severity is the synonym axis on :op-type restricted to
+            the three tiers"
+    (is (= [2]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:severity :error}))))
+    (is (= [3]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:severity :warning}))))
+    (is (= [5]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:severity :info}))))))
+
+(deftest filter-by-event-id
+  (is (= [1]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:event-id :user/login})))))
+
+(deftest filter-by-handler-id
+  (is (= [2]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:handler-id :user/login-handler})))))
+
+(deftest filter-by-source
+  (is (= [3]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:source :timer}))))
+  (is (= [5]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:source :http})))))
+
+(deftest filter-by-origin
+  (is (= [3]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:origin :pair})))))
+
+(deftest filter-by-dispatch-id
+  (is (= [1 2 4]
+         (mapv :id (h/apply-filters (events-fixture)
+                                    {:dispatch-id 10})))))
+
+(deftest filter-by-since-ms
+  (testing ":since-ms restricts events whose :time is strictly greater"
+    (is (= [4 5]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:since-ms 300}))))))
+
+(deftest filter-by-between
+  (testing ":between is a [t0 t1] inclusive window"
+    (is (= [2 3 4]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:between [200 400]}))))))
+
+(deftest filter-by-pred
+  (testing ":pred is an arbitrary fn against the raw event map"
+    (is (= [3]
+           (mapv :id (h/apply-filters
+                       (events-fixture)
+                       {:pred (fn [e]
+                                (= "rf.warning" (some-> e :operation
+                                                        namespace)))}))))))
+
+;; ---- (3) axes compose AND-wise -----------------------------------------
+
+(deftest filters-compose-and-wise
+  (testing "two axes intersect"
+    (is (= [3]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:op-type :warning
+                                       :frame   :rf/causa})))))
+  (testing "three axes intersect"
+    (is (= [4]
+           (mapv :id (h/apply-filters (events-fixture)
+                                      {:dispatch-id 10
+                                       :source      :ui
+                                       :op-type     :sub/run}))))))
+
+;; ---- (4) normalise-filters / any-filter? -------------------------------
+
+(deftest normalise-drops-nil-and-empty
+  (is (= {} (h/normalise-filters nil)))
+  (is (= {} (h/normalise-filters {})))
+  (is (= {} (h/normalise-filters {:op-type nil})))
+  (is (= {} (h/normalise-filters {:operation nil :source nil})))
+  (is (= {:op-type :event}
+         (h/normalise-filters {:op-type :event :source nil}))))
+
+(deftest any-filter-active-mirrors-normalise
+  (is (false? (h/any-filter-active? nil)))
+  (is (false? (h/any-filter-active? {:op-type nil})))
+  (is (true?  (h/any-filter-active? {:op-type :event}))))
+
+;; ---- (5) distinct-values + axis-counts ---------------------------------
+
+(deftest distinct-values-first-seen-order
+  (let [rows (h/project-rows (events-fixture))]
+    (is (= [:event :error :warning :sub/run :info]
+           (h/distinct-values rows :op-type)))
+    (is (= [:ui :timer :http]
+           (h/distinct-values rows :source)))
+    (is (= [:app :pair]
+           (h/distinct-values rows :origin)))
+    (is (= [:rf/default :rf/causa]
+           (h/distinct-values rows :frame)))))
+
+(deftest axis-counts-correct-histogram
+  (let [rows (h/project-rows (events-fixture))]
+    (is (= {:ui 3 :timer 1 :http 1}
+           (h/axis-counts rows :source)))
+    (is (= {:app 4 :pair 1}
+           (h/axis-counts rows :origin)))))
+
+;; ---- (6) project-feed (composite) --------------------------------------
+
+(deftest project-feed-empty-buffer
+  (let [feed (h/project-feed [] {})]
+    (is (= 0 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (= :no-events (:empty-kind feed)))
+    (is (false? (:any-filter? feed)))))
+
+(deftest project-feed-no-matches
+  (let [feed (h/project-feed (events-fixture)
+                             {:op-type :error :frame :rf/causa})]
+    (is (= 5 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (= :no-matches (:empty-kind feed)))
+    (is (true?  (:any-filter? feed)))))
+
+(deftest project-feed-rows-newest-first
+  (let [feed (h/project-feed (events-fixture) {})]
+    (testing ":rows is newest first for display"
+      (is (= [5 4 3 2 1] (mapv :id (:rows feed)))))
+    (testing ":empty-kind is nil when there are matches"
+      (is (nil? (:empty-kind feed))))))
+
+(deftest project-feed-distinct-and-counts-per-axis
+  (let [feed (h/project-feed (events-fixture) {})]
+    (is (= [:ui :timer :http]
+           (get-in feed [:distinct :source])))
+    (is (= {:ui 3 :timer 1 :http 1}
+           (get-in feed [:counts :source])))
+    (is (contains? (:distinct feed) :op-type))
+    (is (contains? (:distinct feed) :severity))
+    (is (contains? (:distinct feed) :origin))
+    (is (contains? (:distinct feed) :frame))))
+
+(deftest project-feed-filters-pass-through-normalised
+  (let [feed (h/project-feed (events-fixture)
+                             {:op-type :error :source nil})]
+    (testing "normalised filters drop the nil axis"
+      (is (= {:op-type :error} (:filters feed))))))
+
+;; ---- (7) format-time ---------------------------------------------------
+
+(deftest format-time-renders-hms-with-millis
+  (testing "format-time returns nil on non-numeric input"
+    (is (nil? (h/format-time nil)))
+    (is (nil? (h/format-time "not a number"))))
+  (testing "format-time returns a HH:MM:SS.mmm-shaped string"
+    (let [s (h/format-time 12345)]
+      (is (string? s))
+      (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
+
+;; ---- (8) find-row ------------------------------------------------------
+
+(deftest find-row-by-id
+  (let [rows [{:id 1} {:id 2} {:id 3}]]
+    (is (= {:id 2} (h/find-row rows 2)))
+    (is (nil? (h/find-row rows 99)))))
+
+;; ---- (9) op-type-colour ------------------------------------------------
+
+(deftest op-type-colour-mapping
+  (is (= "#F87171" (h/op-type-colour :error)))
+  (is (= "#FBBF24" (h/op-type-colour :warning)))
+  (is (= "#43C3D0" (h/op-type-colour :info)))
+  (is (= "#7C5CFF" (h/op-type-colour :event)))
+  (is (= "#4ADE80" (h/op-type-colour :fx)))
+  (is (= "#E879F9" (h/op-type-colour :view/render)))
+  ;; Defensive fallback.
+  (is (= "#A8AEC0" (h/op-type-colour :totally-unknown))))
+
+;; ---- (10) source-coord -------------------------------------------------
+
+(deftest source-coord-projection
+  (testing "source-coord pulls file:line from :rf.trace/trigger-handler"
+    (is (= "src/foo.cljs:42"
+           (h/source-coord
+             {:id 1 :op-type :event
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"
+                                                        :line 42}}}))))
+  (testing "missing trigger-handler returns nil"
+    (is (nil? (h/source-coord {:id 1 :op-type :event}))))
+  (testing "missing :line returns just the file"
+    (is (= "src/foo.cljs"
+           (h/source-coord
+             {:id 1 :op-type :event
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"}}})))))
+
+;; ---- (11) short-description --------------------------------------------
+
+(deftest short-description-priority-order
+  (testing "event vector is preferred"
+    (is (re-find #"counter/inc"
+                 (h/short-description
+                   (ev {:id 1 :op-type :event :operation :event/dispatched
+                        :tags {:event [:counter/inc]}})))))
+  (testing "reason is used when no event vec"
+    (is (re-find #"because"
+                 (h/short-description
+                   (ev {:id 1 :op-type :error :operation :rf.error/x
+                        :tags {:reason "because"}})))))
+  (testing "exception-message is used when no reason"
+    (is (re-find #"boom"
+                 (h/short-description
+                   (ev {:id 1 :op-type :error :operation :rf.error/x
+                        :tags {:exception-message "boom"}})))))
+  (testing "sub-id is used for sub events"
+    (is (re-find #"app/counter"
+                 (h/short-description
+                   (ev {:id 1 :op-type :sub/run :operation :sub/run
+                        :tags {:sub-id :app/counter}})))))
+  (testing "fallback is the operation keyword alone"
+    (is (= ":event/dispatched"
+           (h/short-description
+             (ev {:id 1 :op-type :event :operation :event/dispatched
+                  :tags {}}))))))
+
+;; ---- (12) filter-axes coverage matches the bead's contract -------------
+
+(deftest filter-axes-cover-the-bead-contract
+  (testing "the panel surfaces every named axis from Spec 009
+            §Filter vocabulary that has a chip-row presentation"
+    (let [axes (set h/filter-axes)]
+      (is (contains? axes :op-type))
+      (is (contains? axes :severity))
+      (is (contains? axes :source))
+      (is (contains? axes :origin))
+      (is (contains? axes :frame))
+      (is (contains? axes :operation))
+      (is (contains? axes :event-id))
+      (is (contains? axes :handler-id))
+      (is (contains? axes :dispatch-id)))))


### PR DESCRIPTION
## Summary

Phase 5 of **rf2-5aw5v** (Causa v1.0 epic). Implements the **Trace panel** — the UI consumer of the canonical 9-axis filter vocabulary documented in `spec/009-Instrumentation.md` §Filter vocabulary (substrate landed in **rf2-97ah0** / #531).

Where the Issues ribbon (rf2-d1p4o / #607) collapses the trace stream to issues only, the Trace panel surfaces the **raw** stream — every op-type, every operation — so a programmer can grep across the full vocabulary.

## What's in

- **`panels/trace.cljs`** — scrollable, timestamped event ribbon. Per-axis chip-filter rows in the header (only renders chips for axes with ≥2 distinct values); per-row chip-filters for `:source` / `:origin` / `:frame`. Row click → pivots to event-detail for the parent `:dispatch-id`. Empty states: `:no-events` / `:no-matches`. Pure hiccup per rf2-tijr.
- **`panels/trace_helpers.cljc`** — pure-data filter application (delegates to `trace-bus/filter-events` for vocabulary lockstep), row projection (every Spec-009 axis surfaced), per-axis distinct enumeration + histograms, composite `project-feed` for the view to read in one pass.
- **`registry.cljs`** — `:rf.causa/trace-feed` composite sub + `:rf.causa/trace-filters` sub + `:rf.causa/set-trace-filter` / `:rf.causa/clear-trace-filters` event-dbs.
- **`shell.cljs`** — `:trace` sidebar entry → `trace-view`.
- **`trace_helpers_cljs_test.cljc`** — 27 tests covering every axis, AND-wise composition, normalisation, projection, enumeration, empty-state classification.

## Filter axes implemented (per Spec 009 §Filter vocabulary)

All 13 axes the vocabulary documents — `:operation`, `:op-type`, `:since`, `:frame`, `:severity`, `:event-id`, `:handler-id`, `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`, `:pred`. The 9 enumerable-as-chip axes (the 4 numeric/predicate axes are accepted by the filter algebra; a follow-on bead wires drag-zoom + expression input UI).

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 268 tests / 771 assertions / **0 failures**
- [x] `npm run test:cljs` — 1182 tests / 3114 assertions / **0 failures**

## Spec / lineage

- Spec 009 §Filter vocabulary — the canonical 9-axis substrate
- `tools/causa/spec/000-Vision.md` L89 — panel-inventory row
- Parent epic: rf2-5aw5v
- Substrate: rf2-97ah0 / #531 (filter-vocab tests merged)
- Precedent: rf2-d1p4o / #607 (Issues ribbon — closest in spirit)